### PR TITLE
Use new resize handle images for component resize [#171965133]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 - travis_retry bundle install
 - travis_retry gem install s3_website
 - travis_retry pip install awscli --upgrade --user
-- travis_retry yarn
+- travis_retry npm ci
 script: npm run build:travis
 after_script: "./bin/s3_deploy.sh"
 cache:

--- a/apps/dg/resources/dg.css
+++ b/apps/dg/resources/dg.css
@@ -353,28 +353,46 @@ html, body {
 }
 
 /* visible in selected components */
-.dg-component-view.dg-component-view-selected {
-    overflow: visible;
-
-    .dg-component-container {
-        overflow: visible;
-
-        .sc-split-view {
-            overflow: visible;
-        }
-    }
+.dg-component-view {
 
     .dg-component-resize-handle-interior {
-        background-color: gray;
-        opacity: 0.2;
-        border: 1px solid black;
-        z-index: 9999;
+        visibility: hidden;
     }
 
-    .dg-floating-plus {
-        visibility: visible;
-        opacity: 0.5;
-        cursor: pointer;
+    &.dg-component-view-selected {
+        overflow: visible;
+
+        .dg-component-container {
+            overflow: visible;
+
+            .sc-split-view {
+                overflow: visible;
+            }
+        }
+
+        .dg-component-resize-handle-interior {
+            visibility: visible;
+            background-image: static_url('images/se_corner_handle.svg');
+            z-index: 9999;
+
+            &:active {
+                background-image: static_url('images/se_corner_handle-hi.svg');
+            }
+        }
+
+        .dg-floating-plus {
+            visibility: visible;
+            opacity: 0.5;
+            cursor: pointer;
+        }
+    }
+}
+
+/* only show hover effect on mouse devices that support hover */
+/* avoids bugs related to iOS Safari's simulated hover effects */
+@media(hover: hover) and (pointer: fine) {
+    .dg-component-view.dg-component-view-selected .dg-component-resize-handle-interior:hover {
+        background-image: static_url('images/se_corner_handle-hi.svg');
     }
 }
 

--- a/apps/dg/resources/images/se_corner_handle-hi.svg
+++ b/apps/dg/resources/images/se_corner_handle-hi.svg
@@ -1,0 +1,1 @@
+<svg id="se_corner_handle" data-name="se corner handle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path id="back" d="M19,25H0L25,0V19A6,6,0,0,1,19,25Z" style="fill:#177991"/><path id="grabber_lines" data-name="grabber lines" d="M16.48,22.35l-1.7-1.7,5.86-5.86,1.7,1.7ZM22.35,10.5l-1.7-1.7L8.83,20.62l1.7,1.7Z" style="fill:#fff"/></svg>

--- a/apps/dg/resources/images/se_corner_handle.svg
+++ b/apps/dg/resources/images/se_corner_handle.svg
@@ -1,0 +1,1 @@
+<svg id="se_corner_handle" data-name="se corner handle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path id="back" d="M19,25H0L25,0V19A6,6,0,0,1,19,25Z" style="fill:#177991"/><path id="grabber_lines" data-name="grabber lines" d="M16.48,22.35l-1.7-1.7,5.86-5.86,1.7,1.7ZM22.35,10.5l-1.7-1.7L8.83,20.62l1.7,1.7Z" style="fill:#d3d3d3"/></svg>

--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -22,9 +22,9 @@
 sc_require('views/drag_border_view');
 sc_require('views/titlebar_button_view');
 
-var kResizeHandleSize = 16,
-    kResizeHandleHalfSize = kResizeHandleSize / 2,
-    kResizeHandleInset = 2;
+var kResizeHandleSize = 26, // total size of interactable area
+    kResizeHandleInset = 4; // size of interactable area outside the component
+                            // difference is the size of the visible handle
 
 /** @class
 
@@ -148,12 +148,6 @@ DG.ComponentView = SC.View.extend(
           this.get('borderLeft').set('isVisible', false);
           this.get('borderBottomLeft').set('isVisible', false);
           this.get('borderBottomRight').set('isVisible', false);
-/*
-          this.get('resizeRight').set('isVisible', false);
-          this.get('resizeBottom').set('isVisible', false);
-          this.get('resizeLeft').set('isVisible', false);
-          this.get('resizeBottomLeft').set('isVisible', false);
-*/
           this.get('resizeBottomRight').set('isVisible', false);
         },
         /**
@@ -185,8 +179,7 @@ DG.ComponentView = SC.View.extend(
         }.property(),
         childViews: ('containerView' +
                       (DG.get('componentMode') === 'no'
-                        ? ' borderRight borderBottom borderLeft borderBottomLeft borderBottomRight' +
-                          /*'resizeRight resizeBottom resizeLeft resizeBottomLeft'*/ ' resizeBottomRight'
+                        ? ' borderRight borderBottom borderLeft borderBottomLeft borderBottomRight resizeBottomRight'
                         : '')).w(),
         containerView: SC.View.design({
           classNames: ['dg-component-container'],
@@ -432,72 +425,10 @@ DG.ComponentView = SC.View.extend(
             {
               layout: {right: 0, width: 2 * kDragWidth, bottom: 0, height: 2 * kDragWidth}
             }),
-/*
-        resizeRight: DG.DragRightBorderView.design(
-            {
-              classNames: ['dg-component-resize-handle'],
-              layout: {centerY: 0, right: -kResizeHandleHalfSize,
-                        width: kResizeHandleSize, height: kResizeHandleSize},
-              didCreateLayer: function() {
-                this.set('isVisible', this.canBeDragged());
-              },
-              childViews: ['interior'],
-              interior: SC.View.design({
-                classNames: ['dg-component-resize-handle-interior'],
-                layout: {left: kResizeHandleInset, top: kResizeHandleInset,
-                        right: kResizeHandleInset, bottom: kResizeHandleInset}
-              })
-            }),
-        resizeBottom: DG.DragBottomBorderView.design(
-            {
-              classNames: ['dg-component-resize-handle'],
-              layout: {centerX: 0, bottom: -kResizeHandleHalfSize,
-                        width: kResizeHandleSize, height: kResizeHandleSize},
-              didCreateLayer: function() {
-                this.set('isVisible', this.canBeDragged());
-              },
-              childViews: ['interior'],
-              interior: SC.View.design({
-                classNames: ['dg-component-resize-handle-interior'],
-                layout: {left: kResizeHandleInset, top: kResizeHandleInset,
-                        right: kResizeHandleInset, bottom: kResizeHandleInset}
-              })
-            }),
-        resizeLeft: DG.DragLeftBorderView.design(
-            {
-              classNames: ['dg-component-resize-handle'],
-              layout: {left: -kResizeHandleHalfSize, centerY: 0,
-                        width: kResizeHandleSize, height: kResizeHandleSize},
-              didCreateLayer: function() {
-                this.set('isVisible', this.canBeDragged());
-              },
-              childViews: ['interior'],
-              interior: SC.View.design({
-                classNames: ['dg-component-resize-handle-interior'],
-                layout: {left: kResizeHandleInset, top: kResizeHandleInset,
-                        right: kResizeHandleInset, bottom: kResizeHandleInset}
-              })
-            }),
-        resizeBottomLeft: DG.DragBottomLeftBorderView.design(
-            {
-              classNames: ['dg-component-resize-handle'],
-              layout: {left: -kResizeHandleHalfSize, bottom: -kResizeHandleHalfSize,
-                      width: kResizeHandleSize, height: kResizeHandleSize},
-              didCreateLayer: function() {
-                this.set('isVisible', this.canBeDragged());
-              },
-              childViews: ['interior'],
-              interior: SC.View.design({
-                classNames: ['dg-component-resize-handle-interior'],
-                layout: {left: kResizeHandleInset, top: kResizeHandleInset,
-                        right: kResizeHandleInset, bottom: kResizeHandleInset}
-              })
-            }),
-*/
         resizeBottomRight: DG.DragBottomRightBorderView.design(
             {
               classNames: ['dg-component-resize-handle'],
-              layout: {right: -kResizeHandleHalfSize, bottom: -kResizeHandleHalfSize,
+              layout: {right: -kResizeHandleInset, bottom: -kResizeHandleInset,
                         width: kResizeHandleSize, height: kResizeHandleSize},
               didCreateLayer: function() {
                 this.set('isVisible', this.canBeDragged());
@@ -505,7 +436,7 @@ DG.ComponentView = SC.View.extend(
               childViews: ['interior'],
               interior: SC.View.design({
                 classNames: ['dg-component-resize-handle-interior'],
-                layout: {left: kResizeHandleInset, top: kResizeHandleInset,
+                layout: {left: 0, top: 0,
                         right: kResizeHandleInset, bottom: kResizeHandleInset}
               })
             }),


### PR DESCRIPTION
Testable at https://codap-dev.concord.org/branch/171965133-resize-icon/.

Also changes the travis build to use `npm ci` rather than `yarn`, which should have been part of the switch from `yarn` to `npm` a while ago.