### PR TITLE
Added snapshot icon to case table

### DIFF
--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -582,6 +582,16 @@ DG.CaseTableController = DG.ComponentController.extend(
         });
       },
 
+      exportPrimaryCaseData: function () {
+        var tDataContext = this.get('dataContext'),
+            name, caseDataString;
+        if (tDataContext && (tDataContext.collections.length > 0)) {
+          name =  tDataContext.collections[0].get('name');
+          caseDataString = tDataContext.exportCaseData(name);
+          DG.exportFile(caseDataString, "csv", "text/plain");
+        }
+      },
+
       modelDidChange: function() {
       }.observes('model'),
 
@@ -1245,6 +1255,16 @@ DG.CaseTableController = DG.ComponentController.extend(
               target: this,
               action: 'showAttributesPopup',
               toolTip: 'DG.Inspector.attributes.toolTip',
+              localize: true
+            })
+        );
+        tButtons.push(DG.IconButton.create({
+              layout: {width: 32},
+              classNames: 'table-attributes'.w(),
+              iconClass: 'moonicon-icon-noteTool',
+              target: this,
+              action: 'exportPrimaryCaseData',
+              toolTip: 'DG.Inspector.exportPrimaryCaseData.toolTip',
               localize: true
             })
         );

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -642,6 +642,7 @@ SC.stringsFor('English', {
   'DG.Inspector.newAttribute': "New Attribute in %@...",  // "New Attribute in %@..."
   'DG.Inspector.randomizeAllAttributes': "Rerandomize All", // "Randomize Attributes"
   'DG.Inspector.exportCaseData': "Export Case Data...", // "Export Case Data..."
+  'DG.Inspector.exportPrimaryCaseData.toolTip': "Export Primary Case Data...", // "Export Primary Case Data..."
 
   // Map Inspector
   'DG.Inspector.mapGrid': "Grid",  // "Grid"


### PR DESCRIPTION
This code was removed from https://github.com/concord-consortium/codap/pull/144 into its own PR so 
that it can be evaluated independently.

The use case for this new feature is to have exports of graphs and tables both be in the slideout menu so they can be used with the minimal number of clicks when the sharinator is in use.