### PR TITLE
Support aggregate functions in plotted values and functions

### DIFF
--- a/apps/dg/components/graph/adornments/plot_adornment_model.js
+++ b/apps/dg/components/graph/adornments/plot_adornment_model.js
@@ -24,14 +24,20 @@ DG.PlotAdornmentModel = SC.Object.extend(
 /** @scope DG.PlotAdornmentModel.prototype */
 {
   /**
-    The plot model to which the adornment is attached.
-    @property   {DG.PlotModel}
+    The plot model to which the adornment is attached; set on construction
+    @type   {DG.PlotModel}
    */
   plotModel: null,
   
   /**
+    The 'type' string by which this model is registered; set on construction
+    @type   {string}
+   */
+  adornmentKey: null,
+
+  /**
     True if the adornment should be displayed, false if it's hidden.
-    @property   {Boolean}
+    @type   {Boolean}
    */
   isVisible: true,
   

--- a/apps/dg/components/graph/adornments/plotted_function_adornment.js
+++ b/apps/dg/components/graph/adornments/plotted_function_adornment.js
@@ -82,7 +82,7 @@ DG.PlottedFunctionAdornment = DG.PlotAdornment.extend(
         for( tPixelX = tPixelMin; tPixelX <= tPixelMax; tPixelX += kPixelGap) {
           tX = tXAxisView.coordinateToData( tPixelX);
           // Note: If an exception is thrown on evaluate(), we exit the loop
-          tY = tModel.evaluate( tX);
+          tY = tModel.evaluate({ x: tX });
           if( DG.isFinite( tY)) {
             tPixelY = tYAxisView.dataToCoordinate( tY);
             tPoints.push( {top: tPixelY, left: tPixelX});

--- a/apps/dg/components/graph/plots/dot_plot_view.js
+++ b/apps/dg/components/graph/plots/dot_plot_view.js
@@ -197,6 +197,10 @@ DG.DotPlotView = DG.PlotView.extend(
     updateOneAvgAdorn( this.plottedMedianAdorn );
     updateOneAvgAdorn( this.plottedStDevAdorn );
     updateOneAvgAdorn( this.plottedIQRAdorn );
+
+    if (this.plottedValueAdorn) {
+      this.plottedValueAdorn.updateToModel();
+    }
   },
 
   /**

--- a/apps/dg/components/graph/plots/plot_model.js
+++ b/apps/dg/components/graph/plots/plot_model.js
@@ -432,7 +432,7 @@ DG.PlotModel = SC.Object.extend( DG.Destroyable,
     if( !model) {
       var modelClass = DG.PlotAdornmentModel.registry[ iAdornmentKey];
       DG.assert( modelClass, "No model class registered for '%@'".fmt( iAdornmentKey));
-      model = modelClass && modelClass.create({ plotModel: this });
+      model = modelClass && modelClass.create({ plotModel: this, adornmentKey: iAdornmentKey });
       if( model)
         this.setAdornmentModel( iAdornmentKey, model);
     }

--- a/apps/dg/components/graph/plots/scatter_plot_model.js
+++ b/apps/dg/components/graph/plots/scatter_plot_model.js
@@ -154,11 +154,6 @@ DG.ScatterPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
 
         function toggle() {
           this_.toggleAdornmentVisibility('plottedFunction', 'togglePlotFunction');
-          if (this_.isAdornmentVisible('plottedFunction')) {
-            var plottedFunction = this_.getAdornmentModel('plottedFunction');
-            if (plottedFunction)
-              plottedFunction.set('dataConfiguration', this_.get('dataConfiguration'));
-          }
         }
 
         var willShow = !this.isAdornmentVisible('plottedFunction');

--- a/apps/dg/components/graph/plots/scatter_plot_view.js
+++ b/apps/dg/components/graph/plots/scatter_plot_view.js
@@ -122,6 +122,10 @@ DG.ScatterPlotView = DG.PlotView.extend(
     if( this.connectingLineAdorn ) {
       this.connectingLineAdorn.invalidateModel();
     }
+
+    // update plotted function
+    if (this.functionAdorn)
+      this.functionAdorn.updateToModel();
   },
   
   /**
@@ -151,6 +155,10 @@ DG.ScatterPlotView = DG.PlotView.extend(
       this.connectingLineAdorn.invalidateModel();
       this.connectingLineAdorn.updateToModel();
     }
+
+    // update plotted function
+    if (this.functionAdorn)
+      this.functionAdorn.updateToModel();
     
     this.rescaleOnParentCaseCompletion( tCases);
 

--- a/apps/dg/formula/aggregate_function.js
+++ b/apps/dg/formula/aggregate_function.js
@@ -205,6 +205,18 @@ DG.ParentCaseAggregate = DG.IteratingAggregate.extend({
   },
 
   /**
+    Returns the value of the first argument, primarily for the benefit of
+    univariate aggregate functions. If no arguments were specified, will
+    use the univariate axis variable if a function for it was provided.
+    Clients such as plotted values can set the 'uniVarFn' property of the
+    instance to enable defaulting to the univariate axis variable.
+   */
+  getValue: function( iContext, iEvalContext, iInstance) {
+    var valueFn = iInstance.argFns[0] || iInstance.uniVarFn;
+    return valueFn && valueFn( iContext, iEvalContext);
+  },
+  
+  /**
     Returns the numeric value of the first argument, primarily for the benefit
     of univariate aggregate functions. If no arguments were specified, will
     use the univariate axis variable if a function for it was provided.

--- a/apps/dg/formula/aggregate_function.js
+++ b/apps/dg/formula/aggregate_function.js
@@ -156,12 +156,29 @@ DG.ParentCaseAggregate = DG.IteratingAggregate.extend({
 
   // find the parent case that corresponds to the EvalContext's _collectionID_
   // if the _collectionID_ is the evaluated case, then default to its parent
-  getGroupID: function(iEvalContext) {
-    var tCase = iEvalContext._case_,
-        tParent = tCase && tCase.get('parent');
-    for (; tCase; tCase = tCase.get('parent'), tParent = tCase) {
-      if (tCase.getPath('collection.id') === iEvalContext._collectionID_)
-        return tParent ? tParent.get('id') : null;
+  getGroupID: function(iContext, iEvalContext) {
+    var tCase = iEvalContext._case_;
+
+    // if we are evaluating a particular case, then derive the group from it
+    if (tCase) {
+      // if a specifid grouping variable was specified, then use it
+      var groupVarID = iContext && iContext.get('groupVarID');
+      if (groupVarID) {
+        var groupID = iContext.getAttrValue(tCase, groupVarID);
+        return !SC.empty(groupID) ? groupID : null;
+      }
+      else {
+        // no grouping variable specified -- group by collection
+        var tParent = tCase && tCase.get('parent');
+        for (; tCase; tCase = tCase.get('parent'), tParent = tCase) {
+          if (tCase.getPath('collection.id') === iEvalContext._collectionID_)
+            return tParent ? tParent.get('id') : null;
+        }
+      }
+    }
+    // we're not evaluating a case; if client specified the group, then use it
+    else {
+      if (iEvalContext._groupID_) return iEvalContext._groupID_;
     }
     return null;
   },
@@ -180,11 +197,23 @@ DG.ParentCaseAggregate = DG.IteratingAggregate.extend({
     if( iInstance.results) {
       if( iInstance.results[ iEvalContext._id_] !== undefined)
         return iInstance.results[ iEvalContext._id_];
-      var cacheID = this.getGroupID( iEvalContext);
+      var cacheID = this.getGroupID( iContext, iEvalContext);
       if( iInstance.results[ cacheID] !== undefined)
         return iInstance.results[ cacheID];
     }
     return undefined;
+  },
+
+  /**
+    Returns the numeric value of the first argument, primarily for the benefit
+    of univariate aggregate functions. If no arguments were specified, will
+    use the univariate axis variable if a function for it was provided.
+    Clients such as plotted values can set the 'uniVarFn' property of the
+    instance to enable defaulting to the univariate axis variable.
+   */
+  getNumericValue: function( iContext, iEvalContext, iInstance) {
+    var valueFn = iInstance.argFns[0] || iInstance.uniVarFn;
+    return valueFn && DG.getNumeric(valueFn( iContext, iEvalContext));
   },
   
   /**
@@ -214,7 +243,7 @@ DG.ParentCaseAggregate = DG.IteratingAggregate.extend({
       var tCase = cases.objectAt( i),
           tEvalContext = $.extend({}, iEvalContext,
                                   { _case_: tCase, _id_: tCase && tCase.get('id') }),
-          cacheID = this.getGroupID(tEvalContext);
+          cacheID = this.getGroupID(iContext, tEvalContext);
       this.evalCase( iContext, tEvalContext, iInstance, cacheID);
     }
     
@@ -244,8 +273,7 @@ DG.SortDataFunction = DG.ParentCaseAggregate.extend({
     @param  {Number|null}         iCacheID -- The cache ID to use for cache lookups for this case.
    */
   evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
-    var valueFn = iInstance.argFns[0],
-        value = valueFn && DG.getNumeric(valueFn( iContext, iEvalContext));
+    var value = this.getNumericValue(iContext, iEvalContext, iInstance);
     // Currently, we only sort numeric values.
     // To support a Fathom-like alphanumeric sort, we would have to change the test here.
     if( DG.isFinite( value)) {

--- a/apps/dg/formula/univariate_stats_fns.js
+++ b/apps/dg/formula/univariate_stats_fns.js
@@ -41,8 +41,7 @@ DG.UnivariateStatsFns = {
     requiredArgs: { min: 0, max: 1 },
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
-      var valueFn = iInstance.argFns[0],
-          value = valueFn && valueFn( iContext, iEvalContext);
+      var value = this.getNumericValue( iContext, iEvalContext, iInstance);
       // Count:
       //  -- all cases if there are no arguments (!valueFn)
       //  -- non-empty values except for boolean false and empty string
@@ -63,11 +62,10 @@ DG.UnivariateStatsFns = {
    */
   min: DG.ParentCaseAggregate.create({
   
-    requiredArgs: { min: 1, max: 1 },
+    requiredArgs: { min: 0, max: 1 },
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
-      var valueFn = iInstance.argFns[0],
-          value = valueFn && DG.getNumeric(valueFn( iContext, iEvalContext));
+      var value = this.getNumericValue( iContext, iEvalContext, iInstance);
       if( DG.isFinite( value)) {
         var cache = iInstance.caches[ iCacheID];
         if( cache) {
@@ -94,11 +92,10 @@ DG.UnivariateStatsFns = {
    */
   max: DG.ParentCaseAggregate.create({
   
-    requiredArgs: { min: 1, max: 1 },
+    requiredArgs: { min: 0, max: 1 },
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
-      var valueFn = iInstance.argFns[0],
-          value = valueFn && DG.getNumeric(valueFn( iContext, iEvalContext));
+      var value = this.getNumericValue( iContext, iEvalContext, iInstance);
       if( DG.isFinite( value)) {
         var cache = iInstance.caches[ iCacheID];
         if( cache) {
@@ -125,11 +122,10 @@ DG.UnivariateStatsFns = {
    */
   mean: DG.ParentCaseAggregate.create({
   
-    requiredArgs: { min: 1, max: 1 },
+    requiredArgs: { min: 0, max: 1 },
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
-      var valueFn = iInstance.argFns[0],
-          value = valueFn && DG.getNumeric(valueFn( iContext, iEvalContext));
+      var value = this.getNumericValue( iContext, iEvalContext, iInstance);
       if( DG.isFinite( value)) {
         var cache = iInstance.caches[ iCacheID];
         if( cache) {
@@ -158,7 +154,7 @@ DG.UnivariateStatsFns = {
    */
   median: DG.SortDataFunction.create({
   
-    requiredArgs: { min: 1, max: 1 },
+    requiredArgs: { min: 0, max: 1 },
 
     extractResult: function( iCachedValues) {
       return DG.MathUtilities.medianOfNumericArray( iCachedValues);
@@ -171,11 +167,10 @@ DG.UnivariateStatsFns = {
    */
   sum: DG.ParentCaseAggregate.create({
   
-    requiredArgs: { min: 1, max: 1 },
+    requiredArgs: { min: 0, max: 1 },
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
-      var valueFn = iInstance.argFns[0],
-          value = valueFn && DG.getNumeric(valueFn( iContext, iEvalContext));
+      var value = this.getNumericValue( iContext, iEvalContext, iInstance);
       if( DG.isFinite( value)) {
         if( iInstance.results[ iCacheID])
           iInstance.results[ iCacheID] += value;

--- a/apps/dg/formula/univariate_stats_fns.js
+++ b/apps/dg/formula/univariate_stats_fns.js
@@ -41,13 +41,13 @@ DG.UnivariateStatsFns = {
     requiredArgs: { min: 0, max: 1 },
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
-      var value = this.getNumericValue( iContext, iEvalContext, iInstance);
+      var value = this.getValue( iContext, iEvalContext, iInstance);
       // Count:
       //  -- all cases if there are no arguments (!valueFn)
       //  -- non-empty values except for boolean false and empty string
       //      (this way count(x>0) returns the expected result)
       // We don't use the cache, since all we need is the result counts.
-      if( !valueFn || (!SC.empty( value) && (value !== false))) {
+      if( !SC.empty( value) && (value !== false)) {
         if( iInstance.results[ iCacheID])
           ++iInstance.results[ iCacheID];
         else


### PR DESCRIPTION
Support aggregate functions in plotted values and functions
Support 'x' or axis attribute name in plotted values and plotted functions
Addresses [[#118567825]](https://www.pivotaltracker.com/story/show/118567825)

With this PR aggregate functions are supported in plotted values and plotted functions, but in a split dot plot only a single value is currently displayed across all sub-plots. Split evaluation is supported by the engine and can be enabled by setting the 'splitEval' property of the DG.PlottedFunctionModel, but the proper rendering of such split values is captured in a separate PT story [[#119751249]](https://www.pivotaltracker.com/story/show/119751249).

To demonstrate that split evaluation is working, set the 'splitEval' property of DG.PlottedFunctionModel to true, after which plotted values will be calculated for the first cell and plotted accordingly. To test computation of other cells, set the 'currentIndex' property of DG.PlottedValueAdornment to the index of the desired cell.