### PR TITLE
Fix getNameFromURL function

### DIFF
--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -870,14 +870,19 @@ DG.DocumentController = SC.Object.extend(
       },
 
       addGame: function (iParentView, iComponent, isInitialization) {
+        // It should return a document name, e.g.:
+        // /sage/sagemodeler.html => sagemodeler
+        // /sage/sagemodeler.html?param=abc.123 => sagemodeler
+        // /sage/sagemodeler?param=abc.123 => sagemodeler
         function getNameFromURL(iUrl) {
           if (!iUrl) {
             return;
           }
-          var match = /.*\/([^\/]*)\.[^\/.]*$/.exec(iUrl);
-          if (match) {
-            return match[1];
-          }
+          var a = document.createElement("a");
+          a.href = iUrl;
+          var doc = a.pathname.split("/").slice(-1)[0].split(".");
+          // At this point doc is equal to ["sagemodeler", "html"] or ["sagemodeler"] if .html was not present.
+          return doc[0];
         }
 
         var tGameParams = {

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -871,9 +871,9 @@ DG.DocumentController = SC.Object.extend(
 
       addGame: function (iParentView, iComponent, isInitialization) {
         // It should return a document name, e.g.:
-        // /sage/sagemodeler.html => sagemodeler
-        // /sage/sagemodeler.html?param=abc.123 => sagemodeler
-        // /sage/sagemodeler?param=abc.123 => sagemodeler
+        // /datagame/game.html => game
+        // /datagame/game.html?param=abc.123 => game
+        // /datagame/game?param=abc.123 => game
         function getNameFromURL(iUrl) {
           if (!iUrl) {
             return;
@@ -881,7 +881,7 @@ DG.DocumentController = SC.Object.extend(
           var a = document.createElement("a");
           a.href = iUrl;
           var doc = a.pathname.split("/").slice(-1)[0].split(".");
-          // At this point doc is equal to ["sagemodeler", "html"] or ["sagemodeler"] if .html was not present.
+          // At this point doc could be equal to ["game", "html"] or ["game"] if .html was not present.
           return doc[0];
         }
 


### PR DESCRIPTION
URL params with `.` were breaking it. E.g. for `/sage/sagemodeler.html?timestep=0.125` it was returning
`sagemodeler.html?timestep=0` while it should have been just `sagemodeler`. It was causing some other failures later in the code, which resulted in the model iframe being 300x200px only (sagemodeler app).

Related PT story: https://www.pivotaltracker.com/story/show/170507635