### PR TITLE
Fix case table date entry [#137050469]

### DIFF
--- a/apps/dg/components/case_table/case_table_data_manager.js
+++ b/apps/dg/components/case_table/case_table_data_manager.js
@@ -174,7 +174,10 @@ DG.CaseTableDataManager = SC.Object.extend({
         },
 
         getStrValue: function(columnID) {
-          return this._values[columnID];
+          var value = this._values[columnID];
+          return DG.DataUtilities.isDate(value)
+                    ? DG.DataUtilities.formatDate(value)
+                    : value;
         },
 
         getValue: function(columnID) {

--- a/apps/dg/models/case_model.js
+++ b/apps/dg/models/case_model.js
@@ -35,31 +35,11 @@ DG.Case = DG.BaseModel.extend((function() {
   /** @scope DG.Case.prototype */
 
   /**
-    Default formatting for Date objects.
-    Uses toLocaleDateString() for default date formatting.
-    Optionally uses toLocaleTimeString() for default time formatting.
-   */
-  function formatDate(x) {
-    if (!(x && DG.isDate(x))) return "";
-    // use a JS Date object for formatting, since our valueOf()
-    // change seems to affect string formatting
-    var date = new Date(Number(x) * 1000),
-        h = date.getHours(),
-        m = date.getMinutes(),
-        s = date.getSeconds(),
-        ms = date.getMilliseconds(),
-        hasTime = (h + m + s + ms) > 0,
-        dateStr = date.toLocaleDateString(),
-        timeStr = hasTime ? " " + date.toLocaleTimeString() : "";
-    return dateStr + timeStr;
-  }
-
-  /**
     Utility function to convert dates to strings while leaving
     all other values alone.
    */
   function convertValue(x) {
-    return DG.isDate(x) ? formatDate(x) : x;
+    return DG.DataUtilities.isDate(x) ? DG.DataUtilities.formatDate(x) : x;
   }
 
   return {

--- a/apps/dg/tests/utilities/data_utilities_test.js
+++ b/apps/dg/tests/utilities/data_utilities_test.js
@@ -98,3 +98,22 @@ test("Tests data utilities", function() {
   testInvalidDateString('1/2');
 
 });
+
+test("Test canonicalizeInputValue()", function() {
+  equals(DG.DataUtilities.canonicalizeInputValue(), "");
+  equals(DG.DataUtilities.canonicalizeInputValue(null), "");
+  equals(DG.DataUtilities.canonicalizeInputValue("undefined"), "");
+  equals(DG.DataUtilities.canonicalizeInputValue(""), "");
+  equals(DG.DataUtilities.canonicalizeInputValue("foo"), "foo");
+  ok(DG.DataUtilities.canonicalizeInputValue("2002-12-31T23:00:00+01:00") instanceof Date, "canonicalizeInputValue('2002-12-31T23:00:00+01:00')");
+  ok(DG.DataUtilities.canonicalizeInputValue("2016-02-01") instanceof Date, "canonicalizeInputValue('2016-02-01')");
+});
+
+test("Test canonicalizeInternalValue()", function() {
+  equals(DG.DataUtilities.canonicalizeInternalValue(), "");
+  equals(DG.DataUtilities.canonicalizeInternalValue(null), "");
+  equals(DG.DataUtilities.canonicalizeInternalValue("undefined"), "");
+  equals(DG.DataUtilities.canonicalizeInternalValue("foo"), "foo");
+  ok(DG.DataUtilities.canonicalizeInternalValue("2002-12-31T23:00:00+01:00") instanceof Date, "canonicalizeInternalValue('2002-12-31T23:00:00+01:00')");
+  equals(DG.DataUtilities.canonicalizeInternalValue("2016-02-01"), "2016-02-01", "canonicalizeInternalValue('2016-02-01')");
+});

--- a/apps/dg/utilities/data_utilities.js
+++ b/apps/dg/utilities/data_utilities.js
@@ -118,12 +118,31 @@ DG.DataUtilities.canonicalizeInputValue = function( iValue) {
   if( typeof iValue !== 'string')
       return iValue;
 
-  // canonicalize dates (cf. http://stackoverflow.com/a/37563868)
-  var ISO_8601_FULL = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(([+-]\d\d:\d\d)|Z)?$/i;
-  if (ISO_8601_FULL.test(iValue)) return DG.createDate(iValue);
+  var value = iValue.trim();
+  return DG.DataUtilities.isDateString(value) ? DG.DataUtilities.createDate(value) : value;
+};
 
-  // Now, all we have left are plain strings. Trim them.
-  return iValue.trim();
+/**
+  Canonicalize/sanitize case values converted to strings internally.
+  Currently, we only check for the "undefined" string and canonical
+  (ISO 8601) date strings.
+  @param    iValue  The string value to be converted
+  @returns          The canonicalized value
+ */
+DG.DataUtilities.canonicalizeInternalValue = function(iValue) {
+  // canonicalize null, undefined, and "undefined"
+  if ((iValue == null) || (iValue === "undefined")) return "";
+  if( typeof iValue !== 'string')
+      return iValue;
+
+  var isIso8601DateString = function(iValue) {
+    // canonicalize dates (cf. http://stackoverflow.com/a/37563868)
+    var ISO_8601_FULL = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(([+-]\d\d:\d\d)|Z)?$/i;
+    return (typeof iValue === 'string' && ISO_8601_FULL.test(iValue));
+  }.bind(this);
+
+  var value = iValue.trim();
+  return isIso8601DateString(value) ? DG.DataUtilities.createDate(value) : value;
 };
 
 /**

--- a/apps/dg/utilities/data_utilities.js
+++ b/apps/dg/utilities/data_utilities.js
@@ -106,6 +106,26 @@ DG.DataUtilities.isDateString = function(iValue) {
 DG.isDateString = DG.DataUtilities.isDateString;
 
 /**
+  Default formatting for Date objects.
+  Uses toLocaleDateString() for default date formatting.
+  Optionally uses toLocaleTimeString() for default time formatting.
+ */
+DG.DataUtilities.formatDate = function(x) {
+  if (!(x && DG.isDate(x))) return "";
+  // use a JS Date object for formatting, since our valueOf()
+  // change seems to affect string formatting
+  var date = new Date(Number(x) * 1000),
+      h = date.getHours(),
+      m = date.getMinutes(),
+      s = date.getSeconds(),
+      ms = date.getMilliseconds(),
+      hasTime = (h + m + s + ms) > 0,
+      dateStr = date.toLocaleDateString(),
+      timeStr = hasTime ? " " + date.toLocaleTimeString() : "";
+  return dateStr + timeStr;
+};
+
+/**
   Canonicalize/sanitize case values sent to us from the game.
   Currently, we only check for the "undefined" string, but this is
   the appropriate place to perform any other validation as well.


### PR DESCRIPTION
- implement DG.DataUtilities.canonicalizeInternalValue()
- handle date conversion in values entered in case table, including new case row

Also added PT chore [#137067599](https://www.pivotaltracker.com/story/show/137067599) to assess callers of the canonicalize...() conversion functions to make sure the appropriate conversion is occurring.