### PR TITLE
Prevent deletion of plugin-protected cases

### DIFF
--- a/apps/dg/components/case_table/case_table_view.js
+++ b/apps/dg/components/case_table/case_table_view.js
@@ -1594,12 +1594,14 @@ DG.CaseTableView = SC.View.extend( (function() // closure
         var hierTableView = this.get('parentView');
         hierTableView.hideHeaderMenus();
 
-        var dataItem = this._slickGrid.getDataItem(iCell.row),
+        var dataContext = this.get('dataContext'),
+            dataItem = this._slickGrid.getDataItem(iCell.row),
             isProtoCase = dataItem && dataItem._isProtoCase;
         if (iCell.cell === 0) {
           if (isProtoCase)
             this.get('gridAdapter').deselectAllCases();
-          this.showCaseIndexPopup(iEvent, iCell);
+          if (DG.DataContextUtilities.isCaseEditable(dataContext, dataItem))
+            this.showCaseIndexPopup(iEvent, iCell);
         }
       }.bind(this));
     },


### PR DESCRIPTION
PR #275 added support for the plugin to protect individual cases. In that PR, users are prevented from editing protected cells in the case table. This PR extends that protection to deletion of protected cases. This is accomplished by disabling the caseIndex popup menu entirely and by enabling/disabling items in the inspector menu appropriately and then restricting deletion to unprotected cases.

As a result of this PR, the items in the inspector menu are reinterpreted to apply to deletable cases, i.e. "Delete Selected Cases" is interpreted as "Delete [Deletable] Selected Cases" and is enabled if any selected cases are deletable. Likewise, "Delete Unselected Cases" is interpreted as "Delete [Deletable] Unselected Cases" and is enabled if any unselected cases are deletable, and "Delete All [Deletable] Cases" is enabled if any cases are deletable. In all cases, only deletable cases are deleted.

At an implementation level, previously, selected cases were determined in `DataContext.getSelectedCases()`, while unselected cases were determined in `CaseDisplayController._deleteOrSetAsideUnselectedCases()`. With this PR, `DataContext.getSelectedCases()` now optionally returns unselected cases as well, eliminating the need for the `CaseDisplayController` to do so. The `CaseDisplayController` applies the deletability filter based on the plugin-protected status of each case.

PT [#165434514](https://www.pivotaltracker.com/story/show/165434514)