### PR TITLE
Fix reload document bugs

### DIFF
--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -285,6 +285,14 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
       this.dataContextDidChange();
   },
 
+  destroy: function() {
+    if (this.gridDataView) {
+      this.gridDataView.destroy();
+      this.gridDataView = null;
+    }
+    sc_super();
+  },
+
   /**
     Returns true if this adapter's collection has a parent collection,
     false if it is the most senior collection, i.e. has no parent.

--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -375,6 +375,7 @@ DG.CaseTableController = DG.CaseDisplayController.extend(
           case 'deleteDataContext':
             this.dataContextWasDeleted();
             break;
+          case 'updateDataContext':
           case 'createItems':
           case 'updateItems':
           case 'deleteItems':

--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -106,7 +106,9 @@ DG.CaseTableController = DG.CaseDisplayController.extend(
             collectionRecords = dataContext && dataContext.get('collections') || [],
             // The controller model is a component object. We want the model for the
             // component's content.
-            caseTableModel = this.model && this.model.get('content');
+            caseTableModel = this.model && this.model.get('content'),
+            // new array to capture adapter order
+            newAdapters = [];
 
         // Utility function for finding or creating (if necessary) an appropriate
         // adapter for the specified collection.
@@ -122,12 +124,12 @@ DG.CaseTableController = DG.CaseDisplayController.extend(
               collection: collection,
               model: caseTableModel
             });
-            // add the new adapter to the adapter array
-            this.caseTableAdapters.push( adapter);
           }
+          newAdapters.push(adapter);
         }.bind(this);
 
         collectionRecords.forEach( guaranteeAdapterForCollectionRecord);
+        this.set('caseTableAdapters', newAdapters);
       },
 
       /**

--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -104,12 +104,9 @@ DG.CaseTableController = DG.CaseDisplayController.extend(
       updateTableAdapters: function() {
         var dataContext = this.get('dataContext'),
             collectionRecords = dataContext && dataContext.get('collections') || [],
-            newAdapters = [],
             // The controller model is a component object. We want the model for the
             // component's content.
             caseTableModel = this.model && this.model.get('content');
-
-        this.caseTableAdapters = newAdapters;
 
         // Utility function for finding or creating (if necessary) an appropriate
         // adapter for the specified collection.
@@ -125,10 +122,9 @@ DG.CaseTableController = DG.CaseDisplayController.extend(
               collection: collection,
               model: caseTableModel
             });
-
+            // add the new adapter to the adapter array
+            this.caseTableAdapters.push( adapter);
           }
-          // add the new/found adapter to the adapter array
-          newAdapters.push( adapter);
         }.bind(this);
 
         collectionRecords.forEach( guaranteeAdapterForCollectionRecord);

--- a/apps/dg/components/case_table/case_table_data_manager.js
+++ b/apps/dg/components/case_table/case_table_data_manager.js
@@ -62,10 +62,10 @@ DG.CaseTableDataManager = SC.Object.extend({
   _rowCaseMap: null,
 
   /**
-   * Map from collection ID to proto-case. Map is shared among all instances.
+   * Map from collection ID to proto-case.
    * @type {Object}
    */
-  _protoCases: {},
+  _protoCases: null,
 
   /**
    *
@@ -78,6 +78,7 @@ DG.CaseTableDataManager = SC.Object.extend({
 
   init: function () {
     this._rowCaseMap = [];
+    this._protoCases = {};
     this.onRowCountChanged = new Slick.Event();
     this.onRowsChanged = new Slick.Event();
   },

--- a/apps/dg/components/case_table/case_table_view.js
+++ b/apps/dg/components/case_table/case_table_view.js
@@ -1191,7 +1191,10 @@ DG.CaseTableView = SC.View.extend( (function() // closure
       Destroys the SlickGrid object, its DataView object, and the CaseTableAdapter.
      */
     _destroy: function() {
-      this.scrollAnimator.destroy();
+      if (this.scrollAnimator) {
+        this.scrollAnimator.destroy();
+        this.scrollAnimator = null;
+      }
       this.destroySlickGrid();
 
       if( this.gridAdapter)
@@ -2202,10 +2205,11 @@ DG.CaseTableView = SC.View.extend( (function() // closure
       var viewportHeight = viewport.bottom - viewport.top - 1;
       var dataView = this.getPath('gridAdapter.gridDataView');
       var rightTable = this.get('childTable');
-      var rightViewport = rightTable.get('gridViewport');
-      var rightDataView = rightTable.getPath('gridAdapter.gridDataView');
+      var rightViewport = rightTable && rightTable.get('gridViewport');
+      var rightDataView = rightTable && rightTable.getPath('gridAdapter.gridDataView');
       var didScroll = false;
-      if (dataView.getLength() === 0 || rightDataView.getLength() === 0) {
+      if (!dataView || (dataView.getLength() === 0) ||
+          !rightDataView || (rightDataView.getLength() === 0)) {
         // nothing to do
         return false;
       }

--- a/apps/dg/components/case_table/hier_table_view.js
+++ b/apps/dg/components/case_table/hier_table_view.js
@@ -670,14 +670,16 @@ DG.HierTableView = SC.ScrollView.extend( (function() {
       }
       DG.assert(collectionClient.constructor === DG.CollectionClient, 'Correct type');
       var view = this.findViewForCollection(collectionClient);
-      view.scrollToCase(caseID);
+      if (view)
+        view.scrollToCase(caseID);
     },
 
     findViewForCollection: function (iCollection) {
+      var collectionID = iCollection.get('id');
       var childTableViews = this.get('childTableViews') || [];
       return childTableViews.find(function (childTableView) {
         var viewCollection = childTableView.getPath('gridAdapter.collection');
-        return viewCollection === iCollection;
+        return viewCollection.get('id') === collectionID;
       });
     }
   }; // end return from closure

--- a/apps/dg/components/data_interactive/notification_manager.js
+++ b/apps/dg/components/data_interactive/notification_manager.js
@@ -147,9 +147,11 @@ DG.NotificationManager = SC.Object.extend(/** @scope DG.NotificationManager.prot
             switch (k) {
               case 'success':
               case 'properties':
-              case 'caseIDs':
-              case 'caseID':
               case 'attrIDs':
+              case 'caseID':
+              case 'caseIDs':
+              case 'itemID':
+              case 'itemIDs':
                 result[k] = v;
                 break;
               case 'collection':


### PR DESCRIPTION
In working with shared tables, Sam and I encountered a situation in which re-loading a document would result in inability to add new items to the table (cf. [CODAP Shared Table Plugin #23](https://github.com/concord-consortium/codap-shared-table-plugin/pull/23)). Debugging this turned into something of an odyssey that involved excursions into multiple rabbit holes that seemed relevant but ultimately proved unrelated -- Why are we generating duplicate case table views and case table adapters and could that be causing the problem? Why are we getting these warning messages in the console and could they be indicating something relevant? In the end, each of the seven commits in this PR fix one or more separate issues including the one that actually mattered -- the `CaseTableDataManager` sharing ProtoCases across document instances. I do not understand precisely why the shared tables feature triggered all of these issues, but hope to discuss that with @jsandoe .

@jsandoe Based on the above, review is probably best done commit-by-commit and synchronous review probably makes sense. Individual commit comments often have details on the motivation for the change.

cf. [PT #165201891](https://www.pivotaltracker.com/story/show/165201891)