### PR TITLE
V3—brush palette changes tied to graph model

### DIFF
--- a/v3/src/components/graph/components/background.tsx
+++ b/v3/src/components/graph/components/background.tsx
@@ -1,4 +1,5 @@
-import React, {forwardRef, MutableRefObject, useCallback, useEffect, useRef} from "react"
+import {onAction} from "mobx-state-tree"
+import React, {forwardRef, MutableRefObject, useEffect, useRef} from "react"
 import {drag, select} from "d3"
 import RTree from 'rtree'
 import {InternalizedData, Point, rTreeRect} from "../graphing-types"
@@ -9,48 +10,45 @@ import {useCurrent} from "../../../hooks/use-current"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {MarqueeState} from "../models/marquee-state"
 import {useGraphModelContext} from "../models/graph-model"
-import {onAction} from "mobx-state-tree"
 
 interface IProps {
   marqueeState: MarqueeState
 }
 
-const prepareTree = (areaSelector: string, circleSelector: string, offset:Point): typeof RTree => {
-  const selectionTree = RTree(10)
-  select(areaSelector).selectAll(circleSelector)
-    .each((datum: InternalizedData, index, groups) => {
-      const element: any = groups[index],
-        rect = {
-          x: Number(element.cx.baseVal.value) + offset.x,
-          y: Number(element.cy.baseVal.value) + offset.y,
-          w: 1, h: 1
-        }
-      selectionTree.insert(rect, element.__data__)
-    })
-  // @ts-expect-error fromJSON
-  return selectionTree
-},
+const prepareTree = (areaSelector: string, circleSelector: string, offset: Point): typeof RTree => {
+    const selectionTree = RTree(10)
+    select(areaSelector).selectAll(circleSelector)
+      .each((datum: InternalizedData, index, groups) => {
+        const element: any = groups[index],
+          rect = {
+            x: Number(element.cx.baseVal.value) + offset.x,
+            y: Number(element.cy.baseVal.value) + offset.y,
+            w: 1, h: 1
+          }
+        selectionTree.insert(rect, element.__data__)
+      })
+    // @ts-expect-error fromJSON
+    return selectionTree
+  },
 
-getCasesForDelta = (tree: any, newRect: rTreeRect, prevRect: rTreeRect) => {
-  const diffRects = rectangleSubtract(newRect, prevRect)
-  let caseIDs: string[] = []
-  diffRects.forEach(aRect => {
-    const newlyFoundIDs = tree.search(aRect)
-    caseIDs = caseIDs.concat(newlyFoundIDs)
-  })
-  return caseIDs
-}
+  getCasesForDelta = (tree: any, newRect: rTreeRect, prevRect: rTreeRect) => {
+    const diffRects = rectangleSubtract(newRect, prevRect)
+    let caseIDs: string[] = []
+    diffRects.forEach(aRect => {
+      const newlyFoundIDs = tree.search(aRect)
+      caseIDs = caseIDs.concat(newlyFoundIDs)
+    })
+    return caseIDs
+  }
 
 export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
-  const {marqueeState } = props,
+  const {marqueeState} = props,
     dataset = useCurrent(useDataSetContext()),
     layout = useGraphLayoutContext(),
     graphModel = useGraphModelContext(),
     bounds = layout.computedBounds.get('plot') as Bounds,
     plotWidth = bounds.width,
     plotHeight = bounds.height,
-    backgroundColor = graphModel.plotBackgroundColor,
-    isTransparent = graphModel.isTransparent,
     transform = `translate(${bounds.left}, ${bounds.top})`,
     bgRef = ref as MutableRefObject<SVGGElement | null>,
     startX = useRef(0),
@@ -58,62 +56,61 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
     width = useRef(0),
     height = useRef(0),
     selectionTree = useRef<typeof RTree | null>(null),
-    previousMarqueeRect = useRef<rTreeRect>(),
+    previousMarqueeRect = useRef<rTreeRect>()
 
-    onDragStart = useCallback((event:{ x: number; y: number; sourceEvent: {shiftKey: boolean} }) => {
-      const { computedBounds } = layout,
-      plotBounds = computedBounds.get('plot') as Bounds
-      appState.beginPerformance()
-      selectionTree.current = prepareTree('.graph-dot-area', 'circle',
-        {x: plotBounds.left, y: plotBounds.top})
-      startX.current = event.x
-      startY.current = event.y
-      width.current = 0
-      height.current = 0
-      if( !event.sourceEvent.shiftKey) {
-        dataset.current?.setSelectedCases([])
-      }
-      marqueeState.setMarqueeRect({x: event.x, y: event.y, width: 0, height: 0})
-    }, [dataset, marqueeState, layout]),
+  useEffect(() => {
+    const onDragStart = (event: { x: number; y: number; sourceEvent: { shiftKey: boolean } }) => {
+        const {computedBounds} = layout,
+          plotBounds = computedBounds.get('plot') as Bounds
+        appState.beginPerformance()
+        selectionTree.current = prepareTree('.graph-dot-area', 'circle',
+          {x: plotBounds.left, y: plotBounds.top})
+        startX.current = event.x
+        startY.current = event.y
+        width.current = 0
+        height.current = 0
+        if (!event.sourceEvent.shiftKey) {
+          dataset.current?.setSelectedCases([])
+        }
+        marqueeState.setMarqueeRect({x: event.x, y: event.y, width: 0, height: 0})
+      },
 
-    onDrag = useCallback((event: { dx: number; dy: number }) => {
-      if (event.dx !== 0 || event.dy !== 0) {
-        previousMarqueeRect.current = rectNormalize(
-          {x: startX.current, y: startY.current, w: width.current, h: height.current})
-        width.current = width.current + event.dx
-        height.current = height.current + event.dy
-        const marqueeRect = marqueeState.marqueeRect
-        marqueeState.setMarqueeRect( {
+      onDrag = (event: { dx: number; dy: number }) => {
+        if (event.dx !== 0 || event.dy !== 0) {
+          previousMarqueeRect.current = rectNormalize(
+            {x: startX.current, y: startY.current, w: width.current, h: height.current})
+          width.current = width.current + event.dx
+          height.current = height.current + event.dy
+          const marqueeRect = marqueeState.marqueeRect
+          marqueeState.setMarqueeRect({
             x: marqueeRect.x, y: marqueeRect.y,
             width: marqueeRect.width + event.dx,
             height: marqueeRect.height + event.dy
           })
-        const currentRect = rectNormalize({
-            x: startX.current, y: startY.current,
-            w: width.current,
-            h: height.current
-          }),
-          newSelection = getCasesForDelta(selectionTree.current, currentRect, previousMarqueeRect.current),
-          newDeselection = getCasesForDelta(selectionTree.current, previousMarqueeRect.current, currentRect)
-        newSelection.length && dataset.current?.selectCases(newSelection, true)
-        newDeselection.length && dataset.current?.selectCases(newDeselection, false)
-      }
-    }, [dataset, marqueeState]),
+          const currentRect = rectNormalize({
+              x: startX.current, y: startY.current,
+              w: width.current,
+              h: height.current
+            }),
+            newSelection = getCasesForDelta(selectionTree.current, currentRect, previousMarqueeRect.current),
+            newDeselection = getCasesForDelta(selectionTree.current, previousMarqueeRect.current, currentRect)
+          newSelection.length && dataset.current?.selectCases(newSelection, true)
+          newDeselection.length && dataset.current?.selectCases(newDeselection, false)
+        }
+      },
 
-    onDragEnd = useCallback(() => {
-      marqueeState.setMarqueeRect({x: 0, y: 0, width: 0, height: 0})
-      selectionTree.current = null
-      appState.endPerformance()
-    }, [marqueeState])
-
-  useEffect(() => {
-    const dragBehavior = drag()
+      onDragEnd = () => {
+        marqueeState.setMarqueeRect({x: 0, y: 0, width: 0, height: 0})
+        selectionTree.current = null
+        appState.endPerformance()
+      },
+      dragBehavior = drag()
         .on("start", onDragStart)
         .on("drag", onDrag)
         .on("end", onDragEnd),
       groupElement = bgRef.current
     select(groupElement).on('click', (event) => {
-      if( !event.shiftKey) {
+      if (!event.shiftKey) {
         dataset.current?.selectAll(false)
       }
     })
@@ -134,17 +131,16 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
             .attr('height', plotHeight)
             .attr('x', 0)
             .attr('y', 0)
-            .style('fill', backgroundColor)
-            .style('fill-opacity', isTransparent ? 0 : 1)
+            .style('fill', graphModel.plotBackgroundColor)
+            .style('fill-opacity', graphModel.isTransparent ? 0 : 1)
         }
       )
-  }, [bgRef, transform, dataset, onDrag, onDragEnd, onDragStart, plotHeight, plotWidth,
-    backgroundColor, isTransparent])
+  }, [bgRef, transform, dataset, plotHeight, plotWidth, graphModel, layout, marqueeState])
 
   // respond to point properties change
   useEffect(function respondToGraphPointVisualAction() {
     const disposer = onAction(graphModel, action => {
-      if (['setPlotBackgroundColor', 'setIsTransparent'].includes(action.name) ) {
+      if (['setPlotBackgroundColor', 'setIsTransparent'].includes(action.name)) {
         select(bgRef.current).selectAll('rect')
           .style('fill', graphModel.plotBackgroundColor)
           .style('fill-opacity', graphModel.isTransparent ? 0 : 1)

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -25,9 +25,7 @@ export const CaseDots = memo(function CaseDots(props: {
     legendAttrID = dataConfiguration?.attributeID('legend'),
     layout = useGraphLayoutContext(),
     randomPointsRef = useRef<Record<string, { x: number, y: number }>>({}),
-    selectedPointRadius = graphModel.getPointRadius('select'),
     dragPointRadius = graphModel.getPointRadius('hover-drag'),
-    {pointColor, pointStrokeColor} = graphModel,
     [dragID, setDragID] = useState(''),
     currPos = useRef({x: 0, y: 0}),
     target = useRef<any>(),
@@ -71,20 +69,22 @@ export const CaseDots = memo(function CaseDots(props: {
         target.current
           .classed('dragging', false)
           .transition()
-          .attr('r', selectedPointRadius)
+          .attr('r', graphModel.getPointRadius('select'))
         setDragID(() => '')
         target.current = null
       }
-    }, [selectedPointRadius, dragID])
+    }, [dragID, graphModel])
 
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
   const refreshPointSelection = useCallback(() => {
+    const {pointColor, pointStrokeColor} = graphModel,
+      selectedPointRadius = graphModel.getPointRadius('select')
     dataConfiguration && setPointSelection({
       dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(), selectedPointRadius,
       pointColor, pointStrokeColor
     })
-  }, [dataConfiguration, graphModel, dotsRef, selectedPointRadius, pointColor, pointStrokeColor])
+  }, [dataConfiguration, graphModel, dotsRef])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
     const
@@ -111,14 +111,14 @@ export const CaseDots = memo(function CaseDots(props: {
         return yMax + pointRadius + randomPointsRef.current[anID].y * (yMin - yMax - 2 * pointRadius)
       })
       .style('fill', (anID: string) => {
-        return (legendAttrID && anID && dataConfiguration?.getLegendColorForCase(anID)) ?? pointColor
+        return (legendAttrID && anID && dataConfiguration?.getLegendColorForCase(anID)) ?? graphModel.pointColor
       })
       .style('stroke', (id: string) => (legendAttrID && dataset?.isCaseSelected(id)) ?
         defaultSelectedStroke : graphModel.pointStrokeColor)
       .style('stroke-width', (id: string) => (legendAttrID && dataset?.isCaseSelected(id)) ?
         defaultSelectedStrokeWidth : defaultStrokeWidth)
       .attr('r', (anID: string) => pointRadius + (dataset?.isCaseSelected(anID) ? pointRadiusSelectionAddend : 0))
-  }, [dataset, legendAttrID, dataConfiguration, graphModel, pointColor,
+  }, [dataset, legendAttrID, dataConfiguration, graphModel,
     layout, dotsRef, enableAnimation, xScale, yScale])
 
   useEffect(function initDistribution() {

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -6,19 +6,16 @@ import {useDataConfigurationContext} from "../hooks/use-data-configuration-conte
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {Bounds, useGraphLayoutContext} from "../models/graph-layout"
 import {setPointSelection} from "../utilities/graph-utils"
-import {IGraphModel} from "../models/graph-model"
+import {useGraphModelContext} from "../models/graph-model"
 import {attrRoleToAxisPlace} from "../models/axis-model"
-import {defaultPointColor, defaultSelectedColor} from "../../../utilities/color-utils"
-
-interface IProps {
-  graphModel: IGraphModel
-  plotProps: PlotProps
-}
+import {defaultSelectedColor} from "../../../utilities/color-utils"
 
 type BinMap = Record<string, Record<string, number>>
 
-export const ChartDots = memo(function ChartDots(props: IProps) {
-  const {graphModel, plotProps: {dotsRef, enableAnimation}} = props,
+export const ChartDots = memo(function ChartDots(props: PlotProps) {
+  const { dotsRef, enableAnimation} = props,
+    graphModel= useGraphModelContext(),
+    {pointColor, pointStrokeColor} = graphModel,
     dataConfiguration = useDataConfigurationContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
@@ -62,11 +59,10 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
   }, [dataset, dataConfiguration?.cases, primaryAttrID, secondaryAttrID])
 
   const refreshPointSelection = useCallback(() => {
-    dataConfiguration && setPointSelection({
-      dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(),
-      selectedPointRadius: graphModel.getPointRadius('select')
+    dataConfiguration && setPointSelection({ pointColor, pointStrokeColor, dotsRef, dataConfiguration,
+      pointRadius: graphModel.getPointRadius(), selectedPointRadius: graphModel.getPointRadius('select')
     })
-  }, [dataConfiguration, dotsRef, graphModel])
+  }, [dataConfiguration, dotsRef, graphModel, pointColor, pointStrokeColor])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
     // We're pretending that the primaryPlace is the bottom just to help understand the naming
@@ -131,7 +127,7 @@ export const ChartDots = memo(function ChartDots(props: IProps) {
         const isSelected = dataset?.isCaseSelected(id),
           legendColor = getLegendColor?.(id) ?? ''
         return legendColor !== '' ? legendColor :
-          isSelected ? defaultSelectedColor : defaultPointColor
+          isSelected ? defaultSelectedColor : graphModel.pointColor
       },
       onComplete = () => {
         if (enableAnimation.current) {

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -1,8 +1,7 @@
 import {max, range, ScaleBand, select} from "d3"
 import {observer} from "mobx-react-lite"
 import React, {memo, useCallback, useRef, useState} from "react"
-import {PlotProps}
-  from "../graphing-types"
+import {PlotProps} from "../graphing-types"
 import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {appState} from "../../app-state"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
@@ -10,16 +9,12 @@ import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {Bounds, ScaleNumericBaseType, useGraphLayoutContext} from "../models/graph-layout"
 import {ICase} from "../../../models/data/data-set"
 import {getScreenCoord, handleClickOnDot, setPointCoordinates, setPointSelection} from "../utilities/graph-utils"
-import {IGraphModel} from "../models/graph-model"
 import {attrRoleToAxisPlace} from "../models/axis-model"
+import {useGraphModelContext} from "../models/graph-model"
 
-interface IProps {
-  graphModel: IGraphModel
-  plotProps: PlotProps
-}
-
-export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
-  const {graphModel, plotProps: {dotsRef, enableAnimation}} = props,
+export const DotPlotDots = memo(observer(function DotPlotDots(props: PlotProps) {
+  const {dotsRef, enableAnimation} = props,
+    graphModel = useGraphModelContext(),
     dataConfiguration = useDataConfigurationContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
@@ -41,7 +36,8 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
     selectedDataObjects = useRef<Record<string, number>>({}),
     pointRadius = graphModel.getPointRadius(),
     selectedPointRadius = graphModel.getPointRadius('select'),
-    dragPointRadius = graphModel.getPointRadius('hover-drag')
+    dragPointRadius = graphModel.getPointRadius('hover-drag'),
+    { pointColor, pointStrokeColor } = graphModel
 
 
   const onDragStart = useCallback((event: any) => {
@@ -124,10 +120,10 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
   const refreshPointSelection = useCallback(() => {
-    dataConfiguration && setPointSelection({
+    dataConfiguration && setPointSelection({ pointColor, pointStrokeColor,
       dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(), selectedPointRadius
     })
-  }, [dataConfiguration, dotsRef, graphModel, selectedPointRadius])
+  }, [dataConfiguration, dotsRef, graphModel, selectedPointRadius, pointColor, pointStrokeColor])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
       const
@@ -178,7 +174,7 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
 
       const
         // Note that we can get null for either or both of the next two functions. It just means that we have
-        // a circle for the case but we're not plotting it.
+        // a circle for the case, but we're not plotting it.
         getPrimaryScreenCoord = (anID: string) => {
           return getScreenCoord(dataset, anID, primaryAttrID, primaryScale)
         },
@@ -191,13 +187,13 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: IProps) {
         plotBounds = layout.computedBounds.get('plot') as Bounds
 
       setPointCoordinates({
-        dataset, pointRadius, selectedPointRadius, dotsRef, selectedOnly,
+        dataset, pointRadius, selectedPointRadius, dotsRef, selectedOnly, pointColor, pointStrokeColor,
         getScreenX, getScreenY, getLegendColor, enableAnimation, plotBounds
       })
     },
     [dataConfiguration?.cases, dataset, pointRadius, selectedPointRadius, dotsRef, enableAnimation,
       legendAttrID, primaryAttrID, secondaryAttrID, primaryLength, primaryIsBottom, primaryScale, secondaryScale,
-      dataConfiguration?.getLegendColorForCase, layout.computedBounds])
+      dataConfiguration?.getLegendColorForCase, layout.computedBounds, pointColor, pointStrokeColor])
 
   usePlotResponders({
     graphModel, primaryAttrID, secondaryAttrID, legendAttrID, layout, dotsRef,

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -10,10 +10,22 @@ import {kTitleBarHeight} from "../graphing-types"
 import {EmptyAxisModel} from "../models/axis-model"
 import {DataConfigurationModel} from "../models/data-configuration-model"
 import {GraphLayout, GraphLayoutContext} from "../models/graph-layout"
-import {GraphModel} from "../models/graph-model"
+import {GraphModel, GraphModelContext} from "../models/graph-model"
 import {Graph} from "./graph"
+import {defaultBackgroundColor, defaultPointColor, defaultStrokeColor} from "../../../utilities/color-utils"
 
 const defaultGraphModel = GraphModel.create({
+  id: undefined,
+  isTransparent: false,
+  plotBackgroundColor: defaultBackgroundColor,
+  plotBackgroundImageID: '',
+  plotBackgroundLockInfo: undefined,
+  pointColor: defaultPointColor,
+  pointSizeMultiplier: 1,
+  _pointStrokeColor: defaultStrokeColor,
+  pointStrokeSameAsFill: false,
+  showMeasuresForSelection: false,
+  showParentToggles: false,
   axes: {
     bottom: EmptyAxisModel.create({place: 'bottom'}),
     left: EmptyAxisModel.create({place: 'left'})
@@ -45,18 +57,19 @@ export const GraphComponent = observer(({broker}: IProps) => {
   setNodeRef(graphRef.current)
 
   return (
-      <DataSetContext.Provider value={dataset}>
-        <InstanceIdContext.Provider value={instanceId}>
-          <GraphLayoutContext.Provider value={layout}>
-            <Graph model={defaultGraphModel}
-              graphRef={graphRef}
-              enableAnimation={enableAnimation}
-              dotsRef={dotsRef}
-              showInspector={showInspector}
-              setShowInspector={setShowInspector}
+    <DataSetContext.Provider value={dataset}>
+      <InstanceIdContext.Provider value={instanceId}>
+        <GraphLayoutContext.Provider value={layout}>
+          <GraphModelContext.Provider value={defaultGraphModel}>
+            <Graph graphRef={graphRef}
+                   enableAnimation={enableAnimation}
+                   dotsRef={dotsRef}
+                   showInspector={showInspector}
+                   setShowInspector={setShowInspector}
             />
-          </GraphLayoutContext.Provider>
-        </InstanceIdContext.Provider>
-      </DataSetContext.Provider>
+          </GraphModelContext.Provider>
+        </GraphLayoutContext.Provider>
+      </InstanceIdContext.Provider>
+    </DataSetContext.Provider>
   )
 })

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -17,7 +17,7 @@ import {useGraphController} from "../hooks/use-graph-controller"
 import {useGraphModel} from "../hooks/use-graph-model"
 import {attrRoleToGraphPlace, GraphPlace, graphPlaceToAttrPlace} from "../models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
-import {IGraphModel, isSetAttributeIDAction} from "../models/graph-model"
+import {isSetAttributeIDAction, useGraphModelContext} from "../models/graph-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {MarqueeState} from "../models/marquee-state"
 import {Legend} from "./legend/legend"
@@ -28,7 +28,6 @@ import {useDataTips} from "../hooks/use-data-tips"
 import "./graph.scss"
 
 interface IProps {
-  model: IGraphModel
   graphRef: MutableRefObject<HTMLDivElement>
   enableAnimation: MutableRefObject<boolean>
   dotsRef: React.RefObject<SVGSVGElement>
@@ -39,8 +38,9 @@ interface IProps {
 const marqueeState = new MarqueeState()
 
 export const Graph = observer((
-  {model: graphModel, graphRef, enableAnimation, dotsRef, showInspector, setShowInspector}: IProps) => {
-  const {plotType} = graphModel,
+  {graphRef, enableAnimation, dotsRef, showInspector, setShowInspector}: IProps) => {
+  const graphModel = useGraphModelContext(),
+    {plotType} = graphModel,
     instanceId = useInstanceIdContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
@@ -99,10 +99,7 @@ export const Graph = observer((
 
   const getPlotComponent = () => {
     const props = {
-        graphModel,
-        plotProps: {
           xAttrID, yAttrID, dotsRef, enableAnimation
-        }
       },
       typeToPlotComponentMap = {
         casePlot: <CaseDots {...props}/>,
@@ -151,7 +148,6 @@ export const Graph = observer((
           />
 
           <Legend
-            graphModel={graphModel}
             legendAttrID={graphModel.getAttributeID('legend')}
             graphElt={graphRef.current}
             onDropAttribute={handleChangeAttribute}

--- a/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
+++ b/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
@@ -1,9 +1,12 @@
-import React, { useState } from "react"
-import { Checkbox, Flex, FormControl, FormLabel, Input, Slider, SliderThumb,
-  SliderTrack }from "@chakra-ui/react"
+import React from "react"
+import {
+  Checkbox, Flex, FormControl, FormLabel, Input, Slider, SliderThumb,
+  SliderTrack
+} from "@chakra-ui/react"
 import t from "../../../../utilities/translation/translate"
-import { IGraphModel } from "../../models/graph-model"
-import { InspectorPalette } from "../../../inspector-panel"
+import {useForceUpdate} from "../../../../hooks/use-force-update"
+import {IGraphModel} from "../../models/graph-model"
+import {InspectorPalette} from "../../../inspector-panel"
 import StylesIcon from "../../../../assets/icons/icon-styles.svg"
 
 import "./point-format-panel.scss"
@@ -13,65 +16,80 @@ interface IProps {
 }
 
 export const PointFormatPalette = ({graphModel}: IProps) => {
-  const [pointColor, setPointColor] = useState<string>("#E6805B")
-  const [pointStroke, setPointStroke] = useState<string>("#FFFFFF")
+
+  const forceUpdate = useForceUpdate()
 
   const handlePointSizeMultiplierSetting = (val: any) => {
     graphModel.setPointSizeMultiplier(val)
   }
-  const handleTransparencySetting = (val: boolean) => {
-    graphModel.setIsTransparent(val)
+  const handleTransparencySetting = (isTransparent: boolean) => {
+    graphModel.setIsTransparent(isTransparent)
+    forceUpdate()
   }
   const handleBackgroundColorSetting = (color: string) => {
     graphModel.setPlotBackgroundColor(color)
+    forceUpdate()
   }
   const handlePointColorSetting = (color: string) => {
-    setPointColor(color)
+    graphModel.setPointColor(color)
+    forceUpdate()
   }
   const handlePointStrokeColorSetting = (color: string) => {
-    setPointStroke(color)
+    graphModel.setPointStrokeColor(color)
+    forceUpdate()
+  }
+  const handleStrokeSameAsPointColorSetting = (isTheSame: boolean) => {
+    graphModel.setPointStrokeSameAsFill(isTheSame)
+    forceUpdate()
   }
 
   return (
     <InspectorPalette
       title={t("DG.Inspector.styles")}
-      Icon={<StylesIcon />}
+      Icon={<StylesIcon/>}
       buttonLocation={115}
       paletteTop={35}
     >
       <Flex className="palette-form" direction="column">
         <FormControl size="xs">
           <FormLabel className="form-label">{t("DG.Inspector.pointSize")}
-          <Slider aria-label="point-size-slider" ml="10px" min={0} max={2} defaultValue={1} step={0.01}
-            onChange={(val)=>handlePointSizeMultiplierSetting(val)}>
-            <SliderTrack />
-            <SliderThumb />
-          </Slider>
+            <Slider aria-label="point-size-slider" ml="10px" min={0} max={2}
+                    defaultValue={graphModel.pointSizeMultiplier} step={0.01}
+                    onChange={(val) => handlePointSizeMultiplierSetting(val)}>
+              <SliderTrack/>
+              <SliderThumb/>
+            </Slider>
           </FormLabel>
         </FormControl>
         <FormControl>
           <FormLabel className="form-label">{t("DG.Inspector.color")}
-          <Input type="color" className="color-picker-thumb" value={pointColor}
-            onChange={e => handlePointColorSetting(e.target.value)} />
+            <Input type="color" className="color-picker-thumb" value={graphModel.pointColor}
+                   onChange={e => handlePointColorSetting(e.target.value)}/>
           </FormLabel>
         </FormControl>
-        <FormControl>
+        <FormControl isDisabled={graphModel.pointStrokeSameAsFill}>
           <FormLabel className="form-label">{t("DG.Inspector.stroke")}
-            <Input type="color" className="color-picker-thumb" value={pointStroke}
-            onChange={e => handlePointStrokeColorSetting(e.target.value)}/>
+            <Input type="color" className="color-picker-thumb" value={graphModel.pointStrokeColor}
+                   onChange={e => handlePointStrokeColorSetting(e.target.value)}/>
           </FormLabel>
         </FormControl>
         <FormControl>
-          <Checkbox>{t("DG.Inspector.strokeSameAsFill")}</Checkbox>
+          <Checkbox
+            isChecked={graphModel.pointStrokeSameAsFill}
+            onChange={e => handleStrokeSameAsPointColorSetting(e.target.checked)}>
+            {t("DG.Inspector.strokeSameAsFill")}
+          </Checkbox>
         </FormControl>
         <FormControl>
           <FormLabel className="form-label">{t("DG.Inspector.backgroundColor")}
             <Input type="color" className="color-picker-thumb" value={graphModel.plotBackgroundColor}
-            onChange={e => handleBackgroundColorSetting(e.target.value)}/>
+                   onChange={e => handleBackgroundColorSetting(e.target.value)}/>
           </FormLabel>
         </FormControl>
         <FormControl>
-          <Checkbox onChange={e => handleTransparencySetting(e.target.checked)}>
+          <Checkbox
+            isChecked={graphModel.isTransparent}
+            onChange={e => handleTransparencySetting(e.target.checked)}>
             {t("DG.Inspector.graphTransparency")}
           </Checkbox>
         </FormControl>

--- a/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
+++ b/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
@@ -1,10 +1,10 @@
 import React from "react"
+import {observer} from "mobx-react-lite"
 import {
   Checkbox, Flex, FormControl, FormLabel, Input, Slider, SliderThumb,
   SliderTrack
 } from "@chakra-ui/react"
 import t from "../../../../utilities/translation/translate"
-import {useForceUpdate} from "../../../../hooks/use-force-update"
 import {IGraphModel} from "../../models/graph-model"
 import {InspectorPalette} from "../../../inspector-panel"
 import StylesIcon from "../../../../assets/icons/icon-styles.svg"
@@ -15,32 +15,25 @@ interface IProps {
   graphModel: IGraphModel
 }
 
-export const PointFormatPalette = ({graphModel}: IProps) => {
-
-  const forceUpdate = useForceUpdate()
+export const PointFormatPalette = observer(({graphModel}: IProps) => {
 
   const handlePointSizeMultiplierSetting = (val: any) => {
     graphModel.setPointSizeMultiplier(val)
   }
   const handleTransparencySetting = (isTransparent: boolean) => {
     graphModel.setIsTransparent(isTransparent)
-    forceUpdate()
   }
   const handleBackgroundColorSetting = (color: string) => {
     graphModel.setPlotBackgroundColor(color)
-    forceUpdate()
   }
   const handlePointColorSetting = (color: string) => {
     graphModel.setPointColor(color)
-    forceUpdate()
   }
   const handlePointStrokeColorSetting = (color: string) => {
     graphModel.setPointStrokeColor(color)
-    forceUpdate()
   }
   const handleStrokeSameAsPointColorSetting = (isTheSame: boolean) => {
     graphModel.setPointStrokeSameAsFill(isTheSame)
-    forceUpdate()
   }
 
   return (
@@ -80,7 +73,7 @@ export const PointFormatPalette = ({graphModel}: IProps) => {
             {t("DG.Inspector.strokeSameAsFill")}
           </Checkbox>
         </FormControl>
-        <FormControl>
+        <FormControl isDisabled={graphModel.isTransparent}>
           <FormLabel className="form-label">{t("DG.Inspector.backgroundColor")}
             <Input type="color" className="color-picker-thumb" value={graphModel.plotBackgroundColor}
                    onChange={e => handleBackgroundColorSetting(e.target.value)}/>
@@ -96,4 +89,4 @@ export const PointFormatPalette = ({graphModel}: IProps) => {
       </Flex>
     </InspectorPalette>
   )
-}
+})

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -1,6 +1,5 @@
 import React, {memo, useMemo, useRef} from "react"
 import {Active} from "@dnd-kit/core"
-import {IGraphModel} from "../../models/graph-model"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {Bounds, useGraphLayoutContext} from "../../models/graph-layout"
 import {AttributeLabel} from "../attribute-label"
@@ -13,7 +12,6 @@ import {useDropHintString} from "../../../../hooks/use-drop-hint-string"
 import {GraphAttrRole} from "../../models/data-configuration-model"
 
 interface ILegendProps {
-  graphModel: IGraphModel
   legendAttrID: string
   graphElt: HTMLDivElement | null
   onDropAttribute: (place: any, attrId: string) => void

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -18,8 +18,6 @@ export const ScatterDots = memo(function ScatterDots(props: PlotProps) {
     dataConfiguration = useDataConfigurationContext(),
     dataset = useDataSetContext(),
     pointRadius = graphModel.getPointRadius(),
-    pointColor = graphModel.pointColor,
-    pointStrokeColor = graphModel.pointStrokeColor,
     selectedPointRadius = graphModel.getPointRadius('select'),
     dragPointRadius = graphModel.getPointRadius('hover-drag'),
     layout = useGraphLayoutContext(),
@@ -124,12 +122,13 @@ export const ScatterDots = memo(function ScatterDots(props: PlotProps) {
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
   const refreshPointSelection = useCallback(() => {
+    const {pointColor, pointStrokeColor } = graphModel
     dataConfiguration && setPointSelection(
       {dotsRef, dataConfiguration, pointRadius, selectedPointRadius, pointColor, pointStrokeColor})
-  }, [dataConfiguration, dotsRef, pointRadius, selectedPointRadius, pointColor, pointStrokeColor])
+  }, [dataConfiguration, dotsRef, pointRadius, selectedPointRadius, graphModel])
 
   const refreshPointPositionsD3 = useCallback((selectedOnly: boolean) => {
-    const
+    const {pointColor, pointStrokeColor } = graphModel,
       getScreenX = (anID: string) => getScreenCoord(dataset, anID, primaryAttrID, xScale),
       getScreenY = (anID: string) => getScreenCoord(dataset, anID, secondaryAttrID, yScale),
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined,
@@ -140,8 +139,8 @@ export const ScatterDots = memo(function ScatterDots(props: PlotProps) {
       dataset, dotsRef, pointRadius, selectedPointRadius, plotBounds, selectedOnly,
       getScreenX, getScreenY, getLegendColor, enableAnimation, pointColor, pointStrokeColor
     })
-  }, [dataset, pointRadius, selectedPointRadius, pointColor, pointStrokeColor, dotsRef, layout, primaryAttrID,
-    xScale, secondaryAttrID, legendAttrID, yScale, enableAnimation, dataConfiguration])
+  }, [dataset, pointRadius, selectedPointRadius, dotsRef, layout, primaryAttrID,
+    xScale, secondaryAttrID, legendAttrID, yScale, enableAnimation, dataConfiguration, graphModel])
 
   const refreshPointPositionsSVG = useCallback((selectedOnly: boolean) => {
     const {cases, selection} = dataConfiguration || {}

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -9,19 +9,17 @@ import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {Bounds, ScaleNumericBaseType, useGraphLayoutContext} from "../models/graph-layout"
 import {ICase} from "../../../models/data/data-set"
 import {getScreenCoord, handleClickOnDot, setPointCoordinates, setPointSelection} from "../utilities/graph-utils"
-import {IGraphModel} from "../models/graph-model"
+import {useGraphModelContext} from "../models/graph-model"
 
-interface IProps {
-  graphModel:IGraphModel
-  plotProps:PlotProps
-}
-
-export const ScatterDots = memo(function ScatterDots(props: IProps) {
-  const {graphModel, plotProps: {dotsRef, enableAnimation}} = props,
+export const ScatterDots = memo(function ScatterDots(props: PlotProps) {
+  const {dotsRef, enableAnimation} = props,
+    graphModel = useGraphModelContext(),
     instanceId = useInstanceIdContext(),
     dataConfiguration = useDataConfigurationContext(),
     dataset = useDataSetContext(),
     pointRadius = graphModel.getPointRadius(),
+    pointColor = graphModel.pointColor,
+    pointStrokeColor = graphModel.pointStrokeColor,
     selectedPointRadius = graphModel.getPointRadius('select'),
     dragPointRadius = graphModel.getPointRadius('hover-drag'),
     layout = useGraphLayoutContext(),
@@ -52,8 +50,8 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
         currPos.current = {x: event.clientX, y: event.clientY}
 
         handleClickOnDot(event, tItsID, dataset)
-        // Record the current values so we can change them during the drag and restore them when done
-        const { selection } = dataConfiguration || {}
+        // Record the current values, so we can change them during the drag and restore them when done
+        const {selection} = dataConfiguration || {}
         selection?.forEach(anID => {
           selectedDataObjects.current[anID] = {
             x: dataset?.getNumeric(anID, primaryAttrID) ?? 0,
@@ -75,7 +73,7 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
           const deltaX = Number(xScale.invert(dx)) - Number(xScale.invert(0)),
             deltaY = Number(yScale.invert(dy)) - Number(yScale.invert(0)),
             caseValues: ICase[] = [],
-            { selection } = dataConfiguration || {}
+            {selection} = dataConfiguration || {}
           selection?.forEach(anID => {
             const currX = Number(dataset?.getNumeric(anID, primaryAttrID)),
               currY = Number(dataset?.getNumeric(anID, secondaryAttrID))
@@ -107,7 +105,7 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
 
         if (didDrag.current) {
           const caseValues: ICase[] = [],
-            { selection } = dataConfiguration || {}
+            {selection} = dataConfiguration || {}
           selection?.forEach(anID => {
             caseValues.push({
               __id__: anID,
@@ -126,24 +124,27 @@ export const ScatterDots = memo(function ScatterDots(props: IProps) {
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
   const refreshPointSelection = useCallback(() => {
-    dataConfiguration && setPointSelection({dotsRef, dataConfiguration, pointRadius, selectedPointRadius})
-  }, [dataConfiguration, dotsRef, pointRadius, selectedPointRadius])
+    dataConfiguration && setPointSelection(
+      {dotsRef, dataConfiguration, pointRadius, selectedPointRadius, pointColor, pointStrokeColor})
+  }, [dataConfiguration, dotsRef, pointRadius, selectedPointRadius, pointColor, pointStrokeColor])
 
   const refreshPointPositionsD3 = useCallback((selectedOnly: boolean) => {
     const
       getScreenX = (anID: string) => getScreenCoord(dataset, anID, primaryAttrID, xScale),
       getScreenY = (anID: string) => getScreenCoord(dataset, anID, secondaryAttrID, yScale),
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined,
-      { computedBounds } = layout,
+      {computedBounds} = layout,
       plotBounds = computedBounds.get('plot') as Bounds
 
-    setPointCoordinates({dataset, dotsRef, pointRadius, selectedPointRadius, plotBounds, selectedOnly,
-      getScreenX, getScreenY, getLegendColor, enableAnimation})
-  }, [dataset, pointRadius, selectedPointRadius, dotsRef, layout, primaryAttrID, xScale,
-            secondaryAttrID, legendAttrID, yScale, enableAnimation, dataConfiguration])
+    setPointCoordinates({
+      dataset, dotsRef, pointRadius, selectedPointRadius, plotBounds, selectedOnly,
+      getScreenX, getScreenY, getLegendColor, enableAnimation, pointColor, pointStrokeColor
+    })
+  }, [dataset, pointRadius, selectedPointRadius, pointColor, pointStrokeColor, dotsRef, layout, primaryAttrID,
+    xScale, secondaryAttrID, legendAttrID, yScale, enableAnimation, dataConfiguration])
 
   const refreshPointPositionsSVG = useCallback((selectedOnly: boolean) => {
-    const { cases, selection } = dataConfiguration || {}
+    const {cases, selection} = dataConfiguration || {}
     const updateDot = (caseId: string) => {
       const dot = dotsRef.current?.querySelector(`#${instanceId}_${caseId}`)
       if (dot) {

--- a/v3/src/components/graph/hooks/use-graph-model.ts
+++ b/v3/src/components/graph/hooks/use-graph-model.ts
@@ -1,7 +1,7 @@
 import {MutableRefObject, RefObject, useCallback, useEffect} from "react"
 import {onAction} from "mobx-state-tree"
 import {matchCirclesToData, setNiceDomain} from "../utilities/graph-utils"
-import {IGraphModel} from "../models/graph-model"
+import {IGraphModel, isGraphVisualPropsAction} from "../models/graph-model"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {INumericAxisModel} from "../models/axis-model"
 
@@ -24,6 +24,8 @@ export function useGraphModel(props: IProps) {
       dataset,
       caseIDs: dataConfig.cases,
       pointRadius: graphModel.getPointRadius(),
+      pointColor: graphModel.pointColor,
+      pointStrokeColor: graphModel.pointStrokeColor,
       dotsElement: dotsRef.current,
       enableAnimation, instanceId
     })
@@ -49,5 +51,15 @@ export function useGraphModel(props: IProps) {
     }, true)
     return () => disposer()
   }, [dataConfig.cases, dataset, enableAnimation, graphModel, yAttrID, yAxisModel])
+
+  // respond to point properties change
+  useEffect(function respondToGraphPointVisualAction() {
+    const disposer = onAction(graphModel, action => {
+      if (isGraphVisualPropsAction(action)) {
+        callMatchCirclesToData()
+      }
+    }, true)
+    return () => disposer()
+  }, [callMatchCirclesToData, graphModel])
 
 }

--- a/v3/src/components/graph/hooks/use-movables.ts
+++ b/v3/src/components/graph/hooks/use-movables.ts
@@ -1,17 +1,17 @@
 import {useCallback, useEffect} from "react"
-import {IGraphModel} from "../models/graph-model"
 import {ScaleNumericBaseType, useGraphLayoutContext} from "../models/graph-layout"
 import {IMovableLineModel, IMovableValueModel} from "../adornments/adornment-models"
 import {onAction} from "mobx-state-tree"
+import {useGraphModelContext} from "../models/graph-model"
 
 interface IProps {
-  graphModel: IGraphModel
   movableLineModel: IMovableLineModel
   movableValueModel: IMovableValueModel
 }
 
 export function useMovables(props: IProps) {
-  const {graphModel, movableValueModel, movableLineModel} = props,
+  const { movableValueModel, movableLineModel} = props,
+    graphModel = useGraphModelContext(),
     layout = useGraphLayoutContext(),
     xScale = layout.axisScale('bottom') as ScaleNumericBaseType,
     yScale = layout.axisScale('left') as ScaleNumericBaseType

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -136,6 +136,8 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           dataset,
           caseIDs: dataConfiguration.cases,
           pointRadius: graphModel.getPointRadius(),
+          pointColor: graphModel.pointColor,
+          pointStrokeColor: graphModel.pointStrokeColor,
           dotsElement: dotsRef.current,
           enableAnimation, instanceId
         })

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -79,7 +79,9 @@ export class GraphController {
         matchCirclesToData({
           dataset: this.dataset,
           caseIDs: dataConfig.cases, dotsElement: dotsRef.current,
-          pointRadius: graphModel.getPointRadius(), enableAnimation, instanceId
+          pointRadius: graphModel.getPointRadius(), enableAnimation, instanceId,
+          pointColor: graphModel.pointColor,
+          pointStrokeColor: graphModel.pointStrokeColor
         })
       }
       layout.setAxisScale('bottom', scaleOrdinal())

--- a/v3/src/components/graph/models/graph-model.ts
+++ b/v3/src/components/graph/models/graph-model.ts
@@ -1,4 +1,5 @@
 import {Instance, ISerializedActionCall, types} from "mobx-state-tree"
+import {createContext, useContext} from "react"
 import {AxisModelUnion, AxisPlace, IAxisModelUnion} from "./axis-model"
 import {
   hoverRadiusFactor,
@@ -10,11 +11,23 @@ import {
 } from "../graphing-types"
 import {DataConfigurationModel, GraphAttrRole} from "./data-configuration-model"
 import {uniqueId} from "../../../utilities/js-utils"
+import {defaultPointColor, defaultStrokeColor} from "../../../utilities/color-utils"
 
 export interface GraphProperties {
   axes: Record<string, IAxisModelUnion>
   plotType: PlotType
 }
+
+export type BackgroundLockInfo = {
+  locked: true,
+  xAxisLowerBound: number,
+  xAxisUpperBound: number,
+  yAxisLowerBound: number,
+  yAxisUpperBound: number
+}
+
+export const NumberToggleModel = types
+  .model('NumberToggleModel', {})
 
 export const GraphModel = types
   .model("GraphModel", {
@@ -23,22 +36,31 @@ export const GraphModel = types
     axes: types.map(types.maybe(AxisModelUnion)),
     plotType: types.enumeration([...PlotTypes]),
     config: DataConfigurationModel,
-    pointSizeMultiplier: 1,
     // Visual properties
-    isTransparent: false,
+    pointColor: types.optional(types.string, defaultPointColor),
+    _pointStrokeColor: types.optional(types.string, defaultStrokeColor),
+    pointStrokeSameAsFill: types.optional(types.boolean, false),
     plotBackgroundColor: types.optional(types.string, 'white'),
-    plotBackgroundOpacity: 1,
+    pointSizeMultiplier: 1,
+    isTransparent: false,
+    plotBackgroundImageID: types.optional(types.string, ''),
+    // todo: how to use this type?
+    plotBackgroundLockInfo: types.frozen<BackgroundLockInfo | undefined>(),
+    // numberToggleModel: types.optional(types.union(NumberToggleModel, null))
     showParentToggles: false,
     showMeasuresForSelection: false
   })
   .views(self => ({
+    get pointStrokeColor() {
+      return self.pointStrokeSameAsFill ? self.pointColor : self._pointStrokeColor
+    },
     getAxis(place: AxisPlace) {
       return self.axes.get(place)
     },
     getAttributeID(place: GraphAttrRole) {
       return self.config.attributeID(place) ?? ''
     },
-    getPointRadius(use:'normal' | 'hover-drag' | 'select' = 'normal') {
+    getPointRadius(use: 'normal' | 'hover-drag' | 'select' = 'normal') {
       let r = pointRadiusMax
       const numPoints = self.config.cases.length
       // for loop is fast equivalent to radius = max( minSize, maxSize - floor( log( logBase, max( dataLength, 1 )))
@@ -62,13 +84,10 @@ export const GraphModel = types
       self.axes.set(place, axis)
     },
     setAttributeID(role: GraphAttrRole, id: string) {
-      self.config.setAttribute(role, { attributeID: id })
+      self.config.setAttribute(role, {attributeID: id})
     },
     setPlotType(type: PlotType) {
       self.plotType = type
-    },
-    setPointSizeMultiplier(multiplier:number) {
-      self.pointSizeMultiplier = multiplier
     },
     setGraphProperties(props: GraphProperties) {
       (Object.keys(props.axes) as AxisPlace[]).forEach(aKey => {
@@ -76,14 +95,23 @@ export const GraphModel = types
       })
       self.plotType = props.plotType
     },
-    setIsTransparent(transparent: boolean) {
-      self.isTransparent = transparent
+    setPointColor(color: string) {
+      self.pointColor = color
+    },
+    setPointStrokeColor(color: string) {
+      self._pointStrokeColor = color
+    },
+    setPointStrokeSameAsFill(isTheSame: boolean) {
+      self.pointStrokeSameAsFill = isTheSame
     },
     setPlotBackgroundColor(color: string) {
       self.plotBackgroundColor = color
     },
-    setPlotBackgroundOpacity(opacity: number) {
-      self.plotBackgroundOpacity = opacity
+    setPointSizeMultiplier(multiplier: number) {
+      self.pointSizeMultiplier = multiplier
+    },
+    setIsTransparent(transparent: boolean) {
+      self.isTransparent = transparent
     },
     setShowParentToggles(show: boolean) {
       self.showParentToggles = show
@@ -102,5 +130,19 @@ export function isSetAttributeIDAction(action: ISerializedActionCall): action is
   return action.name === "setAttributeID"
 }
 
+export interface SetGraphVisualPropsAction extends ISerializedActionCall {
+  name: "setGraphVisualProps"
+  args: [GraphAttrRole, string]
+}
+
+export function isGraphVisualPropsAction(action: ISerializedActionCall): action is SetGraphVisualPropsAction {
+  return ['setPointColor', 'setPointStrokeColor', 'setPointStrokeSameAsFill', 'setPlotBackgroundColor',
+    'setPointSizeMultiplier', 'setIsTransparent'].includes(action.name)
+}
+
 export interface IGraphModel extends Instance<typeof GraphModel> {
 }
+
+export const GraphModelContext = createContext<IGraphModel>({} as IGraphModel)
+
+export const useGraphModelContext = () => useContext(GraphModelContext)

--- a/v3/src/components/graph/models/graph-model.ts
+++ b/v3/src/components/graph/models/graph-model.ts
@@ -132,7 +132,7 @@ export function isSetAttributeIDAction(action: ISerializedActionCall): action is
 
 export interface SetGraphVisualPropsAction extends ISerializedActionCall {
   name: "setGraphVisualProps"
-  args: [GraphAttrRole, string]
+  args: [string | number | boolean]
 }
 
 export function isGraphVisualPropsAction(action: ISerializedActionCall): action is SetGraphVisualPropsAction {

--- a/v3/src/utilities/color-utils.ts
+++ b/v3/src/utilities/color-utils.ts
@@ -13,12 +13,13 @@ export const kellyColors = [
   '#593315', '#232C16', '#FF7A5C', '#F6768E'
 ]
 
-export const defaultPointColor = '#E6805BFF',
-  defaultSelectedColor = '#4682B4FF',
+export const defaultPointColor = '#E6805B',
+  defaultSelectedColor = '#4682B4',
   defaultStrokeWidth = 1,
   defaultStrokeOpacity = 0.4,
   missingColor = '#888888',
   defaultStrokeColor = '#FFFFFF',
   defaultSelectedStroke = '#FF0000',
   defaultSelectedStrokeWidth = 2,
-  defaultSelectedStrokeOpacity = 1
+  defaultSelectedStrokeOpacity = 1,
+  defaultBackgroundColor = '#FFFFFF'


### PR DESCRIPTION
* Took this opportunity to introduce UseGraphModel rather than drill the graphModel down further
* point-format-palette now passes all user-initiated changes to the graphModel
* useGraphModel and background observe graphModel changes and redisplay as needed