### PR TITLE
Workaround for inability to export CODAP documents from Safari

### DIFF
--- a/apps/dg/views/single_text_dialog.js
+++ b/apps/dg/views/single_text_dialog.js
@@ -31,6 +31,8 @@ DG.SingleTextDialog = SC.PalettePane.extend(
 /** @scope DG.SingleTextDialog.prototype */ {
 
   isModal: true,
+  // Use to opt in to allowing HTML in the prompt
+  escapePromptHTML: true,
 
   layout: { width: 400, height: 120, centerX: 0, centerY: 0 },
 
@@ -38,9 +40,11 @@ DG.SingleTextDialog = SC.PalettePane.extend(
 
     childViews: 'promptView editView okButton cancelButton'.w(),
     promptView: SC.LabelView.extend({
+      displayProperties: ['escapeHTML'],
       layout: { top: 10, left: 5, right: 5, height:24 },
       localize: true,
-      value: ''
+      value: '',
+      escapeHTMLBinding: '.parentView.parentView.escapePromptHTML'
     }),
     editView: SC.TextFieldView.design({
       layout: { top: 40, left: 5, right: 5, height:24 },


### PR DESCRIPTION
Safari doesn't seem to implement any specific support for named downloads of client-side generated content; see discussion at the bottom of https://bugs.webkit.org/show_bug.cgi?id=102914 (referenced by https://github.com/eligrey/FileSaver.js/issues/12 -- we use FileSaver.js to support other browsers)

I attempted to use [Downloadify](https://github.com/dcneiner/downloadify) to allow named downloads with the same UI in Safari as in the other browsers, but something about SproutCore and/or CODAP blocked the Downloadify Flash widget from seeing mousedown and mouse click events. (Downloadify's own examples work fine in Safari, but when it was embedded in CODAP I could see the Flash widget change its ui state in response to mouseover, but not mousedown.) WIth no debug information from Flash and Downloadify, I abandoned that approach after several experiments; perhaps it could be made to work.

This is an alternate, serverless solution that takes into account that users of exportDocument are mostly CC collaborators and developers, not general users. It presents a small download link in the modal dialog where we ask users to select a filename. Users can right/command-click the link, from which they can choose "Download link" or "Download link as". If they choose the former, Safari downloads the file and gives it the name `Unknown` (!); if they choose the latter, they are prompted for a name before saving. After that, they can dismiss the dialog by clicking either OK or cancel.

Rough edges: 
  * in Safari, the filename input and OK/Cancel button are still presented even though they don't work. (The OK button does close the dialog, and is useful in that sense). One reason to leave it that way is that non-Safari users might find the download link useful.
  * ordinary clicking on the link doesn't do anything. This seems to be because browser vendors have agreed for security reasons not to _open_ links whose `href` is a data URIs, only to allow them to be downloaded. (Thought: we could dynamically update the `download` attribute of the link--not supported in Safari--to match the filename, in order to provide a better experience to non-Safari users)

(The `href` of the link is a data URI with MIME type `application/json`)

