### PR TITLE
Fix aggregate missing value handling; fix standard deviation adornment

### DIFF
--- a/apps/dg/components/graph/adornments/plotted_average_model.js
+++ b/apps/dg/components/graph/adornments/plotted_average_model.js
@@ -174,8 +174,10 @@ DG.PlottedStDevModel = DG.PlottedMeanStDevModel.extend(
 
     // compute st.dev. of cases in each cell
     tValues.forEach( function( iValue ) {
-      if( iValue.count > 0 ) {
-        iValue.stdev = Math.sqrt(( iValue.sumOfSquares / iValue.count) - ( iValue.mean * iValue.mean ));
+      if( iValue.count > 1 ) {
+        iValue.stdev = Math.sqrt(( iValue.sumOfSquares -
+                                  ( iValue.mean * iValue.mean ) * iValue.count) /
+                                    (iValue.count - 1));
         iValue.stDevMinus1 = iValue.mean - iValue.stdev;
       }
     });

--- a/apps/dg/formula/aggregate_function.js
+++ b/apps/dg/formula/aggregate_function.js
@@ -307,7 +307,7 @@ DG.CachedValuesParentCaseAggregate = DG.ParentCaseAggregate.extend({
    */
   evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
     var value = this.getNumericValue( iContext, iEvalContext, iInstance);
-    if( !isNaN(value)) {
+    if( value != null) {
       var cache = iInstance.caches[ iCacheID];
       if( cache) {
         cache.sum += value;
@@ -400,7 +400,7 @@ DG.SortDataFunction = DG.ParentCaseAggregate.extend({
     var value = this.getNumericValue(iContext, iEvalContext, iInstance);
     // Currently, we only sort numeric values.
     // To support a Fathom-like alphanumeric sort, we would have to change the test here.
-    if( !isNaN(value)) {
+    if( value != null) {
       var cache = iInstance.caches[ iCacheID];
       if( cache) {
         cache.push( value);

--- a/apps/dg/formula/univariate_stats_fns.js
+++ b/apps/dg/formula/univariate_stats_fns.js
@@ -68,7 +68,7 @@ return {
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
       var value = this.getNumericValue( iContext, iEvalContext, iInstance);
-      if( !isNaN(value)) {
+      if( value != null) {
         var cache = iInstance.caches[ iCacheID];
         if( cache) {
           if( cache.min > value)
@@ -98,7 +98,7 @@ return {
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
       var value = this.getNumericValue( iContext, iEvalContext, iInstance);
-      if( !isNaN(value)) {
+      if( value != null) {
         var cache = iInstance.caches[ iCacheID];
         if( cache) {
           if( cache.max < value)
@@ -128,7 +128,7 @@ return {
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
       var value = this.getNumericValue( iContext, iEvalContext, iInstance);
-      if( !isNaN(value)) {
+      if( value != null) {
         var cache = iInstance.caches[ iCacheID];
         if( cache) {
           cache.count += 1;
@@ -241,7 +241,7 @@ return {
 
     evalCase: function( iContext, iEvalContext, iInstance, iCacheID) {
       var value = this.getNumericValue( iContext, iEvalContext, iInstance);
-      if( !isNaN(value)) {
+      if( value != null) {
         if( iInstance.results[ iCacheID])
           iInstance.results[ iCacheID] += value;
         else


### PR DESCRIPTION
- Clients of getNumericValue() must handle null return values
- Standard deviation adornment should use sample standard deviation rather than population standard deviation (for consistency with stdDev() function among other reasons)
 - Fixes bug Evangeline found while testing [#126931797]
