### PR TITLE
Preserve active edit of parent case when responding to `rowsChanged` notification

### DIFF
--- a/apps/dg/components/case_table/case_table_view.js
+++ b/apps/dg/components/case_table/case_table_view.js
@@ -967,7 +967,11 @@ DG.CaseTableView = SC.View.extend( (function() // closure
       dataView.onRowsChanged.subscribe(function (e, args) {
         SC.run( function() {
           if( this._slickGrid) {
+            var editState = this.saveEditState();
             this._slickGrid.invalidate();
+            if (editState) {
+              this.restoreEditStateWhenReady(editState);
+            }
           }
         }.bind( this));
       }.bind( this));


### PR DESCRIPTION
A previous PR (#286) preserved edits in several circumstances but not of a parent case, so we add save/restore of active edit state in the `onRowsChanged` handler of `DG.CaseTableView`.