### PR TITLE
Add support for plot dependencies so that hiding/showing cases in the plot…

### DIFF
--- a/apps/dg/components/graph/adornments/plotted_function_model.js
+++ b/apps/dg/components/graph/adornments/plotted_function_model.js
@@ -121,6 +121,26 @@ DG.PlottedFunctionContext = DG.CollectionFormulaContext.extend((function() {
   },
   
   /**
+    Called when the formula has been recompiled to clear any stale dependencies.
+    Derived classes may override as appropriate.
+   */
+  didCompile: function() {
+    sc_super();
+
+    // register the 'plot' dependency for invalidation
+    var plotModel = this.get('plotModel'),
+        // TODO: use a more robust ID
+        plotID = DG.Debug.scObjectID(plotModel);
+    this.registerDependency({ independentSpec: {
+                                type: DG.DEP_TYPE_PLOT,
+                                id: plotID,
+                                name: 'plot-' + plotID
+                              },
+                              aggFnIndices: this.ALL_FUNCTIONS
+                            });
+  },
+
+  /**
     Direct evaluation of the expression without an intervening compilation.
     This is unlikely to be used for plotted funtions where the expression is
     generally evaluated enough times to make compilation to JavaScript

--- a/apps/dg/formula/collection_formula_context.js
+++ b/apps/dg/formula/collection_formula_context.js
@@ -33,6 +33,12 @@ DG.CollectionFormulaContext = DG.GlobalFormulaContext.extend((function() {
   return {
 
   /**
+    Constant used when registering dependencies to indicate that all functions are affected.
+    @type {String}
+   */
+  ALL_FUNCTIONS: '__ALL__',
+
+  /**
     Properties of the formula owner for use by the dependency manager.
     Generally passed in by the client on construction.
     @type {object}
@@ -210,7 +216,7 @@ DG.CollectionFormulaContext = DG.GlobalFormulaContext.extend((function() {
     Called when the formula has been recompiled to clear any stale dependencies.
     Derived classes may override as appropriate.
    */
-  didCompile: function() {
+  completeCompile: function() {
     sc_super();
 
     // prune (remove) prior dependencies that are no longer extant
@@ -236,8 +242,15 @@ DG.CollectionFormulaContext = DG.GlobalFormulaContext.extend((function() {
     if (!dependency.dependentSpec)
       dependency.dependentSpec = this.get('ownerSpec');
     DG.assert(dependency.independentSpec);
-    if (!dependency.aggFnIndices)
+    if (!dependency.aggFnIndices) {
       dependency.aggFnIndices = this.getAggregateFunctionIndices();
+    }
+    else if (dependency.aggFnIndices === this.ALL_FUNCTIONS) {
+      dependency.aggFnIndices = [];
+      for (var i = 0; i < this.aggFnInstances.length; ++i) {
+        dependency.aggFnIndices.push(i);
+      }
+    }
     if (!dependency.dependentContext)
       dependency.dependentContext = this;
     this.get('dependencyMgr').registerDependency(dependency);

--- a/apps/dg/formula/dependency_mgr.js
+++ b/apps/dg/formula/dependency_mgr.js
@@ -39,6 +39,7 @@ DG.depMgrLog = function() {};
  */
 DG.DEP_TYPE_ATTRIBUTE = 'attribute';
 DG.DEP_TYPE_GLOBAL = 'global';
+DG.DEP_TYPE_PLOT = 'plot';
 DG.DEP_TYPE_SPECIAL = 'special';
 DG.DEP_TYPE_UNDEFINED = 'undefined';
 

--- a/apps/dg/formula/formula.js
+++ b/apps/dg/formula/formula.js
@@ -145,6 +145,7 @@ return {
       context.willCompile();
       var output = DG.Formula.compileToJavaScript( parsed, context);
       context.didCompile();
+      context.completeCompile();
       compiled = DG.FormulaContext.createContextFunction( output);
     }
     return compiled;

--- a/apps/dg/formula/formula_context.js
+++ b/apps/dg/formula/formula_context.js
@@ -164,6 +164,13 @@ DG.FormulaContext = SC.Object.extend( (function() {
   },
 
   /**
+    Called when the formula has been recompiled to clear any stale dependencies.
+    Derived classes may override as appropriate.
+   */
+  completeCompile: function() {
+  },
+
+  /**
     Called when dependents change to clear function caches.
     Derived classes may override as appropriate.
    */


### PR DESCRIPTION
… can trigger aggregate function invalidation [#140775373]

I tested this by adding this method to `plot_model.js`:
```
  invalidateAggregateAdornments: function() {
    // TODO: use more robust ID
    var id = DG.Debug.scObjectID(this),
        depMgr = this.getPath('dataConfiguration.dataContext.dependencyMgr');
    if (depMgr)
      depMgr.invalidateDependentsOf([{ type: DG.DEP_TYPE_PLOT, id: id, name: 'plot-' + id }]);
  },
```
and adding the following lines at the beginning of `DG.GraphModel.hiddenCasesDidChange()`:
```
      this.get('plots').forEach(function(plot) {
        plot.invalidateAggregateAdornments();
      });
```
but there may be better ways to integrate the code.

Also, note that the `DependencyMgr` requires that each node have a unique ID, for which I'm currently using `DG.Debug.scObjectID()`, but there may be a more appropriate ID.