### PR TITLE
Hidden attribute property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ nbproject
 .pt
 # Packages
 node_modules/
+.ruby-gemset
+.ruby-version

--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -342,7 +342,9 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
             }
           };
       updateDynamicColumnProperties( iAttribute, columnInfo);
-      columnDefs.push( columnInfo);
+      if(! iAttribute.get('hidden')) {
+        columnDefs.push( columnInfo);
+      }
     }
 
     function updateNewAttributeColumnDefinition() {

--- a/apps/dg/components/graph_map_common/data_display_controller.js
+++ b/apps/dg/components/graph_map_common/data_display_controller.js
@@ -745,7 +745,7 @@ DG.DataDisplayController = DG.ComponentController.extend(
           tContexts.forEach( function( iContext) {
             iContext.forEachCollection( function( iCollClient) {
               var tName = iCollClient.get('name'),
-                  tAttrNames = iCollClient.getAttributeNames();
+                  tAttrNames = iCollClient.getVisibleAttributeNames();
               tMenuItems.push({ title: tName,
                 subMenu: tAttrNames.map( function( iAttrName) {
                   return { title: iAttrName, collection: iCollClient, context: iContext };

--- a/apps/dg/controllers/collection_client.js
+++ b/apps/dg/controllers/collection_client.js
@@ -210,6 +210,15 @@ DG.CollectionClient = SC.Object.extend(
     return this.attrsController.getEach('name');
   },
 
+    /**
+     Returns an array with the names of the visible attributes in the collection.
+     Omits any attributes with 'hidden' property set to true
+     @returns    {[string]}   The array of attribute names
+     */
+    getVisibleAttributeNames: function() {
+      return this.attrsController.filterProperty('hidden', false).getEach('name');
+    },
+
   /**
     Returns the number of attributes in the collection.
     @returns    {Number}    The number of attributes in the collection

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -115,6 +115,13 @@ DG.Attribute = DG.BaseModel.extend(
     editable: false,
 
     /**
+     * True if the attribute is hidden from the user, false otherwise.
+     * By default attributes are visible.
+     * @property {Boolean}
+     */
+    hidden: false,
+
+    /**
      * True if the attribute is renameable, false otherwise.
      * @property {Boolean}
      */
@@ -387,6 +394,7 @@ DG.Attribute = DG.BaseModel.extend(
         colormap: this.colormap || undefined,
         blockDisplayOfEmptyCategories: this.blockDisplayOfEmptyCategories || undefined,
         editable: this.editable,
+        hidden: this.hidden,
         formula: this.hasFormula()? this.formula: undefined,
         guid: this.id,
         precision: this.precision,

--- a/apps/dg/tests/controllers/test_collection_client.js
+++ b/apps/dg/tests/controllers/test_collection_client.js
@@ -25,15 +25,18 @@ test("test DG.CollectionClient", function () {
     tIDs,tNames, cases = [];
   tCollectionModel.createAttribute({ name: 'first' });
   tCollectionModel.createAttribute({ name: 'second' });
+  tCollectionModel.createAttribute({ name: 'hidden', 'hidden':true });
   cases.push(tCollectionModel.createCase({values: {first: '1', second: 'a'}}));
   cases.push(tCollectionModel.createCase({values: {first: '2', second: 'b'}}));
   tClient = DG.CollectionClient.create({});
   ok(tClient, 'Can create CollectionClient');
   tClient.setTargetCollection(tCollectionModel);
   tIDs = tClient.getAttributeIDs();
-  equals(tIDs.length, 2, 'Can get attribute IDs');
+  equals(tIDs.length, 3, 'Can get attribute IDs');
   tNames = tClient.getAttributeNames();
-  equals(tNames.length, 2, 'Can get attribute names');
+  equals(tNames.length, 3, 'Can get attribute names');
+  // hidden attributes should be excluded from getVisibleAttributeNames() result:
+  equals(tClient.getVisibleAttributeNames().length, 2, 'Can get visible attribute names');
   ok(tNames[0] === 'first' && tNames[1] === 'second', 'Attribute names match.');
   tIDs = tClient.getCaseIDs();
   equals(tIDs.length, 2, 'Can get case IDs');

--- a/apps/dg/tests/models/test_attribute_model.js
+++ b/apps/dg/tests/models/test_attribute_model.js
@@ -45,6 +45,7 @@ test('test DG.Attribute', function() {
       editable: true
     }),
     tFormAttr = tCollectionModel.createAttribute({ name: 'yesFormula', formula: '42' }),
+    tAttrHidden = tCollectionModel.createAttribute({name: 'hidden', hidden: true}),
     tID,
     tAnother;
 
@@ -62,6 +63,7 @@ test('test DG.Attribute', function() {
   // features
   equals( tAttr.hasFormula(), false, 'Empty attribute has no formula.');
   equals( tFormAttr.hasFormula(), true, 'Formula attribute has a formula.');
+  equals( tAttrHidden.get('hidden'), true, 'Hidden attribute is hidden.');
 
   equals( tFormAttr.evalFormula(), 42, 'Simple formulae with no namespace evaluate correctly.');
   tFormAttr.set('formula', 'sqrt(49)');


### PR DESCRIPTION
When a attribute defines a `hidden` property that is `true` it will not be displayed in the case tables.

This was the simplest method I could think of. Please let me know if there is a better approach, especially for the view code.

There is no UI for modifying this property at the moment. 
 

