### PR TITLE
Disable ES5Shim's DateShim

### DIFF
--- a/webpack-entry.js
+++ b/webpack-entry.js
@@ -3,7 +3,13 @@
   Popper:true, Tooltip:true, Papa:true, L:true, deepEqual:true, Promise:true, pluralize:true, dayjs:true, nanoid:true, RTree:true */
 /* exported _, CodeMirror, React, ReactDOM, ReactDOMFactories, PropTypes, createReactClass, createReactClassFactory,
   createReactFactory, createReactFC, ReactSizeMe, Popper, Tooltip, Papa, L, deepEqual, Promise, pluralize, dayjs, nanoid, RTree */
+var NativeDate = Date;
 require('es5-shim');
+// Our monkey-patch of valueOf() (cf. DG.DateUtilities.createDate) conflicts with ES5Shim's assumptions
+// about the behavior of native Dates, so we replace ES5Shim's Date with the browser's original Date
+// and figure we can live with whatever browser foibles we've been living with before now.
+// eslint-disable-next-line no-implicit-globals, no-global-assign
+Date = NativeDate;
 require('es6-shim');
 _ = require('lodash');
 CodeMirror = require('codemirror/lib/codemirror.js');


### PR DESCRIPTION
Disable ES5Shim's DateShim because it conflicts with our non-standard use of Dates.

Ultimately the fault is ours -- we should really eliminate our non-standard use of Dates -- but in the short term it's easier to disable the conflicting shim and go back to whatever date-related browser bugs we were dealing with before.

Testable at https://codap-dev.concord.org/branch/172366270-fix-date-format/.