### PR TITLE
Preserve edits upon receipt of data context notifications

### DIFF
--- a/apps/dg/components/case_table/case_table_adapter.js
+++ b/apps/dg/components/case_table/case_table_adapter.js
@@ -353,6 +353,12 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
     return columnWidth;
   },
 
+  getColumnIndexFromAttribute: function (attr) {
+    return this.gridColumns.findIndex(function (columnInfo) {
+      return columnInfo.attribute && (attr.id === columnInfo.attribute.id);
+    });
+  },
+
   getColumnFromAttribute: function (attr) {
     return this.gridColumns.find(function (columnInfo) {
       return columnInfo.attribute && (attr.id === columnInfo.attribute.id);
@@ -705,13 +711,17 @@ DG.CaseTableAdapter = SC.Object.extend( (function() // closure
     Refreshes the contents of the table.
    */
   refresh: function() {
+    this.set('lastRefresh', null);
     this.invokeOnce(function() {
+      this.set('lastRefresh', null);
       var gridDataView = this.get('gridDataView');
       if( gridDataView) {
         gridDataView.refresh();
         this.notifyPropertyChange('tableDidRefresh');
       }
+      this.set('lastRefresh', new Date());
     }.bind(this));
+    this.set('lastRefresh', new Date());
   },
 
   /**
@@ -957,6 +967,22 @@ DG.CaseTableCellEditor = function CaseTableCellEditor(args) {
 
   this.serializeValue = function () {
     return $input.val();
+  };
+
+  this.saveEditState = function () {
+    return {
+      item: args.item,
+      column: args.column,
+      value: $input.val(),
+      selectionStart: $input[0].selectionStart,
+      selectionEnd: $input[0].selectionEnd,
+      selectionDirection: $input[0].selectionDirection
+    };
+  };
+
+  this.restoreEditState = function (state) {
+    $input.val(state.value);
+    $input[0].setSelectionRange(state.selectionStart, state.selectionEnd, state.selectionDirection);
   };
 
   /**


### PR DESCRIPTION
This comes up frequently when using the CODAP Shared Tables Plugin, but could arise with any plugin that generates data. If a user is in the middle of editing a case table cell when a plugin creates a new case or edits an existing case value, CODAP currently sometimes accepts the incomplete edit and sometimes cancels the incomplete edit. The preferred behavior is to preserve the edit state so that the user can continue their editing after the case table changes have occurred. Corresponds to [PT #166856056](https://www.pivotaltracker.com/story/show/166856056).

The approach taken here is to preserve the active edit state before the edit is committed/canceled and then to restore the active edit state after the table is done responding to the notifications. The tricky parts of the implementation are deciding where to intercede -- when to save the state and then how to determine when the response is complete and hence when to restore the edit state. This is complicated by the facts that data context notifications sometimes occur in batches, where we want to wait until the batch is complete before restoring the edit, and that the case table response to notifications can be asynchronous (e.g. `invokeOnce()`).

After extensive investigation, with this PR we track calls to `DG.CaseTableView.refresh()` and `DG.CaseTableAdapter.refresh()`, and wait until a period of time has elapsed (50ms) after the last refresh has completed. Testing so far suggests that this period is long enough to allow batches of notifications and their asynchronous operations to complete while still seeming reasonably immediate for the user.

Intuitively, this seems like the right behavior in the general case. If there are situations in which it is determined this is not the preferred behavior, clients can simply call `commitCurrentEdit()` or `cancelCurrentEdit()` before the save/restore of edit state occurs.