### PR TITLE
Fix file drop in Import Local File dialog

### DIFF
--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -605,8 +605,7 @@ DG.main = function main() {
 
           case "importedData":
             SC.run(function() {
-              // we don't need to call the following on via == "drop" because the CODAP drop handler will also respond to the drop
-              if (event.data.file && (event.data.via === "select")) {
+              if (event.data.file) {
                 DG.appController.importFile(event.data.file.object);
               }
               else if (event.data.url && (event.data.via === "select")) {


### PR DESCRIPTION
This code used to rely on the fact that both the CFM Local File Dialog drop handler and the CODAP document drop handler would both be triggered by a file drop on the dialog. This double-dispatch was eliminated in an earlier code cleanup on the CFM side (CFM now swallows the drop event) and so the workaround in CODAP code to prevent double-handling is no longer necessary.