### PR TITLE
New attribute auto-edits name in column header without dialog

### DIFF
--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -411,6 +411,22 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
   },
 
   /**
+    Returns the column info for the specified attribute.
+    @param    {string}    iAttrName -- The name of the attribute whose column should be returned
+    @returns  {object}    The column info for the specified attribute
+   */
+  getAttributeColumn: function(iAttrName) {
+    var dataContext = this.get('dataContext'),
+        attr = dataContext && dataContext.getAttributeByName(iAttrName),
+        columnIndex = this.gridColumns.findIndex(
+                                        function(iColumn) {
+                                          return attr && (attr.get('id').toString() === iColumn.id);
+                                        }),
+        columnInfo = columnIndex >= 0 ? this.gridColumns[columnIndex] : null;
+    return columnInfo ? { columnIndex: columnIndex, columnInfo: columnInfo } : null;
+  },
+
+  /**
     Updates the column information for the specified attribute.
     @param    {DG.Attribute}    iAttribute -- The attribute whose column should be updated
     @returns  {Boolean}         True if the attribute exists and was updated, false otherwise

--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -745,32 +745,11 @@ DG.CaseTableCellEditor = function CaseTableCellEditor(args) {
         // Attempt to complete the edit whenever we lose focus
         DG.globalEditorLock.commitCurrentEdit();
       })
+      .bind('mousedown', function(e) { e.stopImmediatePropagation(); })
+      .bind('mouseup', function(e) { e.stopImmediatePropagation(); })
       .bind('click', function (e) {
-        // for unknown reasons, click in the input box does not
-        // position the input caret, so we do it ourselves...
-        function positionCaret($el, text, xPosition) {
-          var $div = $('<div>').text(text);
-          var length = text.length;
-          var pos;
-          $div.css({
-            position: 'absolute',
-            left: '-100px',
-            top: '-100px',
-            fontWeight: $el.css('font-weight'),
-            fontFamily: $el.css('font-family'),
-            fontSize: $el.css('font-size')
-          });
-          $('body').append($div);
-          pos = Math.round(xPosition*length/$div.width());
-          $div.remove();
-          $el[0].setSelectionRange(pos, pos);
-        }
-        positionCaret($(this), $(this).val(), e.offsetX);
         e.preventDefault();
         e.stopImmediatePropagation();
-      })
-      .bind('dblclick', function(e) {
-        this.setSelectionRange(0, $(this).val().length);
       })
       .focus()
       .select();

--- a/apps/dg/components/case_table/hier_table_view.js
+++ b/apps/dg/components/case_table/hier_table_view.js
@@ -394,6 +394,13 @@ DG.HierTableView = SC.ScrollView.extend( (function() {
       contentView.removeChild(view);
     },
 
+    getChildTableViewForCollection: function(collectionID) {
+      var childTableViews = this.get('childTableViews');
+      return DG.ArrayUtils.firstMatch(childTableViews, function(tableView) {
+                              return tableView.getPath('gridAdapter.collection.id') === collectionID;
+                            });
+    },
+
     /**
       An array of child table view object, one for each subtable.
       @property   {[DG.CaseTableView]}

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -2215,6 +2215,25 @@ DG.DataContext = SC.Object.extend((function() // closure
     return attrs;
   },
 
+  getNewAttributeName: function() {
+    var attrName = 'DG.CaseTable.defaultAttrName'.loc();
+    return this.getUniqueAttributeName(attrName);
+  },
+
+  getUniqueAttributeName: function(baseName, allowNames) {
+    var attrNames = this.getAttributes().map(function(attr) {
+                                              return attr.get('name');
+                                            }),
+        newName = this.canonicalizeName(baseName),
+        suffix = 1;
+    while ((attrNames.indexOf(newName) >= 0) &&
+          // eslint-disable-next-line no-unmodified-loop-condition
+          (!allowNames || (allowNames.indexOf(newName) < 0))) {
+      newName = baseName + ++suffix;
+    }
+    return newName;
+  },
+
   /**
    *  Returns the DG.Attribute with the specified name.
    *  Searches its collections from child => parent => grandparent order.

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -516,6 +516,7 @@ SC.stringsFor('English', {
   'DG.TableController.attributeEditor.title': 'Attribute Properties',
   // DG.CaseTableDropTarget
   'DG.CaseTableDropTarget.dropMessage': "drop attribute to create new collection",
+  'DG.CaseTable.defaultAttrName': 'newAttr',
   'DG.CaseTable.indexColumnName': 'index',
   'DG.CaseTable.indexColumnTooltip': 'The row number (caseIndex) within the collection',
   'DG.CaseTable.indexMenu.insertCase': "Insert Case",

--- a/apps/dg/resources/dg-slickgrid.css
+++ b/apps/dg/resources/dg-slickgrid.css
@@ -46,6 +46,12 @@ sc_require('resources/slickgrid/plugins/slick.headermenu.css')
   line-height: 1.2em;
 }
 
+.slick-column-name .dg-attr-name-edit-input {
+  height: 1.6em;
+  border: none;
+  font-weight: normal;
+}
+
 .slick-column-name .two-line-header-line-1, .slick-column-name .two-line-header-line-2 {
   display: block;
   text-align: left;

--- a/apps/dg/resources/dg.css
+++ b/apps/dg/resources/dg.css
@@ -275,6 +275,11 @@
     opacity: 0.5;
 }
 
+/* hidden in selected components when explicitly disabled */
+.dg-component-view-selected .dg-floating-plus.disabled {
+    visibility: hidden;
+}
+
 /* hidden in unselected components */
 .dg-floating-plus {
     visibility: hidden;

--- a/apps/dg/utilities/array_utils.js
+++ b/apps/dg/utilities/array_utils.js
@@ -50,11 +50,11 @@ DG.ArrayUtils = {
   },
 
   /**
-    Returns the index of the first array entry for which the specified
-    match function returns true. Returns -1 if no match is found.
+    Returns the first element of the array for which the specified
+    match function returns true. Returns null if no match is found.
     @param    {Array}     The array in which to search for a match
     @param    {Function}  iMatchFunc: function( iArrayElement) { ... }
-    @returns              index of first match or -1 if no match found
+    @returns              first matching element or null if no match found
    */
   firstMatch: function( iArray, iMatchFunc) {
     var i, len = iArray.length;


### PR DESCRIPTION
Newly created attribute auto-edits attribute name in place, bypassing dialog [#146418727]
- uses jQuery & <input> for editing since SlickGrid doesn't natively support header cell editing
- hide new attribute icon button (floating plus) while attribute name is being edited
