### PR TITLE
Eslint configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+apps/dg/formula/formulaParser.*
+apps/dg/tinkerplots/**
+apps/dg/libraries/**

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,48 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": { "DG": false, "Raphael": false, "$": false, "SC": false, "sc_require": false,
+                "sc_super": false, "static_url": false, "NO": false, "YES": false },
+  "extends": [ "eslint:recommended" ],
+  "rules": {
+    // possible errors
+    "no-console": "off",
+    "no-template-curly-in-string": "warn",
+    "no-unreachable": "error",
+    "no-unsafe-negation": "warn",
+
+    // best practices
+    "array-callback-return": "warn",
+    "block-scoped-var": "warn",
+    "eqeqeq": ["error", "allow-null"],
+    "no-alert": "error",
+    "no-caller": "error",
+    "no-eval": "error",
+    "no-extra-bind": "off",
+    "no-global-assign": "error",
+    "no-invalid-this": "off",
+    "no-loop-func": "warn",
+    "no-unused-expressions": "off",
+    "no-useless-call": "off",
+    "no-useless-escape": "off",
+
+    // variables
+    "no-unused-vars": ["warn", { "vars": "all", "args": "none" }],
+    "no-use-before-define": "off",
+
+    // node.js/CommonJS
+    "no-mixed-requires": "warn",
+
+    // stylistic issues
+    "eol-last": "off",
+    "func-name-matching": "error",
+    "linebreak-style": ["error", "unix"],
+    "no-bitwise": "warn",
+    "no-unneeded-ternary": "warn",
+    "no-underscore-dangle": "off",
+    "quote-props": ["error", "as-needed", { "keywords": true, "unnecessary": false }],
+    "quotes": "off",
+    "semi": ["error", "always"]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ nbproject
 *.iml
 .deployDevCodaprc
 .pt
+# Packages
+node_modules/

--- a/apps/dg/alpha/debug.js
+++ b/apps/dg/alpha/debug.js
@@ -39,6 +39,7 @@ DG.debugForceReload = function() {
   Global function used to drop into the JavaScript debugger, if one is running.
 */
 DG.debugLaunchDebugger = function() {
+  /* eslint no-eval: "off" */
   /* jslint evil:true */
   eval('debugger');
 };
@@ -266,10 +267,11 @@ DG.Debug = SC.Object.create( (function() {
 
         // Stop in debugger in debug builds
         if( stopInDebugger ) {
-            //@if(debug)
+          //@if(debug)
+            /* eslint no-eval: "off" */
             /* jslint evil:true */
             eval('debugger');
-            //@endif
+          //@endif
         }
 
         // Show the assertion failure alert
@@ -408,6 +410,7 @@ DG.Debug = SC.Object.create( (function() {
       DG.Debug.logErrorRaw( "Exception: " + iException.message);
 
       //@if(debug)
+        /* eslint no-eval: "off" */
         /* jslint evil:true */
         eval('debugger');
       //@endif
@@ -455,10 +458,9 @@ SC.Logger._outputMessage = function(type, timestampStr, indentation, message, or
   This can be useful when logging to help identify objects.
  */
 DG.Debug.scObjectID = function( iObject) {
-  var scIDKey, scIDValue = "";
+  var scIDValue = "";
   DG.ObjectMap.findKey( iObject, function( iKey, iValue) {
     if( iKey.substr(0,10) === 'SproutCore') {
-      scIDKey = iKey;
       scIDValue = iValue;
       return true;
     }

--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -780,7 +780,7 @@ DG.CaseTableController = DG.ComponentController.extend(
               }
             },
             undo: function() {
-              var tChange, tResult, action;
+              var tChange, tResult, action; // eslint-disable-line no-unused-vars
               tContext = this._controller().get('dataContext');
               if (isNew) {
                 tRef = tContext.getAttrRefByName( tAttributeName);
@@ -800,7 +800,7 @@ DG.CaseTableController = DG.ComponentController.extend(
               if( tResult.success) {
                 action = isNew ? "attributeCreate" : "attributeEditFormula";
               } else {
-                  this.set('causedChange', false);
+                this.set('causedChange', false);
               }
             },
             redo: function() {

--- a/apps/dg/components/case_table/case_table_row_selection_model.js
+++ b/apps/dg/components/case_table/case_table_row_selection_model.js
@@ -30,7 +30,7 @@ DG.CaseTableRowSelectionModel = function (options) {
   var _handler = new Slick.EventHandler();
   var _inHandler;
   var _options;
-  var _inDrag = false;
+  var _inDrag = false;  // eslint-disable-line no-unused-vars
   var _dragStartRow;
   var _dragStartY = null;
   var _dragStartClientY = null;

--- a/apps/dg/components/case_table/case_table_view.js
+++ b/apps/dg/components/case_table/case_table_view.js
@@ -42,7 +42,8 @@ DG.CaseTableView = SC.View.extend( (function() // closure
    * so that clicks on row boundaries have the expected user effect.
    */
   var kHeaderHeight = 59,//29,
-      kAutoScrollInterval = 200;  //jshint ignore: line
+                                  // eslint-disable-next-line no-unused-vars
+      kAutoScrollInterval = 200;  // jshint ignore: line
                                   // msec == 5 rows/sec
 
   return {  // return from closure

--- a/apps/dg/components/game/game_phone_handler.js
+++ b/apps/dg/components/game/game_phone_handler.js
@@ -123,7 +123,7 @@ DG.GamePhoneHandler = SC.Object.extend(
       getOpenCaseIDs: function (iExcludeChildren) {
         var tGameContext = this.get('context'),
             tOpenCaseIDs = [],
-            tIncludeChildCases = (iExcludeChildren ? false : true);
+            tIncludeChildCases = !iExcludeChildren;
 
         // Adds the id of the specified case and all of its child cases to tOpenCaseIDs.
         function addCase(iCase) {

--- a/apps/dg/components/graph/adornments/plotted_count_model.js
+++ b/apps/dg/components/graph/adornments/plotted_count_model.js
@@ -25,6 +25,7 @@
 // ==========================================================================
 
 sc_require('components/graph/adornments/plot_adornment_model');
+sc_require('components/graph/data_model/analysis');
 
 /**
  * @class  The model for a plotted count and/or percent.

--- a/apps/dg/components/graph/axes/cell_axis_view.js
+++ b/apps/dg/components/graph/axes/cell_axis_view.js
@@ -172,7 +172,7 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
           tLabelSpecs = this.get('labelSpecs') || [],
           tCollision = false,
           tPrevLabelEnd,
-          tDragStartCoord, tCellBeingDragged, tOriginalCellIndex;
+          tDragStartCoord, tCellBeingDragged, tOriginalCellIndex; // eslint-disable-line no-unused-vars
 
       var beginDrag = function ( iWindowX, iWindowY) {
             tOriginalCellIndex = tCellBeingDragged = this.cellNum;

--- a/apps/dg/components/graph/axes/datetime_axis_view_helper.js
+++ b/apps/dg/components/graph/axes/datetime_axis_view_helper.js
@@ -445,7 +445,7 @@ DG.DateTimeAxisViewHelper = DG.AxisViewHelper.extend(
           tThisLabel = getLevelLabelForValue(iLevel, tLowerBoundsMS);
           tFirstLabelString = tThisLabel.labelString;	// Make a copy because it might be what we end up drawing
 
-          while (true) {
+          while (true) {  // eslint-disable-line no-constant-condition
             tNextLabel = getNextLevelLabelForValue(iLevel, tThisLabel.labelDate);
             if (isNaN(tNextLabel.labelDate))
               break;	// we break on invalid dates. Instead of breaking, we could attempt to go on to format any valid

--- a/apps/dg/components/graph/plots/case_plot_view.js
+++ b/apps/dg/components/graph/plots/case_plot_view.js
@@ -156,6 +156,7 @@ DG.CasePlotView = DG.PlotView.extend(
      */
     drawData: function() {
       var tIncrementBy,
+          tLoopIndex = 0,
       animateSomePoints = function() {
         // If the user closes the graph component while the animation is happening, we're likely to
         // crash because we no longer have paper to draw points on. Detect and bail!
@@ -196,7 +197,7 @@ DG.CasePlotView = DG.PlotView.extend(
 
       this._pointRadius = this.calcPointRadius(); // make sure created circles are of right size
       if( this._mustCreatePlottedElements ) {
-        var tLoopIndex = 0;
+        tLoopIndex = 0;
         this._plottedElements.forEach( function( iElement ) {
           iElement.remove();
         } );

--- a/apps/dg/components/graph/plots/plot_model.js
+++ b/apps/dg/components/graph/plots/plot_model.js
@@ -649,7 +649,7 @@ DG.PlotModel = SC.Object.extend( DG.Destroyable,
           return this.getPlottedAttributesIncludeIDs( changedAttrIDs);
         }
         /* jshint -W086 */  // Expected a 'break' statement before 'case'. (W086)
-        // fall-through intentional -- w/o attribute IDs, rely on collection
+        // fall through intentional -- w/o attribute IDs, rely on collection
       case 'createCase':
       case 'createCases':
         // Only if the case(s) created are in a collection that is being plotted

--- a/apps/dg/components/graph/utilities/plot_utilities.js
+++ b/apps/dg/components/graph/utilities/plot_utilities.js
@@ -392,7 +392,7 @@ DG.PlotUtilities = {
             node.setAttribute(att, value);
             o._.dirty = 1;
             break;
-          case "r":
+          case "r":                 // eslint-disable-next-line eqeqeq
             if (o.type == "rect") { // jshint ignore:line
               $(node, {rx: value, ry: value});
             } else {
@@ -417,9 +417,10 @@ DG.PlotUtilities = {
             }
             clr[has]("opacity") && $(node, {"fill-opacity": clr.opacity > 1 ?
                 clr.opacity / 100 : clr.opacity});  // jshint ignore:line
+            // fall through
           case "stroke":
             clr = R.getRGB(value);
-            node.setAttribute(att, clr.hex);
+            node.setAttribute(att, clr.hex);            // eslint-disable-next-line eqeqeq
             att == "stroke" && clr[has]("opacity") &&   // jshint ignore:line
               $(node, {"stroke-opacity": clr.opacity > 1 ? clr.opacity / 100 : clr.opacity});
             break;
@@ -427,9 +428,9 @@ DG.PlotUtilities = {
             if (attrs.gradient && !attrs[has]("stroke-opacity")) {
               $(node, {"stroke-opacity": value > 1 ? value / 100 : value});
             }  // jshint ignore:line
-          // fall
-          default:
-            att == "font-size" && (value = toInt(value, 10) + "px");  // jshint ignore:line
+          // fall through
+          default:                                                      // eslint-disable-next-line eqeqeq
+            att == "font-size" && (value = parseInt(value, 10) + "px"); // jshint ignore:line
             var cssrule = att.replace(/(\-.)/g, function (w) {
               return w.substring(1).toUpperCase();
             });

--- a/apps/dg/components/graph_map_common/data_display_controller.js
+++ b/apps/dg/components/graph_map_common/data_display_controller.js
@@ -946,7 +946,7 @@ DG.DataDisplayController = DG.ComponentController.extend(
           var makeCanvasBlob = function (canvas) {
             var canvasDataURL = canvas.toDataURL("image/png");
             var canvasData = atob(canvasDataURL.substring("data:image/png;base64,".length));
-            var canvasAsArray = new Uint8Array(canvasData.length);
+            var canvasAsArray = new Uint8Array(canvasData.length);  /* global Uint8Array */
 
             for (var i = 0, len = canvasData.length; i < len; ++i) {
               canvasAsArray[i] = canvasData.charCodeAt(i);

--- a/apps/dg/components/guide/guide_configuration_view.js
+++ b/apps/dg/components/guide/guide_configuration_view.js
@@ -157,7 +157,7 @@ DG.GuideConfigurationView = SC.PalettePane.extend(
                 return iRowView.get('rowObject');
               } )
         .filter( function( iObject) {
-                  return iObject ? true : false;
+                  return !!iObject;
                 });
     }.property(),
 

--- a/apps/dg/components/map/map_data_configuration.js
+++ b/apps/dg/components/map/map_data_configuration.js
@@ -311,6 +311,7 @@ DG.MapDataConfiguration = DG.PlotDataConfiguration.extend(
             });
           }
           catch (er) {
+            // ignore exceptions
           }
         });
 

--- a/apps/dg/components/map/map_grid_marquee_view.js
+++ b/apps/dg/components/map/map_grid_marquee_view.js
@@ -69,9 +69,9 @@ DG.MapGridMarqueeView = DG.RaphaelBaseView.extend(
   doDraw: function doDraw() {
     var this_ = this,
         tMarquee,
-        tLastRect,
+        tLastRect,  // eslint-disable-line no-unused-vars
         tStartPt,
-        tBaseSelection = [];
+        tBaseSelection = [];  // eslint-disable-line no-unused-vars
 
     function startMarquee( iWindowX, iWindowY, iEvent) {
       if( iEvent.shiftKey) {

--- a/apps/dg/controllers/app_controller.js
+++ b/apps/dg/controllers/app_controller.js
@@ -1015,12 +1015,14 @@ DG.appController = SC.Object.create((function () // closure
         });
       }.bind( this);
 
+      var docName;
+
       var cancelCloseDocument = function () {
         DG.logUser("cancelCloseDocument: '%@'", docName);
       };
 
       if ((iType === 'JSON') && DG.currDocumentController().get('hasUnsavedChanges')) {
-        var docName = DG.currDocumentController().get('documentName');
+        docName = DG.currDocumentController().get('documentName');
         DG.logUser("confirmCloseDocument?: '%@'", docName);
         DG.AlertPane.warn({
           message: 'DG.AppController.closeDocument.warnMessage',

--- a/apps/dg/controllers/authorization.js
+++ b/apps/dg/controllers/authorization.js
@@ -398,6 +398,7 @@ return {
             parameters = {value: parameters};
           }
         } catch (e) {
+          // ignore exceptions
         }
       }
 

--- a/apps/dg/controllers/document_archiver.js
+++ b/apps/dg/controllers/document_archiver.js
@@ -664,7 +664,6 @@ DG.DocumentArchiver = SC.Object.extend(
         var documentController = DG.currDocumentController(),
             existingSaveInProgress = documentController.get('saveInProgress'),
             saveInProgress,
-            exportPromise,
             oldDifferentialSaving,
             documentArchive;
 
@@ -682,7 +681,7 @@ DG.DocumentArchiver = SC.Object.extend(
         DG.USE_DIFFERENTIAL_SAVING = false;
         saveInProgress.done(function() { DG.USE_DIFFERENTIAL_SAVING = oldDifferentialSaving; });
 
-        exportPromise = documentController.captureCurrentDocumentState(false)
+        documentController.captureCurrentDocumentState(false)
         // FIXME This forces data contexts to always be in a separate doc. Should this depend on other factors?
         .then(function (da) {
           var promises = [];

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -448,14 +448,14 @@ DG.DocumentController = SC.Object.extend(
       var docView = DG.mainPage.get('docView'),
           type = (iComponent && iComponent.get('type')) || iComponentType,
           tView = null,
-          isInitialization = iArgs && iArgs.initiatedViaCommand ? false : true;
+          isInitialization = !(iArgs && iArgs.initiatedViaCommand);
       try {
         switch( type) {
         case 'DG.FlashView':  // For backward compatibility
           if( iComponent)
             iComponent.set('type', 'DG.GameView');
-          // fallthrough intentional
           /* jshint -W086 */  // Expected a 'break' statement before 'case'. (W086)
+          // fallthrough intentional
         case 'DG.GameView':
           tView = this.addGame( docView, iComponent, isInitialization);
           break;
@@ -1383,7 +1383,7 @@ DG.DocumentController = SC.Object.extend(
     },
 
     /**
-     * Ensures that that the state of all components, data contexts and
+     * Ensures that the state of all components, data contexts and
      * data contexts are current and up-to-date.
      *
      * Saves the current state of all the current Data Interactives into the

--- a/apps/dg/formula/dependency_mgr.js
+++ b/apps/dg/formula/dependency_mgr.js
@@ -316,17 +316,20 @@ DG.DependencyMgr = SC.Object.extend((function() {
         i, dependency,
         aggFnIndices = iDependency.aggFnIndices,
         aggFnIndexCount = aggFnIndices ? aggFnIndices.length : 0;
+
+    function trackFnIndices(iAggFnIndex) {
+      if (aggFnIndices.indexOf(iAggFnIndex) < 0) {
+        aggFnIndices.push(iAggFnIndex);
+      }
+    }
+
     for (i = 0; i < dependencyCount; ++i) {
       dependency = dependencies[i];
       // do we already have this dependency in the list?
       if (0 === _compareNodeSpecs(dependency.node, iIndependentNode)) {
         if (aggFnIndexCount) {
           // keep track of aggFnIndices affected
-          aggFnIndices.forEach(function(iAggFnIndex) {
-            if (dependency.aggFnIndices.indexOf(iAggFnIndex) < 0) {
-              dependency.aggFnIndices.push(iAggFnIndex);
-            }
-          });
+          aggFnIndices.forEach(trackFnIndices);
         }
         else {
           dependency.simpleDependency = true;

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -58,8 +58,6 @@ DG.main = function main() {
 
   DG.getPath('mainPage.mainPane').append();
 
-  var documentLoaded = false;
-
   DG.appController.documentNameDidChange();
 
   DG.showUserEntryView = true;
@@ -585,11 +583,9 @@ DG.main = function main() {
       var owner = !SC.empty( DG.startingDocOwner) ? DG.startingDocOwner : DG.iUser;
       DG.appController.openDocumentNamed( DG.startingDocName, owner);
       DG.startingDocName = '';  // Signal that there is no longer a starting doc to open
-      documentLoaded = true;
     } else if( !SC.empty( DG.startingDocId)) {
       DG.appController.openDocumentWithId( DG.startingDocId);
       DG.startingDocId = '';  // Signal that there is no longer a starting doc to open
-      documentLoaded = true;
     }
   }
 
@@ -610,4 +606,4 @@ DG.main = function main() {
 };
 
 /* exported main */
-function main() { DG.main(); }
+window.main = function() { DG.main(); };

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -571,7 +571,7 @@ DG.main = function main() {
       // Add CFM-specific global functions
       DG.exportFile = function(data, extension, mimetype, callback) {
         DG.cfmClient.saveSecondaryFileAsDialog(data, extension, mimetype, callback);
-      }
+      };
     }
   }
 

--- a/apps/dg/tests/.eslintrc.json
+++ b/apps/dg/tests/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  // additional unit testing global variables
+  "globals": { "equals": false, "module": false, "ok": false, "same": false,
+                "start": false, "stop": false, "test": false }
+}

--- a/apps/dg/tests/models/test_document_model.js
+++ b/apps/dg/tests/models/test_document_model.js
@@ -24,7 +24,7 @@ module("DG.Document", {
 });
 
 test("test DG.Document", function () {
-  var document, id;
+  var document;
 
   ok(SC.empty(DG.activeDocument), "Before document creation there is no DG.activeDocument");
 
@@ -34,7 +34,6 @@ test("test DG.Document", function () {
       appVersion: "myVersion",
       appBuildNum: "myBuildNum"
     });
-  id = document.id;
 
   ok(!SC.empty(document), "Can create document");
   ok(!SC.empty(DG.activeDocument), "After creation there is an DG.activeDocument");

--- a/apps/dg/utilities/color_utilities.js
+++ b/apps/dg/utilities/color_utilities.js
@@ -600,6 +600,7 @@ DG.ColorUtilities = {
   rgbColorString_to_PlatformColor: function (iColor, iWantHSB) {
 
     // Allow assignments as comparisons
+    /* eslint no-cond-assign: "off" */
     /* jshint boss:true */
 
     // convert color name to hex color

--- a/apps/dg/utilities/formatter.js
+++ b/apps/dg/utilities/formatter.js
@@ -370,6 +370,7 @@ DG.Format.time = function(type) {
   /** @private */
   function format(t) {
     function toInt(fl) {
+      /* eslint no-bitwise: "off" */
       /* jshint ignore: start */
       return fl >> 0; // bit-shift zero places: converts to 32 bit int
       /* jshint ignore: end */

--- a/apps/dg/utilities/remove_diacritics.js
+++ b/apps/dg/utilities/remove_diacritics.js
@@ -275,9 +275,9 @@ var defaultDiacriticsRemovalMap = [{
 }];
 
 /* exported removeDiacritics */
-function removeDiacritics(str) {
+window.removeDiacritics =function(str) {
     for (var i = 0; i < defaultDiacriticsRemovalMap.length; i++) {
         str = str.replace(defaultDiacriticsRemovalMap[i].letters, defaultDiacriticsRemovalMap[i].base);
     }
     return str;
-}
+};

--- a/apps/dg/utilities/sound_utilities.js
+++ b/apps/dg/utilities/sound_utilities.js
@@ -61,7 +61,7 @@ DG.sounds = SC.Object.extend( {
     // With preloading (see initAudio()) we crashed on certain browsers.
     // For now, we disable audio completely, but leave the implementation
     // in place for further testing/development down the road.
-    if( true)
+    if( true) // eslint-disable-line no-constant-condition
       return;
     
     if( sound && sound.path && !sound.audio)

--- a/apps/dg/views/inspector/inspector_view.js
+++ b/apps/dg/views/inspector/inspector_view.js
@@ -57,7 +57,8 @@ DG.InspectorView = DG.DraggableView.extend(
                 var tChildren = this.get('childViews'),
                     tChild;
                 // We call removeChild for each member of the array. This has the side effect of modifying the array
-                while (tChild = tChildren[0]) {  // jshint ignore:line
+                                                  // eslint-disable-next-line no-cond-assign
+                while (tChild = tChildren[0]) {   // jshint ignore:line
                   this.removeChild(tChild);
                 }
               }.bind(this),

--- a/apps/dg/views/inspector/picker_color_control.js
+++ b/apps/dg/views/inspector/picker_color_control.js
@@ -41,8 +41,9 @@ DG.PickerColorControl = SC.View.extend(
           this.set('lastColor', this.get('initialColor'));
         }
         this.invokeLast(function () {
+          /* global tinycolor */
           this.$('#custom1').spectrum({
-            color: tinycolor(this.initialColor), // jshint ignore:line
+            color: tinycolor(this.initialColor),
             appendTo: this.appendToLayerFunc(),
             showAlpha: true,
             showInitial: true,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "CODAP",
+  "description": "Common Online Data Analysis Platform",
+  "main": "apps/dg/index.html",
+  "scripts": {
+    "lint": "eslint apps",
+    "test": "sc-phantom --include-targets=/dg"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/concord-consortium/codap.git"
+  },
+  "author": "Concord Consortium",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/concord-consortium/codap/issues"
+  },
+  "homepage": "http://codap.concord.org/",
+  "devDependencies": {
+    "eslint": "^3.9.1",
+    "phantomjs-prebuilt": "^2.1.13"
+  }
+}


### PR DESCRIPTION
- configure `eslint` for use with CODAP
- fix issues found by `eslint`
- add `package.json` with
  - `dev-dependencies` so that `npm install` will install required tools (`eslint`, `phantomjs`)
  - `lint` script so that `npm run lint` runs `eslint`
  - `test` script so that `npm test` runs unit tests via `phantomjs`

`eslint` has surpassed `jshint` as the linter of choice these days. In working on the story to eliminate unused code, I found it useful to run `eslint` and the unit tests frequently to make sure I hadn't broken anything that could be checked statically. Also, `eslint`'s editor integration made it easier to see errors while I was removing code. Furthermore, while I was working on this Jonathan encountered the issue with `export` being used as a property name which caused `yuicompressor` to barf and took a fair amount of time to track down given the lack of useful error message. When I mentioned to Jonathan that I had `eslint` working locally he immediately tracked down the relevant `eslint` rule (`quote-props`) and I added it to our `eslint` configuration so that this problem will be caught more quickly the next time around.

Note that for now, both `eslint` and `jshint` are currently supported, but that we will likely choose to drop support for `jshint` at some point as `eslint` is clearly superior at this point.