### PR TITLE
183598561 axis drop zone pos

### DIFF
--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -75,8 +75,6 @@ export class GraphLayout {
 
       if (place === "left"){
         newBounds.height = Math.min(bounds.height, this.graphHeight - this.legendHeight)
-        newBounds.left = 0
-        newBounds.width = this.graphWidth - this.plotWidth - this.margin.left - this.margin.right
         // if gridlines are present, axis will grow to .width + plotWidth, so we recalculate
         if (bounds.width > this.plotWidth){
           newBounds.width -= this.plotWidth

--- a/v3/src/hooks/use-drop-hint-string.test.ts
+++ b/v3/src/hooks/use-drop-hint-string.test.ts
@@ -7,13 +7,19 @@ interface Scenario {
   dropType: AttributeType
   existingType?: AttributeType
 }
-const numericToEmptyAxis: Scenario = { role: "x", dropType: "numeric", existingType: undefined }
+const numericToEmptyXAxis: Scenario = { role: "x", dropType: "numeric", existingType: undefined }
+const numericToEmptyYAxis: Scenario = { role: "y", dropType: "numeric", existingType: undefined }
 const numericToPopulatedAxis: Scenario = { role: "x", dropType: "numeric", existingType: "numeric" }
 const categoricalToPlot: Scenario = { role: "legend", dropType: "categorical", existingType: "categorical" }
 
 describe("determineBaseString should return correct string key for potential plot drops", () => {
-  it("returns key for numeric attr to empty axis", () => {
-    const { role, dropType, existingType } = numericToEmptyAxis
+  it("returns key for numeric attr to empty x axis", () => {
+    const { role, dropType, existingType } = numericToEmptyXAxis
+    const result = determineBaseString(role, dropType, existingType)
+    expect(result).toEqual("DG.GraphView.addToEmptyX")
+  })
+  it("returns key for numeric attr to empty y axis", () => {
+    const { role, dropType, existingType } = numericToEmptyYAxis
     const result = determineBaseString(role, dropType, existingType)
     expect(result).toEqual("DG.GraphView.addToEmptyPlace")
   })


### PR DESCRIPTION
This makes two small adjustments. 
1. Adds a test within `use-drop-hint-string.test.ts` so that numeric attribute drops on empty x has differentiated expected behavior from y
2. No longer forces left side axis drop zone to have `bounds.left = 0` - this is likely to be revisited as graph becomes more responsive