### PR TITLE
Listen for CFM log messages and handle LARA data

### DIFF
--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -329,6 +329,13 @@ DG.main = function main() {
     return baseURL + location.search+hash;
   }
 
+  function handleLogLaraData(obj) {
+    if (obj.run_remote_endpoint) {
+      DG.set('run_remote_endpoint', obj.run_remote_endpoint);
+    }
+    DG.logUser("laraData: %@".fmt(JSON.stringify(obj)));
+  }
+
   function cfmInit(iCloudFileManager, iViewConfig) {
     var options = {
           autoSaveInterval: 5,
@@ -413,10 +420,7 @@ DG.main = function main() {
                 return obj.guid || JSON.stringify(obj);
               },
               logLaraData: function(obj) {
-                if (obj.run_remote_endpoint) {
-                  DG.set('run_remote_endpoint', obj.run_remote_endpoint);
-                }
-                DG.logUser("laraData: %@".fmt(JSON.stringify(obj)));
+                handleLogLaraData(obj);
               }
             },
             {
@@ -959,6 +963,14 @@ DG.main = function main() {
               var document = DG.currDocumentController();
               var name = event.state.metadata.name;
               document.set('documentName', name);
+            });
+            break;
+
+          case "log":
+            SC.run(function() {
+              if (event.data.logEvent === "logLaraData") {
+                handleLogLaraData(event.data.logEventData);
+              }
             });
             break;
         }


### PR DESCRIPTION
This is designed to fix the issue where CODAP is embedded in SageModeler, and never receives the `logLaraData` event in its LARA provider definition, because the SageModeler LARA provider is being used instead.

The CFM is being updated to re-broadcast logLaraData events as a new client event called "log." This will be received by any client that uses `clientConnect`. This new feature is in https://github.com/concord-consortium/cloud-file-manager/pull/153.

If CODAP receives a log event with the event type "logLaraData", it will treat it the same as when "logLaraData" is called when it is at the top level.

https://www.pivotaltracker.com/story/show/172071393