### PR TITLE
V3 181912236 axis menu

### DIFF
--- a/v3/src/components/graph/components/axis-attribute-menu.tsx
+++ b/v3/src/components/graph/components/axis-attribute-menu.tsx
@@ -26,7 +26,7 @@ export const AxisAttributeMenu = ({ place, target, portal, onChangeAttribute, on
   const overlayBounds = useOverlayBounds({target, portal})
   const buttonStyles: CSSProperties = { position: "absolute", color: "transparent" }
 
-  if (attrId === undefined && place === "bottom"){
+  if (!attrId && place === "bottom"){
     buttonStyles.top = plotHeight + 4
     buttonStyles.left = ( plotWidth * .5 ) - margin.right - 8 // ~ width of y scale
   }

--- a/v3/src/components/graph/components/axis-attribute-menu.tsx
+++ b/v3/src/components/graph/components/axis-attribute-menu.tsx
@@ -18,31 +18,23 @@ interface IProps {
 export const AxisAttributeMenu = ({ place, target, portal, onChangeAttr, onTreatAttrAs }: IProps ) => {
   const data = useDataSetContext()
   const dataConfig = useDataConfigurationContext()
-  const { graphWidth, plotWidth, plotHeight, margin } = useGraphLayoutContext()
+  const { plotWidth, plotHeight, margin } = useGraphLayoutContext()
   const role = place === "left" ? "y" : "x"
   const attrId = dataConfig?.attributeID(role)
   const attribute = attrId ? data?.attrFromID(attrId) : null
   const treatAs = attribute?.type === "numeric" ? "categorical" : "numeric"
   const overlayBounds = useOverlayBounds({target, portal})
+  const buttonStyles: CSSProperties = { position: "absolute", color: "transparent" }
 
-  const buttonStyles: CSSProperties = {
-    background: "blue", opacity: 0.2,  //only for debugging during development
-    position: "absolute",
-    color: "transparent"
-  }
-
-  // if no attr on x axis yet, we need to manually position the button over the labels
   if (attrId === undefined && place === "bottom"){
     buttonStyles.top = plotHeight + 4
     buttonStyles.left = ( plotWidth * .5 ) - margin.right - 8 // ~ width of y scale
   }
 
-  const style = { ...overlayBounds, ...buttonStyles }
-
   return (
     <div className="axis-attribute-menu">
       <Menu>
-        <MenuButton style={style}>{attribute?.name}</MenuButton>
+        <MenuButton style={{ ...overlayBounds, ...buttonStyles }}>{attribute?.name}</MenuButton>
         <MenuList>
           { data?.attributes?.map((attr) => {
             return (
@@ -56,10 +48,10 @@ export const AxisAttributeMenu = ({ place, target, portal, onChangeAttr, onTreat
               <MenuDivider />
               <MenuItem onClick={() => onChangeAttr(place, "")}>
                 { place === "left" &&
-                  t("DG.DataDisplayMenu.removeAttribute_y", { vars: [ attribute?.name ] })
+                  t("DG.DataDisplayMenu.removeAttribute_y", {vars: [attribute?.name]})
                 }
                 { place === "bottom" &&
-                  t("DG.DataDisplayMenu.removeAttribute_x", { vars: [ attribute?.name ] })
+                  t("DG.DataDisplayMenu.removeAttribute_x", {vars: [attribute?.name]})
                 }
               </MenuItem>
               <MenuItem onClick={() => onTreatAttrAs(place, attribute?.id, treatAs)}>
@@ -73,79 +65,3 @@ export const AxisAttributeMenu = ({ place, target, portal, onChangeAttr, onTreat
     </div>
   )
 }
-
-
-
-/*
-import { Menu, MenuItem, MenuList, MenuButton, MenuDivider } from "@chakra-ui/react"
-import React, { CSSProperties } from "react"
-import { useDataSetContext } from "../../../hooks/use-data-set-context"
-import { AxisPlace, GraphPlace } from "../models/axis-model"
-import { useGraphLayoutContext} from "../models/graph-layout"
-import { measureText } from "../../../hooks/use-measure-text"
-import t from "../../../utilities/translation/translate"
-
-interface IProps {
-  attrId: string
-  place: GraphPlace,
-  onChangeAttr: (place: GraphPlace, attrId: string) => void
-  onTreatAttrAs: (place: GraphPlace, attrId: string, treatAs: string) => void
-}
-
-export const AxisAttributeMenu = ({ attrId, place, onChangeAttr, onTreatAttrAs }: IProps ) => {
-  const data = useDataSetContext()
-  const attribute = data?.attrFromID(attrId)
-  const treatAs = attribute?.type === "numeric" ? "categorical" : "numeric"
-  const layout = useGraphLayoutContext()
-  const { margin } = layout
-  const textLength = measureText(attribute?.name || "")
-
-  // TODO - replace with a more reliable calculation or way of placing button
-  const calcLeft = () => {
-    const bounds = layout.getAxisBounds(place as AxisPlace)
-    if (!bounds) return 0
-    return place === "left" ? -30 : (bounds.width * .5) - (textLength * .5) + margin.left - 5
-  }
-
-  const buttonStyles: CSSProperties = {
-    border: "1px dashed blue",  //only for debugging during development
-    opacity: 0.3,               //only for debugging during development
-    position: "absolute",
-    color: "transparent",
-    rotate: place === "left" ? "270deg" : "0deg",
-    top: place === "left" ? (.5 * layout.plotHeight) - (.2 * textLength) : layout.plotHeight + 20,
-    left: calcLeft()
-  }
-
-  return (
-    <div className="axis-attribute-menu">
-      <Menu>
-        <MenuButton style={{...buttonStyles }}>{attribute?.name}</MenuButton>
-        <MenuList>
-          { data?.attributes?.map((attr) => {
-            return (
-              <MenuItem onClick={() => onChangeAttr(place, attr.id)} key={attr.id}>
-                {attr.name}
-              </MenuItem>
-            )
-          })}
-          <MenuDivider />
-          <MenuItem onClick={() => onChangeAttr(place, "")}>
-            { place === "left" &&
-              t("DG.DataDisplayMenu.removeAttribute_y", { vars: [ attribute?.name ] })
-            }
-            { place === "bottom" &&
-              t("DG.DataDisplayMenu.removeAttribute_x", { vars: [ attribute?.name ] })
-            }
-          </MenuItem>
-          <MenuItem onClick={() => onTreatAttrAs(place, attrId, treatAs)}>
-            {treatAs === "categorical" && t("DG.DataDisplayMenu.treatAsCategorical")}
-            {treatAs === "numeric" && t("DG.DataDisplayMenu.treatAsNumeric")}
-          </MenuItem>
-        </MenuList>
-      </Menu>
-    </div>
-  )
-}
-
-*/

--- a/v3/src/components/graph/components/axis-attribute-menu.tsx
+++ b/v3/src/components/graph/components/axis-attribute-menu.tsx
@@ -1,0 +1,145 @@
+import { Menu, MenuItem, MenuList, MenuButton, MenuDivider } from "@chakra-ui/react"
+import React, { CSSProperties, useRef } from "react"
+import { useDataSetContext } from "../../../hooks/use-data-set-context"
+import { attrRoleToAxisPlace, AxisPlace, axisPlaceToAttrRole, GraphPlace } from "../models/axis-model"
+import { useGraphLayoutContext} from "../models/graph-layout"
+import { measureText } from "../../../hooks/use-measure-text"
+import t from "../../../utilities/translation/translate"
+import { useOverlayBounds } from "../../../hooks/use-overlay-bounds"
+import { useDataConfigurationContext } from "../hooks/use-data-configuration-context"
+
+interface IProps {
+  place: GraphPlace,
+  target: SVGGElement | null
+  portal: HTMLElement | null
+}
+
+export const AxisAttributeMenu = ({ place, target, portal }: IProps ) => {
+  const data = useDataSetContext()
+  const dataConfig = useDataConfigurationContext()
+  const role = place === "left" ? "y" : "x"
+  const attrId = dataConfig?.attributeID(role)
+  const attribute = attrId ? data?.attrFromID(attrId) : null
+  const treatAs = attribute?.type === "numeric" ? "categorical" : "numeric"
+  const overlayBounds = useOverlayBounds({target, portal})
+
+  const buttonStyles: CSSProperties = {
+    background: "blue", opacity: 0.2,  //only for debugging during development
+    position: "absolute",
+    color: "transparent"
+  }
+
+  // TODO
+  // 1 if no attr on axis yet, we need to manually position over the labels
+  // 2 in above state, make menu not render stuff it shouldn't like "remove..."
+  // 3 reimplement the functionality
+
+  const style = { ...overlayBounds, ...buttonStyles }
+  console.log({place, style})
+
+  return (
+    <div className="axis-attribute-menu">
+      <Menu>
+        <MenuButton style={style}>{attribute?.name}</MenuButton>
+        <MenuList>
+          { data?.attributes?.map((attr) => {
+            return (
+              <MenuItem onClick={() => console.log("change: ", place, attr.id)} key={attr.id}>
+                {attr.name}
+              </MenuItem>
+            )
+          })}
+          <MenuDivider />
+          <MenuItem onClick={() => console.log(place, "")}>
+            { place === "left" &&
+              t("DG.DataDisplayMenu.removeAttribute_y", { vars: [ attribute?.name ] })
+            }
+            { place === "bottom" &&
+              t("DG.DataDisplayMenu.removeAttribute_x", { vars: [ attribute?.name ] })
+            }
+          </MenuItem>
+          <MenuItem onClick={() => console.log(place, attrId, treatAs)}>
+            {treatAs === "categorical" && t("DG.DataDisplayMenu.treatAsCategorical")}
+            {treatAs === "numeric" && t("DG.DataDisplayMenu.treatAsNumeric")}
+          </MenuItem>
+        </MenuList>
+      </Menu>
+    </div>
+  )
+}
+
+
+
+/*
+import { Menu, MenuItem, MenuList, MenuButton, MenuDivider } from "@chakra-ui/react"
+import React, { CSSProperties } from "react"
+import { useDataSetContext } from "../../../hooks/use-data-set-context"
+import { AxisPlace, GraphPlace } from "../models/axis-model"
+import { useGraphLayoutContext} from "../models/graph-layout"
+import { measureText } from "../../../hooks/use-measure-text"
+import t from "../../../utilities/translation/translate"
+
+interface IProps {
+  attrId: string
+  place: GraphPlace,
+  onChangeAttr: (place: GraphPlace, attrId: string) => void
+  onTreatAttrAs: (place: GraphPlace, attrId: string, treatAs: string) => void
+}
+
+export const AxisAttributeMenu = ({ attrId, place, onChangeAttr, onTreatAttrAs }: IProps ) => {
+  const data = useDataSetContext()
+  const attribute = data?.attrFromID(attrId)
+  const treatAs = attribute?.type === "numeric" ? "categorical" : "numeric"
+  const layout = useGraphLayoutContext()
+  const { margin } = layout
+  const textLength = measureText(attribute?.name || "")
+
+  // TODO - replace with a more reliable calculation or way of placing button
+  const calcLeft = () => {
+    const bounds = layout.getAxisBounds(place as AxisPlace)
+    if (!bounds) return 0
+    return place === "left" ? -30 : (bounds.width * .5) - (textLength * .5) + margin.left - 5
+  }
+
+  const buttonStyles: CSSProperties = {
+    border: "1px dashed blue",  //only for debugging during development
+    opacity: 0.3,               //only for debugging during development
+    position: "absolute",
+    color: "transparent",
+    rotate: place === "left" ? "270deg" : "0deg",
+    top: place === "left" ? (.5 * layout.plotHeight) - (.2 * textLength) : layout.plotHeight + 20,
+    left: calcLeft()
+  }
+
+  return (
+    <div className="axis-attribute-menu">
+      <Menu>
+        <MenuButton style={{...buttonStyles }}>{attribute?.name}</MenuButton>
+        <MenuList>
+          { data?.attributes?.map((attr) => {
+            return (
+              <MenuItem onClick={() => onChangeAttr(place, attr.id)} key={attr.id}>
+                {attr.name}
+              </MenuItem>
+            )
+          })}
+          <MenuDivider />
+          <MenuItem onClick={() => onChangeAttr(place, "")}>
+            { place === "left" &&
+              t("DG.DataDisplayMenu.removeAttribute_y", { vars: [ attribute?.name ] })
+            }
+            { place === "bottom" &&
+              t("DG.DataDisplayMenu.removeAttribute_x", { vars: [ attribute?.name ] })
+            }
+          </MenuItem>
+          <MenuItem onClick={() => onTreatAttrAs(place, attrId, treatAs)}>
+            {treatAs === "categorical" && t("DG.DataDisplayMenu.treatAsCategorical")}
+            {treatAs === "numeric" && t("DG.DataDisplayMenu.treatAsNumeric")}
+          </MenuItem>
+        </MenuList>
+      </Menu>
+    </div>
+  )
+}
+
+*/

--- a/v3/src/components/graph/components/axis-attribute-menu.tsx
+++ b/v3/src/components/graph/components/axis-attribute-menu.tsx
@@ -11,11 +11,11 @@ interface IProps {
   place: GraphPlace,
   target: SVGGElement | null
   portal: HTMLElement | null
-  onChangeAttr: (place: GraphPlace, attrId: string) => void
+  onChangeAttribute: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
-export const AxisAttributeMenu = ({ place, target, portal, onChangeAttr, onTreatAttributeAs }: IProps ) => {
+export const AxisAttributeMenu = ({ place, target, portal, onChangeAttribute, onTreatAttributeAs }: IProps ) => {
   const data = useDataSetContext()
   const dataConfig = useDataConfigurationContext()
   const { plotWidth, plotHeight, margin } = useGraphLayoutContext()
@@ -38,7 +38,7 @@ export const AxisAttributeMenu = ({ place, target, portal, onChangeAttr, onTreat
         <MenuList>
           { data?.attributes?.map((attr) => {
             return (
-              <MenuItem onClick={() => onChangeAttr(place, attr.id)} key={attr.id}>
+              <MenuItem onClick={() => onChangeAttribute(place, attr.id)} key={attr.id}>
                 {attr.name}
               </MenuItem>
             )
@@ -46,7 +46,7 @@ export const AxisAttributeMenu = ({ place, target, portal, onChangeAttr, onTreat
           { attribute &&
             <>
               <MenuDivider />
-              <MenuItem onClick={() => onChangeAttr(place, "")}>
+              <MenuItem onClick={() => onChangeAttribute(place, "")}>
                 { place === "left" &&
                   t("DG.DataDisplayMenu.removeAttribute_y", {vars: [attribute?.name]})
                 }

--- a/v3/src/components/graph/components/axis-attribute-menu.tsx
+++ b/v3/src/components/graph/components/axis-attribute-menu.tsx
@@ -12,10 +12,10 @@ interface IProps {
   target: SVGGElement | null
   portal: HTMLElement | null
   onChangeAttr: (place: GraphPlace, attrId: string) => void
-  onTreatAttrAs: (place: GraphPlace, attrId: string, treatAs: string) => void
+  onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
-export const AxisAttributeMenu = ({ place, target, portal, onChangeAttr, onTreatAttrAs }: IProps ) => {
+export const AxisAttributeMenu = ({ place, target, portal, onChangeAttr, onTreatAttributeAs }: IProps ) => {
   const data = useDataSetContext()
   const dataConfig = useDataConfigurationContext()
   const { plotWidth, plotHeight, margin } = useGraphLayoutContext()
@@ -54,7 +54,7 @@ export const AxisAttributeMenu = ({ place, target, portal, onChangeAttr, onTreat
                   t("DG.DataDisplayMenu.removeAttribute_x", {vars: [attribute?.name]})
                 }
               </MenuItem>
-              <MenuItem onClick={() => onTreatAttrAs(place, attribute?.id, treatAs)}>
+              <MenuItem onClick={() => onTreatAttributeAs(place, attribute?.id, treatAs)}>
                 {treatAs === "categorical" && t("DG.DataDisplayMenu.treatAsCategorical")}
                 {treatAs === "numeric" && t("DG.DataDisplayMenu.treatAsNumeric")}
               </MenuItem>

--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -14,7 +14,6 @@ import {AxisDragRects} from "./axis-drag-rects"
 import {AxisAttributeMenu} from "./axis-attribute-menu"
 import t from "../../../utilities/translation/translate"
 import { createPortal } from "react-dom"
-import { useToast } from "@chakra-ui/react"
 
 import "./axis.scss"
 
@@ -39,8 +38,7 @@ export const Axis = ({attributeID, getAxisModel, transform, showGridLines, onDro
     scale = layout.axisScale(place),
     hintString = useDropHintString({ role: axisPlaceToAttrRole[place] }),
     [axisElt, setAxisElt] = useState<SVGGElement | null>(null),
-    titleRef = useRef<SVGGElement | null>(null),
-    toast = useToast()
+    titleRef = useRef<SVGGElement | null>(null)
 
   const {graphElt, wrapperElt, setWrapperElt} = useAxisBoundsProvider(place)
 
@@ -104,8 +102,6 @@ export const Axis = ({attributeID, getAxisModel, transform, showGridLines, onDro
       })
       observer.observe(axisElt)
     }
-
-    // occurs to me that we could use above to update some state getCLientBoundsRect(axisElt) and then pass that to the menu...
 
     return () => observer?.disconnect()
   }, [axisElt, place, halfRange, label, transform])

--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -23,10 +23,10 @@ interface IProps {
   transform: string
   showGridLines: boolean
   onDropAttribute: (place: AxisPlace, attrId: string) => void
-  onTreatAttrAs: (place: GraphPlace, attrId: string, treatAs: string) => void
+  onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
-export const Axis = ({attributeID, getAxisModel, transform, showGridLines, onDropAttribute, onTreatAttrAs}: IProps) => {
+export const Axis = ({attributeID, getAxisModel, transform, showGridLines, onDropAttribute, onTreatAttributeAs}: IProps) => {
   const
     instanceId = useInstanceIdContext(),
     dataset = useDataSetContext(),
@@ -119,7 +119,7 @@ export const Axis = ({attributeID, getAxisModel, transform, showGridLines, onDro
           portal={graphElt}
           place={place}
           onChangeAttr={onDropAttribute}
-          onTreatAttrAs={onTreatAttrAs}
+          onTreatAttributeAs={onTreatAttributeAs}
         />, graphElt)
       }
 

--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -26,7 +26,8 @@ interface IProps {
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
-export const Axis = ({attributeID, getAxisModel, transform, showGridLines, onDropAttribute, onTreatAttributeAs}: IProps) => {
+export const Axis = ({attributeID, getAxisModel, transform, showGridLines,
+  onDropAttribute, onTreatAttributeAs}: IProps) => {
   const
     instanceId = useInstanceIdContext(),
     dataset = useDataSetContext(),

--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -119,7 +119,7 @@ export const Axis = ({attributeID, getAxisModel, transform, showGridLines,
           target={titleRef.current}
           portal={graphElt}
           place={place}
-          onChangeAttr={onDropAttribute}
+          onChangeAttribute={onDropAttribute}
           onTreatAttributeAs={onTreatAttributeAs}
         />, graphElt)
       }

--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -1,5 +1,6 @@
 import {Active} from "@dnd-kit/core"
 import React, {useCallback, useEffect, useRef, useState} from "react"
+import {createPortal} from "react-dom"
 import {select} from "d3"
 import {DroppableAxis} from "./droppable-axis"
 import {useAxisBoundsProvider} from "../hooks/use-axis-bounds"
@@ -13,7 +14,7 @@ import {useGraphLayoutContext} from "../models/graph-layout"
 import {AxisDragRects} from "./axis-drag-rects"
 import {AxisAttributeMenu} from "./axis-attribute-menu"
 import t from "../../../utilities/translation/translate"
-import { createPortal } from "react-dom"
+
 
 import "./axis.scss"
 

--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -11,9 +11,11 @@ import {useAxis} from "../hooks/use-axis"
 import {AxisPlace, axisPlaceToAttrRole, IAxisModel, INumericAxisModel} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {AxisDragRects} from "./axis-drag-rects"
+import {AxisAttributeMenu} from "./axis-attribute-menu"
 import t from "../../../utilities/translation/translate"
 
 import "./axis.scss"
+import { createPortal } from "react-dom"
 
 interface IProps {
   getAxisModel: () => IAxisModel | undefined
@@ -101,6 +103,8 @@ export const Axis = ({attributeID, getAxisModel, transform, showGridLines, onDro
       observer.observe(axisElt)
     }
 
+    // occurs to me that we could use above to update some state getCLientBoundsRect(axisElt) and then pass that to the menu...
+
     return () => observer?.disconnect()
   }, [axisElt, place, halfRange, label, transform])
 
@@ -110,6 +114,11 @@ export const Axis = ({attributeID, getAxisModel, transform, showGridLines, onDro
         <g className='axis' ref={elt => setAxisElt(elt)} data-testid={`axis-${place}`}/>
         <g ref={titleRef}/>
       </g>
+
+      { graphElt &&
+        createPortal(<AxisAttributeMenu target={titleRef.current} portal={graphElt} place={place} />, graphElt)
+      }
+
       {axisModel?.type === 'numeric' ?
         <AxisDragRects axisModel={axisModel as INumericAxisModel} axisWrapperElt={wrapperElt}/> : null}
         <DroppableAxis

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -77,18 +77,20 @@ export const Graph = observer((
 
   const toast = useToast()
 
-  const handleDropAttribute = (place: GraphPlace, attrId: string) => {
+  const handleChangeAttribute = (place: GraphPlace, attrId: string ) => {
+    if (attrId === ""){ // when request is to remove the attribute
+      const toRemove = dataset?.attrFromID(graphModel.getAttributeID(graphPlaceToAttrPlace(place))).name
+      toast({
+        title: `Remove attribute`,
+        description:`remove ${toRemove} from graph`,
+        status: 'success', duration: 5000, isClosable: true,
+      })
+    }
     const computedPlace = place === 'plot' && graphModel.config.noAttributesAssigned ? 'bottom' : place
     const attrPlace = graphPlaceToAttrPlace(computedPlace)
-    const attrName = dataset?.attrFromID(attrId)?.name
-    toast({
-      position: "top-right",
-      title: "Attribute dropped",
-      description: `The attribute ${attrName || attrId} was dropped on the ${place} place!`,
-      status: "success"
-    })
     graphModel.setAttributeID(attrPlace, attrId)
   }
+
   // respond to assignment of new attribute ID
   useEffect(function handleNewAttributeID() {
     const disposer = graphModel && onAction(graphModel, action => {
@@ -101,6 +103,14 @@ export const Graph = observer((
     }, true)
     return () => disposer?.()
   }, [graphController, dataset, layout, enableAnimation, graphModel])
+
+  const handleTreatAttrAs = (place: GraphPlace, attrId: string, treatAs: string ) => {
+    toast({
+      title: `Treat attribute as`,
+      description:`treat ${dataset?.attrFromID(attrId).name} at the place ${place} as ${treatAs}`,
+      status: 'success', duration: 5000, isClosable: true,
+    })
+  }
 
   // We only need to make the following connection once
   useEffect(function passDotsRefToController() {
@@ -164,13 +174,15 @@ export const Graph = observer((
                 attributeID={yAttrID}
                 transform={`translate(${margin.left - 1}, 0)`}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
-                onDropAttribute={handleDropAttribute}
+                onDropAttribute={handleChangeAttribute}
+                onTreatAttrAs={handleTreatAttrAs}
           />
           <Axis getAxisModel={() => graphModel.getAxis('bottom')}
                 attributeID={xAttrID}
                 transform={`translate(${margin.left}, ${layout.plotHeight})`}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
-                onDropAttribute={handleDropAttribute}
+                onDropAttribute={handleChangeAttribute}
+                onTreatAttrAs={handleTreatAttrAs}
           />
 
           <svg ref={plotAreaSVGRef} className='graph-dot-area'>
@@ -181,7 +193,7 @@ export const Graph = observer((
           </svg>
 
           <DroppablePlot graphElt={graphRef.current} plotElt={backgroundSvgRef.current}
-                         onDropAttribute={handleDropAttribute}/>
+                         onDropAttribute={handleChangeAttribute}/>
           <Legend
             graphModel={graphModel}
             legendAttrID={graphModel.getAttributeID('legend')}

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -175,14 +175,14 @@ export const Graph = observer((
                 transform={`translate(${margin.left - 1}, 0)`}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
                 onDropAttribute={handleChangeAttribute}
-                onTreatAttrAs={handleTreatAttrAs}
+                onTreatAttributeAs={handleTreatAttrAs}
           />
           <Axis getAxisModel={() => graphModel.getAxis('bottom')}
                 attributeID={xAttrID}
                 transform={`translate(${margin.left}, ${layout.plotHeight})`}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
                 onDropAttribute={handleChangeAttribute}
-                onTreatAttrAs={handleTreatAttrAs}
+                onTreatAttributeAs={handleTreatAttrAs}
           />
 
           <svg ref={plotAreaSVGRef} className='graph-dot-area'>

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -78,7 +78,7 @@ export const Graph = observer((
   const toast = useToast()
 
   const handleChangeAttribute = (place: GraphPlace, attrId: string ) => {
-    if (attrId === ""){ // when request is to remove the attribute
+    if (!attrId){ // when request is to remove the attribute
       const toRemove = dataset?.attrFromID(graphModel.getAttributeID(graphPlaceToAttrPlace(place))).name
       toast({
         title: `Remove attribute`,


### PR DESCRIPTION
This pull request replaces #548 

1. The `axis-attribute-menu` is now instantiated on the `Axis` and is renderable "within" the svg area via a `portal`
2. Menu functionality:
 - change attribute - results in changing attribute
 - remove attribute - results in a toast with params
 - treat attribute as - results in a toast with params
3. On first load, bottom axis menu button requires calculation to arrive at the right spot, otherwise they leverage the new `useOverlayBounds` hook
4. Buttons are now fully invisible
5. Since a single `handleChangeAttribute` function is now set up for handling a removal and a change of an attribute, the instantiated `Axis` and `DroppableSvg` now include: ` onDropAttribute={handleChangeAttribute}`

