### PR TITLE
Fix save/restore of Sage graphs in CODAP

### DIFF
--- a/apps/dg/components/graph/graph_model.js
+++ b/apps/dg/components/graph/graph_model.js
@@ -222,9 +222,12 @@ DG.GraphModel = DG.DataDisplayModel.extend(
           delete this[iKey + 'AttributeName'];  // Because that was how it was passed in
           tAttribute = tDataContext ? tDataContext.getAttributeByName(tAttributeName) :
               (tCollectionClient ? tCollectionClient.getAttributeByName(tAttributeName) : null);
-          if( tAttribute)
+          if( tAttribute) {
+            if (tDataContext && !tCollectionClient)
+              tCollectionClient = tDataContext.getCollectionForAttribute(tAttribute);
             this.get('dataConfiguration').setAttributeAndCollectionClient( iKey + 'AttributeDescription',
                 { collection: tCollectionClient, attributes: [ tAttribute]});
+          }
         }
       }.bind(this);
       var tDataContext = this.initialDataContext;


### PR DESCRIPTION
- Fixes CODAP [#143413541] and Sage [#143413567]
- `GraphModel`'s `configureAttributeDescription` function now sets collection properly when initialized with a data context