### PR TITLE
Touch-enable case card affordances [#171587490]

### DIFF
--- a/apps/dg/components/case_card/attribute_name_cell.js
+++ b/apps/dg/components/case_card/attribute_name_cell.js
@@ -114,7 +114,7 @@ DG.React.ready(function () {
                 tNewAttrButton = (this.props.index === 0) ?
                     img({
                       src: static_url('images/add_circle_grey_72x72.png'),
-                      className: 'dg-floating-plus' + tNewAttrDisabledClass,
+                      className: 'dg-floating-plus dg-wants-touch' + tNewAttrDisabledClass,
                       width: 19,
                       height: 19,
                       title: 'DG.TableController.newAttributeTooltip'.loc(),

--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -537,7 +537,7 @@ DG.React.ready(function () {
             return tr({
               key: 'attr-' + iAttrIndex,
               className: 'react-data-card-row'
-            }, tCell, td({className: tValueClassName}, tValueField));
+            }, tCell, td({className: 'dg-wants-touch ' + tValueClassName}, tValueField));
           },
 
           /**

--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -199,7 +199,6 @@ DG.React.ready(function () {
             }
 
             function handleTouchStart(iEvent) {
-              iEvent.preventDefault();
               handleMouseDown(iEvent.touches[0]);
             }
 
@@ -217,7 +216,6 @@ DG.React.ready(function () {
             }
 
             function handleTouchMove(iEvent) {
-              iEvent.preventDefault();
               handleMouseMove(iEvent.touches[0]);
             }
 
@@ -231,7 +229,6 @@ DG.React.ready(function () {
             }
 
             function handleTouchEnd(iEvent) {
-              iEvent.preventDefault();
               handleMouseUp();
             }
 

--- a/apps/dg/components/case_card/case_card_view.js
+++ b/apps/dg/components/case_card/case_card_view.js
@@ -83,6 +83,16 @@ DG.CaseCardView = SC.View.extend(
           ReactDOM.render( DG.React.Components.CaseCard( currProps), this.reactDiv);
         },
 
+        touchStart: function (evt) {
+          evt.allowDefault();
+          return YES;
+        },
+
+        touchEnd: function (evt) {
+          evt.allowDefault();
+          return YES;
+        },
+
         isValidAttribute: function (iDrag) {
           var tDragAttr = iDrag.data.attribute,
               tAttrs = this.get('context').getAttributes();

--- a/apps/dg/components/case_card/dropdown/dropdown.js
+++ b/apps/dg/components/case_card/dropdown/dropdown.js
@@ -37,13 +37,13 @@ DG.React.ready(function () {
           },
 
           componentDidMount: function () {
-            DG.mainPage.mainPane.addListener({action: 'click', target: this, method: this._onWindowClick});
-            DG.mainPage.mainPane.addListener({action: 'touchstart', target: this, method: this._onWindowClick});
+            window.addEventListener("touchstart", this._onWindowClick, true);
+            window.addEventListener("mousedown", this._onWindowClick, true);
           },
 
           componentWillUnmount: function () {
-            DG.mainPage.mainPane.removeListener({action: 'click', target: this, method: this._onWindowClick});
-            DG.mainPage.mainPane.removeListener({action: 'touchstart', target: this, method: this._onWindowClick});
+            window.removeEventListener("touchstart", this._onWindowClick, true);
+            window.removeEventListener("mousedown", this._onWindowClick, true);
           },
 
           hide: function () {
@@ -61,8 +61,9 @@ DG.React.ready(function () {
           },
 
           _onWindowClick: function( event) {
-            var dropdownElement = findDOMNode(this);
-            if (event.target !== dropdownElement && !dropdownElement.contains(event.target) && this.state.active) {
+            if (this.state.active &&
+                !event.target.classList.contains("react-data-card-attribute-menu-item") &&
+                !event.target.classList.contains("dropdown__content")) {
               this.hide();
             }
           },

--- a/apps/dg/components/case_card/nav_buttons.js
+++ b/apps/dg/components/case_card/nav_buttons.js
@@ -64,7 +64,7 @@ DG.React.ready(function () {
                   onClick: this.getNewCase
                 });
 
-            return span({className: 'react-data-card-navbuttons navbuttons-arrow'},
+            return span({className: 'react-data-card-navbuttons navbuttons-arrow dg-wants-touch'},
                 tFirstButton, tSecondButton, tAddCaseButton);
           }
         };

--- a/apps/dg/components/case_card/text_input.js
+++ b/apps/dg/components/case_card/text_input.js
@@ -29,13 +29,12 @@ DG.React.ready(function () {
           },
 
           componentDidMount: function () {
-            // Note that this depends on SproutCore in the midst of a React component. Not good!
-            DG.mainPage.mainPane.addListener({action: 'click', target: this, method: this._onWindowClick});
-            DG.mainPage.mainPane.addListener({action: 'touchstart', target: this, method: this._onWindowClick});
+            window.addEventListener("touchstart", this._onWindowClick, true);
+            window.addEventListener("mousedown", this._onWindowClick, true);
           },
           componentWillUnmount: function () {
-            DG.mainPage.mainPane.removeListener({action: 'click', target: this, method: this._onWindowClick});
-            DG.mainPage.mainPane.removeListener({action: 'touchstart', target: this, method: this._onWindowClick});
+            window.removeEventListener("touchstart", this._onWindowClick, true);
+            window.removeEventListener("mousedown", this._onWindowClick, true);
           },
 
           componentWillReceiveProps: function (iNewProps) {
@@ -72,7 +71,7 @@ DG.React.ready(function () {
                 kCompletionCodes = [13, 9],
                 tResult = this.state.editing ?
                     input({
-                      className: 'dg-wants-mouse',
+                      className: 'react-data-card-value-input dg-wants-mouse dg-wants-touch',
                       type: 'text',
                       // ref is called on creation of the input element
                       ref: function( input) {
@@ -94,7 +93,7 @@ DG.React.ready(function () {
                       }
                     }) :
                     span({
-                      className: tValueClassName + this.props.className,
+                      className: tValueClassName + (this.props.className || ''),
                       onClick: function ( iEvent) {
                         if (!this.state.editing && this.props.onToggleEditing && this.props.isEditable) {
                           this.props.onToggleEditing(this);

--- a/apps/dg/resources/case_card.css
+++ b/apps/dg/resources/case_card.css
@@ -22,8 +22,9 @@
     white-space: nowrap;
 }
 
-.react-data-card input {
+.react-data-card .react-data-card-value-input {
     font-size: 11px;
+    width: calc(100% - 1px);
 }
 
 .react-data-card-navbuttons {

--- a/apps/dg/resources/case_card.css
+++ b/apps/dg/resources/case_card.css
@@ -43,8 +43,18 @@
     cursor: pointer;
 }
 
-.navbuttons-arrow [class*="moonicon-"]:hover {
-    color: #72bfca;
+/* only show hover effect on mouse devices that support hover */
+/* avoids bugs related to iOS Safari's simulated hover effects */
+@media(hover: hover) and (pointer: fine) {
+    .navbuttons-arrow [class*="moonicon-"]:hover {
+        color: #72bfca;
+    }
+}
+/* otherwise, highlight on touch/click instead of hover */
+@media(hover: none), (pointer: coarse) {
+    .navbuttons-arrow [class*="moonicon-"]:active {
+        color: #72bfca;
+    }
 }
 
 .react-data-card-collection-header {

--- a/apps/dg/resources/case_card.css
+++ b/apps/dg/resources/case_card.css
@@ -17,6 +17,7 @@
     background-color: white;
     overflow-x: hidden;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     font-family: 'Montserrat', sans-serif;
     table-layout: fixed;
     white-space: nowrap;


### PR DESCRIPTION
1. "+" in upper right to make new case
2. "+" in upper left to create new attribute
3. Touch on attribute to bring up attribute menu
4. Left and right arrows to move from case to next or previous
5. Touch on value to initiate editing.

Testable at https://codap-dev.concord.org/branch/171587490-touch-case-card/.