### PR TITLE
Improve component resize affordances

### DIFF
--- a/apps/dg/resources/dg.css
+++ b/apps/dg/resources/dg.css
@@ -353,10 +353,29 @@ html, body {
 }
 
 /* visible in selected components */
-.dg-component-view-selected .dg-floating-plus {
-    visibility: visible;
-    opacity: 0.5;
-    cursor: pointer;
+.dg-component-view.dg-component-view-selected {
+    overflow: visible;
+
+    .dg-component-container {
+        overflow: visible;
+
+        .sc-split-view {
+            overflow: visible;
+        }
+    }
+
+    .dg-component-resize-handle-interior {
+        background-color: gray;
+        opacity: 0.2;
+        border: 1px solid black;
+        z-index: 9999;
+    }
+
+    .dg-floating-plus {
+        visibility: visible;
+        opacity: 0.5;
+        cursor: pointer;
+    }
 }
 
 /* hidden in selected components when explicitly disabled */

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -19,205 +19,12 @@
 //  limitations under the License.
 // ==========================================================================
 
+sc_require('views/drag_border_view');
 sc_require('views/titlebar_button_view');
 
 var kResizeHandleSize = 24,
     kResizeHandleHalfSize = kResizeHandleSize / 2,
     kResizeHandleInset = 2;
-
-/** @class
-
-    DragBorderView is typically a thin view configured to lie on the border of a component
- view. It implements the dragging functionality except for the actual change in the
- frame's layout.
-
- @extends SC.View
- */
-DG.DragBorderView = SC.View.extend(
-    (function () {
-
-      return {
-        /** @scope DG.DragBorderView.prototype */
-        dragCursor: null,
-        cursor: function () {
-          if (this.parentView.get('isResizable'))
-            return this.dragCursor;
-          else
-            return null;
-        }.property('dragCursor').cacheable(),
-        mouseDown: function (evt) {
-          if (evt.button === 2 || evt.ctrlKey) {
-            return NO;
-          }
-          DG.globalEditorLock.commitCurrentEdit();
-          var tView = this.viewToDrag(),
-              tParentView = tView.get('parentView');
-          // Make sure the enclosing view will be movable
-          DG.ViewUtilities.convertViewLayoutToAbsolute(tView);
-          // A click on a border should bring the view to the front
-          tView.select();
-          if (!this.canBeDragged())
-            return NO;  // We won't get other events either
-          if( tParentView.coverUpComponentViews)
-            tParentView.coverUpComponentViews('cover');
-
-          var layout = this.viewToDrag().get('layout');
-          this._mouseDownInfo = {
-            pageX: evt.pageX, // save mouse pointer loc for later use
-            pageY: evt.pageY, // save mouse pointer loc for later use
-            left: layout.left,
-            top: layout.top,
-            height: layout.height,
-            width: layout.width
-          };
-          var tViewToDrag = this.viewToDrag();
-          DG.currDocumentController().notificationManager.sendNotification({
-            action: 'notify',
-            resource: 'component',
-            values: {
-              operation: 'beginMoveOrResize',
-              type: tViewToDrag.getPath('controller.model.type'),
-              id: tViewToDrag.getPath('controller.model.id')
-            }
-          });
-          tView.get('controller').updateModelLayout();
-          return YES; // so we get other events
-        },
-
-        mouseUp: function (evt) {
-          var tViewToDrag = this.viewToDrag(),
-              tContainer = tViewToDrag.get('parentView'),
-              tOldLayout = this._mouseDownInfo,
-              tNewLayout = tViewToDrag.get('layout'),
-              isResize = (!SC.none(this.getPath('cursor.cursorStyle'))) && this.getPath('cursor.cursorStyle').indexOf('-resize') !== -1;
-          // apply one more time to set final position
-          this.mouseDragged(evt);
-          this._mouseDownInfo = null; // cleanup info
-          if( tContainer.coverUpComponentViews) {
-            tContainer.coverUpComponentViews('uncover');
-            tContainer.updateFrame();
-          }
-          if ((tOldLayout.left !== tNewLayout.left) || (tOldLayout.top !== tNewLayout.top) ||
-              (tOldLayout.height !== tNewLayout.height) || (tOldLayout.width !== tNewLayout.width)) {
-
-            DG.UndoHistory.execute(DG.Command.create({
-              name: (isResize ? 'component.resize' : 'component.move'),
-              undoString: (isResize ? 'DG.Undo.componentResize' : 'DG.Undo.componentMove'),
-              redoString: (isResize ? 'DG.Redo.componentResize' : 'DG.Redo.componentMove'),
-              executeNotification: {
-                action: 'notify',
-                resource: 'component',
-                values: {
-                  operation: isResize ? 'resize' : 'move',
-                  type: tViewToDrag.getPath('controller.model.type'),
-                  id: tViewToDrag.getPath('controller.model.id'),
-                  title: tViewToDrag.getPath('controller.model.title')
-                }
-              },
-              log: '%@ component "%@"'.fmt((isResize ? 'Resized' : 'Moved'), tViewToDrag.get('title')),
-              _componentId: tViewToDrag.getPath('controller.model.id'),
-              _controller: function () {
-                return DG.currDocumentController().componentControllersMap[this._componentId];
-              },
-              _oldLayout: null,
-              execute: function () {
-                this._oldLayout = this._controller().updateModelLayout();
-                if (!this._oldLayout) {
-                  this.causedChange = false;
-                }
-              },
-              undo: function () {
-                var layout = SC.clone(this._oldLayout);
-                if (tViewToDrag.isMinimized()) {
-                  this._oldHeight = this._oldLayout.height;
-                  layout.height = 25;
-                }
-                tViewToDrag.animate(layout,
-                    {duration: 0.4, timing: 'ease-in-out'},
-                    function () {
-                      // bizarre bug leaves the last animated transition property still
-                      // with a delay even after the end of an animation, so we clear it by hand
-                      tViewToDrag._view_layer.style.transition = "";
-                      // set actual model layout once animation has completed
-                      this._oldLayout = this._controller().revertModelLayout(layout);
-                      this._oldLayout.height = layout.height;
-                      tContainer.updateFrame();
-                    }.bind(this));
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tViewToDrag.configureViewBoundsLayout({height:layout.height,
-                                             width:layout.width,
-                                             x:layout.left,
-                                             y:layout.top});
-                }
-              },
-              redo: function () {
-                var layout = SC.clone(this._oldLayout);
-                if (tViewToDrag.isMinimized()) {
-                  layout.height = 25;
-                }
-                tViewToDrag.animate(layout,
-                    {duration: 0.4, timing: 'ease-in-out'},
-                    function () {
-                      tViewToDrag._view_layer.style.transition = "";
-                      this._oldLayout = this._controller().revertModelLayout(this._oldLayout);
-                      tContainer.updateFrame();
-                    }.bind(this));
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tViewToDrag.configureViewBoundsLayout({height:layout.height,
-                                             width:layout.width,
-                                             x:layout.left,
-                                             y:layout.top});
-                }
-              }
-            }));
-          }
-          if (DG.KEEP_IN_BOUNDS_PREF) {
-            DG.currDocumentController().computeScaleBounds();
-          }
-          return YES; // handled!
-        },
-
-        mouseDragged: function (evt) {
-          var info = this._mouseDownInfo;
-
-          if (info) {
-            this.dragAdjust(evt, info);
-            return YES; // event was handled!
-          }
-          else
-            return NO;
-        },
-        canBeDragged: function () {
-          return NO;  // default
-        },
-        touchStart: function (evt) {
-          return this.mouseDown(evt);
-        },
-        touchEnd: function (evt) {
-          return this.mouseUp(evt);
-        },
-        touchesDragged: function (evt, touches) {
-          return this.mouseDragged(evt);
-        },
-        dragAdjust: function (evt, info) {
-          // default is to do nothing
-        },
-        viewToDrag: function () {
-          return DG.ComponentView.findComponentViewParent(this);
-        },
-        getContainerWidth: function () {
-          return $('#codap').width();
-        },
-        getContainerHeight: function () {
-          var tDocView = this.viewToDrag();
-          while (!SC.none(tDocView.parentView.parentView)) {
-            tDocView = tDocView.parentView;
-          }
-          return $('#codap').height() - tDocView.get('frame').y;
-        }
-      };
-    }())
-);
 
 /** @class
 
@@ -236,14 +43,8 @@ DG.ComponentView = SC.View.extend(
     (function () {
       var kTitleBarHeight = DG.ViewUtilities.kTitleBarHeight,
           kMinSize = 50,
-          kMaxSize = Number.MAX_VALUE,
           kDragWidth = DG.ViewUtilities.kDragWidth,
           kBorderWidth = DG.ViewUtilities.kBorderWidth,
-          kRightBorderCursor = SC.Cursor.create({cursorStyle: SC.E_RESIZE_CURSOR}),
-          kBottomBorderCursor = SC.Cursor.create({cursorStyle: SC.S_RESIZE_CURSOR}),
-          kLeftBorderCursor = SC.Cursor.create({cursorStyle: SC.W_RESIZE_CURSOR}),
-          kBottomLeftBorderCursor = SC.Cursor.create({cursorStyle: SC.SW_RESIZE_CURSOR}),
-          kBottomRightBorderCursor = SC.Cursor.create({cursorStyle: SC.SE_RESIZE_CURSOR}),
           kViewInComponentMode = DG.get('componentMode') === 'yes',
           kViewInEmbeddedMode = DG.get('embeddedMode') === 'yes',
           kHideUndoRedoInComponent = DG.get('hideUndoRedoInComponent') === 'yes',
@@ -606,169 +407,30 @@ DG.ComponentView = SC.View.extend(
           }
 
         }), // containerView
-        borderRight: DG.DragBorderView.design(
+        borderRight: DG.DragRightBorderView.design(
             {
               classNames: ['dg-component-border'],
-              layout: {top: kTitleBarHeight, right: 0, width: kDragWidth},
-              dragCursor: kRightBorderCursor,
-              dragAdjust: function (evt, info) {
-                // Don't let user drag right edge off left of window
-                var tMinWidth = this.get('contentMinWidth') || kMinSize,
-                    tLoc = Math.max(evt.pageX, tMinWidth),
-                    tNewWidth = DG.ViewUtilities.roundToGrid(info.width + (tLoc - info.pageX)),
-                    tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxSize,
-                    tContainerWidth = this.getContainerWidth();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInspectorDimensions = this.parentView.getInspectorDimensions();
-                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
-                }
-                // Don't let width of component become too small
-                tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
-                this.parentView.adjust('width', tNewWidth);
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              layout: {top: kTitleBarHeight, right: 0, width: kDragWidth}
             }),
-        borderBottom: DG.DragBorderView.design(
+        borderBottom: DG.DragBottomBorderView.design(
             {
               classNames: ['dg-component-border'],
-              layout: {bottom: 0, height: kDragWidth},
-              dragCursor: kBottomBorderCursor,
-              dragAdjust: function (evt, info) {
-                var tMinHeight = this.get('contentMinHeight') || kMinSize,
-                    tMaxHeight = this.get('contentMaxHeight') || kMaxSize,
-                    tNewHeight = info.height + (evt.pageY - info.pageY),
-                    tContainerHeight = this.getContainerHeight();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tMaxHeight = Math.min(tMaxHeight, tContainerHeight - info.top);
-                }
-                tNewHeight = DG.ViewUtilities.roundToGrid(Math.min(
-                    Math.max(tNewHeight, tMinHeight), tMaxHeight));
-                this.parentView.adjust('height', tNewHeight);
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              layout: {bottom: 0, height: kDragWidth}
             }),
-        borderLeft: DG.DragBorderView.design(
+        borderLeft: DG.DragLeftBorderView.design(
             {
               classNames: ['dg-component-border'],
-              layout: {left: 0, width: kDragWidth},
-              dragCursor: kLeftBorderCursor,
-              dragAdjust: function (evt, info) {
-                var tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxSize,
-                    tMinWidth = this.get('contentMinWidth') || kMinSize,
-                    tContainerWidth = this.getContainerWidth();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  evt.pageX = Math.max(0, evt.pageX);
-                }
-                var tNewWidth = DG.ViewUtilities.roundToGrid(info.width - (evt.pageX - info.pageX)),
-                    tLoc;
-                tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
-                tLoc = info.left + info.width - tNewWidth;
-                if (tLoc < tContainerWidth - tMinWidth) {
-                  this.parentView.adjust('width', tNewWidth);
-                  this.parentView.adjust('left', tLoc);
-                }
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
-                  this.parentView.originalLayout.left = tLoc / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              layout: {left: 0, width: kDragWidth}
             }),
-        borderBottomLeft: DG.DragBorderView.design(
+        borderBottomLeft: DG.DragBottomLeftBorderView.design(
             {
-              layout: {left: 0, width: 2 * kDragWidth, bottom: 0, height: 2 * kDragWidth},
-              dragCursor: kBottomLeftBorderCursor,
-              dragAdjust: function (evt, info) {
-                // Don't let user drag right edge off left of window
-                var tMinHeight = this.get('contentMinHeight') || kMinSize,
-                    tMaxHeight = this.get('contentMaxHeight') || kMaxSize,
-                    tMinWidth = this.get('contentMinWidth') || kMinSize,
-                    tLoc = Math.max(evt.pageX, tMinWidth),
-                    tNewWidth = DG.ViewUtilities.roundToGrid(info.width - (evt.pageX - info.pageX)),
-                    tNewHeight = DG.ViewUtilities.roundToGrid(info.height + (evt.pageY - info.pageY)),
-                    tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxSize,
-                    tContainerWidth = this.getContainerWidth(),
-                    tContainerHeight = this.getContainerHeight();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tMaxHeight = tContainerHeight - info.top;
-                  var tInspectorDimensions = this.parentView.getInspectorDimensions();
-                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
-                }
-                // Don't let width or height of component become too small
-                tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
-                tLoc = info.left + info.width - tNewWidth;
-                if (tLoc < tContainerWidth - tMinWidth) {
-                  this.parentView.adjust('width', tNewWidth);
-                  this.parentView.adjust('left', tLoc);
-                }
-                tNewHeight = Math.min(Math.max(tNewHeight, tMinHeight), tMaxHeight);
-                this.parentView.adjust('height', tNewHeight);
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
-                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              layout: {left: 0, width: 2 * kDragWidth, bottom: 0, height: 2 * kDragWidth}
             }),
-        borderBottomRight: DG.DragBorderView.design(
+        borderBottomRight: DG.DragBottomRightBorderView.design(
             {
-              layout: {right: 0, width: 2 * kDragWidth, bottom: 0, height: 2 * kDragWidth},
-              dragCursor: kBottomRightBorderCursor,
-              dragAdjust: function (evt, info) {
-                // Don't let user drag right edge off left of window
-                var tMinHeight = this.get('contentMinHeight') || kMinSize,
-                    tMaxHeight = this.get('contentMaxHeight') || kMaxSize,
-                    tMinWidth = this.get('contentMinWidth') || kMinSize,
-                    tLoc = Math.max(evt.pageX, tMinWidth),
-                    tNewWidth = DG.ViewUtilities.roundToGrid(info.width + (tLoc - info.pageX)),
-                    tNewHeight = DG.ViewUtilities.roundToGrid(info.height + (evt.pageY - info.pageY)),
-                    tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxSize,
-                    tContainerWidth = this.getContainerWidth(),
-                    tContainerHeight = this.getContainerHeight();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tMaxHeight = tContainerHeight - info.top;
-                  var tInspectorDimensions = this.parentView.getInspectorDimensions();
-                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
-                }
-                // Don't let width or height of component become too small
-                tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
-                this.parentView.adjust('width', tNewWidth);
-                tNewHeight = Math.min(Math.max(tNewHeight, tMinHeight), tMaxHeight);
-                this.parentView.adjust('height', tNewHeight);
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
-                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              layout: {right: 0, width: 2 * kDragWidth, bottom: 0, height: 2 * kDragWidth}
             }),
-        resizeRight: DG.DragBorderView.design(
+        resizeRight: DG.DragRightBorderView.design(
             {
               classNames: ['dg-component-resize-handle'],
               layout: {centerY: 0, right: -kResizeHandleHalfSize,
@@ -781,33 +443,9 @@ DG.ComponentView = SC.View.extend(
                 classNames: ['dg-component-resize-handle-interior'],
                 layout: {left: kResizeHandleInset, top: kResizeHandleInset,
                         right: kResizeHandleInset, bottom: kResizeHandleInset}
-              }),
-              dragCursor: kRightBorderCursor,
-              dragAdjust: function (evt, info) {
-                // Don't let user drag right edge off left of window
-                var tMinWidth = this.get('contentMinWidth') || kMinSize,
-                    tLoc = Math.max(evt.pageX, tMinWidth),
-                    tNewWidth = DG.ViewUtilities.roundToGrid(info.width + (tLoc - info.pageX)),
-                    tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxSize,
-                    tContainerWidth = this.getContainerWidth();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInspectorDimensions = this.parentView.getInspectorDimensions();
-                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
-                }
-                // Don't let width of component become too small
-                tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
-                this.parentView.adjust('width', tNewWidth);
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              })
             }),
-        resizeBottom: DG.DragBorderView.design(
+        resizeBottom: DG.DragBottomBorderView.design(
             {
               classNames: ['dg-component-resize-handle'],
               layout: {centerX: 0, bottom: -kResizeHandleHalfSize,
@@ -820,30 +458,9 @@ DG.ComponentView = SC.View.extend(
                 classNames: ['dg-component-resize-handle-interior'],
                 layout: {left: kResizeHandleInset, top: kResizeHandleInset,
                         right: kResizeHandleInset, bottom: kResizeHandleInset}
-              }),
-              dragCursor: kBottomBorderCursor,
-              dragAdjust: function (evt, info) {
-                var tMinHeight = this.get('contentMinHeight') || kMinSize,
-                    tMaxHeight = this.get('contentMaxHeight') || kMaxSize,
-                    tNewHeight = info.height + (evt.pageY - info.pageY),
-                    tContainerHeight = this.getContainerHeight();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tMaxHeight = Math.min(tMaxHeight, tContainerHeight - info.top);
-                }
-                tNewHeight = DG.ViewUtilities.roundToGrid(Math.min(
-                    Math.max(tNewHeight, tMinHeight), tMaxHeight));
-                this.parentView.adjust('height', tNewHeight);
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              })
             }),
-        resizeLeft: DG.DragBorderView.design(
+        resizeLeft: DG.DragLeftBorderView.design(
             {
               classNames: ['dg-component-resize-handle'],
               layout: {left: -kResizeHandleHalfSize, centerY: 0,
@@ -856,35 +473,9 @@ DG.ComponentView = SC.View.extend(
                 classNames: ['dg-component-resize-handle-interior'],
                 layout: {left: kResizeHandleInset, top: kResizeHandleInset,
                         right: kResizeHandleInset, bottom: kResizeHandleInset}
-              }),
-              dragCursor: kLeftBorderCursor,
-              dragAdjust: function (evt, info) {
-                var tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxSize,
-                    tMinWidth = this.get('contentMinWidth') || kMinSize,
-                    tContainerWidth = this.getContainerWidth();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  evt.pageX = Math.max(0, evt.pageX);
-                }
-                var tNewWidth = DG.ViewUtilities.roundToGrid(info.width - (evt.pageX - info.pageX)),
-                    tLoc;
-                tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
-                tLoc = info.left + info.width - tNewWidth;
-                if (tLoc < tContainerWidth - tMinWidth) {
-                  this.parentView.adjust('width', tNewWidth);
-                  this.parentView.adjust('left', tLoc);
-                }
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
-                  this.parentView.originalLayout.left = tLoc / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              })
             }),
-        resizeBottomLeft: DG.DragBorderView.design(
+        resizeBottomLeft: DG.DragBottomLeftBorderView.design(
             {
               classNames: ['dg-component-resize-handle'],
               layout: {left: -kResizeHandleHalfSize, bottom: -kResizeHandleHalfSize,
@@ -897,45 +488,9 @@ DG.ComponentView = SC.View.extend(
                 classNames: ['dg-component-resize-handle-interior'],
                 layout: {left: kResizeHandleInset, top: kResizeHandleInset,
                         right: kResizeHandleInset, bottom: kResizeHandleInset}
-              }),
-              dragCursor: kBottomLeftBorderCursor,
-              dragAdjust: function (evt, info) {
-                // Don't let user drag right edge off left of window
-                var tMinHeight = this.get('contentMinHeight') || kMinSize,
-                    tMaxHeight = this.get('contentMaxHeight') || kMaxSize,
-                    tMinWidth = this.get('contentMinWidth') || kMinSize,
-                    tLoc = Math.max(evt.pageX, tMinWidth),
-                    tNewWidth = DG.ViewUtilities.roundToGrid(info.width - (evt.pageX - info.pageX)),
-                    tNewHeight = DG.ViewUtilities.roundToGrid(info.height + (evt.pageY - info.pageY)),
-                    tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxSize,
-                    tContainerWidth = this.getContainerWidth(),
-                    tContainerHeight = this.getContainerHeight();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tMaxHeight = tContainerHeight - info.top;
-                  var tInspectorDimensions = this.parentView.getInspectorDimensions();
-                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
-                }
-                // Don't let width or height of component become too small
-                tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
-                tLoc = info.left + info.width - tNewWidth;
-                if (tLoc < tContainerWidth - tMinWidth) {
-                  this.parentView.adjust('width', tNewWidth);
-                  this.parentView.adjust('left', tLoc);
-                }
-                tNewHeight = Math.min(Math.max(tNewHeight, tMinHeight), tMaxHeight);
-                this.parentView.adjust('height', tNewHeight);
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
-                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              })
             }),
-        resizeBottomRight: DG.DragBorderView.design(
+        resizeBottomRight: DG.DragBottomRightBorderView.design(
             {
               classNames: ['dg-component-resize-handle'],
               layout: {right: -kResizeHandleHalfSize, bottom: -kResizeHandleHalfSize,
@@ -948,39 +503,7 @@ DG.ComponentView = SC.View.extend(
                 classNames: ['dg-component-resize-handle-interior'],
                 layout: {left: kResizeHandleInset, top: kResizeHandleInset,
                         right: kResizeHandleInset, bottom: kResizeHandleInset}
-              }),
-              dragCursor: kBottomRightBorderCursor,
-              dragAdjust: function (evt, info) {
-                // Don't let user drag right edge off left of window
-                var tMinHeight = this.get('contentMinHeight') || kMinSize,
-                    tMaxHeight = this.get('contentMaxHeight') || kMaxSize,
-                    tMinWidth = this.get('contentMinWidth') || kMinSize,
-                    tLoc = Math.max(evt.pageX, tMinWidth),
-                    tNewWidth = DG.ViewUtilities.roundToGrid(info.width + (tLoc - info.pageX)),
-                    tNewHeight = DG.ViewUtilities.roundToGrid(info.height + (evt.pageY - info.pageY)),
-                    tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxSize,
-                    tContainerWidth = this.getContainerWidth(),
-                    tContainerHeight = this.getContainerHeight();
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  tMaxHeight = tContainerHeight - info.top;
-                  var tInspectorDimensions = this.parentView.getInspectorDimensions();
-                  tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
-                }
-                // Don't let width or height of component become too small
-                tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
-                this.parentView.adjust('width', tNewWidth);
-                tNewHeight = Math.min(Math.max(tNewHeight, tMinHeight), tMaxHeight);
-                this.parentView.adjust('height', tNewHeight);
-                if (DG.KEEP_IN_BOUNDS_PREF) {
-                  var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
-                      tScaleFactor = tInBoundsScaling.scaleFactor;
-                  this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
-                  this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
-                }
-              },
-              canBeDragged: function () {
-                return this.parentView.get('isResizable');
-              }
+              })
             }),
 
         title: function (iKey, iValue) {

--- a/apps/dg/views/drag_border_view.js
+++ b/apps/dg/views/drag_border_view.js
@@ -1,0 +1,361 @@
+//                          DG.DragBorderView
+//
+//  Views for managing component resizing
+//
+//  Author:   William Finzer / Kirk Swenson
+//
+//  Copyright (c) 2020 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+
+var kMinComponentSize = 50,
+    kMaxComponentSize = Number.MAX_VALUE,
+    kRightBorderCursor = SC.Cursor.create({cursorStyle: SC.E_RESIZE_CURSOR}),
+    kBottomBorderCursor = SC.Cursor.create({cursorStyle: SC.S_RESIZE_CURSOR}),
+    kLeftBorderCursor = SC.Cursor.create({cursorStyle: SC.W_RESIZE_CURSOR}),
+    kBottomLeftBorderCursor = SC.Cursor.create({cursorStyle: SC.SW_RESIZE_CURSOR}),
+    kBottomRightBorderCursor = SC.Cursor.create({cursorStyle: SC.SE_RESIZE_CURSOR});
+
+/** @class
+
+    DragBorderView is typically a thin view configured to lie on the border of a component
+ view. It implements the dragging functionality except for the actual change in the
+ frame's layout.
+
+ @extends SC.View
+ */
+DG.DragBorderView = SC.View.extend(
+    (function () {
+
+      return {
+        /** @scope DG.DragBorderView.prototype */
+        dragCursor: null,
+        canBeDragged: function () {
+          return this.parentView.get('isResizable');
+        },
+        cursor: function () {
+          if (this.canBeDragged())
+            return this.dragCursor;
+          else
+            return null;
+        }.property('dragCursor').cacheable(),
+        mouseDown: function (evt) {
+          if (evt.button === 2 || evt.ctrlKey) {
+            return NO;
+          }
+          DG.globalEditorLock.commitCurrentEdit();
+          var tView = this.viewToDrag(),
+              tParentView = tView.get('parentView');
+          // Make sure the enclosing view will be movable
+          DG.ViewUtilities.convertViewLayoutToAbsolute(tView);
+          // A click on a border should bring the view to the front
+          tView.select();
+          if (!this.canBeDragged())
+            return NO;  // We won't get other events either
+          if( tParentView.coverUpComponentViews)
+            tParentView.coverUpComponentViews('cover');
+
+          var layout = this.viewToDrag().get('layout');
+          this._mouseDownInfo = {
+            pageX: evt.pageX, // save mouse pointer loc for later use
+            pageY: evt.pageY, // save mouse pointer loc for later use
+            left: layout.left,
+            top: layout.top,
+            height: layout.height,
+            width: layout.width
+          };
+          var tViewToDrag = this.viewToDrag();
+          DG.currDocumentController().notificationManager.sendNotification({
+            action: 'notify',
+            resource: 'component',
+            values: {
+              operation: 'beginMoveOrResize',
+              type: tViewToDrag.getPath('controller.model.type'),
+              id: tViewToDrag.getPath('controller.model.id')
+            }
+          });
+          tView.get('controller').updateModelLayout();
+          return YES; // so we get other events
+        },
+
+        mouseUp: function (evt) {
+          var tViewToDrag = this.viewToDrag(),
+              tContainer = tViewToDrag.get('parentView'),
+              tOldLayout = this._mouseDownInfo,
+              tNewLayout = tViewToDrag.get('layout'),
+              isResize = (!SC.none(this.getPath('cursor.cursorStyle'))) && this.getPath('cursor.cursorStyle').indexOf('-resize') !== -1;
+          // apply one more time to set final position
+          this.mouseDragged(evt);
+          this._mouseDownInfo = null; // cleanup info
+          if( tContainer.coverUpComponentViews) {
+            tContainer.coverUpComponentViews('uncover');
+            tContainer.updateFrame();
+          }
+          if ((tOldLayout.left !== tNewLayout.left) || (tOldLayout.top !== tNewLayout.top) ||
+              (tOldLayout.height !== tNewLayout.height) || (tOldLayout.width !== tNewLayout.width)) {
+
+            DG.UndoHistory.execute(DG.Command.create({
+              name: (isResize ? 'component.resize' : 'component.move'),
+              undoString: (isResize ? 'DG.Undo.componentResize' : 'DG.Undo.componentMove'),
+              redoString: (isResize ? 'DG.Redo.componentResize' : 'DG.Redo.componentMove'),
+              executeNotification: {
+                action: 'notify',
+                resource: 'component',
+                values: {
+                  operation: isResize ? 'resize' : 'move',
+                  type: tViewToDrag.getPath('controller.model.type'),
+                  id: tViewToDrag.getPath('controller.model.id'),
+                  title: tViewToDrag.getPath('controller.model.title')
+                }
+              },
+              log: '%@ component "%@"'.fmt((isResize ? 'Resized' : 'Moved'), tViewToDrag.get('title')),
+              _componentId: tViewToDrag.getPath('controller.model.id'),
+              _controller: function () {
+                return DG.currDocumentController().componentControllersMap[this._componentId];
+              },
+              _oldLayout: null,
+              execute: function () {
+                this._oldLayout = this._controller().updateModelLayout();
+                if (!this._oldLayout) {
+                  this.causedChange = false;
+                }
+              },
+              undo: function () {
+                var layout = SC.clone(this._oldLayout);
+                if (tViewToDrag.isMinimized()) {
+                  this._oldHeight = this._oldLayout.height;
+                  layout.height = 25;
+                }
+                tViewToDrag.animate(layout,
+                    {duration: 0.4, timing: 'ease-in-out'},
+                    function () {
+                      // bizarre bug leaves the last animated transition property still
+                      // with a delay even after the end of an animation, so we clear it by hand
+                      tViewToDrag._view_layer.style.transition = "";
+                      // set actual model layout once animation has completed
+                      this._oldLayout = this._controller().revertModelLayout(layout);
+                      this._oldLayout.height = layout.height;
+                      tContainer.updateFrame();
+                    }.bind(this));
+                if (DG.KEEP_IN_BOUNDS_PREF) {
+                  tViewToDrag.configureViewBoundsLayout({height:layout.height,
+                                             width:layout.width,
+                                             x:layout.left,
+                                             y:layout.top});
+                }
+              },
+              redo: function () {
+                var layout = SC.clone(this._oldLayout);
+                if (tViewToDrag.isMinimized()) {
+                  layout.height = 25;
+                }
+                tViewToDrag.animate(layout,
+                    {duration: 0.4, timing: 'ease-in-out'},
+                    function () {
+                      tViewToDrag._view_layer.style.transition = "";
+                      this._oldLayout = this._controller().revertModelLayout(this._oldLayout);
+                      tContainer.updateFrame();
+                    }.bind(this));
+                if (DG.KEEP_IN_BOUNDS_PREF) {
+                  tViewToDrag.configureViewBoundsLayout({height:layout.height,
+                                             width:layout.width,
+                                             x:layout.left,
+                                             y:layout.top});
+                }
+              }
+            }));
+          }
+          if (DG.KEEP_IN_BOUNDS_PREF) {
+            DG.currDocumentController().computeScaleBounds();
+          }
+          return YES; // handled!
+        },
+
+        mouseDragged: function (evt) {
+          var info = this._mouseDownInfo;
+
+          if (info) {
+            this.dragAdjust(evt, info);
+            return YES; // event was handled!
+          }
+          else
+            return NO;
+        },
+        touchStart: function (evt) {
+          return this.mouseDown(evt);
+        },
+        touchEnd: function (evt) {
+          return this.mouseUp(evt);
+        },
+        touchesDragged: function (evt, touches) {
+          return this.mouseDragged(evt);
+        },
+        dragAdjust: function (evt, info) {
+          // default is to do nothing
+        },
+        viewToDrag: function () {
+          return DG.ComponentView.findComponentViewParent(this);
+        },
+        getContainerWidth: function () {
+          return $('#codap').width();
+        },
+        getContainerHeight: function () {
+          var tDocView = this.viewToDrag();
+          while (!SC.none(tDocView.parentView.parentView)) {
+            tDocView = tDocView.parentView;
+          }
+          return $('#codap').height() - tDocView.get('frame').y;
+        }
+      };
+    }())
+);
+
+DG.DragLeftBorderView = DG.DragBorderView.extend({
+  dragCursor: kLeftBorderCursor,
+  dragAdjust: function (evt, info) {
+    var tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxComponentSize,
+        tMinWidth = this.get('contentMinWidth') || kMinComponentSize,
+        tContainerWidth = this.getContainerWidth();
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      evt.pageX = Math.max(0, evt.pageX);
+    }
+    var tNewWidth = DG.ViewUtilities.roundToGrid(info.width - (evt.pageX - info.pageX)),
+        tLoc;
+    tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
+    tLoc = info.left + info.width - tNewWidth;
+    if (tLoc < tContainerWidth - tMinWidth) {
+      this.parentView.adjust('width', tNewWidth);
+      this.parentView.adjust('left', tLoc);
+    }
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+          tScaleFactor = tInBoundsScaling.scaleFactor;
+      this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
+      this.parentView.originalLayout.left = tLoc / tScaleFactor;
+    }
+  }
+});
+
+DG.DragRightBorderView = DG.DragBorderView.extend({
+  dragCursor: kRightBorderCursor,
+  dragAdjust: function (evt, info) {
+    // Don't let user drag right edge off left of window
+    var tMinWidth = this.get('contentMinWidth') || kMinComponentSize,
+        tLoc = Math.max(evt.pageX, tMinWidth),
+        tNewWidth = DG.ViewUtilities.roundToGrid(info.width + (tLoc - info.pageX)),
+        tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxComponentSize,
+        tContainerWidth = this.getContainerWidth();
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      var tInspectorDimensions = this.parentView.getInspectorDimensions();
+      tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
+    }
+    // Don't let width of component become too small
+    tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
+    this.parentView.adjust('width', tNewWidth);
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+          tScaleFactor = tInBoundsScaling.scaleFactor;
+      this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
+    }
+  }
+});
+
+DG.DragBottomBorderView = DG.DragBorderView.extend({
+  dragCursor: kBottomBorderCursor,
+  dragAdjust: function (evt, info) {
+    var tMinHeight = this.get('contentMinHeight') || kMinComponentSize,
+        tMaxHeight = this.get('contentMaxHeight') || kMaxComponentSize,
+        tNewHeight = info.height + (evt.pageY - info.pageY),
+        tContainerHeight = this.getContainerHeight();
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      tMaxHeight = Math.min(tMaxHeight, tContainerHeight - info.top);
+    }
+    tNewHeight = DG.ViewUtilities.roundToGrid(Math.min(
+        Math.max(tNewHeight, tMinHeight), tMaxHeight));
+    this.parentView.adjust('height', tNewHeight);
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+          tScaleFactor = tInBoundsScaling.scaleFactor;
+      this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
+    }
+  }
+});
+
+DG.DragBottomLeftBorderView = DG.DragBorderView.extend({
+  dragCursor: kBottomLeftBorderCursor,
+  dragAdjust: function (evt, info) {
+    // Don't let user drag right edge off left of window
+    var tMinHeight = this.get('contentMinHeight') || kMinComponentSize,
+        tMaxHeight = this.get('contentMaxHeight') || kMaxComponentSize,
+        tMinWidth = this.get('contentMinWidth') || kMinComponentSize,
+        tLoc = Math.max(evt.pageX, tMinWidth),
+        tNewWidth = DG.ViewUtilities.roundToGrid(info.width - (evt.pageX - info.pageX)),
+        tNewHeight = DG.ViewUtilities.roundToGrid(info.height + (evt.pageY - info.pageY)),
+        tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxComponentSize,
+        tContainerWidth = this.getContainerWidth(),
+        tContainerHeight = this.getContainerHeight();
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      tMaxHeight = tContainerHeight - info.top;
+      var tInspectorDimensions = this.parentView.getInspectorDimensions();
+      tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
+    }
+    // Don't let width or height of component become too small
+    tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
+    tLoc = info.left + info.width - tNewWidth;
+    if (tLoc < tContainerWidth - tMinWidth) {
+      this.parentView.adjust('width', tNewWidth);
+      this.parentView.adjust('left', tLoc);
+    }
+    tNewHeight = Math.min(Math.max(tNewHeight, tMinHeight), tMaxHeight);
+    this.parentView.adjust('height', tNewHeight);
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+          tScaleFactor = tInBoundsScaling.scaleFactor;
+      this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
+      this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
+    }
+  }
+});
+
+DG.DragBottomRightBorderView = DG.DragBorderView.extend({
+  dragCursor: kBottomRightBorderCursor,
+  dragAdjust: function (evt, info) {
+    // Don't let user drag right edge off left of window
+    var tMinHeight = this.get('contentMinHeight') || kMinComponentSize,
+        tMaxHeight = this.get('contentMaxHeight') || kMaxComponentSize,
+        tMinWidth = this.get('contentMinWidth') || kMinComponentSize,
+        tLoc = Math.max(evt.pageX, tMinWidth),
+        tNewWidth = DG.ViewUtilities.roundToGrid(info.width + (tLoc - info.pageX)),
+        tNewHeight = DG.ViewUtilities.roundToGrid(info.height + (evt.pageY - info.pageY)),
+        tMaxWidth = this.parentView.get('contentMaxWidth') || kMaxComponentSize,
+        tContainerWidth = this.getContainerWidth(),
+        tContainerHeight = this.getContainerHeight();
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      tMaxHeight = tContainerHeight - info.top;
+      var tInspectorDimensions = this.parentView.getInspectorDimensions();
+      tMaxWidth = Math.min(tMaxWidth, tContainerWidth - (info.left + tInspectorDimensions.width));
+    }
+    // Don't let width or height of component become too small
+    tNewWidth = Math.min(Math.max(tNewWidth, tMinWidth), tMaxWidth);
+    this.parentView.adjust('width', tNewWidth);
+    tNewHeight = Math.min(Math.max(tNewHeight, tMinHeight), tMaxHeight);
+    this.parentView.adjust('height', tNewHeight);
+    if (DG.KEEP_IN_BOUNDS_PREF) {
+      var tInBoundsScaling = DG.currDocumentController().inBoundsScaling(),
+          tScaleFactor = tInBoundsScaling.scaleFactor;
+      this.parentView.originalLayout.height = tNewHeight / tScaleFactor;
+      this.parentView.originalLayout.width = tNewWidth / tScaleFactor;
+    }
+  }
+});


### PR DESCRIPTION
ON HOLD: Until further UI review.

@bfinzer ~~Hold off on review -- I'm doing some refactoring.~~ Refactoring completed.

- Visible component frame resize affordances
- Make touch/mouse-able affordances larger than visible borders

We add visible resize handles to the selected component.

Testable at https://codap-dev.concord.org/branch/158700917-component-resize/.