### PR TITLE
183895168 v3 dnd rerender

### DIFF
--- a/v3/src/components/axis/components/axis-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-attribute-menu.tsx
@@ -1,5 +1,5 @@
 import { Menu, MenuItem, MenuList, MenuButton, MenuDivider } from "@chakra-ui/react"
-import React, { CSSProperties } from "react"
+import React, { CSSProperties, memo } from "react"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
 import { GraphPlace } from "../../graph/graphing-types"
 import { useGraphLayoutContext} from "../../graph/models/graph-layout"
@@ -15,7 +15,7 @@ interface IProps {
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
-export const AxisAttributeMenu = ({ place, target, portal, onChangeAttribute, onTreatAttributeAs }: IProps ) => {
+const _AxisAttributeMenu = ({ place, target, portal, onChangeAttribute, onTreatAttributeAs }: IProps ) => {
   const data = useDataSetContext()
   const dataConfig = useDataConfigurationContext()
   const { plotWidth, plotHeight } = useGraphLayoutContext()
@@ -65,3 +65,5 @@ export const AxisAttributeMenu = ({ place, target, portal, onChangeAttribute, on
     </div>
   )
 }
+
+export const AxisAttributeMenu = memo(_AxisAttributeMenu)

--- a/v3/src/components/axis/components/axis.tsx
+++ b/v3/src/components/axis/components/axis.tsx
@@ -28,6 +28,8 @@ interface IProps {
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
+const handleIsActive = (active: Active) => !!getDragAttributeId(active)
+
 export const Axis = ({
                        parentSelector, label, getAxisModel, showScatterPlotGridLines = false,
                        centerCategoryLabels = true, onDropAttribute, enableAnimation, onTreatAttributeAs
@@ -49,8 +51,6 @@ export const Axis = ({
     axisModel, axisElt, label, enableAnimation, showScatterPlotGridLines, centerCategoryLabels,
     titleRef
   })
-
-  const handleIsActive = (active: Active) => !!getDragAttributeId(active)
 
   useDropHandler(droppableId, active => {
     const droppedAttrId = getDragAttributeId(active)

--- a/v3/src/components/graph/components/droppable-plot.tsx
+++ b/v3/src/components/graph/components/droppable-plot.tsx
@@ -1,11 +1,11 @@
-import { Active } from "@dnd-kit/core"
-import React,  { useMemo} from "react"
-import { getDragAttributeId, useDropHandler } from "../../../hooks/use-drag-drop"
-import { useDropHintString } from "../../../hooks/use-drop-hint-string"
-import { useInstanceIdContext } from "../../../hooks/use-instance-id-context"
-import { GraphPlace } from "../graphing-types"
-import { DroppableSvg } from "./droppable-svg"
-import { useDataConfigurationContext} from "../hooks/use-data-configuration-context"
+import {Active} from "@dnd-kit/core"
+import React, {memo} from "react"
+import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
+import {useDropHintString} from "../../../hooks/use-drop-hint-string"
+import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
+import {GraphPlace} from "../graphing-types"
+import {DroppableSvg} from "./droppable-svg"
+import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 
 interface IProps {
   graphElt: HTMLDivElement | null
@@ -15,7 +15,7 @@ interface IProps {
 
 const handleIsActive = (active: Active) => !!getDragAttributeId(active)
 
-export const DroppablePlot = ({ graphElt, plotElt, onDropAttribute }: IProps) => {
+const _DroppablePlot = ({ graphElt, plotElt, onDropAttribute }: IProps) => {
   const instanceId = useInstanceIdContext()
   const dataConfig = useDataConfigurationContext()
   const droppableId = `${instanceId}-plot-area-drop`
@@ -38,3 +38,4 @@ export const DroppablePlot = ({ graphElt, plotElt, onDropAttribute }: IProps) =>
     />
   )
 }
+export const DroppablePlot = memo(_DroppablePlot)

--- a/v3/src/components/graph/components/droppable-plot.tsx
+++ b/v3/src/components/graph/components/droppable-plot.tsx
@@ -1,5 +1,5 @@
 import { Active } from "@dnd-kit/core"
-import React from "react"
+import React,  { useMemo} from "react"
 import { getDragAttributeId, useDropHandler } from "../../../hooks/use-drag-drop"
 import { useDropHintString } from "../../../hooks/use-drop-hint-string"
 import { useInstanceIdContext } from "../../../hooks/use-instance-id-context"
@@ -12,14 +12,15 @@ interface IProps {
   plotElt: SVGGElement | null
   onDropAttribute: (place: GraphPlace, attrId: string) => void
 }
+
+const handleIsActive = (active: Active) => !!getDragAttributeId(active)
+
 export const DroppablePlot = ({ graphElt, plotElt, onDropAttribute }: IProps) => {
   const instanceId = useInstanceIdContext()
   const dataConfig = useDataConfigurationContext()
   const droppableId = `${instanceId}-plot-area-drop`
   const role = dataConfig?.noAttributesAssigned ? 'x' : 'legend'
   const hintString = useDropHintString({ role })
-
-  const handleIsActive = (active: Active) => !!getDragAttributeId(active)
 
   useDropHandler(droppableId, active => {
     const dragAttributeID = getDragAttributeId(active)

--- a/v3/src/components/graph/components/droppable-svg.tsx
+++ b/v3/src/components/graph/components/droppable-svg.tsx
@@ -1,5 +1,5 @@
 import { Active, useDroppable } from "@dnd-kit/core"
-import React, { CSSProperties } from "react"
+import React, { CSSProperties, memo } from "react"
 import { createPortal } from "react-dom"
 import { useOverlayBounds } from "../../../hooks/use-overlay-bounds"
 import { DropHint } from "./drop-hint"
@@ -14,7 +14,8 @@ interface IProps {
   onIsActive?: (active: Active) => boolean
   hintString?: string
 }
-export const DroppableSvg = ({
+
+const _DroppableSvg = ({
     className, portal, target, dropId, onIsActive, hintString }: IProps) => {
   const { active, isOver, setNodeRef } = useDroppable({ id: dropId })
   const isActive = active && onIsActive?.(active)
@@ -31,3 +32,4 @@ export const DroppableSvg = ({
     portal
   )
 }
+export const DroppableSvg = memo(_DroppableSvg)

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -17,6 +17,8 @@ interface ILegendProps {
   onDropAttribute: (place: any, attrId: string) => void
 }
 
+const handleIsActive = (active: Active) => !!getDragAttributeId(active)
+
 export const Legend = memo(function Legend({legendAttrID, graphElt, onDropAttribute}: ILegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
     layout = useGraphLayoutContext(),
@@ -28,8 +30,6 @@ export const Legend = memo(function Legend({legendAttrID, graphElt, onDropAttrib
     role = 'legend' as GraphAttrRole,
     hintString = useDropHintString({role}),
     attributeIDs = useMemo(() => legendAttrID ? [legendAttrID] : [], [legendAttrID])
-
-  const handleIsActive = (active: Active) => !!getDragAttributeId(active)
 
   useDropHandler(droppableId, active => {
     const dragAttributeID = getDragAttributeId(active)


### PR DESCRIPTION
These are a few changes that have the effect of reducing the number of elements that re-render as a result of their parents re-render.  The parents are those topmost components who re-render as a result of changes within DndKit Context state that occur during drag.

- The `handleIsActive` function definition that is defined in `axis.tsx`, `droppable-plot.tsx`, `legend.tsx` is moved from the body of the component function to the file scope, so that it is a constant. 
- `AxisAttributeMenu` is memoized, and this prevents it from re-rendering with its parent. 
- `DroppableSvg` is memoized, and this removes the majority of its re-renders. 
- `DroppablePlot` is memoized.  It is now a closer match to its sibling, `Legend`.  Both are memoized, however both still re-render with changing drag state.   (More info on that in pivotal)