### PR TITLE
V3: Support dropping attributes on graph axes

### DIFF
--- a/v3/src/components/data-summary.tsx
+++ b/v3/src/components/data-summary.tsx
@@ -65,8 +65,11 @@ interface ISummaryDropTargetProps {
   onDrop?: (attributeId: string) => void
 }
 const SummaryDropTarget = ({ attribute, onDrop }: ISummaryDropTargetProps) => {
-  const data: IDropData = { accepts: ["attribute"],
-                            onDrop: (active: Active) => onDrop?.(active.data?.current?.attributeId) }
+  const handleDrop = (active: Active) => {
+    const dragAttributeID = getDragAttributeId(active)
+    dragAttributeID && onDrop?.(dragAttributeID)
+  }
+  const data: IDropData = { accepts: ["attribute"], onDrop: handleDrop }
   const { isOver, setNodeRef } = useDroppable({ id: "summary-inspector-drop", data })
   return (
     <>

--- a/v3/src/components/graph/adornments/movable-line.tsx
+++ b/v3/src/components/graph/adornments/movable-line.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useEffect, useRef, useState} from "react"
 import {autorun} from "mobx"
 import {drag, select} from "d3"
+import { kGraphClassSelector } from "../graphing-types"
 import {INumericAxisModel} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {equationString, IAxisIntercepts, lineToAxisIntercepts} from "../utilities/graph_utils"
@@ -164,7 +165,7 @@ export const MovableLine = (props: {
       .attr('class', 'movable-line-cover movable-line-middle-cover')
     newLineObject.upper = selection.append('line')
       .attr('class', 'movable-line-cover movable-line-upper-cover')
-    const equationDiv = select('.graph-plot').append('div')
+    const equationDiv = select(kGraphClassSelector).append('div')
       .attr('class', 'movable-line-equation-container')
     newLineObject.equation = equationDiv
       .append('p')

--- a/v3/src/components/graph/adornments/movable-value.tsx
+++ b/v3/src/components/graph/adornments/movable-value.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useEffect, useRef, useState} from "react"
 import {drag, select} from "d3"
 import {autorun, reaction} from "mobx"
 import {IMovableValueModel} from "./adornment-models"
+import { kGraphClassSelector } from "../graphing-types"
 import { INumericAxisModel } from "../models/axis-model"
 import { useGraphLayoutContext } from "../models/graph-layout"
 import {valueLabelString} from "../utilities/graph_utils"
@@ -92,7 +93,7 @@ export const MovableValue = (props: {
     newValueObject.cover = selection.append('line')
       .attr('class', 'movable-value-cover')
       .attr('transform', transform)
-    newValueObject.valueLabel = select('.graph-plot').append('div')
+    newValueObject.valueLabel = select(kGraphClassSelector).append('div')
       .attr('class', 'movable-value-label')
     setValueObject(newValueObject)
 

--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -2,6 +2,7 @@ import { Active } from "@dnd-kit/core"
 import React, {useCallback, useEffect, useRef, useState} from "react"
 import {drag, select} from "d3"
 import { DroppableSvg } from "./droppable-svg"
+import { kGraphClassSelector } from "../graphing-types"
 import { getDragAttributeId, IDropData } from "../../../hooks/use-drag-drop"
 import { useInstanceIdContext } from "../../../hooks/use-instance-id-context"
 import {useNumericAxis} from "../hooks/use-numeric-axis"
@@ -36,7 +37,7 @@ export const Axis = ({ model, transform, label, onDropAttribute }: IProps) => {
     orientation = model.place
 
   useEffect(() => {
-    graphRef.current = axisElt?.closest(".graph-plot") ?? null
+    graphRef.current = axisElt?.closest(kGraphClassSelector) ?? null
   }, [axisElt])
 
   useNumericAxis({ axisModel: model, axisElt })
@@ -48,7 +49,7 @@ export const Axis = ({ model, transform, label, onDropAttribute }: IProps) => {
     droppedAttrId && onDropAttribute(model.place, droppedAttrId)
   }, [model.place, onDropAttribute])
 
-  const data: IDropData = { accepts: ["attribute"], onDrop: (active: Active) => handleDrop(active)}
+  const data: IDropData = { accepts: ["attribute"], onDrop: handleDrop }
 
   useEffect(function createAndRefresh() {
     let scaleAtStart: any = null,

--- a/v3/src/components/graph/components/droppable-svg.scss
+++ b/v3/src/components/graph/components/droppable-svg.scss
@@ -1,0 +1,13 @@
+.droppable-svg {
+  position: absolute;
+  background: transparent;
+  pointer-events: none;
+  opacity: 50%;
+  // patterned after CODAP v2 drag-highlight
+  &.active {
+    border: 5px solid rgb(255, 216, 102);
+  }
+  &.over {
+    background: yellow;
+  }
+}

--- a/v3/src/components/graph/components/droppable-svg.tsx
+++ b/v3/src/components/graph/components/droppable-svg.tsx
@@ -1,0 +1,46 @@
+import { Active, useDroppable } from "@dnd-kit/core"
+import React, { CSSProperties, useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+
+import "./droppable-svg.scss"
+
+interface IProps {
+  className?: string
+  portal: HTMLElement | null
+  target: SVGGElement | null
+  dropId: string
+  dropData: any
+  onIsActive?: (active: Active) => boolean
+}
+export const DroppableSvg = ({ className, portal, target, dropId, dropData, onIsActive }: IProps) => {
+  const [portalBounds, setPortalBounds] = useState<DOMRect | null>(null)
+  const [targetBounds, setTargetBounds] = useState<DOMRect | null>(null)
+
+  const { active, isOver, setNodeRef } = useDroppable({ id: dropId, data: dropData })
+  const isActive = active && onIsActive?.(active)
+
+  useEffect(() => {
+    // track the bounds of the graph and axis elements
+    const observer = target && new ResizeObserver(() => {
+      const _portalBounds = portal?.getBoundingClientRect()
+      const _targetBounds = target?.getBoundingClientRect()
+      _portalBounds && setPortalBounds(_portalBounds)
+      _targetBounds && setTargetBounds(_targetBounds)
+    })
+    target && observer?.observe(target)
+
+    return () => observer?.disconnect()
+  }, [portal, target])
+
+  // calculate the position of the overlay
+  const left = (targetBounds?.left ?? 0) - (portalBounds?.left ?? 0)
+  const top = (targetBounds?.top ?? 0) - (portalBounds?.top ?? 0)
+  const style: CSSProperties = targetBounds
+                                ? { left, top, width: targetBounds.width, height: targetBounds.height }
+                                : {}
+  const classes = `droppable-svg ${className} ${isActive ? "active" : ""} ${isOver ? "over" : ""}`
+  return portal && createPortal(
+    <div ref={setNodeRef} className={classes} style={style} />,
+    portal
+  )
+}

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -1,4 +1,5 @@
 .graph-plot {
+  position: relative;
   width: 100%;
   height: 100%;
   background-color: aliceblue;

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -4,7 +4,7 @@ import {observer} from "mobx-react-lite"
 import React, {MutableRefObject, useEffect, useRef, useState} from "react"
 import {Axis} from "./axis"
 import {Background} from "./background"
-import {plotProps, defaultRadius} from "../graphing-types"
+import {defaultRadius, kGraphClass, plotProps} from "../graphing-types"
 import {ScatterDots} from "./scatterdots"
 import {DotPlotDots} from "./dotplotdots"
 import {Marquee} from "./marquee"
@@ -101,7 +101,7 @@ export const Graph = observer(({ model: graphModel, graphRef }: IProps) => {
     const handleDropAttribute = (place: AxisPlace, attrId: string) => {
       const attrName = dataset?.attrFromID(attrId)?.name
       toast({
-        position: "top",
+        position: "top-right",
         title: "Attribute dropped",
         description: `The attribute ${attrName || attrId} was dropped on the ${place} axis!`,
         status: "success"
@@ -109,7 +109,7 @@ export const Graph = observer(({ model: graphModel, graphRef }: IProps) => {
     }
 
     return (
-      <div className='graph-plot' ref={graphRef} data-testid="graph">
+      <div className={kGraphClass} ref={graphRef} data-testid="graph">
         <svg className='graph-svg' ref={svgRef}>
           {plotType === 'scatterPlot' ?
             <Axis model={yAxisModel} label={yName}

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -1,3 +1,4 @@
+import { useToast } from "@chakra-ui/react"
 import {format, select} from "d3"
 import {observer} from "mobx-react-lite"
 import React, {MutableRefObject, useEffect, useRef, useState} from "react"
@@ -9,7 +10,7 @@ import {DotPlotDots} from "./dotplotdots"
 import {Marquee} from "./marquee"
 import {MovableLine} from "../adornments/movable-line"
 import {MovableValue} from "../adornments/movable-value"
-import { INumericAxisModel } from "../models/axis-model"
+import { AxisPlace, INumericAxisModel } from "../models/axis-model"
 import { useGraphLayoutContext } from "../models/graph-layout"
 import { IGraphModel } from "../models/graph-model"
 import {useGetData} from "../hooks/graph-hooks"
@@ -96,29 +97,30 @@ export const Graph = observer(({ model: graphModel, graphRef }: IProps) => {
       movableValueModel.setValue(xScale.domain()[0] + xDomainDelta / 3)
     }, [movableLineModel, movableValueModel, xScale, yScale, graphData.xAttributeID, graphData.yAttributeID])
 
+    const toast = useToast()
+    const handleDropAttribute = (place: AxisPlace, attrId: string) => {
+      const attrName = dataset?.attrFromID(attrId)?.name
+      toast({
+        position: "top",
+        title: "Attribute dropped",
+        description: `The attribute ${attrName || attrId} was dropped on the ${place} axis!`,
+        status: "success"
+      })
+    }
+
     return (
       <div className='graph-plot' ref={graphRef} data-testid="graph">
         <svg className='graph-svg' ref={svgRef}>
           {plotType === 'scatterPlot' ?
-            <Axis svgRef={svgRef}
-                  axisProps={
-                    {
-                      model: yAxisModel,
-                      transform: `translate(${margin.left - 1}, 0)`,
-                      label: yName
-                    }
-                  }
+            <Axis model={yAxisModel} label={yName}
+                  transform={`translate(${margin.left - 1}, 0)`}
+                  onDropAttribute={handleDropAttribute}
             />
-            : ''
+            : null
           }
-          <Axis svgRef={svgRef}
-                axisProps={
-                  {
-                    model: xAxisModel,
-                    transform: `translate(${margin.left}, ${layout.plotHeight})`,
-                    label: xName
-                  }
-                }
+          <Axis model={xAxisModel} label={xName}
+                transform={`translate(${margin.left}, ${layout.plotHeight})`}
+                onDropAttribute={handleDropAttribute}
           />
           <Background dots={dotsProps} marquee={{rect: marqueeRect, setRect: setMarqueeRect}} />
           <svg ref={plotAreaSVGRef} className='graph-dot-area'>

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -27,3 +27,6 @@ export const transitionDuration = 1000,
 
 export const PlotTypes = ["dotPlot", "scatterPlot"] as const
 export type PlotType = typeof PlotTypes[number]
+
+export const kGraphClass = "graph-plot"
+export const kGraphClassSelector = `.${kGraphClass}`

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -1,11 +1,3 @@
-import {INumericAxisModel} from "./models/axis-model"
-
-export interface AxisProps {
-  model: INumericAxisModel,
-  transform: string,
-  label: string | undefined
-}
-
 // One element of the data array assigned to the points
 export interface InternalizedData {
   xAttributeID: string,

--- a/v3/src/hooks/use-drag-drop.ts
+++ b/v3/src/hooks/use-drag-drop.ts
@@ -1,0 +1,35 @@
+import { Active, DataRef, useDraggable, UseDraggableArguments } from "@dnd-kit/core"
+
+// list of draggable types
+const DragTypes = ["attribute"] as const
+type DragType = typeof DragTypes[number]
+
+export interface IDragData {
+  type: DragType
+}
+
+export interface IDropData {
+  accepts: DragType[]
+  onDrop?: (active: Active) => void
+}
+
+export interface IDragAttributeData {
+  type: "attribute"
+  attributeId: string
+}
+export function isDragAttributeData(data: DataRef): data is DataRef<IDragAttributeData> {
+  return data.current?.type === "attribute"
+}
+export const getDragAttributeId = (active: Active | null) => {
+  return active && isDragAttributeData(active.data) ? active.data.current?.attributeId : undefined
+}
+
+export interface IUseDraggableAttribute extends Omit<UseDraggableArguments, "id"> {
+  // should generally include instanceId to support dragging from multiple component instances
+  prefix: string
+  attributeId: string
+}
+export const useDraggableAttribute = ({ prefix, attributeId, ...others }: IUseDraggableAttribute) => {
+  const data: IDragAttributeData = { type: "attribute", attributeId }
+  return useDraggable({ ...others, id: `${prefix}-${attributeId}`, data })
+}

--- a/v3/src/hooks/use-drag-drop.ts
+++ b/v3/src/hooks/use-drag-drop.ts
@@ -13,7 +13,7 @@ export interface IDropData {
   onDrop?: (active: Active) => void
 }
 
-export interface IDragAttributeData {
+export interface IDragAttributeData extends IDragData {
   type: "attribute"
   attributeId: string
 }


### PR DESCRIPTION
PT: [[#181909395]](https://www.pivotaltracker.com/story/show/181909395)
Demo: https://codap3.concord.org/branch/v3-axis-attribute/?sample=mammals

- Shows CODAP-inspired drop target highlighting on axes while an attribute is being dragged and when a dragged attribute is over an axis.
- The implementation was made more difficult by the fact that `DnDKit` doesn't support SVG elements as drop targets, so I implemented a `DroppableSvg` component which is a transparent overlay on top of an SVG element to handle the drop behavior.
- For now, when a drop occurs a message is presented to the user. Actually handling the dropped attribute by changing the graph model is left as an exercise for a future PR.