### PR TITLE
V3—Categorical legends appear below plot

### DIFF
--- a/v3/src/components/graph/components/attribute-label.tsx
+++ b/v3/src/components/graph/components/attribute-label.tsx
@@ -6,15 +6,15 @@ import {GraphAttrRole} from "../models/data-configuration-model"
 
 import "./legend/legend.scss"
 
-interface IAxisLabelProps {
+interface IAttributeLabelProps {
   transform: string
   attributeRole: GraphAttrRole
   orientation: AxisOrientation
   attributeIDs:string[]
 }
 
-export const AxisLabel = forwardRef<SVGGElement, IAxisLabelProps>(
-  ({ transform, attributeIDs }:IAxisLabelProps, ref) => {
+export const AttributeLabel = forwardRef<SVGGElement, IAttributeLabelProps>(
+  ({ transform, attributeIDs }:IAttributeLabelProps, ref) => {
   const dataConfiguration = useDataConfigurationContext(),
     attrNames = attributeIDs.map(anID => dataConfiguration?.dataset?.attrFromID(anID).name),
     svgRef = ref as MutableRefObject<SVGGElement | null>,
@@ -35,4 +35,4 @@ export const AxisLabel = forwardRef<SVGGElement, IAxisLabelProps>(
     <g className='legend-label' ref={svgRef}/>
   )
 })
-AxisLabel.displayName = "AxisLabel"
+AttributeLabel.displayName = "AttributeLabel"

--- a/v3/src/components/graph/components/axis-label.tsx
+++ b/v3/src/components/graph/components/axis-label.tsx
@@ -1,0 +1,36 @@
+import React, {memo, useEffect, useRef} from "react"
+import {select} from "d3"
+import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
+import {AxisOrientation} from "../models/axis-model"
+import {GraphAttrRole} from "../models/data-configuration-model"
+
+import "./legend/legend.scss"
+
+interface IAxisLabelProps {
+  transform: string
+  attributeRole: GraphAttrRole
+  orientation: AxisOrientation
+  attributeIDs:string[]
+}
+
+export const AxisLabel = memo(function AxisLabel({ transform, attributeIDs }: IAxisLabelProps) {
+  const dataConfiguration = useDataConfigurationContext(),
+    attrNames = attributeIDs.map(anID => dataConfiguration?.dataset?.attrFromID(anID).name),
+    labelRef = useRef<any>()
+
+  useEffect(function adjustLabel() {
+    if( !labelRef.current) {
+      labelRef.current = select('.legend-label')
+        .append('text')
+        .attr('class', 'attribute-label')
+    }
+    labelRef.current
+      .attr('transform', transform)
+      .text(attrNames[0] || 'Legend Attribute')
+  },[attrNames, transform])
+
+  return (
+    <svg className='legend-label'/>
+  )
+})
+AxisLabel.displayName = "AxisLabel"

--- a/v3/src/components/graph/components/axis-label.tsx
+++ b/v3/src/components/graph/components/axis-label.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useEffect, useRef} from "react"
+import React, {forwardRef, MutableRefObject, useEffect, useRef} from "react"
 import {select} from "d3"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {AxisOrientation} from "../models/axis-model"
@@ -13,9 +13,11 @@ interface IAxisLabelProps {
   attributeIDs:string[]
 }
 
-export const AxisLabel = memo(function AxisLabel({ transform, attributeIDs }: IAxisLabelProps) {
+export const AxisLabel = forwardRef<SVGGElement, IAxisLabelProps>(
+  ({ transform, attributeIDs }:IAxisLabelProps, ref) => {
   const dataConfiguration = useDataConfigurationContext(),
     attrNames = attributeIDs.map(anID => dataConfiguration?.dataset?.attrFromID(anID).name),
+    svgRef = ref as MutableRefObject<SVGGElement | null>,
     labelRef = useRef<any>()
 
   useEffect(function adjustLabel() {
@@ -30,7 +32,7 @@ export const AxisLabel = memo(function AxisLabel({ transform, attributeIDs }: IA
   },[attrNames, transform])
 
   return (
-    <svg className='legend-label'/>
+    <g className='legend-label' ref={svgRef}/>
   )
 })
 AxisLabel.displayName = "AxisLabel"

--- a/v3/src/components/graph/components/axis.scss
+++ b/v3/src/components/graph/components/axis.scss
@@ -47,10 +47,12 @@
   stroke: lightgrey;
   stroke-opacity: 0.7;
   shape-rendering: crispEdges;
+  pointer-events: none;
 }
 
 .zero .tick line {
   stroke: #444444;
   stroke-opacity: 0.8;
   shape-rendering: crispEdges;
+  pointer-events: none;
 }

--- a/v3/src/components/graph/components/axis.scss
+++ b/v3/src/components/graph/components/axis.scss
@@ -2,7 +2,8 @@
   background-color: white;
 
 
-  .axis-title {
+  axis-title text {
+    fill: blue;
   }
 
 }

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -107,6 +107,7 @@ export const CaseDots = memo(function CaseDots(props: {
       .attr('cy', (anID: string) => {
         return yMax + pointRadius + randomPointsRef.current[anID].y * (yMin - yMax - 2 * pointRadius)
       })
+      // @ts-expect-error anID may be null
       .style('fill', (anID: string) => {
         return (legendAttrID && anID) ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
       })

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -107,7 +107,6 @@ export const CaseDots = memo(function CaseDots(props: {
       .attr('cy', (anID: string) => {
         return yMax + pointRadius + randomPointsRef.current[anID].y * (yMin - yMax - 2 * pointRadius)
       })
-      // @ts-expect-error anID may be null
       .style('fill', (anID: string) => {
         return (legendAttrID && anID) ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
       })

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -107,9 +107,8 @@ export const CaseDots = memo(function CaseDots(props: {
       .attr('cy', (anID: string) => {
         return yMax + pointRadius + randomPointsRef.current[anID].y * (yMin - yMax - 2 * pointRadius)
       })
-      // @ts-expect-error anID may be null
       .style('fill', (anID: string) => {
-        return legendAttrID ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
+        return (legendAttrID && anID) ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
       })
       .attr('r', (anID: string) => pointRadius + (dataset?.isCaseSelected(anID) ? pointRadiusSelectionAddend : 0))
   }, [dataset, legendAttrID, dataConfiguration, pointRadius, dotsRef, enableAnimation, xScale, yScale])

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -7,7 +7,7 @@ import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {setPointSelection} from "../utilities/graph-utils"
 import {IGraphModel} from "../models/graph-model"
-import {attrPlaceToAxisPlace} from "../models/axis-model"
+import {attrRoleToGraphPlace, AxisPlace} from "../models/axis-model"
 import {defaultPointColor} from "../../../utilities/color-utils"
 
 interface IProps {
@@ -23,11 +23,11 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
     primaryAttrPlace = dataConfiguration?.primaryPlace ?? 'x',
-    primaryAxisPlace = attrPlaceToAxisPlace[primaryAttrPlace] ?? 'bottom',
+    primaryAxisPlace = attrRoleToGraphPlace[primaryAttrPlace] as AxisPlace ?? 'bottom',
     primaryIsBottom = primaryAxisPlace === 'bottom',
     primaryAttrID = dataConfiguration?.attributeID(primaryAttrPlace),
     secondaryAttrPlace = primaryAttrPlace === 'x' ? 'y' : 'x',
-    secondaryAxisPlace = attrPlaceToAxisPlace[secondaryAttrPlace] ?? 'left',
+    secondaryAxisPlace = attrRoleToGraphPlace[secondaryAttrPlace] as AxisPlace ?? 'left',
     secondaryAttrID = dataConfiguration?.attributeID(secondaryAttrPlace),
     legendAttrID = dataConfiguration?.attributeID('legend'),
     primaryScale = layout.axisScale(primaryAxisPlace) as ScaleBand<string>,
@@ -150,6 +150,7 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
           return NaN
         }
       })
+      // @ts-expect-error anID may be undefined
       .style('fill', (anID: string) => {
         return legendAttrID ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
       })

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -7,7 +7,7 @@ import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {setPointSelection} from "../utilities/graph-utils"
 import {IGraphModel} from "../models/graph-model"
-import {attrRoleToGraphPlace, AxisPlace} from "../models/axis-model"
+import {attrRoleToAxisPlace} from "../models/axis-model"
 import {defaultPointColor} from "../../../utilities/color-utils"
 
 interface IProps {
@@ -23,11 +23,11 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
     primaryAttrPlace = dataConfiguration?.primaryPlace ?? 'x',
-    primaryAxisPlace = attrRoleToGraphPlace[primaryAttrPlace] as AxisPlace ?? 'bottom',
+    primaryAxisPlace = attrRoleToAxisPlace[primaryAttrPlace] ?? 'bottom',
     primaryIsBottom = primaryAxisPlace === 'bottom',
     primaryAttrID = dataConfiguration?.attributeID(primaryAttrPlace),
     secondaryAttrPlace = primaryAttrPlace === 'x' ? 'y' : 'x',
-    secondaryAxisPlace = attrRoleToGraphPlace[secondaryAttrPlace] as AxisPlace ?? 'left',
+    secondaryAxisPlace = attrRoleToAxisPlace[secondaryAttrPlace] ?? 'left',
     secondaryAttrID = dataConfiguration?.attributeID(secondaryAttrPlace),
     legendAttrID = dataConfiguration?.attributeID('legend'),
     primaryScale = layout.axisScale(primaryAxisPlace) as ScaleBand<string>,
@@ -150,7 +150,6 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
           return NaN
         }
       })
-      // @ts-expect-error anID may be undefined
       .style('fill', (anID: string) => {
         return legendAttrID ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
       })

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -150,7 +150,6 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
           return NaN
         }
       })
-      // @ts-expect-error anID may be undefined
       .style('fill', (anID: string) => {
         return legendAttrID ? dataConfiguration?.getLegendColorForCase(anID) : defaultPointColor
       })

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -11,7 +11,7 @@ import {ScaleNumericBaseType, useGraphLayoutContext} from "../models/graph-layou
 import {ICase} from "../../../data-model/data-set"
 import {getScreenCoord, setPointCoordinates, setPointSelection} from "../utilities/graph-utils"
 import {IGraphModel} from "../models/graph-model"
-import {attrPlaceToAxisPlace} from "../models/axis-model"
+import {attrRoleToGraphPlace, AxisPlace} from "../models/axis-model"
 
 interface IProps {
   graphModel: IGraphModel
@@ -24,11 +24,11 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
     primaryAttrPlace = dataConfiguration?.primaryPlace ?? 'x',
-    primaryAxisPlace = attrPlaceToAxisPlace[primaryAttrPlace] ?? 'bottom',
+    primaryAxisPlace = attrRoleToGraphPlace[primaryAttrPlace] as AxisPlace ?? 'bottom',
     primaryIsBottom = primaryAxisPlace === 'bottom',
     primaryAttrID = dataConfiguration?.attributeID(primaryAttrPlace),
     secondaryAttrPlace = primaryAttrPlace === 'x' ? 'y' : 'x',
-    secondaryAxisPlace = attrPlaceToAxisPlace[secondaryAttrPlace] ?? 'left',
+    secondaryAxisPlace = attrRoleToGraphPlace[secondaryAttrPlace] as AxisPlace ?? 'left',
     secondaryAttrID = dataConfiguration?.attributeID(secondaryAttrPlace),
     legendAttrID = dataConfiguration?.attributeID('legend'),
     primaryScale = layout.axisScale(primaryAxisPlace) as ScaleNumericBaseType,

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -11,7 +11,7 @@ import {ScaleNumericBaseType, useGraphLayoutContext} from "../models/graph-layou
 import {ICase} from "../../../data-model/data-set"
 import {getScreenCoord, setPointCoordinates, setPointSelection} from "../utilities/graph-utils"
 import {IGraphModel} from "../models/graph-model"
-import {attrRoleToGraphPlace, AxisPlace} from "../models/axis-model"
+import {attrRoleToAxisPlace} from "../models/axis-model"
 
 interface IProps {
   graphModel: IGraphModel
@@ -24,11 +24,11 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
     primaryAttrPlace = dataConfiguration?.primaryPlace ?? 'x',
-    primaryAxisPlace = attrRoleToGraphPlace[primaryAttrPlace] as AxisPlace ?? 'bottom',
+    primaryAxisPlace = attrRoleToAxisPlace[primaryAttrPlace] ?? 'bottom',
     primaryIsBottom = primaryAxisPlace === 'bottom',
     primaryAttrID = dataConfiguration?.attributeID(primaryAttrPlace),
     secondaryAttrPlace = primaryAttrPlace === 'x' ? 'y' : 'x',
-    secondaryAxisPlace = attrRoleToGraphPlace[secondaryAttrPlace] as AxisPlace ?? 'left',
+    secondaryAxisPlace = attrRoleToAxisPlace[secondaryAttrPlace] ?? 'left',
     secondaryAttrID = dataConfiguration?.attributeID(secondaryAttrPlace),
     legendAttrID = dataConfiguration?.attributeID('legend'),
     primaryScale = layout.axisScale(primaryAxisPlace) as ScaleNumericBaseType,

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -25,6 +25,7 @@ import {getPointTipText} from "../utilities/graph-utils"
 import {MarqueeState} from "../models/marquee-state"
 
 import "./graph.scss"
+import {Legend} from "./legend/legend"
 
 interface IProps {
   model: IGraphModel
@@ -178,7 +179,11 @@ export const Graph = observer((
 
           <DroppablePlot graphElt={graphRef.current} plotElt={backgroundSvgRef.current}
             onDropAttribute={handleDropAttribute}/>
-
+          <Legend
+            graphModel={graphModel}
+            legendAttrID = {graphModel.getAttributeID('legend')}
+            transform={`translate(${margin.left}, ${layout.plotHeight + 40})`}
+          />
         </svg>
       </div>
     </DataConfigurationContext.Provider>

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -150,18 +150,6 @@ export const Graph = observer((
     return typeToPlotComponentMap[plotType]
   }
 
-  const handleIsActive = (active: Active) => !!getDragAttributeId(active)
-
-  const handlePlotDropAttribute = (active: Active) => {
-    const dragAttributeID = getDragAttributeId(active)
-    if (dragAttributeID) {
-      handleDropAttribute('plot', dragAttributeID)
-    }
-  }
-
-  const data: IDropData = {accepts: ["attribute"], onDrop: handlePlotDropAttribute}
-  console.log(`transform = ${legendTransformRef.current}; 
-  plotHeight = ${layout.plotHeight}; bottom = ${bottomAxisHeight}`)
   return (
     <DataConfigurationContext.Provider value={graphModel.config}>
       <div className={kGraphClass} ref={graphRef} data-testid="graph">

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -17,15 +17,15 @@ import {DataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphController} from "../hooks/use-graph-controller"
 import {useGraphModel} from "../hooks/use-graph-model"
-import {attrRoleToGraphPlace, AxisPlace, GraphPlace, graphPlaceToAttrPlace} from "../models/axis-model"
+import {attrRoleToAxisPlace, GraphPlace, graphPlaceToAttrPlace} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel, isSetAttributeIDAction} from "../models/graph-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {getPointTipText} from "../utilities/graph-utils"
 import {MarqueeState} from "../models/marquee-state"
+import {Legend} from "./legend/legend"
 
 import "./graph.scss"
-import {Legend} from "./legend/legend"
 
 interface IProps {
   model: IGraphModel
@@ -93,7 +93,7 @@ export const Graph = observer((
     const disposer = graphModel && onAction(graphModel, action => {
       if (isSetAttributeIDAction(action)) {
         const [place, attrID] = action.args,
-          axisPlace = attrRoleToGraphPlace[place] as AxisPlace
+          axisPlace = attrRoleToAxisPlace[place]
         enableAnimation.current = true
         axisPlace && graphController?.handleAttributeAssignment(axisPlace, attrID)
       }
@@ -180,7 +180,7 @@ export const Graph = observer((
           </svg>
 
           <DroppablePlot graphElt={graphRef.current} plotElt={backgroundSvgRef.current}
-            onDropAttribute={handleDropAttribute}/>
+                         onDropAttribute={handleDropAttribute}/>
           <Legend
             graphModel={graphModel}
             legendAttrID={graphModel.getAttributeID('legend')}

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -1,12 +1,17 @@
-import React, {memo, useEffect, useRef} from "react"
+import {reaction} from "mobx"
+import {range, select, selection} from "d3"
+import React, {memo, useCallback, useEffect, useRef, useState} from "react"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
-import {range, select} from "d3"
+import {useGraphLayoutContext} from "../../models/graph-layout"
+import {missingColor} from "../../../../utilities/color-utils"
+
+import './legend.scss'
 
 interface ICategoricalLegendProps {
-  legendAttrID: string
+  transform: string,
+  legendLabelRef: React.RefObject<SVGGElement>
 }
 
-/*
 interface Key {
   category: string
   color: string
@@ -14,53 +19,142 @@ interface Key {
   column: number,
   row: number
 }
-*/
 
-const keySize = 10
+interface Layout {
+  maxWidth: number
+  fullWidth: number
+  numColumns: number,
+  numRows: number,
+  columnWidth: number
+}
 
-export const CategoricalLegend = memo(function CategoricalLegend({legendAttrID}: ICategoricalLegendProps) {
-  const keysRef = useRef<SVGSVGElement>(null),
-    dataConfiguration = useDataConfigurationContext(),
+const keySize = 15,
+  padding = 5
+
+export const CategoricalLegend = memo(function CategoricalLegend(
+    {transform, legendLabelRef}: ICategoricalLegendProps) {
+  const dataConfiguration = useDataConfigurationContext(),
+    layout = useGraphLayoutContext(),
     categories = dataConfiguration?.categorySetForPlace('legend'),
     numCategories = categories?.size,
-    categoryData = categories && Array.from(categories).map((cat: string, index) => {
-      return {
-        category: cat,
-        color: dataConfiguration?.getLegendColorForCategory(cat),
-        index,
-        column: Math.floor(index / 2),
-        row: index % 2
+    categoryData = useRef<Key[]>([]),
+    layoutData = useRef<Layout>({
+        maxWidth: 0,
+        fullWidth: 0,
+        numColumns: 0,
+        numRows: 0,
+        columnWidth: 0
       }
-    }),
-    keyFunc = (index: number) => index
+    ),
+    // keyFunc = (index: number) => index,
+    [keysElt, setKeysElt] = useState<SVGGElement | null>(null),
 
-  useEffect(function setup() {
-    if (keysRef.current && categoryData) {
-      select(keysRef.current).selectAll('rect')
-        .data(range(0, numCategories ?? 0), keyFunc)
+    computeLayout = useCallback(() => {
+      const lod: Layout = layoutData.current
+      lod.fullWidth = layout.axisLength('bottom')
+      lod.maxWidth = 0
+      categories?.forEach(cat => {
+        const text = selection().append('text').attr('y', 500).text(cat),
+          width = text.node()?.getBoundingClientRect()?.width
+        lod.maxWidth = Math.max(lod.maxWidth, width ?? 0)
+        text.remove()
+      })
+      lod.maxWidth += keySize + padding
+      lod.numColumns = Math.floor(lod.fullWidth / lod.maxWidth)
+      lod.columnWidth = lod.fullWidth / lod.numColumns
+      lod.numRows = Math.ceil((numCategories ?? 0) / lod.numColumns)
+      categoryData.current.length = 0
+      categories && Array.from(categories).forEach((cat: string, index) => {
+        categoryData.current.push({
+          category: cat,
+          color: dataConfiguration?.getLegendColorForCategory(cat) || missingColor,
+          index,
+          row: Math.floor(index / lod.numColumns),
+          column: index % lod.numColumns
+        })
+      })
+      layoutData.current = lod
+    }, [layout, categories, numCategories, dataConfiguration]),
+
+    refreshKeys = useCallback(() => {
+      const labelHeight = legendLabelRef.current?.getBoundingClientRect().height ?? 0
+      select(keysElt)
+        .selectAll('rect')
+        .data(range(0, numCategories ?? 0))
         .join(
           // @ts-expect-error void => Selection
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
           (enter) => {
-            enter.append('rect')
-              .attr('class', 'key')
-              .attr('width', keySize)
-              .attr('height', keySize)
-              .attr('fill', index => categoryData[index].color || 'white')
           },
-          (update) => {
-            update.attr('x', (index) => {
-                const x = categoryData[index].column * 50
-                console.log(`[${index}]: x = ${x}`)
-                return x
-              })
-              .attr('y', index => categoryData[index].row * 15)
-          }
+          update => update
+            .attr('transform', transform)
+            .style('fill', (index: number) => categoryData.current[index].color || 'white')
+            .attr('x', (index: number) => {
+              return categoryData.current[index].column * layoutData.current.columnWidth
+            })
+            .attr('y',
+              (index: number) => 10 + labelHeight + categoryData.current[index].row * (keySize + padding))
         )
+
+      select(keysElt).selectAll('text')
+        .data(range(0, numCategories ?? 0))
+        .join(
+          // @ts-expect-error void => Selection
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          (enter) => {
+          },
+          update => update
+            .text((index: number) => categoryData.current[index].category)
+            .attr('transform', transform)
+            .attr('x', (index: number) => {
+              return categoryData.current[index].column * layoutData.current.columnWidth + keySize + 3
+            })
+            .attr('y',
+              (index: number) => labelHeight + 1.5 * keySize + categoryData.current[index].row * (keySize + padding))
+        )
+    }, [keysElt, numCategories, transform, legendLabelRef])
+
+  useEffect(function respondToLayoutChange() {
+    const disposer = reaction(
+      () => {
+        const {graphHeight, graphWidth} = layout
+        return [graphHeight, graphWidth]
+      },
+      () => {
+        computeLayout()
+        refreshKeys()
+      }, {fireImmediately: true}
+    )
+    return () => disposer()
+  }, [layout, computeLayout, refreshKeys])
+
+  useEffect(function setup() {
+    if (keysElt && categoryData.current) {
+      select(keysElt)
+        .selectAll('rect')
+        .data(range(0, numCategories ?? 0))
+        .join(
+          enter => enter.append('rect')
+            .attr('class', 'key')
+            .attr('width', keySize)
+            .attr('height', keySize)
+            .on('click',
+              (event, i) => {
+                dataConfiguration?.selectCasesForLegendValue(categoryData.current[i].category, event.shiftKey)
+              })
+        )
+
+      select(keysElt).selectAll('text')
+        .data(range(0, numCategories ?? 0))
+        .join(
+          enter => enter.append('text')
+        )
+      refreshKeys()
     }
-  }, [keysRef, categoryData, numCategories])
+  }, [keysElt, categoryData, numCategories, transform, refreshKeys, dataConfiguration])
 
   return (
-    <svg className='categories' ref={keysRef}></svg>
+    <svg className='categories' ref={elt => setKeysElt(elt)}></svg>
   )
 })
 CategoricalLegend.displayName = "CategoricalLegend"

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -1,0 +1,67 @@
+import React, {memo, useEffect, useRef} from "react"
+import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
+import {range, select} from "d3"
+
+interface ICategoricalLegendProps {
+  legendAttrID: string
+}
+
+/*
+interface Key {
+  category: string
+  color: string
+  index: number
+  column: number,
+  row: number
+}
+*/
+
+const keySize = 10
+
+export const CategoricalLegend = memo(function CategoricalLegend({legendAttrID}: ICategoricalLegendProps) {
+  const keysRef = useRef<SVGSVGElement>(null),
+    dataConfiguration = useDataConfigurationContext(),
+    categories = dataConfiguration?.categorySetForPlace('legend'),
+    numCategories = categories?.size,
+    categoryData = categories && Array.from(categories).map((cat: string, index) => {
+      return {
+        category: cat,
+        color: dataConfiguration?.getLegendColorForCase(cat),
+        index,
+        column: Math.floor(index / 2),
+        row: index % 2
+      }
+    }),
+    keyFunc = (index: number) => index
+
+  useEffect(function setup() {
+    if (keysRef.current && categoryData) {
+      select(keysRef.current).selectAll('.key')
+        .data(range(0, numCategories ?? 0), keyFunc)
+        .join(
+          // @ts-expect-error void => Selection
+          (enter) => {
+            enter.append('rect')
+              .attr('class', 'key')
+              .attr('width', keySize)
+              .attr('height', keySize)
+              .attr('fill', index => categoryData[index].color || 'white')
+          },
+          (update) => {
+            update
+              .attr('x', (index) => {
+                const x = categoryData[index].column * 50
+                console.log(`[${index}]: x = ${x}`)
+                return x
+              })
+              .attr('y', index => categoryData[index].row * 15)
+          }
+        )
+    }
+  }, [keysRef, categoryData, numCategories])
+
+  return (
+    <svg className='categories' ref={keysRef}></svg>
+  )
+})
+CategoricalLegend.displayName = "CategoricalLegend"

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -26,7 +26,7 @@ export const CategoricalLegend = memo(function CategoricalLegend({legendAttrID}:
     categoryData = categories && Array.from(categories).map((cat: string, index) => {
       return {
         category: cat,
-        color: dataConfiguration?.getLegendColorForCase(cat),
+        color: dataConfiguration?.getLegendColorForCategory(cat),
         index,
         column: Math.floor(index / 2),
         row: index % 2
@@ -36,7 +36,7 @@ export const CategoricalLegend = memo(function CategoricalLegend({legendAttrID}:
 
   useEffect(function setup() {
     if (keysRef.current && categoryData) {
-      select(keysRef.current).selectAll('.key')
+      select(keysRef.current).selectAll('rect')
         .data(range(0, numCategories ?? 0), keyFunc)
         .join(
           // @ts-expect-error void => Selection
@@ -48,8 +48,7 @@ export const CategoricalLegend = memo(function CategoricalLegend({legendAttrID}:
               .attr('fill', index => categoryData[index].color || 'white')
           },
           (update) => {
-            update
-              .attr('x', (index) => {
+            update.attr('x', (index) => {
                 const x = categoryData[index].column * 50
                 console.log(`[${index}]: x = ${x}`)
                 return x

--- a/v3/src/components/graph/components/legend/legend.scss
+++ b/v3/src/components/graph/components/legend/legend.scss
@@ -1,0 +1,34 @@
+.legend {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: lightgreen;
+
+  svg {
+    width: 100%;
+    height: 100%;
+    fill: yellow;
+  }
+
+  text {
+    fill: black;
+    font: 12px sans-serif;
+  }
+
+  rect {
+    fill: lightblue;
+  }
+}
+
+.legend-label text {
+  fill: blue;
+  text-align: center;
+}
+
+.categories {
+
+}
+
+.key {
+
+}

--- a/v3/src/components/graph/components/legend/legend.scss
+++ b/v3/src/components/graph/components/legend/legend.scss
@@ -16,7 +16,9 @@
   }
 
   rect {
-    fill: lightblue;
+    opacity: 0.85;
+    stroke: #315B7D;
+    cursor: pointer;
   }
 }
 

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -15,23 +15,26 @@ interface ILegendProps {
 export const Legend = memo(function Legend({legendAttrID, graphModel, transform}: ILegendProps) {
   useInstanceIdContext()
   const dataConfiguration = useDataConfigurationContext(),
-    // legendAttrID = dataConfiguration?.attributeID('legend') ?? '',
     attrType = dataConfiguration?.dataset?.attrFromID(legendAttrID ?? '')?.type,
+    legendLabelRef = useRef<SVGGElement>(null),
     legendRef = useRef() as React.RefObject<SVGSVGElement>
 
-  return (
+  return legendAttrID ? (
     <svg ref={legendRef} className='legend'>
       <AxisLabel
+        ref={legendLabelRef}
         transform = {transform}
         attributeIDs={legendAttrID !== '' ? [legendAttrID] : []}
         orientation='horizontal'
         attributeRole='legend'
       />
       {
-        attrType === 'categorical' ? <CategoricalLegend legendAttrID={legendAttrID}/> :
-          attrType === 'numeric' ? <NumericLegend legendAttrID={legendAttrID}/> : null
+        attrType === 'categorical' ? <CategoricalLegend transform = {transform}
+                                                        legendLabelRef={legendLabelRef}/> :
+          attrType === 'numeric' ? <NumericLegend legendAttrID={legendAttrID}
+                                                  transform = {transform}/> : null
       }
     </svg>
-  )
+  ) : null
 })
 Legend.displayName = "Legend"

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -1,0 +1,37 @@
+import React, {memo, useRef} from "react"
+import {IGraphModel} from "../../models/graph-model"
+import {useInstanceIdContext} from "../../../../hooks/use-instance-id-context"
+import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
+import {AxisLabel} from "../axis-label"
+import {CategoricalLegend} from "./categorical-legend"
+import {NumericLegend} from "./numeric-legend"
+
+interface ILegendProps {
+  graphModel: IGraphModel
+  transform: string
+  legendAttrID:string
+}
+
+export const Legend = memo(function Legend({legendAttrID, graphModel, transform}: ILegendProps) {
+  useInstanceIdContext()
+  const dataConfiguration = useDataConfigurationContext(),
+    // legendAttrID = dataConfiguration?.attributeID('legend') ?? '',
+    attrType = dataConfiguration?.dataset?.attrFromID(legendAttrID ?? '')?.type,
+    legendRef = useRef() as React.RefObject<SVGSVGElement>
+
+  return (
+    <svg ref={legendRef} className='legend'>
+      <AxisLabel
+        transform = {transform}
+        attributeIDs={legendAttrID !== '' ? [legendAttrID] : []}
+        orientation='horizontal'
+        attributeRole='legend'
+      />
+      {
+        attrType === 'categorical' ? <CategoricalLegend legendAttrID={legendAttrID}/> :
+          attrType === 'numeric' ? <NumericLegend legendAttrID={legendAttrID}/> : null
+      }
+    </svg>
+  )
+})
+Legend.displayName = "Legend"

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -1,8 +1,7 @@
 import React, {memo, useRef} from "react"
 import {IGraphModel} from "../../models/graph-model"
-import {useInstanceIdContext} from "../../../../hooks/use-instance-id-context"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
-import {AxisLabel} from "../axis-label"
+import {AttributeLabel} from "../attribute-label"
 import {CategoricalLegend} from "./categorical-legend"
 import {NumericLegend} from "./numeric-legend"
 
@@ -13,7 +12,6 @@ interface ILegendProps {
 }
 
 export const Legend = memo(function Legend({legendAttrID, graphModel, transform}: ILegendProps) {
-  useInstanceIdContext()
   const dataConfiguration = useDataConfigurationContext(),
     attrType = dataConfiguration?.dataset?.attrFromID(legendAttrID ?? '')?.type,
     legendLabelRef = useRef<SVGGElement>(null),
@@ -21,10 +19,10 @@ export const Legend = memo(function Legend({legendAttrID, graphModel, transform}
 
   return legendAttrID ? (
     <svg ref={legendRef} className='legend'>
-      <AxisLabel
+      <AttributeLabel
         ref={legendLabelRef}
         transform = {transform}
-        attributeIDs={legendAttrID !== '' ? [legendAttrID] : []}
+        attributeIDs={legendAttrID ? [legendAttrID] : []}
         orientation='horizontal'
         attributeRole='legend'
       />

--- a/v3/src/components/graph/components/legend/numeric-legend.tsx
+++ b/v3/src/components/graph/components/legend/numeric-legend.tsx
@@ -2,6 +2,7 @@ import React, {memo} from "react"
 
 interface INumericLegendProps {
   legendAttrID: string
+  transform:string
 }
 
 export const NumericLegend = memo(function NumericLegend({legendAttrID}: INumericLegendProps) {

--- a/v3/src/components/graph/components/legend/numeric-legend.tsx
+++ b/v3/src/components/graph/components/legend/numeric-legend.tsx
@@ -1,0 +1,17 @@
+import React, {memo} from "react"
+
+interface INumericLegendProps {
+  legendAttrID: string
+}
+
+export const NumericLegend = memo(function NumericLegend({legendAttrID}: INumericLegendProps) {
+/*
+  const dataConfiguration = useDataConfigurationContext(),
+    values = dataConfiguration?.numericValuesForPlace('legend')
+*/
+
+  return (
+    <></>
+  )
+})
+NumericLegend.displayName = "NumericLegend"

--- a/v3/src/components/graph/hooks/use-axis-bounds.ts
+++ b/v3/src/components/graph/hooks/use-axis-bounds.ts
@@ -1,4 +1,3 @@
-import {reaction} from "mobx"
 import {useEffect, useState} from "react"
 import {kGraphClassSelector} from "../graphing-types"
 import {AxisPlace} from "../models/axis-model"

--- a/v3/src/components/graph/hooks/use-axis-bounds.ts
+++ b/v3/src/components/graph/hooks/use-axis-bounds.ts
@@ -42,6 +42,7 @@ export const useAxisBoundsProvider = (place: AxisPlace) => {
     return () => observer?.disconnect()
   }, [graphElt, layout, place, wrapperElt])
 
+/*
   useEffect(function respondToLegendHeightChange() {
     const disposer = reaction(
       () => {
@@ -54,6 +55,7 @@ export const useAxisBoundsProvider = (place: AxisPlace) => {
     )
     return () => disposer()
   })
+*/
 
   return {graphElt, wrapperElt, setWrapperElt}
 }

--- a/v3/src/components/graph/hooks/use-axis-bounds.ts
+++ b/v3/src/components/graph/hooks/use-axis-bounds.ts
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react"
-import { kGraphClassSelector } from "../graphing-types"
-import { AxisPlace } from "../models/axis-model"
-import { useGraphLayoutContext } from "../models/graph-layout"
+import {reaction} from "mobx"
+import {useEffect, useState} from "react"
+import {kGraphClassSelector} from "../graphing-types"
+import {AxisPlace} from "../models/axis-model"
+import {useGraphLayoutContext} from "../models/graph-layout"
 
 export const useAxisBounds = (place: AxisPlace) => {
   const layout = useGraphLayoutContext()
@@ -34,13 +35,25 @@ export const useAxisBoundsProvider = (place: AxisPlace) => {
         }
       })
       observer.observe(wrapperElt)
-    }
-    else {
+    } else {
       layout.setAxisBounds(place, undefined)
     }
 
     return () => observer?.disconnect()
   }, [graphElt, layout, place, wrapperElt])
 
-  return { graphElt, wrapperElt, setWrapperElt }
+  useEffect(function respondToLegendHeightChange() {
+    const disposer = reaction(
+      () => {
+        const {legendHeight} = layout
+        return legendHeight
+      },
+      (legendHeight) => {
+        console.log('legendHeight =',legendHeight)
+      }
+    )
+    return () => disposer()
+  })
+
+  return {graphElt, wrapperElt, setWrapperElt}
 }

--- a/v3/src/components/graph/models/axis-model.ts
+++ b/v3/src/components/graph/models/axis-model.ts
@@ -6,13 +6,16 @@ export const GraphPlaces = [...AxisPlaces, "plot", "legend"] as const
 export type AxisPlace = typeof AxisPlaces[number]
 export type GraphPlace = typeof GraphPlaces[number]
 
-export const attrRoleToGraphPlace: Partial<Record<GraphAttrRole, GraphPlace>> = {
+export const attrRoleToAxisPlace: Partial<Record<GraphAttrRole, AxisPlace>> = {
   x: "bottom",
   y: "left",
-  legend: 'legend',
   y2: "right",
   rightSplit: "right",
   topSplit: "top"
+}
+export const attrRoleToGraphPlace: Partial<Record<GraphAttrRole, GraphPlace>> = {
+  ...attrRoleToAxisPlace,
+  legend: "legend"
 }
 
 export const axisPlaceToAttrPlace: Record<AxisPlace, GraphAttrRole> = {
@@ -22,11 +25,11 @@ export const axisPlaceToAttrPlace: Record<AxisPlace, GraphAttrRole> = {
   right: "y2",  // Todo: how to deal with 'rightSplit'?
 }
 
-export const graphPlaceToAttrPlace = (graphPlace:GraphPlace) => {
+export const graphPlaceToAttrPlace = (graphPlace: GraphPlace) => {
   return AxisPlaces.includes(graphPlace as AxisPlace) ? axisPlaceToAttrPlace[graphPlace as AxisPlace] : 'legend'
 }
 
-export function otherPlace(aPlace:AxisPlace):AxisPlace {
+export function otherPlace(aPlace: AxisPlace): AxisPlace {
   return aPlace === 'bottom' ? 'left' : 'bottom'
 }
 
@@ -104,10 +107,9 @@ export const NumericAxisModel = AxisModel
     setDomain(min: number, max: number) {
       // If we're close enough to zero on either end, we snap to it
       const snapFactor = 100
-      if((max > 0) && (Math.abs(min) <= max / snapFactor)) {
+      if ((max > 0) && (Math.abs(min) <= max / snapFactor)) {
         min = 0
-      }
-      else if( (min < 0) && (Math.abs(max) < Math.abs(min / snapFactor)) ) {
+      } else if ((min < 0) && (Math.abs(max) < Math.abs(min / snapFactor))) {
         max = 0
       }
       self.min = min

--- a/v3/src/components/graph/models/axis-model.ts
+++ b/v3/src/components/graph/models/axis-model.ts
@@ -6,9 +6,10 @@ export const GraphPlaces = [...AxisPlaces, "plot", "legend"] as const
 export type AxisPlace = typeof AxisPlaces[number]
 export type GraphPlace = typeof GraphPlaces[number]
 
-export const attrPlaceToAxisPlace: Partial<Record<GraphAttrRole, AxisPlace>> = {
+export const attrRoleToGraphPlace: Partial<Record<GraphAttrRole, GraphPlace>> = {
   x: "bottom",
   y: "left",
+  legend: 'legend',
   y2: "right",
   rightSplit: "right",
   topSplit: "top"

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -160,12 +160,14 @@ export const DataConfigurationModel = types
     }))
   .views(self => (
     {
-      getLegendColorForCase(id: string | undefined) {
+      getLegendColorForCategory(cat: string) {
+        const catIndex = Array.from(self.categorySetForPlace('legend')).indexOf(cat)
+        return catIndex >= 0 ? kellyColors[catIndex % kellyColors.length] : missingColor
+      },
+      getLegendColorForCase(id?: string) {
         const legendID = self.attributeID('legend'),
-          legendValue = legendID ? self.dataset?.getValue(id ?? '', legendID) : null,
-          catIndex = Array.from(self.categorySetForPlace('legend')).indexOf(legendValue)
-        return legendValue === null ? '' :
-          catIndex >= 0 ? kellyColors[catIndex % kellyColors.length] : missingColor
+          legendValue = id && legendID ? self.dataset?.getValue(id, legendID) : null
+        return legendValue == null ? '' : this.getLegendColorForCategory( legendValue)
       },
       selectCasesForLegendValue(aValue: string, extend = false) {
         const dataset = self.dataset,
@@ -181,11 +183,6 @@ export const DataConfigurationModel = types
     }))
   .views(self => (
     {
-      getLegendColorForCategory(cat: string) {
-        const catIndex = Array.from(self.categorySetForPlace('legend')).indexOf(cat)
-        return cat === null ? '' :
-          catIndex >= 0 ? kellyColors[catIndex % kellyColors.length] : missingColor
-      }
     }))
   .actions(self => ({
     setDataset(dataset: IDataSet) {

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -166,11 +166,22 @@ export const DataConfigurationModel = types
           catIndex = Array.from(self.categorySetForPlace('legend')).indexOf(legendValue)
         return legendValue === null ? '' :
           catIndex >= 0 ? kellyColors[catIndex % kellyColors.length] : missingColor
+      },
+      selectCasesForLegendValue(aValue: string, extend = false) {
+        const dataset = self.dataset,
+          legendID = self.attributeID('legend'),
+          selection = legendID && self.cases.filter((anID: string) => {
+            return dataset?.getValue(anID, legendID) === aValue
+          })
+        if (selection) {
+          if (extend) dataset?.selectCases(selection)
+          else dataset?.setSelectedCases(selection)
+        }
       }
     }))
   .views(self => (
     {
-      getLegendColorForCategory(cat:string) {
+      getLegendColorForCategory(cat: string) {
         const catIndex = Array.from(self.categorySetForPlace('legend')).indexOf(cat)
         return cat === null ? '' :
           catIndex >= 0 ? kellyColors[catIndex % kellyColors.length] : missingColor
@@ -203,7 +214,9 @@ export const DataConfigurationModel = types
     onAction(handler: (actionCall: ISerializedActionCall) => void) {
       const id = uniqueId()
       self.handlers.set(id, handler)
-      return () => { self.handlers.delete(id) }
+      return () => {
+        self.handlers.delete(id)
+      }
     }
   }))
 

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -160,11 +160,19 @@ export const DataConfigurationModel = types
     }))
   .views(self => (
     {
-      getLegendColorForCase(id: string) {
+      getLegendColorForCase(id: string | undefined) {
         const legendID = self.attributeID('legend'),
-          legendValue = legendID ? self.dataset?.getValue(id, legendID) : null,
+          legendValue = legendID ? self.dataset?.getValue(id ?? '', legendID) : null,
           catIndex = Array.from(self.categorySetForPlace('legend')).indexOf(legendValue)
         return legendValue === null ? '' :
+          catIndex >= 0 ? kellyColors[catIndex % kellyColors.length] : missingColor
+      }
+    }))
+  .views(self => (
+    {
+      getLegendColorForCategory(cat:string) {
+        const catIndex = Array.from(self.categorySetForPlace('legend')).indexOf(cat)
+        return cat === null ? '' :
           catIndex >= 0 ? kellyColors[catIndex % kellyColors.length] : missingColor
       }
     }))

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -11,7 +11,7 @@ import {
   CategoricalAxisModel,
   ICategoricalAxisModel,
   INumericAxisModel,
-  NumericAxisModel, axisPlaceToAttrPlace, attrRoleToGraphPlace
+  NumericAxisModel, axisPlaceToAttrPlace, attrRoleToAxisPlace
 } from "./axis-model"
 import {PlotType} from "../graphing-types"
 import {matchCirclesToData, setNiceDomain} from "../utilities/graph-utils"
@@ -113,26 +113,28 @@ export class GraphController {
     })
     graphModel.setPlotType(plotChoices[attrTypes.x][attrTypes.y]);
     ['x', 'y'].forEach((attrPlace: GraphAttrRole) => {
-      const axisPlace = attrRoleToGraphPlace[attrPlace] as AxisPlace,
+      const axisPlace = attrRoleToAxisPlace[attrPlace],
         attrType = attrTypes[attrPlace]
-      let axisModel
-      switch (attrType) {
-        case 'numeric':
-          axisModel = NumericAxisModel.create({place: axisPlace, min: 0, max: 1})
-          graphModel.setAxis(axisPlace, axisModel)
-          layout.setAxisScale(axisPlace, scaleLinear())
-          setNiceDomain(dataConfig.numericValuesForPlace(attrPlace), axisModel)
-          break
-        case 'categorical':
-          axisModel = CategoricalAxisModel.create({place: axisPlace})
-          graphModel.setAxis(axisPlace, axisModel)
-          layout.setAxisScale(axisPlace,
-            scaleBand().domain(dataConfig.categorySetForPlace(attrPlace)))
-          break
-        default:
-          axisModel = EmptyAxisModel.create({place: axisPlace})
-          graphModel.setAxis(axisPlace, axisModel)
-          layout.setAxisScale(axisPlace, scaleOrdinal())
+      if(axisPlace) {
+        let axisModel
+        switch (attrType) {
+          case 'numeric':
+            axisModel = NumericAxisModel.create({place: axisPlace, min: 0, max: 1})
+            graphModel.setAxis(axisPlace, axisModel)
+            layout.setAxisScale(axisPlace, scaleLinear())
+            setNiceDomain(dataConfig.numericValuesForPlace(attrPlace), axisModel)
+            break
+          case 'categorical':
+            axisModel = CategoricalAxisModel.create({place: axisPlace})
+            graphModel.setAxis(axisPlace, axisModel)
+            layout.setAxisScale(axisPlace,
+              scaleBand().domain(dataConfig.categorySetForPlace(attrPlace)))
+            break
+          default:
+            axisModel = EmptyAxisModel.create({place: axisPlace})
+            graphModel.setAxis(axisPlace, axisModel)
+            layout.setAxisScale(axisPlace, scaleOrdinal())
+        }
       }
     })
   }

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -11,7 +11,7 @@ import {
   CategoricalAxisModel,
   ICategoricalAxisModel,
   INumericAxisModel,
-  NumericAxisModel, axisPlaceToAttrPlace, attrPlaceToAxisPlace
+  NumericAxisModel, axisPlaceToAttrPlace, attrRoleToGraphPlace
 } from "./axis-model"
 import {PlotType} from "../graphing-types"
 import {matchCirclesToData, setNiceDomain} from "../utilities/graph-utils"
@@ -113,7 +113,7 @@ export class GraphController {
     })
     graphModel.setPlotType(plotChoices[attrTypes.x][attrTypes.y]);
     ['x', 'y'].forEach((attrPlace: GraphAttrRole) => {
-      const axisPlace = attrPlaceToAxisPlace[attrPlace] as AxisPlace,
+      const axisPlace = attrRoleToGraphPlace[attrPlace] as AxisPlace,
         attrType = attrTypes[attrPlace]
       let axisModel
       switch (attrType) {
@@ -139,6 +139,7 @@ export class GraphController {
 
   handleAttributeAssignment(axisPlace: AxisPlace, attrID: string) {
     if(['plot', 'legend'].includes( axisPlace)) {
+      this.layout.setLegendHeight(50) // todo: temporary!
       return  // Since there is no axis associated with the legend and the plotType will not change, we bail
     }
     const {dataset, graphModel, layout} = this,

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -8,6 +8,7 @@ export type ScaleType = ScaleContinuousNumeric<number, number> | ScaleOrdinal<st
 
 export const kDefaultGraphWidth = 480
 export const kDefaultGraphHeight = 0
+export const kDefaultLegendHeight = 50
 export const kDefaultPlotWidth = 0.8 * kDefaultGraphWidth
 export const kDefaultPlotHeight = 0.8 * kDefaultGraphHeight
 
@@ -21,6 +22,7 @@ export interface Bounds {
 export class GraphLayout {
   @observable graphWidth = kDefaultGraphWidth
   @observable graphHeight = kDefaultGraphHeight
+  @observable legendHeight = kDefaultLegendHeight
   @observable margin = ({ top: 10, right: 30, bottom: 30, left: 60 })
   @observable axisBounds: Map<AxisPlace, Bounds> = new Map()
   axisScales: Map<AxisPlace, ScaleType> = new Map()
@@ -35,7 +37,7 @@ export class GraphLayout {
   }
 
   @computed get plotHeight() {
-    return 0.8 * this.graphHeight
+    return Math.max(0, 0.8 * this.graphHeight - this.legendHeight)
   }
 
   isHorizontal(place: AxisPlace) {
@@ -66,7 +68,8 @@ export class GraphLayout {
         left: bounds.left,
         top: place === 'bottom' ? this.axisLength('left') : bounds.top,
         width: place === 'left' ? this.graphWidth - this.axisLength('bottom') : bounds.width,
-        height: place === 'bottom' ? this.graphHeight - this.axisLength('left') : bounds.height
+        height: place === 'bottom' ? this.graphHeight - this.axisLength('left') - this.legendHeight :
+          place === 'left' ? this.graphHeight - this.legendHeight : bounds.height
       }
       this.axisBounds.set(place, newBounds)
     }
@@ -86,7 +89,7 @@ export class GraphLayout {
 
   @action setGraphExtent(width: number, height: number) {
     const plotWidth = 0.8 * width
-    const plotHeight = 0.8 * height
+    const plotHeight = 0.8 * height - this.legendHeight
 
     // update d3 scale ranges before updating graph properties
     AxisPlaces.forEach(place => {

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -8,7 +8,7 @@ export type ScaleType = ScaleContinuousNumeric<number, number> | ScaleOrdinal<st
 
 export const kDefaultGraphWidth = 480
 export const kDefaultGraphHeight = 0
-export const kDefaultLegendHeight = 50
+export const kDefaultLegendHeight = 0
 export const kDefaultPlotWidth = 0.8 * kDefaultGraphWidth
 export const kDefaultPlotHeight = 0.8 * kDefaultGraphHeight
 
@@ -66,10 +66,14 @@ export class GraphLayout {
       // todo: check to make sure this still works with top and right axes
       const newBounds = {
         left: bounds.left,
-        top: place === 'bottom' ? this.axisLength('left') : bounds.top,
-        width: place === 'left' ? this.graphWidth - this.axisLength('bottom') : bounds.width,
-        height: place === 'bottom' ? this.graphHeight - this.axisLength('left') - this.legendHeight :
-          place === 'left' ? this.graphHeight - this.legendHeight : bounds.height
+        top: place === 'bottom' ?
+          Math.min(bounds.top, this.axisLength('left')) : bounds.top,
+        width: place === 'left' ?
+          Math.min(bounds.width, this.graphWidth - this.axisLength('bottom')) : bounds.width,
+        height: place === 'bottom' ?
+          Math.min(bounds.height, this.graphHeight - this.axisLength('left') - this.legendHeight) :
+          place === 'left' ?
+            Math.min(bounds.height, this.graphHeight - this.legendHeight) : bounds.height
       }
       this.axisBounds.set(place, newBounds)
     }
@@ -87,18 +91,27 @@ export class GraphLayout {
     this.axisScales.set(place, scale)
   }
 
+  updateScaleRanges(plotWidth:number, plotHeight:number) {
+    AxisPlaces.forEach(place => {
+      const range = this.isVertical(place) ? [plotHeight, 0] : [0, plotWidth]
+      this.axisScale(place)?.range(range)
+    })
+  }
+
   @action setGraphExtent(width: number, height: number) {
     const plotWidth = 0.8 * width
     const plotHeight = 0.8 * height - this.legendHeight
 
     // update d3 scale ranges before updating graph properties
-    AxisPlaces.forEach(place => {
-      const range = this.isVertical(place) ? [plotHeight, 0] : [0, plotWidth]
-      this.axisScale(place)?.range(range)
-    })
+    this.updateScaleRanges(plotWidth, plotHeight)
 
     this.graphWidth = width
     this.graphHeight = height
+  }
+
+  @action setLegendHeight(height:number) {
+    this.updateScaleRanges(this.plotWidth, 0.8 * this.graphHeight - height)
+    this.legendHeight = height
   }
 }
 


### PR DESCRIPTION
Please consider this a first pass.
## Works
* The legend attribute name appears below the x-axis
* The categories appear as colored squares with a label just to the right
* The number of columns and rows responds dynamically to resize of the browser window

## Does NOT work
I'm logging these as bugs
* [Layout in the vertical direction is wonky](https://www.pivotaltracker.com/story/show/183656309)
* [Clicking on text doesn't work](https://www.pivotaltracker.com/story/show/183656431)