### PR TITLE
Support multiple data interactive URLs in the `di` URL parameter

### DIFF
--- a/apps/dg/controllers/document_archiver.js
+++ b/apps/dg/controllers/document_archiver.js
@@ -379,19 +379,21 @@ DG.DocumentArchiver = SC.Object.extend(
      * @param iURL - URL of data interactive
      * @returns {DG.Document}
      */
-    createNewDocumentWithDataInteractiveURL: function (iURL) {
+    createNewDocumentWithDataInteractives: function (iURLs) {
+      var tComponents = (iURLs || [])
+            .map(function(url) {
+              return {
+                "type": "DG.GameView",
+                "componentStorage": {
+                  "currentGameName": "",
+                  "currentGameUrl": url
+                }
+              };
+            });
       var tDoc = {
         name: 'DG.Document.defaultDocumentName'.loc(),
         guid: 1,
-        components: [
-          {
-            "type": "DG.GameView",
-            "componentStorage": {
-              "currentGameName": "",
-              "currentGameUrl": iURL
-            }
-          }
-        ],
+        components: tComponents,
         appName: DG.APPNAME,
         appVersion: DG.VERSION,
         appBuildNum: DG.BUILD_NUM,

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -66,15 +66,15 @@ DG.main = function main() {
   /* begin CFM load/configuration */
   /* global Promise */
 
-  function openDataInteractive(iURL) {
-    if (iURL) {
+  function openDataInteractives(iURLs) {
+    if (iURLs) {
       // Create document-specific store.
       var archiver = DG.DocumentArchiver.create({}), newDocument;
 
       DG.currDocumentController().closeDocument();
 
       // Make a data interactive iFrame using the given URL
-      newDocument = archiver.createNewDocumentWithDataInteractiveURL(iURL);
+      newDocument = archiver.createNewDocumentWithDataInteractives(iURLs);
 
       DG.currDocumentController().setDocument(newDocument);
     }
@@ -161,13 +161,25 @@ DG.main = function main() {
   }
   function translateQueryParameters() {
     var startingDataInteractive = DG.get('startingDataInteractive');
+    var diURLs = [];
+    if (startingDataInteractive) {
+      var diLen = startingDataInteractive.length;
+      if ((diLen > 2) && (startingDataInteractive[0] === '[') &&
+          (startingDataInteractive[diLen - 1] === ']')) {
+        var diStrings = startingDataInteractive.substr(1, diLen - 2);
+        diURLs = diStrings.split(',');
+      }
+      else {
+        diURLs.push(startingDataInteractive);
+      }
+    }
 
     if (DG.get('runKey'))
       DG.set('showUserEntryView', false);
 
-    if (startingDataInteractive) {
+    if (diURLs.length) {
       DG.set('showUserEntryView', false);
-      openDataInteractive(startingDataInteractive);
+      openDataInteractives(diURLs);
     }
   }
 


### PR DESCRIPTION
Support multiple data interactive URLs in the `di` URL parameter
- supports array syntax for the `di` URL parameter
  - e.g. `di=[https://plugin.example.com,https://plugin2.example.com]`

Corresponds to PT [#166894511](https://www.pivotaltracker.com/story/show/166894511).