### PR TITLE
Fix display of qualitative and color cells [#146961277]

### DIFF
--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -69,7 +69,12 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
         }
         else if( DG.isColorSpecString(cellValue))
           return colorFormatter(rowIndex, colIndex, cellValue, colInfo, rowItem);
-        return cellValue.toString();
+
+        // standard values are HTML-escaped
+        return cellValue.toString()
+                        .replace(/&/g, '&amp;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;');
       },
 
       qualBarFormatter = function (row, cell, value, columnDef, dataContext) {

--- a/apps/dg/libraries/slickgrid/slick.grid.js
+++ b/apps/dg/libraries/slickgrid/slick.grid.js
@@ -1531,15 +1531,21 @@ if (typeof Slick === "undefined") {
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       var value = "",
           tooltip = "",
+          tooltipValue = "",
           tooltipAttr = "";
       if (d) {
         value = getDataItemValueForColumn(d, m);
         value = getFormatter(row, m)(row, cell, value, m, d);
-        value = value ? String(value).replace(/&/g, '&amp;')
-                                     .replace(/</g, '&lt;')
-                                     .replace(/>/g, '&gt;')
-                      : "";
-        tooltip = value && m.showCellTooltips ? value.replace(/"/g, '&quot;') : "";
+
+        // don't show tooltips for DG-formatted HTML values
+        tooltipValue = /<span.*class='dg-.*'.*<\/span>/.test(value) ? "" : value;
+        // HTML-escape tooltips for other values
+        tooltip = tooltipValue && m.showCellTooltips
+                    ? value.replace(/&/g, '&amp;')
+                           .replace(/</g, '&lt;')
+                           .replace(/>/g, '&gt;')
+                           .replace(/"/g, '&quot;')
+                    : "";
         tooltipAttr = tooltip ? " title=\"" + tooltip + "\"" : "";
       }
 


### PR DESCRIPTION
- these were broken by HTML-escaping added in PR #169
- fixed by moving HTML-escaping to the cell formatter
- requires separate HTML-escaping of tooltip values

Note: it occurred to me while working on this that having a client-provided `tooltipFormatter` would be a better architecture, but for now we fix the bug and leave that for a later improvement.