### PR TITLE
V3: Implement attribute drag from summary component

### DIFF
--- a/v3/.eslintrc.cjs
+++ b/v3/.eslintrc.cjs
@@ -83,7 +83,7 @@ module.exports = {
     "radix": "error",
     "react/jsx-closing-tag-location": "error",
     "react/jsx-handler-names": "off",
-    "react/jsx-no-useless-fragment": "error",
+    "react/jsx-no-useless-fragment": "off",
     "react/no-access-state-in-setstate": "error",
     "react/no-danger": "error",
     "react/no-unsafe": ["off", { checkAliases: true }],

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@dnd-kit/core": "^6.0.5",
         "d3": "^7.6.1",
         "escape-string-regexp": "^5.0.0",
         "expr-eval": "^2.0.2",
@@ -2070,6 +2071,42 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
+      "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.5.tgz",
+      "integrity": "sha512-3nL+Zy5cT+1XwsWdlXIvGIFvbuocMyB4NBxTN74DeBaBqeWdH9JsnKwQv7buZQgAHmAH+eIENfS1ginkvW6bCw==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.0.0",
+        "@dnd-kit/utilities": "^3.2.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.0.tgz",
+      "integrity": "sha512-h65/pn2IPCCIWwdlR2BMLqRkDxpTEONA+HQW3n765HBijLYGyrnTCLa2YQt8VVjjSQD6EfFlTE6aS2Q/b6nb2g==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -19503,6 +19540,32 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
+    },
+    "@dnd-kit/accessibility": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
+      "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/core": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.5.tgz",
+      "integrity": "sha512-3nL+Zy5cT+1XwsWdlXIvGIFvbuocMyB4NBxTN74DeBaBqeWdH9JsnKwQv7buZQgAHmAH+eIENfS1ginkvW6bCw==",
+      "requires": {
+        "@dnd-kit/accessibility": "^3.0.0",
+        "@dnd-kit/utilities": "^3.2.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/utilities": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.0.tgz",
+      "integrity": "sha512-h65/pn2IPCCIWwdlR2BMLqRkDxpTEONA+HQW3n765HBijLYGyrnTCLa2YQt8VVjjSQD6EfFlTE6aS2Q/b6nb2g==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",

--- a/v3/package.json
+++ b/v3/package.json
@@ -130,6 +130,7 @@
     "webpack-dev-server": "^4.9.3"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.0.5",
     "d3": "^7.6.1",
     "escape-string-regexp": "^5.0.0",
     "expr-eval": "^2.0.2",

--- a/v3/src/components/app.test.tsx
+++ b/v3/src/components/app.test.tsx
@@ -9,6 +9,26 @@ jest.mock("../hooks/use-measure-text", () => ({
 }))
 
 describe("App component", () => {
+  const originalLocation = window.location
+
+  const mockWindowLocation = (newLocation: Location | URL) => {
+    delete (window as any).location
+    window.location = newLocation as Location
+  }
+
+  const setLocation = (url: string) => {
+    mockWindowLocation(new URL(url))
+  }
+
+  const setQueryParams = (params?: string) => {
+    setLocation(`https://concord.org${params ? `?${params}` : ""}`)
+  }
+
+  afterEach(() => {
+    gDataBroker.clear()
+    mockWindowLocation(originalLocation)
+  })
+
   it("should import data into a DataSet and into the DataBroker", () => {
     handleImportData([{ a: "a1", b: "b1" }, { a: "a2", b: "b2" }], "test")
     expect(gDataBroker.length).toBe(1)
@@ -19,7 +39,13 @@ describe("App component", () => {
     expect(ds?.cases.length).toBe(2)
   })
 
-  it("should render the App component", () => {
+  it("should render the App component with no data", () => {
+    render(<App/>)
+    expect(screen.getByTestId("app")).toBeInTheDocument()
+  })
+
+  it("should render the App component with mammals data", () => {
+    setQueryParams("mammals")
     render(<App/>)
     expect(screen.getByTestId("app")).toBeInTheDocument()
   })

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -1,4 +1,5 @@
-import React from "react"
+import { DndContext, DragEndEvent, DragStartEvent } from "@dnd-kit/core"
+import React, { useEffect } from "react"
 import { CaseTable } from "./case-table/case-table"
 import {Container} from "./container"
 import {DataSummary} from "./data-summary"
@@ -6,8 +7,10 @@ import {gDataBroker} from "../data-model/data-broker"
 import {DataSet, toCanonical} from "../data-model/data-set"
 import {Graph} from "./graph/graph"
 import {Text} from "./text"
+import { dndDetectCollision } from "./dnd-detect-collision"
 import {useDropHandler} from "../hooks/use-drop-handler"
 import {useSampleText} from "../hooks/use-sample-text"
+import { importMammals } from "../sample-data/mammals"
 import Icon from "../assets/concord.png"
 
 import "./app.scss"
@@ -29,21 +32,42 @@ export const App = () => {
 
   useDropHandler("#app", handleImportData)
 
+  function handleDragStart(evt: DragStartEvent) {
+    // console.log("DnDKit [handleDragStart]")
+  }
+
+  function handleDragEnd(evt: DragEndEvent) {
+    const {active, over} = evt
+    if (over?.data?.current?.accepts.includes(active?.data?.current?.type)) {
+      over.data.current.onDrop(active)
+    }
+  }
+
+  useEffect(() => {
+    if (gDataBroker.dataSets.size === 0) {
+      if (window.location.search.includes("mammals")) {
+        handleImportData(importMammals(), "mammals")
+      }
+    }
+  }, [])
+
   return (
-    <div className="app" data-testid="app">
-      <Container>
-        {/* each top-level child will be wrapped in a CodapComponent */}
-        <DataSummary/>
-        <div className="hello-codap3">
-          <div>
-            <img src={Icon}/>
-            <Text text={sampleText}/>
-            <p>Drag a CSV file into this window to get some data.</p>
+    <DndContext collisionDetection={dndDetectCollision} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <div className="app" data-testid="app">
+        <Container>
+          {/* each top-level child will be wrapped in a CodapComponent */}
+          <DataSummary/>
+          <div className="hello-codap3">
+            <div>
+              <img src={Icon}/>
+              <Text text={sampleText}/>
+              <p>Drag a CSV file into this window to get some data.</p>
+            </div>
           </div>
-        </div>
-        <CaseTable />
-        <Graph></Graph>
-      </Container>
-    </div>
+          <CaseTable />
+          <Graph></Graph>
+        </Container>
+      </div>
+    </DndContext>
   )
 }

--- a/v3/src/components/case-table/attribute-drag-overlay.tsx
+++ b/v3/src/components/case-table/attribute-drag-overlay.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+import { TColumn } from "./case-table-types"
+import { ColumnHeader } from "./column-header"
+
+interface IProps {
+  activeDragAttrId?: string
+  column: TColumn
+}
+export const AttributeDragOverlay = ({ activeDragAttrId, column }: IProps) => {
+  return (
+    activeDragAttrId
+      ? <div className="attribute-drag-overlay">
+          <ColumnHeader {...{ column } as any} />
+        </div>
+      : null
+  )
+}

--- a/v3/src/components/case-table/case-table-types.ts
+++ b/v3/src/components/case-table/case-table-types.ts
@@ -1,7 +1,10 @@
 import { IDataSet } from "../../data-model/data-set"
-import { CalculatedColumn, Column, FormatterProps } from "react-data-grid"
+import { CalculatedColumn, Column, FormatterProps, HeaderRendererProps } from "react-data-grid"
 
-export type TRow = IDataSet["cases"][0]
+export type TRow = IDataSet["cases"][number]
 export type TColumn = Column<TRow>
 export type TCalculatedColumn = CalculatedColumn<TRow>
 export type TFormatterProps = FormatterProps<TRow>
+export type THeaderRendererProps = HeaderRendererProps<TRow>
+
+export const kIndexColumnKey = "__index__"

--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -1,4 +1,5 @@
 .case-table {
+  position: relative;
   width: 100%;
   height: 100%;
 
@@ -7,8 +8,13 @@
     height: 100%;
 
     .rdg-header-row {
-      .rdg-cell {
+      .codap-column-header {
         text-align: center;
+
+        .codap-column-header-content {
+          width: 100%;
+          height: 100%;
+        }
       }
     }
 
@@ -23,6 +29,17 @@
           justify-content: center;
         }
       }
+    }
+  }
+
+  .codap-column-header-divider {
+    position: absolute;
+    background: black;
+    opacity: 0%;
+    pointer-events: none;
+
+    &.over {
+      opacity: 30%;
     }
   }
 }

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -1,0 +1,60 @@
+import { Active, useDroppable } from "@dnd-kit/core"
+import React, { CSSProperties, useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+import { IMoveAttributeOptions } from "../../data-model/data-set"
+import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { kIndexColumnKey } from "./case-table-types"
+
+interface IProps {
+  columnKey: string
+  cellElt: HTMLElement | null
+}
+export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
+  const data = useDataSetContext()
+  const [tableElt, setTableElt] = useState<HTMLElement | null>(null)
+  const tableBounds = tableElt?.getBoundingClientRect()
+  const cellBounds = cellElt?.getBoundingClientRect()
+
+  const handleDrop = (active: Active) => {
+    const dragAttrId = active.data?.current?.attributeId
+    const options: IMoveAttributeOptions = columnKey === kIndexColumnKey
+                                            ? { before: data?.attributes[0].id }
+                                            : { after: columnKey }
+    dragAttrId && data?.moveAttribute(dragAttrId, options)
+  }
+
+  const dropData: any = { accepts: ["attribute"], onDrop: handleDrop }
+  const { isOver, setNodeRef: setDropRef } = useDroppable({ id: `table-attribute:${columnKey}`, data: dropData })
+
+  // find the `case-table` DOM element; divider must be drawn relative
+  // to the `case-table` (via React portal) so it isn't clipped by the cell
+  useEffect(() => {
+    if (cellElt && !tableElt) {
+      let parent: HTMLElement | null
+      for (parent = cellElt; parent; parent = parent.parentElement) {
+        if (parent.classList.contains("case-table")) {
+          setTableElt(parent)
+          break
+        }
+      }
+    }
+  }, [cellElt, tableElt])
+
+  // compute the divider position relative to the `case-table` element
+  const kDividerWidth = 7
+  const kDividerOffset = 8 - Math.floor(kDividerWidth / 2)
+  const style: CSSProperties = tableBounds && cellBounds
+                  ? {
+                      top: cellBounds.top - tableBounds.top,
+                      height: cellBounds.height,
+                      left: cellBounds.right - tableBounds.left + kDividerOffset,
+                      width: kDividerWidth
+                    }
+                  : {}
+
+  return tableElt && tableBounds && cellBounds && (cellBounds?.right < tableBounds?.right)
+          ? createPortal((
+              <div ref={setDropRef} className={`codap-column-header-divider ${isOver ? "over" : ""}`} style={style}/>
+            ), tableElt)
+          : null
+}

--- a/v3/src/components/case-table/column-header.tsx
+++ b/v3/src/components/case-table/column-header.tsx
@@ -1,0 +1,20 @@
+import React, { useState } from "react"
+import { THeaderRendererProps } from "./case-table-types"
+import { ColumnHeaderDivider } from "./column-header-divider"
+
+export const ColumnHeader = ({ column }: Pick<THeaderRendererProps, "column">) => {
+
+  const [cellElt, setCellElt] = useState<HTMLElement | null>(null)
+
+  const setNodeRef = (elt: HTMLDivElement | null) => {
+    setCellElt(elt)
+  }
+
+  return (
+    <div className="codap-column-header-content" ref={setNodeRef}>
+      {column?.name}
+      {column &&
+        <ColumnHeaderDivider key={column?.key} columnKey={column?.key} cellElt={cellElt}/>}
+    </div>
+  )
+}

--- a/v3/src/components/case-table/use-columns.tsx
+++ b/v3/src/components/case-table/use-columns.tsx
@@ -1,6 +1,8 @@
-import React, { useCallback, useMemo } from "react"
+import { autorun } from "mobx"
+import React, { useCallback, useEffect, useState } from "react"
 import { IDataSet } from "../../data-model/data-set"
 import { TColumn, TFormatterProps } from "./case-table-types"
+import { ColumnHeader } from "./column-header"
 
 interface IUseColumnsProps {
   data?: IDataSet
@@ -8,28 +10,39 @@ interface IUseColumnsProps {
 }
 export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
 
+  const [columns, setColumns] = useState<TColumn[]>([])
+
   // cell formatter/renderer
-  const cellFormatter = useCallback(({ column, row }: TFormatterProps) => {
+  const CellFormatter = useCallback(({ column, row }: TFormatterProps) => {
     const value = data?.getValue(row.__id__, column.key) ?? ""
     // for now we just render the raw string value; eventually,
     // we can support other formats here (dates, colors, etc.)
-    return <span>{value}</span>
+    return <>{value}</>
   }, [data])
 
-  // column definitions
-  const columns: TColumn[] = useMemo(() => data
-    ? [
-        indexColumn,
-        // attribute column definitions
-        ...data.attributes.map(({ id, name }) => ({
-          key: id,
-          name,
-          resizable: true,
-          cellClass: "codap-data-cell",
-          formatter: cellFormatter
-        }))
-    ]
-    : [], [cellFormatter, data, indexColumn])
+  useEffect(() => {
+    // rebuild column definitions when referenced properties change
+    const disposer = autorun(() => {
+      // column definitions
+      const _columns = data
+        ? [
+            indexColumn,
+            // attribute column definitions
+            ...data.attributes.map(({ id, name }) => ({
+              key: id,
+              name,
+              resizable: true,
+              headerCellClass: "codap-column-header",
+              headerRenderer: ColumnHeader,
+              cellClass: "codap-data-cell",
+              formatter: CellFormatter
+            }))
+        ]
+        : []
+      setColumns(_columns)
+    })
+    return () => disposer()
+  }, [CellFormatter, data, indexColumn])
 
   return columns
 }

--- a/v3/src/components/data-summary.scss
+++ b/v3/src/components/data-summary.scss
@@ -1,6 +1,39 @@
 .data-summary {
+  position: relative;
   width: 100%;
   height: 100%;
   background-color: aliceblue;
   padding: 5px;
+
+  .summary-inspector-drop {
+    position: absolute;
+    left: 10px;
+    bottom: 20px;
+    border: 1px solid gray;
+    padding: 5px 10px;
+    background: #eee;
+
+    &.over {
+      background: #ccc;
+    }
+  }
+
+  .summary-attribute-info {
+    position: absolute;
+    left: 180px;
+    bottom: 5px;
+    padding: 5px;
+  }
+}
+
+.draggable-attribute {
+  display: inline-block;
+  border: 1px solid gray;
+  padding: 3px;
+  margin: 3px;
+  background: #eee;
+
+  &.overlay {
+    opacity: 50%;
+  }
 }

--- a/v3/src/components/data-summary.test.tsx
+++ b/v3/src/components/data-summary.test.tsx
@@ -22,6 +22,7 @@ describe("DataSummary component", () => {
     expect(screen.queryByText("No data")).not.toBeInTheDocument()
     expect(screen.getByText(`Parsed "foo"`, { exact: false })).toBeInTheDocument()
     expect(screen.getByText("1 case(s)", { exact: false })).toBeInTheDocument()
-    expect(screen.getByText("a, b", { exact: false })).toBeInTheDocument()
+    expect(screen.getAllByText("a")).toBeTruthy()
+    expect(screen.getAllByText("b")).toBeTruthy()
   })
 })

--- a/v3/src/components/data-summary.tsx
+++ b/v3/src/components/data-summary.tsx
@@ -1,5 +1,7 @@
+import { Active, DragOverlay, useDndContext, useDraggable, useDroppable } from "@dnd-kit/core"
 import { observer } from "mobx-react-lite"
-import React from "react"
+import React, { useState } from "react"
+import { IAttribute } from "../data-model/attribute"
 import { DataBroker } from "../data-model/data-broker"
 
 import "./data-summary.scss"
@@ -9,16 +11,67 @@ interface IProps {
 }
 export const DataSummary = observer(({ broker }: IProps) => {
   const data = broker?.last
-  const summary = data
-                    ? [
-                      `Parsed "${data.name}" with ${data.cases.length} case(s) and attributes:`,
-                      "",
-                      `${data.attributes.map(attr => attr.name).join(", ")}.`
-                    ]
-                    : ["No data"]
+  const { active } = useDndContext()
+
+  // used to determine when a dragged attribute is over the summary component
+  const { setNodeRef } = useDroppable({ id: "summary-component-drop", data: { accepts: ["attribute"] } })
+
+  const [selectedAttribute, setSelectedAttribute] = useState<IAttribute | undefined>()
+
+  const handleDrop = (attribute: IAttribute) => {
+    setSelectedAttribute(attribute)
+  }
+
   return (
-    <div className="data-summary">
-      {summary.map((line, i) => <p key={`${i}-${line}`}>{line}</p>)}
+    <div ref={setNodeRef} className="data-summary">
+      <p>{data ? `Parsed "${data.name}" with ${data.cases.length} case(s) and attributes:` : "No data"}</p>
+      <div className="data-attributes">
+        {data?.attributes.map(attr => (
+          <DraggableAttribute key={attr.id} attribute={attr} />
+        ))}
+      </div>
+      {data && <SummaryDropTarget attribute={selectedAttribute} onDrop={handleDrop}/>}
+      <DragOverlay dropAnimation={null}>
+        {data && active
+          ? <DraggableAttribute attribute={data?.attrFromID(`${active.id}`)} isOverlay={true}/>
+          : null}
+      </DragOverlay>
     </div>
   )
 })
+
+interface IDraggableAttributeProps {
+  attribute: IAttribute
+  isOverlay?: boolean;
+}
+const DraggableAttribute = ({ attribute, isOverlay = false }: IDraggableAttributeProps) => {
+  const data: any = { type: "attribute", attributeId: attribute.id }
+  const { attributes, listeners, setNodeRef } = useDraggable({ id: attribute.id, data })
+  const overlayClass = isOverlay ? "overlay" : ""
+  return (
+    <div ref={setNodeRef} className={`draggable-attribute ${overlayClass}`} {...attributes} {...listeners}>
+      {attribute.name}
+    </div>
+  )
+}
+
+interface ISummaryDropTargetProps {
+  attribute?: IAttribute
+  onDrop?: (attribute: IAttribute) => void
+}
+const SummaryDropTarget = ({ attribute, onDrop }: ISummaryDropTargetProps) => {
+  const data: any = { accepts: ["attribute"], onDrop: (active: Active) => onDrop?.(active.data?.current?.attribute)}
+  const { isOver, setNodeRef } = useDroppable({ id: "summary-inspector-drop", data })
+  return (
+    <>
+      <div ref={setNodeRef} className={`summary-inspector-drop ${isOver ? "over" : ""}`}>
+        Attribute Inspector
+      </div>
+      {attribute &&
+        <div className="summary-attribute-info">
+          <p><b>{`${attribute.name}`}</b> is a <i>{`${attribute.type}`}</i> attribute.</p>
+        </div>
+      }
+    </>
+  )
+}

--- a/v3/src/components/data-summary.tsx
+++ b/v3/src/components/data-summary.tsx
@@ -18,8 +18,8 @@ export const DataSummary = observer(({ broker }: IProps) => {
 
   const [selectedAttribute, setSelectedAttribute] = useState<IAttribute | undefined>()
 
-  const handleDrop = (attribute: IAttribute) => {
-    setSelectedAttribute(attribute)
+  const handleDrop = (attributeId: string) => {
+    setSelectedAttribute(data?.attrFromID(attributeId))
   }
 
   return (
@@ -57,10 +57,10 @@ const DraggableAttribute = ({ attribute, isOverlay = false }: IDraggableAttribut
 
 interface ISummaryDropTargetProps {
   attribute?: IAttribute
-  onDrop?: (attribute: IAttribute) => void
+  onDrop?: (attributeId: string) => void
 }
 const SummaryDropTarget = ({ attribute, onDrop }: ISummaryDropTargetProps) => {
-  const data: any = { accepts: ["attribute"], onDrop: (active: Active) => onDrop?.(active.data?.current?.attribute)}
+  const data: any = { accepts: ["attribute"], onDrop: (active: Active) => onDrop?.(active.data?.current?.attributeId)}
   const { isOver, setNodeRef } = useDroppable({ id: "summary-inspector-drop", data })
   return (
     <>

--- a/v3/src/components/dnd-detect-collision.ts
+++ b/v3/src/components/dnd-detect-collision.ts
@@ -1,0 +1,20 @@
+import { closestCenter, CollisionDetection, pointerWithin, rectIntersection } from "@dnd-kit/core"
+
+export const dndDetectCollision: CollisionDetection = (args) => {
+  // use pointerWithin to determine the component we're in
+  const collisions = pointerWithin(args)
+
+  // if we're in the summary component, use rectangle intersection on the inspector button
+  if (collisions.find(collision => collision.id === "summary-component-drop")) {
+    const containers = args.droppableContainers.filter(({id}) => id === "summary-inspector-drop")
+    return rectIntersection({ ...args, droppableContainers: containers })
+  }
+
+  // if we're in the case table component, use closest center on the column header dividers
+  if (collisions.find(collision => collision.id === "case-table-drop")) {
+    const containers = args.droppableContainers.filter(({id}) => `${id}`.includes("table-attribute"))
+    return closestCenter({ ...args, droppableContainers: containers })
+  }
+
+  return collisions
+}

--- a/v3/src/data-model/data-broker.ts
+++ b/v3/src/data-model/data-broker.ts
@@ -60,6 +60,11 @@ export class DataBroker {
   removeDataSet(id: string) {
     this.dataSets.delete(id)
   }
+
+  @action
+  clear() {
+    this.dataSets.clear()
+  }
 }
 
 // for MVP we only support a single DataSet

--- a/v3/src/data-model/data-set.test.ts
+++ b/v3/src/data-model/data-set.test.ts
@@ -149,15 +149,24 @@ test("DataSet basic functionality", () => {
   expect(dataset.attributes[0].name).toBe("num")
   expect(dataset.attributes[1].name).toBe("str")
   // move second attribute before the first
-  dataset.moveAttribute(strAttrID, numAttrID)
+  dataset.moveAttribute(strAttrID, { before: numAttrID })
   expect(dataset.attributes[0].name).toBe("str")
   expect(dataset.attributes[1].name).toBe("num")
-  strAttr = dataset.attrFromName("str")
-  expect(strAttr?.id).toBe(strAttrID)
+  // move first attribute after the second
+  dataset.moveAttribute(strAttrID, { after: numAttrID })
+  expect(dataset.attributes[0].name).toBe("num")
+  expect(dataset.attributes[1].name).toBe("str")
+  // move attribute to bugus location moves it to end
+  dataset.moveAttribute(numAttrID, { after: "bogus" })
+  expect(dataset.attributes[0].name).toBe("str")
+  expect(dataset.attributes[1].name).toBe("num")
   // moving a non-existent attribute is a no-op
   dataset.moveAttribute("")
   expect(dataset.attributes[0].name).toBe("str")
   expect(dataset.attributes[1].name).toBe("num")
+
+  strAttr = dataset.attrFromName("str")
+  expect(strAttr?.id).toBe(strAttrID)
 
   // validate attribute indices
   dataset.attributes.forEach((attr, index) => {

--- a/v3/src/hooks/use-data-set-context.ts
+++ b/v3/src/hooks/use-data-set-context.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from "react"
+import { IDataSet } from "../data-model/data-set"
+
+export const DataSetContext = createContext<IDataSet | undefined>(undefined)
+
+export const useDataSetContext = () => {
+  return useContext(DataSetContext)
+}

--- a/v3/src/sample-data/mammals.ts
+++ b/v3/src/sample-data/mammals.ts
@@ -1,0 +1,36 @@
+import { parse } from "papaparse"
+
+export const mammalsCsv =
+  "Mammal,Order,LifeSpan,Height,Mass,Sleep,Speed,Habitat,Diet\n" +
+  "African Elephant,Proboscidae,70,4,6400,3,40,land,plants\n" +
+  "Asian Elephant,Proboscidae,70,3,5000,4,40,land,plants\n" +
+  "Big Brown Bat,Chiroptera,19,0.1,0.02,20,40,land,meat\n" +
+  "Bottlenose Dolphin,Cetacea,25,3.5,635,5,37,water,meat\n" +
+  "Cheetah,Carnivora,14,1.5,50,12,110,land,meat\n" +
+  "Chimpanzee,Primate,40,1.5,68,10,,land,both\n" +
+  "Domestic Cat,Carnivora,16,0.8,4.5,12,50,land,meat\n" +
+  "Donkey,Perissodactyla,40,1.2,187,3,50,land,plants\n" +
+  "Giraffe,Artiodactyla,25,5,1100,2,50,land,plants\n" +
+  "Gray Wolf,Carnivora,16,1.6,80,13,64,land,meat\n" +
+  "Grey Seal,Pinnipedia,30,2.1,275,6,19,both,meat\n" +
+  "Ground Squirrel,Rodentia,9,0.3,0.1,15,19,land,both\n" +
+  "Horse,Perissodactyla,25,1.5,521,3,69,land,plants\n" +
+  "House Mouse,Rodentia,3,0.1,0.03,12,13,land,both\n" +
+  "Human,Primate,80,1.9,80,8,45,land,both\n" +
+  "Jaguar,Carnivora,20,1.8,115,11,60,land,meat\n" +
+  "Killer Whale,Cetacea,50,6.5,4000,,48,water,meat\n" +
+  "Lion,Carnivora,15,2.5,250,20,80,land,meat\n" +
+  "N. American Opossum,Didelphimorphia,5,0.5,5,19,,land,both\n" +
+  "Nine-Banded Armadillo,Xenarthra,10,0.6,7,17,1,land,meat\n" +
+  "Owl Monkey,Primate,12,0.4,1,17,,land,both\n" +
+  "Patas Monkey,Primate,20,0.9,13,,55,land,both\n" +
+  "Pig,Artiodactyla,10,1,192,8,18,land,both\n" +
+  "Pronghorn Antelope,Artiodactyla,10,0.9,70,,98,land,plants\n" +
+  "Rabbit,Lagomorpha,5,0.5,3,11,56,land,plants\n" +
+  "Red Fox,Carnivora,7,0.8,5,10,48,land,both\n" +
+  "Spotted Hyena,Carnivora,25,0.9,70,18,64,land,meat"
+
+export function importMammals() {
+  const { data } = parse(mammalsCsv, { header: true })
+  return data as Array<Record<string, string>>
+}


### PR DESCRIPTION
Demo: https://codap3.concord.org/branch/v3-attribute-drag/

Dragging from the case table column headers is a little bit tricky because of the interplay between ReactDataGrid and DnDKit. Therefore, this PR implements the ability to drag attributes from the summary component instead. Attributes can be dropped on the Inspector button in the summary component itself, resulting in a report on the attribute's type, or on the case table column header row which is interpreted as a means to change the order of the attributes.

- attributes can be dragged from the summary component
- attributes can be dropped on the Inspector button in the summary component
- attributes can be dropped on the case table column headers to reorder attributes
- `mammals` URL parameter preloads mammals data for easier development/debugging

@bfinzer Probably a good candidate for a sync review.