### PR TITLE
Fix loading of Example Documents; use $.ajax instead of SC.Request.

### DIFF
--- a/apps/dg/controllers/user_entry_controller.js
+++ b/apps/dg/controllers/user_entry_controller.js
@@ -82,11 +82,16 @@ DG.userEntryController = SC.Object.create( DG.CODAPCommonStorage, (function() {
       var selected = this._dialog.getPath('contentView.choiceViews.contentView.selected');
 
       if (selected) {
-        this._urlForGetRequests( selected.location )
-        .notify(this, '_handleResponse',
-          function(body) { DG.appController.receivedOpenDocumentSuccess(body, false); },
-          function(errorCode) { DG.appController.receivedOpenDocumentFailure(errorCode, false); })
-        .send();
+        $.ajax({
+          url: selected.location,
+          success: function(iResponse) {
+            DG.appController.receivedOpenDocumentSuccess(iResponse);
+          },
+          error: function(jqXHR, textStatus, errorThrown) {
+            // could try to parse the error more precisely
+            DG.appController.receivedOpenDocumentFailure('error.general');
+          }
+        });
         DG.logUser("openExample: '%@'", selected.location);
       }
     },


### PR DESCRIPTION
A recent change to the CORS settings for codap_resources.concord.org broke Example Documents for the deployed CODAP for reasons that would have been difficult to anticipate. Background for the curious: SproutCore uses its own SC.Request mechanism for handling HTTP requests internally. In the version of SproutCore currently used by CODAP (1.9.2), SC.Request doesn’t support the withCredentials field. But CODAP needs to specify withCredentials for loading/saving documents, etc. so CODAP contains a monkey-patch of SproutCore’s SC.Request code which unconditionally forces withCredentials to true on all uses of SC.Request. In conjunction with the recent change to the CORS settings, requests to codap_resources.concord.org are met with the following error:

```XMLHttpRequest cannot load https://codap-resources.concord.org/examples/index.json. Response to preflight request doesn't pass access control check: A wildcard '*' cannot be used in the 'Access-Control-Allow-Origin' header when the credentials flag is true. Origin 'http://localhost:4020' is therefore not allowed access.```

This is presumably why the CORS settings were set the way they were originally. Rather than changing the CORS settings back we fix the problem by having CODAP load the Example Documents using $.ajax and bypass SC.Request altogether. Note that in the previous version more work went into parsing errors so that users could be given appropriate error messages. Some of this error parsing relied on SC.Request's error-handling. In the interest of expediency, along with the fact that the Example Documents infrastructure is expected to change  with the upcoming CFM integration, this code simply reverts to fairly generic error messages on failure.