### PR TITLE
Remove duplicate logging events

### DIFF
--- a/apps/dg/components/graph/plots/plot_model.js
+++ b/apps/dg/components/graph/plots/plot_model.js
@@ -229,7 +229,6 @@ DG.PlotModel = SC.Object.extend( DG.Destroyable,
         var tWantVisible = !this_.plottedCount.get('isVisible');
         this_.plottedCount.set('isVisible', tWantVisible );
       }
-      DG.logUser("togglePlottedCount: %@", this_.plottedCount.get('isVisible') ? "show" : "hide");
     }
 
     var isShowCount = !this.plottedCount || !this.plottedCount.get('isVisible');
@@ -408,8 +407,6 @@ DG.PlotModel = SC.Object.extend( DG.Destroyable,
     var adornmentModel = this.getAdornmentModel( iAdornmentKey ),
         tIsVisible = adornmentModel && adornmentModel.get('isVisible');
     this.setAdornmentVisibility( iAdornmentKey, !tIsVisible);
-    DG.logUser("%@: %@", iToggleLogString || "toggle" + iAdornmentKey,
-                          !tIsVisible ? "show" : "hide");
     return adornmentModel;
   },
 

--- a/apps/dg/components/graph/plots/scatter_plot_model.js
+++ b/apps/dg/components/graph/plots/scatter_plot_model.js
@@ -244,7 +244,7 @@ DG.ScatterPlotModel = DG.PlotModel.extend( DG.NumericPlotModelMixin,
       iAnimatePoints = true;
     this.doRescaleAxesFromData( [DG.GraphTypes.EPlace.eX, DG.GraphTypes.EPlace.eY, DG.GraphTypes.EPlace.eY2],
                                 iAllowScaleShrinkage, iAnimatePoints, isUserAction);
-    if( iLogIt)
+    if( iLogIt && !isUserAction)
       DG.logUser("rescaleScatterplot");
   },
 

--- a/apps/dg/components/map/map_view.js
+++ b/apps/dg/components/map/map_view.js
@@ -199,17 +199,14 @@ DG.MapView = SC.View.extend( DG.GraphDropTarget,
           },
           execute: function() {
             this._controller().setPath('view.contentView.model.baseMapLayerName', tBackground);
-            DG.logUser('changeMapBackground: %@', tBackground);
           },
           undo: function() {
             this._controller().setPath('view.contentView.model.baseMapLayerName', tOldBackground);
             this._controller().setPath('view.contentView.backgroundControl.value', [tOldBackground]);
-            DG.logUser('changeMapBackground (undo): %@', tOldBackground);
           },
           redo: function() {
             this._controller().setPath('view.contentView.model.baseMapLayerName', tBackground);
             this._controller().setPath('view.contentView.backgroundControl.value', [tBackground]);
-            DG.logUser('changeMapBackground (undo): %@', tBackground);
           }
         }));
       },

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -537,7 +537,6 @@ DG.ComponentView._createComponent = function (iComponentLayout, iComponentClass,
   if (!SC.none(iIsVisible))
     tComponentView.set('isVisible', iIsVisible);
 
-  DG.logUser("componentCreated: %@", iComponentClass);
   SC.Benchmark.end('createComponent: ' + iComponentClass);
   SC.Benchmark.log('createComponent: ' + iComponentClass);
   return tComponentView;


### PR DESCRIPTION
By adding some instrumentation to the log events, plus a bunch of manual tracing through event paths, I believe I've found all the cases where we were duplicating the logging of undoable events, and removed those.

Each of these log events was logging an event that was already being logged by the undo-redo controller (via the `log` property of an undoable command).

[#104009308]