### PR TITLE
Implement "Last" mode for Parent Visibility Toggles

### DIFF
--- a/apps/dg/components/graph/graph_controller.js
+++ b/apps/dg/components/graph/graph_controller.js
@@ -67,6 +67,8 @@ DG.GraphController = DG.DataDisplayController.extend(
           storage.plotBackgroundColor = this.getPath('graphModel.plotBackgroundColor');
           storage.plotBackgroundOpacity = this.getPath('graphModel.plotBackgroundOpacity');
           storage.enableNumberToggle = this.getPath('graphModel.enableNumberToggle');
+          if (storage.enableNumberToggle)
+            storage.numberToggleLastMode = this.getPath('graphModel.numberToggle.lastMode');
 
           this.storeDimension(dataConfiguration, storage, 'x');
           this.storeDimension(dataConfiguration, storage, 'y');

--- a/apps/dg/components/graph/graph_model.js
+++ b/apps/dg/components/graph/graph_model.js
@@ -744,6 +744,8 @@ DG.GraphModel = DG.DataDisplayModel.extend(
         this.set('plotBackgroundOpacity', iStorage.plotBackgroundOpacity);
       if( !SC.none( iStorage.enableNumberToggle))
         this.set('enableNumberToggle', iStorage.enableNumberToggle);
+      if( iStorage.enableNumberToggle && !SC.none( iStorage.numberToggleLastMode))
+        this.setPath('numberToggle.lastMode', iStorage.numberToggleLastMode);
 
       this.set('aboutToChangeConfiguration', true ); // signals dependents to prepare
 

--- a/apps/dg/components/graph/graph_model.js
+++ b/apps/dg/components/graph/graph_model.js
@@ -842,17 +842,10 @@ DG.GraphModel = DG.DataDisplayModel.extend(
       this.get('plots' ).forEach( function( iPlot) {
         iPlot.handleDataContextNotification( iNotifier, iChange);
       });
-    },
-
-    /**
-      Responder for notifications from the DataContext.
-     */
-    handleDataContextNotification: function( iNotifier) {
-      sc_super(); // Bulk of work will be done in calls to handleOneDataContextChange
-
-      if( this.get('numberToggle')) {
-        // The numberToggle does not need to respond to individual notifications
-        this.get('numberToggle' ).handleDataContextNotification( iNotifier);
+      // Forward the notification to the number toggle, so it can respond as well.
+      var numberToggleModel = this.get('numberToggle');
+      if(numberToggleModel) {
+        numberToggleModel.handleDataContextNotification(iNotifier, iChange);
       }
     },
 

--- a/apps/dg/components/graph/plots/number_toggle_model.js
+++ b/apps/dg/components/graph/plots/number_toggle_model.js
@@ -31,6 +31,14 @@ DG.NumberToggleModel = SC.Object.extend(
   */
   dataConfiguration: null,
 
+  hiddenCasesBinding: '*dataConfiguration.hiddenCases',
+
+  /**
+   * Whether we are in show last parent case only mode
+   * @property {Boolean}
+   */
+  lastMode: false,
+
   _cachedCaseCount: null,
   _cachedParentCases: null,
 
@@ -39,10 +47,22 @@ DG.NumberToggleModel = SC.Object.extend(
    */
   parentCases: function() {
     var tParents = [],
-        tCases = this.getPath('dataConfiguration.allCases' );
+        tCases = this.getPath('dataConfiguration.allCases' ),
+        isHierarchical = false;
     if( !tCases)
       return [];
     tCases = tCases.flatten();
+
+    function getUltimateParent(iCase) {
+      var lastCase;
+      while(iCase) {
+        lastCase = iCase;
+        iCase = iCase.get('parent');
+        if (iCase) isHierarchical = true;
+      }
+      return lastCase;
+    }
+
     // This check for whether we can use the cached parents isn't completely foolproof because
     // cases could come and go leaving us with the same number between calls.
     if( tCases.length === this._cachedCaseCount) {
@@ -57,6 +77,7 @@ DG.NumberToggleModel = SC.Object.extend(
       });
       this._cachedCaseCount = tCases.length;
       this._cachedParentCases = tParents;
+      this._isHierarchical = isHierarchical;
     }
     return tParents;
   }.property(),
@@ -114,7 +135,8 @@ DG.NumberToggleModel = SC.Object.extend(
    * @property{Integer}
    */
   indicesRepresentChildren: function() {
-    return this.get('numberOfParents') > 0;
+    this.get('parentCases');
+    return this._isHierarchical;
   }.property('numberOfParents'),
 
   /**
@@ -150,8 +172,29 @@ DG.NumberToggleModel = SC.Object.extend(
    * @return{Boolean}
    */
   allCasesAreVisible: function() {
-    var hiddenCases = this.getPath('dataConfiguration.hiddenCases');
+    var hiddenCases = this.get('hiddenCases');
     return !hiddenCases || !hiddenCases.length;
+  },
+
+  /*
+   * For tracking whether we are in the process of making visibility changes.
+   * Allows differential response to visibility changes caused by others.
+   */
+  _isChangingVisibility: 0,
+
+  beginVisibilityChanges: function() {
+    ++ this._isChangingVisibility;
+  },
+
+  endVisibilityChanges: function() {
+    // use invokeLater() so notifications have a chance to propagate
+    this.invokeLater(function() {
+      -- this._isChangingVisibility;
+    }.bind(this));
+  },
+
+  isChangingVisibility: function() {
+    return this._isChangingVisibility > 0;
   },
 
   /**
@@ -160,12 +203,14 @@ DG.NumberToggleModel = SC.Object.extend(
    */
   changeAllCaseVisibility: function() {
     var tConfig = this.get('dataConfiguration' );
+    this.beginVisibilityChanges();
     if( this.allCasesAreVisible()) {
       tConfig.hideCases( tConfig.get('cases'));
     }
     else {
       tConfig.showAllCases();
     }
+    this.endVisibilityChanges();
   },
 
   /**
@@ -183,12 +228,14 @@ DG.NumberToggleModel = SC.Object.extend(
       return tHidden.indexOf( iCase) < 0;
     }
 
+    this.beginVisibilityChanges();
     if( tChildren.some( isVisible)) {
       tConfig.hideCases( tChildren);
     }
     else {
       tConfig.showCases( tChildren);
     }
+    this.endVisibilityChanges();
   },
 
   /**
@@ -204,11 +251,67 @@ DG.NumberToggleModel = SC.Object.extend(
           tCases = tConfig ? tConfig.get('allCases').flatten() : [],
           tHidden = tConfig ? tConfig.get('hiddenCases' ) : [],
           tCase = (tCases.length > iIndex) ? tCases[ iIndex] : null;
+      this.beginVisibilityChanges();
       if( tHidden.indexOf( tCase) < 0)
         tConfig.hideCases([tCase]);
       else
         tConfig.showCases([tCase]);
+      this.endVisibilityChanges();
     }
+  },
+
+  /**
+   * Hide/show the children of the specified parent case
+   * @param {Number}  iIndex - parent case index
+   * @param {Boolean} iVisible - true to show; false to hide
+   */
+  setVisibility: function(iIndex, iVisible) {
+    var tConfig = this.get('dataConfiguration'),
+        tCasesToHideShow;
+
+    if (this.get('indicesRepresentChildren')) {
+      tCasesToHideShow = this.childrenOfParent(iIndex);
+    }
+    else {
+      var tCases = tConfig ? tConfig.get('allCases').flatten() : [],
+          tCase = (tCases.length > iIndex) ? tCases[iIndex] : null;
+      tCasesToHideShow = tCase ? [tCase] : null;
+      if (!tCasesToHideShow) return;
+    }
+
+    this.beginVisibilityChanges();
+      if(iVisible) {
+        tConfig.showCases(tCasesToHideShow);
+      }
+      else {
+        tConfig.hideCases(tCasesToHideShow);
+      }
+    this.endVisibilityChanges();
+  },
+
+  /**
+   * Observer function for 'lastMode' changes
+   * Enabling 'lastMode' hides all but the last parent case.
+   * Disabling 'lastMode' exits the mode but doesn't change case visibility.
+   */
+  lastModeDidChange: function() {
+    var lastMode = this.get('lastMode');
+    if (lastMode) {
+      this.showOnlyLastParentCase();
+    }
+  }.observes('lastMode'),
+
+  /**
+   * Show the last parent case and hide all the other parent cases.
+   */
+  showOnlyLastParentCase: function() {
+    var toggleIndex, toggleCount = this.get('numberOfToggleIndices');
+    this.beginVisibilityChanges();
+    for (toggleIndex = 0; toggleIndex < toggleCount - 1; ++toggleIndex) {
+      this.setVisibility(toggleIndex, false);
+    }
+    this.setVisibility(toggleIndex, true);
+    this.endVisibilityChanges();
   },
 
   /**
@@ -231,10 +334,10 @@ DG.NumberToggleModel = SC.Object.extend(
    */
   allChildrenAreHidden: function( iIndex) {
     var tChildren = this.childrenOfParent( iIndex ),
-        tHidden = this.getPath('dataConfiguration.hiddenCases' );
+        tHidden = this.get('hiddenCases');
 
     function isVisible( iCase) {
-      return tHidden.indexOf( iCase) < 0;
+      return !tHidden || (tHidden.indexOf( iCase) < 0);
     }
 
     return !tChildren.some( isVisible);
@@ -258,10 +361,8 @@ DG.NumberToggleModel = SC.Object.extend(
     }
   },
 
-      /**
-   *
+  /**
    * Note: returns true if no cases are hidden when there are no cases
-   * @param iIndex
    * @return {Boolean}
    */
   allCasesAreHidden: function() {
@@ -269,14 +370,35 @@ DG.NumberToggleModel = SC.Object.extend(
   },
 
   /**
+   * Respond to shown/hidden cases
+   */
+  hiddenCasesDidChange: function() {
+    // if user hides/shows cases via other means, exit lastMode
+    if (this.get('lastMode') && !this.isChangingVisibility())
+      this.set('lastMode', false);
+  }.observes('hiddenCases'),
+
+  /**
    * When the data context changes we notify
    */
-  handleDataContextNotification: function( iNotifier) {
-    // 'caseCount' is used as a proxy to indicate that some change occurred
-    // GraphView.handleNumberToggleDidChange() observes 'caseCount'
-    // not clear why invokeOnceLater() is (or was) required
-    if (this.get('isEnabled'))
-      this.invokeOnceLater( this.propertyDidChange, 10, 'caseCount');
+  handleDataContextNotification: function(iNotifier, iChange) {
+    if (this.get('isEnabled')) {
+      // if cases are created while in lastMode, ensure only last parent is visible
+      if (this.get('lastMode') && (iChange.operation.indexOf('createCase') === 0)) {
+        this.invokeOnce(function() { this.showOnlyLastParentCase(); }.bind(this));
+        return;
+      }
+
+      if (['createCollection', 'deleteCollection', 'moveAttribute'].indexOf(iChange.operation) >= 0) {
+        this._cachedCaseCount = this._cachedParentCases = this._isHierarchical = null;
+      }
+
+      // 'caseCount' is used as a proxy to indicate that some change occurred
+      // GraphView.handleNumberToggleDidChange() observes 'caseCount'
+      // not clear why invokeOnceLater() is (or was) required
+      else
+        this.invokeOnceLater( this.propertyDidChange, 1, 'caseCount');
+    }
   }
 
 });

--- a/apps/dg/components/graph/plots/number_toggle_view.js
+++ b/apps/dg/components/graph/plots/number_toggle_view.js
@@ -249,6 +249,9 @@ DG.NumberToggleView = DG.RaphaelBaseView.extend(
                                 ? 'DG.NumberToggleView.disableLastModeTooltip'.loc()
                                 : 'DG.NumberToggleView.enableLastModeTooltip'.loc(),
                 tClickHandling = false,
+                lastDashElt = this._paper.text(-9999, 0, 'DG.NumberToggleView.lastDash'.loc())
+                                .attr({ 'font-family': kLabelFontFamily, 'font-size': kLabelFontSize,
+                                        cursor: 'pointer', 'text-anchor': 'start', fill: 'black' }),
                 checkElt = this._paper.text(-9999, 0, lastCheck)
                             .attr({ 'font-family': kLabelFontFamily, 'font-size': kCheckFontSize,
                                     cursor: 'pointer', 'text-anchor': 'start',
@@ -275,9 +278,11 @@ DG.NumberToggleView = DG.RaphaelBaseView.extend(
                             toggleLastMode();
                           tClickHandling = false;
                         });
-            checkElt.width = checkElt.getBBox().width;
-            lastElt.width = lastElt.getBBox().width;
-            return [checkElt, lastElt];
+            var lastElements = [lastDashElt, checkElt, lastElt];
+            lastElements.forEach(function(elt) {
+              elt.width = elt.getBBox().width;
+            });
+            return lastElements;
           }.bind(this),
 
           createNumberElements = function(lastElements) {

--- a/apps/dg/components/graph_map_common/plot_data_configuration.js
+++ b/apps/dg/components/graph_map_common/plot_data_configuration.js
@@ -24,7 +24,7 @@
   @extends SC.Object
 */
 DG.PlotDataConfiguration = SC.Object.extend(
-/** @scope DG.PlotDataConfiguration.prototype */ 
+/** @scope DG.PlotDataConfiguration.prototype */
 {
   /**
     The data context which is the source of the data for this graph.
@@ -36,7 +36,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
     this.invalidateCaches();
     this.notifyPropertyChange('defaultTitle');
   }.observes('dataContext'),
-  
+
   /**
     The outer array is indexed by DG.GraphTypes.EPlace
     @property { Array of {Array of {DG.AttributeDescription}}}
@@ -59,15 +59,15 @@ DG.PlotDataConfiguration = SC.Object.extend(
     }
     return tResult;
   }.property('xCollectionClient','yCollectionClient', 'legendCollectionClient', 'dataContext'),
-  
+
   xCollectionClient: function() {
     return this.getPath('xAttributeDescription.collectionClient');
   }.property(),
-  
+
   yCollectionClient: function() {
     return this.getPath('yAttributeDescription.collectionClient');
   }.property(),
-  
+
   y2CollectionClient: function() {
     return this.getPath('y2AttributeDescription.collectionClient');
   }.property(),
@@ -79,11 +79,11 @@ DG.PlotDataConfiguration = SC.Object.extend(
   xCollectionDidChange: function() {
     this.notifyPropertyChange('xCollectionClient');
   }.observes('*xAttributeDescription.collectionClient'),
-  
+
   yCollectionDidChange: function() {
     this.notifyPropertyChange('yCollectionClient');
   }.observes('*yAttributeDescription.collectionClient'),
-  
+
   y2CollectionDidChange: function() {
     this.notifyPropertyChange('y2CollectionClient');
   }.observes('*y2AttributeDescription.collectionClient'),
@@ -160,7 +160,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
   firstAttributeDescriptionForRole: function( iRole) {
     return this.firstPlaceAndAttributeDescriptionForRole( iRole).attributeDescription;
   },
-  
+
   /**
     @param{DG.Analysis.EAnalysisRole}
     @return{DG.AttributePlacementDescription}
@@ -169,7 +169,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
     var tResult = this.firstPlaceAndAttributeDescriptionForRole( iRole);
     return tResult.attributeDescription.get('attributeID');
   },
-  
+
   /**
     @param{DG.Analysis.EAnalysisRole}
     @return{DG.GraphTypes.EPlace}
@@ -177,11 +177,11 @@ DG.PlotDataConfiguration = SC.Object.extend(
   getPlaceForRole: function( iRole) {
     return this.firstPlaceAndAttributeDescriptionForRole( iRole).place;
   },
-  
+
   xAttributeID: function() {
     return this.getPath('xAttributeDescription.attributeID');
   }.property(),
-  
+
   yAttributeID: function() {
     return this.getPath('yAttributeDescription.attributeID');
   }.property(),
@@ -197,19 +197,19 @@ DG.PlotDataConfiguration = SC.Object.extend(
   xAttributeIDDidChange: function() {
     this.notifyPropertyChange('xAttributeID');
   }.observes('*xAttributeDescription.attributeID'),
-  
+
   yAttributeIDDidChange: function() {
     this.notifyPropertyChange('yAttributeID');
   }.observes('*yAttributeDescription.attributeID'),
-  
+
   y2AttributeIDDidChange: function() {
     this.notifyPropertyChange('y2AttributeID');
   }.observes('*y2AttributeDescription.attributeID'),
-  
+
   legendAttributeIDDidChange: function() {
     this.notifyPropertyChange('legendAttributeID');
   }.observes('*legendAttributeDescription.attributeID'),
-  
+
   /**
     @property {Boolean}
   */
@@ -234,15 +234,15 @@ DG.PlotDataConfiguration = SC.Object.extend(
   xIsNumericDidChange: function() {
     this.notifyPropertyChange('xIsNumeric');
   }.observes('*xAttributeDescription.isNumeric'),
-  
+
   yIsNumericDidChange: function() {
     this.notifyPropertyChange('yIsNumeric');
   }.observes('*yAttributeDescription.isNumeric'),
-  
+
   y2IsNumericDidChange: function() {
     this.notifyPropertyChange('y2IsNumeric');
   }.observes('*y2AttributeDescription.isNumeric'),
-  
+
   /**
     @property {DG.Analysis.EAttributeType}
   */
@@ -267,15 +267,15 @@ DG.PlotDataConfiguration = SC.Object.extend(
   xTypeDidChange: function() {
     this.notifyPropertyChange('xType');
   }.observes('*xAttributeDescription.attributeType'),
-  
+
   yTypeDidChange: function() {
     this.notifyPropertyChange('yType');
   }.observes('*yAttributeDescription.attributeType'),
-  
+
   y2TypeDidChange: function() {
     this.notifyPropertyChange('y2Type');
   }.observes('*y2AttributeDescription.attributeType'),
-  
+
   /**
    * This property is never actually assigned. It is used only as a notification bottleneck
    * @property { null }
@@ -299,10 +299,10 @@ DG.PlotDataConfiguration = SC.Object.extend(
   hasAggregates: function() {
     var collectionIDs = {},
         foundID,
-    
+
         /**
           Utility function used to help identify the minimum set of collections that
-          have to be checked for aggregate functions. Since most graphs refer to 
+          have to be checked for aggregate functions. Since most graphs refer to
           attributes for a single collection, there's no point in redundantly checking
           for aggregates in the same collection due to multiple attribute references.
           Adds the specified collection to the collectionIDs local variable map.
@@ -314,12 +314,12 @@ DG.PlotDataConfiguration = SC.Object.extend(
           if( !SC.none( collectionID))
             collectionIDs[ collectionID] = collection;
         }.bind( this);
-    
+
     // Consider each of our possible collections in turn
     considerCollection('x');
     considerCollection('y');
     considerCollection('legend');
-    
+
     // Search through our set of collections, stopping on the first one that has aggregates.
     foundID = DG.ObjectMap.findKey( collectionIDs,
                                     function( iCollectionID, iCollection) {
@@ -381,7 +381,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
 
     sc_super();
   },
-  
+
   /**
     Sets the specified attribute for the specified attribute description,
     e.g. puts the specified attribute in the appropriate place for an axis.
@@ -441,7 +441,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
       tStats.set('attributeType', tType);
     }
   },
-  
+
   /**
    * Choose one collection to treat as the child collection.
    * If there is no parent/child relationship, just pick a collection.
@@ -618,11 +618,11 @@ DG.PlotDataConfiguration = SC.Object.extend(
         iArray.forEach( iDoF);
       });
   },
-  
+
   /**
     Return the first attribute description for which iTestF returns true.
     @param{Function} with signature (DG.AttributePlacementDescription) returning Boolean
-    @return {{attributeDescription: {DG.AttributePlacementDescription}, 
+    @return {{attributeDescription: {DG.AttributePlacementDescription},
               place: {DG.Analysis.EPlace} }}
   */
   firstAttributeDescriptionSuchThat: function( iTestF) {
@@ -641,10 +641,10 @@ DG.PlotDataConfiguration = SC.Object.extend(
     }
     return { attributeDescription: null, place: DG.GraphTypes.EPlace.eUndefined };
   },
-  
+
   /**
     @param{DG.Analysis.EAnalysisRole}
-    @return{{attributeDescription: {DG.AttributePlacementDescription}, 
+    @return{{attributeDescription: {DG.AttributePlacementDescription},
               place: {DG.Analysis.EPlace} }}
   */
   firstPlaceAndAttributeDescriptionForRole: function( iRole) {
@@ -664,7 +664,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
     this.get('legendAttributeDescription').invalidateCaches( iCases, iChange);
 
  },
-  
+
   /**
     Pass along to attribute descriptions
   */
@@ -740,10 +740,10 @@ DG.PlotDataConfiguration = SC.Object.extend(
       if( tCC)
         tArrays.push( tCC.casesController.arrangedObjects());
     }
-    
+
     return tArrays;
   }.property('xCollectionClient', 'yCollectionClient', 'legendCollectionClient'),
-  
+
   /**
     @param { DG.GraphTypes.EPlace }
     @return{ {min:{Number}, max:{Number} isDataInteger:{Boolean}} }
@@ -784,15 +784,17 @@ DG.PlotDataConfiguration = SC.Object.extend(
    * @param iArrayOfCases
    */
   hideCases: function( iArrayOfCases) {
+    if (!iArrayOfCases || !iArrayOfCases.length) return;
     this.set('hiddenCases', this.get('hiddenCases' ).concat( iArrayOfCases ).uniq());
   },
-  
+
   /**
    * The given array of cases will be subtracted from the current array of hidden cases.
    * By using 'set' we trigger notification for observers.
    * @param iArrayOfCases
    */
   showCases: function( iArrayOfCases) {
+    if (!iArrayOfCases || !iArrayOfCases.length) return;
     this.set('hiddenCases', DG.ArrayUtils.subtract( this.get('hiddenCases' ), iArrayOfCases,
                                                     function( iCase) {
                                                       return iCase.get('id');
@@ -813,8 +815,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
    * @param iArrayOfCaseIDs {Array} of {Number}
    */
   restoreHiddenCases: function( iArrayOfCaseIDs) {
-    if(SC.none( iArrayOfCaseIDs))
-      return;
+    if (!iArrayOfCaseIDs || !iArrayOfCaseIDs.length) return;
     this.set('hiddenCases', iArrayOfCaseIDs.map( function( iID) {
                                   return this.dataContext.getCaseByID( iID);
                                 }.bind(this)

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -548,8 +548,11 @@ SC.stringsFor('English', {
   // DG.NumberToggleView
   'DG.NumberToggleView.showAll': "Show All \u2013",  // "Show All -"
   'DG.NumberToggleView.hideAll': "Hide All \u2013",  // "Hide All -"
+  'DG.NumberToggleView.lastLabel': "Last",
   'DG.NumberToggleView.showAllTooltip': "Click to show all cases\nClick parent case labels to toggle visibility",
   'DG.NumberToggleView.hideAllTooltip': "Click to hide all cases\nClick parent case labels to toggle visibility",
+  'DG.NumberToggleView.enableLastModeTooltip': "Click to show last parent case only",
+  'DG.NumberToggleView.disableLastModeTooltip': "Click to exit last parent case mode",
   'DG.NumberToggleView.indexTooltip': "Click to toggle visibility",  // "Click to toggle visibility"
 
   // DG.PlottedAverageAdornment

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -548,8 +548,9 @@ SC.stringsFor('English', {
   // DG.NumberToggleView
   'DG.NumberToggleView.showAll': "Show All \u2013", // "Show All -"
   'DG.NumberToggleView.hideAll': "Hide All \u2013", // "Hide All -"
-  'DG.NumberToggleView.lastUnchecked': "\u2013 \u2610",  // "- [ ]"
-  'DG.NumberToggleView.lastChecked': "\u2013 \u2612",    // "- [x]"
+  'DG.NumberToggleView.lastDash': "\u2013",         // "-"
+  'DG.NumberToggleView.lastUnchecked': "\u2610",    // "[ ]"
+  'DG.NumberToggleView.lastChecked': "\u2612",      // "[x]"
   'DG.NumberToggleView.lastLabel': "Last",    // "Last"
   'DG.NumberToggleView.showAllTooltip': "Click to show all cases\nClick parent case labels to toggle visibility",
   'DG.NumberToggleView.hideAllTooltip': "Click to hide all cases\nClick parent case labels to toggle visibility",

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -546,9 +546,11 @@ SC.stringsFor('English', {
   'DG.LegendView.attributeTooltip': "Click to change legend attribute",  // "Click to change legend attribute"
 
   // DG.NumberToggleView
-  'DG.NumberToggleView.showAll': "Show All \u2013",  // "Show All -"
-  'DG.NumberToggleView.hideAll': "Hide All \u2013",  // "Hide All -"
-  'DG.NumberToggleView.lastLabel': "Last",
+  'DG.NumberToggleView.showAll': "Show All \u2013", // "Show All -"
+  'DG.NumberToggleView.hideAll': "Hide All \u2013", // "Hide All -"
+  'DG.NumberToggleView.lastUnchecked': "\u2013 \u2610",  // "- [ ]"
+  'DG.NumberToggleView.lastChecked': "\u2013 \u2612",    // "- [x]"
+  'DG.NumberToggleView.lastLabel': "Last",    // "Last"
   'DG.NumberToggleView.showAllTooltip': "Click to show all cases\nClick parent case labels to toggle visibility",
   'DG.NumberToggleView.hideAllTooltip': "Click to hide all cases\nClick parent case labels to toggle visibility",
   'DG.NumberToggleView.enableLastModeTooltip': "Click to show last parent case only",


### PR DESCRIPTION
- Implement 'lastMode' in which only the last parent case is visible [#143267369]
- Parent visibility toggles use leftmost attribute of "highest" parent collection [#144046029

Now includes two additional commits based on feedback from demo meeting:
- Hiding/showing cases works as expected with more than two hierarchical levels
- Use Unicode checkbox to indicate last mode state rather than gray/black text
- Add dash (and checkbox) to set "Last" apart from regular value strings

@bfinzer We can do a synchronous review at some point as well, if you'd like.

Now includes two more commits based on synchronous code review with Bill:
- `lastMode` state is saved/restored with graph
- the dash before "[] Last" is now the same size as the dash after "Show/Hide All"