### PR TITLE
Plotted value updates on axis attribute change [#121455949]

### DIFF
--- a/apps/dg/components/graph/adornments/plotted_function_model.js
+++ b/apps/dg/components/graph/adornments/plotted_function_model.js
@@ -323,9 +323,16 @@ DG.PlottedFunctionModel = DG.PlotAdornmentModel.extend(
    */
   globalNamesDidChange: function() {
     // Name changes require recompilation
+    this.invalidateExpression();
+  }.observes('DG.globalsController.globalNameChanges'),
+
+  /**
+    Invalidate the expression so it gets recompiled/evaluated.
+   */
+  invalidateExpression: function() {
     if( this._expression)
       this._expression.invalidate();
-  }.observes('DG.globalsController.globalNameChanges'),
+  },
   
   /**
     Evaluates the plotted function at the specified x value.

--- a/apps/dg/components/graph/adornments/plotted_value_adornment.js
+++ b/apps/dg/components/graph/adornments/plotted_value_adornment.js
@@ -177,6 +177,10 @@ DG.PlottedValueAdornment = DG.PlotAdornment.extend( DG.LineLabelMixin,
     this.updateTextToModel( 1/4); // offset from top of plot
   }.observes('DG.globalsController.globalNameChanges'),
 
+  valueAxisAttrDidChange: function() {
+    this.get('model').invalidateExpression();
+  }.observes('*valueAxisView.model.firstAttributeName'),
+
   /**
 
   */

--- a/apps/dg/components/graph/axes/axis_model.js
+++ b/apps/dg/components/graph/axes/axis_model.js
@@ -98,7 +98,7 @@ DG.AxisModel = SC.Object.extend(
   }.property(),
   firstAttributeNameDidChange: function() {
     this.notifyPropertyChange('firstAttributeName');
-  }.observes('*attributeDescription.attributes'),
+  }.observes('*attributeDescription.attribute', '*attributeDescription.attributes'),
 
   /**
   One by default. Subclasses will likely override.


### PR DESCRIPTION
On the plotted value side, the simple fix is to invalidate the expression when the axis attribute changes. Getting the notification turned out to be the trickier part. I ended up updating `DG.AxisModel. firstAttributeNameDidChange` because it wasn't triggering before the change.