### PR TITLE
Fix IME input (e.g. Chinese, Japanese); fix auto-scroll to selection

### DIFF
--- a/apps/dg/components/text/text_view.js
+++ b/apps/dg/components/text/text_view.js
@@ -172,8 +172,10 @@ DG.TextView = SC.View.extend((function() {
                 modalDialogClassName: 'codap-slate-modal' + kWantsEventsClasses,
                 className: 'codap-slate-toolbar' + kWantsEventsClasses,
                 orientation: 'vertical',
-                colors: { fill: "#ffffff", background: "#177991" },
-                selectedColors: { fill: "#177991", background: "#72bfca" },
+                colors: {
+                  buttonColors: { fill: "#ffffff", background: "#177991" },
+                  selectedColors: { fill: "#177991", background: "#72bfca" }
+                },
                 buttonsPerRow: 9,
                 order: [
                     //column 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,11 +35,11 @@
       }
     },
     "@concord-consortium/slate-editor": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.4.2.tgz",
-      "integrity": "sha512-zM0ven+d3aJ9no4RDBp6E60ql7I9Re9wkXA4g7WKgs/4Zs6wDq08VBWbWoSBJnSInorpIuiGc1aPcO7DwvGXfg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.4.3.tgz",
+      "integrity": "sha512-QmTCkz4aSdQH8SjbKbQ1Pa3NidZyyBmlmXONdd93Im67r1Gnw8+Bmvvz+NFY6VjhqRvXaxQp7jGvEAJ+NQmu9w==",
       "requires": {
-        "@concord-consortium/slate-react": "^0.22.10-cc.2",
+        "@concord-consortium/slate-react": "^0.22.10-cc.3",
         "classnames": "^2.2.6",
         "immutable": "^3.8.2",
         "is-hotkey": "^0.1.6",
@@ -51,9 +51,9 @@
       }
     },
     "@concord-consortium/slate-react": {
-      "version": "0.22.10-cc.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.2.tgz",
-      "integrity": "sha512-nvNg8NSN63TvHisgufTRaIiejJ8AlhrBBjr3BsAKDWdFzQDX4NRJD1nrEYvevJp/KOV1rDD8UMSFT07QS2MpNQ==",
+      "version": "0.22.10-cc.3",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.3.tgz",
+      "integrity": "sha512-wYGAHZf62ygpPlgHXvXWCg/waf59ZHoFoeAvC/7A9v5qJcMPaL1QkCIsdGJXTKqSK+GMdwttNAix0A2ECDe0xg==",
       "requires": {
         "debug": "^3.1.0",
         "get-window": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,19 +35,52 @@
       }
     },
     "@concord-consortium/slate-editor": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.3.0.tgz",
-      "integrity": "sha512-XZEr39BhSmBpUGSruRZ7m322T9BfX6twWx5nsvvZ3ShuCicy9p8HCblovZVkXU0cmDRtEFURbrshE1sqB6vM0Q==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.4.2.tgz",
+      "integrity": "sha512-zM0ven+d3aJ9no4RDBp6E60ql7I9Re9wkXA4g7WKgs/4Zs6wDq08VBWbWoSBJnSInorpIuiGc1aPcO7DwvGXfg==",
       "requires": {
+        "@concord-consortium/slate-react": "^0.22.10-cc.2",
         "classnames": "^2.2.6",
         "immutable": "^3.8.2",
         "is-hotkey": "^0.1.6",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.19",
         "slate": "^0.47.9",
         "slate-html-serializer": "^0.8.13",
         "slate-plain-serializer": "^0.7.13",
-        "slate-react": "^0.22.10",
         "style-to-object": "^0.3.0"
+      }
+    },
+    "@concord-consortium/slate-react": {
+      "version": "0.22.10-cc.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-react/-/slate-react-0.22.10-cc.2.tgz",
+      "integrity": "sha512-nvNg8NSN63TvHisgufTRaIiejJ8AlhrBBjr3BsAKDWdFzQDX4NRJD1nrEYvevJp/KOV1rDD8UMSFT07QS2MpNQ==",
+      "requires": {
+        "debug": "^3.1.0",
+        "get-window": "^1.1.1",
+        "is-window": "^1.0.2",
+        "lodash": "^4.1.1",
+        "memoize-one": "^4.0.0",
+        "prop-types": "^15.5.8",
+        "react-immutable-proptypes": "^2.1.0",
+        "selection-is-backward": "^1.0.0",
+        "slate-base64-serializer": "^0.2.112",
+        "slate-dev-environment": "^0.2.2",
+        "slate-hotkeys": "^0.2.9",
+        "slate-plain-serializer": "^0.7.11",
+        "slate-prop-types": "^0.5.42",
+        "slate-react-placeholder": "^0.2.9",
+        "tiny-invariant": "^1.0.1",
+        "tiny-warning": "^0.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "@cypress/listr-verbose-renderer": {
@@ -1688,6 +1721,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "ms": {
@@ -4605,9 +4644,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -6609,39 +6648,6 @@
       "version": "0.5.44",
       "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.5.44.tgz",
       "integrity": "sha512-JS0iW7uaciE/W3ADuzeN1HOnSjncQhHPXJ65nZNQzB0DF7mXVmbwQKI6cmCo/xKni7XRJT0JbWSpXFhEdPiBUA=="
-    },
-    "slate-react": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.22.10.tgz",
-      "integrity": "sha512-B2Ms1u/REbdd8yKkOItKgrw/tX8klgz5l5x6PP86+oh/yqmB6EHe0QyrYlQ9fc3WBlJUVTOL+nyAP1KmlKj2/w==",
-      "requires": {
-        "debug": "^3.1.0",
-        "get-window": "^1.1.1",
-        "is-window": "^1.0.2",
-        "lodash": "^4.1.1",
-        "memoize-one": "^4.0.0",
-        "prop-types": "^15.5.8",
-        "react-immutable-proptypes": "^2.1.0",
-        "selection-is-backward": "^1.0.0",
-        "slate-base64-serializer": "^0.2.112",
-        "slate-dev-environment": "^0.2.2",
-        "slate-hotkeys": "^0.2.9",
-        "slate-plain-serializer": "^0.7.11",
-        "slate-prop-types": "^0.5.42",
-        "slate-react-placeholder": "^0.2.9",
-        "tiny-invariant": "^1.0.1",
-        "tiny-warning": "^0.0.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
     },
     "slate-react-placeholder": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "dependencies": {
-    "@concord-consortium/slate-editor": "^0.4.2",
+    "@concord-consortium/slate-editor": "^0.4.3",
     "codemirror": "^5.39.2",
     "create-react-class": "^15.6.3",
     "dayjs": "^1.8.14",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "dependencies": {
-    "@concord-consortium/slate-editor": "^0.3.0",
+    "@concord-consortium/slate-editor": "^0.4.2",
     "codemirror": "^5.39.2",
     "create-react-class": "^15.6.3",
     "dayjs": "^1.8.14",
@@ -127,7 +127,7 @@
     "es6-shim": "^0.35.5",
     "esri-leaflet": "^2.2.1",
     "leaflet": "1.0.0",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "nanoid": "^2.0.1",
     "pluralize": "^4.0.0",
     "popper.js": "^1.14.3",


### PR DESCRIPTION
Update to @concord-consortium/slate-editor 0.4.3
- fixes IME (e.g. Chinese/Japanese/etc. keyboard) bugs
- fixes auto-scroll to selection on toolbar actions

Update to lodash@4.17.19
- eliminates security vulnerability warnings