### PR TITLE
Fixes crash when opening Markov sample document [#165403555]

### DIFF
--- a/apps/dg/controllers/app_controller.js
+++ b/apps/dg/controllers/app_controller.js
@@ -118,7 +118,7 @@ DG.appController = SC.Object.create((function () // closure
               caseTable = documentController.addCaseTable(
                   DG.mainPage.get('docView'), null,
                   {position: 'top', dataContext: dataContext});
-              selectView(caseTable.get('controller'));
+              selectView(caseTable);
             },
             undo: function () {
               removeCaseDisplay(caseTable.getPath('model.id'));


### PR DESCRIPTION
In `AppController.showCaseDisplayFor()` the code was passing a controller to the `selectView()` function which now expects a view.

The relevant code was changed in 0480 as part of synchronizing behavior between case table and data card.

Note: while this fixes the crash on creating a case table, in my local debugging the Markov Sample document still doesn't work due to apparently unrelated issues with the IFramePhone connection. It's not clear whether this is a debugging artifact or indicative of another issue. ... After further investigation it looks like it was a debugging artifact.