### PR TITLE
Restore inadvertently removed functionality of `cfmBaseUrl` query parameter

### DIFF
--- a/apps/dg/lib/index.rhtml
+++ b/apps/dg/lib/index.rhtml
@@ -99,15 +99,20 @@
     <!-- https://www.html5rocks.com/en/tutorials/speed/script-loading/ -->
     <script>
       (function() {
+        // load the CFM here if cfmBaseUrl is not specified
+        // otherwise, we delay-load CFM using cfmBaseUrl in main.js
+        var loadCfm = window.location.search.indexOf('cfmBaseUrl=') < 0;
         [
           "<%= sc_static('build/codap-lib-bundle.js.ignore') %>",
-          "<%= sc_static('cloud-file-manager/js/globals.js.ignore') %>",
-          "<%= sc_static('cloud-file-manager/js/app.js.ignore') %>"
+          loadCfm ? "<%= sc_static('cloud-file-manager/js/globals.js.ignore') %>" : null,
+          loadCfm ? "<%= sc_static('cloud-file-manager/js/app.js.ignore') %>" : null
         ].forEach(function(src) {
-          var script = document.createElement('script');
-          script.src = src;
-          script.async = false;
-          document.head.appendChild(script);
+          if (src) {
+            var script = document.createElement('script');
+            script.src = src;
+            script.async = false;
+            document.head.appendChild(script);
+          }
         });
       }());
     </script>

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -121,6 +121,66 @@ DG.main = function main() {
       openDataInteractive(startingDataInteractive);
     }
   }
+
+  function cfmUrl(filename) {
+    var url = null,
+        a;
+
+    if (DG.cfmBaseUrl) {
+      // safely parse the url and check to only allow codap.concord.org or a domain with no tld (like localhost or dev)
+      a = document.createElement("A");
+      a.href = DG.cfmBaseUrl;
+      if ((a.hostname === 'codap.concord.org') || (a.hostname.indexOf('.') === -1)) {
+        a.pathname = (a.pathname[a.pathname.length - 1] === '/' ? a.pathname : (a.pathname + '/')) + filename;
+        url = a.href;
+        DG.logWarn('Loading the ' + filename + ' CFM file from ' + url);
+      }
+      else {
+        DG.logError('The cfmBaseUrl domain (' + a.hostname + ') either needs to be codap.concord.org or not have a TLD (like localhost)');
+      }
+    }
+
+    if (!url) {
+      // static_url is run at build time so we have to directly reference the paths
+      if (filename === 'globals.js') {
+        url = static_url('cloud-file-manager/js/globals.js.ignore');
+      }
+      else if (filename === 'app.js') {
+        url = static_url('cloud-file-manager/js/app.js.ignore');
+      }
+    }
+
+    return url;
+  }
+  function cfmGlobalsLoaded() {
+    return new Promise(function(resolve, reject) {
+                $.ajax({
+                  url: cfmUrl('globals.js'),
+                  dataType: 'script',
+                  success: function() {
+                    resolve(true);
+                  },
+                  failure: function() {
+                    reject(false);
+                  }
+                });
+              });
+  }
+  function cfmAppLoaded() {
+    return new Promise(function(resolve, reject) {
+                $.ajax({
+                  url: cfmUrl('app.js'),
+                  dataType: 'script',
+                  success: function() {
+                    resolve(true);
+                  },
+                  failure: function() {
+                    reject(false);
+                  }
+                });
+              });
+  }
+
   /**
    * Returns a promise which is resolved when the CFM is loaded.
    * The bundled libraries (e.g. React) and the CFM bundles are loaded via
@@ -130,6 +190,12 @@ DG.main = function main() {
    * only check that the CFM is defined to determine that all scripts are loaded.
    */
   function cfmLoaded() {
+    // if a cfmBaseUrl was specified, load the CFM libs dynamically via ajax
+    if (DG.cfmBaseUrl != null) {
+      return Promise.all([cfmGlobalsLoaded(), cfmAppLoaded()]);
+    }
+
+    // if no cfmBaseUrl was specified, the CFM should have been loaded in index.rhtml
     return new Promise(function(resolve, reject) {
       function checkCfm() {
         if (typeof CloudFileManager !== "undefined")


### PR DESCRIPTION
In an earlier effort to consolidate the way CODAP loads its bundled libraries, I switched the loading of the CFM to dynamically-generated script tags rather than using ajax calls. In the process, I inadvertently eliminated support Doug had added for loading the CFM dynamically from an external URL, primarily for debugging purposes. With this PR, if the `cfmBaseUrl` query parameter is not specified, the CFM will continue to be loaded by dynamic script tag. When the `cfmBaseUrl` query parameter is present, however, the previous ajax method will be used. This allows the shipping version of CODAP, for instance, to be tested with an alternate CFM implementation. As part of Doug's original work, the specified `cfmBaseUrl` must be hosted at `codap.concord.org` for security reasons.