### PR TITLE
Adjust useEffect dependencies

### DIFF
--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -31,11 +31,12 @@ export const CaseDots = memo(function CaseDots(props: {
     yScale = layout.axisScale('left') as ScaleNumericBaseType
 
   useEffect(function initDistribution() {
+    const { cases } = dataset || {}
     const uniform = randomUniform()
-    dataset?.cases.forEach(({__id__}) => {
+    cases?.forEach(({__id__}) => {
       randomPointsRef.current[__id__] = {x: uniform(), y: uniform()}
     })
-  }, [dataset?.cases])
+  }, [dataset])
 
   const onDragStart = useCallback((event: MouseEvent) => {
       enableAnimation.current = false // We don't want to animate points until end of drag


### PR DESCRIPTION
>>It seems like this would cause the point positions to be rerandomized on insertion/removal of cases, but that doesn't seem to be the case in testing. 🤔
>
>I agree that it should and am also puzzled if it doesn't. How can I set it up so that the useEffect only runs if there is a new dataset, but not when the cases change?