### PR TITLE
Add touch-and-hold tooltips to toolbar icons

### DIFF
--- a/apps/dg/resources/popper.css
+++ b/apps/dg/resources/popper.css
@@ -1,0 +1,145 @@
+.link-anchor {
+  position: relative;
+  width: 0;
+  font-size: .8em;
+  opacity: 0;
+  transition: opacity .2s ease-in-out;
+}
+.anchor-wrapper {
+  border: none;
+}
+.anchor-wrapper:hover .link-anchor {
+  opacity: 1;
+}
+
+section h1[id]:focus,
+section h2[id]:focus,
+section h3[id]:focus,
+section h4[id]:focus,
+section h5[id]:focus {
+  outline: 0;
+}
+
+p.thin {
+    font-weight: 100;
+    margin: 0;
+    line-height: 1.2em;
+}
+
+p.bold {
+    font-weight: 900;
+    margin: 0;
+    margin-top: -5px;
+}
+
+.rel {
+    width: 30%;
+    margin: 0 auto;
+    position: relative;
+    text-align: center;
+    padding: 20px;
+    border-style: dotted;
+    border-color: white;
+    border-width: medium;
+}
+
+.popper,
+.tooltip {
+    position: absolute;
+    background: #EEEEEE;
+    color: black;
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
+    width: fit-content;
+    border-radius: 3px;
+    box-shadow: 0 0 2px rgba(0,0,0,0.5);
+    padding: 10px;
+    text-align: center;
+}
+.style5 .tooltip {
+    background: #1E252B;
+    color: #FFFFFF;
+    max-width: 200px;
+    width: auto;
+    font-size: .8rem;
+    padding: .5em 1em;
+}
+.popper .popper__arrow,
+.tooltip .tooltip-arrow {
+    display: none;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    position: absolute;
+    margin: 5px;
+}
+
+.tooltip .tooltip-arrow,
+.popper .popper__arrow {
+    display: none;
+    border-color: #FFC107;
+}
+.style5 .tooltip .tooltip-arrow {
+    display: none;
+    border-color: #1E252B;
+}
+.popper[x-placement^="top"],
+.tooltip[x-placement^="top"] {
+    margin-bottom: 5px;
+}
+.popper[x-placement^="top"] .popper__arrow,
+.tooltip[x-placement^="top"] .tooltip-arrow {
+    border-width: 5px 5px 0 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    bottom: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+.popper[x-placement^="bottom"],
+.tooltip[x-placement^="bottom"] {
+    margin-top: 5px;
+}
+.tooltip[x-placement^="bottom"] .tooltip-arrow,
+.popper[x-placement^="bottom"] .popper__arrow {
+    border-width: 0 5px 5px 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    top: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+.tooltip[x-placement^="right"],
+.popper[x-placement^="right"] {
+    margin-left: 5px;
+}
+.popper[x-placement^="right"] .popper__arrow,
+.tooltip[x-placement^="right"] .tooltip-arrow {
+    border-width: 5px 5px 5px 0;
+    border-left-color: transparent;
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    left: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
+}
+.popper[x-placement^="left"],
+.tooltip[x-placement^="left"] {
+    margin-right: 5px;
+}
+.popper[x-placement^="left"] .popper__arrow,
+.tooltip[x-placement^="left"] .tooltip-arrow {
+    border-width: 5px 0 5px 5px;
+    border-top-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    right: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
+}

--- a/apps/dg/utilities/tap_hold_gesture.js
+++ b/apps/dg/utilities/tap_hold_gesture.js
@@ -1,0 +1,73 @@
+/**
+  ## What is a "tapHold"?
+
+  A tapHold is a tap gesture that is held for an extended time (default: 500 ms) with little movement.
+  Again, to be considered a tap, there should be very little movement of any touches on either axis
+  while still touching. The amount of movement allowed is defined by `tapWiggle`.
+
+  @class
+  @extends SC.TapGesture
+*/
+DG.TapHoldGesture = SC.TapGesture.extend(
+  /** @scope DG.TapHoldGesture.prototype */{
+
+  /** @private The touch that started the timer. */
+  _sc_timerStartTouch: null,
+
+  /**
+    @type String
+    @default "tapHold"
+    @readOnly
+  */
+ name: "tapHold",
+
+ /**
+    The amount of time in milliseconds after the first touch starts at which, *if the tap hasn't
+    ended in that time*, the `tapStart` event should trigger.
+
+    Because taps may be very short or because movement of the touch may invalidate a tap gesture
+    entirely, you generally won't want to update the state of the view immediately when a touch
+    starts.
+
+    @type Number
+    @default 500
+    */
+   tapStartDelay: 500,
+
+  /** @private Triggers the tapStart event. Should *not* be reachable unless the tap is still valid. */
+  _sc_triggerTapStart: function () {
+    // Trigger the gesture, 'tapStart'.
+    this.start(this._sc_timerStartTouch);
+    // // Trigger the gesture, 'tap'.
+    this.trigger(this._sc_timerStartTouch, this._sc_numberOfTouches);
+
+    this._sc_isTapping = true;
+  },
+
+  /**
+    Registers when the first touch started.
+
+    @param {SC.Touch} touch The touch that started the session.
+    @returns {void}
+    @see SC.Gesture#touchSessionStarted
+    */
+   touchSessionStarted: function (touch) {
+    sc_super();
+    this._sc_timerStartTouch = touch;
+  },
+
+  /**
+    Cleans up all touch session variables and triggers the gesture.
+
+    @returns {void}
+    @see SC.Gesture#touchSessionEnded
+    */
+  touchSessionEnded: function () {
+    // Trigger the gesture, 'tap'.
+    // this.trigger(this._sc_timerStartTouch, this._sc_numberOfTouches);
+
+    // Clean up (will fire tapEnd if _sc_isTapping is true).
+    this._sc_cleanUpTouchSession(false);
+  }
+
+});

--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
     "moment": "^2.22.2",
     "papaparse": "^4.5.0",
     "pluralize": "^4.0.0",
+    "popper.js": "^1.14.3",
     "react": "^15.6.2",
-    "react-dom": "^15.6.2"
+    "react-dom": "^15.6.2",
+    "tooltip.js": "^1.2.0"
   }
 }

--- a/webpack-entry.js
+++ b/webpack-entry.js
@@ -1,8 +1,10 @@
-/*global require:true, React:true, ReactDOM:true, iframePhone:true, Papa:true */
-/*global L:true, deepEqual:true, Promise:true, pluralize:true, moment:true */
-/* exported React, ReactDOM, iframePhone, Papa, deepEqual, Promise, pluralize, moment */
+/*global require:true, React:true, ReactDOM:true, Popper:true, Tooltip:true, Papa:true */
+/*global iframePhone:true, L:true, deepEqual:true, Promise:true, pluralize:true, moment:true */
+/* exported React, ReactDOM, Popper, Tooltip, iframePhone, Papa, deepEqual, Promise, pluralize, moment */
 React = require('react');
 ReactDOM = require('react-dom');
+Popper = require('popper.js');
+Tooltip = require('tooltip.js')['default'];
 iframePhone = require('iframe-phone');
 Papa = require('papaparse');
 L = require('leaflet');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2121,6 +2121,10 @@ pluralize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
 
+popper.js@^1.0.2, popper.js@^1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -2727,6 +2731,12 @@ tiny-binary-search@^1.0.3:
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+
+tooltip.js@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tooltip.js/-/tooltip.js-1.2.0.tgz#8b16482f04397f4f9d7387843dccf186890c8860"
+  dependencies:
+    popper.js "^1.0.2"
 
 tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
Add touch-and-hold tooltips to toolbar icons [#158703450]
- uses SproutCore's gesture recognition system for event handling
- uses Popper.js/Tooltip.js for tooltip display

@jsandoe This PR depends on #230 and #231. Once those are merged, I'll rebase this PR.