### PR TITLE
Improve case table vertical scrolling on touch devices

### DIFF
--- a/apps/dg/components/case_table/case_table_view.js
+++ b/apps/dg/components/case_table/case_table_view.js
@@ -826,6 +826,7 @@ DG.CaseTableView = SC.View.extend( (function() // closure
                                                   buttonImage: static_url("images/down.gif")
                                                 });
         this._slickGrid.registerPlugin(this.headerMenu);
+        this.$('.slick-viewport').addClass('dg-wants-touch');
 
         this.headerMenu.onBeforeMenuShow.subscribe(function(e, args) {
           hierTableView.hideHeaderMenus();

--- a/apps/dg/libraries/jquery/jquery.event.drag-2.2.js
+++ b/apps/dg/libraries/jquery/jquery.event.drag-2.2.js
@@ -37,6 +37,7 @@ drag = $special.drag = {
 		not: ':input', // selector to suppress dragging on target elements
 		handle: null, // selector to match handle target elements
 		relative: false, // true to use "position", false to use "offset"
+		touch: true, // [CC] false to suppress touch dragging, true to allow
 		drop: true, // false to suppress drop events, true or selector to allow
 		click: false // false to suppress click events after dragend (no proxy)
 	},
@@ -108,6 +109,8 @@ drag = $special.drag = {
 			return;
 		// the drag/drop interaction data
 		var dd = event.data, results;
+		// [CC] allow disabling of touch-dragging
+		if ( !dd.touch && event.type == 'touchstart') return;
 		// check the which directive
 		if ( event.which != 0 && dd.which > 0 && event.which != dd.which ) 
 			return; 

--- a/apps/dg/libraries/slickgrid/slick.grid.js
+++ b/apps/dg/libraries/slickgrid/slick.grid.js
@@ -401,7 +401,7 @@ if (typeof Slick === "undefined") {
             .bind("click", handleClick)
             .bind("dblclick", handleDblClick)
             .bind("contextmenu", handleContextMenu)
-            .bind("draginit", handleDragInit)
+            .bind("draginit", {touch: false}, handleDragInit)
             .bind("dragstart", {distance: 3}, handleDragStart)
             .bind("drag", handleDrag)
             .bind("dragend", handleDragEnd)

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -47,7 +47,18 @@ DG.main = function main() {
         wantsSCTouch = $(evt.target).closest('.dg-wants-sc-touch').length;
     return wantsSCTouch
               ? NO
-              : (dgWantsTouch ? YES : orgIgnoreTouchHandle(evt));
+              : (dgWantsTouch ? YES : orgIgnoreTouchHandle.call(this, evt));
+  };
+
+  // Fix to prevent assignment of touches that have already ended.
+  var orgAssignTouch = SC.RootResponder.prototype.assignTouch;
+  SC.RootResponder.prototype.assignTouch = function(touch, view) {
+    if (touch.hasEnded) {
+      console.warn("Attempt to assign a touch that is already finished.");
+    }
+    else {
+      orgAssignTouch.call(this, touch, view);
+    }
   };
 
   var orgIgnoreMouseHandle = SC.RootResponder.prototype.ignoreMouseHandle;

--- a/apps/dg/resources/dg-slickgrid.css
+++ b/apps/dg/resources/dg-slickgrid.css
@@ -161,6 +161,8 @@ sc_require('resources/slickgrid/plugins/slick.headermenu.css')
 }
 
 .slick-viewport {
+  /* enable momentum scrolling in case table body */
+  -webkit-overflow-scrolling: touch;
   /*
    * The following is address webkit bug where scroller thumb did not respect z-axis.
    * See: http://stackoverflow.com/questions/16874546/strange-z-index-behavior-with-scrollbars-under-chrome


### PR DESCRIPTION
Testable at https://codap-dev.concord.org/branch/121247039-touch-vertical-scroll/.

- Add `dg-wants-touch` to the table body to keep SproutCore from interfering with touch events there.
- Disable touch drag selection in the body of the case table to make it easier to scroll the table contents vertically.
    - In consultation with @bfinzer we disable drag-row-selection on touch events while leaving single-touch case selection to simplify vertical scrolling by touch in the body of the case table.
- Enable momentum scrolling.

~~Note that this PR also includes a hard-coded version of the Mammals sample document to make it easier to test scrolling. This should be removed before merging.~~