### PR TITLE
Specify `appSetsWindowTitle` in CFM configuration

### DIFF
--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -331,6 +331,7 @@ DG.main = function main() {
               { name: 'DG.fileMenu.menuItem.renameDocument'.loc(), action: 'renameDialog' }
             ],
           },
+          appSetsWindowTitle: true, // CODAP takes responsibility for the window title
           wrapFileContent: false,
           mimeType: 'application/json',
           readableMimeTypes: ['application/x-codap-document'],


### PR DESCRIPTION
Depends on [CFM PR #110](https://github.com/concord-consortium/cloud-file-manager/pull/110).

@jsandoe Just trying to save you the trouble of having to maintain the CODAP branch of the CFM repository. 😉 