### PR TITLE
V3 Graph refactor to use setPointCoordinates utility function

### DIFF
--- a/v3/src/components/graph/dotplotdots.tsx
+++ b/v3/src/components/graph/dotplotdots.tsx
@@ -1,17 +1,11 @@
 import {max, range, select} from "d3"
 import React, {memo, useCallback, useEffect, useRef, useState} from "react"
 import {observer} from "mobx-react-lite"
-import {
-  plotProps,
-  transitionDuration,
-  InternalizedData,
-  defaultRadius,
-  defaultDiameter,
-  dragRadius
-} from "./graphing-types"
+import {plotProps, InternalizedData, defaultRadius, defaultDiameter, dragRadius}
+  from "./graphing-types"
 import {useDragHandlers, useSelection} from "./graph-hooks/graph-hooks"
 import {IDataSet} from "../../data-model/data-set"
-import {getScreenCoord} from "./graph-utils/graph_utils"
+import {getScreenCoord, setPointCoordinates} from "./graph-utils/graph_utils"
 
 
 export const DotPlotDots = memo(observer(function DotPlotDots(props: {
@@ -20,7 +14,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: {
   plotHeight: number,
   xMin: number,
   xMax: number,
-  worldDataRef:  React.MutableRefObject<IDataSet | undefined>,
+  worldDataRef: React.MutableRefObject<IDataSet | undefined>,
   graphDataRef: React.MutableRefObject<InternalizedData>,
   dotsRef: React.RefObject<SVGSVGElement>
 }) {
@@ -96,7 +90,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: {
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
   useEffect(function refreshPoints() {
-    const xAttrID = graphDataRef.current.xAttributeID
+      const xAttrID = graphDataRef.current.xAttributeID
 
       function computeBinPlacements() {
         const numBins = Math.ceil(plotWidth / defaultDiameter) + 1,
@@ -122,34 +116,14 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: {
 
       const
         yHeight = Number(yScale?.range()[0]),
-        dotsSvgElement = dotsRef.current,
-        binMap: { [id: string]: { yIndex: number } } = {},
-        tTransitionDuration = firstTime ? transitionDuration : 0
+        binMap: { [id: string]: { yIndex: number } } = {}
       let overlap = 0
       computeBinPlacements()
 
-      const selection = select(dotsSvgElement).selectAll('circle')
-        .classed('dot-highlighted',
-          (anID:string ) => !!(worldDataRef.current?.isCaseSelected(anID)))
-      if (tTransitionDuration > 0) {
-        selection
-          .transition()
-          .duration(tTransitionDuration)
-          .on('end', () => {
-            setFirstTime(false)
-          })
-          .attr('cx', (anID:string) => getScreenCoord(worldDataRef.current, anID, xAttrID, xScale))
-          .attr('cy', (anID: string) => computeYCoord(binMap[anID]))
-          .attr('r', defaultRadius)
-      } else {
-        selection
-          .attr('cx', (anID: string) => getScreenCoord(worldDataRef.current, anID, xAttrID, xScale))
-          .attr('cy', (anID: string) => computeYCoord(binMap[anID]))
-      }
-      select(dotsSvgElement)
-        .selectAll('.dot-highlighted')
-        .raise()
+      const getScreenX = (anID: string) => getScreenCoord(worldDataRef.current, anID, xAttrID, xScale),
+        getScreenY = (anID: string) => computeYCoord(binMap[anID])
 
+      setPointCoordinates({dotsRef, worldDataRef, firstTime, setFirstTime, getScreenX, getScreenY})
     }, [firstTime, dotsRef, xScale, yScale, xMin, xMax, graphDataRef, worldDataRef,
       plotWidth, plotHeight, refreshCounter, forceRefreshCounter]
   )

--- a/v3/src/components/graph/graph-hooks/graph-hooks.ts
+++ b/v3/src/components/graph/graph-hooks/graph-hooks.ts
@@ -48,7 +48,7 @@ export const useGetData = (props: IUseGetDataProps) => {
       if (iAttr.type === 'numeric') {
         if (result.xAttrId === '') {
           result.xAttrId = iAttr.id
-        } else if (result.yAttrId === '') {
+        }else if (result.yAttrId === '') {
           result.yAttrId = iAttr.id
         } else {
           break

--- a/v3/src/components/graph/graph.tsx
+++ b/v3/src/components/graph/graph.tsx
@@ -4,7 +4,7 @@ import React, {useEffect, useRef, useState} from "react"
 import {useResizeDetector} from "react-resize-detector"
 import {Axis} from "./axis"
 import {Background} from "./background"
-import {plotProps, InternalizedData} from "./graphing-types"
+import {plotProps, InternalizedData, defaultRadius} from "./graphing-types"
 import {ScatterDots} from "./scatterdots"
 import {DotPlotDots} from "./dotplotdots"
 import {Marquee} from "./marquee"
@@ -46,7 +46,6 @@ export const Graph = observer(({broker}: IProps) => {
     plotWidthRef = useCurrent(plotWidth),
     plotHeight = 0.8 * (height || 500),
     plotHeightRef = useCurrent(plotHeight),
-    defaultRadius = 5,
 
     [plotType, setPlotType] = useState<'scatterplot' | 'dotplot'>('scatterplot'),
     [counter, setCounter] = useState(0),


### PR DESCRIPTION
There was a 25-line redundancy in scatterdtots and dotplotdots now factored out into a utility function