### PR TITLE
Let client app pass dirtyDocument=false flag while deleting attribute

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1009,7 +1009,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           };
           return applyChangeAndProcessResult(context, change, iMetadata);
         },
-        'delete': function (iResources) {
+        'delete': function (iResources, iValues, iMetadata) {
           var context = iResources.dataContext;
           var change = {
             operation: 'deleteAttributes',
@@ -1017,6 +1017,9 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
             attrs: [iResources.attribute],
             requester: this.get('id')
           };
+          if (iMetadata && iMetadata.dirtyDocument === false) {
+            change.dirtyDocument = false;
+          }
           var changeResult = context.applyChange(change);
           var success = (changeResult && changeResult.success);
           return {


### PR DESCRIPTION
This change seems necessary to complete this story:
https://www.pivotaltracker.com/story/show/161790553

Basically, various actions in Sage need to update CODAP data context. E.g. adding a new node in Sage adds a new context attribute in CODAP. Renaming Sage node renames CODAP attribute. 

To make all that working with undo/redo buttons, Sage seems to pass `{dirtyDocument: false}` metadata to CODAP, so CODAP doesn't mark the document as dirty and doesn't reset undo stack. In some sense, Sage is undoing CODAP changes manually, just making sure that CODAP data context stays in sync with its own state.

Metadata is supported in other handlers above (update, create, etc., via `applyChangeAndProcessResult`), but for some reason, it's not supported in `delete`.

