### PR TITLE
Fix gradient rendering bug when document URL contains '#' character

### DIFF
--- a/apps/dg/libraries/raphael.js
+++ b/apps/dg/libraries/raphael.js
@@ -5921,7 +5921,7 @@
             }
         }
         $(o, {
-            fill: "url('" + document.location + "#" + id + "')",
+            fill: "url('" /* [CC] + document.location [/CC] */ + "#" + id + "')",
             opacity: 1,
             "fill-opacity": 1
         });


### PR DESCRIPTION
Fix gradient rendering bug when document URL contains '#' character -- as is true with CODAP/CFM ([PT#113134011](https://www.pivotaltracker.com/story/show/113134011)).

This one's fascinating. A CODAP document with a graph showing a numeric legend works properly initially, but after saving/reopening via CFM the gradient rectangle in the graph legend is blank.

In a document with a working legend view (e.g. before saving/reopening via CFM), inspecting the gradient element in the debugger reveals the following: ```fill="url('http://codap.concord.org/releases/latest/static/dg/en/cert/index.html?documentServer=http%3A%2F%2Fdocument-store.herokuapp.com%2F&recordid=8500#9030-_fff-rgb_0_108_54_')"``` Elsewhere in the document, we see the definition of a linear gradient with ```id="9030-_fff-rgb_0_108_54_"``` Clearly the code is using an absolute URL reference where a relative URL reference would seem to be all that's needed.

In the CODAP/CFM version, the same gradient fill reference looks like this: ```fill="url('http://codap.concord.org/~kswenson/cfm-library/static/dg/en/cert/index.html?doc=FastPlants+40+cfm&documentServer=http%3A%2F%2Fdocument-store.herokuapp.com%2F&owner=kswenson#file=documentStore:8503#20490-_fff-rgb_0_108_54_')"```

There are now two `#` signs in the URL, one `"#file=documentStore:8503"` put there by the CFM and the other `#20490-_fff-rgb_0_108_54_` as part of the SVG reference. But the double-`#` prevents SVG from parsing it properly, and so it can't load the gradient.

As it happens this bug has already been logged against Raphael and been fixed in a more recent version than the one currently used by CODAP: [SVG gradients don't render with hash urls (#933)](https://github.com/DmitryBaranovskiy/raphael/issues/933). But the implemented fix seems to cause other problems: [Gradient and document.location.origin in Firefox (#998)](https://github.com/DmitryBaranovskiy/raphael/issues/998) and [Gradient not filled when page's url contains "?" character (#999)](https://github.com/DmitryBaranovskiy/raphael/issues/999).

Further investigation reveals that there seem to be two situations in which absolute URLs are required. If the `fill:url(#id)` is in an external stylesheet ([Firefox SVG with fill:url(#id) style in external stylesheet broken](http://stackoverflow.com/questions/15842224/firefox-svg-with-fillurlid-style-in-external-stylesheet-broken-inline-style)) and if there is a `<base>` element in the page ([URL to linear gradient doesn't work](http://stackoverflow.com/a/30494690)) -- which apparently affects applications using angular.js. This is presumably why Raphael used the full URL in the first place.

But neither of these scenarios affect CODAP/CFM, so we decided to proceed with the simple fix of patching Raphael to use relative URLs rather than absolute URLs.