### PR TITLE
Splash screen improvements

### DIFF
--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -313,7 +313,6 @@ DG.main = function main() {
         message: DialogContents({}), // jshint ignore:line
         onDrop: function () { DG.cfmClient.hideBlockingModal(); }}
       );
-      DG.splash.hideSplash();
     }
   }
 
@@ -359,15 +358,11 @@ DG.main = function main() {
               syncDocumentDirtyState();
             });
 
-            // this is an unfortunately cfm-specific way to find out if the cfm
-            // is going to try an open a document after the connection
-            if (DG.cfm.appOptions.hashParams.sharedContentId || DG.cfm.appOptions.hashParams.fileParams) {
-              DG.set('showUserEntryView', false);
-            } else {
-              cfmShowUserEntryView();
-            }
-
             break;
+
+          case "ready":
+            cfmShowUserEntryView();
+            DG.splash.hideSplash();
 
           case "closedFile":
             cfmShowUserEntryView();
@@ -416,7 +411,7 @@ DG.main = function main() {
                         DG.store = DG.ModelStore.create();
                         DG.currDocumentController()
                           .setDocument(DG.Document.createDocument(iDocContents));
-                        DG.splash.hideSplash();
+                        DG.set('showUserEntryView', false);
                         if(event.callback) {
                           // acknowledge successful open; return shared metadata
                           event.callback(null, cfmSharedMetadata);

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -313,6 +313,7 @@ DG.main = function main() {
         message: DialogContents({}), // jshint ignore:line
         onDrop: function () { DG.cfmClient.hideBlockingModal(); }}
       );
+      DG.splash.hideSplash();
     }
   }
 
@@ -358,7 +359,14 @@ DG.main = function main() {
               syncDocumentDirtyState();
             });
 
-            cfmShowUserEntryView();
+            // this is an unfortunately cfm-specific way to find out if the cfm
+            // is going to try an open a document after the connection
+            if (DG.cfm.appOptions.hashParams.sharedContentId || DG.cfm.appOptions.hashParams.fileParams) {
+              DG.set('showUserEntryView', false);
+            } else {
+              cfmShowUserEntryView();
+            }
+
             break;
 
           case "closedFile":
@@ -403,6 +411,7 @@ DG.main = function main() {
                       DG.store = DG.ModelStore.create();
                       DG.currDocumentController()
                         .setDocument(DG.Document.createDocument(iDocContents));
+                      DG.splash.hideSplash();
                       if(event.callback) {
                         // acknowledge successful open; return shared metadata
                         event.callback(null, cfmSharedMetadata);

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -398,33 +398,39 @@ DG.main = function main() {
 
           case 'openedFile':
             SC.run(function() {
-              DG.cfmClient.hideBlockingModal();
-              docContentsPromise(event.data.content)
-                .then(function(iDocContents) {
-                  SC.run(function() {
-                    var metadata = event.data.content.metadata,
-                          sharedMetadata = metadata && metadata.shared,
-                          cfmSharedMetadata = sharedMetadata
-                                                ? $.extend(true, {}, sharedMetadata)
-                                                : {};
-                      DG.appController.closeAndNewDocument();
-                      DG.store = DG.ModelStore.create();
-                      DG.currDocumentController()
-                        .setDocument(DG.Document.createDocument(iDocContents));
-                      DG.splash.hideSplash();
-                      if(event.callback) {
-                        // acknowledge successful open; return shared metadata
-                        event.callback(null, cfmSharedMetadata);
-                      }
-                    },  // then() error handler
-                    function(iReason) {
-                      DG.AlertPane.error({
-                        localize: true,
-                        message: 'DG.AppController.openDocument.error.general'
+              DG.splash.showSplash();
+            });
+
+            setTimeout(function(){
+              SC.run(function() {
+                DG.cfmClient.hideBlockingModal();
+                docContentsPromise(event.data.content)
+                  .then(function(iDocContents) {
+                    SC.run(function() {
+                      var metadata = event.data.content.metadata,
+                            sharedMetadata = metadata && metadata.shared,
+                            cfmSharedMetadata = sharedMetadata
+                                                  ? $.extend(true, {}, sharedMetadata)
+                                                  : {};
+                        DG.appController.closeAndNewDocument();
+                        DG.store = DG.ModelStore.create();
+                        DG.currDocumentController()
+                          .setDocument(DG.Document.createDocument(iDocContents));
+                        DG.splash.hideSplash();
+                        if(event.callback) {
+                          // acknowledge successful open; return shared metadata
+                          event.callback(null, cfmSharedMetadata);
+                        }
+                      },  // then() error handler
+                      function(iReason) {
+                        DG.AlertPane.error({
+                          localize: true,
+                          message: 'DG.AppController.openDocument.error.general'
+                        });
                       });
                     });
-                  });
-            });
+              });
+            }, 0);
             break;
 
           case 'savedFile':

--- a/apps/dg/resources/cloud-file-manager/js/app.js.ignore
+++ b/apps/dg/resources/cloud-file-manager/js/app.js.ignore
@@ -9495,6 +9495,8 @@ CloudFileManager = (function() {
       return this.client.openProviderFile(providerName, providerParams);
     } else if (hashParams.copyParams) {
       return this.client.openCopiedFile(hashParams.copyParams);
+    } else {
+      return this.client.ready();
     }
   };
 
@@ -9665,6 +9667,10 @@ CloudFileManagerClient = (function() {
     return this._event('connected', {
       client: this
     });
+  };
+
+  CloudFileManagerClient.prototype.ready = function() {
+    return this._event('ready');
   };
 
   CloudFileManagerClient.prototype.listen = function(listener) {
@@ -10459,7 +10465,8 @@ CloudFileManagerClient = (function() {
           if (!_this.appOptions.wrapFileContent) {
             content.addMetadata(iSharedMetadata);
           }
-          return _this._updateState(content, metadata, additionalState, hashParams);
+          _this._updateState(content, metadata, additionalState, hashParams);
+          return _this.ready();
         }
       };
     })(this));

--- a/apps/dg/resources/splash.js
+++ b/apps/dg/resources/splash.js
@@ -16,40 +16,44 @@
 //  limitations under the License.
 // ==========================================================================
 
+var tSplash;
+
 DG.splash = SC.Object.create({
+
   isShowing: false,
 
   showSplash: function () {
-    if (DG.Browser.isCompatibleBrowser()) {
+    if (DG.Browser.isCompatibleBrowser() && !this.get('isShowing')) {
       var kHeight = 200,
           kPadding = 20,
-          kRatio = 1936 / 649,
-          tSplash = SC.PanelPane.create({
-            classNames: ['dg-splash'],
-            layout: {width: kRatio * kHeight + 2 * kPadding, height: kHeight + 2 * kPadding, centerX: 0, centerY: 0},
-            contentView: SC.ImageView.extend({
-              layout: { left: kPadding, right: kPadding, top: kPadding, bottom: kPadding },
-              value: static_url('images/codap-splash-screen.png'),
-              click: function () {
-                this.get('parentView').close();
-              },
-              keyDown: function () {
-                this.get('parentView').close();
-              },
-              acceptsFirstResponder: true
-            }),
-            acceptsKeyPane: true,
-            close: function() {
-              this.destroy();
-              DG.splash.set('isShowing', false);
-            }
-          }).append();
+          kRatio = 1936 / 649;
+      tSplash = SC.PanelPane.create({
+        classNames: ['dg-splash'],
+        layout: {width: kRatio * kHeight + 2 * kPadding, height: kHeight + 2 * kPadding, centerX: 0, centerY: 0},
+        contentView: SC.ImageView.extend({
+          layout: { left: kPadding, right: kPadding, top: kPadding, bottom: kPadding },
+          value: static_url('images/codap-splash-screen.png'),
+          click: function () {
+            DG.splash.hideSplash();
+          },
+          keyDown: function () {
+            DG.splash.hideSplash();
+          },
+          acceptsFirstResponder: true
+        }),
+        acceptsKeyPane: true,
+        close: function() {
+          this.destroy();
+          DG.splash.set('isShowing', false);
+        }
+      }).append();
       tSplash.contentView.becomeFirstResponder();
       this.set('isShowing', true);
-      this.invokeLater(function () {
-        if(tSplash) { tSplash.close(); }
-      }, 4000);
     }
+  },
+
+  hideSplash: function() {
+    if(tSplash) { tSplash.close(); }
   }
 
 });


### PR DESCRIPTION
This closes the splash screen when the document is ready (either the "What would you like to do?" dialog is showing or the document has loaded), and re-opens it when the user initiates an Open).

There are a couple questionable parts (checking the CFM params to see if it intends to open a document after the initial `"connect"` event, and abuse of `setTimeout(..., 0)` in order to cause a UI refresh) that could use another pair of eyes.