### PR TITLE
Fix aggregate function evaluation in presence of missing child cases

### DIFF
--- a/apps/dg/formula/aggregate_function.js
+++ b/apps/dg/formula/aggregate_function.js
@@ -78,6 +78,11 @@ DG.IteratingAggregate = DG.AggregateFunction.extend({
   queryCache: function( iContext, iEvalContext, iInstance) {
     return iInstance.results ? iInstance.results[ iEvalContext._id_] : undefined;
   },
+
+  preEvaluate: function(iContext, iEvalContext, iInstance) {
+    iInstance.caches = {};
+    iInstance.results = {};
+  },
   
   /**
     Evaluates the aggregate function and returns a computed result for the specified case.
@@ -96,14 +101,14 @@ DG.IteratingAggregate = DG.AggregateFunction.extend({
     var cachedResult = this.queryCache( iContext, iEvalContext, iInstance);
     if( cachedResult !== undefined) return cachedResult;
 
+    this.preEvaluate(iContext, iEvalContext, iInstance);
+
     // Prepare for iteration over all the cases.
     var collection = iContext && iContext.getCollectionToIterate(),
         cases = collection && collection.get('cases'),
         caseCount = cases && cases.get('length');
 
     // iterate over all the cases.
-    if (!iInstance.caches) iInstance.caches = {};
-    if (!iInstance.results) iInstance.results = {};
     for( var i = 0; i < caseCount; ++i) {
       var tCase = cases.objectAt( i),
           e = { _case_: tCase, _id_: tCase && tCase.get('id') };
@@ -265,12 +270,12 @@ DG.ParentCaseAggregate = DG.IteratingAggregate.extend({
     var cachedResult = this.queryCache( iContext, iEvalContext, iInstance);
     if( cachedResult !== undefined) return cachedResult;
 
+    this.preEvaluate(iContext, iEvalContext, iInstance);
+
     var collection = iContext && iContext.getCollectionToIterate(),
         cases = collection && collection.get('cases'),
         caseCount = cases && cases.get('length');
 
-    if (!iInstance.caches) iInstance.caches = {};
-    if (!iInstance.results) iInstance.results = {};
     for( var i = 0; i < caseCount; ++i) {
       var tCase = cases.objectAt( i),
           tEvalContext = $.extend({}, iEvalContext,

--- a/apps/dg/formula/univariate_stats_fns.js
+++ b/apps/dg/formula/univariate_stats_fns.js
@@ -223,7 +223,9 @@ return {
     // todo: Figure out what should be the min number of arguments. 2 or 1?
     requiredArgs: { min: 2, max: 2 },
 
-    evaluate: function( iContext, iEvalContext, iInstance) {
+    preEvaluate: function(iContext, iEvalContext, iInstance) {
+      sc_super();
+
       var tPercValueFn = iInstance.argFns[1],
           percValue = tPercValueFn ? tPercValueFn(iContext, iEvalContext) : undefined;
       // Note that the percentile argument could evaluate to a different value for every
@@ -233,7 +235,6 @@ return {
       // aggregate which could evaluate to a different value for every case.
       if (!iInstance.caches) iInstance.caches = {};
       iInstance.caches._percentile_ = percValue;
-      return sc_super();
     },
 
     extractResult: function (iCachedValues, iEvalContext, iInstance) {


### PR DESCRIPTION
Fix aggregate function evaluation in presence of missing child cases [#131740097]
- clear internal aggregate function instance caches before looping over cases