### PR TITLE
Disable name canonicalization globally; support backtick identifiers in formulas

### DIFF
--- a/apps/dg/controllers/collection_client.js
+++ b/apps/dg/controllers/collection_client.js
@@ -305,8 +305,8 @@ DG.CollectionClient = SC.Object.extend(
   willDestroyAttribute: function( iAttribute) {
   },
 
-  makeAttributeNameLegal: function (iName) {
-    return DG.Attribute.legalizeAttributeName(iName);
+  canonicalizeName: function (iName) {
+    return DG.Attribute.canonicalizeName(iName);
   },
 
   /**
@@ -322,7 +322,7 @@ DG.CollectionClient = SC.Object.extend(
     iProperties = iProperties || {};
 
     if (!SC.none(iProperties.name)) {
-      iProperties.name = this.makeAttributeNameLegal(iProperties.name);
+      iProperties.name = this.canonicalizeName(iProperties.name);
     }
 
     // if the property has an ID then it is an existing attribute, possibly from

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -119,6 +119,10 @@ DG.DataContext = SC.Object.extend((function() // closure
   //      this.get('flexibleGroupingChangeFlag'));
   //}.observes('*model.flexibleGroupingChangeFlag'),
 
+  canonicalizeName: function(iName) {
+    return DG.Attribute.canonicalizeName(iName);
+  },
+
   /**
    *  The id of our DG.DataContextRecord.
    *  Bound to the 'id' property of the model.
@@ -820,7 +824,7 @@ DG.DataContext = SC.Object.extend((function() // closure
         iCase.beginCaseValueChanges();
         DG.ObjectMap.forEach(values, function(key, value) {
           var attr = this.getAttributeByName(key)
-              || this.getAttributeByName(DG.Attribute.legalizeAttributeName(key));
+              || this.getAttributeByName(this.canonicalizeName(key));
           if (attr) {
             iCase.setValue(attr.id, value);
           } else {
@@ -1074,7 +1078,7 @@ DG.DataContext = SC.Object.extend((function() // closure
                                   oldName = attribute.get('name');
                                   if (names.indexOf(oldName) < 0)
                                     names.push(oldName);
-                                  iValue = collection.makeAttributeNameLegal(iValue);
+                                  iValue = collection.canonicalizeName(iValue);
                                   if (names.indexOf(iValue) < 0)
                                     names.push(iValue);
                                 }

--- a/apps/dg/controllers/document_archiver.js
+++ b/apps/dg/controllers/document_archiver.js
@@ -310,8 +310,10 @@ DG.DocumentArchiver = SC.Object.extend(
       tDoc.contexts[0].collections[0].name = tChildName;
       tDoc.contexts[0].name = tContextName;
 
+      var canonicalName;
       for (ix = 0; ix < tTableStats.maxCols; ix += 1) {
-         tAttrNames.push(guaranteeUnique(DG.Attribute.legalizeAttributeName(tAttrNamesRow[ix]), tAttrNames));
+        canonicalName = DG.Attribute.canonicalizeName(tAttrNamesRow[ix]);
+        tAttrNames.push(guaranteeUnique(canonicalName, tAttrNames));
       }
 
       tAttrNames.forEach(function (iName) {

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -362,6 +362,11 @@ DG = SC.Application.create((function () // closure
       return SC.clone(iObject, YES);
     },
 
+    /**
+     * Determines whether attribute/slider names will be automatically canonicalized
+     */
+    canonicalizeNames: false,
+
     // CFM functions, null until connected
     exportFile: null,
 

--- a/apps/dg/formula/codapFormulaMode.js
+++ b/apps/dg/formula/codapFormulaMode.js
@@ -16,7 +16,8 @@ CodeMirror.defineSimpleMode("codapFormula", {
     {regex: /0x[a-f\d]+|[-+]?(?:\.\d+|\d+\.?\d*)(?:e[-+]?\d+)?/i, token: "number"},
     {regex: /[-+\/*=<>!^]+/, token: "operator"},
     {regex: DG.Formula.functionRegExp, token: "function"},
-    {regex: DG.Formula.identifierRegExp, token: "variable"}
+    {regex: DG.Formula.identifierRegExp, token: "variable"},
+    {regex: /(?:`(?:[^\\]|\\.)*?(?:`|$))/, token: "variable"}
   ],
   // The meta property contains global information about the mode. It
   // can contain properties like lineComment, which are supported by

--- a/apps/dg/formula/formulaGrammar.pegjs
+++ b/apps/dg/formula/formulaGrammar.pegjs
@@ -5,6 +5,7 @@
     -- No assignment
     -- No regular expressions
     -- No bitwise operators (bitwise '~', '^', '&', '|')
+    -- Backticks around identifiers to support arbitrary identifier names
     -- '=' instead of '=='/'===' for equality comparison
     -- '!=' (not '!==') for inequality comparison
         (We also support single-character Unicode not-equals.)
@@ -21,15 +22,15 @@
            random(min,max) -- pseudo-random number in range [min,max)
         4. round(x,digits) -- rounds to the specified number of decimal places
         5. trunc(x) -- truncates to the integer portion
-  
+
   The grammar was developed by starting with the example JavaScript grammar at
-  
+
     https://github.com/dmajda/pegjs/blob/master/examples/javascript.pegjs
-  
+
   and then 1) eliminating the unneeded portions (statements, bitwise operators, etc.)
   and 2) making the additional changes mentioned above, e.g. support for '^' operator
   for exponentiation.
-  
+
   To generate the parser itself, run "npm run build:parser". This will create
   "formulaParser.js" from this file.
 
@@ -57,6 +58,7 @@ LineTerminatorSequence "end of line"
 
 Identifier "identifier"
   = !ReservedWord name:IdentifierName { return name; }
+  / BacktickIdentifier
 
 IdentifierName "identifier"
   = start:IdentifierStart parts:IdentifierPart* {
@@ -71,6 +73,16 @@ IdentifierPart
   = IdentifierStart
   / UnicodeDigit
   / UnicodeConnectorPunctuation
+
+BacktickIdentifier
+  = parts:('`' BacktickIdentifierCharacters '`') { return parts[1]; }
+
+BacktickIdentifierCharacters
+  = chars:BacktickIdentifierChar+ { return chars.join(""); }
+
+BacktickIdentifierChar
+  = !("`" / "\\" / LineTerminator) char_:SourceCharacter { return char_; }
+  / "\\" sequence:EscapeSequence { return sequence; }
 
 UnicodeLetter
   = Lu / Ll

--- a/apps/dg/formula/formulaParser.js
+++ b/apps/dg/formula/formulaParser.js
@@ -46,6 +46,9 @@ DG.formulaParser = (function(){
         "IdentifierName": parse_IdentifierName,
         "IdentifierStart": parse_IdentifierStart,
         "IdentifierPart": parse_IdentifierPart,
+        "BacktickIdentifier": parse_BacktickIdentifier,
+        "BacktickIdentifierCharacters": parse_BacktickIdentifierCharacters,
+        "BacktickIdentifierChar": parse_BacktickIdentifierChar,
         "UnicodeLetter": parse_UnicodeLetter,
         "Literal": parse_Literal,
         "BooleanLiteral": parse_BooleanLiteral,
@@ -330,6 +333,9 @@ DG.formulaParser = (function(){
         if (result0 === null) {
           pos = pos0;
         }
+        if (result0 === null) {
+          result0 = parse_BacktickIdentifier();
+        }
         reportFailures--;
         if (reportFailures === 0 && result0 === null) {
           matchFailed("identifier");
@@ -403,6 +409,170 @@ DG.formulaParser = (function(){
           result0 = parse_Nd();
           if (result0 === null) {
             result0 = parse_Pc();
+          }
+        }
+        return result0;
+      }
+      
+      function parse_BacktickIdentifier() {
+        var result0, result1, result2;
+        var pos0, pos1;
+        
+        pos0 = pos;
+        pos1 = pos;
+        if (input.charCodeAt(pos) === 96) {
+          result0 = "`";
+          pos++;
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"`\"");
+          }
+        }
+        if (result0 !== null) {
+          result1 = parse_BacktickIdentifierCharacters();
+          if (result1 !== null) {
+            if (input.charCodeAt(pos) === 96) {
+              result2 = "`";
+              pos++;
+            } else {
+              result2 = null;
+              if (reportFailures === 0) {
+                matchFailed("\"`\"");
+              }
+            }
+            if (result2 !== null) {
+              result0 = [result0, result1, result2];
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+        } else {
+          result0 = null;
+          pos = pos1;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, parts) { return parts[1]; })(pos0, result0);
+        }
+        if (result0 === null) {
+          pos = pos0;
+        }
+        return result0;
+      }
+      
+      function parse_BacktickIdentifierCharacters() {
+        var result0, result1;
+        var pos0;
+        
+        pos0 = pos;
+        result1 = parse_BacktickIdentifierChar();
+        if (result1 !== null) {
+          result0 = [];
+          while (result1 !== null) {
+            result0.push(result1);
+            result1 = parse_BacktickIdentifierChar();
+          }
+        } else {
+          result0 = null;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, chars) { return chars.join(""); })(pos0, result0);
+        }
+        if (result0 === null) {
+          pos = pos0;
+        }
+        return result0;
+      }
+      
+      function parse_BacktickIdentifierChar() {
+        var result0, result1;
+        var pos0, pos1, pos2;
+        
+        pos0 = pos;
+        pos1 = pos;
+        pos2 = pos;
+        reportFailures++;
+        if (input.charCodeAt(pos) === 96) {
+          result0 = "`";
+          pos++;
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"`\"");
+          }
+        }
+        if (result0 === null) {
+          if (input.charCodeAt(pos) === 92) {
+            result0 = "\\";
+            pos++;
+          } else {
+            result0 = null;
+            if (reportFailures === 0) {
+              matchFailed("\"\\\\\"");
+            }
+          }
+          if (result0 === null) {
+            result0 = parse_LineTerminator();
+          }
+        }
+        reportFailures--;
+        if (result0 === null) {
+          result0 = "";
+        } else {
+          result0 = null;
+          pos = pos2;
+        }
+        if (result0 !== null) {
+          result1 = parse_SourceCharacter();
+          if (result1 !== null) {
+            result0 = [result0, result1];
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+        } else {
+          result0 = null;
+          pos = pos1;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, char_) { return char_; })(pos0, result0[1]);
+        }
+        if (result0 === null) {
+          pos = pos0;
+        }
+        if (result0 === null) {
+          pos0 = pos;
+          pos1 = pos;
+          if (input.charCodeAt(pos) === 92) {
+            result0 = "\\";
+            pos++;
+          } else {
+            result0 = null;
+            if (reportFailures === 0) {
+              matchFailed("\"\\\\\"");
+            }
+          }
+          if (result0 !== null) {
+            result1 = parse_EscapeSequence();
+            if (result1 !== null) {
+              result0 = [result0, result1];
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+          if (result0 !== null) {
+            result0 = (function(offset, sequence) { return sequence; })(pos0, result0[1]);
+          }
+          if (result0 === null) {
+            pos = pos0;
           }
         }
         return result0;

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -445,7 +445,7 @@ DG.Attribute.createAttribute = function( iProperties) {
 /**
  * Convert a string to a "legal" attribute name.
  */
-DG.Attribute.legalizeAttributeName = function (iName) {
+DG.Attribute.canonicalizeName = function(iName, iCanonicalize) {
   var tName = String(SC.none(iName)? '': iName),
       tReg = /\((.*)\)/,  // Identifies first parenthesized substring
       tMatch = tReg.exec( tName),
@@ -458,7 +458,8 @@ DG.Attribute.legalizeAttributeName = function (iName) {
   // TODO: We are eliminating all but Latin characters here. We should be more general and allow
   // non-Latin alphanumeric characters.
   tNewName = tNewName.trim(); // Get rid of trailing white space
-  tNewName = tNewName.replace(/\W/g, '_');  // Replace non-word characters with underscore
+  if (iCanonicalize || ((iCanonicalize == null) && DG.canonicalizeNames))
+    tNewName = tNewName.replace(/\W/g, '_');  // Replace non-word characters with underscore
   // if after all this we have an empty string replace with a default name.
   if (tNewName.length === 0) {
     tNewName = 'attr';

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -458,7 +458,7 @@ DG.Attribute.legalizeAttributeName = function (iName) {
   // TODO: We are eliminating all but Latin characters here. We should be more general and allow
   // non-Latin alphanumeric characters.
   tNewName = tNewName.trim(); // Get rid of trailing white space
-  tNewName = tNewName.replace(/\W/g, '_');  // Replace white space with underscore
+  tNewName = tNewName.replace(/\W/g, '_');  // Replace non-word characters with underscore
   // if after all this we have an empty string replace with a default name.
   if (tNewName.length === 0) {
     tNewName = 'attr';

--- a/apps/dg/utilities/data_utilities.js
+++ b/apps/dg/utilities/data_utilities.js
@@ -178,7 +178,7 @@ DG.DataUtilities.canonicalizeAttributeValues = function(iAttrs, iDataMap) {
   DG.ObjectMap.forEach(iDataMap, function (iKey, iValue) {
 
     var attr = iAttrs.findProperty('name', iKey) ||
-            iAttrs.findProperty('name', DG.Attribute.legalizeAttributeName(iKey)),
+            iAttrs.findProperty('name', DG.Attribute.canonicalizeName(iKey)),
         value = DG.DataUtilities.canonicalizeInputValue(iValue);
     if(attr != null) {
       valuesMap[attr.id] = value;

--- a/apps/dg/views/attribute_formula_view.js
+++ b/apps/dg/views/attribute_formula_view.js
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                        DG.AttributeFormulaView
-// 
+//
 //  Implements a dialog with edit fields for attribute name and formula.
-//  
+//
 //  Authors:  William Finzer, Kirk Swenson
 //
 //  Copyright (c) 2014 by The Concord Consortium, Inc. All rights reserved.
@@ -146,7 +146,7 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
               ? this.getPath('contentView.attrName.value')
               : this.setPath('contentView.attrName.value', iValue);
   }.property(),
-  
+
   /**
     Forwarding property for the dialog's formula value.
     @property   {String}
@@ -156,7 +156,7 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
               ? this.getPath('contentView.formula.formulaExpression')
               : this.setPath('contentView.formula.formulaExpression', iValue);
   }.property(),
-  
+
   /**
     Initialization function.
    */
@@ -173,7 +173,7 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
     }
     return NO;
   },
-  
+
   /**
     Observer function called when the user selects an item from the Operands popup.
    */
@@ -181,7 +181,10 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
     // Extract the text of the selected item
     var insertionString = this.getPath('contentView.operandPopup.menu.selectedItem.title');
     if( !SC.empty( insertionString)) {
-      var formulaView = this.getPath('contentView.formula');
+      var canonicalString = DG.Attribute.canonicalizeName(insertionString, true),
+          formulaView = this.getPath('contentView.formula');
+      if (insertionString !== canonicalString)
+        insertionString = '`' + insertionString + '`';
       // Replace the current selection with the selected item text
       if( formulaView) {
         formulaView.becomeFirstResponder();
@@ -191,7 +194,7 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
     // Clear the selected item so the same item can be selected multiple times
     this.setPath('contentView.operandPopup.menu.selectedItem', null);
   }.observes('.contentView.operandPopup.menu.selectedItem'),
-  
+
   /**
     Close the dialog.
    */
@@ -209,7 +212,7 @@ DG.CreateAttributeFormulaView = function( iProperties) {
       attrNameValue: 'attrName.value',
       attrNameHint: 'attrName.hint',
       attrNameIsEnabled: 'attrName.isEnabled',
-      
+
       formulaPrompt: 'formula.leftAccessoryView.value',
       formulaValue: 'formula.value',
       formulaExpression: 'formula.formulaExpression',
@@ -224,14 +227,14 @@ DG.CreateAttributeFormulaView = function( iProperties) {
       applyTarget: 'apply.target',
       applyAction: 'apply.action',
       applyTooltip: 'apply.toolTip',
-      
+
       cancelTitle: 'cancel.title',
       cancelTooltip: 'cancel.toolTip'
     },
     tContentView = tDialog.get('contentView'),
     tAttrNameView = tContentView.attrName,
     tFormulaView = tContentView.formula;
-  
+
   // Loop through client-specified properties, applying them to the
   // appropriate property via its path given in the kParamMap.
   DG.ObjectMap.forEach( iProperties,
@@ -245,6 +248,6 @@ DG.CreateAttributeFormulaView = function( iProperties) {
 
   var tInitialView = tAttrNameView.get('isEnabled') ? tAttrNameView : tFormulaView;
   tInitialView.becomeFirstResponder();
-  
+
   return tDialog;
 };

--- a/apps/dg/views/formula_rich_edit_view.js
+++ b/apps/dg/views/formula_rich_edit_view.js
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                      DG.FormulaTextEditView
-// 
+//
 //  Provides a DG-specific text editor for entering a formula.
-//  
+//
 //  Authors:  William Finzer, Kirk Swenson
 //
 //  Copyright (c) 2016 by The Concord Consortium, Inc. All rights reserved.
@@ -119,7 +119,7 @@ return {
   autoCorrect: false,
 
   autoCapitalize: false,
-  
+
   names: [],  // Will be filled with attribute and global variable names by client
 
   _disableNextSelectRoot: false,
@@ -208,8 +208,13 @@ return {
           isVariable = classes.indexOf('cm-variable') >= 0,
           isFunction = classes.indexOf('cm-function') >= 0,
           nodeText = $(node).text(),
+          nodeTextLength = nodeText ? nodeText.length : 0,
           completions = cm.options.hintOptions && cm.options.hintOptions.completionData,
           i, completionCount = completions && completions.length;
+      if (isVariable && (nodeTextLength > 2) &&
+          (nodeText[0] === '`') && (nodeText[nodeTextLength-1] === '`')) {
+        nodeText = nodeText.substring(1, nodeTextLength - 1);
+      }
       // linear search could be replaced with faster (e.g. binary) search
       // if performance becomes a problem.
       for (i = 0; i < completionCount; ++i) {
@@ -231,7 +236,7 @@ return {
       this._cm.setValue(iValue || "");
     }
   }.property('value'),
-  
+
   /**
     Replace the current selection with the specified string.
     @param    {String}    iNewString -- the string to insert


### PR DESCRIPTION
- Attribute/slider name canonicalization is disabled by default
- Canonicalization can be enabled/disabled globally via `DG.canonicalizeNames` (which could be set by URL parameter, for example)
- With canonicalization disabled, names that would have been canonicalized (e.g. non-ascii unicode characters, spaces, punctuation) must be enclosed in backticks when referenced in formulas

Note that the set of characters that would be canonicalized (i.e. require enclosing in backticks) is not changed by this PR. The set of characters that are allowed in identifers without requiring backticks can be expanded greatly by changing the formula parser. That would require upgrading to the latest version of PEG.js, which will require additional effort and can be prioritized accordingly.

This PR superceded PR #158 when it became apparent that disabling canonicalization globally was preferred to disabling it on a per-context basis. PR #158 was pushed and closed to archive this effort in case there is ever a desire to return to it in some fashion.