### PR TITLE
Prevent propagation of mouse events on case card to allow proper input handling

### DIFF
--- a/apps/dg/components/case_card/text_input.js
+++ b/apps/dg/components/case_card/text_input.js
@@ -29,13 +29,16 @@ DG.React.ready(function () {
           },
 
           componentDidMount: function () {
+            window.addEventListener('mousedown', this._onMouseDown, true);
+            window.addEventListener('mouseup', this._onMouseUp, true);
             DG.mainPage.mainPane.addListener({action: 'click', target: this, method: this._onWindowClick});
             DG.mainPage.mainPane.addListener({action: 'touchstart', target: this, method: this._onWindowClick});
           },
-
           componentWillUnmount: function () {
             DG.mainPage.mainPane.removeListener({action: 'click', target: this, method: this._onWindowClick});
             DG.mainPage.mainPane.removeListener({action: 'touchstart', target: this, method: this._onWindowClick});
+            window.removeListener('mousedown', this._onMouseDown, true);
+            window.removeListener('mouseup', this._onMouseUp, true);
           },
 
           componentWillReceiveProps: function (iNewProps) {
@@ -43,6 +46,20 @@ DG.React.ready(function () {
               this.setState({value: iNewProps.value});
             if (iNewProps.unit !== this.state.unit)
               this.setState({unit: iNewProps.unit});
+          },
+
+          _onMouseDown: function (e) {
+            var inputElement = findDOMNode(this);
+            if (e.target === inputElement) {
+              e.stopPropagation();
+            }
+          },
+
+          _onMouseUp: function (e) {
+            var inputElement = findDOMNode(this);
+            if (e.target === inputElement) {
+              e.stopPropagation();
+            }
           },
 
           _onWindowClick: function (event) {

--- a/apps/dg/components/case_card/text_input.js
+++ b/apps/dg/components/case_card/text_input.js
@@ -29,16 +29,12 @@ DG.React.ready(function () {
           },
 
           componentDidMount: function () {
-            window.addEventListener('mousedown', this._onMouseDown, true);
-            window.addEventListener('mouseup', this._onMouseUp, true);
             DG.mainPage.mainPane.addListener({action: 'click', target: this, method: this._onWindowClick});
             DG.mainPage.mainPane.addListener({action: 'touchstart', target: this, method: this._onWindowClick});
           },
           componentWillUnmount: function () {
             DG.mainPage.mainPane.removeListener({action: 'click', target: this, method: this._onWindowClick});
             DG.mainPage.mainPane.removeListener({action: 'touchstart', target: this, method: this._onWindowClick});
-            window.removeListener('mousedown', this._onMouseDown, true);
-            window.removeListener('mouseup', this._onMouseUp, true);
           },
 
           componentWillReceiveProps: function (iNewProps) {
@@ -46,20 +42,6 @@ DG.React.ready(function () {
               this.setState({value: iNewProps.value});
             if (iNewProps.unit !== this.state.unit)
               this.setState({unit: iNewProps.unit});
-          },
-
-          _onMouseDown: function (e) {
-            var inputElement = findDOMNode(this);
-            if (e.target === inputElement) {
-              e.stopPropagation();
-            }
-          },
-
-          _onMouseUp: function (e) {
-            var inputElement = findDOMNode(this);
-            if (e.target === inputElement) {
-              e.stopPropagation();
-            }
           },
 
           _onWindowClick: function (event) {
@@ -80,6 +62,7 @@ DG.React.ready(function () {
                 tValue = SC.empty( this.state.value) ? '____' : this.state.value,
                 tResult = this.state.editing ?
                     input({
+                      className: 'dg-wants-mouse',
                       type: 'text',
                       value: this.state.value,
                       onChange: this.handleChange,

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -50,6 +50,15 @@ DG.main = function main() {
               : (dgWantsTouch ? YES : orgIgnoreTouchHandle(evt));
   };
 
+  var orgIgnoreMouseHandle = SC.RootResponder.prototype.ignoreMouseHandle;
+  SC.RootResponder.prototype.ignoreMouseHandle = function(evt) {
+    var dgWantsMouse = $(evt.target).closest('.dg-wants-mouse').length,
+        wantsSCMouse = $(evt.target).closest('.dg-wants-sc-mouse').length;
+    return wantsSCMouse
+              ? NO
+              : (dgWantsMouse ? YES : orgIgnoreMouseHandle(evt));
+  };	
+	
   DG.getPath('mainPage.mainPane').appendTo($('#codap'));
 
   DG.showUserEntryView = true;


### PR DESCRIPTION
Prevent propagation of mouse events on case card to allow proper input handling.  Mousedown and mouseup events were being bubbled up to SproutCore listener which was preventing default behaviors (focus, selection, cursor movement, etc.).  If we handle these events specifically on a case card input field, be sure to prevent them from being bubbled up to SproutCore.
[#158852455]