### PR TITLE
TouchTooltips refactor

### DIFF
--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -55,8 +55,6 @@ DG.main = function main() {
   SC.RootResponder.prototype.ignoreTouchHandle = function(evt) {
     var dgWantsTouch = $(evt.target).closest('.dg-wants-touch').length,
         wantsSCTouch = $(evt.target).closest('.dg-wants-sc-touch').length;
-    DG.log("ignoreTouchHandle: dgWantsTouch: %@, wantsSCTouch: %@",
-            !!dgWantsTouch, !!wantsSCTouch);
     return wantsSCTouch
               ? NO
               : (dgWantsTouch ? YES : orgIgnoreTouchHandle(evt));

--- a/apps/dg/utilities/touch_tooltips.js
+++ b/apps/dg/utilities/touch_tooltips.js
@@ -1,0 +1,108 @@
+// ==========================================================================
+//                          DG.TouchTooltips
+//
+//  Utility class to support tooltips on touch-hold gestures.
+//
+//  Author:   Kirk Swenson
+//
+//  Copyright (c) 2018 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included
+//  in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+// ==========================================================================
+/* global Tooltip */
+
+DG.TouchTooltips = (function() {
+
+  var kTouchTooltipDefault = 5000,
+      kTouchTooltipMax = 8000,
+
+      tooltips = {};
+
+  return {
+    showTouchTooltip: function(touch, triggerView, title, placement) {
+      var touchID = touch.identifier,
+          layer = triggerView.get('layer'),
+          container = DG.mainPage.getPath('mainPane.layer'),
+          _placement = placement || 'bottom-start',
+          tooltip = new Tooltip(layer, {
+                                  container: container,
+                                  placement: _placement,
+                                  trigger: 'manual',
+                                  title: title
+                                });
+
+      DG.TouchTooltips.hideAllTouchTooltips();
+
+      tooltip.show();
+      tooltips[touchID] = { touch: touch, tooltip: tooltip };
+
+      DG.TouchTooltips.hideTouchTooltip(touchID, kTouchTooltipMax);
+
+      return touchID;
+    },
+
+    hideTouchTooltip: function(touchID, delay) {
+      var entry = tooltips[touchID],
+          hideTooltip = function() {
+            var entry = tooltips[touchID];
+            if (entry) {
+              if (entry.tooltip) {
+                entry.tooltip.dispose();
+                entry.tooltip = null;
+              }
+              entry.timer = null;
+              if (entry.finished)
+                delete tooltips[touchID];
+            }
+          };
+      if (!entry) return;
+      
+      if (entry.timer) {
+        clearTimeout(entry.timer);
+        entry.timer = null;
+      }
+
+      if (delay == null) delay = kTouchTooltipDefault;
+      if (delay) {
+        entry.timer = setTimeout(hideTooltip, delay);
+      }
+      else {
+        hideTooltip();
+      }
+    },
+
+    clearTouchTooltip: function(touchID) {
+      var entry = tooltips[touchID];
+      if (entry) {
+        entry.finished = true;
+        DG.TouchTooltips.hideTouchTooltip(touchID);
+        return true;
+      }
+      return false;
+    },
+
+    hideAllTouchTooltips: function() {
+      DG.ObjectMap.forEach(tooltips,
+                          function(touchID) {
+                            DG.TouchTooltips.hideTouchTooltip(touchID, 0);
+                          });
+    }
+
+  };
+})();

--- a/apps/dg/views/icon_button.js
+++ b/apps/dg/views/icon_button.js
@@ -19,7 +19,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // ==========================================================================
-/* global Tooltip */
 sc_require('utilities/tap_hold_gesture');
 sc_require('views/image_view');
 sc_require('views/tooltip_enabler');
@@ -174,7 +173,7 @@ DG.IconButton = SC.View.extend(SC.Gesturable, DG.TooltipEnabler,
       },
       touchEnd: function( iTouch) {
         this.gestureTouchEnd(iTouch);
-        if (!DG.IconButton.clearTouchTooltip(iTouch.identifier))
+        if (!DG.TouchTooltips.clearTouchTooltip(iTouch.identifier))
           this._action(iTouch);
         this.beginPropertyChanges();
         this.set( 'isMouseOver', NO);
@@ -183,19 +182,13 @@ DG.IconButton = SC.View.extend(SC.Gesturable, DG.TooltipEnabler,
       },
 
       tapHold: function(touch) {
-        var tooltip = new Tooltip(this.get('layer'), {
-                                    container: DG.mainPage.getPath('mainPane.layer'),
-                                    placement: 'bottom-start',
-                                    trigger: 'manual',
-                                    title: this.get('displayToolTip')
-                                  });
-        DG.IconButton.showTouchTooltip(touch, tooltip);
-        this._tooltipTouchID = touch.identifier;
+        this._tooltipTouchID = DG.TouchTooltips.showTouchTooltip(
+                                    touch, this, this.get('displayToolTip'));
       },
 
       tapHoldCancelled: function() {
         if (this._tooltipTouchID) {
-          DG.IconButton.hideTouchTooltip(this._tooltipTouchID, DG.IconButton.kTouchTooltipDefault);
+          DG.TouchTooltips.hideTouchTooltip(this._tooltipTouchID);
         }
       },
 
@@ -218,64 +211,3 @@ DG.IconButton = SC.View.extend(SC.Gesturable, DG.TooltipEnabler,
     };
   }()) // function closure
 );
-
-DG.IconButton.kTouchTooltipDefault = 5000;
-DG.IconButton.kTouchTooltipMin = 2000;
-DG.IconButton.kTouchTooltipMax = 8000;
-DG.IconButton.tooltips = {};
-
-DG.IconButton.showTouchTooltip = function(touch, tooltip) {
-  DG.IconButton.hideAllTouchTooltips();
-
-  tooltip.show();
-  DG.IconButton.tooltips[touch.identifier] =
-                  { touch: touch, tooltip: tooltip };
-
-  DG.IconButton.hideTouchTooltip(touch.identifier, DG.IconButton.kTouchTooltipMax);
-};
-
-DG.IconButton.hideTouchTooltip = function(touchID, delay) {
-  var entry = DG.IconButton.tooltips[touchID],
-      hideTooltip = function() {
-        var entry = DG.IconButton.tooltips[touchID];
-        if (entry) {
-          if (entry.tooltip) {
-            entry.tooltip.dispose();
-            entry.tooltip = null;
-          }
-          entry.timer = null;
-          if (entry.finished)
-            delete DG.IconButton.tooltips[touchID];
-        }
-      };
-  if (!entry) return;
-  
-  if (entry.timer) {
-    clearTimeout(entry.timer);
-    entry.timer = null;
-  }
-
-  if (delay) {
-    entry.timer = setTimeout(hideTooltip, delay);
-  }
-  else {
-    hideTooltip();
-  }
-};
-
-DG.IconButton.clearTouchTooltip = function(touchID) {
-  var entry = DG.IconButton.tooltips[touchID];
-  if (entry) {
-    entry.finished = true;
-    DG.IconButton.hideTouchTooltip(touchID, DG.IconButton.kTouchTooltipDefault);
-    return true;
-  }
-  return false;
-};
-
-DG.IconButton.hideAllTouchTooltips = function(delay) {
-  DG.ObjectMap.forEach(DG.IconButton.tooltips,
-                      function(touchID) {
-                        DG.IconButton.hideTouchTooltip(touchID, delay);
-                      });
-};


### PR DESCRIPTION
Refactor TouchTooltips implementation into separate DG.TouchTooltips utility class.
I was hoping that this would make it easy to implement touch tooltips for attributes on the case table headers. The touch tooltips for attributes turned out to be more difficult to implement than hoped, but the refactor seems worth it in any case. It will make it easier to use touch tooltips elsewhere in CODAP and will result in only one touch tooltip being present in the application at once, rather than one of each kind of touch tooltip (e.g. tool shelf, attribute, etc.).