### PR TITLE
V3—Attribute dropped in empty plot puts attribute on x-axis

### DIFF
--- a/v3/src/components/graph/components/droppable-plot.tsx
+++ b/v3/src/components/graph/components/droppable-plot.tsx
@@ -5,6 +5,7 @@ import { useDropHintString } from "../../../hooks/use-drop-hint-string"
 import { useInstanceIdContext } from "../../../hooks/use-instance-id-context"
 import { GraphPlace } from "../models/axis-model"
 import { DroppableSvg } from "./droppable-svg"
+import { useDataConfigurationContext} from "../hooks/use-data-configuration-context";
 
 interface IProps {
   graphElt: HTMLDivElement | null
@@ -13,8 +14,10 @@ interface IProps {
 }
 export const DroppablePlot = ({ graphElt, plotElt, onDropAttribute }: IProps) => {
   const instanceId = useInstanceIdContext()
+  const dataConfig = useDataConfigurationContext()
   const droppableId = `${instanceId}-plot-area-drop`
-  const hintString = useDropHintString({ role: "legend" })
+  const role = dataConfig?.noAttributesAssigned ? 'x' : 'legend'
+  const hintString = useDropHintString({ role })
 
   const handleIsActive = (active: Active) => !!getDragAttributeId(active)
 

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -75,7 +75,8 @@ export const Graph = observer((
   const toast = useToast()
 
   const handleDropAttribute = (place: GraphPlace, attrId: string) => {
-    const attrPlace = graphPlaceToAttrPlace(place)
+    const computedPlace = place === 'plot' && graphModel.config.noAttributesAssigned ? 'bottom' : place
+    const attrPlace = graphPlaceToAttrPlace(computedPlace)
     const attrName = dataset?.attrFromID(attrId)?.name
     toast({
       position: "top-right",

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -116,6 +116,10 @@ export const DataConfigurationModel = types
     get uniqueTipAttributes() {
       return Array.from(new Set<string>(this.tipAttributes))
     },
+    get noAttributesAssigned() {
+      // The first attribute is always assigned as 'caption'. So it's really no attributes assigned except for that
+      return this.attributes.length <= 1
+    },
     get cases() {
       const caseIDs = self.filteredCases?.caseIds || [],
         legendAttrID = self.attributeID('legend')

--- a/v3/src/hooks/use-drop-hint-string.ts
+++ b/v3/src/hooks/use-drop-hint-string.ts
@@ -20,7 +20,7 @@ export function determineBaseString(role: GraphAttrRole, dropType?: AttributeTyp
   const stringMap: HintMap = {
     x: {
       numeric: {
-        empty: "addToEmptyPlace",
+        empty: "addToEmptyX",
         existing: "replaceAttribute"
       },
       categorical: {


### PR DESCRIPTION
* Use new property of data configuration to detect noAttributesAssigned
* Changed drop hint droppable-plot
* Changed behavior in graph component