### PR TITLE
[#160357895] Bug fix: With DropHTMLTable plugin, cannot save document

### DIFF
--- a/apps/dg/components/game/game_controller.js
+++ b/apps/dg/components/game/game_controller.js
@@ -272,7 +272,7 @@ DG.GameController = DG.ComponentController.extend(
             // Documented property for plugin state is result.values
             // Some plugins use result.status for historical reasons.
             // We continue to support, for now.
-            modelStorage.savedGameState = result.values || result.state;
+            modelStorage.savedGameState = result && (result.values || result.state);
             callback(result);
           });
         } else {


### PR DESCRIPTION
Plugin was not returning a result from requestDataInteractiveState. Check for null.