### PR TITLE
Case card refactor and bug-fixes

### DIFF
--- a/apps/dg/components/case_card/attribute_name_cell.js
+++ b/apps/dg/components/case_card/attribute_name_cell.js
@@ -7,7 +7,7 @@ DG.React.ready(function () {
       div = ReactDOMFactories.div,
       td = ReactDOMFactories.td;
 
-  DG.React.Components.AttributeNameCell = DG.React.createComponent(
+  DG.React.AttributeNameCell = DG.React.createComponent(
       (function () {
 
         return {

--- a/apps/dg/components/case_card/attribute_name_cell.js
+++ b/apps/dg/components/case_card/attribute_name_cell.js
@@ -165,7 +165,7 @@ DG.React.ready(function () {
                                 ? (Math.round(this.props.columnWidthPct * 1000) / 10) + '%'
                                 : undefined,
                 tContents = this.props.isEditing
-                              ? DG.React.Components.SimpleEdit({
+                              ? DG.React.SimpleEdit({
                                   className: 'react-data-card-attr-name-input',
                                   value: this.props.attribute.get('name'),
                                   onCompleteEdit: this.props.onEndRenameAttribute

--- a/apps/dg/components/case_card/attribute_value_cell.js
+++ b/apps/dg/components/case_card/attribute_value_cell.js
@@ -1,0 +1,136 @@
+sc_require('models/attribute_model');
+sc_require('models/case_model');
+sc_require('react/dg-react');
+/* global createReactFC, PropTypes, ReactDOMFactories, tinycolor */
+
+DG.React.ready(function () {
+  var img = ReactDOMFactories.img,
+      span = ReactDOMFactories.span,
+      td = ReactDOMFactories.td;
+
+  /**
+   * AttributeValueCell
+   *    displays the contents of the attribute value cell in the case card
+   */
+  var config = {
+    displayName: "AttributeValueCell",
+    propTypes: {
+      // {DG.Attribute} the attribute to display
+      attribute: PropTypes.instanceOf(DG.Attribute).isRequired,
+      // {DG.Case} the case to display; undefined to summarize
+      displayCase: PropTypes.instanceOf(DG.Case),
+      // {[DG.Case]} - the cases to summarize; undefined for single case
+      summaryCases: PropTypes.arrayOf(PropTypes.instanceOf(DG.Case)),
+      editProps: PropTypes.exact({
+        isEditing: PropTypes.bool.isRequired,
+        // function(attribute) - toggle into/out of editing mode
+        onToggleEditing: PropTypes.func.isRequired,
+        // function(attribute) - escape out of editing mode
+        onEscapeEditing: PropTypes.func.isRequired,
+        // function(attribute) - callback to inform caller of TextInput
+        onEditModeCallback: PropTypes.func.isRequired 
+      }).isRequired
+    }
+  };
+  function AttributeValueCell(props) {
+    var tAttr = props.attribute,
+        tAttrID = tAttr.get('id'),
+        tUnit = tAttr.get('unit') || '',
+        tHasFormula = tAttr.get('hasFormula'),
+        tValue = props.displayCase && props.displayCase.getValue(tAttrID),
+        tType = tValue && tValue.jsonBoundaryObject
+                  ? 'boundary'
+                  : tAttr.get('type'),
+        tColorValueField,
+        tQualitativeValueField,
+        tBoundaryValueField,
+        tColor,
+        spanStyle,
+        tBoundaryInternalImage,
+        tQualitativeInternalSpan;
+    if (tValue instanceof Error) {
+      tValue = tValue.name + tValue.message;
+    } else if (DG.isColorSpecString(tValue)) {
+      tColor = tinycolor( tValue.toLowerCase().replace(/\s/gi,''));
+      spanStyle = {
+        backgroundColor: tColor.toString('rgb')
+      };
+      tColorValueField = span({
+        className: 'react-data-card-color-table-cell',
+        style: spanStyle
+      });
+    } else if (tType === 'qualitative') {
+      if (SC.empty(tValue)) {
+        tValue = "";
+      } else {
+        tColor = DG.PlotUtilities.kDefaultPointColor;
+        spanStyle = {
+          backgroundColor: tColor,
+          width: tValue + '%',
+        };
+        tQualitativeInternalSpan = span({
+          className: 'react-data-card-qualitative-bar',
+          style: spanStyle
+        });
+        tQualitativeValueField = span({
+          className: 'react-data-card-qualitative-backing'
+        }, tQualitativeInternalSpan);
+      }
+    } else if (tType === 'boundary') {
+      var tResult = 'a boundary',
+          tBoundaryObject = DG.GeojsonUtils.boundaryObjectFromBoundaryValue(tValue),
+          tThumb = tBoundaryObject && tBoundaryObject.jsonBoundaryObject &&
+              tBoundaryObject.jsonBoundaryObject.properties &&
+              tBoundaryObject.jsonBoundaryObject.properties.THUMB;
+      if (tThumb !== null && tThumb !== undefined) {
+            tBoundaryInternalImage = img({
+              className: 'react-data-card-thumbnail',
+              src: tThumb
+            });
+        tBoundaryValueField = span({}, tBoundaryInternalImage);
+      }
+      else if( tBoundaryObject && (tBoundaryObject.jsonBoundaryObject instanceof Error)) {
+        tValue = tBoundaryObject.jsonBoundaryObject.name + tBoundaryObject.jsonBoundaryObject.message;
+      }
+      tValue = tResult;
+    } else if (DG.isNumeric(tValue) && typeof tValue !== 'boolean') {
+      var tPrecision = tAttr.get('precision');
+      tPrecision = SC.none(tPrecision) ? 2 : tPrecision;
+      tValue = DG.MathUtilities.formatNumber(tValue, tPrecision);
+    } else if (SC.none(tValue) || (typeof tValue === 'object')) {
+      tValue = '';
+    }
+    var tValueField = props.summaryCases
+          ? DG.React.Components.AttributeSummary({
+              cases: props.summaryCases,
+              attrID: tAttrID,
+              unit: tUnit
+            })
+          : DG.React.Components.TextInput({
+              attr: tAttr,
+              'case': props.displayCase,
+              value: tValue,
+              unit: tUnit,
+              isEditable: tAttr.get('editable') && !tAttr.get('hasFormula'),
+              createInEditMode: props.editProps.isEditing,
+              onToggleEditing: props.editProps.onToggleEditing,
+              onEscapeEditing: props.editProps.onEscapeEditing,
+              onEditModeCallback: props.editProps.onEditModeCallback
+            }),
+        tValueClassName = tHasFormula ? 'react-data-card-formula' : '';
+    if (tColorValueField) {
+      tValueField = tColorValueField;
+    }
+    else if (tBoundaryValueField) {
+      tValueField = tBoundaryValueField;
+    }
+    else if (tQualitativeValueField) {
+      tValueField = tQualitativeValueField;
+    }
+    return (
+      td({className: 'dg-wants-touch ' + tValueClassName}, tValueField)
+    );
+  }
+  // two-stage definition required for React-specific eslint rules
+  DG.React.AttributeValueCell = createReactFC(config, AttributeValueCell);
+});

--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -1,7 +1,8 @@
-/* global ReactDOMFactories, tinycolor */
-// sc_require('react/dg-react');
+sc_require('components/case_card/case_card_collection');
 sc_require('components/case_card/column_resize_handle');
 sc_require('components/case_card/text_input');
+sc_require('react/dg-react');
+/* global PropTypes, ReactDOMFactories, tinycolor */
 
 DG.React.ready(function () {
   var div = ReactDOMFactories.div,
@@ -15,14 +16,6 @@ DG.React.ready(function () {
   DG.React.Components.CaseCard = DG.React.createComponent(
       (function () {
 
-      /**
-       * props are
-       *  container: {DOM element} - DOM element for case card
-       *  context: {DG.DataContext} - data context for case card
-       *  columnWidthPct: {number} - percentage width of attribute column
-       *  onResizeColumn(widthPct: number): {function} - Called with updated value of width property
-       *  dragStatus: {object} - drag/drop support
-       */
         var kSelectDelay = 1000,  // ms
             kSelectInterval = 100,  // ms
             gWaitingForSelect = false,
@@ -134,7 +127,7 @@ DG.React.ready(function () {
               attrIdOfNameToEdit: null,
               attrIdOfValueToEdit: null,
               containerWidth: null,
-              columnWidth: null
+              columnWidths: {}
             };
           },
 
@@ -163,7 +156,7 @@ DG.React.ready(function () {
             }
           },
 
-          updateColumnWidth: function (width) {
+          updateColumnWidth: function (collection, width) {
             // attempt to maintain minimum column width
             var adjustedWidth = null;
             if ((width < kMinColumnWidth) && (this.state.containerWidth >= 2 * kMinColumnWidth)) {
@@ -175,10 +168,15 @@ DG.React.ready(function () {
             }
 
             width = adjustedWidth || width;
-            if (width !== this.state.columnWidth) {
+            if (width !== this.state.columnWidths[collection]) {
               if (adjustedWidth && this.props.onResizeColumn)
-                this.props.onResizeColumn(adjustedWidth / this.state.containerWidth);
-              this.setState({ columnWidth: width });
+                this.props.onResizeColumn(collection, adjustedWidth / this.state.containerWidth);
+              var columnWidths = SC.clone(this.state.columnWidths);
+              if (width)
+                columnWidths[collection] = width;
+              else
+                delete columnWidths[collection];
+              this.setState({ columnWidths: columnWidths });
             }
           },
 
@@ -227,7 +225,7 @@ DG.React.ready(function () {
             });
           },
 
-          renderAttribute: function (iContext, iCollection, iCollIndex, iCases,
+          renderAttribute: function (iContext, iCollection, iCases,
                                      iAttr, iAttrIndex, iShouldSummarize, iChildmostSelected) {
             var kThresholdDistance2 = 0, // pixels^2
                 tMouseIsDown = false,
@@ -461,7 +459,8 @@ DG.React.ready(function () {
             /**
              * --------------------------Body of renderAttribute-----------------
              */
-            var tAttrID = iAttr.get('id'),
+            var tCollectionName = iCollection.get('name'),
+                tAttrID = iAttr.get('id'),
                 tUnit = iAttr.get('unit') || '',
                 tHasFormula = iAttr.get('hasFormula'),
                 tCase = iShouldSummarize ? null : (iChildmostSelected && iChildmostSelected[0]) || iCases[0],
@@ -557,10 +556,13 @@ DG.React.ready(function () {
                     iNewName && renameAttribute(iNewName);
                     this.setState({ attrIdOfNameToEdit: null });
                   }.bind(this),
-                  columnWidthPct: (iCollIndex === 0) && (iAttrIndex === 0)
-                                    ? this.props.columnWidthPct : undefined,
-                  onColumnWidthChanged: (iCollIndex === 0) && (iAttrIndex === 0) &&
-                                        function(width) { this.updateColumnWidth(width); }.bind(this),
+                  columnWidthPct: (iAttrIndex === 0) && this.props.columnWidthMap
+                                    ? this.props.columnWidthMap[tCollectionName]
+                                    : undefined,
+                  onColumnWidthChanged: (iAttrIndex === 0) &&
+                                        function(width) {
+                                          this.updateColumnWidth(tCollectionName, width);
+                                        }.bind(this),
                   editAttributeCallback: editAttribute,
                   editFormulaCallback: editFormula,
                   deleteAttributeCallback: deleteAttribute,
@@ -796,6 +798,7 @@ DG.React.ready(function () {
                   }
 
                   var tCollClient = tContext.getCollectionByID(iCollection.get('id')),
+                      tCollectionName = tCollClient.get('name'),
                       tSelectedCases = tCollClient ? tCollClient.getPath('casesController.selection').toArray() : null,
                       tSelLength = tSelectedCases ? tSelectedCases.length : 0,
                       tCases = tSelLength > 0 ? tSelectedCases :
@@ -804,37 +807,50 @@ DG.React.ready(function () {
                       tCase = tSelLength === 1 ? tSelectedCases[0] :
                           (tCasesLength === 1 ? tCases[0] : null),
                       tShouldSummarize = SC.none( tCase),
+                      tCollectionHeader = this.renderCollectionHeader(iCollIndex, tCollClient, tCase && tCase.get('id')),
+                      tColumnWidth = this.state.columnWidths[tCollectionName],
                       tAttrEntries = [],
-                      tCollectionHeader = this.renderCollectionHeader(iCollIndex, tCollClient, tCase && tCase.get('id'));
+                      tResizeHandle;
 
                   iCollection.get('attrs').forEach(function (iAttr, iAttrIndex) {
                     if (!iAttr.get('hidden')) {
                       tAttrEntries.push(
-                          this.renderAttribute(tContext, iCollection, iCollIndex, tCases,
+                          this.renderAttribute(tContext, iCollection, tCases,
                               iAttr, iAttrIndex, tShouldSummarize,
                               tChildmostSelection));
                     }
                   }.bind(this));
-                  tCollEntries.push(table({ key: 'table-' + iCollIndex },
-                                    tbody({}, tCollectionHeader, tAttrEntries)));
+
+                  if (this.state.containerWidth && tColumnWidth) {
+                    var kResizeHandleClass = "case-card-column-resize-handle";
+                    tResizeHandle = DG.React.ColumnResizeHandle({
+                                      className: kResizeHandleClass,
+                                      key: kResizeHandleClass + iCollIndex + '-' + tCollectionName,
+                                      enabled: true,
+                                      containerWidth: this.state.containerWidth,
+                                      columnWidth: tColumnWidth,
+                                      minWidth: kMinColumnWidth,
+                                      onResize: function(width, isComplete) {
+                                        var widthPct = width / this.state.containerWidth;
+                                        this.props.onResizeColumn &&
+                                          this.props.onResizeColumn(tCollectionName, widthPct, isComplete);
+                                      }.bind(this)
+                                    });
+                  }
+
+                  tCollEntries.push(
+                    div({ className: 'case-card-collection',
+                          key: 'collection-' + iCollIndex + '-' + tCollectionName },
+                      table({},
+                        tbody({},
+                          tCollectionHeader, tAttrEntries)
+                      ),
+                      tResizeHandle
+                    )
+                  );
                 }.bind(this)
             );
 
-            if (this.state.containerWidth && this.state.columnWidth) {
-              var kResizeHandleClass = "case-card-column-resize-handle";
-              tCollEntries.push(DG.React.Components.ColumnResizeHandle({
-                                  className: kResizeHandleClass,
-                                  key: kResizeHandleClass,
-                                  enabled: true,
-                                  containerWidth: this.state.containerWidth,
-                                  columnWidth: this.state.columnWidth,
-                                  minWidth: kMinColumnWidth,
-                                  onResize: function(width) {
-                                    var widthPct = width / this.state.containerWidth;
-                                    this.props.onResizeColumn && this.props.onResizeColumn(widthPct);
-                                  }.bind(this)
-                                }));
-            }
             return div({
               className: 'react-data-card',
               ref: function(elt) { this.caseCardElt = elt; }.bind(this)
@@ -842,5 +858,16 @@ DG.React.ready(function () {
           }
         };
       }()), []);
+
+  DG.React.Components.CaseCard.propTypes = {
+    // the data context
+    context: PropTypes.instanceOf(DG.DataContext).isRequired,
+    // drag/drop support
+    dragStatus: PropTypes.object,
+    // map from collection name => column width percentage (0-1)
+    columnWidthMap: PropTypes.objectOf(PropTypes.number).isRequired,
+    // function(collectionName, columnWidth) - update column width in model
+    onResizeColumn: PropTypes.func.isRequired,
+  };
 
 });

--- a/apps/dg/components/case_card/case_card_controller.js
+++ b/apps/dg/components/case_card/case_card_controller.js
@@ -144,16 +144,20 @@ DG.CaseCardController = DG.CaseDisplayController.extend(
         var caseCardModel = this.getPath('model.content'),
             dataContext = caseCardModel.get('context'),
             isActive = caseCardModel.get('isActive'),
-            columnWidthPct = caseCardModel.get('columnWidthPct'),
+            columnWidthMap = caseCardModel.get('columnWidthMap'),
             storage = {
               isActive: isActive
             };
         if( dataContext) {
           this.addLink(storage, 'context', dataContext);
         }
-        if (columnWidthPct != null) {
-          // round to three decimal places for saving
-          storage.columnWidthPct = JSON.stringify(Math.round(columnWidthPct * 1000) / 1000);
+        if (columnWidthMap) {
+          var columnWidthMapArchive = {};
+          DG.ObjectMap.forEach(columnWidthMap, function(key, value) {
+            // round to four decimal places for saving
+            columnWidthMapArchive[key] = DG.MathUtilities.roundToDecimalPlaces(value, 4);
+          });
+          storage.columnWidthMap = columnWidthMapArchive;
         }
         return storage;
       },
@@ -163,17 +167,14 @@ DG.CaseCardController = DG.CaseDisplayController.extend(
         if (caseCardModel) {
           var contextID = this.getLinkID( iStorage, 'context'),
               dataContext = contextID
-                  && DG.currDocumentController().getContextByID(contextID),
-              columnWidthPct = iStorage.columnWidthPct != null
-                                ? parseFloat(iStorage.columnWidthPct)
-                                : null;
+                  && DG.currDocumentController().getContextByID(contextID);
           if( dataContext) {
             caseCardModel.set('context', dataContext);
             this.set('dataContext', dataContext);
           }
           caseCardModel.set('isActive', iStorage.isActive);
-          if (iStorage.columnWidthPct != null)
-            caseCardModel.set('columnWidthPct', columnWidthPct);
+          if (iStorage.columnWidthMap)
+            caseCardModel.set('columnWidthMap', SC.clone(iStorage.columnWidthMap));
         }
       }
 

--- a/apps/dg/components/case_card/collection_header.js
+++ b/apps/dg/components/case_card/collection_header.js
@@ -83,7 +83,7 @@ DG.React.ready(function () {
 
             var renderEditableLabel = function(iCollectionName) {
               return (
-                DG.React.Components.SimpleEdit({
+                DG.React.SimpleEdit({
                   className: 'collection-label',
                   value: iCollectionName,
                   onCompleteEdit: function(iNewName) {

--- a/apps/dg/components/case_card/column_resize_handle.js
+++ b/apps/dg/components/case_card/column_resize_handle.js
@@ -8,7 +8,10 @@ DG.React.ready(function () {
     e.stopPropagation();
   }
 
-  DG.React.DragHandle = createReactFC({
+  /**
+   * DragHandle
+   */
+  var dhConfig = {
     displayName: "DragHandle",
     propTypes: {
       className: PropTypes.string,
@@ -16,15 +19,21 @@ DG.React.ready(function () {
       onUpdateDrag: PropTypes.func.isRequired,
       onEndDrag: PropTypes.func.isRequired
     }
-  }, function(props) {
+  };
+  function DragHandle(props) {
     var useDragOnDemand = DG.React.useDragOnDemand;
 
     useDragOnDemand(props.touchId, props.onUpdateDrag, props.onEndDrag);
 
     return div({ className: props.className });
-  });
+  }
+  // two-stage definition required for React-specific eslint rules
+  DG.React.DragHandle = createReactFC(dhConfig, DragHandle);
 
-  DG.React.ColumnResizeHandle = createReactFC({
+  /**
+   * ColumnResizeHandle
+   */
+  var crConfig = {
     displayName: "ColumnResizeHandle",
     propTypes: {
       containerWidth: PropTypes.number,
@@ -32,8 +41,8 @@ DG.React.ready(function () {
       minWidth: PropTypes.number.isRequired,
       onResize: PropTypes.func
     }
-  }, function(props) {
-
+  };
+  function ColumnResizeHandle(props) {
     var isResizingState = React.useState(false),
         isResizing = isResizingState[0],
         setIsResizing = isResizingState[1],
@@ -41,9 +50,7 @@ DG.React.ready(function () {
         resizeWidth = resizeWidthState[0],
         resizeWidthRef = resizeWidthState[1],
         setResizeWidth = resizeWidthState[2],
-        touchIdState = React.useState(null),
-        touchId = touchIdState[0],
-        setTouchId = touchIdState[1],
+        touchId = React.useRef(),
         deltaStartRef = React.useRef();
 
     React.useLayoutEffect(function() {
@@ -85,7 +92,7 @@ DG.React.ready(function () {
       if (!props.enabled || isResizing) return;
 
       var touch = e.changedTouches[0];
-      setTouchId(touch.identifier);
+      touchId.current = touch.identifier;
       beginResize(touch);
 
       stop(e);
@@ -104,11 +111,12 @@ DG.React.ready(function () {
         },
         isResizing && DG.React.DragHandle({
           className: "column-resize-handle-render is-resizing",
-          touchId: touchId,
+          touchId: touchId.current,
           onUpdateDrag: continueResize,
           onEndDrag: endResize
         }))
     );
-
-  });
+  }
+  // two-stage definition required for React-specific eslint rules
+  DG.React.ColumnResizeHandle = createReactFC(crConfig, ColumnResizeHandle);
 });

--- a/apps/dg/components/case_card/column_resize_handle.js
+++ b/apps/dg/components/case_card/column_resize_handle.js
@@ -1,148 +1,114 @@
-/* global ReactDOMFactories */
+/* global createReactFC, PropTypes, React, ReactDOMFactories */
 
 DG.React.ready(function () {
   var div = ReactDOMFactories.div;
 
-  /**
-   * Provides a vertical column-resizing control handle.
-   * Loosely patterned after https://github.com/MonsantoCo/column-resizer.
-   */
-  DG.React.Components.ColumnResizeHandle = DG.React.createComponent(
-    (function () {
+  function stop(e) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
 
-      /**
-       * props are
-       *  className: {string} - className attribute applied to the dom element
-       *  enabled: {boolean} - enable/disable resizing
-       *  containerWidth: {number} - width of table in pixels
-       *  columnWidth: {number} - width of column to resize in pixels
-       *  minWidth: {number} - minimum width of column in pixels
-       *  maxWidth: {number} - maximum width of column in pixels
-       *  onResize(width: number): {function} - Called with updated value of width property
-       */
-      var resizeTouchId = null,
-          deltaStart = null;
+  DG.React.DragHandle = createReactFC({
+    displayName: "DragHandle",
+    propTypes: {
+      className: PropTypes.string,
+      touchId: PropTypes.string,
+      onUpdateDrag: PropTypes.func.isRequired,
+      onEndDrag: PropTypes.func.isRequired
+    }
+  }, function(props) {
+    var useDragOnDemand = DG.React.useDragOnDemand;
 
-      function stop(e) {
-        e.preventDefault();
-        e.stopPropagation();
+    useDragOnDemand(props.touchId, props.onUpdateDrag, props.onEndDrag);
+
+    return div({ className: props.className });
+  });
+
+  DG.React.ColumnResizeHandle = createReactFC({
+    displayName: "ColumnResizeHandle",
+    propTypes: {
+      containerWidth: PropTypes.number,
+      columnWidth: PropTypes.number,
+      minWidth: PropTypes.number.isRequired,
+      onResize: PropTypes.func
+    }
+  }, function(props) {
+
+    var isResizingState = React.useState(false),
+        isResizing = isResizingState[0],
+        setIsResizing = isResizingState[1],
+        resizeWidthState = DG.React.useRefState(null),
+        resizeWidth = resizeWidthState[0],
+        resizeWidthRef = resizeWidthState[1],
+        setResizeWidth = resizeWidthState[2],
+        touchIdState = React.useState(null),
+        touchId = touchIdState[0],
+        setTouchId = touchIdState[1],
+        deltaStartRef = React.useRef();
+
+    React.useLayoutEffect(function() {
+      setResizeWidth(props.columnWidth);
+    }, [props.columnWidth, setResizeWidth]);
+
+    function beginResize(e) {
+      deltaStartRef.current = e.pageX - resizeWidthRef.current;
+      setIsResizing(true);
+    }
+
+    function continueResize(e) {
+      var newWidth = e.pageX - deltaStartRef.current,
+          minWidth = props.minWidth || 20,
+          maxWidth = props.containerWidth - minWidth;
+      newWidth = Math.max(newWidth, minWidth);
+      newWidth = Math.min(newWidth, maxWidth);
+      deltaStartRef.current = e.pageX - newWidth;
+      if (newWidth !== resizeWidthRef.current) {
+        props.onResize && props.onResize(newWidth);
+        setResizeWidth(newWidth);
       }
+    }
 
-      return {
+    function endResize() {
+      if (props.onResize) {
+        props.onResize(resizeWidthRef.current, true);
+      }
+      setIsResizing(false);
+    }
 
-        getInitialState: function() {
-          return {
-            isResizing: false,
-            resizeWidth: null
-          };
+    function handleMouseDown(e) {
+      if (!props.enabled || isResizing || (e.button !== 0)) return;
+      beginResize(e);
+      stop(e);
+    }
+
+    function handleInitialTouch(e) {
+      if (!props.enabled || isResizing) return;
+
+      var touch = e.changedTouches[0];
+      setTouchId(touch.identifier);
+      beginResize(touch);
+
+      stop(e);
+    }
+
+    var style = resizeWidth != null
+                  ? { left: resizeWidth }
+                  : null;
+    return (
+      (props.enabled || isResizing) &&
+        div({
+          className: props.className + ' column-resize-handle dg-wants-mouse dg-wants-touch',
+          onMouseDown: handleMouseDown,
+          onTouchStart: handleInitialTouch,
+          style: style
         },
+        isResizing && DG.React.DragHandle({
+          className: "column-resize-handle-render is-resizing",
+          touchId: touchId,
+          onUpdateDrag: continueResize,
+          onEndDrag: endResize
+        }))
+    );
 
-        componentDidMount: function() {
-          this.componentDidRender();
-        },
-
-        componentDidUpdate: function() {
-          this.componentDidRender();
-        },
-
-        componentDidRender: function() {
-          if (this.state.resizeWidth !== this.props.columnWidth)
-            this.setState({ resizeWidth: this.props.columnWidth });
-        },
-
-        render: function() {
-          var style = this.state.resizeWidth != null
-                        ? { left: this.state.resizeWidth }
-                        : null;
-          return (this.props.enabled || this.state.isResizing) &&
-            div({
-              className: this.props.className + ' column-resize-handle dg-wants-mouse dg-wants-touch',
-              onMouseDown: this.handleMouseDown,
-              onTouchStart: this.handleInitialTouch,
-              style: style
-            },
-            div({
-              className: "column-resize-handle-render" +
-                          (this.state.isResizing ? " is-resizing" : "")
-            }));
-        },
-
-        beginResize: function(e) {
-          deltaStart = e.pageX - this.state.resizeWidth;
-          this.setState({ isResizing: true });
-        },
-
-        continueResize: function(e) {
-          var newWidth = e.pageX - deltaStart,
-              minWidth = this.props.minWidth || 20,
-              maxWidth = this.props.containerWidth - minWidth;
-          newWidth = Math.max(newWidth, minWidth);
-          newWidth = Math.min(newWidth, maxWidth);
-          deltaStart = e.pageX - newWidth;
-          if (newWidth !== this.state.resizeWidth) {
-            if (this.props.onResize)
-              this.props.onResize(newWidth);
-            else
-              this.setState({ resizeWidth: newWidth });
-          }
-        },
-
-        endResize: function() {
-          this.setState({ isResizing: false });
-        },
-
-        handleMouseDown: function(e) {
-          if (!this.props.enabled || (e.button !== 0)) return;
-          this.beginResize(e);
-          document.addEventListener('mousemove', this.handleMouseMove, true);
-          document.addEventListener('mouseup', this.handleMouseUp, true);
-          stop(e);
-        },
-
-        handleMouseMove: function(e) {
-          this.continueResize(e);
-          stop(e);
-        },
-
-        handleMouseUp: function(e) {
-          this.endResize();
-          document.removeEventListener('mousemove', this.handleMouseMove, true);
-          document.removeEventListener('mouseup', this.handleMouseUp, true);
-          stop(e);
-        },
-
-        handleInitialTouch: function(e) {
-          if (!this.props.enabled) return;
-
-          var touch = e.changedTouches[0];
-          resizeTouchId = touch.identifier;
-          this.beginResize(touch);
-
-          // An individual 'touchstart' or 'touchmove' may be for some other touch, so we
-          // don't care about the type of event, only whether the resize touch is still active.
-          document.addEventListener('touchstart', this.handleSubsequentTouch, true);
-          document.addEventListener('touchmove', this.handleSubsequentTouch, true);
-          document.addEventListener('touchcancel', this.handleSubsequentTouch, true);
-          document.addEventListener('touchend', this.handleSubsequentTouch, true);
-          stop(e);
-        },
-
-        handleSubsequentTouch: function(e) {
-          for (var i = 0; i < e.touches.length; ++i) {
-            if (e.touches[i].identifier === resizeTouchId) {
-              // resize touch is still active
-              this.continueResize(e.touches[i]);
-              return;
-            }
-          }
-          // resize touch is no longer active
-          this.endResize();
-
-          document.removeEventListener('touchstart', this.handleSubsequentTouch, true);
-          document.removeEventListener('touchmove', this.handleSubsequentTouch, true);
-          document.removeEventListener('touchcancel', this.handleSubsequentTouch, true);
-          document.removeEventListener('touchend', this.handleSubsequentTouch, true);
-        }
-      };
-    })());
+  });
 });

--- a/apps/dg/components/case_card/simple-edit.js
+++ b/apps/dg/components/case_card/simple-edit.js
@@ -1,6 +1,6 @@
 sc_require('react/dg-react');
 sc_require('react/custom_hooks');
-/* global createReactFactory, React, ReactDOMFactories */
+/* global createReactFC, PropTypes, React, ReactDOMFactories */
 
 DG.React.ready(function () {
   var useCallbackOnOutsideEvent = DG.React.useCallbackOnOutsideEvent,
@@ -10,15 +10,21 @@ DG.React.ready(function () {
   /**
    * This uncontrolled component (https://reactjs.org/docs/uncontrolled-components.html)
    * wraps a regular <input> element to provide a simple reusable editing component.
-   * 
-   * props are
-   *    className: {string} - className attribute applied to the input element
-   *    value: {string} - initial value of edit
-   *    onCompleteEdit(value?: string): {function} - Called with final value at completion of edit;
-   *                                                 `undefined` => canceled/completed with no change.
    */
-  DG.React.SimpleEdit = createReactFactory(function(props) {
-
+  var config = {
+    displayName: "SimpleEdit",
+    propTypes: {
+      // className attribute applied to the input element
+      className: PropTypes.string,
+      // initial value of edit
+      value: PropTypes.string,
+      // onCompleteEdit(value?: string)
+      // Called with final value at completion of edit;
+      //  `undefined` => canceled/completed with no change.
+      onCompleteEdit: PropTypes.func.isRequired
+    }
+  };
+  function SimpleEdit(props) {
     // reference to <input> DOM element
     var inputRef = React.useRef();
 
@@ -40,7 +46,7 @@ DG.React.ready(function () {
       className: props.className + ' dg-wants-mouse dg-wants-touch',
       type: 'text',
       ref: inputRef,
-      defaultValue: props.value,
+      defaultValue: props.value || "",
       onKeyDown: function (evt) {
         var handled = true;
         switch (evt.keyCode) {
@@ -63,5 +69,7 @@ DG.React.ready(function () {
         completeEdit(evt.target.value);
       }
     });
-  });
+  }
+  // two-stage definition required for React-specific eslint rules
+  DG.React.SimpleEdit = createReactFC(config, SimpleEdit);
 });

--- a/apps/dg/components/case_card/simple-edit.js
+++ b/apps/dg/components/case_card/simple-edit.js
@@ -1,88 +1,67 @@
-/* global ReactDOMFactories */
+sc_require('react/dg-react');
+sc_require('react/custom_hooks');
+/* global createReactFactory, React, ReactDOMFactories */
 
 DG.React.ready(function () {
-  var input = ReactDOMFactories.input;
+  var useCallbackOnOutsideEvent = DG.React.useCallbackOnOutsideEvent,
+      useFocusSelectOnMount = DG.React.useFocusSelectOnMount,
+      input = ReactDOMFactories.input;
 
   /**
    * This uncontrolled component (https://reactjs.org/docs/uncontrolled-components.html)
    * wraps a regular <input> element to provide a simple reusable editing component.
+   * 
+   * props are
+   *    className: {string} - className attribute applied to the input element
+   *    value: {string} - initial value of edit
+   *    onCompleteEdit(value?: string): {function} - Called with final value at completion of edit;
+   *                                                 `undefined` => canceled/completed with no change.
    */
-  DG.React.Components.SimpleEdit = DG.React.createComponent(
-    (function () {
+  DG.React.SimpleEdit = createReactFactory(function(props) {
 
-      /**
-       * props are
-       *    className: {string} - className attribute applied to the input element
-       *    value: {string} - initial value of edit
-       *    onCompleteEdit(value?: string): {function} - Called with final value at completion of edit;
-       *                                                 `undefined` => canceled/completed with no change.
-       */
-      var inputElt = null;
+    // reference to <input> DOM element
+    var inputRef = React.useRef();
 
-      function onWindowClick(evt) {
-        if (evt.target !== inputElt && !inputElt.contains(evt.target)) {
-          inputElt.blur();
+    // complete the edit on outside touches/clicks
+    useCallbackOnOutsideEvent(inputRef, function(elt) { elt.blur(); });
+
+    // focus/select the contents initially
+    useFocusSelectOnMount(inputRef);
+
+    function cancelEdit() {
+      props.onCompleteEdit();
+    }
+
+    function completeEdit(value) {
+      props.onCompleteEdit(value !== props.value ? value : undefined);
+    }
+
+    return input({
+      className: props.className + ' dg-wants-mouse dg-wants-touch',
+      type: 'text',
+      ref: inputRef,
+      defaultValue: props.value,
+      onKeyDown: function (evt) {
+        var handled = true;
+        switch (evt.keyCode) {
+          case 27:
+            cancelEdit();
+            break;
+          case 13:
+            completeEdit(evt.target.value);
+            break;
+          default:
+            handled = false;
+            break;
         }
+        if (handled) {
+          evt.preventDefault();
+          evt.stopPropagation();
+        }
+      },
+      onBlur: function(evt) {
+        completeEdit(evt.target.value);
       }
-
-      return {
-
-        componentDidMount: function() {
-          window.addEventListener("touchstart", onWindowClick, true);
-          window.addEventListener("mousedown", onWindowClick, true);
-          setTimeout(function() {
-            inputElt.focus();
-            inputElt.select();
-          });
-        },
-
-        componentWillUnmount: function() {
-          window.removeEventListener("touchstart", onWindowClick, true);
-          window.removeEventListener("mousedown", onWindowClick, true);
-        },
-
-        cancelEdit: function() {
-          this.props.onCompleteEdit();
-        },
-
-        completeEdit: function(value) {
-          var result = value !== this.props.value
-                        ? value
-                        : undefined;
-          this.props.onCompleteEdit(result);
-        },
-
-        render: function() {
-          return input({
-            className: this.props.className + ' dg-wants-mouse dg-wants-touch',
-            type: 'text',
-            ref: function(elt) {
-              inputElt = elt;
-            },
-            defaultValue: this.props.value,
-            onKeyDown: function (evt) {
-              var handled = true;
-              switch (evt.keyCode) {
-                case 27:
-                  this.cancelEdit();
-                  break;
-                case 13:
-                  this.completeEdit(evt.target.value);
-                  break;
-                default:
-                  handled = false;
-                  break;
-              }
-              if (handled) {
-                evt.preventDefault();
-                evt.stopPropagation();
-              }
-            }.bind(this),
-            onBlur: function(evt) {
-              this.completeEdit(evt.target.value);
-            }.bind(this)
-          });
-        }
-      };
-    })());
+    });
+  });
 });

--- a/apps/dg/react/custom_hooks.js
+++ b/apps/dg/react/custom_hooks.js
@@ -1,44 +1,146 @@
 sc_require('react/dg-react');
 /* global React */
 
-/**
- * Calls the specified callback function on a touch/click outside the element.
- * @param {ReactReference} elementRef 
- * @param {function} callback(elt) where elt is the DOM element
- */
-DG.React.useCallbackOnOutsideEvent = function(elementRef, callback) {
-  React.useEffect(function() {
-    function onWindowClick(evt) {
-      var elt = elementRef.current;
-      if (elt && (evt.target !== elt) && !elt.contains(evt.target)) {
-        callback(elt);
+(function() {
+
+  /**
+   * cf. https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+   * cf. https://usehooks.com/usePrevious/
+   * @param {*} value 
+   */
+  var usePrevious = function(value) { 
+    var ref = React.useRef();
+    React.useEffect(function() {
+      ref.current = value;
+    }, [value]);
+    return ref.current;
+  };
+  DG.React.usePrevious = usePrevious;
+
+  /**
+   * Combines useState and useRef hooks to provide a state value that can be referenced
+   * from function callbacks that would otherwise close around a stale state value.
+   * cf. https://blog.castiel.me/posts/2019-02-19-react-hooks-get-current-state-back-to-the-future/
+   * @param {*} initialValue 
+   */
+  var useRefState = function(initialValue) {
+    var stateArray = React.useState(initialValue),
+        state = stateArray[0],
+        setState = stateArray[1],
+        stateRef = React.useRef(state);
+    React.useEffect(function() {
+      stateRef.current = state;
+    }, [state]);
+    return [state, stateRef, setState];
+  };
+  DG.React.useRefState = useRefState;
+
+  /**
+   * Calls the specified callback function on a touch/click outside the element.
+   * @param {ReactReference} elementRef 
+   * @param {function} callback(elt) where elt is the DOM element
+   */
+  var useCallbackOnOutsideEvent = function(elementRef, callback) {
+    React.useEffect(function() {
+      function onWindowClick(evt) {
+        var elt = elementRef.current;
+        if (elt && (evt.target !== elt) && !elt.contains(evt.target)) {
+          callback(elt);
+        }
       }
-    }
 
-    // didMount
-    window.addEventListener("touchstart", onWindowClick, true);
-    window.addEventListener("mousedown", onWindowClick, true);
+      // didMount
+      window.addEventListener("touchstart", onWindowClick, true);
+      window.addEventListener("mousedown", onWindowClick, true);
 
-    // willUnmount
-    return function() {
-      window.removeEventListener("touchstart", onWindowClick, true);
-      window.removeEventListener("mousedown", onWindowClick, true);
-    };
-  }, []); // !didUpdate
-};
+      // willUnmount
+      return function() {
+        window.removeEventListener("touchstart", onWindowClick, true);
+        window.removeEventListener("mousedown", onWindowClick, true);
+      };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+  };
+  DG.React.useCallbackOnOutsideEvent = useCallbackOnOutsideEvent;
 
-/**
- * Focuses and selects the content of the specified element on mounting the component.
- * @param {ReactReference} elementRef - the element (e.g. <input>) to focus
- */
-DG.React.useFocusSelectOnMount = function(elementRef) {
-  // focus/select the contents initially
-  React.useEffect(function() {
-    // didMount
-    setTimeout(function() {
-      var elt = elementRef.current;
-      elt && elt.focus();
-      elt && elt.select();
-    });
-  }, []); // !didUpdate
-};
+  /**
+   * Focuses and selects the content of the specified element on mounting the component.
+   * @param {ReactReference} elementRef - the element (e.g. <input>) to focus
+   */
+  var useFocusSelectOnMount = function(elementRef) {
+    // focus/select the contents initially
+    React.useEffect(function() {
+      // didMount
+      setTimeout(function() {
+        var elt = elementRef.current;
+        elt && elt.focus();
+        elt && elt.select();
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+  };
+  DG.React.useFocusSelectOnMount = useFocusSelectOnMount;
+
+  /**
+   * Initiates a drag by installing the relevant mouse/touch handlers.
+   * @param {string} touchId
+   * @param {function(MouseEvent/Touch)} onUpdateDrag
+   * @param {function(MouseEvent/Touch)} onEndDrag
+   */
+  var useDragOnDemand = function(touchId, onUpdateDrag, onEndDrag) {
+
+    React.useEffect(function() {
+      function handleMouseMove(e) {
+        onUpdateDrag(e);
+        stop(e);
+      }
+
+      function handleMouseUp(e) {
+        onEndDrag();
+        stop(e);
+      }
+
+      function handleTouch(e) {
+        for (var i = 0; i < e.touches.length; ++i) {
+          if (e.touches[i].identifier === touchId) {
+            // touch is still active
+            onUpdateDrag(e.touches[i]);
+            return;
+          }
+        }
+        // touch is no longer active
+        onEndDrag();
+      }
+
+      if (touchId) {
+        // An individual 'touchstart' or 'touchmove' may be for some other touch, so we
+        // don't care about the type of event, only whether the resize touch is still active.
+        document.addEventListener('touchstart', handleTouch, true);
+        document.addEventListener('touchmove', handleTouch, true);
+        document.addEventListener('touchcancel', handleTouch, true);
+        document.addEventListener('touchend', handleTouch, true);
+      }
+      else {
+        document.addEventListener('mousemove', handleMouseMove, true);
+        document.addEventListener('mouseup', handleMouseUp, true);
+      }
+
+      return function() {
+        if (touchId) {
+          document.removeEventListener('touchstart', handleTouch, true);
+          document.removeEventListener('touchmove', handleTouch, true);
+          document.removeEventListener('touchcancel', handleTouch, true);
+          document.removeEventListener('touchend', handleTouch, true);
+        }
+        else {
+          document.removeEventListener('mousemove', handleMouseMove, true);
+          document.removeEventListener('mouseup', handleMouseUp, true);
+        }
+      };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [touchId]);
+
+  };
+  DG.React.useDragOnDemand = useDragOnDemand;
+
+})();

--- a/apps/dg/react/custom_hooks.js
+++ b/apps/dg/react/custom_hooks.js
@@ -1,0 +1,44 @@
+sc_require('react/dg-react');
+/* global React */
+
+/**
+ * Calls the specified callback function on a touch/click outside the element.
+ * @param {ReactReference} elementRef 
+ * @param {function} callback(elt) where elt is the DOM element
+ */
+DG.React.useCallbackOnOutsideEvent = function(elementRef, callback) {
+  React.useEffect(function() {
+    function onWindowClick(evt) {
+      var elt = elementRef.current;
+      if (elt && (evt.target !== elt) && !elt.contains(evt.target)) {
+        callback(elt);
+      }
+    }
+
+    // didMount
+    window.addEventListener("touchstart", onWindowClick, true);
+    window.addEventListener("mousedown", onWindowClick, true);
+
+    // willUnmount
+    return function() {
+      window.removeEventListener("touchstart", onWindowClick, true);
+      window.removeEventListener("mousedown", onWindowClick, true);
+    };
+  }, []); // !didUpdate
+};
+
+/**
+ * Focuses and selects the content of the specified element on mounting the component.
+ * @param {ReactReference} elementRef - the element (e.g. <input>) to focus
+ */
+DG.React.useFocusSelectOnMount = function(elementRef) {
+  // focus/select the contents initially
+  React.useEffect(function() {
+    // didMount
+    setTimeout(function() {
+      var elt = elementRef.current;
+      elt && elt.focus();
+      elt && elt.select();
+    });
+  }, []); // !didUpdate
+};

--- a/apps/dg/resources/case_card.css
+++ b/apps/dg/resources/case_card.css
@@ -49,46 +49,50 @@
 
 $nav-header-width: 75px;
 .react-data-card {
-    .collection-header-row {
-        height: 27px;
-        background: #bddfdf !important;
+    .case-card-collection {
+        position: relative;
 
-        &.drop {
-            border-top: yellow 10px solid;
-        }
+        .collection-header-row {
+            height: 27px;
+            background: #bddfdf !important;
 
-        .collection-header-cell {
-            border: none;
-            font-weight: bold;
+            &.drop {
+                border-top: yellow 10px solid;
+            }
 
-            .collection-header-contents {
-                display: flex;
-                align-items: center;
+            .collection-header-cell {
+                border: none;
+                font-weight: bold;
 
-                .collection-label {
-                    flex: 1 1 auto;
-                    white-space: normal; // wraps text within the cell
-                    cursor: text;
-                }
+                .collection-header-contents {
+                    display: flex;
+                    align-items: center;
 
-                .nav-header {
-                    padding-right: 5px;
-                    flex: 0 0 $nav-header-width;
-                    text-align: right;
+                    .collection-label {
+                        flex: 1 1 auto;
+                        white-space: normal; // wraps text within the cell
+                        cursor: text;
+                    }
 
-                    .nav-buttons {
-                        right: 0;
-                        width: fit-content;
-                        display: inline-block;
+                    .nav-header {
+                        padding-right: 5px;
+                        flex: 0 0 $nav-header-width;
                         text-align: right;
-                        color: cadetblue;
 
-                        [class*="moonicon-"] {
-                            font-size: 12px;
-                            padding-left: 5px;
-                            padding-right: 10px;
-                            vertical-align: middle;
-                            cursor: pointer;
+                        .nav-buttons {
+                            right: 0;
+                            width: fit-content;
+                            display: inline-block;
+                            text-align: right;
+                            color: cadetblue;
+
+                            [class*="moonicon-"] {
+                                font-size: 12px;
+                                padding-left: 5px;
+                                padding-right: 10px;
+                                vertical-align: middle;
+                                cursor: pointer;
+                            }
                         }
                     }
                 }

--- a/apps/dg/utilities/math_utilities.js
+++ b/apps/dg/utilities/math_utilities.js
@@ -19,6 +19,18 @@
 // ==========================================================================
 
 DG.MathUtilities = {
+
+  /**
+   Utility function to round a real to a specified number of decimal places.
+   @param{Number}
+   @param{Number} integer
+   @return{Number}
+   */
+  roundToDecimalPlaces: function (iValue, iDecimalPlaces) {
+    var factor = Math.pow(10, iDecimalPlaces);
+    return Math.round(iValue* factor) / factor;
+  },
+
   /**
    Utility function to round a real to a specified number of significant
    digits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5964,9 +5964,9 @@
       "integrity": "sha1-63cFxNs2+1AbOqOP91lhaqD/luA="
     },
     "react-is": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "read-pkg": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "papaparse": "^4.5.0",
     "pluralize": "^4.0.0",
     "popper.js": "^1.14.3",
+    "prop-types": "^15.7.2",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-dom-factories": "^1.0.2",

--- a/webpack-entry.js
+++ b/webpack-entry.js
@@ -1,8 +1,8 @@
-/*global CodeMirror:true, React:true, ReactDOM:true, ReactDOMFactories:true, createReactClass:true */
-/*global createReactFactory:true, createReactClassFactory:true, Popper:true, Tooltip:true, Papa:true */
-/*global iframePhone:true, L:true, deepEqual:true, Promise:true, pluralize:true, dayjs:true, nanoid:true */
-/* exported CodeMirror, React, ReactDOM, ReactDOMFactories, createReactClass, createReactFactory, createReactClassFactory */
-/* exported Popper, Tooltip, iframePhone, Papa, deepEqual, Promise, pluralize, dayjs, nanoid */
+/* global CodeMirror:true, React:true, ReactDOM:true, ReactDOMFactories:true, PropTypes:true, createReactClass:true,
+  createReactFactory:true, createReactFC:true, createReactClassFactory:true, Popper:true, Tooltip:true, Papa:true,
+  L:true, deepEqual:true, Promise:true, pluralize:true, dayjs:true, nanoid:true */
+/* exported CodeMirror, React, ReactDOM, ReactDOMFactories, PropTypes, createReactClass, createReactFactory,
+  createReactFC, createReactClassFactory, Popper, Tooltip, Papa, L, deepEqual, Promise, pluralize, dayjs, nanoid */
 CodeMirror = require('codemirror/lib/codemirror.js');
 require('codemirror/lib/codemirror.css');
 require('codemirror/addon/display/placeholder.js');
@@ -14,9 +14,21 @@ ReactDOM = require('react-dom');
 ReactDOMFactories = require('react-dom-factories');
 // https://reactjs.org/docs/react-without-es6.html
 createReactClass = require('create-react-class');
+// https://reactjs.org/docs/typechecking-with-proptypes.html
+PropTypes = require('prop-types');
 // https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-reactcreatefactory
 createReactFactory = function(type) { return React.createElement.bind(null, type); };
 createReactClassFactory = function(classDef) { return createReactFactory(createReactClass(classDef)); };
+// creates a functional component (FC) with optional properties like displayName and propTypes
+createReactFC = function(optsOrFn, maybeFn) {
+  var fn = maybeFn || optsOrFn;
+  if (optsOrFn && (typeof maybeFn === "function")) {
+    for (var p in optsOrFn) {
+      optsOrFn.hasOwnProperty(p) && (fn[p] = optsOrFn[p]);
+    }
+  }
+  return createReactFactory(fn);
+};
 Popper = require('popper.js');
 Tooltip = require('tooltip.js')['default'];
 /*


### PR DESCRIPTION
Fixes:
- [[#171987585](https://www.pivotaltracker.com/story/show/171987585)] Case card column adjustment should work for each collection independently
- [[#171987694](https://www.pivotaltracker.com/story/show/171987694)] Case card column resize should be undoable.

Also:
- separates AttributeValueCell component from CaseCard component
- AttributeValueCell, ColumnResizeHandle, and SimpleEdit components now written as functional components using hooks where appropriate.

@bfinzer Note that there have been some changes since our synchronous review yesterday. See [this commit](https://github.com/concord-consortium/codap/pull/342/commits/fd1c9a65fa2b86bf45378c3b9e7d26be5ce2ed14) for details. In addition to fixing a couple bugs I also separated the AttributeValueCell and changed the way the function components were defined slightly so that the React-specific eslint hooks could process them better.