### PR TITLE
Graph and map components make use of 'dependentCases' notification

### DIFF
--- a/apps/dg/components/graph/graph_model.js
+++ b/apps/dg/components/graph/graph_model.js
@@ -741,6 +741,7 @@ DG.GraphModel = DG.DataDisplayModel.extend(
           this.dataDidChange( null, null, iChange);
           break;
         case 'updateCases':
+        case 'dependentCases':
         case 'createAttributes':
         case 'updateAttributes':
           // We must invalidate before we build indices because the change may

--- a/apps/dg/components/graph/graph_model.js
+++ b/apps/dg/components/graph/graph_model.js
@@ -807,6 +807,7 @@ DG.GraphModel = DG.DataDisplayModel.extend(
         }
       }
       // Must redraw everything if there are aggregate functions
+      // Should be able to refine this to only changes that affect the plot
       if( this.getPath('dataConfiguration.hasAggregates'))
         this.invalidate();
     },

--- a/apps/dg/components/graph/graph_types.js
+++ b/apps/dg/components/graph/graph_types.js
@@ -25,12 +25,14 @@ DG.GraphTypes = {
    */
   EPlace: {
         eUndefined: -1,
+        eFirstPlace: 0,
         eX: 0,
         eY: 1,
         eLegend: 2,
         eY2: 3,
         eArea: 4,
         eCaption: 5,
+        eLastPlace: 5,
         eNumPlaces: 6
   }
 

--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -230,6 +230,11 @@ DG.GraphView = SC.View.extend(
   categoriesDidChange: function( iObject, iProperty) {
     if( this.getPath('model.aboutToChangeConfiguration'))
       return; // So we don't attempt to draw in the midst of a configuration change
+
+    this.get('plotViews').forEach( function( iPlotView, iIndex) {
+      iPlotView.categoriesDidChange();
+    });
+
     var tLegendView = this.get('legendView');
     this.drawPlots();
     if( tLegendView)

--- a/apps/dg/components/graph/plots/dot_plot_view.js
+++ b/apps/dg/components/graph/plots/dot_plot_view.js
@@ -174,6 +174,13 @@ DG.DotPlotView = DG.PlotView.extend(
   }.observes('*secondaryAxisView.model.numberOfCells'),
 
   /**
+    Called when the order of the categories on an axis changes (e.g. cells are dragged)
+  */
+  categoriesDidChange: function() {
+    this.updateAverages();
+  },
+
+  /**
    * Invalidate and update the averages adornments.
    * To be called when cases or plot configuration
    * changes, that the averages depend upon.

--- a/apps/dg/components/graph/plots/plot_view.js
+++ b/apps/dg/components/graph/plots/plot_view.js
@@ -461,6 +461,12 @@ DG.PlotView = DG.PlotLayer.extend(
   }.observes('.model.plottedCount'),
 
   /**
+    Called when the order of the categories on an axis changes (e.g. cells are dragged)
+  */
+  categoriesDidChange: function( iObject, iProperty) {
+  },
+
+  /**
     * Here we do the initialization that relies on there being a paper to draw on.
     */
   didCreateLayer: function() {

--- a/apps/dg/components/graph_map_common/plot_data_configuration.js
+++ b/apps/dg/components/graph_map_common/plot_data_configuration.js
@@ -357,7 +357,6 @@ DG.PlotDataConfiguration = SC.Object.extend(
   init: function() {
     sc_super();
     this._hiddenCases = [];
-    DG.globalsController.addObserver('globalValueChanges', this, 'globalValueDidChange');
   },
 
   destroy: function() {
@@ -380,7 +379,6 @@ DG.PlotDataConfiguration = SC.Object.extend(
     }.bind( this));
 
     this._hiddenCases = [];  // For good measure
-    DG.globalsController.removeObserver('globalValueChanges', this, 'globalValueDidChange');
 
     sc_super();
   },
@@ -654,14 +652,6 @@ DG.PlotDataConfiguration = SC.Object.extend(
     this._casesCache = null;
     this.invalidateAxisDescriptionCaches();
   }.observes('hiddenCases'),
-
-  /**
-   * Set up to trigger during init
-   */
-  globalValueDidChange:function() {
-    if( this.atLeastOneFormula())
-      this.invalidateCaches();
-  },
 
   /**
    * Something has happened such that cases have been deleted. Some cases in our hiddenCases array

--- a/apps/dg/components/graph_map_common/plot_data_configuration.js
+++ b/apps/dg/components/graph_map_common/plot_data_configuration.js
@@ -478,6 +478,27 @@ DG.PlotDataConfiguration = SC.Object.extend(
   }.property('collectionClient','xCollectionClient',
               'yCollectionClient','y2CollectionClient','legendCollectionClient').cacheable(),
 
+  /**
+    Returns an array of attribute IDs representing the attributes
+    that are assigned to any place in the configuration.
+    @returns  {number[]} - array of unique attribute IDs assigned to places
+   */
+  placedAttributeIDs: function() {
+    var place, i, attrDesc, attrID, attrs, attrCount,
+        placedAttrs = [];
+    for (place = DG.GraphTypes.EPlace.eFirstPlace; place <= DG.GraphTypes.EPlace.eLastPlace; ++place) {
+      attrDesc = this.attributeDescriptionForPlace(null, null, place);
+      attrs = attrDesc && attrDesc.get('attributes');
+      attrCount = attrs ? attrs.length : 0;
+      for (i = 0; i < attrCount; ++i) {
+        attrID = attrDesc.attributeIDAt(i);
+        if (placedAttrs.indexOf(attrID) < 0)
+          placedAttrs.push(attrID);
+      }
+    }
+    return placedAttrs;
+  }.property(),
+
   _casesCache: null, // Array of DG.Case
 
   /**

--- a/apps/dg/components/graph_map_common/plot_layer.js
+++ b/apps/dg/components/graph_map_common/plot_layer.js
@@ -298,6 +298,7 @@ DG.PlotLayer = SC.Object.extend( DG.Destroyable,
         }
         break;
       case 'updateCases':
+      case 'dependentCases':
       case 'createAttributes':
       case 'updateAttributes':
         this.dataRangeDidChange( this, 'revision', this, lastChange.indices);


### PR DESCRIPTION
- Graph responds appropriately to 'dependentCases' notification
- Graph only redraws in response to 'updateCases' notification if a plotted attribute is affected, rather than any time a plotted attribute contains a formula.
- PlotModel and PlotDataConfiguration no longer force a redraw whenever a global value (i.e. slider) changes in the presence of formulas.
- Map responds appropriately to 'dependentCases' notification
- Map only redraws in response to 'updateCases' and 'dependentCases' notifications if a plotted attribute is affected, rather than any time a change occurs.
- Update adornments when categories are dragged [#120028403]