### PR TITLE
Fix case card title-editing bugs [#158201775]

### DIFF
--- a/apps/dg/components/case_card/case_card_model.js
+++ b/apps/dg/components/case_card/case_card_model.js
@@ -16,19 +16,13 @@
 //  limitations under the License.
 // ==========================================================================
 
+sc_require('components/case_table/data_context_base_model');
 
 /** @class
 
     A for a case card.
 
- @extends SC.Object
+ @extends DG.DataContextBaseModel
  */
 
-DG.CaseCardModel = SC.Object.extend( {
-  /**
-   @property { DG.DataContext }
-   */
-  context: null,
-
-  title: null
-});
+DG.CaseCardModel = DG.DataContextBaseModel.extend();

--- a/apps/dg/components/case_card/case_card_view.js
+++ b/apps/dg/components/case_card/case_card_view.js
@@ -93,6 +93,10 @@ DG.CaseCardView = SC.View.extend(
           return YES;
         },
 
+        mouseDown: function (evt) {
+          DG.globalEditorLock.commitCurrentEdit();
+        },
+
         isValidAttribute: function (iDrag) {
           var tDragAttr = iDrag.data.attribute,
               tAttrs = this.get('context').getAttributes();

--- a/apps/dg/components/case_table/case_table_drop_target.js
+++ b/apps/dg/components/case_table/case_table_drop_target.js
@@ -237,7 +237,8 @@ DG.CaseTableDropTarget = SC.View.extend(SC.SplitChild, (function () {
           }
         },
         click: function () {
-          // DG.log('Drop Target click!');
+          DG.globalEditorLock.commitCurrentEdit();
+
           var dataContext = this.get('dataContext');
           var tChange = {
             operation: 'selectCases',

--- a/apps/dg/components/case_table/case_table_model.js
+++ b/apps/dg/components/case_table/case_table_model.js
@@ -16,57 +16,14 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // ==========================================================================
+
+sc_require('components/case_table/data_context_base_model');
+
 /** @class  DG.CaseTableModel - The model for a case table.
 
- @extends SC.Object
+ @extends DG.DataContextBaseModel
  */
-DG.CaseTableModel = SC.Object.extend(/** @scope DG.CaseTableModel.prototype */ {
-  /**
-   @property { DG.DataContext }
-   */
-  context: null,
-
-  id: null,
-  idBinding: '*context.id',
-
-  /**
-   * Name of the case table, always the data context name.
-   * @property {string}
-   */
-  name: function (k, v) {
-    this.context.applyChange({
-      operation: 'updateDataContext',
-      properties: {name: v}
-    });
-    return this.getPath('context.name');
-  }.property(),
-
-  /**
-   * Title of the case table: always the data context title.
-   * @property {string}
-   */
-  title: function(k, v) {
-    if (!SC.none(v)) {
-      this.context.applyChange({
-        operation: 'updateDataContext',
-        properties: {title: v}
-      });
-    }
-    return this.getPath('context.title');
-  }.property(),
-
-  titleDidChange: function () {
-    return this.notifyPropertyChange('title');
-  }.observes('*context.title'),
-
-  defaultTitle: function() {
-    return this.getPath('context.defaultTitle');
-  }.property(),
-
-  defaultTitleDidChange: function () {
-    return this.notifyPropertyChange('defaultTitle');
-  }.observes('*context.defaultTitle'),
-
+DG.CaseTableModel = DG.DataContextBaseModel.extend(/** @scope DG.CaseTableModel.prototype */ {
   /**
    * Attribute widths as requested by the user, keyed by attribute id.
    *

--- a/apps/dg/components/case_table/data_context_base_model.js
+++ b/apps/dg/components/case_table/data_context_base_model.js
@@ -1,0 +1,72 @@
+// ==========================================================================
+//  
+//  Author:   kswenson
+//
+//  Copyright (c) 2020 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+/** @class  DG.DataContextBaseModel - The base model for a case table or case card component.
+
+ @extends SC.Object
+ */
+DG.DataContextBaseModel = SC.Object.extend(/** @scope DG.DataContextBaseModel.prototype */ {
+  /**
+   @property { DG.DataContext }
+   */
+  context: null,
+
+  id: null,
+  idBinding: '*context.id',
+
+  /**
+   * Name of the component, always the data context name.
+   * @property {string}
+   */
+  name: function (k, v) {
+    if (!SC.none(v)) {
+      this.context.applyChange({
+        operation: 'updateDataContext',
+        properties: {name: v}
+      });
+    }
+    return this.getPath('context.name');
+  }.property(),
+
+  /**
+   * Title of the component: always the data context title.
+   * @property {string}
+   */
+  title: function(k, v) {
+    if (!SC.none(v)) {
+      this.context.applyChange({
+        operation: 'updateDataContext',
+        properties: {title: v}
+      });
+    }
+    return this.getPath('context.title');
+  }.property(),
+
+  titleDidChange: function () {
+    return this.notifyPropertyChange('title');
+  }.observes('*context.title'),
+
+  defaultTitle: function() {
+    return this.getPath('context.defaultTitle');
+  }.property(),
+
+  defaultTitleDidChange: function () {
+    return this.notifyPropertyChange('defaultTitle');
+  }.observes('*context.defaultTitle')
+
+});

--- a/apps/dg/models/component_model.js
+++ b/apps/dg/models/component_model.js
@@ -55,10 +55,11 @@ DG.Component = DG.BaseModel.extend(
       userSetTitle: false,
 
       titleChanged: function () {
+        // clear local cache when content title changes
         this._title = null;
         this.notifyPropertyChange('title');
       }.observes('*content.title', '*content.defaultTitle'),
-      
+
       /*
        * The width and height of this component in pixels to be used in layout.
        * @property {Object}


### PR DESCRIPTION
- add calls to `DG.globalEditorLock.commitCurrentEdit()` to where appropriate to complete title edits.
- connect `DG.DataCardModel` to the data context (analogous to `DG.CaseTableModel`) so that title changes are propagated to the data context.

Testable at https://codap-dev.concord.org/branch/158201775-case-card-bugs/static/dg/en/cert/index.html.