### PR TITLE
Formula engine caching and invalidation

### DIFF
--- a/apps/dg/controllers/collection_client.js
+++ b/apps/dg/controllers/collection_client.js
@@ -68,7 +68,7 @@ DG.CollectionClient = SC.Object.extend(
 
   casesController: null,
   
-  attrFormulaChanges: 0,
+  attrFormulaChanges: null,
   attrFormulaDependentChanges: 0,
   
   /**
@@ -131,11 +131,11 @@ DG.CollectionClient = SC.Object.extend(
     }
   },
 
-    getParentCollectionID: function () {
-      var collectionModel = this.get('collection');
-      var parent = collectionModel && collectionModel.parent;
-      return (parent && parent.id);
-    },
+  getParentCollectionID: function () {
+    var collectionModel = this.get('collection');
+    var parent = collectionModel && collectionModel.parent;
+    return (parent && parent.id);
+  },
 
   /**
     Returns true if iOtherCollection is descended from this collection.
@@ -174,25 +174,26 @@ DG.CollectionClient = SC.Object.extend(
                           }.bind( this));
   },
 
-    /**
-     * Reorders the attributes according to the order specified by the attribute
-     * list. The attribute list is an array of attribute names. All names in the
-     * list must be present as named attributes or the reordering will be
-     * abandoned. There may be attributes not specified in the list. These will
-     * be ordered after the attributes named in the list in their present order.
-     *
-     * @param {[String]} iAttributeNameList an array of attribute names
-     */
-    reorderAttributes: function(iAttributeNameList) {
-      var nameListLength = iAttributeNameList.length;
-      this.collection.attrs.sort(function(attr1, attr2) {
-        var ix1 = iAttributeNameList.indexOf(attr1.name),
-          ix2 = iAttributeNameList.indexOf(attr2.name);
-        if (ix1 < 0) {ix1 = nameListLength;}
-        if (ix2 < 0) {ix2 = nameListLength;}
-        return ix1 - ix2;
-      });
-    },
+  /**
+   * Reorders the attributes according to the order specified by the attribute
+   * list. The attribute list is an array of attribute names. All names in the
+   * list must be present as named attributes or the reordering will be
+   * abandoned. There may be attributes not specified in the list. These will
+   * be ordered after the attributes named in the list in their present order.
+   *
+   * @param {[String]} iAttributeNameList an array of attribute names
+   */
+  reorderAttributes: function(iAttributeNameList) {
+    var nameListLength = iAttributeNameList.length;
+    this.collection.attrs.sort(function(attr1, attr2) {
+      var ix1 = iAttributeNameList.indexOf(attr1.name),
+        ix2 = iAttributeNameList.indexOf(attr2.name);
+      if (ix1 < 0) {ix1 = nameListLength;}
+      if (ix2 < 0) {ix2 = nameListLength;}
+      return ix1 - ix2;
+    });
+  },
+
   /**
     Returns an array with the IDs of the attributes in the collection.
    */
@@ -417,7 +418,7 @@ DG.CollectionClient = SC.Object.extend(
     }
     // Signal a formula change manually. See comment under newAttribute
     // for details of why we're signalling manually.
-    this.attributeFormulaDidChange();
+    this.attributeFormulaDidChange(iAttribute);
   },
   
   /**
@@ -517,15 +518,23 @@ DG.CollectionClient = SC.Object.extend(
   },
   
   /**
-    Increments the 'attrFormulaChanges' property, triggering any observers of that property.
+    Updates the 'attrFormulaChanges' property, triggering any observers of that property.
    */
-  attributeFormulaDidChange: function() {
-    this.incrementProperty('attrFormulaChanges');
+  attributeFormulaDidChange: function(iAttribute) {
+    var attrID = iAttribute.get('id'),
+        prevID = this.get('attrFormulaChanges');
+    this.beginPropertyChanges();
+      // force notification, even if the attribute is the same
+      if (prevID === attrID) {
+        this.set('attrFormulaChanges', null);
+      }
+      this.set('attrFormulaChanges', attrID);
+    this.endPropertyChanges();
   },
   
   /**
     Observer function for attribute formulas' 'dependentChange' notifications.
-    Increments the 'attrFormulaChanges' property, triggering any observers of that property.
+    Increments the 'attrFormulaDependentChanges' property, triggering observers.
    */
   attrFormulaDependentDidChange: function() {
     this.incrementProperty('attrFormulaDependentChanges');

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -47,7 +47,15 @@ DG.DataContext = SC.Object.extend((function() // closure
    */
   model: null,
 
-    defaultTitleBinding: 'model.defaultTitle',
+  /**
+    The Dependency Manager object for this context
+    @property {DG.DependencyMgr}
+   */
+  dependencyMgr: function() {
+    return this.getPath('model.dependencyMgr');
+  }.property(),
+
+  defaultTitleBinding: 'model.defaultTitle',
 
   /**
     The number of change requests that have been applied.
@@ -127,7 +135,7 @@ DG.DataContext = SC.Object.extend((function() // closure
     // Reset and restock the cached array
     this.collections = [];
 
-// find the ur-parent, then follow it to all its children.
+    // find the ur-parent, then follow it to all its children.
     c = srcCollectionArray[0]; i = 0;
     if (c) {
       while (!SC.none(c.get('parent')) && i <= collectionCount) {
@@ -179,12 +187,16 @@ DG.DataContext = SC.Object.extend((function() // closure
     this._collectionClients = {};
     this.changes = [];
     this.collectionsDidChange();
+
+    DG.globalsController.addObserver('globalValueChanges', this, 'globalValuesDidChange');
   },
 
   /**
     Destruction method.
    */
   destroy: function() {
+    DG.globalsController.removeObserver('globalValueChanges', this, 'globalValuesDidChange');
+
     var i, collectionCount = this.get('collectionCount');
     for( i=0; i<collectionCount; ++i) {
       var collection = this.getCollectionAtIndex( i);
@@ -461,6 +473,15 @@ DG.DataContext = SC.Object.extend((function() // closure
       collection.casesController.endPropertyChanges();
     }
 
+    // invalidate dependents; aggregate functions may need to recalculate
+    var i, attr, attrCount = collection.getAttributeCount(),
+        attrNodes = [];
+    for (i = 0; i < attrCount; ++i) {
+      attr = collection.getAttributeAt(i);
+      attrNodes.push({ type: DG.DEP_TYPE_ATTRIBUTE, id: attr.get('id'), name: attr.get('name') });
+    }
+    this.invalidateNodesAndNotify(attrNodes, iChange);
+
     return result;
   },
   
@@ -650,6 +671,15 @@ DG.DataContext = SC.Object.extend((function() // closure
       }
       tCase.endCaseValueChanges();
     }
+
+    // invalidate dependents
+    var attrNodes = attrSpecs.map(function(iSpec) {
+                      var attr = DG.Attribute.getAttributeByID(iSpec.attributeID);
+                      return { type: DG.DEP_TYPE_ATTRIBUTE, id: iSpec.attributeID,
+                                name: attr.get('name') };
+                    });
+    this.invalidateNodesAndNotify(attrNodes, iChange);
+
     return { success: true };
   },
 
@@ -789,6 +819,19 @@ DG.DataContext = SC.Object.extend((function() // closure
 
       }
     }));
+
+    // invalidate dependents; aggregate functions may need to recalculate
+    var attrNodes = [];
+    DG.ObjectMap.forEach(iChange.collectionIDs, function(id, iCollectionClient) {
+      var i, attr, attrCount = iCollectionClient.getAttributeCount();
+      for (i = 0; i < attrCount; ++i) {
+        attr = iCollectionClient.getAttributeAt(i);
+        if (attr) {
+          attrNodes.push({ type: DG.DEP_TYPE_ATTRIBUTE, id: attr.get('id'), name: attr.get('name') });
+        }
+      }
+    });
+    this.invalidateNodesAndNotify(attrNodes, iChange);
 
     return { success: true };
   },
@@ -1050,6 +1093,173 @@ DG.DataContext = SC.Object.extend((function() // closure
       DG.store.destroyAllRecordsOfType( DG.Attribute);
       DG.store.destroyAllRecordsOfType( DG.CollectionRecord);
 //      DG.store.destroyAllRecordsOfType( DG.DataContextRecord);
+  },
+
+  /**
+    Handler for global value (e.g. slider) changes.
+    Invalidates all dependent nodes and sends out an appropriate
+    'dependentCases' notification, indicating that all cases of
+    the dependent attributes are affected.
+    @param  {object}  iNotifier - generally the DG.globalsController
+    @param  {string}  iKey - generally 'globalValuesChanged'
+   */
+  globalValuesDidChange: function(iNotifier, iKey) {
+    var names = iNotifier.get(iKey);
+    if (names && names.length) {
+      var type = DG.DEP_TYPE_GLOBAL,
+          nodes = [];
+      names.forEach(function(iName) {
+        var globalValue = DG.globalsController.getGlobalValueByName(iName),
+            globalID = globalValue && globalValue.get('id');
+        if (globalValue) {
+          nodes.push({ type: DG.DEP_TYPE_GLOBAL, id: globalID, name: iName });
+        }
+      });
+
+      this.invalidateNodesAndNotify(nodes);
+    }
+  },
+
+  /**
+    Notifies clients of dependent changes to cases.
+    Invalidates the specified nodes in the DependencyMgr, which invalidates
+    all dependent nodes and then returns the sets of nodes that are affected
+    in a simple (non-aggregate) or an aggregate manner respectively.
+    This information is then used to send out up to two 'dependentCases'
+    notifications, indicating the set of attributes in each affected collection
+    which require recalculation in a simple (non-aggregate) sense and then in
+    a separate notification that set of attributes in each affected collection
+    which require recalculation in an aggregate sense (i.e. all cases affected).
+    The format of the 'depdentCases' notifications is described below.
+    @param  {object[]}  iNodes
+            {string}    .type (e.g. DG.DEP_TYPE_ATTRIBUTE|DG.DEP_TYPE_GLOBAL)
+            {string}    .id
+            {string}    .name (primarily used for debugging)
+    @param  {object}    iChange
+            {string}    .operation (e.g. 'createCases'|'updateCases'|'deleteCases')
+
+      The iChange object is the same change object used by applyChange(),
+      performChange(), etc. The format varies depending on the nature of the
+      change, but often follow a pattern such as that below for 'updateCases'.
+      See the handler for each change for details.
+
+            {DG.CollectionClient}   iChange.collection (optional) -- collection containing cases
+            {Array of Number}       iChange.attributeIDs (optional) -- affected attributes
+            {Array of DG.Case}      iChange.cases -- DG.Case objects to be changed
+
+      The 'dependentCases' information is packaged into the form of a change request
+      and then applyChange() is called to notify downstream clients.
+
+    @param  {Object}                iChange
+            {String}                iChange.operation -- 'dependentCases'
+            {Array of Object}       iChange.changes
+              {DG.CollectionClient} iChange.changes.collection -- collection containing cases
+              {Array of Number}     iChange.changes.attributeIDs -- attributes whose values
+                                    are to be changed for each case.
+              {Array of DG.Case}    iChange.changes.cases -- DG.Case objects to be changed
+   */
+  invalidateNodesAndNotify: function(iNodes, iChange) {
+    var changeCollection = iChange && iChange.collection,
+        changeCollectionID = changeCollection && changeCollection.get('id'),
+        changeCases = (iChange && iChange.cases) || [],
+        result = this.get('dependencyMgr').invalidateNodes(iNodes),
+        simpleNotification, aggregateNotification;
+
+    var convertDependenciesToNotification = function(iDependencies, iChange) {
+      var notification = { operation: 'dependentCases', changes: [], isComplete: true },
+          changeCases = (iChange && iChange.cases) || [],
+          collectionChanges = {};
+
+      iDependencies.forEach(function(iDep) {
+        var type = iDep.type,
+            attr = type === DG.DEP_TYPE_ATTRIBUTE
+                    ? DG.Attribute.getAttributeByID(iDep.id) : null,
+            collectionRecord = attr && attr.get('collection'),
+            collectionID = collectionRecord && collectionRecord.get('id'),
+            collectionClient = collectionID && this.getCollectionByID(collectionID),
+            affectedCases,
+            change = collectionChanges[collectionID];
+        if (!change) {
+          // For simple dependencies within the same collection as the original
+          // change, only the cases originally changed can be affected.
+          // For aggregate dependencies or dependencies across collections,
+          // we simplify by reporting that all cases are affected. This is
+          // less than optimally efficient in the case of non-aggregate references
+          // from a child collection attribute formula to a parent collection
+          // attribute, but for now we make this simplifying assumption.
+          affectedCases = collectionID === changeCollectionID ? changeCases : [];
+          change = collectionChanges[collectionID] = { collection: collectionClient,
+                                                        attributeIDs: [ iDep.id ],
+                                                        cases: affectedCases };
+        }
+        else {
+          change.attributeIDs.push(iDep.id);
+        }
+      }.bind(this));
+
+      DG.ObjectMap.forEach(collectionChanges, function(iID, iCollectionChange) {
+        notification.changes.push(iCollectionChange);
+      });
+
+      return notification;
+    }.bind(this);
+
+    if (!result.simpleDependencies.length && !result.aggregateDependencies.length) {
+      DG.log("DG.DataContext.invalidateNodesAndNotify: No dependents")
+    }
+    else {
+      if (!iChange && result.simpleDependencies.length) {
+        // global value changes affect all cases, like aggregate functions
+        result.aggregateDependencies = result.aggregateDependencies.concat(
+                                          result.simpleDependencies);
+        result.simpleDependencies = [];
+      }
+
+      // check if all changed cases are from the same collection
+      if (!changeCollection) {
+        var commonCollection, commonCollectionID;
+        changeCases.forEach(function(iCase) {
+          var caseCollection = iCase.get('collection'),
+              caseCollectionID = caseCollection && caseCollection.get('id');
+          if (!commonCollectionID) {
+            commonCollection = caseCollection;
+            commonCollectionID = caseCollectionID;
+          }
+          else if (caseCollectionID !== commonCollectionID)
+            commonCollectionID = -1;
+        });
+        if (commonCollectionID && (commonCollectionID !== -1)) {
+          changeCollection = commonCollection;
+          changeCollectionID = commonCollectionID;
+        }
+      }
+
+      // handle simple dependencies, but only for updateCases
+      if (result.simpleDependencies.length &&
+          iChange && (iChange.operation === 'updateCases')) {
+        DG.log("DG.DataContext.invalidateNodesAndNotify: simpleDependents: [%@]",
+                result.simpleDependencies.map(function(iDep) {
+                                            return "'" + iDep.name + "'";
+                                          })
+                                          .join(", "));
+        simpleNotification = convertDependenciesToNotification(result.simpleDependencies, iChange);
+      }
+
+      // handle aggregate dependencies
+      if (result.aggregateDependencies.length) {
+        DG.log("DG.DataContext.invalidateNodesAndNotify: aggregateDependents: [%@]",
+                result.aggregateDependencies.map(function(iDep) {
+                                                return "'" + iDep.name + "'";
+                                              })
+                                              .join(", "));
+        aggregateNotification = convertDependenciesToNotification(result.aggregateDependencies);
+      }
+
+      if (simpleNotification)
+        this.applyChange(simpleNotification);
+      if (aggregateNotification)
+        this.applyChange(aggregateNotification);
+    }
   },
 
 
@@ -1353,13 +1563,18 @@ DG.DataContext = SC.Object.extend((function() // closure
    *
    * @param iNotifier {DG.Collection}
    */
-  attrFormulaDidChange: function( iNotifier) {
-    var change = {
+  attrFormulaDidChange: function( iNotifier, iKey) {
+    var attrID = iNotifier.get(iKey),
+        change = {
           operation: 'updateCases',
           collection: iNotifier,
           isComplete: true
         };
     this.applyChange( change);
+
+    var attr = DG.Attribute.getAttributeByID(attrID),
+        attrNodes = [{ type: DG.DEP_TYPE_ATTRIBUTE, id: attrID, name: attr.get('name') }];
+    this.invalidateNodesAndNotify(attrNodes);
   },
   
   /**

--- a/apps/dg/controllers/globals_controller.js
+++ b/apps/dg/controllers/globals_controller.js
@@ -39,7 +39,7 @@ DG.globalsController = SC.Controller.create( (function() {
       Array of strings representing the names of the changed global values.
       @property   {Array of String}
      */
-    globalValueChanges: 0,
+    globalValueChanges: null,
     
     /**
       @private

--- a/apps/dg/formula/aggregate_function.js
+++ b/apps/dg/formula/aggregate_function.js
@@ -101,9 +101,9 @@ DG.IteratingAggregate = DG.AggregateFunction.extend({
         cases = collection && collection.get('cases'),
         caseCount = cases && cases.get('length');
 
-    // Clear the cache and iterate over all the cases.
-    iInstance.caches = {};
-    iInstance.results = {};
+    // iterate over all the cases.
+    if (!iInstance.caches) iInstance.caches = {};
+    if (!iInstance.results) iInstance.results = {};
     for( var i = 0; i < caseCount; ++i) {
       var tCase = cases.objectAt( i),
           e = { _case_: tCase, _id_: tCase && tCase.get('id') };
@@ -249,8 +249,8 @@ DG.ParentCaseAggregate = DG.IteratingAggregate.extend({
         cases = collection && collection.get('cases'),
         caseCount = cases && cases.get('length');
 
-    iInstance.caches = {};
-    iInstance.results = {};
+    if (!iInstance.caches) iInstance.caches = {};
+    if (!iInstance.results) iInstance.results = {};
     for( var i = 0; i < caseCount; ++i) {
       var tCase = cases.objectAt( i),
           tEvalContext = $.extend({}, iEvalContext,

--- a/apps/dg/formula/dependency_mgr.js
+++ b/apps/dg/formula/dependency_mgr.js
@@ -1,0 +1,412 @@
+// ==========================================================================
+//
+//  Author:   kswenson
+//
+//  The DependencyMgr tracks formula dependencies between attributes.
+//  It maintains a dependency graph where every attribute with a formula
+//  and every attribute or global value (e.g. slider) that is referenced
+//  by an attribute formula is a node in the graph, and each node contains
+//  a list of dependencies (nodes that a given node references in its
+//  formula) and dependents (nodes whose formulas reference this node).
+//  The dependency graph must be kept up to date with any changes to
+//  formulas, etc., at which point the invalidateNodes() method can be
+//  called to invalidate the relevant attribute values and return a
+//  list of affected attributes in each affected collection.
+//
+//  Copyright (c) 2016 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+
+DG.depMgrLog = function() {};
+// @if (debug)
+// uncomment to enable debug logging
+//DG.depMgrLog = DG.log;
+// @endif
+
+/**
+  Node type constants
+ */
+DG.DEP_TYPE_ATTRIBUTE = 'attribute';
+DG.DEP_TYPE_GLOBAL = 'global';
+
+/**
+ * A class for managing formula dependencies
+ */
+DG.DependencyMgr = SC.Object.extend((function() {
+/** @scope DG.DependencyMgr.prototype */ 
+
+  // comparison function for node specification objects,
+  // which are used for keys into the dependency graph, etc.
+  function _compareNodeSpecs(iNodeSpec1, iNodeSpec2) {
+    if (iNodeSpec1.type < iNodeSpec2.type) return -1;
+    if (iNodeSpec1.type > iNodeSpec2.type) return 1;
+    if (iNodeSpec1.id < iNodeSpec2.id) return -1;
+    if (iNodeSpec1.id > iNodeSpec2.id) return 1;
+    return 0;
+  }
+
+  return {
+
+  /**
+    The data context for which dependencies are being tracked
+    @type {DG.DataContext}
+   */
+  context: null,
+
+  /**
+    The nodes of the dependency graph
+    @private
+    @type {object{}}
+   */
+  _nodes: null,
+
+  /**
+    Invalidation counter - used to prevent multiple invalidation, infinite recursion, etc.
+    @private
+    @type {number}
+   */
+  _currentInvalidation: 0,
+
+  /**
+    Initialization function
+   */
+  init: function() {
+    this._nodes = {};
+  },
+
+  /**
+    Create a map key from the specified node specification
+    @param  {object}  iNodeSpec - the node specification
+    @param  {string}  .type - the type of the node
+    @param  {string}  .id - the id of the node
+   */
+  createKey: function(iNodeSpec) {
+    return iNodeSpec.type + ':' + iNodeSpec.id;
+  },
+
+  /**
+    Returns true if the specified node is already present in the dependency map
+    @param  {object}  iNodeSpec - the node specification
+    @param  {string}  .type - the type of the node
+    @param  {string}  .id - the id of the node
+   */
+  hasNode: function(iNodeSpec) {
+    return !!this.findNode(iNodeSpec);
+  },
+
+  /**
+    Returns the specified node (if present) or undefined
+    @param  {object}  iNodeSpec - the node specification
+    @param  {string}  .type - the type of the node
+    @param  {string}  .id - the id of the node
+   */
+  findNode: function(iNodeSpec) {
+    var key = this.createKey(iNodeSpec);
+    return this._nodes[key];
+  },
+
+  /**
+    Adds the specified node to the dependency map if it's not already present,
+    and returns the found or registered node.
+    @param  {object}  iNodeSpec - the node specification
+    @param  {string}  .type - the type of the node
+    @param  {string}  .id - the id of the node
+   */
+  findOrRegisterNode: function(iNodeSpec) {
+    return this.findNode(iNodeSpec) || this.registerNode(iNodeSpec);
+  },
+
+  /**
+    Adds the specified node to the dependency map if it's not already present
+    @param  {object}  iNodeSpec - the node specification
+    @param  {string}  .type - the type of the node
+    @param  {string}  .id - the id of the node
+   */
+  registerNode: function(iNodeSpec) {
+    if (this.hasNode(iNodeSpec)) return this.findNode(iNodeSpec);
+
+    var key = this.createKey(iNodeSpec);
+        node = $.extend({}, iNodeSpec, {
+                    // nodes that this formula depends on
+                    dependencies: [],
+                    // nodes that depend on this node
+                    dependents: [],
+                    // last invalidation indicator
+                    lastInvalidation: 0
+                  });
+    this._nodes[key] = node;
+    return node;
+  },
+
+  /**
+    Adds the specified node to the dependency map if it's not already present
+    @param  {object}  iNodeSpec - the node specification
+    @param  {string}  .type - the type of the node
+    @param  {string}  .id - the id of the node
+   */
+  removeNode: function(iNodeSpec) {
+    // remove the node's dependencies
+    this._clearDependencies(iNodeSpec);
+    this._pruneDependencies(iNodeSpec);
+
+    // remove the node itself, as long as it doesn't have dependents
+    var key = this.createKey(iNodeSpec),
+        node = this._nodes[key];
+    if (node && !(node.dependents && node.dependents.length)) {
+      DG.depMgrLog("DG.DependencyMgr.removeNode: Removing %@ '%@' from the dependency graph",
+                  iNodeSpec.type, iNodeSpec.name);
+      delete this._nodes[key];
+    }
+  },
+
+  /**
+    Registers the specified dependency, adding a new node for the independent
+    node if necessary (the dependent node should already be present because
+    a formula should be registered before it is compiled).
+    @param {object}   iDependency - the specification of the dependency to be added
+    @param {object}   .dependentSpec - the specification of the dependent node
+    @param {string}     .type - the type of the node
+    @param {string}     .id - the id of the node
+    @param {object}   .independentSpec - the specification of the independent node
+    @param {string}     .type - the type of the node
+    @param {string}     .id - the id of the node
+    @param {number[]} .aggFnIndices - the indices of any dependent aggregate functions
+   */
+  registerDependency: function(iDependency) {
+    var dependentNode = this.findNode(iDependency.dependentSpec),
+        prevIndependent = this.findNode(iDependency.independentSpec),
+        descriptors = prevIndependent ? ["a non-aggregate", "an aggregate"]
+                                      : ["a new non-aggregate", "a new aggregate"],
+        independentNode = this.findOrRegisterNode(iDependency.independentSpec);
+
+    DG.depMgrLog("DG.DependencyMgr.registerDependency:\n%@ '%@' has %@ dependency on %@ '%@'",
+                iDependency.dependentSpec.type, iDependency.dependentSpec.name,
+                descriptors[iDependency.aggFnIndices.length > 0 ? 1 : 0],
+                iDependency.independentSpec.type, iDependency.independentSpec.name);
+
+    DG.assert(dependentNode != null,
+              "DG.DependencyMgr.registerDependency: dependentNode not found!",
+              "Formulas should be registered before they are compiled.");
+
+    this._addDependency(dependentNode, independentNode, iDependency.aggFnIndices);
+    this._addDependent(dependentNode, independentNode);
+  },
+
+  /**
+    Adds a dependency on the independent node from the dependent node.
+    @param {object}   iDependentNode - the node to which the dependency is to be added
+    @param {object}   iIndependentNode - the node which is dependend upon
+    @param {number[]} iAggFnIndices - array of aggregate function indices
+    @private
+   */
+  _addDependency: function(iDependentNode, iIndependentNode, iAggFnIndices) {
+    var dependencies = iDependentNode.dependencies,
+        dependencyCount = dependencies.length,
+        i, dependency,
+        aggFnIndexCount = iAggFnIndices ? iAggFnIndices.length : 0;
+    for (i = 0; i < dependencyCount; ++i) {
+      dependency = dependencies[i];
+      // do we already have this dependency in the list?
+      if (0 === _compareNodeSpecs(dependency.node, iIndependentNode)) {
+        if (aggFnIndexCount) {
+          // keep track of aggFnIndices affected
+          iAggFnIndices.forEach(function(iAggFnIndex) {
+            if (dependency.aggFnIndices.indexOf(iAggFnIndex) < 0) {
+              dependency.aggFnIndices.push(iAggFnIndex);
+            }
+          });
+        }
+        else {
+          dependency.simpleDependency = true;
+        }
+        return;
+      }
+    }
+    // if it's not already present in the list, add it
+    dependencies.push({ node: iIndependentNode,
+                        simpleDependency: !aggFnIndexCount,
+                        aggFnIndices: aggFnIndexCount ? iAggFnIndices.slice() : [] });
+  },
+
+  /**
+    Returns the dependency object (if any) of iDependentNode on iIndependentNode.
+    @private
+   */
+  _findDependency: function(iDependentNode, iIndependentNode) {
+    var dependentNode = this.findNode(iDependentNode),
+        dependencies = dependentNode.dependencies,
+        dependencyCount = dependencies.length,
+        i, dependency;
+    for (i = 0; i < dependencyCount; ++i) {
+      dependency = dependencies[i];
+      // do we already have this dependency in the list?
+      if (0 === _compareNodeSpecs(dependency.node, iIndependentNode)) {
+        return dependency;
+      }
+    }
+    return null;
+  },
+
+  /**
+    Adds a dependent to the independent node for the dependent node.
+    Note that the pointer from the independent to the dependent is a simple pointer
+    that doesn't contain the additional information maintained by the dependent node
+    in its dependency object.
+    @param {object}   iDependentNode - the dependent node
+    @param {object}   iIndependentNode - the node to which the dependent is to be added
+    @private
+   */
+  _addDependent: function(iDependentNode, iIndependentNode) {
+    var dependents = iIndependentNode.dependents,
+        dependentCount = dependents.length,
+        i, dependentNode;
+    for (i = 0; i < dependentCount; ++i) {
+      dependentNode = dependents[i];
+      // we already have this dependent in the list
+      if (0 === _compareNodeSpecs(dependentNode, iDependentNode)) return;
+    }
+    // if it's not already present in the list, add it
+    dependents.push(iDependentNode);
+  },
+
+  /**
+    Adds a dependent to the independent node for the dependent node.
+    Note that the pointer from the independent to the dependent is a simple pointer
+    that doesn't contain the additional information maintained by the dependent node
+    in its dependency object.
+    @param {object}   iDependentNode - the dependent node
+    @param {object}   iIndependentNode - the node to which the dependent is to be added
+    @private
+   */
+  _removeDependent: function(iDependentNode, iIndependentNode) {
+    var dependents = iIndependentNode.dependents,
+        dependentCount = dependents.length,
+        i, dependentNode;
+    for (i = dependentCount - 1; i >= 0; --i) {
+      dependentNode = dependents[i];
+      // remove the matching item
+      if (0 === _compareNodeSpecs(dependentNode, iDependentNode)) {
+        dependents.splice(i, 1);
+        return;
+      }
+    }
+  },
+
+  /**
+    Clears the detailed dependency information (e.g. 'simpleDependency' and 'aggFnIndices')
+    from every dependency of the specified node. This is generally done before recompiling
+    the formula so that dependencies that are no longer valid can be identified and pruned.
+    @param  {object}  iDependentSpec - the node specification
+    @param  {string}  .type - the type of the node
+    @param  {string}  .id - the id of the node
+    @private
+   */
+  _clearDependencies: function(iDependentSpec) {
+    var dependentNode = this.findNode(iDependentSpec);
+    if (!dependentNode) return;
+
+    var dependencies = dependentNode.dependencies,
+        dependencyCount = dependencies.length,
+        i, dependency;
+    for (i = 0; i < dependencyCount; ++i) {
+      dependency = dependencies[i];
+      dependency.simpleDependency = false;
+      dependency.aggFnIndices = [];
+    }
+  },
+
+  /**
+    Removes dependencies that are no longer required. This is generally done
+    after _clearDependencies() and then compiling the formula. Any dependencies
+    that are still empty after compilation are no longer valid and can be pruned.
+    @param  {object}  iDependentSpec - the node specification
+    @param  {string}  .type - the type of the node
+    @param  {string}  .id - the id of the node
+    @private
+   */
+  _pruneDependencies: function(iDependentSpec) {
+    var dependentNode = this.findNode(iDependentSpec);
+    if (!dependentNode) return;
+
+    var dependencies = dependentNode.dependencies,
+        dependencyCount = dependencies.length,
+        independentNode,
+        i, dependency;
+    for (i = dependencyCount - 1; i >= 0; --i) {
+      dependency = dependencies[i];
+      if (!dependency.simpleDependency && !dependency.aggFnIndices.length) {
+        independentNode = dependency.node;
+        DG.depMgrLog("DG.DependencyMgr._pruneDependencies:\nRemoving dependence of %@ '%@' on %@ '%@'",
+                    dependentNode.type, dependentNode.name,
+                    independentNode.type, independentNode.name)
+        this._removeDependent(dependentNode, independentNode);
+        dependencies.splice(i, 1);
+      }
+    }
+  },
+
+  /**
+    Invalidate the specified nodes; returns an object indicating the affected nodes.
+    @param {object[]}   iNodeSpecs
+    @returns {object}   result
+                        .simpleDependencies[]
+                        .aggregateDependencies[]
+   */
+  invalidateNodes: function(iNodeSpecs, iCases) {
+    var i, nodeSpec, nodeSpecCount = iNodeSpecs.length,
+        result = { simpleDependencies: [], aggregateDependencies: [] };
+
+    // increment our invalidation counter
+    ++this._currentInvalidation;
+
+    var invalidateDependents = function(iIndNode, iForceAggregate) {
+
+      iIndNode.dependents.forEach(function(iDependent) {
+
+        // if we've already invalidated this node, we don't need to do so again
+        if (iDependent.lastInvalidation >= this._currentInvalidation) return;
+        iDependent.lastInvalidation = this._currentInvalidation;
+
+        var dependency = this._findDependency(iDependent, iIndNode),
+            attributeID = iDependent && iDependent.id,
+            attribute = attributeID && DG.Attribute.getAttributeByID(attributeID);
+
+        if (!iForceAggregate && dependency.simpleDependency) {
+          attribute.invalidateCases(iCases);
+          result.simpleDependencies.push(iDependent);
+        }
+        if (iForceAggregate || dependency.aggFnIndices.length) {
+          attribute.invalidateCases(null, dependency.aggFnIndices);
+          result.aggregateDependencies.push(iDependent);
+        }
+        DG.depMgrLog("DG.DependencyMgr.invalidateDependents: Invalidating %@ '%@'",
+                    iDependent.type, iDependent.name);
+        // recursively invalidate additional affected nodes
+        invalidateDependents(iDependent, iForceAggregate || dependency.aggFnIndices.length);
+      }.bind(this));
+    }.bind(this);
+
+    for (i = 0; i < nodeSpecCount; ++i) {
+      indNode = this.findNode(iNodeSpecs[i]);
+      if (indNode) {
+        indNode.lastInvalidation = this._currentInvalidation;
+        invalidateDependents(indNode);
+      }
+    }
+
+    return result;
+  }
+
+  }; // return from function closure
+}())); // function closure

--- a/apps/dg/formula/formula.js
+++ b/apps/dg/formula/formula.js
@@ -139,8 +139,9 @@ DG.Formula = SC.Object.extend({
       this.context = context; // no reason to notify, so no set()
     }
     if( parsed) {
-      context.clearCaches();
+      context.willCompile();
       var output = DG.Formula.compileToJavaScript( parsed, context);
+      context.didCompile();
       compiled = DG.FormulaContext.createContextFunction( output);
     }
     return compiled;
@@ -286,13 +287,17 @@ DG.Formula.compileToJavaScript = function( iParseTree, iContext) {
   }
   
   function visitFunctionCall( iNode) {
-    var i, len = iNode.args && iNode.args.length,
+    var fnName = iNode.name.name,
+        isAggFn = iContext.isAggregate(fnName),
+        i, len = iNode.args && iNode.args.length,
         args = [];
+    iContext.beginFunctionContext({ name: fnName, isAggregate: isAggFn });
     for( i = 0; i < len; ++i) {
       args.push( visit( iNode.args[i]));
     }
+    iContext.endFunctionContext({ name: fnName });
     // Pass function references to the context
-    return iContext.compileFunction( iNode.name.name, args);
+    return iContext.compileFunction( fnName, args);
   }
   
   function visitTerm( iNode) {

--- a/apps/dg/formula/formula_context.js
+++ b/apps/dg/formula/formula_context.js
@@ -48,10 +48,73 @@ DG.FormulaContext = SC.Object.extend( (function() {
   return {
   
   /**
-    Called when the formula is recompiled to clear any cached data.
+    During compilation, a stack of function contexts indicating the functions
+    being processed, e.g. in the expression mean(count(round(x))), when x is
+    compiled there are three function contexts on the stack.
+    @type {object[]}
+   */
+  _functionContextStack: null,
+
+  /**
+    Initialization function
+   */
+  init: function() {
+    this._functionContextStack = [];
+  },
+
+  /**
+    Adds a function context to the top of stack
+    @param  {object}  iFunctionContext
+   */
+  beginFunctionContext: function(iFunctionContext) {
+    this._functionContextStack.push(iFunctionContext);
+  },
+
+  /**
+    Pops a function context from the top of the stack
+    @param  {object}  iFunctionContext
+   */
+  endFunctionContext: function(iFunctionContext) {
+    var endName = iFunctionContext && iFunctionContext.name,
+        stackSize = this._functionContextStack.length,
+        topName = stackSize ? this._functionContextStack[stackSize - 1].name : '';
+    if (endName === topName)
+      -- this._functionContextStack.length;
+    else
+      DG.logError("Error: DG.FormulaContext.endFunctionContext -- attempt to end incorrect function context")
+  },
+
+  /**
+    Called when a dependency is identified during compilation.
+    Derived classes may override as appropriate.
+    @param {object}   iNodeSpec - the specs of the node being depended upon
+    @param {string}   .type - the type of the node being depended upon
+    @param {string}   .id - the id of the node being depended upon
+    @param {string}   .name - the name of the node being depended upon
+   */
+  registerDependency: function(iNodeSpec) {
+  },
+
+  /**
+    Called when the formula is about to be recompiled to clear any cached data.
     Derived classes may override as appropriate.
    */
-  clearCaches: function() {
+  willCompile: function() {
+    this.clearCaches();
+  },
+
+  /**
+    Called when the formula has been recompiled to clear any stale dependencies.
+    Derived classes may override as appropriate.
+   */
+  didCompile: function() {
+  },
+
+  /**
+    Called when dependents change to clear function caches.
+    Derived classes may override as appropriate.
+   */
+  invalidateFunctions: function(iFunctionIndices) {
   },
 
   /**

--- a/apps/dg/formula/global_formula_context.js
+++ b/apps/dg/formula/global_formula_context.js
@@ -62,8 +62,12 @@ DG.GlobalFormulaContext = DG.FormulaContext.extend({
   compileVariable: function( iName) {
   
     // Check for a match with any global variables (e.g. sliders)
-    var global = DG.globalsController.getGlobalValueByName( iName);
-    if( global) {
+    var globalValue = DG.globalsController.getGlobalValueByName( iName);
+    if( globalValue) {
+      // register the dependency for tracking/invalidation purposes
+      this.registerDependency({ type: DG.DEP_TYPE_GLOBAL,
+                                id: globalValue.get('id'), name: iName });
+
       // Having identified the global value to be referenced, we attach
       // a function that can access the appropriate value, making use of
       // JavaScript variable scoping to make sure that the new function has
@@ -75,7 +79,7 @@ DG.GlobalFormulaContext = DG.FormulaContext.extend({
       // from the context with code that looks something like 'return c.g["v1"]'.
       if( !this.g) this.g = {};
       this.g[iName] = function() {
-                        return global.get('value');
+                        return globalValue.get('value');
                       };
       return 'c.g["' + iName + '"]()';
     }
@@ -98,10 +102,10 @@ DG.GlobalFormulaContext = DG.FormulaContext.extend({
   evaluateVariable: function( iName, iEvalContext) {
 
     // Check for a match with any global variables (e.g. sliders)
-    var global = DG.globalsController.findGlobalByName( iName);
-    if( global) {
+    var globalValue = DG.globalsController.findGlobalByName( iName);
+    if( globalValue) {
       this.g[ iName] = true;  // add entry in map for dependency tracking
-      return global.get('value');
+      return globalValue.get('value');
     }
 
     // If we don't match any variables we're in charge of,

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -87,13 +87,13 @@ DG.Attribute = DG.BaseModel.extend(
      */
     precision: 2,
 
-      /**
-       * Currently the only significance of this string property is that it
-       * shows in parentheses next to attribute names in case table column
-       * headers and graph axis labels.
-       * @property{String}
-       */
-      unit: null,
+    /**
+     * Currently the only significance of this string property is that it
+     * shows in parentheses next to attribute names in case table column
+     * headers and graph axis labels.
+     * @property{String}
+     */
+    unit: null,
 
     /**
      * True if the attribute is user-editable, false otherwise.
@@ -124,6 +124,13 @@ DG.Attribute = DG.BaseModel.extend(
     _dgFormula: null,
 
     /**
+     @private
+     Cached values and validFlags.
+     @property   {Object.<string, {isValid: boolean, value: any}>}
+     */
+    _cachedValues: null,
+
+    /**
      Initialization function.
      */
     init: function() {
@@ -139,6 +146,8 @@ DG.Attribute = DG.BaseModel.extend(
         this.collection = DG.store.find(DG.Attribute, this.collection);
       }
       this.colormap = {};
+
+      this._cachedValues = {};
     },
 
     verify: function () {
@@ -180,10 +189,15 @@ DG.Attribute = DG.BaseModel.extend(
      and hooking up the necessary observers.
      */
     createDGFormula: function() {
-      this._dgFormula = DG.Formula.create({
-        context: DG.CollectionFormulaContext.
-          create({ collection: this.get('collection') })
-      });
+      var context = DG.CollectionFormulaContext.create({
+                        ownerSpec: {
+                          type: DG.DEP_TYPE_ATTRIBUTE,
+                          id: this.get('id'),
+                          name: this.get('name')
+                        },
+                        collection: this.get('collection') });
+      this._dgFormula = DG.Formula.create({ context: context });
+
       this._dgFormula.addObserver('dependentChange', this, 'dependentDidChange');
     },
 
@@ -212,13 +226,29 @@ DG.Attribute = DG.BaseModel.extend(
      */
     evalFormula: function( iCase) {
       var tFormula = this._dgFormula,
-        tReturnValue = NaN;
+          tReturnValue = NaN,
+          tCaseID = iCase && iCase.get('id'),
+          cacheEntry = this._cachedValues[tCaseID];
+
+      // if we have a valid cache entry, use it
+      if (cacheEntry && cacheEntry.isValid)
+        return cacheEntry.value;
+
       try {
         // Client is responsible for passing _case_ and _id_
         tReturnValue = tFormula.evaluate({
                                   _case_: iCase,
                                   _id_: iCase && iCase.get('id'),
                                   _collectionID_: this.getPath('collection.id') });
+        if (cacheEntry) {
+          // update the existing cache entry
+          cacheEntry.isValid = true;
+          cacheEntry.value = tReturnValue;
+        }
+        else {
+          // cache a new entry
+          this._cachedValues[tCaseID] = { isValid: true, value: tReturnValue };
+        }
       }
       catch(e) {
         // Return error objects as attribute values.
@@ -226,6 +256,40 @@ DG.Attribute = DG.BaseModel.extend(
       }
 
       return tReturnValue;
+    },
+
+    /*
+     Invalidate the cached values for the specified cases, or for all cases
+     if no specific cases are identified. Invalidates the attribute value
+     cache along with the specified aggregate function caches as well.
+     @param {DG.Case[]}   iCases - array of cases to invalidate
+                                    if no cases specified, invalidate all cases
+     @param {number[]}    iAggFnIndices - array of aggregate function indices
+     */
+    invalidateCases: function(iCases, iAggFnIndices) {
+      var caseCount = iCases && iCases.length;
+      if (caseCount > 0) {
+        // invalidate specified cases
+        iCases.forEach(function(iCase) {
+          var caseID = iCase && iCase.get('id'),
+              cachedValue = this._cachedValues[caseID];
+          if (cachedValue)
+            cachedValue.isValid = false;
+        }.bind(this));
+      }
+      else {
+        // invalidate all cases
+        DG.ObjectMap.forEach(this._cachedValues, function(iCaseID, iCachedValue) {
+          iCachedValue.isValid = false;
+        });
+      }
+
+      // invalidate specified aggregate function caches
+      if (iAggFnIndices && iAggFnIndices.length) {
+        var formulaContext = this.getPath('_dgFormula.context');
+        if (formulaContext)
+          formulaContext.invalidateFunctions(iAggFnIndices);
+      }
     },
 
     /**
@@ -244,12 +308,19 @@ DG.Attribute = DG.BaseModel.extend(
           this.createDGFormula();
         // Update the DG.Formula with the new source
         this._dgFormula.set('source', tSource);
+
+        // mark all cached values as invalid
+        DG.ObjectMap.forEach(this._cachedValues,
+                              function(id, iCachedValue) {
+                                iCachedValue.isValid = false;
+                              })
       }
 
       // empty formula string -- no need for a DG.Formula
       else {
         if( this._dgFormula)
           this.destroyDGFormula();
+        this._cachedValues = {};
       }
     }.observes('formula'),
 

--- a/apps/dg/models/data_context_record.js
+++ b/apps/dg/models/data_context_record.js
@@ -59,6 +59,11 @@ DG.DataContextRecord = DG.BaseModel.extend(
     }.property(),
 
     /**
+      The dependency mananager
+     */
+    dependencyMgr: null,
+
+    /**
      * The base data set for the collections in this context.
      * @property {DG.DataSet}
      */
@@ -71,7 +76,7 @@ DG.DataContextRecord = DG.BaseModel.extend(
      */
     flexibleGroupingChangeFlag: false,
 
-      /**
+    /**
      * Per-component storage, in a component specific format.
      * @property {JSON}
      */
@@ -81,6 +86,7 @@ DG.DataContextRecord = DG.BaseModel.extend(
 
     init: function () {
       this.collections = {};
+      this.dependencyMgr = DG.DependencyMgr.create();
       this.dataSet = DG.DataSet.create({dataContextRecord: this});
       sc_super();
     },


### PR DESCRIPTION
- cache computed attribute values in DG.Attribute
- cache aggregate function results in DG.CollectionFormulaContext
- Add DG.DependencyMgr to track all dependencies
- invalidate caches of dependent attributes when
-- a formula changes
-- a formula is recompiled
-- case values are changed
-- cases are created/deleted
-- a global value (e.g. slider) changes
- Track dependencies of individual aggregate functions
- Invalidate individual aggregate function caches when dependents change
- DataContext sends out 'dependentCases' notification listing all affected attributes