### PR TITLE
Wip split plots

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1958,10 +1958,6 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
                   errorMessage = "Global not found: '%@'".loc(tValues.globalValueName);
                 }
               }
-              else {
-                component = DG.currDocumentController().createComponentAndView(DG.Component.createComponent(props));
-                errorMessage = !component && 'Component creation failed';
-              }
             }
 
             if (success && component) {

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1958,6 +1958,10 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
                   errorMessage = "Global not found: '%@'".loc(tValues.globalValueName);
                 }
               }
+              else {
+                component = DG.currDocumentController().createComponentAndView(DG.Component.createComponent(props));
+                errorMessage = !component && 'Component creation failed';
+              }
             }
 
             if (success && component) {

--- a/apps/dg/components/graph/adornments/plotted_function_model.js
+++ b/apps/dg/components/graph/adornments/plotted_function_model.js
@@ -23,59 +23,59 @@ sc_require('components/graph/adornments/plot_adornment_model');
 
 /** @class  The formula context used by the PlottedFunctionModel
 
-  @extends DG.GlobalFormulaContext
-*/
-DG.PlottedFunctionContext = DG.CollectionFormulaContext.extend((function() {
+ @extends DG.GlobalFormulaContext
+ */
+DG.PlottedFunctionContext = DG.CollectionFormulaContext.extend((function () {
 
   return {
 
-  /**
-    Set on construction: ['plottedValue' | 'plottedFunction']
-    @type {string}
-   */
-  adornmentKey: null,
+    /**
+     Set on construction: ['plottedValue' | 'plottedFunction']
+     @type {string}
+     */
+    adornmentKey: null,
 
-  /**
-    Set on construction
-    @type {DG.PlotModel}
-   */
-  plotModel: null,
+    /**
+     Set on construction
+     @type {DG.PlotModel}
+     */
+    plotModel: null,
 
-  /**
-    Utility function for identifying the name of the primary attribute.
-    @returns  {String}  the name of the variable on the primary axis
-   */
-  primaryVarName: function() {
-    var xVarID = this.getPath('plotModel.primaryVarID') || this.getPath('plotModel.xVarID'),
-        xVarAttr = xVarID && DG.Attribute.getAttributeByID(xVarID),
-        xVarName = xVarAttr && xVarAttr.get('name');
-    return !SC.empty( xVarName) ? xVarName : null;
-  }.property('plotModel'),
+    /**
+     Utility function for identifying the name of the primary attribute.
+     @returns  {String}  the name of the variable on the primary axis
+     */
+    primaryVarName: function () {
+      var xVarID = this.getPath('plotModel.primaryVarID') || this.getPath('plotModel.xVarID'),
+          xVarAttr = xVarID && DG.Attribute.getAttributeByID(xVarID),
+          xVarName = xVarAttr && xVarAttr.get('name');
+      return !SC.empty(xVarName) ? xVarName : null;
+    }.property('plotModel'),
 
-  /**
-    Utility function for identifying the name of the X-axis attribute.
-    @param    {String}    iName -- The name of the identifier being matched
-    @returns  {Boolean}   True if the identifier matches the name of the
-                            x-axis attribute, false otherwise.
-   */
-  isPrimaryVarName: function( iName) {
-    if (SC.empty(iName)) return false;
-    if (iName === this.get('primaryVarName')) return true;
-    if ((iName === 'x') && (this.get('adornmentKey') === 'plottedFunction')) return true;
-    return false;
-  }.property('primaryVarName'),
+    /**
+     Utility function for identifying the name of the X-axis attribute.
+     @param    {String}    iName -- The name of the identifier being matched
+     @returns  {Boolean}   True if the identifier matches the name of the
+     x-axis attribute, false otherwise.
+     */
+    isPrimaryVarName: function (iName) {
+      if (SC.empty(iName)) return false;
+      if (iName === this.get('primaryVarName')) return true;
+      if ((iName === 'x') && (this.get('adornmentKey') === 'plottedFunction')) return true;
+      return false;
+    }.property('primaryVarName'),
 
-  /**
-    Utility function for identifying the ID of the secondary/split attribute.
-    @returns  {String}  the ID of the variable on the secondary axis
-   */
-  groupVarID: function() {
-    // for plotted values/functions, we always want to override the default
-    // grouping by collection; therefore, if we don't have a split attribute
-    // we specify a non-falsy 'groupVarID' which will prevent the default
-    // grouping but won't actually generate values that would split into groups.
-    return this.getPath('plotModel.secondaryVarID') || -1;
-  }.property('plotModel'),
+    /**
+     Utility function for identifying the ID of the secondary/split attribute.
+     @returns  {String}  the ID of the variable on the secondary axis
+     */
+    groupVarID: function () {
+      // for plotted values/functions, we always want to override the default
+      // grouping by collection; therefore, if we don't have a split attribute
+      // we specify a non-falsy 'groupVarID' which will prevent the default
+      // grouping but won't actually generate values that would split into groups.
+      return this.getPath('plotModel.secondaryVarID') || -1;
+    }.property('plotModel'),
 
     /**
      * Return true if the given case is currently among those being plotted.
@@ -86,132 +86,133 @@ DG.PlottedFunctionContext = DG.CollectionFormulaContext.extend((function() {
     filterCase: function (iEvalContext) {
       var tResult = sc_super(),
           tCases = this.getPath('plotModel.cases');
-      return tResult && tCases.indexOf( iEvalContext._case_) >= 0;
+      return tResult && tCases.indexOf(iEvalContext._case_) >= 0;
     },
 
     /**
-    Compiles a variable reference into the JavaScript code for accessing
-    the appropriate value. For the PlottedFunctionContext, this means
-    binding to 'x' and any global values (e.g. sliders).
-    @param    {String}    iName -- The variable name to be bound
-    @returns  {String}    The JavaScript code for accessing the value
-    @throws   {VarReferenceError} Base class throws VarReferenceError for
-                                  variable names that are not recognized.
-   */
-  compileVariable: function( iName) {
-  
-    // Plotted functions can always refer to 'x' or the name of the attribute
-    // on the x-axis, either of which correspond to the value of the x-axis 
-    // for the point being evaluated. For compilation purposes, we assume 
-    // that the value is passed in by the client as part
-    // of the evaluation context.
-    if( this.isPrimaryVarName( iName)) {
-      if (this.get('adornmentKey') === 'plottedValue') {
-        // let base class handle it by attribute name
-        // cf. http://sproutcore-gyan.blogspot.com/2010/03/modify-argument-value-before-calling.html
-        iName = this.get('primaryVarName');
+     Compiles a variable reference into the JavaScript code for accessing
+     the appropriate value. For the PlottedFunctionContext, this means
+     binding to 'x' and any global values (e.g. sliders).
+     @param    {String}    iName -- The variable name to be bound
+     @returns  {String}    The JavaScript code for accessing the value
+     @throws   {VarReferenceError} Base class throws VarReferenceError for
+     variable names that are not recognized.
+     */
+    compileVariable: function (iName) {
+
+      // Plotted functions can always refer to 'x' or the name of the attribute
+      // on the x-axis, either of which correspond to the value of the x-axis
+      // for the point being evaluated. For compilation purposes, we assume
+      // that the value is passed in by the client as part
+      // of the evaluation context.
+      if (this.isPrimaryVarName(iName)) {
+        if (this.get('adornmentKey') === 'plottedValue') {
+          // let base class handle it by attribute name
+          // cf. http://sproutcore-gyan.blogspot.com/2010/03/modify-argument-value-before-calling.html
+          iName = this.get('primaryVarName');
+        }
+        else {
+          return 'e.x';
+        }
       }
-      else {
-        return 'e.x';
+
+      // If we don't match any variables we're in charge of,
+      // let the base class have a crack at it.
+      return sc_super();
+    },
+
+    /**
+     Called when the formula has been recompiled to clear any stale dependencies.
+     Derived classes may override as appropriate.
+     */
+    didCompile: function () {
+      sc_super();
+
+      // register the 'plot' dependency for invalidation
+      var plotModel = this.get('plotModel'),
+          // TODO: use a more robust ID
+          plotID = DG.Debug.scObjectID(plotModel);
+      this.registerDependency({
+        independentSpec: {
+          type: DG.DEP_TYPE_PLOT,
+          id: plotID,
+          name: 'plot-' + plotID
+        },
+        aggFnIndices: this.ALL_FUNCTIONS
+      });
+    },
+
+    /**
+     Direct evaluation of the expression without an intervening compilation.
+     This is unlikely to be used for plotted funtions where the expression is
+     generally evaluated enough times to make compilation to JavaScript
+     worthwhile, but we support it for consistency and completeness.
+     @param    {String}    iName -- The variable name to be bound
+     @returns  {Number}            The value of the specified variable or global
+     @throws   {VarReferenceError} Base class throws VarReferenceError for
+     variable names that are not recognized.
+     */
+    evaluateVariable: function (iName, iEvalContext) {
+
+      // Plotted functions can always refer to 'x' or the name of the attribute
+      // on the x-axis, either of which correspond to the value of the x-axis
+      // for the point being evaluated. For compilation purposes, we assume
+      // that the value is passed in by the client as part
+      // of the evaluation context.
+      if (this.isPrimaryVarName(iName)) {
+        if (this.get('adornmentKey') === 'plottedValue') {
+          // let base class handle it by attribute name
+          // cf. http://sproutcore-gyan.blogspot.com/2010/03/modify-argument-value-before-calling.html
+          iName = this.get('primaryVarName');
+        }
+        else {
+          return iEvalContext.x;
+        }
       }
+
+      // If we don't match any variables we're in charge of,
+      // let the base class have a crack at it.
+      return sc_super();
+    },
+
+    /**
+     Builds the array of argument expressions.
+     */
+    marshalArguments: function (iAggregateFn, iEvalContext, iInstance) {
+      sc_super();
+
+      var reqArgs = iAggregateFn.get('requiredArgs'),
+          argCount = iInstance.args.length;
+      // if not enough arguments were specified, make a reference to the primary
+      // univariate variable available, since some functions will use it
+      if ((argCount < reqArgs.min) && (this.get('adornmentKey') === 'plottedValue')) {
+        var uniVarName = this.get('primaryVarName'),
+            uniVarExpr = uniVarName
+                && this.compileVariable(uniVarName, iInstance.aggFnIndices);
+        if (uniVarExpr)
+          iInstance.argFns.unshift(DG.FormulaContext.createContextFunction(uniVarExpr));
+      }
+    },
+
+    /**
+     Called by the DependencyMgr to invalidate dependent nodes.
+     @param {object}     ioResult
+     @param {object}     iDependent
+     @param {object}     iDependency
+     @param {DG.Case[]}  iCases - array of cases affected
+     if no cases specified, all cases are affected
+     @param {boolean}    iForceAggregate - treat the dependency as an aggregate dependency
+     */
+    invalidateDependent: function (ioResult, iDependent, iDependency, iCases, iForceAggregate) {
+      // invalidate affected aggregate functions
+      if (iDependency.aggFnIndices)
+        this.invalidateFunctions(iDependency.aggFnIndices);
+      // Note that there is a redundancy between this notification, which indicates when
+      // any dependent has changed, and the DG.GlobalFormulaContext sending of the same
+      // notification when a global value changes. Ultimately, the GlobalFormulaContext
+      // mechanism should be disabled, but we leave that for another day.
+      this.notifyPropertyChange('dependentChange');
     }
-    
-    // If we don't match any variables we're in charge of,
-    // let the base class have a crack at it.
-    return sc_super();
-  },
-  
-  /**
-    Called when the formula has been recompiled to clear any stale dependencies.
-    Derived classes may override as appropriate.
-   */
-  didCompile: function() {
-    sc_super();
-
-    // register the 'plot' dependency for invalidation
-    var plotModel = this.get('plotModel'),
-        // TODO: use a more robust ID
-        plotID = DG.Debug.scObjectID(plotModel);
-    this.registerDependency({ independentSpec: {
-                                type: DG.DEP_TYPE_PLOT,
-                                id: plotID,
-                                name: 'plot-' + plotID
-                              },
-                              aggFnIndices: this.ALL_FUNCTIONS
-                            });
-  },
-
-  /**
-    Direct evaluation of the expression without an intervening compilation.
-    This is unlikely to be used for plotted funtions where the expression is
-    generally evaluated enough times to make compilation to JavaScript
-    worthwhile, but we support it for consistency and completeness.
-    @param    {String}    iName -- The variable name to be bound
-    @returns  {Number}            The value of the specified variable or global
-    @throws   {VarReferenceError} Base class throws VarReferenceError for
-                                  variable names that are not recognized.
-   */
-  evaluateVariable: function( iName, iEvalContext) {
-
-    // Plotted functions can always refer to 'x' or the name of the attribute
-    // on the x-axis, either of which correspond to the value of the x-axis 
-    // for the point being evaluated. For compilation purposes, we assume 
-    // that the value is passed in by the client as part
-    // of the evaluation context.
-    if( this.isPrimaryVarName( iName)) {
-      if (this.get('adornmentKey') === 'plottedValue') {
-        // let base class handle it by attribute name
-        // cf. http://sproutcore-gyan.blogspot.com/2010/03/modify-argument-value-before-calling.html
-        iName = this.get('primaryVarName');
-      }
-      else {
-        return iEvalContext.x;
-      }
-    }
-    
-    // If we don't match any variables we're in charge of,
-    // let the base class have a crack at it.
-    return sc_super();
-  },
-  
-  /**
-    Builds the array of argument expressions.
-   */
-  marshalArguments: function( iAggregateFn, iEvalContext, iInstance) {
-    sc_super();
-
-    var reqArgs = iAggregateFn.get('requiredArgs'),
-        argCount = iInstance.args.length;
-    // if not enough arguments were specified, make a reference to the primary
-    // univariate variable available, since some functions will use it
-    if ((argCount < reqArgs.min) && (this.get('adornmentKey') === 'plottedValue')) {
-      var uniVarName = this.get('primaryVarName'),
-          uniVarExpr = uniVarName
-                        && this.compileVariable(uniVarName, iInstance.aggFnIndices);
-      if (uniVarExpr)
-        iInstance.argFns.unshift(DG.FormulaContext.createContextFunction(uniVarExpr));
-    }
-  },
-  
-  /**
-    Called by the DependencyMgr to invalidate dependent nodes.
-    @param {object}     ioResult
-    @param {object}     iDependent
-    @param {object}     iDependency
-    @param {DG.Case[]}  iCases - array of cases affected
-                                 if no cases specified, all cases are affected
-    @param {boolean}    iForceAggregate - treat the dependency as an aggregate dependency
-   */
-  invalidateDependent: function(ioResult, iDependent, iDependency, iCases, iForceAggregate) {
-    // invalidate affected aggregate functions
-    if (iDependency.aggFnIndices)
-      this.invalidateFunctions(iDependency.aggFnIndices);
-    // Note that there is a redundancy between this notification, which indicates when
-    // any dependent has changed, and the DG.GlobalFormulaContext sending of the same
-    // notification when a global value changes. Ultimately, the GlobalFormulaContext
-    // mechanism should be disabled, but we leave that for another day.
-    this.notifyPropertyChange('dependentChange');
-  }
 
   }; // return from function closure
 }())); // function closure
@@ -219,165 +220,178 @@ DG.PlottedFunctionContext = DG.CollectionFormulaContext.extend((function() {
 
 /** @class  The model for a plotted function.
 
-  @extends DG.PlotAdornmentModel
-*/
+ @extends DG.PlotAdornmentModel
+ */
 DG.PlottedFunctionModel = DG.PlotAdornmentModel.extend(
-/** @scope DG.PlottedFunctionModel.prototype */ 
-{
-  /**
-    The algebraic expression to plot.
-    @property {DG.Formula}
-  */
-  _expression: null,
-  
-  /**
-    Computed property: Returns the source string for the expression.
-    Intended to be used with .get('expression')/.set('expression') to
-    get or set the string representation for the formula expression.
-    
-    For get('expression'):
-    @returns  {String}    the formula string used for the expression
-    
-    For set('expression'):
-    @param    {String}    iKey -- Passed by SproutCore (generall 'expression')
-    @param    {String}    iValue -- The formula string to use for the expression
-    @returns  {Object}    this -- so that methods can be chained
-   */
-  expression: function( iKey, iValue) {
-    if( iValue !== undefined) {
-      if( SC.empty( iValue))
-        this._expression = null;
-      else {
-        if( SC.none( this._expression)) {
-          this.createDGFormula( iValue);
+    /** @scope DG.PlottedFunctionModel.prototype */
+    {
+      /**
+       The algebraic expression to plot.
+       @property {DG.Formula}
+       */
+      _expression: null,
+
+      /**
+       Computed property: Returns the source string for the expression.
+       Intended to be used with .get('expression')/.set('expression') to
+       get or set the string representation for the formula expression.
+
+       For get('expression'):
+       @returns  {String}    the formula string used for the expression
+
+       For set('expression'):
+       @param    {String}    iKey -- Passed by SproutCore (generall 'expression')
+       @param    {String}    iValue -- The formula string to use for the expression
+       @returns  {Object}    this -- so that methods can be chained
+       */
+      expression: function (iKey, iValue) {
+        if (iValue !== undefined) {
+          var tSiblings = this.get('siblingPlottedFunctions');
+          if( tSiblings)
+            tSiblings.forEach( function( iPlottedFunctionModel) {
+              iPlottedFunctionModel.set('expression', iValue);
+            });
+          if (SC.empty(iValue))
+            this._expression = null;
+          else {
+            if (SC.none(this._expression)) {
+              this.createDGFormula(iValue);
+            }
+            else
+              this._expression.set('source', iValue);
+          }
+          return this;  // for chaining
         }
-        else
-          this._expression.set('source', iValue);
+        return (this._expression && this._expression.get('source')) || '';
+      }.property(),
+
+      /**
+       * In the context of split plots, one plotted function drives the equations of all others
+       * @property {[DG.PlottedFunctionModel]}
+     */
+      siblingPlottedFunctions: null,
+
+      /**
+       Destruction function.
+       */
+      destroy: function () {
+        if (this._expression)
+          this.destroyDGFormula();
+        sc_super();
+      },
+
+      /**
+       Utility function for creating the DG.Formula.
+       */
+      createDGFormula: function (iSource) {
+        var adornmentKey = this.get('adornmentKey'),
+            id = this.get('id'),
+            owner = {type: adornmentKey, id: id, name: adornmentKey + id},
+            context = DG.PlottedFunctionContext
+                .create({
+                  ownerSpec: owner,
+                  adornmentKey: adornmentKey,
+                  plotModel: this.get('plotModel'),
+                  collection: this.get('primaryCollection')
+                });
+        this._expression = DG.Formula.create({context: context, source: iSource});
+        this._expression.addObserver('dependentChange', this, 'dependentDidChange');
+      },
+
+      /**
+       Utility function for destroying the DG.Formula.
+       */
+      destroyDGFormula: function () {
+        this._expression.removeObserver('dependentChange', this, 'dependentDidChange');
+        this._expression.destroy();
+        this._expression = null;
+      },
+
+      /**
+       Utility function to return the collection represented by the attribute on the
+       "primary" axis (X for scatter plots, could be X or Y for univariate plots)
+       */
+      primaryCollection: function () {
+        var attrID = this.getPath('plotModel.primaryVarID') || this.getPath('plotModel.xVarID'),
+            attribute = attrID && DG.Attribute.getAttributeByID(attrID),
+            collection = attribute && attribute.get('collection');
+        return collection;
+      }.property('plotModel'),
+
+      /**
+       Utility function to return the split axis, i.e. the categorical attribute
+       on the secondary axis, if any.
+       */
+      splitAxisModel: function () {
+        if (!this.getPath('plotModel.yAxis.isNumeric'))
+          return this.getPath('plotModel.yAxis');
+        if (!this.getPath('plotModel.xAxis.isNumeric'))
+          return this.getPath('plotModel.xAxis');
+        return null;
+      }.property('plotModel'),
+
+      /**
+       Observer function called when the formula indicates that
+       a dependent has changed. This method merely propagates the
+       notification to clients.
+       */
+      dependentDidChange: function (iNotifier, iKey) {
+        this.notifyPropertyChange(iKey);
+      },
+
+      /**
+       Observer function which invalidates the intermediate compile results
+       for the formula when global value names are added, removed, or changed.
+       These changes can affect the bindings of the formula, so a recompilation
+       is required when they occur.
+       */
+      globalNamesDidChange: function () {
+        // Name changes require recompilation
+        this.invalidateExpression();
+      }.observes('DG.globalsController.globalNameChanges'),
+
+      /**
+       Invalidate the expression so it gets recompiled/evaluated.
+       */
+      invalidateExpression: function () {
+        if (this._expression)
+          this._expression.invalidate();
+      },
+
+      /**
+       Evaluates the plotted function at the specified x value.
+       @param    {Object}            The set of values available to the expression the expression
+       @returns  {Number|undefined}  The evaluated result
+       */
+      evaluate: function (iEvalContext) {
+        if (!this._expression) return;
+
+        // Note that this will propagate any exceptions thrown.
+        return this._expression.evaluate(iEvalContext);
+      },
+
+      /**
+       * @return { Object }
+       */
+      createStorage: function () {
+        var storage = sc_super();
+
+        storage.adornmentKey = this.get('adornmentKey');
+        storage.expression = this.get('expression');
+
+        return storage;
+      },
+
+      /**
+       * @param { Object }
+       */
+      restoreStorage: function (iStorage) {
+        sc_super();
+        this.set('adornmentKey', iStorage.adornmentKey);
+        this.set('expression', iStorage.expression);
       }
-      return this;  // for chaining
-    }
-    return (this._expression && this._expression.get('source')) || '';
-  }.property(),
-  
-  /**
-    Destruction function.
-   */
-  destroy: function() {
-    if( this._expression)
-      this.destroyDGFormula();
-    sc_super();
-  },
-  
-  /**
-    Utility function for creating the DG.Formula.
-   */
-  createDGFormula: function( iSource) {
-    var adornmentKey = this.get('adornmentKey'),
-        id = this.get('id'),
-        owner = { type: adornmentKey, id: id, name: adornmentKey + id },
-        context = DG.PlottedFunctionContext
-                      .create({ ownerSpec: owner,
-                                adornmentKey: adornmentKey,
-                                plotModel: this.get('plotModel'),
-                                collection: this.get('primaryCollection') });
-    this._expression = DG.Formula.create({ context: context, source: iSource });
-    this._expression.addObserver('dependentChange', this, 'dependentDidChange');
-  },
-  
-  /**
-    Utility function for destroying the DG.Formula.
-   */
-  destroyDGFormula: function() {
-    this._expression.removeObserver('dependentChange', this, 'dependentDidChange');
-    this._expression.destroy();
-    this._expression = null;
-  },
-  
-  /**
-    Utility function to return the collection represented by the attribute on the
-    "primary" axis (X for scatter plots, could be X or Y for univariate plots)
-   */
-  primaryCollection: function() {
-    var attrID = this.getPath('plotModel.primaryVarID') || this.getPath('plotModel.xVarID'),
-        attribute = attrID && DG.Attribute.getAttributeByID(attrID),
-        collection = attribute && attribute.get('collection');
-    return collection;
-  }.property('plotModel'),
 
-  /**
-    Utility function to return the split axis, i.e. the categorical attribute
-    on the secondary axis, if any.
-   */
-  splitAxisModel: function() {
-    if (!this.getPath('plotModel.yAxis.isNumeric'))
-      return this.getPath('plotModel.yAxis');
-    if (!this.getPath('plotModel.xAxis.isNumeric'))
-      return this.getPath('plotModel.xAxis');
-    return null;
-  }.property('plotModel'),
-
-  /**
-    Observer function called when the formula indicates that
-    a dependent has changed. This method merely propagates the
-    notification to clients.
-   */
-  dependentDidChange: function( iNotifier, iKey) {
-    this.notifyPropertyChange( iKey);
-  },
-  
-  /**
-    Observer function which invalidates the intermediate compile results
-    for the formula when global value names are added, removed, or changed.
-    These changes can affect the bindings of the formula, so a recompilation
-    is required when they occur.
-   */
-  globalNamesDidChange: function() {
-    // Name changes require recompilation
-    this.invalidateExpression();
-  }.observes('DG.globalsController.globalNameChanges'),
-
-  /**
-    Invalidate the expression so it gets recompiled/evaluated.
-   */
-  invalidateExpression: function() {
-    if( this._expression)
-      this._expression.invalidate();
-  },
-  
-  /**
-    Evaluates the plotted function at the specified x value.
-    @param    {Object}            The set of values available to the expression the expression
-    @returns  {Number|undefined}  The evaluated result
-   */
-  evaluate: function( iEvalContext) {
-    if( !this._expression) return;
-
-    // Note that this will propagate any exceptions thrown.
-    return this._expression.evaluate( iEvalContext);
-  },
-
-  /**
-   * @return { Object }
-   */
-  createStorage: function() {
-    var storage = sc_super();
-    
-    storage.adornmentKey = this.get('adornmentKey');
-    storage.expression = this.get('expression');
-
-    return storage;
-  },
-
-  /**
-   * @param { Object } 
-   */
-  restoreStorage: function( iStorage) {
-    sc_super();
-    this.set('adornmentKey', iStorage.adornmentKey);
-    this.set('expression', iStorage.expression);
-  }
-
-});
+    });
 
 DG.PlotAdornmentModel.registry.plottedValue = DG.PlottedFunctionModel;
 DG.PlotAdornmentModel.registry.plottedFunction = DG.PlottedFunctionModel;

--- a/apps/dg/components/graph/adornments/point_data_tip.js
+++ b/apps/dg/components/graph/adornments/point_data_tip.js
@@ -44,7 +44,7 @@ DG.PointDataTip = DG.DataTip.extend(
 
         var this_ = this,
             tPlot = this.getPath('plotLayer.model'),  // Use of plotBinding doesn't work the first time
-            tCases = tPlot.get('cases'),
+            tCases = tPlot && tPlot.get('cases'),
             tCase = tCases ? tCases.unorderedAt(this.get('caseIndex')) : null;
 
         function getNameValuePair(iKey) {

--- a/apps/dg/components/graph/axes/axis_coordinator.js
+++ b/apps/dg/components/graph/axes/axis_coordinator.js
@@ -1,0 +1,95 @@
+// ==========================================================================
+//                          DG.AxisCoordinator
+//
+//  Author:   William Finzer
+//
+//  Copyright (c) 2019 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+
+/** @class  When a graph is split, this object keeps numeric axis scales in synch.
+
+  @extends SC.Object
+*/
+DG.AxisCoordinator = SC.Object.extend(
+/** @scope DG.AxisCoordinator.prototype */ 
+{
+  /**
+   * Owned by the graph model.
+   * @property {[DG.AxisModel] }
+   */
+  xAxisArray: null,
+
+  /**
+   * Owned by the graph model.
+   * @property {[DG.AxisModel] }
+   */
+  yAxisArray: null,
+
+  /**
+   * Owned by the graph model.
+   * @property {[DG.AxisModel] }
+   */
+  y2AxisArray: null,
+
+  _handlingChange: false,
+
+  init: function() {
+    this.xAxisArray = [];
+    this.yAxisArray = [];
+    this.y2AxisArray = [];
+  },
+
+  destroy: function() {
+
+    this.xAxisArray.forEach( this.removeAxisObservers);
+    this.yAxisArray.forEach( this.removeAxisObservers);
+    this.yAxisArray.forEach( this.removeAxisObservers);
+
+    this.xAxisArray = [];
+    this.yAxisArray = [];
+    this.y2AxisArray = [];
+  },
+
+  removeAxisObservers: function( iAxis) {
+    if( iAxis) {
+      iAxis.removeObserver( 'lowerBound', this, this.boundChanged);
+      iAxis.removeObserver( 'upperBound', this, this.boundChanged);
+    }
+  },
+
+  setAxis: function( iKey, iIndex, iAxis) {
+    var tAxisArray = this.get(iKey + 'AxisArray');
+    this.removeAxisObservers( tAxisArray[iIndex]);
+    iAxis.addObserver( 'lowerBound', this, this.boundChanged, iKey);
+    iAxis.addObserver( 'upperBound', this, this.boundChanged, iKey);
+    tAxisArray[iIndex] = iAxis;
+  },
+
+  boundChanged: function( iAxis, iKey, iValue, iAxisKey) {
+    if( this._handlingChange)
+      return;
+
+    var tArray = this.get( iAxisKey + 'AxisArray'),
+        tValue = iAxis.get( iKey);
+    this._handlingChange = true;
+    tArray.forEach( function( oneAxis) {
+      if( iAxis !== oneAxis)
+        oneAxis.set( iKey, tValue);
+    });
+    this._handlingChange = false;
+  }
+
+});
+

--- a/apps/dg/components/graph/axes/axis_label_view.js
+++ b/apps/dg/components/graph/axes/axis_label_view.js
@@ -1,0 +1,46 @@
+// ==========================================================================
+//                              DG.AxisLabelView
+//
+//  Author:   William Finzer
+//
+//  Copyright (c) 2014 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+
+sc_require('components/graph/utilities/graph_drop_target');
+sc_require('views/raphael_base');
+sc_require('utilities/rendering_utilities');
+
+/** @class  DG.AxisLabelView - Displays attribute name(s) on left or bottom of graph.
+ *          Particularly important when a plot has been split so there are multiple independent axes there.
+
+
+ @extends DG.RaphaelBaseView
+ */
+DG.AxisLabelView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
+    /** @scope DG.AxisLabelView.prototype */
+    (function () {
+      return {
+
+        classNames: 'dg-axis-view'.w(),
+
+        orientation: null,
+
+        blankDropHint: 'DG.GraphView.addToEmptyPlace',
+
+        desiredExtent: DG.RenderingUtilities.kCaptionFontHeight
+
+      };
+    }()));
+

--- a/apps/dg/components/graph/axes/axis_model.js
+++ b/apps/dg/components/graph/axes/axis_model.js
@@ -145,8 +145,7 @@ DG.AxisModel = SC.Object.extend(
   isNumeric: null,
 
   noAttributes: function() {
-    var tAttributes = this.getPath('attributeDescription.attributes');
-    return !tAttributes || !SC.isArray(tAttributes) || (tAttributes.length === 0);
+    return this.getPath('attributeDescription.noAttributes');
   }.property(),
 
   /**

--- a/apps/dg/components/graph/axes/axis_multi_target.js
+++ b/apps/dg/components/graph/axes/axis_multi_target.js
@@ -101,9 +101,10 @@ DG.AxisMultiTarget = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
           tOtherAttr = this.get('otherPlottedAttribute'),
           tOtherDescr = this.get('otherAttributeDescription');
       return (tOtherAttr !== DG.Analysis.kNullAttribute) &&
-             (tCurrAttr !== DG.Analysis.kNullAttribute) &&
-             (tCurrAttr !== tDragAttr) &&
-             tOtherDescr && tOtherDescr.get('isNumeric');
+          (tCurrAttr !== DG.Analysis.kNullAttribute) &&
+          (tCurrAttr !== tDragAttr) &&
+          !tDragAttr.isNominal() &&
+          tOtherDescr && tOtherDescr.get('isNumeric');
     },
 
     // Draw an orange frame to show we're a drop target.

--- a/apps/dg/components/graph/axes/axis_multi_target.js
+++ b/apps/dg/components/graph/axes/axis_multi_target.js
@@ -38,6 +38,8 @@ DG.AxisMultiTarget = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
 
     dragIsInside: false,
 
+    dataConfiguration: null,
+
     /**
      We're adding attributes to this description
      @property { DG.AttributeDescription }
@@ -89,7 +91,8 @@ DG.AxisMultiTarget = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
     },
 
     /**
-     * A dragged attribute is valid for a drop if there is already at least one attribute
+     * For adding a numeric attribute to the y-axis:
+     * A dragged attribute is valid for such a drop if there is already at least one attribute
      * and the dragged attribute is not one of them. There must also be an attribute on the
      * 'other' axis since we only support multiple attributes for scatter plots for now.
      * @param iDrag
@@ -97,14 +100,19 @@ DG.AxisMultiTarget = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
      */
     isValidAttribute: function( iDrag) {
       var tDragAttr = iDrag.data.attribute,
-          tCurrAttr = this.get('plottedAttribute' ),
+          tDragAttrIsNominal = tDragAttr.isNominal(),
+          tCurrAttr = this.get('plottedAttribute'),
           tOtherAttr = this.get('otherPlottedAttribute'),
-          tOtherDescr = this.get('otherAttributeDescription');
-      return (tOtherAttr !== DG.Analysis.kNullAttribute) &&
-          (tCurrAttr !== DG.Analysis.kNullAttribute) &&
-          (tCurrAttr !== tDragAttr) &&
-          !tDragAttr.isNominal() &&
-          tOtherDescr && tOtherDescr.get('isNumeric');
+          tOtherDescr = this.get('otherAttributeDescription'),
+          tValidForScatterplot = (tOtherAttr !== DG.Analysis.kNullAttribute) &&
+              (tCurrAttr !== DG.Analysis.kNullAttribute) &&
+              (tCurrAttr !== tDragAttr) &&
+              !tDragAttrIsNominal &&
+              tOtherDescr && tOtherDescr.get('isNumeric'),
+          tConfigurationHasAtLeastOneAttribute = this.get('dataConfiguration').hasAtLeastOneAttributeAssigned(),
+          tValidForPlotSplit = tDragAttrIsNominal && tConfigurationHasAtLeastOneAttribute;
+
+      return tValidForScatterplot || tValidForPlotSplit;
     },
 
     // Draw an orange frame to show we're a drop target.

--- a/apps/dg/components/graph/axes/axis_multi_target.js
+++ b/apps/dg/components/graph/axes/axis_multi_target.js
@@ -133,7 +133,7 @@ DG.AxisMultiTarget = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
         var tDraggedName = iDrag.data.attribute.get( 'name' ),
             tString = tIsValidForScatterplot ?
                 'DG.GraphView.addAttribute'.loc( tDraggedName ) :
-                'DG.GraphView.splitPlotVertically'.loc( tDraggedName);
+                'DG.GraphView.layoutPlotsSideBySide'.loc( tDraggedName);
         this.set( 'dropHintString', tString );
       }
     },

--- a/apps/dg/components/graph/axes/axis_multi_target.js
+++ b/apps/dg/components/graph/axes/axis_multi_target.js
@@ -93,38 +93,28 @@ DG.AxisMultiTarget = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
     /**
      * For adding a numeric attribute to the y-axis:
      * A dragged attribute is valid for such a drop if there is already at least one attribute
-     * and the dragged attribute is not one of them. There must also be an attribute on the
-     * 'other' axis since we only support multiple attributes for scatter plots for now.
+     * and the dragged attribute is not one of them.
+     * If the dragged attribute is not nominal there must also be an attribute on the
+     * 'other' axis since we only support multiple numeric attributes for scatter plots for now.
      * @param iDrag
      * @return {Boolean}
      */
     isValidAttribute: function( iDrag) {
-      var tDragAttr = iDrag.data.attribute,
-          tDragAttrIsNominal = tDragAttr.isNominal(),
-          tCurrAttr = this.get('plottedAttribute'),
-          tOtherAttr = this.get('otherPlottedAttribute'),
-          tOtherDescr = this.get('otherAttributeDescription'),
-          tValidForScatterplot = (tOtherAttr !== DG.Analysis.kNullAttribute) &&
-              (tCurrAttr !== DG.Analysis.kNullAttribute) &&
-              (tCurrAttr !== tDragAttr) &&
-              !tDragAttrIsNominal &&
-              tOtherDescr && tOtherDescr.get('isNumeric'),
-          tConfigurationHasAtLeastOneAttribute = this.get('dataConfiguration').hasAtLeastOneAttributeAssigned(),
-          tValidForPlotSplit = tDragAttrIsNominal && tConfigurationHasAtLeastOneAttribute;
-
-      return tValidForScatterplot || tValidForPlotSplit;
+      return this.isValidAttributeForScatterplot( iDrag) || this.isValidAttributeForPlotSplit( iDrag);
     },
 
     // Draw an orange frame to show we're a drop target.
     dragStarted:function ( iDrag ) {
       var kPadding = 3,
-          kPlusWidth = 24;
+          kPlusWidth = 24,
+          tIsValidForScatterplot = this.isValidAttributeForScatterplot( iDrag),
+          tIsValidForPlotSplit = this.isValidAttributeForPlotSplit( iDrag);
 
       function pathForPlus() {
         return 'M-6,-18 h6 v6 h6 v6 h-6 v6 h-6 v-6 h-6 v-6 h6 v-6Z';
       }
 
-      if( this.isValidAttribute( iDrag ) ) {
+      if( tIsValidForScatterplot || tIsValidForPlotSplit ) {
         this.set('isVisible', true);
         var tParentView = this.get('parentView');
         if( tParentView)
@@ -141,7 +131,9 @@ DG.AxisMultiTarget = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
           .show();
 
         var tDraggedName = iDrag.data.attribute.get( 'name' ),
-            tString = 'DG.GraphView.addAttribute'.loc( tDraggedName );
+            tString = tIsValidForScatterplot ?
+                'DG.GraphView.addAttribute'.loc( tDraggedName ) :
+                'DG.GraphView.splitPlotVertically'.loc( tDraggedName);
         this.set( 'dropHintString', tString );
       }
     },

--- a/apps/dg/components/graph/axes/axis_view.js
+++ b/apps/dg/components/graph/axes/axis_view.js
@@ -452,6 +452,7 @@ DG.AxisView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
         isValidAttribute: function (iDrag) {
           if (this.get('orientation') === 'vertical2') {
             var tDragAttr = iDrag.data.attribute,
+                tDragAttrIsNominal = tDragAttr.isNominal(),
                 tCurrAttr = this.get('plottedAttribute'),
                 tXDescription = this.get('xAttributeDescription'),
                 tCurrXAttr = tXDescription ? tXDescription.get('attribute') : DG.Analysis.kNullAttribute,
@@ -462,7 +463,8 @@ DG.AxisView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
                 (tY1Attr !== tDragAttr) &&
                 (tCurrAttr !== tDragAttr) &&
                 tXDescription.get('isNumeric') &&
-                tY1Description.get('isNumeric');
+                tY1Description.get('isNumeric') &&
+                !tDragAttrIsNominal;
           }
           else
             return DG.GraphDropTarget.isValidAttribute.call(this, iDrag);

--- a/apps/dg/components/graph/axes/axis_view.js
+++ b/apps/dg/components/graph/axes/axis_view.js
@@ -451,20 +451,8 @@ DG.AxisView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
 
         isValidAttribute: function (iDrag) {
           if (this.get('orientation') === 'vertical2') {
-            var tDragAttr = iDrag.data.attribute,
-                tDragAttrIsNominal = tDragAttr.isNominal(),
-                tCurrAttr = this.get('plottedAttribute'),
-                tXDescription = this.get('xAttributeDescription'),
-                tCurrXAttr = tXDescription ? tXDescription.get('attribute') : DG.Analysis.kNullAttribute,
-                tY1Description = this.get('otherYAttributeDescription'),
-                tY1Attr = tY1Description ? tY1Description.get('attribute') : DG.Analysis.kNullAttribute;
-            return (tCurrXAttr !== DG.Analysis.kNullAttribute) &&
-                (tY1Attr !== DG.Analysis.kNullAttribute) &&
-                (tY1Attr !== tDragAttr) &&
-                (tCurrAttr !== tDragAttr) &&
-                tXDescription.get('isNumeric') &&
-                tY1Description.get('isNumeric') &&
-                !tDragAttrIsNominal;
+            return this.isValidAttributeForScatterplot( iDrag) ||
+                this.isValidAttributeForPlotSplit( iDrag);
           }
           else
             return DG.GraphDropTarget.isValidAttribute.call(this, iDrag);

--- a/apps/dg/components/graph/axes/axis_view.js
+++ b/apps/dg/components/graph/axes/axis_view.js
@@ -70,9 +70,18 @@ DG.AxisView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
          */
         desiredExtent: function () {
           var tLabelExtent = this.get('labelExtent'),
-              tDimension = (Raphael.version < "2.0") ?
-                  'y' :
-                  ((this.get('orientation') === 'horizontal') ? 'y' : 'x');
+              tDimension;
+          switch (this.get('orientation')) {
+            case 'horizontal':
+            case 'top':
+              tDimension = 'y';
+              break;
+            case 'vertical':
+            case 'vertical2':
+            case 'right':
+              tDimension = 'x';
+              break;
+          }
           return tLabelExtent[ tDimension];
         }.property('labelNode'),
 
@@ -289,31 +298,37 @@ DG.AxisView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
               tDrawWidth = this.get('drawWidth'),
               tDrawHeight = this.get('drawHeight'),
               tIsVertical = this.get('isVertical'),
-              //tRotation = tIsVertical ? -90 : 0,
+              tOrientation = this.get('orientation'),
               tTotalLength = 0,
               tLayout = tNodes.map(function (iNode) {
                 var tExtent = iNode.extent();
                 tTotalLength += tIsVertical ? tExtent.height : tExtent.width;
                 return { node: iNode, extent: tExtent };
               }),
-              tPosition = tIsVertical ? ((tDrawHeight + tTotalLength) / 2) : ((tDrawWidth - tTotalLength) / 2),
-              tV2 = this.get('orientation') === 'vertical2';
+              tPosition = tIsVertical ? ((tDrawHeight + tTotalLength) / 2) : ((tDrawWidth - tTotalLength) / 2);
           tLayout.forEach(function (iLayout) {
             var tNode = iLayout.node,
                 tLabelExtent = { x: iLayout.extent.width, y: iLayout.extent.height },
                 tLoc = { }; // The center of the node
 
-            if (tIsVertical) {
-              tLoc.x = tLabelExtent.x / 4 + 2;
-              tLoc.y = tPosition - tLabelExtent.y / 2;
-              tPosition -= tLabelExtent.y + 4;
-              if (tV2)
-                tLoc.x = tDrawWidth - tLabelExtent.x / 2 - 2;
-            }
-            else {  // horizontal
-              tLoc.x = tPosition + tLabelExtent.x / 2;
-              tLoc.y = tDrawHeight - tLabelExtent.y / 2 - 2;
-              tPosition += tLabelExtent.x + 4;
+            switch( tOrientation) {
+              case 'vertical':
+              case 'vertical2':
+              case 'right':
+                tLoc.x = tLabelExtent.x / 4 + 2;
+                tLoc.y = tPosition - tLabelExtent.y / 2;
+                tPosition -= tLabelExtent.y + 4;
+                if (tOrientation === 'vertical2' || tOrientation === 'right')
+                  tLoc.x = tDrawWidth - tLabelExtent.x / 2 - 2;
+                break;
+              case 'horizontal':
+              case 'top':
+                tLoc.x = tPosition + tLabelExtent.x / 2;
+                tLoc.y = tDrawHeight - tLabelExtent.y / 2 - 2;
+                tPosition += tLabelExtent.x + 4;
+                if( tOrientation === 'top')
+                  tLoc.y = tLabelExtent.y / 3;
+                break;
             }
             tNode.set('loc', tLoc);
           });
@@ -397,11 +412,16 @@ DG.AxisView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
               tPixelWidth = Math.abs( this.get('pixelMax') - this.get('pixelMin')),
               tDistanceToCell = (iCellNum + 0.5) / tNumCells * tPixelWidth,
               tCoordinate;
-          if( this.get('orientation') === 'horizontal') {
-            tCoordinate = this.get('pixelMin') + tDistanceToCell;
-          }
-          else {
-            tCoordinate = this.get('pixelMin') - tDistanceToCell;
+          switch (this.get('orientation')) {
+            case 'horizontal':
+            case 'top':
+              tCoordinate = this.get('pixelMin') + tDistanceToCell;
+              break;
+            case 'vertical':
+            case 'vertical2':
+            case 'right':
+              tCoordinate = this.get('pixelMin') - tDistanceToCell;
+              break;
           }
 
           return tCoordinate;

--- a/apps/dg/components/graph/axes/cell_axis_view.js
+++ b/apps/dg/components/graph/axes/cell_axis_view.js
@@ -36,12 +36,22 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
      @property { Number }
      */
     desiredExtent: function() {
-      var tExtent = sc_super();
+      var tExtent = sc_super(),
+          kWidthFudge = 5;
       if( !this.get('isNumeric')) { // Not yet handling numeric axis broken up by cells
-        tExtent += kTickLength + kAxisGap + this.get('maxLabelExtent');
+        tExtent += kTickLength + kAxisGap + kWidthFudge + this.get('maxLabelExtent');
       }
       return tExtent;
     }.property('maxLabelExtent'),
+
+    /**
+     * When we are the "other" axis, our partner needs to know how much to offset pixelMin.
+     * For me, it's the same as desiredExtent
+     * @property {Number}
+     */
+    pixelMinOffset: function() {
+      return this.get('desiredExtent');
+    }.property('desiredExtent'),
 
     /**
      I'm not supposed to work with numbers.
@@ -115,7 +125,7 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
           tStop = { x: tPixelMax, y: tCoord - 1 };
           break;
       }
-      return this._paper.line( tStart.x, tStart.y, tStop.x, tStop.y)
+      return this.get('paper').line( tStart.x, tStart.y, tStop.x, tStop.y)
         .attr( { stroke: DG.PlotUtilities.kAxisColor,
           strokeWidth: 2 });
     },
@@ -195,11 +205,11 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
             tStartingCellnames = this_.getPath('model.cellNames');
             tOriginalCellIndex = tCellBeingDragged = this.cellNum;
             tDragStartCoord = DG.ViewUtilities.windowToViewCoordinates({x: iWindowX, y: iWindowY}, this_);
-            tDragStartCoord = (tOrientation === 'horizontal') ? tDragStartCoord.x : tDragStartCoord.y;
+            tDragStartCoord = tIsHorizontal ? tDragStartCoord.x : tDragStartCoord.y;
           },
           doDrag = function (iDeltaX, iDeltaY, iWindowX, iWindowY) {
             var tModel = this_.get('model'),
-                tCurrentCoord = tDragStartCoord + ((tOrientation === 'horizontal') ? iDeltaX : iDeltaY),
+                tCurrentCoord = tDragStartCoord + (tIsHorizontal ? iDeltaX : iDeltaY),
                 tCategoryInCurrentCell = this_.whichCell( tCurrentCoord);
             // Todo Touch is currently returning NaN for window coordinates. Fix this
             if( isNaN(tCurrentCoord))
@@ -271,7 +281,7 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
         }
         var tTextElement;
         if( !tLabelSpecs[iCellNum]) {
-          tTextElement = this_._paper.text(0, 0, iCellName)
+          tTextElement = this_.get('paper').text(0, 0, iCellName)
               .addClass('dg-axis-tick-label')
               .addClass(tCursorClass)
               .drag(doDrag, beginDrag, endDrag);
@@ -289,8 +299,10 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
 
         tMaxHeight = Math.max( tMaxHeight, tTextExtent.height);
         tMaxWidth = Math.max( tMaxWidth, tTextExtent.width);
-        if(SC.none( tPrevLabelEnd))
+        if(SC.none( tPrevLabelEnd)) {
           tCollision = tTextExtent.width > this_.get('fullCellWidth');
+          tPrevLabelEnd = tIsHorizontal ? tCoord + tTextExtent.width / 2 : tCoord - tTextExtent.width / 2;
+        }
         else if( tIsHorizontal) {
           tCollision = tCollision || (tCoord - tTextExtent.width / 2 < tPrevLabelEnd);
           tPrevLabelEnd = (tCoord + tTextExtent.width / 2);
@@ -304,15 +316,16 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
       // iLabelSpec has form { element: {Raphael element}, coord: {Number}, height: {Number}, width: {Number} }
       function drawOneCell( iLabelSpec, iIndex) {
         var tCoord = iLabelSpec.coord,
+            // tTextHeight = iLabelSpec.height,
             tLabelX, tLabelY;
         switch( this_.get('orientation')) {
           case 'vertical':
           case 'vertical2':
             this_._elementsToClear.push(
-              this_._paper.line( tBaseline, tCoord + tTickOffset, tBaseline - kTickLength, tCoord + tTickOffset)
+              this_.get('paper').line( tBaseline, tCoord + tTickOffset, tBaseline - kTickLength, tCoord + tTickOffset)
                 .attr( { stroke: DG.PlotUtilities.kAxisColor }));
             tLabelX = tBaseline - kTickLength - kAxisGap - iLabelSpec.height / 3;
-            tLabelY = tCoord + tTickOffset;
+            tLabelY = tCoord + tTickOffset - ((iIndex === 0 && !tCentering) ? iLabelSpec.height / 2 : 0);
             if( tRotation === 0) {
               tAnchor = 'end';
             }
@@ -320,7 +333,7 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
 
           case 'horizontal':
             this_._elementsToClear.push(
-              this_._paper.line( tCoord - tTickOffset, tBaseline, tCoord - tTickOffset, tBaseline + kTickLength)
+              this_.get('paper').line( tCoord - tTickOffset, tBaseline, tCoord - tTickOffset, tBaseline + kTickLength)
                 .attr( { stroke: DG.PlotUtilities.kAxisColor }));
             tLabelX = tCoord - tTickOffset + 1;
             tLabelY = tBaseline + kTickLength + kAxisGap + iLabelSpec.height / 3;
@@ -332,19 +345,19 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
             break;
           case 'top':
             this_._elementsToClear.push(
-                this_._paper.line( tCoord - tTickOffset, tBaseline, tCoord - tTickOffset, tBaseline - kTickLength)
+                this_.get('paper').line( tCoord - tTickOffset, tBaseline, tCoord - tTickOffset, tBaseline - kTickLength)
                     .attr( { stroke: DG.PlotUtilities.kAxisColor }));
             tLabelX = tCoord - tTickOffset + 1;
             tLabelY = tBaseline - kTickLength - kAxisGap - iLabelSpec.height / 3;
             if( tRotation === -90) {
-              tAnchor = 'end';
+              tAnchor = 'start';
               if( iIndex === 0)
                 tLabelX += iLabelSpec.height / 3;
             }
             break;
           case 'right':
             this_._elementsToClear.push(
-                this_._paper.line( tBaseline, tCoord + tTickOffset, tBaseline + kTickLength, tCoord + tTickOffset)
+                this_.get('paper').line( tBaseline, tCoord + tTickOffset, tBaseline + kTickLength, tCoord + tTickOffset)
                     .attr( { stroke: DG.PlotUtilities.kAxisColor }));
             tLabelX = tBaseline + kTickLength + kAxisGap + iLabelSpec.height / 3;
             tLabelY = tCoord + tTickOffset;
@@ -370,7 +383,7 @@ DG.CellAxisView = DG.AxisView.extend( (function() {
         tSpec.element.remove();
       }
       if( tCollision) // labels must be perpendicular to axis
-        tRotation = (tOrientation === 'horizontal') ? -90 : 0;
+        tRotation = tIsHorizontal ? -90 : 0;
       tLabelSpecs.forEach( drawOneCell);
 
       this.set('labelSpecs', tLabelSpecs);

--- a/apps/dg/components/graph/axes/cell_linear_axis_view.js
+++ b/apps/dg/components/graph/axes/cell_linear_axis_view.js
@@ -184,15 +184,17 @@ DG.CellLinearAxisView = DG.CellAxisView.extend(
         }
 
         function doTranslate( idX, idY) {
-          if( !tClickHandling && this_._isDragging) {
-            //DG.SoundUtilities.drag();
-            var tDelta = this_.get('isVertical') ? idY : idX,
-                tLowerBound = this_.getPath('model.lowerBound'),
-                tCurrentDelta = tHelper.coordinateToDataGivenCell( 0, 0) -
-                    tHelper.coordinateToDataGivenCell( 0, tDelta),
-                tIncDelta = tCurrentDelta - (tLowerBound - this_._lowerBoundAtDragStart);
-            this_.get('model').translate( tIncDelta);
-          }
+          SC.run(function () {
+            if (!tClickHandling && this_._isDragging) {
+              //DG.SoundUtilities.drag();
+              var tDelta = this_.get('isVertical') ? idY : idX,
+                  tLowerBound = this_.getPath('model.lowerBound'),
+                  tCurrentDelta = tHelper.coordinateToDataGivenCell(0, 0) -
+                      tHelper.coordinateToDataGivenCell(0, tDelta),
+                  tIncDelta = tCurrentDelta - (tLowerBound - this_._lowerBoundAtDragStart);
+              this_.get('model').translate(tIncDelta);
+            }
+          });
         }
 
         // We are dragging in the lower portion of the axis. The upper bound will remain fixed

--- a/apps/dg/components/graph/axes/cell_linear_axis_view.js
+++ b/apps/dg/components/graph/axes/cell_linear_axis_view.js
@@ -142,13 +142,14 @@ DG.CellLinearAxisView = DG.CellAxisView.extend(
               oldLowerBound = this_._lowerBoundAtDragStart,
               oldUpperBound = this_._upperBoundAtDragStart,
               wasDilate = (newLowerBound === oldLowerBound || newUpperBound === oldUpperBound),
-              tAxisKey = null, tGraphModelId = null;
+              tGraphView = this_.get('parentView'),
+              tAxisKey, tGraphModelId;
           if      (tOrientation === 'horizontal') { tAxisKey = 'xAxisView'; }
           else if (tOrientation === 'vertical')   { tAxisKey = 'yAxisView'; }
           else                                    { tAxisKey = 'y2AxisView'; }
 
           DG.ObjectMap.forEach(DG.currDocumentController().componentControllersMap, function(id, controller) {
-            if (controller.get(tAxisKey) === this_) {
+            if (controller.get('graphView') === tGraphView) {
               tGraphModelId = id;
             }
           });
@@ -296,7 +297,7 @@ DG.CellLinearAxisView = DG.CellAxisView.extend(
 
         // ============body of setupEventHandling===========
         if( SC.none( this_._midPanel)) {
-          this_._midPanel = this_._paper.rect(0, 0, 0, 0)
+          this_._midPanel = this_.get('paper').rect(0, 0, 0, 0)
                     .attr({ stroke: DG.RenderingUtilities.kTransparent,
                             fill: DG.RenderingUtilities.kSeeThrough });
           this_._lowerPanel = this_._midPanel.clone();

--- a/apps/dg/components/graph/axes/qual_cell_linear_axis_view.js
+++ b/apps/dg/components/graph/axes/qual_cell_linear_axis_view.js
@@ -70,7 +70,7 @@ DG.QualCellLinearAxisView = DG.CellLinearAxisView.extend(
               drawLowHigh = function () {
                 [{value: kDefaultLow, string: ''}, {value: kDefaultHigh, string: ''}].forEach(
                     function (iLabel) {
-                      var tLabelElement = this._paper.text(0, 0, iLabel.string)
+                      var tLabelElement = this.get('paper').text(0, 0, iLabel.string)
                           .addClass('dg-axis-tick-label');
                       this._elementsToClear.push(tLabelElement);
                       var tLabelExtent = DG.RenderingUtilities.getExtentForTextElement(

--- a/apps/dg/components/graph/data_model/analysis.js
+++ b/apps/dg/components/graph/data_model/analysis.js
@@ -36,7 +36,7 @@ DG.Analysis = {
   },
 
   /**
-   * Enumeration of possible types for attributes.
+   * Enumeration of possible roles for attributes.
    */
   EAnalysisRole: {
         eInvalid: -1,
@@ -46,7 +46,9 @@ DG.Analysis = {
         ePrimaryCategorical: 3,
         eSecondaryCategorical: 4,
         eLegendNumeric: 5,
-        eLegendCategorical: 6
+        eLegendCategorical: 6,
+        eVerticalSplit: 7,      // for attribute in place DG.GraphTypes.EPlace.eTopSplit
+        eHorizontalSplit: 8     // for attribute in place DG.GraphTypes.EPlace.eRightSplit
   },
 
   EPercentKind: {

--- a/apps/dg/components/graph/data_model/attribute_placement_description.js
+++ b/apps/dg/components/graph/data_model/attribute_placement_description.js
@@ -76,12 +76,14 @@ DG.AttributePlacementDescription = SC.Object.extend(
        * @param iAttribute
        */
       addAttribute: function (iAttribute) {
-        if (!this._attributes.contains(iAttribute))
-          this._attributes.push(iAttribute);
-        this.setupStats();
-        this.invalidateCaches();
-        this.notifyPropertyChange('attribute');
-        iAttribute.addObserver('collection', this, 'collectionDidChange');
+        if( iAttribute) {
+          if (!this._attributes.contains(iAttribute))
+            this._attributes.push(iAttribute);
+          this.setupStats();
+          this.invalidateCaches();
+          this.notifyPropertyChange('attribute');
+          iAttribute.addObserver('collection', this, 'collectionDidChange');
+        }
       },
 
       removeAttributeAtIndex: function (iIndex) {
@@ -215,6 +217,14 @@ DG.AttributePlacementDescription = SC.Object.extend(
       isNull: function () {
         return this.get('attributeID') === null;
       }.property('attributeID'),
+
+      /**
+       @property {Boolean}
+       */
+      noAttributes: function () {
+        var tAttributes = this.get('attributes');
+        return !tAttributes || !SC.isArray(tAttributes) || (tAttributes.length === 0);
+      }.property('attributes'),
 
       /**
        @property {Boolean}

--- a/apps/dg/components/graph/data_model/attribute_placement_description.js
+++ b/apps/dg/components/graph/data_model/attribute_placement_description.js
@@ -282,6 +282,7 @@ DG.AttributePlacementDescription = SC.Object.extend(
        */
       colorMapDidChange: function () {
         this.invalidateCaches();
+        this.propertyDidChange('categoryMap');
       }.observes('attribute.categoryMap'),
 
       casesForCategory: function (iCellName) {

--- a/apps/dg/components/graph/data_model/graph_data_configuration.js
+++ b/apps/dg/components/graph/data_model/graph_data_configuration.js
@@ -154,12 +154,12 @@ DG.GraphDataConfiguration = DG.PlotDataConfiguration.extend(
     
     // Actually, during this coding transition, we're going to stash the previously
     // initialized attribute descriptions in attributesByPlace.
-    this.attributesByPlace[ DG.GraphTypes.EPlace.eX][0] = attributeDescriptions.x;
-    this.attributesByPlace[ DG.GraphTypes.EPlace.eY][0] = attributeDescriptions.y;
-    this.attributesByPlace[ DG.GraphTypes.EPlace.eY2][0] = attributeDescriptions.y2;
-    this.attributesByPlace[ DG.GraphTypes.EPlace.eLegend][0] = attributeDescriptions.legend;
-    this.attributesByPlace[ DG.GraphTypes.EPlace.eTopSplit][0] = attributeDescriptions.top;
-    this.attributesByPlace[ DG.GraphTypes.EPlace.eRightSplit][0] = attributeDescriptions.right;
+    this.attributeDescriptionForPlace('x', attributeDescriptions.x, DG.GraphTypes.EPlace.eX);
+    this.attributeDescriptionForPlace('y', attributeDescriptions.y, DG.GraphTypes.EPlace.eY);
+    this.attributeDescriptionForPlace('y2', attributeDescriptions.y2, DG.GraphTypes.EPlace.eY2);
+    this.attributeDescriptionForPlace('legend', attributeDescriptions.legend, DG.GraphTypes.EPlace.eLegend);
+    this.attributeDescriptionForPlace('topSplit', attributeDescriptions.top, DG.GraphTypes.EPlace.eTopSplit);
+    this.attributeDescriptionForPlace('right', attributeDescriptions.right, DG.GraphTypes.EPlace.eRightSplit);
   },
 
   destroy: function () {

--- a/apps/dg/components/graph/data_model/graph_data_configuration.js
+++ b/apps/dg/components/graph/data_model/graph_data_configuration.js
@@ -28,51 +28,51 @@ sc_require('components/graph_map_common/plot_data_configuration');
 DG.GraphDataConfiguration = DG.PlotDataConfiguration.extend(
 /** @scope DG.GraphDataConfiguration.prototype */ 
 {
-  topSplitCollectionClient: function () {
-    return this.getPath('topSplitAttributeDescription.collectionClient');
+  topCollectionClient: function () {
+    return this.getPath('topAttributeDescription.collectionClient');
   }.property(),
 
-  rightSplitCollectionClient: function () {
-    return this.getPath('rightSplitAttributeDescription.collectionClient');
+  rightCollectionClient: function () {
+    return this.getPath('rightAttributeDescription.collectionClient');
   }.property(),
 
-  topSplitCollectionDidChange: function () {
-    this.notifyPropertyChange('topSplitCollectionClient');
-  }.observes('*topSplitAttributeDescription.collectionClient'),
+  topCollectionDidChange: function () {
+    this.notifyPropertyChange('topCollectionClient');
+  }.observes('*topAttributeDescription.collectionClient'),
 
-  rightSplitCollectionDidChange: function () {
-    this.notifyPropertyChange('rightSplitCollectionClient');
-  }.observes('*rightSplitAttributeDescription.collectionClient'),
+  rightCollectionDidChange: function () {
+    this.notifyPropertyChange('rightCollectionClient');
+  }.observes('*rightAttributeDescription.collectionClient'),
 
   /**
    @property { DG.AttributePlacementDescription }
    */
-  topSplitAttributeDescription: function (iKey, iValue) {
+  topAttributeDescription: function (iKey, iValue) {
     return this.attributeDescriptionForPlace(iKey, iValue, DG.GraphTypes.EPlace.eTopSplit);
   }.property(),
 
   /**
    @property { DG.AttributePlacementDescription }
    */
-  rightSplitAttributeDescription: function (iKey, iValue) {
+  rightAttributeDescription: function (iKey, iValue) {
     return this.attributeDescriptionForPlace(iKey, iValue, DG.GraphTypes.EPlace.eRightSplit);
   }.property(),
 
-  topSplitAttributeID: function () {
-    return this.getPath('topSplitAttributeDescription.attributeID');
+  topAttributeID: function () {
+    return this.getPath('topAttributeDescription.attributeID');
   }.property(),
 
-  rightSplitAttributeID: function () {
-    return this.getPath('rightSplitAttributeDescription.attributeID');
+  rightAttributeID: function () {
+    return this.getPath('rightAttributeDescription.attributeID');
   }.property(),
 
-  topSplitAttributeIDDidChange: function () {
-    this.notifyPropertyChange('topSplitAttributeID');
-  }.observes('*topSplitAttributeDescription.attributeID'),
+  topAttributeIDDidChange: function () {
+    this.notifyPropertyChange('topAttributeID');
+  }.observes('*topAttributeDescription.attributeID'),
 
-  rightSplitAttributeIDDidChange: function () {
-    this.notifyPropertyChange('rightSplitAttributeID');
-  }.observes('*rightSplitAttributeDescription.attributeID'),
+  rightAttributeIDDidChange: function () {
+    this.notifyPropertyChange('rightAttributeID');
+  }.observes('*rightAttributeDescription.attributeID'),
 
   /**
    * It is in initialization that we specialize from base class
@@ -84,8 +84,8 @@ DG.GraphDataConfiguration = DG.PlotDataConfiguration.extend(
           y: DG.AttributePlacementDescription.create(),
           y2: DG.AttributePlacementDescription.create(),
           legend: DG.AttributePlacementDescription.create(),
-          topSplit: DG.AttributePlacementDescription.create(),
-          rightSplit: DG.AttributePlacementDescription.create()
+          top: DG.AttributePlacementDescription.create(),
+          right: DG.AttributePlacementDescription.create()
         },
         tPlace,
         tDefaults = DG.currDocumentController().collectionDefaults();
@@ -158,18 +158,18 @@ DG.GraphDataConfiguration = DG.PlotDataConfiguration.extend(
     this.attributesByPlace[ DG.GraphTypes.EPlace.eY][0] = attributeDescriptions.y;
     this.attributesByPlace[ DG.GraphTypes.EPlace.eY2][0] = attributeDescriptions.y2;
     this.attributesByPlace[ DG.GraphTypes.EPlace.eLegend][0] = attributeDescriptions.legend;
-    this.attributesByPlace[ DG.GraphTypes.EPlace.eTopSplit][0] = attributeDescriptions.topSplit;
-    this.attributesByPlace[ DG.GraphTypes.EPlace.eRightSplit][0] = attributeDescriptions.rightSplit;
+    this.attributesByPlace[ DG.GraphTypes.EPlace.eTopSplit][0] = attributeDescriptions.top;
+    this.attributesByPlace[ DG.GraphTypes.EPlace.eRightSplit][0] = attributeDescriptions.right;
   },
 
   destroy: function () {
-    var topSplitDesc = this.get('topSplitAttributeDescription'),
-        rightSplitDesc = this.get('rightSplitAttributeDescription');
+    var topDesc = this.get('topAttributeDescription'),
+        rightDesc = this.get('rightAttributeDescription');
 
-    if (topSplitDesc)
-      topSplitDesc.removeObserver('collectionClient', this, 'topSplitCollectionDidChange');
-    if (rightSplitDesc)
-      rightSplitDesc.removeObserver('collectionClient', this, 'rightSplitCollectionDidChange');
+    if (topDesc)
+      topDesc.removeObserver('collectionClient', this, 'topCollectionDidChange');
+    if (rightDesc)
+      rightDesc.removeObserver('collectionClient', this, 'rightCollectionDidChange');
 
     sc_super();
   },
@@ -197,8 +197,8 @@ DG.GraphDataConfiguration = DG.PlotDataConfiguration.extend(
           }.bind(this);
 
       // Consider each of our split collections in turn
-      considerCollection('topSplit');
-      considerCollection('rightSplit');
+      considerCollection('top');
+      considerCollection('right');
 
       // Search through our set of collections, stopping on the first one that has aggregates.
       foundID = DG.ObjectMap.findKey(collectionIDs,
@@ -214,22 +214,18 @@ DG.GraphDataConfiguration = DG.PlotDataConfiguration.extend(
    * @property {Boolean}
    */
   hasSplitAttribute: function() {
-    return !!this.get('rightSplitAttributeID') || !!this.get('topSplitAttributeID');
-  }.property( 'rightSplitAttributeID', 'topSplitAttributeID'),
-
-  attributeAssignmentDidChange: function () {
-    sc_super();
-  }.observes('.topSplitAttributeDescription.attribute', '.rightSplitAttributeDescription.attribute'),
+    return !!this.get('rightAttributeID') || !!this.get('topAttributeID');
+  }.property( 'rightAttributeID', 'topAttributeID'),
 
   /**
    * Utility method
    */
   invalidateAttributeDescriptionCaches: function (iCases, iChange) {
     sc_super();
-    if (this.get('topSplitAttributeDescription'))
-      this.get('topSplitAttributeDescription').invalidateCaches(iCases, iChange);
-    if (this.get('rightSplitAttributeDescription'))
-      this.get('rightSplitAttributeDescription').invalidateCaches(iCases, iChange);
+    if (this.get('topAttributeDescription'))
+      this.get('topAttributeDescription').invalidateCaches(iCases, iChange);
+    if (this.get('rightAttributeDescription'))
+      this.get('rightAttributeDescription').invalidateCaches(iCases, iChange);
   },
 
   /**
@@ -237,7 +233,7 @@ DG.GraphDataConfiguration = DG.PlotDataConfiguration.extend(
    * @returns {Boolean}
    */
   atLeastOneFormula: function () {
-    var tProperties = ['topSplitAttributeDescription', 'rightSplitAttributeDescription'];
+    var tProperties = ['topAttributeDescription', 'rightAttributeDescription'];
     return (sc_super() ||
         tProperties.some(function (iProperty) {
           return this.getPath(iProperty + '.hasFormula');

--- a/apps/dg/components/graph/graph_controller.js
+++ b/apps/dg/components/graph/graph_controller.js
@@ -497,19 +497,26 @@ DG.GraphController = DG.DataDisplayController.extend(
               controller.handlePossibleForeignDataContext( iDragData.context);
 
               var tDataContext = controller.get('dataContext'),
-                tCollectionClient = getCollectionClientFromDragData(tDataContext, iDragData);
+                  tCollectionClient = getCollectionClientFromDragData(tDataContext, iDragData),
+                  tGraphModel = controller.get('graphModel'),
+                  tAttrRefs = {
+                    collection: tCollectionClient,
+                    attributes: [iDragData.attribute]
+                  };
 
               iAxisMultiTarget.dragData = null;
 
-              controller.get('graphModel').addAttributeToAxis(
-                tDataContext,
-                {
-                  collection: tCollectionClient,
-                  attributes: [iDragData.attribute]
-                });
-              controller.get('view').select();
+              if( iDragData.attribute.isNominal()) {
+                tGraphModel.splitVerticallyByAttribute( tDataContext, tAttrRefs);
 
-              this.log = 'Attribute dragged and dropped: %@, %@'.fmt('vertical', iDragData.attribute.get('name'));
+                this.log = 'Graph split vertically attribute %@'.fmt(iDragData.attribute.get('name'));
+              }
+              else {
+                tGraphModel.addAttributeToAxis( tDataContext, tAttrRefs);
+
+                this.log = 'Attribute dragged and dropped: %@, %@'.fmt('vertical', iDragData.attribute.get('name'));
+              }
+              controller.get('view').select();
             },
             undo: function() {
               var controller = this._controller();

--- a/apps/dg/components/graph/graph_model.js
+++ b/apps/dg/components/graph/graph_model.js
@@ -1271,7 +1271,7 @@ DG.GraphModel = DG.DataLayerModel.extend(
       });
       tSplitPlotArray.length = 1;
       tSplitPlotArray[0].length = 1;
-      tRootPlot.set('siblingPlots', [])
+      tRootPlot.set('siblingPlots', []);
 
       wipeOutAxisArray( this.get('xAxisArray'));
       wipeOutAxisArray( this.get('yAxisArray'));

--- a/apps/dg/components/graph/graph_model.js
+++ b/apps/dg/components/graph/graph_model.js
@@ -951,12 +951,7 @@ DG.GraphModel = DG.DataLayerModel.extend(
       tOperativePlot.setIfChanged( 'dataConfiguration', tConfig );
       tOperativePlot.setIfChanged( 'xAxis', this.get( 'xAxis' ) );
       tOperativePlot.setIfChanged( 'yAxis', this.get( 'yAxis' ) );
-      for( var tProperty in tAdornmentModels ) {
-        if( tAdornmentModels.hasOwnProperty( tProperty )) {
-          var tModel = tAdornmentModels[tProperty];
-          tOperativePlot.setIfChanged( tProperty, tModel);
-        }
-      }
+      tOperativePlot.installAdornmentModels( tAdornmentModels);
       tOperativePlot.endPropertyChanges();
 
       this.setIfChanged('plot', tOperativePlot);
@@ -1108,7 +1103,9 @@ DG.GraphModel = DG.DataLayerModel.extend(
      */
     updateSplitPlotArray: function() {
       var this_ = this,
-          tPlotClass = this.get('plot').constructor;  // All plots will be of this class
+          tRootPlot = this.get('plot'),
+          tPlotClass = tRootPlot.constructor;  // All plots will be of this class
+
       this.forEachSplitPlotElementDo( function( iPlotArray, iRow, iCol) {
         var tCurrentPlot = iPlotArray[0],
             tNewPlot;
@@ -1123,6 +1120,7 @@ DG.GraphModel = DG.DataLayerModel.extend(
             yAttributeIndex: 0
           });
           tNewPlot = tPlotClass.create(tProperties);
+          tNewPlot.installAdornmentModelsFrom( tRootPlot);
           this_.addPlotObserver(tNewPlot);
           iPlotArray[0] = tNewPlot;
           if (tCurrentPlot) {

--- a/apps/dg/components/graph/graph_types.js
+++ b/apps/dg/components/graph/graph_types.js
@@ -32,8 +32,10 @@ DG.GraphTypes = {
         eY2: 3,
         ePolygon: 4,
         eCaption: 5,
-        eLastPlace: 5,
-        eNumPlaces: 6
+        eTopSplit: 6,
+        eRightSplit: 7,
+        eLastPlace: 7,
+        eNumPlaces: 8
   }
 
 };

--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -662,7 +662,7 @@ DG.GraphView = SC.View.extend(
           }
         }
 
-        function layoutSplitPlots() {
+        function layoutSplitPlots( iTopHeight, iRightSpace) {
           var tXAxisViewArray = this_.get('xAxisViewArray'),
               tYAxisViewArray = this_.get('yAxisViewArray'),
               tY2AxisViewArray = this_.get('y2AxisViewArray'),
@@ -672,36 +672,36 @@ DG.GraphView = SC.View.extend(
               tFrame = this_.get('frame'),
               tSpaceAboveTopAxis = tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight,
               tRowHeight = (tFrame.height - tXHeight - tLegendHeight - tFunctionViewHeight -
-                  tPlottedValueViewHeight - tNumberToggleHeight - tTopHeight) / tNumRows,
-              tColWidth = (tFrame.width - tYWidth - tSpaceForY2 - tRightSpace) / tNumColumns,
+                  tPlottedValueViewHeight - tNumberToggleHeight - iTopHeight) / tNumRows,
+              tColWidth = (tFrame.width - tYWidth - tSpaceForY2 - iRightSpace) / tNumColumns,
               tRowIndex, tColIndex;
           if (firstTime) {
             tTopAxisView.set('layout', {
               left: tYWidth, top: tSpaceAboveTopAxis,
-              right: tRightSpace, height: tTopHeight
+              right: iRightSpace, height: iTopHeight
             });
             tRightAxisView.set('layout', {
-              width: tRightSpace, top: tSpaceAboveTopAxis + tTopHeight,
+              width: iRightSpace, top: tSpaceAboveTopAxis + iTopHeight,
               right: 0, bottom: tLegendHeight + tXHeight
             });
           }
           else {
-            tTopAxisView.adjust({top: tSpaceAboveTopAxis, left: tYWidth, right: tRightSpace, height: tTopHeight});
+            tTopAxisView.adjust({top: tSpaceAboveTopAxis, left: tYWidth, right: iRightSpace, height: iTopHeight});
             tRightAxisView.adjust({
-              width: tRightSpace, top: tSpaceAboveTopAxis + tTopHeight,
+              width: iRightSpace, top: tSpaceAboveTopAxis + iTopHeight,
               bottom: tLegendHeight + tXHeight
             });
           }
           for (tRowIndex = 0; tRowIndex < tNumRows; tRowIndex++) {
             var tThisYAxisView = tYAxisViewArray[tRowIndex],
-                tTop = tSpaceAboveTopAxis + tTopHeight + (tNumRows - tRowIndex - 1) * tRowHeight;
+                tTop = tSpaceAboveTopAxis + iTopHeight + (tNumRows - tRowIndex - 1) * tRowHeight;
             if (tThisYAxisView) {
               if (firstTime) {
                 tThisYAxisView.set('layout', {
                   left: tWidthForLeftLabel, top: tTop, height: tRowHeight, width: tYAxisWidth
                 });
                 tY2AxisViewArray[tRowIndex].set('layout', {
-                  right: tRightSpace, top: tTop, height: tRowHeight, width: tY2DesiredWidth
+                  right: iRightSpace, top: tTop, height: tRowHeight, width: tY2DesiredWidth
                 });
                 if (!tHasY2Attribute) {
                   tY2AxisViewArray[tRowIndex].set('isVisible', false);
@@ -714,7 +714,7 @@ DG.GraphView = SC.View.extend(
                 if (tCurrYWidth !== tYAxisWidth && tRowIndex === 0)
                   tThisYAxisView.notifyPropertyChange('drawWidth');
                 tY2AxisViewArray[tRowIndex].adjust({
-                  right: tRightSpace, top: tTop,
+                  right: iRightSpace, top: tTop,
                   height: tRowHeight, width: tY2DesiredWidth
                 });
               }
@@ -813,7 +813,7 @@ DG.GraphView = SC.View.extend(
             bottom: tHeightForBottomLabel + tLegendHeight, left: 0, width: tWidthForLeftLabel
           });
           if (this.getPath('model.isSplit'))
-            layoutSplitPlots();
+            layoutSplitPlots( tTopHeight, tRightSpace);
           else
             layoutUnsplitPlot();
           if (tFunctionView)

--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -488,9 +488,15 @@ DG.GraphView = SC.View.extend(
       }.observes('model.pointColor', 'model.strokeColor', 'model.pointSizeMultiplier',
           'model.transparency', 'model.strokeTransparency'),
 
-      categoriesDidChange: function (iObject, iProperty) {
+      categoriesDidChange: function (iAxisView, iProperty) {
         if (this.getPath('model.aboutToChangeConfiguration') || !this.get('plotViews'))
           return; // So we don't attempt to draw during init or in the midst of a configuration change
+
+/*
+        var tOrientation = iAxisView.get('orientation');
+        if( tOrientation === 'top' || tOrientation === 'right')
+          this.get('model').splitCategoriesDidChange();
+*/
 
         this.get('plotViews').forEach(function (iPlotView, iIndex) {
           iPlotView.categoriesDidChange();
@@ -501,7 +507,8 @@ DG.GraphView = SC.View.extend(
         if (tLegendView)
           tLegendView.displayDidChange();
         // Note: Asterisks below are necessary in case axis view gets swapped out
-      }.observes('*xAxisView.categoriesDragged', '*yAxisView.categoriesDragged'),
+      }.observes('*xAxisView.categoriesDragged', '*yAxisView.categoriesDragged',
+          '*topAxisView.categoriesDragged', '*rightAxisView.categoriesDragged'),
 
       prepareToSelectPoints: function () {
         this.forEachPlotViewDo(function (iPlotView) {
@@ -1090,7 +1097,7 @@ DG.GraphView = SC.View.extend(
         configurePlotViewArrays();
         this._isConfigurationInProgress = false;
 
-      }.observes('.model.splitAttributeChange'),
+      }.observes('.model.splitPlotChange'),
 
       allModelSplitsWereRemoved: function () {
         var this_ = this,

--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -884,6 +884,7 @@ DG.GraphView = SC.View.extend(
         var tMulti = DG.AxisMultiTarget.create(),
             tExtent = tMulti.get('desiredExtent');
         this.appendChild(tMulti);
+        tMulti.set('dataConfiguration', this.getPath('model.dataConfiguration'));
         tMulti.set('attributeDescription', this.getPath('model.yAxis.attributeDescription'));
         tMulti.set('otherAttributeDescription', this.getPath('model.xAxis.attributeDescription'));
         //tMulti.set('layout', { left: 0, top: 0, width: tExtent.width, height: tExtent.height });

--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -37,6 +37,12 @@ DG.GraphView = SC.View.extend(
 
       controller: null,
 
+      /**
+       * @property { SC.View }
+       */
+      leftEdgeBackground: null,
+      rightEdgeBackground: null,
+
       yAxisMultiTarget: null,
       legendView: null,
       numberToggleView: null,
@@ -51,12 +57,25 @@ DG.GraphView = SC.View.extend(
       y2AxisViewArray: null,
 
       /**
+       * The following two axis views lay out the categories when the graph is split in one
+       * or both dimensions.
+       * @property {DG.CellAxisView}
+       */
+      topAxisView: null,
+      rightAxisView: null,
+
+      // When a graph is split, we have multiple axis views, but we only want one label
+      // We use these for bottom and left axis labels regardless, though.
+      bottomAxisLabelView: null,
+      leftAxisLabelView: null,
+
+      /**
        @property { DG.AxisView }
        */
-      xAxisView: function( iKey, iValue) {
-        if( !this.xAxisViewArray)
+      xAxisView: function (iKey, iValue) {
+        if (!this.xAxisViewArray)
           this.xAxisViewArray = [];
-        if( iValue) {
+        if (iValue) {
           this.get('xAxisViewArray')[0] = iValue;
         }
         return this.xAxisViewArray[0];
@@ -65,10 +84,10 @@ DG.GraphView = SC.View.extend(
       /**
        @property { DG.AxisView }
        */
-      yAxisView: function( iKey, iValue) {
-        if( !this.yAxisViewArray)
+      yAxisView: function (iKey, iValue) {
+        if (!this.yAxisViewArray)
           this.yAxisViewArray = [];
-        if( iValue) {
+        if (iValue) {
           this.get('yAxisViewArray')[0] = iValue;
         }
         return this.yAxisViewArray[0];
@@ -77,10 +96,10 @@ DG.GraphView = SC.View.extend(
       /**
        * @property { DG.AxisView }
        */
-      y2AxisView: function( iKey, iValue) {
-        if( !this.y2AxisViewArray)
+      y2AxisView: function (iKey, iValue) {
+        if (!this.y2AxisViewArray)
           this.y2AxisViewArray = [];
-        if( iValue) {
+        if (iValue) {
           this.get('y2AxisViewArray')[0] = iValue;
         }
         return this.y2AxisViewArray[0];
@@ -99,15 +118,13 @@ DG.GraphView = SC.View.extend(
       plotBackgroundViewArray: null,
 
       _functionEditorView: null,
-      functionEditorView: function( iKey, iValue) {
-        if( iValue !== undefined) {
-          if( this._functionEditorView)
-          {
-            this.removeChild( this._functionEditorView);
+      functionEditorView: function (iKey, iValue) {
+        if (iValue !== undefined) {
+          if (this._functionEditorView) {
+            this.removeChild(this._functionEditorView);
           }
-          if( iValue)
-          {
-            this.appendChild( iValue);
+          if (iValue) {
+            this.appendChild(iValue);
             iValue.addObserver('isVisible', this, this.handleAxisOrLegendLayoutChange);
           }
           this._functionEditorView = iValue;
@@ -116,15 +133,13 @@ DG.GraphView = SC.View.extend(
       }.property(),
 
       _plottedValueEditorView: null,
-      plottedValueEditorView: function( iKey, iValue) {
-        if( iValue !== undefined) {
-          if( this._plottedValueEditorView)
-          {
-            this.removeChild( this._plottedValueEditorView);
+      plottedValueEditorView: function (iKey, iValue) {
+        if (iValue !== undefined) {
+          if (this._plottedValueEditorView) {
+            this.removeChild(this._plottedValueEditorView);
           }
-          if( iValue)
-          {
-            this.appendChild( iValue);
+          if (iValue) {
+            this.appendChild(iValue);
             iValue.addObserver('isVisible', this, this.handleAxisOrLegendLayoutChange);
           }
           this._plottedValueEditorView = iValue;
@@ -192,17 +207,22 @@ DG.GraphView = SC.View.extend(
         }
       },
 
-      addPlotViewObserver: function( iPlotView) {
-        iPlotView.addObserver('plotDisplayDidChange', this, function () {
-          this._displayDidChangeInvocationsOfDrawPlots++;
-          this.invokeOnceLater(function () {
-            this._displayDidChangeInvocationsOfDrawPlots--;
-            if( this._displayDidChangeInvocationsOfDrawPlots === 0)
-            {
-              this.drawPlots();
-            }
-          });
+      plotDisplayDidChange: function () {
+        this._displayDidChangeInvocationsOfDrawPlots++;
+        this.invokeOnceLater(function () {
+          this._displayDidChangeInvocationsOfDrawPlots--;
+          if (this._displayDidChangeInvocationsOfDrawPlots === 0) {
+            this.drawPlots();
+          }
         });
+      },
+
+      addPlotViewObserver: function (iPlotView) {
+        iPlotView.addObserver('plotDisplayDidChange', this, this.plotDisplayDidChange);
+      },
+
+      removePlotViewObserver: function (iPlotView) {
+        iPlotView.removeObserver('plotDisplayDidChange', this, this.plotDisplayDidChange);
       },
 
       /**
@@ -213,33 +233,41 @@ DG.GraphView = SC.View.extend(
        */
       setPlotViewProperties: function (iPlotView, iPlotModel, iYAxisKey, iCurrentPoints) {
 
-        var installAxisView = function( iAxisViewDescription) {
+        var installAxisView = function (iAxisViewDescription) {
           var tNewViewClass = iAxisViewDescription.axisClass,
               tPrefix = iAxisViewDescription.axisKey;
           if (!SC.none(tNewViewClass)) {
             var tOldView = this.get(tPrefix + 'AxisView');
-            if( tOldView.constructor === tNewViewClass)
+            if (tOldView.constructor === tNewViewClass)
               return; // Already done
 
-            var tNewModelClass = DG.PlotUtilities.mapAxisViewClassToAxisModelClass( tNewViewClass),
-                tNewModel = tNewModelClass.create(),
+            var tNewModelClass = DG.PlotUtilities.mapAxisViewClassToAxisModelClass(tNewViewClass),
+                tExistingAxisModel = this.getPath('model.' + tPrefix + 'Axis'),
+                tExistingAxisModelClass = tExistingAxisModel && tExistingAxisModel.constructor,
+                tOrientation = tOldView.get('orientation'),
+                tPaperSource = iAxisViewDescription.axisKey === 'x' ?
+                    this.get('bottomAxisLabelView') : this.get('leftAxisLabelView'),
+                tNewAxisModel = (tExistingAxisModelClass === tNewModelClass) ? tExistingAxisModel :
+                    tNewModelClass.create(),
                 tNewView = tNewViewClass.create({
-                  orientation: tOldView.get('orientation'),
-                  model: tNewModel
-                }),
-                tOtherView;
+                  orientation: tOrientation,
+                  model: tNewAxisModel,
+                  paperSourceForLabel: tPaperSource
+                });
             this.removeChild(tOldView);
             this.appendChild(tNewView);
             this.set(tPrefix + 'AxisView', tNewView);
             this.setPath('plotBackgroundView.' + tPrefix + 'AxisView', tNewView);
             this.setPath('plotView.' + tPrefix + 'AxisView', tNewView);
             this.setPath('controller.' + tPrefix + 'AxisView', tNewView);
-            tOtherView = this.get(((tPrefix === 'x') ? 'y' : 'x') + 'AxisView');
-            tNewView.set('otherAxisView', tOtherView);
             tOldView.destroy();
-            this.setPath('model.' + tPrefix + 'Axis', tNewModel);
+            if (tExistingAxisModelClass !== tNewModelClass) {
+              tNewAxisModel.set('attributeDescription',
+                  this.getPath('model.dataConfiguration.' + tPrefix + 'AttributeDescription'));
+              this.setPath('model.' + tPrefix + 'Axis', tNewAxisModel);
+            }
           }
-        }.bind( this);
+        }.bind(this);
 
         var tAxisViewDescription; // { x|y: AxisView }
         iYAxisKey = iYAxisKey || 'yAxisView';
@@ -251,15 +279,15 @@ DG.GraphView = SC.View.extend(
         iPlotView.setIfChanged('yAxisView', this.get(iYAxisKey));
         // special requirements set up here, with possible return of description of an axis to be added
         tAxisViewDescription = iPlotView.configureAxes();
-        if( !SC.none( tAxisViewDescription)) {
-          installAxisView( tAxisViewDescription);
+        if (!SC.none(tAxisViewDescription)) {
+          installAxisView(tAxisViewDescription);
         }
         iPlotView.setupAxes();
         if (!SC.none(iCurrentPoints))
           iPlotView.set('transferredElementCoordinates', iCurrentPoints);
         iPlotView.endPropertyChanges();
 
-        this.addPlotViewObserver( iPlotView);
+        this.addPlotViewObserver(iPlotView);
       },
 
       init: function () {
@@ -283,8 +311,8 @@ DG.GraphView = SC.View.extend(
 
         function initPlotViewArrays() {
           this_._plotViews = [];
-          this_.splitPlotViewArray = [[ this_._plotViews]];
-          this_.plotBackgroundViewArray = [[ this_.plotBackgroundView]];
+          this_.splitPlotViewArray = [[this_._plotViews]];
+          this_.plotBackgroundViewArray = [[this_.plotBackgroundView]];
         }
 
         var tXAxis = this.getPath('model.xAxis'),
@@ -292,8 +320,14 @@ DG.GraphView = SC.View.extend(
             tYAxis = this.getPath('model.yAxis'),
             tYAxisAttributeType = this.getPath('model.dataConfiguration.yAttributeDescription.attribute.type'),
             tY2Axis = this.getPath('model.y2Axis'),
-            tXAxisView = getAxisViewClass(tXAxis, tXAxisAttributeType).create({orientation: 'horizontal'}),
-            tYAxisView = getAxisViewClass(tYAxis, tYAxisAttributeType).create({orientation: 'vertical'}),
+            tBottomAxisLabelView = DG.AxisLabelView.create({orientation: 'horizontal'}),
+            tLeftAxisLabelView = DG.AxisLabelView.create({orientation: 'vertical'}),
+            tXAxisView = getAxisViewClass(tXAxis, tXAxisAttributeType).create({
+              orientation: 'horizontal', paperSourceForLabel: tBottomAxisLabelView
+            }),
+            tYAxisView = getAxisViewClass(tYAxis, tYAxisAttributeType).create({
+              orientation: 'vertical', paperSourceForLabel: tLeftAxisLabelView
+            }),
             tY2AxisView = getAxisViewClass(tY2Axis).create({orientation: 'vertical2'}),
             tTopAxis = this.getPath('model.topAxis'),
             tTopAxisView = getAxisViewClass(tTopAxis).create({orientation: 'top', centering: 'true'}),
@@ -301,11 +335,23 @@ DG.GraphView = SC.View.extend(
             tRightAxisView = getAxisViewClass(tRightAxis).create({orientation: 'right', centering: 'true'}),
             tBackgroundView = DG.PlotBackgroundView.create({
               xAxisView: tXAxisView, yAxisView: tYAxisView,
-              graphModel: this.get('model')
+              graphModel: this.get('model'),
+              rowIndex: 0,
+              colIndex: 0
             }),
             tPlots = this.getPath('model.plots');
 
         sc_super();
+
+        this.set('leftEdgeBackground', SC.View.create({classNames: 'dg-axis-view'.w()}));
+        this.appendChild(this.get('leftEdgeBackground'));
+        this.set('rightEdgeBackground', SC.View.create({classNames: 'dg-axis-view'.w()}));
+        this.appendChild(this.get('rightEdgeBackground'));
+        this.appendChild(tBottomAxisLabelView);
+        this.set('bottomAxisLabelView', tBottomAxisLabelView);
+        this.appendChild(tLeftAxisLabelView);
+        this.set('leftAxisLabelView', tLeftAxisLabelView);
+
 
         this.set('plotBackgroundView', tBackgroundView);
         initPlotViewArrays();
@@ -328,9 +374,6 @@ DG.GraphView = SC.View.extend(
         this.appendChild(tRightAxisView);
 
         this.appendChild(tBackgroundView);
-        tXAxisView.set('otherAxisView', tYAxisView);
-        tYAxisView.set('otherAxisView', tXAxisView);
-        tY2AxisView.set('otherAxisView', tXAxisView);
 
         this.legendView = DG.LegendView.create({model: this.getPath('model.legend')});
         this.appendChild(this.legendView);
@@ -339,8 +382,10 @@ DG.GraphView = SC.View.extend(
 
         if (this.getPath('model.numberToggle')) {
           var isNumberToggleEnabled = this.getPath('model.numberToggle.isEnabled'),
-              tNumberToggleView = DG.NumberToggleView.create({model: this.getPath('model.numberToggle'),
-                                                              isVisible: isNumberToggleEnabled });
+              tNumberToggleView = DG.NumberToggleView.create({
+                model: this.getPath('model.numberToggle'),
+                isVisible: isNumberToggleEnabled
+              });
           this.set('numberToggleView', tNumberToggleView);
           this.appendChild(tNumberToggleView);
         }
@@ -370,7 +415,7 @@ DG.GraphView = SC.View.extend(
 
       destroy: function () {
         // Plotviews are not actually subviews so sc_super doesn't destroy them
-        this.get('plotViews').forEach( function( iPlotView) {
+        this.get('plotViews').forEach(function (iPlotView) {
           iPlotView.destroy();
         });
         this.model.destroy(); // so that it can unlink observers
@@ -381,14 +426,15 @@ DG.GraphView = SC.View.extend(
        * Override to deal with removing functionEditorView & plottedValueEditorView
        * @param iChildView {SC.View}
        */
-      removeChild: function( iChildView) {
-        if( iChildView && iChildView === this._functionEditorView)
-        {
+      removeChild: function (iChildView) {
+        if (!iChildView.isDescendantOf(this))
+          return; // In a splitting scenario multiple plot views can add editor views.
+                  // Each time, pre-existing editor is removed.
+        if (iChildView && iChildView === this._functionEditorView) {
           this._functionEditorView.removeObserver('isVisible', this, this.handleAxisOrLegendLayoutChange);
           this._functionEditorView = null;
         }
-        if( iChildView && iChildView === this._plottedValueEditorView)
-        {
+        if (iChildView && iChildView === this._plottedValueEditorView) {
           this._plottedValueEditorView.removeObserver('isVisible', this, this.handleAxisOrLegendLayoutChange);
           this._plottedValueEditorView = null;
         }
@@ -405,20 +451,20 @@ DG.GraphView = SC.View.extend(
        * Signature of iFunc is <DG.PlotView, iRow, iCol, iIndex>
        * @param iFunc {Function}
        */
-      forEachPlotViewDo: function( iFunc) {
+      forEachPlotViewDo: function (iFunc) {
         if (this.getPath('model.isSplit')) {
-          this.get('splitPlotViewArray').forEach( function( iColArray, iRowIndex){
-            iColArray.forEach( function( iPlotViewArray, iColIndex) {
-              iPlotViewArray.forEach( function( iPlotView, iIndex) {
-                iFunc( iPlotView, iRowIndex, iColIndex, iIndex);
+          this.get('splitPlotViewArray').forEach(function (iColArray, iRowIndex) {
+            iColArray.forEach(function (iPlotViewArray, iColIndex) {
+              iPlotViewArray.forEach(function (iPlotView, iIndex) {
+                iFunc(iPlotView, iRowIndex, iColIndex, iIndex);
               });
             });
           });
         }
         else {
           var tPlotViews = this.get('plotViews');
-          tPlotViews.forEach( function( iPlotView, iIndex) {
-            iFunc( iPlotView, 0, 0, iIndex);
+          tPlotViews.forEach(function (iPlotView, iIndex) {
+            iFunc(iPlotView, 0, 0, iIndex);
           });
         }
       },
@@ -426,8 +472,8 @@ DG.GraphView = SC.View.extend(
       /**
        * Draw my plot views
        */
-      drawPlots: function ( iChangedProperty) {
-        if( this._isConfigurationInProgress)
+      drawPlots: function (iChangedProperty) {
+        if (this._isConfigurationInProgress)
           return; // Not a good time to draw
         var tNumPlots = this.get('plotViews').length;
         this.forEachPlotViewDo(function (iPlotView, iRow, iCol, iIndex) {
@@ -436,8 +482,8 @@ DG.GraphView = SC.View.extend(
         });
       },
 
-      pointsDidChange: function ( iModel, iProperty) {
-        this.drawPlots( iProperty);
+      pointsDidChange: function (iModel, iProperty) {
+        this.drawPlots(iProperty);
         this.get('legendView').displayDidChange();
       }.observes('model.pointColor', 'model.strokeColor', 'model.pointSizeMultiplier',
           'model.transparency', 'model.strokeTransparency'),
@@ -458,7 +504,7 @@ DG.GraphView = SC.View.extend(
       }.observes('*xAxisView.categoriesDragged', '*yAxisView.categoriesDragged'),
 
       prepareToSelectPoints: function () {
-        this.get('plotViews').forEach(function (iPlotView) {
+        this.forEachPlotViewDo(function (iPlotView) {
           iPlotView.hideDataTip();
           iPlotView.preparePointSelection();
         });
@@ -473,10 +519,14 @@ DG.GraphView = SC.View.extend(
        * Give each plotView a chance
        * Note that it would be more natural for the graph view to tell the graph model to select the cases than
        * to do it here directly with the data context.
+       * Ignore the cases found in iLast
        * @param iRect
        * @param iBaseSelection
+       * @param iLast {{x:number,y:number,width:number,height:number}}
+       * iRowIndex {{Number}} Index into splitPlotViewArray
+       * iColIndex {{Number}} Index into splitPlotViewArray
        */
-      selectPointsInRect: function (iRect, iBaseSelection, iLast) {
+      selectPointsInRect: function (iRect, iBaseSelection, iLast, iRowIndex, iColIndex) {
         iBaseSelection = iBaseSelection || [];
         var tDataContext = this.getPath('model.dataContext');
         var tCollection = this.getPath('model.collectionClient');
@@ -498,7 +548,7 @@ DG.GraphView = SC.View.extend(
         if (SC.none(tDataContext))
           return;
 
-        this.get('plotViews').forEach(function (iPlotView) {
+        this.get('splitPlotViewArray')[iRowIndex][iColIndex].forEach(function (iPlotView) {
           var tPlotSelection = iPlotView.getCasesForDelta(iRect, iLast);
           tSelectChange.cases = tSelectChange.cases.concat(tPlotSelection);
           var tPlotDeselection = iPlotView.getCasesForDelta(iLast, iRect);
@@ -544,94 +594,107 @@ DG.GraphView = SC.View.extend(
         sc_super();
 
         function layoutUnsplitPlot() {
-          tTopAxisView.adjust({ width: 0, height: 0 });
-          tRightAxisView.adjust({ width: 0, height: 0 });
-            if (firstTime) {
-              // set or reset all layout parameters (initializes all parameters)
-              tXAxisView.set('layout', {left: tYWidth, right: tSpaceForY2, bottom: tLegendHeight, height: tXHeight});
-              tYAxisView.set('layout', {
-                left: 0, top: tNumberToggleHeight + tFunctionViewHeight +
-                tPlottedValueViewHeight,
-                bottom: tLegendHeight, width: tYWidth
-              });
-              tY2AxisView.set('layout', {
-                right: 0,
-                top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight,
-                bottom: tLegendHeight,
-                width: tY2DesiredWidth
-              });
-              tPlotBackground.set('layout', {
-                left: tYWidth,
-                right: tSpaceForY2,
-                top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight,
-                bottom: tXHeight + tLegendHeight
-              });
-              this_.makeSubviewFrontmost(tY2AxisView);
-            }
-            else {
-              // adjust() method avoids triggering observers if layout parameter is already at correct value.
-              var tCurrXHeight = tXAxisView.get('layout').height;
-              tXAxisView.adjust({left: tYWidth, right: tSpaceForY2, bottom: tLegendHeight, height: tXHeight});
-              if (tCurrXHeight !== tXHeight)
-                tXAxisView.notifyPropertyChange('drawHeight');
-
-              var tCurrYWidth = tYAxisView.get('layout').width;
-              tYAxisView.adjust({bottom: tLegendHeight, width: tYWidth,
-                top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight});
-              if (tCurrYWidth !== tYWidth)
-                tYAxisView.notifyPropertyChange('drawWidth');
-
-              tY2AxisView.adjust({bottom: tLegendHeight, width: tY2DesiredWidth,
-                top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight});
-              if (!tHasY2Attribute) {
-                tY2AxisView.set('isVisible', false);
-              }
-              tPlotBackground.adjust({
-                left: tYWidth,
-                right: tSpaceForY2,
-                top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight,
-                bottom: tXHeight + tLegendHeight
-              });
-            }
+          tTopAxisView.adjust({width: 0, height: 0});
+          tRightAxisView.adjust({width: 0, height: 0});
+          if (firstTime) {
+            // set or reset all layout parameters (initializes all parameters)
+            tXAxisView.set('layout', {
+              left: tYWidth, right: tSpaceForY2,
+              bottom: tLegendHeight + tHeightForBottomLabel, height: tXAxisHeight
+            });
+            tYAxisView.set('layout', {
+              left: tWidthForLeftLabel, top: tNumberToggleHeight + tFunctionViewHeight +
+              tPlottedValueViewHeight,
+              bottom: tLegendHeight + tXHeight, width: tYAxisWidth
+            });
+            tY2AxisView.set('layout', {
+              right: 0,
+              top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight,
+              bottom: tLegendHeight + tXHeight,
+              width: tY2DesiredWidth
+            });
+            tPlotBackground.set('layout', {
+              left: tYWidth,
+              right: tSpaceForY2,
+              top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight,
+              bottom: tXHeight + tLegendHeight
+            });
+            this_.makeSubviewFrontmost(tY2AxisView);
           }
+          else {
+            // adjust() method avoids triggering observers if layout parameter is already at correct value.
+            var tCurrXHeight = tXAxisView.get('layout').height;
+            tXAxisView.adjust({
+              left: tYWidth, right: tSpaceForY2, bottom: tLegendHeight + tHeightForBottomLabel,
+              height: tXAxisHeight
+            });
+            if (tCurrXHeight !== tXAxisHeight)
+              tXAxisView.notifyPropertyChange('drawHeight');
+
+            var tCurrYWidth = tYAxisView.get('layout').width;
+            tYAxisView.adjust({
+              bottom: tXHeight + tLegendHeight, width: tYAxisWidth,
+              top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight
+            });
+            if (tCurrYWidth !== tYAxisWidth)
+              tYAxisView.notifyPropertyChange('drawWidth');
+
+            tY2AxisView.adjust({
+              bottom: tLegendHeight + tXHeight, width: tY2DesiredWidth,
+              top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight
+            });
+            if (!tHasY2Attribute) {
+              tY2AxisView.set('isVisible', false);
+            }
+            tPlotBackground.adjust({
+              left: tYWidth,
+              right: tSpaceForY2,
+              top: tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight,
+              bottom: tXHeight + tLegendHeight
+            });
+          }
+        }
 
         function layoutSplitPlots() {
-          tTopAxisView.set('isVisible', this_.getPath('model.numSplitColumns') > 1);
-          tRightAxisView.set('isVisible', this_.getPath('model.numSplitRows') > 1);
-
           var tXAxisViewArray = this_.get('xAxisViewArray'),
               tYAxisViewArray = this_.get('yAxisViewArray'),
               tY2AxisViewArray = this_.get('y2AxisViewArray'),
               tPlotBackgroundViewArray = this_.get('plotBackgroundViewArray'),
-              tNumRows = this_.getPath('model.numSplitRows'),
-              tNumColumns = this_.getPath('model.numSplitColumns'),
+              tNumRows = tPlotBackgroundViewArray.length,
+              tNumColumns = tPlotBackgroundViewArray[0].length,
               tFrame = this_.get('frame'),
-              tTopHeight = tTopAxisView.get('isVisible') ? tTopAxisView.get('desiredExtent') : 0,
-              tRightSpace = tRightAxisView.get('isVisible') ? tRightAxisView.get('desiredExtent') : 0,
+              tSpaceAboveTopAxis = tNumberToggleHeight + tFunctionViewHeight + tPlottedValueViewHeight,
               tRowHeight = (tFrame.height - tXHeight - tLegendHeight - tFunctionViewHeight -
                   tPlottedValueViewHeight - tNumberToggleHeight - tTopHeight) / tNumRows,
               tColWidth = (tFrame.width - tYWidth - tSpaceForY2 - tRightSpace) / tNumColumns,
               tRowIndex, tColIndex;
-          if(firstTime) {
-            tTopAxisView.set('layout', { left: tYWidth, top: 0, right: tRightSpace, height: tTopHeight });
-            tRightAxisView.set('layout', { width: tRightSpace, top: tTopHeight,
-              right: 0, bottom: tLegendHeight + tXHeight });
+          if (firstTime) {
+            tTopAxisView.set('layout', {
+              left: tYWidth, top: tSpaceAboveTopAxis,
+              right: tRightSpace, height: tTopHeight
+            });
+            tRightAxisView.set('layout', {
+              width: tRightSpace, top: tSpaceAboveTopAxis + tTopHeight,
+              right: 0, bottom: tLegendHeight + tXHeight
+            });
           }
           else {
-            tTopAxisView.adjust({ left: tYWidth, right: tRightSpace, height: tTopHeight });
-            tRightAxisView.adjust({ width: tRightSpace, top: tTopHeight, bottom: tLegendHeight + tXHeight });
+            tTopAxisView.adjust({top: tSpaceAboveTopAxis, left: tYWidth, right: tRightSpace, height: tTopHeight});
+            tRightAxisView.adjust({
+              width: tRightSpace, top: tSpaceAboveTopAxis + tTopHeight,
+              bottom: tLegendHeight + tXHeight
+            });
           }
-          for( tRowIndex = 0; tRowIndex < tNumRows; tRowIndex++) {
+          for (tRowIndex = 0; tRowIndex < tNumRows; tRowIndex++) {
             var tThisYAxisView = tYAxisViewArray[tRowIndex],
-                tTop = tNumberToggleHeight + tFunctionViewHeight +
-                    tPlottedValueViewHeight + tTopHeight + (tNumRows - tRowIndex - 1) * tRowHeight;
-            if( tThisYAxisView) {
+                tTop = tSpaceAboveTopAxis + tTopHeight + (tNumRows - tRowIndex - 1) * tRowHeight;
+            if (tThisYAxisView) {
               if (firstTime) {
                 tThisYAxisView.set('layout', {
-                  left: 0, top: tTop, height: tRowHeight + tXHeight, width: tYWidth
+                  left: tWidthForLeftLabel, top: tTop, height: tRowHeight, width: tYAxisWidth
                 });
                 tY2AxisViewArray[tRowIndex].set('layout', {
-                  right: tRightSpace, top: tTop, height: tRowHeight + tXHeight, width: tY2DesiredWidth
+                  right: tRightSpace, top: tTop, height: tRowHeight, width: tY2DesiredWidth
                 });
                 if (!tHasY2Attribute) {
                   tY2AxisViewArray[tRowIndex].set('isVisible', false);
@@ -639,11 +702,13 @@ DG.GraphView = SC.View.extend(
               }
               else {
                 var tCurrYWidth = tThisYAxisView.get('layout').width;
-                tThisYAxisView.adjust({height: tRowHeight + tXHeight, width: tYWidth, top: tTop});
-                if (tCurrYWidth !== tYWidth && tRowIndex === 0)
+                tThisYAxisView.adjust({left: tWidthForLeftLabel, height: tRowHeight,
+                  width: tYAxisWidth, top: tTop});
+                if (tCurrYWidth !== tYAxisWidth && tRowIndex === 0)
                   tThisYAxisView.notifyPropertyChange('drawWidth');
-                tY2AxisViewArray[tRowIndex].adjust( {
-                  right: tRightSpace, top: tTop, height: tRowHeight + tXHeight, width: tY2DesiredWidth
+                tY2AxisViewArray[tRowIndex].adjust({
+                  right: tRightSpace, top: tTop,
+                  height: tRowHeight, width: tY2DesiredWidth
                 });
               }
               for (tColIndex = 0; tColIndex < tNumColumns; tColIndex++) {
@@ -656,22 +721,32 @@ DG.GraphView = SC.View.extend(
                   if (tThisXAxisView) {
                     if (firstTime) {
                       tThisXAxisView.set('layout',
-                          {left: tLeft, width: tColWidth, bottom: tLegendHeight, height: tXHeight});
+                          {
+                            left: tLeft, width: tColWidth + 1, bottom: tLegendHeight + tHeightForBottomLabel,
+                            height: tXAxisHeight
+                          });
                     }
                     else {
                       tCurrXHeight = tThisXAxisView.get('layout').height;
-                      tThisXAxisView.adjust({left: tLeft, width: tColWidth, bottom: tLegendHeight, height: tXHeight});
-                      if (tCurrXHeight !== tXHeight && tRowIndex === 0 && tColIndex === 0)
+                      tThisXAxisView.adjust({
+                        left: tLeft, width: tColWidth + 1,
+                        bottom: tLegendHeight + tHeightForBottomLabel, height: tXAxisHeight
+                      });
+                      if (tCurrXHeight !== tXAxisHeight && tRowIndex === 0 && tColIndex === 0)
                         tThisXAxisView.notifyPropertyChange('drawHeight');
-
                     }
                   }
                 }
-                if( tBackgroundView) {
+                if (tBackgroundView) {
                   if (firstTime)
-                    tBackgroundView.set('layout', {left: tLeft, top: tTop, width: tColWidth, height: tRowHeight});
+                    tBackgroundView.set('layout', {
+                      left: tLeft,
+                      top: tTop,
+                      width: tColWidth + 1,
+                      height: tRowHeight + 1
+                    });
                   else
-                    tBackgroundView.adjust({left: tLeft, top: tTop, width: tColWidth, height: tRowHeight});
+                    tBackgroundView.adjust({left: tLeft, top: tTop, width: tColWidth + 1, height: tRowHeight + 1});
                 }
               }
             }
@@ -681,6 +756,12 @@ DG.GraphView = SC.View.extend(
         }
 
         var this_ = this,
+            tLeftEdgeBackgroundView = this.get('leftEdgeBackground'),
+            tRightEdgeBackgroundView = this.get('rightEdgeBackground'),
+            tBottomAxisLabelView = this.get('bottomAxisLabelView'),
+            tHeightForBottomLabel = tBottomAxisLabelView ? tBottomAxisLabelView.get('desiredExtent') : 0,
+            tLeftAxisLabelView = this.get('leftAxisLabelView'),
+            tWidthForLeftLabel = tLeftAxisLabelView ? tLeftAxisLabelView.get('desiredExtent') : 0,
             tXAxisView = this.get('xAxisView'),
             tYAxisView = this.get('yAxisView'),
             tY2AxisView = this.get('y2AxisView'),
@@ -695,8 +776,10 @@ DG.GraphView = SC.View.extend(
             tFunctionView = this.get('functionEditorView'),
             tPlottedValueView = this.get('plottedValueEditorView'),
             tShowNumberToggle = tNumberToggleView && tNumberToggleView.shouldShow(),
-            tXHeight = !tXAxisView ? 0 : tXAxisView.get('desiredExtent'),
-            tYWidth = !tYAxisView ? 0 : tYAxisView.get('desiredExtent'),
+            tXAxisHeight = !tXAxisView ? 0 : tXAxisView.get('desiredExtent'),
+            tXHeight = tXAxisHeight + tHeightForBottomLabel,
+            tYAxisWidth = !tYAxisView ? 0 : tYAxisView.get('desiredExtent'),
+            tYWidth = tYAxisWidth + tWidthForLeftLabel,
             tSpaceForY2 = (!tY2AxisView || !tHasY2Attribute) ? 0 : tY2AxisView.get('desiredExtent'),
             tY2DesiredWidth = !tY2AxisView ? 0 : tY2AxisView.get('desiredExtent'),
             tLegendHeight = !tLegendView ? 0 : tLegendView.get('desiredExtent'),
@@ -706,7 +789,22 @@ DG.GraphView = SC.View.extend(
             tPlottedValueViewHeight = (tPlottedValueView && tPlottedValueView.get('isVisible')) ?
                 tPlottedValueView.get('desiredExtent') : 0;
         if (!SC.none(tXAxisView) && !SC.none(tYAxisView) &&
-            !SC.none( tPlotViews) && ( tPlotViews.length > 0)) {
+            !SC.none(tPlotViews) && (tPlotViews.length > 0)) {
+          tTopAxisView.set('isVisible', this_.getPath('model.numSplitColumns') > 1);
+          tRightAxisView.set('isVisible', this_.getPath('model.numSplitRows') > 1);
+          var tTopHeight = tTopAxisView.get('isVisible') ? tTopAxisView.get('desiredExtent') : 0,
+              tRightSpace = tRightAxisView.get('isVisible') ? tRightAxisView.get('desiredExtent') : 0;
+          tLeftEdgeBackgroundView.set('layout', {left: 0, bottom: 0, top: 0, width: tYWidth});
+          tRightEdgeBackgroundView.set('layout', {right: 0, bottom: 0, top: 0, width: tRightSpace + tSpaceForY2});
+
+          tBottomAxisLabelView.set('layout', {
+            bottom: tLegendHeight, left: tYWidth, right: tSpaceForY2 + tRightSpace,
+            height: tHeightForBottomLabel
+          });
+          tLeftAxisLabelView.set('layout', {
+            top: tNumberToggleHeight + tPlottedValueViewHeight + tFunctionViewHeight,
+            bottom: tHeightForBottomLabel + tLegendHeight, left: 0, width: tWidthForLeftLabel
+          });
           if (this.getPath('model.isSplit'))
             layoutSplitPlots();
           else
@@ -715,7 +813,7 @@ DG.GraphView = SC.View.extend(
             tFunctionView.adjust('top', tNumberToggleHeight);
           if (tPlottedValueView)
             tPlottedValueView.adjust('top', tNumberToggleHeight + tFunctionViewHeight);
-          if( firstTime) {
+          if (firstTime) {
             tLegendView.set('layout', {bottom: 0, height: tLegendHeight});
           }
           else {
@@ -729,8 +827,7 @@ DG.GraphView = SC.View.extend(
         this._drawPlotsInvocations++;
         this.invokeOnceLater(function () {
           this._drawPlotsInvocations--;
-          if( this._drawPlotsInvocations === 0)
-          {
+          if (this._drawPlotsInvocations === 0) {
             this.drawPlots();
           }
         }.bind(this));
@@ -746,8 +843,7 @@ DG.GraphView = SC.View.extend(
        * @param iChildView
        */
       makeSubviewFrontmost: function (iChildView) {
-        if( iChildView && this.get('childViews').indexOf( iChildView) >= 0)
-        {
+        if (iChildView && this.get('childViews').indexOf(iChildView) >= 0) {
           this.removeChild(iChildView);
           this.appendChild(iChildView);
         }
@@ -778,15 +874,17 @@ DG.GraphView = SC.View.extend(
               tViewClass = tView && tView.constructor,
               tNewViewClass, tNewView,
               tPlotView = this_.get('plotView'),
-              tPlace, tAttr, tAttrType = '',
+              tLabelView, tPlace, tAttr, tAttrType = '',
               tSetup;
           switch (iAxisViewKey) {
             case 'xAxisView':
-              tSetup = {orientation: 'horizontal'};
+              tLabelView = this_.get('bottomAxisLabelView');
+              tSetup = {orientation: 'horizontal', paperSourceForLabel: tLabelView};
               tPlace = DG.GraphTypes.EPlace.eX;
               break;
             case 'yAxisView':
-              tSetup = {orientation: 'vertical'};
+              tLabelView = this_.get('leftAxisLabelView');
+              tSetup = {orientation: 'vertical', paperSourceForLabel: tLabelView};
               tPlace = DG.GraphTypes.EPlace.eY;
               break;
             case 'y2AxisView':
@@ -794,7 +892,10 @@ DG.GraphView = SC.View.extend(
               tPlace = DG.GraphTypes.EPlace.eY2;
               break;
           }
-          tSetup.layout = { left: 0, top: 0, width: 0, height: 0 };
+          if (tLabelView && tModel) {
+            tLabelView.set('plottedAttribute', tModel.get('firstAttribute'));
+          }
+          tSetup.layout = {left: 0, top: 0, width: 0, height: 0};
           if (this_.getPath('model.dataConfiguration')) {
             tAttr = this_.getPath('model.dataConfiguration').attributesByPlace[tPlace][0].get('attribute');
             if (tAttr !== DG.Analysis.kNullAttribute) {
@@ -825,8 +926,10 @@ DG.GraphView = SC.View.extend(
             this_.appendChild(tNewView);
             this_.set(iAxisViewKey, tNewView);
             tPlotBackgroundView.set(iAxisViewKey, tNewView);
-            if (!SC.none(tPlotView))
+            if (!SC.none(tPlotView)) {
               tPlotView.set(iAxisViewKey, tNewView);
+              tPlotView.setupAxes();
+            }
             tView.destroy();
             this_.controller.set(iAxisViewKey, tNewView);
             tInitLayout = true; // new view requires a new layout
@@ -836,9 +939,6 @@ DG.GraphView = SC.View.extend(
         handleOneAxis('model.xAxis', 'xAxisView');
         handleOneAxis('model.yAxis', 'yAxisView');
         handleOneAxis('model.y2Axis', 'y2AxisView');
-        this.setPath('xAxisView.otherAxisView', this.get('yAxisView'));
-        this.setPath('yAxisView.otherAxisView', this.get('xAxisView'));
-        this.setPath('y2AxisView.otherAxisView', this.get('xAxisView'));
         this.setPath('y2AxisView.otherYAttributeDescription', this.getPath('model.yAxis.attributeDescription'));
         this.setPath('y2AxisView.xAttributeDescription', this.getPath('model.xAxis.attributeDescription'));
         this.setPath('yAxisMultiTarget.attributeDescription', this.getPath('model.yAxis.attributeDescription'));
@@ -890,7 +990,7 @@ DG.GraphView = SC.View.extend(
        * plots. We make sure we have the necessary axis views and plot views assigned to the correct
        * models.
        */
-      handleSplitAttributeChange: function() {
+      handleSplitAttributeChange: function () {
         var this_ = this;
 
         function configureAxisViewArrays() {
@@ -901,30 +1001,33 @@ DG.GraphView = SC.View.extend(
                 tViewClass = tZerothView.constructor,
                 tOrientation = tZerothView.get('orientation'),
                 tNumModels = iAxisModelArray.length,
-                tOtherView = tZerothView.get('otherAxisView'),
                 tIndex;
-            for( tIndex = 1; tIndex < tNumModels; tIndex++) {
+            for (tIndex = 1; tIndex < tNumModels; tIndex++) {
               var tCurrentView = ioAxisViewArray[tIndex],
                   tNewView;
-              if( !tCurrentView || tCurrentView.constructor !== tViewClass) {
-                tNewView = tViewClass.create( {
+              if (!tCurrentView || tCurrentView.constructor !== tViewClass) {
+                tNewView = tViewClass.create({
                   orientation: tOrientation,
-                  model: iAxisModelArray[ tIndex],
-                  otherAxisView: tOtherView
+                  model: iAxisModelArray[tIndex],
+                  suppressLabel: true
                 });
-                this_.appendChild( tNewView);
-                if( tCurrentView) {
-                  this_.removeChild( tCurrentView);
+                this_.appendChild(tNewView);
+                if (tCurrentView) {
+                  this_.removeChild(tCurrentView);
                   tCurrentView.destroy();
                 }
-                ioAxisViewArray[ tIndex] = tNewView;
+                ioAxisViewArray[tIndex] = tNewView;
               }
             }
+            for (tIndex; tIndex < ioAxisViewArray.length; tIndex++) {
+              ioAxisViewArray[tIndex].destroy();
+            }
+            ioAxisViewArray.length = tNumModels;
           }
 
-          configureOneAxisViewArray( this_.getPath('model.xAxisArray'), this_.get('xAxisViewArray'));
-          configureOneAxisViewArray( this_.getPath('model.yAxisArray'), this_.get('yAxisViewArray'));
-          configureOneAxisViewArray( this_.getPath('model.y2AxisArray'), this_.get('y2AxisViewArray'));
+          configureOneAxisViewArray(this_.getPath('model.xAxisArray'), this_.get('xAxisViewArray'));
+          configureOneAxisViewArray(this_.getPath('model.yAxisArray'), this_.get('yAxisViewArray'));
+          configureOneAxisViewArray(this_.getPath('model.y2AxisArray'), this_.get('y2AxisViewArray'));
         }
 
         function configurePlotViewArrays() {
@@ -932,31 +1035,38 @@ DG.GraphView = SC.View.extend(
               tPlotViewArray = this_.get('splitPlotViewArray'),
               tPlotBackgroundViewArray = this_.get('plotBackgroundViewArray'),
               tPlotViewClass = tPlotViewArray[0][0][0].constructor;
-          tModel.forEachSplitPlotElementDo( function( iPlotModelArray, iRow, iColumn) {
-            if( iRow !== 0 || iColumn !== 0) {
-              iPlotModelArray.forEach( function( iPlotModel, iIndex) {
-                if( !tPlotViewArray[iRow])
+          tModel.forEachSplitPlotElementDo(function (iPlotModelArray, iRow, iColumn) {
+            if (iRow !== 0 || iColumn !== 0) {
+              iPlotModelArray.forEach(function (iPlotModel, iIndex) {
+                if (!tPlotViewArray[iRow])
                   tPlotViewArray[iRow] = [];
-                if( !tPlotViewArray[iRow][iColumn])
+                if (!tPlotViewArray[iRow][iColumn])
                   tPlotViewArray[iRow][iColumn] = [];
-                if( !tPlotBackgroundViewArray[iRow])
+                if (!tPlotBackgroundViewArray[iRow])
                   tPlotBackgroundViewArray[iRow] = [];
                 var
                     tBackgroundView = tPlotBackgroundViewArray[iRow][iColumn],
-                    tCurrentPlotView = tPlotViewArray[ iRow][iColumn][iIndex],
+                    tCurrentPlotView = tPlotViewArray[iRow][iColumn][iIndex],
                     tNewPlotView;
-                if(!tBackgroundView) {
+                if (!tBackgroundView) {
                   tBackgroundView = DG.PlotBackgroundView.create({
                     xAxisView: this_.get('xAxisViewArray')[iColumn],
                     yAxisView: this_.get('yAxisViewArray')[iRow],
                     graphModel: this_.get('model'),
-                    darkenBackground: (iRow + iColumn) % 2 !== 0
+                    darkenBackground: (iRow + iColumn) % 2 !== 0,
+                    rowIndex: iRow,
+                    colIndex: iColumn
                   });
                   tPlotBackgroundViewArray[iRow][iColumn] = tBackgroundView;
-                  this_.appendChild( tBackgroundView);
+                  this_.invokeLast(function () {
+                    // Don't append until after we've established the plot view
+                    this_.appendChild(tBackgroundView);
+                  });
                 }
-                if( !tCurrentPlotView || tCurrentPlotView.constructor !== tPlotViewClass) {
-                  tNewPlotView = tPlotViewClass.create( {
+                tBackgroundView.set('rowIndex', iRow);
+                tBackgroundView.set('colIndex', iColumn);
+                if (!tCurrentPlotView || tCurrentPlotView.constructor !== tPlotViewClass) {
+                  tNewPlotView = tPlotViewClass.create({
                     paperSource: tPlotBackgroundViewArray[iRow][iColumn],
                     model: iPlotModel,
                     parentView: this_,
@@ -964,14 +1074,15 @@ DG.GraphView = SC.View.extend(
                     yAxisView: this_.get('yAxisViewArray')[iRow],
                     y2AxisView: this_.get('y2AxisViewArray')[iRow]
                   });
-                  tPlotViewArray[ iRow][iColumn][iIndex] = tNewPlotView;
-                  this_.addPlotViewObserver( tNewPlotView);
-                  if( tCurrentPlotView)
+                  tPlotViewArray[iRow][iColumn][iIndex] = tNewPlotView;
+                  this_.addPlotViewObserver(tNewPlotView);
+                  if (tCurrentPlotView)
                     tCurrentPlotView.destroy();
                 }
               });
             }
           });
+          this_.notifyPropertyChange('plotViewsReconfigured');
         }
 
         this._isConfigurationInProgress = true; // Prevent drawing until all this is done
@@ -981,14 +1092,48 @@ DG.GraphView = SC.View.extend(
 
       }.observes('.model.splitAttributeChange'),
 
+      allModelSplitsWereRemoved: function () {
+        var this_ = this,
+            tBackgroundViews = this.get('plotBackgroundViewArray');
+        // Our controller is observing these plot views that are about to be deleted so we have to
+        // give it a chance to remove observers
+        this_.notifyPropertyChange('plotViewsWillBeDestroyed');
+        this_.forEachPlotViewDo(function (iPlotView, iRow, iColumn, iIndex) {
+          if (iRow !== 0 || iColumn !== 0) {
+            this_.removePlotViewObserver(iPlotView);
+            iPlotView.destroy();
+            if (iIndex === 0) {
+              var tBackgroundView = tBackgroundViews[iRow][iColumn];
+              this_.removeChild(tBackgroundView);
+              tBackgroundView.destroy();
+              tBackgroundViews[iRow][iColumn] = null;
+            }
+          }
+        });
+        tBackgroundViews[0].length = 1;
+        tBackgroundViews.length = 1;
+        this.get('splitPlotViewArray').length = 1;
+        this.get('splitPlotViewArray')[0].length = 1;
+      }.observes('.model.removedAllSplitPlotsAndAxes'),
+
+      /**
+       * Return the array of plot views for the given row, col
+       * @param iRow {Number}
+       * @param iCol {Number}
+       * @return {[{DG.PlotView}]}
+       */
+      getPlotViewArray: function (iRow, iCol) {
+        return this.get('splitPlotViewArray')[iRow][iCol];
+      },
+
       plotWithoutView: function () {
         var tPlots = this.getPath('model.plots'),
             tPlotViews = this._plotViews,
             tPlotWithoutView;
         tPlots.forEach(function (iPlot) {
           if (!tPlotViews.some(function (iPlotView) {
-                return iPlot === iPlotView.get('model');
-              })) {
+            return iPlot === iPlotView.get('model');
+          })) {
             tPlotWithoutView = iPlot;
           }
         });
@@ -1055,7 +1200,7 @@ DG.GraphView = SC.View.extend(
           }
         });
         tPlotViews.splice(tIndexOfPlotViewToRemove, 1);
-        tPlotViews.forEach( function( iPlotView, iIndex) {
+        tPlotViews.forEach(function (iPlotView, iIndex) {
           iPlotView.set('isFirstPlot', iIndex === 0);
         });
       }.observes('model.attributeRemoved'),
@@ -1103,14 +1248,14 @@ DG.GraphView = SC.View.extend(
               tAttrType = this.getPath('model.dataConfiguration.' + iPrefix + 'AttributeDescription.attribute.type'),
               tCurrentAxisModel = this.getPath('model.' + iPrefix + 'Axis'),
               tCurrentAxisModelClass = tCurrentAxisModel.constructor,
-              tNewViewClass, tNewView, tOldView, tOtherView;
+              tNewViewClass, tNewView, tOldView;
           if (tCurrentViewClass === DG.CellLinearAxisView && tAttrType === 'qualitative') {
             tNewViewClass = DG.QualCellLinearAxisView;
           }
           else if (tCurrentViewClass === DG.QualCellLinearAxisView && tAttrType === 'numeric') {
             tNewViewClass = DG.CellLinearAxisView;
           }
-          else if( tCurrentAxisModelClass === DG.CountAxisModel) {
+          else if (tCurrentAxisModelClass === DG.CountAxisModel) {
             tNewViewClass = DG.CountAxisView;
           }
           if (!SC.none(tNewViewClass) && tNewViewClass !== tCurrentViewClass) {
@@ -1125,8 +1270,6 @@ DG.GraphView = SC.View.extend(
             this.setPath('plotBackgroundView.' + iPrefix + 'AxisView', tNewView);
             this.setPath('plotView.' + iPrefix + 'AxisView', tNewView);
             this.setPath('controller.' + iPrefix + 'AxisView', tNewView);
-            tOtherView = this.get(((iPrefix === 'x') ? 'y' : 'x') + 'AxisView');
-            tNewView.set('otherAxisView', tOtherView);
             tOldView.destroy();
             tInitLayout = true;
           }
@@ -1148,7 +1291,8 @@ DG.GraphView = SC.View.extend(
       handleAxisOrLegendLayoutChange: function () {
         this.renderLayout(this.renderContext(this.get('tagName')));
       }.observes('*xAxisView.desiredExtent', '*yAxisView.desiredExtent',
-          '.legendView.desiredExtent', '.legendView.labelNode', '*y2AxisView.desiredExtent'),
+          '.legendView.desiredExtent', '.legendView.labelNode', '*y2AxisView.desiredExtent',
+          '.rightAxisView.desiredExtent', '.topAxisView.desiredExtent'),
 
       /**
        * When the number toggle changes, we need to adjust the layout of the plot and axes.

--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -949,7 +949,8 @@ DG.GraphView = SC.View.extend(
                   tBackgroundView = DG.PlotBackgroundView.create({
                     xAxisView: this_.get('xAxisViewArray')[iColumn],
                     yAxisView: this_.get('yAxisViewArray')[iRow],
-                    graphModel: this_.get('model')
+                    graphModel: this_.get('model'),
+                    darkenBackground: (iRow + iColumn) % 2 !== 0
                   });
                   tPlotBackgroundViewArray[iRow][iColumn] = tBackgroundView;
                   this_.appendChild( tBackgroundView);

--- a/apps/dg/components/graph/plots/dot_plot_model.js
+++ b/apps/dg/components/graph/plots/dot_plot_model.js
@@ -473,7 +473,7 @@ DG.DotPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
         DG.ObjectMap.forEach( this._adornmentModels, function( iKey, iAdorn) {
           tSpecs.push( {
             key: iKey,
-            class: iAdorn.constructor,
+            "class": iAdorn.constructor,
             useAdornmentModelsArray: true,
             storage: iAdorn.createStorage()
           });

--- a/apps/dg/components/graph/plots/dot_plot_model.js
+++ b/apps/dg/components/graph/plots/dot_plot_model.js
@@ -425,6 +425,24 @@ DG.DotPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
           tMultipleMovable.set('axisModel', this.get('primaryAxisModel'));
       },
 
+      /**
+       * Return a list of objects { key, class, useAdornmentModelsArray, storage }
+       * Subclasses should override calling sc_super first.
+       * @return {[Object]}
+       */
+      getAdornmentSpecs: function() {
+        var tSpecs = sc_super(),
+            tMedianAdorn = this.getAdornmentModel('plottedMedian');
+        if( tMedianAdorn)
+          tSpecs.push( {
+            key: 'plottedMedian',
+            class: tMedianAdorn.constructor,
+            useAdornmentModelsArray: true,
+            storage: tMedianAdorn.createStorage()
+          });
+        return tSpecs;
+      },
+
       checkboxDescriptions: function () {
         var this_ = this;
         return sc_super().concat([

--- a/apps/dg/components/graph/plots/dot_plot_model.js
+++ b/apps/dg/components/graph/plots/dot_plot_model.js
@@ -122,14 +122,22 @@ DG.DotPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
           return;
         }
 
-        var tMultipleMovableValues = this.get('multipleMovableValuesModel'),
-            toggle = function () {
-              var tCurrentValue = tMultipleMovableValues.get('isShowing' + iWhat);
-              tMultipleMovableValues.setComputingNeeded();
-              tMultipleMovableValues.set('isShowing' + iWhat, !tCurrentValue);
-            }.bind(this),
+        var this_ = this;
 
-            tInitialValue = tMultipleMovableValues.get('isShowing' + iWhat),
+        function toggle() {
+
+          function doToggle( iPlot) {
+            var tMultipleMovableValues = iPlot.get('multipleMovableValuesModel'),
+                tCurrentValue = tMultipleMovableValues.get('isShowing' + iWhat);
+            tMultipleMovableValues.setComputingNeeded();
+            tMultipleMovableValues.set('isShowing' + iWhat, !tCurrentValue);
+          }
+
+          doToggle( this_);
+          this_.get('siblingPlots').forEach( doToggle);
+        }
+
+        var tInitialValue = this.getPath('multipleMovableValuesModel.isShowing' + iWhat),
             tUndo = tInitialValue ? ('DG.Undo.graph.hide' + iWhat) : ('DG.Undo.graph.show' + iWhat),
             tRedo = tInitialValue ? ('DG.Redo.graph.hide' + iWhat) : ('DG.Redo.graph.show' + iWhat);
         DG.UndoHistory.execute(DG.Command.create({
@@ -162,30 +170,49 @@ DG.DotPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
        * If it's the first one, we may have to deal with counts showing via the base class adornment.
        */
       addMovableValue: function () {
-        var tAddedValue,
+        var this_ = this,
+            tAddedValues = [];
 
-            doAddMovableValue = function () {
-              var tMultipleMovableValues = this.get('multipleMovableValuesModel'),
-                  tNumAlreadyShowing = tMultipleMovableValues.get('values').length,
-                  tPlottedCount = this.get('plottedCount'), // from base class
-                  tBaseClassCountIsShowing = (tNumAlreadyShowing === 0) && tPlottedCount &&
-                      tPlottedCount.get('isShowingCount');
-              if (tAddedValue) {
-                tMultipleMovableValues.addThisValue(tAddedValue);
-                tAddedValue = null;
-              }
-              else
-                tAddedValue = tMultipleMovableValues.addValue();
-              if( tBaseClassCountIsShowing) {
-                tPlottedCount.set('isShowingCount', false);
-                tMultipleMovableValues.set('isShowingCount', true);
-              }
-              this.notifyPropertyChange('movableValueChange');
-            }.bind(this),
+            function doAddMovableValue() {
 
-            doUndoAddMovableValue = function () {
-              this.getAdornmentModel('multipleMovableValues').removeThisValue(tAddedValue);
-            }.bind(this);
+              function addMovableValueToPlot( iPlot, iIndexMinusOne) {
+                var tIndex = iIndexMinusOne + 1,
+                    tMultipleMovableValues = iPlot.get('multipleMovableValuesModel'),
+                    tNumAlreadyShowing = tMultipleMovableValues.get('values').length,
+                    tPlottedCount = iPlot.get('plottedCount'), // from base class
+                    tBaseClassCountIsShowing = (tNumAlreadyShowing === 0) && tPlottedCount &&
+                        tPlottedCount.get('isShowingCount'),
+                    tAddedValue = tAddedValues[ tIndex];
+                if (tAddedValue) {
+                  tMultipleMovableValues.addThisValue(tAddedValue);
+                  tAddedValues[ tIndex] = null;
+                }
+                else {
+                  tAddedValue = tMultipleMovableValues.addValue();
+                  tAddedValues[ tIndex] = tAddedValue;
+                }
+                if (tBaseClassCountIsShowing) {
+                  tPlottedCount.set('isShowingCount', false);
+                  tMultipleMovableValues.set('isShowingCount', true);
+                }
+                iPlot.notifyPropertyChange('movableValueChange');
+              }
+
+              addMovableValueToPlot( this_, -1);
+              this_.get('siblingPlots').forEach( addMovableValueToPlot);
+            }
+
+            function doUndoAddMovableValue() {
+
+              function undoAddMovableValueFromPlot( iPlot, iIndexMinusOne) {
+                var tIndex = iIndexMinusOne + 1,
+                    tAddedValue = tAddedValues[ tIndex];
+                iPlot.getAdornmentModel('multipleMovableValues').removeThisValue(tAddedValue);
+              }
+
+              undoAddMovableValueFromPlot( this_, -1);
+              this_.get('siblingPlots').forEach( undoAddMovableValueFromPlot);
+            }
 
         DG.UndoHistory.execute(DG.Command.create({
           name: "graph.addMovableValue",
@@ -261,15 +288,22 @@ DG.DotPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
         var this_ = this;
 
         function toggle() {
-          var avg = this_.toggleAdornmentVisibility(iAdornmentKey, iToggleLogString);
-          if (avg) {
-            if (avg.get('isVisible')) {
-              avg.recomputeValue();     // initialize
-            } else {
-              avg.setComputingNeeded(); // make sure we recompute when made visible again
+
+          function doToggle( iPlot) {
+            var avg = iPlot.toggleAdornmentVisibility(iAdornmentKey, iToggleLogString);
+            if (avg) {
+              if (avg.get('isVisible')) {
+                avg.recomputeValue();     // initialize
+              } else {
+                avg.setComputingNeeded(); // make sure we recompute when made visible again
+              }
             }
           }
-          return !avg || avg.get('isVisible');
+
+          doToggle( this_);
+          this_.get('siblingPlots').forEach( doToggle);
+
+          return this_.getAdornmentModel( iAdornmentKey).get('isVisible');
         }
 
         DG.UndoHistory.execute(DG.Command.create({
@@ -326,13 +360,8 @@ DG.DotPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
         this.toggleAverage('plottedBoxPlot', 'togglePlottedBoxPlot');
       },
 
-      handleDataConfigurationChange: function ( iKey) {
-        if (!DG.assert(!this.get('isDestroyed'), "DG.DotPlotModel.handleDataConfiguration() shouldn't be triggered after destroy()!"))
-          return;
+      updateAdornmentsModels: function() {
         sc_super();
-        var kAnimate = true, kDontLog = false;
-        this.rescaleAxesFromData( iKey !== 'hiddenCases', kAnimate, kDontLog);
-
         ['multipleMovableValues', 'plottedMean', 'plottedMedian', 'plottedStDev', 'plottedBoxPlot', 'plottedCount'].forEach(function (iAdornmentKey) {
           var adornmentModel = this.getAdornmentModel(iAdornmentKey);
           if (adornmentModel) {
@@ -346,6 +375,15 @@ DG.DotPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
             }
           }
         }.bind(this));
+      },
+
+      handleDataConfigurationChange: function ( iKey) {
+        if (!DG.assert(!this.get('isDestroyed'), "DG.DotPlotModel.handleDataConfiguration() shouldn't be triggered after destroy()!"))
+          return;
+        sc_super();
+        var kAnimate = true, kDontLog = false;
+        this.rescaleAxesFromData( iKey !== 'hiddenCases', kAnimate, kDontLog);
+        this.updateAdornmentModels();
       },
 
       /**
@@ -431,16 +469,27 @@ DG.DotPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
        * @return {[Object]}
        */
       getAdornmentSpecs: function() {
-        var tSpecs = sc_super(),
-            tMedianAdorn = this.getAdornmentModel('plottedMedian');
-        if( tMedianAdorn)
+        var tSpecs = sc_super();
+        DG.ObjectMap.forEach( this._adornmentModels, function( iKey, iAdorn) {
           tSpecs.push( {
-            key: 'plottedMedian',
-            class: tMedianAdorn.constructor,
+            key: iKey,
+            class: iAdorn.constructor,
             useAdornmentModelsArray: true,
-            storage: tMedianAdorn.createStorage()
+            storage: iAdorn.createStorage()
           });
+        });
         return tSpecs;
+      },
+
+      /**
+       * Base class will do most of the work. We just have to finish up the multipleMovableValues model.
+       * @param {DG.PlotModel} iSourcePlot
+       */
+      installAdornmentModelsFrom: function( iSourcePlot) {
+        sc_super();
+        var tMultipleMovable = this.getAdornmentModel('multipleMovableValues');
+        if (tMultipleMovable)
+          tMultipleMovable.set('axisModel', this.get('primaryAxisModel'));
       },
 
       checkboxDescriptions: function () {

--- a/apps/dg/components/graph/plots/plot_background_view.js
+++ b/apps/dg/components/graph/plots/plot_background_view.js
@@ -37,7 +37,7 @@ DG.PlotBackgroundView = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
                       'graphModel.plotBackgroundColor', 'graphModel.plotBackgroundOpacity'],
 
   classNames: 'dg-plot-view'.w(),
-  // classNameBindings: ['graphModel.isTransparent:dg-plot-view-transparent'],
+  classNameBindings: ['graphModel.isTransparent:dg-plot-view-transparent'],
 
   /**
    * @property {DG.GraphModel}
@@ -52,6 +52,18 @@ DG.PlotBackgroundView = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
     @property { DG.AxisView }
   */
   yAxisView: null,
+
+  /**
+   * Which of the split plots do I correspond to?
+   * @property (Number}
+   */
+  rowIndex: 0,
+
+  /**
+   * Which of the split plots do I correspond to?
+   * @property (Number}
+   */
+  colIndex: 0,
 
   /**
    * Dynamically set to true/false during episodes such as marquee select
@@ -98,7 +110,7 @@ DG.PlotBackgroundView = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
   didCreateLayer:function () {
     var tGraphView = this.get( 'parentView' );
     sc_super();
-    tGraphView.get( 'plotViews' ).forEach( function ( iPlotView ) {
+    tGraphView.getPlotViewArray( this.get('rowIndex'), this.get('colIndex')).forEach( function ( iPlotView ) {
       iPlotView.didCreateLayer();
     } );
     tGraphView.drawPlots();
@@ -273,7 +285,8 @@ DG.PlotBackgroundView = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
         });
       }
       SC.run(function(){
-        this_.get('parentView').selectPointsInRect( tRect, tBaseSelection, tLastRect);
+        this_.get('parentView').selectPointsInRect( tRect, tBaseSelection, tLastRect,
+            this_.get('rowIndex'), this_.get('colIndex'));
       });
       tLastRect = tRect;
     }

--- a/apps/dg/components/graph/plots/plot_background_view.js
+++ b/apps/dg/components/graph/plots/plot_background_view.js
@@ -37,7 +37,7 @@ DG.PlotBackgroundView = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
                       'graphModel.plotBackgroundColor', 'graphModel.plotBackgroundOpacity'],
 
   classNames: 'dg-plot-view'.w(),
-  classNameBindings: ['graphModel.isTransparent:dg-plot-view-transparent'],
+  // classNameBindings: ['graphModel.isTransparent:dg-plot-view-transparent'],
 
   /**
    * @property {DG.GraphModel}
@@ -64,12 +64,20 @@ DG.PlotBackgroundView = DG.RaphaelBaseView.extend( DG.GraphDropTarget,
 
   _backgroundImage: null,
 
+  /**
+   * If true, darken the background slightly (useful for grid of plots)
+   * @property {Boolean}
+   */
+  darkenBackground: false,
+
   colorDidChange: function() {
     var tStoredColor = this.getPath('graphModel.plotBackgroundColor') || 'white',
         tStoredOpacity = this.getPath('graphModel.plotBackgroundOpacity'),
         tNewColor = tStoredColor ? SC.Color.from( tStoredColor) : null;
     if( !tNewColor)
         return;
+    if( this.get('darkenBackground'))
+      tNewColor = tNewColor.sub( SC.Color.from('#101010'));
     if( !SC.none(tStoredOpacity))
         tNewColor.set('a', tStoredOpacity);
     this.set('backgroundColor', tNewColor.get('cssText'));

--- a/apps/dg/components/graph/plots/plot_model.js
+++ b/apps/dg/components/graph/plots/plot_model.js
@@ -1062,6 +1062,52 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
       },
 
       /**
+       *
+       * @param {Object} iAdornments
+       */
+      installAdornmentModels: function( iAdornments) {
+        var this_ = this;
+        DG.ObjectMap.forEach( iAdornments, function( iKey, iValue) {
+          this_.set( iKey, iValue);
+        });
+      },
+
+      /**
+       * Return a list of objects { key, class, storage }
+       * Subclasses should override calling sc_super first.
+       * @return {[Object]}
+       */
+      getAdornmentSpecs: function() {
+        var tSpecs = [],
+            tPlottedCount = this.get('plottedCount');
+        if( tPlottedCount)
+          tSpecs.push( {
+            key: 'plottedCount',
+            class: tPlottedCount.constructor,
+            storage: tPlottedCount.createStorage()
+          });
+        return tSpecs;
+      },
+
+      /**
+       * For each adornment in source, make a corresponding adornment for me.
+       * @param {DG.PlotModel} iSourcePlot
+       */
+      installAdornmentModelsFrom: function( iSourcePlot) {
+        var this_ = this,
+            tAdornmentSpecs = iSourcePlot.getAdornmentSpecs();
+        tAdornmentSpecs.forEach( function( iSpec) {
+          var tAdornmentModel = iSpec.class.create();
+          tAdornmentModel.restoreStorage( iSpec.storage);
+          tAdornmentModel.set('plotModel', this_);
+          if( iSpec.useAdornmentModelsArray)
+            this_.setAdornmentModel( iSpec.key, tAdornmentModel);
+          else
+            this_.set( iSpec.key, tAdornmentModel);
+        });
+      },
+
+      /**
        * Get an array of non-missing case counts in each axis cell.
        * Also cell index on primary and secondary axis, with primary axis as major axis.
        * @return {Array} [{count, primaryCell, secondaryCell},...] (all values are integers 0+).

--- a/apps/dg/components/graph/plots/plot_model.js
+++ b/apps/dg/components/graph/plots/plot_model.js
@@ -44,6 +44,14 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
       splitPlotColIndex: 0,
 
       /**
+       * The zeroth plot in a graph that has been split has siblings. When things change
+       * that should be reflected in these siblings, the zeroth plot explicitly tells sibs
+       * to make the change.
+       * @property {[{DG.PlotModel}]}
+       */
+      siblingPlots: null,
+
+      /**
        @property { DG.DataContext }  The data context
        */
       dataContext: function () {
@@ -80,8 +88,8 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
         var tCases;
         if( this.getPath('dataConfiguration.hasSplitAttribute')) {
           if( !this._casesCache) {
-            var tRowAttrDescription = this.getPath('dataConfiguration.rightSplitAttributeDescription'),
-                tColAttrDescription = this.getPath('dataConfiguration.topSplitAttributeDescription'),
+            var tRowAttrDescription = this.getPath('dataConfiguration.rightAttributeDescription'),
+                tColAttrDescription = this.getPath('dataConfiguration.topAttributeDescription'),
                 tRowAttrID = tRowAttrDescription.getPath('attribute.id'),
                 tColAttrID = tColAttrDescription.getPath('attribute.id'),
                 tRowValue = (tRowAttrID === DG.Attribute.kNullAttribute) ? null :
@@ -352,7 +360,22 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
         var this_ = this;
 
         function toggle() {
-          this_.toggleAdornmentVisibility('plottedValue', 'togglePlotValue');
+
+          function doToggle( iPlot) {
+            iPlot.toggleAdornmentVisibility('plottedValue', 'togglePlotValue');
+          }
+
+          this_.get('siblingPlots').forEach( doToggle);
+          doToggle( this_);
+        }
+
+        function connectFunctions() {
+          var tSiblingPlots = this_.get('siblingPlots'),
+              tMasterPlottedValue = this_.getAdornmentModel('plottedValue');
+          tMasterPlottedValue.set('siblingPlottedFunctions',
+              tSiblingPlots.map( function( iPlot) {
+                return iPlot.getAdornmentModel( 'plottedValue');
+              }));
         }
 
         var willShow = !this.isAdornmentVisible('plottedValue');
@@ -363,9 +386,11 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
           log: "togglePlotValue: %@".fmt(willShow ? "show" : "hide"),
           execute: function () {
             toggle();
+            connectFunctions();
           },
           undo: function () {
             toggle();
+            this_.getAdornmentModel('plottedValue').set('siblingPlottedFunctions', null);
           }
         }));
       },
@@ -377,8 +402,14 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
         var this_ = this;
 
         function toggle() {
-          var tCurrentValue = this_.getPath('plottedCount.isShowing' + iWhat);
-          this_.setPath('plottedCount.isShowing' + iWhat, !tCurrentValue);
+
+          function doToggle( iPlot) {
+            var tCurrentValue = iPlot.getPath('plottedCount.isShowing' + iWhat);
+            iPlot.setPath('plottedCount.isShowing' + iWhat, !tCurrentValue);
+          }
+
+          doToggle( this_);
+          this_.get('siblingPlots').forEach( doToggle);
         }
 
         var tInitialValue = this_.getPath('plottedCount.isShowing' + iWhat),
@@ -405,6 +436,7 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
         sc_super();
 
         this._adornmentModels = {};
+        this.siblingPlots = [];
 
         this.addObserver('dataConfiguration', this, 'dataConfigurationDidChange');
         this.addObserver('xAxis', this, 'xAxisDidChange');
@@ -441,6 +473,7 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
                 iModel.destroy();
             });
         this._adornmentModels = null;
+        this.siblingPlots = null;
 
         sc_super();
 
@@ -486,6 +519,10 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
           yAxis.addObserver('upperBound', this, 'axisBoundsDidChange');
           this._observedYAxis = yAxis;
         }
+      },
+
+      addSibling: function( iPlotModel) {
+        this.get('siblingPlots').push( iPlotModel);
       },
 
       /**
@@ -597,6 +634,7 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
        */
       invalidateCaches: function () {
         this._casesCache = null;
+        this.invalidateAggregateAdornments();
         this.notifyPropertyChange('plotConfiguration');
       },
 
@@ -609,6 +647,22 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
       getDataMinAndMaxForDimension: function (iPlace) {
         var tDataConfiguration = this.get('dataConfiguration');
         return tDataConfiguration && tDataConfiguration.getDataMinAndMaxForDimension(iPlace);
+      },
+
+      updateAdornmentModels: function() {
+        ['multipleMovableValues', 'plottedMean', 'plottedMedian', 'plottedStDev', 'plottedBoxPlot', 'plottedCount'].forEach(function (iAdornmentKey) {
+          var adornmentModel = this.getAdornmentModel(iAdornmentKey);
+          if (adornmentModel) {
+            if (adornmentModel.setComputingNeeded)
+              adornmentModel.setComputingNeeded();  // invalidate if axis model/attribute change
+            if (iAdornmentKey === 'multipleMovableValues') {
+              adornmentModel.recomputeValueIfNeeded(this.get('primaryAxisModel'));
+            }
+            else {
+              adornmentModel.recomputeValueIfNeeded(); // recompute only if/when visible
+            }
+          }
+        }.bind(this));
       },
 
       /**
@@ -978,6 +1032,15 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
       },
 
       /**
+       * When making a copy of a plot (e.g. for use in split) the returned object
+       * holds those properties that should be assigned to the copy.
+       * @return {{}}
+       */
+      getPropsForCopy: function() {
+        return {};
+      },
+
+      /**
        * Create the model data to save with document.
        * Derived plot models will add to this storage.
        * @return {Object} the saved data.
@@ -1097,9 +1160,8 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
         var this_ = this,
             tAdornmentSpecs = iSourcePlot.getAdornmentSpecs();
         tAdornmentSpecs.forEach( function( iSpec) {
-          var tAdornmentModel = iSpec.class.create();
+          var tAdornmentModel = iSpec.class.create({ plotModel: this_ });
           tAdornmentModel.restoreStorage( iSpec.storage);
-          tAdornmentModel.set('plotModel', this_);
           if( iSpec.useAdornmentModelsArray)
             this_.setAdornmentModel( iSpec.key, tAdornmentModel);
           else

--- a/apps/dg/components/graph/plots/plot_model.js
+++ b/apps/dg/components/graph/plots/plot_model.js
@@ -1146,7 +1146,7 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
         if( tPlottedCount)
           tSpecs.push( {
             key: 'plottedCount',
-            class: tPlottedCount.constructor,
+            "class": tPlottedCount.constructor,
             storage: tPlottedCount.createStorage()
           });
         return tSpecs;
@@ -1160,7 +1160,7 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
         var this_ = this,
             tAdornmentSpecs = iSourcePlot.getAdornmentSpecs();
         tAdornmentSpecs.forEach( function( iSpec) {
-          var tAdornmentModel = iSpec.class.create({ plotModel: this_ });
+          var tAdornmentModel = iSpec["class"].create({ plotModel: this_ });
           tAdornmentModel.restoreStorage( iSpec.storage);
           if( iSpec.useAdornmentModelsArray)
             this_.setAdornmentModel( iSpec.key, tAdornmentModel);

--- a/apps/dg/components/graph/plots/plot_model.js
+++ b/apps/dg/components/graph/plots/plot_model.js
@@ -123,7 +123,14 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
        @property { SC.SelectionSet }
        */
       selection: function () {
-        return this.getPath('dataConfiguration.selection');
+        var tSelection = this.getPath('dataConfiguration.selection');
+        if( this.getPath('dataConfiguration.hasSplitAttribute')) {
+          var tCases = this.get('cases').toArray();
+          tSelection = tSelection.filter( function( iCase) {
+            return tCases.indexOf( iCase) >= 0;
+          });
+        }
+        return tSelection;
       }.property(),
 
       selectionDidChange: function () {
@@ -866,6 +873,7 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
           this._observedDataConfiguration.removeObserver('attributeAssignment', this, 'dataConfigurationDidChange');
           this._observedDataConfiguration.removeObserver('arrangedObjectArrays', this, 'sourceArraysDidChange');
           this._observedDataConfiguration.removeObserver('hiddenCases', this, 'dataConfigurationDidChange');
+          this._observedDataConfiguration.removeObserver('hasSplitAttribute', this, 'dataConfigurationDidChange');
           this._observedDataConfiguration = null;
         }
 
@@ -879,6 +887,7 @@ DG.PlotModel = SC.Object.extend(DG.Destroyable,
             dataConfiguration.addObserver('attributeAssignment', this, 'dataConfigurationDidChange');
             dataConfiguration.addObserver('arrangedObjectArrays', this, 'sourceArraysDidChange');
             dataConfiguration.addObserver('hiddenCases', this, 'dataConfigurationDidChange');
+            dataConfiguration.addObserver('hasSplitAttribute', this, 'dataConfigurationDidChange');
             this._observedDataConfiguration = dataConfiguration;
             dataConfiguration.set('sortCasesByLegendCategories', true); // subclasses may override to false
           }

--- a/apps/dg/components/graph/plots/plot_view.js
+++ b/apps/dg/components/graph/plots/plot_view.js
@@ -207,7 +207,7 @@ DG.PlotView = DG.PlotLayer.extend(
   /**
     For use in transferring current element positions of this plot to a new plot about
     to take its place.
-    @return {Array of {cx:{Number}, cy:{Number}, r: {Number}, fill: {String} }
+    @return {[{cx:{Number}, cy:{Number}, r: {Number}, fill: {String} ]}
   */
   getElementPositionsInParentFrame: function() {
     var tFrame = this.get('frame'),

--- a/apps/dg/components/graph/plots/plot_view.js
+++ b/apps/dg/components/graph/plots/plot_view.js
@@ -239,7 +239,8 @@ DG.PlotView = DG.PlotLayer.extend(
         tOldPointAttrs = this.get('transferredElementCoordinates'),
         tNewPointAttrs = [], // used if many-to-one animation
         tNewToOldCaseMap = [],
-        tOldToNewCaseMap = [];
+        tOldToNewCaseMap = [],
+        tLoopIndex = 0;
     // During undo/redo we can get here without cases. Bail!
     if( !tCases || !tRC)
       return;
@@ -275,7 +276,8 @@ DG.PlotView = DG.PlotLayer.extend(
           var tPt = getCaseCurrentLocation( iIndex ),
               tAnimate = false,
               tCallBack,
-              tNewElement = this.callCreateElement( iCase, iIndex, false);
+              tNewElement = this.callCreateElement( iCase, tLoopIndex, false);
+          tLoopIndex++;
           if( !SC.none( tPt)) {
             tNewElement.attr( tPt);
             tAnimate = true;

--- a/apps/dg/components/graph/plots/scatter_plot_model.js
+++ b/apps/dg/components/graph/plots/scatter_plot_model.js
@@ -529,7 +529,7 @@ DG.ScatterPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
           if (tAdorn)
             tSpecs.push({
               key: iKey,
-              class: tAdorn.constructor,
+              "class": tAdorn.constructor,
               useAdornmentModelsArray: false,
               storage: tAdorn.createStorage()
             });
@@ -537,7 +537,7 @@ DG.ScatterPlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
         DG.ObjectMap.forEach( this._adornmentModels, function( iKey, iAdorn) {
           tSpecs.push( {
             key: iKey,
-            class: iAdorn.constructor,
+            "class": iAdorn.constructor,
             useAdornmentModelsArray: true,
             storage: iAdorn.createStorage()
           });

--- a/apps/dg/components/graph/plots/scatter_plot_view.js
+++ b/apps/dg/components/graph/plots/scatter_plot_view.js
@@ -176,18 +176,9 @@ DG.ScatterPlotView = DG.PlotView.extend(
        Method name is legacy artifact of SproutCore range observer implementation.
        */
       dataRangeDidChange: function (iSource, iQuestion, iKey, iChanges) {
-        var this_ = this,
-            tPlotElementLength = this.get('plottedElements').length,
-            tCases = this.getPath('model.cases'),
-            tRC = this.createRenderContext(),
-            // iChanges can be a single index or an array of indices
-            tChanges = (SC.typeOf(iChanges) === SC.T_NUMBER ? [iChanges] : iChanges);
-        tChanges = tChanges || [];
-        tChanges.forEach(function (iIndex) {
-          if (iIndex >= tPlotElementLength)
-            this_.callCreateElement(tCases.at(iIndex), iIndex, this_._createAnimationOn);
-          this_.setCircleCoordinate(tRC, tCases.at(iIndex), iIndex);
-        });
+        var tCases = this.getPath('model.cases');
+
+        this.notifyPropertyChange('plotDisplayDidChange');
 
         // If we are displaying squares then we invalidate the display so squares will be updated
         if (this.getPath('model.areSquaresVisible'))
@@ -201,7 +192,7 @@ DG.ScatterPlotView = DG.PlotView.extend(
 
         this.updateAdornments();
 
-        this.rescaleOnParentCaseCompletion(tCases);
+        this.rescaleOnParentCaseCompletion( tCases);
 
         sc_super();
       },

--- a/apps/dg/components/graph/utilities/graph_drop_target.js
+++ b/apps/dg/components/graph/utilities/graph_drop_target.js
@@ -186,7 +186,7 @@ DG.GraphDropTarget =
 
   isVertical: function() {
     var tOrientation = this.get('orientation');
-    return tOrientation && tOrientation.indexOf( 'vertical') >= 0;
+    return tOrientation && ['vertical', 'vertical2', 'right'].indexOf( tOrientation) >= 0;
   }.property(),
 
   showDropHint: function() {

--- a/apps/dg/components/graph/utilities/graph_drop_target.js
+++ b/apps/dg/components/graph/utilities/graph_drop_target.js
@@ -42,6 +42,10 @@ DG.GraphDropTarget =
    */
   dragData:null,
 
+  getDataConfiguration: function() {
+    return this.get('dataConfiguration') || this.getPath('model.dataConfiguration');
+  },
+
   /**
    * Override SC.View for CODAP drop targets.
    * [CODAP fix] When the CODAP div is not at (0, 0) and when the page is scrolled,
@@ -79,6 +83,30 @@ DG.GraphDropTarget =
     return YES;
   },
 
+  isValidAttributeForPlotSplit: function( iDrag) {
+    var tDragAttr = iDrag.data.attribute,
+        tDragAttrIsNominal = tDragAttr.isNominal(),
+        tDataConfiguration = this.getDataConfiguration(),
+        tConfigurationHasAtLeastOneAttribute = tDataConfiguration &&
+            tDataConfiguration.hasAtLeastOneAttributeAssigned(),
+        tValidForPlotSplit = tDragAttrIsNominal && tConfigurationHasAtLeastOneAttribute;
+    return tValidForPlotSplit;
+  },
+
+  isValidAttributeForScatterplot: function( iDrag) {
+    var tDragAttr = iDrag.data.attribute,
+        tDragAttrIsNominal = tDragAttr.isNominal(),
+        tCurrAttr = this.get('plottedAttribute'),
+        tOtherAttr = this.get('otherPlottedAttribute'),
+        tOtherDescr = this.get('otherAttributeDescription'),
+        tValidForScatterplot = (tOtherAttr !== DG.Analysis.kNullAttribute) &&
+            (tCurrAttr !== DG.Analysis.kNullAttribute) &&
+            (tCurrAttr !== tDragAttr) &&
+            !tDragAttrIsNominal &&
+            tOtherDescr && tOtherDescr.get('isNumeric');
+    return tValidForScatterplot;
+  },
+
   isValidAttribute: function( iDrag) {
     var tDragAttr = iDrag.data.attribute,
         tCurrAttr = this.get('plottedAttribute');
@@ -87,45 +115,51 @@ DG.GraphDropTarget =
 
   // Draw an orange frame to show we're a drop target.
   dragStarted: function( iDrag) {
-    var kWidth = 3,
-        tPaper = this.get('paper' ),
-        tFrame;
-
+    var tPaper = this.get('paper' );
     if (!tPaper) return;
+
+    var kWidth = 3,
+        tFrame,
+        tDraggedName = iDrag.data.attribute.get('name'),
+        tAttrName = this.getPath('plottedAttribute.name'),
+        tDropHint;
 
     function isEmpty( iString) {
       return SC.empty( iString) || iString === 'undefined';
     }
 
     if( this.isValidAttribute( iDrag)) {
-      if( this.get('orientation') === 'vertical2') {
+      if (this.get('orientation') === 'vertical2') {
         this.set('isVisible', true);
         var tParentView = this.get('parentView');
-        if( tParentView)
-          tParentView.makeSubviewFrontmost( this);
+        if (tParentView)
+          tParentView.makeSubviewFrontmost(this);
+        tDropHint = 'DG.GraphView.splitPlotHorizontally'.loc( tDraggedName);
+      }
+      else {
+        tDropHint = isEmpty(tAttrName) ? this.get('blankDropHint').loc(tDraggedName) :
+            'DG.GraphView.replaceAttribute'.loc(tAttrName, tDraggedName);
       }
 
-      tFrame = { x: kWidth, y: kWidth,
-                    width: tPaper.width - 2 * kWidth,
-                    height: tPaper.height - 2 * kWidth };
+      tFrame = {
+        x: kWidth, y: kWidth,
+        width: tPaper.width - 2 * kWidth,
+        height: tPaper.height - 2 * kWidth
+      };
 
-      if( this.get('isVertical')) {
+      if (this.get('isVertical')) {
         tFrame.y += 18 + 2 * kWidth;
         tFrame.height -= 18 + 2 * kWidth;
       }
 
-      if( SC.none( this.borderFrame)) {
+      if (SC.none(this.borderFrame)) {
         this.borderFrame = tPaper.path('')
-          .addClass( this.kDropFrameClass);
+            .addClass(this.kDropFrameClass);
       }
-      this.borderFrame.attr( { path:  DG.RenderingUtilities.pathForFrame( tFrame) } )
-                      .show();
+      this.borderFrame.attr({path: DG.RenderingUtilities.pathForFrame(tFrame)})
+          .show();
 
-      var tDraggedName = iDrag.data.attribute.get('name' ),
-          tAttrName = this.getPath('plottedAttribute.name' ),
-          tString = isEmpty( tAttrName) ? this.get('blankDropHint' ).loc(tDraggedName) :
-                                          'DG.GraphView.replaceAttribute'.loc( tAttrName, tDraggedName );
-      this.set('dropHintString', tString);
+      this.set('dropHintString', tDropHint);
     }
   },
 

--- a/apps/dg/components/graph/utilities/graph_drop_target.js
+++ b/apps/dg/components/graph/utilities/graph_drop_target.js
@@ -97,6 +97,19 @@ DG.GraphDropTarget =
     var tDragAttr = iDrag.data.attribute,
         tDragAttrIsNominal = tDragAttr.isNominal(),
         tCurrAttr = this.get('plottedAttribute'),
+        tXDescription = this.getPath('dataConfiguration.xAttributeDescription'),
+        tCurrXAttr = tXDescription ? tXDescription.get('attribute') : DG.Analysis.kNullAttribute,
+        tY1Description = this.getPath('dataConfiguration.yAttributeDescription'),
+        tY1Attr = tY1Description ? tY1Description.get('attribute') : DG.Analysis.kNullAttribute,
+        tValidForScatterplot = (tCurrXAttr !== DG.Analysis.kNullAttribute) &&
+            (tY1Attr !== DG.Analysis.kNullAttribute) &&
+            (tY1Attr !== tDragAttr) &&
+            (tCurrAttr !== tDragAttr) &&
+            tXDescription.get('isNumeric') &&
+            tY1Description.get('isNumeric') &&
+            !tDragAttrIsNominal;
+
+/*
         tOtherAttr = this.get('otherPlottedAttribute'),
         tOtherDescr = this.get('otherAttributeDescription'),
         tValidForScatterplot = (tOtherAttr !== DG.Analysis.kNullAttribute) &&
@@ -104,6 +117,7 @@ DG.GraphDropTarget =
             (tCurrAttr !== tDragAttr) &&
             !tDragAttrIsNominal &&
             tOtherDescr && tOtherDescr.get('isNumeric');
+*/
     return tValidForScatterplot;
   },
 
@@ -113,7 +127,11 @@ DG.GraphDropTarget =
     return SC.none( tCurrAttr) || (tCurrAttr !== tDragAttr);
   },
 
-  // Draw an orange frame to show we're a drop target.
+  /**
+   * Draw an orange frame to show we're a drop target.
+   * Set the dropHintString for later display on dragEntered
+   * @param iDrag {Object}
+   */
   dragStarted: function( iDrag) {
     var tPaper = this.get('paper' );
     if (!tPaper) return;
@@ -134,12 +152,10 @@ DG.GraphDropTarget =
         var tParentView = this.get('parentView');
         if (tParentView)
           tParentView.makeSubviewFrontmost(this);
-        tDropHint = 'DG.GraphView.splitPlotHorizontally'.loc( tDraggedName);
       }
-      else {
-        tDropHint = isEmpty(tAttrName) ? this.get('blankDropHint').loc(tDraggedName) :
-            'DG.GraphView.replaceAttribute'.loc(tAttrName, tDraggedName);
-      }
+      tDropHint = iDrag.data.attribute.isNominal() ? 'DG.GraphView.layoutPlotsVertically'.loc(tDraggedName) :
+          (isEmpty(tAttrName) ? this.get('blankDropHint').loc(tDraggedName) :
+              'DG.GraphView.replaceAttribute'.loc(tAttrName, tDraggedName));
 
       tFrame = {
         x: kWidth, y: kWidth,

--- a/apps/dg/components/graph/utilities/plot_case_array.js
+++ b/apps/dg/components/graph/utilities/plot_case_array.js
@@ -39,8 +39,8 @@ DG.PlotUtilities.PlotCaseArray = SC.Object.extend( {
   },
 
   length: function() {
-    return this._cases.length;
-  }.property( '_cases'),
+    return this._map.length;
+  }.property( '_map'),
 
   at: function( iIndex) {
     return this._cases[this._map[iIndex]];
@@ -84,7 +84,7 @@ DG.PlotUtilities.PlotCaseArray = SC.Object.extend( {
    */
   forEachWithInvokeLater: function( iDoF, iEndF) {
     var tLoopIndex = 0,
-        tNumCases = this._cases.length,
+        tNumCases = this.length(),
         // Get a bit happening early with two iterations.
         tFirstIncrement = Math.min(200, tNumCases / 20),
         tCountdown = (tNumCases > 1000) ? 5 : 0,

--- a/apps/dg/components/graph/utilities/plot_case_array.js
+++ b/apps/dg/components/graph/utilities/plot_case_array.js
@@ -125,8 +125,9 @@ DG.PlotUtilities.PlotCaseArray = SC.Object.extend( {
     var tResult = DG.PlotUtilities.PlotCaseArray.create();
     this.forEach( function( iCase, iMapIndex) {
       if( iBoolF( iCase, iMapIndex)) {
-        tResult._cases[ iMapIndex] = iCase;
-        tResult._map.push( iMapIndex);
+        var tCaseIndex = tResult._cases.length;
+        tResult._cases.push( iCase);
+        tResult._map.push( tCaseIndex);
       }
     }.bind( this));
     return tResult;

--- a/apps/dg/components/graph/utilities/plot_utilities.js
+++ b/apps/dg/components/graph/utilities/plot_utilities.js
@@ -391,19 +391,21 @@ DG.PlotUtilities = {
    * @param iLayerManager
    */
   doHideRemoveAnimation: function( iElement, iLayerManager) {
-    iElement.animate( { 'fill-opacity': 0, opacity: 0}, this.kDefaultAnimationTime, '<>',
-      function() {
-        // Remove event handlers
-        if( iElement.events) {
-          iElement.events.forEach(function (iHandler) {
-            iHandler.unbind();
+    if( iElement) {
+      iElement.animate({'fill-opacity': 0, opacity: 0}, this.kDefaultAnimationTime, '<>',
+          function () {
+            // Remove event handlers
+            if (iElement.events) {
+              iElement.events.forEach(function (iHandler) {
+                iHandler.unbind();
+              });
+              iElement.events.length = 0;
+            }
+            iElement.hide();
+            if (iLayerManager)
+              iLayerManager.removeElement(this);
           });
-          iElement.events.length = 0;
-        }
-        iElement.hide();
-        if( iLayerManager)
-          iLayerManager.removeElement( this);
-      });
+    }
   },
 
   /**

--- a/apps/dg/components/graph/utilities/plot_utilities.js
+++ b/apps/dg/components/graph/utilities/plot_utilities.js
@@ -391,7 +391,7 @@ DG.PlotUtilities = {
    * @param iLayerManager
    */
   doHideRemoveAnimation: function( iElement, iLayerManager) {
-    if( iElement) {
+    if( iElement)
       iElement.animate({'fill-opacity': 0, opacity: 0}, this.kDefaultAnimationTime, '<>',
           function () {
             // Remove event handlers
@@ -405,7 +405,6 @@ DG.PlotUtilities = {
             if (iLayerManager)
               iLayerManager.removeElement(this);
           });
-    }
   },
 
   /**

--- a/apps/dg/components/graph_map_common/data_display_controller.js
+++ b/apps/dg/components/graph_map_common/data_display_controller.js
@@ -670,7 +670,7 @@ DG.DataDisplayController = DG.ComponentController.extend(
                   this_.addAxisHandler(tView);
                 });
           }
-        }.observes('xAxisView', 'yAxisView', 'y2AxisView', 'legendView'),
+        }.observes('xAxisView', 'yAxisView', 'y2AxisView', 'legendView', 'topAxisView', 'rightAxisView'),
 
         setupAttributeMenu: function (event, iAxisView, iAttrIndex) {
           var tDataDisplayModel = this.get('dataDisplayModel'),
@@ -708,6 +708,8 @@ DG.DataDisplayController = DG.ComponentController.extend(
               case 'vertical2':
                 tAxisKey = 'y2';
                 break;
+              default:
+                tAxisKey = tOrientation;
             }
           }
 

--- a/apps/dg/components/graph_map_common/data_layer_model.js
+++ b/apps/dg/components/graph_map_common/data_layer_model.js
@@ -514,6 +514,10 @@ DG.DataLayerModel = SC.Object.extend( DG.Destroyable,
         case 'legend':
           tAction = this.removeLegendAttribute;
           break;
+        case 'top':
+        case 'right':
+          tAction = this.removeSplitAttribute;
+          break;
       }
       return {
         title: tTitle,
@@ -647,6 +651,12 @@ DG.DataLayerModel = SC.Object.extend( DG.Destroyable,
      */
     removeLegendAttribute: function() {
       this.changeAttributeForLegend( null, null);
+    },
+
+    /**
+     * Subclasses will override
+     */
+    removeSplitAttribute: function() {
     },
 
     /**

--- a/apps/dg/components/graph_map_common/label_node.js
+++ b/apps/dg/components/graph_map_common/label_node.js
@@ -61,6 +61,18 @@ DG.LabelNode = SC.Object.extend(
         sc_super();
       },
 
+      hide: function() {
+        this._textElement.hide();
+        if( this._circleElement)
+          this._circleElement.hide();
+      },
+
+      show: function() {
+        this._textElement.show();
+        if( this._circleElement)
+          this._circleElement.show();
+      },
+
       numColorsChanged: function() {
         var tTextColor = 'blue',
             tPointColor = 'lightblue';

--- a/apps/dg/components/graph_map_common/plot_data_configuration.js
+++ b/apps/dg/components/graph_map_common/plot_data_configuration.js
@@ -401,7 +401,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
       setAttributeAndCollectionClient: function (iDescription, iAttrRefs, iRole, iType) {
         this._casesCache = null;  // because setting a new attribute and collection client can require recomputation of cases
         var tDescription = this.get(iDescription);
-        if( tDescription) {
+        if (tDescription) {
           //tDescription.invalidateCaches();  // So that notification order won't be important
           tDescription.removeAllAttributes();
           tDescription.beginPropertyChanges();
@@ -698,7 +698,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
       /**
        * Utility method
        */
-      invalidateAxisDescriptionCaches: function (iCases, iChange) {
+      invalidateAttributeDescriptionCaches: function (iCases, iChange) {
         if (this.get('xAttributeDescription'))
           this.get('xAttributeDescription').invalidateCaches(iCases, iChange);
         if (this.get('yAttributeDescription'))
@@ -742,12 +742,12 @@ DG.PlotDataConfiguration = SC.Object.extend(
           this._casesCache = null;
           tCases = iCases || this.get('cases');
         }
-        this.invalidateAxisDescriptionCaches(tCases, iChange);
+        this.invalidateAttributeDescriptionCaches(tCases, iChange);
       },
 
       hiddenCasesDidChange: function () {
         this._casesCache = null;
-        this.invalidateAxisDescriptionCaches();
+        this.invalidateAttributeDescriptionCaches();
       }.observes('hiddenCases'),
 
       /**
@@ -823,7 +823,8 @@ DG.PlotDataConfiguration = SC.Object.extend(
        * @returns {Boolean}
        */
       atLeastOneFormula: function () {
-        var tProperties = ['xAttributeDescription', 'yAttributeDescription', 'legendAttributeDescription'];
+        var tProperties = ['xAttributeDescription', 'yAttributeDescription', 'legendAttributeDescription',
+        'y2AttributeDescription'];
         return tProperties.some(function (iProperty) {
           return this.getPath(iProperty + '.hasFormula');
         }.bind(this));
@@ -878,7 +879,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
        * @param ioStorage {Object}
        * @param iDim {String}
        */
-      addToStorageForDimension: function( ioStorage, iDim) {
+      addToStorageForDimension: function (ioStorage, iDim) {
         var tCollection = this.get(iDim + 'CollectionClient'),
             tAttrDesc = this.get(iDim + 'AttributeDescription'),
             tAttrs = (tAttrDesc && tAttrDesc.get('attributes')) || [];
@@ -889,7 +890,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
             DG.ArchiveUtils.addLink(ioStorage, tKey, iAttr);
           });
         }
-        if( tAttrDesc) {
+        if (tAttrDesc) {
           ioStorage[iDim + 'Role'] = tAttrDesc.get('role');  // Has a role even without an attribute
           ioStorage[iDim + 'AttributeType'] = tAttrDesc.get('attributeType');
         }

--- a/apps/dg/components/graph_map_common/plot_data_configuration.js
+++ b/apps/dg/components/graph_map_common/plot_data_configuration.js
@@ -135,6 +135,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
           DG.assert(iValue instanceof DG.AttributePlacementDescription);
           this.attributesByPlace[iPlace][0] = iValue;
           iValue.addObserver('collection', this, 'collectionDidChange');
+          iValue.addObserver('categoryMap', this, 'categoryMapDidChange');
         }
 
         return !SC.none(this.attributesByPlace) ?
@@ -151,6 +152,14 @@ DG.PlotDataConfiguration = SC.Object.extend(
         var tID = iAttrDescription.getPath('attribute.collection.id'),
             tClient = this.get('dataContext').getCollectionByID(tID);
         iAttrDescription.set('collectionClient', tClient);
+      },
+
+      /**
+       * One of my attribute description's attribute's category map changed; e.g. by user dragging
+       * categories displayed on cell axis.
+       */
+      categoryMapDidChange: function () {
+        this.propertyDidChange('categoryMap');
       },
 
       /**
@@ -387,6 +396,7 @@ DG.PlotDataConfiguration = SC.Object.extend(
         if (this.get('attributesByPlace'))
           this.get('attributesByPlace').forEach(function (iAttrDesc) {
             iAttrDesc.removeObserver('collection', this, 'collectionDidChange');
+            iAttrDesc.removeObserver('categoryMap', this, 'categoryMapDidChange');
           }.bind(this));
 
         this._hiddenCases = [];  // For good measure

--- a/apps/dg/components/graph_map_common/plot_data_configuration.js
+++ b/apps/dg/components/graph_map_common/plot_data_configuration.js
@@ -292,6 +292,16 @@ DG.PlotDataConfiguration = SC.Object.extend(
       },
 
       /**
+       *
+       * @param iPrefixes {[String]}
+       */
+      noAttributesFor: function( iPrefixes) {
+        return iPrefixes.every( function( iPrefix) {
+          return this.getPath( iPrefix + 'AttributeDescription.noAttributes');
+        }.bind( this));
+      },
+
+      /**
        Returns true if this graph references attributes in collections with aggregate
        functions, which is useful when determining whether a graph needs to be redrawn.
        @property   {Boolean}
@@ -647,7 +657,8 @@ DG.PlotDataConfiguration = SC.Object.extend(
       attributeAssignmentDidChange: function () {
         this.notifyPropertyChange('attributeAssignment');
       }.observes('.xAttributeDescription.attribute', '.yAttributeDescription.attribute', '.y2AttributeDescription.attribute',
-          '.legendAttributeDescription.attribute'),
+          '.legendAttributeDescription.attribute', '.topAttributeDescription.attribute',
+          '.rightAttributeDescription.attribute'),
 
       /**
        Iteration through all attribute descriptions.

--- a/apps/dg/components/graph_map_common/plot_layer.js
+++ b/apps/dg/components/graph_map_common/plot_layer.js
@@ -576,7 +576,7 @@ DG.PlotLayer = SC.Object.extend(DG.Destroyable,
    */
   removeExtraElements: function() {
 
-    var tCasesLength = this.getPath('model.cases.length'),
+    var tCasesLength = this.getPath('model.cases').length(),
 
         tPlottedElements = this.get('plottedElements'),
         tPlotElementLength = tPlottedElements.length,

--- a/apps/dg/components/graph_map_common/plot_layer.js
+++ b/apps/dg/components/graph_map_common/plot_layer.js
@@ -407,6 +407,7 @@ DG.PlotLayer = SC.Object.extend(DG.Destroyable,
       },
 
       callCreateElement: function (iCase, iIndex, iAnimate, iIsVisible) {
+        // console.log('create element at index ' + iIndex);
         var tPlottedElements = this.get('plottedElements'),
             tElement;
         if (tPlottedElements[iIndex]) {

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -712,6 +712,8 @@ SC.stringsFor("en", {
     // DG.GraphView
     "DG.GraphView.replaceAttribute": "Replace %@ with %@",
     "DG.GraphView.addAttribute": "Add attribute %@",
+    "DG.GraphView.splitPlotVertically": "Split vertically by attribute %@",
+    "DG.GraphView.splitPlotHorizontally": "Split horizontally by attribute %@",
     "DG.GraphView.addToEmptyPlace": "Create axis with %@",
     "DG.GraphView.addToEmptyX": "Create x-axis with %@",
     "DG.GraphView.dropInPlot": "Color points by values of %@",

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -688,6 +688,8 @@ SC.stringsFor("en", {
     "DG.DataDisplayMenu.removeAttribute_y": "Remove Y: %@", // %@ = attribute name
     "DG.DataDisplayMenu.removeAttribute_y2": "Remove Y: %@", // %@ = attribute name
     "DG.DataDisplayMenu.removeAttribute_legend": "Remove Legend: %@", // %@ = attribute name
+    "DG.DataDisplayMenu.removeAttribute_top": "Remove Side-by-side Layout by %@", // %@ = attribute name
+    "DG.DataDisplayMenu.removeAttribute_right": "Remove Vertical Layout by %@", // %@ = attribute name
     "DG.DataDisplayMenu.treatAsCategorical": "Treat as Categorical",
     "DG.DataDisplayMenu.treatAsNumeric": "Treat as Numeric",
     "DG.DataDisplayMenu.hide": "Hide and Show",
@@ -712,8 +714,8 @@ SC.stringsFor("en", {
     // DG.GraphView
     "DG.GraphView.replaceAttribute": "Replace %@ with %@",
     "DG.GraphView.addAttribute": "Add attribute %@",
-    "DG.GraphView.splitPlotVertically": "Split vertically by attribute %@",
-    "DG.GraphView.splitPlotHorizontally": "Split horizontally by attribute %@",
+    "DG.GraphView.layoutPlotsSideBySide": "Layout side-by-side by %@",
+    "DG.GraphView.layoutPlotsVertically": "Layout vertically by %@",
     "DG.GraphView.addToEmptyPlace": "Create axis with %@",
     "DG.GraphView.addToEmptyX": "Create x-axis with %@",
     "DG.GraphView.dropInPlot": "Color points by values of %@",

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -233,6 +233,25 @@ DG.Attribute = DG.BaseModel.extend(
       },
 
       /**
+       * Determine based on type or, if not set, iterate through case values, returning true if
+       * at least one non-numeric value is encountered.
+       * @return {boolean}
+       */
+      isNominal: function() {
+        var tResult = false,
+            tCollection = this.get('collection');
+        if( tCollection) {
+          var tAttrID = this.get('id'),
+              tCases = tCollection.get('cases');
+          tResult = tCases && tCases.some(function (iCase) {
+            var tValue = iCase.getValue(tAttrID);
+            return !SC.empty( tValue) && !DG.MathUtilities.isNumeric( tValue);
+          });
+        }
+        return tResult;
+      },
+
+      /**
        * Iterate through the categories in the order maintained in the categoryMap
        *
        * @param iFunc has signature String, Color, Integer

--- a/apps/dg/models/attribute_model.js
+++ b/apps/dg/models/attribute_model.js
@@ -239,8 +239,11 @@ DG.Attribute = DG.BaseModel.extend(
        */
       isNominal: function() {
         var tResult = false,
+            tType = this.get('type'),
             tCollection = this.get('collection');
-        if( tCollection) {
+        if( tType === 'nominal')
+          tResult = true;
+        else if( tCollection) {
           var tAttrID = this.get('id'),
               tCases = tCollection.get('cases');
           tResult = tCases && tCases.some(function (iCase) {

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -338,7 +338,12 @@ DG.ComponentView = SC.View.extend(
             titleView.beginEditing();
           }
         },
-        contentView: SC.outlet('containerView.contentView'),
+        contentView: function( iKey, iValue) {
+          if( iValue) {
+            this.setPath('containerView.contentView', iValue);
+          }
+          return this.getPath('containerView.contentView');
+        }.property(),
         childViews: ('containerView' + (DG.get('componentMode') === 'no' ?
             ' borderRight borderBottom borderLeft borderTop borderCorner' : '')).w(),
         containerView: SC.View.design({
@@ -976,6 +981,9 @@ DG.ComponentView._createComponent = function (iParams) {
         showTitleBar: !tIsStandaloneInteractive,
         isResizable: !tIsStandaloneInteractive
       });
+  if( iParams.controller)
+    iParams.controller.set('view', tComponentView);
+  iParams.contentProperties.controller = iParams.controller;
   tComponentView.addContent(tComponentClass.create(iParams.contentProperties));
 
   if (iParams.controller)
@@ -999,8 +1007,10 @@ DG.ComponentView.restoreComponent = function (iParams) {
       tSuperView = iParams.parentView,
       tUseLayoutForPosition = iParams.useLayout;
 
-  if (iParams.controller)
+  if (iParams.controller) {
+    iParams.controller.set('view', tComponentView);
     tComponentView.set('controller', iParams.controller);
+  }
 
   //default to use the existing layout if present, even when requested otherwise.
   if (SC.none(tUseLayoutForPosition) && !SC.none(iParams.layout.left) && !SC.none(iParams.layout.top)) {

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -986,8 +986,10 @@ DG.ComponentView._createComponent = function (iParams) {
   iParams.contentProperties.controller = iParams.controller;
   tComponentView.addContent(tComponentClass.create(iParams.contentProperties));
 
-  if (iParams.controller)
+  if (iParams.controller) {
     tComponentView.set('controller', iParams.controller);
+    iParams.controller.set('contentView', tComponentView.getPath('containerView.contentView'));
+  }
   if (tIsStandaloneInteractive)
     tIsResizable = false;
   if (!SC.none(tIsResizable))

--- a/lang/strings/en-US.json
+++ b/lang/strings/en-US.json
@@ -712,6 +712,8 @@
     // DG.GraphView
     "DG.GraphView.replaceAttribute": "Replace %@ with %@",
     "DG.GraphView.addAttribute": "Add attribute %@",
+    "DG.GraphView.splitPlotVertically": "Split vertically by attribute %@",
+    "DG.GraphView.splitPlotHorizontally": "Split horizontally by attribute %@",
     "DG.GraphView.addToEmptyPlace": "Create axis with %@",
     "DG.GraphView.addToEmptyX": "Create x-axis with %@",
     "DG.GraphView.dropInPlot": "Color points by values of %@",

--- a/lang/strings/en-US.json
+++ b/lang/strings/en-US.json
@@ -688,6 +688,8 @@
     "DG.DataDisplayMenu.removeAttribute_y": "Remove Y: %@", // %@ = attribute name
     "DG.DataDisplayMenu.removeAttribute_y2": "Remove Y: %@", // %@ = attribute name
     "DG.DataDisplayMenu.removeAttribute_legend": "Remove Legend: %@", // %@ = attribute name
+    "DG.DataDisplayMenu.removeAttribute_top": "Remove Side-by-side Layout by %@", // %@ = attribute name
+    "DG.DataDisplayMenu.removeAttribute_right": "Remove Vertical Layout by %@", // %@ = attribute name
     "DG.DataDisplayMenu.treatAsCategorical": "Treat as Categorical",
     "DG.DataDisplayMenu.treatAsNumeric": "Treat as Numeric",
     "DG.DataDisplayMenu.hide": "Hide and Show",
@@ -712,8 +714,8 @@
     // DG.GraphView
     "DG.GraphView.replaceAttribute": "Replace %@ with %@",
     "DG.GraphView.addAttribute": "Add attribute %@",
-    "DG.GraphView.splitPlotVertically": "Split vertically by attribute %@",
-    "DG.GraphView.splitPlotHorizontally": "Split horizontally by attribute %@",
+    "DG.GraphView.layoutPlotsSideBySide": "Layout side-by-side by %@",
+    "DG.GraphView.layoutPlotsVertically": "Layout vertically by %@",
     "DG.GraphView.addToEmptyPlace": "Create axis with %@",
     "DG.GraphView.addToEmptyX": "Create x-axis with %@",
     "DG.GraphView.dropInPlot": "Color points by values of %@",


### PR DESCRIPTION
This implements a major feature described in [this epic](https://www.pivotaltracker.com/epic/show/4236779).

**Notes on implementation**

-  What previously would have been the _only_ plot should now be thought of as the _root_ plot.
- The root plot is "replicated" along with its adornments for each row and column category.
  - This scheme allows us to leave nearly all the existing configuration of plots and plot views in place, only having to add code that deals with replication (or tearing down replication)
- Each plot knows about its row_index and column_index and uses these to limit the cases it displays to those that have values for the "top" and "right" attributes that correspond to the numbered categories for the appropriate attribute.
- When the user changes something that affects the "splitting," the response is to tear down all the "non-root" split plots and their views before making the change to the root plot. After the change is complete, we build up the split plots. Although this is less efficient than it could be, it also seems less error prone.
- Its not just the plots and plot views that are replicated. Axes and axis views also replicate.
  - Numeric axes that are replicated are also linked together as "siblings" so that changes to the bounds of one propagate to all.