### PR TITLE
158015541 case card does not show certain

### DIFF
--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -311,6 +311,8 @@ DG.React.ready(function () {
                 tCase = iShouldSummarize ? null : (iChildmostSelected && iChildmostSelected[0]) || iCases[0],
                 tValue = iShouldSummarize ? '' : tCase && tCase.getValue(tAttrID),
                 tType = iAttr.get('type');
+            if( tValue && tValue.jsonBoundaryObject)
+              tType = 'boundary';								
             this.state.attrIndex++;
             if (isNotEmpty(tUnit))
               tUnitWithParens = ' (' + tUnit + ')';

--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -355,13 +355,13 @@ DG.React.ready(function () {
                       tBoundaryObject.jsonBoundaryObject.properties.THUMB;
               if (tThumb !== null && tThumb !== undefined) {
                     tBoundaryInternalImage = img({
-											className: 'react-data-card-thumbnail',
+                      className: 'react-data-card-thumbnail',
                       src: tThumb
                     });
                 tBoundaryValueField = span({}, tBoundaryInternalImage);
               }
               else if( tBoundaryObject && (tBoundaryObject.jsonBoundaryObject instanceof Error)) {
-								tValue = tBoundaryObject.jsonBoundaryObject.name + tBoundaryObject.jsonBoundaryObject.message;
+                tValue = tBoundaryObject.jsonBoundaryObject.name + tBoundaryObject.jsonBoundaryObject.message;
               }
               tValue = tResult;
             } else if (DG.isNumeric(tValue) && typeof tValue != 'boolean') {

--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -330,11 +330,10 @@ DG.React.ready(function () {
                 style: spanStyle
               });
             } else if (tType === 'qualitative') {
-              if (tValue === null || tValue === undefined || tValue === "") {
+              if (SC.empty(tValue)) {
                 tValue = "";
               } else {
                 var color = DG.PlotUtilities.kDefaultPointColor,
-                    tWidth = tValue;
                     spanStyle = {
                       backgroundColor: color,
                       width: tValue + '%',
@@ -364,7 +363,7 @@ DG.React.ready(function () {
                 tValue = tBoundaryObject.jsonBoundaryObject.name + tBoundaryObject.jsonBoundaryObject.message;
               }
               tValue = tResult;
-            } else if (DG.isNumeric(tValue) && typeof tValue != 'boolean') {
+            } else if (DG.isNumeric(tValue) && typeof tValue !== 'boolean') {
               var tPrecision = iAttr.get('precision');
               tPrecision = SC.none(tPrecision) ? 2 : tPrecision;
               tValue = DG.MathUtilities.formatNumber(tValue, tPrecision);

--- a/apps/dg/resources/case_card.css
+++ b/apps/dg/resources/case_card.css
@@ -156,6 +156,32 @@ tr:nth-child(even) td.attr-cell {
     cursor: text;
 }
 
+.react-data-card-color-table-cell {
+    display: inline-block;
+    width: 100%;
+    height: 15px;
+}
+
+.react-data-card-qualitative-backing {
+    width: 100%;
+    display: block;
+    height: 7px;
+    border-radius: 3px;
+    background-color: lightgrey;
+}
+
+.react-data-card-qualitative-bar {
+    display: block;
+    height: 7px;
+    border-width:0;
+    border-radius: 3px;
+    box-sizing: border-box;
+}
+
+.react-data-card-thumbnail {
+		width: 14px;
+}
+
 .react-data-card-attribute-summary {
     font-style: italic;
 }


### PR DESCRIPTION
Extend display capabilities in case card cell to handle the following new types: Boundary thumbnails, Errors, Color bars, Booleans, Qualitative bars.  Added new CSS instead of recycling existing CSS from non-case card stylesheet (to avoid unexpected changes and allow case-card specific tweaks).  Some of this code has redundancy with similar case table handling in `case_table_adapter.js`.  However, React implementation vs. SlickGrid implementation requires subtle differences between the two.  
[#158015541]