### PR TITLE
Remove attribute menu item implementation

### DIFF
--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -78,14 +78,6 @@ export const Graph = observer((
   const toast = useToast()
 
   const handleChangeAttribute = (place: GraphPlace, attrId: string ) => {
-    if (!attrId){ // when request is to remove the attribute
-      const toRemove = dataset?.attrFromID(graphModel.getAttributeID(graphPlaceToAttrPlace(place))).name
-      toast({
-        title: `Remove attribute`,
-        description:`remove ${toRemove} from graph`,
-        status: 'success', duration: 5000, isClosable: true,
-      })
-    }
     const computedPlace = place === 'plot' && graphModel.config.noAttributesAssigned ? 'bottom' : place
     const attrPlace = graphPlaceToAttrPlace(computedPlace)
     graphModel.setAttributeID(attrPlace, attrId)

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -235,7 +235,7 @@ export const DataConfigurationModel = types
       }
     },
     setAttribute(role: GraphAttrRole, desc?: IAttributeDescriptionSnapshot) {
-      if (desc) {
+      if (desc && desc.attributeID !== '') {
         self.attributeDescriptions.set(role, desc)
       } else {
         self.attributeDescriptions.delete(role)

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -11,7 +11,7 @@ import {
   CategoricalAxisModel,
   ICategoricalAxisModel,
   INumericAxisModel,
-  NumericAxisModel, axisPlaceToAttrRole, attrRoleToAxisPlace, GraphPlace
+  NumericAxisModel, axisPlaceToAttrRole, attrRoleToAxisPlace, GraphPlace, IEmptyAxisModel
 } from "./axis-model"
 import {PlotType} from "../graphing-types"
 import {matchCirclesToData, setNiceDomain} from "../utilities/graph-utils"
@@ -182,6 +182,13 @@ export class GraphController {
         layout.setAxisScale(axisPlace, scaleBand())
       }
       layout.axisScale(axisPlace)?.domain(setOfValues)
+    }
+    else {  // attributeType is 'empty'
+      if( currentAxisType !== attributeType) {
+        const newAxisModel = EmptyAxisModel.create({place: axisPlace})
+        graphModel.setAxis(axisPlace, newAxisModel as IEmptyAxisModel)
+        layout.setAxisScale(axisPlace, scaleOrdinal())
+      }
     }
   }
 


### PR DESCRIPTION
Getting the **Remove Attribute** to behave properly required a few tweaks to deal with the situation in which an attribute ID is not present where it was before.