### PR TITLE
Changes required for sagemodeler.concord.org

### DIFF
--- a/apps/dg/controllers/app_controller.js
+++ b/apps/dg/controllers/app_controller.js
@@ -488,24 +488,34 @@ DG.appController = SC.Object.create((function () // closure
     },
     /**
      *
-     * @param iURL - the URL of a data interactive, csv or json document based on
+     * @param iURL - the URL of a webpage, data interactive, csv or json document based on
      * file extension in pathname.
+     * @param iComponentType - (optional) the type of the component, defaults to DG.GameView
      * @returns {Boolean}
      */
-    importURL: function (iURL) {
+    importURL: function (iURL, iComponentType) {
 
       var addInteractive = function () {
         var tDoc = DG.currDocumentController(),
-          tComponent = DG.Component.createComponent({
-            "type": "DG.GameView",
-            "document": tDoc.get('content') ,
-            "componentStorage": {
-              "currentGameName": "",
-              "currentGameUrl": iURL,
-              allowInitGameOverride: true
-            }
-          });
-        tDoc.createComponentAndView( tComponent);
+            tComponent;
+
+        switch (iComponentType || "DG.GameView") {
+          case "DG.GameView":
+            tComponent = DG.Component.createComponent({
+              "type": "DG.GameView",
+              "document": tDoc.get('content') ,
+              "componentStorage": {
+                "currentGameName": "",
+                "currentGameUrl": iURL,
+                allowInitGameOverride: true
+              }
+            });
+            tDoc.createComponentAndView( tComponent);
+            break;
+          case "DG.WebView":
+            tDoc.addWebView(DG.mainPage.get('docView'), null, iURL, 'Web Page', {width: 600, height: 400});
+            break;
+        }
       }.bind(this);
 
       // from: http://www.abeautifulsite.net/parsing-urls-in-javascript/

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -508,6 +508,24 @@ DG = SC.Application.create((function () // closure
     }.property(),
 
     /**
+     * hideSplashScreen can be passed as a Url parameter named tools with values 'yes' or 'no'.
+     *  With the value 'yes' DG will not display the CODAP splash screen.
+     *  The default is 'no'.
+     */
+    hideSplashScreen: function () {
+      return getUrlParameter('hideSplashScreen', 'no');
+    }.property(),
+
+    /**
+     * hideWebViewLoading can be passed as a Url parameter named tools with values 'yes' or 'no'.
+     *  With the value 'yes' DG will not display the loading view when loading webviews.
+     *  The default is 'no'.
+     */
+    hideWebViewLoading: function () {
+      return getUrlParameter('hideWebViewLoading', 'no');
+    }.property(),
+
+    /**
      * If set, amends the options object sent to the CFM at initialization.
      * See the main.js:cfmInit().
      * @param {Object}

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -57,8 +57,8 @@ DG.main = function main() {
     return wantsSCMouse
               ? NO
               : (dgWantsMouse ? YES : orgIgnoreMouseHandle(evt));
-  };	
-	
+  };
+
   DG.getPath('mainPage.mainPane').appendTo($('#codap'));
 
   DG.showUserEntryView = true;
@@ -171,7 +171,7 @@ DG.main = function main() {
   function removeDuplicateCaseIDs(content) {
     var cases = {},
         duplicates = {};
-    
+
     if (content.contexts) {
       content.contexts.forEach(function(context) {
         if (context.collections) {
@@ -783,6 +783,7 @@ DG.main = function main() {
     $('html').addClass('dg-embedded-mode');
 
     startEmbeddedServer();
+    translateQueryParameters();
   }
   else {
     // only start embedded server if embeddedMode is not on

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -755,7 +755,7 @@ DG.main = function main() {
                 DG.appController.importFile(event.data.file.object);
               }
               else if (event.data.url && (event.data.via === "select")) {
-                DG.appController.importURL(event.data.url);
+                DG.appController.importURL(event.data.url, event.data.componentType);
               }
             });
             break;

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -207,16 +207,16 @@ DG.main = function main() {
         a;
 
     if (DG.cfmBaseUrl) {
-      // safely parse the url and check to only allow codap.concord.org or a domain with no tld (like localhost or dev)
+      // safely parse the url and check to only allow *.concord.org or a domain with no tld (like localhost or dev)
       a = document.createElement("A");
       a.href = DG.cfmBaseUrl;
-      if ((a.hostname === 'codap.concord.org') || (a.hostname.indexOf('.') === -1)) {
+      if (/\.concord\.org$/.test(a.hostname) || (a.hostname.indexOf('.') === -1)) {
         a.pathname = (a.pathname[a.pathname.length - 1] === '/' ? a.pathname : (a.pathname + '/')) + filename;
         url = a.href;
         DG.logWarn('Loading the ' + filename + ' CFM file from ' + url);
       }
       else {
-        DG.logError('The cfmBaseUrl domain (' + a.hostname + ') either needs to be codap.concord.org or not have a TLD (like localhost)');
+        DG.logError('The cfmBaseUrl domain (' + a.hostname + ') either needs to be *.concord.org or not have a TLD (like localhost)');
       }
     }
 

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -757,6 +757,9 @@ DG.main = function main() {
               else if (event.data.url && (event.data.via === "select")) {
                 DG.appController.importURL(event.data.url, event.data.componentType);
               }
+              else if (event.data.text && event.data.name) {
+                DG.appController.importText(event.data.text, event.data.name);
+              }
             });
             break;
 

--- a/apps/dg/resources/splash.js
+++ b/apps/dg/resources/splash.js
@@ -23,7 +23,7 @@ DG.splash = SC.Object.create({
   isShowing: false,
 
   showSplash: function () {
-    if (DG.Browser.isCompatibleBrowser() && !this.get('isShowing') &&  DG.get('componentMode') !== 'yes' ) {
+    if (DG.Browser.isCompatibleBrowser() && !this.get('isShowing') &&  DG.get('componentMode') !== 'yes' && DG.get('hideSplashScreen') !== 'yes') {
       var kHeight = 200,
           kPadding = 20,
           kRatio = 1936 / 649;

--- a/apps/dg/views/web_view.js
+++ b/apps/dg/views/web_view.js
@@ -27,7 +27,7 @@
 DG.WebView = SC.View.extend(
 /** @scope DG.WebView.prototype */ {
       classNames: ['dg-web-view'],
-      childViews: ['loadingView', 'webView'],
+      childViews: DG.get('hideWebViewLoading') !== 'yes' ? ['loadingView', 'webView'] : ['webView'],
 
       isTextSelectable: YES,
 


### PR DESCRIPTION
- Added call to translateQueryParameters when in embedded mode
- Added component type override to importUrl() to allow for webpages to be imported
- Added hideSplashScreen and hideWebViewLoading url parameters
- Added import of text in cfm client callback to support creating new tables
- Changed cfm test from codap.concord.org to *.concord.org 