### PR TITLE
V3—2D_dot_chart

### DIFF
--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -1,87 +1,116 @@
 import {ScaleBand, select} from "d3"
-import React, {memo, useCallback, useEffect, useRef} from "react"
+import React, {memo, useCallback, useEffect} from "react"
 import {PlotProps, transitionDuration} from "../graphing-types"
 import {usePlotResponders} from "../hooks/graph-hooks"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
-import {ScaleType, useGraphLayoutContext} from "../models/graph-layout"
+import {useGraphLayoutContext} from "../models/graph-layout"
 import {setPointSelection} from "../utilities/graph_utils"
 import {IGraphModel} from "../models/graph-model"
+import {attrPlaceToAxisPlace} from "../models/axis-model"
 
 interface IProps {
-  graphModel:IGraphModel
-  plotProps:PlotProps
+  graphModel: IGraphModel
+  plotProps: PlotProps
 }
+
+type BinMap = Record<string, Record<string, number>>
 
 export const ChartDots = memo(function ChartDots(props: IProps) {
   const {graphModel, plotProps: {dotsRef, enableAnimation}} = props,
     dataConfig = useDataConfigurationContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
-    xAttrID = dataConfig?.attributeID('x'),
-    xAttributeType = dataConfig?.attributeType('x'),
-    yAttrID = dataConfig?.attributeID('y'),
-    // yAttributeType = dataset?.attrFromID(yAttrID)?.type,
-    primaryPlace = xAttributeType === 'categorical' ? 'bottom' : 'left',
-    primaryAttributeID = primaryPlace === 'left' ? yAttrID : xAttrID,
-    secondaryPlace = primaryPlace === 'left' ? 'bottom' : 'left',
-    primaryScale = layout.axisScale(primaryPlace) as ScaleBand<string>,
-    secondaryScale = layout.axisScale(secondaryPlace) as ScaleType,
-    attribute = primaryAttributeID && dataset?.attrFromID(primaryAttributeID) || undefined,
-    categories = Array.from(new Set(attribute?.strValues)),
-    categoriesMapRef = useRef<Record<string, { cell: number, numSoFar: number }>>({})
+    primaryAttrPlace = dataConfig?.primaryPlace ?? 'x',
+    primaryAxisPlace = attrPlaceToAxisPlace[primaryAttrPlace] ?? 'bottom',
+    primaryIsBottom = primaryAxisPlace === 'bottom',
+    primaryAttrID = dataConfig?.attributeID(primaryAttrPlace),
+    secondaryAttrPlace = primaryAttrPlace === 'x' ? 'y' : 'x',
+    secondaryAxisPlace = attrPlaceToAxisPlace[secondaryAttrPlace] ?? 'left',
+    secondaryAttrID = dataConfig?.attributeID(secondaryAttrPlace),
+    primaryScale = layout.axisScale(primaryAxisPlace) as ScaleBand<string>,
+    secondaryScale = layout.axisScale(secondaryAxisPlace) as ScaleBand<string>
 
   const computeMaxOverAllCells = useCallback(() => {
-    const values = attribute?.strValues,
-      bins: Record<string, number> = {}
-    values?.forEach(aValue => {
-      if (bins[aValue] === undefined) {
-        bins[aValue] = 0
+    const valuePairs = dataConfig?.cases.map(caseID => {
+        return {
+          primary: (primaryAttrID && dataset?.getValue(caseID, primaryAttrID)) ?? '',
+          secondary: (secondaryAttrID && dataset?.getValue(caseID, secondaryAttrID)) ?? '__main__'
+        }
+      }),
+      bins: BinMap = {}
+    valuePairs?.forEach(aValue => {
+      if (bins[aValue.primary] === undefined) {
+        bins[aValue.primary] = {}
       }
-      bins[aValue]++
+      if (bins[aValue.primary][aValue.secondary] === undefined) {
+        bins[aValue.primary][aValue.secondary] = 0
+      }
+      bins[aValue.primary][aValue.secondary]++
     })
-    return Object.keys(bins).reduce((max, aKey) => Math.max(max, bins[aKey]), 0)
-  }, [attribute])
+    return Object.keys(bins).reduce((hMax, hKey) => {
+      return Math.max(hMax, Object.keys(bins[hKey]).reduce((vMax, vKey) => {
+        return Math.max(vMax, bins[hKey][vKey])
+      }, 0))
+    }, 0)
+  }, [dataConfig?.cases, dataset, primaryAttrID, secondaryAttrID])
 
   const refreshPointSelection = useCallback(() => {
-    setPointSelection({dotsRef, dataset, pointRadius: graphModel.getPointRadius(),
-      selectedPointRadius: graphModel.getPointRadius('select')})
+    setPointSelection({
+      dotsRef, dataset, pointRadius: graphModel.getPointRadius(),
+      selectedPointRadius: graphModel.getPointRadius('select')
+    })
   }, [dataset, dotsRef, graphModel])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
+    // We're pretending that the primaryPlace is the bottom just to help understand the naming
     const
+      primaryCategoriesArray: string[] = dataConfig ? Array.from(dataConfig.categorySetForPlace(primaryAttrPlace)) : [],
+      secondaryCategoriesArray: string[] = dataConfig ?
+        Array.from(dataConfig.categorySetForPlace(secondaryAttrPlace)) : [],
       pointDiameter = 2 * graphModel.getPointRadius(),
       selection = select(dotsRef.current).selectAll(selectedOnly ? '.graph-dot-highlighted' : '.graph-dot'),
       duration = enableAnimation.current ? transitionDuration : 0,
-      cellWidth = primaryScale.bandwidth()
+      primaryCellWidth = primaryScale.bandwidth(),
+      primaryHeight = secondaryScale.bandwidth ? secondaryScale.bandwidth() :
+        layout.axisLength(secondaryAxisPlace),
+      categoriesMap: Record<string, Record<string, { cell: { h: number, v: number }, numSoFar: number }>> = {}
 
     const computeCellParams = () => {
-        categories.forEach((cat, i) => {
-          categoriesMapRef.current[cat] = {cell: i, numSoFar: 0}
+        primaryCategoriesArray.forEach((primeCat, i) => {
+          if( !categoriesMap[primeCat]) {
+            categoriesMap[primeCat] = {}
+          }
+          secondaryCategoriesArray.forEach((secCat, j) => {
+            categoriesMap[primeCat][secCat] = {cell: {h: i, v: j}, numSoFar: 0}
+          })
         })
 
-        const cellHeight = layout.axisLength(secondaryPlace),
+        const
+          secondaryGap = 5,
           maxInCell = computeMaxOverAllCells(),
-          allowedPointsPerColumn = Math.max(1, Math.floor(cellHeight / pointDiameter)),
-          allowedPointsPerRow = Math.max(1, Math.floor(cellWidth / pointDiameter)),
+          allowedPointsPerColumn = Math.max(1, Math.floor((primaryHeight - secondaryGap) / pointDiameter)),
+          primaryGap = 18,
+          allowedPointsPerRow = Math.max(1, Math.floor((primaryCellWidth - primaryGap) / pointDiameter)),
           numPointsInRow = Math.max(1, Math.min(allowedPointsPerRow,
             Math.ceil(maxInCell / allowedPointsPerColumn))),
           actualPointsPerColumn = Math.ceil(maxInCell / numPointsInRow),
-          overlap = -Math.max(0, ((actualPointsPerColumn + 1) * pointDiameter - cellHeight) /
+          overlap = -Math.max(0, ((actualPointsPerColumn + 1) * pointDiameter - primaryHeight) /
             actualPointsPerColumn)
         return {numPointsInRow, overlap}
       },
       cellParams = computeCellParams(),
 
       buildMapOfIndicesByCase = () => {
-        const indices: Record<string, { cell: number, row: number, column: number }> = {}
-        primaryAttributeID && dataConfig?.cases.forEach(anID => {
-          const cat = dataset?.getValue(anID, primaryAttributeID),
-            cell = categoriesMapRef.current[cat].cell,
-            numInCell = categoriesMapRef.current[cat].numSoFar++,
+        const indices: Record<string, { cell: { h: number, v: number }, row: number, column: number }> = {}
+        primaryAttrID && dataConfig?.cases.forEach(anID => {
+          const hCat = dataset?.getValue(anID, primaryAttrID),
+            vCat = secondaryAttrID ? dataset?.getValue(anID, secondaryAttrID) : '__main__',
+            mapEntry = categoriesMap[hCat][vCat],
+            numInCell = mapEntry.numSoFar++,
             row = Math.floor(numInCell / cellParams.numPointsInRow),
             column = numInCell % cellParams.numPointsInRow
-          indices[anID] = {cell, row, column}
+          indices[anID] = {cell: mapEntry.cell, row, column}
         })
         return indices
       },
@@ -89,38 +118,40 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
         enableAnimation.current = false
       } : undefined,
       cellIndices = buildMapOfIndicesByCase(),
-      baseCoord = primaryPlace === 'bottom' ? 0 : layout.axisLength('left'),
-      signForOffset = primaryPlace === 'bottom' ? 1 : -1,
-      primaryCenterKey = primaryPlace === 'bottom' ? 'cx' : 'cy',
-      secondaryCenterKey = primaryPlace === 'bottom' ? 'cy' : 'cx'
+      baseCoord = primaryIsBottom ? 0 : layout.axisLength('left'),
+      signForOffset = primaryIsBottom ? 1 : -1,
+      primaryCenterKey = primaryIsBottom ? 'cx' : 'cy',
+      secondaryCenterKey = primaryIsBottom ? 'cy' : 'cx'
 
     selection
       .transition()
       .duration(duration)
       .on('end', (id, i) => (i === selection.size() - 1) && onComplete?.())
       .attr(primaryCenterKey, (anID: string) => {
-        if(cellIndices[anID]) {
-          const {cell, column} = cellIndices[anID]
-          return baseCoord + signForOffset * ((cell + 0.5) * cellWidth) + (column + 0.5) * pointDiameter -
+        if (cellIndices[anID]) {
+          const {column} = cellIndices[anID],
+            {h} = cellIndices[anID].cell
+          return baseCoord + signForOffset * ((h + 0.5) * primaryCellWidth) + (column + 0.5) * pointDiameter -
             cellParams.numPointsInRow * pointDiameter / 2
-        }
-        else {
+        } else {
           return NaN
         }
       })
       .attr(secondaryCenterKey, (anID: string) => {
-        if(cellIndices[anID]) {
-          const {row} = cellIndices[anID]
-          return secondaryScale.range()[0] - signForOffset * ((row + 0.5) * pointDiameter + row * cellParams.overlap)
-        }
-        else {
+        if (cellIndices[anID]) {
+          const {row} = cellIndices[anID],
+            {v} = cellIndices[anID].cell
+          return secondaryScale.range()[0] -
+            signForOffset * (v * primaryHeight + (row + 0.5) * pointDiameter + row * cellParams.overlap)
+        } else {
           return NaN
         }
       })
-  }, [graphModel, categories, computeMaxOverAllCells, dataConfig?.cases, dataset, dotsRef, enableAnimation, layout,
-      primaryAttributeID, primaryPlace, primaryScale, secondaryPlace, secondaryScale])
+  }, [dataConfig, primaryAttrPlace, secondaryAttrPlace, graphModel, dotsRef,
+            enableAnimation, primaryScale, primaryIsBottom, layout, secondaryAxisPlace,
+            computeMaxOverAllCells, primaryAttrID, secondaryAttrID, dataset, secondaryScale])
 
-  useEffect(()=>{
+  useEffect(() => {
     select(dotsRef.current).on('click', (event) => {
       const element = select(event.target as SVGSVGElement)
       if (element.node()?.nodeName === 'circle') {

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -19,6 +19,7 @@ type BinMap = Record<string, Record<string, number>>
 export const ChartDots = memo(function ChartDots(props: IProps) {
   const {graphModel, plotProps: {dotsRef, enableAnimation}} = props,
     dataConfig = useDataConfigurationContext(),
+    cases = dataConfig?.cases || [],
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
     primaryAttrPlace = dataConfig?.primaryPlace ?? 'x',
@@ -32,7 +33,7 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
     secondaryScale = layout.axisScale(secondaryAxisPlace) as ScaleBand<string>
 
   const computeMaxOverAllCells = useCallback(() => {
-    const valuePairs = dataConfig?.cases.map(caseID => {
+    const valuePairs = cases.map(caseID => {
         return {
           primary: (primaryAttrID && dataset?.getValue(caseID, primaryAttrID)) ?? '',
           secondary: (secondaryAttrID && dataset?.getValue(caseID, secondaryAttrID)) ?? '__main__'
@@ -53,7 +54,7 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
         return Math.max(vMax, bins[hKey][vKey])
       }, 0))
     }, 0)
-  }, [dataConfig?.cases, dataset, primaryAttrID, secondaryAttrID])
+  }, [cases, dataset, primaryAttrID, secondaryAttrID])
 
   const refreshPointSelection = useCallback(() => {
     setPointSelection({
@@ -103,7 +104,7 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
 
       buildMapOfIndicesByCase = () => {
         const indices: Record<string, { cell: { h: number, v: number }, row: number, column: number }> = {}
-        primaryAttrID && dataConfig?.cases.forEach(anID => {
+        primaryAttrID && cases.forEach(anID => {
           const hCat = dataset?.getValue(anID, primaryAttrID),
             vCat = secondaryAttrID ? dataset?.getValue(anID, secondaryAttrID) : '__main__',
             mapEntry = categoriesMap[hCat][vCat],

--- a/v3/src/components/graph/models/data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/data-configuration-model.test.ts
@@ -166,4 +166,26 @@ describe("DataConfigurationModel", () => {
     expect(config.primaryPlace).toBe("y")
   })
 
+  it("returns an attribute values array and category set that ignore empty values", () => {
+    data.addCases(toCanonical(data,[
+      { __id__: "c4", n: "n1", x: 1, y: 1 },
+      { __id__: "c5", n: "", x: 6, y: 1 },
+      { __id__: "c6", n: "n1", x: 6, y: 6 }]))
+    const config = DataConfigurationModel.create()
+    config.setDataset(data)
+    config.setAttribute("x", { attributeID: "xId" })
+    config.setAttribute("y", { attributeID: "yId" })
+    config.setAttribute("caption", { attributeID: "nId" })
+    expect(config.attributeValuesForPlace("x")).toEqual(["1", "1", "6", "6"])
+    expect(config.attributeValuesForPlace("y")).toEqual(["1", "1", "1", "6"])
+    expect(config.attributeValuesForPlace("caption")).toEqual(["n1", "n1", "n1"])
+    expect(config.categorySetForPlace("x")).toEqual(new Set(["1", "6"]))
+    expect(config.categorySetForPlace("y")).toEqual(new Set(["1", "6"]))
+    expect(config.categorySetForPlace("caption")).toEqual(new Set(["n1"]))
+
+    config.setAttribute("y")
+    expect(config.attributeValuesForPlace("y")).toEqual([])
+    expect(config.categorySetForPlace("y")).toEqual(new Set(["__main__"]))
+  })
+
 })

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -93,6 +93,21 @@ export const DataConfigurationModel = types
       return selection.filter(caseId => self.filteredCases?.hasCaseId(caseId))
     }
   }))
+  .views(self => ({
+    attributeValuesForPlace(place:GraphAttrPlace):string[] {
+      const attrID = self.attributeID(place),
+        dataset = self.dataset
+      return attrID ? self.cases.map(anID => String(dataset?.getValue(anID, attrID))) : []
+    },
+    categorySetForPlace(place:GraphAttrPlace):Set<string> {
+      const result:Set<string> = new Set(this.attributeValuesForPlace(place))
+      result.delete('')
+      if(result.size === 0) {
+        result.add('__main__')
+      }
+      return result
+    }
+  }))
   .actions(self => ({
     setDataset(dataset: IDataSet) {
       self.dataset = dataset

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -97,7 +97,8 @@ export const DataConfigurationModel = types
     attributeValuesForPlace(place:GraphAttrPlace):string[] {
       const attrID = self.attributeID(place),
         dataset = self.dataset
-      return attrID ? self.cases.map(anID => String(dataset?.getValue(anID, attrID))) : []
+      return attrID ? self.cases.map(anID => String(dataset?.getValue(anID, attrID)))
+        .filter(aValue => aValue !== '') : []
     },
     categorySetForPlace(place:GraphAttrPlace):Set<string> {
       const result:Set<string> = new Set(this.attributeValuesForPlace(place))

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -103,8 +103,8 @@ export class GraphController {
         setNiceDomain(attribute?.numValues || [], axisModel as INumericAxisModel)
       }
     } else if (attributeType === 'categorical') {
-      const setOfValues = new Set(attribute?.strValues)
-      setOfValues.delete('')  // To eliminate category for empty values
+      const setOfValues = new Set(dataConfig.attributeValuesForPlace(graphAttributePlace))
+      setOfValues.delete('')
       const categories = Array.from(setOfValues)
       if (currentAxisType !== attributeType) {
         const newAxisModel = CategoricalAxisModel.create({place: axisPlace})


### PR DESCRIPTION
Given a dot chart, dropping a categorical attribute on the empty axis splits the dot chart by the new categories.
* Note that the stack of dots grows perpendicular to the _first_ attribute and that therefore the stacks can be made to grow either vertically _or_ horizontally depending on which attribute was first. There are some subtleties brought about by _replacing_ the first attribute with a different categorical which currently forces the growth direction to switch. We may want to change this behavior.
* As with split dot plots the grid lines remain to be implemented