### PR TITLE
Fix plotted function dependencies [#130218151]

### DIFF
--- a/apps/dg/components/graph/adornments/plot_adornment_model.js
+++ b/apps/dg/components/graph/adornments/plot_adornment_model.js
@@ -20,6 +20,9 @@
  * @class  DG.PlotAdornmentModel -- Base class for plot adornment models.
  * @extends SC.Object
  */
+
+DG.PlotAdornmentModelNextID = 0;
+
 DG.PlotAdornmentModel = SC.Object.extend(
 /** @scope DG.PlotAdornmentModel.prototype */
 {
@@ -41,6 +44,13 @@ DG.PlotAdornmentModel = SC.Object.extend(
    */
   isVisible: true,
   
+  /**
+    Initialization method
+   */
+  init: function() {
+    this.set('id', ++ DG.PlotAdornmentModelNextID);
+  },
+
   /**
     Destruction method
    */

--- a/apps/dg/components/graph/adornments/plotted_function_model.js
+++ b/apps/dg/components/graph/adornments/plotted_function_model.js
@@ -261,10 +261,12 @@ DG.PlottedFunctionModel = DG.PlotAdornmentModel.extend(
     Utility function for creating the DG.Formula.
    */
   createDGFormula: function( iSource) {
-    var owner = { type: 'plottedValue', id: 1, name: 'plottedValue1' },
+    var adornmentKey = this.get('adornmentKey'),
+        id = this.get('id'),
+        owner = { type: adornmentKey, id: id, name: adornmentKey + id },
         context = DG.PlottedFunctionContext
                       .create({ ownerSpec: owner,
-                                adornmentKey: this.get('adornmentKey'),
+                                adornmentKey: adornmentKey,
                                 plotModel: this.get('plotModel'),
                                 splitEval: this.get('splitEval'),
                                 collection: this.get('primaryCollection') });


### PR DESCRIPTION
- DG.PlotAdornmentModels now have a unique id which is used to distinguish dependencies

The bug occurred because plotted values/functions used a hard-coded ID, so when multiple plots registered the same dependency, all dependencies after the first were considered redundant.
