### PR TITLE
V3: Fix drag/drop with keyboard

### DIFF
--- a/v3/src/components/case-table/case-table-component.tsx
+++ b/v3/src/components/case-table/case-table-component.tsx
@@ -12,8 +12,8 @@ interface IProps {
 export const CaseTableComponent = observer(({ broker }: IProps) => {
   const instanceId = useNextInstanceId("case-table")
   const data = broker?.selectedDataSet || broker?.last
-
-  const { setNodeRef } = useDroppable({ id: `${instanceId}-component-drop`, data: { accepts: ["attribute"] } })
+  const id = `${instanceId}-component-drop-overlay`
+  const { setNodeRef } = useDroppable({ id, data: { accepts: ["attribute"] } })
 
   return (
     <DataSetContext.Provider value={data}>

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -3,6 +3,7 @@ import React, { CSSProperties, useEffect, useState } from "react"
 import { createPortal } from "react-dom"
 import { IMoveAttributeOptions } from "../../data-model/data-set"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { useInstanceIdContext } from "../../hooks/use-instance-id-context"
 import { kIndexColumnKey } from "./case-table-types"
 
 interface IProps {
@@ -10,6 +11,7 @@ interface IProps {
   cellElt: HTMLElement | null
 }
 export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
+  const instanceId = useInstanceIdContext()
   const data = useDataSetContext()
   const [tableElt, setTableElt] = useState<HTMLElement | null>(null)
   const tableBounds = tableElt?.getBoundingClientRect()
@@ -24,7 +26,8 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
   }
 
   const dropData: any = { accepts: ["attribute"], onDrop: handleDrop }
-  const { isOver, setNodeRef: setDropRef } = useDroppable({ id: `table-attribute:${columnKey}`, data: dropData })
+  const id = `${instanceId}-attribute:${columnKey}-drop`
+  const { isOver, setNodeRef: setDropRef } = useDroppable({ id, data: dropData })
 
   // find the `case-table` DOM element; divider must be drawn relative
   // to the `case-table` (via React portal) so it isn't clipped by the cell

--- a/v3/src/components/codap-dnd-context.tsx
+++ b/v3/src/components/codap-dnd-context.tsx
@@ -1,5 +1,6 @@
 import {
-  DndContext, DragEndEvent, DragStartEvent, KeyboardSensor, PointerSensor, useSensor, useSensors
+  DndContext, DragEndEvent, DragStartEvent, KeyboardCoordinateGetter, KeyboardSensor,
+  PointerSensor, useSensor, useSensors
 } from "@dnd-kit/core"
 import React, { ReactNode } from "react"
 import { dndDetectCollision } from "./dnd-detect-collision"
@@ -23,7 +24,7 @@ export const CodapDndContext = ({ children }: IProps) => {
   const sensors = useSensors(
                     // pointer must move three pixels before starting a drag
                     useSensor(PointerSensor, { activationConstraint: { distance: 3 }}),
-                    useSensor(KeyboardSensor))
+                    useSensor(KeyboardSensor, { coordinateGetter: customCoordinatesGetter }))
 
   return (
     <DndContext collisionDetection={dndDetectCollision} sensors={sensors}
@@ -31,4 +32,34 @@ export const CodapDndContext = ({ children }: IProps) => {
       {children}
     </DndContext>
   )
+}
+
+const customCoordinatesGetter: KeyboardCoordinateGetter = (event, { currentCoordinates }) => {
+  // arrow keys move 15 pixels at a time (rather than default of 25)
+  const delta = 15
+
+  switch (event.code) {
+    case 'ArrowRight':
+      return {
+        ...currentCoordinates,
+        x: currentCoordinates.x + delta,
+      }
+    case 'ArrowLeft':
+      return {
+        ...currentCoordinates,
+        x: currentCoordinates.x - delta,
+      }
+    case 'ArrowDown':
+      return {
+        ...currentCoordinates,
+        y: currentCoordinates.y + delta,
+      }
+    case 'ArrowUp':
+      return {
+        ...currentCoordinates,
+        y: currentCoordinates.y - delta,
+      }
+  }
+
+  return undefined
 }

--- a/v3/src/components/dnd-detect-collision.ts
+++ b/v3/src/components/dnd-detect-collision.ts
@@ -1,8 +1,9 @@
 import { closestCenter, CollisionDetection, pointerWithin, rectIntersection } from "@dnd-kit/core"
 
 export const dndDetectCollision: CollisionDetection = (args) => {
-  // use pointerWithin to determine the component we're in
-  const collisions = pointerWithin(args)
+  // first determine the component we're in using pointerWithin (for pointer sensor) or
+  // rectIntersection (for keyboard sensor)
+  const collisions = args.pointerCoordinates ? pointerWithin(args) : rectIntersection(args)
 
   // if we're in the summary component, use rectangle intersection on the inspector button
   if (collisions.find(collision => collision.id === "summary-component-drop")) {
@@ -11,12 +12,12 @@ export const dndDetectCollision: CollisionDetection = (args) => {
   }
 
   // if we're in the case table component, use closest center on the column header dividers
-  if (collisions.find(collision => /case-table.+component-drop/.test(`${collision.id}`))) {
-    const containers = args.droppableContainers.filter(({id}) => `${id}`.includes("table-attribute"))
+  if (collisions.find(collision => /case-table.+component-drop-overlay/.test(`${collision.id}`))) {
+    const containers = args.droppableContainers.filter(({id}) => /case-table.+attribute.+-drop/.test(`${id}`))
     return closestCenter({ ...args, droppableContainers: containers })
   }
 
-  // if we're in the graph component, use rectangle intersection on the drop targets (e.g. axes)
+  // if we're in the graph component, use rectangle intersection on the drop targets (e.g. axes, plot)
   if (collisions.find(collision => /graph.+component-drop-overlay/.test(`${collision.id}`))) {
     const containers = args.droppableContainers.filter(({id}) => /graph.+-drop/.test(`${id}`))
     return rectIntersection({ ...args, droppableContainers: containers })


### PR DESCRIPTION
- fix our custom collision-detection function to work with keyboard sensor
- case table adopts latest droppable id convention

Note that currently drag/drop of attributes from the summary view works fine, but drag/drop from the case table column headers doesn't work because the enter/return/space keys bring up the column header menu rather than initiating a drag. We'll have to figure out some way of enabling both behaviors at some point.

@bacalj I'm assigning this to you for review since you're now more familiar with the dnd-kit API than others.