### PR TITLE
Support substring matching of the `formatStr` for log monitors

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1690,11 +1690,11 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
 
       handleLogMessageMonitor: {
         register: function (iResource, iValues) {
-          if (!iValues.topic && !iValues.topicPrefix && !iValues.formatStr && !iValues.message) {
+          if (!iValues.topic && !iValues.topicPrefix && !iValues.formatStr && !iValues.formatPrefix && !iValues.message) {
             return {
               success: false,
               values: {
-                error: 'At least one of the following values must be passed: topic, topicPrefix, formatStr or message.'
+                error: 'At least one of the following values must be passed: topic, topicPrefix, formatStr, formatPrefix or message.'
               }
             };
           }
@@ -1708,6 +1708,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
               topic: iValues.topic,
               topicPrefix: iValues.topicPrefix,
               formatStr: iValues.formatStr,
+              formatPrefix: iValues.formatPrefix,
               message: iValues.message
             }
           });

--- a/apps/dg/components/data_interactive/notification_manager.js
+++ b/apps/dg/components/data_interactive/notification_manager.js
@@ -224,11 +224,13 @@ DG.NotificationManager = SC.Object.extend(/** @scope DG.NotificationManager.prot
           topicMatches: logMonitorValues.topic && (logMonitorValues.topic === iValues.topic),
           topicPrefixMatches: logMonitorValues.topicPrefix && iValues.topic && (logMonitorValues.topicPrefix === iValues.topic.substr(0, logMonitorValues.topicPrefix.length)),
           formatStrMatches: logMonitorValues.formatStr && (logMonitorValues.formatStr === iValues.formatStr),
+          formatPrefixMatches: logMonitorValues.formatPrefix && iValues.formatStr && (logMonitorValues.formatPrefix === iValues.formatStr.substr(0, logMonitorValues.formatPrefix.length)),
           messageMatches: logMonitorValues.message &&
             ((logMonitorValues.message === values.message)||
                 (logMonitorValues.message === "*"))
         }, logMonitorValues);
-        if (logMonitorValues.topicMatches || logMonitorValues.topicPrefixMatches || logMonitorValues.formatStrMatches || logMonitorValues.messageMatches) {
+        if (logMonitorValues.topicMatches || logMonitorValues.topicPrefixMatches ||
+            logMonitorValues.formatStrMatches || logMonitorValues.formatPrefixMatches || logMonitorValues.messageMatches) {
           values.logMonitor = logMonitorValues;
           logMonitor.iPhoneHandler.sendMessage({
             action: "notify",


### PR DESCRIPTION
Previously, log monitors could match on topic string (full or substring) or format string (full). This extends the matching to support substring matches on format strings. This is in service of Inquiry Space PT story [#151097630](https://www.pivotaltracker.com/story/show/151097630).