### PR TITLE
Import .csv data into DataBroker

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -12,6 +12,8 @@
         "escape-string-regexp": "^5.0.0",
         "expr-eval": "^2.0.2",
         "lodash": "^4.17.21",
+        "mobx": "^6.6.1",
+        "mobx-react-lite": "^3.4.0",
         "mobx-state-tree": "^5.1.5",
         "nanoid": "^4.0.0",
         "papaparse": "^5.3.2",
@@ -13055,10 +13057,30 @@
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.6.1.tgz",
       "integrity": "sha512-7su3UZv5JF+ohLr2opabjbUAERfXstMY+wiBtey8yNAPoB8H187RaQXuhFjNkH8aE4iHbDWnhDFZw0+5ic4nGQ==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-react-lite": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
+      "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.1.0",
+        "react": "^16.8.0 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/mobx-state-tree": {
@@ -26981,8 +27003,13 @@
     "mobx": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.6.1.tgz",
-      "integrity": "sha512-7su3UZv5JF+ohLr2opabjbUAERfXstMY+wiBtey8yNAPoB8H187RaQXuhFjNkH8aE4iHbDWnhDFZw0+5ic4nGQ==",
-      "peer": true
+      "integrity": "sha512-7su3UZv5JF+ohLr2opabjbUAERfXstMY+wiBtey8yNAPoB8H187RaQXuhFjNkH8aE4iHbDWnhDFZw0+5ic4nGQ=="
+    },
+    "mobx-react-lite": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
+      "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
+      "requires": {}
     },
     "mobx-state-tree": {
       "version": "5.1.5",

--- a/v3/package.json
+++ b/v3/package.json
@@ -25,7 +25,7 @@
     ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less|sass)$": "identity-obj-proxy"
+      "\\.(css|less|sass|scss)$": "identity-obj-proxy"
     },
     "moduleFileExtensions": [
       "ts",
@@ -129,6 +129,8 @@
     "escape-string-regexp": "^5.0.0",
     "expr-eval": "^2.0.2",
     "lodash": "^4.17.21",
+    "mobx": "^6.6.1",
+    "mobx-react-lite": "^3.4.0",
     "mobx-state-tree": "^5.1.5",
     "nanoid": "^4.0.0",
     "papaparse": "^5.3.2",

--- a/v3/src/components/app.scss
+++ b/v3/src/components/app.scss
@@ -18,10 +18,3 @@
   right: 0;
   bottom: 0;
 }
-
-.output-text {
-  width: 50%;
-  height: 20%;
-  background-color: aliceblue;
-  padding: 5px;
-}

--- a/v3/src/components/app.test.tsx
+++ b/v3/src/components/app.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react"
+import React from "react"
+import { gDataBroker } from "../data-model/data-broker"
+import { App, handleImportData } from "./app"
+
+describe("App component", () => {
+  it("should import data into a DataSet and into the DataBroker", () => {
+    handleImportData([{ a: "a1", b: "b1" }, { a: "a2", b: "b2" }], "test")
+    expect(gDataBroker.length).toBe(1)
+    expect(gDataBroker.first?.name).toBe("test")
+    const ds = gDataBroker.getDataSetByName("test")
+    expect(ds).toBeDefined()
+    expect(ds?.attributes.length).toBe(2)
+    expect(ds?.cases.length).toBe(2)
+  })
+
+  it("should render the App component", () => {
+    render(<App/>)
+    expect(screen.getByTestId("app")).toBeInTheDocument()
+  })
+})

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -1,4 +1,7 @@
 import React from "react"
+import { DataSummary } from "./data-summary"
+import { gDataBroker } from "../data-model/data-broker"
+import { DataSet, toCanonical } from "../data-model/data-set"
 import { Text } from "./text"
 import { useSampleText } from "../hooks/use-sample-text"
 import {DropHandler} from "./drop-handler"
@@ -6,14 +9,27 @@ import Icon from "../assets/concord.png"
 
 import "./app.scss"
 
+export function handleImportData(data: Array<Record<string, string>>, fName?: string) {
+  const ds = DataSet.create({ name: fName })
+  // add attributes
+  for (const pName in data[0]) {
+    ds.addAttribute({ name: pName })
+  }
+  // add cases
+  ds.addCases(toCanonical(ds, data))
+  // add data set
+  gDataBroker.addDataSet(ds)
+}
+
 export const App = () => {
   const sampleText = useSampleText()
   return (
-    <div className="app">
+    <div className="app" data-testid="app">
+      <DataSummary/>
       <img src={Icon}/>
       <Text text={sampleText} />
       <p>Drag a CSV file into this window to get some data.</p>
-      <DropHandler></DropHandler>
+      <DropHandler onImportData={handleImportData}></DropHandler>
     </div>
   )
 }

--- a/v3/src/components/data-summary.scss
+++ b/v3/src/components/data-summary.scss
@@ -1,0 +1,9 @@
+.data-summary {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 50vw;
+  height: 20vh;
+  background-color: aliceblue;
+  padding: 5px;
+}

--- a/v3/src/components/data-summary.test.tsx
+++ b/v3/src/components/data-summary.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react"
+import React from "react"
+import { gDataBroker } from "../data-model/data-broker"
+import { DataSet, toCanonical } from "../data-model/data-set"
+import { DataSummary } from "./data-summary"
+
+describe("DataSummary component", () => {
+  it("should render `No data` initially", () => {
+    render(<DataSummary/>)
+    expect(screen.getByText("No data")).toBeInTheDocument()
+  })
+
+  it("should summarize data once added", () => {
+    render(<DataSummary/>)
+    expect(screen.getByText("No data")).toBeInTheDocument()
+
+    const ds = DataSet.create({ name: "foo" })
+    ds.addAttribute({ name: "a" })
+    ds.addAttribute({ name: "b" })
+    ds.addCases(toCanonical(ds, [{ a: 1, b: 1 }]))
+    gDataBroker.addDataSet(ds)
+    expect(screen.queryByText("No data")).not.toBeInTheDocument()
+    expect(screen.getByText(`Parsed "foo"`, { exact: false })).toBeInTheDocument()
+    expect(screen.getByText("1 case(s)", { exact: false })).toBeInTheDocument()
+    expect(screen.getByText("a, b", { exact: false })).toBeInTheDocument()
+  })
+})

--- a/v3/src/components/data-summary.tsx
+++ b/v3/src/components/data-summary.tsx
@@ -1,0 +1,21 @@
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { gDataBroker } from "../data-model/data-broker"
+
+import "./data-summary.scss"
+
+export const DataSummary = observer(() => {
+  const data = gDataBroker.last
+  const summary = data
+                    ? [
+                      `Parsed "${data.name}" with ${data.cases.length} case(s) and attributes:`,
+                      "",
+                      `${data.attributes.map(attr => attr.name).join(", ")}.`
+                    ]
+                    : ["No data"]
+  return (
+    <div className="data-summary">
+      {summary.map((line, i) => <p key={`${i}-${line}`}>{line}</p>)}
+    </div>
+  )
+})

--- a/v3/src/components/drop-handler.tsx
+++ b/v3/src/components/drop-handler.tsx
@@ -1,9 +1,13 @@
-import React, {useEffect, useRef, useState} from "react"
-import {parse} from 'papaparse'
+import React, {useEffect, useRef} from "react"
+import {parse, ParseResult} from 'papaparse'
 
-export const DropHandler = () => {
-  const drop = useRef<HTMLDivElement>(null),
-    [outputText, setOutputText] = useState('No data')
+type RowType = Record<string, string>
+
+interface IProps {
+  onImportData: (data: Array<RowType>, name?: string) => void
+}
+export const DropHandler = ({ onImportData }: IProps) => {
+  const drop = useRef<HTMLDivElement>(null)
 
   useEffect(function installListeners() {
     function dragOverHandler(event: DragEvent) {
@@ -13,13 +17,8 @@ export const DropHandler = () => {
 
     function dropHandler(event: DragEvent) {
 
-      function finishUp(results: any, aFile: any) {
-        const attributes = Object.keys(results.data[0])
-        setOutputText(`Parsed ${aFile.name}
-        with ${results.data.length} cases and
-        the following attributes: 
-        
-        ${attributes.join(', ')}`)
+      function finishUp(results: ParseResult<RowType>, aFile: any) {
+        onImportData?.(results.data, aFile.name)
       }
 
       // Prevent default behavior (Prevent file from being opened)
@@ -65,13 +64,10 @@ export const DropHandler = () => {
         currRef.removeEventListener('drop', dropHandler)
       }
     }
-  }, [])
+  }, [onImportData])
 
   return (
     <div className={'drop-handler'} ref={drop}>
-      <div className='output-text'>
-        {outputText}
-      </div>
     </div>
   )
 }

--- a/v3/src/data-model/attribute.test.ts
+++ b/v3/src/data-model/attribute.test.ts
@@ -11,7 +11,7 @@ describe("Attribute", () => {
     process.env.NODE_ENV = origNodeEnv
   })
 
-  test.skip("Value conversions", () => {
+  test("Value conversions", () => {
     expect(importValueToString(null as any)).toBe("")
     expect(importValueToString(undefined)).toBe("")
     expect(importValueToString(0)).toBe("0")

--- a/v3/src/data-model/data-broker.test.ts
+++ b/v3/src/data-model/data-broker.test.ts
@@ -1,0 +1,88 @@
+import { reaction } from "mobx"
+import { DataBroker } from "./data-broker"
+import { DataSet, toCanonical } from "./data-set"
+
+describe("DataBroker", () => {
+  let broker = new DataBroker()
+  const dsEmpty = DataSet.create({ name: "empty"})
+  const dsCases = DataSet.create( { name: "cases" })
+  dsCases.addAttribute({ name: "a" })
+  dsCases.addCases(toCanonical(dsCases, [{ a: 1 }, { a: 2 }, { a: 3 }]))
+
+  it("should work as expected when empty", () => {
+    expect(broker.length).toBe(0)
+    expect(broker.first).toBeUndefined()
+    expect(broker.last).toBeUndefined()
+    expect(broker.summaries).toEqual([])
+    expect(broker.getDataSet("foo")).toBeUndefined()
+    expect(broker.getDataSetByName("foo")).toBeUndefined()
+  })
+
+  it("should work as expected with a single DataSet", () => {
+    broker.addDataSet(dsEmpty)
+    expect(broker.length).toBe(1)
+    expect(broker.first).toEqual(dsEmpty)
+    expect(broker.last).toEqual(dsEmpty)
+    expect(broker.summaries).toEqual([{ id: dsEmpty.id, name: "empty", attributes: 0, cases: 0 }])
+    expect(broker.getDataSet(dsEmpty.id)).toEqual(dsEmpty)
+    expect(broker.getDataSetByName("empty")).toEqual(dsEmpty)
+  })
+
+  it("should work as expected with multiple DataSets", () => {
+    broker.addDataSet(dsCases)
+    expect(broker.length).toBe(2)
+    expect(broker.first).toEqual(dsEmpty)
+    expect(broker.last).toEqual(dsCases)
+    expect(broker.summaries).toEqual([
+      { id: dsEmpty.id, name: "empty", attributes: 0, cases: 0 },
+      { id: dsCases.id, name: "cases", attributes: 1, cases: 3 }])
+    expect(broker.getDataSet(dsCases.id)).toEqual(dsCases)
+    expect(broker.getDataSetByName("cases")).toEqual(dsCases)
+
+    broker.removeDataSet(dsEmpty.id)
+    expect(broker.length).toBe(1)
+    expect(broker.first).toEqual(dsCases)
+    expect(broker.last).toEqual(dsCases)
+    expect(broker.summaries).toEqual([{ id: dsCases.id, name: "cases", attributes: 1, cases: 3 }])
+  })
+
+  it("should be observable using MobX mechanisms", () => {
+    let lastSummaries: any
+    const handler = jest.fn((summaries: any) => lastSummaries = summaries)
+    reaction(() => broker.summaries, summaries => handler(summaries))
+    // adding a DataSet triggers the reaction
+    broker.addDataSet(dsEmpty)
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(lastSummaries).toEqual([
+      { id: dsCases.id, name: "cases", attributes: 1, cases: 3 },
+      { id: dsEmpty.id, name: "empty", attributes: 0, cases: 0 }])
+    // removing a DataSet triggers the reaction
+    broker.removeDataSet(dsEmpty.id)
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(lastSummaries).toEqual([{ id: dsCases.id, name: "cases", attributes: 1, cases: 3 }])
+    // replacing a DataSet triggers the reaction
+    broker.addDataSet(DataSet.create({ id: dsCases.id, name: dsCases.name }))
+    expect(handler).toHaveBeenCalledTimes(3)
+    expect(lastSummaries).toEqual([{ id: dsCases.id, name: "cases", attributes: 0, cases: 0 }])
+  })
+
+  it("should work as expected when configured for a single dataset", () => {
+    broker = new DataBroker({ allowMultiple: false })
+    broker.addDataSet(dsEmpty)
+    broker.addDataSet(dsCases)
+    expect(broker.length).toBe(1)
+    expect(broker.first).toEqual(dsCases)
+    expect(broker.last).toEqual(dsCases)
+    expect(broker.summaries).toEqual([{ id: dsCases.id, name: "cases", attributes: 1, cases: 3 }])
+    expect(broker.getDataSet(dsEmpty.id)).toBeUndefined()
+    expect(broker.getDataSet(dsCases.id)).toEqual(dsCases)
+    expect(broker.getDataSetByName("cases")).toEqual(dsCases)
+
+    broker.removeDataSet(dsEmpty.id)
+    expect(broker.length).toBe(1)
+    expect(broker.first).toEqual(dsCases)
+    expect(broker.last).toEqual(dsCases)
+    expect(broker.summaries).toEqual([{ id: dsCases.id, name: "cases", attributes: 1, cases: 3 }])
+  })
+
+})

--- a/v3/src/data-model/data-broker.ts
+++ b/v3/src/data-model/data-broker.ts
@@ -62,4 +62,5 @@ export class DataBroker {
   }
 }
 
-export const gDataBroker = new DataBroker()
+// for MVP we only support a single DataSet
+export const gDataBroker = new DataBroker({ allowMultiple: false })

--- a/v3/src/data-model/data-broker.ts
+++ b/v3/src/data-model/data-broker.ts
@@ -13,7 +13,7 @@ interface IDataBrokerOptions {
 }
 export class DataBroker {
   @observable dataSets = new Map<string, IDataSet>()
-  @observable readonly allowMultiple: boolean
+  readonly allowMultiple: boolean
 
   constructor(options?: IDataBrokerOptions) {
     const { allowMultiple = true } = options || {}

--- a/v3/src/data-model/data-broker.ts
+++ b/v3/src/data-model/data-broker.ts
@@ -1,0 +1,65 @@
+import { action, makeObservable, observable } from "mobx"
+import { IDataSet } from "./data-set"
+
+export interface IDataSetSummary {
+  id: string;
+  name: string;
+  attributes: number;
+  cases: number;
+}
+
+interface IDataBrokerOptions {
+  allowMultiple?: boolean
+}
+export class DataBroker {
+  @observable dataSets = new Map<string, IDataSet>()
+  @observable readonly allowMultiple: boolean
+
+  constructor(options?: IDataBrokerOptions) {
+    const { allowMultiple = true } = options || {}
+    makeObservable(this)
+    this.allowMultiple = allowMultiple
+  }
+
+  get length() {
+    return this.dataSets.size
+  }
+
+  get first(): IDataSet | undefined {
+    return this.dataSets.values().next().value
+  }
+
+  get last(): IDataSet | undefined {
+    let dsLast: IDataSet | undefined
+    this.dataSets.forEach(ds => dsLast = ds)
+    return dsLast
+  }
+
+  get summaries() {
+    return Array.from(this.dataSets.values()).map(({ id, name, attributes, cases }) =>
+      ({ id, name, attributes: attributes.length, cases: cases.length }))
+  }
+
+  getDataSet(id: string): IDataSet | undefined {
+    return this.dataSets.get(id)
+  }
+
+  getDataSetByName(name: string): IDataSet | undefined {
+    for (const ds of this.dataSets.values()) {
+      if (ds.name === name) return ds
+    }
+  }
+
+  @action
+  addDataSet(ds: IDataSet) {
+    !this.allowMultiple && this.dataSets.clear()
+    this.dataSets.set(ds.id, ds)
+  }
+
+  @action
+  removeDataSet(id: string) {
+    this.dataSets.delete(id)
+  }
+}
+
+export const gDataBroker = new DataBroker()


### PR DESCRIPTION
Adds a `DataBroker` which can manage multiple `DataSet`s, although initially it is configured to support only a single one. The .csv import code is updated to import the data into a `DataSet` and add it to the `DataBroker`. The code for displaying the result of the import is separated into its own component which re-renders via MobX mechanisms when the `DataBroker` changes.