### PR TITLE
V3—Fix to graph response to add/remove cases

### DIFF
--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -136,7 +136,7 @@ export const CaseDots = memo(function CaseDots(props: {
   }, [dataset, legendAttrID, dataConfiguration, pointRadius, dotsRef, enableAnimation, xScale, yScale])
 
   usePlotResponders({
-    dataset, legendAttrID, layout, refreshPointPositions, refreshPointSelection, enableAnimation
+    graphModel, dotsRef, legendAttrID, layout, refreshPointPositions, refreshPointSelection, enableAnimation
   })
 
   return (

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -170,8 +170,8 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
   })
 
   usePlotResponders({
-    dataset, layout, refreshPointPositions, refreshPointSelection, enableAnimation, primaryAttrID, secondaryAttrID,
-    legendAttrID
+    graphModel,layout, dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation,
+    primaryAttrID, secondaryAttrID, legendAttrID
   })
 
   return (

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -201,7 +201,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
       dataConfiguration?.getLegendColorForCase])
 
   usePlotResponders({
-    dataset, xAxisModel, yAxisModel, primaryAttrID, secondaryAttrID, legendAttrID, layout,
+    graphModel, primaryAttrID, secondaryAttrID, legendAttrID, layout, dotsRef,
     refreshPointPositions, refreshPointSelection, enableAnimation
   })
 

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -171,7 +171,7 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
   }, [refreshPointPositionsD3, refreshPointPositionsSVG])
 
   usePlotResponders({
-    dataset, xAxisModel, yAxisModel, primaryAttrID, secondaryAttrID, layout,
+    graphModel, primaryAttrID, secondaryAttrID, layout, dotsRef,
     refreshPointPositions, refreshPointSelection, enableAnimation
   })
 

--- a/v3/src/components/graph/hooks/graph-hooks.ts
+++ b/v3/src/components/graph/hooks/graph-hooks.ts
@@ -1,14 +1,16 @@
 /**
  * Graph Custom Hooks
  */
-import {useCallback, useEffect, useRef} from "react"
+import React, {useCallback, useEffect, useRef} from "react"
 import {reaction} from "mobx"
 import {onAction} from "mobx-state-tree"
 import {isSelectionAction, isSetCaseValuesAction} from "../../../data-model/data-set-actions"
-import {IDataSet} from "../../../data-model/data-set"
-import {IAxisModel, INumericAxisModel} from "../models/axis-model"
+import {INumericAxisModel} from "../models/axis-model"
 import {GraphLayout} from "../models/graph-layout"
 import {useCurrent} from "../../../hooks/use-current"
+import {IGraphModel} from "../models/graph-model"
+import {matchCirclesToData} from "../utilities/graph-utils"
+import {useInstanceIdContext} from "../../../hooks/use-instance-id-context";
 
 interface IDragHandlers {
   start: (event: MouseEvent) => void
@@ -31,34 +33,35 @@ export const useDragHandlers = (target: any, {start, drag, end}: IDragHandlers) 
 }
 
 export interface IPlotResponderProps {
-  dataset: IDataSet | undefined
-  xAxisModel?: IAxisModel
-  yAxisModel?: IAxisModel
+  graphModel: IGraphModel
   primaryAttrID?: string
   secondaryAttrID?: string
   legendAttrID?: string
   layout: GraphLayout
   refreshPointPositions: (selectedOnly: boolean) => void
   refreshPointSelection: () => void
+  dotsRef:  React.RefObject<SVGSVGElement>
   enableAnimation: React.MutableRefObject<boolean>
 }
 
 export const usePlotResponders = (props: IPlotResponderProps) => {
   const {
-      dataset, primaryAttrID, secondaryAttrID, legendAttrID, xAxisModel, yAxisModel, enableAnimation,
-      refreshPointPositions, refreshPointSelection, layout
+      graphModel, primaryAttrID, secondaryAttrID, legendAttrID, enableAnimation,
+      refreshPointPositions, refreshPointSelection, dotsRef, layout
     } = props,
-    xNumeric = xAxisModel as INumericAxisModel,
-    yNumeric = yAxisModel as INumericAxisModel,
-    refreshPointsRef = useCurrent(refreshPointPositions)
+    dataset = graphModel.config.dataset,
+    xNumeric = graphModel.getAxis('bottom') as INumericAxisModel,
+    yNumeric = graphModel.getAxis('left') as INumericAxisModel,
+    refreshPointsRef = useCurrent(refreshPointPositions),
+    instanceId = useInstanceIdContext()
 
-  /* This routine is frequently called many times in a row when something about the graph changes that requires
-  * refreshing the plot's point positions. That, by itself, would be a reason to ensure that
-  * the actual refreshPointPositions function is only called once. But another, even more important reason is
-  * that there is no guarantee that when callRefreshPointPositions is invoked, the d3 points in the plot
-  * have been synched with the data configuration's notion of which cases are plottable. Delaying the actual
-  * plotting of points until the next event cycle ensures that the data configuration's filter process will
-  * have had a chance to take place. */
+    /* This routine is frequently called many times in a row when something about the graph changes that requires
+    * refreshing the plot's point positions. That, by itself, would be a reason to ensure that
+    * the actual refreshPointPositions function is only called once. But another, even more important reason is
+    * that there is no guarantee that when callRefreshPointPositions is invoked, the d3 points in the plot
+    * have been synched with the data configuration's notion of which cases are plottable. Delaying the actual
+    * plotting of points until the next event cycle ensures that the data configuration's filter process will
+    * have had a chance to take place. */
   const timer = useRef<any>()
   const callRefreshPointPositions = useCallback((selectedOnly: boolean) => {
     if (timer.current) {
@@ -126,4 +129,22 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     enableAnimation.current = true
     callRefreshPointPositions(false)
   }, [callRefreshPointPositions, primaryAttrID, secondaryAttrID, legendAttrID, enableAnimation])
+
+  // respond to added or removed cases
+  useEffect(function handleAddRemoveCases() {
+    const dataConfiguration = graphModel.config
+    const disposer = onAction(dataConfiguration, action => {
+      if (['addCases', 'removeCases'].includes(action.name)) {
+        matchCirclesToData({
+          caseIDs: dataConfiguration.cases,
+          pointRadius: graphModel.getPointRadius(),
+          dotsElement: dotsRef.current ,
+          enableAnimation, instanceId
+        })
+        callRefreshPointPositions(false)
+      }
+    }, true)
+    return () => disposer()
+  }, [enableAnimation, graphModel])
+
 }

--- a/v3/src/components/graph/hooks/use-graph-model.ts
+++ b/v3/src/components/graph/hooks/use-graph-model.ts
@@ -12,11 +12,10 @@ interface IProps {
   instanceId: string | undefined
 }
 
-export function useGraphModel(props:IProps) {
+export function useGraphModel(props: IProps) {
   const {graphModel, enableAnimation, dotsRef, instanceId} = props,
     dataConfig = graphModel.config,
     yAxisModel = graphModel.getAxis('left'),
-    // xAttrID = graphModel.getAttributeID('x'),
     yAttrID = graphModel.getAttributeID('y'),
     dataset = useDataSetContext()
 
@@ -30,7 +29,7 @@ export function useGraphModel(props:IProps) {
   }, [dataConfig.cases, graphModel, dotsRef, enableAnimation, instanceId])
 
   useEffect(function createCircles() {
-      callMatchCirclesToData()
+    callMatchCirclesToData()
   }, [callMatchCirclesToData])
 
   // respond to change in plotType
@@ -41,7 +40,7 @@ export function useGraphModel(props:IProps) {
           attrIDs = newPlotType === 'dotPlot' ? [xAttrID] : [xAttrID, yAttrID]*/
         enableAnimation.current = true
         // In case the y-values have changed we rescale
-        if( newPlotType === 'scatterPlot') {
+        if (newPlotType === 'scatterPlot') {
           const values = dataConfig.cases.map(anID => dataset?.getNumeric(anID, yAttrID)) as number[]
           setNiceDomain(values || [], yAxisModel as INumericAxisModel)
         }


### PR DESCRIPTION
The graph in `usePlotResponders` now has a useEffect handler for dealing with addCases and removeCases actions.

This one lies on the border between `usePlotResponders` and `useGraphModel`. I chose the former and expanded the interface just a bit.