### PR TITLE
Fix double-tap required to dismiss attribute menu

### DIFF
--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -27,7 +27,8 @@ DG.GraphView = SC.View.extend(
     {
       displayProperties: ['model.dataConfiguration.attributeAssignment'],
 
-      classNames: 'dg-graph-view'.w(),
+      // touch is generally handled by Raphael rather than SproutCore
+      classNames: ['dg-graph-view', 'dg-wants-touch'],
 
       /**
        The model on which this view is based.

--- a/apps/dg/components/graph_map_common/data_display_controller.js
+++ b/apps/dg/components/graph_map_common/data_display_controller.js
@@ -728,6 +728,8 @@ DG.DataDisplayController = DG.ComponentController.extend(
                 SC.run( function() {
                   this_.setupAttributeMenu(iEvent, iAxisView, iIndex);
                 });
+                iEvent.preventDefault();
+                iEvent.stopImmediatePropagation();
               }
 
               iNode.unmousedown(mouseDownHandler); // In case it got added already


### PR DESCRIPTION
Fix double-tap required to dismiss attribute menu [#159408178]
- the problem was that two menus were being displayed
