### PR TITLE
159930197 create items or create cases

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1132,7 +1132,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           var context = iResources.dataContext;
           var collection = iResources.collection;
           var cases = Array.isArray(iValues)?iValues: [iValues];
-          var caseIDs = [];
+          var IDs = [];
           var requester = this.get('id');
           var requests = [];
 
@@ -1146,12 +1146,14 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
             var changeResult = context.applyChange(req);
             var success = success && (changeResult && changeResult.success);
             if (changeResult.success) {
-              changeResult.caseIDs.forEach(function (id) {
-                caseIDs.push({id: id});
-              });
+              for (index = 0; index < changeResult.caseIDs.length; index++) {
+                var caseid = changeResult.caseIDs[index];
+                var itemid = (index <= changeResult.itemIDs.length) ? changeResult.itemIDs[index] : null;
+                IDs.push({id: caseid, itemID: itemid});
+              }
             }
           });
-          return {success: success, values: caseIDs};
+          return {success: success, values: IDs};
         }
       },
 

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -1394,7 +1394,7 @@ DG.DataContext = SC.Object.extend((function() // closure
 
     this.invalidateAttrsOfCollections(collections, change);
 
-    // generate object containing case and items ids
+    // generate object containing case and item ids
     function creatIdObject() {
       var caseIDs = [];
       var itemIDs = [];

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -558,6 +558,8 @@ DG.DataContext = SC.Object.extend((function() // closure
                   {Boolean}             result.success -- true on success, false on failure
                   {Number}              result.caseID -- the case ID of the first newly created case
                   {[Number]}            result.caseIDs -- an array ids of all cases created
+                  {Number}              result.itemID -- the item ID of the first newly created item
+                  {[Number]}            result.itemIDs -- an array ids of all items created
 
    */
   doCreateCases: function( iChange) {
@@ -578,7 +580,8 @@ DG.DataContext = SC.Object.extend((function() // closure
       }
       if (newCase) {
         result.success = true;
-        result.caseIDs.push( newCase.get('id'));
+        result.caseIDs.push(newCase.get('id'));
+        result.itemIDs.push(newCase.item.id);
       }
     }
     /**
@@ -601,7 +604,7 @@ DG.DataContext = SC.Object.extend((function() // closure
     var collection,
         valuesArrays,
         parentIsValid = true,
-        result = { success: false, caseIDs: [] };
+        result = { success: false, caseIDs: [], itemIDs: [] };
 
     if( !iChange.collection) {
       iChange.collection = this.get('childCollection');
@@ -630,6 +633,9 @@ DG.DataContext = SC.Object.extend((function() // closure
         if( result.caseIDs && (result.caseIDs.length > 0)) {
           result.caseID = result.caseIDs[0];
         }
+        if( result.itemIDs && (result.itemIDs.length > 0)) {
+          result.itemID = result.itemIDs[0];
+        }
       }
     } finally {
       collection.casesController.endPropertyChanges();
@@ -651,9 +657,11 @@ DG.DataContext = SC.Object.extend((function() // closure
    */
   doCreateItems: function (iChange) {
 
-    var caseIDs = this.addItems(iChange.items);
+    var IDs = this.addItems(iChange.items);
+    var caseIDs = IDs.caseIDs;
+    var itemIDs = IDs.itemIDs;
 
-    return {success: true, caseIDs: caseIDs};
+    return {success: true, caseIDs: caseIDs, itemIDs: itemIDs};
   },
   /**
      Updates values in one or more items
@@ -1386,9 +1394,17 @@ DG.DataContext = SC.Object.extend((function() // closure
 
     this.invalidateAttrsOfCollections(collections, change);
 
-    return results && results.createdCases.map(function(iCase){
-      return iCase.id;
-    });
+    // generate object containing case and items ids
+    function creatIdObject() {
+      var caseIDs = [];
+      var itemIDs = [];
+      results.createdCases.forEach(function(iCase) {
+        caseIDs.push(iCase.id);
+        itemIDs.push(iCase.item.id);
+      });
+      return {caseIDs: caseIDs, itemIDs: itemIDs}
+    }
+    return results && creatIdObject();
   },
 
     /**


### PR DESCRIPTION
When creating items or cases via the CODAP data interactive API, return the item IDs (along with the existing case IDs) of the newly created items.  Tried to ensure that existing structure of return values remains intact to prevent breaking existing implementations.  Exact naming conventions of item ids that get returned could be tweaked if needed (do we prefer "ID" or "id", etc.).  I did several rounds of testing using the data interactive test API and using dataflow as a true integrated, real-world component (values were returned as expected).