### PR TITLE
Fix rich text save -- accommodate slate-editor API change

### DIFF
--- a/apps/dg/components/text/text_view.js
+++ b/apps/dg/components/text/text_view.js
@@ -224,7 +224,7 @@ DG.TextView = SC.View.extend((function() {
                 }.bind(this),
                 onContentChange: function(content) {
                   SC.run(function() {
-                    this.set('value', content);
+                    this.set('value', SlateEditor.serializeValue(content));
                   }.bind(this));
                 }.bind(this),
                 onFocus: function() {


### PR DESCRIPTION
🤦 There was an API change in the `slate-editor` library in 0.2.1 which required a change to client code.

Testable at https://codap-dev.concord.org/branch/fix-rich-text-save/.