### PR TITLE
Fix DG.MenuPane.getDesiredMenuWidth() crash [#153686730]

### DIFF
--- a/apps/dg/utilities/menu_pane.js
+++ b/apps/dg/utilities/menu_pane.js
@@ -50,7 +50,7 @@ DG.MenuPane = SC.MenuPane.extend(
       if (!iItem) {
         return;
       }
-      var charCount;
+      var charCount = 0;
       if( iItem.title && (typeof iItem.title === 'string')) {
         charCount =  iItem.title.loc().length;
       }


### PR DESCRIPTION
Bug was introduced in commit 7d65f5b972560dfd1db35c5c32ae235b05e011d0.