### PR TITLE
V3: Add FilteredCases class

### DIFF
--- a/v3/cypress/support/e2e.js
+++ b/v3/cypress/support/e2e.js
@@ -21,3 +21,6 @@
 
 // add code coverage support
 import "@cypress/code-coverage/support"
+
+// https://github.com/quasarframework/quasar/issues/2233#issuecomment-1006506083
+Cypress.on("uncaught:exception", err => !err.message.includes("ResizeObserver"))

--- a/v3/src/data-model/filtered-cases.test.ts
+++ b/v3/src/data-model/filtered-cases.test.ts
@@ -25,7 +25,7 @@ describe("DerivedDataSet", () => {
   it("handles construction with a filter", () => {
     const filtered = new FilteredCases(data,
       (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
-                                     isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+                         isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
     expect(filtered.caseIds.length).toBe(1)
     expect(filtered.caseIds).toEqual(["c1"])
     expect(filtered.hasCaseId("c1")).toBe(true)
@@ -36,7 +36,7 @@ describe("DerivedDataSet", () => {
   it("handles filtering when adding/removing cases", () => {
     const filtered = new FilteredCases(data,
       (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
-                                     isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+                         isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
     data.addCases([{ __id__: "c4", xId: 4, yId: 4 }])
     expect(filtered.caseIds.length).toBe(2)
     expect(filtered.caseIds).toEqual(["c1", "c4"])
@@ -53,7 +53,7 @@ describe("DerivedDataSet", () => {
   it("handles updated values which change filtering", () => {
     const filtered = new FilteredCases(data,
       (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
-                                     isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+                         isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
     data.setCaseValues([{ __id__: "c3", xId: 3 }])
     expect(filtered.caseIds.length).toBe(2)
     expect(filtered.caseIds).toEqual(["c1", "c3"])

--- a/v3/src/data-model/filtered-cases.test.ts
+++ b/v3/src/data-model/filtered-cases.test.ts
@@ -1,0 +1,69 @@
+import { DataSet, IDataSet, toCanonical } from "./data-set"
+import { FilteredCases } from "./filtered-cases"
+
+describe("DerivedDataSet", () => {
+  let data: IDataSet
+
+  beforeEach(() => {
+    data = DataSet.create()
+    data.addAttribute({ id: "xId", name: "x" })
+    data.addAttribute({ id: "yId", name: "y" })
+    data.addCases(toCanonical(data, [
+      { __id__: "c1", x: 1, y: 1 }, { __id__: "c2", x: 2 }, { __id__: "c3", y: 3 }
+    ]))
+  })
+
+  it("handles construction without a filter", () => {
+    const filtered = new FilteredCases(data)
+    expect(filtered.caseIds.length).toBe(3)
+    expect(filtered.caseIds).toEqual(["c1", "c2", "c3"])
+    expect(filtered.hasCaseId("c1")).toBe(true)
+    expect(filtered.hasCaseId("c3")).toBe(true)
+    filtered.destroy()
+  })
+
+  it("handles construction with a filter", () => {
+    const filtered = new FilteredCases(data,
+      (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
+                                     isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+    expect(filtered.caseIds.length).toBe(1)
+    expect(filtered.caseIds).toEqual(["c1"])
+    expect(filtered.hasCaseId("c1")).toBe(true)
+    expect(filtered.hasCaseId("c3")).toBe(false)
+    filtered.destroy()
+  })
+
+  it("handles filtering when adding/removing cases", () => {
+    const filtered = new FilteredCases(data,
+      (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
+                                     isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+    data.addCases([{ __id__: "c4", xId: 4, yId: 4 }])
+    expect(filtered.caseIds.length).toBe(2)
+    expect(filtered.caseIds).toEqual(["c1", "c4"])
+    expect(filtered.hasCaseId("c4")).toBe(true)
+
+    data.removeCases(["c1"])
+    expect(filtered.caseIds.length).toBe(1)
+    expect(filtered.caseIds).toEqual(["c4"])
+    expect(filtered.hasCaseId("c1")).toBe(false)
+
+    filtered.destroy()
+  })
+
+  it("handles updated values which change filtering", () => {
+    const filtered = new FilteredCases(data,
+      (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
+                                     isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+    data.setCaseValues([{ __id__: "c3", xId: 3 }])
+    expect(filtered.caseIds.length).toBe(2)
+    expect(filtered.caseIds).toEqual(["c1", "c3"])
+    expect(filtered.hasCaseId("c3")).toBe(true)
+
+    data.setCaseValues([{ __id__: "c1", xId: "" }])
+    expect(filtered.caseIds.length).toBe(1)
+    expect(filtered.caseIds).toEqual(["c3"])
+    expect(filtered.hasCaseId("c1")).toBe(false)
+
+    filtered.destroy()
+  })
+})

--- a/v3/src/data-model/filtered-cases.ts
+++ b/v3/src/data-model/filtered-cases.ts
@@ -1,0 +1,91 @@
+import { action, computed, makeObservable, observable } from "mobx"
+import { ISerializedActionCall, onAction } from "mobx-state-tree"
+import { IDataSet } from "./data-set"
+import { isSetCaseValuesAction } from "./data-set-actions"
+
+export class FilteredCases {
+  private source: IDataSet
+  @observable private filter?: (data: IDataSet, caseId: string) => boolean
+  private prevCaseIdSet = new Set<string>()
+  private onActionDisposers: Array<() => void>
+
+  constructor(source: IDataSet, filter?: (data: IDataSet, caseId: string) => boolean) {
+    this.source = source
+    this.filter = filter
+
+    makeObservable(this)
+
+    this.onActionDisposers = [
+      onAction(this.source, this.handleBeforeAction, false),  // runs before the action
+      onAction(this.source, this.handleAction, true),         // runs after the action
+    ]
+  }
+
+  destroy() {
+    this.onActionDisposers.forEach(disposer => disposer())
+  }
+
+  @computed
+  get caseIds(): string[] {
+    // MobX will cache the resulting array until either the source's `cases` array changes or the
+    // filter function changes, at which point it will run the filter function over all the cases.
+    // We could be more efficient if we handled the caching ourselves, e.g. by only filtering new
+    // cases when cases are inserted, but that would be more code to write/maintain and running
+    // the filter function over an array of cases should be quick so rather than succumb to the
+    // temptation of premature optimization, let's wait to see whether it becomes a bottleneck.
+    return this.source.cases
+            .map(aCase => aCase.__id__)
+            .filter(id => !this.filter || this.filter(this.source, id))
+  }
+
+  @computed
+  get caseIdSet(): Set<string> {
+    return new Set(this.caseIds)
+  }
+
+  hasCaseId = (caseId: string) => {
+    return this.caseIdSet.has(caseId)
+  }
+
+  @action
+  setCaseFilter(caseFilter?: (data: IDataSet, caseId: string) => boolean) {
+    this.filter = caseFilter
+  }
+
+  @action
+  invalidateCases() {
+    // invalidate the case caches
+    const _caseFilter = this.filter
+    this.setCaseFilter()
+    this.setCaseFilter(_caseFilter)
+  }
+
+  private handleBeforeAction = (actionCall: ISerializedActionCall) => {
+    if (isSetCaseValuesAction(actionCall)) {
+      // cache the pre-change filter state of the affected cases
+      this.prevCaseIdSet.clear()
+      const cases = actionCall.args[0]
+      cases.forEach(aCase => {
+        if (this.hasCaseId(aCase.__id__)) {
+          this.prevCaseIdSet.add(aCase.__id__)
+        }
+      })
+    }
+  }
+
+  private handleAction = (actionCall: ISerializedActionCall) => {
+    if (isSetCaseValuesAction(actionCall)) {
+      const cases = actionCall.args[0]
+      const filteredCasesDidChange = cases.some(aCase => {
+        // compare the pre-/post-change filter state of the affected cases
+        const wasIncluded = this.prevCaseIdSet.has(aCase.__id__)
+        const nowIncluded = this.hasCaseId(aCase.__id__)
+        return nowIncluded !== wasIncluded
+      })
+      // if any cases changed filter state, invalidate the cached results
+      if (filteredCasesDidChange) {
+        this.invalidateCases()
+      }
+    }
+  }
+}


### PR DESCRIPTION
I started out thinking this would be a more elaborate `DerivedDataSet` or `DataSetProxy` but the attribute filtering and API forwarding aspects of it seemed to extra work for relatively little gain, so I decided to focus more narrowly on the case filtering aspect.