### PR TITLE
Changed launchFromLara param from a check for "true" to an existence check

### DIFF
--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -356,7 +356,7 @@ DG = SC.Application.create((function () // closure
      */
     componentMode: getUrlParameter('componentMode', 'no'),
 
-    hideCFMMenu: getUrlParameter('launchFromLara') === 'true',
+    hideCFMMenu: !!getUrlParameter('launchFromLara'),
 
     toolButtons: [ // These appear on the left side of the tool shelf
       //'fileMenu',


### PR DESCRIPTION
This is needed as the v2 document store api uses the launchFromLara param to pass a encoded json object