### PR TITLE
Add CODAP plugin API support for changing the order of cases

### DIFF
--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -357,6 +357,7 @@ DG.CaseTableController = DG.ComponentController.extend(
             break;
           case 'createCase':
           case 'createCases':
+          case 'moveCases':
             this.doCreateCases( iChange);
             invalidateAggregates = false; // handled by doDependentCases
             break;

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1294,6 +1294,33 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
             values: values
           };
         },
+        notify: function (iResources, iValues) {
+          if (!iResources.collection) {
+            return {success: false, values: {error: 'Collection not found'}};
+          }
+          if (!(iResources.caseByID || iResources.caseByIndex)) {
+            return {success: false, values: {error: 'Case not found'}};
+          }
+
+          var context = iResources.dataContext;
+          var collection = iResources.collection;
+          var theCase = iResources.caseByIndex || iResources.caseByID;
+          var success = false;
+          var changeResult;
+          if (collection && theCase && iValues && iValues.caseOrder) {
+            changeResult = context.applyChange({
+              operation: 'moveCases',
+              collection: collection,
+              cases: [theCase],
+              caseOrder: [iValues.caseOrder],
+              requester: this.get('id')
+            });
+            success = (changeResult && changeResult.success);
+          }
+          return {
+            success: success
+          };
+        },
         update: function (iResources, iValues) {
           if (!iResources.collection) {
             return {success: false, values: {error: 'Collection not found'}};
@@ -1307,21 +1334,14 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           var theCase = iResources.caseByIndex || iResources.caseByID;
           var success = false;
           var changeResult;
-          if (collection && theCase && iValues) {
-            var change = {
+          if (collection && theCase && iValues && iValues.values) {
+            changeResult = context.applyChange({
+              operation: 'updateCases',
               collection: collection,
               cases: [theCase],
+              values: [iValues.values],
               requester: this.get('id')
-            };
-            if (iValues.caseOrder) {
-              change.operation = 'moveCases';
-              change.caseOrder = [iValues.caseOrder];
-            }
-            else {
-              change.operation = 'updateCases';
-              change.values = [iValues.values];
-            }
-            changeResult = context.applyChange(change);
+            });
             success = (changeResult && changeResult.success);
           }
           return {

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1308,13 +1308,20 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           var success = false;
           var changeResult;
           if (collection && theCase && iValues) {
-            changeResult = context.applyChange({
-              operation: 'updateCases',
+            var change = {
               collection: collection,
               cases: [theCase],
-              values: [iValues.values],
               requester: this.get('id')
-            });
+            };
+            if (iValues.caseOrder) {
+              change.operation = 'moveCases';
+              change.caseOrder = [iValues.caseOrder];
+            }
+            else {
+              change.operation = 'updateCases';
+              change.values = [iValues.values];
+            }
+            changeResult = context.applyChange(change);
             success = (changeResult && changeResult.success);
           }
           return {

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -452,6 +452,9 @@ DG.DataContext = SC.Object.extend((function() // closure
       case 'updateCases':
         result = this.doUpdateCases( iChange);
         break;
+      case 'moveCases':
+        result = this.doMoveCases( iChange);
+        break;
       case 'deleteCases':
         result = this.doDeleteCases( iChange);
         shouldDirtyDoc = false;
@@ -1087,6 +1090,42 @@ DG.DataContext = SC.Object.extend((function() // closure
     } else {
       return this.doUpdateCasesFromHashOfNameValues(iChange);
     }
+  },
+
+  /*
+   * Change the order of cases within the collection.
+   */
+  doMoveCases: function( iChange) {
+    var cases = iChange.cases;
+    var changeCount = cases.length;
+    var success = true;
+    var caseIDs = [];
+    cases.forEach(function (iCase, iIndex) {
+      var collection = iCase.get('collection');
+      var caseOrder = iChange.caseOrder[iIndex];
+      // only update the ID map after the last case
+      var skipIDMapUpdate = iIndex < changeCount - 1;
+      if (caseOrder === 'first') {
+        collection.moveCase(iCase, 0, skipIDMapUpdate);
+      }
+      else if (caseOrder === 'last') {
+        var caseCount = collection.getPath('cases.length');
+        collection.moveCase(iCase, caseCount - 1, skipIDMapUpdate);
+      }
+      else {
+        // could potentially support moving a case to a particular index,
+        // or perhaps before/after another case with a particular ID, etc.
+      }
+      // Note that when a sort occurs, all of the caseIDs are listed.
+      // In this case, we could list all of the cases affected, i.e. all of
+      // the cases whose indices were changed, or simply list all of the
+      // cases as is true when sorting. In point of fact, however, there
+      // don't appear to be any clients that use this information, so
+      // simply listing the IDs of the cases that were actually moved
+      // seems sufficient.
+      caseIDs.push(iCase.id);
+    });
+    return { success: success, caseIDs: caseIDs};
   },
 
   /**

--- a/apps/dg/models/collection_model.js
+++ b/apps/dg/models/collection_model.js
@@ -487,12 +487,26 @@ DG.Collection = DG.BaseModel.extend( (function() // closure
       }
     },
 
-    moveCase: function(iCase, position) {
+    /**
+     * Changes the order of the specified case within this collection.
+     * If moving multiple cases, clients should pass false for iSkipIDMapUpdate
+     * in all calls except the last, or call updateCaseIDToIndexMap() directly
+     * once all moves are complete.
+     * @param   {DG.Case} iCase The case to move.
+     * @param   {number}  position The desired index of the moved case
+     * @param   {boolean} iSkipIDMapUpdate If true, the re-mapping of case IDs to indices will be skipped.
+     */
+    moveCase: function(iCase, position, iSkipIDMapUpdate) {
       var currentPosition = this.cases.indexOf(iCase);
       if (currentPosition >= 0 && currentPosition !== position) {
-        this.cases.insertAt(position, this.cases.removeAt(currentPosition));
+        this.cases.removeAt(currentPosition);
+        this.cases.insertAt(position, iCase);
+      }
+      if (!iSkipIDMapUpdate) {
+        this.updateCaseIDToIndexMap();
       }
     },
+
     /**
      * Deletes the specified case from this collection.
      * Clients should call updateCaseIDToIndexMap() after deleting cases.


### PR DESCRIPTION
The API is handled as a case `update` to the `caseOrder` property, e.g.
```
codapInterface.sendRequest({
  action: "update",
  resource: "dataContext[myDataContext].collection[myCollection].caseByID[myCaseID],
  values: { caseOrder: "last" }
});
```
- Rather than `position`, as we talked about, I decided to use `caseOrder`, as `position` seems like it could refer to coordinate location rather than order of the cases within the collection. 
- Currently, `first` and `last` are the only `caseOrder` values supported, but there are code comments indicating where the API could be extended to support things like `index:n` or `before:id`.
- At the DataContext level, the API allows an array of cases so it would be possible to sort the entire collection by specifying an array of cases to be moved to `last` in the order of the array.
- There is some preexisting support for a `moveCases` notification, so I made use of this existing notification internally.
- There was a preexisting `moveCase()` method in the `CollectionModel` which was sufficiently broken that it seems clear it was not previously used. It is now fixed and in use.
- I added an `iSkipIDMapUpdate` parameter to the `moveCase()` method so that the default behavior is to update the ID map on each call, but clients can disable the update for all but the last call when multiple cases are to be moved. Excessive calls to `updateCaseIDToIndexMap()` has been a performance issue in the past, so this should make it possible to avoid that.
