### PR TITLE
Fixed loading of non-CODAP files [#132715321]

### DIFF
--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -455,21 +455,23 @@ DG.main = function main() {
                             cfmSharedMetadata = sharedMetadata
                                                   ? $.extend(true, {}, sharedMetadata)
                                                   : {};
+
+                        // check if this is a valid CODAP document
+                        if (!iDocContents || (iDocContents.appName !== DG.APPNAME) || !iDocContents.appVersion || !iDocContents.appBuildNum) {
+                          event.callback('DG.AppController.openDocument.error.invalid_format'.loc());
+                          return;
+                        }
+
                         DG.appController.closeAndNewDocument();
                         DG.store = DG.ModelStore.create();
                         DG.currDocumentController()
                           .setDocument(DG.Document.createDocument(iDocContents));
                         DG.set('showUserEntryView', false);
-                        if(event.callback) {
-                          // acknowledge successful open; return shared metadata
-                          event.callback(null, cfmSharedMetadata);
-                        }
+                        // acknowledge successful open; return shared metadata
+                        event.callback(null, cfmSharedMetadata);
                       },  // then() error handler
                       function(iReason) {
-                        DG.AlertPane.error({
-                          localize: true,
-                          message: 'DG.AppController.openDocument.error.general'
-                        });
+                        event.callback('DG.AppController.openDocument.error.general'.loc());
                       });
                     });
               });

--- a/apps/dg/resources/en/strings.js
+++ b/apps/dg/resources/en/strings.js
@@ -104,7 +104,8 @@ SC.stringsFor('English', {
   'DG.AppController.validateDocument.unresolvedID' : 'Unresolved id: %@1',
   'DG.AppController.validateDocument.parseError' : 'Parse error in document: %@1',
   'DG.AppController.validateDocument.invalidDocument' : 'Invalid JSON Document: %@1',
-
+  'DG.AppController.openDocument.error.general': 'Unable to open document',
+  'DG.AppController.openDocument.error.invalid_format': 'CODAP can not read this type of document',
 
   'DG.SingleTextDialog.okButton.title': "OK",
   'DG.SingleTextDialog.cancelButton.title': "Cancel",


### PR DESCRIPTION
Files without the correct app name or missing the app version or build number now return an error to the CFM which prevents their load.