### PR TITLE
Invalidate count() when adding single cases [#136645861]

### DIFF
--- a/apps/dg/models/collection_model.js
+++ b/apps/dg/models/collection_model.js
@@ -456,6 +456,7 @@ DG.Collection = DG.BaseModel.extend( (function() // closure
         this.caseIDToGroupedIndexMap[caseID] = caseCounts[parentID]++;
         caseIDToIndexMap[caseID] = this.cases.length;
         this.cases.pushObject(iCase);
+        this.notifyPropertyChange('caseIDToIndexMap');
       } else {
         insertCaseInCollection(parentID, iCase);
       }


### PR DESCRIPTION
When cases are added one at a time in DG.CollectionModel.addCases, no notification was being sent that the case indices were changed.