### PR TITLE
V3: Add selection to DataConfigurationModel

### DIFF
--- a/v3/src/components/data-summary.tsx
+++ b/v3/src/components/data-summary.tsx
@@ -60,7 +60,11 @@ export const DataSummary = observer(({ broker, v2Document }: IProps) => {
 
   return (
     <div ref={setNodeRef} className="data-summary">
-      <p>{data ? `Parsed "${data.name}" with ${data.cases.length} case(s) and...` : "No data"}</p>
+      <p>
+        {data
+          ? `Parsed "${data.name}" with ${data.cases.length} case(s) (${data.selection.size} selected) and...`
+          : "No data"}
+      </p>
       {componentList &&
         <div className="data-components">
           <div className="data-components-title"><b>Components</b></div>

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -57,14 +57,15 @@ export const DotPlotDots = memo(observer(function DotPlotDots( props: IProps) {
         const [, caseId] = tItsID.split("_")
         dataset?.selectCases([caseId])
         // Record the current values so we can change them during the drag and restore them when done
-        dataset?.selection.forEach(anID => {
+        const { selection } = dataConfig || {}
+        selection?.forEach(anID => {
           const itsValue = primaryAttributeID && dataset?.getNumeric(anID, primaryAttributeID) || undefined
           if (itsValue != null) {
             selectedDataObjects.current[anID] = itsValue
           }
         })
       }
-    }, [dataset, dragPointRadius, primaryPlace, primaryAttributeID, enableAnimation]),
+    }, [dataConfig, dataset, dragPointRadius, primaryPlace, primaryAttributeID, enableAnimation]),
 
     onDrag = useCallback((event: MouseEvent) => {
       if (dragID) {
@@ -74,8 +75,9 @@ export const DotPlotDots = memo(observer(function DotPlotDots( props: IProps) {
         if (deltaPixels !== 0) {
           didDrag.current = true
           const delta = Number(primaryScale?.invert(deltaPixels)) - Number(primaryScale?.invert(0)),
-            caseValues: ICase[] = []
-          primaryAttributeID && dataset?.selection.forEach(anID => {
+            caseValues: ICase[] = [],
+            { selection } = dataConfig || {}
+          primaryAttributeID && selection?.forEach(anID => {
             const currValue = Number(dataset?.getNumeric(anID, primaryAttributeID))
             if (isFinite(currValue)) {
               caseValues.push({ __id__: anID, [primaryAttributeID]: currValue + delta })
@@ -84,7 +86,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots( props: IProps) {
           caseValues.length && dataset?.setCaseValues(caseValues)
         }
       }
-    }, [dataset, dragID, primaryAttributeID, primaryScale, primaryPlace]),
+    }, [dataConfig, dataset, dragID, primaryAttributeID, primaryPlace, primaryScale]),
 
     onDragEnd = useCallback(() => {
       dataset?.endCaching()
@@ -99,8 +101,9 @@ export const DotPlotDots = memo(observer(function DotPlotDots( props: IProps) {
         target.current = null
 
         if (didDrag.current) {
-          const caseValues: ICase[] = []
-          primaryAttributeID && dataset?.selection.forEach(anID => {
+          const caseValues: ICase[] = [],
+                { selection } = dataConfig || {}
+          primaryAttributeID && selection?.forEach(anID => {
             caseValues.push({
               __id__: anID,
               [primaryAttributeID]: selectedDataObjects.current[anID]
@@ -111,7 +114,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots( props: IProps) {
           didDrag.current = false
         }
       }
-    }, [dataset, selectedPointRadius, dragID, enableAnimation, primaryAttributeID])
+    }, [dataConfig, dataset, selectedPointRadius, dragID, enableAnimation, primaryAttributeID])
 
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -50,14 +50,15 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
         const [, caseId] = tItsID.split("_")
         dataset?.selectCases([caseId])
         // Record the current values so we can change them during the drag and restore them when done
-        xAttrID && yAttrID && dataset?.selection.forEach(anID => {
+        const { selection } = dataConfig || {}
+        xAttrID && yAttrID && selection?.forEach(anID => {
           selectedDataObjects.current[anID] = {
             x: dataset?.getNumeric(anID, xAttrID) ?? 0,
             y: dataset?.getNumeric(anID, yAttrID) ?? 0
           }
         })
       }
-    }, [dataset, pointRadius, xAttrID, yAttrID, enableAnimation]),
+    }, [dataConfig, dataset, enableAnimation, pointRadius, xAttrID, yAttrID]),
 
     onDrag = useCallback((event: MouseEvent) => {
       if (dragID !== '') {
@@ -69,8 +70,9 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
           didDrag.current = true
           const deltaX = Number(xScale.invert(dx)) - Number(xScale.invert(0)),
             deltaY = Number(yScale.invert(dy)) - Number(yScale.invert(0)),
-            caseValues: ICase[] = []
-          xAttrID && yAttrID && dataset?.selection.forEach(anID => {
+            caseValues: ICase[] = [],
+            { selection } = dataConfig || {}
+          xAttrID && yAttrID && selection?.forEach(anID => {
             const currX = Number(dataset?.getNumeric(anID, xAttrID)),
               currY = Number(dataset?.getNumeric(anID, yAttrID))
             if (isFinite(currX) && isFinite(currY)) {
@@ -84,7 +86,7 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
           caseValues.length && dataset?.setCaseValues(caseValues)
         }
       }
-    }, [dataset, dragID, xAttrID, xScale, yAttrID, yScale]),
+    }, [dataConfig, dataset, dragID, xAttrID, xScale, yAttrID, yScale]),
 
     onDragEnd = useCallback(() => {
       dataset?.endCaching()
@@ -99,8 +101,9 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
         target.current = null
 
         if (didDrag.current) {
-          const caseValues: ICase[] = []
-          xAttrID && yAttrID && dataset?.selection.forEach(anID => {
+          const caseValues: ICase[] = [],
+            { selection } = dataConfig || {}
+          xAttrID && yAttrID && selection?.forEach(anID => {
             caseValues.push({
               __id__: anID,
               [xAttrID]: selectedDataObjects.current[anID].x,
@@ -112,7 +115,7 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
           didDrag.current = false
         }
       }
-    }, [dataset, pointRadius, dragID, xAttrID, yAttrID, enableAnimation])
+    }, [dataConfig, dataset, dragID, pointRadius, xAttrID, yAttrID, enableAnimation])
 
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
@@ -134,6 +137,7 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
   }, [dataset, pointRadius, selectedPointRadius, dotsRef, xAttrID, xScale, yAttrID, yScale, enableAnimation])
 
   const refreshPointPositionsSVG = useCallback((selectedOnly: boolean) => {
+    const { cases, selection } = dataConfig || {}
     const updateDot = (caseId: string) => {
       const dot = dotsRef.current?.querySelector(`#${instanceId}_${caseId}`)
       if (dot) {
@@ -147,11 +151,11 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
       }
     }
     if (selectedOnly) {
-      dataset?.selection.forEach(caseId => updateDot(caseId))
+      selection?.forEach(caseId => updateDot(caseId))
     } else {
-      dataConfig?.cases.forEach(anID => updateDot(anID))
+      cases?.forEach(anID => updateDot(anID))
     }
-  }, [dataConfig?.cases, dataset, dotsRef, instanceId, xAttrID, xScale, yAttrID, yScale])
+  }, [dataConfig, dataset, dotsRef, instanceId, xAttrID, xScale, yAttrID, yScale])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
     if (appState.isPerformanceMode) {

--- a/v3/src/components/graph/models/data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/data-configuration-model.test.ts
@@ -136,4 +136,25 @@ describe("DataConfigurationModel", () => {
     expect(config.cases).toEqual(["c1", "c2", "c3"])
   })
 
+  it("selection behaves as expected", () => {
+    const config = DataConfigurationModel.create()
+    config.setAttribute("x", { attributeID: "xId" })
+    expect(config.selection.length).toBe(0)
+
+    config.setDataset(data)
+    data.selectAll()
+    expect(config.selection.length).toBe(3)
+
+    config.setAttribute("x", { attributeID: "xId" })
+    expect(config.selection.length).toBe(2)
+
+    const selectionReaction = jest.fn()
+    const disposer = reaction(() => config.selection, () => selectionReaction())
+    expect(selectionReaction).toHaveBeenCalledTimes(0)
+    config.setAttribute("y", { attributeID: "yId" })
+    expect(config.selection.length).toBe(1)
+    expect(selectionReaction).toHaveBeenCalledTimes(1)
+    disposer()
+})
+
 })

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -86,6 +86,11 @@ export const DataConfigurationModel = types
     },
     get cases() {
       return self.filteredCases?.caseIds || []
+    },
+    get selection() {
+      if (!self.dataset || !self.filteredCases) return []
+      const selection = Array.from(self.dataset.selection)
+      return selection.filter(caseId => self.filteredCases?.hasCaseId(caseId))
     }
   }))
   .actions(self => ({
@@ -101,6 +106,7 @@ export const DataConfigurationModel = types
       else {
         self.attributeDescriptions.delete(place)
       }
+      self.filteredCases?.invalidateCases()
     }
   }))
 export interface IDataConfigurationModel extends Instance<typeof DataConfigurationModel> {}

--- a/v3/src/data-model/data-set.ts
+++ b/v3/src/data-model/data-set.ts
@@ -34,6 +34,7 @@
   of people on the planet for whom that reference makes any sense.
  */
 
+import { observable } from "mobx"
 import { addMiddleware, getEnv, Instance, types } from "mobx-state-tree"
 import { Attribute, IAttribute, IAttributeSnapshot, IValueType } from "./attribute"
 import { CollectionModel, ICollectionModelSnapshot } from "./collection"
@@ -159,7 +160,7 @@ export const DataSet = types.model("DataSet", {
 })
 .volatile(self => ({
   transactionCount: 0,
-  selection: new Set<string>(),
+  selection: observable.set<string>(),
   cachingCount: 0,
   caseCache: new Map<string, ICase>()
 }))


### PR DESCRIPTION
Adds a `selection` property to the `DataConfigurationModel`, which returns an array of the selected case ids filtered by the data configuration's filtering rule. Updates the `DotPlotDots` and `ScatterDots` objects to use the `DataConfigurationModel`'s `selection` property rather than the `DataSet`'s.