### PR TITLE
Add google analytics support and tracking

### DIFF
--- a/Buildfile
+++ b/Buildfile
@@ -21,12 +21,14 @@ config :dg,
 # Production build (e.g. sc-build, make deploy) configuration
 mode :production do
   config :dg,
+         :google_analytics_id => "UA-6899787-45",
          :layout => 'dg:lib/index.rhtml'
 end
 
 # Debug build (e.g. sc-server) configuration
 mode :debug do
   config :dg ,
+         :google_analytics_id => nil,
          :javascript_libs => [# these urls will be inserted as the src of <script> tags in the <head> element
          ]
 #          :layout => 'sproutcore:lib/index.rhtml',

--- a/apps/dg/resources/scripts.rhtml
+++ b/apps/dg/resources/scripts.rhtml
@@ -1,0 +1,13 @@
+<% content_for :page_javascript do %>
+<% if config.google_analytics_id %>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '<%= config.google_analytics_id %>', 'auto');
+    ga('send', 'pageview');
+  </script>
+<% end %>
+<% end %>

--- a/apps/dg/utilities/analytics.js
+++ b/apps/dg/utilities/analytics.js
@@ -1,0 +1,101 @@
+/* global ga */
+(function () {
+
+DG.Analytics = {};
+
+DG.Analytics.Category = {
+  GENERAL:  "General",  // catch-all for events that we haven't categorized yet
+  DATA:     "Data",     // Interactions with generated data
+  DOCUMENT: "Document", // Document interactions
+  GAME:     "Game",     // Game interactions
+  MODEL:    "Model",    // Model interactions
+  PLOT:     "Plot",     // Plot interactions
+  SESSION:  "Session",  // Session events (log in/out)
+};
+
+var _timeStart = {};
+
+// These were hand-pulled from existing log data, so inevitably there were some missed.
+// Really, we should be more explicit about event types, categories, and whatnot
+// at the point that we initiate the logging, rather than trying to map them like this.
+DG.Analytics.categoryForEvent = function(event) {
+  switch (event) {
+    case "Show all cases":
+    case "Show all":
+    case "openCase":
+    case "Hide all":
+    case "deselectAll":
+    case "createCases":
+    case "createCase":
+    case "closeCase":
+    case "attributeRemoved":
+    case "attributeCreate":
+      return DG.Analytics.Category.DATA;
+    case "openDocument":
+    case "closeDocument":
+    case "componentCreated":
+    case "closeComponent":
+    case "autoSaveDocument":
+      return DG.Analytics.Category.DOCUMENT;
+    case "initGame":
+    case "backToGame":
+      return DG.Analytics.Category.GAME;
+    case "LoadedModel":
+    case "StartedModel":
+      return DG.Analytics.Category.MODEL;
+    case "togglePlottedMean":
+    case "togglePlotFunction":
+    case "rescaleScatterplot":
+    case "rescaleDotPlot":
+    case "plotFunction":
+    case "plotAxisAttributeChangeType":
+    case "plotAxisAttributeChange":
+    case "legendAttributeChange":
+    case "hoverOverGraphLine":
+    case "ExportedModel":
+    case "addAxisAttribute":
+      return DG.Analytics.Category.PLOT;
+    case "Logout":
+    case "Login":
+      return DG.Analytics.Category.SESSION;
+    default:
+      if (event.search(/Hide .* selected cases/) !== -1) {
+        return DG.Analytics.Category.DATA;
+      }
+      return DG.Analytics.Category.GENERAL;
+  }
+};
+
+DG.Analytics.trackEvent = function(category, action, label, value) {
+  if (!ga) return;
+
+  var evt = ['send', 'event', category, action];
+  if (label) {
+    evt.push(label);
+    if (value) {
+      evt.push(value);
+    }
+  }
+  ga.apply(window, evt);
+};
+
+DG.Analytics.trackTimingStart = function(category) {
+  if (!ga) return;
+
+  _timeStart[category] = new Date().getTime();
+};
+
+DG.Analytics.trackTimingEnd = function(category) {
+  if (!ga || !_timeStart[category]) return;
+
+  var timeSpent = new Date().getTime() - _timeStart[category];
+  _timeStart[category] = null;
+
+  // sanity-check: time spend should be positive, and less than two hours
+  if (timeSpent > 0 && timeSpent < (1000 * 60 * 120)) {
+    var evt = ['send', 'timing', category, 'Time spent', timeSpent];
+    ga.apply(window, evt);
+  }
+};
+
+})();


### PR DESCRIPTION
PT Story [#82318322](https://www.pivotaltracker.com/story/show/82318322)

It tries to automatically interpret log events, categorize them and send the appropriate data to Google Analytics. We'll probably need to adjust this once we start collecting data and have a better idea of what we want to track.