### PR TITLE
Handle `position` parameters while creating various components

### DIFF
--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -901,6 +901,7 @@ DG.DocumentController = SC.Object.extend(
                 width: tGameParams.width,
                 height: tGameParams.height
               },
+              position: iComponent.position,
               title: tGameName,
               isResizable: true,
               useLayout: !SC.none(iComponent),
@@ -1113,6 +1114,7 @@ DG.DocumentController = SC.Object.extend(
                     model: SC.Object.create({})
                   },
                   defaultLayout: {width: 300, height: 100},
+                  position: iComponent.position,
                   title: 'DG.DocumentController.textTitle'.loc(), // "Text"
                   isResizable: true
                 }
@@ -1152,6 +1154,7 @@ DG.DocumentController = SC.Object.extend(
                   componentClass: {type: 'DG.MapView', constructor: DG.MapView},
                   contentProperties: {model: tMapModel},
                   defaultLayout: {width: 530, height: 360},
+                  position: iComponent.position,
                   title: 'DG.DocumentController.mapTitle'.loc(), // "Map"
                   isResizable: true
                 }
@@ -1193,6 +1196,7 @@ DG.DocumentController = SC.Object.extend(
                   componentClass: {type: 'DG.SliderView', constructor: DG.SliderView},
                   contentProperties: {id: this._componentId, model: tSliderModel},
                   defaultLayout: {width: 300, height: 98},
+                  position: iComponent.position,
                   isResizable: true
                 }
             );
@@ -1216,6 +1220,7 @@ DG.DocumentController = SC.Object.extend(
               componentClass: {type: 'DG.Calculator', constructor: DG.Calculator},
               contentProperties: {},
               defaultLayout: {},
+              position: iComponent.position,
               title: 'DG.DocumentController.calculatorTitle'.loc(), // "Calculator"
               isResizable: false
             }
@@ -1358,6 +1363,7 @@ DG.DocumentController = SC.Object.extend(
                   componentClass: {type: 'DG.WebView', constructor: DG.WebView},
                   contentProperties: {value: iURL, backgroundColor: 'white', model: this.model},
                   defaultLayout: iLayout,
+                  position: iComponent.position,
                   title: iTitle,
                   isResizable: true,
                   useLayout: !SC.none(iComponent) || !SC.none(iLayout.centerX) || !SC.none(iLayout.left)
@@ -1402,6 +1408,7 @@ DG.DocumentController = SC.Object.extend(
                       closeAction: {action: this.closeGuideView, target: this}
                     },
                     defaultLayout: {width: 400, height: 200},
+                    position: iComponent.position,
                     isResizable: true,
                     useLayout: true
                   }
@@ -1772,6 +1779,7 @@ DG.DocumentController = SC.Object.extend(
                 allow_user_variables: iAllowUserVariables
               },
               defaultLayout: {},
+              position: iComponent.position,
               title: iTitle,
               isResizable: true
             }


### PR DESCRIPTION
[#162022418]

It follows the pattern that already existed for some components (e.g. table). Note that docs are suggesting that `position` parameter is supported in all these components, so I guess it could be considered a bug fix. I extended this to all the components (or calls to `createComponentView`) just in case.