### PR TITLE
Fix editing of hierarchical case card attribute names and values [#171709682]

### DIFF
--- a/apps/dg/utilities/data_context_utilities.js
+++ b/apps/dg/utilities/data_context_utilities.js
@@ -605,8 +605,8 @@ DG.DataContextUtilities = {
     DG.UndoHistory.execute(cmd);
   },
 
-  newAttribute: function( iDataContext, iCollection, iPosition, iEditorView, iAutoEdit) {
-    if (iEditorView) {
+  newAttribute: function( iDataContext, iCollection, iPosition, iEditorViewOrCallback, iAutoEdit) {
+    if (iEditorViewOrCallback) {
       DG.globalEditorLock.commitCurrentEdit();
     }
     var tAttrName = iDataContext.getNewAttributeName(),
@@ -629,9 +629,13 @@ DG.DataContextUtilities = {
           if(!isRedo && result.success) {
             this.log = "%@: { name: '%@', collection: '%@', formula: '%@' }".fmt(
                 'attributeCreate', tAttrName, iCollection.get('name'));
-            if (iAutoEdit && iEditorView) {
-              iEditorView.invokeLater(function() {
-                iEditorView.beginEditAttributeName(tAttrName);
+            // simple callback function
+            if (typeof iEditorViewOrCallback === "function") {
+              iEditorViewOrCallback(tAttrName);
+            }
+            else if (iAutoEdit && iEditorViewOrCallback) {
+              iEditorViewOrCallback.invokeLater(function() {
+                iEditorViewOrCallback.beginEditAttributeName(tAttrName);
               });
             }
           } else {


### PR DESCRIPTION
Use IDs to track row being edited rather than indices. Fixes bugs in hierarchical contexts when:
- editing attribute names
- auto-editing names of new attributes
- editing attribute values
- navigating attribute values

Testable at https://codap-dev.concord.org/branch/171709682-case-card-edit-cell/.