### PR TITLE
183534287 observer warning

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -11,6 +11,7 @@ import {Text} from "./text"
 import {useDropHandler} from "../hooks/use-drop-handler"
 import { useKeyStates } from "../hooks/use-key-states"
 import {useSampleText} from "../hooks/use-sample-text"
+import { V2DocumentContext } from "../hooks/use-v2-document-context"
 import Icon from "../assets/concord.png"
 import { importSample, sampleData, SampleType } from "../sample-data"
 import { urlParams } from "../utilities/url-params"
@@ -69,25 +70,27 @@ export const App = () => {
 
   return (
     <CodapDndContext>
-      <div className="app" data-testid="app">
-        <ToolShelf/>
-        <Container>
-          {/* each top-level child will be wrapped in a CodapComponent */}
-          <DataSummary v2Document={v2Document} />
-          <div className="hello-codap3">
-            <div className="version-build-number">
-              <span>v{pkg.version}-build-{build.buildNumber}</span>
+      <V2DocumentContext.Provider value={v2Document}>
+        <div className="app" data-testid="app">
+          <ToolShelf/>
+          <Container>
+            {/* each top-level child will be wrapped in a CodapComponent */}
+            <DataSummary />
+            <div className="hello-codap3">
+              <div className="version-build-number">
+                <span>v{pkg.version}-build-{build.buildNumber}</span>
+              </div>
+              <div>
+                <img src={Icon}/>
+                <Text text={sampleText}/>
+                <p>Drag a CSV file into this window to get some data.</p>
+              </div>
             </div>
-            <div>
-              <img src={Icon}/>
-              <Text text={sampleText}/>
-              <p>Drag a CSV file into this window to get some data.</p>
-            </div>
-          </div>
-          <CaseTableComponent/>
-          <GraphComponent v2Document={v2Document}/>
-        </Container>
-      </div>
+            <CaseTableComponent/>
+            <GraphComponent />
+          </Container>
+        </div>
+      </V2DocumentContext.Provider>
     </CodapDndContext>
   )
 }

--- a/v3/src/components/data-summary.tsx
+++ b/v3/src/components/data-summary.tsx
@@ -5,17 +5,17 @@ import React, { useState } from "react"
 import { IAttribute } from "../data-model/attribute"
 import { DataBroker } from "../data-model/data-broker"
 import { getDragAttributeId, IDropData, IUseDraggableAttribute, useDraggableAttribute } from '../hooks/use-drag-drop'
+import { useV2DocumentContext } from '../hooks/use-v2-document-context'
 import { prf } from "../utilities/profiler"
-import { CodapV2Document } from '../v2/codap-v2-document'
 
 import "./data-summary.scss"
 
 interface IProps {
   broker?: DataBroker
-  v2Document?: CodapV2Document
 }
-export const DataSummary = observer(({ broker, v2Document }: IProps) => {
+export const DataSummary = observer(({ broker }: IProps) => {
   const data = broker?.selectedDataSet || broker?.last
+  const v2Document = useV2DocumentContext()
 
   const { active } = useDndContext()
   const isSummaryDrag = active && `${active.id}`.startsWith("summary")

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -42,7 +42,9 @@ export const GraphComponent = observer(({broker, v2Document}: IProps) => {
         graphModel: defaultGraphModel,
         dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
       }),
-      [dataset, layout, instanceId, v2Document])
+      [/* dataset, */ layout, instanceId, v2Document])
+      // removing this dependency works, but dots won't load
+      // experiment with putting graphController in a memo as here, but maybe in a ref instead
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setGraphExtent(width, height)

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -11,8 +11,6 @@ import {DataConfigurationModel} from "../models/data-configuration-model"
 import {GraphLayout, GraphLayoutContext} from "../models/graph-layout"
 import {GraphModel} from "../models/graph-model"
 import {Graph} from "./graph"
-import {CodapV2Document} from "../../../v2/codap-v2-document"
-import {useGraphController} from '../hooks/use-graph-controller'
 
 const defaultGraphModel = GraphModel.create({
   axes: {
@@ -25,21 +23,15 @@ const defaultGraphModel = GraphModel.create({
 
 interface IProps {
   broker?: DataBroker
-  v2Document?: CodapV2Document
 }
 
-export const GraphComponent = observer(({broker, v2Document}: IProps) => {
+export const GraphComponent = observer(({broker}: IProps) => {
   const instanceId = useNextInstanceId("graph")
   const layout = useMemo(() => new GraphLayout(), [])
   const {width, height, ref: graphRef} = useResizeDetector({refreshMode: "debounce", refreshRate: 200})
   const enableAnimation = useRef(true)
   const dataset = broker?.selectedDataSet || broker?.last
   const dotsRef = useRef<SVGSVGElement>(null)
-
-  const graphController = useGraphController({
-    graphModel: defaultGraphModel,
-    layout, dataset, enableAnimation, dotsRef, v2Document
-  })
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setGraphExtent(width, height)
@@ -55,7 +47,6 @@ export const GraphComponent = observer(({broker, v2Document}: IProps) => {
       <InstanceIdContext.Provider value={instanceId}>
         <GraphLayoutContext.Provider value={layout}>
           <Graph model={defaultGraphModel}
-            graphController={graphController.current}
             graphRef={graphRef}
             enableAnimation={enableAnimation}
             dotsRef={dotsRef}

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -63,7 +63,7 @@ export const GraphComponent = observer(({broker, v2Document}: IProps) => {
       <InstanceIdContext.Provider value={instanceId}>
         <GraphLayoutContext.Provider value={layout}>
           <Graph model={defaultGraphModel}
-            graphController={graphController.current || getNewGraphController()}
+            graphController={graphController.current}
             graphRef={graphRef}
             enableAnimation={enableAnimation}
             dotsRef={dotsRef}

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -36,15 +36,14 @@ export const GraphComponent = observer(({broker, v2Document}: IProps) => {
   const dataset = broker?.selectedDataSet || broker?.last
   const dotsRef = useRef<SVGSVGElement>(null)
 
-  const
-    graphController = useMemo(
-      () => new GraphController({
-        graphModel: defaultGraphModel,
-        dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
-      }),
-      [/* dataset, */ layout, instanceId, v2Document])
-      // removing this dependency works, but dots won't load
-      // experiment with putting graphController in a memo as here, but maybe in a ref instead
+  const getNewGraphController = () => {
+    return new GraphController({
+      graphModel: defaultGraphModel,
+      dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
+    })
+  }
+
+  const graphController = useMemo(()=> getNewGraphController(),[dataset, layout, instanceId, v2Document])
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setGraphExtent(width, height)

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -35,6 +35,7 @@ export const GraphComponent = observer(({broker, v2Document}: IProps) => {
   const enableAnimation = useRef(true)
   const dataset = broker?.selectedDataSet || broker?.last
   const dotsRef = useRef<SVGSVGElement>(null)
+  const graphController = useRef<GraphController>()
 
   const getNewGraphController = () => {
     return new GraphController({
@@ -43,7 +44,10 @@ export const GraphComponent = observer(({broker, v2Document}: IProps) => {
     })
   }
 
-  const graphController = useMemo(()=> getNewGraphController(),[dataset, layout, instanceId, v2Document])
+  useEffect(() => {
+    graphController.current = getNewGraphController()
+  },[dataset, layout, instanceId, v2Document])
+
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setGraphExtent(width, height)
@@ -59,10 +63,10 @@ export const GraphComponent = observer(({broker, v2Document}: IProps) => {
       <InstanceIdContext.Provider value={instanceId}>
         <GraphLayoutContext.Provider value={layout}>
           <Graph model={defaultGraphModel}
-                 graphController={graphController}
-                 graphRef={graphRef}
-                 enableAnimation={enableAnimation}
-                 dotsRef={dotsRef}
+            graphController={graphController.current || getNewGraphController()}
+            graphRef={graphRef}
+            enableAnimation={enableAnimation}
+            dotsRef={dotsRef}
           />
         </GraphLayoutContext.Provider>
       </InstanceIdContext.Provider>

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -38,7 +38,7 @@ export const GraphComponent = observer(({broker, v2Document}: IProps) => {
 
   const graphController = useGraphController({
     graphModel: defaultGraphModel,
-    dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
+    layout, dataset, enableAnimation, dotsRef, v2Document
   })
 
   useEffect(() => {

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -1,6 +1,6 @@
 import {useDroppable} from '@dnd-kit/core'
 import {observer} from "mobx-react-lite"
-import { getSnapshot } from "mobx-state-tree"
+import {getSnapshot} from "mobx-state-tree"
 import React, {useEffect, useMemo, useRef} from "react"
 import {useResizeDetector} from "react-resize-detector"
 import {DataBroker} from "../../../data-model/data-broker"
@@ -10,10 +10,9 @@ import {EmptyAxisModel} from "../models/axis-model"
 import {DataConfigurationModel} from "../models/data-configuration-model"
 import {GraphLayout, GraphLayoutContext} from "../models/graph-layout"
 import {GraphModel} from "../models/graph-model"
-import {GraphController} from "../models/graph-controller"
 import {Graph} from "./graph"
 import {CodapV2Document} from "../../../v2/codap-v2-document"
-import { useGraphController } from '../hooks/use-graph-controller'
+import {useGraphController} from '../hooks/use-graph-controller'
 
 const defaultGraphModel = GraphModel.create({
   axes: {

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -13,6 +13,7 @@ import {GraphModel} from "../models/graph-model"
 import {GraphController} from "../models/graph-controller"
 import {Graph} from "./graph"
 import {CodapV2Document} from "../../../v2/codap-v2-document"
+import { useGraphController } from '../hooks/use-graph-controller'
 
 const defaultGraphModel = GraphModel.create({
   axes: {
@@ -35,19 +36,11 @@ export const GraphComponent = observer(({broker, v2Document}: IProps) => {
   const enableAnimation = useRef(true)
   const dataset = broker?.selectedDataSet || broker?.last
   const dotsRef = useRef<SVGSVGElement>(null)
-  const graphController = useRef<GraphController>()
 
-  const getNewGraphController = () => {
-    return new GraphController({
-      graphModel: defaultGraphModel,
-      dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
-    })
-  }
-
-  useEffect(() => {
-    graphController.current = getNewGraphController()
-  },[dataset, layout, instanceId, v2Document])
-
+  const graphController = useGraphController({
+    graphModel: defaultGraphModel,
+    dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
+  })
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setGraphExtent(width, height)

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -15,13 +15,13 @@ import {ChartDots} from "./chartdots"
 import {Marquee} from "./marquee"
 import {DataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
+import {useGraphController} from "../hooks/use-graph-controller"
 import {useGraphModel} from "../hooks/use-graph-model"
 import {IAxisModel, attrPlaceToAxisPlace, GraphPlace, graphPlaceToAttrPlace} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel, isSetAttributeIDAction} from "../models/graph-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {getPointTipText} from "../utilities/graph-utils"
-import {GraphController} from "../models/graph-controller"
 import {MarqueeState} from "../models/marquee-state"
 import {DroppableSvg} from "./droppable-svg"
 import {getDragAttributeId, IDropData} from "../../../hooks/use-drag-drop"
@@ -29,7 +29,6 @@ import {getDragAttributeId, IDropData} from "../../../hooks/use-drag-drop"
 import "./graph.scss"
 
 interface IProps {
-  graphController: GraphController | undefined // TODO, better approach?
   model: IGraphModel
   graphRef: MutableRefObject<HTMLDivElement>
   enableAnimation: MutableRefObject<boolean>
@@ -44,7 +43,7 @@ const marqueeState = new MarqueeState(),
     })
 
 export const Graph = observer((
-  {graphController, model: graphModel, graphRef, enableAnimation, dotsRef}: IProps) => {
+  {model: graphModel, graphRef, enableAnimation, dotsRef}: IProps) => {
   const xAxisModel = graphModel.getAxis("bottom") as IAxisModel,
     yAxisModel = graphModel.getAxis("left") as IAxisModel,
     {plotType} = graphModel,
@@ -65,6 +64,8 @@ export const Graph = observer((
     droppableId = `${instanceId}-plot-area-drop`
 
   useGraphModel({dotsRef, graphModel, enableAnimation, instanceId})
+
+  const graphController = useGraphController({ graphModel, enableAnimation, dotsRef })
 
   useEffect(function setupPlotArea() {
     if (xScale && xScale?.range().length > 0) {

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -157,7 +157,7 @@ export const Graph = observer((
 
   const handlePlotDropAttribute = (active: Active) => {
     const dragAttributeID = getDragAttributeId(active)
-    if( dragAttributeID) {
+    if (dragAttributeID) {
       handleDropAttribute('plot', dragAttributeID)
     }
   }

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -16,7 +16,7 @@ import {Marquee} from "./marquee"
 import {DataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphModel} from "../hooks/use-graph-model"
-import { IAxisModel, attrPlaceToAxisPlace, GraphPlace, graphPlaceToAttrPlace } from "../models/axis-model"
+import {IAxisModel, attrPlaceToAxisPlace, GraphPlace, graphPlaceToAttrPlace} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel, isSetAttributeIDAction} from "../models/graph-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
@@ -29,7 +29,7 @@ import {getDragAttributeId, IDropData} from "../../../hooks/use-drag-drop"
 import "./graph.scss"
 
 interface IProps {
-  graphController: GraphController
+  graphController: GraphController | undefined // TODO, better approach?
   model: IGraphModel
   graphRef: MutableRefObject<HTMLDivElement>
   enableAnimation: MutableRefObject<boolean>
@@ -96,7 +96,7 @@ export const Graph = observer((
         const [place, attrID] = action.args,
           axisPlace = attrPlaceToAxisPlace[place]
         enableAnimation.current = true
-        axisPlace && graphController.handleAttributeAssignment(axisPlace, attrID)
+        axisPlace && graphController?.handleAttributeAssignment(axisPlace, attrID)
       }
     }, true)
     return () => disposer?.()
@@ -104,7 +104,7 @@ export const Graph = observer((
 
   // We only need to make the following connection once
   useEffect(function passDotsRefToController() {
-    graphController.setDotsRef(dotsRef)
+    graphController?.setDotsRef(dotsRef)
   }, [dotsRef, graphController])
 
   // MouseOver events, if over an element, brings up hover text

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,16 +1,31 @@
-import {useRef, useEffect} from "react"
-import {GraphController, IGraphControllerProps} from "../models/graph-controller"
+import {useRef, useEffect, useContext} from "react"
+import {InstanceIdContext} from "../../../hooks/use-instance-id-context"
+import {GraphController} from "../models/graph-controller"
+import {GraphLayout} from "../models/graph-layout"
+import {CodapV2Document} from "../../../v2/codap-v2-document"
+import {IGraphModel} from "../models/graph-model"
+import {IDataSet} from "../../../data-model/data-set"
+
+export interface IUseGraphControllerProps {
+  graphModel: IGraphModel,
+  layout: GraphLayout,
+  dataset: IDataSet | undefined,
+  enableAnimation: React.MutableRefObject<boolean>
+  dotsRef: React.RefObject<SVGSVGElement>
+  v2Document?: CodapV2Document
+}
 
 export const useGraphController = ({
-  graphModel, dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
-}: IGraphControllerProps) => {
-  const graphController = useRef<GraphController>()
+  graphModel, layout, dataset, enableAnimation, dotsRef, v2Document
+}: IUseGraphControllerProps) => {
+  const graphControllerRef = useRef<GraphController>()
+  const instanceId = useContext(InstanceIdContext) as string
 
   useEffect(() => {
-    graphController.current = new GraphController({
-      graphModel,dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
+    graphControllerRef.current = new GraphController({
+      graphModel, layout, dataset, enableAnimation, instanceId, dotsRef, v2Document
     })
   },[dataset, layout, instanceId, v2Document])
 
-  return graphController
+  return graphControllerRef
 }

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,31 +1,14 @@
 import {useRef, useEffect} from "react"
-import { GraphController } from "../models/graph-controller"
-
-export interface IUseGraphController {
-  graphModel: any,
-  dataset: any,
-  layout: any,
-  enableAnimation: any,
-  instanceId: any,
-  dotsRef: any,
-  v2Document: any
-}
+import {GraphController, IGraphControllerProps} from "../models/graph-controller"
 
 export const useGraphController = ({
-  graphModel,
-  dataset,
-  layout,
-  enableAnimation,
-  instanceId,
-  dotsRef,
-  v2Document
-}: IUseGraphController) => {
+  graphModel, dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
+}: IGraphControllerProps) => {
   const graphController = useRef<GraphController>()
 
   const getNewGraphController = () => {
     return new GraphController({
-      graphModel,
-      dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
+      graphModel,dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
     })
   }
 
@@ -35,5 +18,3 @@ export const useGraphController = ({
 
   return graphController
 }
-
-

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,23 +1,21 @@
 import {useRef, useEffect, useContext} from "react"
+import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {InstanceIdContext} from "../../../hooks/use-instance-id-context"
+import {useV2DocumentContext} from "../../../hooks/use-v2-document-context"
 import {GraphController} from "../models/graph-controller"
-import {GraphLayout} from "../models/graph-layout"
-import {CodapV2Document} from "../../../v2/codap-v2-document"
+import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel} from "../models/graph-model"
-import {IDataSet} from "../../../data-model/data-set"
 
 export interface IUseGraphControllerProps {
   graphModel: IGraphModel,
-  layout: GraphLayout,
-  dataset: IDataSet | undefined,
   enableAnimation: React.MutableRefObject<boolean>
   dotsRef: React.RefObject<SVGSVGElement>
-  v2Document?: CodapV2Document
 }
 
-export const useGraphController = ({
-  graphModel, layout, dataset, enableAnimation, dotsRef, v2Document
-}: IUseGraphControllerProps) => {
+export const useGraphController = ({ graphModel, enableAnimation, dotsRef }: IUseGraphControllerProps) => {
+  const v2Document = useV2DocumentContext()
+  const dataset = useDataSetContext()
+  const layout = useGraphLayoutContext()
   const graphControllerRef = useRef<GraphController>()
   const instanceId = useContext(InstanceIdContext) as string
 
@@ -25,7 +23,7 @@ export const useGraphController = ({
     graphControllerRef.current = new GraphController({
       graphModel, layout, dataset, enableAnimation, instanceId, dotsRef, v2Document
     })
-  },[dataset, layout, instanceId, v2Document, dotsRef, enableAnimation, graphModel])
+  }, [graphModel, layout, dataset, enableAnimation, instanceId, dotsRef, v2Document])
 
-  return graphControllerRef
+  return graphControllerRef.current
 }

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,0 +1,39 @@
+import {useRef, useEffect} from "react"
+import { GraphController } from "../models/graph-controller"
+
+export interface IUseGraphController {
+  graphModel: any,
+  dataset: any,
+  layout: any,
+  enableAnimation: any,
+  instanceId: any,
+  dotsRef: any,
+  v2Document: any
+}
+
+export const useGraphController = ({
+  graphModel,
+  dataset,
+  layout,
+  enableAnimation,
+  instanceId,
+  dotsRef,
+  v2Document
+}: IUseGraphController) => {
+  const graphController = useRef<GraphController>()
+
+  const getNewGraphController = () => {
+    return new GraphController({
+      graphModel,
+      dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
+    })
+  }
+
+  useEffect(() => {
+    graphController.current = getNewGraphController()
+  },[dataset, layout, instanceId, v2Document])
+
+  return graphController
+}
+
+

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -25,7 +25,7 @@ export const useGraphController = ({
     graphControllerRef.current = new GraphController({
       graphModel, layout, dataset, enableAnimation, instanceId, dotsRef, v2Document
     })
-  },[dataset, layout, instanceId, v2Document])
+  },[dataset, layout, instanceId, v2Document, dotsRef, enableAnimation, graphModel])
 
   return graphControllerRef
 }

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -6,14 +6,10 @@ export const useGraphController = ({
 }: IGraphControllerProps) => {
   const graphController = useRef<GraphController>()
 
-  const getNewGraphController = () => {
-    return new GraphController({
+  useEffect(() => {
+    graphController.current = new GraphController({
       graphModel,dataset, layout, enableAnimation, instanceId, dotsRef, v2Document
     })
-  }
-
-  useEffect(() => {
-    graphController.current = getNewGraphController()
   },[dataset, layout, instanceId, v2Document])
 
   return graphController

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -67,6 +67,8 @@ export class GraphController {
       this.processV2Document()
     }
     else {
+      // TODO, this may not be the reliable thing to test for AND/OR
+      // we may need to be able to call setGraphProperties when axis' models are in place?
       if (!dotsRef.current){
         graphModel.setGraphProperties({
           axes: {bottom: EmptyAxisModel.create({place: 'bottom'}),
@@ -81,6 +83,8 @@ export class GraphController {
       }
       layout.setAxisScale('bottom', scaleOrdinal())
       layout.setAxisScale('left', scaleOrdinal())
+      // TODO the first drop of a numeric attr on an empty axis results in warning:
+      // Unexpected value NaN parsing cy attribute.
     }
   }
 

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -62,21 +62,26 @@ export class GraphController {
   initializeGraph() {
     const {graphModel, layout, dotsRef, enableAnimation, instanceId, v2Document} = this,
       dataConfig = graphModel.config
+
     if (v2Document) {
       this.processV2Document()
-    } else {
-      graphModel.setGraphProperties({
-        axes: {bottom: EmptyAxisModel.create({place: 'bottom'}),
+    }
+
+    else {
+      if (!dotsRef.current){
+        graphModel.setGraphProperties({
+          axes: {bottom: EmptyAxisModel.create({place: 'bottom'}),
           left: EmptyAxisModel.create({place: 'left'})}, plotType: 'casePlot'
-      })
+        })
+      }
+      if (dotsRef.current) {
+        matchCirclesToData({
+          caseIDs: dataConfig.cases, dotsElement: dotsRef.current,
+          pointRadius: graphModel.getPointRadius(), enableAnimation, instanceId
+        })
+      }
       layout.setAxisScale('bottom', scaleOrdinal())
       layout.setAxisScale('left', scaleOrdinal())
-    }
-    if (dotsRef.current) {
-      matchCirclesToData({
-        caseIDs: dataConfig.cases, dotsElement: dotsRef.current,
-        pointRadius: graphModel.getPointRadius(), enableAnimation, instanceId
-      })
     }
   }
 

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -65,14 +65,15 @@ export class GraphController {
 
     if (v2Document) {
       this.processV2Document()
-    } else {
+    }
+    else {
       if (!dotsRef.current){
         graphModel.setGraphProperties({
           axes: {bottom: EmptyAxisModel.create({place: 'bottom'}),
           left: EmptyAxisModel.create({place: 'left'})}, plotType: 'casePlot'
         })
       }
-      else if (dotsRef.current) {
+      else {
         matchCirclesToData({
           caseIDs: dataConfig.cases, dotsElement: dotsRef.current,
           pointRadius: graphModel.getPointRadius(), enableAnimation, instanceId

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -65,16 +65,14 @@ export class GraphController {
 
     if (v2Document) {
       this.processV2Document()
-    }
-
-    else {
+    } else {
       if (!dotsRef.current){
         graphModel.setGraphProperties({
           axes: {bottom: EmptyAxisModel.create({place: 'bottom'}),
           left: EmptyAxisModel.create({place: 'left'})}, plotType: 'casePlot'
         })
       }
-      if (dotsRef.current) {
+      else if (dotsRef.current) {
         matchCirclesToData({
           caseIDs: dataConfig.cases, dotsElement: dotsRef.current,
           pointRadius: graphModel.getPointRadius(), enableAnimation, instanceId

--- a/v3/src/hooks/use-v2-document-context.ts
+++ b/v3/src/hooks/use-v2-document-context.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from "react"
+import { CodapV2Document } from "../v2/codap-v2-document"
+
+export const V2DocumentContext = createContext<CodapV2Document | undefined>(undefined)
+
+export const useV2DocumentContext = () => {
+  return useContext(V2DocumentContext)
+}


### PR DESCRIPTION
Addresses persistent console warning: "Cannot update a component (`observerComponent`) while rendering a different component"

`graph-component.tsx`
- moves instantiation of new/replacement `GraphController` to a dedicated function 
- new instance is stored in a dedicated `ref`, whose current value is passed to the `Graph`
- conditional logic for re-creating the object is moved to a `useState` call with the same dependencies as the original memo

`graph-controller`
- model will only set the `axes` and `left` properties to an instance of an `EmptyAxisModel` if the `dotsRef` does not yet hold an svg
- if it does, it will `matchCirclesToData`

`graph.tsx`
- returns an unrelated indentation to its correct level