### PR TITLE
Fix log message when switching from case table to case card [#171793101]

### DIFF
--- a/apps/dg/views/titlebar_button_view.js
+++ b/apps/dg/views/titlebar_button_view.js
@@ -283,7 +283,7 @@ DG.CaseCardToggleButton = SC.View.extend(DG.MouseAndTouchView, DG.TooltipEnabler
                 name: 'toggle.toCaseCard',
                 undoString: 'DG.Undo.component.toggleTableToCard',
                 redoString: 'DG.Redo.component.toggleTableToCard',
-                log: 'Toggle case card to case table',
+                log: 'Toggle case table to case card',
                 execute: function() {
                   DG.currDocumentController().toggleTableToCard(tComponentView);
                 },


### PR DESCRIPTION
Quick fix for something I noticed while debugging. Presumably as the result of an earlier copy/paste error, the same log message was used when switching from case table => case card and the other direction.