### PR TITLE
Eliminate spurious "Unhandled operation: updateItems" warning

### DIFF
--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -398,10 +398,12 @@ DG.CaseTableController = DG.ComponentController.extend(
             this.dataContextWasDeleted();
             break;
           case 'createItems':
-            // Nothing to do here because we'll come back around to do createCases
+          case 'updateItems':
+          case 'deleteItems':
+            // Nothing to do here because we'll receive corresponding case notifications
             break;
           default:
-            DG.logWarn('Unhandled operation: ' + iChange.operation);
+            DG.logWarn("DG.CaseTableController -- Unhandled operation: " + iChange.operation);
           }
         }.bind( this);
 


### PR DESCRIPTION
Minor code cleanup that didn't fit naturally in other PRs:
- CaseTableController need not respond separately to updateItems (or deleteItems) notification
- Clarify source of warning in message to reduce future confusion