### PR TITLE
Click on case card should select component [#171839695]

### DIFF
--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -283,12 +283,6 @@ DG.React.ready(function () {
               iEvent.preventDefault();
             }
 
-            // Prevents page scroll when scrolling in the case card
-            // function handleWheel(iEvent) {
-              // iEvent.preventDefault();
-              // iEvent.stopPropagation();
-            // }
-
             function handleMouseLeave(iEvent) {
               if (tMouseIsDown) {
                 if (!tDragInProgress) {
@@ -549,8 +543,6 @@ DG.React.ready(function () {
             var tDiv = div({
                   className: 'react-data-card-attribute',
                   title: tTitle,
-                  // onWheel: handleWheel,
-                  // onScroll: handleWheel,
                   onMouseDown: handleMouseDown,
                   onMouseUp: handleMouseUp,
                   onMouseLeave: handleMouseLeave,
@@ -851,7 +843,7 @@ DG.React.ready(function () {
                                 }.bind(this)
                               }));
             return div({
-              className: 'react-data-card dg-wants-mouse',
+              className: 'react-data-card',
               ref: function(elt) { this.caseCardElt = elt; }.bind(this)
             }, tCollEntries);
           }

--- a/apps/dg/components/case_card/case_card_view.js
+++ b/apps/dg/components/case_card/case_card_view.js
@@ -115,6 +115,11 @@ DG.CaseCardView = SC.View.extend(
           DG.globalEditorLock.commitCurrentEdit();
         },
 
+        mouseWheel: function (evt) {
+          // don't propagate to document
+          return YES;
+        },
+
         isValidAttribute: function (iDrag) {
           var tDragAttr = iDrag.data.attribute,
               tAttrs = this.get('context').getAttributes();


### PR DESCRIPTION
- click on case card should select component [[#171839695](https://www.pivotaltracker.com/story/show/171839695)]
- scroll wheel should scroll case card not document [[#161033540](https://www.pivotaltracker.com/story/show/161033540)]

This bug has a rather tortuous history. The original bug was that using the scroll wheel over the CaseCard would scroll both the case card and the document. The [first attempt](https://github.com/concord-consortium/codap/commit/33349bcb6fe641028eaaa1ca4b76e4c7d0966717) to fix this was to call `preventDefault()` on the `wheel` event from a React event handler in the CaseCard, but that seems to have broken scrolling more generally and was [reverted](https://github.com/concord-consortium/codap/commit/334d1c6a4911e4c222e19ecd86a7c51ad37b0728). The [next attempt](https://github.com/concord-consortium/codap/commit/922748260d74c57ef03261872bfb69319a934b19) was to add the `dg-wants-mouse` class to the CaseCard generally, with the rather suspect comment "Thanks to suggestion from Kirk." 😳 Unfortunately, this tells SproutCore to ignore all mouse events in the CaseCard, which breaks click-to-select, thus introducing [[#171839695](https://www.pivotaltracker.com/story/show/171839695)].

The fix proposed here is to remove the `dg-wants-mouse` class from the CaseCard component (thus restoring the click-to-select behavior) and then override the SproutCore `mouseWheel()` method in `DG.CaseCardView` to return YES, indicating that we've handled the event, which is apparently sufficient to prevent SproutCore from using it to scroll the document.

Testable at https://codap-dev.concord.org/branch/171839695-case-card-click/.