### PR TITLE
Enable ESLint's `no-sequences` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
     "no-loop-func": "warn",
     "no-new-wrappers": "error",
     "no-proto": "error",
+    "no-sequences": "error",
     "no-unmodified-loop-condition": "error",
     "no-unused-expressions": ["error", { "allowShortCircuit": true }],
     "no-useless-call": "error",


### PR DESCRIPTION
Would have caught the dot plot bug that failed build 0489.

I'm surprised this isn't part of the default `eslint:recommended` set.