### PR TITLE
Added data interactive log monitor

### DIFF
--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -228,11 +228,24 @@ DG.DocumentController = SC.Object.extend(
     _changedObjects: null,
     _skipPatchNextTime: [],
 
+    /**
+       Object containing data interactive log monitor properties used in DG.DataInteractivePhoneHandler
+       @property {Object} dataInteractiveLogMonitor
+                 {Array}  logMonitors -- array of active log monitors set in DG.DataInteractivePhoneHandler
+                 {Number} nextLogMonitorId -- incrementing id of log monitor instances
+     */
+    dataInteractiveLogMonitor: null,
+
     init: function() {
       sc_super();
 
       this._singletonViews = {};
       this.contexts = [];
+
+      this.dataInteractiveLogMonitor = SC.Object.create({
+        logMonitors: [],
+        nextLogMonitorId: 1
+      });
 
       // If we were created with a 'content' property pointing to our document,
       // then use it; otherwise, create a new document.


### PR DESCRIPTION
This addition exposes a new DI API endpoint resource: "logMessageMonitor" with two new actions:

* register - this takes at least one of the following parameters which are used to match incoming log messages
  * topic - matches against the topic set in the log message
  * topicPrefix - matches against the start of the topic in the log message
  * formatStr - matches the formatStr used in the log message
  * message - matches the formatStr merged with the log parameters

  and can take an additional optional clientId parameter which is an opaque value used in unregister

* unregister - this takes one of the following two parameters
  * id - the autogenerated id returned from the register call
  * clientId - this is a opaque value provided by the client in the register call

When a DI registers for log messages and a log message is matched against the parameters in the register call the DI will receive a "notify" action on the "logMessageNotice" resource with the log message plus information about how the log message was matched.