### PR TITLE
Line/bar plot (bars for points) [#174776114] 

### DIFF
--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -1387,6 +1387,9 @@ DG.GraphView = SC.View.extend(
           case DG.BinnedPlotModel:
             tNewViewClass = iPlotModel.get('dotsAreFused') ? DG.HistogramView : DG.BinnedPlotView;
             break;
+          case DG.LinePlotModel:
+            tNewViewClass = DG.LinePlotView;
+            break;
           case DG.ScatterPlotModel:
             tNewViewClass = DG.ScatterPlotView;
             break;
@@ -1419,4 +1422,3 @@ DG.GraphView = SC.View.extend(
       }
 
     });
-

--- a/apps/dg/components/graph/plots/bar_chart_view.js
+++ b/apps/dg/components/graph/plots/bar_chart_view.js
@@ -31,6 +31,11 @@ DG.BarChartView = DG.ChartView.extend(
     /** @scope DG.BarChartView.prototype */
     {
       /**
+       * Expected type of plotted elements
+       */
+      plottedElementType: 'rect',
+
+      /**
        * If we're displaying as a barchart, this is how high the slices are in a given bar
        * @property {[Number]}
        */
@@ -573,4 +578,3 @@ DG.BarChartView = DG.ChartView.extend(
       }
     })
 ;
-

--- a/apps/dg/components/graph/plots/binned_plot_model.js
+++ b/apps/dg/components/graph/plots/binned_plot_model.js
@@ -456,7 +456,7 @@ DG.BinnedPlotModel = DG.UnivariatePlotModel.extend((function () {
               tRedo = tDotsStartOutFused ? 'DG.Redo.graph.dissolveRectanglesToDots' :
                   'DG.Redo.graph.fuseDotsToRectangles';
           DG.UndoHistory.execute(DG.Command.create({
-            name: "graph.toggleBinningType",
+            name: "graph.changeDotPlotModelType",
             undoString: tUndo,
             redoString: tRedo,
             log: ("toggleShowAs: %@").fmt(tDotsStartOutFused ? "Histogram" : "BinnedDotPlot"),
@@ -567,4 +567,3 @@ DG.BinnedPlotModel.configureRoles = function (iConfig) {
   // Base class has method for this
   DG.UnivariatePlotModel.configureRoles(iConfig);
 };
-

--- a/apps/dg/components/graph/plots/dot_plot_model.js
+++ b/apps/dg/components/graph/plots/dot_plot_model.js
@@ -19,7 +19,6 @@
 // ==========================================================================
 
 sc_require('components/graph/plots/univariate_plot_model');
-sc_require('components/graph/plots/numeric_plot_model_mixin');
 
 /** @class  DG.DotPlotModel The model for a dot plot.
 
@@ -629,4 +628,3 @@ DG.DotPlotModel.configureRoles = function (iConfig) {
   // Base class has method for this
   DG.UnivariatePlotModel.configureRoles( iConfig);
 };
-

--- a/apps/dg/components/graph/plots/dot_plot_view.js
+++ b/apps/dg/components/graph/plots/dot_plot_view.js
@@ -25,7 +25,7 @@ sc_require('components/graph/plots/univariate_plot_view');
   @extends DG.UnivariatePlotView
 */
 DG.DotPlotView = DG.UnivariatePlotView.extend(
-/** @scope DG.DotPlotView.prototype */ 
+/** @scope DG.DotPlotView.prototype */
 {
   displayProperties: ['primaryAxisView.model.lowerBound', 'primaryAxisView.model.upperBound'],
 
@@ -44,7 +44,7 @@ DG.DotPlotView = DG.UnivariatePlotView.extend(
 
   /** @property {DG.plottedStDevAdorn} */
   plottedStDevAdorn: null,
-  
+
   /** @property {DG.plottedMadAdorn} */
   plottedMadAdorn: null,
 
@@ -153,6 +153,28 @@ DG.DotPlotView = DG.UnivariatePlotView.extend(
     if (this.plottedValueAdorn) {
       this.plottedValueAdorn.updateToModel();
     }
+  },
+
+  /**
+   * Called from animateFromTransferredElements to create animatable elements.
+   * @param {DG.Case} iCase
+   * @param {number} iIndex
+   * @param {Object} iOldEltAttrs
+   */
+  createAnimatingElement: function(iCase, iIndex, iOldEltAttrs) {
+    var tOldElementIsRect = iOldEltAttrs && iOldEltAttrs.type === 'rect',
+        tElement = this.callCreateElement(iCase, iIndex, false),
+        attrs = iOldEltAttrs && {
+          r: tOldElementIsRect
+              ? Math.min(iOldEltAttrs.width, iOldEltAttrs.height) / 2
+              : iOldEltAttrs.r || this._pointRadius,
+          cx: tOldElementIsRect ? iOldEltAttrs.x + iOldEltAttrs.width / 2 : iOldEltAttrs.cx,
+          cy: tOldElementIsRect ? iOldEltAttrs.y + iOldEltAttrs.height / 2 : iOldEltAttrs.cy,
+          fill: iOldEltAttrs.fill,
+          stroke: iOldEltAttrs.stroke
+        };
+    attrs && tElement.attr(attrs);
+    return tElement;
   },
 
   /**
@@ -380,7 +402,7 @@ DG.DotPlotView = DG.UnivariatePlotView.extend(
 
       if( tMaxThatFit <= 0) // If things are really tight, overlap points directly on top of each other
         return iBinWidth;
-          
+
       tCases.forEach( function( iCase) {
         var tColorValue = !SC.none( tColorID) ? iCase.getValue( tColorID) : null,
             tNumericCoord = tNumericAxisView.dataToCoordinate( iCase.getForcedNumericValue( tNumericVarID)),
@@ -405,7 +427,7 @@ DG.DotPlotView = DG.UnivariatePlotView.extend(
       }
       return tOverlap;
     } // computeOverlap()
-    
+
     // Fill arrays with zeroes
     this.set( 'binArrays', DG.MathUtilities.range( tNumCells ).map( function() {
       return DG.MathUtilities.range( tNumBins ).map( function() {
@@ -461,7 +483,7 @@ DG.DotPlotView = DG.UnivariatePlotView.extend(
   plottedStDevChanged: function() {
     this.adornmentDidChange('plottedStDev', 'plottedStDevAdorn', DG.PlottedStDevAdornment);
   }.observes('*model.plottedStDev'),
-  
+
   /**
    Presumably our model has created a plotted St.Dev. We need to create our adornment.
    */
@@ -475,7 +497,7 @@ DG.DotPlotView = DG.UnivariatePlotView.extend(
   plottedBoxPlotChanged: function() {
     this.adornmentDidChange('plottedBoxPlot', 'plottedBoxPlotAdorn', DG.PlottedBoxPlotAdornment);
   }.observes('*model.plottedBoxPlot'),
-  
+
   /**
     Update an adornment after a change to its corresponding adornment model.
     @param    {String}    iAdornmentKey -- e.g. 'plottedMean' or 'plottedMedian'
@@ -540,4 +562,3 @@ DG.DotPlotView = DG.UnivariatePlotView.extend(
   }
 
 });
-

--- a/apps/dg/components/graph/plots/histogram_view.js
+++ b/apps/dg/components/graph/plots/histogram_view.js
@@ -31,6 +31,11 @@ DG.HistogramView = DG.UnivariatePlotView.extend(
       kLineSlideVCur: DG.Browser.customCursorStr(static_url('cursors/LineSlide.cur'), 8, 8),
 
       /**
+       * Expected type of plotted elements
+       */
+      plottedElementType: 'rect',
+
+      /**
        * @property {[{coverRect: Element, draggableEdge: Element,
        *            lowerEdgeWorldValue: Number, lowerEdgeScreenCoord: Number }]}
        */
@@ -609,4 +614,3 @@ DG.HistogramView = DG.UnivariatePlotView.extend(
       }
 
     });
-

--- a/apps/dg/components/graph/plots/line-plot-model.js
+++ b/apps/dg/components/graph/plots/line-plot-model.js
@@ -1,0 +1,50 @@
+// ==========================================================================
+//                            DG.LinePlotModel
+//
+//  Author:   Kirk Swenson
+//
+//  Copyright (c) 2020 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+
+sc_require('components/graph/plots/dot_plot_model');
+
+/** @class  DG.LinePlotModel The model for a line/bar plot.
+
+ @extends SC.LinePlotModel
+ */
+DG.LinePlotModel = DG.DotPlotModel.extend(
+  /** @scope DG.LinePlotModel.prototype */
+  {
+    /**
+     * Originally a boolean; extended to support line/bar plot
+     * @property {Boolean | "bars"}
+     */
+    displayAsBinned: "bars",
+
+    handleDataConfigurationChange: function(iKey) {
+      // override to prevent unnecessary call to rescaleAxesFromData() by base class
+      this.updateAdornmentModels();
+    }
+  }
+);
+
+/**
+ class method called before plot creation to make sure roles are correct
+ @param {DG.GraphDataConfiguration}
+ */
+DG.LinePlotModel.configureRoles = function(iConfig) {
+  // Base class has method for this
+  DG.UnivariatePlotModel.configureRoles(iConfig);
+};

--- a/apps/dg/components/graph/plots/line-plot-view.js
+++ b/apps/dg/components/graph/plots/line-plot-view.js
@@ -1,0 +1,275 @@
+// ==========================================================================
+//                          DG.LinePlotView
+//
+//  Author:   Kirk Swenson
+//
+//  Copyright (c) 2020 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+
+sc_require('components/graph/plots/dot_plot_view');
+
+/** @class  DG.LinePlotView - A line/bar for each case
+
+  @extends DG.DotPlotView
+*/
+DG.LinePlotView = DG.DotPlotView.extend(
+/** @scope DG.LinePlotView.prototype */
+{
+  /**
+   * Expected type of plotted elements
+   */
+  plottedElementType: 'rect',
+
+  /**
+   * Array of { caseCount: number, indexMap: { caseIndexInCollection: caseIndexInCell } } per cell
+   */
+  cellCaseInfo: null,
+
+  /**
+   * Max number of cases in a cell
+   */
+  maxCaseCountInCell: 0,
+
+  /**
+   * Configure axes
+   */
+  setupAxes: function () {
+    sc_super();
+
+    this.setPath('primaryAxisView.model.preferZeroLowerBound', true);
+    this.setPath('primaryAxisView.model.drawZeroLine', true);
+
+    var model = this.get('model');
+    model && model.rescaleAxesFromData(true);
+  },
+
+  /**
+   * Update the cell counts.
+   */
+  updateCellCaseInfo: function() {
+    var categoryAxisModel = this.getPath('secondaryAxisView.model');
+    if (!categoryAxisModel) return;
+    var cellCount = categoryAxisModel.get('numberOfCells'),
+        cellCaseInfo = new Array(cellCount),
+        maxCaseCountInCell = 0;
+    for (var i = 0; i < cellCount; ++i) {
+      // map from index in collection to index in cell
+      cellCaseInfo[i] = {
+        caseCount: 0,
+        indexMap: {}
+      };
+    }
+    var tCases = this.getPath('model.cases'),
+        tCategoryVarID = this.getPath('model.secondaryVarID');
+    if (tCases) {
+      tCases.forEach(function(iCase, iCaseIndex) {
+        var cellIndex = categoryAxisModel.cellNameToCellNumber(iCase.getStrValue(tCategoryVarID));
+        if (cellIndex >= 0) {
+          var cellInfo = cellCaseInfo[cellIndex];
+          if (cellInfo) {
+            cellInfo.indexMap[iCaseIndex] = cellInfo.caseCount;
+            if (++cellInfo.caseCount > maxCaseCountInCell)
+              maxCaseCountInCell = cellInfo.caseCount;
+          }
+        }
+      });
+    }
+    this.set('cellCaseInfo', cellCaseInfo);
+    this.set('maxCaseCountInCell', maxCaseCountInCell);
+  },
+
+  /**
+    Before we recompute coordinates, we need to compute the cell counts.
+   */
+  prepareToResetCoordinates: function() {
+    sc_super();
+    this.updateCellCaseInfo();
+  },
+
+  /**
+   * @param iCase
+   * @param iIndex
+   * @param iAnimate
+   */
+  createElement: function (iCase, iIndex, iAnimate) {
+    // Can't create rects if we don't have paper for them
+    if (!this.get('paper')) return;
+
+    var tRect = this.get('paper').rect(-1000, -1000, 0, 0)
+        .attr({
+          fill: DG.PlotUtilities.kDefaultPointColor,
+          stroke: 'none'
+        });
+    tRect.node.setAttribute('shape-rendering', 'geometric-precision');
+    /*
+            if (iAnimate)
+              DG.PlotUtilities.doCreateRectAnimation(tRect);
+    */
+    return tRect;
+  },
+
+  /**
+    For use in transferring current element positions of this plot to a new plot about
+    to take its place.
+    @return {[{cx:{Number}, cy:{Number}, r: {Number}, fill: {String} ]}
+  */
+  getElementPositionsInParentFrame: function() {
+    var tFrame = this.get('frame'),
+        tPlottedElements = this.get('plottedElements');
+    DG.assert(tPlottedElements.length === 0 || tPlottedElements[0][0].constructor === SVGRectElement,
+              'Expecting rectangle');
+    return tPlottedElements.map( function( iElement) {
+        var tX = iElement.attr('x') + tFrame.x,
+            tY = iElement.attr('y') + tFrame.y,
+            tWidth = iElement.isHidden() ? 0 : iElement.attr('width'),    // use 0 for hidden plot element
+            tHeight = iElement.isHidden() ? 0 : iElement.attr('height');  // use 0 for hidden plot element
+            return {
+              x: tX,
+              y: tY,
+              width: tWidth,
+              height: tHeight,
+              fill: iElement.attr('fill'),
+              stroke: iElement.attr('stroke'),
+              type: 'rect'};
+      });
+  },
+
+  /**
+   * Called from animateFromTransferredElements to create animatable elements.
+   * @param {DG.Case} iCase
+   * @param {number} iIndex
+   * @param {Object} iOldEltAttrs
+   */
+  createAnimatingElement: function(iCase, iIndex, iOldEltAttrs) {
+    var tOldElementIsCircle = iOldEltAttrs && iOldEltAttrs.type === 'circle',
+        tElement = this.callCreateElement(iCase, iIndex, false),
+        attrs = iOldEltAttrs && {
+          r: tOldElementIsCircle ? iOldEltAttrs.r : 0,
+          x: tOldElementIsCircle ? iOldEltAttrs.cx - iOldEltAttrs.r : iOldEltAttrs.x,
+          y: tOldElementIsCircle ? iOldEltAttrs.cy - iOldEltAttrs.r : iOldEltAttrs.y,
+          width: tOldElementIsCircle ? 2 * iOldEltAttrs.r : iOldEltAttrs.width,
+          height: tOldElementIsCircle ? 2 * iOldEltAttrs.r : iOldEltAttrs.height,
+          fill: iOldEltAttrs.fill,
+          stroke: iOldEltAttrs.stroke
+        };
+    attrs && tElement.attr(attrs);
+    return tElement;
+  },
+
+  /**
+   * Set the coordinates and other attributes of the case rectangle (a Rafael element in this.get('plottedElements')).
+   * @param {{}} iRC case-invariant Render Context
+   * @param {DG.Case} iCase the case data
+   * @param {number} iIndex index of case in collection
+   * @param {Boolean} iAnimate (optional) want changes to be animated into place?
+   * @param {function} iCallback
+   * @returns {{cx:{Number},cy:{Number}}} final coordinates or null if not defined (hidden plot element)
+   */
+  setCircleCoordinate: function( iRC, iCase, iIndex, iAnimate, iCallback ) {
+    var tPlottedElements = this.get('plottedElements');
+    DG.assert( iCase, 'There must be a case' );
+    DG.assert( DG.MathUtilities.isInIntegerRange( iIndex, 0, tPlottedElements.length ),
+        'index %@ out of bounds for plottedElements of length %@'.loc(iIndex, tPlottedElements.length));
+    var tRect = tPlottedElements[iIndex],
+        tWorld = iCase.getForcedNumericValue(iRC.primaryVarID),
+        tScreenCoord = iRC.primaryAxisView.dataToCoordinate(tWorld),
+        tZeroCoord = iRC.primaryAxisView.dataToCoordinate(0),
+        tIsMissingCase = !DG.isFinite(tScreenCoord) || (iRC.primaryAxisPlace === DG.GraphTypes.EPlace.eUndefined);
+
+    // show or hide if needed, then update if shown.
+    if( this.showHidePlottedElement(tRect, tIsMissingCase, iIndex) && iRC.categoryAxisModel) {
+
+      var tCellNumber = iRC.categoryAxisModel.cellNameToCellNumber(iCase.getStrValue(iRC.categoryVarID )),
+          tMaxCaseCountInCell = this.get('maxCaseCountInCell'),
+          tCellCaseInfo = this.get('cellCaseInfo')[tCellNumber],
+          tIndexInCell = tCellCaseInfo ? tCellCaseInfo.indexMap[iIndex] : 0,
+          tCasesInCell = tCellCaseInfo ? tCellCaseInfo.caseCount : 0,
+          tCellCoord = SC.none(tCellNumber) ? 0 : iRC.categoryAxisView.cellToCoordinate(tCellNumber),
+          tCellWidth = iRC.categoryAxisView.get('fullCellWidth'),
+          tCellStart = tCellCoord - tCellWidth / 2,
+          tBarWidth = tCellWidth / (tMaxCaseCountInCell + 1), // +1 for half bar-width padding on either side
+          tCellPadding = (tMaxCaseCountInCell - tCasesInCell) * tBarWidth / 2,
+          tCoordX, tCoordY, tWidth, tHeight;
+
+      // Express coordinates in terms of x and y
+      switch(iRC.primaryAxisPlace) {
+        case DG.GraphTypes.EPlace.eX:
+          tCoordX = tWorld < 0 ? tScreenCoord : tZeroCoord;
+          tCoordY = tCellStart + tCellWidth - (tCellPadding + (tIndexInCell + 1.5) * tBarWidth);
+          tWidth = Math.abs(tScreenCoord - tZeroCoord);
+          tHeight = tBarWidth;
+          break;
+        case DG.GraphTypes.EPlace.eY:
+          tCoordX = tCellStart + tCellPadding + (tIndexInCell + 0.5) * tBarWidth;
+          tCoordY = tWorld < 0 ? tZeroCoord : tScreenCoord;
+          tWidth = tBarWidth;
+          tHeight = Math.abs(tScreenCoord - tZeroCoord);
+          break;
+      }
+
+      var tAttrs = {x: tCoordX, y: tCoordY, width: tWidth, height: tHeight, r: 0.1,
+                    fill: iRC.calcCaseColorString( iCase ),
+                    stroke: iRC.calcStrokeColorString( iCase), 'fill-opacity': iRC.transparency, 'stroke-opacity': iRC.strokeTransparency};
+      this.updatePlottedElement( tRect, tAttrs, iAnimate, iCallback);
+      return { x: tCoordX, y: tCoordY, width: tWidth, height: tHeight };
+    }
+    return null;
+  },
+
+  showDataTip: function (iElement, iIndex, event) {
+    if (DG.NO_DATA_TIP_PREF || this.getPath('paperSource.tempDisallowDataTips'))
+      return;
+    this.get('dataTip').show(event.offsetX, event.offsetY, 8, iIndex);
+  },
+
+  assignElementAttributes: function( iElement, iIndex, iAnimate) {
+    var this_ = this,
+        kOpaque = 1;
+
+    // duplicated from DG.PlotLayer
+    // Remove event handlers
+    if (iElement.events) {
+      iElement.events.forEach(function (iHandler) {
+        iHandler.unbind();
+      });
+      iElement.events.length = 0;
+    }
+    iElement.addClass(DG.PlotUtilities.kColoredDotClassName)
+        .attr({cursor: 'pointer'})
+        .mousedown(function (iEvent) {
+          SC.run(function () {
+            this_.get('model').selectCaseByIndex(iIndex, iEvent.shiftKey);
+          });
+        });
+    iElement.index = iIndex;
+
+    iElement.hover(
+      function (event) {  // over
+        this.animate({
+          opacity: kOpaque,
+        }, DG.PlotUtilities.kHighlightHideTime);
+        this_.showDataTip(this, iIndex, event);
+      },
+      function (event) { // out
+        this.stop();
+        this.animate({
+          opacity: DG.PlotUtilities.kDefaultPointOpacity,
+        }, DG.PlotUtilities.kHighlightHideTime);
+        this_.hideDataTip();
+      });
+    return iElement;
+  }
+
+});

--- a/apps/dg/components/graph/plots/plot_background_view.js
+++ b/apps/dg/components/graph/plots/plot_background_view.js
@@ -26,17 +26,17 @@ sc_require('views/raphael_base');
   @extends DG.RaphaelBaseView
 */
 DG.PlotBackgroundView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
-    
-    
+
     /** @scope DG.PlotBackgroundView.prototype */
     (function () {
       var marqueeInfo;
-      
+
       return {
         autoDestroyProperties: ['_backgroundForClick'],
 
-        displayProperties: ['xAxisView.model.lowerBound', 'xAxisView.model.upperBound',
-          'yAxisView.model.lowerBound', 'yAxisView.model.upperBound',
+        displayProperties: [
+          'xAxisView.model.lowerBound', 'xAxisView.model.upperBound', 'xAxisView.model.drawZeroLine',
+          'yAxisView.model.lowerBound', 'yAxisView.model.upperBound', 'yAxisView.model.drawZeroLine',
           'xAxisView.model.attributeDescription.attributeStats.categoricalStats.numberOfCells',
           'yAxisView.model.attributeDescription.attributeStats.categoricalStats.numberOfCells',
           'graphModel.plotBackgroundColor', 'graphModel.plotBackgroundOpacity'],
@@ -247,6 +247,8 @@ DG.PlotBackgroundView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
               tFrame = this.get('frame'),
               tXAxisView = this.get('xAxisView'),
               tYAxisView = this.get('yAxisView'),
+              tDrawXZeroLine = tXAxisView.getPath('model.drawZeroLine'),
+              tDrawYZeroLine = tYAxisView.getPath('model.drawZeroLine'),
               tBackgroundLayer = this.getPath('layerManager.' + DG.LayerNames.kBackground),
               tGridLayer = this.getPath('layerManager.' + DG.LayerNames.kGrid),
               tBothWaysNumeric = (tXAxisView.get('isNumeric') && tYAxisView.get('isNumeric')),
@@ -302,24 +304,28 @@ DG.PlotBackgroundView = DG.RaphaelBaseView.extend(DG.GraphDropTarget,
               hLine(iY, DG.PlotUtilities.kRuleColor, DG.PlotUtilities.kRuleWidth);
             }
 
-            function drawZeroLines() {
+            function drawZeroLines(iDrawXLine, iDrawYLine, iColor) {
 
               function drawLine(iAxisView, iDrawingFunc) {
-                var tZeroCoord = iAxisView.get('zeroPixel');
-                if (tZeroCoord && !iAxisView.get('isDateTime'))
-                  iDrawingFunc(tZeroCoord, DG.PlotUtilities.kZeroLineColor, DG.PlotUtilities.kZeroLineWidth);
+                var tZeroCoord = iAxisView.get('zeroPixel'),
+                    tColor = iColor || DG.PlotUtilities.kZeroLineColor;
+                if ((tZeroCoord != null) && !iAxisView.get('isDateTime'))
+                  iDrawingFunc(tZeroCoord, tColor, DG.PlotUtilities.kZeroLineWidth);
               }
 
-              drawLine(tXAxisView, vLine);
-              drawLine(tYAxisView, hLine);
+              iDrawXLine && drawLine(tXAxisView, vLine);
+              iDrawYLine && drawLine(tYAxisView, hLine);
             }
 
             if (tBothWaysNumeric) {
               tXAxisView.forEachTickDo(drawVRule);
               if (!tHasY2Attribute)
                 tYAxisView.forEachTickDo(drawHRule);
-              drawZeroLines();
+              drawZeroLines(true, true);
             } // else suppress numeric grid lines for dot plots (numeric only on one axis), because it interferes with mean/median lines, etc.
+            else if (tDrawXZeroLine || tDrawYZeroLine) {
+              drawZeroLines(tDrawXZeroLine, tDrawYZeroLine, DG.PlotUtilities.kRuleColor);
+            }
           } // createRulerLines
 
           function showCursor(iEvent) {

--- a/apps/dg/components/graph/plots/univariate_plot_model.js
+++ b/apps/dg/components/graph/plots/univariate_plot_model.js
@@ -215,21 +215,38 @@ DG.UnivariatePlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
       }.property(),
 
       configurationDescriptions: function() {
-        var this_ = this,
+        var kRowHeight = 20,
             tDescriptions = sc_super();
         tDescriptions.push(
             {
-              constructorClass: SC.CheckboxView,
+              constructorClass: SC.RadioView,
               properties:
-                  {
-                    title: 'DG.Inspector.graphGroupIntoBins',
-                    value: this_.get('displayAsBinned'),
-                    classNames: 'dg-graph-binned-check'.w(),
-                    valueDidChange: function () {
-                      this_.toggleDisplayBins();
-                      DG.mainPage.mainPane.hideInspectorPicker();
-                    }.observes('value')
-                  }
+                {
+                  layout: { height: 3 * kRowHeight },
+                  items: [
+                    {
+                      title: 'DG.Inspector.graphPlotPoints'.loc(),
+                      value: false, // was originally a boolean
+                      enabled: YES
+                    },
+                    {
+                      title: 'DG.Inspector.graphGroupIntoBins'.loc(),
+                      value: true,  // was originally a boolean
+                      enabled: YES
+                    },
+                    {
+                      title: 'DG.Inspector.graphBarForEachPoint'.loc(),
+                      value: 'bars',
+                      enabled: YES
+                    }
+                  ],
+                  value: false,
+                  itemTitleKey: 'title',
+                  itemValueKey: 'value',
+                  itemIsEnabledKey: 'enabled',
+                  isEnabled: YES,
+                  layoutDirection: SC.LAYOUT_VERTICAL
+                }
             }
         );
         return tDescriptions;
@@ -256,4 +273,3 @@ DG.UnivariatePlotModel.configureRoles = function (iConfig) {
   iConfig.setPath(tOtherAxisKey + 'AttributeDescription.role',
       DG.Analysis.EAnalysisRole.eSecondaryCategorical);
 };
-

--- a/apps/dg/components/graph/plots/univariate_plot_model.js
+++ b/apps/dg/components/graph/plots/univariate_plot_model.js
@@ -29,7 +29,8 @@ DG.UnivariatePlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
     /** @scope DG.UnivariatePlotModel.prototype */
     {
       /**
-       * @property {Boolean}
+       * Originally a boolean; extended to support line/bar plot
+       * @property {Boolean | "bars"}
        */
       displayAsBinned: null,
 
@@ -158,7 +159,7 @@ DG.UnivariatePlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
        * @return {Array} [{count, primaryCell, secondaryCell},...] (all values are integers 0+).
        */
       getCellCaseCounts: function ( iForSelectionOnly) {
-       var  tNumericAxisModel = this.get('primaryAxisModel'),
+        var tNumericAxisModel = this.get('primaryAxisModel'),
             tCategoricalAxisModel = this.get('secondaryAxisModel'),
             tValueArray = [];
 
@@ -183,8 +184,8 @@ DG.UnivariatePlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
           if( isFinite( tCellIndex) && DG.MathUtilities.isInIntegerRange( tCellIndex, 0, tNumCells )) {
             var iValue = tValueArray[ tCellIndex ];
             iValue.count += 1;
-            DG.assert( iValue.primaryCell === (iPrimaryCell || 0), "primary cell index error in DG.ChartModel.getCellCaseCounts()" );
-            DG.assert( iValue.secondaryCell === (iSecondaryCell || 0), "secondary cell index error in DG.ChartModel.getCellCaseCounts()" );
+            DG.assert( iValue.primaryCell === (iPrimaryCell || 0), "primary cell index error in DG.UnivariatePlotModel.getCellCaseCounts()" );
+            DG.assert( iValue.secondaryCell === (iSecondaryCell || 0), "secondary cell index error in DG.UnivariatePlotModel.getCellCaseCounts()" );
           }
         });
 
@@ -202,10 +203,6 @@ DG.UnivariatePlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
         return tValueArray;
       },
 
-      toggleDisplayBins: function() {
-        this.toggleProperty('displayAsBinned');
-      },
-
       /**
        * A dot plot can be configured as a binned chart
        * @property {Boolean}
@@ -215,7 +212,8 @@ DG.UnivariatePlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
       }.property(),
 
       configurationDescriptions: function() {
-        var kRowHeight = 20,
+        var this_ = this,
+            kRowHeight = 20,
             tDescriptions = sc_super();
         tDescriptions.push(
             {
@@ -240,7 +238,12 @@ DG.UnivariatePlotModel = DG.PlotModel.extend(DG.NumericPlotModelMixin,
                       enabled: YES
                     }
                   ],
-                  value: false,
+                  value: this_.get('displayAsBinned'),
+                  valueDidChange: function () {
+                    var value = this.get('value');
+                    this_.set('displayAsBinned', value);
+                    DG.mainPage.mainPane.hideInspectorPicker();
+                  }.observes('value'),
                   itemTitleKey: 'title',
                   itemValueKey: 'value',
                   itemIsEnabledKey: 'enabled',

--- a/apps/dg/components/graph/plots/univariate_plot_view.js
+++ b/apps/dg/components/graph/plots/univariate_plot_view.js
@@ -78,10 +78,20 @@ DG.UnivariatePlotView = DG.PlotView.extend(
       }.observes('*model.secondaryAxisPlace', 'xAxisView', 'yAxisView'),
 
       /**
-       * The secondaryAxisView needs to be told that its tick marks and labels are not to be centered in each cell.
-       * Though this is the default, if the prior plot was a dot chart, the axis will be stuck in centering mode.
+       * Prepare axes for univariate plot, including resetting plot-specific values.
        */
       setupAxes: function () {
+        // Review question: would these resets make more sense in DG.PlotView?
+        var tPrimaryAxisModel = this.getPath('primaryAxisView.model');
+        if (tPrimaryAxisModel) {
+          if (tPrimaryAxisModel.get('preferZeroLowerBound'))
+            tPrimaryAxisModel.set('preferZeroLowerBound', false);
+          if (tPrimaryAxisModel.get('drawZeroLine'))
+            tPrimaryAxisModel.set('drawZeroLine', false);
+        }
+
+        // The secondaryAxisView needs to be told that its tick marks and labels are not to be centered in each cell.
+        // Though this is the default, if the prior plot was a dot chart, the axis will be stuck in centering mode.
         var tCellAxis = this.get('secondaryAxisView');
         if (tCellAxis) {
           tCellAxis.set('centering', false);
@@ -160,4 +170,3 @@ DG.UnivariatePlotView = DG.PlotView.extend(
       }
 
     });
-

--- a/apps/dg/components/graph/utilities/plot_utilities.js
+++ b/apps/dg/components/graph/utilities/plot_utilities.js
@@ -411,7 +411,7 @@ DG.PlotUtilities = {
   },
 
   /**
-   * Modification of Raphael's setFillAndStroke, tuned to CODAP's situation of just working with circle elements
+   * Modification of Raphael's setFillAndStroke, tuned to CODAP's situation of just working with circle and rect elements
    * @param o {Raphael Element}
    * @param params {Object}
    */
@@ -438,15 +438,18 @@ DG.PlotUtilities = {
             o.transform(value);
             break;
           case "cx":
-            node.setAttribute(att, value);
-            o._.dirty = 1;
-            break;
           case "cy":
-            node.setAttribute(att, value);
-            o._.dirty = 1;
+          case "x":
+          case "y":
+          case "width":
+          case "height":
+            if (isFinite(value)) {
+              node.setAttribute(att, value);
+              o._.dirty = 1;
+            }
             break;
-          case "r":                 // eslint-disable-next-line eqeqeq
-            if (o.type == "rect") { // jshint ignore:line
+          case "r":
+            if (o.type == "rect") { // eslint-disable-line eqeqeq
               $(node, {rx: value, ry: value});
             } else {
               node.setAttribute(att, value);
@@ -469,21 +472,21 @@ DG.PlotUtilities = {
               $(node, {"fill-opacity": attrs["fill-opacity"]});
             }
             clr[has]("opacity") && $(node, {"fill-opacity": clr.opacity > 1 ?
-                clr.opacity / 100 : clr.opacity});  // jshint ignore:line
+                clr.opacity / 100 : clr.opacity});
             // fall through
           case "stroke":
             clr = R.getRGB(value);
-            node.setAttribute(att, clr.hex);            // eslint-disable-next-line eqeqeq
-            att == "stroke" && clr[has]("opacity") &&   // jshint ignore:line
+            node.setAttribute(att, clr.hex);
+            att == "stroke" && clr[has]("opacity") &&   // eslint-disable-line eqeqeq
               $(node, {"stroke-opacity": clr.opacity > 1 ? clr.opacity / 100 : clr.opacity});
             break;
           case "opacity":
             if (attrs.gradient && !attrs[has]("stroke-opacity")) {
               $(node, {"stroke-opacity": value > 1 ? value / 100 : value});
-            }  // jshint ignore:line
+            }
           // fall through
-          default:                                                      // eslint-disable-next-line eqeqeq
-            att == "font-size" && (value = parseInt(value, 10) + "px"); // jshint ignore:line
+          default:
+            att == "font-size" && (value = parseInt(value, 10) + "px"); // eslint-disable-line eqeqeq
             var cssrule = att.replace(/(\-.)/g, function (w) {
               return w.substring(1).toUpperCase();
             });
@@ -533,4 +536,3 @@ DG.PlotUtilities = {
   }
 
 };
-

--- a/apps/dg/components/graph_map_common/data_display_controller.js
+++ b/apps/dg/components/graph_map_common/data_display_controller.js
@@ -288,7 +288,7 @@ DG.DataDisplayController = DG.ComponentController.extend(
                       init: function () {
                         sc_super();
                         this_.getPath('dataDisplayModel.configurationDescriptions').forEach(function (iDesc) {
-                          iDesc.properties.layout = {height: kRowHeight};
+                          iDesc.properties.layout = Object.assign({height: kRowHeight}, iDesc.properties.layout);
                           iDesc.properties.localize = true;
                           this.appendChild(iDesc.constructorClass.create(iDesc.properties));
                         }.bind(this));
@@ -975,4 +975,3 @@ DG.DataDisplayController = DG.ComponentController.extend(
 
     }()) // function closure
 );
-

--- a/apps/dg/components/graph_map_common/plot_layer.js
+++ b/apps/dg/components/graph_map_common/plot_layer.js
@@ -412,7 +412,6 @@ DG.PlotLayer = SC.Object.extend(DG.Destroyable,
       },
 
       callCreateElement: function (iCase, iIndex, iAnimate, iIsVisible) {
-        // console.log('create element at index ' + iIndex);
         var tPlottedElements = this.get('plottedElements'),
             tLayerManager = this.get('layerManager'),
             tDestLayer = tLayerManager.getLayer(DG.LayerNames.kPoints),
@@ -1155,4 +1154,3 @@ DG.PlotLayer = SC.Object.extend(DG.Destroyable,
       }
 
     });
-

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -30,7 +30,7 @@ SC.stringsFor("en", {
     "DG.mainPage.mainPane.messageView.value": "Unfortunately, CODAP is not currently supported on your browser. CODAP is supported on Firefox 46+, Chrome 50+, Windows Edge 14+, and Safari 10+. CODAP is not actively supported on other browsers at this time.",
     "DG.mainPage.titleBar.saved": "Document Saved!",
     "DG.mainPage.exceptionMessage": "An error has occurred that may affect how this program behaves. You may wish to reload this page after you save your work. (Error: %@)",
-  
+
     // IS_BUILD variants of strings for InquirySpace
     "DG.mainPage.mainPane.versionString.IS_BUILD": "Version %@ (%@ IS)",
 
@@ -904,7 +904,9 @@ SC.stringsFor("en", {
     "DG.Inspector.graphBoxPlotShowOutliers": "Show Outliers",
     "DG.Inspector.graphPlottedValue": "Plotted Value",
     "DG.Inspector.graphBarChart": "Fuse Dots into Bars",
+    "DG.Inspector.graphPlotPoints": "Points",
     "DG.Inspector.graphGroupIntoBins": "Group into Bins",
+    "DG.Inspector.graphBarForEachPoint": "Bar for Each Point",
     "DG.Inspector.graphBinWidth": "Bin width",
     "DG.Inspector.graphAlignment": "Alignment",
 

--- a/apps/dg/utilities/tool_tip.js
+++ b/apps/dg/utilities/tool_tip.js
@@ -23,7 +23,7 @@
   @extends SC.Object
 */
 DG.ToolTip = SC.Object.extend(
-/** @scope DG.ToolTip.prototype */ 
+/** @scope DG.ToolTip.prototype */
 {
   /**
     Our gateway to attributes, values, and axes
@@ -131,9 +131,9 @@ DG.ToolTip = SC.Object.extend(
 
     // Adjust tX and tY so that the tip will be within the plotview
     if( tX + tShadowXOffset > tPaper.width)
-      tX -= (tX + tShadowXOffset) - tPaper.width;
+      tX = Math.max(-kRectXOffset, tX - (tX + tShadowXOffset - tPaper.width));
     if( tY + tShadowYOffset + tRectHeight > tPaper.height)
-      tY -= (tY + tShadowYOffset + tRectHeight) - tPaper.height;
+      tY = Math.max(-kRectYOffset, tY - (tY + tShadowYOffset + tRectHeight - tPaper.height));
     // If the tip rectangle encompasses tipOrigin, move the tip rectangle up and to the left
     if( DG.ViewUtilities.ptInRect( this.tipOrigin,
             { x: tX, y: tY, width: tRectWidth + kShadowWidth + 5, height: tRectHeight + kShadowWidth + 5})) {
@@ -190,4 +190,3 @@ DG.ToolTip = SC.Object.extend(
   }
 
 });
-

--- a/lang/strings/en-US.json
+++ b/lang/strings/en-US.json
@@ -30,7 +30,7 @@
     "DG.mainPage.mainPane.messageView.value": "Unfortunately, CODAP is not currently supported on your browser. CODAP is supported on Firefox 46+, Chrome 50+, Windows Edge 14+, and Safari 10+. CODAP is not actively supported on other browsers at this time.",
     "DG.mainPage.titleBar.saved": "Document Saved!",
     "DG.mainPage.exceptionMessage": "An error has occurred that may affect how this program behaves. You may wish to reload this page after you save your work. (Error: %@)",
-  
+
     // IS_BUILD variants of strings for InquirySpace
     "DG.mainPage.mainPane.versionString.IS_BUILD": "Version %@ (%@ IS)",
 
@@ -904,7 +904,9 @@
     "DG.Inspector.graphBoxPlotShowOutliers": "Show Outliers",
     "DG.Inspector.graphPlottedValue": "Plotted Value",
     "DG.Inspector.graphBarChart": "Fuse Dots into Bars",
+    "DG.Inspector.graphPlotPoints": "Points",
     "DG.Inspector.graphGroupIntoBins": "Group into Bins",
+    "DG.Inspector.graphBarForEachPoint": "Bar for Each Point",
     "DG.Inspector.graphBinWidth": "Bin width",
     "DG.Inspector.graphAlignment": "Alignment",
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -691,11 +691,6 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -1603,11 +1598,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
     "core-js-pure": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
@@ -1688,11 +1678,10 @@
       }
     },
     "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
+      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
       "requires": {
-        "fbjs": "^0.8.9",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
@@ -2132,14 +2121,6 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -2754,20 +2735,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      }
     },
     "fd-slicer": {
       "version": "1.0.1",
@@ -3836,6 +3803,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -4313,7 +4281,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.5",
@@ -4380,15 +4349,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/isomorphic-base64/-/isomorphic-base64-1.0.2.tgz",
       "integrity": "sha1-9Caq6CVpuopOxcpzrSGkSrHueAM="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -5223,15 +5183,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -6041,14 +5992,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -6618,7 +6561,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "scheduler": {
       "version": "0.19.1",
@@ -6648,12 +6592,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
-    },
-    "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
     "set-blocking": {
@@ -6688,7 +6626,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
@@ -7489,16 +7428,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -7514,6 +7453,15 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
           }
         }
       }
@@ -7732,11 +7680,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "union-value": {
       "version": "1.0.1",
@@ -8103,11 +8046,6 @@
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
   "dependencies": {
     "@concord-consortium/slate-editor": "^0.5.0",
     "codemirror": "^5.39.2",
-    "create-react-class": "^15.6.3",
+    "create-react-class": "^15.7.0",
     "dayjs": "^1.8.14",
     "es5-shim": "^4.5.14",
     "es6-shim": "^0.35.5",


### PR DESCRIPTION
@bfinzer I've updated the PR to fix the remaining issues we were aware of. The failure to respond to changes after restoring from document turned out to be due to `DG.PlotUtilities.setPlottedPointAttributes()` failure to handle `rect` attributes, which was apparently introduced as part of a performance optimization four years ago. When that function (like Raphael's `attr()` function upon which it is based) encounters an attribute it doesn't recognize, it installs it as a CSS `style` attribute. Since `rect` attributes were not explicitly handled, they were installed as part of the CSS `style`, and inline styles override SVG attributes. The result was that Raphael was properly animating the SVG attributes as requested, but those SVG attributes had no effect in the presence of the overriding inline style.