### PR TITLE
Update `slate-editor` to 0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,15 +35,15 @@
       }
     },
     "@concord-consortium/slate-editor": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.0.8.tgz",
-      "integrity": "sha512-zICWJhYi00jNhJVRt/Qolc2FxFE36CGJ7KEYPv49NAVqLjfM6qTg+G6Z3IqQx2s7GHkQ1j2O0auSxWiUBcsGBw==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.0.9.tgz",
+      "integrity": "sha512-T+duqpYClpOIPXTliIiJoi+0V4EkdJOX4RqEzoDUkQpp8GfmQw535c/XVsmjrx5VtL1v8DD2pkAya6shlAboXg==",
       "requires": {
         "immutable": "^3.8.2",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.15",
         "slate": "^0.47.9",
-        "slate-plain-serializer": "^0.7.11",
+        "slate-plain-serializer": "^0.7.13",
         "slate-react": "^0.22.10"
       }
     },
@@ -1035,8 +1035,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -1776,8 +1775,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -8043,10 +8041,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-      "dev": true,
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "dependencies": {
-    "@concord-consortium/slate-editor": "0.0.8",
+    "@concord-consortium/slate-editor": "^0.0.9",
     "codemirror": "^5.39.2",
     "create-react-class": "^15.6.3",
     "dayjs": "^1.8.14",


### PR DESCRIPTION
- Prevents wrapping links in links
- Allows client to specify tooltips for localization
