### PR TITLE
Disable name canonicalization per context; support backtick identifiers in formulas

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -216,6 +216,8 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           if (!result.dataContext) { return result;}
         }
 
+        var dataContext = result.dataContext;
+
         if (resourceSelector.component) {
           result.component = DG.currDocumentController().getComponentByName(resourceSelector.component) ||
               (!isNaN(resourceSelector.component) &&
@@ -227,37 +229,39 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
         }
 
         if (resourceSelector.collection) {
-          result.collection = result.dataContext &&
-              (result.dataContext.getCollectionByName(resourceSelector.collection) ||
+          result.collection = dataContext &&
+              (dataContext.getCollectionByName(resourceSelector.collection) ||
               (!isNaN(resourceSelector.collection) &&
-                  result.dataContext.getCollectionByID(resourceSelector.collection)));
+                  dataContext.getCollectionByID(resourceSelector.collection)));
         }
+
+        var collection = result.collection;
 
         if (resourceSelector.attribute) {
           result.attribute = (
             (
-              result.dataContext && (
-                  result.dataContext.getAttributeByName(resourceSelector.attribute) ||
-                  result.dataContext.getAttributeByName(DG.Attribute.legalizeAttributeName(resourceSelector.attribute))
+              dataContext && (
+                  dataContext.getAttributeByName(resourceSelector.attribute) ||
+                  dataContext.getAttributeByName(dataContext.canonicalizeName(resourceSelector.attribute))
               )
             ) ||
             (
               !isNaN(resourceSelector.attribute) &&
-              result.collection && result.collection.getAttributeByID(resourceSelector.attribute)
+              collection && collection.getAttributeByID(resourceSelector.attribute)
             )
           );
         }
 
         if (resourceSelector.caseByID) {
-          result.caseByID = result.dataContext.getCaseByID(resourceSelector.caseByID);
+          result.caseByID = dataContext.getCaseByID(resourceSelector.caseByID);
         }
 
         if (resourceSelector.caseByIndex) {
-          result.caseByIndex = result.collection && result.collection.getCaseAt(Number(resourceSelector.caseByIndex));
+          result.caseByIndex = collection && collection.getCaseAt(Number(resourceSelector.caseByIndex));
         }
 
         if (resourceSelector.caseSearch) {
-          result.caseSearch = result.collection && result.collection.searchCases(resourceSelector.caseSearch);
+          result.caseSearch = collection && collection.searchCases(resourceSelector.caseSearch);
         }
 
         DG.ObjectMap.forEach(resourceSelector, function (key, value) {
@@ -275,13 +279,13 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
        * names will need to conform to the conventions established by the API.
        * @param iValues {Object}
        */
-      validateValues: function( iValues) {
+      validateValues: function(iDataContext, iValues) {
         if( SC.none( iValues))
           return;
         if( iValues.type === 'graph') {
           ['xAttributeName', 'yAttributeName', 'y2AttributeName', 'legendAttributeName'].forEach( function( iPropName) {
-            if( !SC.none( iValues[iPropName])) {
-              iValues[ iPropName] = DG.Attribute.legalizeAttributeName( iValues[ iPropName]);
+            if( !SC.none(iDataContext) && !SC.none( iValues[iPropName])) {
+              iValues[ iPropName] = iDataContext.canonicalizeName( iValues[ iPropName]);
             }
           });
         }
@@ -326,15 +330,14 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
 
         try {
           // parse the resource name into constituent parts
-          var selectorMap = iCmd.resource && this.parseResourceSelector(
-                  iCmd.resource);
+          var selectorMap = iCmd.resource && this.parseResourceSelector(iCmd.resource);
 
           // resolve identified resources
           var resourceMap = this.resolveResources(selectorMap, iCmd.action);
 
           var action = iCmd.action;
           var type = selectorMap && selectorMap.type;
-          var values = this.validateValues( iCmd.values);
+          var values = this.validateValues(resourceMap.dataContext, iCmd.values);
           var metadata = iCmd.meta;
 
           var handler = type && this.handlerMap[type];
@@ -479,6 +482,11 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
               resultValues = DG.clone(iValues);
           // we don't want to create the collections yet
           delete createSpec.collections;
+          // rename 'canonicalizeNames' to 'initCanonicalizeNames' for initialization purposes
+          if (createSpec.canonicalizeNames != null) {
+            createSpec.initCanonicalizeNames = createSpec.canonicalizeNames;
+            delete createSpec.canonicalizeNames;
+          }
           context = DG.currDocumentController().createNewDataContext(createSpec);
           if (iResources.isDefaultDataContext) {
             this.setPath('controller.context', context);
@@ -495,7 +503,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
                 collectionSpec.attrs.forEach(function(attr) {
                   // original name and new name will be returned to client
                   attr.clientName = attr.name;
-                  attr.name = DG.Attribute.legalizeAttributeName(attr.name);
+                  attr.name = context.canonicalizeName(attr.name);
                 });
               }
 
@@ -839,12 +847,12 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           if (!iResources.collection) {
             return {success: false, values: {error: 'Collection not found'}};
           }
+          var context = iResources.dataContext;
           var attrSpecs = SC.clone(Array.isArray(iValues) ? iValues : [iValues]);
           attrSpecs.forEach(function(attrSpec) {
             attrSpec.clientName = attrSpec.name;
-            attrSpec.name = DG.Attribute.legalizeAttributeName(attrSpec.name);
+            attrSpec.name = context.canonicalizeName(attrSpec.name);
           });
-          var context = iResources.dataContext;
           var change = {
             operation: 'createAttributes',
             collection: iResources.collection,
@@ -867,7 +875,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
             iValues.name = iResources.attribute.name;
           else if (iValues.name) {
             iValues.clientName = iValues.name;
-            iValues.name = DG.Attribute.legalizeAttributeName(iValues.name);
+            iValues.name = context.canonicalizeName(iValues.name);
           }
           var change = {
             operation: 'updateAttributes',

--- a/apps/dg/controllers/app_controller.js
+++ b/apps/dg/controllers/app_controller.js
@@ -87,7 +87,8 @@ DG.appController = SC.Object.create((function () // closure
           execute: function () {
             dataContext = DG.appController.createDataContextFromCSV(
                 'DG.AppController.createDataSet.initialAttribute'.loc(), /*'new'*/
-                'DG.AppController.createDataSet.name'.loc() /* 'new_dataset' */
+                'DG.AppController.createDataSet.name'.loc(), /* 'new_dataset' */
+                DG.canonicalizeNamesDefault
             );
             caseTable = documentController.addCaseTable(
                 DG.mainPage.get('docView'), null, {position: 'top', dataContext: dataContext});
@@ -335,13 +336,13 @@ DG.appController = SC.Object.create((function () // closure
      * @param iName {string}
      * @return {DG.DataContext}
      */
-    createDataContextFromCSV: function (iText, iName) {
+    createDataContextFromCSV: function (iText, iName, iCanonicalizeNames) {
       // Create document-specific store.
       var newDocument, context, contextRecord,
           documentController = DG.currDocumentController();
 
       // Parse the document contents from the retrieved docText.
-      newDocument = this.documentArchiver.convertCSVDataToCODAPDocument( iText, iName);
+      newDocument = this.documentArchiver.convertCSVDataToCODAPDocument( iText, iName, iCanonicalizeNames);
 
       if (SC.none(newDocument)) {
         throw new Error('DG.AppController.validateDocument.parseError'.loc(iName));
@@ -368,7 +369,7 @@ DG.appController = SC.Object.create((function () // closure
      * @returns {Boolean}
      */
     importText: function( iText, iName, iShowCaseTable) {
-      var context = this.createDataContextFromCSV(iText, iName);
+      var context = this.createDataContextFromCSV(iText, iName, DG.canonicalizeNamesDefault);
 
       iShowCaseTable = SC.none( iShowCaseTable) || iShowCaseTable;
       if( iShowCaseTable) {

--- a/apps/dg/controllers/collection_client.js
+++ b/apps/dg/controllers/collection_client.js
@@ -30,6 +30,12 @@ DG.CollectionClient = SC.Object.extend(
   collection: null, // DG.Collection
 
   /**
+   * Whether attribute names should be canonicalized.
+   * @property {Boolean}
+   */
+  canonicalizeNamesBinding: SC.Binding.oneWay('*collection.canonicalizeNames'),
+
+  /**
    * The id of the underlying DG.CollectionRecord.
    * @property {Number}
    */
@@ -305,8 +311,9 @@ DG.CollectionClient = SC.Object.extend(
   willDestroyAttribute: function( iAttribute) {
   },
 
-  makeAttributeNameLegal: function (iName) {
-    return DG.Attribute.legalizeAttributeName(iName);
+  canonicalizeName: function (iName) {
+    var canonicalize = this.get('canonicalizeNames');
+    return DG.Attribute.canonicalizeName(iName, canonicalize);
   },
 
   /**
@@ -322,7 +329,7 @@ DG.CollectionClient = SC.Object.extend(
     iProperties = iProperties || {};
 
     if (!SC.none(iProperties.name)) {
-      iProperties.name = this.makeAttributeNameLegal(iProperties.name);
+      iProperties.name = this.canonicalizeName(iProperties.name);
     }
 
     // if the property has an ID then it is an existing attribute, possibly from

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -119,6 +119,13 @@ DG.DataContext = SC.Object.extend((function() // closure
   //      this.get('flexibleGroupingChangeFlag'));
   //}.observes('*model.flexibleGroupingChangeFlag'),
 
+  canonicalizeNamesBinding: '*model.canonicalizeNames',
+
+  canonicalizeName: function(iName) {
+    var canonicalizeNames = this.get('canonicalizeNames');
+    return DG.Attribute.canonicalizeName(iName, canonicalizeNames);
+  },
+
   /**
    *  The id of our DG.DataContextRecord.
    *  Bound to the 'id' property of the model.
@@ -820,7 +827,7 @@ DG.DataContext = SC.Object.extend((function() // closure
         iCase.beginCaseValueChanges();
         DG.ObjectMap.forEach(values, function(key, value) {
           var attr = this.getAttributeByName(key)
-              || this.getAttributeByName(DG.Attribute.legalizeAttributeName(key));
+              || this.getAttributeByName(this.canonicalizeName(key));
           if (attr) {
             iCase.setValue(attr.id, value);
           } else {
@@ -1074,7 +1081,7 @@ DG.DataContext = SC.Object.extend((function() // closure
                                   oldName = attribute.get('name');
                                   if (names.indexOf(oldName) < 0)
                                     names.push(oldName);
-                                  iValue = collection.makeAttributeNameLegal(iValue);
+                                  iValue = collection.canonicalizeName(iValue);
                                   if (names.indexOf(iValue) < 0)
                                     names.push(iValue);
                                 }
@@ -1178,12 +1185,13 @@ DG.DataContext = SC.Object.extend((function() // closure
     var results;
     var collections = [];
     var collectionIDCaseMap = {};
+    var canonicalize = this.get('canonicalizeNames');
     items.forEach(function (item) {
       var canonicalItem;
       if (item instanceof DG.DataItem) {
         canonicalItem = item;
       } else {
-        canonicalItem = DG.DataUtilities.canonicalizeAttributeValues(attrs, item);
+        canonicalItem = DG.DataUtilities.canonicalizeAttributeValues(attrs, item, canonicalize);
         dataSet.addDataItem(canonicalItem);
       }
     });

--- a/apps/dg/controllers/document_archiver.js
+++ b/apps/dg/controllers/document_archiver.js
@@ -174,7 +174,7 @@ DG.DocumentArchiver = SC.Object.extend(
      *   CSV text was extracted.
      * @returns {Object||undefined} A streamable CODAP document.
      */
-    convertCSVDataToCODAPDocument: function (iText, iFileName) {
+    convertCSVDataToCODAPDocument: function (iText, iFileName, iCanonicalizeNames) {
       /**
        * Returns table stats object:
        *   numRows {number}
@@ -310,8 +310,10 @@ DG.DocumentArchiver = SC.Object.extend(
       tDoc.contexts[0].collections[0].name = tChildName;
       tDoc.contexts[0].name = tContextName;
 
+      var canonicalName;
       for (ix = 0; ix < tTableStats.maxCols; ix += 1) {
-         tAttrNames.push(guaranteeUnique(DG.Attribute.legalizeAttributeName(tAttrNamesRow[ix]), tAttrNames));
+        canonicalName = DG.Attribute.canonicalizeName(tAttrNamesRow[ix], iCanonicalizeNames);
+        tAttrNames.push(guaranteeUnique(canonicalName, tAttrNames));
       }
 
       tAttrNames.forEach(function (iName) {

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -362,6 +362,11 @@ DG = SC.Application.create((function () // closure
       return SC.clone(iObject, YES);
     },
 
+    canonicalizeNamesDefault: (function() {
+      var allowUnicodeNames = getUrlParameter('allowUnicodeNames');
+      return allowUnicodeNames !== 'true';
+    }()),
+
     // CFM functions, null until connected
     exportFile: null,
 

--- a/apps/dg/formula/codapFormulaMode.js
+++ b/apps/dg/formula/codapFormulaMode.js
@@ -16,7 +16,8 @@ CodeMirror.defineSimpleMode("codapFormula", {
     {regex: /0x[a-f\d]+|[-+]?(?:\.\d+|\d+\.?\d*)(?:e[-+]?\d+)?/i, token: "number"},
     {regex: /[-+\/*=<>!^]+/, token: "operator"},
     {regex: DG.Formula.functionRegExp, token: "function"},
-    {regex: DG.Formula.identifierRegExp, token: "variable"}
+    {regex: DG.Formula.identifierRegExp, token: "variable"},
+    {regex: /(?:`(?:[^\\]|\\.)*?(?:`|$))/, token: "variable"}
   ],
   // The meta property contains global information about the mode. It
   // can contain properties like lineComment, which are supported by

--- a/apps/dg/formula/formulaGrammar.pegjs
+++ b/apps/dg/formula/formulaGrammar.pegjs
@@ -5,6 +5,7 @@
     -- No assignment
     -- No regular expressions
     -- No bitwise operators (bitwise '~', '^', '&', '|')
+    -- Backticks around identifiers to support arbitrary identifier names
     -- '=' instead of '=='/'===' for equality comparison
     -- '!=' (not '!==') for inequality comparison
         (We also support single-character Unicode not-equals.)
@@ -21,15 +22,15 @@
            random(min,max) -- pseudo-random number in range [min,max)
         4. round(x,digits) -- rounds to the specified number of decimal places
         5. trunc(x) -- truncates to the integer portion
-  
+
   The grammar was developed by starting with the example JavaScript grammar at
-  
+
     https://github.com/dmajda/pegjs/blob/master/examples/javascript.pegjs
-  
+
   and then 1) eliminating the unneeded portions (statements, bitwise operators, etc.)
   and 2) making the additional changes mentioned above, e.g. support for '^' operator
   for exponentiation.
-  
+
   To generate the parser itself, run "npm run build:parser". This will create
   "formulaParser.js" from this file.
 
@@ -57,6 +58,7 @@ LineTerminatorSequence "end of line"
 
 Identifier "identifier"
   = !ReservedWord name:IdentifierName { return name; }
+  / BacktickIdentifier
 
 IdentifierName "identifier"
   = start:IdentifierStart parts:IdentifierPart* {
@@ -71,6 +73,16 @@ IdentifierPart
   = IdentifierStart
   / UnicodeDigit
   / UnicodeConnectorPunctuation
+
+BacktickIdentifier
+  = parts:('`' BacktickIdentifierCharacters '`') { return parts[1]; }
+
+BacktickIdentifierCharacters
+  = chars:BacktickIdentifierChar+ { return chars.join(""); }
+
+BacktickIdentifierChar
+  = !("`" / "\\" / LineTerminator) char_:SourceCharacter { return char_; }
+  / "\\" sequence:EscapeSequence { return sequence; }
 
 UnicodeLetter
   = Lu / Ll

--- a/apps/dg/formula/formulaParser.js
+++ b/apps/dg/formula/formulaParser.js
@@ -46,6 +46,9 @@ DG.formulaParser = (function(){
         "IdentifierName": parse_IdentifierName,
         "IdentifierStart": parse_IdentifierStart,
         "IdentifierPart": parse_IdentifierPart,
+        "BacktickIdentifier": parse_BacktickIdentifier,
+        "BacktickIdentifierCharacters": parse_BacktickIdentifierCharacters,
+        "BacktickIdentifierChar": parse_BacktickIdentifierChar,
         "UnicodeLetter": parse_UnicodeLetter,
         "Literal": parse_Literal,
         "BooleanLiteral": parse_BooleanLiteral,
@@ -330,6 +333,9 @@ DG.formulaParser = (function(){
         if (result0 === null) {
           pos = pos0;
         }
+        if (result0 === null) {
+          result0 = parse_BacktickIdentifier();
+        }
         reportFailures--;
         if (reportFailures === 0 && result0 === null) {
           matchFailed("identifier");
@@ -403,6 +409,170 @@ DG.formulaParser = (function(){
           result0 = parse_Nd();
           if (result0 === null) {
             result0 = parse_Pc();
+          }
+        }
+        return result0;
+      }
+      
+      function parse_BacktickIdentifier() {
+        var result0, result1, result2;
+        var pos0, pos1;
+        
+        pos0 = pos;
+        pos1 = pos;
+        if (input.charCodeAt(pos) === 96) {
+          result0 = "`";
+          pos++;
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"`\"");
+          }
+        }
+        if (result0 !== null) {
+          result1 = parse_BacktickIdentifierCharacters();
+          if (result1 !== null) {
+            if (input.charCodeAt(pos) === 96) {
+              result2 = "`";
+              pos++;
+            } else {
+              result2 = null;
+              if (reportFailures === 0) {
+                matchFailed("\"`\"");
+              }
+            }
+            if (result2 !== null) {
+              result0 = [result0, result1, result2];
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+        } else {
+          result0 = null;
+          pos = pos1;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, parts) { return parts[1]; })(pos0, result0);
+        }
+        if (result0 === null) {
+          pos = pos0;
+        }
+        return result0;
+      }
+      
+      function parse_BacktickIdentifierCharacters() {
+        var result0, result1;
+        var pos0;
+        
+        pos0 = pos;
+        result1 = parse_BacktickIdentifierChar();
+        if (result1 !== null) {
+          result0 = [];
+          while (result1 !== null) {
+            result0.push(result1);
+            result1 = parse_BacktickIdentifierChar();
+          }
+        } else {
+          result0 = null;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, chars) { return chars.join(""); })(pos0, result0);
+        }
+        if (result0 === null) {
+          pos = pos0;
+        }
+        return result0;
+      }
+      
+      function parse_BacktickIdentifierChar() {
+        var result0, result1;
+        var pos0, pos1, pos2;
+        
+        pos0 = pos;
+        pos1 = pos;
+        pos2 = pos;
+        reportFailures++;
+        if (input.charCodeAt(pos) === 96) {
+          result0 = "`";
+          pos++;
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"`\"");
+          }
+        }
+        if (result0 === null) {
+          if (input.charCodeAt(pos) === 92) {
+            result0 = "\\";
+            pos++;
+          } else {
+            result0 = null;
+            if (reportFailures === 0) {
+              matchFailed("\"\\\\\"");
+            }
+          }
+          if (result0 === null) {
+            result0 = parse_LineTerminator();
+          }
+        }
+        reportFailures--;
+        if (result0 === null) {
+          result0 = "";
+        } else {
+          result0 = null;
+          pos = pos2;
+        }
+        if (result0 !== null) {
+          result1 = parse_SourceCharacter();
+          if (result1 !== null) {
+            result0 = [result0, result1];
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+        } else {
+          result0 = null;
+          pos = pos1;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, char_) { return char_; })(pos0, result0[1]);
+        }
+        if (result0 === null) {
+          pos = pos0;
+        }
+        if (result0 === null) {
+          pos0 = pos;
+          pos1 = pos;
+          if (input.charCodeAt(pos) === 92) {
+            result0 = "\\";
+            pos++;
+          } else {
+            result0 = null;
+            if (reportFailures === 0) {
+              matchFailed("\"\\\\\"");
+            }
+          }
+          if (result0 !== null) {
+            result1 = parse_EscapeSequence();
+            if (result1 !== null) {
+              result0 = [result0, result1];
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+          if (result0 !== null) {
+            result0 = (function(offset, sequence) { return sequence; })(pos0, result0[1]);
+          }
+          if (result0 === null) {
+            pos = pos0;
           }
         }
         return result0;

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -445,7 +445,7 @@ DG.Attribute.createAttribute = function( iProperties) {
 /**
  * Convert a string to a "legal" attribute name.
  */
-DG.Attribute.legalizeAttributeName = function (iName) {
+DG.Attribute.canonicalizeName = function(iName, iCanonicalize) {
   var tName = String(SC.none(iName)? '': iName),
       tReg = /\((.*)\)/,  // Identifies first parenthesized substring
       tMatch = tReg.exec( tName),
@@ -458,7 +458,8 @@ DG.Attribute.legalizeAttributeName = function (iName) {
   // TODO: We are eliminating all but Latin characters here. We should be more general and allow
   // non-Latin alphanumeric characters.
   tNewName = tNewName.trim(); // Get rid of trailing white space
-  tNewName = tNewName.replace(/\W/g, '_');  // Replace non-word characters with underscore
+  if (iCanonicalize)
+    tNewName = tNewName.replace(/\W/g, '_');  // Replace non-word characters with underscore
   // if after all this we have an empty string replace with a default name.
   if (tNewName.length === 0) {
     tNewName = 'attr';

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -458,7 +458,7 @@ DG.Attribute.legalizeAttributeName = function (iName) {
   // TODO: We are eliminating all but Latin characters here. We should be more general and allow
   // non-Latin alphanumeric characters.
   tNewName = tNewName.trim(); // Get rid of trailing white space
-  tNewName = tNewName.replace(/\W/g, '_');  // Replace white space with underscore
+  tNewName = tNewName.replace(/\W/g, '_');  // Replace non-word characters with underscore
   // if after all this we have an empty string replace with a default name.
   if (tNewName.length === 0) {
     tNewName = 'attr';

--- a/apps/dg/models/collection_model.js
+++ b/apps/dg/models/collection_model.js
@@ -21,7 +21,7 @@ sc_require('models/base_model');
 /** @class
 
   A container for the cases and attributes that make up a collection.
-  
+
   @extends SC.Object
 */
 DG.Collection = DG.BaseModel.extend( (function() // closure
@@ -46,6 +46,12 @@ DG.Collection = DG.BaseModel.extend( (function() // closure
      * @type {DG.DataSet}
      */
     dataSet: null,
+
+    /**
+     * Whether attribute names should be canonicalized.
+     * @property {Boolean}
+     */
+    canonicalizeNamesBinding: SC.Binding.oneWay('*dataSet.canonicalizeNames'),
 
     /**
      * A relational link back to the parent collection (if any).

--- a/apps/dg/models/data_context_record.js
+++ b/apps/dg/models/data_context_record.js
@@ -85,6 +85,12 @@ DG.DataContextRecord = DG.BaseModel.extend(
     dataSet: null,
 
     /**
+     * Whether attribute names should be canonicalized.
+     * @property {Boolean}
+     */
+    canonicalizeNamesBinding: '*dataSet.canonicalizeNames',
+
+    /**
      * The context is has had its original organization modified.
      * No new data should be added.
      * @property {boolean}
@@ -102,7 +108,12 @@ DG.DataContextRecord = DG.BaseModel.extend(
     init: function () {
       this.collections = {};
       this.dependencyMgr = DG.DependencyMgr.create({ dataContext: this });
-      this.dataSet = DG.DataSet.create({dataContextRecord: this});
+      // explicit client request supercedes application default
+      var canonicalizeNames = this.initCanonicalizeNames != null
+                                ? this.initCanonicalizeNames
+                                : DG.canonicalizeNamesDefault;
+      this.dataSet = DG.DataSet.create({dataContextRecord: this,
+                                        canonicalizeNames: canonicalizeNames});
       sc_super();
     },
 

--- a/apps/dg/models/data_set.js
+++ b/apps/dg/models/data_set.js
@@ -61,6 +61,13 @@ DG.DataSet = SC.Object.extend((function() // closure
      */
     collectionOrder: null,
 
+    /**
+     * Setting that determines whether attribute names will be canonicalized.
+     *
+     * @type {Boolean}
+     */
+    canonicalizeNames: false,
+
     init: function () {
       this.dataItems = [];
       this.attrs = [];

--- a/apps/dg/utilities/data_utilities.js
+++ b/apps/dg/utilities/data_utilities.js
@@ -173,12 +173,12 @@ DG.DataUtilities.canonicalizeInternalValue = function(iValue) {
   @param    iDataMap  A map from attribute names to values
   @returns          The canonicalized value map (attribute IDs to values)
  */
-DG.DataUtilities.canonicalizeAttributeValues = function(iAttrs, iDataMap) {
+DG.DataUtilities.canonicalizeAttributeValues = function(iAttrs, iDataMap, iCanonicalizeNames) {
   var valuesMap = {};
   DG.ObjectMap.forEach(iDataMap, function (iKey, iValue) {
 
     var attr = iAttrs.findProperty('name', iKey) ||
-            iAttrs.findProperty('name', DG.Attribute.legalizeAttributeName(iKey)),
+            iAttrs.findProperty('name', DG.Attribute.canonicalizeName(iKey, iCanonicalizeNames)),
         value = DG.DataUtilities.canonicalizeInputValue(iValue);
     if(attr != null) {
       valuesMap[attr.id] = value;

--- a/apps/dg/views/attribute_formula_view.js
+++ b/apps/dg/views/attribute_formula_view.js
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                        DG.AttributeFormulaView
-// 
+//
 //  Implements a dialog with edit fields for attribute name and formula.
-//  
+//
 //  Authors:  William Finzer, Kirk Swenson
 //
 //  Copyright (c) 2014 by The Concord Consortium, Inc. All rights reserved.
@@ -146,7 +146,7 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
               ? this.getPath('contentView.attrName.value')
               : this.setPath('contentView.attrName.value', iValue);
   }.property(),
-  
+
   /**
     Forwarding property for the dialog's formula value.
     @property   {String}
@@ -156,7 +156,7 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
               ? this.getPath('contentView.formula.formulaExpression')
               : this.setPath('contentView.formula.formulaExpression', iValue);
   }.property(),
-  
+
   /**
     Initialization function.
    */
@@ -173,7 +173,7 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
     }
     return NO;
   },
-  
+
   /**
     Observer function called when the user selects an item from the Operands popup.
    */
@@ -181,7 +181,10 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
     // Extract the text of the selected item
     var insertionString = this.getPath('contentView.operandPopup.menu.selectedItem.title');
     if( !SC.empty( insertionString)) {
-      var formulaView = this.getPath('contentView.formula');
+      var canonicalString = DG.Attribute.canonicalizeName(insertionString, true),
+          formulaView = this.getPath('contentView.formula');
+      if (insertionString !== canonicalString)
+        insertionString = '`' + insertionString + '`';
       // Replace the current selection with the selected item text
       if( formulaView) {
         formulaView.becomeFirstResponder();
@@ -191,7 +194,7 @@ DG.AttributeFormulaView = SC.PalettePane.extend(
     // Clear the selected item so the same item can be selected multiple times
     this.setPath('contentView.operandPopup.menu.selectedItem', null);
   }.observes('.contentView.operandPopup.menu.selectedItem'),
-  
+
   /**
     Close the dialog.
    */
@@ -209,7 +212,7 @@ DG.CreateAttributeFormulaView = function( iProperties) {
       attrNameValue: 'attrName.value',
       attrNameHint: 'attrName.hint',
       attrNameIsEnabled: 'attrName.isEnabled',
-      
+
       formulaPrompt: 'formula.leftAccessoryView.value',
       formulaValue: 'formula.value',
       formulaExpression: 'formula.formulaExpression',
@@ -224,14 +227,14 @@ DG.CreateAttributeFormulaView = function( iProperties) {
       applyTarget: 'apply.target',
       applyAction: 'apply.action',
       applyTooltip: 'apply.toolTip',
-      
+
       cancelTitle: 'cancel.title',
       cancelTooltip: 'cancel.toolTip'
     },
     tContentView = tDialog.get('contentView'),
     tAttrNameView = tContentView.attrName,
     tFormulaView = tContentView.formula;
-  
+
   // Loop through client-specified properties, applying them to the
   // appropriate property via its path given in the kParamMap.
   DG.ObjectMap.forEach( iProperties,
@@ -245,6 +248,6 @@ DG.CreateAttributeFormulaView = function( iProperties) {
 
   var tInitialView = tAttrNameView.get('isEnabled') ? tAttrNameView : tFormulaView;
   tInitialView.becomeFirstResponder();
-  
+
   return tDialog;
 };

--- a/apps/dg/views/formula_rich_edit_view.js
+++ b/apps/dg/views/formula_rich_edit_view.js
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                      DG.FormulaTextEditView
-// 
+//
 //  Provides a DG-specific text editor for entering a formula.
-//  
+//
 //  Authors:  William Finzer, Kirk Swenson
 //
 //  Copyright (c) 2016 by The Concord Consortium, Inc. All rights reserved.
@@ -119,7 +119,7 @@ return {
   autoCorrect: false,
 
   autoCapitalize: false,
-  
+
   names: [],  // Will be filled with attribute and global variable names by client
 
   _disableNextSelectRoot: false,
@@ -208,8 +208,13 @@ return {
           isVariable = classes.indexOf('cm-variable') >= 0,
           isFunction = classes.indexOf('cm-function') >= 0,
           nodeText = $(node).text(),
+          nodeTextLength = nodeText ? nodeText.length : 0,
           completions = cm.options.hintOptions && cm.options.hintOptions.completionData,
           i, completionCount = completions && completions.length;
+      if (isVariable && (nodeTextLength > 2) &&
+          (nodeText[0] === '`') && (nodeText[nodeTextLength-1] === '`')) {
+        nodeText = nodeText.substring(1, nodeTextLength - 1);
+      }
       // linear search could be replaced with faster (e.g. binary) search
       // if performance becomes a problem.
       for (i = 0; i < completionCount; ++i) {
@@ -231,7 +236,7 @@ return {
       this._cm.setValue(iValue || "");
     }
   }.property('value'),
-  
+
   /**
     Replace the current selection with the specified string.
     @param    {String}    iNewString -- the string to insert


### PR DESCRIPTION
- Attribute/slider name canonicalization is disabled by default
- Canonicalization can be enabled/disabled per DataContext via plugin API or URL parameter
- With canonicalization disabled, names that would have been canonicalized (e.g. non-ascii unicode characters, spaces, punctuation) must be enclosed in backticks when referenced in formulas

Note that the set of characters that would be canonicalized (i.e. require enclosing in backticks) is not changed by this PR. The set of characters that are allowed in identifers without requiring backticks can be expanded greatly by changing the formula parser. That would require upgrading to the latest version of PEG.js, which will require additional effort and can be prioritized accordingly.

This PR is being closed without merging because it has been superceded by PR #157 when it became apparent that disabling canonicalization globally was preferred to disabling it on a per-context basis. I'm creating and closing this PR to archive this effort in case there is ever a desire to return to it in some fashion.