### PR TITLE
Simple change to update the url hash for examples

### DIFF
--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -148,8 +148,9 @@ DG.main = function main() {
           enableLaraSharing: true,
           providers: [
             {
-              "displayName": "Example Documents",
               "name": "readOnly",
+              "displayName": "Example Documents",
+              "urlDisplayName": "examples",
               "src": DG.exampleListURL,
               alphabetize: true,
               // json: [


### PR DESCRIPTION
This changes the readOnly url format from
https://codap.concord.org/releases/build_0349/static/dg/en/cert/index.html#file=readOnly:Four%20Seals
to
https://codap.concord.org/releases/latest/static/dg/en/cert/index.html#file=examples:Four%20Seals