### PR TITLE
Invalidate formulas that depend on 'caseIndex' when indices change

### DIFF
--- a/apps/dg/controllers/collection_client.js
+++ b/apps/dg/controllers/collection_client.js
@@ -165,7 +165,7 @@ DG.CollectionClient = SC.Object.extend(
     @param    {DG.CollectionModel}  iCollection -- The collection to be used as this object's model
    */
   setTargetCollection: function( iCollection) {
-    this.collection = iCollection;
+    this.set('collection', iCollection);
     this.attrsController.set('content', iCollection.attrs);
     this.casesController.set('content', iCollection.cases);
     
@@ -456,12 +456,23 @@ DG.CollectionClient = SC.Object.extend(
     return caseIDToIndexMap && caseIDToIndexMap[iCaseID];
   },
 
+  /**
+   * @param iCaseID {number|string}
+   * @returns {DG.Cases}
+   */
   getCaseByID: function(iCaseID) {
     var ix = this.getCaseIndexByID(iCaseID);
     if (!SC.none(ix)) {
       return this.getCaseAt(ix);
     }
   },
+
+  /**
+   * Observer function which notifies when case indices change.
+   */
+  caseIndicesDidChange: function() {
+    this.notifyPropertyChange('caseIndices');
+  }.observes('*collection.caseIDToIndexMap'),
 
   /**
     Returns true if the case at the specified index is selected, false otherwise.

--- a/apps/dg/formula/collection_formula_context.js
+++ b/apps/dg/formula/collection_formula_context.js
@@ -294,7 +294,17 @@ DG.CollectionFormulaContext = DG.GlobalFormulaContext.extend((function() {
     // Client is responsible for putting '_id_' into the evaluation context.
     // This context's getCaseIndex() method provides the implementation,
     // which requires the caseIDToIndexMap, which is built on demand.
-    if( iName === 'caseIndex') return 'c.getCaseIndex(e._id_)';
+    if( iName === 'caseIndex') {
+      // register the 'caseIndex' dependency for invalidation
+      this.registerDependency({ independentSpec: {
+                                  type: DG.DEP_TYPE_SPECIAL,
+                                  id: 'caseIndex',
+                                  name: 'caseIndex'
+                                },
+                                aggFnIndices: iAggFnIndices
+                              });
+      return 'c.getCaseIndex(e._id_)';
+    }
     
     var attribute = this.getAttributeByName(iName),
         collection = attribute && this.getCollectionForAttribute(attribute),

--- a/apps/dg/formula/dependency_mgr.js
+++ b/apps/dg/formula/dependency_mgr.js
@@ -39,6 +39,7 @@ DG.depMgrLog = function() {};
  */
 DG.DEP_TYPE_ATTRIBUTE = 'attribute';
 DG.DEP_TYPE_GLOBAL = 'global';
+DG.DEP_TYPE_SPECIAL = 'special';
 DG.DEP_TYPE_UNDEFINED = 'undefined';
 
 /**
@@ -78,7 +79,7 @@ DG.DependencyMgr = SC.Object.extend((function() {
       _invalidateDependents(ioResult, iDepMgr, iDependent,
                             iForceAggregate || dependency.aggFnIndices.length);
     });
-  };
+  }
 
   return {
 


### PR DESCRIPTION
- Fixes [#126825749]
- Fix "Deleted 0 cases" log message so it reports the correct number of cases deleted
- Eliminate JSHint warning