### PR TITLE
#183559661 V3: Columns respect attribute editable property

### DIFF
--- a/v3/src/components/case-table/use-columns.tsx
+++ b/v3/src/components/case-table/use-columns.tsx
@@ -59,7 +59,7 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
         ? [
             indexColumn,
             // attribute column definitions
-            ...visibleAttrs.map(({ id, name }) => ({
+            ...visibleAttrs.map(({ id, name, userEditable }) => ({
               key: id,
               name,
               resizable: true,
@@ -67,7 +67,7 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
               headerRenderer: ColumnHeader,
               cellClass: "codap-data-cell",
               formatter: CellFormatter,
-              editor: CellTextEditor
+              editor: userEditable ? CellTextEditor : undefined
             }))
         ]
         : []

--- a/v3/src/data-model/attribute.ts
+++ b/v3/src/data-model/attribute.ts
@@ -58,7 +58,7 @@ export const Attribute = types.model("Attribute", {
   // userFormat: types.maybe(types.string),
   units: types.maybe(types.string),
   userPrecision: types.maybe(types.number),
-  userEditable: types.maybe(types.boolean),
+  userEditable: true,
   hidden: false,
   formula: types.optional(Formula, () => Formula.create()),
   // simple array -- _not_ MST all the way down to the array elements


### PR DESCRIPTION
Allows user to specify whether an attribute is editable or not. Currently, editable is defaulted to true.