### PR TITLE
Fixed bug in which a newly-opened document would be dirty immediately

### DIFF
--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -655,8 +655,6 @@ DG.DocumentController = SC.Object.extend(
         }
         tComponentView.set('model', tComponent);
         tComponent.set('layout', tComponentView.get('layout'));
-
-        DG.dirtyCurrentDocument(); // TODO We can remove this after we're sure all components get created via Undo
       }
 
       return tComponentView;


### PR DESCRIPTION
Fixed bug in which a newly-opened document would be dirty immediately, triggering auto-save ([PT#113048513](https://www.pivotaltracker.com/story/show/113048513)).

The comment on the line being removed states that the line can be removed once all components are created with undoable actions, which is now true. The effect of this in current production CODAP is limited, but it will be greater once CFM is integrated with its auto-save capability.