### PR TITLE
184098347 v3 slider drag

### DIFF
--- a/v3/.vscode/settings.json
+++ b/v3/.vscode/settings.json
@@ -7,6 +7,7 @@
   "typescript.tsdk": "./node_modules/typescript/lib",
   "cSpell.words": [
     "Chakra",
+    "clsx",
     "papaparse",
     "portaling",
     "ulid"

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -14,6 +14,7 @@
         "@dnd-kit/core": "^6.0.5",
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
+        "clsx": "^1.2.1",
         "d3": "^7.6.1",
         "d3-v6-tip": "^1.0.9",
         "escape-string-regexp": "^5.0.0",

--- a/v3/package.json
+++ b/v3/package.json
@@ -146,6 +146,7 @@
     "@dnd-kit/core": "^6.0.5",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "clsx": "^1.2.1",
     "d3": "^7.6.1",
     "d3-v6-tip": "^1.0.9",
     "escape-string-regexp": "^5.0.0",

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -9,7 +9,7 @@ interface IProps {
   sliderModel: ISliderModel
 }
 
-const kDecimalPlaces = 4
+const kDecimalPlaces = 2
 const d3Format = format(`.${kDecimalPlaces}~f`)
 
 const formatValue = (model: ISliderModel) => d3Format(model.globalValue.value)

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -9,7 +9,7 @@ interface IProps {
   sliderModel: ISliderModel
 }
 
-const kDecimalPlaces = 2
+const kDecimalPlaces = 4
 const d3Format = format(`.${kDecimalPlaces}~f`)
 
 const formatValue = (model: ISliderModel) => d3Format(model.globalValue.value)

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -37,7 +37,7 @@ export const EditableSliderValue = observer(({sliderModel} : IProps) => {
   const handleBlur = () => {
     const myFloat = parseFloat(candidate)
     if (isFinite(myFloat)) {
-      sliderModel.setValue(myFloat)
+      sliderModel.setValueRoundedToMultipleOf(myFloat)
     } else {
       setCandidate(formatValue(sliderModel))
     }

--- a/v3/src/components/slider/slider-component.tsx
+++ b/v3/src/components/slider/slider-component.tsx
@@ -68,7 +68,7 @@ export const SliderComponent = observer(({sliderModel} : IProps) => {
   }
 
   const incrementSliderValue = () => {
-    sliderModel.setValue(sliderModel.value + sliderModel.multipleOf)
+    sliderModel.setValueRoundedToMultipleOf(sliderModel.value + sliderModel.multipleOf)
   }
 
   const titleM = measureText(sliderModel.name)
@@ -156,7 +156,7 @@ export const SliderComponent = observer(({sliderModel} : IProps) => {
               />
             </svg>
 
-            <CodapSliderThumb sliderModel={sliderModel} />
+            <CodapSliderThumb sliderContainer={sliderRef.current} sliderModel={sliderModel} />
 
           </div>
         </div>

--- a/v3/src/components/slider/slider-component.tsx
+++ b/v3/src/components/slider/slider-component.tsx
@@ -125,7 +125,6 @@ export const SliderComponent = observer(({sliderModel} : IProps) => {
                 </button>
               </Center>
               <Center>
-                {/* TODO - editing looks better than before, but still needs a bit of polish */}
                 <div className="slider-inputs">
                   { isEditingName ?
                     <input

--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -6,6 +6,7 @@ import { uniqueId } from "../../utilities/js-utils"
 export const SliderModel = types.model("SliderModel", {
     id: types.optional(types.identifier, () => uniqueId()),
     multipleOf: 0.5,
+    resolution: .01,
     globalValue: types.optional(GlobalValue, {
       // TODO: generate unique name from registry
       name: "slider-1",
@@ -42,7 +43,7 @@ export const SliderModel = types.model("SliderModel", {
     },
     setValue(n: number) {
       if (self.multipleOf !== 0) {
-        n = Math.round(n / .01) * .01
+        n = Math.round(n / self.resolution) * self.resolution
       }
       self.globalValue.setValue(n)
     },

--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -42,7 +42,7 @@ export const SliderModel = types.model("SliderModel", {
       self.globalValue.setValue(n)
     },
     setValue(n: number) {
-      if (self.multipleOf !== 0) {
+      if (self.resolution !== 0) {
         n = Math.round(n / self.resolution) * self.resolution
       }
       self.globalValue.setValue(n)

--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -34,9 +34,15 @@ export const SliderModel = types.model("SliderModel", {
     setName(name: string) {
       self.globalValue.setName(name)
     },
-    setValue(n: number) {
+    setValueRoundedToMultipleOf(n: number) {
       if (self.multipleOf !== 0) {
         n = Math.round(n / self.multipleOf) * self.multipleOf
+      }
+      self.globalValue.setValue(n)
+    },
+    setValue(n: number) {
+      if (self.multipleOf !== 0) {
+        n = Math.round(n / .01) * .01
       }
       self.globalValue.setValue(n)
     },

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -28,5 +28,5 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
     top: 60
   }
 
-  return <ThumbIcon style={thumbStyle}/>
+  return <ThumbIcon style={thumbStyle} className="slider-thumb-svg"/>
 })

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -1,3 +1,4 @@
+import { clsx } from "clsx"
 import { observer } from "mobx-react-lite"
 import React, {CSSProperties, useEffect, useState, useRef} from "react"
 import {ISliderModel} from "./slider-model"
@@ -8,60 +9,74 @@ import ThumbIcon from "../../assets/icons/icon-thumb.svg"
 import './slider.scss'
 
 interface IProps {
+  sliderContainer: HTMLDivElement
   sliderModel: ISliderModel
 }
 
-export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
+// offset from left edge of thumb to center of thumb
+const kThumbOffset = 8
+
+export const CodapSliderThumb = observer(({sliderContainer, sliderModel} : IProps) => {
   const layout = useAxisLayoutContext()
   const length = layout.getAxisLength("bottom")
   const scale = layout.getAxisScale("bottom") as ScaleNumericBaseType
-  const wholeSlider = document.querySelector(".slider-wrapper")
-  const componentX = wholeSlider?.getBoundingClientRect().x
   const [thumbPos, setThumbPos] = useState(0)
   const [isDragging, setIsDragging] = useState(false)
-  const mouseDownX = useRef(0)
+  // offset from center of thumb to pointerDown
+  const downOffset = useRef(0)
 
   useEffect(() => {
-    const kThumbOffset = 8
     setThumbPos(scale(sliderModel.value) - kThumbOffset)
   }, [length, scale, sliderModel.domain, sliderModel.value])
 
   const thumbStyle: CSSProperties = {
-    position: "absolute",
-    left: thumbPos,
-    top: isDragging ? 59 : 60,
-    filter: isDragging ? "drop-shadow(3px 1px 1px #555)" : "none"
+    left: thumbPos
   }
+
+  useEffect(() => {
+    const containerX = sliderContainer?.getBoundingClientRect().x
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if ((containerX != null) && isDragging) {
+        const pixelTarget = e.clientX + downOffset.current
+        const scaledValue = scale.invert(pixelTarget - containerX)
+        sliderModel.setValueRoundedToMultipleOf(scaledValue)
+      }
+      e.preventDefault()
+      e.stopImmediatePropagation()
+    }
+
+    const handlePointerUp = (e: PointerEvent) => {
+      downOffset.current = 0
+      setIsDragging(false)
+      e.preventDefault()
+      e.stopImmediatePropagation()
+    }
+
+    if (isDragging) {
+      document.addEventListener("pointermove", handlePointerMove, { capture: true })
+      document.addEventListener("pointerup", handlePointerUp, { capture: true })
+    }
+
+    return () => {
+      if (isDragging) {
+        document.removeEventListener("pointermove", handlePointerMove, { capture: true })
+        document.removeEventListener("pointerup", handlePointerUp, { capture: true })
+      }
+    }
+  }, [isDragging, scale, sliderContainer, sliderModel])
 
   const handlePointerDown = (e: React.PointerEvent) => {
-    mouseDownX.current = e.clientX
-    if (wholeSlider) {
-      wholeSlider.addEventListener("pointermove", (ev) => handlePointerMove(ev as any))
-      wholeSlider.addEventListener("pointerup", (ev) => handlePointerUp(ev as any))
-    }
-  }
-
-  const handlePointerMove = (e: React.PointerEvent) => {
-    const targetElt = e.target as HTMLElement
-    const dragOk = !targetElt.classList.contains("dragRect")
-    if (componentX && dragOk) {
-      setIsDragging(true)
-      const pixelTarget = e.clientX - componentX
-      const scaledValue = scale.invert(pixelTarget)
-      sliderModel.setValue(scaledValue)
-    }
-  }
-
-  const handlePointerUp = (e: React.PointerEvent) => {
-    setIsDragging(false)
+    const containerX = sliderContainer?.getBoundingClientRect().x
+    downOffset.current = thumbPos + kThumbOffset - (e.clientX - containerX)
+    setIsDragging(true)
   }
 
   return (
      <ThumbIcon
+      className={clsx("slider-thumb-icon", { dragging: isDragging })}
       onPointerDown={handlePointerDown}
       style={thumbStyle}
-      className="slider-thumb-svg"
     />
   )
 })
-

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -11,22 +11,15 @@ interface IProps {
   sliderModel: ISliderModel
 }
 
-const getComponentX = () => {
-  const wholeSlider = document.querySelector(".slider-wrapper")
-  const sliderBounds = wholeSlider?.getBoundingClientRect()
-  return sliderBounds?.x
-}
-
 export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
   const layout = useAxisLayoutContext()
   const length = layout.getAxisLength("bottom")
   const scale = layout.getAxisScale("bottom") as ScaleNumericBaseType
+  const wholeSlider = document.querySelector(".slider-wrapper")
+  const componentX = wholeSlider?.getBoundingClientRect().x
   const [thumbPos, setThumbPos] = useState(0)
-  //const [isDragging, setIsDragging] = useState(false)
   const mouseDownX = useRef(0)
-  const componentX = getComponentX()
 
-  // when sliderModel.value changes, the thumb position changes
   useEffect(() => {
     const kThumbOffset = 8
     setThumbPos(scale(sliderModel.value) - kThumbOffset)
@@ -40,14 +33,15 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
 
   const handlePointerDown = (e: React.PointerEvent) => {
     mouseDownX.current = e.clientX
-  }
-
-  const handlePointerUp = (e: React.PointerEvent) => {
-    console.log('mouse went up')
+    if (wholeSlider) {
+      wholeSlider.addEventListener("pointermove", (ev) => handlePointerMove(ev as any))
+    }
   }
 
   const handlePointerMove = (e: React.PointerEvent) => {
-    if (componentX) {
+    const targetElt = e.target as HTMLElement
+    const dragOk = !targetElt.classList.contains("dragRect")
+    if (componentX && dragOk) {
       const pixelTarget = e.clientX - componentX
       const scaledValue = scale.invert(pixelTarget)
       sliderModel.setValue(scaledValue)
@@ -57,8 +51,6 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
   return (
      <ThumbIcon
       onPointerDown={handlePointerDown}
-      onPointerUp={handlePointerUp}
-      onPointerMove={handlePointerMove}
       style={thumbStyle}
       className="slider-thumb-svg"
     />

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -60,7 +60,6 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
   }
 
   const handlePointerUp = (e: React.PointerEvent) => {
-    //setIsDragging(false)
     console.log('mouse went up')
   }
 
@@ -68,8 +67,9 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
     if (componentX) {
       const pixelTarget = e.clientX - componentX
       const scaledValue = scale.invert(pixelTarget)
-      console.log("scaledValue is: ", scaledValue)
+      console.log("scaledValue is so set slider to it: ", scaledValue)
       sliderModel.setValue(scaledValue)
+      console.log("now sliderModel.value is: ", sliderModel.value)
     }
   }
 

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -11,22 +11,95 @@ interface IProps {
   sliderModel: ISliderModel
 }
 
+const getClientX = (elt: any) => {
+  const { x } = elt.getBoundingClientRect()
+  return x
+}
+
 export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
   const layout = useAxisLayoutContext()
   const length = layout.getAxisLength("bottom")
   const scale = layout.getAxisScale("bottom") as ScaleNumericBaseType
   const [thumbPos, setThumbPos] = useState(0)
+  const [initialThumbX, setInitialThumbX] = useState(0)
+  const [newSliderValueCandidate, setNewSliderValueCandidate] = useState(.5)
 
+  // when sliderModel.value changes, the thumb position changes
   useEffect(() => {
     const kThumbOffset = 8
     setThumbPos(scale(sliderModel.value) - kThumbOffset)
   }, [length, scale, sliderModel.domain, sliderModel.value])
 
+
+  useEffect(() => {
+    console.log(newSliderValueCandidate)
+    sliderModel.setValue(newSliderValueCandidate)
+  },[newSliderValueCandidate])
+
+  // get and store in state the initial clientX position of thumb, as we init with 0 before model is here?
+  useEffect(() => {
+    const thumb = document.querySelector(".slider-thumb-svg") // use ref?
+    if (thumb) {
+      setInitialThumbX(getClientX(thumb))
+    }
+  },[])
+
   const thumbStyle: CSSProperties = {
     position: "absolute",
     left: thumbPos,
-    top: 60
+    top: 60,
   }
 
-  return <ThumbIcon style={thumbStyle} className="slider-thumb-svg"/>
+  const handlePointerMove = (e: any) => {
+    const objecto = {
+      //initialThumbX 687
+      //thumbPos,
+      // "C currentMouseXPos": e.clientX.toFixed(3),
+      "1 sliderModel.value": sliderModel.value,
+      "2 scale(sliderModel.value)": scale(sliderModel.value) + "px",
+// is this is pixel value from left!
+      "3 thumbPos (scaled - 8)": thumbPos + "px",
+      "4 pixels back to value: ": scale.invert(scale(sliderModel.value)),
+      "5 mouse delta in pixels: ": e.clientX - initialThumbX - 8,
+      "6 that change represents a value change of: ": scale.invert(e.clientX - initialThumbX - 8),
+      "7 so new sliderModel value should be += that change: ": sliderModel.value + scale.invert(e.clientX - initialThumbX - 8),
+      //"so measured change in pixels: " : e.clientX - initialThumbX,
+     // "can be converted to change in value: " : scale.invert(e.clientX - initialThumbX),
+      // "T scale.invert(thumbPos)": scale.invert(thumbPos).toFixed(3),
+      // "D delta": (e.clientX - initialThumbX).toFixed(3),
+      // "D scale(delta)": scale(e.clientX - initialThumbX).toFixed(3),
+      // "D invert(scale(delta))": scale.invert(e.clientX - initialThumbX).toFixed(3)
+    }
+    //console.table({objecto})
+    const maybeValue = sliderModel.value + scale.invert(e.clientX - initialThumbX - 8)
+    console.log("maybe val: ", maybeValue)
+    setNewSliderValueCandidate(maybeValue)    //sliderModel.setValue(sliderModel.value + scale.invert(e.clientX - initialThumbX - 8))
+    //sliderModel.setValue(scale.invert(e.clientX + initialThumbX))
+    // const currentMouseXPos = e.clientX
+    // //console.log("InitialThumbX: ", initialThumbX, " vs ", "currentMouseXPos: ", currentMouseXPos)
+    // const delta = currentMouseXPos - initialThumbX
+    // console.log("delta: ", delta)
+    //const scaledChange = scale.invert(e.clientX - initialThumbX)
+    //console.log("scaledChange: ", scaledChange)
+    //sliderModel.setValue(sliderModel.value + scaledChange)
+  }
+
+  const addListenerToThumb = (e: React.PointerEvent) => {
+    const thumb = e.currentTarget as HTMLElement
+    setInitialThumbX(getClientX(thumb))
+    thumb.addEventListener("pointermove", handlePointerMove)
+  }
+
+  return (
+    <>
+    {newSliderValueCandidate}
+     <ThumbIcon
+      onPointerDown={addListenerToThumb}
+      style={thumbStyle}
+      className="slider-thumb-svg"
+    />
+
+    </>
+
+  )
 })

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -18,6 +18,7 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
   const wholeSlider = document.querySelector(".slider-wrapper")
   const componentX = wholeSlider?.getBoundingClientRect().x
   const [thumbPos, setThumbPos] = useState(0)
+  const [isDragging, setIsDragging] = useState(false)
   const mouseDownX = useRef(0)
 
   useEffect(() => {
@@ -28,13 +29,15 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
   const thumbStyle: CSSProperties = {
     position: "absolute",
     left: thumbPos,
-    top: 60
+    top: isDragging ? 59 : 60,
+    filter: isDragging ? "drop-shadow(3px 1px 1px #555)" : "none"
   }
 
   const handlePointerDown = (e: React.PointerEvent) => {
     mouseDownX.current = e.clientX
     if (wholeSlider) {
       wholeSlider.addEventListener("pointermove", (ev) => handlePointerMove(ev as any))
+      wholeSlider.addEventListener("pointerup", (ev) => handlePointerUp(ev as any))
     }
   }
 
@@ -42,10 +45,15 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
     const targetElt = e.target as HTMLElement
     const dragOk = !targetElt.classList.contains("dragRect")
     if (componentX && dragOk) {
+      setIsDragging(true)
       const pixelTarget = e.clientX - componentX
       const scaledValue = scale.invert(pixelTarget)
       sliderModel.setValue(scaledValue)
     }
+  }
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    setIsDragging(false)
   }
 
   return (

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -35,28 +35,11 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
   const thumbStyle: CSSProperties = {
     position: "absolute",
     left: thumbPos,
-    top: 60,
-   // backgroundColor: isDragging ? "red" : "transparent"
+    top: 60
   }
 
   const handlePointerDown = (e: React.PointerEvent) => {
-    // setIsDragging(true)
     mouseDownX.current = e.clientX
-    console.log("downX is: ", mouseDownX.current)
-
-    // console.log({downX, sliderX})
-    // if (downX !== foundMouse.current) {
-    //   foundMouse.current = downX//set foundMouse.
-    // }
-    // console.log("mouse went down at foundMouse.current: ", foundMouse.current)
-
-    //console.log("axisBounds is: ", axisBounds)
-    // foundMouse.current = getClientX(e.currentTarget)
-    // console.log("mouse went down at foundMouse.current: ", foundMouse.current) //set foundMouse.current
-    //
-    // const axisEdge = getClientX(theAxis)
-    // console.log("axisEdge is: ", axisEdge)
-    // setIsDragging(true)
   }
 
   const handlePointerUp = (e: React.PointerEvent) => {
@@ -67,9 +50,7 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
     if (componentX) {
       const pixelTarget = e.clientX - componentX
       const scaledValue = scale.invert(pixelTarget)
-      console.log("scaledValue is so set slider to it: ", scaledValue)
       sliderModel.setValue(scaledValue)
-      console.log("now sliderModel.value is: ", sliderModel.value)
     }
   }
 

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite"
-import React, {CSSProperties, useEffect, useState} from "react"
+import React, {CSSProperties, useEffect, useState, useRef} from "react"
 import {ISliderModel} from "./slider-model"
 import { ScaleNumericBaseType } from "../axis/axis-types"
 import { useAxisLayoutContext } from "../axis/models/axis-layout-context"
@@ -11,9 +11,10 @@ interface IProps {
   sliderModel: ISliderModel
 }
 
-const getClientX = (elt: any) => {
-  const { x } = elt.getBoundingClientRect()
-  return x
+const getComponentX = () => {
+  const wholeSlider = document.querySelector(".slider-wrapper")
+  const sliderBounds = wholeSlider?.getBoundingClientRect()
+  return sliderBounds?.x
 }
 
 export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
@@ -21,8 +22,9 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
   const length = layout.getAxisLength("bottom")
   const scale = layout.getAxisScale("bottom") as ScaleNumericBaseType
   const [thumbPos, setThumbPos] = useState(0)
-  const [initialThumbX, setInitialThumbX] = useState(0)
-  const [newSliderValueCandidate, setNewSliderValueCandidate] = useState(.5)
+  //const [isDragging, setIsDragging] = useState(false)
+  const mouseDownX = useRef(0)
+  const componentX = getComponentX()
 
   // when sliderModel.value changes, the thumb position changes
   useEffect(() => {
@@ -30,76 +32,55 @@ export const CodapSliderThumb = observer(({sliderModel} : IProps) => {
     setThumbPos(scale(sliderModel.value) - kThumbOffset)
   }, [length, scale, sliderModel.domain, sliderModel.value])
 
-
-  useEffect(() => {
-    console.log(newSliderValueCandidate)
-    sliderModel.setValue(newSliderValueCandidate)
-  },[newSliderValueCandidate])
-
-  // get and store in state the initial clientX position of thumb, as we init with 0 before model is here?
-  useEffect(() => {
-    const thumb = document.querySelector(".slider-thumb-svg") // use ref?
-    if (thumb) {
-      setInitialThumbX(getClientX(thumb))
-    }
-  },[])
-
   const thumbStyle: CSSProperties = {
     position: "absolute",
     left: thumbPos,
     top: 60,
+   // backgroundColor: isDragging ? "red" : "transparent"
   }
 
-  const handlePointerMove = (e: any) => {
-    const objecto = {
-      //initialThumbX 687
-      //thumbPos,
-      // "C currentMouseXPos": e.clientX.toFixed(3),
-      "1 sliderModel.value": sliderModel.value,
-      "2 scale(sliderModel.value)": scale(sliderModel.value) + "px",
-// is this is pixel value from left!
-      "3 thumbPos (scaled - 8)": thumbPos + "px",
-      "4 pixels back to value: ": scale.invert(scale(sliderModel.value)),
-      "5 mouse delta in pixels: ": e.clientX - initialThumbX - 8,
-      "6 that change represents a value change of: ": scale.invert(e.clientX - initialThumbX - 8),
-      "7 so new sliderModel value should be += that change: ": sliderModel.value + scale.invert(e.clientX - initialThumbX - 8),
-      //"so measured change in pixels: " : e.clientX - initialThumbX,
-     // "can be converted to change in value: " : scale.invert(e.clientX - initialThumbX),
-      // "T scale.invert(thumbPos)": scale.invert(thumbPos).toFixed(3),
-      // "D delta": (e.clientX - initialThumbX).toFixed(3),
-      // "D scale(delta)": scale(e.clientX - initialThumbX).toFixed(3),
-      // "D invert(scale(delta))": scale.invert(e.clientX - initialThumbX).toFixed(3)
+  const handlePointerDown = (e: React.PointerEvent) => {
+    // setIsDragging(true)
+    mouseDownX.current = e.clientX
+    console.log("downX is: ", mouseDownX.current)
+
+    // console.log({downX, sliderX})
+    // if (downX !== foundMouse.current) {
+    //   foundMouse.current = downX//set foundMouse.
+    // }
+    // console.log("mouse went down at foundMouse.current: ", foundMouse.current)
+
+    //console.log("axisBounds is: ", axisBounds)
+    // foundMouse.current = getClientX(e.currentTarget)
+    // console.log("mouse went down at foundMouse.current: ", foundMouse.current) //set foundMouse.current
+    //
+    // const axisEdge = getClientX(theAxis)
+    // console.log("axisEdge is: ", axisEdge)
+    // setIsDragging(true)
+  }
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    //setIsDragging(false)
+    console.log('mouse went up')
+  }
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (componentX) {
+      const pixelTarget = e.clientX - componentX
+      const scaledValue = scale.invert(pixelTarget)
+      console.log("scaledValue is: ", scaledValue)
+      sliderModel.setValue(scaledValue)
     }
-    //console.table({objecto})
-    const maybeValue = sliderModel.value + scale.invert(e.clientX - initialThumbX - 8)
-    console.log("maybe val: ", maybeValue)
-    setNewSliderValueCandidate(maybeValue)    //sliderModel.setValue(sliderModel.value + scale.invert(e.clientX - initialThumbX - 8))
-    //sliderModel.setValue(scale.invert(e.clientX + initialThumbX))
-    // const currentMouseXPos = e.clientX
-    // //console.log("InitialThumbX: ", initialThumbX, " vs ", "currentMouseXPos: ", currentMouseXPos)
-    // const delta = currentMouseXPos - initialThumbX
-    // console.log("delta: ", delta)
-    //const scaledChange = scale.invert(e.clientX - initialThumbX)
-    //console.log("scaledChange: ", scaledChange)
-    //sliderModel.setValue(sliderModel.value + scaledChange)
-  }
-
-  const addListenerToThumb = (e: React.PointerEvent) => {
-    const thumb = e.currentTarget as HTMLElement
-    setInitialThumbX(getClientX(thumb))
-    thumb.addEventListener("pointermove", handlePointerMove)
   }
 
   return (
-    <>
-    {newSliderValueCandidate}
      <ThumbIcon
-      onPointerDown={addListenerToThumb}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerMove={handlePointerMove}
       style={thumbStyle}
       className="slider-thumb-svg"
     />
-
-    </>
-
   )
 })
+

--- a/v3/src/components/slider/slider.scss
+++ b/v3/src/components/slider/slider.scss
@@ -57,6 +57,10 @@
         // padding: 2px 0px;
       }
     }
+
+    .slider-thumb-svg {
+      transition: left 0.15s linear;
+    }
   }
 }
 

--- a/v3/src/components/slider/slider.scss
+++ b/v3/src/components/slider/slider.scss
@@ -58,8 +58,14 @@
       }
     }
 
-    .slider-thumb-svg {
-      transition: left 0.15s linear;
+    .slider-thumb-icon {
+      position: absolute;
+      top: 60px;
+
+      &.dragging {
+        top: 59px;
+        filter: drop-shadow(3px 1px 1px #555);
+      }
     }
   }
 }


### PR DESCRIPTION
This adds drag and animation functionality to the slider.

**Drag Functionality**
- ~~The rounding for dragged values is now configured by a property on the model called `resolution`, hardcoded to `.01`~~
-  The `multipleOf` property ~~still~~ applies to incrementing the slider with the play button, ~~but does not apply to~~ dragging ~~or~~ and keyboard input of values (same as v2)
- The above are differentiated by distinguishing two methods on the model: `setValue` which rounds to the `resolution`, and `setValueRoundedToMultipleOf`, which rounds to the user-changeable `multipleOf` value. (same as v2)
- ~~D3 also has a method called `nice()` that could apply here, I think, but I have not tried it yet.~~

~~I'm aware that  the changes described above may be based on incomplete or incorrect assumptions about how `multiplesOf` is intended to work, so I wanted to be sure to flag them.~~
 
**Animation**
- ~~The motion of the slider across values is implemented with a CSS transition~~
- There is an `isDragging` piece of state on the thumbnail. I added some placeholder styles (a "pick up" effect with a drop shadow -- just a placeholder for the moment.

**clsx**
I've taken this opportunity to add the [clsx](https://www.npmjs.com/package/clsx) library to CODAP, which can be used to simplify adding classes to elements conditionally, for instance.