### PR TITLE
V3—Graph responds properly to csv and codap drops

### DIFF
--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -7,32 +7,35 @@ import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {getDragAttributeId, IDropData} from "../../../hooks/use-drag-drop"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {useAxis} from "../hooks/use-axis"
-import {AxisPlace, IAxisModel, INumericAxisModel} from "../models/axis-model"
+import {AxisPlace, INumericAxisModel} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {AxisDragRects} from "./axis-drag-rects"
+import {IGraphModel} from "../models/graph-model"
+
 import "./axis.scss"
 
 interface IProps {
+  graphModel: IGraphModel
+  place: AxisPlace
   attributeID: string,
-  axisModel: IAxisModel
   transform: string
   showGridLines: boolean
   onDropAttribute: (place: AxisPlace, attrId: string) => void
 }
 
-export const Axis = ({attributeID, axisModel, transform, showGridLines, onDropAttribute}: IProps) => {
+export const Axis = ({attributeID, graphModel, place, transform, showGridLines, onDropAttribute}: IProps) => {
   const
     instanceId = useInstanceIdContext(),
     dataset = useDataSetContext(),
+    axisModel = graphModel.getAxis(place),
     label = dataset?.attrFromID(attributeID)?.name,
-    droppableId = `${instanceId}-${axisModel.place}-axis-drop`,
+    droppableId = `${instanceId}-${place}-axis-drop`,
     layout = useGraphLayoutContext(),
-    scale = layout.axisScale(axisModel.place),
+    scale = layout.axisScale(place),
     [axisElt, setAxisElt] = useState<SVGGElement | null>(null),
-    titleRef = useRef<SVGGElement | null>(null),
-    place = axisModel.place
+    titleRef = useRef<SVGGElement | null>(null)
 
-  const {graphElt, wrapperElt, setWrapperElt} = useAxisBoundsProvider(axisModel.place)
+  const {graphElt, wrapperElt, setWrapperElt} = useAxisBoundsProvider(place)
 
   useAxis({axisModel, axisElt, showGridLines})
 
@@ -45,8 +48,8 @@ export const Axis = ({attributeID, axisModel, transform, showGridLines, onDropAt
 
   const handleDrop = useCallback((active: Active) => {
     const droppedAttrId = active.data?.current?.attributeId
-    droppedAttrId && onDropAttribute(axisModel.place, droppedAttrId)
-  }, [axisModel.place, onDropAttribute])
+    droppedAttrId && onDropAttribute(place, droppedAttrId)
+  }, [place, onDropAttribute])
 
   const data: IDropData = {accepts: ["attribute"], onDrop: handleDrop}
 
@@ -105,9 +108,9 @@ export const Axis = ({attributeID, axisModel, transform, showGridLines, onDropAt
         <g className='axis' ref={elt => setAxisElt(elt)} data-testid={`axis-${place}`}/>
         <g ref={titleRef}/>
       </g>
-      {axisModel.type === 'numeric' ?
+      {axisModel?.type === 'numeric' ?
         <AxisDragRects axisModel={axisModel as INumericAxisModel} axisWrapperElt={wrapperElt}/> : null}
-      <DroppableAxis place={`${axisModel.place}`} dropId={droppableId} dropData={data}
+      <DroppableAxis place={`${place}`} dropId={droppableId} dropData={data}
                      portal={graphElt} target={wrapperElt} onIsActive={handleIsActive}/>
     </>
   )

--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -7,27 +7,26 @@ import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {getDragAttributeId, IDropData} from "../../../hooks/use-drag-drop"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {useAxis} from "../hooks/use-axis"
-import {AxisPlace, INumericAxisModel} from "../models/axis-model"
+import {AxisPlace, IAxisModel, INumericAxisModel} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {AxisDragRects} from "./axis-drag-rects"
-import {IGraphModel} from "../models/graph-model"
 
 import "./axis.scss"
 
 interface IProps {
-  graphModel: IGraphModel
-  place: AxisPlace
+  getAxisModel: () => IAxisModel | undefined
   attributeID: string,
   transform: string
   showGridLines: boolean
   onDropAttribute: (place: AxisPlace, attrId: string) => void
 }
 
-export const Axis = ({attributeID, graphModel, place, transform, showGridLines, onDropAttribute}: IProps) => {
+export const Axis = ({attributeID, getAxisModel, transform, showGridLines, onDropAttribute}: IProps) => {
   const
     instanceId = useInstanceIdContext(),
     dataset = useDataSetContext(),
-    axisModel = graphModel.getAxis(place),
+    axisModel = getAxisModel(),
+    place = axisModel?.place || 'bottom',
     label = dataset?.attrFromID(attributeID)?.name,
     droppableId = `${instanceId}-${place}-axis-drop`,
     layout = useGraphLayoutContext(),

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -37,27 +37,6 @@ export const CaseDots = memo(function CaseDots(props: {
     xScale = layout.axisScale('bottom') as ScaleNumericBaseType,
     yScale = layout.axisScale('left') as ScaleNumericBaseType
 
-  useEffect(function initDistribution() {
-    const {cases} = dataset || {}
-    const uniform = randomUniform()
-
-    const initCases = (_cases?: typeof cases | ICase[]) => {
-      _cases?.forEach(({__id__}) => {
-        randomPointsRef.current[__id__] = {x: uniform(), y: uniform()}
-      })
-    }
-
-    initCases(cases)
-
-    const disposer = dataset && onAction(dataset, action => {
-      if (isAddCasesAction(action)) {
-        initCases(action.args[0])
-      }
-    }, true)
-
-    return () => disposer?.()
-  }, [dataset])
-
   const onDragStart = useCallback((event: MouseEvent) => {
       enableAnimation.current = false // We don't want to animate points until end of drag
       target.current = select(event.target as SVGSVGElement)
@@ -134,6 +113,28 @@ export const CaseDots = memo(function CaseDots(props: {
       })
       .attr('r', (anID: string) => pointRadius + (dataset?.isCaseSelected(anID) ? pointRadiusSelectionAddend : 0))
   }, [dataset, legendAttrID, dataConfiguration, pointRadius, dotsRef, enableAnimation, xScale, yScale])
+
+  useEffect(function initDistribution() {
+    const {cases} = dataset || {}
+    const uniform = randomUniform()
+
+    const initCases = (_cases?: typeof cases | ICase[]) => {
+      _cases?.forEach(({__id__}) => {
+        randomPointsRef.current[__id__] = {x: uniform(), y: uniform()}
+      })
+    }
+
+    initCases(cases)
+    refreshPointPositions(false)
+
+    const disposer = dataset && onAction(dataset, action => {
+      if (isAddCasesAction(action)) {
+        initCases(action.args[0])
+      }
+    }, true)
+
+    return () => disposer?.()
+  }, [dataset, refreshPointPositions])
 
   usePlotResponders({
     dataset, legendAttrID, layout, refreshPointPositions, refreshPointSelection, enableAnimation

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -19,10 +19,12 @@ interface IProps {
 }
 
 export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
-  const {graphModel, plotProps: {dotsRef, xAxisModel, yAxisModel, enableAnimation}} = props,
+  const {graphModel, plotProps: {dotsRef, enableAnimation}} = props,
     dataConfiguration = useDataConfigurationContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
+    xAxisModel = graphModel.getAxis('bottom'),
+    yAxisModel = graphModel.getAxis('left'),
     primaryAttrPlace = dataConfiguration?.primaryPlace ?? 'x',
     primaryAxisPlace = attrPlaceToAxisPlace[primaryAttrPlace] ?? 'bottom',
     primaryIsBottom = primaryAxisPlace === 'bottom',

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -17,7 +17,7 @@ import {DataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphController} from "../hooks/use-graph-controller"
 import {useGraphModel} from "../hooks/use-graph-model"
-import {IAxisModel, attrPlaceToAxisPlace, GraphPlace, graphPlaceToAttrPlace} from "../models/axis-model"
+import {attrPlaceToAxisPlace, GraphPlace, graphPlaceToAttrPlace} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel, isSetAttributeIDAction} from "../models/graph-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
@@ -44,9 +44,7 @@ const marqueeState = new MarqueeState(),
 
 export const Graph = observer((
   {model: graphModel, graphRef, enableAnimation, dotsRef}: IProps) => {
-  const xAxisModel = graphModel.getAxis("bottom") as IAxisModel,
-    yAxisModel = graphModel.getAxis("left") as IAxisModel,
-    {plotType} = graphModel,
+  const {plotType} = graphModel,
     instanceId = useInstanceIdContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
@@ -101,7 +99,7 @@ export const Graph = observer((
       }
     }, true)
     return () => disposer?.()
-  }, [graphController, dataset, layout, xAxisModel, yAxisModel, enableAnimation, graphModel])
+  }, [graphController, dataset, layout, enableAnimation, graphModel])
 
   // We only need to make the following connection once
   useEffect(function passDotsRefToController() {
@@ -140,9 +138,7 @@ export const Graph = observer((
     const props = {
         graphModel,
         plotProps: {
-          xAttrID, yAttrID, dotsRef, enableAnimation,
-          xAxisModel,
-          yAxisModel
+          xAttrID, yAttrID, dotsRef, enableAnimation
         }
       },
       typeToPlotComponentMap = {
@@ -174,12 +170,12 @@ export const Graph = observer((
             marqueeState={marqueeState}
             ref={backgroundSvgRef}
           />
-          <Axis axisModel={yAxisModel} attributeID={yAttrID}
+          <Axis graphModel={graphModel} place={'left'} attributeID={yAttrID}
                 transform={`translate(${margin.left - 1}, 0)`}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
                 onDropAttribute={handleDropAttribute}
           />
-          <Axis axisModel={xAxisModel} attributeID={xAttrID}
+          <Axis graphModel={graphModel} place={'bottom'} attributeID={xAttrID}
                 transform={`translate(${margin.left}, ${layout.plotHeight})`}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
                 onDropAttribute={handleDropAttribute}

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -170,12 +170,14 @@ export const Graph = observer((
             marqueeState={marqueeState}
             ref={backgroundSvgRef}
           />
-          <Axis graphModel={graphModel} place={'left'} attributeID={yAttrID}
+          <Axis getAxisModel={() => graphModel.getAxis('left')}
+                attributeID={yAttrID}
                 transform={`translate(${margin.left - 1}, 0)`}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
                 onDropAttribute={handleDropAttribute}
           />
-          <Axis graphModel={graphModel} place={'bottom'} attributeID={xAttrID}
+          <Axis getAxisModel={() => graphModel.getAxis('bottom')}
+                attributeID={xAttrID}
                 transform={`translate(${margin.left}, ${layout.plotHeight})`}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
                 onDropAttribute={handleDropAttribute}

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -17,10 +17,12 @@ interface IProps {
 }
 
 export const ScatterDots = memo(function ScatterDots(props: IProps) {
-  const {graphModel, plotProps: {dotsRef, xAxisModel, yAxisModel, enableAnimation}} = props,
+  const {graphModel, plotProps: {dotsRef, enableAnimation}} = props,
     instanceId = useInstanceIdContext(),
     dataConfiguration = useDataConfigurationContext(),
     dataset = useDataSetContext(),
+    xAxisModel = graphModel.getAxis('bottom'),
+    yAxisModel = graphModel.getAxis('left'),
     pointRadius = graphModel.getPointRadius(),
     selectedPointRadius = graphModel.getPointRadius('select'),
     dragPointRadius = graphModel.getPointRadius('hover-drag'),

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -1,10 +1,7 @@
 import React from "react"
-import {IAxisModel} from "./models/axis-model"
 
 export interface PlotProps {
   dotsRef: React.RefObject<SVGSVGElement>
-  xAxisModel: IAxisModel
-  yAxisModel: IAxisModel
   enableAnimation: React.MutableRefObject<boolean>
 }
 

--- a/v3/src/components/graph/hooks/graph-hooks.ts
+++ b/v3/src/components/graph/hooks/graph-hooks.ts
@@ -121,7 +121,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     }
   }, [dataset, callRefreshPointPositions, refreshPointSelection])
 
-  // respond to x, y or legend attribute id change
+  // respond to dataset, x, y or legend attribute id change
   useEffect(() => {
     enableAnimation.current = true
     callRefreshPointPositions(false)

--- a/v3/src/components/graph/hooks/use-axis.ts
+++ b/v3/src/components/graph/hooks/use-axis.ts
@@ -6,17 +6,17 @@ import {ScaleNumericBaseType, useGraphLayoutContext} from "../models/graph-layou
 import {between} from "../utilities/math-utils"
 
 export interface IUseAxis {
-  axisModel: IAxisModel
+  axisModel?: IAxisModel
   axisElt: SVGGElement | null
   showGridLines: boolean
 }
 
 export const useAxis = ({axisModel, axisElt, showGridLines}: IUseAxis) => {
   const layout = useGraphLayoutContext(),
-    scale = layout.axisScale(axisModel.place),
-    place = axisModel.place,
+    place = axisModel?.place ?? 'bottom',
+    scale = layout.axisScale(place),
     axisFunc = place === 'bottom' ? axisBottom : axisLeft,
-    isNumeric = axisModel.isNumeric
+    isNumeric = axisModel?.isNumeric
 
   const refreshAxis = useCallback((duration = 0) => {
 
@@ -60,21 +60,23 @@ export const useAxis = ({axisModel, axisElt, showGridLines}: IUseAxis) => {
 
   // update d3 scale and axis when scale type changes
   useEffect(() => {
-    const disposer = reaction(
-      () => {
-        const {place: aPlace, scale: scaleType} = axisModel
-        return {place: aPlace, scaleType}
-      },
-      ({place: aPlace, scaleType}) => {
-        const newScale =
-          scaleType === 'log' ? scaleLog() :
-            scaleType === 'linear' ? scaleLinear() :
-              scaleOrdinal()
-        layout.setAxisScale(aPlace, newScale)
-        refreshAxis()
-      }
-    )
-    return () => disposer()
+    if( axisModel) {
+      const disposer = reaction(
+        () => {
+          const {place: aPlace, scale: scaleType} = axisModel
+          return {place: aPlace, scaleType}
+        },
+        ({place: aPlace, scaleType}) => {
+          const newScale =
+            scaleType === 'log' ? scaleLog() :
+              scaleType === 'linear' ? scaleLinear() :
+                scaleOrdinal()
+          layout.setAxisScale(aPlace, newScale)
+          refreshAxis()
+        }
+      )
+      return () => disposer()
+    }
   }, [isNumeric, axisModel, layout, refreshAxis])
 
   // update d3 scale and axis when axis domain changes


### PR DESCRIPTION
This used to work, presumably because there were redundancies in the code that caused the display of points to happen. Improvements removed a redundancy that was being relied on. So now we have to be more aware of what is changing when a csv or codap file is dragged in.