### PR TITLE
add name to component deletion notification

### DIFF
--- a/apps/dg/utilities/close-component.js
+++ b/apps/dg/utilities/close-component.js
@@ -55,6 +55,7 @@ DG.closeComponent = function (iComponentID) {
             operation: 'delete',
             type: tController.getPath('model.type'),
             id: tController.getPath('model.id'),
+            name: tController.getPath('model.name'),
             title: tController.getPath('model.title')
           }
         });


### PR DESCRIPTION
This adds the `name` of a component to the notification that is sent when a component is deleted. Right now it sends the `id` and `title`, but we are using names to track which text components have been created by transformers. This makes it easy for us to listen for text component deletion.

The name seemed readily accessible and simple enough to put into the notification, but let me know if there's an issue with doing this!