### PR TITLE
V3—choropleth-legend—184029172

### DIFF
--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -200,7 +200,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
   }, [keysElt, categoryData, setupKeys, refreshKeys, dataConfiguration])
 
   return (
-    <svg className='categories' ref={elt => setKeysElt(elt)}></svg>
+    <svg className='legend-categories' ref={elt => setKeysElt(elt)}></svg>
   )
 })
 CategoricalLegend.displayName = "CategoricalLegend"

--- a/v3/src/components/graph/components/legend/choroplethLegend/choroplethLegend.ts
+++ b/v3/src/components/graph/components/legend/choroplethLegend/choroplethLegend.ts
@@ -13,7 +13,7 @@ import {
   scaleLinear,
   format,
   // range,
-  select, range, min, max
+  select, range, min, max, ScaleQuantile
 } from "d3"
 import {kChoroplethHeight} from "../../../graphing-types"
 import {neededSigDigitsArrayForQuantiles} from "../../../../../utilities/math-utils"
@@ -31,16 +31,17 @@ export type ChoroplethLegendProps = {
   casesInQuantileSelectedHandler: (quantile: number) => boolean
 }
 
-export function choroplethLegend(scale: any, choroplethElt: SVGGElement, props: ChoroplethLegendProps) {
+type ChoroplethScale = ScaleQuantile<string>
+export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElement, props: ChoroplethLegendProps) {
   const {
       tickSize = 6, transform = '', width = 320, marginTop = 0, marginRight = 0, marginLeft = 0,
       ticks = 5, clickHandler, casesInQuantileSelectedHandler
     } = props,
-    minValue = min(scale.domain()),
-    maxValue = max(scale.domain())
+    minValue = min(scale.domain()) ?? 0,
+    maxValue = max(scale.domain()) ?? 0
 
-  let tickFormat: any = '.2r',
-    tickValues: any = []
+  let tickFormat: string | ((i: number) => string) = '.2r',
+    tickValues: number[] = []
 
   select(choroplethElt).selectAll("*").remove()
   const svg = select(choroplethElt).append("svg")

--- a/v3/src/components/graph/components/legend/choroplethLegend/choroplethLegend.ts
+++ b/v3/src/components/graph/components/legend/choroplethLegend/choroplethLegend.ts
@@ -1,0 +1,180 @@
+// Copyright 2021, Observable Inc.
+// Released under the ISC license.
+// https://observablehq.com/@d3/scale-legend
+import {
+  axisBottom,
+  interpolate,
+  interpolateRound,
+  quantize,
+  scaleBand,
+  ScaleContinuousNumeric,
+  scaleLinear,
+  format,
+  range,
+  select
+} from "d3"
+import {kChoroplethHeight} from "../../../graphing-types"
+
+export function choroplethLegend(scale:any, choroplethElt:SVGGElement, {
+  title='',
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+  tickSize = 6,
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+  width = 320,
+  height = 44 + tickSize,
+  rectHeight = 16,
+  transform = '',
+  marginTop = 0,
+  marginRight = 0,
+  marginBottom = 16 + tickSize,
+  marginLeft = 0,
+  ticks = width / 64,
+  tickFormat='',
+  tickValues:any = []
+} = {}) {
+
+  function ramp(iScale:ScaleContinuousNumeric<number, string>, n = 256) {
+    const canvas = document.createElement("canvas")
+    canvas.width = n
+    canvas.height = 1
+    const context = canvas.getContext("2d") as CanvasRenderingContext2D
+    for (let i = 0; i < n; ++i) {
+      context.fillStyle = iScale(i / (n - 1))
+      context.fillRect(i, 0, 1, 1)
+    }
+    return canvas
+  }
+
+  const svg = select(choroplethElt).append("svg")
+    .attr('transform', transform)
+    .attr("width", width)
+    .attr("height", height)
+    // .attr("viewBox", [0, 0, width, height])
+    .style("overflow", "visible")
+    .style("display", "block")
+
+  // let tickAdjust = (g:any) => g.selectAll(".tick line").attr("y1", marginTop + marginBottom - height)
+  let x:any
+
+  // Continuous
+  if (scale.interpolate) {
+    const n = Math.min(scale.domain().length, scale.range().length)
+
+    x = scale.copy().rangeRound(quantize(interpolate(marginLeft, width - marginRight), n))
+
+    svg.append("image")
+      .attr("x", marginLeft)
+      .attr("y", marginTop)
+      .attr("width", width - marginLeft - marginRight)
+      .attr("height", height - marginTop - marginBottom)
+      .attr("preserveAspectRatio", "none")
+      .attr("xlink:href", ramp(scale.copy().domain(quantize(interpolate(0, 1), n))).toDataURL())
+  }
+
+  // Sequential
+  else if (scale.interpolator) {
+    x = Object.assign(scale.copy()
+        .interpolator(interpolateRound(marginLeft, width - marginRight)),
+      {range() { return [marginLeft, width - marginRight] }})
+
+    svg.append("image")
+      .attr("x", marginLeft)
+      .attr("y", marginTop)
+      .attr("width", width - marginLeft - marginRight)
+      .attr("height", height - marginTop - marginBottom)
+      .attr("preserveAspectRatio", "none")
+      .attr("xlink:href", ramp(scale.interpolator()).toDataURL())
+
+    // scaleSequentialQuantile doesn’t implement ticks or tickFormat.
+    if (!x.ticks) {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+      if (tickValues === undefined) {
+        const n = Math.round(ticks + 1)
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+        tickValues = range(n).map(i => quantile(scale.domain(), i / (n - 1)))
+      }
+      if (typeof tickFormat !== "function") {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+        tickFormat = format(tickFormat === undefined ? ",f" : tickFormat)
+      }
+    }
+  }
+
+  // Threshold
+  else if (scale.invertExtent) {
+    const thresholds
+      = scale.thresholds ? scale.thresholds() // scaleQuantize
+      : scale.quantiles ? scale.quantiles() // scaleQuantile
+        : scale.domain() // scaleThreshold
+
+    const thresholdFormat
+      = tickFormat === undefined ? (d:any) => d
+      : typeof tickFormat === "string" ? format(tickFormat)
+        : tickFormat
+
+    x = scaleLinear()
+      .domain([-1, scale.range().length - 1])
+      .rangeRound([marginLeft, width - marginRight])
+
+    svg.append("g")
+      .selectAll("rect")
+      .data(scale.range())
+      .join("rect")
+      .attr('transform', transform)
+      .attr("x", (d, i) => x(i - 1))
+      .attr("y", marginTop)
+      .attr("width", (d, i) => x(i) - x(i - 1))
+      .attr("height", kChoroplethHeight /*height - marginTop - marginBottom*/)
+      .attr("fill", (d:string) => d)
+
+    // const tickValues = range(thresholds.length)
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+    tickFormat = i => thresholdFormat(thresholds[i], i)
+  }
+
+  // Ordinal
+  else {
+    x = scaleBand()
+      .domain(scale.domain())
+      .rangeRound([marginLeft, width - marginRight])
+
+    svg.append("g")
+      .selectAll("rect")
+      .data(scale.domain())
+      .join("rect")
+      .attr("x", x)
+      .attr("y", marginTop)
+      .attr("width", Math.max(0, x.bandwidth() - 1))
+      .attr("height", height - marginTop - marginBottom)
+      .attr("fill", scale)
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    // tickAdjust = () => {}
+  }
+
+  svg.append("g")
+    .attr("transform", transform + `translate(0,${kChoroplethHeight})`)
+    .call(axisBottom(x)
+      .ticks(ticks, typeof tickFormat === "string" ? tickFormat : undefined))
+      // .tickFormat(typeof tickFormat === "function" ? tickFormat : undefined)
+      // .tickSize(tickSize)
+      // .tickValues(tickValues))
+    // .call(tickAdjust)
+    // .call(g => g.select(".domain").remove())
+    // .call(g => g.append("text")
+    //   .attr("x", marginLeft)
+    //   .attr("y", marginTop + marginBottom - height - 6)
+    //   .attr("fill", "currentColor")
+    //   .attr("text-anchor", "start")
+    //   .attr("font-weight", "bold")
+    //   .attr("class", "title")
+    //   .text(title))
+
+  return svg.node()
+}

--- a/v3/src/components/graph/components/legend/legend.scss
+++ b/v3/src/components/graph/components/legend/legend.scss
@@ -33,7 +33,7 @@
   text-align: center;
 }
 
-.categories {
+.legend-categories {
 
 }
 

--- a/v3/src/components/graph/components/legend/numeric-legend.tsx
+++ b/v3/src/components/graph/components/legend/numeric-legend.tsx
@@ -70,12 +70,12 @@ export const NumericLegend = memo(function NumericLegend({transform, legendAttrI
   }, [layout, dataConfiguration, refreshScale])
 
   useEffect(function respondToSelectionChange() {
-    return onAction(dataset, action => {
+    return dataConfiguration?.onAction(action => {
       if (isSelectionAction(action)) {
         refreshScale()
       }
-    }, true)
-  }, [refreshScale, dataset])
+    })
+  }, [refreshScale, dataConfiguration])
 
   // todo: This reaction is not being triggered when a legend attribute value is changed.
   // It should be.

--- a/v3/src/components/graph/components/legend/numeric-legend.tsx
+++ b/v3/src/components/graph/components/legend/numeric-legend.tsx
@@ -1,18 +1,55 @@
-import React, {memo} from "react"
+import React, {memo, useCallback, useEffect, useRef, useState} from "react"
+import {ScaleQuantile, scaleQuantile, schemeBlues} from "d3"
+import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
+import {useGraphLayoutContext} from "../../models/graph-layout"
+import {choroplethLegend} from "./choroplethLegend/choroplethLegend"
+import {measureTextExtent} from "../../../../hooks/use-measure-text"
+import {useDataSetContext} from "../../../../hooks/use-data-set-context"
+import {kChoroplethHeight, kGraphFont} from "../../graphing-types"
+import {axisGap} from "../../../axis/axis-types"
 
 interface INumericLegendProps {
   legendAttrID: string
-  transform:string
+  transform: string
 }
 
-export const NumericLegend = memo(function NumericLegend({legendAttrID}: INumericLegendProps) {
-/*
+export const NumericLegend = memo(function NumericLegend({transform, legendAttrID}: INumericLegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
-    values = dataConfiguration?.numericValuesForAttrRole('legend')
+    layout = useGraphLayoutContext(),
+    dataset = useDataSetContext(),
+    quantileScale = useRef<ScaleQuantile<string>>(scaleQuantile()),
+    [choroplethElt, setChoroplethElt] = useState<SVGGElement | null>(null),
+    valuesRef = useRef<number[]>([]),
+
+    computeDesiredExtent = useCallback(() => {
+      const labelHeight = measureTextExtent(dataset?.attrFromID(legendAttrID).name ?? '', kGraphFont).height
+      return 2 * labelHeight + kChoroplethHeight + 2 * axisGap
+    }, [dataset, legendAttrID])
+
+  useEffect(() => {
+    if (choroplethElt) {
+      layout.setDesiredExtent('legend', computeDesiredExtent())
+      quantileScale.current.domain(valuesRef.current).range(schemeBlues[5])
+      const bounds = layout.computedBounds.get('legend'),
+        translate = `translate(${bounds?.left}, ${bounds?.top})`
+      choroplethLegend(quantileScale.current, choroplethElt,
+        {
+          transform: translate, width: bounds?.width, height: bounds?.height, marginLeft: 6, marginRight: 6
+        })
+    }
+  }, [dataConfiguration, layout, legendAttrID, computeDesiredExtent, choroplethElt])
+
+
+/*
+  useEffect(function setup() {
+    if (choroplethElt) {
+      layout.setDesiredExtent('legend', computeDesiredExtent())
+      quantileScale.current.domain(valuesRef.current).range(schemeBlues[5])
+    }
+  }, [choroplethElt, computeDesiredExtent, layout, dataConfiguration])
 */
 
-  return (
-    <></>
-  )
+
+  return <svg className='legend-categories' ref={elt => setChoroplethElt(elt)}></svg>
 })
 NumericLegend.displayName = "NumericLegend"

--- a/v3/src/components/graph/components/legend/numeric-legend.tsx
+++ b/v3/src/components/graph/components/legend/numeric-legend.tsx
@@ -77,6 +77,8 @@ export const NumericLegend = memo(function NumericLegend({transform, legendAttrI
     return disposer
   }, [refreshScale, dataset])
 
+  // todo: This reaction is not begin trigger when a value of the legend attribute is changed.
+  // It should be.
   useEffect(function respondToNumericValuesChange() {
     const disposer = reaction(
       () => dataConfiguration?.numericValuesForAttrRole('legend'),
@@ -85,7 +87,6 @@ export const NumericLegend = memo(function NumericLegend({transform, legendAttrI
       })
     return disposer
   }, [dataConfiguration, refreshScale])
-
 
   return <svg className='legend-categories' ref={elt => setChoroplethElt(elt)}></svg>
 })

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -67,7 +67,8 @@ export const kTitleBarHeight = 25,
   pointRadiusLogBase = 2.0, // reduce point radius from max by log of (num. cases) base (LogBase).
   pointRadiusSelectionAddend = 1,
   hoverRadiusFactor = 1.5,
-  kGraphFont = '12px sans-serif'
+  kGraphFont = '12px sans-serif',
+  kChoroplethHeight = 16
 
 export const PlotTypes = ["casePlot", "dotPlot", "dotChart", "scatterPlot"] as const
 export type PlotType = typeof PlotTypes[number]

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -71,7 +71,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     }, 10)
   }, [refreshPointsRef])
 
-  useEffect(() => {
+  useEffect(function doneWithTimer() {
     return () => {
       if (timer.current) {
         clearTimeout(timer.current)

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -251,22 +251,7 @@ export const DataConfigurationModel = types
           })) ?? []
         return selection.length > 0 && (selection as Array<string>).every(anID => dataset?.isCaseSelected(anID))
       },
-      selectCasesForLegendQuantile(quantile: number, extend = false) {
-        const dataset = self.dataset,
-          legendID = self.attributeID('legend'),
-          thresholds = self.legendQuantileScale.quantiles(),
-          min = quantile === 0 ? -Infinity : thresholds[quantile - 1],
-          max = quantile === thresholds.length ? Infinity : thresholds[quantile],
-          selection = legendID && self.cases.filter((anID: string) => {
-            const value = dataset?.getNumeric(anID, legendID)
-            return value !== undefined && value >= min && value < max
-          })
-        if (selection) {
-          if (extend) dataset?.selectCases(selection)
-          else dataset?.setSelectedCases(selection)
-        }
-      },
-      casesInQuantileSelected(quantile: number): boolean {
+      selectedCasesForLegendQuantile(quantile: number) {
         const dataset = self.dataset,
           legendID = self.attributeID('legend'),
           thresholds = self.legendQuantileScale.quantiles(),
@@ -278,7 +263,18 @@ export const DataConfigurationModel = types
               return value !== undefined && value >= min && value < max
             })
             : []
-        return !!(selection.length > 0 &&selection?.every((anID: string) => dataset?.isCaseSelected(anID)))
+        return selection
+      },
+      selectCasesForLegendQuantile(quantile: number, extend = false) {
+        const selection = this.selectedCasesForLegendQuantile(quantile)
+        if (selection) {
+          if (extend) self.dataset?.selectCases(selection)
+          else self.dataset?.setSelectedCases(selection)
+        }
+      },
+      casesInQuantileSelected(quantile: number): boolean {
+        const selection = this.selectedCasesForLegendQuantile(quantile)
+        return !!(selection.length > 0 && selection?.every((anID: string) => self.dataset?.isCaseSelected(anID)))
       }
     }))
   .views(self => (

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -131,7 +131,7 @@ export class GraphLayout {
       {left: leftAxisWidth, top: topAxisHeight + plotHeight, width: plotWidth,
         height: bottomAxisHeight})
     newBounds.set('legend',
-      {left: leftAxisWidth, top: graphHeight - legendHeight, width: graphWidth,
+      {left: 6, top: graphHeight - legendHeight, width: graphWidth - 6,
         height: legendHeight})
     newBounds.set('right',
       {left: rightAxisWidth + plotWidth, top: topAxisHeight, width: rightAxisWidth,

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -1,7 +1,98 @@
+import {format} from "d3"
 
-
-export function between(num:number, min:number, max:number) {
+export function between(num: number, min: number, max: number) {
   return min < max ? (min <= num && num <= max) : (max <= num && num <= min)
 }
 
+/* Given two numbers, determine the least number of significant figures needed for their display to distinguish
+* between them. */
+export function neededSignificantDigits(num1: number, num2: number) {
+  let significantDigits = 0,
+    f: (n: (number | { valueOf(): number })) => string,
+    done = false
+  while (!done) {
+    f = format(`.${significantDigits}r`)
+    const num1str = f(num1),
+      num2str = f(num2)
+    done = num1str !== num2str
+    if (!done) {
+      significantDigits++
+    }
+  }
+  return significantDigits
+}
 
+/**
+ * Given an array of numbers, return a new array of signficiant digits needed for each number in the array to
+ * distinguish it from the numbers on either side of it. For the first and last numbers, the number of significant
+ * digits needed only need consider the second and second to last numbers, respectively. Use
+ * `neededSignificantDigits` to determine the number of significant digits needed for each pair of numbers.
+ */
+export function neededSignificantDigitsArray(numbers: number[]) {
+  return numbers.map((num, index) => {
+    if (index === 0) {
+      return neededSignificantDigits(numbers[1], num)
+    } else if (index === numbers.length - 1) {
+      return neededSignificantDigits(numbers[numbers.length - 2], num)
+    } else {
+      return Math.max(neededSignificantDigits(numbers[index - 1], num),
+        neededSignificantDigits(numbers[index + 1], num))
+    }
+  })
+}
+
+/**
+ * Given an array of quantile boundary values and an array of numbers, return a new array of significant digits
+ * needed for each quantile boundary value to distinguish it from the numbers on either side of it in the array.
+ * Both the array of quantile boundary values and the array of numbers is assumed to be sorted.
+ */
+export function neededSigDigitsArrayForQuantiles(quantiles: number[], values: number[]) {
+
+  const sigDigits = (n1: number, n2: number, operator: '<' | '>' | '<=' | '>=') => {
+    let significantDigits = 0,
+      f: (n: (number | { valueOf(): number })) => string,
+      done = false
+    while (!done) {
+      f = format(`.${significantDigits}r`)
+      const n1Afterformatting = Number(f(n1))
+      switch (operator) {
+        case '<':
+          done = n1Afterformatting < n2
+          break
+        case ">":
+          done = n1Afterformatting > n2
+          break
+        case "<=":
+          done = n1Afterformatting <= n2
+          break
+        case ">=":
+          done = n1Afterformatting >= n2
+      }
+      if (!done) {
+        significantDigits++
+      }
+    }
+    return significantDigits
+
+  }
+
+  const lastQuantileIndex = quantiles.length - 1,
+    lastValuesIndex = values.length - 1
+  return quantiles.map((boundaryValue, index) => {
+    const
+      leftValue = index === 0 ? boundaryValue
+        : values.find((value, i) => {
+          return i < lastValuesIndex && value < boundaryValue && values[i + 1] >= boundaryValue
+        }),
+      rightValue = index === lastQuantileIndex ? boundaryValue
+        : values.find((value, i) => {
+          return i > 0 && value > boundaryValue && values[i - 1] <= boundaryValue
+        })
+    const
+      leftDigits = leftValue !== undefined ? sigDigits(leftValue, boundaryValue,
+        index === 0 ? '<=' : '<') : 0,
+      rightDigits = rightValue !== undefined ? sigDigits(rightValue, boundaryValue,
+        index === lastQuantileIndex ? '>=' : '>') : 0
+    return Math.max(leftDigits, rightDigits)
+  })
+}

--- a/v3/webpack.config.js
+++ b/v3/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = (env, argv) => {
       client: {
         overlay: {
           errors: true,
-          warnings: true,
+          warnings: false,
         },
       },
     },

--- a/v3/webpack.config.js
+++ b/v3/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = (env, argv) => {
       client: {
         overlay: {
           errors: true,
-          warnings: false,
+          warnings: true,
         },
       },
     },


### PR DESCRIPTION
With this pull request assigning a numeric attribute as a legend colors points according to which of 5 quintiles their legend attribute values lie in.

Note that there is a function `neededSignificantDigitsArray` in math-utils that is not currently being used. But I'd like to keep it around, at least for awhile.