### PR TITLE
Sharing plugin improvements

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1941,14 +1941,18 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
               // copy those properties that can be handled by simple remap
               remapProperties(tValues, props.componentStorage, type);
 
+              var tableDataContext;
               if (tValues.type === 'caseTable') {
                 mapTableLinkPropertiesFromDI(tValues, props.componentStorage);
+                if (tValues.dataContext)
+                  tableDataContext = DG.currDocumentController().getContextByName(tValues.dataContext);
               }
-              if (!(tValues.type === 'slider' && tValues.globalValueName)) {
-                component = DG.currDocumentController().createComponentAndView(DG.Component.createComponent(props));
-                errorMessage = !component && 'Component creation failed';
+              // tables with data contexts
+              if ((tValues.type === 'caseTable') && tableDataContext) {
+                DG.appController.showCaseDisplayFor(tableDataContext);
               }
-              else {
+              // sliders with global values
+              else if ((tValues.type === 'slider') && tValues.globalValueName) {
                 global = DG.globalsController.getGlobalValueByName(tValues.globalValueName);
                 if (global) {
                   DG.ArchiveUtils.addLink(props.componentStorage, "model", global);
@@ -1957,6 +1961,11 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
                 } else {
                   errorMessage = "Global not found: '%@'".loc(tValues.globalValueName);
                 }
+              }
+              // all other components
+              else {
+                component = DG.currDocumentController().createComponentAndView(DG.Component.createComponent(props));
+                errorMessage = !component && 'Component creation failed';
               }
             }
 

--- a/apps/dg/models/data_set.js
+++ b/apps/dg/models/data_set.js
@@ -158,6 +158,9 @@ DG.DataSet = SC.Object.extend((function() // closure
         // the object may be just values or an object with id and values
         if (data.values && typeof data.values === 'object') {
           data.dataSet = this;
+          if (!data.id) {
+            data.id = DG.DataUtilities.createUniqueID();
+          }
           data.values = DG.DataUtilities.canonicalizeAttributeValues(this.attrs, data.values);
           dataItem = DG.DataItem.create(data);
         } else {


### PR DESCRIPTION
Fix item creation
- add id to DataItem in `DataSet.addDataItem()` if not present

Fix table creation
- only allow one table/data card for each context
