### PR TITLE
Synchronize dismissal click behaviors [#136280933]

### DIFF
--- a/apps/dg/react/dg-react.js
+++ b/apps/dg/react/dg-react.js
@@ -66,6 +66,8 @@ DG.React.HighOrderComponents = {
         // the clicked node was outside the child container so unmount it
         if (!clickedNode) {
           this.unmount();
+          e.preventDefault();
+          e.stopPropagation();
         }
       },
 


### PR DESCRIPTION
Clicking outside the function popup simply dismisses the function popup.