### PR TITLE
Modifications for transformations plugin

### DIFF
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -2364,7 +2364,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
         get: function() {
           return {
             success: true,
-            values: DG.functionRegistry.get("namesArray"),
+            values: DG.functionRegistry.get("categorizedFunctionInfo"),
           };
         },
         notify: function (_iResources, iValues) {

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -509,13 +509,31 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
 
       /**
        *     {{
-       *      action: 'update'|'get'|'delete'
+       *      action: 'create'|'update'|'get'|'delete'
        *      what: {type: 'interactiveFrame'}
        *      values: { {title: {String}, version: {String}, dimensions: { width: {Number}, height: {Number} }}}
        *     }}
        * @return {object} Object should include status and values.
        */
       handleInteractiveFrame: {
+        create: function (iResources, iValues) {
+          var tDoc = DG.currDocumentController(),
+                tComponent;
+          tComponent = DG.Component.createComponent({
+            "type": "DG.GameView",
+            "document": tDoc.get('content') ,
+            "componentStorage": {
+              "currentGameName": iValues.name || iValues.url || "",
+              "currentGameUrl": iValues.url,
+              allowInitGameOverride: true
+            }
+          });
+          tDoc.createComponentAndView( tComponent);
+
+          return {
+            success: true,
+          };
+        },
         update: function (iResources, iValues) {
           var diModel = iResources.interactiveFrame.getPath('model.content');
           var diComponent = DG.currDocumentController().getComponentByID(this.get('id'));

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -115,8 +115,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           logMessageMonitor: this.handleLogMessageMonitor,
           selectionList: this.handleSelectionList,
           undoChangeNotice: this.handleUndoChangeNotice,
-          evalExpression: this.handleEvalExpression,
-          functionNames: this.handleFunctionNames,
+          formulaEngine: this.handleFormulaEngine,
         };
       },
 
@@ -249,8 +248,7 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
               'document',
               'global',
               'globalList',
-              'evalExpression',
-              'functionNames',].indexOf(resourceSelector.type) < 0) {
+              'formulaEngine',].indexOf(resourceSelector.type) < 0) {
           // if no data context provided, and we are not creating one, the
           // default data context is implied
           if (!(resourceSelector.dataContext) ) {
@@ -2362,39 +2360,49 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           return {success: true, values: result};
         }
       },
-      handleEvalExpression: {
-        get: function (_iResources, iValues) {
-          var source = iValues.source;
-          try {
-            return {
-              success: true,
-              values: iValues.records.map(function(record) {
-                var context = DG.FormulaContext.create({
-                  vars: record,
-                });
-                var formula = DG.Formula.create({
-                  source: source,
-                  context: context,
-                });
-                return formula.evaluateDirect();
-              }),
-            };
-          } catch (ex) {
-            return {
-              success: false,
-              values: {
-                error: ex.toString(),
-              },
-            };
-          }
-        }
-      },
-      handleFunctionNames: {
+      handleFormulaEngine: {
         get: function() {
           return {
             success: true,
             values: DG.functionRegistry.get("namesArray"),
           };
+        },
+        notify: function (_iResources, iValues) {
+          var request = iValues.request;
+          switch (request) {
+            case "evalExpression":
+              var source = iValues.source;
+              try {
+                return {
+                  success: true,
+                  values: iValues.records.map(function(record) {
+                    var context = DG.FormulaContext.create({
+                      vars: record,
+                    });
+                    var formula = DG.Formula.create({
+                      source: source,
+                      context: context,
+                    });
+                    return formula.evaluateDirect();
+                  }),
+                };
+              } catch (ex) {
+                return {
+                  success: false,
+                  values: {
+                    error: ex.toString(),
+                  },
+                };
+              }
+              break;
+            default:
+              return {
+                success: false,
+                values: {
+                  error: "Unsupported request type: " + request,
+                },
+              };
+          }
         }
       },
       //get: function (iResources) {

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -114,7 +114,9 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           logMessage: this.handleLogMessage,
           logMessageMonitor: this.handleLogMessageMonitor,
           selectionList: this.handleSelectionList,
-          undoChangeNotice: this.handleUndoChangeNotice
+          undoChangeNotice: this.handleUndoChangeNotice,
+          evalExpression: this.handleEvalExpression,
+          functionNames: this.handleFunctionNames,
         };
       },
 
@@ -246,7 +248,9 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
               'componentList',
               'document',
               'global',
-              'globalList'].indexOf(resourceSelector.type) < 0) {
+              'globalList',
+              'evalExpression',
+              'functionNames',].indexOf(resourceSelector.type) < 0) {
           // if no data context provided, and we are not creating one, the
           // default data context is implied
           if (!(resourceSelector.dataContext) ) {
@@ -2357,7 +2361,42 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
           }).filter(function(el) { return el; });
           return {success: true, values: result};
         }
-      }
+      },
+      handleEvalExpression: {
+        get: function (_iResources, iValues) {
+          var source = iValues.source;
+          try {
+            return {
+              success: true,
+              values: iValues.records.map(function(record) {
+                var context = DG.FormulaContext.create({
+                  vars: record,
+                });
+                var formula = DG.Formula.create({
+                  source: source,
+                  context: context,
+                });
+                return formula.evaluateDirect();
+              }),
+            };
+          } catch (ex) {
+            return {
+              success: false,
+              values: {
+                error: ex.toString(),
+              },
+            };
+          }
+        }
+      },
+      handleFunctionNames: {
+        get: function() {
+          return {
+            success: true,
+            values: DG.functionRegistry.get("namesArray"),
+          };
+        }
+      },
       //get: function (iResources) {
       //  return {
       //    success: true,

--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -509,31 +509,13 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
 
       /**
        *     {{
-       *      action: 'create'|'update'|'get'|'delete'
+       *      action: 'update'|'get'|'delete'
        *      what: {type: 'interactiveFrame'}
        *      values: { {title: {String}, version: {String}, dimensions: { width: {Number}, height: {Number} }}}
        *     }}
        * @return {object} Object should include status and values.
        */
       handleInteractiveFrame: {
-        create: function (iResources, iValues) {
-          var tDoc = DG.currDocumentController(),
-                tComponent;
-          tComponent = DG.Component.createComponent({
-            "type": "DG.GameView",
-            "document": tDoc.get('content') ,
-            "componentStorage": {
-              "currentGameName": iValues.name || iValues.url || "",
-              "currentGameUrl": iValues.url,
-              allowInitGameOverride: true
-            }
-          });
-          tDoc.createComponentAndView( tComponent);
-
-          return {
-            success: true,
-          };
-        },
         update: function (iResources, iValues) {
           var diModel = iResources.interactiveFrame.getPath('model.content');
           var diComponent = DG.currDocumentController().getComponentByID(this.get('id'));

--- a/apps/dg/controllers/document_controller.js
+++ b/apps/dg/controllers/document_controller.js
@@ -493,6 +493,19 @@ DG.DocumentController = SC.Object.extend(
             this.contexts.splice(dataContextIndex, 1);
             this.propertyDidChange('contextsLength');
             this.tableCardRegistry.deregisterViews(dataContextID);
+
+            // Send notification indicating which data context was deleted
+            this.notificationManager.sendNotification({
+              action: 'notify',
+              resource: 'documentChangeNotice',
+              values: {
+                operation: 'dataContextDeleted',
+                deletedContext: dataContext.get('name'),
+              }
+            }, function (response) {
+              DG.log('Sent notification for deletion of context ' + dataContextID);
+              DG.log('Response: ' + JSON.stringify(response));
+            });
           } else {
             DG.logWarn('Attempt to destroy data context %@. Not known to document'.loc(dataContextID));
           }


### PR DESCRIPTION
### Changes
- Add `evalExpression` resource, which evaluates a given codap language expression. The request values must include a string `source` field, which is the expression to be evaluated, and a `records` field, which is an array of data items, serving as the environment in which the expression is evaluated. The expression is evaluated once for each record in the array. Response values is an array of results.
- Add `functionNames` resource, which supports the `get` action. Returns an array of function names in the expression language. This enables autocompleting codap functions in our expression editors. 
- Add `create` action to `interactiveFrame` resource, which spawns a new plugin window with the given name and url.
- Add notification for context deletion that indicates the name of the context being deleted.

Please let us know your feedback.

Paul, Thomas, and Jason