### PR TITLE
V3—Fix for plot background response to window size change—184125835

### DIFF
--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -1,6 +1,7 @@
 import {observer} from "mobx-react-lite"
 import {onAction} from "mobx-state-tree"
 import React, {MutableRefObject, useEffect, useRef} from "react"
+import {select} from "d3";
 import {Background} from "./background"
 import {DroppablePlot} from "./droppable-plot"
 import {GraphAxis} from "./graph-axis"
@@ -42,6 +43,7 @@ export const Graph = observer((
     instanceId = useInstanceIdContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
+    xScale = layout.getAxisScale("bottom"),
     svgRef = useRef<SVGSVGElement>(null),
     backgroundSvgRef = useRef<SVGGElement>(null),
     xAttrID = graphModel.getAttributeID('x'),
@@ -50,6 +52,16 @@ export const Graph = observer((
   useGraphModel({dotsRef, graphModel, enableAnimation, instanceId})
 
   const graphController = useGraphController({graphModel, enableAnimation, dotsRef})
+
+  useEffect(function setupPlotArea() {
+    if (xScale && xScale?.range().length > 0) {
+      select(dotsRef.current)
+        .attr('x', xScale?.range()[0])
+        .attr('y', 0)
+        .attr('width', layout.plotWidth)
+        .attr('height', layout.plotHeight)
+    }
+  }, [layout.plotHeight, layout.plotWidth, xScale])
 
   const handleChangeAttribute = (place: GraphPlace, attrId: string) => {
     const computedPlace = place === 'plot' && graphModel.config.noAttributesAssigned ? 'bottom' : place


### PR DESCRIPTION
Pull request #599 attempted to fix an unwanted clipping of graph points dragged to the right of the plot area. Unfortunately, those changes resulted in the bug described in #184125835.

* This pull request reinstates the Graph:setupPlotArea useEffect