### PR TITLE
Specify https scheme for help and CODAP project page URLs

### DIFF
--- a/apps/dg/controllers/app_controller.js
+++ b/apps/dg/controllers/app_controller.js
@@ -1485,7 +1485,7 @@ DG.appController = SC.Object.create((function () // closure
             width: kWidth, height: kHeight };
       // Changed link to play.codap.concord.org/support
       DG.currDocumentController().addWebView(DG.mainPage.get('docView'), null,
-          'http://' +  ('DG.AppController.showHelpURL'.loc()),
+          'https://' +  ('DG.AppController.showHelpURL'.loc()),
         'DG.AppController.showHelpTitle'.loc(), //'Help with CODAP'
           tLayout);
 
@@ -1552,7 +1552,7 @@ DG.appController = SC.Object.create((function () // closure
 
       //var windowFeatures = "location=yes,scrollbars=yes,status=yes,titlebar=yes";
       DG.currDocumentController().addWebView(DG.mainPage.get('docView'), null,
-          'http://' +  ('DG.AppController.showWebSiteURL'.loc()),
+          'https://' +  ('DG.AppController.showWebSiteURL'.loc()),
         'DG.AppController.showWebSiteTitle'.loc(), //'About CODAP'
           tLayout);
 


### PR DESCRIPTION
Specify https scheme for help and CODAP project page URLs to bypass https/http mismatch warnings.

Note: I considered protocol-relative URLs, but given that protocol-relative URLs are no longer recommended (e.g. http://www.paulirish.com/2010/the-protocol-relative-url/) we just specify https explicitly.