### PR TITLE
Allow the collection header to bleed into the next column [#157138901]

### DIFF
--- a/apps/dg/components/case_card/attribute_name_cell.js
+++ b/apps/dg/components/case_card/attribute_name_cell.js
@@ -11,8 +11,27 @@ DG.React.ready(function () {
       (function () {
 
         return {
-
+          cellRef: null,
+          cellWidth: null,
           moveDirection: '',
+
+          componentDidMount: function () {
+            this.componentDidRender();
+          },
+
+          componentDidUpdate: function () {
+            this.componentDidRender();
+          },
+
+          componentDidRender: function () {
+            if (this.cellRef && this.props.onColumnWidthChanged) {
+              var bounds = this.cellRef.getBoundingClientRect();
+              if (bounds.width !== this.cellWidth) {
+                this.cellWidth = bounds.width;
+                this.props.onColumnWidthChanged(this.cellWidth);
+              }
+            }
+          },
 
           render: function () {
             var this_ = this;
@@ -142,6 +161,9 @@ DG.React.ready(function () {
                       title: 'DG.TableController.newAttributeTooltip'.loc(),
                       onClick: newAttributeClickHandler
                     }),
+                tColumnWidth = this.props.columnWidthPct != null
+                                ? (Math.round(this.props.columnWidthPct * 1000) / 10) + '%'
+                                : undefined,
                 tContents = this.props.isEditing
                               ? DG.React.Components.SimpleEdit({
                                   className: 'react-data-card-attr-name-input',
@@ -151,7 +173,8 @@ DG.React.ready(function () {
                               : renderStaticContents();
             return td({
                       className: tClassName,
-                      ref: assignCellRef
+                      ref: assignCellRef,
+                      style: { width: tColumnWidth }
                     }, tNewAttrButton, tContents);
           }
         };

--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -153,15 +153,34 @@ DG.React.ready(function () {
             this.changeListener = null;
           },
 
-          componentDidUpdate: function() {
+          componentDidUpdate: function () {
             this.componentDidRender();
           },
 
-          componentDidRender: function() {
+          componentDidRender: function () {
             var containerBounds = this.caseCardElt && this.caseCardElt.getBoundingClientRect(),
                 containerWidth = containerBounds && containerBounds.width;
             if (containerWidth !== this.state.containerWidth) {
               this.setState({ containerWidth: containerWidth });
+            }
+          },
+
+          updateColumnWidth: function (width) {
+            // attempt to maintain minimum column width
+            var adjustedWidth = null;
+            if ((width < kMinColumnWidth) && (this.state.containerWidth >= 2 * kMinColumnWidth)) {
+              adjustedWidth = kMinColumnWidth;
+            }
+            if ((this.state.containerWidth - width < kMinColumnWidth) &&
+                (this.state.containerWidth > kMinColumnWidth + 20)) {
+              adjustedWidth = this.state.containerWidth - kMinColumnWidth;
+            }
+
+            width = adjustedWidth || width;
+            if (width !== this.state.columnWidth) {
+              if (adjustedWidth && this.props.onResizeColumn)
+                this.props.onResizeColumn(adjustedWidth / this.state.containerWidth);
+              this.setState({ columnWidth: width });
             }
           },
 
@@ -196,26 +215,6 @@ DG.React.ready(function () {
               index: iIndex,
               collClient: iCollClient,
               caseID: iCaseID,
-              columnWidthPct: this.props.columnWidthPct,
-              onHeaderWidthChange: (iIndex === 0) &&
-                                    function(width) {
-                                      // attempt to maintain minimum column width
-                                      var adjustedWidth = null;
-                                      if ((width < kMinColumnWidth) && (this.state.containerWidth >= 2 * kMinColumnWidth)) {
-                                        adjustedWidth = kMinColumnWidth;
-                                      }
-                                      if ((this.state.containerWidth - width < kMinColumnWidth) &&
-                                          (this.state.containerWidth > kMinColumnWidth + 20)) {
-                                        adjustedWidth = this.state.containerWidth - kMinColumnWidth;
-                                      }
-
-                                      width = adjustedWidth || width;
-                                      if (width !== this.state.columnWidth) {
-                                        if (adjustedWidth && this.props.onResizeColumn)
-                                          this.props.onResizeColumn(adjustedWidth / this.state.containerWidth);
-                                        this.setState({ columnWidth: width });
-                                      }
-                                    }.bind(this),
               onNext: this.moveToNextCase,
               onPrevious: this.moveToPreviousCase,
               onNewCase: this.newCase,
@@ -224,7 +223,7 @@ DG.React.ready(function () {
             });
           },
 
-          renderAttribute: function (iContext, iCollection, iCases,
+          renderAttribute: function (iContext, iCollection, iCollIndex, iCases,
                                      iAttr, iAttrIndex, iShouldSummarize, iChildmostSelected) {
             var kThresholdDistance2 = 0, // pixels^2
                 tMouseIsDown = false,
@@ -240,6 +239,7 @@ DG.React.ready(function () {
              * -------------------------Dragging this attribute----------------
              */
             function handleMouseDown(iEvent) {
+              if ((iEvent.type === 'mousedown') && (iEvent.button !== 0)) return;
               tMouseIsDown = true;
               tStartCoordinates = {x: iEvent.clientX, y: iEvent.clientY};
               tDragInProgress = false;
@@ -566,6 +566,10 @@ DG.React.ready(function () {
                     iNewName && renameAttribute(iNewName);
                     this.setState({ attrIdOfNameToEdit: null });
                   }.bind(this),
+                  columnWidthPct: (iCollIndex === 0) && (iAttrIndex === 0)
+                                    ? this.props.columnWidthPct : undefined,
+                  onColumnWidthChanged: (iCollIndex === 0) && (iAttrIndex === 0) &&
+                                        function(width) { this.updateColumnWidth(width); }.bind(this),
                   editAttributeCallback: editAttribute,
                   editFormulaCallback: editFormula,
                   deleteAttributeCallback: deleteAttribute,
@@ -815,17 +819,13 @@ DG.React.ready(function () {
                   iCollection.get('attrs').forEach(function (iAttr, iAttrIndex) {
                     if (!iAttr.get('hidden')) {
                       tAttrEntries.push(
-                          this.renderAttribute(tContext, iCollection, tCases,
+                          this.renderAttribute(tContext, iCollection, iCollIndex, tCases,
                               iAttr, iAttrIndex, tShouldSummarize,
                               tChildmostSelection));
                     }
                   }.bind(this));
-                  tCollEntries.push(table({
-                        key: 'table-' + iCollIndex
-                        // style: {'marginLeft': (iCollIndex * 10 + 5) + 'px'}
-                      },
-                      tbody({},
-                          tCollectionHeader, tAttrEntries)));
+                  tCollEntries.push(table({ key: 'table-' + iCollIndex },
+                                    tbody({}, tCollectionHeader, tAttrEntries)));
                 }.bind(this)
             );
 

--- a/apps/dg/components/case_card/collection_header.js
+++ b/apps/dg/components/case_card/collection_header.js
@@ -62,7 +62,7 @@ DG.React.ready(function () {
             var tCollClient = this.props.collClient,
                 tCaseID = this.props.caseID,
                 tIndex = this.props.index,
-                tRowClass = 'react-data-card-collection-header' + (dragIsInMe() ? ' drop' : ''),
+                tRowClass = 'collection-header-row' + (dragIsInMe() ? ' drop' : ''),
                 tCollection = tCollClient.get('collection'),
                 tName = tCollection.get('name'),
                 tNumCases = tCollection.get('cases').length,
@@ -89,11 +89,11 @@ DG.React.ready(function () {
                 th({
                     colSpan: 2,
                     style: { paddingLeft: (tIndex * 10 + 5) + 'px' },
-                    className: 'react-data-card-coll-header-cell',
+                    className: 'collection-header-cell',
                   },
-                  div({ className: 'react-data-card-coll-header-contents' }, 
-                      div({ className: 'react-data-card-collection-string' }, tHeaderString),
-                      div({ className: 'react-data-card-nav-header-cell' }, tNavButtons)
+                  div({ className: 'collection-header-contents' }, 
+                      div({ className: 'collection-label' }, tHeaderString),
+                      div({ className: 'nav-header' }, tNavButtons)
                   )
                 )
               )

--- a/apps/dg/components/case_card/collection_header.js
+++ b/apps/dg/components/case_card/collection_header.js
@@ -5,7 +5,7 @@ DG.React.ready(function () {
   var
       tr = React.DOM.tr,
       th = React.DOM.th,
-      td = React.DOM.td;
+      div = React.DOM.div;
 
   DG.React.Components.CollectionHeader = DG.React.createComponent(
       (function () {
@@ -20,29 +20,9 @@ DG.React.ready(function () {
          *    dragStatus {Object}
          */
 
-        var domRow = null,
-            domHeader = null,
-            headerWidth = null;
+        var domRow = null;
 
         return {
-
-          componentDidMount: function () {
-            this.componentDidRender();
-          },
-
-          componentDidUpdate: function () {
-            this.componentDidRender();
-          },
-
-          componentDidRender: function () {
-            if (domHeader) {
-              var bounds = domHeader.getBoundingClientRect();
-              if (headerWidth !== bounds.width) {
-                headerWidth = bounds.width;
-                this.props.onHeaderWidthChange && this.props.onHeaderWidthChange(headerWidth);
-              }
-            }
-          },
 
           render: function () {
             var this_ = this;
@@ -79,10 +59,6 @@ DG.React.ready(function () {
 
             handleDropIfAny();
 
-            var toggleEditing = function () {
-
-            }.bind(this);
-
             var tCollClient = this.props.collClient,
                 tCaseID = this.props.caseID,
                 tIndex = this.props.index,
@@ -96,9 +72,6 @@ DG.React.ready(function () {
                 tHeaderString = tNumSelected > 0 ?
                     'DG.CaseCard.namePlusSelectionCount'.loc(tNumSelected, tNumCases, tName) :
                     'DG.CaseCard.namePlusCaseCount'.loc(tNumCases, tName),
-                tHeaderWidth = this.props.columnWidthPct != null
-                                ? (Math.round(this.props.columnWidthPct * 1000) / 10) + '%'
-                                : undefined,
                 tNavButtons = DG.React.Components.NavButtons({
                   collectionClient: tCollClient,
                   caseIndex: tCaseIndex,
@@ -106,24 +79,24 @@ DG.React.ready(function () {
                   onPrevious: this.props.onPrevious,
                   onNext: this.props.onNext,
                   onNewCase: this.props.onNewCase
-                }),
-                tHeaderComponent = DG.React.Components.TextInput({
-                  value: tHeaderString,
-                  onToggleEditing: toggleEditing
                 });
-            return tr({
+            return (
+              tr({
                   key: 'coll-' + tIndex,
                   className: tRowClass,
                   ref: function(elt) { domRow = elt; }
                 },
                 th({
-                  style: { paddingLeft: (tIndex * 10 + 5) + 'px', width: tHeaderWidth },
-                  className: 'react-data-card-coll-header-cell',
-                  ref: function(elt) { domHeader = elt; }
-                }, tHeaderComponent),
-                td({
-                  className: 'react-data-card-nav-header-cell'
-                }, tNavButtons)
+                    colSpan: 2,
+                    style: { paddingLeft: (tIndex * 10 + 5) + 'px' },
+                    className: 'react-data-card-coll-header-cell',
+                  },
+                  div({ className: 'react-data-card-coll-header-contents' }, 
+                      div({ className: 'react-data-card-collection-string' }, tHeaderString),
+                      div({ className: 'react-data-card-nav-header-cell' }, tNavButtons)
+                  )
+                )
+              )
             );
           }
         };

--- a/apps/dg/components/case_card/nav_buttons.js
+++ b/apps/dg/components/case_card/nav_buttons.js
@@ -64,7 +64,7 @@ DG.React.ready(function () {
                   onClick: this.getNewCase
                 });
 
-            return span({className: 'react-data-card-navbuttons navbuttons-arrow dg-wants-touch'},
+            return span({className: 'nav-buttons dg-wants-touch'},
                 tFirstButton, tSecondButton, tAddCaseButton);
           }
         };

--- a/apps/dg/resources/case_card.css
+++ b/apps/dg/resources/case_card.css
@@ -63,27 +63,35 @@
     }
 }
 
+$nav-header-width: 75px;
 .react-data-card-collection-header {
+    height: 27px;
     background: #bddfdf !important;
-    margin-left: 0;
-    padding: 5px 0;
-    padding-left: 10px;
-}
 
-.react-data-card-collection-header.drop {
-    border-top: yellow 10px solid ;
-}
+    &.drop {
+        border-top: yellow 10px solid;
+    }
 
-.react-data-card-coll-header-cell {
-    width: 50%;
-    border: none;
-    text-align: left;
-    font-weight: bold;
-    white-space: normal;
-}
+    .react-data-card-coll-header-cell {
+        border: none;
+        font-weight: bold;
 
-.react-data-card-nav-header-cell {
-    text-align: right;
+        .react-data-card-coll-header-contents {
+            display: flex;
+            align-items: center;
+
+            .react-data-card-collection-string {
+                flex: 1 1 auto;
+                white-space: normal; /* wraps text within the cell */
+            }
+
+            .react-data-card-nav-header-cell {
+                padding-right: 5px;
+                flex: 0 0 $nav-header-width;
+                text-align: right;
+            }
+        }
+    }
 }
 
 .react-data-card table {
@@ -117,29 +125,9 @@
     text-overflow: ellipsis;
 }
 
-.react-data-card td.columnA {
-    width: 50%;
-}
-
-.react-data-card td.columnB {
-    width: 50%;
-}
-
 .react-data-card td span {
     margin-right: 0;
     font-size: 11px;
-}
-
-.react-data-card-header {
-    background-color: #f2ffe9 !important;
-    padding-top: 5px;
-    font-style: italic;
-    font-weight: bold;
-    margin-left: 5px;
-}
-
-.react-data-card-row {
-    width: 1px; /* Hack so that width of 100% for attribute name will work */
 }
 
 .react-data-card-attribute {

--- a/apps/dg/resources/case_card.css
+++ b/apps/dg/resources/case_card.css
@@ -33,62 +33,64 @@
     width: calc(100% - 1px);
 }
 
-.react-data-card-navbuttons {
-    right: 0;
-    width: fit-content;
-    display: inline-block;
-    text-align: right;
-    color: cadetblue;
-}
-
-.navbuttons-arrow [class*="moonicon-"] {
-    font-size: 12px;
-    padding-left: 5px;
-    padding-right: 10px;
-    vertical-align: middle;
-    cursor: pointer;
-}
-
 /* only show hover effect on mouse devices that support hover */
 /* avoids bugs related to iOS Safari's simulated hover effects */
 @media(hover: hover) and (pointer: fine) {
-    .navbuttons-arrow [class*="moonicon-"]:hover {
+    .react-data-card .nav-buttons [class*="moonicon-"]:hover {
         color: #72bfca;
     }
 }
 /* otherwise, highlight on touch/click instead of hover */
 @media(hover: none), (pointer: coarse) {
-    .navbuttons-arrow [class*="moonicon-"]:active {
+    .react-data-card .nav-buttons [class*="moonicon-"]:active {
         color: #72bfca;
     }
 }
 
 $nav-header-width: 75px;
-.react-data-card-collection-header {
-    height: 27px;
-    background: #bddfdf !important;
+.react-data-card {
+    .collection-header-row {
+        height: 27px;
+        background: #bddfdf !important;
 
-    &.drop {
-        border-top: yellow 10px solid;
-    }
+        &.drop {
+            border-top: yellow 10px solid;
+        }
 
-    .react-data-card-coll-header-cell {
-        border: none;
-        font-weight: bold;
+        .collection-header-cell {
+            border: none;
+            font-weight: bold;
 
-        .react-data-card-coll-header-contents {
-            display: flex;
-            align-items: center;
+            .collection-header-contents {
+                display: flex;
+                align-items: center;
 
-            .react-data-card-collection-string {
-                flex: 1 1 auto;
-                white-space: normal; /* wraps text within the cell */
-            }
+                .collection-label {
+                    flex: 1 1 auto;
+                    white-space: normal; // wraps text within the cell
+                }
 
-            .react-data-card-nav-header-cell {
-                padding-right: 5px;
-                flex: 0 0 $nav-header-width;
-                text-align: right;
+                .nav-header {
+                    padding-right: 5px;
+                    flex: 0 0 $nav-header-width;
+                    text-align: right;
+
+                    .nav-buttons {
+                        right: 0;
+                        width: fit-content;
+                        display: inline-block;
+                        text-align: right;
+                        color: cadetblue;
+
+                        [class*="moonicon-"] {
+                            font-size: 12px;
+                            padding-left: 5px;
+                            padding-right: 10px;
+                            vertical-align: middle;
+                            cursor: pointer;
+                        }
+                    }
+                }
             }
         }
     }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -102,7 +102,7 @@ Cypress.Commands.add('dragAttributeToTarget', (source, attribute, target,num=0)=
   const el={  tableHeader: '.slick-header-column .two-line-header-line-1',
               caseCardHeader: '.react-data-card-attribute',
               caseCardHeaderDropZone: '.react-data-card .data-cell-lower',
-              caseCardCollectionDropZone: '.react-data-card-collection-header',
+              caseCardCollectionDropZone: '.react-data-card .collection-header-row',
               graphTile: '.dg-graph-view',
               x_axis:'.dg-axis-view.dg-h-axis',
               x_axis_label: '.dg-axis-view.dg-h-axis .dg-axis-label',

--- a/cypress/support/elements/TableTile.js
+++ b/cypress/support/elements/TableTile.js
@@ -94,16 +94,16 @@ class TableTileObject{
         cy.clickMenuItem('Switch to case table view of the data')
     }
     getCaseCardCollectionHeader(position=0){
-        return cy.get('.react-data-card-collection-header').eq(position)
+        return cy.get('.react-data-card .collection-header-row').eq(position)
     }
     getCaseCardNavBackIcon(){
-        return cy.get('.react-data-card-navbuttons .moonicon-icon-reverse-play')
+        return cy.get('.react-data-card .nav-buttons .moonicon-icon-reverse-play')
     }
     getCaseCardNavForwardIcon(){
-        return cy.get('.react-data-card-navbuttons .moonicon-icon-play')
+        return cy.get('.react-data-card .nav-buttons .moonicon-icon-play')
     }
     getCaseCardAddCasePlusIcon(){
-        return cy.get('.react-data-card-nav-header-cell .dg-floating-plus-right')
+        return cy.get('.react-data-card .nav-header .dg-floating-plus-right')
     }
     getCaseCardAddAttributePlusIcon(){
         return cy.get('.react-data-card-row .dg-floating-plus')


### PR DESCRIPTION
The collection header row is now a single cell that spans both columns and thus can allocate its internal space without regard to the column boundaries. This required changes to the resizing code which is now tied to the first attribute row rather than the header row. Also did some refactoring of the .css using SASS nesting to make the class hierarchy clearer.

Testable at https://codap-dev.concord.org/branch/157138901-column-overflow/.