### PR TITLE
Prevent renaming of non-renameable attributes [#166918802]

### DIFF
--- a/apps/dg/components/case_table/attribute_editor_view.js
+++ b/apps/dg/components/case_table/attribute_editor_view.js
@@ -26,7 +26,7 @@ sc_require('views/inspector/picker_control_view');
  @extends SC.View
  */
 DG.AttributeEditorView = SC.PalettePane.extend( (function() // closure
-    /** @scope DG.AttribueEditorView.prototype */ {
+    /** @scope DG.AttributeEditorView.prototype */ {
     var kRowHeight = 20;
     var kControlHeight = kRowHeight - 2;
     var kTitleHeight = 26;
@@ -262,6 +262,12 @@ DG.AttributeEditorView = SC.PalettePane.extend( (function() // closure
         if (attrRef) {
           DG.ObjectMap.forEach(attr, function(key, val) {
             var ctlName = key + 'Ctl';
+            // Don't allow non-renameable attributes to be renamed
+            if (key === 'name') {
+              var isEditable = attr.get('renameable');
+              contentView.setPath('nameCtl.controlView.enabledState',
+                                  isEditable ? SC.CoreView.ENABLED : SC.CoreView.DISABLED);
+            }
             // Convert attribute type nominal to categorical
             if (key === 'type' && val === DG.Attribute.TYPE_NOMINAL) {
               val = DG.Attribute.TYPE_CATEGORICAL;


### PR DESCRIPTION
The `renameable` property was added to `DG.Attribute` on 2016-01-14, but no code (currently) makes use of the property. There is some evidence that this used to be prevented ([#110594718](https://www.pivotaltracker.com/story/show/110594718/comments/127099243)).

After searching for the appropriate mechanism for disabling a `SC.TextFieldView` (`isEditable`? no; `isTextSelectable`? no; `isEnabledinPane`? closer), we set the `enabledState` based on the attribute's `renameable` property.