### PR TITLE
Fix number toggle fix

### DIFF
--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -1050,7 +1050,7 @@ DG.CaseTableController = DG.ComponentController.extend(
         }
 
         function refreshTable() {
-          dataContext.regenerateCollectionCases();
+          dataContext.regenerateCollectionCases(null, 'moveCases');
           if (hierTableView)
             hierTableView.updateRowData();
         }

--- a/apps/dg/components/graph/plots/number_toggle_model.js
+++ b/apps/dg/components/graph/plots/number_toggle_model.js
@@ -434,7 +434,7 @@ return {
   isAffectedByChange: function(iChange) {
 
     function isCollectionChange(iChange) {
-      var operations = ['createCollection', 'deleteCollection', 'moveAttribute'];
+      var operations = ['createCollection', 'deleteCollection', 'moveAttribute', 'moveCases'];
       return operations.indexOf(iChange.operation) >= 0;
     }
 

--- a/apps/dg/components/graph/plots/number_toggle_model.js
+++ b/apps/dg/components/graph/plots/number_toggle_model.js
@@ -187,7 +187,8 @@ return {
   childrenOfParent: function( iIndex) {
     var tParents = this.get('parentCases' ),
         tParent = (iIndex < tParents.length) ? tParents[ iIndex] : null,
-        tChildren = tParent ? tParent.get('children') : [];
+                    // flatten() used to make copy of children
+        tChildren = tParent ? tParent.get('children').flatten() : [];
     // use for-loop since tChildren is modified recursively
     for (var i = 0; i < tChildren.get('length'); ++i) {
       var child = tChildren.objectAt(i),

--- a/apps/dg/components/graph/plots/number_toggle_model.js
+++ b/apps/dg/components/graph/plots/number_toggle_model.js
@@ -65,6 +65,22 @@ return {
   _cachedCaseCount: null,
   _cachedParentCases: null,
 
+  invalidate: function(iClearCaches) {
+    if (iClearCaches)
+      this._cachedCaseCount = this._cachedParentCases = this._isHierarchical = null;
+
+    // 'caseCount' is used as a proxy to indicate that some change occurred
+    // GraphView.handleNumberToggleDidChange() observes 'caseCount'
+    // not clear why invokeOnceLater() is (or was) required
+    this.invokeOnceLater( this.propertyDidChange, 1, 'caseCount');
+  },
+
+  isEnabledDidChange: function() {
+    // sync up with any changes that occurred while disabled
+    if (this.get('isEnabled'))
+      this.invalidate(true);
+  }.observes('isEnabled'),
+
   /**
    * @property{SC.Array of DG.Case}
    */
@@ -448,14 +464,7 @@ return {
         return;
       }
 
-      if (this.isAffectedByChange(iChange)) {
-        this._cachedCaseCount = this._cachedParentCases = this._isHierarchical = null;
-      }
-
-      // 'caseCount' is used as a proxy to indicate that some change occurred
-      // GraphView.handleNumberToggleDidChange() observes 'caseCount'
-      // not clear why invokeOnceLater() is (or was) required
-      this.invokeOnceLater( this.propertyDidChange, 1, 'caseCount');
+      this.invalidate(this.isAffectedByChange(iChange));
     }
   }
 

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -1286,7 +1286,7 @@ DG.DataContext = SC.Object.extend((function() // closure
      * or destruction.
      * @return {[DG.Case]}
      */
-  regenerateCollectionCases: function (affectedCollections) {
+  regenerateCollectionCases: function (affectedCollections, notifyOperation) {
     var topCollection = this.getCollectionAtIndex(0),
         collections = {},   // map from id to collection
         createdCases,       // array of created cases
@@ -1337,8 +1337,14 @@ DG.DataContext = SC.Object.extend((function() // closure
     this.forEachCollection(function (collection) {
       collection.get('collection').updateCaseIDToIndexMap();
     });
-    return { collections: DG.ObjectMap.values(collections),
-            createdCases: createdCases, deletedCases: deletedCases };
+    var change = { collections: DG.ObjectMap.values(collections),
+                  createdCases: createdCases, deletedCases: deletedCases };
+    if (notifyOperation) {
+      change.operation = notifyOperation;
+      change.isComplete = true;
+      this.applyChange(change);
+    }
+    return change;
   },
 
   /**


### PR DESCRIPTION
Fix recently introduced bug in `childrenOfParent()` [#152368313]
- copy children array so as not to affect original

Sync model when disabled/enabled [#152566901]

NumberToggleModel responds to sort notification [#152567182]
- Add sort notifications to DataContext