### PR TITLE
Use square brackets when compiling variables

### DIFF
--- a/apps/dg/formula/formula_context.js
+++ b/apps/dg/formula/formula_context.js
@@ -211,7 +211,7 @@ DG.FormulaContext = SC.Object.extend( (function() {
 
       var vars = this.get('vars');
       if( vars && (vars[iName] !== undefined))
-        return 'c.vars.' + iName;
+        return 'c.vars["' + iName + '"]';
     }
     this.registerDependency({ independentSpec: {
                                 type: DG.DEP_TYPE_UNDEFINED,


### PR DESCRIPTION
Using the dot syntax causes an issue with variable names containing spaces. The name "Attribute Name" will be compiled to `c.vars.Attribute Name`, which will error. This edit fixes the issue.