### PR TITLE
V3: Deselects row when in cell edit mode

### DIFF
--- a/v3/src/components/case-table/cell-text-editor.tsx
+++ b/v3/src/components/case-table/cell-text-editor.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react"
+import React, { useEffect, useRef } from "react"
 import { textEditorClassname } from "react-data-grid"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { TEditorProps } from "./case-table-types"
@@ -25,6 +25,10 @@ export default function CellTextEditor({ row, column, onRowChange, onClose }: TE
   const data = useDataSetContext()
   const initialValueRef = useRef(data?.getValue(row.__id__, column.key))
   const valueRef = useRef(initialValueRef.current)
+
+  useEffect(()=>{
+    data?.setSelectedCases([])
+  }, [data])
 
   const handleChange = (value: string) => {
     valueRef.current = value


### PR DESCRIPTION
Deselects current selected row when user is in cell edit mode.
Note that "Enter" and "Tab" just accepts changes of the currently selected cell and does not move to the next row/cell, which is the behavior in V2. The current behavior is the default behavior in react-data-grid.