### PR TITLE
Support ability for plugin to control editability of cases in the case table

### DIFF
--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -439,12 +439,14 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
   },
 
   isCellEditable: function(row, column) {
-    var //dataView = this.get('gridDataView'),
-        //dataItem = dataView.getItem(row),
+    var dataView = this.get('gridDataView'),
+        dataContext = this.get('dataContext'),
+        aCase = dataView.getItem(row),
         colInfo = this.gridColumns[column],
         attr = colInfo && colInfo.attribute,
-        attrIsEditable = attr && attr.get('editable') && !attr.get('hasFormula');
-    return attrIsEditable;
+        attrIsEditable = attr && attr.get('editable') && !attr.get('hasFormula'),
+        caseIsEditable = DG.DataContextUtilities.isCaseEditable(dataContext, aCase);
+    return attrIsEditable && caseIsEditable;
   },
 
   isCellRowSelectable: function(row, column) {

--- a/apps/dg/components/case_table/case_table_view.js
+++ b/apps/dg/components/case_table/case_table_view.js
@@ -372,7 +372,10 @@ DG.CaseTableView = SC.View.extend( (function() // closure
         var context = this.getPath('parentView.gridAdapter.dataContext');
         var isTopLevel = !this.getPath('parentView.gridAdapter.hasParentCollection');
         return isTopLevel && DG.DataContextUtilities.isTopLevelReorgPrevented(context);
-      }.property(),
+      }.property('_dataContextDidChange'),
+      dataContextDidChange: function() {
+        this.notifyPropertyChange('_dataContextDidChange');
+      }.observes('parentView.gridAdapter.dataContext.metadataChangeCount'),
       didAppendToDocument: function() {
         sc_super();
 

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -688,11 +688,12 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
         update: function (iResources, iValues) {
           var context = iResources.dataContext;
           if (context) {
-            ['title', 'description','preventReorg'].forEach(function (prop) {
-              if (!SC.none(iValues[prop])) {
-                context.set(prop, iValues[prop]);
-              }
-            });
+            ['managingController', 'title', 'description', 'preventReorg']
+              .forEach(function (prop) {
+                if (!SC.none(iValues[prop])) {
+                  context.set(prop, iValues[prop]);
+                }
+              });
           }
           return {
             success: true

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -31,6 +31,11 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
        */
       controller: null,
 
+      modelProps: ['version', 'dimensions',
+                  'preventBringToFront', 'preventDataContextReorg', 'preventTopLevelReorg',
+                  'preventAttributeDeletion', 'allowEmptyAttributeDeletion',
+                  'respectEditableItemAttribute'],
+
       /**
        * We need to be able to set title.
        */
@@ -496,28 +501,16 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
             if (!SC.none(title) && !userSetTitle) {
               diModel.set('title', title);
             }
-
-            if (iValues.version != null)
-              diModel.set('version', iValues.version);
-            if (iValues.dimensions)
-              diModel.set('dimensions', iValues.dimensions);
-            if (!SC.none(iValues.cannotClose))
+            if (iValues.cannotClose != null) {
               diComponent.set('cannotClose', iValues.cannotClose);
-            if (iValues.preventBringToFront != null) {
-              diModel.set('preventBringToFront', iValues.preventBringToFront);
             }
-            if (iValues.preventDataContextReorg != null) {
-              diModel.set('preventDataContextReorg', iValues.preventDataContextReorg);
-            }
-            if (iValues.preventTopLevelReorg != null) {
-              diModel.set('preventTopLevelReorg', iValues.preventTopLevelReorg);
-            }
-            if (iValues.preventAttributeDeletion != null) {
-              diModel.set('preventAttributeDeletion', iValues.preventAttributeDeletion);
-            }
-            if (iValues.allowEmptyAttributeDeletion != null) {
-              diModel.set('allowEmptyAttributeDeletion', iValues.allowEmptyAttributeDeletion);
-            }
+
+            var props = this.get('modelProps');
+            props.forEach(function(prop) {
+              if (iValues[prop] != null) {
+                diModel.set(prop, iValues[prop]);
+              }
+            });
           }
 
           return {
@@ -534,13 +527,12 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           var tReturnValues = {};
           tReturnValues.id = this.get('id');
           tReturnValues.title = diModel.get('title');
-          tReturnValues.version = diModel.get('version');
-          tReturnValues.dimensions = diModel.get('dimensions');
-          tReturnValues.preventBringToFront = diModel.get('preventBringToFront');
-          tReturnValues.preventDataContextReorg = diModel.get('preventDataContextReorg');
-          tReturnValues.preventTopLevelReorg = diModel.get('preventTopLevelReorg');
-          tReturnValues.preventAttributeDeletion = diModel.get('preventAttributeDeletion');
-          tReturnValues.allowEmptyAttributeDeletion = diModel.get('allowEmptyAttributeDeletion');
+
+          var props = this.get('modelProps');
+          props.forEach(function(prop) {
+            tReturnValues[prop] = diModel.get(prop);
+          });
+
           // if embedded mode, set externalUndoAvailable, if standalone mode,
           // set standaloneUndoModeAvailable.
           tReturnValues.externalUndoAvailable = !DG.STANDALONE_MODE;

--- a/apps/dg/components/game/game_controller.js
+++ b/apps/dg/components/game/game_controller.js
@@ -86,7 +86,8 @@ DG.GameController = DG.ComponentController.extend(
        * List of properties stored to/restored from component storage.
        */
       storedProperties: ['preventBringToFront', 'preventDataContextReorg', 'preventTopLevelReorg',
-                          'preventAttributeDeletion', 'allowEmptyAttributeDeletion'],
+                          'preventAttributeDeletion', 'allowEmptyAttributeDeletion',
+                          'respectEditableItemAttribute'],
 
       /**
        * If false, permit the data interactive to participate in normal component
@@ -139,6 +140,17 @@ DG.GameController = DG.ComponentController.extend(
        */
       allowEmptyAttributeDeletion: function(key, value) {
         var path = 'model.content.allowEmptyAttributeDeletion';
+        if (value != null) this.setPath(path, value);
+        return this.getPath(path);
+      }.property(),
+
+      /**
+       * If true, the case table should respect the item/case editable
+       * indicated by the hidden '__editable__' attribute
+       * @type {boolean}
+       */
+      respectEditableItemAttribute: function(key, value) {
+        var path = 'model.content.respectEditableItemAttribute';
         if (value != null) this.setPath(path, value);
         return this.getPath(path);
       }.property(),

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -33,7 +33,7 @@
 DG.DataContext = SC.Object.extend((function() // closure
 /** @scope DG.DataContext.prototype */ {
   /**
-   * Returns an integer constrained within the specified limits including the max.
+ * Returns an integer constrained within the specified limits including the max.
    * If undefined, returns the max value.
    * @param {number|undefined} num
    * @param {number} min // assumed an integer
@@ -53,6 +53,12 @@ DG.DataContext = SC.Object.extend((function() // closure
    *  @property {String}
    */
   type: 'DG.DataContext',
+
+  /**
+   *  The id of the DG.GameController | DG.ComponentController that manages this context.
+   *  @property {string}
+   */
+  _managingControllerID: null,
 
   /**
    *  The DG.DataContextRecord for which this is the controller.
@@ -250,7 +256,7 @@ DG.DataContext = SC.Object.extend((function() // closure
   _collectionClients: null,
 
   /**
-   * Whether there are Data Interactives for which are affiliated with this
+   * Whether there are Data Interactives which are affiliated with this
    * data context.
    * @type {boolean}
    */
@@ -272,6 +278,30 @@ DG.DataContext = SC.Object.extend((function() // closure
     }.bind(this));
     DG.assert(SC.none(found) || found.constructor === DG.GameController, "Found Game Controller");
     return found;
+  }.property(),
+
+  /**
+   * Returns the Data Interactive which manages this data context.
+   * May be generalized to support affiliation with other components at some point.
+   * @type {DG.GameController}
+   */
+  managingController: function (key, value) {
+    if (value != null) {
+      this._managingControllerID = value;
+    }
+
+    // if no manager specified, default to owner
+    if (this._managingControllerID == null)
+      return this.get('owningDataInteractive');
+
+    // search for manager
+    var dataInteractives = DG.currDocumentController().get('dataInteractives');
+    return dataInteractives &&
+            DG.ObjectMap.values(dataInteractives)
+              .find(function (dataInteractive) {
+                var id = (dataInteractive.getPath('model.id'));
+                return ((id != null) && (id === this._managingControllerID));
+              }.bind(this));
   }.property(),
 
   /**

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -1086,6 +1086,7 @@ DG.DataContext = SC.Object.extend((function() // closure
   doUpdateCasesFromHashOfNameValues: function (iChange) {
     var cases = iChange.cases;
     var success = true;
+    var attrs = {};
     var caseIDs = [];
     cases.forEach(function (iCase, iCaseIx) {
       var values = iChange.values[iCaseIx];
@@ -1096,6 +1097,7 @@ DG.DataContext = SC.Object.extend((function() // closure
           var attr = this.getAttributeByName(key)
               || this.getAttributeByName(this.canonicalizeName(key));
           if (attr) {
+            attrs[attr.id] = attr;
             iCase.setValue(attr.id, value);
           } else {
             DG.logWarn('DataContext.doUpdateCasesFromHashOfNameValues: Cannot resolve attribute: ' + key);
@@ -1105,6 +1107,13 @@ DG.DataContext = SC.Object.extend((function() // closure
         iCase.endCaseValueChanges();
       }
     }.bind(this));
+
+    var attrNodes = [];
+    DG.ObjectMap.forEach(attrs, function(id, attr) {
+      attrNodes.push({ type: DG.DEP_TYPE_ATTRIBUTE, id: attr.id, name: attr.get('name') });
+    });
+    this.invalidateDependentsAndNotify(attrNodes, iChange);
+
     return { success: success, caseIDs: caseIDs};
   },
 

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -1453,8 +1453,6 @@ DG.DataContext = SC.Object.extend((function() // closure
     });
     results = this.regenerateCollectionCases();
 
-    // We should never be deleting cases while creating items.
-    DG.assert(results && (!results.deletedCases || results.deletedCases.length === 0), 'Unexpected deleted cases');
     results.createdCases.forEach(function (iCase) {
       var collectionID = iCase.collection.get('id');
       var collectionCases = collectionIDCaseMap[collectionID];

--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -124,6 +124,14 @@ DG.DataContext = SC.Object.extend((function() // closure
   selectionChangeCount: 0,
 
   /**
+   * The number of metadata changes that have occurred.
+   * Clients can observe this to be notified of metadata changes.
+   * Initially triggered only by the 'managingController' property.
+   * @property  {Number}
+   */
+  metadataChangeCount: 0,
+
+  /**
     Array of change objects that have been applied to/by this data context.
     Newly-applied changes are appended to the array, so the most recent changes
     are at the end.
@@ -288,6 +296,7 @@ DG.DataContext = SC.Object.extend((function() // closure
   managingController: function (key, value) {
     if (value != null) {
       this._managingControllerID = value;
+      this.incrementProperty('metadataChangeCount');
     }
 
     // if no manager specified, default to owner

--- a/apps/dg/models/data_item.js
+++ b/apps/dg/models/data_item.js
@@ -72,7 +72,7 @@ DG.DataItem = SC.Object.extend({
     var tCase;
     if (attr.hasFormula()) {
       tCase = DG.Case.findCase(attr.collection.id, this.id);
-      return (tCase.getRawValue(attributeID));
+      return (tCase && tCase.getRawValue(attributeID));
     } else {
       return this.values[attributeID];
     }

--- a/apps/dg/utilities/data_context_utilities.js
+++ b/apps/dg/utilities/data_context_utilities.js
@@ -23,7 +23,7 @@
 DG.DataContextUtilities = {
 
   isTopLevelReorgPrevented: function(iDataContext) {
-    var pluginController = iDataContext.get('owningDataInteractive');
+    var pluginController = iDataContext.get('managingController');
     return !!pluginController && pluginController.get('preventTopLevelReorg');
   },
 
@@ -41,7 +41,7 @@ DG.DataContextUtilities = {
   isAttributeDeletable: function(iDataContext, iAttribute) {
     if (!iAttribute.get('deleteable')) return false;
 
-    var pluginController = iDataContext.get('owningDataInteractive');
+    var pluginController = iDataContext.get('managingController');
     var pluginPreventsTopLevelReorg = !!pluginController &&
                                             pluginController.get('preventTopLevelReorg');
     var isTopLevelAttribute = !iAttribute.getPath('collection.parent');
@@ -69,7 +69,7 @@ DG.DataContextUtilities = {
     // we don't disable rows that don't correspond to cases, e.g. proto-case rows
     if (!iCase) return true;
     // is the plugin controlling editability?
-    var pluginController = iDataContext.get('owningDataInteractive');
+    var pluginController = iDataContext.get('managingController');
     var pluginRespectsEditableAttribute = pluginController && pluginController.get('respectEditableItemAttribute');
     if (!pluginRespectsEditableAttribute) return true;
     // do we have an __editable__ attribute?
@@ -118,7 +118,7 @@ DG.DataContextUtilities = {
     if (!ownsThisAttribute) return false;
 
     // check whether plugin prevents all reorganization
-    var pluginController = iDataContext.get('owningDataInteractive');
+    var pluginController = iDataContext.get('managingController');
     if (pluginController && pluginController.get('preventDataContextReorg'))
       return false;
 


### PR DESCRIPTION
In consultation with @jsandoe , the approach taken here is:
1. Add a hidden `__editable__` attribute at the top-level with a formula that sets the value of the attribute according to the contents of the `__collaborator__` attribute.
2. Set the value of the `managingController` property for any DataContext we're sharing.
3. Set the value of the `respectEditableItemAttribute` property on the plugin
4. Case table checks value of `__editable__` property when appropriate to determine row editability.

The result is that the "special" properties enabled by the plugin/GameController (`preventDataContextReorg`, ..., `respectEditableItemAttribute`) are only enabled while the collection is being shared.

Note: along the way I fixed a dependency management bug -- one of the `updateCases` paths wasn't performing the required dependency invalidation.

cf. [SharedTable PR#28](https://github.com/concord-consortium/codap-shared-table-plugin/pull/28)