### PR TITLE
Fix unit tests and latent IE bugs

### DIFF
--- a/apps/dg/components/graph/axes/cell_linear_axis_model.js
+++ b/apps/dg/components/graph/axes/cell_linear_axis_model.js
@@ -263,20 +263,20 @@ DG.CellLinearAxisModel = DG.CellAxisModel.extend(
         tTickGap;
 
     function defaultsForType( iType) {
-      DG.assert( iType === DG.Analysis.EAttributeType.eNumeric ||
-          iType === DG.Analysis.EAttributeType.eDateTime );
       switch( iType) {
-        case DG.Analysis.EAttributeType.eNumeric:
-          return {
-            min: 0,
-            max: 10,
-            addend: 5
-          };
         case DG.Analysis.EAttributeType.eDateTime:
           return {
             min: Date.now() / 1000 - 10 * 24 * 60 * 60,
             max: Date.now() / 1000,
             addend: 5 * 24 * 60 * 60
+          };
+        case DG.Analysis.EAttributeType.eNumeric:
+          /* falls through */
+        default:
+          return {
+            min: 0,
+            max: 10,
+            addend: 5
           };
       }
     }

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -34,6 +34,53 @@ if (!Object.keys) Object.keys = function (o) {
   return ret;
 };
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
+// https://tc39.github.io/ecma262/#sec-array.prototype.findIndex
+if (!Array.prototype.findIndex) {
+  Object.defineProperty(Array.prototype, 'findIndex', {
+    value: function(predicate) {
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      /*jshint bitwise:false */ // allow bitwise operations
+      var len = o.length >>> 0; // eslint-disable-line no-bitwise
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return k.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return k;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return -1.
+      return -1;
+    }
+  });
+}
+
 /*
  Function.prototype.bind is a method introduced in ECMAScript 262-5 which allows
  changes to the running context of a function  (i.e. the 'this' variable)


### PR DESCRIPTION
- add polyfill for `Array.findIndex()` (not implemented in IE or PhantomJS)
- remove assert from `DG.CellLinearAxisModel._computeBoundsForTickGap.defaultsForType()` function as it is called from unit tests in situations in which the assertion isn't true

There were about a half dozen calls to `Array.findIndex()` in the code.