### PR TITLE
Function strings

### DIFF
--- a/apps/dg/resources/en/function_strings.json
+++ b/apps/dg/resources/en/function_strings.json
@@ -763,12 +763,12 @@
   },
   "percentile": {
     "displayName": "percentile",
-    "description": "Takes two arguments, the first being the desired percentile and the second the attribute for which the percentile will be computed.",
+    "description": "Takes two arguments, the first being the attribute for which the percentile will be computed, and the second being the desired percentile.",
     "args": [
       {
         "name": "constant",
         "type": "value",
-        "description": "The percentile value in the range 0 to 100, inclusive."
+        "description": "The percentile value in the range 0 to 1, inclusive."
       },
       {
         "name": "expression",
@@ -777,8 +777,8 @@
       }
     ],
     "examples": [
-      "percentile(50,Speed) is another way to compute the median for the attribute Speed",
-      "percentile(95,Score) will return the Score corresponding to the 95th percentile"
+      "percentile(Speed, .5) is another way to compute the median for the attribute Speed",
+      "percentile(Score, .95) will return the Score corresponding to the 95th percentile"
     ]
   },
   "stdDev": {

--- a/apps/dg/resources/en/function_strings.json
+++ b/apps/dg/resources/en/function_strings.json
@@ -212,8 +212,8 @@
       },
       {
         "name": "seconds",
-      "type": "number",
-      "description": "Represents the seconds of the minute, from 1 to 59."
+        "type": "number",
+        "description": "Represents the seconds of the minute, from 1 to 59."
       }
     ],
     "examples": [
@@ -236,7 +236,6 @@
     "examples": [
       "dayOfMonth(\"9/1/2016\") returns 1",
       "dayOfMonth(\"6-14-2008\") returns 14"
-
     ]
   },
   "dayOfWeek": {
@@ -536,7 +535,7 @@
         "type": "boolean",
         "description": "The specified argument."
       }
-      ],
+    ],
     "examples": [
       "boolean(age > 60) is true or false",
       "age > 60 is true or false"
@@ -664,13 +663,12 @@
       "string(\"H\"+\"i\") returns Hi"
     ]
   },
-
   /*
    * Statistical Functions
    */
   "count": {
     "displayName": "count",
-    "description": "Returns the number of cases with non-empty/non-false values for its expression argument.",
+    "description": "Returns the number of cases in the collection.",
     "args": [
       {
         "name": "expression",
@@ -680,89 +678,246 @@
       {
         "name": "filter",
         "type": "boolean",
-        "description": "An expression that determines the cases to be considered."
+        "description": "Serves as a filter for the cases that will be counted."
       }
     ],
     "examples": [
-      "count() with no arguments is interpreted differently depending on the context. In an attribute formula it returns the number of child cases. In a plotted value, it is equivalent to count(xAxisAttribute).",
-      "count(height) returns 3 if the 'height' attribute contains [1, \"yes\", true, false, \"\"].",
-      "count(height, age<18) returns 3 if the 'height' attribute contains [1, \"yes\", true, false, \"\"] for the cases with a value for the age attribute that is less than 18."
+      "count() returns the number of cases",
+      "count(Height) returns the number of cases for the attribute Height",
+      "count(Height, Age<18) returns the number of cases for the attribute Height with a value for the Age attribute that is less than 18."
     ]
   },
-  /*
-   * String Functions
-   */
-  "beginsWith": {
-    "displayName": "",
-    "description": "",
-    "examples": [
-    ]
-  },
-  "charAt": {
-    "displayName": "",
-    "description": "",
-    "examples": [
-    ]
-  },
-  "concat": {
-    "displayName": "concat",
-    "description": "Combines multiple strings into a single string.",
+  "max": {
+    "displayName": "max",
+    "description": "Returns the largest value in a collection.",
     "args": [
       {
-        "name": "str1",
-        "type": "string",
-        "description": "the first string"
+        "name": "expression",
+        "type": "any",
+        "description": "The argument for which you want the maximum value."
       },
       {
-        "name": "str2",
-        "type": "string",
-        "description": "the next string"
-      },
-      {
-        "name": "...",
-        "type": "string",
-        "description": "additional strings"
+        "name": "filter",
+        "type": "boolean",
+        "description": "Serves as a filter for the cases that will be counted."
       }
     ],
     "examples": [
+      "max(Age) returns the maximum age",
+      "max(Age, Sex=\"Female\") returns maximum age among females"
     ]
   },
-  "endsWith": {
-    "displayName": "",
-    "description": "",
-    "examples": [
-    ]
-  },
-  "join": {
-    "displayName": "join",
-    "description": "Combines multiple strings into a single string with a delimiter.",
+  "mean": {
+    "displayName": "mean",
+    "description": "Returns the arithmetic mean (sum divided by count) of its argument evaluated for every case.",
     "args": [
       {
-        "name": "delimiter",
-        "type": "string",
-        "description": "the string used to separate the other strings"
+        "name": "mu",
+        "type": "any",
+        "description": "The argument for which you want to compute the mean."
       },
       {
-        "name": "str1",
-        "type": "string",
-        "description": "the first string"
-      },
-      {
-        "name": "str2",
-        "type": "string",
-        "description": "the next string"
-      },
-      {
-        "name": "...",
-        "type": "string",
-        "description": "additional strings"
+        "name": "filter",
+        "type": "boolean",
+        "description": "Serves as a filter for the cases that will be counted."
       }
     ],
     "examples": [
+      "mean(Height) computes the mean of the attribute Height",
+      "mean(Height, Sex = \"F\") computes the mean Height of females"
     ]
-  }
+  },
+  "median": {
+    "displayName": "median",
+    "description": "Returns the median. Half the values of the attribute will be above this and half will be below.",
+    "args": [
+      {
+        "name": "expression",
+        "type": "any",
+        "description": "The argument for which you want to compute the median."
+      }
+    ],
+    "examples": [
+      "median(Height) computes the median of the attribute Height"
+    ]
+  },
+  "min": {
+    "displayName": "min",
+    "description": "Returns the smallest value in a collection.",
+    "args": [
+      {
+        "name": "expression",
+        "type": "any",
+        "description": "The argument for which you want the minimum value."
+      },
+      {
+        "name": "filter",
+        "type": "boolean",
+        "description": "Serves as a filter for the cases that will be counted."
+      }
+    ],
+    "examples": [
+      "min(Age) returns the maximum Age",
+      "min(Age, Sex=\"Male\") returns minimum age among males"
+    ]
+  },
+  "percentile": {
+    "displayName": "percentile",
+    "description": "Takes two arguments, the first being the desired percentile and the second the attribute for which the percentile will be computed.",
+    "args": [
+      {
+        "name": "constant",
+        "type": "value",
+        "description": "The percentile value in the range 0 to 100, inclusive."
+      },
+      {
+        "name": "expression",
+        "type": "attribute",
+        "description": "The attribute of the percentile that will be calculated."
+      }
+    ],
+    "examples": [
+      "percentile(50,Speed) is another way to compute the median for the attribute Speed",
+      "percentile(95,Score) will return the Score corresponding to the 95th percentile"
+    ]
+  },
+  "stdDev": {
+    "displayName": "stdDev",
+    "description": "Computes the sample standard deviation.",
+    "args": [
+      {
+        "name": "value",
+        "type": "attribute",
+        "description": "The attribute for which you want to find the standard deviation."
+      }
+    ],
+    "examples": [
+      "stdDev(Pressure) computes the sample standard deviation of the attribute Pressure"
+    ]
+  },
+  "stdErr": {
+    "displayName": "stdErr",
+    "description": "Returns the standard error.",
+    "args": [
+      {
+        "name": "value",
+        "type": "attribute",
+        "description": "The attribute for which you want to find the standard error."
+      }
+    ],
+    "examples": [
+      "stdError(Score) computes the sample standard error of the attribute Score"
+    ]
+  },
+  "sum": {
+    "displayName": "sum",
+    "description": "Returns the sum of its argument evaluated for every case.",
+    "args": [
+      {
+        "name": "expression",
+        "type": "any",
+        "description": "The attribute for which you want to find the sum."
+      },
+      {
+        "name": "filter",
+        "type": "expression",
+        "description": "Additional filter, numbers, or ranges for which you want the first case."
+      }
+    ],
+    "examples": [
+      "sum(grade_point) computes the sum of the grade points",
+      "sum(Mass, Height>60) returns the sum of the masses for heights taller than 60"
+    ]
+  },
+  "variance": {
+    "displayName": "variance",
+    "description": "Computes the variance of an attribute, that is, the square of the standard deviation.",
+    "args": [
+      {
+        "name": "expression",
+        "type": "attribute",
+        "description": "The attribute for which you want to find the variance."
+      }
+    ],
+    "examples": [
+      "variance(test_scores) computes the variance of the test scores",
+      "variance(Before-After) computes the variance of the difference of the two attributes Before and After"
+    ]
+  },
+/*
+ * String Functions
+ */
+"beginsWith": {
+"displayName": "",
+"description": "",
+"examples": [
+]
+},
+"charAt": {
+"displayName": "",
+"description": "",
+"examples": [
+]
+},
+"concat": {
+"displayName": "concat",
+"description": "Combines multiple strings into a single string.",
+"args": [
+{
+"name": "str1",
+"type": "string",
+"description": "the first string"
+},
+{
+"name": "str2",
+"type": "string",
+"description": "the next string"
+},
+{
+"name": "...",
+"type": "string",
+"description": "additional strings"
+}
+],
+"examples": [
+]
+},
+"endsWith": {
+"displayName": "",
+"description": "",
+"examples": [
+]
+},
+"join": {
+"displayName": "join",
+"description": "Combines multiple strings into a single string with a delimiter.",
+"args": [
+{
+"name": "delimiter",
+"type": "string",
+"description": "the string used to separate the other strings"
+},
+{
+"name": "str1",
+"type": "string",
+"description": "the first string"
+},
+{
+"name": "str2",
+"type": "string",
+"description": "the next string"
+},
+{
+"name": "...",
+"type": "string",
+"description": "additional strings"
+}
+],
+"examples": [
+]
+}
 
-  /*
-   * Trigonometric Functions
-   */
+/*
+ * Trigonometric Functions
+ */
 }

--- a/apps/dg/resources/en/function_strings.json
+++ b/apps/dg/resources/en/function_strings.json
@@ -8,28 +8,27 @@
    */
   "abs": {
     "displayName": "abs",
-    "description": "Returns the absolute value of its numeric argument.",
+    "description": "Computes the absolute value of its argument. This is equivalent to using the absolute value bars.",
     "args": [
       {
         "name": "number",
         "type": "number",
-        "description": "a numeric value"
+        "description": "The number of which you want the absolute value."
       }
     ],
     "examples": [
-      "abs(-1) returns 1",
-      "abs(speed) returns 10 when speed is -10 or 10"
+      "abs(3 – 5) is 2",
+      "abs(3-7) = |3 – 7|=4"
     ]
   },
-
   "ceil": {
     "displayName": "ceil",
-    "description": "Returns the smallest integer greater than or equal to its numeric argument.",
+    "description": "Returns the closest integer greater than or equal to its argument.",
     "args": [
       {
         "name": "number",
         "type": "number",
-        "description": "a numeric value"
+        "description": "The number that should be rounded up."
       }
     ],
     "examples": [
@@ -38,7 +37,6 @@
       "ceil(-1.5) returns -1"
     ]
   },
-
   "exp": {
     "displayName": "exp",
     "description": "Returns the result of computing the constant e to the power of its numeric argument.",
@@ -46,13 +44,13 @@
       {
         "name": "number",
         "type": "number",
-        "description": "a numeric value"
+        "description": "The exponent applied to the base e."
       }
     ],
     "examples": [
+      "exp(2) is 7.39, the same as e squared"
     ]
   },
-
   "floor": {
     "displayName": "floor",
     "description": "Returns the largest integer less than or equal to its numeric argument.",
@@ -60,7 +58,7 @@
       {
         "name": "number",
         "type": "number",
-        "description": "a numeric value"
+        "description": "The number that should be rounded down."
       }
     ],
     "examples": [
@@ -69,56 +67,117 @@
       "floor(-1.5) returns -2"
     ]
   },
-
   "frac": {
-    "displayName": "",
-    "description": "",
+    "displayName": "frac",
+    "description": "Returns the fractional or noninteger part of a number x.",
+    "args": [
+      {
+        "name": "number",
+        "type": "number",
+        "description": "The number for which you want the fractional part."
+      }
+    ],
     "examples": [
+      "frac(1.5) returns 0.5",
+      "frac(-2.3) returns -0.3"
     ]
   },
-
   "ln": {
-    "displayName": "",
-    "description": "",
+    "displayName": "ln",
+    "description": "Returns the logarithm of a number to base e.",
+    "args": [
+      {
+        "name": "number",
+        "type": "number",
+        "description": "The number for which you want the natural logarithm."
+      }
+    ],
     "examples": [
+      "ln(100) is 4.61"
     ]
   },
-
   "log": {
-    "displayName": "",
-    "description": "",
+    "displayName": "log",
+    "description": "Returns the logarithm of a number to base 10.",
+    "args": [
+      {
+        "name": "number",
+        "type": "number",
+        "description": "The number for which you want the logarithm."
+      }
+    ],
     "examples": [
+      "log(100) is 2"
     ]
   },
-
   "pow": {
-    "displayName": "",
-    "description": "",
+    "displayName": "pow",
+    "description": "Returns the result of a number raised to a power.",
+    "args": [
+      {
+        "name": "number",
+        "type": "number",
+        "description": "The base number."
+      },
+      {
+        "name": "power",
+        "type": "number",
+        "description": "The power of the exponent."
+      }
+    ],
     "examples": [
+      "pow(2,5) is 2 to the 5, returns 32"
     ]
   },
-
   "round": {
-    "displayName": "",
-    "description": "",
+    "displayName": "round",
+    "description": "Returns the value of its argument rounded to the specified number of decimal places (default 0). This function has an optional, second argument that specifies how many decimals to round to.",
+    "args": [
+      {
+        "name": "number",
+        "type": "number",
+        "description": "The number for which you want to round to the nearest integer."
+      },
+      {
+        "name": "digits",
+        "type": "number",
+        "description": "The number of digits to the right of the decimal point. The argument can be negative to round off digits left to the decimal point."
+      }
+    ],
     "examples": [
+      "round(3.14) is 3",
+      "round(π, 4) is 3.1416",
+      "round(1234, –2) is 1200"
     ]
   },
-
   "sqrt": {
-    "displayName": "",
-    "description": "",
+    "displayName": "sqrt",
+    "description": "Returns the square root of its numeric argument.",
+    "args": [
+      {
+        "name": "number",
+        "type": "number",
+        "description": "The number for which you want the square root."
+      }
+    ],
     "examples": [
+      "sqrt(100) returns 10"
     ]
   },
-
   "trunc": {
-    "displayName": "",
-    "description": "",
+    "displayName": "round",
+    "description": "Returns the nearest integer equal to or smaller in magnitude (closer to zero) than its argument.",
+    "args": [
+      {
+        "name": "number",
+        "type": "number",
+        "description": "The number to truncate."
+      }
+    ],
     "examples": [
+      " trunc(5.5) returns 5"
     ]
   },
-
   /*
    * Date/Time Functions
    */
@@ -128,7 +187,6 @@
     "examples": [
     ]
   },
-
   /*
    * Lookup Functions
    */
@@ -138,7 +196,6 @@
     "examples": [
     ]
   },
-
   /*
    * Other Functions
    */
@@ -148,7 +205,6 @@
     "examples": [
     ]
   },
-
   /*
    * Statistical Functions
    */
@@ -173,7 +229,6 @@
       "count(height, age<18) returns 3 if the 'height' attribute contains [1, \"yes\", true, false, \"\"] for the cases with a value for the age attribute that is less than 18."
     ]
   },
-
   /*
    * String Functions
    */
@@ -183,14 +238,12 @@
     "examples": [
     ]
   },
-
   "charAt": {
     "displayName": "",
     "description": "",
     "examples": [
     ]
   },
-
   "concat": {
     "displayName": "concat",
     "description": "Combines multiple strings into a single string.",
@@ -214,14 +267,12 @@
     "examples": [
     ]
   },
-
   "endsWith": {
     "displayName": "",
     "description": "",
     "examples": [
     ]
   },
-
   "join": {
     "displayName": "join",
     "description": "Combines multiple strings into a single string with a delimiter.",

--- a/apps/dg/resources/en/function_strings.json
+++ b/apps/dg/resources/en/function_strings.json
@@ -28,7 +28,7 @@
       {
         "name": "number",
         "type": "number",
-        "description": "The number that should be rounded up."
+        "description": "The value you want to round up."
       }
     ],
     "examples": [
@@ -58,7 +58,7 @@
       {
         "name": "number",
         "type": "number",
-        "description": "The number that should be rounded down."
+        "description": "The value you want to round."
       }
     ],
     "examples": [
@@ -69,7 +69,7 @@
   },
   "frac": {
     "displayName": "frac",
-    "description": "Returns the fractional or noninteger part of a number x.",
+    "description": "Returns the fractional or noninteger part of a number.",
     "args": [
       {
         "name": "number",
@@ -141,7 +141,7 @@
       {
         "name": "digits",
         "type": "number",
-        "description": "The number of digits to the right of the decimal point. The argument can be negative to round off digits left to the decimal point."
+        "description": "The number of digits to which you want to round the numeric argument. The argument can be negative to round off digits left to the decimal point."
       }
     ],
     "examples": [
@@ -264,7 +264,7 @@
       }
     ],
     "examples": [
-      "If the date is Aug 31, 2005, dayOfWeek(\"8-31-2005\") returns the string Wednesday"
+      "If the date is Aug 31, 2005, dayOfWeek(\"8-31-2005\") returns Wednesday"
     ]
   },
   "hours": {
@@ -274,11 +274,11 @@
       {
         "name": "date_time",
         "type": "string",
-        "description": "The specified date. Note that this needs to be inputted as a string."
+        "description": "The specified date and time. Note that this needs to be inputted as a string."
       }
     ],
     "examples": [
-      "If date_time is 8:57 PM on Aug 31, 2005, hours(\"8-31-2005 8:57 PM\") returns 20"
+      "If the date is 8:57 PM on Aug 31, 2005, hours(\"8-31-2005 8:57 PM\") returns 20"
     ]
   },
   "minutes": {
@@ -288,7 +288,7 @@
       {
         "name": "date_time",
         "type": "string",
-        "description": "The specified date. Note that this needs to be inputted as a string."
+        "description": "The specified date and time. Note that this needs to be inputted as a string."
       }
     ],
     "examples": [
@@ -300,13 +300,13 @@
     "description": "Returns the number of the month corresponding to the given date.",
     "args": [
       {
-        "name": "date_time",
+        "name": "date",
         "type": "string",
         "description": "The specified date. Note that this needs to be inputted as a string."
       }
     ],
     "examples": [
-      "If date_time is 3:30 PM on Aug 31, 2005, month(\"8-31-2005 3:30 PM\") returns 8"
+      "If the date is Aug 31, 2005, month(\"8-31-2005\") returns 8"
     ]
   },
   "monthName": {
@@ -314,18 +314,23 @@
     "description": "Returns the name of the month corresponding to the given date.",
     "args": [
       {
-        "name": "date_time",
+        "name": "date",
         "type": "string",
         "description": "The specified date. Note that this needs to be inputted as a string."
       }
     ],
     "examples": [
-      "If date_time is 3:30 PM on Aug 31, 2005, monthName(\"8-31-2005 8:57 PM\") returns the string August"
+      "If the date is Aug 31, 2005, monthName(\"8-31-2005\") returns August"
     ]
   },
   "now": {
     "displayName": "now",
     "description": "Returns the current date and time.",
+    "args": [
+      {
+        "description": "There are no parameters for this function."
+      }
+    ],
     "examples": [
       "If the current date and time is 3:30:51 PM on Aug 31, 2005, now() returns 8/31/2005 3:30:51 PM"
     ]
@@ -337,7 +342,7 @@
       {
         "name": "date_time",
         "type": "string",
-        "description": "The specified date. Note that this needs to be inputted as a string."
+        "description": "The specified date and time. Note that this needs to be inputted as a string."
       }
     ],
     "examples": [
@@ -347,6 +352,11 @@
   "today": {
     "displayName": "today",
     "description": "Returns current date with no time.",
+    "args": [
+      {
+        "description": "There are no parameters for this function."
+      }
+    ],
     "examples": [
       "If today's date is December 20, 2016, today() returns 12/20/2016"
     ]
@@ -358,7 +368,7 @@
       {
         "name": "date_time",
         "type": "string",
-        "description": "The specified date. Note that this needs to be inputted as a string."
+        "description": "The specified date and time. Note that this needs to be inputted as a string."
       }
     ],
     "examples": [
@@ -370,9 +380,146 @@
    * Lookup Functions
    */
   "first": {
-    "displayName": "",
-    "description": "",
+    "displayName": "first",
+    "description": "Returns the value of its argument evaluated for the first case.",
+    "args": [
+      {
+        "name": "attribute",
+        "type": "attribute",
+        "description": "The specified attribute."
+      },
+      {
+        "name": "filter",
+        "type": "filter",
+        "description": "Additional filter, numbers, or ranges for which you want the first case."
+      }
+    ],
     "examples": [
+      "first(population) returns the first value of the attribute population",
+      "first(population,sex=\"female\") returns the first value for the attribute population for which the attribute sex is female"
+    ]
+  },
+  "last": {
+    "displayName": "last",
+    "description": "Returns the value of its argument evaluated for the last case.",
+    "args": [
+      {
+        "name": "attribute",
+        "type": "attribute",
+        "description": "The specified attribute."
+      },
+      {
+        "name": "filter",
+        "type": "filter",
+        "description": "Additional filter, numbers, or ranges for which you want the last case."
+      }
+    ],
+    "examples": [
+      "last(amountInBank) returns the last value of the attribute amountInBank",
+      "last(amountInBank, year>2010) returns the last value for the attribute amountInBank for which the year is greater than 2010"
+    ]
+  },
+  "lookupByIndex": {
+    "displayName": "lookupByIndex",
+    "description": "Returns the value of the specified attribute for the case at the specified (1-based) index in the data set name. Note that dataSetName and attributeName must be strings (or expressions that evaluate to strings), while index should evaluate to an integer.",
+    "args": [
+      {
+        "name": "\"remoteDataSetName\"",
+        "type": "data set",
+        "description": "The data set where you want to look up the value."
+      },
+      {
+        "name": "\"remoteAttributeName\"",
+        "type": "attribute",
+        "description": "The attribute in the data set containing the return value."
+      },
+      {
+        "name": "index",
+        "type": "number",
+        "description": "The index point of the data set."
+      }
+    ],
+    "examples": [
+      "lookupByIndex(\"United_States\", \"Full_state_name\", index) looks up the attribute Full_state_name in the United_States data set at the index point. It then returns Full_state_name in your data set."
+    ]
+  },
+  "lookupByKey": {
+    "displayName": "lookupByKey",
+    "description": "Returns the value of the specified returned attribute for the case with the specified keyValue as its value for the keyAttributeName attribute in the specified data set.",
+    "args": [
+      {
+        "name": "\"remoteDataSetName\"",
+        "type": "data set",
+        "description": "The data set where you want to look up the value."
+      },
+      {
+        "name": "\"remoteAttributeName\"",
+        "type": "attribute",
+        "description": "The attribute in the data set containing the return value."
+      },
+      {
+        "name": "\"keyAttributeName\"",
+        "type": "attribute",
+        "description": "The matching attribute in the returning data set."
+      },
+      {
+        "name": "keyValue",
+        "type": "attribute",
+        "description": "The result attribute to return."
+      }
+    ],
+    "examples": [
+      "lookupByKey(\"United_States\", \"State_abbreviations1\", \"State_abbreviations2\", Full_state_name) looks up the states in the data set \"United_States.\" The attribute \"State_abbreviations1\" from the first data set matches the attribute \"State_abbreviations2\" from the second data set. The function looks up the states \"CA,\" \"WA,\" \"OR\" and returns \"California,\" \"Washington,\" \"Oregon.\""
+    ]
+  },
+  "next": {
+    "displayName": "next",
+    "description": "Returns the value of that expression for the next case.",
+    "args": [
+      {
+        "name": "attribute",
+        "type": "attribute",
+        "description": "The specified attribute."
+      },
+      {
+        "name": "filter",
+        "type": "filter",
+        "description": "Additional filter, numbers, or ranges for which you want the next case."
+      },
+      {
+        "name": "filter",
+        "type": "filter",
+        "description": "Additional filter, numbers, or ranges for which you want the next case."
+      }
+    ],
+    "examples": [
+      "next(number) is 10",
+      "next(number, City=\"Tucson\") returns the next value for the attribute number for which the attribute City is Tucson"
+    ]
+  },
+  "prev": {
+    "displayName": "prev",
+    "description": "Returns the value of that expression for the previous case.",
+    "args": [
+      {
+        "name": "attribute",
+        "type": "attribute",
+        "description": "The specified attribute."
+      },
+      {
+        "name": "filter",
+        "type": "filter",
+        "description": "Additional filter, numbers, or ranges for which you want the previous case."
+      },
+      {
+        "name": "filter",
+        "type": "filter",
+        "description": "Additional filter, numbers, or ranges for which you want the previous case."
+      }
+    ],
+    "examples": [
+      "prev(height) returns 9",
+      "prev(height, sex=\"female\") returns the previous value for the attribute height for which the attribute sex is female"
     ]
   },
   /*

--- a/apps/dg/resources/en/function_strings.json
+++ b/apps/dg/resources/en/function_strings.json
@@ -182,9 +182,188 @@
    * Date/Time Functions
    */
   "date": {
-    "displayName": "",
-    "description": "",
+    "displayName": "date",
+    "description": "Returns a new date created from its arguments. If any argument is omitted it is defaulted to 0 (or 1 for the day). If a single large argument is specified, it is assumed to be seconds since January 1, 1970 and is converted accordingly.",
+    "args": [
+      {
+        "name": "year",
+        "type": "number",
+        "description": "Represents the year of the date. This can be a 1-digit, 2-digit, 3-digit, or 4-digit number."
+      },
+      {
+        "name": "month",
+        "type": "number",
+        "description": "Represents the month of the year, from 1 to 12."
+      },
+      {
+        "name": "day",
+        "type": "number",
+        "description": "Represents the day of the month, from 1 to 31."
+      },
+      {
+        "name": "hour",
+        "type": "number",
+        "description": "Represents the hour of the day, from 1 to 23."
+      },
+      {
+        "name": "minute",
+        "type": "number",
+        "description": "Represents the minutes of the hour, from 1 to 59."
+      },
+      {
+        "name": "seconds",
+      "type": "number",
+      "description": "Represents the seconds of the minute, from 1 to 59."
+      }
+    ],
     "examples": [
+      "date(1969, 7, 16) returns 7/16/1969",
+      "date(1395154345) returns 3/18/2014 7:52:25 AM",
+      "date(2016, 12, 19, 13, 59, 15, 26) returns 12/19/2016 1:59:15 PM",
+      "date(16) returns 1/1/2016"
+    ]
+  },
+  "dayOfMonth": {
+    "displayName": "dayOfMonth",
+    "description": "Returns the day of the month corresponding to the given date.",
+    "args": [
+      {
+        "name": "date",
+        "type": "string",
+        "description": "The specified date. Note that this needs to be inputted as a string."
+      }
+    ],
+    "examples": [
+      "dayOfMonth(\"9/1/2016\") returns 1",
+      "dayOfMonth(\"6-14-2008\") returns 14"
+
+    ]
+  },
+  "dayOfWeek": {
+    "displayName": "dayOfWeek",
+    "description": "Returns the numeric day of the week corresponding to the given date.",
+    "args": [
+      {
+        "name": "date",
+        "type": "string",
+        "description": "The specified date. Note that this needs to be inputted as a string."
+      }
+    ],
+    "examples": [
+      "If the date is Aug 31, 2005, dayOfWeek(\"8-31-2005\") returns 4 because August 31, 2005 is a Wednesday"
+    ]
+  },
+  "dayOfWeekName": {
+    "displayName": "dayOfWeekName",
+    "description": "Returns the word name of the day of the week corresponding to the given date. ",
+    "args": [
+      {
+        "name": "date",
+        "type": "string",
+        "description": "The specified date. Note that this needs to be inputted as a string."
+      }
+    ],
+    "examples": [
+      "If the date is Aug 31, 2005, dayOfWeek(\"8-31-2005\") returns the string Wednesday"
+    ]
+  },
+  "hours": {
+    "displayName": "hours",
+    "description": "Returns the hour of the day corresponding to the given date.",
+    "args": [
+      {
+        "name": "date_time",
+        "type": "string",
+        "description": "The specified date. Note that this needs to be inputted as a string."
+      }
+    ],
+    "examples": [
+      "If date_time is 8:57 PM on Aug 31, 2005, hours(\"8-31-2005 8:57 PM\") returns 20"
+    ]
+  },
+  "minutes": {
+    "displayName": "minutes",
+    "description": "Returns the minute of the hour corresponding to the given date.",
+    "args": [
+      {
+        "name": "date_time",
+        "type": "string",
+        "description": "The specified date. Note that this needs to be inputted as a string."
+      }
+    ],
+    "examples": [
+      "If date_time is 8:57 PM on Aug 31, 2005, minutes(\"8-31-2005 8:57 PM\") returns 57"
+    ]
+  },
+  "month": {
+    "displayName": "month",
+    "description": "Returns the number of the month corresponding to the given date.",
+    "args": [
+      {
+        "name": "date_time",
+        "type": "string",
+        "description": "The specified date. Note that this needs to be inputted as a string."
+      }
+    ],
+    "examples": [
+      "If date_time is 3:30 PM on Aug 31, 2005, month(\"8-31-2005 3:30 PM\") returns 8"
+    ]
+  },
+  "monthName": {
+    "displayName": "month",
+    "description": "Returns the name of the month corresponding to the given date.",
+    "args": [
+      {
+        "name": "date_time",
+        "type": "string",
+        "description": "The specified date. Note that this needs to be inputted as a string."
+      }
+    ],
+    "examples": [
+      "If date_time is 3:30 PM on Aug 31, 2005, monthName(\"8-31-2005 8:57 PM\") returns the string August"
+    ]
+  },
+  "now": {
+    "displayName": "now",
+    "description": "Returns the current date and time.",
+    "examples": [
+      "If the current date and time is 3:30:51 PM on Aug 31, 2005, now() returns 8/31/2005 3:30:51 PM"
+    ]
+  },
+  "seconds": {
+    "displayName": "seconds",
+    "description": "Returns the seconds of the minute corresponding to the given date.",
+    "args": [
+      {
+        "name": "date_time",
+        "type": "string",
+        "description": "The specified date. Note that this needs to be inputted as a string."
+      }
+    ],
+    "examples": [
+      "If the date is 3:30:51 PM on Aug 31, 2005, seconds(\"8-31-2005 3:30:51 PM\") returns 51"
+    ]
+  },
+  "today": {
+    "displayName": "today",
+    "description": "Returns current date with no time.",
+    "examples": [
+      "If today's date is December 20, 2016, today() returns 12/20/2016"
+    ]
+  },
+  "year": {
+    "displayName": "year",
+    "description": "Returns the year corresponding to the given date.",
+    "args": [
+      {
+        "name": "date_time",
+        "type": "string",
+        "description": "The specified date. Note that this needs to be inputted as a string."
+      }
+    ],
+    "examples": [
+      "If the date is 3:30 PM on Aug 31, 2005, year(\"8-31-2005 3:30 PM\") returns 2005",
+      "year(\"8/25/1492\") returns 1492"
     ]
   },
   /*

--- a/apps/dg/resources/en/function_strings.json
+++ b/apps/dg/resources/en/function_strings.json
@@ -425,22 +425,23 @@
     "args": [
       {
         "name": "\"remoteDataSetName\"",
-        "type": "data set",
-        "description": "The data set where you want to look up the value."
+        "type": "string",
+        "description": "The collection where you want to look up the value."
       },
       {
         "name": "\"remoteAttributeName\"",
         "type": "attribute",
-        "description": "The attribute in the data set containing the return value."
+        "description": "The name of the attribute in the collection containing the return value."
       },
       {
         "name": "index",
         "type": "number",
-        "description": "The index point of the data set."
+        "description": "The index of a case in that collection."
       }
     ],
     "examples": [
-      "lookupByIndex(\"United_States\", \"Full_state_name\", index) looks up the attribute Full_state_name in the United_States data set at the index point. It then returns Full_state_name in your data set."
+      "lookupByIndex(\"United_States\", \"Full_state_name\", index) looks up the attribute Full_state_name in the United_States data set at the index point. It then returns Full_state_name in your data set",
+      "In a document that has a collection States, lookupValueByIndex(\"States\", \"Name\", 3) would give \"Arizona\" as the result"
     ]
   },
   "lookupByKey": {
@@ -449,27 +450,28 @@
     "args": [
       {
         "name": "\"remoteDataSetName\"",
-        "type": "data set",
-        "description": "The data set where you want to look up the value."
+        "type": "string",
+        "description": "The collection where you want to look up the value."
       },
       {
         "name": "\"remoteAttributeName\"",
-        "type": "attribute",
-        "description": "The attribute in the data set containing the return value."
+        "type": "string",
+        "description": "The name of an attribute whose value is to be looked up in that collection."
       },
       {
         "name": "\"keyAttributeName\"",
-        "type": "attribute",
-        "description": "The matching attribute in the returning data set."
+        "type": "string",
+        "description": "The name of an attribute to be used as a \"key\" into the collection."
       },
       {
         "name": "keyValue",
-        "type": "attribute",
-        "description": "The result attribute to return."
+        "type": "value",
+        "description": "The value to be matched with the key."
       }
     ],
     "examples": [
-      "lookupByKey(\"United_States\", \"State_abbreviations1\", \"State_abbreviations2\", Full_state_name) looks up the states in the data set \"United_States.\" The attribute \"State_abbreviations1\" from the first data set matches the attribute \"State_abbreviations2\" from the second data set. The function looks up the states \"CA,\" \"WA,\" \"OR\" and returns \"California,\" \"Washington,\" \"Oregon.\""
+      "lookupByKey(\"States\", \"Population\", \"State\", \"CA\") would return 39000000, the result of looking up the population for California in a collection of states",
+      "lookupByKey(\"United_States\", \"State_abbreviations1\", \"State_abbreviations2\", Full_state_name) looks up the states in the data set \"United_States.\" The attribute \"State_abbreviations1\" from the first data set matches the attribute \"State_abbreviations2\" from the second data set. The function looks up the states \"CA,\" \"WA,\" \"OR\" and returns \"California,\" \"Washington,\" \"Oregon\""
     ]
   },
   "next": {
@@ -526,11 +528,143 @@
    * Other Functions
    */
   "boolean": {
-    "displayName": "",
-    "description": "",
+    "displayName": "boolean",
+    "description": "Returns the condition true if the conditions in a test are true and false otherwise.",
+    "args": [
+      {
+        "name": "argument",
+        "type": "boolean",
+        "description": "The specified argument."
+      }
+      ],
     "examples": [
+      "boolean(age > 60) is true or false",
+      "age > 60 is true or false"
     ]
   },
+  "greatCircleDistance": {
+    "displayName": "greatCircleDistance",
+    "description": "Returns the shortest distance between two latitude and longitude points on the surface of the earth.",
+    "args": [
+      {
+        "name": "latitude1",
+        "type": "latitude",
+        "description": "The latitude of the first point."
+      },
+      {
+        "name": "longitude1",
+        "type": "longitude",
+        "description": "The longitude of the first point."
+      },
+      {
+        "name": "latitude2",
+        "type": "latitude",
+        "description": "The latitude of the second point."
+      },
+      {
+        "name": "longitude2",
+        "type": "longitude",
+        "description": "The longitude of the second point."
+      }
+    ],
+    "examples": [
+      "greatCircleDistance(latitude1, longitude1, latitude2, longitude2) returns 112.98"
+    ]
+  },
+  "if": {
+    "displayName": "if",
+    "description": "Creates an “if” block. If the expression in parentheses after if is true, the formula returns the upper value; if not, it returns the lower.",
+    "args": [
+      {
+        "name": "logical_test",
+        "type": "statement",
+        "description": "The logical test of the if statement"
+      },
+      {
+        "name": "value_if_true",
+        "type": "statement",
+        "description": "The value of the if statement if the result is true."
+      },
+      {
+        "name": "value_if_false",
+        "type": "statement",
+        "description": "The value of the if statement if the result is false."
+      }
+    ],
+    "examples": [
+      "if(Speed>40,\"Fast\",\"Slow\") says if the speed is greater than 40, return \"Fast\", otherwise return \"Slow\"",
+      "Speed>40?\"Fast\":\"Slow\" is the same statement as above"
+    ]
+  },
+  "isFinite": {
+    "displayName": "isFinite",
+    "description": "Checks whether a number is a finite number.",
+    "args": [
+      {
+        "name": "value",
+        "type": "value",
+        "description": "The value to be tested"
+      }
+    ],
+    "examples": [
+      "isFinite(5) returns true",
+      "isFinite(5 - 9) returns true",
+      "isFinite(\"123\") returns false",
+      "isFinite(\"Hi\") returns false"
+    ]
+  },
+  "number": {
+    "displayName": "number",
+    "description": "Converts the input value to a numeric value.",
+    "args": [
+      {
+        "name": "value",
+        "type": "value",
+        "description": "The text to be converted to a number."
+      }
+    ],
+    "examples": [
+      "number(\"45\") returns 45",
+      "number(2.00) returns 2"
+    ]
+  },
+  "random": {
+    "displayName": "random",
+    "description": "Returns a random number drawn from a uniform distribution.",
+    "args": [
+      {
+        "name": "min",
+        "type": "value",
+        "description": "The smallest number random() will return."
+      },
+      {
+        "name": "max",
+        "type": "value",
+        "description": "The largest number random() will return."
+      }
+    ],
+    "examples": [
+      "random() will return a random number between 0 and 1",
+      "random(100) will return a random number between 0 and 100",
+      "random(1, 100) will return a random number between 1 and 100"
+    ]
+  },
+  "string": {
+    "displayName": "string",
+    "description": "Converts the input value to a string.",
+    "args": [
+      {
+        "name": "value",
+        "type": "value",
+        "description": "The text to be converted to a string."
+      }
+    ],
+    "examples": [
+      "string(45) returns the string 45",
+      "string(\"H\"+\"i\") returns Hi"
+    ]
+  },
+
   /*
    * Statistical Functions
    */

--- a/apps/dg/resources/en/function_strings.json
+++ b/apps/dg/resources/en/function_strings.json
@@ -1185,8 +1185,111 @@
       "trim(\" Fall Semester \") removes the unwanted first and last characters in the string and returns \"Fall Semester\"",
       "trim(\"First sentence.  Second sentence\") removes the extra space between the two sentences and returns \"First sentence. Second sentence.\""
     ]
-  }
+  },
   /*
  * Trigonometric Functions
  */
+  "acos": {
+    "displayName": "acos",
+    "description": "Returns the angle in radians that corresponds to the specified arccosine value [–1, 1].",
+    "args": [
+      {
+        "name": "radians",
+        "type": "number",
+        "description": "The arccosine of the angle you want, must be from -1 to 1."
+      }
+    ],
+    "examples": [
+      "acos(1) returns 0 radians"
+    ]
+  },
+  "asin": {
+    "displayName": "asin",
+    "description": "Returns the angle in radians that corresponds to the specified arcsine value [–1, 1].",
+    "args": [
+      {
+        "name": "radians",
+        "type": "number",
+        "description": "The arcsine of the angle you want, must be from -1 to 1."
+      }
+    ],
+    "examples": [
+      "asin(1) returns 1.57, pi/2 radians"
+    ]
+  },
+  "atan": {
+    "displayName": "atan",
+    "description": "Returns the angle in radians that corresponds to the specified arctangent value [–1, 1].",
+    "args": [
+      {
+        "name": "radians",
+        "type": "number",
+        "description": "The arctangent of the angle you want, must be from -1 to 1."
+      }
+    ],
+    "examples": [
+      "atan(1) returns 0.79, pi/4 radians"
+    ]
+  },
+  "atan2": {
+    "displayName": "atan2",
+    "description": "Returns the angle in radians between the x-axis and the specified coordinate point.",
+    "args": [
+      {
+        "name": "x",
+        "type": "number",
+        "description": "The x-value of the coordinate point."
+      },
+      {
+        "name": "y",
+        "type": "number",
+        "description": "The y-value of the coordinate point."
+      }
+    ],
+    "examples": [
+      "atan2(1,1) returns 0.79, pi/4 radians"
+    ]
+  },
+  "cos": {
+    "displayName": "cos",
+    "description": "Returns the angle in radians that corresponds to the specified cosine value [–1, 1].",
+    "args": [
+      {
+        "name": "radians",
+        "type": "number",
+        "description": "The arctangent of the angle you want, must be from -1 to 1."
+      }
+    ],
+    "examples": [
+      "cos(0.5) returns 0.88 radians"
+    ]
+  },
+  "sin": {
+    "displayName": "sin",
+    "description": "Returns the angle in radians that corresponds to the specified sine value [–1, 1].",
+    "args": [
+      {
+        "name": "radians",
+        "type": "number",
+        "description": "The sine of the angle you want, must be from -1 to 1."
+      }
+    ],
+    "examples": [
+      "sin(pi/2) returns 1"
+    ]
+  },
+  "tan": {
+    "displayName": "tan",
+    "description": "Returns the angle in radians that corresponds to the specified tangent value [–1, 1].",
+    "args": [
+      {
+        "name": "radians",
+        "type": "number",
+        "description": "The tangent of the angle you want, must be from -1 to 1."
+      }
+    ],
+    "examples": [
+      "tan(pi/4) returns 1"
+    ]
+  }
 }

--- a/apps/dg/resources/en/function_strings.json
+++ b/apps/dg/resources/en/function_strings.json
@@ -271,7 +271,7 @@
     "description": "Returns the hour of the day corresponding to the given date.",
     "args": [
       {
-        "name": "date_time",
+        "name": "dateTime",
         "type": "string",
         "description": "The specified date and time. Note that this needs to be inputted as a string."
       }
@@ -285,13 +285,13 @@
     "description": "Returns the minute of the hour corresponding to the given date.",
     "args": [
       {
-        "name": "date_time",
+        "name": "dateTime",
         "type": "string",
         "description": "The specified date and time. Note that this needs to be inputted as a string."
       }
     ],
     "examples": [
-      "If date_time is 8:57 PM on Aug 31, 2005, minutes(\"8-31-2005 8:57 PM\") returns 57"
+      "If dateTime is 8:57 PM on Aug 31, 2005, minutes(\"8-31-2005 8:57 PM\") returns 57"
     ]
   },
   "month": {
@@ -339,7 +339,7 @@
     "description": "Returns the seconds of the minute corresponding to the given date.",
     "args": [
       {
-        "name": "date_time",
+        "name": "dateTime",
         "type": "string",
         "description": "The specified date and time. Note that this needs to be inputted as a string."
       }
@@ -365,7 +365,7 @@
     "description": "Returns the year corresponding to the given date.",
     "args": [
       {
-        "name": "date_time",
+        "name": "dateTime",
         "type": "string",
         "description": "The specified date and time. Note that this needs to be inputted as a string."
       }
@@ -766,14 +766,14 @@
     "description": "Takes two arguments, the first being the attribute for which the percentile will be computed, and the second being the desired percentile.",
     "args": [
       {
-        "name": "constant",
-        "type": "value",
-        "description": "The percentile value in the range 0 to 1, inclusive."
-      },
-      {
         "name": "expression",
         "type": "attribute",
         "description": "The attribute of the percentile that will be calculated."
+      },
+      {
+        "name": "constant",
+        "type": "value",
+        "description": "The percentile value in the range 0 to 1, inclusive."
       }
     ],
     "examples": [
@@ -844,80 +844,349 @@
       "variance(Before-After) computes the variance of the difference of the two attributes Before and After"
     ]
   },
-/*
+  /*
  * String Functions
  */
-"beginsWith": {
-"displayName": "",
-"description": "",
-"examples": [
-]
-},
-"charAt": {
-"displayName": "",
-"description": "",
-"examples": [
-]
-},
-"concat": {
-"displayName": "concat",
-"description": "Combines multiple strings into a single string.",
-"args": [
-{
-"name": "str1",
-"type": "string",
-"description": "the first string"
-},
-{
-"name": "str2",
-"type": "string",
-"description": "the next string"
-},
-{
-"name": "...",
-"type": "string",
-"description": "additional strings"
-}
-],
-"examples": [
-]
-},
-"endsWith": {
-"displayName": "",
-"description": "",
-"examples": [
-]
-},
-"join": {
-"displayName": "join",
-"description": "Combines multiple strings into a single string with a delimiter.",
-"args": [
-{
-"name": "delimiter",
-"type": "string",
-"description": "the string used to separate the other strings"
-},
-{
-"name": "str1",
-"type": "string",
-"description": "the first string"
-},
-{
-"name": "str2",
-"type": "string",
-"description": "the next string"
-},
-{
-"name": "...",
-"type": "string",
-"description": "additional strings"
-}
-],
-"examples": [
-]
-}
-
-/*
+  "beginsWith": {
+    "displayName": "beginsWith",
+    "description": "Takes two arguments and returns true if the first begins with the second. Note that beginsWith is case sensitive.",
+    "args": [
+      {
+        "name": "stringToLookIn",
+        "type": "attribute",
+        "description": "The attribute for which you want to find the string."
+      },
+      {
+        "name": "stringToFind",
+        "type": "string",
+        "description": "The string to search for."
+      }
+    ],
+    "examples": [
+      "beginsWith(LastName, \"Mc\") will return true for \"McBride\" and false for \"Binker\"",
+      "beginsWith(City, \"Atlanta\") will return true for \"Atlanta\" and false for \"atlanta\""
+    ]
+  },
+  "charAt": {
+    "displayName": "charAt",
+    "description": "Returns the character at the specified position. Note that if there is a space in the string, charAt returns 0 at that position.",
+    "args": [
+      {
+        "name": "stringToLookIn",
+        "type": "string",
+        "description": "The string for which you want to find the character."
+      },
+      {
+        "name": "index",
+        "type": "number",
+        "description": "Index of the character to be returned, starting at 1."
+      }
+    ],
+    "examples": [
+      "charAt(\"water\", 3) returns t",
+      "charAt(Name, 1) returns the first letter of each Name"
+    ]
+  },
+  "concat": {
+    "displayName": "concat",
+    "description": "Combines multiple strings into a single string.",
+    "args": [
+      {
+        "name": "string1",
+        "type": "string",
+        "description": "the first string"
+      },
+      {
+        "name": "string2",
+        "type": "string",
+        "description": "the next string"
+      },
+      {
+        "name": "...",
+        "type": "string",
+        "description": "additional strings to join"
+      }
+    ],
+    "examples": [
+      "concat(\"H\", \"i\") returns Hi",
+      "concat(FirstName, \" \", LastName) joins three strings, the string in the attribute FirstName, a space character, and the string in the attribute LastName. The result is Jane Smith. "
+    ]
+  },
+  "endsWith": {
+    "displayName": "endsWith",
+    "description": "Takes two arguments and returns true if the first ends with the second.",
+    "args": [
+      {
+        "name": "stringToLookIn",
+        "type": "string",
+        "description": "The attribute for which you want to find the string."
+      },
+      {
+        "name": "stringToFind",
+        "type": "string",
+        "description": "The string to search for."
+      }
+    ],
+    "examples": [
+      "endsWith(LastName, \"er\") will return true for \"Binker\" and false for \"McBride\""
+    ]
+  },
+  "findString": {
+    "displayName": "findString",
+    "description": "Searches the first string argument (optionally starting at the specified position) for the specified target string.",
+    "args": [
+      {
+        "name": "stringToLookIn",
+        "type": "string",
+        "description": "The string to search in."
+      },
+      {
+        "name": "stringToFind",
+        "type": "string",
+        "description": "The string to search for."
+      },
+      {
+        "name": "index",
+        "type": "number",
+        "description": "The string to search for, starting at 1."
+      }
+    ],
+    "examples": [
+      "findString(\"mathematics\", \"the\") returns 3",
+      "findString(\"mathematics\", \"the\", 3) returns 0"
+    ]
+  },
+  "includes": {
+    "displayName": "includes",
+    "description": "Takes two arguments and returns true if the second argument is a substring of the first (also treated as a string).",
+    "args": [
+      {
+        "name": "stringToLookIn",
+        "type": "string",
+        "description": "The string to search in."
+      },
+      {
+        "name": "stringToFind",
+        "type": "string",
+        "description": "The string to search for."
+      }
+    ],
+    "examples": [
+      "includes(\"the\", \"he\") returns true",
+      "includes(\"dancing\", \"joy\") returns false",
+      "includes(1234, 23) returns true"
+    ]
+  },
+  "join": {
+    "displayName": "join",
+    "description": "Combines multiple strings into a single string with a delimiter.",
+    "args": [
+      {
+        "name": "delimiter",
+        "type": "string",
+        "description": "The string used to separate the other strings."
+      },
+      {
+        "name": "string1",
+        "type": "string",
+        "description": "The first string."
+      },
+      {
+        "name": "string2",
+        "type": "string",
+        "description": "The next string."
+      },
+      {
+        "name": "...",
+        "type": "string",
+        "description": "Additional strings."
+      }
+    ],
+    "examples": [
+      "join(\"-\", \"a\", \"b\", \"c\") returns a-b-c",
+      "join(\"-\", m, d, y) returns a date in format \"m-d-y\""
+    ]
+  },
+  "repeatString": {
+    "displayName": "repeatString",
+    "description": "Takes two arguments, the first a string and the second a nonnegative integer. Returns the result of concatenating aString numRepetitions times.",
+    "args": [
+      {
+        "name": "aString",
+        "type": "string",
+        "description": "The string you want to repeat."
+      },
+      {
+        "name": "numRepetitions",
+        "type": "number",
+        "description": "The number of times to repeat the string, starting at 0."
+      }
+    ],
+    "examples": [
+      "repeatString(\"ha\", 4) returns \"hahahaha\""
+    ]
+  },
+  "replaceChars": {
+    "displayName": "replaceChars",
+    "description": "Returns the string formed by replacing the specified characters with the specified replacement string.",
+    "args": [
+      {
+        "name": "aString",
+        "type": "string",
+        "description": "The original string that contains characters you want to replace."
+      },
+      {
+        "name": "start",
+        "type": "string",
+        "description": "The starting location for the substitution, starting at 1."
+      },
+      {
+        "name": "numChars",
+        "type": "number",
+        "description": "The number of characters to be replaced."
+      },
+      {
+        "name": "substituteString",
+        "type": "string",
+        "description": "The string that is to be substituted."
+      }
+    ],
+    "examples": [
+      "replaceChars(\"computer\", 3, 4, \"nfus\") returns \"confuser\""
+    ]
+  },
+  "replaceString": {
+    "displayName": "replaceString",
+    "description": "Takes three string arguments and substitutes the third for all occurrences of the second in the first.",
+    "args": [
+      {
+        "name": "aString",
+        "type": "string",
+        "description": "The original string that contains characters you want to replace."
+      },
+      {
+        "name": "stringToFind",
+        "type": "string",
+        "description": "The starting location for the substitution, starting at 1."
+      },
+      {
+        "name": "substituteString",
+        "type": "number",
+        "description": "The number of characters to be replaced."
+      }
+    ],
+    "examples": [
+      "replaceString(\"12:30:45\", \":\", \" and \") returns \"12 and 30 and 45\""
+    ]
+  },
+  "split": {
+    "displayName": "split",
+    "description": "Returns the string formed by splitting a string by the specified separator and then returning the element at the specified index. Given an attribute \"d\" that contains strings of the form \"mm-dd-yyyy\", split(d,\"-\",1) returns the month, split(d,\"-\",2) returns the day, and split(d,\"-\",3) returns the year.",
+    "args": [
+      {
+        "name": "aString",
+        "type": "string",
+        "description": "The original string that contains characters you want to split."
+      },
+      {
+        "name": "separator",
+        "type": "string",
+        "description": "The starting location for the split."
+      },
+      {
+        "name": "index",
+        "type": "number",
+        "description": "The index that specifies the placement of the splits, starting at 1."
+      }
+    ],
+    "examples": [
+      "split(\"09/01/2016\", \"/\", 1) returns 9",
+      "split(\"Hi, what's new?\", \"a\") returns \"Hi, wh\""
+    ]
+  },
+  "stringLength": {
+    "displayName": "stringLength",
+    "description": "Returns the number of characters in the string representation of the argument.",
+    "args": [
+      {
+        "name": "string",
+        "type": "string",
+        "description": "The string for which you want to know the number of characters."
+      }
+    ],
+    "examples": [
+      "stringLength(\"CODAP\") returns 5",
+      "stringLength(321) returns 3"
+    ]
+  },
+  "subString": {
+    "displayName": "subString",
+    "description": "Returns a substring of the specified string, determined by its position and length arguments.",
+    "args": [
+      {
+        "name": "string",
+        "type": "string",
+        "description": "The string for which you want the substring."
+      },
+      {
+        "name": "position",
+        "type": "number",
+        "description": "The starting position of the substring, begins at 1."
+      },
+      {
+        "name": "length",
+        "type": "number",
+        "description": "The length of the substring that you want."
+      }
+    ],
+    "examples": [
+      "substring(\"abcd\",2,3) returns bcd"
+    ]
+  },
+  "toLower": {
+    "displayName": "toLower",
+    "description": "Converts upper-case characters in its argument to lower-case.",
+    "args": [
+      {
+        "name": "string",
+        "type": "string",
+        "description": "The string that you want to appear in lower-case."
+      }
+    ],
+    "examples": [
+      "toLower(\"String\") returns string"
+    ]
+  },
+  "toUpper": {
+    "displayName": "toUpper",
+    "description": "Converts lower-case characters in its argument to upper-case.",
+    "args": [
+      {
+        "name": "string",
+        "type": "string",
+        "description": "The string that you want to appear in upper-case."
+      }
+    ],
+    "examples": [
+      "toUpper(\"String\") returns STRING"
+    ]
+  },
+  "trim": {
+    "displayName": "trim",
+    "description": "Removes leading, trailing, and redundant white space characters from its argument. (e.g. double spaces are converted to single spaces).",
+    "args": [
+      {
+        "name": "string",
+        "type": "string",
+        "description": "The string from which you want spaces removed."
+      }
+    ],
+    "examples": [
+      "trim(\" Fall Semester \") removes the unwanted first and last characters in the string and returns \"Fall Semester\"",
+      "trim(\"First sentence.  Second sentence\") removes the extra space between the two sentences and returns \"First sentence. Second sentence.\""
+    ]
+  }
+  /*
  * Trigonometric Functions
  */
 }


### PR DESCRIPTION
Here are the inputted function strings for information about the CODAP functions, @bfinzer and @kswenson.

I noticed a few issues while inputting the function_string information, my notes follow:

1. Some of the arg values, such as for the function date(), contain a long amount of arguments to input, which offsets the information (i) icon away from its default location. One fix I could do is shorten the arg string lengths for these functions. Another option is to make the function information box a little longer. Would either of these work?
2. The now() and today() functions do not have parameters to input. In the "Parameters" text, this shows as "undefined." I added the text, "There are no parameters for this function." Should we include anything in the displayName "name" and type "description" for these functions? Or does the text work as is?
3. Maybe I wasn't understanding how arg types would be used, but a few times I was unclear how to input the type value. For example, "index" could be listed as a type "number" or a "value." Another example is in the function lookupByKey(), I inputted the type as "string", but technically the first input is a data set or attribute in a case table, correct?
4. It would be nice if the user could select and copy text in the information bar, for trying out the function in the formula editor.
5. It would be nice to produce LaTeX code or a mathematical formula for the stdDev(), stdError(), and variance() functions.
6. A couple times I wanted to include extra notes that didn't fit in the current format about the function. For example, one can write nested if() statements in CODAP, or in number(), if an empty string "" is included, the result is 0. These kind of instances seemed to belong in their own Notes section, perhaps below the Examples.
7. Should we display special built-in functions and constants, such as caseIndex, pi, and e? If so, where do they belong?
8. I received a warning message when I tried to use the "/" character for describing dates, such as "mm/dd/yyyy". I used the "-" character instead, so the text reads "mm-dd-yyyy."
9. A couple of the examples, such as in year(), includes samples that are broken into two lines of text. Is it possible to force a text break on a new line to avoid this kind of situation?

That's all for now! Thanks for assigning this to me, it was a fun project to work on.