### PR TITLE
Regroup cases on `updateCases` when parent attributes are changed

### DIFF
--- a/apps/dg/controllers/data_context.js
+++ b/apps/dg/controllers/data_context.js
@@ -1123,11 +1123,15 @@ DG.DataContext = SC.Object.extend((function() // closure
     }
 
     // invalidate dependents
-    var attrNodes = attrSpecs.map(function(iSpec) {
+    var hasGroupingAttr = false,
+        attrNodes = attrSpecs.map(function(iSpec) {
                       var attr = DG.Attribute.getAttributeByID(iSpec.attributeID);
+                      if (!hasGroupingAttr && attr.getPath('collection.children'))
+                        hasGroupingAttr = true;
                       return { type: DG.DEP_TYPE_ATTRIBUTE, id: iSpec.attributeID,
                                 name: attr.get('name') };
                     });
+    if (hasGroupingAttr) this.regenerateCollectionCases(null, 'updateCases');
     this.invalidateDependentsAndNotify(attrNodes, iChange);
 
     return { success: true, caseIDs: iChange.caseIDs };
@@ -1168,10 +1172,14 @@ DG.DataContext = SC.Object.extend((function() // closure
       }
     }.bind(this));
 
-    var attrNodes = [];
+    var attrNodes = [],
+        hasGroupingAttr = false;
     DG.ObjectMap.forEach(attrs, function(id, attr) {
+      if (!hasGroupingAttr && attr.getPath('collection.children'))
+        hasGroupingAttr = true;
       attrNodes.push({ type: DG.DEP_TYPE_ATTRIBUTE, id: attr.id, name: attr.get('name') });
     });
+    if (hasGroupingAttr) this.regenerateCollectionCases(null, 'updateCases');
     this.invalidateDependentsAndNotify(attrNodes, iChange);
 
     return { success: success, caseIDs: caseIDs};


### PR DESCRIPTION
Regroup (regenerate) cases on `updateCases` when grouping attributes are changed [#166894198]
- updating grouping values can require rearranging cases

Corresponds to PT [#166894198](https://www.pivotaltracker.com/story/show/166894198): Plugin API: changing case values can result in duplicate parent cases.

Noticed when developing the shared table plugin. Programmatically changing parent case values via the plugin API can result in duplicate parent case values because `regenerateCases()` doesn't get called.