### PR TITLE
Improve number toggle performance [#152949179]

### DIFF
--- a/apps/dg/components/graph/plots/number_toggle_model.js
+++ b/apps/dg/components/graph/plots/number_toggle_model.js
@@ -65,9 +65,8 @@ return {
   _cachedCaseCount: null,
   _cachedParentCases: null,
 
-  invalidate: function(iClearCaches) {
-    if (iClearCaches)
-      this._cachedCaseCount = this._cachedParentCases = this._isHierarchical = null;
+  invalidate: function() {
+    this._cachedCaseCount = this._cachedParentCases = this._isHierarchical = null;
 
     // 'caseCount' is used as a proxy to indicate that some change occurred
     // GraphView.handleNumberToggleDidChange() observes 'caseCount'
@@ -78,7 +77,7 @@ return {
   isEnabledDidChange: function() {
     // sync up with any changes that occurred while disabled
     if (this.get('isEnabled'))
-      this.invalidate(true);
+      this.invalidate();
   }.observes('isEnabled'),
 
   /**
@@ -414,8 +413,10 @@ return {
 
   isAffectedByChange: function(iChange) {
 
-    function isCollectionChange(iChange) {
-      var operations = ['createCollection', 'deleteCollection', 'moveAttribute', 'moveCases'];
+    function isRelevantChange(iChange) {
+      var operations = ['createCollection', 'deleteCollection', 'moveCases', 'moveAttribute',
+                          'createCases', 'createCase', 'deleteCases', 'createAttributes',
+                          'updateAttributes', 'deleteAttributes'];
       return operations.indexOf(iChange.operation) >= 0;
     }
 
@@ -431,7 +432,7 @@ return {
       return false;
     }.bind(this);
 
-    return isCollectionChange(iChange) || isToggleAttributeChange(iChange);
+    return isRelevantChange(iChange) || isToggleAttributeChange(iChange);
   },
 
   /**
@@ -444,8 +445,8 @@ return {
         this.invokeOnce(function() { this.showOnlyLastParentCase(); }.bind(this));
         return;
       }
-
-      this.invalidate(this.isAffectedByChange(iChange));
+      if( this.isAffectedByChange(iChange))
+        this.invalidate();
     }
   }
 

--- a/apps/dg/components/graph/plots/number_toggle_model.js
+++ b/apps/dg/components/graph/plots/number_toggle_model.js
@@ -90,7 +90,7 @@ return {
         isHierarchical = false;
     if( !tCases)
       return [];
-    tCases = tCases.flatten();
+    tCases = tCases.slice();
 
     function getUltimateParent(iCase) {
       var lastCase;
@@ -124,17 +124,11 @@ return {
     this.notifyPropertyChange('parentCases');
   }.observes('*dataConfiguration.cases'),
 
-  getParentCollection: function() {
-    return this.get('numberOfParents') > 0
-              ? this.get('parentCases')[0].get('collection')
-              : null;
-  },
-
   getFirstParentAttribute: function() {
-    var collection = this.getParentCollection(),
-        attrs = collection && collection.get('attrs'),
-        attr = attrs && attrs[0];
-    return attr;
+    var dataContext = this.getPath('dataConfiguration.dataContext'),
+        collectionClient = dataContext.getCollectionAtIndex(0),
+        attrs = collectionClient && collectionClient.getPath('collection.attrs');
+    return attrs && attrs[0];
   },
 
   getParentLabel: function(iIndex) {
@@ -155,18 +149,6 @@ return {
   numberOfParents: function() {
     return this.get('parentCases' ).length;
   }.property('parentCases'),
-
-  /**
-   * We assume that there is only one parent collection and that it doesn't matter which case we use to get the name.
-   * @property {String}
-   */
-  nameOfParentCollection: function() {
-    var tName = '';
-    if( this.get('numberOfParents') > 0) {
-      tName = this.get('parentCases')[ 0].getPath('collection.name');
-    }
-    return tName;
-  }.property(),
 
   /**
    * True if cases have parents
@@ -203,8 +185,7 @@ return {
   childrenOfParent: function( iIndex) {
     var tParents = this.get('parentCases' ),
         tParent = (iIndex < tParents.length) ? tParents[ iIndex] : null,
-                    // flatten() used to make copy of children
-        tChildren = tParent ? tParent.get('children').flatten() : [];
+        tChildren = tParent ? tParent.get('children').slice() : [];
     // use for-loop since tChildren is modified recursively
     for (var i = 0; i < tChildren.get('length'); ++i) {
       var child = tChildren.objectAt(i),
@@ -272,7 +253,7 @@ return {
     }
     else {
       var tAllCases = tConfig ? tConfig.get('allCases') : [],
-          tCases = tAllCases ? tAllCases.flatten() : [],
+          tCases = tAllCases ? tAllCases.slice() : [],
           tCase = (tCases.length > iIndex) ? tCases[iIndex] : null;
       tResultCases = tCase ? [tCase] : null;
     }
@@ -304,7 +285,7 @@ return {
     }
     else {
       var tConfig = this.get('dataConfiguration'),
-          tCases = tConfig ? tConfig.get('allCases').flatten() : [],
+          tCases = tConfig ? tConfig.get('allCases').slice() : [],
           tHidden = tConfig ? tConfig.get('hiddenCases' ) : [],
           tCase = (tCases.length > iIndex) ? tCases[ iIndex] : null;
       this.beginVisibilityChanges();
@@ -407,7 +388,7 @@ return {
     }
     else {
       var tConfig = this.get('dataConfiguration'),
-          tCases = tConfig ? tConfig.get('allCases').flatten() : [],
+          tCases = tConfig ? tConfig.get('allCases').slice() : [],
           tHidden = tConfig ? tConfig.get('hiddenCases' ) : [],
           tCase = (tCases.length > iIndex) ? tCases[ iIndex] : null;
       return( tHidden.indexOf( tCase) >= 0);


### PR DESCRIPTION
- eliminate bottleneck in `getFirstParentAttribute()`
- replace calls to `flatten()` with calls to `slice()` which should perform slightly better and is clearer

@bfinzer You might consider adding your commit to this PR (use the `number-toggle-performance` branch), which would allow the two to be tested together.