### PR TITLE
Add null test for `tColor` in `forEachCategory`

### DIFF
--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -226,7 +226,7 @@ DG.Attribute = DG.BaseModel.extend(
         DG.assert(!SC.none( tCategories) && SC.isArray( tCategories.__order));
         tCategories.__order.forEach( function( iCategory, iIndex) {
           var tColor = tCategories[iCategory];
-          tColor = tColor && tColor.colorString;
+          tColor = tColor && tColor.colorString ? tColor.colorString : tColor;
           iFunc( iCategory, tColor, iIndex);
         });
       },

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -226,7 +226,7 @@ DG.Attribute = DG.BaseModel.extend(
         DG.assert(!SC.none( tCategories) && SC.isArray( tCategories.__order));
         tCategories.__order.forEach( function( iCategory, iIndex) {
           var tColor = tCategories[iCategory];
-          tColor = tColor.colorString || tColor;
+          tColor = tColor && tColor.colorString;
           iFunc( iCategory, tColor, iIndex);
         });
       },


### PR DESCRIPTION
@bfinzer This is a local fix for a broken graph that showed up in an InquirySpace 2 document. I didn't look into it further than making the minimal null test change. You may want to see if there's more that should be done in this situation. Evangeline will probably create a [PT story](https://www.pivotaltracker.com/story/show/151827266) if she hasn't already, but the document is https://codap.concord.org/releases/staging/static/dg/en/cert/index.html#shared=24532.

@bfinzer Ignore the "failing" tests reported below. Jonathan and I were in the middle of setting up the Travis build on Friday and ran into some issues that have yet to be resolved.