### PR TITLE
Snapshot draw tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: false
 language: node_js
 node_js: node
-before_install:
-- rvm use 2.2.7
 install:
-- travis_retry gem install s3_website -v 2.12.3
+- travis_retry gem install s3_website
 - travis_retry gem install sproutcore -v 1.11
 - travis_retry pip install awscli --upgrade --user
 - travis_retry yarn
@@ -16,4 +14,5 @@ cache:
   - node_modules
 notifications:
   slack:
+    on_pull_requests: false
     secure: ZRC3DvCAynz+Zp5sLYdaozBPRCCO08i8gaQKzEjBwllJSO+5lRfLzjPYlyMJYtmTLq+ILM0CRhoGfCE3o7F/bdtJiEhNxWTsO17JqSlnvttCee0P7zeNIOJUP7mVFjX52yH3yPrCA8WTz97ocdtb9yue4P4bRs4umeEuRFzW0kM=

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -444,11 +444,15 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           DG.assert(diModel, 'DataInteractiveModel  exists' );
           DG.assert(diModel.constructor === DG.DataInteractiveModel, 'model content is DataInteractiveModel');
           if (iValues) {
-            diModel.set('title', iValues.title);
-            this.setPath('view.title', title);
+            if (iValues.title != null) {
+              diModel.set('title', iValues.title);
+              this.setPath('view.title', title);
+            }
 
-            diModel.set('version', iValues.version);
-            diModel.set('dimensions', iValues.dimensions);
+            if (iValues.version != null)
+              diModel.set('version', iValues.version);
+            if (iValues.dimensions)
+              diModel.set('dimensions', iValues.dimensions);
             if (!SC.none(iValues.preventBringToFront)) {
               // Todo 7/2016: we should be managing this value in the model only,
               // and deriving the value in the controller.

--- a/apps/dg/components/graph/graph_controller.js
+++ b/apps/dg/components/graph/graph_controller.js
@@ -146,6 +146,17 @@ DG.GraphController = DG.DataDisplayController.extend(
           this.convertToImage(graphView.get('layer'), width, height);
         },
 
+        copyAsImage: function () {
+          var componentView = this.get('view'),
+              title = (componentView && componentView.get('title')) ||
+                        "DG.DocumentController.graphTitle".loc(),
+              graphView = componentView && componentView.get('contentView'),
+              layer = graphView && graphView.get('layer'),
+              width = graphView && graphView.getPath('frame.width'),
+              height = graphView && graphView.getPath('frame.height');
+          if (graphView)
+            this.openDrawToolWithImage(layer, width, height, title);
+        },
 
         rescaleAxes: function () {
           this.graphModel.rescaleAxes();

--- a/apps/dg/components/graph_map_common/data_display_controller.js
+++ b/apps/dg/components/graph_map_common/data_display_controller.js
@@ -124,7 +124,20 @@ DG.DataDisplayController = DG.ComponentController.extend(
           sc_super();
         },
 
-        createInspectorButtons: function () {
+      /** Submenu items for copying/exporting component images */
+      createImageExportMenuItems: function() {
+
+        return [
+          // Note that these 'built' string keys will have to be specially handled by any
+          // minifier we use
+          { title: ('DG.DataDisplayMenu.copyAsImage'), isEnabled: true,
+            target: this, action: 'copyAsImage' },
+          { title: ('DG.DataDisplayMenu.exportImage'), isEnabled: true,
+            target: this, action: 'makePngImage' }
+        ];
+      },
+      
+      createInspectorButtons: function () {
           var tResult = sc_super(),
               this_ = this;
           if( !this.get('dataDisplayModel').wantsInspector())
@@ -239,17 +252,30 @@ DG.DataDisplayController = DG.ComponentController.extend(
             localize: true
           }));
 
+          var tImageExportButton;
+
+          var showImageExportPopup = function () {
+            var tMenu = DG.MenuPane.create({
+                  classNames: 'dg-display-show-image-popup'.w(),
+                  layout: {width: 200, height: 150}
+                }),
+                tMenuItems = this.createImageExportMenuItems();
+            tMenu.set('items', tMenuItems);
+            tMenu.popup(tImageExportButton);
+          }.bind(this);
+
           if (this.makePngImage) {  // Not implemented for map yet
-            tResult.push(DG.IconButton.create({
+            tImageExportButton = DG.IconButton.create({
               layout: {width: 32},
               iconExtent: {width: 30, height: 25},
               classNames: 'dg-display-camera'.w(),
               iconClass: 'moonicon-icon-tileScreenshot',
               target: this,
-              action: 'makePngImage',
+              action: showImageExportPopup,
               toolTip: 'DG.Inspector.makeImage.toolTip',
               localize: true
-            }));
+            });
+            tResult.push(tImageExportButton);
           }
 
           return tResult;
@@ -894,11 +920,19 @@ DG.DataDisplayController = DG.ComponentController.extend(
             reader.readAsDataURL(pngObject);
           }
 
-          DG.ImageUtilities.captureSVGElementsToImage(rootEl, width, height).then(function (blob) {
-            saveImage(blob);
-          });
-        }
+          DG.ImageUtilities.captureSVGElementsToImage(rootEl, width, height)
+            .then(function (blob) {
+              saveImage(blob);
+            });
+        },
 
+        openDrawToolWithImage: function (rootEl, width, height, title) {
+
+          DG.ImageUtilities.captureSVGElementsToImage(rootEl, width, height, true)
+            .then(function (dataURL) {
+              DG.appController.importDrawToolWithDataURL(dataURL, title);
+            });
+        }
 
       };
 

--- a/apps/dg/controllers/app_controller.js
+++ b/apps/dg/controllers/app_controller.js
@@ -507,6 +507,33 @@ DG.appController = SC.Object.create((function () // closure
       return true;
     },
 
+    importDrawToolWithDataURL: function(iDataURL, iTitle) {
+      var kWidth = 600, kHeight = 400,
+          kComponentType = 'DG.GameView',
+          layout = { width : kWidth, height: kHeight },
+          drawToolUrl = DG.get('drawToolPluginURL'),
+          title = "DG.DataDisplayMenu.imageOfTitle".loc(iTitle),
+          tDoc = DG.currDocumentController(),
+          tComponent = DG.Component.createComponent({
+            type: kComponentType,
+            document: tDoc.get('content'),
+            layout: layout,
+            componentStorage: {
+              currentGameName: title,
+              currentGameUrl: drawToolUrl,
+              allowInitGameOverride: true
+            }
+          }),
+          tComponentArgs = { initiatedViaCommand: true },
+          tView = tDoc.createComponentAndView(tComponent, kComponentType, tComponentArgs),
+          tSuperView = tView && tView.get('parentView'),
+          tController = tView && tView.get('controller');
+      if (tSuperView && tSuperView.positionNewComponent)
+        tSuperView.positionNewComponent(tView, 'top', true);
+      if (tController && tController.sendCommand)
+        tController.sendCommand({ action: 'update', resource: 'backgroundImage', values: { image: iDataURL }});
+    },
+
     /**
      Close the current document and all its components.
      */

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -20,6 +20,7 @@
 //  limitations under the License.
 // ==========================================================================
 
+sc_require('models/document_model');
 sc_require('models/remote_boundaries');
 
 /* globals Promise */

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -317,6 +317,10 @@ DG = SC.Application.create((function () // closure
     */
     pluginMetadata: null,
 
+    drawToolPluginURL: function() {
+      return this.get('pluginURL') + '/DrawTool';
+    }.property(),
+
     /*
      * Logging is enabled when server matches this DNS name.
      */

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -616,6 +616,9 @@ SC.stringsFor("en", {
     "DG.DataDisplayMenu.disableNumberToggle": "Hide Parent Visibility Toggles",
     "DG.DataDisplayMenu.showAll": "Show All Cases",
     "DG.DataDisplayMenu.snapshot": "Make Snapshot",
+    "DG.DataDisplayMenu.copyAsImage": "Copy as Image",
+    "DG.DataDisplayMenu.exportImage": "Export Image...",
+    "DG.DataDisplayMenu.imageOfTitle": "Image of %@",
 
     // DG.GraphView
     "DG.GraphView.replaceAttribute": "Replace %@ with %@",

--- a/apps/dg/utilities/image_utilities.js
+++ b/apps/dg/utilities/image_utilities.js
@@ -29,9 +29,10 @@ DG.ImageUtilities = (function () {
      *   image. HTML DOM element will not be visible.
      * @param width {number}
      * @param height {number}
+     * @param asDataURL {boolean} true - image returned as data URI, otherwise as blob
      * @return {Promise} The promise of an image.
      */
-    captureSVGElementsToImage: function (rootEl, width, height) {
+    captureSVGElementsToImage: function (rootEl, width, height, asDataURL) {
 
       function getCSSText() {
         var text = [], ix, jx;
@@ -168,7 +169,7 @@ DG.ImageUtilities = (function () {
       // when all promises have been fulfilled we make a blob, then invoke the
       // save image dialog.
       return Promise.all(promises).then(function () {
-          return makeCanvasBlob(canvas);
+          return asDataURL ? canvas.toDataURL("image/png") : makeCanvasBlob(canvas);
         },
         function (error) {
           DG.logError(error);

--- a/apps/dg/views/container_view.js
+++ b/apps/dg/views/container_view.js
@@ -278,8 +278,9 @@ DG.ContainerView = SC.View.extend(
         We find a non-overlapping position for the view and place it there.
         @param{DG.ComponentView} - the view to be positioned
         @param {String} Default is 'top'
+        @param {boolean} iPositionGameViews - true to set GameView positions as well as sizes
       */
-      positionNewComponent: function( iView, iPosition) {
+      positionNewComponent: function( iView, iPosition, iPositionGameViews) {
         var this_ = this,
             tViewRect = iView.get( 'frame'),
             tDocRect = this.parentView.get('clippingFrame'),
@@ -299,7 +300,19 @@ DG.ContainerView = SC.View.extend(
             tOptions = { duration: 0.5, timing: 'ease-in-out'},
             tIsGameView = iView.get('contentView').constructor === DG.GameView;
         if( tIsGameView) {
-          iView.adjust( tFinalRect);
+          // As of 2016-10-26, tFinalRect was being passed to iView.adjust() directly for GameViews,
+          // apparently with the intent that the game view would be moved to the rectangle specified.
+          // The adjust() function takes a layout object with { left, right }, rather than a rectangle
+          // with { x, y }, however, so since then the size of GameViews has been set but not their location.
+          // Rather than changing that behavior at this point, we introduce the iPositionGameViews
+          // parameter which allows clients aware of the issue to specify that they do want the
+          // location of GameViews to be set as well.
+          var newLayout = { width: tFinalRect.width, height: tFinalRect.height };
+          if (iPositionGameViews) {
+            newLayout.left = tFinalRect.x;
+            newLayout.top = tFinalRect.y;
+          }
+          iView.adjust(newLayout);
         }
         else {
           tReservedRects.push(tFinalRect);

--- a/lang/strings/en-US.json
+++ b/lang/strings/en-US.json
@@ -616,6 +616,9 @@
     "DG.DataDisplayMenu.disableNumberToggle": "Hide Parent Visibility Toggles",
     "DG.DataDisplayMenu.showAll": "Show All Cases",
     "DG.DataDisplayMenu.snapshot": "Make Snapshot",
+    "DG.DataDisplayMenu.copyAsImage": "Copy as Image",
+    "DG.DataDisplayMenu.exportImage": "Export Image...",
+    "DG.DataDisplayMenu.imageOfTitle": "Image of %@",
 
     // DG.GraphView
     "DG.GraphView.replaceAttribute": "Replace %@ with %@",

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -27,4 +27,4 @@ cloudfront_distribution_config:
   aliases:
     quantity: 1
     items:
-      CNAME0: codap-dev.concord.org
+      - codap-dev.concord.org


### PR DESCRIPTION
Implement "Copy as Image" [#152123215], [#152123320]
- graph snapshot icon brings up menu with two options
  - Copy as Image (brings up Draw Tool component with Graph image)
  - Export image... (export PNG via CFM, as before)

Requires deployment of CODAP Data Interactives [PR#18](https://github.com/concord-consortium/codap-data-interactives/pull/18).