### PR TITLE
Fix Rerandomize Attribute functionality [#137053235]

### DIFF
--- a/apps/dg/components/case_table/case_table_data_manager.js
+++ b/apps/dg/components/case_table/case_table_data_manager.js
@@ -253,8 +253,10 @@ DG.CaseTableDataManager = SC.Object.extend({
     if (this._rowCaseMap.length !== beforeCount) {
       this.onRowCountChanged.notify({previous: beforeCount, current: this._rowCaseMap.length}, null, this);
     }
+    else {
+      this.onRowsChanged.notify({rows: null}, null, this);
+    }
     this.set('refreshNeeded', false);
-    //this.onRowsChanged.notify({rows: {}}, null, self);
   },
 
   /**

--- a/apps/dg/components/case_table/case_table_view.js
+++ b/apps/dg/components/case_table/case_table_view.js
@@ -670,10 +670,11 @@ DG.CaseTableView = SC.View.extend( (function() // closure
     }.bind( this));
     
     dataView.onRowsChanged.subscribe(function (e, args) {
-      if( this._slickGrid) {
-        this._slickGrid.invalidateRows(args.rows);
-        this._slickGrid.render();
-      }
+      SC.run( function() {
+        if( this._slickGrid) {
+          this._slickGrid.invalidate();
+        }
+      }.bind( this));
     }.bind( this));
     
     $(gridLayer).show();


### PR DESCRIPTION
While implementing the add case row in the case table recently, I came across the fact that DG.CaseTableDataManager.refresh() was notifying that the number of rows had changed on every change, whether or not the number of rows had actually changed. This clearly seemed to be incorrect, so I changed it to only notify when the number of rows changed, and when I didn't see any obvious indication that things were broken I left it in. It turns out Rerandomize Attribute was relying on that notification. Rather than using the onRowCountChanged notification inappropriately, however, we use the already defined onRowsChanged notification instead when the row count hasn't changed.