### PR TITLE
V3—Dropping a categorical attribute in middle of plot colors points according to the attribute's categories

### DIFF
--- a/v3/src/components/case-table/attribute-menu.tsx
+++ b/v3/src/components/case-table/attribute-menu.tsx
@@ -48,7 +48,8 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
 
   return (
     <>
-      <MenuList ref={ref} data-testid="attribute-menu-list" lineHeight="none" fontSize="small" onKeyDown={handleMenuKeyDown}>
+      <MenuList ref={ref} data-testid="attribute-menu-list" lineHeight="none" fontSize="small"
+                onKeyDown={handleMenuKeyDown}>
         <MenuItem onClick={onRenameAttribute}>Rename</MenuItem>
         <MenuItem onClick={() => handleMenuItemClick("Fit width")}>Fit width to content</MenuItem>
         <MenuItem onClick={handleEditAttributeProps}>Edit Attribute Properties...</MenuItem>

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -112,8 +112,7 @@ export const CaseDots = memo(function CaseDots(props: {
       .attr('cy', (anID: string) => {
         return yMax + pointRadius + randomPointsRef.current[anID].y * (yMin - yMax - 2 * pointRadius)
       })
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+      // @ts-expect-error anID may be null
       .style('fill', (anID: string) => {
         return legendAttrID ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
       })

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -8,6 +8,7 @@ import {ScaleNumericBaseType, useGraphLayoutContext} from "../models/graph-layou
 import {setPointSelection} from "../utilities/graph-utils"
 import {IGraphModel} from "../models/graph-model"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
+import {defaultPointColor} from "../../../utilities/color-utils"
 
 export const CaseDots = memo(function CaseDots(props: {
   graphModel: IGraphModel
@@ -21,6 +22,7 @@ export const CaseDots = memo(function CaseDots(props: {
     graphModel = props.graphModel,
     dataset = useDataSetContext(),
     dataConfiguration = useDataConfigurationContext(),
+    legendAttrID = dataConfiguration?.attributeID('legend'),
     layout = useGraphLayoutContext(),
     randomPointsRef = useRef<Record<string, { x: number, y: number }>>({}),
     pointRadius = graphModel.getPointRadius(),
@@ -33,7 +35,7 @@ export const CaseDots = memo(function CaseDots(props: {
     yScale = layout.axisScale('left') as ScaleNumericBaseType
 
   useEffect(function initDistribution() {
-    const { cases } = dataset || {}
+    const {cases} = dataset || {}
     const uniform = randomUniform()
     cases?.forEach(({__id__}) => {
       randomPointsRef.current[__id__] = {x: uniform(), y: uniform()}
@@ -110,11 +112,16 @@ export const CaseDots = memo(function CaseDots(props: {
       .attr('cy', (anID: string) => {
         return yMax + pointRadius + randomPointsRef.current[anID].y * (yMin - yMax - 2 * pointRadius)
       })
-      .attr('r', (anID:string) => pointRadius + (dataset?.isCaseSelected(anID) ? pointRadiusSelectionAddend : 0))
-  }, [dataset, pointRadius, dotsRef, enableAnimation, xScale, yScale])
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+      .style('fill', (anID: string) => {
+        return legendAttrID ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
+      })
+      .attr('r', (anID: string) => pointRadius + (dataset?.isCaseSelected(anID) ? pointRadiusSelectionAddend : 0))
+  }, [dataset, legendAttrID, dataConfiguration, pointRadius, dotsRef, enableAnimation, xScale, yScale])
 
   usePlotResponders({
-    dataset, layout, refreshPointPositions, refreshPointSelection, enableAnimation
+    dataset, legendAttrID, layout, refreshPointPositions, refreshPointSelection, enableAnimation
   })
 
   return (

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -150,8 +150,7 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
           return NaN
         }
       })
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error anID may be undefined
       .style('fill', (anID: string) => {
         return legendAttrID ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
       })

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -8,6 +8,7 @@ import {useGraphLayoutContext} from "../models/graph-layout"
 import {setPointSelection} from "../utilities/graph-utils"
 import {IGraphModel} from "../models/graph-model"
 import {attrPlaceToAxisPlace} from "../models/axis-model"
+import {defaultPointColor} from "../../../utilities/color-utils"
 
 interface IProps {
   graphModel: IGraphModel
@@ -28,6 +29,7 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
     secondaryAttrPlace = primaryAttrPlace === 'x' ? 'y' : 'x',
     secondaryAxisPlace = attrPlaceToAxisPlace[secondaryAttrPlace] ?? 'left',
     secondaryAttrID = dataConfiguration?.attributeID(secondaryAttrPlace),
+    legendAttrID = dataConfiguration?.attributeID('legend'),
     primaryScale = layout.axisScale(primaryAxisPlace) as ScaleBand<string>,
     secondaryScale = layout.axisScale(secondaryAxisPlace) as ScaleBand<string>
 
@@ -148,9 +150,14 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
           return NaN
         }
       })
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      .style('fill', (anID: string) => {
+        return legendAttrID ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
+      })
   }, [dataConfiguration, primaryAttrPlace, secondaryAttrPlace, graphModel, dotsRef,
             enableAnimation, primaryScale, primaryIsBottom, layout, secondaryAxisPlace,
-            computeMaxOverAllCells, primaryAttrID, secondaryAttrID, dataset, secondaryScale])
+            computeMaxOverAllCells, primaryAttrID, secondaryAttrID, legendAttrID, dataset, secondaryScale])
 
   useEffect(() => {
     select(dotsRef.current).on('click', (event) => {
@@ -164,7 +171,8 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
   })
 
   usePlotResponders({
-    dataset, layout, refreshPointPositions, refreshPointSelection, enableAnimation
+    dataset, layout, refreshPointPositions, refreshPointSelection, enableAnimation, primaryAttrID, secondaryAttrID,
+    legendAttrID
   })
 
   return (

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -30,6 +30,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
     secondaryAttrPlace = primaryAttrPlace === 'x' ? 'y' : 'x',
     secondaryAxisPlace = attrPlaceToAxisPlace[secondaryAttrPlace] ?? 'left',
     secondaryAttrID = dataConfiguration?.attributeID(secondaryAttrPlace),
+    legendAttrID = dataConfiguration?.attributeID('legend'),
     primaryScale = layout.axisScale(primaryAxisPlace) as ScaleNumericBaseType,
     primaryLength = layout.axisLength(primaryAxisPlace),
     secondaryScale = layout.axisScale(secondaryAxisPlace) as ScaleBand<string>,
@@ -198,7 +199,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
       dataConfiguration?.getLegendColorForCase])
 
   usePlotResponders({
-    dataset, xAxisModel, yAxisModel, primaryAttrID, secondaryAttrID, layout,
+    dataset, xAxisModel, yAxisModel, primaryAttrID, secondaryAttrID, legendAttrID, layout,
     refreshPointPositions, refreshPointSelection, enableAnimation
   })
 

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -16,7 +16,7 @@ import {Marquee} from "./marquee"
 import {DataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphModel} from "../hooks/use-graph-model"
-import {AxisPlace, IAxisModel, attrPlaceToAxisPlace} from "../models/axis-model"
+import {AxisPlace, IAxisModel, attrPlaceToAxisPlace, axisPlaceToAttrPlace} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel, isSetAttributeIDAction} from "../models/graph-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
@@ -44,103 +44,103 @@ const marqueeState = new MarqueeState(),
     })
 
 export const Graph = observer((
-    {graphController, model: graphModel, graphRef, enableAnimation, dotsRef}: IProps) => {
-    const xAxisModel = graphModel.getAxis("bottom") as IAxisModel,
-      yAxisModel = graphModel.getAxis("left") as IAxisModel,
-      {plotType} = graphModel,
-      instanceId = useInstanceIdContext(),
-      dataset = useDataSetContext(),
-      layout = useGraphLayoutContext(),
-      {margin} = layout,
-      xScale = layout.axisScale("bottom"),
-      transform = `translate(${margin.left}, 0)`,
-      svgRef = useRef<SVGSVGElement>(null),
-      backgroundSvgRef = useRef<SVGGElement>(null),
-      plotAreaSVGRef = useRef<SVGSVGElement>(null),
-      xAttrID = graphModel.getAttributeID('x'),
-      yAttrID = graphModel.getAttributeID('y'),
-      pointRadius = graphModel.getPointRadius(),
-      selectedPointRadius = graphModel.getPointRadius('select'),
-      hoverPointRadius = graphModel.getPointRadius('hover-drag'),
-      droppableId = `${instanceId}-plot-area-drop`
+  {graphController, model: graphModel, graphRef, enableAnimation, dotsRef}: IProps) => {
+  const xAxisModel = graphModel.getAxis("bottom") as IAxisModel,
+    yAxisModel = graphModel.getAxis("left") as IAxisModel,
+    {plotType} = graphModel,
+    instanceId = useInstanceIdContext(),
+    dataset = useDataSetContext(),
+    layout = useGraphLayoutContext(),
+    {margin} = layout,
+    xScale = layout.axisScale("bottom"),
+    transform = `translate(${margin.left}, 0)`,
+    svgRef = useRef<SVGSVGElement>(null),
+    backgroundSvgRef = useRef<SVGGElement>(null),
+    plotAreaSVGRef = useRef<SVGSVGElement>(null),
+    xAttrID = graphModel.getAttributeID('x'),
+    yAttrID = graphModel.getAttributeID('y'),
+    pointRadius = graphModel.getPointRadius(),
+    selectedPointRadius = graphModel.getPointRadius('select'),
+    hoverPointRadius = graphModel.getPointRadius('hover-drag'),
+    droppableId = `${instanceId}-plot-area-drop`
 
-    useGraphModel({dotsRef, graphModel, enableAnimation, instanceId})
+  useGraphModel({dotsRef, graphModel, enableAnimation, instanceId})
 
-    useEffect(function setupPlotArea() {
-      if (xScale && xScale?.range().length > 0) {
-        select(plotAreaSVGRef.current)
-          .attr('x', xScale?.range()[0] + margin.left)
-          .attr('y', 0)
-          .attr('width', layout.plotWidth)
-          .attr('height', layout.plotHeight)
-      }
-    }, [layout.plotHeight, layout.plotWidth, margin.left, xScale])
-
-    const toast = useToast()
-
-    const handleDropAttribute = (place: AxisPlace, attrId: string) => {
-      // TODO: will need to be more sophisticated
-      const attrPlace = place === "left" ? "y" : "x"
-      const attrName = dataset?.attrFromID(attrId)?.name
-      toast({
-        position: "top-right",
-        title: "Attribute dropped",
-        description: `The attribute ${attrName || attrId} was dropped on the ${place} axis!`,
-        status: "success"
-      })
-      graphModel.setAttributeID(attrPlace, attrId)
+  useEffect(function setupPlotArea() {
+    if (xScale && xScale?.range().length > 0) {
+      select(plotAreaSVGRef.current)
+        .attr('x', xScale?.range()[0] + margin.left)
+        .attr('y', 0)
+        .attr('width', layout.plotWidth)
+        .attr('height', layout.plotHeight)
     }
-    // respond to assignment of new attribute ID
-    useEffect(function handleNewAttributeID() {
-      const disposer = graphModel && onAction(graphModel, action => {
-        if (isSetAttributeIDAction(action)) {
-          const [place, attrID] = action.args,
-            axisPlace = attrPlaceToAxisPlace[place]
-          enableAnimation.current = true
-          axisPlace && graphController.handleAttributeAssignment(axisPlace, attrID)
-        }
-      }, true)
-      return () => disposer?.()
-    }, [graphController, dataset, layout, xAxisModel, yAxisModel, enableAnimation, graphModel])
+  }, [layout.plotHeight, layout.plotWidth, margin.left, xScale])
 
-    // We only need to make the following connection once
-    useEffect(function passDotsRefToController() {
-      graphController.setDotsRef(dotsRef)
-    }, [dotsRef, graphController])
+  const toast = useToast()
 
-    // MouseOver events, if over an element, brings up hover text
-    function showDataTip(event: MouseEvent) {
-      const target = select(event.target as SVGSVGElement)
-      if (target.node()?.nodeName === 'circle' && dataset) {
-        target.transition().duration(transitionDuration).attr('r', hoverPointRadius)
-        const [, caseID] = target.property('id').split("_"),
-          attrIDs = graphModel.config.uniqueTipAttributes,
-          tipText = getPointTipText(dataset, caseID, attrIDs)
-          tipText !== '' && dataTip.show(tipText, event.target)
-      }
-    }
-
-    function hideDataTip(event: MouseEvent) {
-      const [, caseID] = select(event.target as SVGSVGElement).property('id').split("_"),
-        isSelected = dataset?.isCaseSelected(caseID)
-      dataTip.hide()
-      select(event.target as SVGSVGElement)
-        .transition().duration(transitionDuration)
-        .attr('r', isSelected ? selectedPointRadius : pointRadius)
-    }
-
-    useEffect(function setupDataTip() {
-      select(dotsRef.current)
-        .on('mouseover', showDataTip)
-        .on('mouseout', hideDataTip)
-        .call(dataTip)
+  const handleDropAttribute = (place: AxisPlace, attrId: string) => {
+    // TODO: will need to be more sophisticated
+    const attrPlace = axisPlaceToAttrPlace[place]
+    const attrName = dataset?.attrFromID(attrId)?.name
+    toast({
+      position: "top-right",
+      title: "Attribute dropped",
+      description: `The attribute ${attrName || attrId} was dropped on the ${place} place!`,
+      status: "success"
     })
+    graphModel.setAttributeID(attrPlace, attrId)
+  }
+  // respond to assignment of new attribute ID
+  useEffect(function handleNewAttributeID() {
+    const disposer = graphModel && onAction(graphModel, action => {
+      if (isSetAttributeIDAction(action)) {
+        const [place, attrID] = action.args,
+          axisPlace = attrPlaceToAxisPlace[place]
+        enableAnimation.current = true
+        axisPlace && graphController.handleAttributeAssignment(axisPlace, attrID)
+      }
+    }, true)
+    return () => disposer?.()
+  }, [graphController, dataset, layout, xAxisModel, yAxisModel, enableAnimation, graphModel])
 
-    const getPlotComponent = () => {
-      const props = {
+  // We only need to make the following connection once
+  useEffect(function passDotsRefToController() {
+    graphController.setDotsRef(dotsRef)
+  }, [dotsRef, graphController])
+
+  // MouseOver events, if over an element, brings up hover text
+  function showDataTip(event: MouseEvent) {
+    const target = select(event.target as SVGSVGElement)
+    if (target.node()?.nodeName === 'circle' && dataset) {
+      target.transition().duration(transitionDuration).attr('r', hoverPointRadius)
+      const [, caseID] = target.property('id').split("_"),
+        attrIDs = graphModel.config.uniqueTipAttributes,
+        tipText = getPointTipText(dataset, caseID, attrIDs)
+      tipText !== '' && dataTip.show(tipText, event.target)
+    }
+  }
+
+  function hideDataTip(event: MouseEvent) {
+    const [, caseID] = select(event.target as SVGSVGElement).property('id').split("_"),
+      isSelected = dataset?.isCaseSelected(caseID)
+    dataTip.hide()
+    select(event.target as SVGSVGElement)
+      .transition().duration(transitionDuration)
+      .attr('r', isSelected ? selectedPointRadius : pointRadius)
+  }
+
+  useEffect(function setupDataTip() {
+    select(dotsRef.current)
+      .on('mouseover', showDataTip)
+      .on('mouseout', hideDataTip)
+      .call(dataTip)
+  })
+
+  const getPlotComponent = () => {
+    const props = {
         graphModel,
         plotProps: {
-        xAttrID, yAttrID, dotsRef, enableAnimation,
+          xAttrID, yAttrID, dotsRef, enableAnimation,
           xAxisModel,
           yAxisModel
         }
@@ -151,62 +151,56 @@ export const Graph = observer((
         dotPlot: <DotPlotDots {...props}/>,
         scatterPlot: <ScatterDots {...props}/>
       }
-      return typeToPlotComponentMap[plotType]
+    return typeToPlotComponentMap[plotType]
+  }
+
+  const handleIsActive = (active: Active) => !!getDragAttributeId(active)
+
+  const handlePlotDropAttribute = (active: Active) => {
+    const dragAttributeID = getDragAttributeId(active)
+    if( dragAttributeID) {
+      handleDropAttribute('plot', dragAttributeID)
     }
+  }
 
-    const handleIsActive = (active: Active) => !!getDragAttributeId(active)
+  const data: IDropData = {accepts: ["attribute"], onDrop: handlePlotDropAttribute}
 
-    const handlePlotDropAttribute = (active: Active) => {
-      const dragAttributeID = getDragAttributeId(active)
-      if (dragAttributeID){
-        const attrName = dataset?.attrFromID(dragAttributeID)?.name
-        toast({
-          position: "top-right",
-          title: "Attribute dropped on plot",
-          description: `The attribute ${attrName || dragAttributeID} was dropped on the plot!`,
-          status: "success"
-        })
-      }
-    }
+  return (
+    <DataConfigurationContext.Provider value={graphModel.config}>
+      <div className={kGraphClass} ref={graphRef} data-testid="graph">
+        <svg className='graph-svg' ref={svgRef}>
+          <Axis axisModel={yAxisModel} attributeID={yAttrID}
+                transform={`translate(${margin.left - 1}, 0)`}
+                onDropAttribute={handleDropAttribute}
+          />
+          <Axis axisModel={xAxisModel} attributeID={xAttrID}
+                transform={`translate(${margin.left}, ${layout.plotHeight})`}
+                onDropAttribute={handleDropAttribute}
+          />
+          <Background
+            transform={transform}
+            marqueeState={marqueeState}
+            ref={backgroundSvgRef}
+          />
 
-    const data: IDropData = {accepts: ["attribute"], onDrop: handlePlotDropAttribute}
-
-    return (
-      <DataConfigurationContext.Provider value={graphModel.config}>
-        <div className={kGraphClass} ref={graphRef} data-testid="graph">
-          <svg className='graph-svg' ref={svgRef}>
-            <Axis axisModel={yAxisModel} attributeID={yAttrID}
-                  transform={`translate(${margin.left - 1}, 0)`}
-                  onDropAttribute={handleDropAttribute}
-            />
-            <Axis axisModel={xAxisModel} attributeID={xAttrID}
-                  transform={`translate(${margin.left}, ${layout.plotHeight})`}
-                  onDropAttribute={handleDropAttribute}
-            />
-            <Background
-              transform={transform}
-              marqueeState={marqueeState}
-              ref={backgroundSvgRef}
-            />
-
-            <svg ref={plotAreaSVGRef} className='graph-dot-area'>
-              <svg ref={dotsRef}>
-                {getPlotComponent()}
-              </svg>
-              <Marquee marqueeState={marqueeState}/>
+          <svg ref={plotAreaSVGRef} className='graph-dot-area'>
+            <svg ref={dotsRef}>
+              {getPlotComponent()}
             </svg>
-
-            <DroppableSvg
-              className="droppable-plot"
-              portal={graphRef.current}
-              target={backgroundSvgRef.current}
-              dropId={droppableId}
-              dropData={data}
-              onIsActive={handleIsActive}
-            />
-
+            <Marquee marqueeState={marqueeState}/>
           </svg>
-        </div>
-      </DataConfigurationContext.Provider>
-    )
+
+          <DroppableSvg
+            className="droppable-plot"
+            portal={graphRef.current}
+            target={backgroundSvgRef.current}
+            dropId={droppableId}
+            dropData={data}
+            onIsActive={handleIsActive}
+          />
+
+        </svg>
+      </div>
+    </DataConfigurationContext.Provider>
+  )
 })

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -16,7 +16,7 @@ import {Marquee} from "./marquee"
 import {DataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphModel} from "../hooks/use-graph-model"
-import {AxisPlace, IAxisModel, attrPlaceToAxisPlace, axisPlaceToAttrPlace} from "../models/axis-model"
+import { IAxisModel, attrPlaceToAxisPlace, GraphPlace, graphPlaceToAttrPlace } from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel, isSetAttributeIDAction} from "../models/graph-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
@@ -78,9 +78,8 @@ export const Graph = observer((
 
   const toast = useToast()
 
-  const handleDropAttribute = (place: AxisPlace, attrId: string) => {
-    // TODO: will need to be more sophisticated
-    const attrPlace = axisPlaceToAttrPlace[place]
+  const handleDropAttribute = (place: GraphPlace, attrId: string) => {
+    const attrPlace = graphPlaceToAttrPlace(place)
     const attrName = dataset?.attrFromID(attrId)?.name
     toast({
       position: "top-right",

--- a/v3/src/components/graph/hooks/graph-hooks.ts
+++ b/v3/src/components/graph/hooks/graph-hooks.ts
@@ -36,6 +36,7 @@ export interface IPlotResponderProps {
   yAxisModel?:IAxisModel
   primaryAttrID?: string
   secondaryAttrID?: string
+  legendAttrID?: string
   layout: GraphLayout
   refreshPointPositions:(selectedOnly: boolean) => void
   refreshPointSelection: () => void
@@ -43,7 +44,7 @@ export interface IPlotResponderProps {
 }
 
 export const usePlotResponders = (props: IPlotResponderProps) => {
-  const { dataset, primaryAttrID, secondaryAttrID, xAxisModel, yAxisModel, enableAnimation,
+  const { dataset, primaryAttrID, secondaryAttrID, legendAttrID, xAxisModel, yAxisModel, enableAnimation,
     refreshPointPositions, refreshPointSelection, layout } = props,
     xNumeric = xAxisModel as INumericAxisModel,
     yNumeric = yAxisModel as INumericAxisModel,
@@ -88,9 +89,9 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     }
   }, [dataset, refreshPointsRef, refreshPointSelection])
 
-  // respond to x or y attribute id change
+  // respond to x, y or legend attribute id change
   useEffect(() => {
     enableAnimation.current = true
     refreshPointsRef.current(false)
-  }, [refreshPointsRef, primaryAttrID, secondaryAttrID, enableAnimation])
+  }, [refreshPointsRef, primaryAttrID, secondaryAttrID, legendAttrID, enableAnimation])
 }

--- a/v3/src/components/graph/models/axis-model.ts
+++ b/v3/src/components/graph/models/axis-model.ts
@@ -1,25 +1,28 @@
 import {Instance, types} from "mobx-state-tree"
-import {GraphAttrPlace} from "./data-configuration-model"
+import {GraphAttrRole} from "./data-configuration-model"
 
-export const AxisPlaces = ["bottom", "left", "right", "top", "plot", "legend"] as const
+export const AxisPlaces = ["bottom", "left", "right", "top"] as const
+export const GraphPlaces = [...AxisPlaces, "plot", "legend"] as const
 export type AxisPlace = typeof AxisPlaces[number]
+export type GraphPlace = typeof GraphPlaces[number]
 
-export const attrPlaceToAxisPlace: Partial<Record<GraphAttrPlace, AxisPlace>> = {
+export const attrPlaceToAxisPlace: Partial<Record<GraphAttrRole, AxisPlace>> = {
   x: "bottom",
   y: "left",
   y2: "right",
   rightSplit: "right",
-  topSplit: "top",
-  legend: "legend"
+  topSplit: "top"
 }
 
-export const axisPlaceToAttrPlace: Record<AxisPlace, GraphAttrPlace> = {
+export const axisPlaceToAttrPlace: Record<AxisPlace, GraphAttrRole> = {
   bottom: "x",
   left: "y",
   top: "topSplit",
   right: "y2",  // Todo: how to deal with 'rightSplit'?
-  plot: "legend",
-  legend: "legend"
+}
+
+export const graphPlaceToAttrPlace = (graphPlace:GraphPlace) => {
+  return AxisPlaces.includes(graphPlace as AxisPlace) ? axisPlaceToAttrPlace[graphPlace as AxisPlace] : 'legend'
 }
 
 export type AxisOrientation = "horizontal" | "vertical"

--- a/v3/src/components/graph/models/axis-model.ts
+++ b/v3/src/components/graph/models/axis-model.ts
@@ -1,7 +1,7 @@
 import {Instance, types} from "mobx-state-tree"
 import {GraphAttrPlace} from "./data-configuration-model"
 
-export const AxisPlaces = ["bottom", "left", "right", "top"] as const
+export const AxisPlaces = ["bottom", "left", "right", "top", "plot", "legend"] as const
 export type AxisPlace = typeof AxisPlaces[number]
 
 export const attrPlaceToAxisPlace: Partial<Record<GraphAttrPlace, AxisPlace>> = {
@@ -9,14 +9,17 @@ export const attrPlaceToAxisPlace: Partial<Record<GraphAttrPlace, AxisPlace>> = 
   y: "left",
   y2: "right",
   rightSplit: "right",
-  topSplit: "top"
+  topSplit: "top",
+  legend: "legend"
 }
 
 export const axisPlaceToAttrPlace: Record<AxisPlace, GraphAttrPlace> = {
   bottom: "x",
   left: "y",
   top: "topSplit",
-  right: "y2"  // Todo: how to deal with 'rightSplit'?
+  right: "y2",  // Todo: how to deal with 'rightSplit'?
+  plot: "legend",
+  legend: "legend"
 }
 
 export type AxisOrientation = "horizontal" | "vertical"

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -7,9 +7,9 @@ import {uniqueId} from "../../../utilities/js-utils"
 import {kellyColors, missingColor} from "../../../utilities/color-utils"
 
 export const PrimaryAttrPlaces = ['x', 'y'] as const
-export const TipAttrPlaces = [...PrimaryAttrPlaces, 'caption', 'y2'] as const
+export const TipAttrPlaces = [...PrimaryAttrPlaces, 'legend', 'caption', 'y2'] as const
 export const GraphAttrPlaces = [
-  ...TipAttrPlaces, 'legend', 'polygon', 'topSplit', 'rightSplit'] as const
+  ...TipAttrPlaces, 'polygon', 'topSplit', 'rightSplit'] as const
 export type GraphAttrPlace = typeof GraphAttrPlaces[number]
 
 export const AttributeDescription = types
@@ -132,7 +132,7 @@ export const DataConfigurationModel = types
     get selection() {
       if (!self.dataset || !self.filteredCases) return []
       const selection = Array.from(self.dataset.selection)
-      return selection.filter((caseId:string) => self.filteredCases?.hasCaseId(caseId))
+      return selection.filter((caseId: string) => self.filteredCases?.hasCaseId(caseId))
     }
   }))
   .views(self => (
@@ -140,6 +140,8 @@ export const DataConfigurationModel = types
       valuesForPlace(place: GraphAttrPlace): string[] {
         const attrID = self.attributeID(place),
           dataset = self.dataset,
+          // todo: The following interferes with sorting by legend ID because we're bypassing get cases where the
+          //  sorting happens. But we can't call get cases without introducing infinite loop
           caseIDs = self.filteredCases?.caseIds || []
         return attrID ? caseIDs.map(anID => String(dataset?.getValue(anID, attrID)))
           .filter(aValue => aValue !== '') : []

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -130,6 +130,9 @@ export class GraphController {
   }
 
   handleAttributeAssignment(axisPlace: AxisPlace, attrID: string) {
+    if(['plot', 'legend'].includes( axisPlace)) {
+      return  // Since there is no axis associated with the legend and the plotType will not change, we bail
+    }
     const {dataset, graphModel, layout} = this,
       dataConfig = graphModel.config,
       graphAttributePlace = axisPlaceToAttrPlace[axisPlace],

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -2,7 +2,7 @@ import React from "react"
 import {scaleBand, scaleLinear, scaleOrdinal} from "d3"
 import {IGraphModel} from "./graph-model"
 import {GraphLayout} from "./graph-layout"
-import {GraphAttrPlace, IAttributeDescriptionSnapshot}
+import {GraphAttrRole, IAttributeDescriptionSnapshot}
   from "./data-configuration-model"
 import {IDataSet} from "../../../data-model/data-set"
 import {
@@ -90,7 +90,7 @@ export class GraphController {
     Object.keys(links).forEach((aKey: keyof typeof links) => {
       if (['xAttr', 'yAttr', 'legendAttr'].includes(aKey)) {
         const match = aKey.match(/[a-z]+/),
-          attrPlace = (match?.[0] ?? 'x') as GraphAttrPlace,
+          attrPlace = (match?.[0] ?? 'x') as GraphAttrRole,
           attrV2ID = (links[aKey] as IGuidLink<"DG.Attribute">).id,
           attrName = v2Document?.getAttribute(attrV2ID)?.object.name,
           attribute = dataset?.attrFromName(attrName),
@@ -104,7 +104,7 @@ export class GraphController {
       }
     })
     graphModel.setPlotType(plotChoices[attrTypes.x][attrTypes.y]);
-    ['x', 'y'].forEach((attrPlace: GraphAttrPlace) => {
+    ['x', 'y'].forEach((attrPlace: GraphAttrRole) => {
       const axisPlace = attrPlaceToAxisPlace[attrPlace] as AxisPlace,
         attrType = attrTypes[attrPlace]
       let axisModel

--- a/v3/src/components/graph/models/graph-model.ts
+++ b/v3/src/components/graph/models/graph-model.ts
@@ -8,7 +8,7 @@ import {
   pointRadiusMax,
   pointRadiusMin, pointRadiusSelectionAddend
 } from "../graphing-types"
-import {DataConfigurationModel, GraphAttrPlace} from "./data-configuration-model"
+import {DataConfigurationModel, GraphAttrRole} from "./data-configuration-model"
 import {uniqueId} from "../../../utilities/js-utils"
 
 export interface GraphProperties {
@@ -29,7 +29,7 @@ export const GraphModel = types
     getAxis(place: AxisPlace) {
       return self.axes.get(place)
     },
-    getAttributeID(place: GraphAttrPlace) {
+    getAttributeID(place: GraphAttrRole) {
       return self.config.attributeID(place) ?? ''
     },
     getPointRadius(use:'normal' | 'hover-drag' | 'select' = 'normal') {
@@ -55,7 +55,7 @@ export const GraphModel = types
     setAxis(place: AxisPlace, axis: IAxisModelUnion) {
       self.axes.set(place, axis)
     },
-    setAttributeID(place: GraphAttrPlace, id: string) {
+    setAttributeID(place: GraphAttrRole, id: string) {
       self.config.setAttribute(place, { attributeID: id })
     },
     setPlotType(type: PlotType) {
@@ -74,7 +74,7 @@ export const GraphModel = types
 
 export interface SetAttributeIDAction extends ISerializedActionCall {
   name: "setAttributeID"
-  args: [GraphAttrPlace, string]
+  args: [GraphAttrRole, string]
 }
 
 export function isSetAttributeIDAction(action: ISerializedActionCall): action is SetAttributeIDAction {


### PR DESCRIPTION
Previously the only way to get a graph with a legend attribute assigned to it was to import from a V2 document. With this commit users can drag a categorical attribute into the middle of a plot and the points will be colored according to its categories.