### PR TITLE
V3—Graph point animation fixes

### DIFF
--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -174,7 +174,7 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
       if (element.node()?.nodeName === 'circle') {
         const tItsID: string = element.property('id')
         const [, caseId] = tItsID.split("_")
-        dataset?.selectCases([caseId])
+        dataset?.setSelectedCases([caseId])
       }
     })
   })

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -52,7 +52,9 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
       if (target.current.node()?.nodeName === 'circle') {
         enableAnimation.current = false // We don't want to animate points until end of drag
         appState.beginPerformance()
-        target.current.transition()
+        target.current
+          .property('isDragging', true)
+          .transition()
           .attr('r', dragPointRadius)
         setDragID(() => tItsID)
         currPos.current = primaryIsBottom ? event.clientX : event.clientY
@@ -98,6 +100,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
       if (dragID !== '') {
         target.current
           .classed('dragging', false)
+          .property('isDragging', false)
           .transition()
           .attr('r', selectedPointRadius)
         setDragID('')
@@ -183,17 +186,13 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
         getSecondaryScreenCoord = (anID: string) => {
           return binMap[anID] ? computeSecondaryCoord(binMap[anID].category, binMap[anID].indexInBin) : null
         },
-        duration = enableAnimation.current ? transitionDuration : 0,
-        onComplete = enableAnimation.current ? () => {
-          enableAnimation.current = false
-        } : undefined,
         getScreenX = primaryIsBottom ? getPrimaryScreenCoord : getSecondaryScreenCoord,
         getScreenY = primaryIsBottom ? getSecondaryScreenCoord : getPrimaryScreenCoord,
         getLegendColor = dataConfiguration?.getLegendColorForCase
 
       setPointCoordinates({
         dataset, pointRadius, selectedPointRadius, dotsRef, selectedOnly,
-        getScreenX, getScreenY, getLegendColor, duration, onComplete
+        getScreenX, getScreenY, getLegendColor, enableAnimation
       })
     },
     [dataConfiguration?.cases, dataset, pointRadius, selectedPointRadius, dotsRef, enableAnimation,

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -1,7 +1,7 @@
 import {max, range, ScaleBand, select} from "d3"
 import {observer} from "mobx-react-lite"
 import React, {memo, useCallback, useRef, useState} from "react"
-import {transitionDuration, PlotProps}
+import {PlotProps}
   from "../graphing-types"
 import {useDragHandlers, usePlotResponders} from "../hooks/graph-hooks"
 import {appState} from "../../app-state"
@@ -196,7 +196,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
       })
     },
     [dataConfiguration?.cases, dataset, pointRadius, selectedPointRadius, dotsRef, enableAnimation,
-      primaryAttrID, secondaryAttrID, primaryLength, primaryIsBottom, primaryScale, secondaryScale,
+      legendAttrID, primaryAttrID, secondaryAttrID, primaryLength, primaryIsBottom, primaryScale, secondaryScale,
       dataConfiguration?.getLegendColorForCase])
 
   usePlotResponders({

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -188,7 +188,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
         },
         getScreenX = primaryIsBottom ? getPrimaryScreenCoord : getSecondaryScreenCoord,
         getScreenY = primaryIsBottom ? getSecondaryScreenCoord : getPrimaryScreenCoord,
-        getLegendColor = dataConfiguration?.getLegendColorForCase
+        getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined
 
       setPointCoordinates({
         dataset, pointRadius, selectedPointRadius, dotsRef, selectedOnly,

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -108,15 +108,19 @@ export const Graph = observer((
     graphController?.setDotsRef(dotsRef)
   }, [dotsRef, graphController])
 
+  function okToTransition( target: any) {
+    return target.node()?.nodeName === 'circle' && dataset && !active(target.node()) &&
+      !target.property('isDragging')
+  }
+
   // MouseOver events, if over an element, brings up hover text
   function showDataTip(event: MouseEvent) {
     const target = select(event.target as SVGSVGElement)
-    if (target.node()?.nodeName === 'circle' && dataset && !active(target.node()) &&
-        !target.property('isDragging')) {
+    if (okToTransition(target)) {
       target.transition().duration(transitionDuration).attr('r', hoverPointRadius)
       const [, caseID] = target.property('id').split("_"),
         attrIDs = graphModel.config.uniqueTipAttributes,
-        tipText = getPointTipText(dataset, caseID, attrIDs)
+        tipText = getPointTipText(caseID, attrIDs, dataset)
       tipText !== '' && dataTip.show(tipText, event.target)
     }
   }
@@ -124,8 +128,7 @@ export const Graph = observer((
   function hideDataTip(event: MouseEvent) {
     const target = select(event.target as SVGSVGElement)
     dataTip.hide()
-    if (target.node()?.nodeName === 'circle' && dataset && !active(target.node()) &&
-      !target.property('isDragging')) {
+    if (okToTransition(target)) {
       const [, caseID] = select(event.target as SVGSVGElement).property('id').split("_"),
         isSelected = dataset?.isCaseSelected(caseID)
       select(event.target as SVGSVGElement)

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -27,6 +27,7 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
     layout = useGraphLayoutContext(),
     primaryAttrID = dataConfiguration?.attributeID('x') as string,
     secondaryAttrID = dataConfiguration?.attributeID('y') as string,
+    legendAttrID = dataConfiguration?.attributeID('legend') as string,
     xScale = layout.axisScale("bottom") as ScaleNumericBaseType,
     yScale = layout.axisScale("left") as ScaleNumericBaseType,
     [dragID, setDragID] = useState(''),
@@ -133,10 +134,10 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
     const
       getScreenX = (anID: string) => getScreenCoord(dataset, anID, primaryAttrID, xScale),
       getScreenY = (anID: string) => getScreenCoord(dataset, anID, secondaryAttrID, yScale),
-      {getLegendColorForCase} = dataConfiguration || {}
+      getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined
 
     setPointCoordinates({dataset, dotsRef, pointRadius, selectedPointRadius, selectedOnly,
-      getScreenX, getScreenY, getLegendColor: getLegendColorForCase, enableAnimation})
+      getScreenX, getScreenY, getLegendColor, enableAnimation})
   }, [dataset, pointRadius, selectedPointRadius, dotsRef, primaryAttrID, xScale,
             secondaryAttrID, yScale, enableAnimation, dataConfiguration])
 

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -1,7 +1,7 @@
 import {select} from "d3"
 import React, {memo, useCallback, useRef, useState} from "react"
 import {appState} from "../../app-state"
-import {PlotProps, transitionDuration} from "../graphing-types"
+import {PlotProps} from "../graphing-types"
 import {useDragHandlers, usePlotResponders} from "../hooks/graph-hooks"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
@@ -43,7 +43,9 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
       const tItsID = target.current.property('id')
       if (target.current.node()?.nodeName === 'circle') {
         appState.beginPerformance()
-        target.current.transition()
+        target.current
+          .property('isDragging', true)
+          .transition()
           .attr('r', dragPointRadius)
         setDragID(tItsID)
         currPos.current = {x: event.clientX, y: event.clientY}
@@ -97,6 +99,7 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
       if (dragID !== '') {
         target.current
           .classed('dragging', false)
+          .property('isDragging', false)
           .transition()
           .attr('r', selectedPointRadius)
         setDragID(() => '')
@@ -130,14 +133,10 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
     const
       getScreenX = (anID: string) => getScreenCoord(dataset, anID, primaryAttrID, xScale),
       getScreenY = (anID: string) => getScreenCoord(dataset, anID, secondaryAttrID, yScale),
-      {getLegendColorForCase} = dataConfiguration || {},
-      duration = enableAnimation.current ? transitionDuration : 0,
-      onComplete = enableAnimation.current ? () => {
-        enableAnimation.current = false
-      } : undefined
+      {getLegendColorForCase} = dataConfiguration || {}
 
     setPointCoordinates({dataset, dotsRef, pointRadius, selectedPointRadius, selectedOnly,
-      getScreenX, getScreenY, getLegendColor: getLegendColorForCase, duration, onComplete})
+      getScreenX, getScreenY, getLegendColor: getLegendColorForCase, enableAnimation})
   }, [dataset, pointRadius, selectedPointRadius, dotsRef, primaryAttrID, xScale,
             secondaryAttrID, yScale, enableAnimation, dataConfiguration])
 

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -139,7 +139,7 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
     setPointCoordinates({dataset, dotsRef, pointRadius, selectedPointRadius, selectedOnly,
       getScreenX, getScreenY, getLegendColor, enableAnimation})
   }, [dataset, pointRadius, selectedPointRadius, dotsRef, primaryAttrID, xScale,
-            secondaryAttrID, yScale, enableAnimation, dataConfiguration])
+            secondaryAttrID, legendAttrID, yScale, enableAnimation, dataConfiguration])
 
   const refreshPointPositionsSVG = useCallback((selectedOnly: boolean) => {
     const { cases, selection } = dataConfiguration || {}

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -86,7 +86,7 @@ export function setNiceDomain(values: number[], axisModel: IAxisModel) {
   }
 }
 
-export function getPointTipText(dataset: IDataSet, caseID: string, attributeIDs: string[]) {
+export function getPointTipText(caseID: string, attributeIDs: string[], dataset?: IDataSet) {
   const float = format('.3~f'),
     attrArray = (attributeIDs.map(attrID => {
       const attribute = dataset?.attrFromID(attrID),


### PR DESCRIPTION
In transitions from one plot to another and in animation of dragged points back to their starting place, some points stop part way through.

* Part of the problem was that as points passed under the mouse they would trigger showing and hiding of the data tip. But the code for each of these contains point transitions of their own which cancel the transition that is in progress. So in show/hide data tip, we detect that the target is "active" (animating) and forgo the animation.

* But that isn't quite enough to fully fix things, so, at the end of an animation, we iterate through the points again *without* animation to guarantee that all points get to their destination.

Another problem I noticed was that the border of selected points when there was no legend the stroke for selected points during and after a drag was colored red with a width of 2 which was incorrect. The fix for this was to only pass to `setPointCoordinates` a function to get a legend color (`getLegendColor`) if there actually is a legend attribute.