### PR TITLE
Implement default free layout

### DIFF
--- a/v3/src/components/container.tsx
+++ b/v3/src/components/container.tsx
@@ -1,6 +1,8 @@
 import React from "react"
+import { FreeTileRowComponent } from "./free-tile-row"
 import { MosaicTileRowComponent } from "./mosaic-tile-row"
 import { IDocumentContentModel } from "../models/document/document-content"
+import { isFreeTileRow } from "../models/document/free-tile-row"
 import { isMosaicTileRow } from "../models/document/mosaic-tile-row"
 
 import "./container.scss"
@@ -16,6 +18,8 @@ export const Container: React.FC<IProps> = ({ content }) => {
     <div className="codap-container">
       {isMosaicTileRow(row) &&
         <MosaicTileRowComponent row={row} getTile={getTile} />}
+      {isFreeTileRow(row) &&
+        <FreeTileRowComponent row={row} getTile={getTile} />}
     </div>
   )
 }

--- a/v3/src/components/data-summary/data-summary.scss
+++ b/v3/src/components/data-summary/data-summary.scss
@@ -1,7 +1,9 @@
+@use "../vars.scss";
+
 .data-summary {
   position: relative;
   width: 100%;
-  height: 100%;
+  height: calc(100% - vars.$title-bar-height);
   background-color: aliceblue;
   padding: 5px;
 
@@ -12,7 +14,7 @@
   .summary-inspector-drop {
     position: absolute;
     left: 10px;
-    bottom: 35px;
+    bottom: 10px;
     border: 1px solid gray;
     padding: 5px 10px;
     background: #eee;
@@ -27,14 +29,14 @@
   .summary-attribute-info {
     position: absolute;
     left: 160px;
-    bottom: 35px;
+    bottom: 10px;
     padding: 5px;
   }
 
   .profiler-button {
     position: absolute;
     right: 10px;
-    bottom: 35px;
+    bottom: 10px;
     padding: 5px 10px;
     background: #eee;
   }

--- a/v3/src/components/free-tile-row.scss
+++ b/v3/src/components/free-tile-row.scss
@@ -1,0 +1,10 @@
+.free-tile-row {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+
+  .free-tile-component {
+    position: absolute;
+  }
+}

--- a/v3/src/components/free-tile-row.tsx
+++ b/v3/src/components/free-tile-row.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { IFreeTileRow } from "../models/document/free-tile-row"
+import { getTileComponentInfo } from "../models/tiles/tile-component-info"
+import { ITileModel } from "../models/tiles/tile-model"
+import { CodapComponent } from "./codap-component"
+
+import "./free-tile-row.scss"
+
+interface IFreeTileRowProps {
+  row: IFreeTileRow
+  getTile: (tileId: string) => ITileModel | undefined
+}
+export const FreeTileRowComponent = ({ row, getTile }: IFreeTileRowProps) => {
+  return (
+    <div className="free-tile-row">
+      {
+        row?.tileIds.map(tileId => {
+          const tile = getTile(tileId)
+          const tileType = tile?.content.type
+          const { x: left, y: top, width, height } = row.tiles.get(tileId) || {}
+          const style: React.CSSProperties = { left, top, width, height }
+          const info = getTileComponentInfo(tileType)
+          return (
+            <div className="free-tile-component" style={style} key={tileId}>
+              {tile && info &&
+                <CodapComponent tile={tile} Component={info.Component} tileEltClass={info.tileEltClass} />}
+            </div>
+          )
+        })
+      }
+    </div>
+  )
+}

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -1,13 +1,15 @@
+@use "../../vars.scss";
+
 .graph-plot {
   position: relative;
   width: 100%;
-  height: 100%;
+  height: calc(100% - vars.$title-bar-height);
   background-color: aliceblue;
 
 
   svg {
     width: 100%;
-    height: 100%;
+    height: calc(100% - vars.$title-bar-height);
   }
 
   text {

--- a/v3/src/components/mosaic-tile-row.scss
+++ b/v3/src/components/mosaic-tile-row.scss
@@ -2,6 +2,7 @@
   width: 100%;
   // TODO: will need to handle height dynamically to support multiple rows
   height: 100%;
+  overflow: hidden;
 
   .mosaic-tile-node {
     width: 100%;

--- a/v3/src/components/slider/slider.scss
+++ b/v3/src/components/slider/slider.scss
@@ -1,9 +1,11 @@
 @import "./../vars.scss";
 
+$pseudo-inspector-width: 40px;
+
 .slider-wrapper {
   position: relative;
   overflow: clip;
-  width: calc(100% - 40px);
+  width: calc(100% - $pseudo-inspector-width);
   height: 100px;
   background: #fff;
   border-radius: $border-radius-four-corners;
@@ -72,9 +74,14 @@
 
 .app {
   //temporary until we implement the real inspector
+  .free-tile-row {
+    .slider-wrapper {
+      width: 100%;
+    }
+  }
   .inspector-temporary {
     position: absolute;
-    width: 40px;
+    width: $pseudo-inspector-width;
     text-align: center;
     input {
       width: 34px;

--- a/v3/src/models/document/create-codap-document.ts
+++ b/v3/src/models/document/create-codap-document.ts
@@ -3,12 +3,13 @@ import { DataSummaryModel } from "../../components/data-summary/data-summary-mod
 import { GraphModel } from "../../components/graph/models/graph-model"
 import { HelloCodapModel } from "../../components/hello/hello-model"
 import { SliderModel } from "../../components/slider/slider-model"
+import { urlParams } from "../../utilities/url-params"
 import { TileModel } from "../tiles/tile-model"
 import { createDocumentModel } from "./create-document-model"
 import { IDocumentModel, IDocumentModelSnapshot } from "./document"
 import { DocumentContentModel } from "./document-content"
-// import { FreeTileRow } from "./free-tile-row"
-import { MosaicTileRow } from "./mosaic-tile-row"
+import { FreeTileRow, IFreeTileInRowOptions } from "./free-tile-row"
+import { IMosaicTileInRowOptions, isMosaicTileRow, MosaicTileRow } from "./mosaic-tile-row"
 
 export function createCodapDocument(snapshot?: IDocumentModelSnapshot): IDocumentModel {
   const document = createDocumentModel({ type: "CODAP", ...snapshot })
@@ -16,11 +17,14 @@ export function createCodapDocument(snapshot?: IDocumentModelSnapshot): IDocumen
     document.setContent(DocumentContentModel.create() as any)
   }
   if (document.content?.rowCount === 0) {
+    const isFreeLayout = urlParams.layout === "free"
     // CODAP v2/v3 documents have a single "row" containing all tiles/components
     // const rowCreator = () => FreeTileRow.create()
     // But for now we use a mosaic to preserve the current dashboard behavior until
     // we have the ability to create/move components.
-    const rowCreator = () => MosaicTileRow.create()
+    const rowCreator = isFreeLayout
+                        ? () => FreeTileRow.create()
+                        : () => MosaicTileRow.create()
     const row = rowCreator()
     document.content.setRowCreator(rowCreator)
     document.content.insertRow(row)
@@ -40,6 +44,8 @@ export function setCurrentDocument(snapshot?: IDocumentModelSnapshot) {
   gCurrentDocument = createCodapDocument(snapshot)
 }
 
+type ILayoutOptions = IFreeTileInRowOptions | IMosaicTileInRowOptions | undefined
+
 // TODO: Eliminate (or hide behind a URL parameter) default dashboard content
 export function addDefaultComponents() {
   const content = gCurrentDocument.content
@@ -48,16 +54,40 @@ export function addDefaultComponents() {
   const row = content.getRowByIndex(0)
   if (!row) return
 
+  const kFullWidth = 580
+  const kFullHeight = 300
+  const kHalfHeight = kFullHeight / 2
+  const kGap = 10
+
   setTimeout(() => {
     const summaryTile = TileModel.create({ content: DataSummaryModel.create() })
-    content.insertTileInRow(summaryTile, row)
+    const summaryOptions: ILayoutOptions = isMosaicTileRow(row)
+            ? undefined
+            : { x: 2, y: 2, width: kFullWidth, height: kFullHeight }
+    content.insertTileInRow(summaryTile, row, summaryOptions)
+
     const tableTile = TileModel.create({ content: CaseTableModel.create() })
-    content.insertTileInRow(tableTile, row, { splitTileId: summaryTile.id, direction: "column" })
+    const tableOptions: ILayoutOptions = isMosaicTileRow(row)
+            ? { splitTileId: summaryTile.id, direction: "column" }
+            : { x: 2, y: kFullHeight + kGap, width: kFullWidth, height: kFullHeight }
+    content.insertTileInRow(tableTile, row, tableOptions)
+
     const helloTile = TileModel.create({ content: HelloCodapModel.create() })
-    content.insertTileInRow(helloTile, row, { splitTileId: summaryTile.id, direction: "row" })
+    const helloOptions = isMosaicTileRow(row)
+            ? { splitTileId: summaryTile.id, direction: "row" }
+            : { x: kFullWidth + kGap, y: 2, width: kFullWidth, height: kHalfHeight }
+    content.insertTileInRow(helloTile, row, helloOptions)
+
     const sliderTile = TileModel.create({ content: SliderModel.create() })
-    content.insertTileInRow(sliderTile, row, { splitTileId: helloTile.id, direction: "column" })
+    const sliderOptions = isMosaicTileRow(row)
+            ? { splitTileId: helloTile.id, direction: "column" }
+            : { x: kFullWidth + kGap, y: kHalfHeight + kGap / 2, width: kFullWidth, height: kHalfHeight }
+    content.insertTileInRow(sliderTile, row, sliderOptions)
+
     const graphTile = TileModel.create({ content: GraphModel.create() })
-    content.insertTileInRow(graphTile, row, { splitTileId: tableTile.id, direction: "row" })
+    const graphOptions = isMosaicTileRow(row)
+            ? { splitTileId: tableTile.id, direction: "row" }
+            : { x: kFullWidth + kGap, y: kFullHeight + kGap, width: kFullWidth, height: kFullHeight }
+    content.insertTileInRow(graphTile, row, graphOptions)
   })
 }

--- a/v3/src/models/document/free-tile-row.ts
+++ b/v3/src/models/document/free-tile-row.ts
@@ -1,5 +1,5 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
-import { ITileInRowOptions, TileRowModel } from "./tile-row"
+import { ITileInRowOptions, ITileRowModel, TileRowModel } from "./tile-row"
 
 /*
   Represents the layout of a set of tiles/components with arbitrary rectangular bounds that can
@@ -108,3 +108,7 @@ export const FreeTileRow = TileRowModel
     }
   }))
   export interface IFreeTileRow extends Instance<typeof FreeTileRow> {}
+
+export function isFreeTileRow(row?: ITileRowModel): row is IFreeTileRow {
+  return row?.type === "free"
+}


### PR DESCRIPTION
Add `layout=free` url parameter to enable free (CODAP v2-like) component layout.
Once we have basic component creation, moving, and resize we can make free layout the default.