### PR TITLE
Fix boundary issues

### DIFF
--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -86,6 +86,8 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
             result = errorFormatter(cellValue);
           } else if (type === 'qualitative') {
             result = qualBarFormatter(cellValue);
+          } else if (cellValue instanceof DG.SimpleMap) {
+            result = stringFormatter(cellValue.toString());
           } else if (type === 'boundary') {
             result = boundaryFormatter(cellValue);
           } else if (typeof cellValue === 'boolean') {

--- a/apps/dg/models/global_value_model.js
+++ b/apps/dg/models/global_value_model.js
@@ -54,7 +54,7 @@ DG.GlobalValue = DG.BaseModel.extend(/** @scope DG.GlobalValue.prototype */ {
   },
 
   verify: function () {
-    if (SC.empty(this.document)) {
+    if (SC.empty(this.document) && !this.get('allowDetached')) {
       DG.logWarn('Unattached global value: ' + this.id);
     }
     if (typeof this.document === 'number') {

--- a/apps/dg/models/remote_boundaries.js
+++ b/apps/dg/models/remote_boundaries.js
@@ -129,7 +129,7 @@ DG.RemoteBoundaries.registerDefaultBoundaries = function() {
       DG.remoteBoundaries.forEach(function(remoteBoundary) {
         DG.RemoteBoundaries.addBoundaries(remoteBoundary);
       });
-          }
+    }
   }
 
   // first time - create internal array of boundaries
@@ -141,7 +141,9 @@ DG.RemoteBoundaries.registerDefaultBoundaries = function() {
       success: function (boundarySpecs, status, jqXHR) {
         DG.remoteBoundaries = [];
         boundarySpecs.forEach(function (spec) {
-          DG.remoteBoundaries.push(DG.RemoteBoundaries.create(spec));
+          // eliminate unattached global warning
+          var boundarySpec = $.extend({ allowDetached: true }, spec);
+          DG.remoteBoundaries.push(DG.RemoteBoundaries.create(boundarySpec));
         });
         addBoundaries();
       }.bind(this),


### PR DESCRIPTION
- eliminate "unattached global value" warnings
- fix rendering of `DG.SimpleMap`s, e.g. boundary maps

@jsandoe @eireland Note that a recent refactoring of the table cell formatting code broke formatting of boolean values (fixed in an earlier PR) and `DG.SimpleMap`s (e.g. boundary sets, fixed in this PR), but additional testing to determine whether any other types were affected seems warranted. The refactor includes a `DG.log()` to log unrecognized types, but recent versions of Chrome don't show `DG.log()` messages by default -- they must be enabled by setting the `Verbose` output level in the debugger.