### PR TITLE
Fixes bug with closing the inspector palette

### DIFF
--- a/v3/src/components/graph/components/graph-inspector.tsx
+++ b/v3/src/components/graph/components/graph-inspector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { InspectorButton, InspectorMenu, InspectorPanel } from "../../inspector-panel"
 import ScaleDataIcon from "../../../assets/icons/icon-scaleData.svg"
 import HideShowIcon from "../../../assets/icons/icon-hideShow.svg"
@@ -18,7 +18,14 @@ interface IProps {
 }
 
 export const GraphInspector = ({ graphModel, show }: IProps) => {
-  const [showPalette, setShowPalette] = useState<"format" | "measure" | undefined>()
+  const [showPalette, setShowPalette] = useState<string | undefined>(undefined)
+  useEffect(()=>{
+    !show && setShowPalette(undefined)
+  }, [show])
+
+  const handleResize = () => {
+    setShowPalette(undefined)
+  }
 
   const handleRulerButton = () => {
     setShowPalette("measure")
@@ -31,7 +38,7 @@ export const GraphInspector = ({ graphModel, show }: IProps) => {
     ? <>
         <InspectorPanel component="graph">
           <InspectorButton tooltip={t("DG.Inspector.resize.toolTip")} showMoreOptions={false}
-            testId={"graph-resize-button"} >
+            testId={"graph-resize-button"} onButtonClick={handleResize}>
             <ScaleDataIcon />
           </InspectorButton>
           <InspectorMenu tooltip={t("DG.Inspector.displayStyles.toolTip")}
@@ -56,9 +63,9 @@ export const GraphInspector = ({ graphModel, show }: IProps) => {
           </InspectorButton>
         </InspectorPanel>
         {showPalette === "format" &&
-          <PointFormatPalette graphModel={graphModel} />}
+          <PointFormatPalette graphModel={graphModel} setShowPalette={setShowPalette}/>}
         {showPalette === "measure" &&
-          <GraphMeasurePalette graphModel={graphModel} />}
+          <GraphMeasurePalette graphModel={graphModel} setShowPalette={setShowPalette}/>}
       </>
     : null
   )

--- a/v3/src/components/graph/components/inspector-panel/graph-measure-panel.tsx
+++ b/v3/src/components/graph/components/inspector-panel/graph-measure-panel.tsx
@@ -9,9 +9,10 @@ import "./point-format-panel.scss"
 
 interface IProps {
   graphModel: IGraphModel
+  setShowPalette: (palette: string | undefined) => void
 }
 
-export const GraphMeasurePalette = ({graphModel}: IProps) => {
+export const GraphMeasurePalette = ({graphModel, setShowPalette}: IProps) => {
   const toast = useToast()
 
   const measures = {
@@ -60,6 +61,7 @@ export const GraphMeasurePalette = ({graphModel}: IProps) => {
       Icon={<ValuesIcon />}
       paletteTop={paletteTop}
       buttonLocation={graphModel.plotType === "casePlot" || graphModel.plotType === "dotChart" ? 25 : 75}
+      setShowPalette={setShowPalette}
     >
       <Flex className="palette-form" direction="column">
         <Box className="form-title">Show ...</Box>

--- a/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
+++ b/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
@@ -13,10 +13,10 @@ import "./point-format-panel.scss"
 
 interface IProps {
   graphModel: IGraphModel
+  setShowPalette: (palette: string | undefined) => void;
 }
 
-export const PointFormatPalette = observer(({graphModel}: IProps) => {
-
+export const PointFormatPalette = observer(({graphModel, setShowPalette}: IProps) => {
   const handlePointSizeMultiplierSetting = (val: any) => {
     graphModel.setPointSizeMultiplier(val)
   }
@@ -42,6 +42,7 @@ export const PointFormatPalette = observer(({graphModel}: IProps) => {
       Icon={<StylesIcon/>}
       buttonLocation={115}
       paletteTop={35}
+      setShowPalette={setShowPalette}
     >
       <Flex className="palette-form" direction="column">
         <FormControl size="xs">

--- a/v3/src/components/inspector-panel.tsx
+++ b/v3/src/components/inspector-panel.tsx
@@ -1,5 +1,5 @@
-import { Box, Button, Menu, MenuButton } from "@chakra-ui/react"
-import React, { ReactNode } from "react"
+import { Box, Button, Menu, MenuButton, useOutsideClick } from "@chakra-ui/react"
+import React, { ReactNode, useRef } from "react"
 import MoreOptionsIcon from "../assets/icons/arrow-moreIconOptions.svg"
 
 import "./inspector-panel.scss"
@@ -61,10 +61,11 @@ interface IInspectorPalette {
   title?: string
   paletteTop?: number
   buttonLocation: number
+  setShowPalette: (palette: string | undefined) => void
 }
 
-export const InspectorPalette =({children, Icon, title, paletteTop, buttonLocation}:IInspectorPalette) => {
-
+export const InspectorPalette =({children, Icon, title, paletteTop, buttonLocation,
+    setShowPalette}:IInspectorPalette) => {
   const PalettePointer = () => {
     const pointerStyle = {top: (buttonLocation+11)}
 
@@ -83,8 +84,14 @@ export const InspectorPalette =({children, Icon, title, paletteTop, buttonLocati
     )
   }
   const paletteStyle = {top: paletteTop}
+  const paletteRef = useRef<HTMLDivElement>(null)
+
+  useOutsideClick({
+    ref: paletteRef,
+    handler: () => setShowPalette(undefined),
+  })
   return(
-    <Box className="codap-inspector-palette" style={paletteStyle}
+    <Box ref={paletteRef} className="codap-inspector-palette" style={paletteStyle}
         data-testid="codap-inspector-palette" tabIndex={0} zIndex={1400}>
       <PaletteHeader />
       {children}


### PR DESCRIPTION
Closes the brush and ruler panels when the inspector palette is closed, and when user clicks outside of the palette.