### PR TITLE
Single-click brings up formula editor for plotted values/functions

### DIFF
--- a/apps/dg/components/graph/adornments/plotted_formula_edit_context.js
+++ b/apps/dg/components/graph/adornments/plotted_formula_edit_context.js
@@ -32,6 +32,9 @@ DG.PlottedFormulaEditContext = SC.Object.extend({
     var formulaContext = this,
         formulaLabel = iOptions.formulaPrompt.loc(),
         formulaView = DG.FormulaTextEditView.create({
+                        // SC defers to INPUT elements on mobile Safari in ignoreTouchHandle().
+                        // In this case, we want SC to dispatch the touch normally.
+                        classNames: ['dg-wants-sc-touch'],
                         layout: { height: 20 },
                         borderStyle: SC.BORDER_BEZEL,
                         isVisible: false,
@@ -45,6 +48,9 @@ DG.PlottedFormulaEditContext = SC.Object.extend({
                         desiredExtent: 20,
                         mouseDown: function(evt) {
                           formulaContext.openFormulaEditorDialog();
+                        },
+                        touchStart: function(evt) {
+                          this.mouseDown();
                         }
                       });
     this.set('formulaView', formulaView);

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -53,7 +53,13 @@ DG.main = function main() {
   // then apply to any element that needs it, such as the jQueryUI autocomplete menu.
   var orgIgnoreTouchHandle = SC.RootResponder.prototype.ignoreTouchHandle;
   SC.RootResponder.prototype.ignoreTouchHandle = function(evt) {
-    return $(evt.target).closest('.dg-wants-touch').length || orgIgnoreTouchHandle(evt);
+    var dgWantsTouch = $(evt.target).closest('.dg-wants-touch').length,
+        wantsSCTouch = $(evt.target).closest('.dg-wants-sc-touch').length;
+    DG.log("ignoreTouchHandle: dgWantsTouch: %@, wantsSCTouch: %@",
+            !!dgWantsTouch, !!wantsSCTouch);
+    return wantsSCTouch
+              ? NO
+              : (dgWantsTouch ? YES : orgIgnoreTouchHandle(evt));
   };
 
   DG.getPath('mainPage.mainPane').appendTo($('#codap'));


### PR DESCRIPTION
Support single-click to bring up formula editor for plotted values/functions [#158703520]
- add support for `.dg-wants-sc-touch` class to indicate when SC touch-handling is desired