### PR TITLE
Fix text component save/restore [#166853796]

### DIFF
--- a/apps/dg/components/text/text_controller.js
+++ b/apps/dg/components/text/text_controller.js
@@ -124,7 +124,7 @@ DG.TextComponentController = DG.ComponentController.extend(
     var textFieldView = this.getPath('view.containerView.contentView.editView');
     if( textFieldView)
       textFieldView.bind('value', this, 'theText');
-  }.observes('view')
+  }.observes('*view.containerView.contentView')
   
 });
 


### PR DESCRIPTION
The text component relies on a binding set up in `DG.TextController.viewDidChange()` for model operations such as save/restore of text. Recent changes in component creation code resulted in this function being called before the `contentView` was configured, which prevented the binding from being configured properly. Rather than revisit the component creation code we change the `observes()` clause on `DG.TextController.viewDidChange()` to a chained observer which fires whenever the `contentView` is changed.

Fixes PT [#166853796](https://www.pivotaltracker.com/story/show/166853796)