### PR TITLE
Added name parameter to CFM importedData message [#168406646]

### DIFF
--- a/apps/dg/controllers/app_controller.js
+++ b/apps/dg/controllers/app_controller.js
@@ -361,8 +361,8 @@ DG.appController = SC.Object.create((function () // closure
      * @param {Boolean} iShowCaseTable
      * @return {Deferred|undefined}
      */
-    importTextFromUrl: function (iURL, iShowCaseTable) {
-      var name = this.extractNameFromURLPath(iURL);
+    importTextFromUrl: function (iURL, iShowCaseTable, iName) {
+      var name = iName || this.extractNameFromURLPath(iURL);
       this.openCSVImporter({
         contentType: 'text/csv',
         url: iURL,
@@ -551,7 +551,7 @@ DG.appController = SC.Object.create((function () // closure
      * @param iComponentType - (optional) the type of the component, defaults to DG.GameView
      * @returns {Boolean}
      */
-    importURL: function (iURL, iComponentType) {
+    importURL: function (iURL, iComponentType, iName) {
 
       var addInteractive = function () {
         var tDoc = DG.currDocumentController(),
@@ -588,7 +588,7 @@ DG.appController = SC.Object.create((function () // closure
       if (mimeSpec) {
         switch (mimeSpec.group) {
           case 'TEXT':
-            this.importTextFromUrl(iURL);
+            this.importTextFromUrl(iURL, false, iName);
             break;
           case 'GEOJSON':
             this.importGeoJSONFromURL(iURL);

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -934,7 +934,7 @@ DG.main = function main() {
                 DG.appController.importFile(event.data.file.object);
               }
               else if (event.data.url && (event.data.via === "select")) {
-                DG.appController.importURL(event.data.url, event.data.componentType);
+                DG.appController.importURL(event.data.url, event.data.componentType, event.data.name);
               }
               else if (event.data.text && event.data.name) {
                 DG.appController.importText(event.data.text, event.data.name);


### PR DESCRIPTION
This fixes the importer trying to use the data uri as the name.  A seperate fix is needed in building-models to not send the componentType so that the csv import path can be followed in CODAP.