### PR TITLE
V3: Update deployment instructions in README.md and some build improvements

### DIFF
--- a/.github/workflows/build-num-increment.yml
+++ b/.github/workflows/build-num-increment.yml
@@ -5,13 +5,16 @@ on:
       - main
     paths-ignore:
       - 'v3/build_number.json'
+      - 'v3/CHANGELOG.md' # Do not increment build number when release branches are merged into main, which typically change CHANGELOG.md
+                          # since we want to lock the build number we're about to release and 
+                          # do not want the release branch's merge to main to trigger another build number increment
 jobs:
   test:
     name: Increment value test
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,15 @@ on:
     paths-ignore: # don't run this workflow if it only contains v3 changes
       - 'v3/**'   # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-excluding-paths
       - '.github/workflows/v3.yml'
+    tags-ignore:
+      - '3.*'
 
 jobs:
   build_test:
     name: Build and Run Jest Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
@@ -79,7 +81,7 @@ jobs:
       # - cypress
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -42,7 +42,7 @@ jobs:
         containers: [1]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: cypress-io/github-action@v4
         with:
           working-directory: v3
@@ -77,7 +77,7 @@ jobs:
       - cypress
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
       - name: Install Dependencies
         working-directory: v3

--- a/v3/README.md
+++ b/v3/README.md
@@ -77,17 +77,20 @@ Other branches are deployed to https://codap3.concord.org/branch/{branch-name}/,
 
 To deploy a production release:
 
-1. Increment version number in package.json
-2. Create new entry in CHANGELOG.md
+1. Update the version number in `package.json` and `package-lock.json`
+    - `npm version --no-git-tag-version [patch|minor|major]`
+2. Create new entry in `CHANGELOG.md` with a description of the new version
 3. Run `git log --pretty=oneline --reverse <last release tag>...HEAD | grep '#' | grep -v Merge` and add contents (after edits if needed to CHANGELOG.md)
 4. Run `npm run build`
 5. Copy asset size markdown table from previous release and change sizes to match new sizes in `dist`
-6. Create `release-<version>` branch and commit changes, push to GitHub, create PR and merge
+6. Create `v3-release-<version>` branch and commit changes, push to GitHub, create PR and merge
 7. Checkout `master` and pull
-8. Checkout `v3-production`
-9. Run `git merge master --no-ff`
-10. Push `v3-production` to GitHub
-11. Use https://github.com/concord-consortium/codap/releases to create a new release tag
+8. Make a new version tag using your local git client with the version number in the description (e.g., `git tag -a 3.0.0-pre.1085 -m "version 3.0.0-pre.1085"`) and push the tag to the remote origin (e.g., `git push origin 3.0.0-pre.1085`)
+9. Watch the GitHub actions build to see that the S3 Deploy step finished and then QA this version using the versioned URL (e.g., https://codap3.concord.org/version/3.0.0-pre.1085/)
+10. Checkout `v3-production`
+11. Run `git merge master --no-ff`
+12. Push `v3-production` to GitHub
+13. Use https://github.com/concord-consortium/codap/releases to create a new release tag
 
 ### Testing
 - run `npm run lint` to lint the source files

--- a/v3/README.md
+++ b/v3/README.md
@@ -84,11 +84,11 @@ To deploy a production release:
 4. Run `npm run build`
 5. Copy asset size markdown table from previous release and change sizes to match new sizes in `dist`
 6. Create `v3-release-<version>` branch and commit changes, push to GitHub, create PR and merge
-7. Checkout `master` and pull
+7. Checkout `main` and pull
 8. Make a new version tag using your local git client with the version number in the description (e.g., `git tag -a 3.0.0-pre.1085 -m "version 3.0.0-pre.1085"`) and push the tag to the remote origin (e.g., `git push origin 3.0.0-pre.1085`)
 9. Watch the GitHub actions build to see that the S3 Deploy step finished and then QA this version using the versioned URL (e.g., https://codap3.concord.org/version/3.0.0-pre.1085/)
 10. Checkout `v3-production`
-11. Run `git merge master --no-ff`
+11. Run `git merge main --no-ff`
 12. Push `v3-production` to GitHub
 13. Use https://github.com/concord-consortium/codap/releases to create a new release tag
 


### PR DESCRIPTION
This PR has the following changes:

1. Updating `README.md` with deployment instructions
2. Upgrading actions/checkout@v2 in github workflows to actions/checkout@v3 (to see if this fixes the build number increment failures)
3. Making sure on:push: events for v3 tags don't trigger v2 builds
4. Making sure we lock the build number and don't increment it when release branches are merged into main so that the version number matches the build number