### PR TITLE
Case table dependencies

### DIFF
--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -348,7 +348,9 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
               autoEdit: true, // single click to edit an 'editable' attribute's cell
               editCommandHandler: function( iItem, iColumn, iEditCommand) {
                                     // Called after the cell edit has been deactivated
-                                    iEditCommand.execute();
+                                    SC.run(function() {
+                                      iEditCommand.execute();
+                                    });
                                   },
               dataItemColumnValueExtractor: function (iRowItem, iColumnInfo) {
                 return iRowItem.getValue(iColumnInfo.id);

--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -388,8 +388,12 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
     Refreshes the contents of the table.
    */
   refresh: function() {
-    var gridDataView = this.get('gridDataView');
-    if( gridDataView) gridDataView.refresh();
+    this.invokeOnce(function() {
+      var gridDataView = this.get('gridDataView');
+      if( gridDataView) {
+        gridDataView.refresh();
+      }
+    });
   },
 
   /**
@@ -520,6 +524,7 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
                         dataView.updateItem( caseID, item);
                     });
     dataView.endUpdate();
+    this.refresh();
   },
 
     /**

--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -99,13 +99,25 @@ DG.CaseTableController = DG.ComponentController.extend(
         sc_super();
       },
 
+      // Utility function for identifying existing adapters for the specified collection
+      findAdapterForCollection: function(iCollectionID) {
+        var i, count, adapters = this.caseTableAdapters;
+        if (adapters) {
+          count = adapters.length;
+          for( i = 0; i < count; ++i) {
+            if( adapters[i] && (adapters[i].getPath('collection.id') === iCollectionID))
+              return adapters[i];
+          }
+        }
+        return null;
+      },
+
       /**
         Builds an appropriate DG.CaseTableAdapter for each collection.
        */
       updateTableAdapters: function() {
         var dataContext = this.get('dataContext'),
             collectionRecords = dataContext && dataContext.get('collections') || [],
-            prevAdapters = this.caseTableAdapters,
             newAdapters = [],
             // The controller model is a component object. We want the model for the
             // component's content.
@@ -113,26 +125,13 @@ DG.CaseTableController = DG.ComponentController.extend(
 
         this.caseTableAdapters = newAdapters;
 
-        // Utility function for identifying existing adapters for the specified collection
-        function findAdapterForCollection( iCollectionID) {
-          var i, count;
-          if (prevAdapters) {
-            count = prevAdapters.length;
-            for( i = 0; i < count; ++i) {
-              if( prevAdapters[i] && (prevAdapters[i].getPath('collection.id') === iCollectionID))
-                return prevAdapters[i];
-            }
-          }
-          return null;
-        }
-
         // Utility function for finding or creating (if necessary) an appropriate
         // adapter for the specified collection.
-        function guaranteeAdapterForCollectionRecord( iCollectionRecord) {
+        var guaranteeAdapterForCollectionRecord = function( iCollectionRecord) {
           var collectionID = iCollectionRecord.get('id'),
               collection = dataContext.getCollectionByID( collectionID),
               // try to find an existing adapter for the specified collection
-              adapter = findAdapterForCollection( collectionID);
+              adapter = this.findAdapterForCollection( collectionID);
           if( !adapter) {
             // create a new adapter for the specified collection
             adapter = DG.CaseTableAdapter.create({
@@ -144,7 +143,7 @@ DG.CaseTableController = DG.ComponentController.extend(
           }
           // add the new/found adapter to the adapter array
           newAdapters.push( adapter);
-        }
+        }.bind(this);
 
         collectionRecords.forEach( guaranteeAdapterForCollectionRecord);
       },
@@ -305,17 +304,24 @@ DG.CaseTableController = DG.ComponentController.extend(
           case 'createCase':
           case 'createCases':
             this.doCreateCases( iChange);
+            invalidateAggregates = false; // handled by doDependentCases
             break;
           case 'updateCases':
             this.doUpdateCases( iChange);
+            invalidateAggregates = false; // handled by doDependentCases
             break;
           case 'deleteCases':
             this.doDeleteCases( iChange);
+            invalidateAggregates = false; // handled by doDependentCases
             break;
           case 'selectCases':
             this.doSelectCases( iChange);
             // selection changes don't require aggregate invalidation
             invalidateAggregates = false;
+            break;
+          case 'dependentCases':
+            this.doDependentCases(iChange);
+            invalidateAggregates = false; // handled by doDependentCases
             break;
           case 'createAttributes':
             this.doCreateAttributes(iChange);
@@ -345,13 +351,14 @@ DG.CaseTableController = DG.ComponentController.extend(
                             });
         }
         // If there are aggregate functions, we may have to mark all cases as changed.
+        // With the introduction of the dependency manager, this should be less frequent.
         if( invalidateAggregates) {
           var adapters = this.get('caseTableAdapters');
           if( adapters) {
             adapters.forEach( function( iAdapter) {
-                                                    if( iAdapter.get('hasAggregates'))
-                                                      iAdapter.markCasesChanged();
-                                                  });
+                                if( iAdapter.get('hasAggregates'))
+                                  iAdapter.markCasesChanged();
+                              });
           }
         }
       },
@@ -366,6 +373,20 @@ DG.CaseTableController = DG.ComponentController.extend(
         this.caseCountDidChange( iChange);
         this.doSelectCases(iChange);
         caseTableModel.didDeleteCases(iChange.cases);
+      },
+      doDependentCases: function(iChange) {
+        if (iChange.changes) {
+          iChange.changes.forEach(function(iChange) {
+            var collection = iChange.collection,
+                collectionID = collection && collection.get('id'),
+                invalidCases = iChange.cases && iChange.cases.length
+                                  ? iChange.cases : undefined,
+                adapter = this.findAdapterForCollection(collectionID);
+            if (adapter) {
+              adapter.markCasesChanged(invalidCases);
+            }
+          }.bind(this));
+        }
       },
       doCreateAttributes: function (iChange) {
         this.attributeCountDidChange( iChange);

--- a/apps/dg/controllers/collection_client.js
+++ b/apps/dg/controllers/collection_client.js
@@ -457,22 +457,12 @@ DG.CollectionClient = SC.Object.extend(
   },
 
   /**
-   * Todo: Improve the efficiency of this.
-   * Todo: Used to use caseIDToIndexMap.
    * @param iCaseID {number|string}
    * @returns {number|undefined}
    */
   getCaseIndexByID: function (iCaseID) {
-    var index;
-    this.casesController.some(function (iCase, ix) {
-      if (iCase.id == iCaseID) { // jshint ignore:line
-        index = ix;
-        return true;
-      }
-      return false;
-    });
-    return index;
-    //return this.casesController.caseIDToIndexMap[iCaseID];
+    var caseIDToIndexMap = this.getPath('collection.caseIDToIndexMap');
+    return caseIDToIndexMap && caseIDToIndexMap[iCaseID];
   },
 
   getCaseByID: function(iCaseID) {

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -286,6 +286,10 @@ DG.Attribute = DG.BaseModel.extend(
 
       // invalidate specified aggregate function caches
       if (iAggFnIndices && iAggFnIndices.length) {
+        // @if (debug)
+        DG.log("DG.Attribute.invalidateCases: attribute '%@' invalidating aggregate functions [%@]",
+               this.get('name'), iAggFnIndices.join(", "));
+        // @endif
         var formulaContext = this.getPath('_dgFormula.context');
         if (formulaContext)
           formulaContext.invalidateFunctions(iAggFnIndices);


### PR DESCRIPTION
The case table makes use of 'dependentCases' notifications to fix bugs and improve performance
- Attributes in parent collections that depend on attributes in child collections that depend on sliders update appropriately [#120868671].
- The case table only refreshes tables with aggregate functions that were invalidated, rather than refreshing all tables when any change occurs in the presence of any aggregate functions
- Eliminate a performance bottleneck in DG.CollectionClient.getCaseIndexByID() by making use of the caseIDToIndexMap.
- Eliminate an 'invokeOnce() called outside the runloop' warning.

Note that for now, only 'createCases', 'updateCases', and 'deleteCases' notifications receive the efficiency gains. These are the higher value notifications, but if we wanted to circle back at some point efficiency gains could be made on other notifications like 'createAttribute', 'updateAttribute', and 'deleteAttribute' as well.