### PR TITLE
Update to CFM 1.3.3

### DIFF
--- a/apps/dg/resources/cloud-file-manager/js/app.js.ignore
+++ b/apps/dg/resources/cloud-file-manager/js/app.js.ignore
@@ -37454,7 +37454,7 @@ var CloudFileManagerClient = /** @class */ (function () {
         }
         // initialize the cloudContentFactory with all data we want in the envelope
         provider_interface_1.cloudContentFactory.setEnvelopeMetadata({
-            cfmVersion: '1.3.2',
+            cfmVersion: '1.3.3',
             appName: this.appOptions.appName || "",
             appVersion: this.appOptions.appVersion || "",
             appBuildNum: this.appOptions.appBuildNum || ""
@@ -40097,7 +40097,7 @@ var InteractiveApiProvider = /** @class */ (function (_super) {
                         _a = _b.sent();
                         return [3 /*break*/, 3];
                     case 2:
-                        _a = interactiveState;
+                        _a = lodash_1.cloneDeep(interactiveState);
                         _b.label = 3;
                     case 3: return [2 /*return*/, _a];
                 }
@@ -41384,7 +41384,7 @@ var CloudContentFactory = /** @class */ (function () {
     function CloudContentFactory() {
         this.envelopeMetadata = {
             // replaced by version number at build time
-            cfmVersion: '1.3.2',
+            cfmVersion: '1.3.3',
             appName: '',
             appVersion: '',
             appBuildNum: ''

--- a/cfm-version.txt
+++ b/cfm-version.txt
@@ -1,2 +1,2 @@
-version: 1.3.2
-commit: 2f41c9eacbf32cad2988438ebfdbbe0bf1d2b781
+version: 1.3.3
+commit: dde3c58b5158a8c17752be01b872e78475222e0d


### PR DESCRIPTION
Includes [CFM PR #229](https://github.com/concord-consortium/cloud-file-manager/pull/229), which fixes a bug in the InteractiveApiProvider [[#179611084]](https://www.pivotaltracker.com/story/show/179611084)