### PR TITLE
Enable recommended eslint rules by no longer explicitly disabling them

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -78,8 +78,6 @@
     "quotes": "off",
     "semi": ["error", "always"],
 
-    "no-redeclare": "off",
-
     "react/display-name": "off",
     "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
     "react-hooks/exhaustive-deps": "warn" // Checks effect dependencies

--- a/apps/dg/components/case_table/relation_divider_view.js
+++ b/apps/dg/components/case_table/relation_divider_view.js
@@ -23,7 +23,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // ==========================================================================
-/*global DG, sc_static */
+/*global sc_static */
 
 sc_require('components/case_table/case_table_drop_target');
 sc_require('views/raphael_base');

--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -18,7 +18,7 @@
 //  limitations under the License.
 // ==========================================================================
 /*jslint newcap:true */
-/*global DG:true */
+/*global DG:true */ // eslint-disable-line no-redeclare
 
 /**
  *  Returns an array of all own enumerable properties found upon a given object,


### PR DESCRIPTION
- `no-redeclare`
  - This rule is aimed at eliminating variables that have multiple declarations in the same scope.
- `no-implicit-globals`
  - Disallow declarations in the global scope

Something I encountered while working on other things and thought it made sense to separate from the other work.