### PR TITLE
V3: Drag from case table column headers; general drag/drop improvements

### DIFF
--- a/v3/src/components/app-state.test.ts
+++ b/v3/src/components/app-state.test.ts
@@ -1,0 +1,30 @@
+import { reaction } from "mobx"
+import { appState } from "./app-state"
+
+describe("AppState", () => {
+  it("works when enabled", () => {
+    const performanceReaction = jest.fn()
+    reaction(() => appState.isPerformanceMode, () => performanceReaction())
+    expect(performanceReaction).not.toHaveBeenCalled()
+    appState.beginPerformance()
+    expect(performanceReaction).toHaveBeenCalledTimes(1)
+    appState.endPerformance()
+    expect(performanceReaction).toHaveBeenCalledTimes(2)
+  })
+
+  it("works when disabled", () => {
+    const performanceReaction = jest.fn()
+    appState.disablePerformance()
+    reaction(() => appState.isPerformanceMode, () => performanceReaction())
+    expect(performanceReaction).not.toHaveBeenCalled()
+    appState.beginPerformance()
+    expect(performanceReaction).not.toHaveBeenCalled()
+    appState.endPerformance()
+    expect(performanceReaction).not.toHaveBeenCalled()
+    appState.enablePerformance()
+    appState.beginPerformance()
+    expect(performanceReaction).toHaveBeenCalledTimes(1)
+    appState.endPerformance()
+    expect(performanceReaction).toHaveBeenCalledTimes(2)
+  })
+})

--- a/v3/src/components/app-state.ts
+++ b/v3/src/components/app-state.ts
@@ -15,16 +15,19 @@ class AppState {
   private appModeCount = 0
 
   // enables/disables performance mode globally, e.g. for a/b testing
+  @observable
   private isPerformanceEnabled = true
 
   constructor() {
     makeObservable(this)
   }
 
+  @action
   enablePerformance() {
     this.isPerformanceEnabled = true
   }
 
+  @action
   disablePerformance() {
     this.isPerformanceEnabled = false
   }
@@ -34,6 +37,7 @@ class AppState {
     return this.isPerformanceEnabled && (this.appModeCount > 0) ? "performance" : "normal"
   }
 
+  @computed
   get isPerformanceMode() {
     return this.appMode === "performance"
   }

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -1,6 +1,8 @@
-import { DndContext, DragEndEvent, DragStartEvent } from "@dnd-kit/core"
+import {
+  DndContext, DragEndEvent, DragStartEvent, KeyboardSensor, PointerSensor, useSensor, useSensors
+} from "@dnd-kit/core"
 import React, { useCallback, useEffect, useState } from "react"
-import { CaseTable } from "./case-table/case-table"
+import { CaseTableComponent } from "./case-table/case-table-component"
 import {Container} from "./container"
 import {DataSummary} from "./data-summary"
 import {gDataBroker} from "../data-model/data-broker"
@@ -53,7 +55,7 @@ export const App = () => {
   function handleDragEnd(evt: DragEndEvent) {
     const {active, over} = evt
     if (over?.data?.current?.accepts.includes(active?.data?.current?.type)) {
-      over.data.current.onDrop(active)
+      over.data.current.onDrop?.(active)
     }
   }
 
@@ -76,8 +78,14 @@ export const App = () => {
     }
   }, [])
 
+  const sensors = useSensors(
+                    // pointer must move three pixels before starting a drag
+                    useSensor(PointerSensor, { activationConstraint: { distance: 3 }}),
+                    useSensor(KeyboardSensor))
+
   return (
-    <DndContext collisionDetection={dndDetectCollision} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+    <DndContext collisionDetection={dndDetectCollision} sensors={sensors}
+                onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
       <div className="app" data-testid="app">
         <Container>
           {/* each top-level child will be wrapped in a CodapComponent */}
@@ -89,8 +97,8 @@ export const App = () => {
               <p>Drag a CSV file into this window to get some data.</p>
             </div>
           </div>
-          <CaseTable />
-          <GraphComponent></GraphComponent>
+          <CaseTableComponent/>
+          <GraphComponent/>
         </Container>
       </div>
     </DndContext>

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -1,15 +1,12 @@
-import {
-  DndContext, DragEndEvent, DragStartEvent, KeyboardSensor, PointerSensor, useSensor, useSensors
-} from "@dnd-kit/core"
 import React, { useCallback, useEffect, useState } from "react"
 import { CaseTableComponent } from "./case-table/case-table-component"
+import { CodapDndContext } from "./codap-dnd-context"
 import {Container} from "./container"
 import {DataSummary} from "./data-summary"
 import {gDataBroker} from "../data-model/data-broker"
 import {DataSet, IDataSet, toCanonical} from "../data-model/data-set"
 import { GraphComponent } from "./graph/components/graph-component"
 import {Text} from "./text"
-import { dndDetectCollision } from "./dnd-detect-collision"
 import {useDropHandler} from "../hooks/use-drop-handler"
 import { useKeyStates } from "../hooks/use-key-states"
 import {useSampleText} from "../hooks/use-sample-text"
@@ -48,17 +45,6 @@ export const App = () => {
     onImportDocument: handleImportDocument
   })
 
-  function handleDragStart(evt: DragStartEvent) {
-    // console.log("DnDKit [handleDragStart]")
-  }
-
-  function handleDragEnd(evt: DragEndEvent) {
-    const {active, over} = evt
-    if (over?.data?.current?.accepts.includes(active?.data?.current?.type)) {
-      over.data.current.onDrop?.(active)
-    }
-  }
-
   function createNewStarterDataset() {
     const newData = [{AttributeName: ""}]
     const ds = DataSet.create({name: "New Dataset"})
@@ -78,14 +64,8 @@ export const App = () => {
     }
   }, [])
 
-  const sensors = useSensors(
-                    // pointer must move three pixels before starting a drag
-                    useSensor(PointerSensor, { activationConstraint: { distance: 3 }}),
-                    useSensor(KeyboardSensor))
-
   return (
-    <DndContext collisionDetection={dndDetectCollision} sensors={sensors}
-                onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+    <CodapDndContext>
       <div className="app" data-testid="app">
         <Container>
           {/* each top-level child will be wrapped in a CodapComponent */}
@@ -101,6 +81,6 @@ export const App = () => {
           <GraphComponent/>
         </Container>
       </div>
-    </DndContext>
+    </CodapDndContext>
   )
 }

--- a/v3/src/components/case-table/attribute-drag-overlay.scss
+++ b/v3/src/components/case-table/attribute-drag-overlay.scss
@@ -1,0 +1,13 @@
+.attribute-drag-overlay {
+  width: 100%;
+  height: 100%;
+  border: none;
+  opacity: 75%;
+  background: #f9f9f9;    // --rdg-header-background-color
+  border: 1px solid #ddd; // --rdg-border-color
+  font-weight: bold;
+  color: #888;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/v3/src/components/case-table/attribute-drag-overlay.tsx
+++ b/v3/src/components/case-table/attribute-drag-overlay.tsx
@@ -1,17 +1,25 @@
+import { DragOverlay, useDndContext } from "@dnd-kit/core"
 import React from "react"
-import { TColumn } from "./case-table-types"
-import { ColumnHeader } from "./column-header"
+import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { getDragAttributeId } from "../../hooks/use-drag-drop"
+
+import "./attribute-drag-overlay.scss"
 
 interface IProps {
-  activeDragAttrId?: string
-  column: TColumn
+  activeDragId?: string
 }
-export const AttributeDragOverlay = ({ activeDragAttrId, column }: IProps) => {
+export const AttributeDragOverlay = ({ activeDragId }: IProps) => {
+  const data = useDataSetContext()
+  const { active } = useDndContext()
+  const dragAttrId = activeDragId ? getDragAttributeId(active) : undefined
+  const attr = dragAttrId ? data?.attrFromID(dragAttrId) : undefined
   return (
-    activeDragAttrId
-      ? <div className="attribute-drag-overlay">
-          <ColumnHeader {...{ column } as any} />
-        </div>
-      : null
+    <DragOverlay dropAnimation={null}>
+      {dragAttrId
+        ? <div className="attribute-drag-overlay">
+            {attr?.name}
+          </div>
+        : null}
+    </DragOverlay>
   )
 }

--- a/v3/src/components/case-table/case-table-component.test.tsx
+++ b/v3/src/components/case-table/case-table-component.test.tsx
@@ -3,8 +3,9 @@ import userEvent from '@testing-library/user-event'
 import React from "react"
 import { DataBroker } from "../../data-model/data-broker"
 import { DataSet, toCanonical } from "../../data-model/data-set"
+import { DataSetContext } from "../../hooks/use-data-set-context"
 import { useKeyStates } from "../../hooks/use-key-states"
-import { CaseTable } from "./case-table"
+import { CaseTableComponent } from "./case-table-component"
 
 // used by case table
 jest.mock("../../hooks/use-measure-text", () => ({
@@ -23,12 +24,12 @@ describe("Case Table", () => {
   })
 
   it("renders nothing with no broker", () => {
-    render(<CaseTable />)
+    render(<CaseTableComponent />)
     expect(screen.queryByTestId("case-table")).not.toBeInTheDocument()
   })
 
   it("renders nothing with empty broker", () => {
-    render(<CaseTable broker={broker} />)
+    render(<CaseTableComponent broker={broker} />)
     expect(screen.queryByTestId("case-table")).not.toBeInTheDocument()
   })
 
@@ -38,7 +39,7 @@ describe("Case Table", () => {
     data.addAttribute({ name: "b" })
     data.addCases(toCanonical(data, [{ a: 1, b: 2 }, { a: 3, b: 4 }]))
     broker.addDataSet(data)
-    render(<CaseTable broker={broker} />)
+    render(<CaseTableComponent broker={broker} />)
     expect(screen.getByTestId("case-table")).toBeInTheDocument()
   })
 
@@ -52,20 +53,20 @@ describe("Case Table", () => {
     const { rerender } = render((
       <>
         <UseKeyStatesWrapper/>
-        <CaseTable broker={broker} />
+        <CaseTableComponent broker={broker} />
       </>
     ))
     expect(screen.getByTestId("case-table")).toBeInTheDocument()
     const indexCells = screen.getAllByRole("rowheader")
     expect(indexCells.length).toBe(2)
-    const indexContents =screen.getAllByTestId("codap-index-content")
+    const indexContents = screen.getAllByTestId("codap-index-content")
     expect(indexContents.length).toBe(2)
     expect(data.selection.size).toBe(0)
     await user.click(indexContents[0])
     rerender((
       <>
         <UseKeyStatesWrapper/>
-        <CaseTable broker={broker} />
+        <CaseTableComponent broker={broker} />
       </>
     ))
     expect(data.selection.size).toBe(1)

--- a/v3/src/components/case-table/case-table-component.test.tsx
+++ b/v3/src/components/case-table/case-table-component.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event'
 import React from "react"
 import { DataBroker } from "../../data-model/data-broker"
 import { DataSet, toCanonical } from "../../data-model/data-set"
-import { DataSetContext } from "../../hooks/use-data-set-context"
 import { useKeyStates } from "../../hooks/use-key-states"
 import { CaseTableComponent } from "./case-table-component"
 

--- a/v3/src/components/case-table/case-table-component.tsx
+++ b/v3/src/components/case-table/case-table-component.tsx
@@ -1,0 +1,25 @@
+import { useDroppable } from "@dnd-kit/core"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { DataBroker } from "../../data-model/data-broker"
+import { DataSetContext } from "../../hooks/use-data-set-context"
+import { InstanceIdContext, useNextInstanceId } from "../../hooks/use-instance-id-context"
+import { CaseTable } from "./case-table"
+
+interface IProps {
+  broker?: DataBroker;
+}
+export const CaseTableComponent = observer(({ broker }: IProps) => {
+  const instanceId = useNextInstanceId("case-table")
+  const data = broker?.selectedDataSet || broker?.last
+
+  const { setNodeRef } = useDroppable({ id: `${instanceId}-component-drop`, data: { accepts: ["attribute"] } })
+
+  return (
+    <DataSetContext.Provider value={data}>
+      <InstanceIdContext.Provider value={instanceId}>
+        <CaseTable setNodeRef={setNodeRef} />
+      </InstanceIdContext.Provider>
+    </DataSetContext.Provider>
+  )
+})

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -42,12 +42,12 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
 
   // compute the divider position relative to the `case-table` element
   const kDividerWidth = 7
-  const kDividerOffset = 8 - Math.floor(kDividerWidth / 2)
+  const kDividerOffset = Math.floor(kDividerWidth / 2)
   const style: CSSProperties = tableBounds && cellBounds
                   ? {
                       top: cellBounds.top - tableBounds.top,
                       height: cellBounds.height,
-                      left: cellBounds.right - tableBounds.left + kDividerOffset,
+                      left: cellBounds.right - tableBounds.left - kDividerOffset - 1,
                       width: kDividerWidth
                     }
                   : {}

--- a/v3/src/components/case-table/column-header.tsx
+++ b/v3/src/components/case-table/column-header.tsx
@@ -1,23 +1,37 @@
 import { Tooltip } from "@chakra-ui/react"
+import { useDndContext } from "@dnd-kit/core"
 import React, { useState } from "react"
 import { THeaderRendererProps } from "./case-table-types"
 import { ColumnHeaderDivider } from "./column-header-divider"
+import { IUseDraggableAttribute, useDraggableAttribute } from "../../hooks/use-drag-drop"
+import { useInstanceIdContext } from "../../hooks/use-instance-id-context"
 
 export const ColumnHeader = ({ column }: Pick<THeaderRendererProps, "column">) => {
+  const { active } = useDndContext()
+  const instanceId = useInstanceIdContext() || "table"
+  const [contentElt, setContentElt] = useState<HTMLElement | null>(null)
+  const cellElt = contentElt?.parentElement || null
+  // disable tooltips when there is an active drag in progress
+  const disableTooltips = !!active
 
-  const [cellElt, setCellElt] = useState<HTMLElement | null>(null)
+  const draggableOptions: IUseDraggableAttribute = { prefix: instanceId, attributeId: column.key }
+  const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions)
 
-  const setNodeRef = (elt: HTMLDivElement | null) => {
-    setCellElt(elt)
+  const setCellRef = (elt: HTMLDivElement | null) => {
+    setContentElt(elt)
+    setDragNodeRef(elt?.parentElement || null)
   }
+
   return (
-    <Tooltip label={column?.name ||"attribute"} h="20px" fontSize="12px" color="white"
-        openDelay={1000} placement="bottom" bottom="15px" left="15px">
-      <div className="codap-column-header-content" ref={setNodeRef}>
-        {column?.name}
-        {column &&
-          <ColumnHeaderDivider key={column?.key} columnKey={column?.key} cellElt={cellElt}/>}
-      </div>
-    </Tooltip>
+    <>
+      <Tooltip label={column?.name || "attribute"} h="20px" fontSize="12px" color="white"
+          openDelay={1000} placement="bottom" bottom="15px" left="15px" isDisabled={disableTooltips}>
+        <div className="codap-column-header-content" ref={setCellRef} {...attributes} {...listeners}>
+          {column?.name}
+        </div>
+      </Tooltip>
+      {column &&
+        <ColumnHeaderDivider key={column?.key} columnKey={column?.key} cellElt={cellElt}/>}
+    </>
   )
 }

--- a/v3/src/components/codap-dnd-context.tsx
+++ b/v3/src/components/codap-dnd-context.tsx
@@ -1,0 +1,34 @@
+import {
+  DndContext, DragEndEvent, DragStartEvent, KeyboardSensor, PointerSensor, useSensor, useSensors
+} from "@dnd-kit/core"
+import React, { ReactNode } from "react"
+import { dndDetectCollision } from "./dnd-detect-collision"
+
+interface IProps {
+  children: ReactNode
+}
+export const CodapDndContext = ({ children }: IProps) => {
+
+  function handleDragStart(evt: DragStartEvent) {
+    // console.log("DnDKit [handleDragStart]")
+  }
+
+  function handleDragEnd(evt: DragEndEvent) {
+    const {active, over} = evt
+    if (over?.data?.current?.accepts.includes(active?.data?.current?.type)) {
+      over.data.current.onDrop?.(active)
+    }
+  }
+
+  const sensors = useSensors(
+                    // pointer must move three pixels before starting a drag
+                    useSensor(PointerSensor, { activationConstraint: { distance: 3 }}),
+                    useSensor(KeyboardSensor))
+
+  return (
+    <DndContext collisionDetection={dndDetectCollision} sensors={sensors}
+                onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      {children}
+    </DndContext>
+  )
+}

--- a/v3/src/components/data-summary.tsx
+++ b/v3/src/components/data-summary.tsx
@@ -18,7 +18,9 @@ export const DataSummary = observer(({ broker, v2Document }: IProps) => {
   const data = broker?.selectedDataSet || broker?.last
 
   const { active } = useDndContext()
+  const isSummaryDrag = active && `${active.id}`.startsWith("summary")
   const dragAttributeID = getDragAttributeId(active)
+  const dragAttribute = dragAttributeID ? data?.attrFromID(dragAttributeID) : undefined
 
   // used to determine when a dragged attribute is over the summary component
   const { setNodeRef } = useDroppable({ id: "summary-component-drop", data: { accepts: ["attribute"] } })
@@ -56,7 +58,6 @@ export const DataSummary = observer(({ broker, v2Document }: IProps) => {
   const componentTypes = v2Document?.components.map(component => component.type)
   const componentList = componentTypes?.join(", ")
 
-
   return (
     <div ref={setNodeRef} className="data-summary">
       <p>{data ? `Parsed "${data.name}" with ${data.cases.length} case(s) and...` : "No data"}</p>
@@ -76,8 +77,8 @@ export const DataSummary = observer(({ broker, v2Document }: IProps) => {
       {data && <SummaryDropTarget attribute={selectedAttribute} onDrop={handleDrop}/>}
       {data && <ProfilerButton />}
       <DragOverlay dropAnimation={null}>
-        {data && dragAttributeID
-          ? <DraggableAttribute attribute={data.attrFromID(dragAttributeID)} isOverlay={true}/>
+        {data && isSummaryDrag && dragAttribute
+          ? <OverlayAttribute attribute={dragAttribute} />
           : null}
       </DragOverlay>
     </div>
@@ -86,14 +87,19 @@ export const DataSummary = observer(({ broker, v2Document }: IProps) => {
 
 interface IDraggableAttributeProps {
   attribute: IAttribute
-  isOverlay?: boolean;
 }
-const DraggableAttribute = ({ attribute, isOverlay = false }: IDraggableAttributeProps) => {
+const DraggableAttribute = ({ attribute }: IDraggableAttributeProps) => {
   const draggableOptions: IUseDraggableAttribute = { prefix: "summary", attributeId: attribute.id }
   const { attributes, listeners, setNodeRef } = useDraggableAttribute(draggableOptions)
-  const overlayClass = isOverlay ? "overlay" : ""
   return (
-    <div ref={setNodeRef} className={`draggable-attribute ${overlayClass}`} {...attributes} {...listeners}>
+    <div ref={setNodeRef} className="draggable-attribute" {...attributes} {...listeners}>
+      {attribute.name}
+    </div>
+  )
+}
+const OverlayAttribute = ({ attribute }: IDraggableAttributeProps) => {
+  return (
+    <div className={`draggable-attribute overlay`} >
       {attribute.name}
     </div>
   )

--- a/v3/src/components/dnd-detect-collision.ts
+++ b/v3/src/components/dnd-detect-collision.ts
@@ -11,9 +11,15 @@ export const dndDetectCollision: CollisionDetection = (args) => {
   }
 
   // if we're in the case table component, use closest center on the column header dividers
-  if (collisions.find(collision => collision.id === "case-table-drop")) {
+  if (collisions.find(collision => /case-table.+component-drop/.test(`${collision.id}`))) {
     const containers = args.droppableContainers.filter(({id}) => `${id}`.includes("table-attribute"))
     return closestCenter({ ...args, droppableContainers: containers })
+  }
+
+  // if we're in the graph component, use rectangle intersection on the drop targets (e.g. axes)
+  if (collisions.find(collision => /graph.+component-drop/.test(`${collision.id}`))) {
+    const containers = args.droppableContainers.filter(({id}) => `${id}`.includes("-axis"))
+    return rectIntersection({ ...args, droppableContainers: containers })
   }
 
   return collisions

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -1,4 +1,5 @@
 import {Button} from '@chakra-ui/react'
+import { useDroppable } from '@dnd-kit/core'
 import {observer} from "mobx-react-lite"
 import React, {useEffect, useRef} from "react"
 import {useResizeDetector} from "react-resize-detector"
@@ -36,6 +37,10 @@ export const GraphComponent = observer(({broker}: IProps) => {
   useEffect(() => {
     (width != null) && (height != null) && layout.setGraphExtent(width, height)
   }, [width, height, layout])
+
+  // used to determine when a dragged attribute is over the graph component
+  const { setNodeRef } = useDroppable({ id: `${instanceId}-component-drop`, data: { accepts: ["attribute"] } })
+  setNodeRef(graphRef.current)
 
   return (
     <DataSetContext.Provider value={data}>

--- a/v3/src/components/graph/hooks/use-axis-bounds.ts
+++ b/v3/src/components/graph/hooks/use-axis-bounds.ts
@@ -15,7 +15,7 @@ export const useAxisBoundsProvider = (place: AxisPlace) => {
 
   useEffect(() => {
     setGraphElt(wrapperElt?.closest(kGraphClassSelector) as HTMLDivElement ?? null)
-  }, [wrapperElt, graphElt])
+  }, [wrapperElt])
 
   useEffect(() => {
     // track the bounds of the graph and axis elements


### PR DESCRIPTION
- Drag from case table column headers
- Add `<CaseTableComponent>` which wraps `<CaseTable>` (analogous to `<GraphComponent>`)
- General drag/drop improvements
  - require three-pixel movement before initiating drags (helps disambiguate clicks from drags)
  - hide tooltips during drags
  - use rectangle intersection for dropping attributes on graph axes
  - eliminate unnecessary dependency from `useEffect()` in `useAxisBounds()`