### PR TITLE
Standalone undo redo

### DIFF
--- a/apps/dg/components/game/game_controller.js
+++ b/apps/dg/components/game/game_controller.js
@@ -570,7 +570,11 @@ DG.GameController = DG.ComponentController.extend(
 
     notifyGameAboutExternalUndo: function() {
       if (this.get('gameIsReady') && DG.UndoHistory.get('enabled')) {
-        this.gamePhone.call({ operation: "externalUndoAvailable" });
+        if (DG.STANDALONE_MODE) {
+          this.gamePhone.call({ operation: "standaloneUndoModeAvailable" });
+        } else {
+          this.gamePhone.call({ operation: "externalUndoAvailable" });
+        }
       }
     }.observes('gameIsReady'),
 

--- a/apps/dg/components/game/game_controller.js
+++ b/apps/dg/components/game/game_controller.js
@@ -300,6 +300,14 @@ DG.GameController = DG.ComponentController.extend(
         tRet = this.handleUndoableAction( tCmdObj.args);
         break;
 
+      case 'undo':
+        tRet = DG.UndoHistory.undo();;
+        break;
+
+      case 'redo':
+        tRet = DG.UndoHistory.redo();;
+        break;
+
       /*
        * Old API
        */

--- a/apps/dg/components/game/game_controller.js
+++ b/apps/dg/components/game/game_controller.js
@@ -250,8 +250,9 @@ DG.GameController = DG.ComponentController.extend(
         }.bind(this));
         return;
 
-        case 'createComponent':
-          // If we're in standalone mode, we allow more than one component of a type to be created
+      case 'createComponent':
+        // If we're in standalone mode, we allow more than one component of a type to be created
+        tCmdObj.args.initiatedViaCommand = true;
         tRet = this.handleCreateComponent( tCmdObj.args, DG.STANDALONE_MODE);
         break;
 

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -456,7 +456,8 @@ DG.DocumentController = SC.Object.extend(
     createComponentAndView: function( iComponent, iComponentType, iArgs) {
       var docView = DG.mainPage.get('docView'),
           type = (iComponent && iComponent.get('type')) || iComponentType,
-          tView = null;
+          tView = null
+          isInitialization = iArgs && iArgs.initiatedViaCommand ? false : true;
       try {
         switch( type) {
         case 'DG.FlashView':  // For backward compatibility
@@ -465,7 +466,7 @@ DG.DocumentController = SC.Object.extend(
           // fallthrough intentional
           /* jshint -W086 */  // Expected a 'break' statement before 'case'. (W086)
         case 'DG.GameView':
-          tView = this.addGame( docView, iComponent, true);
+          tView = this.addGame( docView, iComponent, isInitialization);
           break;
         case 'DG.TableView':
           // If there is no component, we are creating new components.
@@ -481,26 +482,26 @@ DG.DocumentController = SC.Object.extend(
           break;
           case 'DG.GraphView':
           // ToDo: pass iArgs along to other 'add' methods in addition to addGraph
-          tView = this.addGraph( docView, iComponent, true, iArgs);
+          tView = this.addGraph( docView, iComponent, isInitialization, iArgs);
           break;
         case 'DG.SliderView':
-          tView = this.addSlider( docView, iComponent, true);
+          tView = this.addSlider( docView, iComponent, isInitialization);
           break;
         case 'DG.Calculator':
-          tView = this.addCalculator( docView, iComponent, true);
+          tView = this.addCalculator( docView, iComponent, isInitialization);
           break;
         case 'DG.TextView':
-          tView = this.addText( docView, iComponent, true);
+          tView = this.addText( docView, iComponent, isInitialization);
           break;
         case 'DG.MapView':
-          tView = this.addMap( docView, iComponent, true);
+          tView = this.addMap( docView, iComponent, isInitialization);
           break;
         case 'SC.WebView':
         case 'DG.WebView':
-          tView = this.addWebView( docView, iComponent, null, null, null, true);
+          tView = this.addWebView( docView, iComponent, null, null, null, isInitialization);
           break;
         case 'DG.GuideView':
-          tView = this.addGuideView( docView, iComponent, true);
+          tView = this.addGuideView( docView, iComponent, isInitialization);
           break;
         default:
           break;


### PR DESCRIPTION
Submitting Sam's work (after rebasing to master) to support undo/redo cooperation between CODAP and interactives, such as Sage Modeler, while he's away.

**Allow DI to send undo and redo requests to CODAP**

**Inform DI if we are in standalone mode**
Specifically, we tell the app that, instead of hiding undo and redo
buttons (`externalUndoAvailable`), the app should show the buttons
but proxy all requests to CODAP (`standaloneUndoModeAvailable`).

**Distinguish between component creation in init and via DI command**

Previously, we added an `isInitialization` flag in all the
`add[Component]` functions that could be called both from
`createComponentAndView` and from the toolbar.

The assumption was that `createComponentAndView` was only called
during initialization (when loading a document with components),
so `createComponentAndView` always passed down `isInitialization=true`.

Now `createComponentAndView` can also be called via a `createComponent`
call from the data interactive.

To distinguish between the two, we add an additional argument to the
component arguments, `initiatedViaCommand`.

However, there may be other ways to distinguish between the two events.