### PR TITLE
Support combining itemSearch and itemOrder to procedurally order items

### DIFF
--- a/apps/dg/components/case_table/case_table_controller.js
+++ b/apps/dg/components/case_table/case_table_controller.js
@@ -381,6 +381,7 @@ DG.CaseTableController = DG.CaseDisplayController.extend(
           case 'createItems':
           case 'updateItems':
           case 'deleteItems':
+          case 'moveItems':
             // Nothing to do here because we'll receive corresponding case notifications
             break;
           default:

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -1310,7 +1310,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
               operation: 'moveCases',
               collection: collection,
               cases: [theCase],
-              caseOrder: [iValues.caseOrder],
+              caseOrder: iValues.caseOrder,
               requester: this.get('id')
             });
             success = (changeResult && changeResult.success);
@@ -1488,9 +1488,22 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
             if (deletedItems) {
               return {success: true, values: deletedItems && deletedItems.map(function (item) {return item.id;})};
             }
-          } else {
-            return {success: false};
           }
+          return {success: false};
+        },
+        notify: function (iResources, iValues) {
+          var items = iResources.itemSearch;
+          var context = iResources.dataContext;
+          if (context && (items != null) && iValues.itemOrder) {
+            context.applyChange({
+              operation: 'moveItems',
+              items: items,
+              itemOrder: iValues.itemOrder,
+              requester: this.get('id')
+            });
+            return {success: true};
+          }
+          return {success: false};
         }
       },
 

--- a/apps/dg/models/data_set.js
+++ b/apps/dg/models/data_set.js
@@ -470,6 +470,25 @@ DG.DataSet = SC.Object.extend((function() // closure
                                                   }.bind(this));
     },
 
+    moveDataItemByID: function (itemID, order) {
+      var clientIndex = this.getDataItemClientIndexByID(itemID);
+      var itemIndex = this._clientToItemIndexMap[clientIndex];
+      if ((clientIndex != null) && order) {
+        var newIndexMap = this._clientToItemIndexMap.slice();
+        newIndexMap.splice(clientIndex, 1);
+        switch (order) {
+          case 'first':
+            newIndexMap.unshift(itemIndex);
+            this.setClientIndexMap(newIndexMap);
+            break;
+          case 'last':
+            newIndexMap.push(itemIndex);
+            this.setClientIndexMap(newIndexMap);
+            break;
+        }
+      }
+    },
+
     compareItemsByClientIndex: function(item1, item2) {
       return item1._clientIndex - item2._clientIndex;
     },


### PR DESCRIPTION
The shared table plugin endeavors to keep each user's cases/items at the bottom of the table for ease of editing. Previously this was accomplished by moving the single top-level case for a given user to the bottom of the table. Unfortunately, since cases are frequently regenerated from items, case order is inherently ephemeral, resulting in the need to frequently move the case again and leading to visible flashing as the cases are regenerated and then moved.

With this PR, we support specifying an `itemOrder` value to the `itemSearch` resource, which allows the set of items that match the search to be ordered. Currently, the only valid values for the `itemOrder` parameter are `first` and `last`, as is true for the `caseOrder` parameter when moving cases.

Note: the Travis build is failing for unrelated reasons that are fixed in a separate PR (#283).