### PR TITLE
Pre-fetch external document contents so we don't have to request them synchronously

### DIFF
--- a/apps/dg/controllers/authorization.js
+++ b/apps/dg/controllers/authorization.js
@@ -484,6 +484,8 @@ return {
         body.externalDocumentId = ''+docId;
       }
       DG.ExternalDocumentCache.cache(id, body);
+    } else {
+      DG.logError('openDocumentFailed:' + JSON.stringify({id: id, status: response.status, body: response.body, address: response.address}) );
     }
   },
 

--- a/apps/dg/models/data_context_record.js
+++ b/apps/dg/models/data_context_record.js
@@ -121,19 +121,16 @@ DG.DataContextRecord.createContext = function( iProperties) {
   if( SC.none( iProperties)) iProperties = {};
   if( !SC.none( iProperties.externalDocumentId)) {
     // We should be loading this info from an external document.
-    var response = DG.authorizationController.openDocumentSynchronously(iProperties.externalDocumentId);
+    var body = DG.ExternalDocumentCache.fetch(iProperties.externalDocumentId);
 
-    if (SC.ok(response)) {
-      var docId = response.headers()['Document-Id'];
-      if (docId) {
-        // make sure we always have the most up-to-date externalDocumentId,
-        // since the document server can change it for permissions reasons.
-        iProperties.externalDocumentId = ''+docId;
+    if (body) {
+      if (!SC.none(body.externalDocumentId)) {
+        delete iProperties.externalDocumentId;
       }
-      shadowCopy = $.extend(true, shadowCopy, response.get('body'));
-      iProperties = $.extend(response.get('body'), iProperties);
+      shadowCopy = $.extend(true, shadowCopy, body);
+      iProperties = $.extend(body, iProperties);
     } else {
-      // FIXME What do we do for an error?
+      // FIXME What do we do when the document wasn't pre-fetched?
     }
   }
   if( SC.none( iProperties.type)) iProperties.type = 'DG.DataContext';

--- a/apps/dg/utilities/external_document_cache.js
+++ b/apps/dg/utilities/external_document_cache.js
@@ -1,0 +1,19 @@
+DG.ExternalDocumentCache = {
+
+  _externalDocumentCache: {},
+
+  /**
+    */
+  clear: function() {
+    this._externalDocumentCache = {};
+  },
+
+  cache: function( iDocumentId, iDocumentContent ) {
+    this._externalDocumentCache[iDocumentId] = iDocumentContent;
+  },
+
+  fetch: function( iDocumentId ) {
+    return this._externalDocumentCache[iDocumentId];
+  }
+
+};

--- a/apps/dg/utilities/string_utilities.js
+++ b/apps/dg/utilities/string_utilities.js
@@ -28,6 +28,26 @@ DG.StringUtilities = {
    */
   guaranteePrefix: function( iString, iPrefix) {
     return (iString.indexOf(iPrefix) === 0) ? iString : iPrefix + iString;
+  },
+
+  /**
+   * Returns a set of regexp results arrays from matches within the string.
+   * If iResultsMapper is defined, then it returns a set of return values from that function.
+   * @param iString {String}
+   * @param iRegexp {RegExp}
+   * @param iResultsMapper {Function} (optional)
+   */
+  scan: function ( iString, iRegexp, iResultsMapper ) {
+    if (!iRegexp.global) throw "regexp must have global flag set";
+    var m, results = [];
+    while ((m = iRegexp.exec(iString)) !== null) {
+      if (iResultsMapper === null) {
+        results.push(m);
+      } else {
+        results.push(iResultsMapper.call(window, m));
+      }
+    }
+    return results;
   }
 };
 


### PR DESCRIPTION
This fixes PT story [#88253392](https://www.pivotaltracker.com/story/show/88253392): Firefox not supporting synchronous loading of resource forks (external documents).

It adds pre-fetching of resource fork contents before handing off the main document to the document initialization process. This way we avoid needing to do an XHR fetch of the contents in the middle of the initialization process.