### PR TITLE
Return `drive` permissions to Drive provider

### DIFF
--- a/apps/dg/resources/cloud-file-manager/js/app.js.ignore
+++ b/apps/dg/resources/cloud-file-manager/js/app.js.ignore
@@ -14485,7 +14485,7 @@ GoogleDriveProvider = (function(superClass) {
         var args;
         args = {
           client_id: _this.clientId,
-          scope: ['https://www.googleapis.com/auth/drive.readonly', 'https://www.googleapis.com/auth/drive.install', 'https://www.googleapis.com/auth/drive.file', 'https://www.googleapis.com/auth/userinfo.profile'],
+          scope: ['https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/drive.install', 'https://www.googleapis.com/auth/drive.file', 'https://www.googleapis.com/auth/userinfo.profile'],
           immediate: immediate
         };
         return gapi.auth.authorize(args, function(authToken) {


### PR DESCRIPTION
This reverts an earlier change, where `drive` was reduced to `drive.readonly`.

Google approved our request for the expanded permissions on 3/23 for CODAP.

This expanded permission will help for managing files in ways beyond directly saving through the CODAP app.

[#133639103]