### PR TITLE
V3: Store DataSets as shared models in document

### DIFF
--- a/v3/patches/mobx-state-tree+5.1.7.patch
+++ b/v3/patches/mobx-state-tree+5.1.7.patch
@@ -1,3 +1,18 @@
+diff --git a/node_modules/mobx-state-tree/dist/mobx-state-tree.js b/node_modules/mobx-state-tree/dist/mobx-state-tree.js
+index e0f7f6a..d721ded 100644
+--- a/node_modules/mobx-state-tree/dist/mobx-state-tree.js
++++ b/node_modules/mobx-state-tree/dist/mobx-state-tree.js
+@@ -3034,8 +3034,8 @@ function onAction(target, listener, attachAfter) {
+     // check all arguments
+     assertIsStateTreeNode(target, 1);
+     if (devMode()) {
+-        if (!isRoot(target))
+-            warnError("Warning: Attaching onAction listeners to non root nodes is dangerous: No events will be emitted for actions initiated higher up in the tree.");
++        // [CC] if (!isRoot(target))
++        // [CC]     warnError("Warning: Attaching onAction listeners to non root nodes is dangerous: No events will be emitted for actions initiated higher up in the tree.");
+         if (!isProtected(target))
+             warnError("Warning: Attaching onAction listeners to non protected nodes is dangerous: No events will be emitted for direct modifications without action.");
+     }
 diff --git a/node_modules/mobx-state-tree/dist/mobx-state-tree.module.js b/node_modules/mobx-state-tree/dist/mobx-state-tree.module.js
 index cffca0a..20dd829 100644
 --- a/node_modules/mobx-state-tree/dist/mobx-state-tree.module.js

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -1,3 +1,4 @@
+import { getEnv } from "mobx-state-tree"
 import React, { useCallback, useEffect, useState } from "react"
 import { CodapDndContext } from "./codap-dnd-context"
 import { ToolShelf } from "./tool-shelf/tool-shelf"
@@ -5,6 +6,8 @@ import {Container} from "./container"
 import {gDataBroker} from "../models/data/data-broker"
 import {DataSet, IDataSet, toCanonical} from "../models/data/data-set"
 import { addDefaultComponents, getCurrentDocument } from "../models/document/create-codap-document"
+import { ISharedModelDocumentManager } from "../models/document/shared-model-document-manager"
+import { ITileEnvironment } from "../models/tiles/tile-content"
 import {useDropHandler} from "../hooks/use-drop-handler"
 import { useKeyStates } from "../hooks/use-key-states"
 import { V2DocumentContext } from "../hooks/use-v2-document-context"
@@ -12,6 +15,7 @@ import { registerTileTypes } from "../register-tile-types"
 import { importSample, sampleData } from "../sample-data"
 import { urlParams } from "../utilities/url-params"
 import { CodapV2Document } from "../v2/codap-v2-document"
+import "../models/shared/shared-data-set-registration"
 
 import "./app.scss"
 
@@ -56,6 +60,14 @@ export const App = () => {
   }
 
   useEffect(() => {
+    // connect the data broker to the shared model manager
+    if (!gDataBroker.sharedModelManager) {
+      const docEnv: ITileEnvironment | undefined = getEnv(getCurrentDocument())
+      const sharedModelManager = docEnv?.sharedModelManager as ISharedModelDocumentManager | undefined
+      sharedModelManager && gDataBroker.setSharedModelManager(sharedModelManager)
+    }
+
+    // create the initial sample data (if specified) or a new data set
     if (gDataBroker.dataSets.size === 0) {
       const sample = sampleData.find(name => urlParams.sample === name)
       if (sample) {

--- a/v3/src/models/data/data-broker.ts
+++ b/v3/src/models/data/data-broker.ts
@@ -1,4 +1,6 @@
 import { action, makeObservable, observable } from "mobx"
+import { ISharedModelDocumentManager } from "../document/shared-model-document-manager"
+import { SharedDataSet } from "../shared/shared-data-set"
 import { IDataSet } from "./data-set"
 
 export interface IDataSetSummary {
@@ -15,6 +17,7 @@ export class DataBroker {
   @observable dataSets = new Map<string, IDataSet>()
   readonly allowMultiple: boolean
   @observable selectedDataSetId = ""
+  sharedModelManager?: ISharedModelDocumentManager
 
   constructor(options?: IDataBrokerOptions) {
     const { allowMultiple = true } = options || {}
@@ -55,12 +58,21 @@ export class DataBroker {
   }
 
   @action
+  setSharedModelManager(manager: ISharedModelDocumentManager) {
+    this.sharedModelManager = manager
+  }
+
+  @action
   setSelectedDataSetId(id:string) {
     this.selectedDataSetId = id || this.last?.id || ""
   }
 
   @action
   addDataSet(ds: IDataSet) {
+    const sharedModel = SharedDataSet.create()
+    sharedModel.setDataSet(ds)
+    this.sharedModelManager?.addSharedModel(sharedModel)
+
     !this.allowMultiple && this.dataSets.clear()
     this.dataSets.set(ds.id, ds)
     this.setSelectedDataSetId(ds.id)

--- a/v3/src/models/document/create-codap-document.test.ts
+++ b/v3/src/models/document/create-codap-document.test.ts
@@ -1,0 +1,87 @@
+import { getEnv, getSnapshot } from "mobx-state-tree"
+import { omitUndefined } from "../../test/test-utils"
+import { gDataBroker } from "../data/data-broker"
+import { DataSet, toCanonical } from "../data/data-set"
+import { ITileEnvironment } from "../tiles/tile-content"
+import { createCodapDocument } from "./create-codap-document"
+import { ISharedModelDocumentManager } from "./shared-model-document-manager"
+import { ISharedDataSet } from "../shared/shared-data-set"
+import "../shared/shared-data-set-registration"
+
+// eslint-disable-next-line no-var
+var mockNodeIdCount = 0
+jest.mock("../../utilities/js-utils", () => ({
+  uniqueId: () => `test-${++mockNodeIdCount}`,
+  uniqueOrderedId: () => `order-${++mockNodeIdCount}`
+}))
+
+describe("createCodapDocument", () => {
+  beforeEach(() => {
+    mockNodeIdCount = 0
+  })
+
+  it("creates an empty document", () => {
+    const doc = createCodapDocument()
+    expect(doc.key).toBe("test-1")
+    expect(doc.type).toBe("CODAP")
+    expect(omitUndefined(getSnapshot(doc.content!))).toEqual({
+      rowMap: { "test-2": { id: "test-2", type: "mosaic", nodes: {}, tiles: {}, root: "" } },
+      rowOrder: ["test-2"],
+      sharedModelMap: {},
+      tileMap: {}
+    })
+  })
+
+  it("DataBroker adds a DataSet to the document as a shared model", () => {
+    const doc = createCodapDocument()
+    const manager = getEnv<ITileEnvironment>(doc).sharedModelManager as ISharedModelDocumentManager
+    const data = DataSet.create()
+    data.addAttribute({ name: "a" })
+    data.addCases(toCanonical(data, [{ a: "1" }, { a: "2" }, { a: "3" }]))
+    gDataBroker.setSharedModelManager(manager)
+    gDataBroker.addDataSet(data)
+
+    const entry = doc.content?.sharedModelMap.get("test-8")
+    const sharedModel = entry?.sharedModel as ISharedDataSet | undefined
+    // the DataSet is not copied -- it's a single instance
+    expect(data).toBe(gDataBroker.last)
+    expect(gDataBroker.last).toBe(sharedModel?.dataSet)
+
+    // need to wrap the serialization in prepareSnapshot()/completeSnapshot() to get the data
+    data.prepareSnapshot()
+    const snapContent = omitUndefined(getSnapshot(doc.content!))
+    data.completeSnapshot()
+
+    // the resulting document content contains the contents of the DataSet
+    expect(snapContent).toEqual({
+      rowMap: { "test-2": { id: "test-2", type: "mosaic", nodes: {}, tiles: {}, root: "" } },
+      rowOrder: ["test-2"],
+      sharedModelMap: {
+        "test-8": {
+          sharedModel: {
+            dataSet: {
+              attributes: [{
+                clientKey: "",
+                formula: {},
+                hidden: false,
+                id: "test-4",
+                name: "a",
+                userEditable: true,
+                values: ["1", "2", "3"]
+              }],
+              cases: [{ __id__: "order-5" }, { __id__: "order-6" }, { __id__: "order-7" }],
+              collections: [],
+              id: "test-3",
+              snapSelection: []
+            },
+            id: "test-8",
+            providerId: "",
+            type: "SharedDataSet"
+          },
+          tiles: []
+        }
+      },
+      tileMap: {}
+    })
+  })
+})

--- a/v3/src/models/document/document.ts
+++ b/v3/src/models/document/document.ts
@@ -1,4 +1,3 @@
-import { uniqueId } from "lodash"
 import { addDisposer, applySnapshot, destroy, getEnv, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { Tree } from "../history/tree"
 import { TreeManager } from "../history/tree-manager"
@@ -9,6 +8,7 @@ import { DocumentContentModel, IDocumentContentSnapshotIn } from "./document-con
 import { IDocumentMetadata } from "./document-metadata"
 import { IDocumentProperties } from "./document-types"
 import { ISharedModelDocumentManager } from "./shared-model-document-manager"
+import { uniqueId } from "../../utilities/js-utils"
 
 export const DocumentModel = Tree.named("Document")
   .props({

--- a/v3/src/models/shared/shared-data-set.ts
+++ b/v3/src/models/shared/shared-data-set.ts
@@ -1,5 +1,5 @@
 import { Instance, types } from "mobx-state-tree"
-import { DataSet } from "../data/data-set"
+import { DataSet, IDataSet } from "../data/data-set"
 import { SharedModel } from "./shared-model"
 
 export const kSharedDataSetType = "SharedDataSet"
@@ -8,15 +8,12 @@ export const SharedDataSet = SharedModel
 .named("SharedDataSet")
 .props({
   type: types.optional(types.literal(kSharedDataSetType), kSharedDataSetType),
-  providerId: types.string,
-  dataSet: DataSet
+  providerId: "",
+  dataSet: types.optional(DataSet, () => DataSet.create())
 })
-.views(self => ({
-  get xLabel() {
-    return self.dataSet.attributes[0]?.name
-  },
-  get yLabel() {
-    return self.dataSet.attributes[1]?.name
-  },
+.actions(self => ({
+  setDataSet(data: IDataSet) {
+    self.dataSet = data
+  }
 }))
-export interface SharedDataSetType extends Instance<typeof SharedDataSet> {}
+export interface ISharedDataSet extends Instance<typeof SharedDataSet> {}

--- a/v3/src/models/shared/shared-model-manager.ts
+++ b/v3/src/models/shared/shared-model-manager.ts
@@ -73,6 +73,20 @@ export interface ISharedModelManager {
   getSharedModelsByType<IT extends typeof SharedModelUnion>(type: string): IT["Type"][];
 
   /**
+   * Add a shared model to the container if it doesn't exist.
+   *
+   * If the shared model was already part of this container it won't be added to
+   * the container twice.
+   *
+   * This method adds a shared model to the container without associating it
+   * with any tiles.
+   *
+   * @param sharedModel the new or existing shared model that is going to be
+   * used by this tile.
+   */
+  addSharedModel(sharedModel: ISharedModel): void;
+
+  /**
    * Add a shared model to the container if it doesn't exist and add a link to
    * the tile from the shared model.
    *


### PR DESCRIPTION
When I embarked on this story I was expecting to have to replace/rewrite much of the `DataBroker` functionality with `SharedModelManager` mechanisms. When I got into it I realized I could leave the `DataBroker` essentially in tact and just have it also add any `DataSet`s to the document as shared models. I doubt the `DataBroker` will survive into production v3, at least not in its current form, but for now we can put off any decisions about it for another day.

While we have not yet implemented document save/restore (export/import), there are jest tests which verify that snapshots of the document contain the contents of the `DataSet` and that there is only one copy of each `DataSet`, i.e. that the `DataBroker` and `SharedModelManager` both have access to the same `DataSet` object rather than separate instances.

This PR also extends our existing patch of `mobx-state-tree` to also disable the warning for jest tests as well.