### PR TITLE
V3—Point radius fixes

### DIFF
--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -5,7 +5,7 @@ import {usePlotResponders} from "../hooks/graph-hooks"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {ScaleType, useGraphLayoutContext} from "../models/graph-layout"
-import {computedPointRadius, setPointSelection} from "../utilities/graph_utils"
+import {setPointSelection} from "../utilities/graph_utils"
 import {IGraphModel} from "../models/graph-model"
 
 interface IProps {
@@ -18,7 +18,6 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
     dataConfig = useDataConfigurationContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
-    pointSizeMultiplier = graphModel.pointSizeMultiplier,
     xAttrID = dataConfig?.attributeID('x'),
     xAttributeType = dataConfig?.attributeType('x'),
     yAttrID = dataConfig?.attributeID('y'),
@@ -45,13 +44,13 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
   }, [attribute])
 
   const refreshPointSelection = useCallback(() => {
-    setPointSelection({dotsRef, dataset})
-  }, [dataset, dotsRef])
+    setPointSelection({dotsRef, dataset, pointRadius: graphModel.getPointRadius(),
+      selectedPointRadius: graphModel.getPointRadius('select')})
+  }, [dataset, dotsRef, graphModel])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
     const
-      numPoints = select(dotsRef.current).selectAll('.graph-dot').size(),
-      pointDiameter = 2 * computedPointRadius(numPoints, pointSizeMultiplier),
+      pointDiameter = 2 * graphModel.getPointRadius(),
       selection = select(dotsRef.current).selectAll(selectedOnly ? '.graph-dot-highlighted' : '.graph-dot'),
       duration = enableAnimation.current ? transitionDuration : 0,
       cellWidth = primaryScale.bandwidth()
@@ -118,8 +117,8 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
           return NaN
         }
       })
-  }, [categories, computeMaxOverAllCells, dataConfig?.cases, dataset, dotsRef, enableAnimation, layout,
-      pointSizeMultiplier, primaryAttributeID, primaryPlace, primaryScale, secondaryPlace, secondaryScale])
+  }, [graphModel, categories, computeMaxOverAllCells, dataConfig?.cases, dataset, dotsRef, enableAnimation, layout,
+      primaryAttributeID, primaryPlace, primaryScale, secondaryPlace, secondaryScale])
 
   useEffect(()=>{
     select(dotsRef.current).on('click', (event) => {

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -6,7 +6,7 @@ import {onAction} from "mobx-state-tree"
 import React, {MutableRefObject, useEffect, useRef} from "react"
 import {Axis} from "./axis"
 import {Background} from "./background"
-import {kGraphClass} from "../graphing-types"
+import {kGraphClass, transitionDuration} from "../graphing-types"
 import {ScatterDots} from "./scatterdots"
 import {DotPlotDots} from "./dotplotdots"
 import {CaseDots} from "./casedots"
@@ -19,7 +19,7 @@ import {AxisPlace, IAxisModel, attrPlaceToAxisPlace} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel, isSetAttributeIDAction} from "../models/graph-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
-import {filterCases, getPointTipText} from "../utilities/graph_utils"
+import {getPointTipText} from "../utilities/graph_utils"
 import {GraphController} from "../models/graph-controller"
 import {MarqueeState} from "../models/marquee-state"
 
@@ -46,6 +46,7 @@ export const Graph = observer((
       {plotType} = graphModel,
       instanceId = useInstanceIdContext(),
       dataset = useDataSetContext(),
+      dataConfig = graphModel.config,
       casesRef = useRef<string[]>([]),
       layout = useGraphLayoutContext(),
       {margin} = layout,
@@ -54,9 +55,11 @@ export const Graph = observer((
       svgRef = useRef<SVGSVGElement>(null),
       plotAreaSVGRef = useRef<SVGSVGElement>(null),
       xAttrID = graphModel.getAttributeID('x'),
-      yAttrID = graphModel.getAttributeID('y')
+      yAttrID = graphModel.getAttributeID('y'),
+      pointRadius = graphModel.getPointRadius(),
+      hoverPointRadius = graphModel.getPointRadius('hover-drag')
 
-    casesRef.current = filterCases(dataset, [xAttrID, yAttrID])
+    casesRef.current = dataConfig?.cases ?? []
 
     useGraphModel({dotsRef, graphModel, enableAnimation, instanceId})
 
@@ -102,21 +105,28 @@ export const Graph = observer((
     }, [dotsRef, graphController])
 
     // MouseOver events, if over an element, brings up hover text
-    function showDataTip(event: MouseEvent, d: any) {
+    function showDataTip(event: MouseEvent) {
       const
         target = select(event.target as SVGSVGElement)
       if (target.node()?.nodeName === 'circle' && dataset) {
+        target.transition().duration(transitionDuration).attr('r', hoverPointRadius)
         const [, caseID] = target.property('id').split("_"),
           attrIDs = graphModel.config.uniqueTipAttributes,
           tipText = getPointTipText(dataset, caseID, attrIDs)
-        dataTip.show(tipText, event.target)
+        tipText !== '' && dataTip.show(tipText, event.target)
       }
+    }
+
+    function hideDataTip(event: MouseEvent) {
+      dataTip.hide()
+      select(event.target as SVGSVGElement)
+        .transition().duration(transitionDuration).attr('r', pointRadius)
     }
 
     useEffect(function setupDataTip() {
       select(dotsRef.current)
         .on('mouseover', showDataTip)
-        .on('mouseout', dataTip.hide)
+        .on('mouseout', hideDataTip)
         .call(dataTip)
     })
 

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -31,11 +31,11 @@ export interface counterProps {
 }
 
 export const transitionDuration = 1000,
-  defaultRadius = 5,
-  dragRadius = 10,
   pointRadiusMax = 10,
   pointRadiusMin = 3,
-  pointRadiusLogBase = 2.0 // reduce point radius from max by log of (num. cases) base (LogBase).
+  pointRadiusLogBase = 2.0, // reduce point radius from max by log of (num. cases) base (LogBase).
+  pointRadiusSelectionAddend = 1,
+  hoverRadiusFactor = 1.5
 
 export const PlotTypes = ["casePlot", "dotPlot", "dotChart", "scatterPlot"] as const
 export type PlotType = typeof PlotTypes[number]

--- a/v3/src/components/graph/hooks/use-graph-model.ts
+++ b/v3/src/components/graph/hooks/use-graph-model.ts
@@ -25,10 +25,11 @@ export function useGraphModel(props:IProps) {
   const callMatchCirclesToData = useCallback(() => {
     matchCirclesToData({
       caseIDs: dataConfig.cases,
+      pointRadius: graphModel.getPointRadius(),
       dotsElement: dotsRef.current,
       enableAnimation, instanceId
     })
-  }, [dataConfig.cases, dotsRef, enableAnimation, instanceId])
+  }, [dataConfig.cases, graphModel, dotsRef, enableAnimation, instanceId])
 
   useEffect(function createCircles() {
       callMatchCirclesToData()

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -2,7 +2,7 @@ import React from "react"
 import {scaleBand, scaleLinear, scaleOrdinal} from "d3"
 import {IGraphModel} from "./graph-model"
 import {GraphLayout} from "./graph-layout"
-import { DataConfigurationModel } from "./data-configuration-model"
+import {DataConfigurationModel, IDataConfigurationModel} from "./data-configuration-model"
 import {IDataSet} from "../../../data-model/data-set"
 import {
   AxisPlace,
@@ -28,6 +28,7 @@ export class GraphController {
   graphModel: IGraphModel
   layout: GraphLayout
   dataset: IDataSet | undefined
+  dataConfig: IDataConfigurationModel
   enableAnimation:  React.MutableRefObject<boolean>
   instanceId:string
   dotsRef:React.RefObject<SVGSVGElement>
@@ -37,6 +38,7 @@ export class GraphController {
     this.graphModel = props.graphModel
     this.layout = props.layout
     this.dataset = props.dataset
+    this.dataConfig = props.graphModel.config
     this.instanceId = props.instanceId
     this.enableAnimation = props.enableAnimation
     this.dotsRef = props.dotsRef
@@ -45,10 +47,10 @@ export class GraphController {
   }
 
   initializeGraph() {
-    const {graphModel, layout, dotsRef, enableAnimation, instanceId} = this
-    if(dotsRef) {
-      matchCirclesToData({caseIDs: graphModel.config.cases, dotsElement: dotsRef.current,
-       enableAnimation, instanceId})
+    const {graphModel, dataConfig, layout, dotsRef, enableAnimation, instanceId} = this
+    if(dotsRef.current) {
+      matchCirclesToData({caseIDs: dataConfig.cases, dotsElement: dotsRef.current,
+       pointRadius: graphModel.getPointRadius(), enableAnimation, instanceId})
     }
     layout.setAxisScale('bottom', scaleOrdinal())
     layout.setAxisScale('left', scaleOrdinal())


### PR DESCRIPTION
The fact that the necessary point radius was being computed in graph-utils where it required a bunch of parameters was making it difficult and confusing to get the right point radius. Most of the changes have to do with refactoring so that the GraphModel coughs up the desired point radius. This makes sense because it has all the information already to make the computation.