### PR TITLE
V3: DataConfigurationModel supports onAction listeners

### DIFF
--- a/v3/src/components/graph/models/data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/data-configuration-model.test.ts
@@ -155,7 +155,31 @@ describe("DataConfigurationModel", () => {
     expect(config.selection.length).toBe(1)
     expect(selectionReaction).toHaveBeenCalledTimes(1)
     disposer()
-})
+  })
+
+  it("calls action listeners when appropriate", () => {
+    const config = DataConfigurationModel.create()
+    config.setDataset(data)
+    config.setAttribute("x", { attributeID: "xId" })
+
+    const handleAction = jest.fn()
+    config.onAction(handleAction)
+
+    data.setCaseValues([{ __id__: "c1", xId: 1.1 }])
+    expect(handleAction).toHaveBeenCalledTimes(1)
+    expect(handleAction.mock.lastCall[0].name).toBe("setCaseValues")
+
+    data.setCaseValues([{ __id__: "c3", xId: 3 }])
+    expect(handleAction).toHaveBeenCalledTimes(2)
+    expect(handleAction.mock.lastCall[0].name).toBe("addCases")
+
+    data.setCaseValues([{ __id__: "c1", xId: "" }])
+    expect(handleAction).toHaveBeenCalledTimes(3)
+    expect(handleAction.mock.lastCall[0].name).toBe("removeCases")
+
+    data.setCaseValues([{ __id__: "c1", xId: 1 }, { __id__: "c2", xId: "" }, { __id__: "c3", xId: 3.3 }])
+    expect(handleAction).toHaveBeenCalledTimes(6)
+  })
 
   it("only allows x and y as primary place", () => {
     const config = DataConfigurationModel.create()

--- a/v3/src/data-model/filtered-cases.test.ts
+++ b/v3/src/data-model/filtered-cases.test.ts
@@ -15,7 +15,7 @@ describe("DerivedDataSet", () => {
   })
 
   it("handles construction without a filter", () => {
-    const filtered = new FilteredCases(data)
+    const filtered = new FilteredCases({ source: data })
     expect(filtered.caseIds.length).toBe(3)
     expect(filtered.caseIds).toEqual(["c1", "c2", "c3"])
     expect(filtered.hasCaseId("c1")).toBe(true)
@@ -24,9 +24,10 @@ describe("DerivedDataSet", () => {
   })
 
   it("handles construction with a filter", () => {
-    const filtered = new FilteredCases(data,
-      (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
-                         isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+    const filtered = new FilteredCases({
+      source: data,
+      filter: (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
+                                 isFinite(_data.getNumeric(caseId, "yId") ?? NaN) })
     expect(filtered.caseIds.length).toBe(1)
     expect(filtered.caseIds).toEqual(["c1"])
     expect(filtered.hasCaseId("c1")).toBe(true)
@@ -35,9 +36,10 @@ describe("DerivedDataSet", () => {
   })
 
   it("handles filtering when adding/removing cases", () => {
-    const filtered = new FilteredCases(data,
-      (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
-                         isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+    const filtered = new FilteredCases({
+      source: data,
+      filter: (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
+                                 isFinite(_data.getNumeric(caseId, "yId") ?? NaN) })
     data.addCases([{ __id__: "c4", xId: 4, yId: 4 }])
     expect(filtered.caseIds.length).toBe(2)
     expect(filtered.caseIds).toEqual(["c1", "c4"])
@@ -51,11 +53,17 @@ describe("DerivedDataSet", () => {
     filtered.destroy()
   })
 
-  it("handles updated values which change filtering", () => {
-    const filtered = new FilteredCases(data,
-      (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
-                         isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+  it("handles updated values which change filtering (no listener)", () => {
+    const filtered = new FilteredCases({
+      source: data,
+      filter: (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
+                                 isFinite(_data.getNumeric(caseId, "yId") ?? NaN) })
     data.setCaseValues([{ __id__: "c3", xId: 3 }])
+    expect(filtered.caseIds.length).toBe(2)
+    expect(filtered.caseIds).toEqual(["c1", "c3"])
+    expect(filtered.hasCaseId("c3")).toBe(true)
+
+    data.setCaseValues([{ __id__: "c3", xId: 4 }])
     expect(filtered.caseIds.length).toBe(2)
     expect(filtered.caseIds).toEqual(["c1", "c3"])
     expect(filtered.hasCaseId("c3")).toBe(true)
@@ -68,10 +76,38 @@ describe("DerivedDataSet", () => {
     filtered.destroy()
   })
 
+  it("handles updated values which change filtering (listener)", () => {
+    const handleSetCaseValues = jest.fn()
+    const filtered = new FilteredCases({
+      source: data,
+      filter: (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
+                                 isFinite(_data.getNumeric(caseId, "yId") ?? NaN),
+      onSetCaseValues: handleSetCaseValues })
+
+    data.setCaseValues([{ __id__: "c3", xId: 3 }])
+    expect(handleSetCaseValues).toHaveBeenCalledTimes(1)
+    expect(handleSetCaseValues.mock.lastCall[1]).toEqual({ added: ["c3"], changed: [], removed: [] })
+
+    data.setCaseValues([{ __id__: "c3", xId: 4 }])
+    expect(handleSetCaseValues).toHaveBeenCalledTimes(2)
+    expect(handleSetCaseValues.mock.lastCall[1]).toEqual({ added: [], changed: ["c3"], removed: [] })
+
+    data.setCaseValues([{ __id__: "c1", xId: "" }])
+    expect(handleSetCaseValues).toHaveBeenCalledTimes(3)
+    expect(handleSetCaseValues.mock.lastCall[1]).toEqual({ added: [], changed: [], removed: ["c1"] })
+
+    data.setCaseValues([{ __id__: "c1", xId: 1 }, { __id__: "c2", xId: 2.2 }, { __id__: "c3", xId: "" }])
+    expect(handleSetCaseValues).toHaveBeenCalledTimes(4)
+    expect(handleSetCaseValues.mock.lastCall[1]).toEqual({ added: ["c1"], changed: ["c2"], removed: ["c3"] })
+
+    filtered.destroy()
+  })
+
   it("triggers observers on value changes which change filtering", () => {
-    const filtered = new FilteredCases(data,
-      (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
-                         isFinite(_data.getNumeric(caseId, "yId") ?? NaN))
+    const filtered = new FilteredCases({
+      source: data,
+      filter: (_data, caseId) => isFinite(_data.getNumeric(caseId, "xId") ?? NaN) &&
+                                 isFinite(_data.getNumeric(caseId, "yId") ?? NaN) })
 
     const trigger = jest.fn()
     reaction(() => filtered.caseIds, () => trigger())

--- a/v3/webpack.config.js
+++ b/v3/webpack.config.js
@@ -148,10 +148,6 @@ module.exports = (env, argv) => {
         'react/jsx-dev-runtime': 'react/jsx-dev-runtime.js',
       },
     },
-    stats: {
-      // suppress "export not found" warnings about re-exported types
-      warningsFilter: /export .* was not found in/,
-    },
     plugins: [
       new ESLintPlugin({
         extensions: ['ts', 'tsx', 'js', 'jsx'],


### PR DESCRIPTION
The `DataConfigurationModel` supports `onAction` listeners. Generally speaking, these are forwarded from the `DataSet` but in the case of `setCaseValues` actions, the `DataConfigurationModel` will notify of `addCases` and `removeCases` changes as well based on any filtering changes that result.