### PR TITLE
remove fast click

### DIFF
--- a/apps/dg/lib/index.rhtml
+++ b/apps/dg/lib/index.rhtml
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Script-Type" content="text/javascript"  >
     <meta name="apple-mobile-web-app-capable" content="yes"  >
     <meta name="apple-mobile-web-app-status-bar-style" content="<%= config.status_bar_style || 'default' %>"  >
-    <meta name="viewport" content="initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"  >
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"  >
 
     <% if config.touch_enabled %>
     <% if config.precomposed_icon %>

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -33,16 +33,6 @@ DG.main = function main() {
 
   SC.$('body' ).addClass( 'dg');
 
-  // The ostensible purpose of the FastClick library is to reduce the 300ms
-  // delay that many browsers introduce between the handling of a mouse up
-  // or touch end event and the sending of the click event. It also serves
-  // to eliminate the ghost click that is sometimes sent by the browser
-  // after touch events have been handled by the application. Eliminating
-  // these ghost clicks improves the behavior of CODAP (e.g. the case table).
-  /* global Origami */
-  var attachFastClick = Origami.fastclick;
-  attachFastClick(document.body);
-
   // Fix to support touch events in non-SproutCore elements like jQuery UI widgets.
   // By default, SC.RootResponder swallows all touch events except for those
   // intended for specific browser tags (input, textarea, a, select). For non-SC

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "codemirror": "^5.39.2",
     "deep-equal": "^1.0.1",
     "esri-leaflet": "^2.2.1",
-    "fastclick": "^1.0.6",
     "iframe-phone": "^1.2.0",
     "leaflet": "1.0.0",
     "moment": "^2.22.2",


### PR DESCRIPTION
Remove fast click library from project which was used to reduce lag on touch screens.  The width=device-width in meta element sets the width of the page to follow the screen-width of the device (which will vary depending on the device).  With this tag, browsers assume you've made text readable on mobile, and the double-tap-to-zoom feature is dropped in favor of faster clicks.
[#159636714]