### PR TITLE
Restore drop-shadow to case table component [#171981408]

### DIFF
--- a/apps/dg/resources/dg.css
+++ b/apps/dg/resources/dg.css
@@ -670,10 +670,6 @@ html, body {
     box-shadow: 0 1px 20px 0 rgba(0, 0, 0, 0.40);
 }
 
-.dg-case-table-component-view {
-    box-shadow: none;
-}
-
 .dg-opaque {
     background-color: white;
 }


### PR DESCRIPTION
This was introduced in [this commit](https://github.com/concord-consortium/codap/commit/2c1f2a3072141c562a46d5b7321b124a067a933b), but the .css change to remove the drop-shadow doesn't appear to be required to fix the bug. Fixes [[#171981408](https://www.pivotaltracker.com/story/show/171981408)].