### PR TITLE
Eliminate duplicate call to `registerDefaultBoundaries()`

### DIFF
--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -300,10 +300,6 @@ DG.DocumentController = SC.Object.extend(
         this.set('changeCount', 0);
         this.updateSavedChangeCount();
         this.set('ready', true);
-
-        this.invokeLater(function() {
-          DG.RemoteBoundaries.registerDefaultBoundaries();
-        });
       } catch (e) {
         DG.logError(e);
       }


### PR DESCRIPTION
Eliminate duplicate call to `registerDefaultBoundaries()` that resulted from rebase/merge