### PR TITLE
WIP: Bar chart formula

### DIFF
--- a/apps/dg/components/graph/graph_view.js
+++ b/apps/dg/components/graph/graph_view.js
@@ -1399,6 +1399,9 @@ DG.GraphView = SC.View.extend(
           case DG.BarChartModel:
             tNewViewClass = DG.BarChartView;
             break;
+          case DG.ComputedBarChartModel:
+            tNewViewClass = DG.ComputedBarChartView;
+            break;
         }
         return tNewViewClass;
       },

--- a/apps/dg/components/graph/plots/bar_chart_base_model.js
+++ b/apps/dg/components/graph/plots/bar_chart_base_model.js
@@ -1,0 +1,196 @@
+// ==========================================================================
+//                          DG.BarChartBaseModel
+//
+//  Author:   William Finzer, Kirk Swenson
+//
+//  Copyright (c) 2020 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+
+sc_require('components/graph/plots/chart_model');
+sc_require('components/graph/plots/numeric_plot_model_mixin');
+
+/** @class  DG.BarChartBaseModel - The model for a plot with categorical axes
+
+ @extends DG.ChartModel
+ */
+DG.BarChartBaseModel = DG.ChartModel.extend(DG.NumericPlotModelMixin,
+    /** @scope DG.BarChartBaseModel.prototype */
+    {
+      /**
+       * Override
+       * @property {Boolean}
+       */
+      displayAsBarChart: true,
+
+      /**
+       * For non-computed bar charts, whether to show count or percent
+       * @property {DG.Analysis.EBreakdownType}
+       */
+      breakdownType: DG.Analysis.EBreakdownType.eCount,
+
+      /**
+       * Whether the bar height is computed from a formula.
+       * @property {Boolean}
+       */
+      isBarHeightComputed: false,
+
+      /**
+       * We want an 'other' axis for count or percent.
+       * @property {Boolean}
+       */
+      wantsOtherAxis: true,
+
+      /**
+       * When making a copy of a plot (e.g. for use in split) the returned object
+       * holds those properties that should be assigned to the copy.
+       * @return {{}}
+       */
+      getPropsForCopy: function() {
+        var tResult = sc_super();
+        return $.extend( tResult, {
+          breakdownType: this.get('breakdownType')
+        });
+      },
+
+      /**
+       *
+       * @param iPlace {DG.GraphTypes.EPlace}
+       * @return { class }
+       */
+      getDesiredAxisClassFor: function( iPlace) {
+        if( iPlace === this.get('primaryAxisPlace'))
+          return DG.CellAxisModel;
+        return sc_super();
+      },
+
+      /**
+       * Change the value corresponding to the given key
+       * @param iKey {String} Should be 'breakdownType'
+       * @param iValue {Boolean}
+       */
+      changeBreakdownType: function( iKey, iValue) {
+        var tInitialValue = this.get(iKey);
+        DG.UndoHistory.execute(DG.Command.create({
+          name: "graph.changeBreakdownType",
+          undoString: 'DG.Undo.graph.changeBreakdownType',
+          redoString: 'DG.Redo.graph.changeBreakdownType',
+          log: ("change %@ from %@ to %@").fmt(iKey, tInitialValue, iValue),
+          execute: function() {
+            this.set(iKey, iValue);
+          }.bind(this),
+          undo: function() {
+            this.set(iKey, tInitialValue);
+          }.bind(this)
+        }));
+      },
+
+      lastConfigurationControls: function () {
+        var tControls = sc_super(),
+            this_ = this,
+            kRowHeight = 18,
+            kChartRadioCount = 0,     // === DG.Analysis.EBreakdownType.eCount
+            kChartRadioPercent = 1,   // === DG.Analysis.EBreakdownType.ePercent
+            kChartRadioFormula = 2;
+
+        function mapModelValuesToRadioValue() {
+          return this_.get('isBarHeightComputed')
+                  ? kChartRadioFormula
+                  : this_.get('breakdownType');
+        }
+
+        tControls.push(
+            SC.LabelView.create({
+              layout: {height: kRowHeight},
+              value: 'DG.Inspector.displayScale',
+              localize: true
+            })
+        );
+
+        tControls.push(
+            SC.RadioView.create({
+              itemTitleKey: 'title',
+              itemValueKey: 'value',
+              items: [
+                { value: kChartRadioCount, title: 'DG.Inspector.graphCount'.loc() },
+                { value: kChartRadioPercent, title: 'DG.Inspector.graphPercent'.loc() },
+                { value: kChartRadioFormula, title: 'DG.Inspector.graphFormula'.loc() }
+              ],
+              value: mapModelValuesToRadioValue(this_),
+              layoutDirection: SC.LAYOUT_VERTICAL,
+              layout: {height: 3.5 * kRowHeight},
+              classNames: 'dg-inspector-radio'.w(),
+              valueDidChange: function () {
+                var currValue = mapModelValuesToRadioValue(this_);
+                switch(this.value) {
+                  case kChartRadioCount:
+                  case kChartRadioPercent:
+                    if (currValue !== kChartRadioFormula) {
+                      // we're not switching plot type
+                      this_.changeBreakdownType('breakdownType', this.value);
+                      break;
+                    }
+                    // so it will be copied to the new plot
+                    this_.set('breakdownType', this.value);
+                    // fallthrough
+                  case kChartRadioFormula:
+                    // we're switching to/from a computed bar chart
+                    this_.set('isBarHeightComputed', this.value === kChartRadioFormula);
+                    DG.mainPage.mainPane.hideInspectorPicker();
+                    break;
+                }
+              }.observes('value')
+            })
+        );
+        return tControls;
+      }.property('plot'),
+
+      /**
+       Each axis should rescale based on the values to be plotted with it.
+       @param iAllowScaleShrinkage{Boolean} Default is false
+       @param iAnimatePoints {Boolean} Default is true
+       @param iLogIt {Boolean} Default is false
+       @param iUserAction {Boolean} Default is false
+       */
+      rescaleAxesFromData: function (iAllowScaleShrinkage, iAnimatePoints, iLogIt, iUserAction) {
+        if (iAnimatePoints === undefined)
+          iAnimatePoints = true;
+        this.doRescaleAxesFromData([this.get('secondaryAxisPlace')], iAllowScaleShrinkage, iAnimatePoints, iUserAction);
+        if (iLogIt)
+          DG.logUser("rescaleBarChart");
+      },
+
+      /**
+       * @return {Object} the saved data.
+       */
+      createStorage: function () {
+        var tStorage = sc_super();
+
+        tStorage.breakdownType = this.breakdownType;
+
+        return tStorage;
+      },
+
+      /**
+       * @param iStorage
+       */
+      restoreStorage: function (iStorage) {
+        sc_super();
+        if (!SC.none(iStorage.breakdownType)) {
+          this.set( 'breakdownType', iStorage.breakdownType);
+        }
+      }
+
+
+    });

--- a/apps/dg/components/graph/plots/bar_chart_base_view.js
+++ b/apps/dg/components/graph/plots/bar_chart_base_view.js
@@ -1,0 +1,569 @@
+// ==========================================================================
+//                          DG.BarChartBaseView
+//
+//  Author:   William Finzer
+//
+//  Copyright (c) 2017 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+
+sc_require('components/graph/plots/chart_view');
+
+/* global pluralize */
+
+/** @class  DG.BarChartBaseView, a plot of rectangles, one for each category. Each rectangle is made of
+ * thinner rectangles, one for each case.
+
+ @extends DG.ChartView
+ */
+DG.BarChartBaseView = DG.ChartView.extend(
+  /** @scope DG.BarChartBaseView.prototype */
+  {
+    /**
+     * Expected type of plotted elements
+     */
+    plottedElementType: 'rect',
+
+    /**
+     * If we're displaying as a barchart, this is how high the slices are in a given bar
+     * @property {[Number]}
+     */
+    barSliceHeights: null,
+
+    _categoryCellToolTip: null,
+    categoryCellToolTip: function() {
+      if( !this._categoryCellToolTip) {
+        this._categoryCellToolTip = DG.ToolTip.create( { paperSource: this,
+          layerName: 'dataTip' });
+      }
+      return this._categoryCellToolTip;
+    }.property(),
+
+    /**
+     * @property {DG.Layer}
+     */
+    _coverRectsLayer: null,
+    coverRectsLayer: function () {
+      if (!this._coverRectsLayer && this.getPath('paperSource.layerManager')) {
+        this._coverRectsLayer = this.getPath('paperSource.layerManager.' + DG.LayerNames.kCoverRects);
+      }
+      return this._coverRectsLayer;
+    }.property(),
+
+    upperBoundDidChange: function () {
+      this.computeCellParams();
+      this.displayDidChange();
+    }.observes('*secondaryAxisView.model.upperBound'),
+
+    init: function () {
+      sc_super();
+
+      this.barSliceHeights = [];
+    },
+
+    destroy: function() {
+      var tLayerManager = this.get('layerManager'),
+          tPlottedElements = this.get('plottedElements');
+      tPlottedElements.forEach( function( iElement) {
+        tLayerManager.removeElement( iElement, true /* callRemove */);
+      });
+      tPlottedElements.length = 0;
+      this.get('coverRectsLayer').clear();
+
+      sc_super();
+    },
+
+    dataRangeDidChange: function (iSource, iQuestion, iKey, iChanges) {
+      var this_ = this,
+          tCases = this.getPath('model.cases'),
+          tRC = this.createRenderContext(),
+          tChanges = (SC.typeOf(iChanges) === SC.T_NUMBER ? [iChanges] : iChanges);
+      tChanges = tChanges || [];
+
+      this.model.invalidateCaches();
+      this.computeCellParams();
+
+      tChanges.forEach(function (iIndex) {
+        // We can get in here after a delete, in which case, iChanges can be referring to
+        // a plot element that no longer exists.
+        if (!this_.get('plottedElements')[iIndex])
+          this_.callCreateElement(tCases.at(iIndex), iIndex, this_._createAnimationOn);
+        var tCellIndices = this_.get('model').lookupCellForCaseIndex(iIndex);
+        this_.privSetElementCoords(tRC, tCases.at(iIndex), iIndex, tCellIndices);
+      });
+      sc_super();
+    },
+
+    /**
+     * Construct and return a new render context
+     * used for setCircleCoordinate()
+     * @return {*}
+     */
+    createRenderContext: function () {
+      var tRC = sc_super();
+
+      // cache some more render parameters common to all cases, but unique to BarChartBaseView.
+      tRC.barSliceHeights = this.get('barSliceHeights');
+      tRC.barWidth = tRC.primaryAxisView.get('fullCellWidth') / 2;
+
+      return tRC;
+    },
+
+    /**
+     * If defined, this function gets called after cases have been added or values changed, but only once,
+     * and only after a sufficient time has elapsed.
+     * @property { Function }
+     */
+    cleanupFunc: function () {
+      this.get('model').rescaleAxesFromData( true /* allow shrinkage */, true /* allow animation */);
+      sc_super();
+    },
+
+    /**
+     * @param iCase
+     * @param iIndex
+     * @param iAnimate
+     */
+    createElement: function (iCase, iIndex, iAnimate) {
+      // Can't create rects if we don't have paper for them
+      if (!this.get('paper')) return;
+
+      var tRect = this.get('paper').rect(-1000, -1000, 0, 0)
+          .attr({
+            fill: DG.PlotUtilities.kDefaultPointColor,
+            stroke: 'none'
+          });
+      tRect.node.setAttribute('shape-rendering', 'geometric-precision');
+      /*
+              if (iAnimate)
+                DG.PlotUtilities.doCreateRectAnimation(tRect);
+      */
+      return tRect;
+    },
+
+    updateAllCoordinates: function (iAnimate, iCallback) {
+      var tModel = this.get('model'),
+          tRC = this.createRenderContext(),
+          tCases = this.getPath('model.cases'),
+          tDataLength = tCases && tCases.get('length');
+      tCases.forEach(function (iCase, iIndex) {
+        var tCallback = iIndex === tDataLength - 1 ? iCallback : null,
+            tCellIndices = tModel.lookupCellForCaseIndex(iIndex);
+        this.privSetElementCoords(tRC, iCase, iIndex, tCellIndices, iAnimate, tCallback);
+      }.bind(this));
+    },
+
+    /**
+     @param { Boolean }
+      @param { Function }
+      */
+    updateElements: function (iAnimate, iCallback) {
+      // It's possible to get here before didCreateLayer() creates the get('paper').
+      if (!this.get('paper'))
+        return;
+      sc_super();
+      this.computeCellParams();
+      var tModel = this.get('model'),
+          tCases = this.getPath('model.cases'),
+          tRC = this.createRenderContext(),
+          tDataLength = tCases && tCases.get('length'),
+          tPlottedElements = this.get('plottedElements'),
+          tPlotElementLength = tPlottedElements.length,
+          tLayerManager = this.get('layerManager'),
+          tIndex, tCellIndices;
+
+      // for any new cases
+      if (tDataLength > tPlotElementLength) {
+        // add plot elements for added cases
+        for (tIndex = tPlotElementLength; tIndex < tDataLength; tIndex++) {
+          this.callCreateElement(tCases.at(tIndex), tIndex, this.animationIsAllowable());
+          tCellIndices = tModel.lookupCellForCaseIndex(tIndex);
+          this.privSetElementCoords(tRC, tCases.at(tIndex), tIndex, tCellIndices, iAnimate, iCallback);
+        }
+      }
+      // Get rid of plot elements for removed cases and update all coordinates
+      if (tDataLength < tPlotElementLength) {
+        for (tIndex = tDataLength; tIndex < tPlotElementLength; tIndex++) {
+          // It can happen during closing of a document that the elements no longer exist, so we have to test
+          if (!SC.none(tPlottedElements[tIndex])) {
+            tPlottedElements[tIndex].stop();
+            DG.PlotUtilities.doHideRemoveAnimation(tPlottedElements[tIndex], tLayerManager);
+          }
+        }
+        // update all coordinates because we don't know which cases were deleted
+        this.updateAllCoordinates(iAnimate, iCallback);
+      }
+      this._isRenderingValid = false;
+    },
+
+    /**
+     Only recreate elements if necessary. Otherwise, just set svg element coordinates.
+      */
+    drawData: function drawData() {
+      sc_super();
+
+      // this.updateSelection();
+
+      this.drawSubBars();
+    },
+
+    getBarHeight: function(iPrimaryName, iCount, iTotal) {
+      return this.getPath('model.breakdownType') === DG.Analysis.EBreakdownType.eCount
+              ? iCount : 100 * iCount / iTotal;
+    },
+
+    /**
+     * Cases are stacked as rectangles, grouped first by a primary attribute and then by a legend attribute.
+     */
+    drawSubBars: function () {
+
+      /**
+       * iPrimaryCoord - left/bottom edge of cell on primary/categorical axis
+       * iStartCoord - bottom/left edge of bar [segment] on secondary/numeric axis
+       *                (top/right edge of previous bar [segment])
+       * iCount - count of cases represented by this bar [segment]
+       * iCaseIndices - the indices of the cases represented by this bar [segment]
+       * iNumCasesInContainingCell - the number of cases in the current cell
+       *                (used for tooltip and percentage calculations)
+       * iCategoryName - the legend category for the current cell, if any (used for tooltip)
+       * iPrimaryName - the primary axis category for the current cell (used for tooltip)
+       * iTotalNumCases - the total number of cases in all cells (used for tooltip only when no legend is present)
+       */
+      var makeRect = function (iPrimaryCoord, iStartCoord, iCount, iCaseIndices,
+                                iNumCasesInContainingCell, iCategoryName, iPrimaryName, iTotalNumCases) {
+        var this_ = this,
+            tTemplate, tToolTipText, tToolTip,
+            tBarTop = this.getBarHeight(iPrimaryName, iCount, iNumCasesInContainingCell),
+            tCurrCoord = tRC.secondaryAxisView.dataToCoordinate(tBarTop),
+            tX, tY, tWidth, tHeight;
+        if( tRC.isVerticalOrientation) {
+          tX = iPrimaryCoord - tRC.barWidth / 2 - 1;
+          tY = tCurrCoord - 1;
+          tWidth = tRC.barWidth + 2;
+          tHeight = iStartCoord - tCurrCoord + 2;
+        }
+        else {
+          tX = iStartCoord;
+          tY = iPrimaryCoord - tRC.barWidth / 2 - 1;
+          tWidth = tCurrCoord + 2 - iStartCoord;
+          tHeight = tRC.barWidth + 2;
+        }
+        var tRect = tPaper.rect( tX, tY, tWidth, tHeight)
+                .attr({stroke: 'none', fill: 'white', 'fill-opacity': 0.001, cursor: 'pointer'})
+                .hover(function (iEvent) {
+                      // Note that Firefox can come through here repeatedly so we have to check for existence
+                      this.animate({
+                        'fill-opacity': 0.4
+                      }, DG.PlotUtilities.kDataTipShowTime);
+                      tToolTip = this_.get('categoryCellToolTip');
+                      if( !SC.none( tLegendVarID)) {
+                        tTemplate = this.caseIndices.length > 1 ? "DG.BarChartModel.cellTipPlural" :
+                            "DG.BarChartModel.cellTipSingular";
+                        if (this.numCasesInContainingCell > 1) {
+                          iPrimaryName = pluralize(iPrimaryName);
+                          if (iPrimaryName.endsWith("S")) {
+                            iPrimaryName = iPrimaryName.replace(/S$/, 's');
+                          }
+                        }
+                        tToolTipText = tTemplate.loc(
+                            this.caseIndices.length,
+                            this.numCasesInContainingCell,
+                            iPrimaryName,
+                            Math.round(1000 * this.caseIndices.length / this.numCasesInContainingCell) / 10,
+                            iCategoryName
+                        );
+                      }
+                      else {
+                        tTemplate = this.caseIndices.length > 1 ? "DG.BarChartModel.cellTipNoLegendPlural" :
+                            "DG.BarChartModel.cellTipNoLegendSingular";
+                        tToolTipText = tTemplate.loc(
+                            this.caseIndices.length,
+                            iTotalNumCases,
+                            Math.round(1000 * this.caseIndices.length / iTotalNumCases) / 10,
+                            iPrimaryName
+                        );
+                      }
+                      tToolTip.set('text', tToolTipText);
+                      tToolTip.set('tipOrigin', {x: iEvent.layerX, y: iEvent.layerY});
+                      tToolTip.show();
+                    },
+                    function (event) { // out
+                      this.stop();
+                      this.animate({
+                        'fill-opacity': 0.001
+                      }, DG.PlotUtilities.kHighlightHideTime);
+                      if(tToolTip)
+                        tToolTip.hide();
+                    }
+                )
+                .mousedown(function (iEvent) {
+                  SC.run(function () {
+                    this_.get('model').selectCasesWithIndices(this.caseIndices, iEvent.shiftKey);
+                  }.bind( this));
+                });
+        tRect.caseIndices = iCaseIndices;
+        tRect.numCasesInContainingCell = iNumCasesInContainingCell;
+        tCoverRectsLayer.push(tRect);
+        return tCurrCoord;
+      }.bind(this);
+
+      var tPaper = this.get('paper'),
+          tCoverRectsLayer = this.get('coverRectsLayer'),
+          tCellArray = this.getPath('model.cachedCells'),
+          tRC = this.createRenderContext(),
+          tPrimaryVarID = this.getPath('model.primaryVarID'),
+          tLegendVarID = this.getPath('model.legendVarID'),
+          tTotalNumCases = this.getPath('model.cases').length();
+      tCoverRectsLayer.clear();
+      tCellArray.forEach(function (iPrimary, iPrimaryIndex) {
+        // This is the primary division. It has an array for each category on the secondary axis
+        var tPrimaryCoord = tRC.primaryAxisView.cellToCoordinate(iPrimaryIndex),
+            tPrimaryName = iPrimary[0][0].theCase.getValue(tPrimaryVarID);
+        iPrimary.forEach(function (iSecondary, iSecondaryIndex) {
+          var tCount = 0,
+              tTotalNumCasesInPrimary = iSecondary.length,
+              tBarTop = this.getBarHeight(tPrimaryName, tCount, tTotalNumCasesInPrimary),
+              tPreviousCoord = tRC.secondaryAxisView.dataToCoordinate(tBarTop),
+              tPreviousValue = null,
+              tCaseIndices = [],
+              tValue;
+          // The given array contains an element for each case belonging to this stack
+          iSecondary.forEach(function (iCaseContainer, iIndex) {
+            tValue = iCaseContainer.theCase.getValue(tLegendVarID);
+            // don't render the first bar segment since it's rendered below
+            if (tPreviousValue && tValue !== tPreviousValue) {
+              tPreviousCoord = makeRect(tPrimaryCoord, tPreviousCoord, tCount,
+                  tCaseIndices, tTotalNumCasesInPrimary, tPreviousValue, tPrimaryName);
+              tCaseIndices = [];
+            }
+            tCaseIndices.push( iCaseContainer.caseIndex);
+            tCount++;
+            tPreviousValue = tValue;
+          }.bind(this));
+          // renders the bar for simple bar charts and the first bar segment for split bars
+          makeRect(tPrimaryCoord, tPreviousCoord, tCount,
+              tCaseIndices, tTotalNumCasesInPrimary, tValue, tPrimaryName, tTotalNumCases);
+        }.bind(this));
+      }.bind(this));
+    },
+
+    /**
+     Override base class because we're dealing with rectangles, not points.
+      @return {Array of {x:{Number}, y:{Number}, width:{Number}, height:{Number}, cx:{Number}, cy:{Number}, r:{Number}, fill:{String}}}
+      */
+    getElementPositionsInParentFrame: function() {
+
+      var tFrame = this.get('frame');
+      return this.get('plottedElements').map( function( iElement) {
+        var tX = iElement.attr('x') + tFrame.x,
+            tY = iElement.attr('y') + tFrame.y,
+            tWidth = iElement.attr('width'),
+            tHeight = iElement.attr('height'),
+            tR = 0, //Math.min( tWidth, tHeight) / 2,
+            tCx = tX + tWidth / 2,
+            tCy = tY + tHeight / 2,
+            tResult = { x: tX, y: tY, width: tWidth, height: tHeight, cx: tCx, cy: tCy, r: tR,
+              fill: iElement.attr('fill'), type: 'rect', stroke: iElement.attr('stroke'),
+              'stroke-opacity': iElement.attr('stroke-opacity')
+            };
+        return tResult;
+      });
+    },
+
+    /**
+     We override the base class implementation
+      */
+    animateFromTransferredElements: function () {
+      var this_ = this,
+          tModel = this.get('model'),
+          tCases = tModel.get('cases'),
+          tRC = this.createRenderContext(),
+          tFrame = this.get('frame'), // to convert from parent frame to this frame
+          tOldElementAttrs = this.get('transferredElementCoordinates'),
+          tNewElementAttrs = [], // used if many-to-one animation (parent to child collection)
+          tNewToOldCaseMap = [],
+          tOldToNewCaseMap = [],
+          tOldElementsAreCircles = tOldElementAttrs[0] && tOldElementAttrs[0].type === 'circle';
+      if (!tCases)
+        return;
+
+      function turnOffAnimation() {
+        tModel.set('isAnimating', false);
+        this_.get('plottedElements').forEach( function( iElement) {
+          iElement.stop();
+        });
+        this_.displayDidChange(); // Force redisplay in correct position
+      }
+
+      function caseLocationSimple(iIndex) {
+        // assume a 1 to 1 correspondence of the current case indices to the new cases
+        return tOldElementAttrs[iIndex];
+      }
+
+      function caseLocationViaMap(iIndex) {
+        // use our case index map to go from current case index to previous case index
+        return tOldElementAttrs[tNewToOldCaseMap[iIndex]];
+      }
+
+      DG.sounds.playMixup();
+      this._getTransferredElementsToCasesMap(tNewToOldCaseMap, tOldToNewCaseMap);
+      var hasElementMap = tNewToOldCaseMap.length > 0,
+          hasVanishingElements = tOldToNewCaseMap.length > 0,
+          getCaseCurrentLocation = (hasElementMap ? caseLocationViaMap : caseLocationSimple),
+          tPlottedElements = this.get('plottedElements'),
+          tTransAttrs;
+
+      this.prepareToResetCoordinates();
+      this.removePlottedElements();
+      // Normally we leave the elements (circles) for re-use. But since we want rects, we have let go of the circles.
+      tPlottedElements.forEach( function( iElement) {
+        iElement.remove();
+      });
+      tPlottedElements.length = 0;
+      this.computeCellParams();
+      tOldElementAttrs.forEach(function (iElement, iIndex) {
+        // adjust old coordinates from parent frame to this view
+        // In case it's a point
+        iElement.cx -= tFrame.x;
+        iElement.cy -= tFrame.y;
+        // in case it's a rect
+        iElement.x -= tFrame.x;
+        iElement.y -= tFrame.y;
+      });
+      tCases.forEach(function (iCase, iIndex) {
+        var tOldElement = getCaseCurrentLocation(iIndex),
+            tCellIndices = tModel.lookupCellForCaseIndex(iIndex),
+            tElement = this_.callCreateElement(iCase, iIndex, false);
+        if (!SC.none(tOldElement)) {
+          tTransAttrs = {
+            r: tOldElementsAreCircles ? tOldElement.r : 0,
+            x: tOldElementsAreCircles ? tOldElement.cx - tOldElement.r : tOldElement.x,
+            y: tOldElementsAreCircles ? tOldElement.cy - tOldElement.r : tOldElement.y,
+            width: tOldElementsAreCircles ? 2 * tOldElement.r : tOldElement.width,
+            height: tOldElementsAreCircles ? 2 * tOldElement.r : tOldElement.height,
+            fill: tOldElement.fill,
+            stroke: tOldElement.fill
+          };
+          tElement.attr(tTransAttrs);
+        }
+        tElement = this_.privSetElementCoords(tRC, iCase, iIndex, tCellIndices, true /* animate */);
+        if (hasVanishingElements) {
+          tNewElementAttrs.push(tElement);
+        }
+      });
+      if (hasVanishingElements) {
+        // create a vanishing element for each old element that needs one (used if many-to-one animation)
+        tOldElementAttrs.forEach(function (iOldAttrs, iIndex) {
+          var tNewIndex = tOldToNewCaseMap[iIndex],
+              tNewAttrs = tNewElementAttrs[tNewIndex];
+          if (SC.none(tNewIndex) || SC.none(tNewAttrs) || (iOldAttrs.r === 0))
+            return; // no vanishing element, if (1) element persists or (2) new element hidden or (3) old element hidden
+          this_.vanishPlottedElement(iOldAttrs, tNewAttrs);
+        });
+      }
+      this.set('transferredElementCoordinates', null);
+
+      tModel.set('isAnimating', true);
+      SC.Timer.schedule({action: turnOffAnimation, interval: DG.PlotUtilities.kDefaultAnimationTime});
+    },
+
+    /**
+     We need to decide on the number of points in a row. To do so, we find the
+      maximum number of points in a cell and choose so that this max number will
+      fit within the length of a cell rect. If there are so many points that they don't fit
+      even by using the full length of a cell rect, then we compute an overlap.
+      */
+    computeCellParams: function () {
+      var tMaxInCell = this.getPath('model.maxInCell'),
+          tSecondaryAxisView = this.get('secondaryAxisView'),
+          tCoordOfMaxInCell = tSecondaryAxisView.dataToCoordinate(tMaxInCell),
+          tCoordOf100Percent = tSecondaryAxisView.dataToCoordinate(100),
+          tCoordOfZero = tSecondaryAxisView.dataToCoordinate(0),
+          tBreakdownType = this.getPath('model.breakdownType'),
+          tMinBarSliceHeight = Math.abs(tCoordOfMaxInCell - tCoordOfZero) / tMaxInCell,
+          tSliceHeights = this.getPath('model.primaryCellCounts').map(function (iCount) {
+            var tSliceHeight = 0;
+            switch (tBreakdownType) {
+              case DG.Analysis.EBreakdownType.eCount:
+                tSliceHeight = tMinBarSliceHeight;
+                break;
+              case DG.Analysis.EBreakdownType.ePercent:
+                tSliceHeight = Math.abs(tCoordOf100Percent - tCoordOfZero) / iCount;
+            }
+            return tSliceHeight;
+          });
+
+      this.setIfChanged('barSliceHeights', tSliceHeights);
+    }
+    ,
+
+    /**
+     *
+     * @param iRC {*}
+     * @param iCase {DG.Case}
+     * @param iIndex {Integer}
+     * @param iCellIndices {{primaryCell, secondaryCell, indexInCell}}
+     * @param iAnimate {Boolean}
+     * @param iCallback {Function}
+     */
+    privSetElementCoords: function (iRC, iCase, iIndex, iCellIndices, iAnimate, iCallback) {
+      DG.assert(iRC && iRC.xAxisView);
+      DG.assert(iCase);
+      DG.assert(DG.MathUtilities.isInIntegerRange(iIndex, 0, this.get('plottedElements').length));
+      var tRect = this.get('plottedElements')[iIndex]/*,
+      tIsMissingCase = SC.none( iCellIndices )*/;
+
+      // It can happen that we don't have cell indices yet. Bail for now cause we'll be back later.
+      if( !iCellIndices)
+        return;
+
+      // show or hide if needed, then update if shown.
+      // if( this.showHidePlottedElement(tRect, tIsMissingCase)) {
+
+      var tCellHalfWidth = iRC.barWidth,
+          tCellHeight = iRC.secondaryAxisView.get('fullCellWidth'),
+          tBarSliceHeight = iRC.barSliceHeights[iCellIndices.primaryCell],
+          tTop = (iCellIndices.indexInCell + 1) * tBarSliceHeight,
+          tEdge = iRC.primaryAxisView.cellToCoordinate(iCellIndices.primaryCell) -
+              tCellHalfWidth / 2,
+          tCoordX, tCoordY, tWidth, tHeight;
+
+      if (iRC.isVerticalOrientation) {
+        tCoordX = tEdge;
+        tCoordY = tCellHeight - tTop;
+        tWidth = tCellHalfWidth;
+        tHeight = tBarSliceHeight;
+      }
+      else {
+        tCoordX = tTop - tBarSliceHeight;
+        tCoordY = tEdge;
+        tWidth = tBarSliceHeight;
+        tHeight = tCellHalfWidth;
+      }
+      var tNewAttrs = {
+        x: tCoordX, y: tCoordY, r: 0.1, width: tWidth, height: tHeight,
+        fill: iRC.calcCaseColorString(iCase),
+        'fill-opacity': iRC.transparency,
+        'stroke-opacity': 0
+      };
+      if (iAnimate) {
+        tRect.animate(tNewAttrs, DG.PlotUtilities.kDefaultAnimationTime, '<>', iCallback);
+      }
+      else {
+        tRect.attr(tNewAttrs);
+      }
+      return tRect;
+    }
+  }
+);

--- a/apps/dg/components/graph/plots/bar_chart_formula_context.js
+++ b/apps/dg/components/graph/plots/bar_chart_formula_context.js
@@ -1,0 +1,103 @@
+sc_require('formula/collection_formula_context');
+
+/** @class  The formula context used by the PlottedFunctionModel
+
+ @extends DG.GlobalFormulaContext
+ */
+DG.BarChartFormulaContext = DG.CollectionFormulaContext.extend((function () {
+
+  return {
+
+    /**
+     Set on construction
+     @type {DG.PlotModel}
+     */
+    plotModel: null,
+
+    /**
+     Utility function for identifying the name of the primary attribute.
+     @returns  {String}  the name of the variable on the primary axis
+     */
+    primaryVarName: function () {
+      var varID = this.getPath('plotModel.primaryVarID'),
+          varAttr = varID && DG.Attribute.getAttributeByID(varID),
+          varName = varAttr && varAttr.get('name');
+      return varName || null;
+    }.property('plotModel'),
+
+    /**
+     Utility function for identifying the name of the X-axis attribute.
+     @param    {String}    iName -- The name of the identifier being matched
+     @returns  {Boolean}   True if the identifier matches the name of the
+     x-axis attribute, false otherwise.
+     */
+    isPrimaryVarName: function (iName) {
+      return !!iName && (iName === this.get('primaryVarName'));
+    }.property('primaryVarName'),
+
+    /**
+     Utility function for identifying the ID of the primary categorical attribute.
+     @returns  {String}  the ID of the primary categorical variable
+     */
+    groupVarID: function () {
+      // we always want to override the default
+      return this.getPath('plotModel.primaryVarID') || -1;
+    }.property('plotModel'),
+
+    /**
+     * Return true if the given case is currently among those being plotted.
+     *
+     * @param  {Object}              iEvalContext -- { _case_: , _id_: }
+     * @return {boolean}
+     */
+    filterCase: function (iEvalContext) {
+      var tResult = sc_super(),
+          tCases = this.getPath('plotModel.cases');
+      return tResult && tCases.indexOf(iEvalContext._case_) >= 0;
+    },
+
+    /**
+     Called when the formula has been recompiled to clear any stale dependencies.
+     Derived classes may override as appropriate.
+     */
+    didCompile: function () {
+      sc_super();
+
+      // register the 'plot' dependency for invalidation
+      var plotModel = this.get('plotModel'),
+          // TODO: use a more robust ID
+          plotID = DG.Debug.scObjectID(plotModel);
+      this.registerDependency({
+        independentSpec: {
+          type: DG.DEP_TYPE_PLOT,
+          id: plotID,
+          name: 'plot-' + plotID
+        },
+        aggFnIndices: this.ALL_FUNCTIONS
+      });
+    },
+
+    /**
+     Called by the DependencyMgr to invalidate dependent nodes.
+     @param {object}     ioResult
+     @param {object}     iDependent
+     @param {object}     iDependency
+     @param {DG.Case[]}  iCases - array of cases affected
+     if no cases specified, all cases are affected
+     @param {boolean}    iForceAggregate - treat the dependency as an aggregate dependency
+     */
+    invalidateDependent: function (ioResult, iDependent, iDependency, iCases, iForceAggregate) {
+      sc_super();
+
+      // invalidate affected aggregate functions
+      if (iDependency.aggFnIndices)
+        this.invalidateFunctions(iDependency.aggFnIndices);
+      // Note that there is a redundancy between this notification, which indicates when
+      // any dependent has changed, and the DG.GlobalFormulaContext sending of the same
+      // notification when a global value changes. Ultimately, the GlobalFormulaContext
+      // mechanism should be disabled, but we leave that for another day.
+      this.notifyPropertyChange('dependentChange');
+    }
+
+  }; // return from function closure
+}())); // function closure

--- a/apps/dg/components/graph/plots/bar_chart_model.js
+++ b/apps/dg/components/graph/plots/bar_chart_model.js
@@ -18,54 +18,24 @@
 //  limitations under the License.
 // ==========================================================================
 
-sc_require('components/graph/plots/chart_model');
-sc_require('components/graph/plots/numeric_plot_model_mixin');
+sc_require('components/graph/plots/bar_chart_base_model');
 
 /** @class  DG.BarChartModel - The model for a plot with categorical axes
 
- @extends DG.ChartModel
+ @extends DG.BarChartBaseModel
  */
-DG.BarChartModel = DG.ChartModel.extend(DG.NumericPlotModelMixin,
+DG.BarChartModel = DG.BarChartBaseModel.extend(
     /** @scope DG.BarChartModel.prototype */
     {
-      /**
-       * Override
-       * @property {Boolean}
-       */
-      displayAsBarChart: true,
-
-      breakdownType: DG.Analysis.EBreakdownType.eCount,
-
-      /**
-       * We want an 'other' axis for count or percent.
-       * @property {Boolean}
-       */
-      wantsOtherAxis: true,
-
-      /**
-       * When making a copy of a plot (e.g. for use in split) the returned object
-       * holds those properties that should be assigned to the copy.
-       * @return {{}}
-       */
-      getPropsForCopy: function() {
-        var tResult = sc_super();
-        return $.extend( tResult, {
-          breakdownType: this.get('breakdownType')
-        });
-      },
-
       /**
        *
        * @param iPlace {DG.GraphTypes.EPlace}
        * @return { class }
        */
       getDesiredAxisClassFor: function( iPlace) {
-        if( iPlace === this.get('primaryAxisPlace'))
-          return DG.CellAxisModel;
-        else if(iPlace === this.get('secondaryAxisPlace')) {
+        if(iPlace === this.get('secondaryAxisPlace'))
           return DG.CountAxisModel;
-        }
-        else return sc_super();
+        return sc_super();
       },
 
       naturalUpperBound: function () {
@@ -97,122 +67,7 @@ DG.BarChartModel = DG.ChartModel.extend(DG.NumericPlotModelMixin,
           isDataInteger: this.get('breakdownType') === DG.Analysis.EBreakdownType.eCount
         };
         return tResult;
-      },
-
-      /**
-       * Change the value corresponding to the given key
-       * @param iKey {String} Should be 'displayAsBinned'
-       * @param iValue {Boolean}
-       */
-      changeBreakdownType: function( iKey, iValue) {
-        var tInitialValue = this.get(iKey);
-        DG.UndoHistory.execute(DG.Command.create({
-          name: "graph.changeBreakdownType",
-          undoString: 'DG.Undo.graph.changeBreakdownType',
-          redoString: 'DG.Redo.graph.changeBreakdownType',
-          log: ("change %@ from %@ to %@").fmt(iKey, tInitialValue, iValue),
-          execute: function() {
-            this.set(iKey, iValue);
-          }.bind(this),
-          undo: function() {
-            this.set(iKey, tInitialValue);
-          }.bind(this)
-        }));
-      },
-
-      lastConfigurationControls: function () {
-        var tControls = sc_super(),
-            this_ = this,
-            kRowHeight = 18,
-            kControlValues = {
-              count: 'DG.Inspector.graphCount'.loc(),
-              percent: 'DG.Inspector.graphPercent'.loc()
-            };
-
-        function mapValueToBreakdownType(iValue) {
-          var tKind = -1;
-          switch (iValue) {
-            case kControlValues.count:
-              tKind = DG.Analysis.EBreakdownType.eCount;
-              break;
-            case kControlValues.percent:
-              tKind = DG.Analysis.EBreakdownType.ePercent;
-              break;
-          }
-          return tKind;
-        }
-
-        function mapBreakdownTypeToValue(iType) {
-          var tValue = '';
-          switch (iType) {
-            case DG.Analysis.EBreakdownType.eCount:
-              tValue = kControlValues.count;
-              break;
-            case DG.Analysis.EBreakdownType.ePercent:
-              tValue = kControlValues.percent;
-              break;
-          }
-          return tValue;
-        }
-
-        tControls.push(
-            SC.LabelView.create({
-              layout: {height: kRowHeight},
-              value: 'DG.Inspector.displayScale',
-              localize: true
-            })
-        );
-
-        tControls.push(
-            SC.RadioView.create({
-              items: [kControlValues.count, kControlValues.percent],
-              value: mapBreakdownTypeToValue(this_.get('breakdownType')),
-              layoutDirection: SC.LAYOUT_VERTICAL,
-              layout: {height: 3 * kRowHeight},
-              classNames: 'dg-inspector-radio'.w(),
-              valueDidChange: function () {
-                this_.changeBreakdownType( 'breakdownType', mapValueToBreakdownType(this.value));
-              }.observes('value')
-            })
-        );
-        return tControls;
-      }.property('plot'),
-
-      /**
-       Each axis should rescale based on the values to be plotted with it.
-       @param iAllowScaleShrinkage{Boolean} Default is false
-       @param iAnimatePoints {Boolean} Default is true
-       @param iLogIt {Boolean} Default is false
-       @param iUserAction {Boolean} Default is false
-       */
-      rescaleAxesFromData: function (iAllowScaleShrinkage, iAnimatePoints, iLogIt, iUserAction) {
-        if (iAnimatePoints === undefined)
-          iAnimatePoints = true;
-        this.doRescaleAxesFromData([this.get('secondaryAxisPlace')], iAllowScaleShrinkage, iAnimatePoints, iUserAction);
-        if (iLogIt)
-          DG.logUser("rescaleDotPlot");
-      },
-      /**
-       * @return {Object} the saved data.
-       */
-      createStorage: function () {
-        var tStorage = sc_super();
-
-        tStorage.breakdownType = this.breakdownType;
-
-        return tStorage;
-      },
-
-      /**
-       * @param iStorage
-       */
-      restoreStorage: function (iStorage) {
-        sc_super();
-        if (!SC.none(iStorage.breakdownType)) {
-          this.set( 'breakdownType', iStorage.breakdownType);
-        }
       }
 
 
     });
-

--- a/apps/dg/components/graph/plots/chart_model.js
+++ b/apps/dg/components/graph/plots/chart_model.js
@@ -25,7 +25,7 @@ sc_require('components/graph/plots/plot_model');
   @extends SC.Object
 */
 DG.ChartModel = DG.PlotModel.extend(
-/** @scope DG.ChartModel.prototype */ 
+/** @scope DG.ChartModel.prototype */
 {
 
   /**
@@ -239,7 +239,7 @@ DG.ChartModel = DG.PlotModel.extend(
       iDoF( iCase, iIndex, tPrimaryCell, tSecondaryCell);
     }
   },
-  
+
   /**
     Call the given function once for each case that has a value for each axis.
     function signature for iDoF is { iCase, iCaseIndex, iPrimaryCellIndex, iSecondaryCellIndex }
@@ -253,7 +253,7 @@ DG.ChartModel = DG.PlotModel.extend(
       this.doForOneCase( iCase, iIndex, tCC, iDoF);
     }.bind(this));
   },
-  
+
   /**
    * @param iKey {String} If present, the property that changed to bring about this call
     My data has changed, so my cache is no longer valid.
@@ -310,7 +310,7 @@ DG.ChartModel = DG.PlotModel.extend(
 
     return tValueArray;
   },
- 
+
   /**
     Build a sparse 3-dim matrix of cases.
   */
@@ -320,6 +320,11 @@ DG.ChartModel = DG.PlotModel.extend(
         tMaxInCell = 0;
     this.forEachBivariateCaseDo( function( iCase, iIndex, iPrimaryCell, iSecondaryCell) {
       var tCellLength;
+      // forEachBivariateCaseDo() assumes that if there is no attribute on the secondary axis,
+      // then there is no secondary cell. This code assumes that if there's no secondary cell
+      // then there's nothing to cache. In the case of a computed bar chart we want to cache
+      // the primary cell counts even when there's no explicit secondary cell.
+      iSecondaryCell = iSecondaryCell || 0;
       if(SC.none( iPrimaryCell) || SC.none( iSecondaryCell))
         return;
 

--- a/apps/dg/components/graph/plots/computed_bar_chart_model.js
+++ b/apps/dg/components/graph/plots/computed_bar_chart_model.js
@@ -1,0 +1,112 @@
+// ==========================================================================
+//                          DG.ComputedBarChartModel
+//
+//  Author:   Kirk Swenson
+//
+//  Copyright (c) 2020 by The Concord Consortium, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// ==========================================================================
+
+sc_require('components/graph/plots/bar_chart_base_model');
+
+/** @class  DG.ComputedBarChartModel - The model for a bar chart with computed height of bars
+
+ @extends DG.BarChartBaseModel
+ */
+DG.ComputedBarChartModel = DG.BarChartBaseModel.extend(
+  /** @scope DG.ComputedBarChartView.prototype */
+  {
+    isBarHeightComputed: true,
+
+    expression: 'mean(num)',
+
+    formula: null,
+
+    formulaContext: null,
+
+    init: function() {
+      sc_super();
+    },
+
+    destroy: function() {
+      this.destroyFormula();
+      sc_super();
+    },
+
+    createFormula: function() {
+      var id = DG.Debug.scObjectID(this),
+          type = 'computedBarChart',
+          owner = { type: type, id: id, name: type + id },
+          attrID = this.get('primaryVarID'),
+          attr = attrID && DG.Attribute.getAttributeByID(attrID),
+          collection = attr && attr.get('collection');
+      this.formulaContext = DG.BarChartFormulaContext.create({
+        ownerSpec: owner,
+        plotModel: this,
+        collection: collection
+      });
+
+      this.set('formula', DG.Formula.create({ context: this.formulaContext, source: this.get('expression') }));
+    },
+
+    destroyFormula: function() {
+      this.formula.destroy();
+    },
+
+    /**
+     *
+     * @param iPlace {DG.GraphTypes.EPlace}
+     * @return { class }
+     */
+    getDesiredAxisClassFor: function( iPlace) {
+      if(iPlace === this.get('secondaryAxisPlace'))
+        return DG.CellLinearAxisModel;
+      return sc_super();
+    },
+
+    /**
+     Subclasses may override
+      @param { DG.GraphTypes.EPlace }
+      @return{ {min:{Number}, max:{Number} isDataInteger:{Boolean}} }
+      */
+    getDataMinAndMaxForDimension: function (iPlace) {
+      // TODO: compute min/max from data
+      var tResult = {
+        min: -5,
+        max: 5,
+        isDataInteger: false
+      };
+      return tResult;
+    },
+
+    getBarHeight: function(iPrimaryName) {
+      // TODO: create/update formula when attribute configuration or expression changes
+      if (!this.get('formula')) this.createFormula();
+      var formula = this.get('formula'),
+          evalContext = iPrimaryName ? { _groupID_: iPrimaryName } : {},
+          result = NaN;
+
+      try {
+        if (formula)
+          result = formula.evaluate(evalContext);
+      }
+      catch(e) {
+        // Propagate errors to return value
+        result = e;
+      }
+
+      return result;
+    }
+  }
+);

--- a/apps/dg/components/graph/plots/computed_bar_chart_view.js
+++ b/apps/dg/components/graph/plots/computed_bar_chart_view.js
@@ -1,9 +1,9 @@
 // ==========================================================================
-//                          DG.BarChartView
+//                          DG.ComputedBarChartView
 //
-//  Author:   William Finzer
+//  Author:   Kirk Swenson
 //
-//  Copyright (c) 2017 by The Concord Consortium, Inc. All rights reserved.
+//  Copyright (c) 2020 by The Concord Consortium, Inc. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -23,35 +23,35 @@ sc_require('components/graph/plots/bar_chart_base_view');
 /** @class  DG.BarChartView, a plot of rectangles, one for each category. Each rectangle is made of
  * thinner rectangles, one for each case.
 
- @extends DG.BarChartBaseView
+ @extends DG.ComputedBarChartView
  */
-DG.BarChartView = DG.BarChartBaseView.extend(
-  /** @scope DG.BarChartView.prototype */
+DG.ComputedBarChartView = DG.BarChartBaseView.extend(
+  /** @scope DG.ComputedBarChartView.prototype */
   {
-    /**
-     * Make sure the count axis has the correct upper bounds
-     */
-    setupAxes: function () {
-      sc_super();
-      var tCountAxisView = this.get('secondaryAxisView');
-      // Only set the bounds if they aren't already present
-      if (tCountAxisView && SC.none( tCountAxisView.getPath('model.lowerBound'))) {
-        tCountAxisView.get('model').setLowerAndUpperBounds(0, this.getPath('model.naturalUpperBound'));
-      }
-    },
-
     /**
      * Return the class of the count axis with the x or y to put it on.
      * @return {[{}]}
      */
     getAxisViewDescriptions: function () {
       var tDescriptions = sc_super(),
-          tCountKey = this.getPath('model.orientation') === DG.GraphTypes.EOrientation.kVertical ? 'y' : 'x';
+          tNumericKey = this.getPath('model.orientation') === DG.GraphTypes.EOrientation.kVertical ? 'y' : 'x';
       tDescriptions.push( {
-        axisKey: tCountKey,
-        axisClass: DG.CountAxisView
+        axisKey: tNumericKey,
+        axisClass: DG.CellLinearAxisView
       });
       return tDescriptions;
+    },
+
+    getBarHeight: function(iPrimaryName, iCount, iTotal) {
+      var model = this.get('model'),
+          barHeight = model && model.getBarHeight(iPrimaryName);
+      return model && barHeight * iCount / iTotal;
+    },
+
+    drawData: function drawData() {
+      var model = this.get('model');
+      model._buildCache();
+      sc_super();
     }
   }
 );

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -882,6 +882,7 @@ SC.stringsFor("en", {
     "DG.Inspector.graphTransparency": "Transparent",
     "DG.Inspector.graphCount": "Count",
     "DG.Inspector.graphPercent": "Percent",
+    "DG.Inspector.graphFormula": "Formula",
     "DG.Inspector.graphRow": "Row",
     "DG.Inspector.graphColumn": "Column",
     "DG.Inspector.graphCell": "Cell",

--- a/apps/dg/formula/formula.js
+++ b/apps/dg/formula/formula.js
@@ -18,9 +18,6 @@
 //  limitations under the License.
 // ==========================================================================
 
-sc_require('formula/formula_common');
-sc_require('formula/formula_context');
-
 /** @class DG.Formula
 
   The DG.Formula object supports parsing, compilation, and evaluation of

--- a/lang/strings/en-US.json
+++ b/lang/strings/en-US.json
@@ -882,6 +882,7 @@
     "DG.Inspector.graphTransparency": "Transparent",
     "DG.Inspector.graphCount": "Count",
     "DG.Inspector.graphPercent": "Percent",
+    "DG.Inspector.graphFormula": "Formula",
     "DG.Inspector.graphRow": "Row",
     "DG.Inspector.graphColumn": "Column",
     "DG.Inspector.graphCell": "Cell",


### PR DESCRIPTION
Turning this over as a work-in-progress per prior agreement.

What's Done:
- New `ComputedBarChartModel` and `ComputedBarChartView` classes are siblings to the preexisting `BarChartModel` and `BarChartView` classes and both derive from new `BarChartBaseModel` and `BarChartBaseView` classes respectively.
- `ComputedBarChartModel` maintains a formula and computes its value across each primary cell.
- `BarChartBaseModel` and `BarChartBaseView` define new `getBarHeight()` virtual method that is overridden by the derived classes to determine the bar height appropriately.
- `BarChartBaseModel` defines a new property, `isBarHeightComputed`, which is true for `ComputedBarChartModel` and false for the original `BarChartModel`.
  - I originally thought that I could add a third option for the `breakdownType` property, but it turns out to be difficult to have a property that is sometimes a simple property (e.g. `count` vs. `percent`) and sometimes a plot-type determining property (e.g. `formula`) as the two are handled completely differently from an undo/redo perspective. Changes to the new property have a one-to-one correspondence with plot type changes.
- New `BarChartFormulaContext` class for use with bar chart formulas.
  - I had originally thought that I might be able to reuse the `PlottedValueFormulaContext` but that turned out not to be the case.
- Inspector UI for switching between computed (`formula`) and simple (`count` or `percent`) bar charts.

What's To Be Done:
- Inspector UI for entering/editing the formula.
  - Formula currently defaults to `mean(num)`
- Formula is currently created on first use rather than being created/updated when plot configuration changes or user enters/edits expression.
- Formula results are computed on demand rather than being cached.
- Axis boundaries are currently hard-coded rather than being determined from computed results.
- As we saw in the demo, computed bars seem to be rendered invisibly in addition to the regular visible bars.
- Verify that some changes made in service of computed bar charts don't adversely affect other plots. If necessary, there may be other ways to achieve the desired results.
  - In `GraphModel.swapPlotForNewPlot()`, calls to `synchAxes()` and `rescaleAxesFromData()` were added.
  - In `ChartModel._buildCache()`, `iSecondaryCell` is defaulted to `0` so that cell counts are computed for the computed bar chart.