### PR TITLE
Improve defaults for new datasets

### DIFF
--- a/apps/dg/controllers/app_controller.js
+++ b/apps/dg/controllers/app_controller.js
@@ -86,8 +86,8 @@ DG.appController = SC.Object.create((function () // closure
           log: 'createNewEmptyDataSet',
           execute: function () {
             dataContext = DG.appController.createDataContextFromCSV(
-                'DG.AppController.createDataSet.initialAttribute'.loc(), /*'new'*/
-                'DG.AppController.createDataSet.name'.loc() /* 'new_dataset' */
+                'DG.AppController.createDataSet.initialAttribute'.loc(), /*'Attribute'*/
+                'DG.AppController.createDataSet.name'.loc() /* 'New Dataset' */
             );
             caseTable = documentController.addCaseTable(
                 DG.mainPage.get('docView'), null, {position: 'top', dataContext: dataContext});
@@ -338,10 +338,21 @@ DG.appController = SC.Object.create((function () // closure
     createDataContextFromCSV: function (iText, iName) {
       // Create document-specific store.
       var newDocument, context, contextRecord,
-          documentController = DG.currDocumentController();
+          documentController = DG.currDocumentController(),
+          baseContextName = iName.replace(/.*[\\\/]/g, '').replace(/\.[^.]*/, ''),
+          contextName = baseContextName,
+          collectionName = 'DG.AppController.createDataSet.collectionName'.loc(),
+          i = 1;
+
+      // guarantee uniqueness of data context name/title
+      while (documentController.getContextByName(contextName) ||
+              documentController.getContextByTitle(contextName)) {
+        contextName = baseContextName + " " + ++i;
+      }
 
       // Parse the document contents from the retrieved docText.
-      newDocument = this.documentArchiver.convertCSVDataToCODAPDocument( iText, iName);
+      newDocument = this.documentArchiver.
+                      convertCSVDataToCODAPDocument( iText, contextName, collectionName, iName);
 
       if (SC.none(newDocument)) {
         throw new Error('DG.AppController.validateDocument.parseError'.loc(iName));

--- a/apps/dg/controllers/document_archiver.js
+++ b/apps/dg/controllers/document_archiver.js
@@ -174,7 +174,7 @@ DG.DocumentArchiver = SC.Object.extend(
      *   CSV text was extracted.
      * @returns {Object||undefined} A streamable CODAP document.
      */
-    convertCSVDataToCODAPDocument: function (iText, iFileName) {
+    convertCSVDataToCODAPDocument: function (iText, iContextName, iCollectionName, iFileName) {
       /**
        * Returns table stats object:
        *   numRows {number}
@@ -222,8 +222,6 @@ DG.DocumentArchiver = SC.Object.extend(
       }
 
       var tValuesArray,
-        tContextName = iFileName.replace(/.*[\\\/]/g, '').replace(/\.[^.]*/, ''),
-        tChildName = tContextName || 'cases',
         tAttrNamesRow,// Column Header Names: should be second row
         tAttrNames = [], tTableStats, ix,
         tDoc = {
@@ -307,8 +305,10 @@ DG.DocumentArchiver = SC.Object.extend(
 
       tAttrNamesRow = tValuesArray.shift();
 
-      tDoc.contexts[0].collections[0].name = tChildName;
-      tDoc.contexts[0].name = tContextName;
+      var tDataContext = tDoc.contexts[0],
+          tCollection = tDataContext.collections[0];
+      tDataContext.name = tDataContext.title = iContextName;
+      tCollection.name = tCollection.title = iCollectionName;
 
       var canonicalName;
       for (ix = 0; ix < tTableStats.maxCols; ix += 1) {

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -106,8 +106,9 @@ SC.stringsFor('English', {
   'DG.AppController.validateDocument.invalidDocument' : 'Invalid JSON Document: %@1',
   'DG.AppController.openDocument.error.general': 'Unable to open document',
   'DG.AppController.openDocument.error.invalid_format': 'CODAP can not read this type of document',
-  'DG.AppController.createDataSet.initialAttribute': 'new', /* new */
-  'DG.AppController.createDataSet.name': 'new_dataset', /* new_dataset */
+  'DG.AppController.createDataSet.initialAttribute': 'Attribute', /* Attribute */
+  'DG.AppController.createDataSet.name': 'New Dataset', /* New Dataset */
+  'DG.AppController.createDataSet.collectionName': 'Cases', /* Cases */
   'DG.AppController.caseTableMenu.newDataSet': '-- new --', /* -- new -- */
 
   'DG.SingleTextDialog.okButton.title': "OK",

--- a/apps/dg/zh.lproj/strings.js
+++ b/apps/dg/zh.lproj/strings.js
@@ -106,8 +106,9 @@ SC.stringsFor('English', {
   'DG.AppController.validateDocument.invalidDocument' : '無效的JSON文件: %@1',
   'DG.AppController.openDocument.error.general': '無法開啟文件',
   'DG.AppController.openDocument.error.invalid_format': 'CODAP 無法讀取此類文件',
-  'DG.AppController.createDataSet.initialAttribute': '未命名', /* new */
-  'DG.AppController.createDataSet.name': '未命名_資料', /* new_dataset */
+  'DG.AppController.createDataSet.initialAttribute': '未命名', /* RETRANSLATE: Attribute */
+  'DG.AppController.createDataSet.name': '未命名_資料', /* RETRANSLATE: New Dataset */
+  'DG.AppController.createDataSet.collectionName': 'Cases', /* TRANSLATE: Cases */
   'DG.AppController.caseTableMenu.newDataSet': '-- new --', /* -- new -- */
 
   'DG.SingleTextDialog.okButton.title': "確認",


### PR DESCRIPTION
Improve defaults for new datasets: [#146418227]
- data context name: "new_dataset" -> "New Dataset"
- collection name: "new_dataset" -> "Cases"
- attribute name: "new" -> "Attribute"
- data context names are guaranteed to be unique ("New Dataset 2", "New Dataset 3", etc.) [#146335573]