### PR TITLE
Support disabling top-level collection reorganization

### DIFF
--- a/apps/dg/components/case_card/attribute_name_cell.js
+++ b/apps/dg/components/case_card/attribute_name_cell.js
@@ -75,7 +75,8 @@ DG.React.ready(function () {
             }
 
             function newAttributeClickHandler() {
-              this_.props.newAttributeCallback();
+              if (this_.props.newAttributeCallback)
+                this_.props.newAttributeCallback();
             }
 
             handleDropIfAny();
@@ -109,10 +110,11 @@ DG.React.ready(function () {
                       },
                       iItem.label);
                 }),
+                tNewAttrDisabledClass = this.props.newAttributeCallback ? '' : ' disabled',
                 tNewAttrButton = (this.props.index === 0) ?
                     img({
                       src: static_url('images/add_circle_grey_72x72.png'),
-                      className: 'dg-floating-plus',
+                      className: 'dg-floating-plus' + tNewAttrDisabledClass,
                       width: 19,
                       height: 19,
                       title: 'DG.TableController.newAttributeTooltip'.loc(),

--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -339,6 +339,11 @@ DG.React.ready(function () {
                   DG.DataContextUtilities.randomizeAttribute(iContext, iAttr.get('id'));
                 },
 
+                isNewAttributeEnabled = function () {
+                  var isTopLevel = !iCollection.get('parent');
+                  return !(isTopLevel && DG.DataContextUtilities.isTopLevelReorgPrevented(iContext));
+                },
+
                 makeNewAttribute = function() {
                   var position = 1; // Just after the first attribute
                   DG.DataContextUtilities.newAttribute(iContext,
@@ -451,7 +456,7 @@ DG.React.ready(function () {
                   attributeIsEditableCallback: formulaIsEditable,
                   attributeCanBeRandomizedCallback: attributeCanBeRandomized,
                   rerandomizeCallback: rerandomizeAttribute,
-                  newAttributeCallback: makeNewAttribute,
+                  newAttributeCallback: isNewAttributeEnabled() ? makeNewAttribute : null,
                   cellLeaveCallback: handleCellLeave
                 }),
                 tValueField = iShouldSummarize ?

--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -864,7 +864,7 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
       var dataContext = this.get('dataContext');
       var isTopLevelDrop = !this.get('hasParentCollection');
       return DG.DataContextUtilities
-                .canAcceptAttributeDrop(dataContext, attr, isTopLevelDrop);
+                .canAcceptAttributeDrop(dataContext, attr, isTopLevelDrop, true);
     }
 
   }; // end return from closure

--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -296,7 +296,7 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
         firstCollection = context && context.getCollectionAtIndex( 0),
         firstCollectionID = firstCollection && firstCollection.get('id');
     return collectionID !== firstCollectionID;
-  },
+  }.property(),
 
   /**
     The number of visible rows in the table, that is the number of rows adjusted
@@ -851,46 +851,20 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
      * Returns whether the attribute can be dropped in the case table associated
      * with this adapter.
      *
-     * If the attribute is a part of this collection, then the it may be dropped
-     * if the context is not owned by a game-based interactive
-     *
-     * If the attribute is a part of a collection in this context, but not this
-     * collection it may be dropped if it is not owned by any data interactive.
-     *
-     * If the attribute is a part of another context, then it may not be dropped.
+     * Drop is disabled if any of the following are true
+     *   (a) the dataContext prevents the drop
+     *   (b) the dragged attribute is from another dataContext,
+     *   (c) the plugin prevents the drop
+     * see DG.DataContextUtilities.canAcceptDrop() for details
      *
      * @param attr
      * @returns {boolean}
      */
     canAcceptDrop: function (attr) {
-      var canAcceptDrop = false;
-      var tContext = this.get('dataContext');
-      var ownedByGame = tContext.get('hasGameInteractive');
-      var attrCollection = attr.collection;
-      var attributeInOtherDataSet = SC.none(tContext.getCollectionByID(attrCollection.id));
-      var attributeInThisCollection = !SC.none(this.collection.getAttributeByID(attr.get('id')));
-      var preventReorgFlag = tContext.get('preventReorg');
-      var dataInteractiveController
-          = tContext.get('owningDataInteractive');
-      // Figure out if we can accept an attribute drop. Assume false.
-      // (a) We can never accept drop if data context is owned by a game-api-plugin
-      // (b) We can never accept drop if the attribute is owned by another data context.
-      // (c) We can always accept a drop if the attribute is owned by the context and
-      //     the context is not owned by a plugin
-      // (d) Otherwise, if the attribute is owned by the context and the context is owned
-      //     by a modern plugin then we can accept the drop if the attribute is owned
-      //     by our collection or 'preventDataContextReorg' is false for the owning plugin
-      // (e) We can never accept drop if data context has preventReorg flag
-      if (!preventReorgFlag && !attributeInOtherDataSet && !ownedByGame) {
-        if (attributeInThisCollection) {
-          canAcceptDrop = true;
-        } else {
-          canAcceptDrop = SC.none(dataInteractiveController) ||
-              !dataInteractiveController.get('preventDataContextReorg');
-        }
-      }
-
-      return canAcceptDrop;
+      var dataContext = this.get('dataContext');
+      var isTopLevelDrop = !this.get('hasParentCollection');
+      return DG.DataContextUtilities
+                .canAcceptAttributeDrop(dataContext, attr, isTopLevelDrop);
     }
 
   }; // end return from closure

--- a/apps/dg/components/case_table/case_table_drop_target.js
+++ b/apps/dg/components/case_table/case_table_drop_target.js
@@ -45,6 +45,12 @@ DG.CaseTableDropTarget = SC.View.extend(SC.SplitChild, (function () {
         layout: { width: 50 },
 
         /**
+         * Is the top-level drop target
+         * @type {Boolean}
+         */
+        isTopLevel: false,
+
+        /**
          * This is a drop target.
          * @type {boolean}
          */
@@ -53,23 +59,17 @@ DG.CaseTableDropTarget = SC.View.extend(SC.SplitChild, (function () {
         }.property(),
 
         /**
-         * Drop is _not_ active if any of the following are true
-         *   (a) the dateContext 'preventReorg' flag is set,
-         *   (b) the dragged attribute is for another dataContext,
-         *   (c) the dataContext has is owned by a plugin using the game API,
-         *   (d) or is owned by a modern plugin that sets preventDataContextReorg.
+         * Drop is disabled if any of the following are true
+         *   (a) the dataContext prevents the drop
+         *   (b) the dragged attribute is from another dataContext,
+         *   (c) the plugin prevents the drop
+         * see DG.DataContextUtilities.canAcceptDrop() for details
          */
         isDropEnabled: function () {
-          var dataInteractiveController = this.dataContext.get('owningDataInteractive');
-          var hasGameInteractive = this.dataContext.get('hasGameInteractive');
-          var preventReorgFlag = this.dataContext.get('preventReorg');
           var dragAttribute = this.get('dragAttribute');
-          var ownsThisAttribute = dragAttribute && !SC.none(this.dataContext.getCollectionByID(dragAttribute.collection.id));
-          var preventReorg = preventReorgFlag ||
-              !ownsThisAttribute ||
-              hasGameInteractive ||
-              (dataInteractiveController && dataInteractiveController.get('preventDataContextReorg'));
-          return !preventReorg;
+          var isTopLevelDrop = this.get('isTopLevel');
+          return DG.DataContextUtilities
+                    .canAcceptAttributeDrop(this.dataContext, dragAttribute, isTopLevelDrop);
         }.property('dragAttribute'),
 
         isDropEnabledDidChange: function () {

--- a/apps/dg/components/case_table/case_table_view.js
+++ b/apps/dg/components/case_table/case_table_view.js
@@ -363,10 +363,16 @@ DG.CaseTableView = SC.View.extend( (function() // closure
 
     newAttrButtonView: DG.ImageView.extend({
       classNames: ['dg-floating-plus'],
+      classNameBindings: ['disabled'],
       layout: { top: 0, right: 0, width: 22, height: 22 },
       // https://www.materialui.co/icon/add-circle
       value: static_url('images/add_circle_grey_72x72.png'),
       tooltip: 'DG.TableController.newAttributeTooltip'.loc(),
+      disabled: function() {
+        var context = this.getPath('parentView.gridAdapter.dataContext');
+        var isTopLevel = !this.getPath('parentView.gridAdapter.hasParentCollection');
+        return isTopLevel && DG.DataContextUtilities.isTopLevelReorgPrevented(context);
+      }.property(),
       didAppendToDocument: function() {
         sc_super();
 

--- a/apps/dg/components/case_table/hier_table_view.js
+++ b/apps/dg/components/case_table/hier_table_view.js
@@ -574,6 +574,7 @@ DG.HierTableView = SC.ScrollView.extend( (function() {
       if (SC.none(this.leftDropTarget)) {
         this.leftDropTarget = DG.CaseTableDropTarget.create({
           name:'leftTarget',
+          isTopLevel: true,
           dataContext: this.model.get('context')
         });
       }

--- a/apps/dg/components/data_interactive/data_interactive_model.js
+++ b/apps/dg/components/data_interactive/data_interactive_model.js
@@ -55,6 +55,11 @@ DG.DataInteractiveModel = SC.Object.extend(/** @scope DG.DataInteractiveModel.pr
   /**
    * @type {boolean}
    */
+  preventTopLevelReorg: false,
+
+  /**
+   * @type {boolean}
+   */
   externalUndoAvailable: false,
 
   /**

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -503,17 +503,14 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
               diModel.set('dimensions', iValues.dimensions);
             if (!SC.none(iValues.cannotClose))
               diComponent.set('cannotClose', iValues.cannotClose);
-            if (!SC.none(iValues.preventBringToFront)) {
-              // Todo 7/2016: we should be managing this value in the model only,
-              // and deriving the value in the controller.
-              this.controller.set('preventBringToFront', iValues.preventBringToFront);
+            if (iValues.preventBringToFront != null) {
               diModel.set('preventBringToFront', iValues.preventBringToFront);
             }
-            if (!SC.none(iValues.preventDataContextReorg)) {
-              // Todo 7/2016: we should be managing this value in the model only,
-              // and deriving the value in the controller.
-              this.controller.set('preventDataContextReorg', iValues.preventDataContextReorg);
+            if (iValues.preventDataContextReorg != null) {
               diModel.set('preventDataContextReorg', iValues.preventDataContextReorg);
+            }
+            if (iValues.preventTopLevelReorg != null) {
+              diModel.set('preventTopLevelReorg', iValues.preventTopLevelReorg);
             }
           }
 
@@ -535,6 +532,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           tReturnValues.dimensions = diModel.get('dimensions');
           tReturnValues.preventBringToFront = diModel.get('preventBringToFront');
           tReturnValues.preventDataContextReorg = diModel.get('preventDataContextReorg');
+          tReturnValues.preventTopLevelReorg = diModel.get('preventTopLevelReorg');
           // if embedded mode, set externalUndoAvailable, if standalone mode,
           // set standaloneUndoModeAvailable.
           tReturnValues.externalUndoAvailable = !DG.STANDALONE_MODE;

--- a/apps/dg/components/game/game_controller.js
+++ b/apps/dg/components/game/game_controller.js
@@ -88,14 +88,39 @@ DG.GameController = DG.ComponentController.extend(
        * As of build ~0428 we allow data interactives to come to the front like any other component
        * @type {boolean}
        */
-      preventBringToFront: false,
+      preventBringToFront: function(key, value) {
+        var path = 'model.content.preventBringToFront';
+        if (value != null) {
+          this.setPath(path, value);
+        }
+        return this.getPath(path);
+      }.property(),
 
       /**
        * If true, prevent collection reorganization for this data interactive's
        * data context.
-       *
+       * @type {boolean}
        */
-      preventDataContextReorg: true,
+      preventDataContextReorg: function(key, value) {
+        var path = 'model.content.preventDataContextReorg';
+        if (value != null) {
+          this.setPath(path, value);
+        }
+        return this.getPath(path);
+      }.property(),
+
+      /**
+       * If true, prevent collection reorganization for the top level of this
+       * data interactive's data context.
+       * @type {boolean}
+       */
+      preventTopLevelReorg: function(key, value) {
+        var path = 'model.content.preventTopLevelReorg';
+        if (value != null) {
+          this.setPath(path, value);
+        }
+        return this.getPath(path);
+      }.property(),
 
       init: function () {
         sc_super();
@@ -301,6 +326,7 @@ DG.GameController = DG.ComponentController.extend(
           tStorage.currentGameUrl = tStorage.currentGameUrl || this.getPath('context.gameUrl');
           tStorage.preventBringToFront = this.get('preventBringToFront');
           tStorage.preventDataContextReorg = this.get('preventDataContextReorg');
+          tStorage.preventTopLevelReorg = this.get('preventTopLevelReorg');
         }
 
         var dataContext = this.get('context');
@@ -363,6 +389,7 @@ DG.GameController = DG.ComponentController.extend(
           this.setPath('context.gameUrl', gameUrl);
           this.set('preventBringToFront', iComponentStorage.preventBringToFront);
           this.set('preventDataContextReorg', iComponentStorage.preventDataContextReorg);
+          this.set('preventTopLevelReorg', iComponentStorage.preventTopLevelReorg);
         }
 
         // If there are user-created formulas to restore, set them in the

--- a/apps/dg/utilities/data_context_utilities.js
+++ b/apps/dg/utilities/data_context_utilities.js
@@ -31,9 +31,12 @@ DG.DataContextUtilities = {
    * @param iDataContext    {DG.DataContext} The DataContext receiving the drop
    * @param iAttribute      {DG.Attribute} The attribute being dragged
    * @param isTopLevelDrop  {Boolean} Whether the proposed drop target is top-level
+   * @param allowTopLevelAttrs {Boolean} Whether to allow drops of top-level attrs,
+   *                        which could indicate a desire to rearrange top-level attrs
+   *                        without changing the collection hierarchy.
    * @returns {Boolean}   Whether the drop should be accepted
    */
-  canAcceptAttributeDrop: function(iDataContext, iAttribute, isTopLevelDrop) {
+  canAcceptAttributeDrop: function(iDataContext, iAttribute, isTopLevelDrop, allowTopLevelAttrs) {
     // check whether DataContext prevents reorganization
     if (iDataContext.get('hasGameInteractive') || iDataContext.get('preventReorg'))
       return false;
@@ -52,8 +55,12 @@ DG.DataContextUtilities = {
     var pluginPreventsTopLevelReorg = pluginController &&
                                         pluginController.get('preventTopLevelReorg');
     var isTopLevelDragAttr = iAttribute && !iAttribute.getPath('collection.parent');
-    if (pluginPreventsTopLevelReorg && (isTopLevelDragAttr || isTopLevelDrop))
-      return false;
+    if (pluginPreventsTopLevelReorg) {
+      if (isTopLevelDragAttr && isTopLevelDrop && allowTopLevelAttrs)
+        return true;
+      if (isTopLevelDragAttr || isTopLevelDrop)
+        return false;
+    }
 
     // otherwise, we accept the drop
     return true;

--- a/apps/dg/utilities/data_context_utilities.js
+++ b/apps/dg/utilities/data_context_utilities.js
@@ -22,6 +22,11 @@
 
 DG.DataContextUtilities = {
 
+  isTopLevelReorgPrevented: function(iDataContext) {
+    var pluginController = iDataContext.get('owningDataInteractive');
+    return !!pluginController && pluginController.get('preventTopLevelReorg');
+  },
+
   /**
    * Drop is disabled if any of the following are true
    *   (a) the dataContext prevents the drop

--- a/apps/dg/utilities/data_context_utilities.js
+++ b/apps/dg/utilities/data_context_utilities.js
@@ -22,6 +22,43 @@
 
 DG.DataContextUtilities = {
 
+  /**
+   * Drop is disabled if any of the following are true
+   *   (a) the dataContext prevents the drop
+   *   (b) the dragged attribute is from another dataContext,
+   *   (c) the plugin prevents the drop
+   *
+   * @param iDataContext    {DG.DataContext} The DataContext receiving the drop
+   * @param iAttribute      {DG.Attribute} The attribute being dragged
+   * @param isTopLevelDrop  {Boolean} Whether the proposed drop target is top-level
+   * @returns {Boolean}   Whether the drop should be accepted
+   */
+  canAcceptAttributeDrop: function(iDataContext, iAttribute, isTopLevelDrop) {
+    // check whether DataContext prevents reorganization
+    if (iDataContext.get('hasGameInteractive') || iDataContext.get('preventReorg'))
+      return false;
+
+    // we can't reorganize drops of attributes from another DataContext
+    var ownsThisAttribute = iAttribute &&
+                              !SC.none(iDataContext.getCollectionByID(iAttribute.collection.id));
+    if (!ownsThisAttribute) return false;
+
+    // check whether plugin prevents all reorganization
+    var pluginController = iDataContext.get('owningDataInteractive');
+    if (pluginController && pluginController.get('preventDataContextReorg'))
+      return false;
+
+    // check whether plugin prevents top-level reorganization
+    var pluginPreventsTopLevelReorg = pluginController &&
+                                        pluginController.get('preventTopLevelReorg');
+    var isTopLevelDragAttr = iAttribute && !iAttribute.getPath('collection.parent');
+    if (pluginPreventsTopLevelReorg && (isTopLevelDragAttr || isTopLevelDrop))
+      return false;
+
+    // otherwise, we accept the drop
+    return true;
+  },
+
   updateAttribute: function (iContext, iCollection, iAttribute, iChangedAttrProps) {
     var tOldAttrProps = {
       id: iAttribute.get('id'),


### PR DESCRIPTION
Provides a mechanism for a plugin to indicate that collection reorganization is allowed generally, but not for the top-level collection. This is used by the shared table plugin to guarantee that the share names remain the top-level collection.

@jsandoe After our conversation, I added two more commits to enable rearranging attributes within the top-level collection if there are multiple attributes and to disable adding attributes to the top-level collection in the case card and the case table.

cf. [PT #165199713](https://www.pivotaltracker.com/story/show/165199713)