### PR TITLE
151536172 embedded mode component rescale

### DIFF
--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -585,8 +585,8 @@ DG.DocumentController = SC.Object.extend(
             });
       },
       /**
-       Computed when we add component, delete component, move component, resize component.
-       ScaleBounds are used to determine if we need to rescale when resize browser
+       Computed when we add, delete, move, resize component.
+       ScaleBounds are used to determine if rescale is needed when browser resizes
        */
       computeScaleBounds: function (iNewPos) {
         var components = this.get('components');
@@ -603,10 +603,20 @@ DG.DocumentController = SC.Object.extend(
               if (iComponent.layout && iComponent.layout.isVisible &&
                   (iComponent.layout.left && iComponent.layout.width &&
                   iComponent.layout.top && iComponent.layout.height)) {
-                scaleBounds.x = Math.max(scaleBounds.x,
-                  iComponent.layout.left + iComponent.layout.width);
-                scaleBounds.y = Math.max(scaleBounds.y,
-                  iComponent.layout.top + iComponent.layout.height);
+                var unscaledRightEdge = iComponent.layout.left + iComponent.layout.width;
+                unscaledRightEdge = unscaledRightEdge / scaleFactor;
+                if (iComponent.layout.inspectorWidth) {
+                  unscaledRightEdge += iComponent.layout.inspectorWidth;
+                }
+                var unscaledBottomEdge = iComponent.layout.top + iComponent.layout.height;
+                unscaledBottomEdge = unscaledBottomEdge / scaleFactor;
+                if (iComponent.layout.inspectorHeight) {
+                  if (iComponent.layout.inspectorHeight > iComponent.layout.height) {
+                    unscaledBottomEdge = iComponent.layout.top / scaleFactor + iComponent.layout.inspectorHeight;
+                  }
+                }
+                scaleBounds.x = Math.max(scaleBounds.x, unscaledRightEdge);
+                scaleBounds.y = Math.max(scaleBounds.y, unscaledBottomEdge);
               }
             }
           }.bind(this));

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -600,7 +600,7 @@ DG.DocumentController = SC.Object.extend(
           }
           DG.ObjectMap.forEach(components, function (key, iComponent) {
             if (iComponent.type !== 'DG.GuideView' || !this.guideViewHidden()) {
-              if (iComponent.layout &&
+              if (iComponent.layout && iComponent.layout.isVisible &&
                   (iComponent.layout.left && iComponent.layout.width &&
                   iComponent.layout.top && iComponent.layout.height)) {
                 scaleBounds.x = Math.max(scaleBounds.x,

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -620,10 +620,10 @@ DG.DocumentController = SC.Object.extend(
               }
             }
           }.bind(this));
-          this.set('scaleBoundsX', scaleBounds.x / scaleFactor);
-          this.set('scaleBoundsY', scaleBounds.y / scaleFactor);
-          console.log("scaleBoundsX: " + scaleBounds.x / scaleFactor);
-          console.log("scaleBoundsY: " + scaleBounds.y / scaleFactor);
+          this.set('scaleBoundsX', scaleBounds.x);
+          this.set('scaleBoundsY', scaleBounds.y);
+          console.log("scaleBoundsX: " + scaleBounds.x);
+          console.log("scaleBoundsY: " + scaleBounds.y);
         }
       },
       /**

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -556,7 +556,7 @@ DG.DocumentController = SC.Object.extend(
           if (DG.KEEP_IN_BOUNDS_PREF) {
             this.set('scaleFactor', 1);
             this.set('scaleBoundsX', 0);
-            this.set('scaleBoundsY', 0);	
+            this.set('scaleBoundsY', 0);
             this.computeScaleBounds();
             if (Object.keys(components).length) {
               this.computeScaleFactor();
@@ -624,10 +624,10 @@ DG.DocumentController = SC.Object.extend(
               }
             }.bind(this));
             var storedScaleBoundsX = this.get('scaleBoundsX'),
-                storedScaleBoundsY = this.get('scaleBoundsY');  
+                storedScaleBoundsY = this.get('scaleBoundsY');
             if ((!storedScaleBoundsX || !storedScaleBoundsX) ||
-							  (storedScaleBoundsX == 0 || storedScaleBoundsX == 0) ||
-							  (scaleBounds.x > storedScaleBoundsX || scaleBounds.y > storedScaleBoundsY)) {
+                (storedScaleBoundsX == 0 || storedScaleBoundsX == 0) ||
+                (scaleBounds.x > storedScaleBoundsX || scaleBounds.y > storedScaleBoundsY)) {
               this.set('scaleBoundsX', scaleBounds.x);
               this.set('scaleBoundsY', scaleBounds.y);
               console.log("scaleBoundsX: " + scaleBounds.x);

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -553,10 +553,37 @@ DG.DocumentController = SC.Object.extend(
       restoreComponentControllersAndViews: function () {
         var components = this.get('components');
         if (components) {
+          if (DG.KEEP_IN_BOUNDS_PREF) {
+            var scaleBounds = {x:0, y:0};
+            DG.ObjectMap.forEach(components, function (key, iComponent) {
+              scaleBounds.x = Math.max(scaleBounds.x, iComponent.layout.left + iComponent.layout.width);
+              scaleBounds.y = Math.max(scaleBounds.y, iComponent.layout.top + iComponent.layout.height);
+            }.bind(this));
+            this.set('scaleBoundsX', scaleBounds.x);
+            this.set('scaleBoundsY', scaleBounds.y);
+          }
           DG.ObjectMap.forEach(components, function (key, iComponent) {
+            if (DG.KEEP_IN_BOUNDS_PREF) {
+              iComponent.layout.leftOrig = iComponent.layout.left;
+              iComponent.layout.topOrig = iComponent.layout.top;
+              iComponent.layout.widthOrig = iComponent.layout.width;
+              iComponent.layout.heightOrig = iComponent.layout.height;
+            }
             this.createComponentAndView(iComponent);
           }.bind(this));
         }
+      },
+
+      enforceViewBounds: function () {
+        DG.ObjectMap.forEach(this.componentControllersMap,
+            function (iComponentID, iController) {
+              if (iController) {
+                var view = iController.get('view');
+                if (view) {
+                  view.enforceViewBounds();
+                }
+              }
+            });
       },
 
       /**

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -580,7 +580,7 @@ DG.DocumentController = SC.Object.extend(
             function (iComponentID, iController) {
               if (iController) {
                 var view = iController.get('view');
-                if (view) {
+                if (view && view.get('isVisible')) {
                   view.enforceViewBounds();
                 }
               }
@@ -635,8 +635,6 @@ DG.DocumentController = SC.Object.extend(
                 (scaleBounds.x > storedScaleBoundsX || scaleBounds.y > storedScaleBoundsY)) {
               this.set('scaleBoundsX', scaleBounds.x);
               this.set('scaleBoundsY', scaleBounds.y);
-              console.log("scaleBoundsX: " + scaleBounds.x);
-              console.log("scaleBoundsY: " + scaleBounds.y);
             }
           }
         }
@@ -662,7 +660,6 @@ DG.DocumentController = SC.Object.extend(
           scaleFactor = Math.min(containerWidth / scaleBoundsX, containerHeight / scaleBoundsY);
         }
         this.set('scaleFactor', scaleFactor);
-        console.log("scaleFactor: " + scaleFactor);
       },
 
       /**

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -555,6 +555,8 @@ DG.DocumentController = SC.Object.extend(
         if (components) {
           if (DG.KEEP_IN_BOUNDS_PREF) {
             this.set('scaleFactor', 1);
+            this.set('scaleBoundsX', 0);
+            this.set('scaleBoundsY', 0);	
             this.computeScaleBounds();
             if (Object.keys(components).length) {
               this.computeScaleFactor();
@@ -594,36 +596,44 @@ DG.DocumentController = SC.Object.extend(
           var scaleBounds = {x:0, y:0},
               storedScaleFactor = this.get('scaleFactor'),
               scaleFactor = storedScaleFactor ? storedScaleFactor : 1;
-          if (iNewPos) {
-            scaleBounds.x = Math.max(scaleBounds.x, iNewPos.x + iNewPos.width);
-            scaleBounds.y = Math.max(scaleBounds.y, iNewPos.y + iNewPos.height);
-          }
-          DG.ObjectMap.forEach(components, function (key, iComponent) {
-            if (iComponent.type !== 'DG.GuideView' || !this.guideViewHidden()) {
-              if (iComponent.layout && iComponent.layout.isVisible &&
-                  (iComponent.layout.left && iComponent.layout.width &&
-                  iComponent.layout.top && iComponent.layout.height)) {
-                var unscaledRightEdge = iComponent.layout.left + iComponent.layout.width;
-                unscaledRightEdge = unscaledRightEdge / scaleFactor;
-                if (iComponent.layout.inspectorWidth) {
-                  unscaledRightEdge += iComponent.layout.inspectorWidth;
-                }
-                var unscaledBottomEdge = iComponent.layout.top + iComponent.layout.height;
-                unscaledBottomEdge = unscaledBottomEdge / scaleFactor;
-                if (iComponent.layout.inspectorHeight) {
-                  if (iComponent.layout.inspectorHeight > iComponent.layout.height) {
-                    unscaledBottomEdge = iComponent.layout.top / scaleFactor + iComponent.layout.inspectorHeight;
-                  }
-                }
-                scaleBounds.x = Math.max(scaleBounds.x, unscaledRightEdge);
-                scaleBounds.y = Math.max(scaleBounds.y, unscaledBottomEdge);
-              }
+          if (scaleFactor = 1) {
+            if (iNewPos) {
+              scaleBounds.x = Math.max(scaleBounds.x, iNewPos.x + iNewPos.width);
+              scaleBounds.y = Math.max(scaleBounds.y, iNewPos.y + iNewPos.height);
             }
-          }.bind(this));
-          this.set('scaleBoundsX', scaleBounds.x);
-          this.set('scaleBoundsY', scaleBounds.y);
-          console.log("scaleBoundsX: " + scaleBounds.x);
-          console.log("scaleBoundsY: " + scaleBounds.y);
+            DG.ObjectMap.forEach(components, function (key, iComponent) {
+              if (iComponent.type !== 'DG.GuideView' || !this.guideViewHidden()) {
+                if (iComponent.layout && iComponent.layout.isVisible &&
+                    (iComponent.layout.left && iComponent.layout.width &&
+                    iComponent.layout.top && iComponent.layout.height)) {
+                  var unscaledRightEdge = iComponent.layout.left + iComponent.layout.width;
+                  unscaledRightEdge = unscaledRightEdge / scaleFactor;
+                  if (iComponent.layout.inspectorWidth) {
+                    unscaledRightEdge += iComponent.layout.inspectorWidth;
+                  }
+                  var unscaledBottomEdge = iComponent.layout.top + iComponent.layout.height;
+                  unscaledBottomEdge = unscaledBottomEdge / scaleFactor;
+                  if (iComponent.layout.inspectorHeight) {
+                    if (iComponent.layout.inspectorHeight > iComponent.layout.height) {
+                      unscaledBottomEdge = iComponent.layout.top / scaleFactor + iComponent.layout.inspectorHeight;
+                    }
+                  }
+                  scaleBounds.x = Math.max(scaleBounds.x, unscaledRightEdge);
+                  scaleBounds.y = Math.max(scaleBounds.y, unscaledBottomEdge);
+                }
+              }
+            }.bind(this));
+            var storedScaleBoundsX = this.get('scaleBoundsX'),
+                storedScaleBoundsY = this.get('scaleBoundsY');  
+            if ((!storedScaleBoundsX || !storedScaleBoundsX) ||
+							  (storedScaleBoundsX == 0 || storedScaleBoundsX == 0) ||
+							  (scaleBounds.x > storedScaleBoundsX || scaleBounds.y > storedScaleBoundsY)) {
+              this.set('scaleBoundsX', scaleBounds.x);
+              this.set('scaleBoundsY', scaleBounds.y);
+              console.log("scaleBoundsX: " + scaleBounds.x);
+              console.log("scaleBoundsY: " + scaleBounds.y);
+            }
+          }
         }
       },
       /**
@@ -1328,7 +1338,7 @@ DG.DocumentController = SC.Object.extend(
         if (tGuideComponentView) {
           tGuideComponentView.set('isVisible', false);
           if (DG.KEEP_IN_BOUNDS_PREF) {
-            this.computeScaleBounds();
+            //this.computeScaleBounds();
           }
         }
       },
@@ -1665,7 +1675,7 @@ DG.DocumentController = SC.Object.extend(
           }
         }
         if (DG.KEEP_IN_BOUNDS_PREF) {
-          this.computeScaleBounds();
+          //this.computeScaleBounds();
         }
         // the view will be destroyed elsewhere
       },

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -597,12 +597,6 @@ DG.DocumentController = SC.Object.extend(
             }
           }
           DG.ObjectMap.forEach(components, function (key, iComponent) {
-            if (DG.KEEP_IN_BOUNDS_PREF) {
-              iComponent.layout.leftOrig = iComponent.layout.left;
-              iComponent.layout.topOrig = iComponent.layout.top;
-              iComponent.layout.widthOrig = iComponent.layout.width;
-              iComponent.layout.heightOrig = iComponent.layout.height;
-            }
             this.createComponentAndView(iComponent);
           }.bind(this));
         }

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -596,7 +596,7 @@ DG.DocumentController = SC.Object.extend(
           var scaleBounds = {x:0, y:0},
               storedScaleFactor = this.get('scaleFactor'),
               scaleFactor = storedScaleFactor ? storedScaleFactor : 1;
-          if (scaleFactor = 1) {
+          if (scaleFactor === 1) {
             if (iNewPos) {
               scaleBounds.x = Math.max(scaleBounds.x, iNewPos.x + iNewPos.width);
               scaleBounds.y = Math.max(scaleBounds.y, iNewPos.y + iNewPos.height);
@@ -606,17 +606,22 @@ DG.DocumentController = SC.Object.extend(
                 if (iComponent.layout && iComponent.layout.isVisible &&
                     (iComponent.layout.left && iComponent.layout.width &&
                     iComponent.layout.top && iComponent.layout.height)) {
-                  var unscaledRightEdge = iComponent.layout.left + iComponent.layout.width;
-                  unscaledRightEdge = unscaledRightEdge / scaleFactor;
-                  if (iComponent.layout.inspectorWidth) {
-                    unscaledRightEdge += iComponent.layout.inspectorWidth;
-                  }
-                  var unscaledBottomEdge = iComponent.layout.top + iComponent.layout.height;
-                  unscaledBottomEdge = unscaledBottomEdge / scaleFactor;
-                  if (iComponent.layout.inspectorHeight) {
-                    if (iComponent.layout.inspectorHeight > iComponent.layout.height) {
-                      unscaledBottomEdge = iComponent.layout.top / scaleFactor + iComponent.layout.inspectorHeight;
+
+                  var tInspectorDimensions = { width: 0, height : 0 };
+                  var controller = DG.currDocumentController().componentControllersMap[iComponent.get('id')];
+                  if (controller) {
+                    var view = controller.get('view');
+                    if (view) {
+                      tInspectorDimensions = view.getInspectorDimensions();
                     }
+                  }
+                  var unscaledRightEdge = (iComponent.layout.left + iComponent.layout.width) / scaleFactor;
+                  if (tInspectorDimensions.width) {
+                    unscaledRightEdge += tInspectorDimensions.width;
+                  }
+                  var unscaledBottomEdge = (iComponent.layout.top + iComponent.layout.height) / scaleFactor;
+                  if (tInspectorDimensions.height && tInspectorDimensions.height > iComponent.layout.height) {
+                    unscaledBottomEdge = iComponent.layout.top / scaleFactor + tInspectorDimensions.height;
                   }
                   scaleBounds.x = Math.max(scaleBounds.x, unscaledRightEdge);
                   scaleBounds.y = Math.max(scaleBounds.y, unscaledBottomEdge);
@@ -626,7 +631,7 @@ DG.DocumentController = SC.Object.extend(
             var storedScaleBoundsX = this.get('scaleBoundsX'),
                 storedScaleBoundsY = this.get('scaleBoundsY');
             if ((!storedScaleBoundsX || !storedScaleBoundsX) ||
-                (storedScaleBoundsX == 0 || storedScaleBoundsX == 0) ||
+                (storedScaleBoundsX === 0 || storedScaleBoundsX === 0) ||
                 (scaleBounds.x > storedScaleBoundsX || scaleBounds.y > storedScaleBoundsY)) {
               this.set('scaleBoundsX', scaleBounds.x);
               this.set('scaleBoundsY', scaleBounds.y);
@@ -1337,9 +1342,6 @@ DG.DocumentController = SC.Object.extend(
         var tGuideComponentView = this._singletonViews.guideView;
         if (tGuideComponentView) {
           tGuideComponentView.set('isVisible', false);
-          if (DG.KEEP_IN_BOUNDS_PREF) {
-            //this.computeScaleBounds();
-          }
         }
       },
 
@@ -1673,9 +1675,6 @@ DG.DocumentController = SC.Object.extend(
             tController.set('model', null);
             tController.set('view', null);
           }
-        }
-        if (DG.KEEP_IN_BOUNDS_PREF) {
-          //this.computeScaleBounds();
         }
         // the view will be destroyed elsewhere
       },

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -622,7 +622,6 @@ DG.DocumentController = SC.Object.extend(
        */
       computeScaleFactor: function () {
         var docView = DG.mainPage.get('docView'),
-            components = this.get('components'),
             containerWidth = window.innerWidth,
             containerHeight = window.innerHeight,
             scaleBoundsX = this.get('scaleBoundsX'),
@@ -635,7 +634,7 @@ DG.DocumentController = SC.Object.extend(
           containerHeight = window.innerHeight - docView.get('frame').y;
         }
         if (containerWidth < scaleBoundsX || containerHeight < scaleBoundsY) {
-          scaleFactor = Math.min(containerWidth / scaleBoundsX, containerHeight / scaleBoundsY)
+          scaleFactor = Math.min(containerWidth / scaleBoundsX, containerHeight / scaleBoundsY);
         }
         this.set('scaleFactor', scaleFactor);
         console.log("scaleFactor: " + scaleFactor);

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -623,7 +623,6 @@ DG.DocumentController = SC.Object.extend(
        @param iNewPos: a new position that will be included in the component
                        list once the component creation is complete
        */
-
       computeScaleBounds: function (iNewPos) {
         var components = this.get('components');
         if (components) {
@@ -691,8 +690,8 @@ DG.DocumentController = SC.Object.extend(
        */
       computeScaleFactor: function () {
         var docView = DG.mainPage.get('docView'),
-            containerWidth = window.innerWidth,
-            containerHeight = window.innerHeight,
+            containerWidth = $('#codap').width(),
+            containerHeight = $('#codap').height(),
             storedInBoundsScaling = this.inBoundsScaling(),
             scaleBoundsX = storedInBoundsScaling.scaleBoundsX,
             scaleBoundsY = storedInBoundsScaling.scaleBoundsY,
@@ -701,7 +700,7 @@ DG.DocumentController = SC.Object.extend(
           while (!SC.none(docView.parentView.parentView)) {
             docView = docView.parentView;
           }
-          containerHeight = window.innerHeight - docView.get('frame').y;
+          containerHeight -= docView.get('frame').y;
         }
         if (containerWidth < scaleBoundsX || containerHeight < scaleBoundsY) {
           scaleFactor = Math.min(containerWidth / scaleBoundsX, containerHeight / scaleBoundsY);

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -554,6 +554,7 @@ DG.DocumentController = SC.Object.extend(
         var components = this.get('components');
         if (components) {
           if (DG.KEEP_IN_BOUNDS_PREF) {
+            this.set('scaleFactor', 1);
             this.computeScaleBounds();
             if (Object.keys(components).length) {
               this.computeScaleFactor();
@@ -583,7 +584,10 @@ DG.DocumentController = SC.Object.extend(
               }
             });
       },
-
+      /**
+       Computed when we add component, delete component, move component, resize component.
+       ScaleBounds are used to determine if we need to rescale when resize browser
+       */
       computeScaleBounds: function (iNewPos) {
         var components = this.get('components');
         if (components) {
@@ -612,7 +616,10 @@ DG.DocumentController = SC.Object.extend(
           console.log("scaleBoundsY: " + scaleBounds.y / scaleFactor);
         }
       },
-
+      /**
+       Computed when we resize browser or load document.
+       ScaleFactor is used to compute non-scaled position and size of components.
+       */
       computeScaleFactor: function () {
         var docView = DG.mainPage.get('docView'),
             components = this.get('components'),

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -253,6 +253,11 @@ DG = SC.Application.create((function () // closure
     return !SC.empty(standaloneParam) && standaloneParam !== 'false';
   };
 
+  var keepInBoundsPref = function () {
+    var keepInBoundsParam = getUrlParameter('inbounds');
+    return !SC.empty(keepInBoundsParam) && keepInBoundsParam === 'true';
+  };
+
   return Object.assign({ // return from closure
 
     NAMESPACE: 'DG',
@@ -392,6 +397,8 @@ DG = SC.Application.create((function () // closure
     IS_DEV_BUILD: isDevBuild(),
 
     NO_DATA_TIP_PREF: noDataTipPref(),
+
+    KEEP_IN_BOUNDS_PREF: keepInBoundsPref(),
 
     STANDALONE_MODE: useStandaloneMode(),
     STANDALONE_PLUGIN: getUrlParameter('standalone'),

--- a/apps/dg/resources/main_page.js
+++ b/apps/dg/resources/main_page.js
@@ -300,6 +300,12 @@ DG.mainPage = SC.Page.design((function() {
       this.invokeLater( 'setupDragDrop', 300);
     },
 
+    viewDidResize: function() {
+      if (DG.KEEP_IN_BOUNDS_PREF) {
+        DG.currDocumentController().enforceViewBounds();
+      }
+    },
+
     classNameBindings: [
         '_isDraggingFileOrURL:dg-receive-outside-drop',
         '_isDraggingAttr:dg-attr-drop'

--- a/apps/dg/resources/main_page.js
+++ b/apps/dg/resources/main_page.js
@@ -268,6 +268,8 @@ DG.mainPage = SC.Page.design((function() {
       layout: { top: kInfobarHeight + kToolbarHeight },
       horizontalAlign: SC.ALIGN_LEFT,
       verticalAlign: SC.ALIGN_TOP,
+      hasVerticalScroller: !DG.KEEP_IN_BOUNDS_PREF,
+      hasHorizontalScroller: !DG.KEEP_IN_BOUNDS_PREF,
       horizontalOverlay: kIsMobileDevice,
       verticalOverlay: kIsMobileDevice,
       classNames: 'dg-doc-background'.w(),

--- a/apps/dg/utilities/view_utilities.js
+++ b/apps/dg/utilities/view_utilities.js
@@ -1,6 +1,6 @@
 // ==========================================================================
 //                          DG.ViewUtilities
-// 
+//
 //  A collection of utilities for manipulating views
 //
 //  Copyright (c) 2014 by The Concord Consortium, Inc. All rights reserved.
@@ -27,6 +27,10 @@ DG.ViewUtilities = {
 
   roundToGrid: function( iNumber) {
     return DG.ViewUtilities.kGridSize * Math.round( iNumber / DG.ViewUtilities.kGridSize);
+  },
+
+  floorToGrid: function( iNumber) {
+    return DG.ViewUtilities.kGridSize * Math.floor( iNumber / DG.ViewUtilities.kGridSize);
   },
 
   /**
@@ -205,7 +209,7 @@ DG.ViewUtilities = {
 
     return tLoc;
   },
-  
+
   /* normalFormForRect: The given rectangle is expected to have properties left, top,
     right, and bottom. Return a rectangle with left <= right and bottom <= top.
   */

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -202,14 +202,14 @@ DG.DragBorderView = SC.View.extend(
           return DG.ComponentView.findComponentViewParent(this);
         },
         getContainerWidth: function () {
-          return window.innerWidth; // go global
+          return containerWidth = $('#codap').width();
         },
         getContainerHeight: function () {
           var tDocView = this.viewToDrag();
           while (!SC.none(tDocView.parentView.parentView)) {
             tDocView = tDocView.parentView;
           }
-          return window.innerHeight - tDocView.get('frame').y;
+          return $('#codap').height() - tDocView.get('frame').y;
         }
       };
     }())

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -496,11 +496,11 @@ DG.ComponentView = SC.View.extend(
                   tMinY = -kTitleBarHeight / 2,
                   tMaxY = tContainerHeight - kTitleBarHeight / 2;
               if (DG.KEEP_IN_BOUNDS_PREF) {
-                var inspectorDimensions = tOuterView.getInspectorDimensions();
+                var tInspectorDimensions = tOuterView.getInspectorDimensions();
                 tMinX = 0;
-                tMaxX = tContainerWidth - (info.width + inspectorDimensions.width);
+                tMaxX = tContainerWidth - (info.width + tInspectorDimensions.width);
                 tMinY = 0;
-                tMaxY = tContainerHeight - (Math.max(info.height, inspectorDimensions.height));
+                tMaxY = tContainerHeight - (Math.max(info.height, tInspectorDimensions.height));
               }
 
               tX = Math.min(Math.max(tX, tMinX), tMaxX);
@@ -511,9 +511,9 @@ DG.ComponentView = SC.View.extend(
 
               if (DG.KEEP_IN_BOUNDS_PREF) {
                 var tLayout = tOuterView.getPath('layout'),
-                    scaleFactor = DG.currDocumentController().get('scaleFactor');
-                tLayout.topOrig = tY / scaleFactor;
-                tLayout.leftOrig = tX / scaleFactor;
+                    tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                tLayout.topOrig = tY / tScaleFactor;
+                tLayout.leftOrig = tX / tScaleFactor;
               }
             },
             canBeDragged: function () {
@@ -542,16 +542,16 @@ DG.ComponentView = SC.View.extend(
                     tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxSize,
                     tContainerWidth = this.getContainerWidth();
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var inspectorDimensions = this.parentView.getInspectorDimensions();
-                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + inspectorDimensions.width));
+                  var tInspectorDimensions = this.parentView.getInspectorDimensions();
+                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
                 }
                 // Don't let width of component become too small
                 tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
                 this.parentView.adjust('width', tNewWidth);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.getPath('layout'),
-                      scaleFactor = DG.currDocumentController().get('scaleFactor');
-                  tLayout.widthOrig = tNewWidth / scaleFactor;
+                      tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                  tLayout.widthOrig = tNewWidth / tScaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -568,15 +568,15 @@ DG.ComponentView = SC.View.extend(
                     tNewHeight = info.height + (evt.pageY - info.pageY),
                     tContainerHeight = this.getContainerHeight();
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tMaxHeight = tContainerHeight - info.top;
+                  tMaxHeight = Math.min(tMaxHeight, tContainerHeight - info.top)
                 }
                 tNewHeight = DG.ViewUtilities.roundToGrid(Math.min(
                     Math.max(tNewHeight, tMinHeight), tMaxHeight));
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.getPath('layout'),
-                      scaleFactor = DG.currDocumentController().get('scaleFactor');
-                  tLayout.heightOrig = tNewHeight / scaleFactor;
+                      tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                  tLayout.heightOrig = tNewHeight / tScaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -593,8 +593,6 @@ DG.ComponentView = SC.View.extend(
                     tContainerWidth = this.getContainerWidth();
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   evt.pageX = Math.max(0, evt.pageX);
-                  //var inspectorDimensions = this.parentView.getInspectorDimensions();
-                  //tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + inspectorDimensions.width));
                 }
                 var tNewWidth = DG.ViewUtilities.roundToGrid(info.width - (evt.pageX - info.pageX)),
                     tLoc;
@@ -606,9 +604,9 @@ DG.ComponentView = SC.View.extend(
                 }
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.getPath('layout'),
-                      scaleFactor = DG.currDocumentController().get('scaleFactor');
-                  tLayout.widthOrig = tNewWidth / scaleFactor;
-                  tLayout.leftOrig = tLoc / scaleFactor;
+                      tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                  tLayout.widthOrig = tNewWidth / tScaleFactor;
+                  tLayout.leftOrig = tLoc / tScaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -639,8 +637,8 @@ DG.ComponentView = SC.View.extend(
                     tContainerHeight = this.getContainerHeight();
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   tMaxHeight = tContainerHeight - info.top;
-                  var inspectorDimensions = this.parentView.getInspectorDimensions();
-                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + inspectorDimensions.width));
+                  var tInspectorDimensions = this.parentView.getInspectorDimensions();
+                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
                 }
                 // Don't let width or height of component become too small
                 tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
@@ -649,9 +647,9 @@ DG.ComponentView = SC.View.extend(
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.getPath('layout'),
-                      scaleFactor = DG.currDocumentController().get('scaleFactor');
-                  tLayout.heightOrig = tNewHeight / scaleFactor;
-                  tLayout.widthOrig = tNewWidth / scaleFactor;
+                      tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                  tLayout.heightOrig = tNewHeight / tScaleFactor;
+                  tLayout.widthOrig = tNewWidth / tScaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -726,14 +724,21 @@ DG.ComponentView = SC.View.extend(
         getInspectorDimensions : function () {
             var tInspectorWidth = 0,
                 tInspectorHeight = 0,
-                tButtons = this.getPath('inspectorButtons');
-
+                tButtons = this.getPath('inspectorButtons'),
+                tLayout = this.getPath('layout');
             if (tButtons && tButtons.length) {
               if (tButtons[0].parentView && tButtons[0].parentView.layout) {
                 tInspectorWidth = tButtons[0].parentView.layout.width;
                 tInspectorHeight = tButtons[0].parentView.layout.height;
+              } else {
+                const BUTTONHORIZONTALSPACE = 50;
+                const BUTTONVERTICALSPACE = 43;
+                tInspectorWidth = BUTTONHORIZONTALSPACE;
+                tInspectorHeight = BUTTONVERTICALSPACE * tButtons.length;
               }
             }
+            tLayout.inspectorWidth = tInspectorWidth;
+            tLayout.inspectorHeight = tInspectorHeight;
             return {width : tInspectorWidth, height : tInspectorHeight};
         },
         enforceViewBounds : function () {
@@ -743,17 +748,19 @@ DG.ComponentView = SC.View.extend(
               tLayout = this.getPath('layout'),
               tContainerWidth = tTitleBar.getContainerWidth(),
               tContainerHeight = tTitleBar.getContainerHeight(),
-              scaleFactor = DG.currDocumentController().get('scaleFactor'),
+              tScaleFactor = DG.currDocumentController().get('scaleFactor'),
               tMinWidth = this.get('contentMinWidth') || kMinSize,
               tMinHeight = this.get('contentMinWidth') || kMinSize;
               if (type === DG.Calculator) {
                 tMinWidth = tLayout.width;
                 tMinHeight = tLayout.height;
               }
-          var tNewWidth = Math.max(tMinWidth, tLayout.widthOrig * scaleFactor),
-              tNewHeight = Math.max(tMinHeight, tLayout.heightOrig * scaleFactor),
-              tNewLeft = tLayout.leftOrig * scaleFactor,
-              tNewTop = tLayout.topOrig * scaleFactor;
+          var tNewWidth = Math.max(tMinWidth,
+              DG.ViewUtilities.floorToGrid(tLayout.widthOrig * tScaleFactor)),
+              tNewHeight = Math.max(tMinHeight,
+              DG.ViewUtilities.floorToGrid(tLayout.heightOrig * tScaleFactor)),
+              tNewLeft = DG.ViewUtilities.floorToGrid(tLayout.leftOrig * tScaleFactor),
+              tNewTop = DG.ViewUtilities.floorToGrid(tLayout.topOrig * tScaleFactor);
           if ((tNewLeft + tNewWidth + tInspectorDimensions.width) > tContainerWidth) {
             tNewLeft = Math.max(0,  tContainerWidth - tNewWidth - tInspectorDimensions.width);
           }
@@ -770,11 +777,11 @@ DG.ComponentView = SC.View.extend(
         },
         configureViewBoundsLayout : function (iNewPos) {
           var tLayout = this.getPath('layout'),
-              scaleFactor = DG.currDocumentController().get('scaleFactor');
-          tLayout.topOrig = iNewPos.y / scaleFactor;
-          tLayout.leftOrig = iNewPos.x / scaleFactor;
-          tLayout.heightOrig = iNewPos.height / scaleFactor;
-          tLayout.widthOrig = iNewPos.width / scaleFactor;
+              tScaleFactor = DG.currDocumentController().get('scaleFactor');
+          tLayout.topOrig = iNewPos.y / tScaleFactor;
+          tLayout.leftOrig = iNewPos.x / tScaleFactor;
+          tLayout.heightOrig = iNewPos.height / tScaleFactor;
+          tLayout.widthOrig = iNewPos.width / tScaleFactor;
         },
 
         destroy: function () {

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -510,7 +510,7 @@ DG.ComponentView = SC.View.extend(
               tOuterView.adjust('top', tY);
 
               if (DG.KEEP_IN_BOUNDS_PREF) {
-                var tLayout = tOuterView.getPath('layout'),
+                var tLayout = tOuterView.get('layout'),
                     tScaleFactor = DG.currDocumentController().get('scaleFactor');
                 tLayout.topOrig = tY / tScaleFactor;
                 tLayout.leftOrig = tX / tScaleFactor;
@@ -549,7 +549,7 @@ DG.ComponentView = SC.View.extend(
                 tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
                 this.parentView.adjust('width', tNewWidth);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tLayout = this.parentView.getPath('layout'),
+                  var tLayout = this.parentView.get('layout'),
                       tScaleFactor = DG.currDocumentController().get('scaleFactor');
                   tLayout.widthOrig = tNewWidth / tScaleFactor;
                 }
@@ -574,7 +574,7 @@ DG.ComponentView = SC.View.extend(
                     Math.max(tNewHeight, tMinHeight), tMaxHeight));
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tLayout = this.parentView.getPath('layout'),
+                  var tLayout = this.parentView.get('layout'),
                       tScaleFactor = DG.currDocumentController().get('scaleFactor');
                   tLayout.heightOrig = tNewHeight / tScaleFactor;
                 }
@@ -603,7 +603,7 @@ DG.ComponentView = SC.View.extend(
                   this.parentView.adjust('left', tLoc);
                 }
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tLayout = this.parentView.getPath('layout'),
+                  var tLayout = this.parentView.get('layout'),
                       tScaleFactor = DG.currDocumentController().get('scaleFactor');
                   tLayout.widthOrig = tNewWidth / tScaleFactor;
                   tLayout.leftOrig = tLoc / tScaleFactor;
@@ -646,7 +646,7 @@ DG.ComponentView = SC.View.extend(
                 tNewHeight = Math.min(Math.max(tNewHeight, tMinHeight), tMaxHeight);
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tLayout = this.parentView.getPath('layout'),
+                  var tLayout = this.parentView.get('layout'),
                       tScaleFactor = DG.currDocumentController().get('scaleFactor');
                   tLayout.heightOrig = tNewHeight / tScaleFactor;
                   tLayout.widthOrig = tNewWidth / tScaleFactor;
@@ -724,7 +724,7 @@ DG.ComponentView = SC.View.extend(
         getInspectorDimensions : function () {
             var tInspectorWidth = 0,
                 tInspectorHeight = 0,
-                tButtons = this.getPath('inspectorButtons');
+                tButtons = this.get('inspectorButtons');
             if (tButtons && tButtons.length) {
               if (tButtons[0].parentView && tButtons[0].parentView.layout) {
                 tInspectorWidth = tButtons[0].parentView.layout.width;
@@ -742,8 +742,8 @@ DG.ComponentView = SC.View.extend(
           var tTitleBar = this.getPath('containerView.titlebar'),
               type = this.getPath('controller.model.type'),
               tInspectorDims = this.getInspectorDimensions(),
-              tLayout = this.getPath('layout'),
-              tIsVisible = this.getPath('isVisible'),
+              tLayout = this.get('layout'),
+              tIsVisible = this.get('isVisible'),
               tContainerWidth = tTitleBar.getContainerWidth(),
               tContainerHeight = tTitleBar.getContainerHeight(),
               tScaleFactor = DG.currDocumentController().get('scaleFactor'),
@@ -779,16 +779,13 @@ DG.ComponentView = SC.View.extend(
           if (tNewTop + tNewHeight > tContainerHeight) {
             tNewTop = Math.max(0, tContainerHeight - tNewHeight);
           }
-          this.adjust('width', tNewWidth);
-          this.adjust('height', tNewHeight);
-          this.adjust('left', tNewLeft);
-          this.adjust('top', tNewTop);
+          this.adjust({width: tNewWidth, height: tNewHeight, left: tNewLeft, top: tNewTop});
           var controller = this.get('controller');
           if (controller && controller.view)
             controller.updateModelLayout();
         },
         configureViewBoundsLayout : function (iNewPos) {
-          var tLayout = this.getPath('layout'),
+          var tLayout = this.get('layout'),
               tScaleFactor = DG.currDocumentController().get('scaleFactor');
           tLayout.topOrig = iNewPos.y / tScaleFactor;
           tLayout.leftOrig = iNewPos.x / tScaleFactor;

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -202,7 +202,7 @@ DG.DragBorderView = SC.View.extend(
           return DG.ComponentView.findComponentViewParent(this);
         },
         getContainerWidth: function () {
-          return containerWidth = $('#codap').width();
+          return $('#codap').width();
         },
         getContainerHeight: function () {
           var tDocView = this.viewToDrag();

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -155,6 +155,9 @@ DG.DragBorderView = SC.View.extend(
               }
             }));
           }
+          if (DG.KEEP_IN_BOUNDS_PREF) {
+            DG.currDocumentController().computeScaleBounds();
+          }
           return YES; // handled!
         },
 
@@ -508,20 +511,9 @@ DG.ComponentView = SC.View.extend(
 
               if (DG.KEEP_IN_BOUNDS_PREF) {
                 var tLayout = tOuterView.getPath('layout'),
-                    scaleBoundsX = DG.currDocumentController().get('scaleBoundsX'),
-                    scaleBoundsY = DG.currDocumentController().get('scaleBoundsY'),
-                    scalePercent = 1;
-                if (tContainerWidth < scaleBoundsX || tContainerHeight < scaleBoundsY) {
-                  scalePercent = Math.min(tContainerWidth / scaleBoundsX, tContainerHeight / scaleBoundsY)
-                }
-                tLayout.topOrig = tY / scalePercent;
-                tLayout.leftOrig = tX / scalePercent;
-                if (tLayout.leftOrig + tLayout.widthOrig > scaleBoundsX) {
-                  DG.currDocumentController().set('scaleBoundsX', tLayout.leftOrig + tLayout.widthOrig);
-                }
-                if (tLayout.topOrig + tLayout.heightOrig > scaleBoundsY) {
-                  DG.currDocumentController().set('scaleBoundsY', tLayout.topOrig + tLayout.heightOrig);
-                }
+                    scaleFactor = DG.currDocumentController().get('scaleFactor');
+                tLayout.topOrig = tY / scaleFactor;
+                tLayout.leftOrig = tX / scaleFactor;
               }
             },
             canBeDragged: function () {
@@ -559,16 +551,8 @@ DG.ComponentView = SC.View.extend(
                 this.parentView.adjust('width', tNewWidth);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.getPath('layout'),
-                    scaleBoundsX = DG.currDocumentController().get('scaleBoundsX'),
-                    scaleBoundsY = DG.currDocumentController().get('scaleBoundsY'),
-                    scalePercent = 1;
-                  if (tContainerWidth < scaleBoundsX || tContainerHeight < scaleBoundsY) {
-                    scalePercent = Math.min(tContainerWidth / scaleBoundsX, tContainerHeight / scaleBoundsY)
-                  }
-                  tLayout.widthOrig = tNewWidth / scalePercent;
-                  if (tLayout.leftOrig + tLayout.widthOrig > scaleBoundsX) {
-                    DG.currDocumentController().set('scaleBoundsX', tLayout.leftOrig + tLayout.widthOrig);
-                  }
+                      scaleFactor = DG.currDocumentController().get('scaleFactor');
+                  tLayout.widthOrig = tNewWidth / scaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -593,16 +577,8 @@ DG.ComponentView = SC.View.extend(
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.getPath('layout'),
-                    scaleBoundsX = DG.currDocumentController().get('scaleBoundsX'),
-                    scaleBoundsY = DG.currDocumentController().get('scaleBoundsY'),
-                    scalePercent = 1;
-                  if (tContainerWidth < scaleBoundsX || tContainerHeight < scaleBoundsY) {
-                    scalePercent = Math.min(tContainerWidth / scaleBoundsX, tContainerHeight / scaleBoundsY)
-                  }
-                  tLayout.heightOrig = tNewHeight / scalePercent;
-                  if (tLayout.topOrig + tLayout.heightOrig > scaleBoundsY) {
-                    DG.currDocumentController().set('scaleBoundsY', tLayout.topOrig + tLayout.heightOrig);
-                  }
+                      scaleFactor = DG.currDocumentController().get('scaleFactor');
+                  tLayout.heightOrig = tNewHeight / scaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -664,20 +640,9 @@ DG.ComponentView = SC.View.extend(
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.getPath('layout'),
-                    scaleBoundsX = DG.currDocumentController().get('scaleBoundsX'),
-                    scaleBoundsY = DG.currDocumentController().get('scaleBoundsY'),
-                    scalePercent = 1;
-                  if (tContainerWidth < scaleBoundsX || tContainerHeight < scaleBoundsY) {
-                    scalePercent = Math.min(tContainerWidth / scaleBoundsX, tContainerHeight / scaleBoundsY)
-                  }
-                  tLayout.heightOrig = tNewHeight / scalePercent;
-                  tLayout.widthOrig = tNewWidth / scalePercent;
-                  if (tLayout.leftOrig + tLayout.widthOrig > scaleBoundsX) {
-                    DG.currDocumentController().set('scaleBoundsX', tLayout.leftOrig + tLayout.widthOrig);
-                  }
-                  if (tLayout.topOrig + tLayout.heightOrig > scaleBoundsY) {
-                    DG.currDocumentController().set('scaleBoundsY',  tLayout.topOrig + tLayout.heightOrig);
-                  }
+                      scaleFactor = DG.currDocumentController().get('scaleFactor');
+                  tLayout.heightOrig = tNewHeight / scaleFactor;
+                  tLayout.widthOrig = tNewWidth / scaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -770,16 +735,13 @@ DG.ComponentView = SC.View.extend(
               tLayout = this.getPath('layout'),
               tContainerWidth = tTitleBar.getContainerWidth(),
               tContainerHeight = tTitleBar.getContainerHeight(),
-              scalePercent = 1;
-          if (tContainerWidth < scaleBoundsX || tContainerHeight < scaleBoundsY) {
-            scalePercent = Math.min(tContainerWidth / scaleBoundsX, tContainerHeight / scaleBoundsY)
-          }
-          var tMinWidth = this.get('contentMinWidth') || kMinSize,
-              tNewWidth = Math.max(tMinWidth, tLayout.widthOrig * scalePercent),
+              scaleFactor = DG.currDocumentController().get('scaleFactor'),
+              tMinWidth = this.get('contentMinWidth') || kMinSize,
+              tNewWidth = Math.max(tMinWidth, tLayout.widthOrig * scaleFactor),
               tMinHeight = this.get('contentMinWidth') || kMinSize,
-              tNewHeight = Math.max(tMinHeight, tLayout.heightOrig * scalePercent),
-              tNewLeft = tLayout.leftOrig * scalePercent,
-              tNewTop = tLayout.topOrig * scalePercent;
+              tNewHeight = Math.max(tMinHeight, tLayout.heightOrig * scaleFactor),
+              tNewLeft = tLayout.leftOrig * scaleFactor,
+              tNewTop = tLayout.topOrig * scaleFactor;
           if ((tNewLeft + tNewWidth + tInspectorDimensions.width) > tContainerWidth) {
             tNewLeft = Math.max(0,  tContainerWidth - tNewWidth - tInspectorDimensions.width);
           }
@@ -793,19 +755,12 @@ DG.ComponentView = SC.View.extend(
         },
         configureViewBoundsLayout : function (iNewPos) {
           var tTitleBar = this.getPath('containerView.titlebar'),
-              scaleBoundsX = DG.currDocumentController().get('scaleBoundsX'),
-              scaleBoundsY = DG.currDocumentController().get('scaleBoundsY'),
               tLayout = this.getPath('layout'),
-              tContainerWidth = tTitleBar.getContainerWidth(),
-              tContainerHeight = tTitleBar.getContainerHeight(),
-              scalePercent = 1;
-          if (tContainerWidth < scaleBoundsX || tContainerHeight < scaleBoundsY) {
-            scalePercent = Math.min(tContainerWidth / scaleBoundsX, tContainerHeight / scaleBoundsY)
-          }
-          tLayout.topOrig = iNewPos.y / scalePercent;
-          tLayout.leftOrig = iNewPos.x / scalePercent;
-          tLayout.heightOrig = iNewPos.height / scalePercent;
-          tLayout.widthOrig = iNewPos.width / scalePercent;
+              scaleFactor = DG.currDocumentController().get('scaleFactor');
+          tLayout.topOrig = iNewPos.y / scaleFactor;
+          tLayout.leftOrig = iNewPos.x / scaleFactor;
+          tLayout.heightOrig = iNewPos.height / scaleFactor;
+          tLayout.widthOrig = iNewPos.width / scaleFactor;
         },
 
         destroy: function () {
@@ -1034,6 +989,7 @@ DG.ComponentView.addComponent = function (iParams) {
 
   if (DG.KEEP_IN_BOUNDS_PREF && !tUseLayoutForPosition) {
     tComponentView.configureViewBoundsLayout(tNewPos);
+    DG.currDocumentController().computeScaleBounds(tNewPos);
   }
 
   return tComponentView;

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -510,11 +510,10 @@ DG.ComponentView = SC.View.extend(
               tOuterView.adjust('top', tY);
 
               if (DG.KEEP_IN_BOUNDS_PREF) {
-                var tLayout = tOuterView.get('layout'),
-                    tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
                     tScaleFactor = tInBoundsScaling.scaleFactor;
-                tLayout.topOrig = tY / tScaleFactor;
-                tLayout.leftOrig = tX / tScaleFactor;
+                tOuterView.originalLayout.top = tY / tScaleFactor;
+                tOuterView.originalLayout.left = tX / tScaleFactor;
               }
             },
             canBeDragged: function () {
@@ -550,10 +549,9 @@ DG.ComponentView = SC.View.extend(
                 tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
                 this.parentView.adjust('width', tNewWidth);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tLayout = this.parentView.get('layout'),
-                      tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
                       tScaleFactor = tInBoundsScaling.scaleFactor;
-                  tLayout.widthOrig = tNewWidth / tScaleFactor;
+                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -576,10 +574,9 @@ DG.ComponentView = SC.View.extend(
                     Math.max(tNewHeight, tMinHeight), tMaxHeight));
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tLayout = this.parentView.get('layout'),
-                      tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
                       tScaleFactor = tInBoundsScaling.scaleFactor;
-                  tLayout.heightOrig = tNewHeight / tScaleFactor;
+                  this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -606,11 +603,10 @@ DG.ComponentView = SC.View.extend(
                   this.parentView.adjust('left', tLoc);
                 }
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tLayout = this.parentView.get('layout'),
-                      tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
                       tScaleFactor = tInBoundsScaling.scaleFactor;
-                  tLayout.widthOrig = tNewWidth / tScaleFactor;
-                  tLayout.leftOrig = tLoc / tScaleFactor;
+                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
+                  this.parentView.originalLayout.left = tLoc / tScaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -650,11 +646,10 @@ DG.ComponentView = SC.View.extend(
                 tNewHeight = Math.min(Math.max(tNewHeight, tMinHeight), tMaxHeight);
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tLayout = this.parentView.get('layout'),
-                      tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
                       tScaleFactor = tInBoundsScaling.scaleFactor;
-                  tLayout.heightOrig = tNewHeight / tScaleFactor;
-                  tLayout.widthOrig = tNewWidth / tScaleFactor;
+                  this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
+                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
                 }
               },
               canBeDragged: function () {
@@ -748,6 +743,7 @@ DG.ComponentView = SC.View.extend(
               type = this.getPath('controller.model.type'),
               tInspectorDims = this.getInspectorDimensions(),
               tLayout = this.get('layout'),
+              tOriginalLayout = this.get('originalLayout'),
               tIsVisible = this.get('isVisible'),
               tContainerWidth = tTitleBar.getContainerWidth(),
               tContainerHeight = tTitleBar.getContainerHeight(),
@@ -774,11 +770,11 @@ DG.ComponentView = SC.View.extend(
                 tMinHeight = tLayout.height;
               }
           var tNewWidth = Math.max(tMinWidth,
-              DG.ViewUtilities.floorToGrid(tLayout.widthOrig * tScaleFactor)),
+              DG.ViewUtilities.floorToGrid(tOriginalLayout.width * tScaleFactor)),
               tNewHeight = Math.max(tMinHeight,
-              DG.ViewUtilities.floorToGrid(tLayout.heightOrig * tScaleFactor)),
-              tNewLeft = DG.ViewUtilities.floorToGrid(tLayout.leftOrig * tScaleFactor),
-              tNewTop = DG.ViewUtilities.floorToGrid(tLayout.topOrig * tScaleFactor);
+              DG.ViewUtilities.floorToGrid(tOriginalLayout.height * tScaleFactor)),
+              tNewLeft = DG.ViewUtilities.floorToGrid(tOriginalLayout.left * tScaleFactor),
+              tNewTop = DG.ViewUtilities.floorToGrid(tOriginalLayout.top * tScaleFactor);
           if ((tNewLeft + tNewWidth + tInspectorDims.width) > tContainerWidth) {
             tNewLeft = Math.max(0,  tContainerWidth - tNewWidth - tInspectorDims.width);
           }
@@ -791,13 +787,13 @@ DG.ComponentView = SC.View.extend(
             controller.updateModelLayout();
         },
         configureViewBoundsLayout : function (iNewPos) {
-          var tLayout = this.get('layout'),
+          var tOriginalLayout = this.get('originalLayout'),
               tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
               tScaleFactor = tInBoundsScaling.scaleFactor;
-          tLayout.topOrig = iNewPos.y / tScaleFactor;
-          tLayout.leftOrig = iNewPos.x / tScaleFactor;
-          tLayout.heightOrig = iNewPos.height / tScaleFactor;
-          tLayout.widthOrig = iNewPos.width / tScaleFactor;
+          tOriginalLayout.top = iNewPos.y / tScaleFactor;
+          tOriginalLayout.left = iNewPos.x / tScaleFactor;
+          tOriginalLayout.height = iNewPos.height / tScaleFactor;
+          tOriginalLayout.width = iNewPos.width / tScaleFactor;
         },
 
         destroy: function () {
@@ -944,6 +940,7 @@ DG.ComponentView._createComponent = function (iParams) {
       tIsResizable = iParams.isResizable,
       tComponentView = DG.ComponentView.create({
         layout: iParams.layout,
+        originalLayout: iParams.layout,
         isVisible: tMakeItVisible,
         showTitleBar: !tIsStandaloneInteractive,
         isResizable: !tIsStandaloneInteractive

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -139,6 +139,12 @@ DG.DragBorderView = SC.View.extend(
                       this._oldLayout.height = layout.height;
                       tContainer.updateFrame();
                     }.bind(this));
+                if (DG.KEEP_IN_BOUNDS_PREF) {
+                  tViewToDrag.configureViewBoundsLayout({height:layout.height,
+                                             width:layout.width,
+                                             x:layout.left,
+                                             y:layout.top});
+                }
               },
               redo: function () {
                 var layout = SC.clone(this._oldLayout);
@@ -152,6 +158,12 @@ DG.DragBorderView = SC.View.extend(
                       this._oldLayout = this._controller().revertModelLayout(this._oldLayout);
                       tContainer.updateFrame();
                     }.bind(this));
+                if (DG.KEEP_IN_BOUNDS_PREF) {
+                  tViewToDrag.configureViewBoundsLayout({height:layout.height,
+                                             width:layout.width,
+                                             x:layout.left,
+                                             y:layout.top});
+                }
               }
             }));
           }

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -511,7 +511,8 @@ DG.ComponentView = SC.View.extend(
 
               if (DG.KEEP_IN_BOUNDS_PREF) {
                 var tLayout = tOuterView.get('layout'),
-                    tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                    tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                    tScaleFactor = tInBoundsScaling.scaleFactor;
                 tLayout.topOrig = tY / tScaleFactor;
                 tLayout.leftOrig = tX / tScaleFactor;
               }
@@ -550,7 +551,8 @@ DG.ComponentView = SC.View.extend(
                 this.parentView.adjust('width', tNewWidth);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.get('layout'),
-                      tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                      tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                      tScaleFactor = tInBoundsScaling.scaleFactor;
                   tLayout.widthOrig = tNewWidth / tScaleFactor;
                 }
               },
@@ -575,7 +577,8 @@ DG.ComponentView = SC.View.extend(
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.get('layout'),
-                      tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                      tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                      tScaleFactor = tInBoundsScaling.scaleFactor;
                   tLayout.heightOrig = tNewHeight / tScaleFactor;
                 }
               },
@@ -604,7 +607,8 @@ DG.ComponentView = SC.View.extend(
                 }
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.get('layout'),
-                      tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                      tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                      tScaleFactor = tInBoundsScaling.scaleFactor;
                   tLayout.widthOrig = tNewWidth / tScaleFactor;
                   tLayout.leftOrig = tLoc / tScaleFactor;
                 }
@@ -647,7 +651,8 @@ DG.ComponentView = SC.View.extend(
                 this.parentView.adjust('height', tNewHeight);
                 if (DG.KEEP_IN_BOUNDS_PREF) {
                   var tLayout = this.parentView.get('layout'),
-                      tScaleFactor = DG.currDocumentController().get('scaleFactor');
+                      tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+                      tScaleFactor = tInBoundsScaling.scaleFactor;
                   tLayout.heightOrig = tNewHeight / tScaleFactor;
                   tLayout.widthOrig = tNewWidth / tScaleFactor;
                 }
@@ -746,15 +751,16 @@ DG.ComponentView = SC.View.extend(
               tIsVisible = this.get('isVisible'),
               tContainerWidth = tTitleBar.getContainerWidth(),
               tContainerHeight = tTitleBar.getContainerHeight(),
-              tScaleFactor = DG.currDocumentController().get('scaleFactor'),
-              tScaleBoundsX = DG.currDocumentController().get('scaleBoundsX'),
-              tScaleBoundsY = DG.currDocumentController().get('scaleBoundsY'),
+              tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+              tScaleFactor = tInBoundsScaling.scaleFactor,
+              tScaleBoundsX = tInBoundsScaling.scaleBoundsX,
+              tScaleBoundsY = tInBoundsScaling.scaleBoundsY,
               tMinWidth = this.get('contentMinWidth') || kMinSize,
               tMinHeight = this.get('contentMinWidth') || kMinSize;
               if (tIsVisible &&
                   tScaleBoundsX < (tLayout.left + tLayout.width + tInspectorDims.width)) {
                 var tNewBoundsX = tLayout.left + tLayout.width + tInspectorDims.width;
-                DG.currDocumentController().set('scaleBoundsX', tNewBoundsX);
+                DG.currDocumentController().setInBoundsScaleBounds(tNewBoundsX, tScaleBoundsY);
               }
               if (tIsVisible &&
                   (tScaleBoundsY < (tLayout.top + tLayout.height) ||
@@ -786,7 +792,8 @@ DG.ComponentView = SC.View.extend(
         },
         configureViewBoundsLayout : function (iNewPos) {
           var tLayout = this.get('layout'),
-              tScaleFactor = DG.currDocumentController().get('scaleFactor');
+              tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+              tScaleFactor = tInBoundsScaling.scaleFactor;
           tLayout.topOrig = iNewPos.y / tScaleFactor;
           tLayout.leftOrig = iNewPos.x / tScaleFactor;
           tLayout.heightOrig = iNewPos.height / tScaleFactor;

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -628,8 +628,8 @@ DG.ComponentView = SC.View.extend(
               dragCursor: kCornerBorderCursor,
               dragAdjust: function (evt, info) {
                 // Don't let user drag right edge off left of window
-                var tMinHeight = this.get('contentMinHeight') || kMinSize;
-                    tMaxHeight = this.get('contentMaxHeight') || kMaxSize;
+                var tMinHeight = this.get('contentMinHeight') || kMinSize,
+                    tMaxHeight = this.get('contentMaxHeight') || kMaxSize,
                     tMinWidth = this.get('contentMinWidth') || kMinSize,
                     tLoc = Math.max(evt.pageX, tMinWidth),
                     tNewWidth = DG.ViewUtilities.roundToGrid(info.width + (tLoc - info.pageX)),
@@ -725,7 +725,7 @@ DG.ComponentView = SC.View.extend(
 
         getInspectorDimensions : function () {
             var tInspectorWidth = 0,
-                tInspectorHeight = 0;
+                tInspectorHeight = 0,
                 tButtons = this.getPath('inspectorButtons');
 
             if (tButtons && tButtons.length) {
@@ -746,7 +746,7 @@ DG.ComponentView = SC.View.extend(
               scaleFactor = DG.currDocumentController().get('scaleFactor'),
               tMinWidth = this.get('contentMinWidth') || kMinSize,
               tMinHeight = this.get('contentMinWidth') || kMinSize;
-              if (type == DG.Calculator) {
+              if (type === DG.Calculator) {
                 tMinWidth = tLayout.width;
                 tMinHeight = tLayout.height;
               }
@@ -769,8 +769,7 @@ DG.ComponentView = SC.View.extend(
             controller.updateModelLayout();
         },
         configureViewBoundsLayout : function (iNewPos) {
-          var tTitleBar = this.getPath('containerView.titlebar'),
-              tLayout = this.getPath('layout'),
+          var tLayout = this.getPath('layout'),
               scaleFactor = DG.currDocumentController().get('scaleFactor');
           tLayout.topOrig = iNewPos.y / scaleFactor;
           tLayout.leftOrig = iNewPos.x / scaleFactor;

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -743,6 +743,7 @@ DG.ComponentView = SC.View.extend(
               type = this.getPath('controller.model.type'),
               tInspectorDims = this.getInspectorDimensions(),
               tLayout = this.getPath('layout'),
+              tIsVisible = this.getPath('isVisible'),
               tContainerWidth = tTitleBar.getContainerWidth(),
               tContainerHeight = tTitleBar.getContainerHeight(),
               tScaleFactor = DG.currDocumentController().get('scaleFactor'),
@@ -750,12 +751,14 @@ DG.ComponentView = SC.View.extend(
               tScaleBoundsY = DG.currDocumentController().get('scaleBoundsY'),
               tMinWidth = this.get('contentMinWidth') || kMinSize,
               tMinHeight = this.get('contentMinWidth') || kMinSize;
-              if (tScaleBoundsX < (tLayout.left + tLayout.width + tInspectorDims.width)) {
+              if (tIsVisible &&
+                  tScaleBoundsX < (tLayout.left + tLayout.width + tInspectorDims.width)) {
                 var tNewBoundsX = tLayout.left + tLayout.width + tInspectorDims.width;
                 DG.currDocumentController().set('scaleBoundsX', tNewBoundsX);
               }
-              if (tScaleBoundsY < (tLayout.top + tLayout.height) ||
-                  tScaleBoundsY < (tLayout.top + tInspectorDims.height)) {
+              if (tIsVisible &&
+                  (tScaleBoundsY < (tLayout.top + tLayout.height) ||
+                  tScaleBoundsY < (tLayout.top + tInspectorDims.height))) {
                 var tHeight = (tLayout.height > tInspectorDims.height) ? tLayout.height : tInspectorDims.height;
                 var tNewBoundsY = tLayout.top + tHeight;
                 DG.currDocumentController().set('scaleBoundsY', tNewBoundsY);

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -568,7 +568,7 @@ DG.ComponentView = SC.View.extend(
                     tNewHeight = info.height + (evt.pageY - info.pageY),
                     tContainerHeight = this.getContainerHeight();
                 if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tMaxHeight = Math.min(tMaxHeight, tContainerHeight - info.top)
+                  tMaxHeight = Math.min(tMaxHeight, tContainerHeight - info.top);
                 }
                 tNewHeight = DG.ViewUtilities.roundToGrid(Math.min(
                     Math.max(tNewHeight, tMinHeight), tMaxHeight));
@@ -724,33 +724,42 @@ DG.ComponentView = SC.View.extend(
         getInspectorDimensions : function () {
             var tInspectorWidth = 0,
                 tInspectorHeight = 0,
-                tButtons = this.getPath('inspectorButtons'),
-                tLayout = this.getPath('layout');
+                tButtons = this.getPath('inspectorButtons');
             if (tButtons && tButtons.length) {
               if (tButtons[0].parentView && tButtons[0].parentView.layout) {
                 tInspectorWidth = tButtons[0].parentView.layout.width;
                 tInspectorHeight = tButtons[0].parentView.layout.height;
               } else {
-                const BUTTONHORIZONTALSPACE = 50;
-                const BUTTONVERTICALSPACE = 43;
+                var BUTTONHORIZONTALSPACE = 50,
+                    BUTTONVERTICALSPACE = 43;
                 tInspectorWidth = BUTTONHORIZONTALSPACE;
                 tInspectorHeight = BUTTONVERTICALSPACE * tButtons.length;
               }
             }
-            tLayout.inspectorWidth = tInspectorWidth;
-            tLayout.inspectorHeight = tInspectorHeight;
             return {width : tInspectorWidth, height : tInspectorHeight};
         },
         enforceViewBounds : function () {
           var tTitleBar = this.getPath('containerView.titlebar'),
               type = this.getPath('controller.model.type'),
-              tInspectorDimensions = this.getInspectorDimensions(),
+              tInspectorDims = this.getInspectorDimensions(),
               tLayout = this.getPath('layout'),
               tContainerWidth = tTitleBar.getContainerWidth(),
               tContainerHeight = tTitleBar.getContainerHeight(),
               tScaleFactor = DG.currDocumentController().get('scaleFactor'),
+              tScaleBoundsX = DG.currDocumentController().get('scaleBoundsX'),
+              tScaleBoundsY = DG.currDocumentController().get('scaleBoundsY'),
               tMinWidth = this.get('contentMinWidth') || kMinSize,
               tMinHeight = this.get('contentMinWidth') || kMinSize;
+              if (tScaleBoundsX < (tLayout.left + tLayout.width + tInspectorDims.width)) {
+                var tNewBoundsX = tLayout.left + tLayout.width + tInspectorDims.width;
+                DG.currDocumentController().set('scaleBoundsX', tNewBoundsX);
+              }
+              if (tScaleBoundsY < (tLayout.top + tLayout.height) ||
+                  tScaleBoundsY < (tLayout.top + tInspectorDims.height)) {
+                var tHeight = (tLayout.height > tInspectorDims.height) ? tLayout.height : tInspectorDims.height;
+                var tNewBoundsY = tLayout.top + tHeight;
+                DG.currDocumentController().set('scaleBoundsY', tNewBoundsY);
+              }
               if (type === DG.Calculator) {
                 tMinWidth = tLayout.width;
                 tMinHeight = tLayout.height;
@@ -761,8 +770,8 @@ DG.ComponentView = SC.View.extend(
               DG.ViewUtilities.floorToGrid(tLayout.heightOrig * tScaleFactor)),
               tNewLeft = DG.ViewUtilities.floorToGrid(tLayout.leftOrig * tScaleFactor),
               tNewTop = DG.ViewUtilities.floorToGrid(tLayout.topOrig * tScaleFactor);
-          if ((tNewLeft + tNewWidth + tInspectorDimensions.width) > tContainerWidth) {
-            tNewLeft = Math.max(0,  tContainerWidth - tNewWidth - tInspectorDimensions.width);
+          if ((tNewLeft + tNewWidth + tInspectorDims.width) > tContainerWidth) {
+            tNewLeft = Math.max(0,  tContainerWidth - tNewWidth - tInspectorDims.width);
           }
           if (tNewTop + tNewHeight > tContainerHeight) {
             tNewTop = Math.max(0, tContainerHeight - tNewHeight);

--- a/apps/dg/views/container_view.js
+++ b/apps/dg/views/container_view.js
@@ -348,6 +348,7 @@ DG.ContainerView = SC.View.extend(
           }.bind(this));
           iView.adjust({width: 0, height: 0});
         }
+        return tFinalRect;
       },
       
       /** coverUpComponentViews - Request each component view to cover up its contents with a see-through layer.

--- a/apps/dg/views/container_view.js
+++ b/apps/dg/views/container_view.js
@@ -1,8 +1,8 @@
 // ==========================================================================
 //                          DG.ContainerView
-// 
+//
 //  The top level view in a DG document.
-//  
+//
 //  Author:   William Finzer
 //
 //  Copyright (c) 2014 by The Concord Consortium, Inc. All rights reserved.
@@ -29,7 +29,7 @@ sc_require('views/inspector/inspector_view');
   @extends SC.View
 */
 DG.ContainerView = SC.View.extend(
-/** @scope DG.ContainerView.prototype */ 
+/** @scope DG.ContainerView.prototype */
   (function() {
     var kDocMargin = 16;
     return {
@@ -68,7 +68,7 @@ DG.ContainerView = SC.View.extend(
       // We want the container to encompass the entire window or the
       // entire content, whichever is greater.
       layout: { left: 0, top: 0, minWidth: '100%', minHeight: '100%' },
-      
+
       /**
         Indicates that this view's layout should never be considered fixed.
         A fixed layout has a fixed width and height and is unaffected by changes
@@ -185,7 +185,7 @@ DG.ContainerView = SC.View.extend(
 
         this.adjust({ width: tWidth, height: tHeight });
       },
-      
+
       removeComponentView: function( iComponentView) {
         var tCloseAction = iComponentView.get('closeAction');
         if( tCloseAction) {
@@ -250,7 +250,7 @@ DG.ContainerView = SC.View.extend(
           this.incrementProperty('nextZIndex');
         }
       },
-      
+
       /* sendToBack - The given child view will be placed at the beginning of the list, thus
         rendered first and appearing behind all others.
       */
@@ -302,8 +302,16 @@ DG.ContainerView = SC.View.extend(
                                       tDocRect,
                                       tOffset,
                                       tViewRects.concat( tReservedRects),
-                                      iPosition),
-            tFinalRect = { x: tLoc.x, y: tLoc.y, width: tViewRect.width, height: tViewRect.height},
+                                      iPosition);
+        if (DG.KEEP_IN_BOUNDS_PREF) {
+          if (tLoc.x + tViewRect.width > window.innerWidth) {
+            tLoc.x = Math.max(0, window.innerWidth - tViewRect.width);
+          }
+          if (tLoc.y + tViewRect.height > window.innerHeight) {
+            tLoc.y = Math.max(0, window.innerHeight - tViewRect.height);
+          }
+        }                             
+        var tFinalRect = { x: tLoc.x, y: tLoc.y, width: tViewRect.width, height: tViewRect.height},
             tOptions = { duration: 0.5, timing: 'ease-in-out'},
             tIsGameView = iView.get('contentView').constructor === DG.GameView;
         if( tIsGameView) {
@@ -350,7 +358,7 @@ DG.ContainerView = SC.View.extend(
         }
         return tFinalRect;
       },
-      
+
       /** coverUpComponentViews - Request each component view to cover up its contents with a see-through layer.
        * We need to do this when we're dragging or resizing one component, so that the event handlers in components
        * we are passing over don't get in the way.


### PR DESCRIPTION
Initial PR for an embedded mode to keep components in-bounds when components are loaded, moved, or resized and scaled when the browser window is resized.  Mode is turned on with URL param `inbounds=true`.  Mode follows these rules:

-Components are kept in bounds (no portion of Component including the Inspector is positioned offscreen) when moving or resizing a Component.

-Components are rescaled and repositioned when document is loaded or when browser resizes and the Components no longer fit within the target boundaries defined by the original Component layout.
example: original layout has target bounds 1000x1000 (right edge is at 1000, bottom edge is at 1000), but browser is resized to 900x900.  Components are rescaled and repositioned to accommodate new browser size.

-New target bounds are computed if a component is opened, moved, or resized so that it is outside the original target bounds.
example: original layout has target bounds 1000x1000, browser has size 1200x1200, Component is positioned so that its right edge is at 1100.  New target bounds is computed as 1100x1000.

-Target bounds are maintained if components are moved within the confines of the existing target bounds.
example: original layout has target bounds 1000x1000, browser has size 1100x1100, rightmost Component is positioned so that its right edge is at 900.  Target bounds remains 1000x1000.