### PR TITLE
Handle namespace changes using the DG.DependencyMgr

### DIFF
--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -385,7 +385,7 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
       this.updateColumnInfo();
     this.markCasesChanged();
     this.gridDataView.refresh();
-  }.observes('.collection.attrFormulaChanges','.collection.attrFormulaDependentChanges'),
+  }.observes('.collection.attrFormulaChanges'),
   
   /**
     Refreshes the contents of the table.

--- a/apps/dg/controllers/collection_client.js
+++ b/apps/dg/controllers/collection_client.js
@@ -71,7 +71,6 @@ DG.CollectionClient = SC.Object.extend(
   casesController: null,
   
   attrFormulaChanges: null,
-  attrFormulaDependentChanges: 0,
   
   /**
     Returns true if this collection contains attributes with formulas that
@@ -287,15 +286,6 @@ DG.CollectionClient = SC.Object.extend(
     @param    {DG.Attribute}  iAttribute -- The attribute being added
    */
   didCreateAttribute: function( iAttribute) {
-    // Ultimately, we want all formula changes to be notified automatically, as the following
-    // line would suggest. Currently, however, using the DG.MemoryDataSource, it seems that
-    // minor changes like adding new cases result in many "all properties changed" notifications,
-    // which result in many spurious calls to this.attributeFormulaDidChange. Therefore, for
-    // the short term we only notify when we know we've made the change (see guaranteeAttribute
-    // below). This issue should be revisited when we have a real data source/back end.
-    //iAttribute.addObserver('formula', this, 'attributeFormulaDidChange');
-    
-    iAttribute.addObserver('dependentChange', this, 'attrFormulaDependentDidChange');
   },
   
   /**
@@ -304,7 +294,6 @@ DG.CollectionClient = SC.Object.extend(
     Removes necessary observers from each attribute in the collection.
    */
   willDestroyAttribute: function( iAttribute) {
-    iAttribute.removeObserver('dependentChange', this, 'attrFormulaDependentDidChange');
   },
 
   makeAttributeNameLegal: function (iName) {
@@ -522,14 +511,6 @@ DG.CollectionClient = SC.Object.extend(
       }
       this.set('attrFormulaChanges', attrID);
     this.endPropertyChanges();
-  },
-  
-  /**
-    Observer function for attribute formulas' 'dependentChange' notifications.
-    Increments the 'attrFormulaDependentChanges' property, triggering observers.
-   */
-  attrFormulaDependentDidChange: function() {
-    this.incrementProperty('attrFormulaDependentChanges');
   },
   
   /**

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -192,6 +192,7 @@ DG.DataContext = SC.Object.extend((function() // closure
     this.changes = [];
     this.collectionsDidChange();
 
+    DG.globalsController.addObserver('globalNameChanges', this, 'globalNamesDidChange');
     DG.globalsController.addObserver('globalValueChanges', this, 'globalValuesDidChange');
   },
 
@@ -199,6 +200,7 @@ DG.DataContext = SC.Object.extend((function() // closure
     Destruction method.
    */
   destroy: function() {
+    DG.globalsController.removeObserver('globalNameChanges', this, 'globalNamesDidChange');
     DG.globalsController.removeObserver('globalValueChanges', this, 'globalValuesDidChange');
 
     var i, collectionCount = this.get('collectionCount');
@@ -976,6 +978,7 @@ DG.DataContext = SC.Object.extend((function() // closure
     var collection = typeof iChange.collection === "string"
                         ? this.getCollectionByName( iChange.collection)
                         : iChange.collection,
+        names = [],
         result = { success: false, attrs: [], attrIDs: [] };
     
     // Function to update each individual attribute
@@ -992,8 +995,14 @@ DG.DataContext = SC.Object.extend((function() // closure
         attribute.beginPropertyChanges();
         DG.ObjectMap.forEach( iAttrProps,
                               function( iKey, iValue) {
+                                var oldName;
                                 if (iKey === 'name') {
+                                  oldName = attribute.get('name');
+                                  if (names.indexOf(oldName) < 0)
+                                    names.push(oldName);
                                   iValue = collection.makeAttributeNameLegal(iValue);
+                                  if (names.indexOf(iValue) < 0)
+                                    names.push(iValue);
                                 }
                                 if( iKey !== "id") {
                                   attribute.set( iKey, iValue);
@@ -1009,6 +1018,10 @@ DG.DataContext = SC.Object.extend((function() // closure
     // Create/update each specified attribute
     if( collection && iChange.attrPropsArray)
       iChange.attrPropsArray.forEach( updateAttribute);
+
+    // invalidate affected formulas
+    this.invalidateNamesAndNotify(names);
+
     return result;
   },
 
@@ -1188,6 +1201,26 @@ DG.DataContext = SC.Object.extend((function() // closure
   },
 
   /**
+    Handler for global value (e.g. slider) name changes.
+    Invalidates all dependent nodes and sends out an appropriate
+    'namespaceChange' notification, indicating that all cases of
+    the dependent attributes are affected.
+    @param  {object}  iNotifier - generally the DG.globalsController
+    @param  {string}  iKey - generally 'globalValuesChanged'
+   */
+  globalNamesDidChange: function(iNotifier, iKey) {
+    var changes = iNotifier && iNotifier.get(iKey),
+        names = [];
+    changes.forEach(function(iChange) {
+      if (iChange.oldName && (names.indexOf(iChange.oldName) < 0))
+        names.push(iChange.oldName);
+      if (iChange.newName && (names.indexOf(iChange.newName) < 0))
+        names.push(iChange.newName);
+    });
+    this.invalidateNamesAndNotify(names);
+  },
+
+  /**
     Handler for global value (e.g. slider) changes.
     Invalidates all dependent nodes and sends out an appropriate
     'dependentCases' notification, indicating that all cases of
@@ -1209,6 +1242,27 @@ DG.DataContext = SC.Object.extend((function() // closure
 
       this.invalidateNodesAndNotify(nodes);
     }
+  },
+
+  /*
+    Notifies clients of namespace changes that affect formulas.
+    Invalidates the specified nodes in the DependencyMgr, which invalidates
+    all dependent nodes and then returns the sets of nodes that are affected.
+    Calls invalidateNodesAndNotify(), so see description of that function
+    for the notifications that can be triggered.
+   */
+  invalidateNamesAndNotify: function(iNames) {
+    var dependencyMgr = this.get('dependencyMgr'),
+        namedNodes = dependencyMgr.findNodesWithNames(iNames),
+        dependentNodes = dependencyMgr.findDependentsOfNodes(namedNodes);
+    dependentNodes.forEach(function(iNode) {
+      var dependency = iNode.dependencies && iNode.dependencies[0],
+          formulaContext = dependency && dependency.dependentContext;
+      if (formulaContext)
+        formulaContext.invalidateNamespace();
+    });
+    // we don't really need to invalidate the named nodes
+    this.invalidateNodesAndNotify(namedNodes);
   },
 
   /**

--- a/apps/dg/formula/formula.js
+++ b/apps/dg/formula/formula.js
@@ -90,6 +90,7 @@ DG.Formula = SC.Object.extend({
     This function just propagates the notification to clients of the formula.
    */
   namespaceDidChange: function( iNotifier, iKey) {
+    this.invalidateContext();
     this.notifyPropertyChange( iKey);
     // For some clients, just knowing that a dependent may have changed is sufficient.
     this.notifyPropertyChange('dependentChange');

--- a/apps/dg/formula/formula_context.js
+++ b/apps/dg/formula/formula_context.js
@@ -104,6 +104,10 @@ DG.FormulaContext = SC.Object.extend( (function() {
   registerDependency: function(iDependency) {
   },
 
+  invalidateNamespace: function() {
+    this.notifyPropertyChange('namespaceChange');
+  },
+
   /**
     Invalidation function for use with the dependency manager.
     Called by the dependency manager when invalidating nodes as a result
@@ -180,6 +184,11 @@ DG.FormulaContext = SC.Object.extend( (function() {
       if( vars && (vars[iName] !== undefined))
         return 'c.vars.' + iName;
     }
+    this.registerDependency({ independentSpec: {
+                                type: DG.DEP_TYPE_UNDEFINED,
+                                id: iName,
+                                name: iName
+                            }});
     return '(function(){throw new DG.VarReferenceError(' + iName + ');})()';
   },
   

--- a/apps/dg/formula/global_formula_context.js
+++ b/apps/dg/formula/global_formula_context.js
@@ -31,26 +31,6 @@ sc_require('formula/formula_context');
 DG.GlobalFormulaContext = DG.FormulaContext.extend({
 
   /**
-    Initialization method.
-    Adds observer for global value changes.
-   */
-  init: function() {
-    sc_super();
-    DG.globalsController.addObserver('globalNameChanges', this, 'globalNamesDidChange');
-    DG.globalsController.addObserver('globalValueChanges', this, 'globalValuesDidChange');
-  },
-  
-  /**
-    Destruction method.
-    Removes observer for global value changes.
-   */
-  destroy: function() {
-    DG.globalsController.removeObserver('globalNameChanges', this, 'globalNamesDidChange');
-    DG.globalsController.removeObserver('globalValueChanges', this, 'globalValuesDidChange');
-    sc_super();
-  },
-  
-  /**
     Compiles a variable reference into the JavaScript code for accessing
     the appropriate value. For the PlottedFunctionContext, this means
     binding to 'x' and any global values (e.g. sliders).
@@ -114,40 +94,6 @@ DG.GlobalFormulaContext = DG.FormulaContext.extend({
     // If we don't match any variables we're in charge of,
     // let the base class have a crack at it.
     return sc_super();
-  },
-  
-  /**
-    Observer method called when global value names (e.g. sliders)
-    are change, e.g. created, deleted, or renamed. Formulas must
-    recompile in case they are affected by the name changes.
-    Sends out a 'dependentChange' notification to notify clients.
-   */
-  globalNamesDidChange: function() {
-    // Eventually, we can be more selective, e.g. only notify
-    // if there are unbound names in the formula, but for now
-    // we assume that all name changes require notification.
-    this.notifyPropertyChange('namespaceChange');
-  },
-
-  /**
-    Observer method called when global values (e.g. sliders) change.
-    This method determines whether the formula is affected based on
-    whether the global values that are referenced in the formula are
-    among those whose value changed. If so, we notify by sending out
-    a 'dependentChange' notification.
-   */
-  globalValuesDidChange: function() {
-    // Get the list of global values that have changed
-    var changes = DG.globalsController.get('globalValueChanges'),
-        i, changeCount = changes && changes.length;
-    // Loop through the list to see if we reference any of them
-    for( i = 0; i < changeCount; ++i) {
-      // If we have an entry in our 'g' map, then we have a reference.
-      if( this.g && this.g[ changes[i]]) {
-        this.notifyPropertyChange('dependentChange');
-        return;
-      }
-    }
   }
   
  });

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -209,6 +209,7 @@ DG.Attribute = DG.BaseModel.extend(
                         collection: this.get('collection') });
       this._dgFormula = DG.Formula.create({ context: context });
 
+      this._dgFormula.addObserver('namespaceChange', this, 'namespaceDidChange');
       this._dgFormula.addObserver('dependentChange', this, 'dependentDidChange');
     },
 
@@ -218,6 +219,7 @@ DG.Attribute = DG.BaseModel.extend(
      */
     destroyDGFormula: function() {
       this._dgFormula.removeObserver('dependentChange', this, 'dependentDidChange');
+      this._dgFormula.removeObserver('namespaceChange', this, 'namespaceDidChange');
       this._dgFormula.destroy();
       this._dgFormula = null;
     },
@@ -338,6 +340,14 @@ DG.Attribute = DG.BaseModel.extend(
         this._cachedValues = {};
       }
     }.observes('formula'),
+
+    namespaceDidChange: function() {
+      // mark all cached values as invalid
+      DG.ObjectMap.forEach(this._cachedValues,
+                            function(id, iCachedValue) {
+                              iCachedValue.isValid = false;
+                            });
+    },
 
     /**
      Observer function called when an attribute formula notifies


### PR DESCRIPTION
- DG.DataContext listens for global value and attribute name changes
- DG.DependencyMgr is used to invalidate only those formulas that could be affected
- DG.DependencyMgr tracks undefined identifier references
- DG.DataContext sends out targeted 'dependentCases' notification
- DG.FormulaContext tracks undefined identifier references
- Eliminate DG.CollectionClient's 'attrFormulaDependentChanges' notification [#126259111]
- Eliminate DG.GlobalFormulaContext need to listen to DG.GlobalsController notifications [#126259111]