### PR TITLE
reimpose size limitations on drop zones to adjust for gridlines

### DIFF
--- a/v3/src/components/graph/components/droppable-plot.tsx
+++ b/v3/src/components/graph/components/droppable-plot.tsx
@@ -5,7 +5,7 @@ import { useDropHintString } from "../../../hooks/use-drop-hint-string"
 import { useInstanceIdContext } from "../../../hooks/use-instance-id-context"
 import { GraphPlace } from "../models/axis-model"
 import { DroppableSvg } from "./droppable-svg"
-import { useDataConfigurationContext} from "../hooks/use-data-configuration-context";
+import { useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 
 interface IProps {
   graphElt: HTMLDivElement | null

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -1,3 +1,4 @@
+import { ThemeProvider } from "@emotion/react"
 import {ScaleBand, ScaleContinuousNumeric, ScaleOrdinal, scaleOrdinal} from "d3"
 import { action, computed, makeObservable, observable } from "mobx"
 import { createContext, useContext } from "react"
@@ -63,18 +64,18 @@ export class GraphLayout {
       // the plot. We tried work arounds to get gridlines that were _not_ part of the axis element with the result
       // that the gridlines got out of synch with axis tick marks during drag. So we have this inelegant solution
       // that shouldn't affect the top and right axes when we get them but
-      // todo: check to make sure this still works with top and right axes
-      const newBounds = {
-        left: bounds.left,
-        top: place === 'bottom' ?
-          Math.min(bounds.top, this.axisLength('left')) : bounds.top,
-        width: place === 'left' ?
-          Math.min(bounds.width, this.graphWidth - this.axisLength('bottom')) : bounds.width,
-        height: place === 'bottom' ?
-          Math.min(bounds.height, this.graphHeight - this.axisLength('left') - this.legendHeight) :
-          place === 'left' ?
-            Math.min(bounds.height, this.graphHeight - this.legendHeight) : bounds.height
+
+      // given state of the graph, we may need to adjust the drop areas' bounds
+      const newBounds = bounds
+
+      if (place === "bottom"){
+        newBounds.top = this.plotHeight
       }
+
+      if (place === "left" && bounds.width > this.plotWidth){
+         newBounds.width -= this.plotWidth
+      }
+
       this.axisBounds.set(place, newBounds)
     }
     else {

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -69,11 +69,13 @@ export class GraphLayout {
       const newBounds = bounds
 
       if (place === "bottom"){
+        newBounds.height = Math.min(bounds.height, this.graphHeight - this.axisLength('left') - this.legendHeight)
         newBounds.top = this.plotHeight
       }
 
       if (place === "left" && bounds.width > this.plotWidth){
-         newBounds.width -= this.plotWidth
+        newBounds.height = Math.min(bounds.height, this.graphHeight - this.legendHeight)
+        newBounds.width -= this.plotWidth
       }
 
       this.axisBounds.set(place, newBounds)

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -1,4 +1,3 @@
-import { ThemeProvider } from "@emotion/react"
 import {ScaleBand, ScaleContinuousNumeric, ScaleOrdinal, scaleOrdinal} from "d3"
 import { action, computed, makeObservable, observable } from "mobx"
 import { createContext, useContext } from "react"

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -62,7 +62,8 @@ export class GraphLayout {
       // part of the axis dom element so that we get in here with bounds that span the entire width or height of
       // the plot. We tried work arounds to get gridlines that were _not_ part of the axis element with the result
       // that the gridlines got out of synch with axis tick marks during drag. So we have this inelegant solution
-      // that shouldn't affect the top and right axes when we get them but
+      // that shouldn't affect the top and right axes when we get them but it may be worthwhile to
+      // (TODO) figure out if there's a better way to render gridlines on background (or plot) so this isn't necessary.
 
       // given state of the graph, we may need to adjust the drop areas' bounds
       const newBounds = bounds

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -73,9 +73,14 @@ export class GraphLayout {
         newBounds.top = this.plotHeight
       }
 
-      if (place === "left" && bounds.width > this.plotWidth){
+      if (place === "left"){
         newBounds.height = Math.min(bounds.height, this.graphHeight - this.legendHeight)
-        newBounds.width -= this.plotWidth
+        newBounds.left = 0
+        newBounds.width = this.graphWidth - this.plotWidth - this.margin.left - this.margin.right
+        // if gridlines are present, axis will grow to .width + plotWidth, so we recalculate
+        if (bounds.width > this.plotWidth){
+          newBounds.width -= this.plotWidth
+        }
       }
 
       this.axisBounds.set(place, newBounds)


### PR DESCRIPTION
This makes the necessary recalculations to keep axis drop zones in the correct positions when a graph has no attributes, one attribute, or two attributes, and re-limits location once gridlines are present.  It replaces a few inline conditionals with a simplified setup so that we can have one set of decisions/recalculations for the left axis and another for the bottom.  

I did also try just mutating the `bounds` prop in place, but stuck with the creation of the `newBounds` for clarity.  Two more comments in-line. 