### PR TITLE
Enable graph numberToggle via plugin API

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1249,7 +1249,8 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
             xAttributeName: directMapping,
             yAttributeName: directMapping,
             y2AttributeName: directMapping,
-            legendAttributeName: directMapping
+            legendAttributeName: directMapping,
+            enableNumberToggle: directMapping
           },
           guideView: {
             name: directMapping,

--- a/apps/dg/components/graph/graph_controller.js
+++ b/apps/dg/components/graph/graph_controller.js
@@ -66,6 +66,7 @@ DG.GraphController = DG.DataDisplayController.extend(
           storage.isTransparent = this.getPath('graphModel.isTransparent');
           storage.plotBackgroundColor = this.getPath('graphModel.plotBackgroundColor');
           storage.plotBackgroundOpacity = this.getPath('graphModel.plotBackgroundOpacity');
+          storage.enableNumberToggle = this.getPath('graphModel.enableNumberToggle');
 
           this.storeDimension(dataConfiguration, storage, 'x');
           this.storeDimension(dataConfiguration, storage, 'y');
@@ -180,7 +181,7 @@ DG.GraphController = DG.DataDisplayController.extend(
             tConfig.invalidateCaches();
           }
         },
-        
+
       /**
        An axis view has received a drop of an attribute. Our job is the tell the graph
        model which attribute and collection client to change so that we move into the

--- a/apps/dg/components/graph/graph_model.js
+++ b/apps/dg/components/graph/graph_model.js
@@ -203,7 +203,7 @@ DG.GraphModel = DG.DataDisplayModel.extend(
      */
     init: function() {
       sc_super();
-      
+
       function getAxisClassFromType( iType) {
         if( iType === DG.Analysis.EAttributeType.eNumeric || iType === DG.Analysis.EAttributeType.eDateTime)
           return DG.CellLinearAxisModel;
@@ -235,8 +235,9 @@ DG.GraphModel = DG.DataDisplayModel.extend(
 
       this._plots = [];
 
-      if( DG.IS_INQUIRY_SPACE_BUILD) {
-        this.set('numberToggle', DG.NumberToggleModel.create( { dataConfiguration: this.get('dataConfiguration')}));
+      if( DG.IS_INQUIRY_SPACE_BUILD || this.get('enableNumberToggle')) {
+        this.set('enableNumberToggle', true);
+        this.syncNumberToggle(true);
       }
       ['x', 'y', 'y2', 'legend'].forEach(function (iKey) {
         configureAttributeDescription(iKey);
@@ -266,6 +267,14 @@ DG.GraphModel = DG.DataDisplayModel.extend(
       this.removeObserver('dataConfiguration.hiddenCases', this.hiddenCasesDidChange);
 
       sc_super();
+    },
+
+    syncNumberToggle: function(iEnable) {
+      if (iEnable === !!this.get('numberToggle')) return;
+      var numberToggle = iEnable
+                          ? DG.NumberToggleModel.create( { dataConfiguration: this.get('dataConfiguration')})
+                          : null;
+      this.set('numberToggle', numberToggle);
     },
 
     /**
@@ -699,6 +708,10 @@ DG.GraphModel = DG.DataDisplayModel.extend(
         this.set('plotBackgroundColor', iStorage.plotBackgroundColor);
       if( !SC.none( iStorage.plotBackgroundOpacity))
         this.set('plotBackgroundOpacity', iStorage.plotBackgroundOpacity);
+      if( !SC.none( iStorage.enableNumberToggle)) {
+        this.set('enableNumberToggle', iStorage.enableNumberToggle);
+        this.syncNumberToggle(iStorage.enableNumberToggle);
+      }
 
       this.set('aboutToChangeConfiguration', true ); // signals dependents to prepare
 
@@ -810,7 +823,7 @@ DG.GraphModel = DG.DataDisplayModel.extend(
         this.get('numberToggle' ).handleDataContextNotification( iNotifier);
       }
     },
-    
+
     /**
      @private
      */

--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -219,7 +219,7 @@ DG.GraphView = SC.View.extend(
 
         this.createMultiTarget();
 
-        if (DG.IS_INQUIRY_SPACE_BUILD) {
+        if (this.getPath('model.numberToggle')) {
           var tNumberToggleView = DG.NumberToggleView.create({model: this.getPath('model.numberToggle')});
           this.set('numberToggleView', tNumberToggleView);
           this.appendChild(tNumberToggleView);

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -675,7 +675,7 @@ DG.DocumentController = SC.Object.extend(
             },
             contentProperties: {
               controller: tController,
-              value: tGameUrl, 
+              value: tGameUrl,
               name: tGameName,
               model: DG.DataInteractiveModel.create()
             },
@@ -831,7 +831,8 @@ DG.DocumentController = SC.Object.extend(
                                     initialDataContext: tStorage && tStorage.dataContext,
                                     xAttributeName: tStorage && tStorage.xAttributeName,
                                     yAttributeName: tStorage && tStorage.yAttributeName,
-                                    legendAttributeName: tStorage && tStorage.legendAttributeName
+                                    legendAttributeName: tStorage && tStorage.legendAttributeName,
+                                    enableNumberToggle: tStorage && tStorage.enableNumberToggle
                                   }) },
                                   defaultLayout: (iComponent && iComponent.size ? iComponent.size : { width: 300, height: 300 }),
                                   position: (iComponent && iComponent.position ? iComponent.position : null),


### PR DESCRIPTION
- can be enabled per graph via plugin API (new functionality)
- can be enabled globally via URL parameter (preexisting condition)
- is saved/restored with graph so restored graphs retain state independent of URL parameters or plugins
- addresses Building Models PT story [#143266621]

Enables Building Models PR [Enable `numberToggle` on graphs](https://github.com/concord-consortium/building-models/pull/263).