### PR TITLE
disable edit of case card cells that contain formula

### DIFF
--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -281,7 +281,7 @@ DG.React.ready(function () {
                 }.bind(this),
 
                 attributeIsEditable = function () {
-                  return iAttr.get('editable');
+                  return iAttr.get('editable') && !iAttr.get('formula');
                 },
 
                 attributeCanBeRandomized = function () {
@@ -357,7 +357,7 @@ DG.React.ready(function () {
                     DG.React.Components.TextInput({
                       value: tValue,
                       unit: tUnit,
-                      isEditable: iAttr.get('editable'),
+                      isEditable: iAttr.get('editable') && !iAttr.get('formula'),
                       onToggleEditing: toggleEditing
                     }),
                 tValueClassName = tHasFormula ? 'react-data-card-formula' : '';


### PR DESCRIPTION
Along with checking the editable field of the attribute, also check if the attribute contains a formula when detemining if a case card cell can be edited.  This prevents user from clicking on a formula in case card view and editing the cell (formulas should not be user-editable).
[#158204969]