### PR TITLE
Allow override of plugin URL stored in document via `di`, `di-override` URL parameters

### DIFF
--- a/apps/dg/components/game/game_controller.js
+++ b/apps/dg/components/game/game_controller.js
@@ -282,7 +282,9 @@ DG.GameController = DG.ComponentController.extend(
        */
       restoreComponentStorage: function (iComponentStorage, iDocumentID) {
         var gameName = iComponentStorage.currentGameName,
-            gameUrl = iComponentStorage.currentGameUrl,
+            // 'di' URL param can override stored URL
+            storedGameUrl = iComponentStorage && iComponentStorage.currentGameUrl,
+            gameUrl = DG.finalGameUrl(storedGameUrl),
             contextID,
             dataContext;
 

--- a/apps/dg/components/game/game_phone_handler.js
+++ b/apps/dg/components/game/game_phone_handler.js
@@ -394,8 +394,10 @@ DG.GamePhoneHandler = SC.Object.extend(
         //DG.log('InitGame: ' + JSON.stringify(iArgs));
         // The game-specified arguments form the core of the new DG.GameSpec.
         var tCurrentGameName = this.getPath('context.gameName'),
-            tCurrentGameUrl = this.getPath('context.gameUrl') ||
-                this.getPath('model.componentStorage.currentGameUrl'),
+            tContextGameUrl = this.getPath('context.gameUrl'),
+            tStoredGameUrl = this.getPath('model.componentStorage.currentGameUrl'),
+            // 'di' URL param can override stored URL
+            tCurrentGameUrl = tContextGameUrl || DG.finalGameUrl(tStoredGameUrl),
             tGameContext = this.get('context'),
             tGameCollections = [],
             tRestoredGameState,

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -661,8 +661,9 @@ DG.DocumentController = SC.Object.extend(
       var tGameParams = {
           width: 640, height: 480
         },
-        tGameUrl = (iComponent && iComponent.getPath(
-          'componentStorage.currentGameUrl')),
+        // 'di' URL param can override stored URL
+        storedGameUrl = iComponent && iComponent.getPath('componentStorage.currentGameUrl'),
+        tGameUrl = DG.finalGameUrl(storedGameUrl),
         tGameName = (iComponent && iComponent.getPath(
             'componentStorage.currentGameName')) ||
             getNameFromURL(tGameUrl) ||

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -260,6 +260,36 @@ DG = SC.Application.create((function () // closure
       return getUrlParameter(iParam, iDefault);
     },
 
+    removeQueryParams: function(iParams) {
+      var queryParams = window.location.search,
+          paramsToRemove = Array.isArray(iParams) ? iParams : [iParams];
+      paramsToRemove.forEach(function(iParam) {
+        iParam = iParam.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+        var regexS = "[\\?&]" + iParam + "=([^&]*)",
+            regex = new RegExp(regexS),
+            result = regex.exec(queryParams),
+            match = result && result[0],
+            matchIndex = result && result.index,
+            matchLength = match && match.length;
+        if ((matchIndex > 0) && (queryParams[matchIndex-1] === '&'))
+          match = '&' + match;
+        else if ((matchIndex + matchLength < queryParams.length) &&
+                  (queryParams[matchIndex + matchLength] === '&')) {
+          match = match + '&';
+        }
+        else if ((matchLength + 1 === queryParams.length))
+          match = '?' + match;
+
+        if (match)
+          queryParams = queryParams.replace(match, '');
+      });
+      if ((queryParams !== window.location.search) && window.history.replaceState) {
+        var newUrl = window.location.protocol + '//' + window.location.host +
+                      window.location.pathname + queryParams + window.location.hash;
+        window.history.replaceState(null, null, newUrl);
+      }
+    },
+
     /**
      * Modify the given string key (usually in strings.js), and return the associated variant of the
      * key if this is an SRRI build (also expected to be in in strings.js).

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -330,6 +330,27 @@ DG = SC.Application.create((function () // closure
     }.property('urlParamGames, _startingDataInteractive'),
 
     /**
+     * enables 'di' URL param to override stored URL that matches
+     */
+    _dataInteractiveOverride: getUrlParameter('di-override'),
+
+    /**
+     * overrides the specified URL with one specified via 'di' URL parameter if
+     * and only if the 'di-override' string is found within the specified URL.
+     */
+    finalGameUrl: function(iGameUrl) {
+      if (!iGameUrl || !DG._startingDataInteractive || !DG._dataInteractiveOverride)
+        return iGameUrl;
+      var hashIndex = iGameUrl.indexOf('#'),
+          gameUrlNoHash = hashIndex >= 0 ? iGameUrl.substring(0, hashIndex) : iGameUrl,
+          gameUrlHash = hashIndex >= 0 ? iGameUrl.substring(hashIndex) : '',
+          matchIndex = gameUrlNoHash.indexOf(DG._dataInteractiveOverride);
+      return matchIndex >= 0
+              ? DG._startingDataInteractive + gameUrlHash
+              : iGameUrl;
+    },
+
+    /**
      * runKey can be passed as a Url parameter named runKey. It is a key which will be passed to the document server to enable
      * anonymous read-write access to documents. It can be any string.
      * ex: 'e342d47a-d3e5-48b8-9675-8622e40bb2c8'

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -553,6 +553,9 @@ DG.main = function main() {
               }
               // synchronize document dirty state after saving, since we may not be clean
               syncDocumentDirtyState();
+
+              // once the file has been saved, we no longer need the 'di'-related URL params
+              DG.removeQueryParams(['di', 'di-override']);
             });
             break;
 


### PR DESCRIPTION
Allow override of plugin URL stored in document via `di`, `di-override` URL parameters
- can be used to "recover" documents saved using temporary URLs, e.g. `localhost` or branch builds
- can be used to debug saved documents by redirecting to `localhost` URL
- can be used to change URL query parameters (e.g. `lang=zh`) stored in document

`di`, `di-override` URL parameters are removed from the URL once the document is saved, i.e. once the information contained in them is captured in the document.