### PR TITLE
Fix issues with document title [#135394919]

### DIFF
--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -176,6 +176,7 @@ DG = SC.Application.create((function () // closure
 
     NAMESPACE: 'DG',
     APPNAME: 'DG',
+    USER_APPNAME: 'CODAP',
 
     /*
      * Semantic version number

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -189,6 +189,7 @@ DG.main = function main() {
           appOrMenuElemId: iViewConfig.navBarId,
           hideMenuBar: DG.get('hideCFMMenu'),
           ui: {
+            windowTitleSuffix: DG.USER_APPNAME,
             menu: [
               { name: 'DG.fileMenu.menuItem.newDocument'.loc(), action: 'newFileDialog' },
               { name: 'DG.fileMenu.menuItem.openDocument'.loc(), action: 'openFileDialog' },


### PR DESCRIPTION
The buggy behavior occurred when CFM attempted to determine the default document title suffix from the document title. There are presumably still improvements that could be made to the CFM behavior, but for now we fix the problem for CODAP by explicitly providing the `windowTitleSuffix` parameter in the CFM configuration which bypasses the CFM's attempt to determine a default suffix.

Note that we also define a new DG.USER_APPNAME constant to be 'CODAP', having come to the startling realization that there previously was no strings constant or strings file entry for the string 'CODAP'.