### PR TITLE
V3: Axis models and useNumericAxisScale hook

### DIFF
--- a/v3/src/components/graph/axis-model.test.ts
+++ b/v3/src/components/graph/axis-model.test.ts
@@ -1,0 +1,7 @@
+import { AxisModel } from "./axis-model"
+
+describe("AxisModel", () => {
+  it("should error if AxisModel is instantiated directly", () => {
+    expect(() => AxisModel.create({ place: "left" })).toThrow()
+  })
+})

--- a/v3/src/components/graph/axis-model.ts
+++ b/v3/src/components/graph/axis-model.ts
@@ -1,0 +1,40 @@
+import { Instance, types } from "mobx-state-tree"
+
+export const AxisPlaces = ["bottom", "left", "right", "top"] as const
+export type AxisPlace = typeof AxisPlaces[number]
+
+export type AxisOrientation = "horizontal" | "vertical"
+
+export const AxisModel = types.model("AxisModel", {
+  type: types.optional(types.string, () => {throw "type must be overridden"}),
+  place: types.enumeration([...AxisPlaces])
+})
+.views(self => ({
+  get orientation(): AxisOrientation {
+    return self.place === "left" || self.place === "right"
+            ? "vertical" : "horizontal"
+  }
+}))
+export interface IAxisModel extends Instance<typeof AxisModel> {}
+
+export const ScaleTypes = ["linear", "log"] as const
+export type ScaleType = typeof ScaleTypes[number]
+
+export const NumericAxisModel = AxisModel
+  .named("NumericAxisModel")
+  .props({
+    type: "numeric",
+    scale: types.optional(types.enumeration([...ScaleTypes]), "linear"),
+    min: types.number,
+    max: types.number
+  })
+  .actions(self => ({
+    setScale(scale: ScaleType) {
+      self.scale = scale
+    },
+    setDomain(min: number, max: number) {
+      self.min = min
+      self.max = max
+    }
+  }))
+export interface INumericAxisModel extends Instance<typeof NumericAxisModel> {}

--- a/v3/src/components/graph/graph-hooks/use-numeric-axis-scale.test.ts
+++ b/v3/src/components/graph/graph-hooks/use-numeric-axis-scale.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { NumericAxisModel } from "../axis-model"
+import { useNumericAxisScale } from "./use-numeric-axis-scale"
+
+const d3 = jest.requireActual("d3")
+const mockScaleLinear = jest.fn((...args: any[]) => d3.scaleLinear(...args))
+const mockScaleLog = jest.fn((...args: any[]) => d3.scaleLog(...args))
+jest.mock("d3", () => ({
+  scaleLinear: (...args: any[]) => mockScaleLinear(...args),
+  scaleLog: (...args: any[]) => mockScaleLog(...args)
+}))
+
+describe("useNumericAxisScale", () => {
+  const xAxis = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
+  const yAxis = NumericAxisModel.create({ place: "left", min: 0, max: 10 })
+
+  beforeEach(() => {
+    mockScaleLinear.mockClear()
+    mockScaleLog.mockClear()
+  })
+
+  it("should update the domain when the axis model changes", () => {
+    const { result } = renderHook(() => useNumericAxisScale({ axis: xAxis, extent: 100 }))
+    expect(result.current.domain()).toEqual([0, 10])
+    expect(result.current.range()).toEqual([0, 100])
+    xAxis.setDomain(0, 100)
+    // domain is updated without an additional render
+    expect(result.current.domain()).toEqual([0, 100])
+    expect(result.current.range()).toEqual([0, 100])
+    expect(mockScaleLinear).toHaveBeenCalledTimes(1)
+    expect(mockScaleLog).toHaveBeenCalledTimes(0)
+  })
+
+  it("should update the range when the extent changes", () => {
+    let width = 100
+    const { rerender, result } = renderHook(() => useNumericAxisScale({ axis: xAxis, extent: width }))
+    expect(result.current.range()).toEqual([0, 100])
+    width = 1000
+    rerender()
+    // range is updated after a render
+    expect(result.current.range()).toEqual([0, 1000])
+    expect(mockScaleLinear).toHaveBeenCalledTimes(1)
+    expect(mockScaleLog).toHaveBeenCalledTimes(0)
+  })
+
+  it("should reverse the range for the vertical axis", () => {
+    let height = 100
+    const { rerender, result } = renderHook(() => useNumericAxisScale({ axis: yAxis, extent: height }))
+    expect(result.current.domain()).toEqual([0, 10])
+    expect(result.current.range()).toEqual([100, 0])
+    yAxis.setDomain(0, 50)
+    expect(result.current.domain()).toEqual([0, 50])
+    expect(result.current.range()).toEqual([100, 0])
+    height = 500
+    expect(result.current.domain()).toEqual([0, 50])
+    expect(result.current.range()).toEqual([100, 0])
+    // range is updated after a render
+    rerender()
+    expect(result.current.domain()).toEqual([0, 50])
+    expect(result.current.range()).toEqual([500, 0])
+    expect(mockScaleLinear).toHaveBeenCalledTimes(1)
+    expect(mockScaleLog).toHaveBeenCalledTimes(0)
+  })
+
+  it("should support logarithmic axes", () => {
+    const { rerender, result } = renderHook(() => useNumericAxisScale({ axis: xAxis, extent: 100 }))
+    expect(result.current.domain()).toEqual([0, 100])
+    expect(result.current.range()).toEqual([0, 100])
+    xAxis.setScale("log")
+    // domain is updated without an additional render
+    expect(result.current.domain()).toEqual([0, 100])
+    expect(result.current.range()).toEqual([0, 100])
+    rerender()
+    expect(mockScaleLinear).toHaveBeenCalledTimes(1)
+    expect(mockScaleLog).toHaveBeenCalledTimes(1)
+    expect(result.current.domain()).toEqual([0, 100])
+    xAxis.setDomain(0, 10)
+    // domain of new scale is updated without a render
+    expect(result.current.domain()).toEqual([0, 10])
+  })
+})

--- a/v3/src/components/graph/graph-hooks/use-numeric-axis-scale.ts
+++ b/v3/src/components/graph/graph-hooks/use-numeric-axis-scale.ts
@@ -1,0 +1,30 @@
+import { scaleLinear, scaleLog } from "d3"
+import { autorun } from "mobx"
+import { useEffect, useMemo } from "react"
+import { INumericAxisModel } from "../axis-model"
+
+interface IProps {
+  axis: INumericAxisModel
+  extent: number
+}
+export function useNumericAxisScale({ axis, extent }: IProps) {
+  const scale = useMemo(() => axis.scale === "log" ? scaleLog() : scaleLinear(), [axis.scale])
+
+  // update domain when axis model changes
+  useEffect(() => {
+    const disposer = autorun(() => {
+      const { min, max } = axis
+      scale.domain([min, max])
+    })
+    return () => disposer()
+  }, [axis, scale])
+
+  // update range when extent changes
+  useEffect(() => {
+    const { orientation } = axis
+    const range = orientation === "vertical" ? [extent, 0] : [0, extent]
+    scale.range(range)
+  }, [axis, extent, scale])
+
+  return scale
+}


### PR DESCRIPTION
For simplicity, we limit ourselves to two axis models, the base `AxisModel` and `NumericAxisModel`. For illustrative purposes, the `NumericAxisModel` supports linear or log scales. The `useNumericAxisScale()` hook returns a `D3` scale of the appropriate type and keeps it synchronized with the model via a MobX `autorun`. These are not yet used by the graph code.