### PR TITLE
Implement rerandomization commands [#124912661]

### DIFF
--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -268,7 +268,7 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
             collectionID: collection.get('id').toString(),
             attribute: iAttribute,
             // Slick.Grid properties
-            id: iAttribute.get('id').toString(),
+            id: attrID,
             name: getColumnHeaderString( iAttribute),
             field: attrName,
             toolTip: getToolTipString( iAttribute),
@@ -281,6 +281,18 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
                     command: 'cmdEditFormula',
                     updater: function( iColumn, iMenu, ioMenuItem) {
                       ioMenuItem.disabled = !iColumn.attribute.get('editable');
+                    }
+                  },
+                  { title: 'DG.TableController.headerMenuItems.randomizeAttribute'.loc(),
+                    command: 'cmdRandomizeAttribute',
+                    updater: function( iColumn, iMenu, ioMenuItem) {
+                      var depMgr = context && context.get('dependencyMgr'),
+                          dependency = depMgr &&
+                                        depMgr.findDependency({ type: DG.DEP_TYPE_ATTRIBUTE,
+                                                                id: attrID },
+                                                              { type: DG.DEP_TYPE_SPECIAL,
+                                                                id: 'random' });
+                      ioMenuItem.disabled = !dependency;
                     }
                   },
                   { title: 'DG.TableController.headerMenuItems.renameAttribute'.loc(),

--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -1096,7 +1096,7 @@ DG.CaseTableController = DG.ComponentController.extend(
                             // enabled if any attributes are dependents
                             return dependents && dependents.some(function(iDependent) {
                               return iDependent.type === DG.DEP_TYPE_ATTRIBUTE;
-                            })
+                            });
                       }.bind(this))()
         });
         tItems.push({

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -1301,7 +1301,7 @@ DG.DataContext = SC.Object.extend((function() // closure
             {string}    .operation (e.g. 'createCases'|'updateCases'|'deleteCases')
    */
   invalidateDependentsAndNotify: function(iNodes, iChange) {
-    var result = this.get('dependencyMgr').invalidateNodes(iNodes);
+    var result = this.get('dependencyMgr').invalidateDependentsOf(iNodes);
     this.notifyInvalidationResult(result, iChange);
   },
 

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -544,7 +544,7 @@ DG.DataContext = SC.Object.extend((function() // closure
       attr = collection.getAttributeAt(i);
       attrNodes.push({ type: DG.DEP_TYPE_ATTRIBUTE, id: attr.get('id'), name: attr.get('name') });
     }
-    this.invalidateNodesAndNotify(attrNodes, iChange);
+    this.invalidateDependentsAndNotify(attrNodes, iChange);
 
     return result;
   },
@@ -744,7 +744,7 @@ DG.DataContext = SC.Object.extend((function() // closure
                       return { type: DG.DEP_TYPE_ATTRIBUTE, id: iSpec.attributeID,
                                 name: attr.get('name') };
                     });
-    this.invalidateNodesAndNotify(attrNodes, iChange);
+    this.invalidateDependentsAndNotify(attrNodes, iChange);
 
     return { success: true, caseIDs: iChange.caseIDs };
   },
@@ -946,7 +946,7 @@ DG.DataContext = SC.Object.extend((function() // closure
         }
       }
     });
-    this.invalidateNodesAndNotify(attrNodes, iChange);
+    this.invalidateDependentsAndNotify(attrNodes, iChange);
 
     return { success: true };
   },
@@ -1267,7 +1267,7 @@ DG.DataContext = SC.Object.extend((function() // closure
         }
       });
 
-      this.invalidateNodesAndNotify(nodes);
+      this.invalidateDependentsAndNotify(nodes);
     }
   },
 
@@ -1275,8 +1275,8 @@ DG.DataContext = SC.Object.extend((function() // closure
     Notifies clients of namespace changes that affect formulas.
     Invalidates the specified nodes in the DependencyMgr, which invalidates
     all dependent nodes and then returns the sets of nodes that are affected.
-    Calls invalidateNodesAndNotify(), so see description of that function
-    for the notifications that can be triggered.
+    Calls invalidateDependentsAndNotify(), so see description of that
+    function for the notifications that can be triggered.
    */
   invalidateNamesAndNotify: function(iNames) {
     var dependencyMgr = this.get('dependencyMgr'),
@@ -1288,8 +1288,35 @@ DG.DataContext = SC.Object.extend((function() // closure
       if (formulaContext)
         formulaContext.invalidateNamespace();
     });
-    // we don't really need to invalidate the named nodes
-    this.invalidateNodesAndNotify(namedNodes);
+    // invalidate dependents of the named nodes
+    this.invalidateDependentsAndNotify(namedNodes);
+  },
+
+  /**
+    Invalidates all dependents of the specified nodes and sends out
+    appropriate dependentCases notifications. See notifyInvalidationResult
+    for details of the notifications.
+    @param  {object[]}  iNodes - array of nodes whose dependents are to be invalidated
+    @param  {object}    iChange - optional change object
+            {string}    .operation (e.g. 'createCases'|'updateCases'|'deleteCases')
+   */
+  invalidateDependentsAndNotify: function(iNodes, iChange) {
+    var result = this.get('dependencyMgr').invalidateNodes(iNodes);
+    this.notifyInvalidationResult(result, iChange);
+  },
+
+  /**
+    Invalidates a particular dependent of the specified node and sends out
+    appropriate dependentCases notifications. See notifyInvalidationResult
+    for details of the notifications.
+    @param  {object}  iDependentSpec - specifier for the dependent node
+    @param  {object}  iIndependentSpec - specifier for the independent node
+    @param  {boolean} iForceAggregate - true if the dependence should be treated as aggregate
+   */
+  invalidateDependencyAndNotify: function(iDependentSpec, iIndependentSpec, iForceAggregate) {
+    var result = this.get('dependencyMgr')
+                  .invalidateDependency(iDependentSpec, iIndependentSpec, iForceAggregate);
+    this.notifyInvalidationResult(result);
   },
 
   /**
@@ -1330,11 +1357,10 @@ DG.DataContext = SC.Object.extend((function() // closure
                                     are to be changed for each case.
               {Array of DG.Case}    iChange.changes.cases -- DG.Case objects to be changed
    */
-  invalidateNodesAndNotify: function(iNodes, iChange) {
+  notifyInvalidationResult: function(iResult, iChange) {
     var changeCollection = iChange && iChange.collection,
         changeCollectionID = changeCollection && changeCollection.get('id'),
         changeCases = (iChange && iChange.cases) || [],
-        result = this.get('dependencyMgr').invalidateNodes(iNodes),
         simpleNotification, aggregateNotification,
         externalDataContexts = [];
 
@@ -1389,15 +1415,15 @@ DG.DataContext = SC.Object.extend((function() // closure
       return notification;
     }.bind(this);
 
-    if (!result.simpleDependencies.length && !result.aggregateDependencies.length) {
-      //DG.log("DG.DataContext.invalidateNodesAndNotify: No dependents");
+    if (!iResult.simpleDependencies.length && !iResult.aggregateDependencies.length) {
+      //DG.log("DG.DataContext.invalidateDependentsAndNotify: No dependents");
     }
     else {
-      if (!iChange && result.simpleDependencies.length) {
+      if (!iChange && iResult.simpleDependencies.length) {
         // global value changes affect all cases, like aggregate functions
-        result.aggregateDependencies = result.aggregateDependencies.concat(
-                                          result.simpleDependencies);
-        result.simpleDependencies = [];
+        iResult.aggregateDependencies = iResult.aggregateDependencies.concat(
+                                          iResult.simpleDependencies);
+        iResult.simpleDependencies = [];
       }
 
       // check if all changed cases are from the same collection
@@ -1420,24 +1446,24 @@ DG.DataContext = SC.Object.extend((function() // closure
       }
 
       // handle simple dependencies, but only for updateCases
-      if (result.simpleDependencies.length &&
+      if (iResult.simpleDependencies.length &&
           iChange && (iChange.operation === 'updateCases')) {
         // DG.log("DG.DataContext.invalidateNodesAndNotify: simpleDependents: [%@]",
-        //         result.simpleDependencies.map(function(iDep) {
+        //         iResult.simpleDependencies.map(function(iDep) {
         //                                     return "'" + iDep.name + "'";
         //                                   })
         //                                   .join(", "));
-        simpleNotification = convertDependenciesToNotification(result.simpleDependencies, iChange);
+        simpleNotification = convertDependenciesToNotification(iResult.simpleDependencies, iChange);
       }
 
       // handle aggregate dependencies
-      if (result.aggregateDependencies.length) {
+      if (iResult.aggregateDependencies.length) {
         // DG.log("DG.DataContext.invalidateNodesAndNotify: aggregateDependents: [%@]",
-        //         result.aggregateDependencies.map(function(iDep) {
+        //         iResult.aggregateDependencies.map(function(iDep) {
         //                                         return "'" + iDep.name + "'";
         //                                       })
         //                                       .join(", "));
-        aggregateNotification = convertDependenciesToNotification(result.aggregateDependencies);
+        aggregateNotification = convertDependenciesToNotification(iResult.aggregateDependencies);
       }
 
       if (simpleNotification)
@@ -1451,7 +1477,6 @@ DG.DataContext = SC.Object.extend((function() // closure
       }
     }
   },
-
 
     /**
      * A utility to find the last collection in the context.

--- a/apps/dg/formula/collection_formula_context.js
+++ b/apps/dg/formula/collection_formula_context.js
@@ -277,7 +277,7 @@ DG.CollectionFormulaContext = DG.GlobalFormulaContext.extend((function() {
     // cascade in the source context, start an invalidation cascade locally.
     var dependencyMgr = this.get('dependencyMgr');
     if (iDependency.srcDependencyMgr && (dependencyMgr !== iDependency.srcDependencyMgr)) {
-      dependencyMgr.invalidateNodes([iDependent]);
+      dependencyMgr.invalidateDependentsOf([iDependent]);
     }
   },
 

--- a/apps/dg/formula/dependency_mgr.js
+++ b/apps/dg/formula/dependency_mgr.js
@@ -58,26 +58,51 @@ DG.DependencyMgr = SC.Object.extend((function() {
     return 0;
   }
 
-  // utility function for recursively invalidating dependents
+  /**
+    Recursive function to invalidate a single dependency and all of the downstream
+    dependents that are affected by it.
+    @param  {object}  ioResult - dependencies are accumulated and returned in this object
+    @param  {object}  iDepMgr - the dependency manager
+    @param  {object}  iDependent - the dependent node
+    @param  {object}  iDependency - the dependency to be invalidated
+    @param  {boolean} iForceAggregate - true if the dependency should be treated as aggregate
+   */
+  function _invalidateDependency(ioResult, iDepMgr, iDependent, iDependency, iForceAggregate) {
+    if (iDependent)
+      iDependent.lastInvalidation = iDepMgr._currentInvalidation;
+
+    if (iDependency && iDependency.dependentContext) {
+      iDependency.dependentContext
+        .invalidateDependent(ioResult, iDependent, iDependency, [], iForceAggregate);
+    }
+    DG.depMgrLog("DG.DependencyMgr[%@]._invalidateDependency: Invalidating %@ '%@'",
+                  iDepMgr.getPath('dataContext.name'), iDependent.type, iDependent.name);
+    if (iDependent && iDependency) {
+      // recursively invalidate additional affected nodes
+      _invalidateDependents(ioResult, iDepMgr, iDependent,
+                            iForceAggregate || (iDependency.aggFnIndices.length > 0));
+    }
+  }
+
+  /**
+    Recursive function to invalidate all dependents of a single nod and all of
+    the downstream dependents that are affected by them.
+    @param  {object}  ioResult - dependencies are accumulated and returned in this object
+    @param  {object}  iDepMgr - the dependency manager
+    @param  {object}  iIndNode - the independent node
+    @param  {boolean} iForceAggregate - true if the dependency should be treated as aggregate
+   */
   function _invalidateDependents(ioResult, iDepMgr, iIndNode, iForceAggregate) {
 
     iIndNode.dependents.forEach(function(iDependent) {
 
       // if we've already invalidated this node, we don't need to do so again
       if (iDependent.lastInvalidation >= iDepMgr._currentInvalidation) return;
-      iDependent.lastInvalidation = iDepMgr._currentInvalidation;
 
       // Call the specified invalidation function
       var dependency = iDepMgr._findDependency(iDependent, iIndNode);
-      if (dependency && dependency.dependentContext) {
-        dependency.dependentContext
-          .invalidateDependent(ioResult, iDependent, dependency, [], iForceAggregate);
-      }
-      DG.depMgrLog("DG.DependencyMgr[%@]._invalidateDependents: Invalidating %@ '%@'",
-                    iDepMgr.getPath('dataContext.name'), iDependent.type, iDependent.name);
-      // recursively invalidate additional affected nodes
-      _invalidateDependents(ioResult, iDepMgr, iDependent,
-                            iForceAggregate || dependency.aggFnIndices.length);
+      if (dependency)
+        _invalidateDependency(ioResult, iDepMgr, iDependent, dependency, iForceAggregate);
     });
   }
 
@@ -228,6 +253,20 @@ DG.DependencyMgr = SC.Object.extend((function() {
   },
 
   /**
+    Returns the dependency object for the specified dependent and independent
+    nodes. Returns undefined if no dependency exists between the nodes.
+    @param    {object}  iDependentSpec - specifier for the dependent node
+    @param    {object}  iIndependentSpec - specifier for the independent node
+    @returns  {object}  dependency object between the specified nodes
+   */
+  findDependency: function(iDependentSpec, iIndependentSpec) {
+    var dependentNode = this.findNode(iDependentSpec),
+        independentNode = this.findNode(iIndependentSpec);
+    return dependentNode && independentNode &&
+            this._findDependency(dependentNode, independentNode);
+  },
+
+  /**
     Registers the specified dependency, adding a new node for the independent
     node if necessary (the dependent node should already be present because
     a formula should be registered before it is compiled).
@@ -309,7 +348,7 @@ DG.DependencyMgr = SC.Object.extend((function() {
    */
   _findDependency: function(iDependentNode, iIndependentNode) {
     var dependentNode = this.findNode(iDependentNode),
-        dependencies = dependentNode.dependencies,
+        dependencies = dependentNode && dependentNode.dependencies,
         dependencyCount = dependencies.length,
         i, dependency;
     for (i = 0; i < dependencyCount; ++i) {
@@ -452,13 +491,36 @@ DG.DependencyMgr = SC.Object.extend((function() {
   },
 
   /**
+    Invalidate a particular dependent of a particular node.
+    returns an object indicating the affected nodes.
+    @param {object}   iDependentSpec - specifier for the dependent node
+    @param {object}   iIndependentSpec - specifier for the independent node
+    @param {boolean}  iForceAggregate - true if the dependency should be treated as aggregate
+    @returns {object}   result
+                        .simpleDependencies[]
+                        .aggregateDependencies[]
+   */
+  invalidateDependency: function(iDependentSpec, iIndependentSpec, iForceAggregate) {
+    var dependentNode = this.findNode(iDependentSpec),
+        dependency = this.findDependency(iDependentSpec, iIndependentSpec),
+        result = { simpleDependencies: [], aggregateDependencies: [] };
+    if (dependency) {
+      // increment our invalidation counter
+      ++this._currentInvalidation;
+      // invalidate the specified dependency
+      _invalidateDependency(result, this, dependentNode, dependency, iForceAggregate);
+    }
+    return result;
+  },
+
+  /**
     Invalidate the specified nodes; returns an object indicating the affected nodes.
     @param {object[]}   iNodeSpecs
     @returns {object}   result
                         .simpleDependencies[]
                         .aggregateDependencies[]
    */
-  invalidateNodes: function(iNodeSpecs, iCases) {
+  invalidateNodes: function(iNodeSpecs) {
     var i, nodeSpecCount = iNodeSpecs.length,
         result = { simpleDependencies: [], aggregateDependencies: [] };
 
@@ -469,8 +531,6 @@ DG.DependencyMgr = SC.Object.extend((function() {
     for (i = 0; i < nodeSpecCount; ++i) {
       var indNode = this.findNode(iNodeSpecs[i]);
       if (indNode) {
-        // invalidate each node
-        indNode.lastInvalidation = this._currentInvalidation;
         // invalidate dependents of each node
         _invalidateDependents(result, this, indNode);
       }

--- a/apps/dg/formula/dependency_mgr.js
+++ b/apps/dg/formula/dependency_mgr.js
@@ -9,8 +9,8 @@
 //  a list of dependencies (nodes that a given node references in its
 //  formula) and dependents (nodes whose formulas reference this node).
 //  The dependency graph must be kept up to date with any changes to
-//  formulas, etc., at which point the invalidateNodes() method can be
-//  called to invalidate the relevant attribute values and return a
+//  formulas, etc., at which point the invalidateDependentsOf() method can
+//  be called to invalidate the relevant attribute values and return a
 //  list of affected attributes in each affected collection.
 //
 //  Copyright (c) 2016 by The Concord Consortium, Inc. All rights reserved.
@@ -520,7 +520,7 @@ DG.DependencyMgr = SC.Object.extend((function() {
                         .simpleDependencies[]
                         .aggregateDependencies[]
    */
-  invalidateNodes: function(iNodeSpecs) {
+  invalidateDependentsOf: function(iNodeSpecs) {
     var i, nodeSpecCount = iNodeSpecs.length,
         result = { simpleDependencies: [], aggregateDependencies: [] };
 

--- a/apps/dg/resources/en/strings.js
+++ b/apps/dg/resources/en/strings.js
@@ -466,8 +466,8 @@ SC.stringsFor('English', {
 
   // DG.TableController
   'DG.TableController.headerMenuItems.editAttribute': "Edit Formula...",
-  'DG.TableController.headerMenuItems.randomizeAttribute': "Randomize Attribute",
-  'DG.TableController.headerMenuItems.renameAttribute': "Rename Attribute...",
+  'DG.TableController.headerMenuItems.randomizeAttribute': "Rerandomize",
+  'DG.TableController.headerMenuItems.renameAttribute': "Rename...",
   'DG.TableController.headerMenuItems.deleteAttribute': "Delete Attribute",
   'DG.TableController.newAttrDlg.defaultAttrName': "new_attr",
   'DG.TableController.newAttrDlg.attrNameHint': "Enter a name for the new attribute",
@@ -654,7 +654,7 @@ SC.stringsFor('English', {
   // Table Inspector
   'DG.Inspector.attributes.toolTip': "Make new attributes. Export case data.",  // "Make new attributes. Export case data."
   'DG.Inspector.newAttribute': "New Attribute in %@...",  // "New Attribute in %@..."
-  'DG.Inspector.randomizeAllAttributes': "Randomize Attributes", // "Randomize Attributes"
+  'DG.Inspector.randomizeAllAttributes': "Rerandomize All", // "Randomize Attributes"
   'DG.Inspector.exportCaseData': "Export Case Data...", // "Export Case Data..."
 
   // Map Inspector

--- a/apps/dg/resources/en/strings.js
+++ b/apps/dg/resources/en/strings.js
@@ -466,6 +466,7 @@ SC.stringsFor('English', {
 
   // DG.TableController
   'DG.TableController.headerMenuItems.editAttribute': "Edit Formula...",
+  'DG.TableController.headerMenuItems.randomizeAttribute': "Randomize Attribute",
   'DG.TableController.headerMenuItems.renameAttribute': "Rename Attribute...",
   'DG.TableController.headerMenuItems.deleteAttribute': "Delete Attribute",
   'DG.TableController.newAttrDlg.defaultAttrName': "new_attr",
@@ -653,6 +654,7 @@ SC.stringsFor('English', {
   // Table Inspector
   'DG.Inspector.attributes.toolTip': "Make new attributes. Export case data.",  // "Make new attributes. Export case data."
   'DG.Inspector.newAttribute': "New Attribute in %@...",  // "New Attribute in %@..."
+  'DG.Inspector.randomizeAllAttributes': "Randomize Attributes", // "Randomize Attributes"
   'DG.Inspector.exportCaseData': "Export Case Data...", // "Export Case Data..."
 
   // Map Inspector


### PR DESCRIPTION
- "Randomize Attribute" in the column header/attribute menu rerandomizes a single attribute
- "Randomize Attribute" is only enabled if the formula contains a random() function
- "Randomize Attributes" in the inspector menu for the table rerandomizes all (random) attributes
- "Randomize Attributes" is only enabled if at least one attribute formula contains a random() function
- DG.DependencyMgr now tracks dependence on random functions so that rerandomize recomputes only what's necessary
- Renamed DG.DataContext.invalidateNodesAndNotify() to DG.DataContext.invalidateDependentsAndNotify() for clarity
- Add DG.DataContext.invalidateDependencyAndNotify() function
- Separate DG.DataContext.notifyInvalidationResult() from previous DG.DataContext.invalidateNodesAndNotify()
- Add DG.DependencyMgr.findDependency(), DG.DependencyMgr.invalidateDependency() functions