### PR TITLE
V3—remove y attribute—184382193

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -12,6 +12,7 @@ interface IProps {
   target: SVGGElement | null
   portal: HTMLElement | null
   onChangeAttribute: (place: GraphPlace, attrId: string) => void
+  onRemoveAttribute: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
@@ -21,7 +22,8 @@ const removeAttrItemLabelKeys: Record<string, string> = {
   "legend": "DG.DataDisplayMenu.removeAttribute_legend"
 }
 
-const _AxisOrLegendAttributeMenu = ({ place, target, portal, onChangeAttribute, onTreatAttributeAs }: IProps) => {
+const _AxisOrLegendAttributeMenu = ({ place, target, portal,
+                                      onChangeAttribute, onRemoveAttribute, onTreatAttributeAs }: IProps) => {
   const data = useDataSetContext()
   const dataConfig = useDataConfigurationContext()
   const role = graphPlaceToAttrRole[place]
@@ -55,7 +57,7 @@ const _AxisOrLegendAttributeMenu = ({ place, target, portal, onChangeAttribute, 
                 { attribute &&
                   <>
                     <MenuDivider />
-                    <MenuItem onClick={() => onChangeAttribute(place, "")}>
+                    <MenuItem onClick={() => onRemoveAttribute(place, attrId)}>
                       {removeAttrItemLabel}
                     </MenuItem>
                     <MenuItem onClick={() => onTreatAttributeAs(place, attribute?.id, treatAs)}>

--- a/v3/src/components/axis/components/axis.tsx
+++ b/v3/src/components/axis/components/axis.tsx
@@ -25,6 +25,7 @@ interface IProps {
   showScatterPlotGridLines?: boolean
   centerCategoryLabels?: boolean
   onDropAttribute?: (place: AxisPlace, attrId: string) => void
+  onRemoveAttribute?: (place: AxisPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
@@ -32,7 +33,8 @@ const handleIsActive = (active: Active) => !!getDragAttributeId(active)
 
 export const Axis = ({
                        parentSelector, label, getAxisModel, showScatterPlotGridLines = false,
-                       centerCategoryLabels = true, onDropAttribute, enableAnimation, onTreatAttributeAs
+                       centerCategoryLabels = true, onDropAttribute, enableAnimation, onTreatAttributeAs,
+                       onRemoveAttribute
                      }: IProps) => {
   const
     instanceId = useInstanceIdContext(),
@@ -81,12 +83,13 @@ export const Axis = ({
         <g ref={titleRef}/>
       </g>
 
-      {parentElt && onDropAttribute && onTreatAttributeAs &&
+      {parentElt && onDropAttribute && onTreatAttributeAs && onRemoveAttribute &&
         createPortal(<AxisOrLegendAttributeMenu
           target={titleRef.current}
           portal={parentElt}
           place={place}
           onChangeAttribute={onDropAttribute}
+          onRemoveAttribute={onRemoveAttribute}
           onTreatAttributeAs={onTreatAttributeAs}
         />, parentElt)
       }
@@ -94,15 +97,15 @@ export const Axis = ({
       {axisModel?.type === 'numeric'
         ? <AxisDragRects axisModel={axisModel as INumericAxisModel} axisWrapperElt={wrapperElt}/> : null}
       {onDropAttribute &&
-        <DroppableAxis
-          place={`${place}`}
-          dropId={droppableId}
+         <DroppableAxis
+            place={`${place}`}
+            dropId={droppableId}
 
-          hintString={hintString}
-          portal={parentElt}
-          target={wrapperElt}
-          onIsActive={handleIsActive}
-        />}
+            hintString={hintString}
+            portal={parentElt}
+            target={wrapperElt}
+            onIsActive={handleIsActive}
+         />}
     </>
   )
 }

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -11,10 +11,12 @@ interface IProps {
   place: AxisPlace
   enableAnimation: MutableRefObject<boolean>
   onDropAttribute?: (place: AxisPlace, attrId: string) => void
+  onRemoveAttribute?: (place: AxisPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
-export const GraphAxis = observer(({ place, enableAnimation, onDropAttribute, onTreatAttributeAs }: IProps) => {
+export const GraphAxis = observer((
+  { place, enableAnimation, onDropAttribute, onRemoveAttribute, onTreatAttributeAs }: IProps) => {
   const dataConfig = useDataConfigurationContext()
   const dataset = dataConfig?.dataset
   const graphModel = useGraphModelContext()
@@ -36,6 +38,7 @@ export const GraphAxis = observer(({ place, enableAnimation, onDropAttribute, on
           showScatterPlotGridLines={graphModel.plotType === 'scatterPlot'}
           centerCategoryLabels={graphModel.config.categoriesForAxisShouldBeCentered(place)}
           onDropAttribute={onDropAttribute}
+          onRemoveAttribute={onRemoveAttribute}
           onTreatAttributeAs={onTreatAttributeAs}
     />
   )

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -72,6 +72,19 @@ export const Graph = observer((
     graphModel.setAttributeID(attrRole, attrId)
   }
 
+  /**
+   * Only in the case that place === 'y' and there is more than one attribute assigned to the y-axis
+   * do we have to do anything special. Otherwise, we can just call handleChangeAttribute.
+   */
+  const handleRemoveAttribute = (place: GraphPlace, idOfAttributeToRemove: string) => {
+    if (place === 'left' && graphModel.config?.yAttributeDescriptions.length > 1) {
+      graphModel.config?.removeYAttributeWithID(idOfAttributeToRemove)
+    }
+    else {
+      handleChangeAttribute(place, '')
+    }
+  }
+
   // respond to assignment of new attribute ID
   useEffect(function handleNewAttributeID() {
     const disposer = graphModel && onAction(graphModel, action => {
@@ -116,6 +129,7 @@ export const Graph = observer((
                         place={place}
                         enableAnimation={enableAnimation}
                         onDropAttribute={handleChangeAttribute}
+                        onRemoveAttribute={handleRemoveAttribute}
                         onTreatAttributeAs={handleTreatAttrAs}
       />
     })
@@ -149,6 +163,7 @@ export const Graph = observer((
             legendAttrID={graphModel.getAttributeID('legend')}
             graphElt={graphRef.current}
             onDropAttribute={handleChangeAttribute}
+            onRemoveAttribute={handleRemoveAttribute}
             onTreatAttributeAs={handleTreatAttrAs}
           />
         </svg>

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -17,13 +17,14 @@ interface ILegendProps {
   legendAttrID: string
   graphElt: HTMLDivElement | null
   onDropAttribute: (place: GraphPlace, attrId: string) => void
+  onRemoveAttribute: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
 const handleIsActive = (active: Active) => !!getDragAttributeId(active)
 
 export const Legend = memo(function Legend({
-  legendAttrID, graphElt, onDropAttribute, onTreatAttributeAs
+  legendAttrID, graphElt, onDropAttribute, onTreatAttributeAs, onRemoveAttribute
 }: ILegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
     layout = useGraphLayoutContext(),
@@ -53,6 +54,7 @@ export const Legend = memo(function Legend({
               target={legendLabelRef.current}
               portal={graphElt}
               onChangeAttribute={onDropAttribute}
+              onRemoveAttribute={onRemoveAttribute}
               onTreatAttributeAs={onTreatAttributeAs}
             />,
           graphElt)

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -429,6 +429,14 @@ export const DataConfigurationModel = types
       }))
       self.setPointsNeedUpdating(true)
     },
+    removeYAttributeWithID(id: string) {
+      const index = self._yAttributeDescriptions.findIndex((aDesc) => aDesc.attributeID === id)
+      if (index >= 0) {
+        self._yAttributeDescriptions.splice(index, 1)
+        self.filteredCases?.splice(index, 1)
+        self.setPointsNeedUpdating(true)
+      }
+    },
     setAttributeType(role: GraphAttrRole, type: AttributeType, plotNumber = 0) {
       if (role === 'y') {
         self._yAttributeDescriptions[plotNumber]?.setType(type)

--- a/v3/src/components/graph/models/graph-model.ts
+++ b/v3/src/components/graph/models/graph-model.ts
@@ -63,7 +63,7 @@ export const GraphModel = TileContentModel
       return this.pointColorAtIndex(0)
     },
     get pointStrokeColor() {
-      return self.pointStrokeSameAsFill ? this.pointColor : self._pointStrokeColor
+      return self.pointStrokeSameAsFill ? this.pointColor() : self._pointStrokeColor
     },
     getAxis(place: AxisPlace) {
       return self.axes.get(place)


### PR DESCRIPTION
Feature: When the user removes the attribute first added to the vertical axis of a scatterplot, any already added additional attributes adjust appropriately
* Also made it possible to import a V2 document in which the graph has multiple y-attributes on the left vertical axis