### PR TITLE
Fix plotted value regression

### DIFF
--- a/apps/dg/components/graph/adornments/plotted_function_model.js
+++ b/apps/dg/components/graph/adornments/plotted_function_model.js
@@ -234,8 +234,10 @@ DG.PlottedFunctionModel = DG.PlotAdornmentModel.extend(
     Utility function for creating the DG.Formula.
    */
   createDGFormula: function( iSource) {
-    var context = DG.PlottedFunctionContext
-                      .create({ adornmentKey: this.get('adornmentKey'),
+    var owner = { type: 'plottedValue', id: 1, name: 'plottedValue1' },
+        context = DG.PlottedFunctionContext
+                      .create({ ownerSpec: owner,
+                                adornmentKey: this.get('adornmentKey'),
                                 plotModel: this.get('plotModel'),
                                 splitEval: this.get('splitEval'),
                                 collection: this.get('primaryCollection') });
@@ -297,6 +299,17 @@ DG.PlottedFunctionModel = DG.PlotAdornmentModel.extend(
     if( this._expression)
       this._expression.invalidate();
   }.observes('DG.globalsController.globalNameChanges'),
+  
+  /**
+    Observer function which invalidates the intermediate compile results
+    for the formula when global value names are added, removed, or changed.
+    These changes can affect the bindings of the formula, so a recompilation
+    is required when they occur.
+   */
+  globalValuesDidChange: function() {
+    if( this._expression)
+      this._expression.invalidate();
+  }.observes('DG.globalsController.globalValueChanges'),
   
   /**
     Evaluates the plotted function at the specified x value.


### PR DESCRIPTION
Plotted value code accommodates recent changes -- must specify 'ownerSpec'.
Invalidate the plotted value on global value changes.
Note: I have an in-progress branch which moves the invalidation code from the DependencyMgr to the FormulaContext and will allow the plotted values/functions to be invalidated only when necessary. For now, we simply invalidate the plotted value on any global value change for simplicity.