### PR TITLE
Enable column resizing by user; disable initial auto-sizing

### DIFF
--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useMemo } from "react"
 import DataGrid, { Column, FormatterProps } from "react-data-grid"
 import { DataBroker } from "../../data-model/data-broker"
 import { IDataSet } from "../../data-model/data-set"
-import { useMaxAttrValueWidths } from "../../hooks/use-max-attr-value-widths"
 
 import "./case-table.scss"
 
@@ -11,16 +10,11 @@ type TRow = IDataSet["cases"][0]
 type TColumn = Column<TRow>
 type TFormatterProps = FormatterProps<TRow>
 
-const kDefaultColumnWidth = 80
-const kCellPadding = 18
-
 interface IProps {
   broker?: DataBroker
 }
 export const CaseTable: React.FC<IProps> = observer(({ broker }) => {
   const data = broker?.last
-
-  const maxWidths = useMaxAttrValueWidths(data)
 
   // cell formatter/renderer
   const formatter = useCallback(({ column, row }: TFormatterProps) => {
@@ -35,11 +29,10 @@ export const CaseTable: React.FC<IProps> = observer(({ broker }) => {
     ? data.attributes.map(({ id, name }) => ({
         key: id,
         name,
-        // auto-size each column; remove (CODAP 2) or adjust heuristic when user-resizing is supported
-        width: Math.max(kDefaultColumnWidth, (maxWidths[id]?.width || 0) + kCellPadding),
+        resizable: true,
         formatter
       }))
-    : [], [data, formatter, maxWidths])
+    : [], [data, formatter])
   if (!data) return null
 
   // row definitions


### PR DESCRIPTION
Turns out user column-resizing is supported out of the box by react-data-grid.