### PR TITLE
V3—Handle legend value change

### DIFF
--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -87,6 +87,41 @@ export const CategoricalLegend = memo(function CategoricalLegend(
       return lod.numRows * (keySize + padding) + labelHeight
     }, [computeLayout, legendLabelRef]),
 
+    setupKeys = useCallback(() => {
+      categoriesRef.current = dataConfiguration?.categorySetForAttrRole('legend')
+      const numCategories = categoriesRef.current?.size
+      if (keysElt && categoryData.current) {
+        select(keysElt).selectAll('key').remove() // start fresh
+
+        const keysSelection = select(keysElt)
+          .selectAll('g')
+          .data(range(0, numCategories ?? 0))
+          .join(
+            enter => enter
+              .append('g')
+              .attr('class', 'key')
+          )
+        keysSelection.each(function (d, n, group) {
+          const sel = select(this),
+            size = sel.selectAll('rect').size()
+          if (size === 0) {
+            sel.append('rect')
+              .attr('width', keySize)
+              .attr('height', keySize)
+              .on('click',
+                (event, i: number) => {
+                  dataConfiguration?.selectCasesForLegendValue(categoryData.current[i].category, event.shiftKey)
+                })
+            sel.append('text')
+              .on('click',
+                (event, i: number) => {
+                  dataConfiguration?.selectCasesForLegendValue(categoryData.current[i].category, event.shiftKey)
+                })
+          }
+        })
+      }
+    }, [dataConfiguration, keysElt]),
+
     refreshKeys = useCallback(() => {
       categoriesRef.current = dataConfiguration?.categorySetForAttrRole('legend')
       const numCategories = categoriesRef.current?.size
@@ -132,6 +167,20 @@ export const CategoricalLegend = memo(function CategoricalLegend(
     return disposer
   }, [refreshKeys, dataset])
 
+  useEffect(function respondToCategorySetsChange() {
+    const disposer = reaction(
+      () => {
+        const sets = dataConfiguration?.categorySets
+        return [sets?.size]
+      },
+      () => {
+        layout.setDesiredExtent('legend', computeDesiredExtent())
+        setupKeys()
+        refreshKeys()
+      }, {})
+    return disposer
+  }, [setupKeys, refreshKeys, dataConfiguration, layout, computeDesiredExtent])
+
   useEffect(function respondToLayoutChange() {
     const disposer = reaction(
       () => {
@@ -148,40 +197,11 @@ export const CategoricalLegend = memo(function CategoricalLegend(
   }, [layout, refreshKeys, computeDesiredExtent, dataConfiguration])
 
   useEffect(function setup() {
-    categoriesRef.current = dataConfiguration?.categorySetForAttrRole('legend')
-    const numCategories = categoriesRef.current?.size
     if (keysElt && categoryData.current) {
-      select(keysElt).selectAll('key').remove() // start fresh
-
-      const keysSelection = select(keysElt)
-        .selectAll('g')
-        .data(range(0, numCategories ?? 0))
-        .join(
-          enter => enter
-            .append('g')
-            .attr('class', 'key')
-        )
-      keysSelection.each(function (d, n, group) {
-        const sel = select(this),
-          size = sel.selectAll('rect').size()
-        if (size === 0) {
-          sel.append('rect')
-            .attr('width', keySize)
-            .attr('height', keySize)
-            .on('click',
-              (event, i: number) => {
-                dataConfiguration?.selectCasesForLegendValue(categoryData.current[i].category, event.shiftKey)
-              })
-          sel.append('text')
-            .on('click',
-              (event, i: number) => {
-                dataConfiguration?.selectCasesForLegendValue(categoryData.current[i].category, event.shiftKey)
-              })
-        }
-      })
+      setupKeys()
       refreshKeys()
     }
-  }, [keysElt, categoryData, refreshKeys, dataConfiguration])
+  }, [keysElt, categoryData, setupKeys, refreshKeys, dataConfiguration])
 
   return (
     <svg className='categories' ref={elt => setKeysElt(elt)}></svg>

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -169,15 +169,12 @@ export const CategoricalLegend = memo(function CategoricalLegend(
 
   useEffect(function respondToCategorySetsChange() {
     const disposer = reaction(
-      () => {
-        const sets = dataConfiguration?.categorySets
-        return [sets?.size]
-      },
+      () => dataConfiguration?.categorySetForAttrRole('legend'),
       () => {
         layout.setDesiredExtent('legend', computeDesiredExtent())
         setupKeys()
         refreshKeys()
-      }, {})
+      })
     return disposer
   }, [setupKeys, refreshKeys, dataConfiguration, layout, computeDesiredExtent])
 

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -1,3 +1,4 @@
+import {observable} from "mobx"
 import {Instance, ISerializedActionCall, onAction, SnapshotIn, types} from "mobx-state-tree"
 import {AttributeType, attributeTypes} from "../../../models/data/attribute"
 import {IDataSet} from "../../../models/data/data-set"
@@ -43,7 +44,7 @@ export const DataConfigurationModel = types
     actionHandlerDisposer: undefined as (() => void) | undefined,
     filteredCases: undefined as FilteredCases | undefined,
     handlers: new Map<string,(actionCall: ISerializedActionCall) => void>(),
-    categorySets: new Map<GraphAttrRole, Set<string> | null>
+    categorySets: observable.map<string | null>()
   }))
   .views(self => ({
     get defaultCaptionAttributeID() {
@@ -69,6 +70,11 @@ export const DataConfigurationModel = types
       self.dataset?.attributes.length && places.add("caption")
       return Array.from(places) as GraphAttrRole[]
     }
+  }))
+  .actions(self => ({
+    clearCategorySets() {
+      self.categorySets.clear()
+    },
   }))
   .views(self => ({
     filterCase(data: IDataSet, caseID: string) {
@@ -116,7 +122,7 @@ export const DataConfigurationModel = types
           }
         })
       } else {
-        self.categorySets.clear()
+        self.clearCategorySets()
       }
     }
   }))

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -44,7 +44,7 @@ export const DataConfigurationModel = types
     actionHandlerDisposer: undefined as (() => void) | undefined,
     filteredCases: undefined as FilteredCases | undefined,
     handlers: new Map<string,(actionCall: ISerializedActionCall) => void>(),
-    categorySets: observable.map<string | null>()
+    categorySets: observable.map<GraphAttrRole, Set<string> | null>()
   }))
   .views(self => ({
     get defaultCaptionAttributeID() {
@@ -96,6 +96,7 @@ export const DataConfigurationModel = types
       self.handlers.forEach(handler => handler(actionCall))
     },
     handleSetCaseValues(actionCall: SetCaseValuesAction, cases: IFilteredChangedCases) {
+      let [affectedCases, affectedAttrIDs] = actionCall.args
       // this is called by the FilteredCases object with additional information about
       // whether the value changes result in adding/removing any cases from the filtered set
       // a single call to setCaseValues can result in up to three calls to the handlers
@@ -108,17 +109,19 @@ export const DataConfigurationModel = types
       }
       if (cases.changed.length) {
         const idSet = new Set(cases.changed)
-        const changedCases = actionCall.args[0].filter(aCase => idSet.has(aCase.__id__))
+        const changedCases = affectedCases.filter(aCase => idSet.has(aCase.__id__))
         self.handlers.forEach(handler => handler({name: "setCaseValues", args: [changedCases]}))
       }
       // Changes to case values require that existing cached categorySets be wiped.
       // But if we know the ids of the attributes involved, we can determine whether
       // an attribute that has a cache is involved
-      const attrIDs = actionCall.args[1]
-      if (attrIDs) {
-        self.attributeDescriptions.forEach((value, key) => {
-          if (attrIDs.includes(value.attributeID)) {
-            self.categorySets.set(key as GraphAttrRole, null)
+      if (!affectedAttrIDs && affectedCases.length === 1) {
+        affectedAttrIDs = Object.keys(affectedCases[0])
+      }
+      if (affectedAttrIDs) {
+        self.attributeDescriptions.forEach((desc, key: GraphAttrRole) => {
+          if (affectedAttrIDs.includes(desc.attributeID)) {
+            self.categorySets.set(key, null)
           }
         })
       } else {


### PR DESCRIPTION
* We can now observe a data configuration model's categorySets. Changing a case value triggers clearing of the category sets which is observed by the legend, which responds by rebuilding its layout.