### PR TITLE
V3—Improve_y-axis_space allocation

### DIFF
--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -6,7 +6,7 @@ import {AxisBounds, axisGap, isVertical, ScaleNumericBaseType} from "../axis-typ
 import {useAxisLayoutContext} from "../models/axis-layout-context"
 import {otherPlace, IAxisModel, INumericAxisModel} from "../models/axis-model"
 import {between} from "../../../utilities/math-utils"
-import {graphPlaceToAttrRole, transitionDuration} from "../../graph/graphing-types"
+import {graphPlaceToAttrRole, kGraphFont, transitionDuration} from "../../graph/graphing-types"
 import {maxWidthOfStringsD3} from "../../graph/utilities/graph-utils"
 import {useDataConfigurationContext} from "../../graph/hooks/use-data-configuration-context"
 import {getCategoricalLabelPlacement} from "../axis-utils"
@@ -49,7 +49,7 @@ export const useAxis = ({
   previousAxisModel.current = axisModel
 
   const getLabelBounds = (s = 'Wy') => {
-      return measureTextExtent(s, '12px sans-serif')
+      return measureTextExtent(s, kGraphFont)
   }
 
   const collisionExists = useCallback(() => {
@@ -73,7 +73,7 @@ export const useAxis = ({
     let ticks: string[] = []
     switch (type) {
       case 'numeric': {
-        const format = scale.tickFormat && scale.tickFormat()
+        const format = scale.tickFormat?.()
         ticks = ((scale.ticks?.()) ?? []).map(tick => format(tick))
         desiredExtent += axisPlace === 'left' ?
           Math.max(getLabelBounds(ticks[0]).width, getLabelBounds(ticks[ticks.length - 1]).width) + axisGap :

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -1,11 +1,12 @@
 import {reaction} from "mobx"
 import {onAction} from "mobx-state-tree"
-import {range, select, selection} from "d3"
+import {range, select} from "d3"
 import React, {memo, useCallback, useEffect, useRef, useState} from "react"
 import {isSelectionAction} from "../../../../models/data/data-set-actions"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {useGraphLayoutContext} from "../../models/graph-layout"
 import {missingColor} from "../../../../utilities/color-utils"
+import {measureText} from "../../../../hooks/use-measure-text"
 
 import './legend.scss'
 
@@ -58,10 +59,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
       lod.fullWidth = layout.getAxisLength('bottom')
       lod.maxWidth = 0
       categoriesRef.current?.forEach(cat => {
-        const text = selection().append('text').attr('y', 500).text(cat),
-          width = text.node()?.getBoundingClientRect()?.width
-        lod.maxWidth = Math.max(lod.maxWidth, width ?? 0)
-        text.remove()
+        lod.maxWidth = Math.max(lod.maxWidth, measureText(cat, '12px sans-serif'))
       })
       lod.maxWidth += keySize + padding
       lod.numColumns = Math.floor(lod.fullWidth / lod.maxWidth)

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -9,6 +9,7 @@ import {missingColor} from "../../../../utilities/color-utils"
 import {measureText} from "../../../../hooks/use-measure-text"
 
 import './legend.scss'
+import {kGraphFont} from "../../graphing-types"
 
 interface ICategoricalLegendProps {
   transform: string,
@@ -59,7 +60,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
       lod.fullWidth = layout.getAxisLength('bottom')
       lod.maxWidth = 0
       categoriesRef.current?.forEach(cat => {
-        lod.maxWidth = Math.max(lod.maxWidth, measureText(cat, '12px sans-serif'))
+        lod.maxWidth = Math.max(lod.maxWidth, measureText(cat, kGraphFont))
       })
       lod.maxWidth += keySize + padding
       lod.numColumns = Math.floor(lod.fullWidth / lod.maxWidth)

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -66,7 +66,8 @@ export const kTitleBarHeight = 25,
   pointRadiusMin = 3,
   pointRadiusLogBase = 2.0, // reduce point radius from max by log of (num. cases) base (LogBase).
   pointRadiusSelectionAddend = 1,
-  hoverRadiusFactor = 1.5
+  hoverRadiusFactor = 1.5,
+  kGraphFont = '12px sans-serif'
 
 export const PlotTypes = ["casePlot", "dotPlot", "dotChart", "scatterPlot"] as const
 export type PlotType = typeof PlotTypes[number]

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -1,7 +1,7 @@
 import {extent, format, select} from "d3"
 import React from "react"
 import {isInteger} from "lodash"
-import {Point, Rect, rTreeRect, transitionDuration} from "../graphing-types"
+import {kGraphFont, Point, Rect, rTreeRect, transitionDuration} from "../graphing-types"
 import {between} from "../../../utilities/math-utils"
 import {IAxisModel, INumericAxisModel} from "../../axis/models/axis-model"
 import {ScaleNumericBaseType} from "../../axis/axis-types"
@@ -21,7 +21,7 @@ import {measureText} from "../../../hooks/use-measure-text"
 export const maxWidthOfStringsD3 = (strings: Iterable<string>) => {
   let maxWidth = 0
   for (const aString of strings) {
-    maxWidth = Math.max(maxWidth, measureText(aString, '12px sans-serif'))
+    maxWidth = Math.max(maxWidth, measureText(aString, kGraphFont))
   }
   return maxWidth
 }

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -1,4 +1,4 @@
-import {extent, format, select, selection} from "d3"
+import {extent, format, select} from "d3"
 import React from "react"
 import {isInteger} from "lodash"
 import {Point, Rect, rTreeRect, transitionDuration} from "../graphing-types"
@@ -12,18 +12,17 @@ import {
   defaultSelectedStrokeWidth, defaultStrokeOpacity, defaultStrokeWidth
 } from "../../../utilities/color-utils"
 import {IDataConfigurationModel} from "../models/data-configuration-model"
+import {measureText} from "../../../hooks/use-measure-text"
 
 /**
  * Utility routines having to do with graph entities
  */
 
 export const maxWidthOfStringsD3 = (strings: Iterable<string>) => {
-  const text = selection().append('svg').append('text').style('font', '12px sans-serif')
   let maxWidth = 0
   for (const aString of strings) {
-    maxWidth = Math.max(maxWidth, text.text(aString).node()?.getComputedTextLength() ?? 0)
+    maxWidth = Math.max(maxWidth, measureText(aString, '12px sans-serif'))
   }
-  text.remove()
   return maxWidth
 }
 

--- a/v3/src/hooks/use-measure-text.ts
+++ b/v3/src/hooks/use-measure-text.ts
@@ -4,11 +4,16 @@ import { defaultFont } from "../components/constants"
 const canvas = document.createElement("canvas")
 const cache: Record<string, Record<string, number>> = {}
 
-export const measureText = (text:string, font = defaultFont) => {
+export const measureTextExtent = (text: string, font = defaultFont) => {
   const context = canvas.getContext("2d")
   context && font && (context.font = font)
+  const metrics = context?.measureText(text) ?? { width: 0, fontBoundingBoxAscent: 0, fontBoundingBoxDescent: 0 }
+  return { width: metrics.width, height: metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent }
+}
+
+export const measureText = (text:string, font = defaultFont) => {
   cache[font] = cache[font] || {}
-  cache[font][text] = cache[font][text] || (context ? Math.ceil(10 * context.measureText(text).width) / 10 : 0)
+  cache[font][text] = cache[font][text] || Math.ceil(10 * measureTextExtent(text, font).width) / 10
   return cache[font][text]
 }
 


### PR DESCRIPTION
* Before computing desired extent of vertical numeric axis, format the numbers using the scale's formatting.
* Also substitute `measureText` in place of getBoundingClientRect where appropriate