### PR TITLE
Refix graph drag on touch [#158701051]

### DIFF
--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -27,8 +27,7 @@ DG.GraphView = SC.View.extend(
     {
       displayProperties: ['model.dataConfiguration.attributeAssignment'],
 
-      // touch is generally handled by Raphael rather than SproutCore
-      classNames: ['dg-graph-view', 'dg-wants-touch'],
+      classNames: ['dg-graph-view'],
 
       /**
        The model on which this view is based.


### PR DESCRIPTION
This seems to have been broken in #238
- apparently, the graph relies on SproutCore dispatch of touch events