### PR TITLE
Add touch-tooltips for case card attributes [#171913001]

### DIFF
--- a/apps/dg/components/case_card/case_card.js
+++ b/apps/dg/components/case_card/case_card.js
@@ -551,7 +551,7 @@ DG.React.ready(function () {
                     isEditing: tAttrID === this.state.attrIdOfValueToEdit,
                     onToggleEditing: toggleEditing,
                     onEscapeEditing: escapeEditing,
-                    editModeCallback: editModeCallback
+                    onEditModeCallback: editModeCallback
                   }
                 });
 

--- a/apps/dg/utilities/touch_tooltips.js
+++ b/apps/dg/utilities/touch_tooltips.js
@@ -41,8 +41,9 @@ DG.TouchTooltips = (function() {
                     ? triggerView.get('layer')
                     : triggerView,
           container = DG.mainPage.getPath('mainPane.layer'),
-          _placement = placement || 'bottom-start',
+          _placement = placement || 'top-start',
           tooltip = new Tooltip(layer, {
+                                  boundariesElement: container,
                                   container: container,
                                   placement: _placement,
                                   trigger: 'manual',


### PR DESCRIPTION
Addresses [[#171913001](https://www.pivotaltracker.com/story/show/171913001)]

Also changes the default position for touch-tooltips to be above the target element rather than below it. Below the target element frequently means underneath the finger, so above is generally more useful in my experience.

Testable at https://codap-dev.concord.org/branch/171913001-case-card-touch-tooltips/.