### PR TITLE
V3: Implement row selection [#181846512]

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -36,6 +36,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^12.1.5",
         "@testing-library/react-hooks": "^8.0.1",
+        "@testing-library/user-event": "^14.3.0",
         "@types/d3": "^7.4.0",
         "@types/jest": "^28.1.6",
         "@types/lodash": "^4.14.182",
@@ -3633,6 +3634,19 @@
         "react-test-renderer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.3.0.tgz",
+      "integrity": "sha512-P02xtBBa8yMaLhK8CzJCIns8rqwnF6FxhR9zs810flHOBXUYCFjLd8Io1rQrAkQRWEmW2PGdZIEdMxf/KLsqFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -20621,6 +20635,13 @@
         "@babel/runtime": "^7.12.5",
         "react-error-boundary": "^3.1.0"
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.3.0.tgz",
+      "integrity": "sha512-P02xtBBa8yMaLhK8CzJCIns8rqwnF6FxhR9zs810flHOBXUYCFjLd8Io1rQrAkQRWEmW2PGdZIEdMxf/KLsqFA==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",

--- a/v3/package.json
+++ b/v3/package.json
@@ -78,6 +78,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/user-event": "^14.3.0",
     "@types/d3": "^7.4.0",
     "@types/jest": "^28.1.6",
     "@types/lodash": "^4.14.182",

--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -15,6 +15,13 @@
     .rdg-cell {
       &.codap-index-cell {
         text-align: center;
+        .codap-index-content {
+          width: 100%;
+          height: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
       }
     }
   }

--- a/v3/src/components/case-table/use-columns.tsx
+++ b/v3/src/components/case-table/use-columns.tsx
@@ -8,20 +8,6 @@ interface IUseColumnsProps {
 }
 export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
 
-  // const handleClick = useCallback((caseId: string, evt: React.MouseEvent) => {
-  //   onIndexClick?.(caseId, evt)
-  // }, [onIndexClick])
-
-  // // index cell formatter/renderer
-  // const indexFormatter = useCallback(({ row }: TFormatterProps) => {
-  //   const index = data?.caseIndexFromID(row.__id__)
-  //   return (
-  //     <div className="codap-index-content" onClick={e => handleClick(row.__id__, e) }>
-  //       {index != null ? `${index + 1}` : ""}
-  //     </div>
-  //   )
-  // }, [data, handleClick])
-
   // cell formatter/renderer
   const cellFormatter = useCallback(({ column, row }: TFormatterProps) => {
     const value = data?.getValue(row.__id__, column.key) ?? ""
@@ -29,16 +15,6 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
     // we can support other formats here (dates, colors, etc.)
     return <span>{value}</span>
   }, [data])
-
-  // // index column definition
-  // const indexColumn: TColumn = useMemo(() => ({
-  //   key: "__index__",
-  //   name: "index",
-  //   minWidth: 52,
-  //   width: 52,
-  //   cellClass: "codap-index-cell",
-  //   formatter: indexFormatter
-  // }), [indexFormatter])
 
   // column definitions
   const columns: TColumn[] = useMemo(() => data

--- a/v3/src/components/case-table/use-columns.tsx
+++ b/v3/src/components/case-table/use-columns.tsx
@@ -2,12 +2,25 @@ import React, { useCallback, useMemo } from "react"
 import { IDataSet } from "../../data-model/data-set"
 import { TColumn, TFormatterProps } from "./case-table-types"
 
-export const useColumns = (data?: IDataSet) => {
-  // index cell formatter/renderer
-  const indexFormatter = useCallback(({ row }: TFormatterProps) => {
-    const index = data?.caseIndexFromID(row.__id__)
-    return <span>{index != null ? `${index + 1}` : ""}</span>
-  }, [data])
+interface IUseColumnsProps {
+  data?: IDataSet
+  indexColumn: TColumn
+}
+export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
+
+  // const handleClick = useCallback((caseId: string, evt: React.MouseEvent) => {
+  //   onIndexClick?.(caseId, evt)
+  // }, [onIndexClick])
+
+  // // index cell formatter/renderer
+  // const indexFormatter = useCallback(({ row }: TFormatterProps) => {
+  //   const index = data?.caseIndexFromID(row.__id__)
+  //   return (
+  //     <div className="codap-index-content" onClick={e => handleClick(row.__id__, e) }>
+  //       {index != null ? `${index + 1}` : ""}
+  //     </div>
+  //   )
+  // }, [data, handleClick])
 
   // cell formatter/renderer
   const cellFormatter = useCallback(({ column, row }: TFormatterProps) => {
@@ -17,15 +30,15 @@ export const useColumns = (data?: IDataSet) => {
     return <span>{value}</span>
   }, [data])
 
-  // index column definition
-  const indexColumn: TColumn = useMemo(() => ({
-    key: "__index__",
-    name: "index",
-    minWidth: 52,
-    width: 52,
-    cellClass: "codap-index-cell",
-    formatter: indexFormatter
-  }), [indexFormatter])
+  // // index column definition
+  // const indexColumn: TColumn = useMemo(() => ({
+  //   key: "__index__",
+  //   name: "index",
+  //   minWidth: 52,
+  //   width: 52,
+  //   cellClass: "codap-index-cell",
+  //   formatter: indexFormatter
+  // }), [indexFormatter])
 
   // column definitions
   const columns: TColumn[] = useMemo(() => data

--- a/v3/src/components/case-table/use-index-column.tsx
+++ b/v3/src/components/case-table/use-index-column.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback, useEffect, useMemo, useRef } from "react"
+import { IDataSet } from "../../data-model/data-set"
+import { TColumn, TFormatterProps } from "./case-table-types"
+
+interface IHookProps {
+  data?: IDataSet
+  onIndexClick?: (caseId: string, evt: React.MouseEvent) => void
+}
+export const useIndexColumn = ({ data, onIndexClick }: IHookProps) => {
+  // formatter/renderer
+  const formatter = useCallback(({ row: { __id__ } }: TFormatterProps) => {
+    const index = data?.caseIndexFromID(__id__)
+    return (
+      <IndexCell caseId={__id__} index={index} onIndexClick={onIndexClick} />
+    )
+  }, [data, onIndexClick])
+
+  // column definition
+  const indexColumn: TColumn = useMemo(() => ({
+    key: "__index__",
+    name: "index",
+    minWidth: 52,
+    width: 52,
+    cellClass: "codap-index-cell",
+    formatter
+  }), [formatter])
+
+  return indexColumn
+}
+
+interface ICellProps {
+  caseId: string
+  index?: number
+  onIndexClick?: (caseId: string, evt: React.MouseEvent) => void
+}
+export const IndexCell = ({ caseId, index, onIndexClick }: ICellProps) => {
+
+  const cellRef = useRef<HTMLDivElement>(null)
+
+  /*
+    To its credit, ReactDataGrid puts appropriate aria role tags on every cell in the grid.
+    Unfortunately, in doing so, it assumes that all grid cells should have role "gridcell".
+    Where the index cell is concerned, however, the "rowheader" role is more appropriate.
+    At some point we could submit a PR to ReactDataGrid that implements a column option for
+    specifying the aria role to be applied to cells in the column. In the meantime, however,
+    we can fix it ourselves by post-processing the role attribute for our parent.
+   */
+  useEffect(() => {
+    const parent = cellRef.current?.parentElement
+    if (parent?.classList.contains("rdg-cell") && parent?.getAttribute("role") === "gridcell") {
+      parent.setAttribute("role", "rowheader")
+    }
+    // no dependencies means we'll check/fix it after every render
+  })
+
+  return (
+    <div ref={cellRef} className="codap-index-content" data-testid="codap-index-content"
+      onClick={e => onIndexClick?.(caseId, e) }>
+      {index != null ? `${index + 1}` : ""}
+    </div>
+  )
+}

--- a/v3/src/components/case-table/use-selected-rows.ts
+++ b/v3/src/components/case-table/use-selected-rows.ts
@@ -1,0 +1,30 @@
+import { autorun } from "mobx"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { IDataSet } from "../../data-model/data-set"
+
+export const useSelectedRows = (data?: IDataSet) => {
+  const [selectedRows, _setSelectedRows] = useState<ReadonlySet<string>>(() => new Set())
+  const syncCount = useRef(0)
+
+  // sync table changes to the model
+  const setSelectedRows = useCallback((rowSet: ReadonlySet<string>) => {
+    const rows = Array.from(rowSet)
+    ++syncCount.current
+    data?.setSelectedCases(rows)
+    --syncCount.current
+    _setSelectedRows(rowSet)
+  }, [data])
+
+  useEffect(() => {
+    // sync model changes to selectedRows state
+    const disposer = autorun(() => {
+      // don't respond if we caused the change
+      if (syncCount.current === 0) {
+        _setSelectedRows(new Set<string>(data?.selection.keys()))
+      }
+    })
+    return () => disposer()
+  }, [data?.selection])
+
+  return [selectedRows, setSelectedRows] as const
+}

--- a/v3/src/data-model/data-set.test.ts
+++ b/v3/src/data-model/data-set.test.ts
@@ -422,6 +422,25 @@ test("Canonical case functionality", () => {
   destroy(dataset)
 })
 
+test("DataSet case selection", () => {
+  const ds = DataSet.create({ name: "data" })
+  ds.addCases([{__id__: "c1"}, {__id__: "c2"}, {__id__: "c3"}, {__id__: "c4"}, {__id__: "c5"}])
+  expect(ds.cases.length).toBe(5)
+  expect(ds.cases.map(c => ds.isCaseSelected(c.__id__))).toEqual([false, false, false, false, false])
+  ds.selectCases(["c1", "c4"])
+  expect(ds.cases.map(c => ds.isCaseSelected(c.__id__))).toEqual([true, false, false, true, false])
+  ds.selectAll(false)
+  expect(ds.cases.map(c => ds.isCaseSelected(c.__id__))).toEqual([false, false, false, false, false])
+  ds.selectAll(true)
+  expect(ds.cases.map(c => ds.isCaseSelected(c.__id__))).toEqual([true, true, true, true, true])
+  ds.selectCases(["c1", "c4"], false)
+  expect(ds.cases.map(c => ds.isCaseSelected(c.__id__))).toEqual([false, true, true, false, true])
+  ds.setSelectedCases(["c1", "c4"])
+  expect(ds.cases.map(c => ds.isCaseSelected(c.__id__))).toEqual([true, false, false, true, false])
+  ds.selectAll()
+  expect(ds.cases.map(c => ds.isCaseSelected(c.__id__))).toEqual([true, true, true, true, true])
+})
+
 test("Derived DataSet functionality", () => {
   const dataset = DataSet.create({ name: "data" })
 

--- a/v3/src/data-model/data-set.ts
+++ b/v3/src/data-model/data-set.ts
@@ -149,6 +149,8 @@ export const DataSet = types.model("DataSet", {
   name: types.maybe(types.string),
   attributes: types.array(Attribute),
   cases: types.array(CaseID),
+  // MST doesn't have a types.set
+  selection: types.map(types.string)
 })
 .volatile(self => ({
   transactionCount: 0
@@ -335,6 +337,9 @@ export const DataSet = types.model("DataSet", {
           cases.push(getCaseAtIndex(i, options))
         }
         return cases
+      },
+      isCaseSelected(caseId: string) {
+        return self.selection.has(caseId)
       },
       get isInTransaction() {
         return self.transactionCount > 0
@@ -601,6 +606,31 @@ export const DataSet = types.model("DataSet", {
             }
           }
         })
+      },
+
+      selectAll(select = true) {
+        if (select) {
+          self.cases.forEach(({__id__}) => self.selection.set(__id__, __id__))
+        }
+        else {
+          self.selection.clear()
+        }
+      },
+
+      selectCases(caseIds: string[], select = true) {
+        caseIds.forEach(id => {
+          if (select) {
+            self.selection.set(id, id)
+          }
+          else {
+            self.selection.delete(id)
+          }
+        })
+      },
+
+      setSelectedCases(caseIds: string[]) {
+        this.selectAll(false)
+        this.selectCases(caseIds)
       }
     }
   }

--- a/v3/src/test/setupTests.ts
+++ b/v3/src/test/setupTests.ts
@@ -1,3 +1,7 @@
 import "@testing-library/jest-dom"
+
 import ResizeObserverPolyfill from "resize-observer-polyfill"
 global.ResizeObserver = ResizeObserverPolyfill
+
+// mock DOM APIs not supported by JSDOM
+Element.prototype.scrollIntoView = jest.fn()


### PR DESCRIPTION
PT: [[#181846512]](https://www.pivotaltracker.com/story/show/181846512)
Demo: https://codap3.concord.org/branch/v3-row-selection/

Case selection is supported in the `DataSet` model.
Clicking in `index` column of case table selects corresponding row.
Clicking with any modifier key held down extends the selection (all modifier keys use discontiguous selection at this point).