### PR TITLE
V3—numeric-axis-animation—183689854

### DIFF
--- a/v3/src/components/graph/components/axis.tsx
+++ b/v3/src/components/graph/components/axis.tsx
@@ -1,5 +1,5 @@
 import {Active} from "@dnd-kit/core"
-import React, {useCallback, useEffect, useRef, useState} from "react"
+import React, {MutableRefObject, useCallback, useEffect, useRef, useState} from "react"
 import {createPortal} from "react-dom"
 import {select} from "d3"
 import {DroppableAxis} from "./droppable-axis"
@@ -22,13 +22,14 @@ interface IProps {
   getAxisModel: () => IAxisModel | undefined
   attributeID: string
   transform: string
+  enableAnimation: MutableRefObject<boolean>
   showGridLines: boolean
   onDropAttribute: (place: AxisPlace, attrId: string) => void
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
 export const Axis = ({attributeID, getAxisModel, transform, showGridLines,
-  onDropAttribute, onTreatAttributeAs}: IProps) => {
+  onDropAttribute, enableAnimation, onTreatAttributeAs}: IProps) => {
   const
     instanceId = useInstanceIdContext(),
     dataset = useDataSetContext(),
@@ -44,7 +45,7 @@ export const Axis = ({attributeID, getAxisModel, transform, showGridLines,
 
   const {graphElt, wrapperElt, setWrapperElt} = useAxisBoundsProvider(place)
 
-  useAxis({axisModel, axisElt, showGridLines})
+  useAxis({axisModel, axisElt, enableAnimation, showGridLines})
 
   useEffect(function setupTransform() {
     axisElt && select(axisElt)

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -173,6 +173,7 @@ export const Graph = observer((
           <Axis getAxisModel={() => graphModel.getAxis('left')}
                 attributeID={yAttrID}
                 transform={`translate(${margin.left - 1}, 0)`}
+                enableAnimation={enableAnimation}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
                 onDropAttribute={handleChangeAttribute}
                 onTreatAttributeAs={handleTreatAttrAs}
@@ -180,6 +181,7 @@ export const Graph = observer((
           <Axis getAxisModel={() => graphModel.getAxis('bottom')}
                 attributeID={xAttrID}
                 transform={`translate(${margin.left}, ${layout.plotHeight})`}
+                enableAnimation={enableAnimation}
                 showGridLines={graphModel.plotType === 'scatterPlot'}
                 onDropAttribute={handleChangeAttribute}
                 onTreatAttributeAs={handleTreatAttrAs}

--- a/v3/src/components/graph/hooks/use-axis.test.tsx
+++ b/v3/src/components/graph/hooks/use-axis.test.tsx
@@ -3,35 +3,37 @@ import { renderHook } from "@testing-library/react"
 import React from "react"
 import { INumericAxisModel, NumericAxisModel } from "../models/axis-model"
 import { GraphLayout, GraphLayoutContext } from "../models/graph-layout"
-import { useAxis } from "./use-axis"
+import {IUseAxis, useAxis} from "./use-axis"
 
 describe("useNumericAxis", () => {
 
   let layout: GraphLayout
   let axisModel: INumericAxisModel
   let axisElt: SVGGElement
+  let useAxisOptions: IUseAxis
 
   beforeEach(() => {
     layout = new GraphLayout()
     axisModel = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
     axisElt = document.createElementNS("http://www.w3.org/2000/svg", "g")
+    useAxisOptions = { axisModel, axisElt, enableAnimation: { current: false }, showGridLines: false }
   })
 
   it("renders a simple horizontal axis", () => {
-    renderHook(() => useAxis({ axisModel, axisElt, showGridLines:false }))
+    renderHook(() => useAxis(useAxisOptions))
     expect(axisElt.querySelector(".axis")).toBeDefined()
     expect(axisElt.querySelector(".tick")).toBeDefined()
   })
 
   it("renders a simple vertical axis", () => {
     axisModel = NumericAxisModel.create({ place: "left", min: 0, max: 10 })
-    renderHook(() => useAxis({ axisModel, axisElt, showGridLines:false }))
+    renderHook(() => useAxis(useAxisOptions))
     expect(axisElt.querySelector(".axis")).toBeDefined()
     expect(axisElt.querySelector(".tick")).toBeDefined()
   })
 
   it("updates scale when axis domain changes", () => {
-    renderHook(() => useAxis({ axisModel, axisElt, showGridLines:false }), {
+    renderHook(() => useAxis(useAxisOptions), {
       wrapper: ({ children }) => (
         <GraphLayoutContext.Provider value={layout}>
           {children}
@@ -43,7 +45,7 @@ describe("useNumericAxis", () => {
   })
 
   it("updates scale when axis range changes", () => {
-    renderHook(() => useAxis({ axisModel, axisElt, showGridLines:false }), {
+    renderHook(() => useAxis(useAxisOptions), {
       wrapper: ({ children }) => (
         <GraphLayoutContext.Provider value={layout}>
           {children}
@@ -55,7 +57,7 @@ describe("useNumericAxis", () => {
   })
 
   it("can switch between linear/log axes", () => {
-    renderHook(() => useAxis({ axisModel, axisElt, showGridLines:false }))
+    renderHook(() => useAxis(useAxisOptions))
     axisModel.setScale("log")
     expect(axisElt.querySelector(".axis")).toBeDefined()
     expect(axisElt.querySelector(".tick")).toBeDefined()


### PR DESCRIPTION
* By passing enableAnimation to the Axis component and then down to useAxis the decision can be made in refreshAxis about whether to animate.

Note that enableAnimation.current is set to true anytime the plot changes. Thus the rule becomes "Axes animate when points animate."