### PR TITLE
Fix new attribute button tracking of component resize under some circumstances

### DIFF
--- a/apps/dg/components/case_table/case_table_view.js
+++ b/apps/dg/components/case_table/case_table_view.js
@@ -318,7 +318,8 @@ DG.CaseTableView = SC.View.extend( (function() // closure
         frame = this.get('frame'),
         visibleBounds = pv ? pv.convertFrameToView(frame, null) : frame,
         bounds, right, bottom;
-    while (pv) {
+    // find boundary of the hierarchical table view
+    while (pv && !(pv instanceof DG.HierTableView)) {
       view = pv;
       pv = view.get('parentView');
       frame = view.get('frame');


### PR DESCRIPTION
Fix new attribute button tracking of component resize under some circumstances [#146957123]

The issue here was that the document container size wraps the content of the document and gets updated at the end of component resize operations, not during them. Rather than doing anything about that issue, we just don't iterate that far through the view hierarchy, as we only care about our immediate superviews for the purpose of placing the new attribute button.