### PR TITLE
Add canUndo/canRedo values to undo-related plugin API calls

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1561,7 +1561,8 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
               DG.UndoHistory.redo();
               break;
           }
-          return {success: success};
+          return {success: success, values: { canUndo: DG.UndoHistory.get('canUndo'),
+                                              canRedo: DG.UndoHistory.get('canRedo') } };
         }
       }
       //get: function (iResources) {

--- a/apps/dg/controllers/undo_history.js
+++ b/apps/dg/controllers/undo_history.js
@@ -103,7 +103,7 @@ DG.UndoHistory = SC.Object.create((function() {
         // Since we're not using set/get to access the stacks, notify changes manually.
         this.notifyPropertyChange('_undoStack');
       } else {
-        // We've hit an not-undoable command, so clear our undo stack
+        // We've hit a not-undoable command, so clear our undo stack
         this._clearUndo();
       }
       // Clear the redo stack every time we add a new command. We *don't* support applying changes
@@ -291,7 +291,7 @@ DG.UndoHistory = SC.Object.create((function() {
     _clearUndo: function() {
       this._undoStack.length = 0;
       this.notifyPropertyChange('_undoStack');
-      DG.sendCommandToDI({action: 'notify', resource: 'undoChangeNotice', values: {operation: 'clearUndo'}});
+      this._sendUndoChangeToDI('clearUndo');
     },
 
     /** @private
@@ -300,7 +300,7 @@ DG.UndoHistory = SC.Object.create((function() {
     _clearRedo: function() {
       this._redoStack.length = 0;
       this.notifyPropertyChange('_redoStack');
-      DG.sendCommandToDI({action: 'notify', resource: 'undoChangeNotice', values: {operation: 'clearRedo'}});
+      this._sendUndoChangeToDI('clearRedo');
     },
 
     _dirtyDocument: function(changedObject) {
@@ -347,6 +347,13 @@ DG.UndoHistory = SC.Object.create((function() {
       if (notification) {
         DG.currDocumentController().notificationManager.sendNotification(notification);
       }
+    },
+
+    _sendUndoChangeToDI: function(operation) {
+      DG.sendCommandToDI({action: 'notify', resource: 'undoChangeNotice',
+                          values: { operation: operation,
+                                    canUndo: this.get('canUndo'),
+                                    canRedo: this.get('canRedo')} });
     }
 
   }; // return from function closure


### PR DESCRIPTION
Enables Building Models PR [Fixed undo/redo buttons so they work in standalone mode](https://github.com/concord-consortium/building-models/pull/258).