### PR TITLE
Fix formulas when attributes are moved between collections

### DIFF
--- a/apps/dg/formula/collection_formula_context.js
+++ b/apps/dg/formula/collection_formula_context.js
@@ -112,7 +112,7 @@ DG.CollectionFormulaContext = DG.GlobalFormulaContext.extend((function() {
     this.collectionAttrRefCounts = {};
     this.aggFnInstances = [];
     this.aggFnCount = 0;
-  },
+  }.observes('collection'),
 
   /**
     Returns the case index for the give case ID.

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -214,8 +214,18 @@ DG.Attribute = DG.BaseModel.extend(
     },
 
     /**
-     Utility function for destroying the DG.Formula when necessary
-     and cleanup up the necessary observers.
+      Update the formula context when the collection changes
+     */
+    collectionDidChange: function() {
+      if (this.hasFormula()) {
+        this._cachedValues = {};
+        this.setPath('_dgFormula.context.collection', this.get('collection'));
+      }
+    }.observes('collection'),
+
+    /**
+      Utility function for destroying the DG.Formula when necessary
+      and cleanup up the necessary observers.
      */
     destroyDGFormula: function() {
       this._dgFormula.removeObserver('dependentChange', this, 'dependentDidChange');

--- a/apps/dg/models/collection_model.js
+++ b/apps/dg/models/collection_model.js
@@ -289,6 +289,7 @@ DG.Collection = DG.BaseModel.extend( (function() // closure
      */
     addAttribute: function (attr, position) {
       attr.set('collection', this);
+
       if (SC.none(position)) {
         this.attrs.pushObject(attr);
       } else {
@@ -613,6 +614,8 @@ DG.Collection = DG.BaseModel.extend( (function() // closure
         }
       }
       this.attrs.removeAt(ix, 1);
+
+      attr.set('collection', null);
       return attr;
     },
 


### PR DESCRIPTION
When an attribute is moved between collections, we need to update its formula context as well as the attribute itself. Previously, the attribute's 'collection' property was being updated but the attribute's formula context was still pointing to the original collection. This was what caused caseIndex to fail to evaluate after an attribute that referenced it was dragged between collections.
