### PR TITLE
Add number toggle UI to graph menu; show values rather than indices for toggles

### DIFF
--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -44,7 +44,6 @@ DG.GraphView = SC.View.extend(
       legendView: null,
       plotBackgroundView: null,
       numberToggleView: null,
-      rescaleButton: null,
 
       _functionEditorView: null,
       functionEditorView: function( iKey, iValue) {
@@ -174,10 +173,6 @@ DG.GraphView = SC.View.extend(
           return null;
         }
 
-        var rescalePlot = function () {
-          this.get('model').rescaleAxesFromData(true, true);
-        }.bind(this);
-
         var tXAxis = this.getPath('model.xAxis'),
             tXAxisAttributeType = this.getPath('model.dataConfiguration.xAttributeDescription.attribute.type'),
             tYAxis = this.getPath('model.yAxis'),
@@ -225,16 +220,6 @@ DG.GraphView = SC.View.extend(
                                                               isVisible: isNumberToggleEnabled });
           this.set('numberToggleView', tNumberToggleView);
           this.appendChild(tNumberToggleView);
-
-          var tRescaleButton = SC.ImageButtonView.create({
-            classNames: ['rescale-button'],
-            layout: {width: 16, height: 16, right: 2, top: 1},
-            toolTip: 'DG.GraphView.rescale'.loc(),
-            action: rescalePlot,
-            isVisible: isNumberToggleEnabled
-          });
-          this.set('rescaleButton', tRescaleButton);
-          this.appendChild(tRescaleButton);
         }
 
         tXAxisView.set('model', tXAxis);
@@ -422,7 +407,6 @@ DG.GraphView = SC.View.extend(
             tNumberToggleView = this.get('numberToggleView'),
             tFunctionView = this.get('functionEditorView'),
             tPlottedValueView = this.get('plottedValueEditorView'),
-            tRescaleButton = this.get('rescaleButton'),
             tShowNumberToggle = tNumberToggleView && tNumberToggleView.shouldShow(),
             tXHeight = !tXAxisView ? 0 : tXAxisView.get('desiredExtent'),
             tYWidth = !tYAxisView ? 0 : tYAxisView.get('desiredExtent'),
@@ -488,10 +472,7 @@ DG.GraphView = SC.View.extend(
             tLegendView.adjust('height', tLegendHeight);
             if (tNumberToggleView)
               tNumberToggleView.adjust('height', tNumberToggleHeight);
-          }
-          // NumberToggleView visibility is handled by binding
-          if (tRescaleButton) {
-            tRescaleButton.set('isVisible', tShowNumberToggle && this.getPath('model.hasNumericAxis'));
+            // NumberToggleView visibility is handled by binding
           }
         }
         this._isRenderLayoutInProgress = false;

--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -220,7 +220,9 @@ DG.GraphView = SC.View.extend(
         this.createMultiTarget();
 
         if (this.getPath('model.numberToggle')) {
-          var tNumberToggleView = DG.NumberToggleView.create({model: this.getPath('model.numberToggle')});
+          var isNumberToggleEnabled = this.getPath('model.numberToggle.isEnabled'),
+              tNumberToggleView = DG.NumberToggleView.create({model: this.getPath('model.numberToggle'),
+                                                              isVisible: isNumberToggleEnabled });
           this.set('numberToggleView', tNumberToggleView);
           this.appendChild(tNumberToggleView);
 
@@ -228,7 +230,8 @@ DG.GraphView = SC.View.extend(
             classNames: ['rescale-button'],
             layout: {width: 16, height: 16, right: 2, top: 1},
             toolTip: 'DG.GraphView.rescale'.loc(),
-            action: rescalePlot
+            action: rescalePlot,
+            isVisible: isNumberToggleEnabled
           });
           this.set('rescaleButton', tRescaleButton);
           this.appendChild(tRescaleButton);
@@ -247,12 +250,9 @@ DG.GraphView = SC.View.extend(
         }.bind(this));
         this.appendChild(tY2AxisView); // So it will be on top and drag-hilite will show over plot
         tY2AxisView.set('isVisible', tY2Axis.constructor !== DG.AxisModel);
-
-        this.addObserver('model.numberToggle.caseCount', this.handleNumberToggleCaseCountChange);
       },
 
       destroy: function () {
-        this.removeObserver('model.numberToggle.caseCount', this.handleNumberToggleCaseCountChange);
         // Plotviews are not actually subviews so sc_super doesn't destroy them
         this.get('plotViews').forEach( function( iPlotView) {
           iPlotView.destroy();
@@ -457,8 +457,6 @@ DG.GraphView = SC.View.extend(
             if( tPlottedValueView)
               tPlottedValueView.adjust( 'top', tFunctionViewHeight);
             tLegendView.set('layout', {bottom: 0, height: tLegendHeight});
-            if (tNumberToggleView)
-              tNumberToggleView.set('layout', {left: tYWidth, height: tNumberToggleHeight});
             this.makeSubviewFrontmost(tY2AxisView);
           }
           else {
@@ -491,13 +489,10 @@ DG.GraphView = SC.View.extend(
             if (tNumberToggleView)
               tNumberToggleView.adjust('height', tNumberToggleHeight);
           }
-          if (tNumberToggleView) {
-            tNumberToggleView.set('isVisible', tShowNumberToggle);
-          }
+          // NumberToggleView visibility is handled by binding
           if (tRescaleButton) {
-            tRescaleButton.set('isVisible', this.getPath('model.hasNumericAxis'));
+            tRescaleButton.set('isVisible', tShowNumberToggle && this.getPath('model.hasNumericAxis'));
           }
-
         }
         this._isRenderLayoutInProgress = false;
         this._drawPlotsInvocations++;
@@ -814,11 +809,11 @@ DG.GraphView = SC.View.extend(
           '*legendView.desiredExtent', '.legendView.labelNode', '*y2AxisView.desiredExtent'),
 
       /**
-       * When the layout needs of an axis change, we need to adjust the layout of the plot and the other axis.
+       * When the number toggle changes, we need to adjust the layout of the plot and axes.
        */
-      handleNumberToggleCaseCountChange: function () {
+      handleNumberToggleDidChange: function () {
         this.renderLayout(this.renderContext(this.get('tagName')));
-      },
+      }.observes('*model.numberToggle.isEnabled', '*model.numberToggle.caseCount'),
 
       mapPlotModelToPlotView: function (iPlotModel) {
         var tModelClass = iPlotModel && iPlotModel.constructor,

--- a/apps/dg/components/graph/plots/number_toggle_model.js
+++ b/apps/dg/components/graph/plots/number_toggle_model.js
@@ -23,7 +23,7 @@
   @extends SC.Object
 */
 DG.NumberToggleModel = SC.Object.extend(
-/** @scope DG.NumberToggleModel.prototype */ 
+/** @scope DG.NumberToggleModel.prototype */
 {
   /**
     Assigned by the graph model that owns me.
@@ -64,8 +64,33 @@ DG.NumberToggleModel = SC.Object.extend(
     this.notifyPropertyChange('parentCases');
   }.observes('*dataConfiguration.cases'),
 
+  getParentCollection: function() {
+    return this.get('numberOfParents') > 0
+              ? this.get('parentCases')[0].get('collection')
+              : null;
+  },
 
-      /**
+  getFirstParentAttribute: function() {
+    var collection = this.getParentCollection(),
+        attrs = collection && collection.get('attrs'),
+        attr = attrs && attrs[0];
+    return attr;
+  },
+
+  getParentLabel: function(iIndex) {
+    var cases = this.get('parentCases'),
+        tCase = cases && cases[iIndex],
+        attr = this.getFirstParentAttribute();
+    return tCase && attr
+              ? tCase.getStrValue(attr.get('id'))
+              : (iIndex + 1).toString();
+  },
+
+  getParentTooltip: function(iIndex) {
+    return SC.String.loc('DG.NumberToggleView.indexTooltip');
+  },
+
+  /**
    * @property {Number}
    */
   numberOfParents: function() {
@@ -125,10 +150,8 @@ DG.NumberToggleModel = SC.Object.extend(
    * @return{Boolean}
    */
   allCasesAreVisible: function() {
-    var dataConfiguration = this.get('dataConfiguration'),
-      allCases = dataConfiguration && dataConfiguration.get('allCases'),
-      allCasesLength = allCases? allCases.length(): 0;
-    return this.getPath('dataConfiguration.cases').length === allCasesLength;
+    var hiddenCases = this.getPath('dataConfiguration.hiddenCases');
+    return !hiddenCases || !hiddenCases.length;
   },
 
   /**
@@ -249,7 +272,11 @@ DG.NumberToggleModel = SC.Object.extend(
    * When the data context changes we notify
    */
   handleDataContextNotification: function( iNotifier) {
-    this.invokeOnceLater( this.propertyDidChange, 300, 'caseCount');
+    // 'caseCount' is used as a proxy to indicate that some change occurred
+    // GraphView.handleNumberToggleDidChange() observes 'caseCount'
+    // not clear why invokeOnceLater() is (or was) required
+    if (this.get('isEnabled'))
+      this.invokeOnceLater( this.propertyDidChange, 10, 'caseCount');
   }
 
 });

--- a/apps/dg/components/graph/plots/number_toggle_view.js
+++ b/apps/dg/components/graph/plots/number_toggle_view.js
@@ -280,14 +280,13 @@ DG.NumberToggleView = DG.RaphaelBaseView.extend(
         if (!this.get('isVisible')) return;
 
         var kSpace = 5,
-            kScaleWidgetWidth = 16,
             tModel = this.get('model' ),
             tNumParents = tModel.get('numberOfToggleIndices' ),
             tNameElement = createShowAllElement(),
             tNameBox = tNameElement.getBBox(),
             tY = tNameBox.height / 2,
             tFirstX = tNameBox.x + tNameBox.width + kSpace,
-            tNumberDisplayWidth = this._paper.width - tFirstX - (kScaleWidgetWidth + kSpace),
+            tNumberDisplayWidth = this._paper.width - tFirstX - kSpace,
             tNeedRightArrow, tNeedLeftArrow,
             tRightArrow, tLeftArrow,
             tNumberElements = [],

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -285,6 +285,10 @@ SC.stringsFor('English', {
   'DG.Redo.hideSelectedCases': "Redo hiding selected cases",
   'DG.Undo.hideUnselectedCases': "Undo hiding unselected cases",
   'DG.Redo.hideUnselectedCases': "Redo hiding unselected cases",
+  'DG.Undo.enableNumberToggle': "Undo Show Parent Visibility Toggles",
+  'DG.Redo.enableNumberToggle': "Redo Show Parent Visibility Toggles",
+  'DG.Undo.disableNumberToggle': "Undo Hide Parent Visibility Toggles",
+  'DG.Redo.disableNumberToggle': "Redo Hide Parent Visibility Toggles",
   'DG.Undo.interactiveUndoableAction': "Undo an action in the interactive",
   'DG.Redo.interactiveUndoableAction': "Redo an action in the interactive",
   'DG.Undo.showAllCases': "Undo showing all cases",
@@ -530,11 +534,11 @@ SC.stringsFor('English', {
   'DG.LegendView.attributeTooltip': "Click to change legend attribute",  // "Click to change legend attribute"
 
   // DG.NumberToggleView
-  'DG.NumberToggleView.showAll': "Show All -",  // "Show All"
-  'DG.NumberToggleView.hideAll': "Hide All -",  // "Hide All"
-  'DG.NumberToggleView.showAllTooltip': "Click numbers to toggle visibility. Click label to show all.",  // "Click numbers to toggle visibility. Click label to show all."
-  'DG.NumberToggleView.hideAllTooltip': "Click numbers to toggle visibility. Click label to hide all.",  // "Click numbers to toggle visibility. Click label to hide all."
-  'DG.NumberToggleView.indexTooltip': "Click to toggle visibility.",  // "Click to toggle visibility."
+  'DG.NumberToggleView.showAll': "Show All \u2013",  // "Show All -"
+  'DG.NumberToggleView.hideAll': "Hide All \u2013",  // "Hide All -"
+  'DG.NumberToggleView.showAllTooltip': "Click to show all cases\nClick parent case labels to toggle visibility",
+  'DG.NumberToggleView.hideAllTooltip': "Click to hide all cases\nClick parent case labels to toggle visibility",
+  'DG.NumberToggleView.indexTooltip': "Click to toggle visibility",  // "Click to toggle visibility"
 
   // DG.PlottedAverageAdornment
   'DG.PlottedAverageAdornment.meanValueTitle': "mean=%@", // "mean=123.456"
@@ -561,6 +565,8 @@ SC.stringsFor('English', {
   'DG.DataDisplayMenu.hideUnselectedPlural': "Hide Unselected Cases",
   'DG.DataDisplayMenu.hideSelectedSing': "Hide Selected Case",
   'DG.DataDisplayMenu.hideUnselectedSing': "Hide Unselected Case",
+  'DG.DataDisplayMenu.enableNumberToggle': "Show Parent Visibility Toggles",
+  'DG.DataDisplayMenu.disableNumberToggle': "Hide Parent Visibility Toggles",
   'DG.DataDisplayMenu.showAll': "Show All Cases",
   'DG.DataDisplayMenu.snapshot': "Make Snapshot",
 

--- a/apps/dg/resources/dg.css
+++ b/apps/dg/resources/dg.css
@@ -479,6 +479,10 @@
     cursor: pointer;
 }
 
+.number-toggle {
+    background-color: #F9F9F9;
+}
+
 .choro-rect {
     cursor: pointer;
 }


### PR DESCRIPTION
- toggle labels default to first parent attribute values rather than parent case indices [#143266497]
- improve layout of toggle labels with arbitrary-length string labels
- add "Show/Hide Parent Visibility Toggles" to the graph menu
- Showing/Hiding Parent Visibility Toggles is undoable
- fix bug in which document would show through transparent number toggle view
- fix bug which prevented "Hide All" label from appearing when appropriate
- fix bug which prevented tooltip from appearing for "Show/Hide All" label

Combining the best attributes of the various naming suggestions provided, I considered using "Show/Hide Parent Case Quick Visibility Filter Toggles-inator", but in consultation with Bill we decided to try "Show/Hide Parent Visibility Toggles" for now.

Also in conversation with Bill, this PR removes the rescale button from the number toggle UI, as it is redundant with the rescale button in the inspector which is generally right next to it.