### PR TITLE
Added embeddedServer url parameter and plugin API support for getting all cases

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -954,6 +954,43 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
       },
 
       handleAllCases: {
+        get: function (iResources) {
+          var context = iResources.dataContext;
+          var collection = iResources.collection;
+          if (!context || !collection) {
+            return {
+              success: false
+            };
+          }
+
+          var serializeCase = function (iCase) {
+            var caseValues = {};
+            collection.forEachAttribute(function (attr) {
+              caseValues[attr.name] = iCase.getValue(attr.id);
+            });
+            return {
+              'case': {
+                id: iCase.id,
+                parent: (iCase.parent && iCase.parent.id),
+                children: iCase.children.map(function (child) {return child.id;}),
+                values: caseValues
+              },
+              caseIndex: collection.getCaseIndexByID(iCase.get('id'))
+            };
+          }.bind(this);
+
+          return {
+            success: true,
+            values: {
+              collection: {
+                name: collection.get('name'),
+                id: collection.get('id')
+              },
+              cases: context.get('allCases').map(serializeCase)
+            }
+          };
+        },
+
         'delete': function (iResources) {
           var context = iResources.dataContext;
           var success = false;

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -308,6 +308,13 @@ DG = SC.Application.create((function () // closure
      */
     embeddedMode: getUrlParameter('embeddedMode', 'no'),
 
+    /**
+     * embeddedServer can be passed as a Url parameter named tools with values 'yes' or 'no'.
+     *  With the value 'yes' the embedded iframePhone server is setup to enable communication with the outside page.
+     *  The default is 'no' and this option is ignored if embeddedMode is 'yes'
+     */
+    embeddedServer: getUrlParameter('embeddedServer', 'no'),
+
     toolButtons: [ // These appear on the left side of the tool shelf
       'tableButton',
       'graphButton',

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -688,6 +688,10 @@ DG.main = function main() {
     startEmbeddedServer();
   }
   else {
+    // only start embedded server if embeddedMode is not on
+    if (DG.embeddedServer === 'yes') {
+      startEmbeddedServer();
+    }
     translateQueryParameters();
   }
 


### PR DESCRIPTION
* The embeddedServer url parameter can be passed with values 'yes' or 'no'.  With the value 'yes' the embedded iframePhone server is setup to enable communication with the outside page.  The default is 'no' and this option is ignored if embeddedMode is 'yes'