### PR TITLE
Loosen document validation so unrecognized properties are simply logged.

### DIFF
--- a/apps/dg/controllers/document_archiver.js
+++ b/apps/dg/controllers/document_archiver.js
@@ -112,10 +112,12 @@ DG.DocumentArchiver = SC.Object.extend(
         'appBuildNum',
         'appName',
         'appVersion',
+        'changeCount',
         'components',
         'contexts',
         'globalValues',
         'guid',
+        'metadata',
         'name',
         '_permissions',
         '_openedFromSharedDocument' // this is an annotation we may create in
@@ -163,7 +165,8 @@ DG.DocumentArchiver = SC.Object.extend(
         );
         DG.ObjectMap.keys(doc).forEach(function (prop) {
             if (expectedProperties.indexOf(prop) < 0) {
-              errors.push('DG.AppController.validateDocument.unexpectedProperty'.loc(prop));
+              // log unexpected properties but don't fail to open
+              DG.log('DG.AppController.validateDocument.unexpectedProperty'.loc(prop));
             }
           }
         );


### PR DESCRIPTION
Add 'changeCount' (added for a period of time) and 'metadata' (added along with CFM integration) to the list of expected top-level properties. Log other unrecognized properties rather than failing to open.