### PR TITLE
Plugin API improvements

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1625,8 +1625,10 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           },
 
           'delete': function (iResource) {
-            var component = iResource.component;
-            component.destroy();
+            var component = iResource.component,
+                componentID = component && component.get('id');
+            if (componentID)
+              DG.closeComponent(componentID);
             return {success: true};
           },
           'toDIType': function (iCODAPType) {

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1447,7 +1447,15 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           webView: {
             name: directMapping,
             title: directMapping,
-            URL: directMapping,
+            URL: function (key, value) {
+              return { key: 'URL', value: value,
+                        set: function(model, value) {
+                          var controller = DG.currDocumentController()
+                                              .getComponentControllerForModel(model);
+                          if (controller) controller.set('theURL', value);
+                        }
+                      };
+            },
           }
         };
 
@@ -1543,14 +1551,27 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           },
 
           update: function (iResources, iValues) {
-            if (!iResources.component) {
+            if (!iResources.component || iResources.component.get('isDestroyed')) {
               return {success: false, values: {error: 'Component not found'}};
             }
 
-            var component = iResources.component;
-            ['title'].forEach(function (prop) {
-              if (iValues[prop]) {
-                component.set(prop, iValues[prop]);
+            var component = iResources.component,
+                componentType = component && component.get('type'),
+                codapType = componentType && kTypeMap[componentType],
+                componentProps = componentType && kComponentStorageProperties[codapType];
+
+            Object.keys(componentProps || []).forEach(function(prop) {
+              var mapping = componentProps[prop],
+                  newValue = iValues[prop];
+              // if it's a simple property, we can set it directly
+              if ((mapping === directMapping) && (newValue !== undefined)) {
+                component.set(prop, newValue);
+              }
+              else {
+                var indirectMapping = mapping && mapping();
+                // if there's a setter function, call it
+                if (indirectMapping && indirectMapping.set)
+                  indirectMapping.set(component, newValue);
               }
             });
             return {
@@ -1604,8 +1625,8 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
               return rtn;
             }
             var component = iResources.component;
-            var document = DG.currDocumentController();
-            var componentController = component && document && document.componentControllersMap[component.get('id')];
+            var componentController = DG.currDocumentController()
+                                          .getComponentControllerForModel(component);
             componentController && componentController.willSaveComponent();
             var archive = component && component.toArchive();
             var serialized = archive && remapArchiveComponent(archive);

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -374,6 +374,11 @@ DG.DocumentController = SC.Object.extend(
       return changes.indexOf(obj) !== -1;
     },
 
+    getComponentControllerForModel: function(iComponentModel) {
+      var id = iComponentModel && iComponentModel.get('id');
+      return id && this.componentControllersMap[id];
+    },
+
     /**
       Creates an appropriate DG.DataContext for the specified DG.DataContextRecord object.
       If no model is specified, creates the DG.DataContextRecord as well.

--- a/apps/dg/utilities/close-component.js
+++ b/apps/dg/utilities/close-component.js
@@ -1,0 +1,61 @@
+DG.closeComponent = function (iComponentID) {
+    var tState;
+
+    // Give the controller a chance to do some housekeeping before we close it (defocus, commit edits, etc.).
+    // Also, do this outside of the undo command, so that it can register its own
+    // separate undo command if desired.
+    var tController = DG.currDocumentController().componentControllersMap[iComponentID];
+    if (!tController) return;
+    tController.willCloseComponent();
+
+    DG.UndoHistory.execute(DG.Command.create({
+      name: 'component.close',
+      undoString: 'DG.Undo.component.close',
+      redoString: 'DG.Redo.component.close',
+      _componentId: iComponentID,
+      _controller: function() {
+        return DG.currDocumentController().componentControllersMap[this._componentId];
+      },
+      _model: null,
+      execute: function() {
+        tController = this._controller();
+        var tComponentView = tController.get('view'),
+            tContainerView = tComponentView.get('parentView');
+
+        this.log = 'closeComponent: %@'.fmt(tComponentView.get('title'));
+        this._model = tController.get('model');
+
+        // Some components (the graph in particular), won't restore correctly without calling willSaveComponent(),
+        // because sometimes not all of the info necessary to restore the view is actively held in the model.
+        // (In the graph's case, there is 'model' which relates to the view, and 'graphModel' which holds all of the
+        // configuration like axis ranges, legends, etc.)
+        tController.willSaveComponent();
+
+        if (tController.saveGameState) {
+          // If we are a GameController, try to save state.
+          // Since this is an asynchronous operation, we have to hold off closing the component
+          // until it is complete (or it will fail).
+          // Also, since closing the document will happen after this command executes, dirtying the
+          // document will clear the undo history, so we must force it not to dirty.
+          tController.saveGameState(function(result) {
+            if (result && result.success) {
+              tState = result.state;
+            }
+            SC.run(function () {
+              tContainerView.removeComponentView( tComponentView);
+            });
+          });
+        } else {
+          tContainerView.removeComponentView( tComponentView);
+        }
+      },
+      undo: function() {
+        DG.currDocumentController().createComponentAndView(this._model);
+
+        tController = this._controller();
+        if (tController.restoreGameState && tState) {
+          tController.restoreGameState({gameState: tState});
+        }
+      }
+    }));
+  };

--- a/apps/dg/views/titlebar_button_view.js
+++ b/apps/dg/views/titlebar_button_view.js
@@ -44,7 +44,7 @@ DG.TitleBarCloseButton = SC.View.extend(DG.MouseAndTouchView,
                   || 'DG.Component.closeComponent.confirmCloseDescription';
 
           var closeComponentAfterConfirm = function () {
-            this.closeComponent(tComponentId, tController);
+            DG.closeComponent(tComponentId);
           }.bind(this);
 
           if (tShouldConfirmClose) {
@@ -66,68 +66,8 @@ DG.TitleBarCloseButton = SC.View.extend(DG.MouseAndTouchView,
             });
 
           } else {
-            this.closeComponent(tComponentId, tController);
+            DG.closeComponent(tComponentId);
           }
-        },
-
-        closeComponent: function (iComponentID, iController) {
-          var tState;
-
-          // Give the controller a chance to do some housekeeping before we close it (defocus, commit edits, etc.).
-          // Also, do this outside of the undo command, so that it can register its own
-          // separate undo command if desired.
-          iController.willCloseComponent();
-
-          DG.UndoHistory.execute(DG.Command.create({
-            name: 'component.close',
-            undoString: 'DG.Undo.component.close',
-            redoString: 'DG.Redo.component.close',
-            _componentId: iComponentID,
-            _controller: function() {
-              return DG.currDocumentController().componentControllersMap[this._componentId];
-            },
-            _model: null,
-            execute: function() {
-              iController = this._controller();
-              var tComponentView = iController.get('view'),
-                  tContainerView = tComponentView.get('parentView');
-
-              this.log = 'closeComponent: %@'.fmt(tComponentView.get('title'));
-              this._model = iController.get('model');
-
-              // Some components (the graph in particular), won't restore correctly without calling willSaveComponent(),
-              // because sometimes not all of the info necessary to restore the view is actively held in the model.
-              // (In the graph's case, there is 'model' which relates to the view, and 'graphModel' which holds all of the
-              // configuration like axis ranges, legends, etc.)
-              iController.willSaveComponent();
-
-              if (iController.saveGameState) {
-                // If we are a GameController, try to save state.
-                // Since this is an asynchronous operation, we have to hold off closing the component
-                // until it is complete (or it will fail).
-                // Also, since closing the document will happen after this command executes, dirtying the
-                // document will clear the undo history, so we must force it not to dirty.
-                iController.saveGameState(function(result) {
-                  if (result && result.success) {
-                    tState = result.state;
-                  }
-                  SC.run(function () {
-                    tContainerView.removeComponentView( tComponentView);
-                  });
-                });
-              } else {
-                tContainerView.removeComponentView( tComponentView);
-              }
-            },
-            undo: function() {
-              DG.currDocumentController().createComponentAndView(this._model);
-
-              iController = this._controller();
-              if (iController.restoreGameState && tState) {
-                iController.restoreGameState({gameState: tState});
-              }
-            }
-          }));
         }
     };
   }()) // function closure


### PR DESCRIPTION
- Fix component deletion
- Support more properties in component `update` calls
  - all `directMapping` properties are supported
  - add specific mapping for `WebView`'s `URL` property
  - return `{ success: false }` when updating a component that has been destroyed

Note: In testing I have seen some intermittent failures of the component deletion code. The plugin API is now calling the same code that is used when clicking the close box of a component, so if there are issues there I believe they are beyond the scope of this PR.