### PR TITLE
Fix slider name editing bugs

### DIFF
--- a/apps/dg/components/slider/slider_view.js
+++ b/apps/dg/components/slider/slider_view.js
@@ -348,11 +348,13 @@ DG.SliderView = SC.View.extend(
       valueViewWasEdited: function() {
         // regular expression for matching 'variable = value'
         // TODO: Do better with white space
-        var kMatchExp = /^\s*([a-zA-Z][\w]*)\s*=\s*([+\-]?[0-9.]+)/,
+        // TODO: Handle scientific notation? Thousands separators? Internationalization?
+        var kMatchExp = /^\s*([a-zA-Z_][\w]*)\s*=\s*([+\-]?[0-9.]+)/,
             tResult, tNewValue, tNewName;
         // We only want to parse the expression if the user actually edited it
         if( this.get('userEdit')) {
           var tNewString = this.getPath('valueView.value');
+          tNewString = tNewString.replace('\u2212', '-');
           this.set('userEdit', false);
           tResult = kMatchExp.exec( tNewString);
           DG.logUser("sliderEdit: { expression: '%@', result: %@ }",

--- a/apps/dg/models/component_model.js
+++ b/apps/dg/models/component_model.js
@@ -50,10 +50,14 @@ DG.Component = DG.BaseModel.extend(
       }.property(),
 
       defaultTitleChanged: function() {
+        // stash previous title for logging purposes
+        this.set('_prevTitle', this.get('title'));
         this.set('title', this.getPath('content.defaultTitle'));
       }.observes('*content.defaultTitle'),
 
       contentTitleChanged: function() {
+        // stash previous title for logging purposes
+        this.set('_prevTitle', this.get('title'));
         this.set('title', this.getPath('content.title'));
       }.observes('*content.title'),
 

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -312,6 +312,10 @@ DG.ComponentView = SC.View.extend(
                     redoString: 'DG.Redo.componentTitleChange',
                     execute: function () {
                       this._beforeStorage = tComponentView.getPath('model.title');
+                      // If the title has already been changed (e.g. due to notification),
+                      // then use the previous title for purposes of logging the change.
+                      if (this._beforeStorage === value)
+                        this._beforeStorage = tComponentView.getPath('model._prevTitle');
                       tComponentView.setPath('model.title', value);
                       this._value;
                       this.log = "Change title '%@' to '%@'".fmt(this._beforeStorage, value);


### PR DESCRIPTION
- Changing the name of a slider with a negative value now works correctly [#126913099]
- Slider names can be edited to have a leading underscore
- Log message for slider name changes includes the correct prior name