### PR TITLE
Add `itemCount` endpoint to CODAP plugin API

### DIFF
--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -186,6 +186,11 @@ DG.DataContext = SC.Object.extend((function() // closure
       return tResult;
     }.property('collectionCount'),
 
+    itemCount: function() {
+      var dataSet = this.get('dataSet');
+      return dataSet && dataSet.getDataItemCount();
+    }.property(),
+
     dataSet: function () {
       return this.getPath('model.dataSet');
     }.property(),

--- a/apps/dg/models/data_set.js
+++ b/apps/dg/models/data_set.js
@@ -342,6 +342,10 @@ DG.DataSet = SC.Object.extend((function() // closure
       return ret;
     },
 
+    getDataItemCount: function() {
+      return this._clientToItemIndexMap.length;
+    },
+
     getDataItems: function() {
       return this._clientToItemIndexMap
               .map(function(index) { return this.dataItems[index]; }.bind(this));


### PR DESCRIPTION
Added an `itemCount` endpoint (analogous to the existing `caseCount` endpoint) to the CODAP plugin API. Consulted with @jsandoe for best way to do this.

@jsandoe I had to move the implementation of the `dataContextList` endpoint into the `resourceResolver()` as well because otherwise it triggered the empty key exception at the end of the `resourceResolver()`. I tried a few other potential API endpoints without finding others that triggered it, but my search was not exhaustive.

Note: I was originally planning to implement an `allItems` endpoint analogous to the existing `allCases` endpoint as well, but @jsandoe has plans for an alternate implementation of this functionality, so I leave that to him.

cc: @sfentress 