### PR TITLE
Add NPM scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,35 @@
 {
   "name": "CODAP",
   "description": "Common Online Data Analysis Platform",
+  "version": "2.0.0",
   "main": "apps/dg/index.html",
   "scripts": {
+    "build:cfm:comment": "echo Usage: `npm run build:cfm` builds CFM for CODAP. Assumes that CFM repository named 'cloud-file-manager' and CODAP repository named 'codap' are siblings.",
+    "build:cfm": "cd ../cloud-file-manager && npm run build:codap && cd ../codap",
+    "build:local": "sproutcore build -vv dg",
+    "build:parser:comment": "echo Usage: `npm run build:parser` uses PEG.js to build the formula parser from the grammar",
     "build:parser": "pegjs --export-var 'DG.formulaParser' 'apps/dg/formula/formulaGrammar.pegjs' 'apps/dg/formula/formulaParser.js'",
+    "clean": "rm -rf tmp",
+    "clean-and-build": "clear && npm run clean && npm run build:local",
+    "codap:comment": "echo Usage: `npm run codap` launches sc-server. Point browser at http://localhost:4020/dg or `npm run open:dev`.",
+    "codap": "sproutcore server",
+    "deploy:dev:comment": "echo Usage: `npm run deploy:dev -- {deployName}` builds and deploys CODAP to 'https://codap.concord.org/~user/deployName'",
+    "deploy:dev": "./bin/deployDevCodap",
     "lint": "eslint apps",
+    "lint:fix:comment": "echo Usage: `npm run lint:fix` runs ESLint configured to fix issues that can be fixed automatically, e.g. missing semicolons.",
+    "lint:fix": "eslint --fix apps",
+    "open:dev": "opener http://localhost:4020/dg",
+    "open:staging": "opener http://codap.concord.org/releases/staging",
+    "open:production": "opener http://codap.concord.org/releases/latest",
+    "prebuild:local": "npm run test",
+    "predeploy:dev": "npm run test",
+    "prepush": "npm run test",
+    "pretest": "npm run lint",
+    "push:comment": "echo Usage: `npm run push` pushes local commits on the current branch to the remote origin, setting up the tracking branch if necessary.",
+    "push": "git push --set-upstream origin HEAD",
+    "test:gui:comment": "echo Usage: `npm run test:gui` opens the default browser to the DG unit tests. Requires that sc-server be running.",
+    "test:gui": "opener http://localhost:4020/dg/en/current/tests.html",
+    "test:comment": "echo Usage: `npm run test` or `npm test` runs DG unit tests via PhantomJS. Does not require that sc-server be running.",
     "test": "sc-phantom --include-targets=/dg"
   },
   "repository": {
@@ -19,6 +44,7 @@
   "homepage": "http://codap.concord.org/",
   "devDependencies": {
     "eslint": "^3.9.1",
+    "opener": "^1.4.2",
     "pegjs": "=0.7.0",
     "phantomjs-prebuilt": "^2.1.13"
   }


### PR DESCRIPTION
Add NPM scripts to package.json to simplify and document various tasks, such as:
- `build:cfm` -- build CFM for CODAP
- `build:local` -- run sc-build
- `clean` -- clean the tmp directory
- `clean-and-build` -- clean the tmp directory and run sc-build
- `deploy:dev` -- run deployDevCodap script
- `lint:fix` -- run ESLint --fix which will automatically fix errors (e.g. missing semicolons) where possible
- `open:dev`, `open:staging`, `open:production` -- open a browser tab/window at the appropriate URL
- `push` -- pushes local commits on the current branch and creates the upstream tracking branch, if necessary
- `test:gui` -- open the unit tests in a browser window

These serve to both document things that are useful to know when working with CODAP (e.g. URLs for development, staging, production, and unit testing, build-related commands, etc. as well as to simplify their use. Many of the build/deploy scripts also automatically run the lint and test scripts as preconditions, making it more likely that lint and unit test failures will be caught locally.