### PR TITLE
Fix focus issues between rich text editor and component title bars

### DIFF
--- a/apps/dg/views/component_view.js
+++ b/apps/dg/views/component_view.js
@@ -218,8 +218,8 @@ DG.ComponentView = SC.View.extend(
                     tFrame = tParent.get('frame'),
                     kXGap = 4, kYGap = 2,
                     tOrigin = DG.ViewUtilities.viewToWindowCoordinates({x: kXGap, y: kYGap}, tParent);
-                tComponentView.select();
                 tParent.set('userEdit', true);
+                tComponentView.select();
 
                 // SC 1.10 introduced a new inline editor model in which
                 // an 'exampleNode' is used to adjust inline editor style.
@@ -243,6 +243,10 @@ DG.ComponentView = SC.View.extend(
                     width: tFrame.width - 2 * kXGap, height: tFrame.height - 2 * kYGap
                   }
                 });
+              },
+              inlineEditorDidEndEditing: function () {
+                sc_super();
+                this.get('parentView').set('userEdit', false);
               },
               valueChanged: function () {
                 var tComponentView = DG.ComponentView.findComponentViewParent(this),

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,16 +35,19 @@
       }
     },
     "@concord-consortium/slate-editor": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.0.9.tgz",
-      "integrity": "sha512-T+duqpYClpOIPXTliIiJoi+0V4EkdJOX4RqEzoDUkQpp8GfmQw535c/XVsmjrx5VtL1v8DD2pkAya6shlAboXg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.3.0.tgz",
+      "integrity": "sha512-XZEr39BhSmBpUGSruRZ7m322T9BfX6twWx5nsvvZ3ShuCicy9p8HCblovZVkXU0cmDRtEFURbrshE1sqB6vM0Q==",
       "requires": {
+        "classnames": "^2.2.6",
         "immutable": "^3.8.2",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.15",
         "slate": "^0.47.9",
+        "slate-html-serializer": "^0.8.13",
         "slate-plain-serializer": "^0.7.13",
-        "slate-react": "^0.22.10"
+        "slate-react": "^0.22.10",
+        "style-to-object": "^0.3.0"
       }
     },
     "@cypress/listr-verbose-renderer": {
@@ -1035,7 +1038,8 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -1191,6 +1195,11 @@
           }
         }
       }
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "cli-cursor": {
       "version": "1.0.2",
@@ -1775,7 +1784,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -3753,6 +3763,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "inquirer": {
       "version": "7.0.4",
@@ -6582,6 +6597,14 @@
         }
       }
     },
+    "slate-html-serializer": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/slate-html-serializer/-/slate-html-serializer-0.8.13.tgz",
+      "integrity": "sha512-TRn81JUs7qbzE19A3f7Cw+YM4aiYiKUZM98hX9AQ7YeFqXosB0S07FwezfFt73qZhvHuJTHlnB58gPa48mEg0w==",
+      "requires": {
+        "type-of": "^2.0.1"
+      }
+    },
     "slate-plain-serializer": {
       "version": "0.7.13",
       "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.7.13.tgz",
@@ -7119,6 +7142,14 @@
             "ajv-keywords": "^3.1.0"
           }
         }
+      }
+    },
+    "style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "requires": {
+        "inline-style-parser": "0.1.1"
       }
     },
     "supports-color": {
@@ -8044,6 +8075,7 @@
       "version": "13.1.2",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "dependencies": {
-    "@concord-consortium/slate-editor": "^0.0.9",
+    "@concord-consortium/slate-editor": "^0.3.0",
     "codemirror": "^5.39.2",
     "create-react-class": "^15.6.3",
     "dayjs": "^1.8.14",


### PR DESCRIPTION
Requires an update to version 0.3.0 of the `slate-editor` library which improves the focus/blur handling, which allows for a simpler CODAP implementation.