### PR TITLE
V3—y2 axis for scatterplot—184382193

### DIFF
--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -2,7 +2,8 @@ import { ScaleBand, ScaleContinuousNumeric, ScaleOrdinal } from "d3"
 
 export const axisGap = 5
 
-export const AxisPlaces = ["bottom", "left", "right", "top"] as const
+// "right" and "top" can only be categorical axes. "v2" can only be numeric
+export const AxisPlaces = ["bottom", "left", "right", "top", "v2"] as const
 export type AxisPlace = typeof AxisPlaces[number]
 
 export function isHorizontal(place: AxisPlace) {
@@ -10,7 +11,7 @@ export function isHorizontal(place: AxisPlace) {
 }
 
 export function isVertical(place: AxisPlace) {
-  return ["left", "right"].includes(place)
+  return ["left", "right", "v2"].includes(place)
 }
 
 export interface AxisBounds {

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -19,6 +19,7 @@ interface IProps {
 const removeAttrItemLabelKeys: Record<string, string> = {
   "x": "DG.DataDisplayMenu.removeAttribute_x",
   "y": "DG.DataDisplayMenu.removeAttribute_y",
+  "y2": "DG.DataDisplayMenu.removeAttribute_y2",
   "legend": "DG.DataDisplayMenu.removeAttribute_legend"
 }
 

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -1,5 +1,6 @@
 import {
-  axisBottom, axisLeft, ScaleBand, scaleLinear, scaleLog, scaleOrdinal, select} from "d3"
+  axisBottom, axisLeft, axisRight, ScaleBand, scaleLinear, scaleLog, scaleOrdinal, select
+} from "d3"
 import {autorun, reaction} from "mobx"
 import {MutableRefObject, useCallback, useEffect, useRef} from "react"
 import {AxisBounds, axisGap, isVertical, ScaleNumericBaseType} from "../axis-types"
@@ -32,7 +33,10 @@ export const useAxis = ({
     scale = layout.getAxisScale(place) as ScaleNumericBaseType,
     ordinalScale = isNumeric || axisModel?.type === 'empty' ? null : scale as unknown as ScaleBand<string>,
     bandWidth = ordinalScale?.bandwidth() ?? 0,
-    axis = (place === 'bottom') ? axisBottom : axisLeft,
+    axis = (place === 'bottom') ? axisBottom
+      : (place === 'left') ? axisLeft
+        : (place === 'v2') ? axisRight
+          : null,
     // By all rights, the following three lines should not be necessary to get installDomainSync to run when
     // GraphController:processV2Document installs a new axis model.
     // Todo: Revisit and figure out whether we can remove the workaround.
@@ -49,7 +53,7 @@ export const useAxis = ({
   previousAxisModel.current = axisModel
 
   const getLabelBounds = (s = 'Wy') => {
-      return measureTextExtent(s, kGraphFont)
+    return measureTextExtent(s, kGraphFont)
   }
 
   const collisionExists = useCallback(() => {
@@ -75,7 +79,7 @@ export const useAxis = ({
       case 'numeric': {
         const format = scale.tickFormat?.()
         ticks = ((scale.ticks?.()) ?? []).map(tick => format(tick))
-        desiredExtent += axisPlace === 'left'
+        desiredExtent += ['left', 'v2'].includes(axisPlace)
           ? Math.max(getLabelBounds(ticks[0]).width, getLabelBounds(ticks[ticks.length - 1]).width) + axisGap
           : labelHeight
         break
@@ -107,26 +111,29 @@ export const useAxis = ({
       },
 
       drawScatterPlotGridLines = () => {
-        select(axisElt).selectAll('.zero, .grid').remove()
-        const tickLength = layout.getAxisLength(otherPlace(axisPlace)) ?? 0
-        select(axisElt).append('g')
-          .attr('class', 'grid')
-          .call(axis(scale).tickSizeInner(-tickLength))
-        select(axisElt).select('.grid').selectAll('text').remove()
-        const numericScale = scale
-        if (between(0, numericScale.domain()[0], numericScale.domain()[1])) {
+        if (axis) {
+          select(axisElt).selectAll('.zero, .grid').remove()
+          const tickLength = layout.getAxisLength(otherPlace(axisPlace)) ?? 0
           select(axisElt).append('g')
-            .attr('class', 'zero')
-            .call(axis(scale).tickSizeInner(-tickLength).tickValues([0]))
-          select(axisElt).select('.zero').selectAll('text').remove()
+            .attr('class', 'grid')
+            .call(axis(scale).tickSizeInner(-tickLength))
+          select(axisElt).select('.grid').selectAll('text').remove()
+          const numericScale = scale
+          if (between(0, numericScale.domain()[0], numericScale.domain()[1])) {
+            select(axisElt).append('g')
+              .attr('class', 'zero')
+              .call(axis(scale).tickSizeInner(-tickLength).tickValues([0]))
+            select(axisElt).select('.zero').selectAll('text').remove()
+          }
         }
       },
 
       drawCategoricalAxis = () => {
+      if (axis) {
         const tickLength = layout.getAxisLength(otherPlace(axisPlace)) ?? 0,
           textHeight = getLabelBounds().height,
           collision = collisionExists()
-        const {translation, rotation, textAnchor } = getCategoricalLabelPlacement(axisPlace, centerCategoryLabels,
+        const {translation, rotation, textAnchor} = getCategoricalLabelPlacement(axisPlace, centerCategoryLabels,
           collision, bandWidth, textHeight)
         select(axisElt)
           .attr("transform", initialTransform)
@@ -144,12 +151,15 @@ export const useAxis = ({
         select(axisElt).selectAll('text')
           .style('text-anchor', textAnchor)
           .attr('transform', `${translation}${rotation}`)
+      }
       },
 
       drawAxisTitle = () => {
         const
           titleTransform = `translate(${axisBounds.left}, ${axisBounds.top})`,
-          tX = (place === 'left') ? getLabelBounds(label).height : halfRange,
+          tX = place === 'left' ? labelBounds.height
+            : place === 'v2' ? axisBounds.width - labelBounds.height / 2
+              : halfRange,
           tY = (place === 'bottom') ? axisBounds.height - labelBounds.height / 2 : halfRange,
           tRotation = place === 'bottom' ? '' : ` rotate(-90,${tX},${tY})`
         if (titleRef) {

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -1,6 +1,6 @@
 import {randomUniform, select} from "d3"
 import {onAction} from "mobx-state-tree"
-import React, {memo, useCallback, useEffect, useRef, useState} from "react"
+import React, {useCallback, useEffect, useRef, useState} from "react"
 import {CaseData, pointRadiusSelectionAddend, transitionDuration} from "../graphing-types"
 import {ICase} from "../../../models/data/data-set"
 import {isAddCasesAction} from "../../../models/data/data-set-actions"
@@ -13,7 +13,7 @@ import {handleClickOnDot, setPointSelection} from "../utilities/graph-utils"
 import {defaultSelectedStroke, defaultSelectedStrokeWidth, defaultStrokeWidth} from "../../../utilities/color-utils"
 import {useGraphModelContext} from "../models/graph-model"
 
-export const CaseDots = memo(function CaseDots(props: {
+export const CaseDots = function CaseDots(props: {
     dotsRef: React.RefObject<SVGSVGElement>
     enableAnimation: React.MutableRefObject<boolean>
 }) {
@@ -148,4 +148,4 @@ export const CaseDots = memo(function CaseDots(props: {
   return (
     <></>
   )
-})
+}

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -1,5 +1,5 @@
 import {ScaleBand, select} from "d3"
-import React, {memo, useCallback} from "react"
+import React, {useCallback} from "react"
 import {attrRoleToAxisPlace, CaseData, PlotProps, transitionDuration} from "../graphing-types"
 import {usePlotResponders} from "../hooks/use-plot"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
@@ -16,7 +16,7 @@ import {
 
 type BinMap = Record<string, Record<string, number>>
 
-export const ChartDots = memo(function ChartDots(props: PlotProps) {
+export const ChartDots = function ChartDots(props: PlotProps) {
   const {dotsRef, enableAnimation} = props,
     graphModel = useGraphModelContext(),
     {pointColor, pointStrokeColor} = graphModel,
@@ -194,4 +194,4 @@ export const ChartDots = memo(function ChartDots(props: PlotProps) {
   return (
     <></>
   )
-})
+}

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -1,6 +1,6 @@
 import {max, range, ScaleBand, select} from "d3"
 import {observer} from "mobx-react-lite"
-import React, {memo, useCallback, useRef, useState} from "react"
+import React, {useCallback, useRef, useState} from "react"
 import { ScaleNumericBaseType } from "../../axis/axis-types"
 import {attrRoleToAxisPlace, CaseData, PlotProps} from "../graphing-types"
 import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
@@ -12,7 +12,7 @@ import {ICase} from "../../../models/data/data-set"
 import {getScreenCoord, handleClickOnDot, setPointCoordinates, setPointSelection} from "../utilities/graph-utils"
 import {useGraphModelContext} from "../models/graph-model"
 
-export const DotPlotDots = memo(observer(function DotPlotDots(props: PlotProps) {
+export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
   const {dotsRef, enableAnimation} = props,
     graphModel = useGraphModelContext(),
     dataConfiguration = useDataConfigurationContext(),
@@ -204,4 +204,4 @@ export const DotPlotDots = memo(observer(function DotPlotDots(props: PlotProps) 
   return (
     <></>
   )
-}))
+})

--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -6,12 +6,13 @@ import {DropHint} from "./drop-hint"
 import {PlotType} from "../graphing-types"
 
 interface IAddAttributeProps {
+  location: 'top' | 'y2'
   plotType: PlotType
   onDrop: (attributeId: string) => void
 }
 
-export const DroppableAddAttribute = ({plotType, onDrop}: IAddAttributeProps) => {
-  const droppableId = "graph-add-attribute-drop",
+export const DroppableAddAttribute = ({location, plotType, onDrop}: IAddAttributeProps) => {
+  const droppableId = `graph-add-attribute-drop-${location}`,
     {active, isOver, setNodeRef} = useDroppable({id: droppableId}),
     hintString = useDropHintString({role: 'yPlus'})
   useDropHandler(droppableId, isActive => {
@@ -21,7 +22,7 @@ export const DroppableAddAttribute = ({plotType, onDrop}: IAddAttributeProps) =>
   if (plotType === 'scatterPlot') {
     return (
       <div ref={setNodeRef} id={droppableId}
-           className={`add-attribute-drop ${isOver ? "over" : ""} ${active ? "active" : ""} }`}>
+           className={`add-attribute-drop-${location} ${isOver ? "over" : ""} ${active ? "active" : ""} }`}>
         {isOver && hintString &&
            <DropHint hintText={hintString}/>
         }

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -1,10 +1,10 @@
-import React, { MutableRefObject } from "react"
-import { AxisPlace } from "../../axis/axis-types"
-import { Axis } from "../../axis/components/axis"
-import { axisPlaceToAttrRole, GraphPlace, kGraphClassSelector } from "../graphing-types"
+import React, {MutableRefObject} from "react"
+import {AxisPlace} from "../../axis/axis-types"
+import {Axis} from "../../axis/components/axis"
+import {axisPlaceToAttrRole, GraphPlace, kGraphClassSelector} from "../graphing-types"
 import t from "../../../utilities/translation/translate"
-import { observer } from "mobx-react-lite"
-import { useGraphModelContext } from "../models/graph-model"
+import {observer} from "mobx-react-lite"
+import {useGraphModelContext} from "../models/graph-model"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 
 interface IProps {
@@ -16,7 +16,7 @@ interface IProps {
 }
 
 export const GraphAxis = observer((
-  { place, enableAnimation, onDropAttribute, onRemoveAttribute, onTreatAttributeAs }: IProps) => {
+  {place, enableAnimation, onDropAttribute, onRemoveAttribute, onTreatAttributeAs}: IProps) => {
   const dataConfig = useDataConfigurationContext()
   const dataset = dataConfig?.dataset
   const graphModel = useGraphModelContext()
@@ -24,9 +24,13 @@ export const GraphAxis = observer((
   const attrId = graphModel.getAttributeID(role)
 
   const getLabel = () => {
-    return (place === 'left' && graphModel.plotType === 'scatterPlot')
-      ? dataConfig?.yAttributeDescriptions.map(desc => desc.attributeID &&
-        dataset?.attrFromID(desc.attributeID)?.name || '').join(', ')
+    const isScatterPlot = graphModel.plotType === 'scatterPlot',
+      yAttributeDescriptions = dataConfig?.yAttributeDescriptions || []
+    return place === 'left' && isScatterPlot
+      ? yAttributeDescriptions.map((desc, index) => {
+        const isY2 = desc.attributeID === graphModel.getAttributeID('y2')
+        return (desc.attributeID && !isY2 && dataset?.attrFromID(desc.attributeID)?.name) || ''
+      }).filter(aName => aName !== '').join(', ')
       : (attrId && dataset?.attrFromID(attrId)?.name) || t('DG.AxisView.emptyGraphCue')
   }
 
@@ -35,7 +39,7 @@ export const GraphAxis = observer((
           getAxisModel={() => graphModel.getAxis(place)}
           label={getLabel()}
           enableAnimation={enableAnimation}
-          showScatterPlotGridLines={graphModel.plotType === 'scatterPlot'}
+          showScatterPlotGridLines={graphModel.plotType === 'scatterPlot' && ['left', 'bottom'].includes(place)}
           centerCategoryLabels={graphModel.config.categoriesForAxisShouldBeCentered(place)}
           onDropAttribute={onDropAttribute}
           onRemoveAttribute={onRemoveAttribute}

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -39,7 +39,7 @@ export const GraphAxis = observer((
           getAxisModel={() => graphModel.getAxis(place)}
           label={getLabel()}
           enableAnimation={enableAnimation}
-          showScatterPlotGridLines={graphModel.plotType === 'scatterPlot' && ['left', 'bottom'].includes(place)}
+          showScatterPlotGridLines={graphModel.axisShouldShowGridLines(place)}
           centerCategoryLabels={graphModel.config.categoriesForAxisShouldBeCentered(place)}
           onDropAttribute={onDropAttribute}
           onRemoveAttribute={onRemoveAttribute}

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -49,12 +49,26 @@
   border-radius: 4px;
 }
 
-.add-attribute-drop {
+.add-attribute-drop-top {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 25px;
+  &.active {
+    border: 5px solid rgb(255, 216, 102);
+  }
+  &.over {
+    background: yellow;
+  }
+}
+
+.add-attribute-drop-y2 {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 25px;
+  height: 100%;
   &.active {
     border: 5px solid rgb(255, 216, 102);
   }

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -124,7 +124,11 @@ export const Graph = observer((
   }
 
   const getGraphAxes = () => {
-    return ['left', 'bottom'].map((place: AxisPlace) => {
+    const places = ['left', 'bottom']
+    if (graphModel.getAxis('v2')) {
+      places.push('v2')
+    }
+    return places.map((place: AxisPlace) => {
       return <GraphAxis key={place}
                         place={place}
                         enableAnimation={enableAnimation}
@@ -168,8 +172,13 @@ export const Graph = observer((
           />
         </svg>
         <DroppableAddAttribute
+          location={'top'}
           plotType = {plotType}
           onDrop={handleChangeAttribute.bind(null, 'yPlus')}/>
+        <DroppableAddAttribute
+          location={'y2'}
+          plotType = {plotType}
+          onDrop={handleChangeAttribute.bind(null, 'v2')}/>
       </div>
       <GraphInspector graphModel={graphModel}
                       show={showInspector}

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -1,5 +1,5 @@
 import {select} from "d3"
-import React, {memo, useCallback, useEffect, useRef, useState} from "react"
+import React, {useCallback, useEffect, useRef, useState} from "react"
 import {autorun} from "mobx"
 import {appState} from "../../../models/app-state"
 import {ScaleNumericBaseType} from "../../axis/axis-types"
@@ -13,7 +13,7 @@ import {ICase} from "../../../models/data/data-set"
 import {getScreenCoord, handleClickOnDot, setPointCoordinates, setPointSelection} from "../utilities/graph-utils"
 import {useGraphModelContext} from "../models/graph-model"
 
-export const ScatterDots = memo(function ScatterDots(props: PlotProps) {
+export const ScatterDots = function ScatterDots(props: PlotProps) {
   const {dotsRef, enableAnimation} = props,
     graphModel = useGraphModelContext(),
     instanceId = useInstanceIdContext(),
@@ -88,7 +88,7 @@ export const ScatterDots = memo(function ScatterDots(props: PlotProps) {
             }
           })
           caseValues.length &&
-            dataset?.setCaseValues(caseValues, [primaryAttrID, secondaryAttrIDs.current[plotNumRef.current]])
+          dataset?.setCaseValues(caseValues, [primaryAttrID, secondaryAttrIDs.current[plotNumRef.current]])
         }
       }
     }, [dataConfiguration, dataset, dragID, primaryAttrID, xScale, secondaryAttrIDs, yScale]),
@@ -139,9 +139,13 @@ export const ScatterDots = memo(function ScatterDots(props: PlotProps) {
   const refreshPointPositionsD3 = useCallback((selectedOnly: boolean) => {
     const yAttrIDs = dataConfiguration?.yAttributeIDs || [],
       {pointColor, pointStrokeColor} = graphModel,
+      hasY2Attribute = dataConfiguration?.hasY2Attribute,
+      v2Scale = layout.getAxisScale("v2") as ScaleNumericBaseType,
+      numberOfPlots = dataConfiguration?.numberOfPlots || 1,
       getScreenX = (anID: string) => getScreenCoord(dataset, anID, primaryAttrID, xScale),
       getScreenY = (anID: string, plotNum = 0) => {
-        return getScreenCoord(dataset, anID, yAttrIDs[plotNum], yScale)
+        const verticalScale = hasY2Attribute && plotNum === numberOfPlots - 1 ? v2Scale : yScale
+        return getScreenCoord(dataset, anID, yAttrIDs[plotNum], verticalScale)
       },
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined,
       {computedBounds} = layout,
@@ -203,4 +207,4 @@ export const ScatterDots = memo(function ScatterDots(props: PlotProps) {
   return (
     <svg/>
   )
-})
+}

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -16,7 +16,7 @@ export type GraphAttrRole = typeof GraphAttrRoles[number]
 export const attrRoleToAxisPlace: Partial<Record<GraphAttrRole, AxisPlace>> = {
   x: "bottom",
   y: "left",
-  y2: "right",
+  y2: "v2",
   rightSplit: "right",
   topSplit: "top"
 }
@@ -30,7 +30,8 @@ export const axisPlaceToAttrRole: Record<AxisPlace, GraphAttrRole> = {
   bottom: "x",
   left: "y",
   top: "topSplit",
-  right: "y2",  // Todo: how to deal with 'rightSplit'?
+  right: "rightSplit",
+  v2: "y2"
 }
 
 export const graphPlaceToAttrRole: Record<GraphPlace, GraphAttrRole> = {

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -47,8 +47,10 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
       refreshPointPositions, refreshPointSelection, dotsRef, layout
     } = props,
     dataset = useDataSetContext(),
+    // numberOfScales = layout.axisScales.entries().size(),
     xNumeric = graphModel.getAxis('bottom') as INumericAxisModel,
     yNumeric = graphModel.getAxis('left') as INumericAxisModel,
+    v2Numeric = graphModel.getAxis('v2') as INumericAxisModel,
     instanceId = useInstanceIdContext()
 
   /* This routine is frequently called many times in a row when something about the graph changes that requires
@@ -80,13 +82,13 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
   // respond to axis domain changes (e.g. axis dragging)
   useEffect(() => {
     const disposer = reaction(
-      () => [xNumeric?.domain, yNumeric?.domain],
+      () => [xNumeric?.domain, yNumeric?.domain, v2Numeric?.domain],
       () => {
         callRefreshPointPositions(false)
       }, {fireImmediately: true}
     )
     return () => disposer()
-  }, [callRefreshPointPositions, xNumeric?.domain, yNumeric?.domain])
+  }, [callRefreshPointPositions, xNumeric?.domain, yNumeric?.domain, v2Numeric?.domain])
 
   // respond to axis range changes (e.g. component resizing)
   useEffect(() => {

--- a/v3/src/components/graph/models/data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/data-configuration-model.test.ts
@@ -43,8 +43,8 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["caption"])
     expect(config.attributes).toEqual(["nId"])
     expect(config.uniqueAttributes).toEqual(["nId"])
-    expect(config.tipAttributes).toEqual(["nId"])
-    expect(config.uniqueTipAttributes).toEqual(["nId"])
+    expect(config.tipAttributes).toEqual([{attributeID: "nId", role: "caption"}])
+    expect(config.uniqueTipAttributes).toEqual([{attributeID: "nId", role: "caption"}])
     expect(config.caseDataArray).toEqual([
       {plotNum: 0, caseID: "c1"},
       {plotNum: 0, caseID: "c2"},
@@ -65,8 +65,9 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["x", "caption"])
     expect(config.attributes).toEqual(["nId", "nId"])
     expect(config.uniqueAttributes).toEqual(["nId"])
-    expect(config.tipAttributes).toEqual(["nId", "nId"])
-    expect(config.uniqueTipAttributes).toEqual(["nId"])
+    expect(config.tipAttributes).toEqual([{attributeID: "nId", role: "x"},
+      {attributeID: "nId", role: "caption"}])
+    expect(config.uniqueTipAttributes).toEqual([{attributeID: "nId", role: "caption"}])
     expect(config.caseDataArray).toEqual([
       {plotNum: 0, caseID: "c1"},
       {plotNum: 0, caseID: "c3"}
@@ -86,8 +87,10 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["x", "caption"])
     expect(config.attributes).toEqual(["xId", "nId"])
     expect(config.uniqueAttributes).toEqual(["xId", "nId"])
-    expect(config.tipAttributes).toEqual(["xId", "nId"])
-    expect(config.uniqueTipAttributes).toEqual(["xId", "nId"])
+    expect(config.tipAttributes).toEqual([{attributeID: "xId", role: "x"},
+      {attributeID: "nId", role: "caption"}])
+    expect(config.uniqueTipAttributes).toEqual([{attributeID: "xId", role: "x"},
+      {attributeID: "nId", role: "caption"}])
     expect(config.caseDataArray).toEqual([
       {plotNum: 0, caseID: "c1"},
       {plotNum: 0, caseID: "c2"}
@@ -110,8 +113,10 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["x", "caption", "y"])
     expect(config.attributes).toEqual(["xId", "nId", "yId"])
     expect(config.uniqueAttributes).toEqual(["xId", "nId", "yId"])
-    expect(config.tipAttributes).toEqual(["xId", "yId", "nId"])
-    expect(config.uniqueTipAttributes).toEqual(["xId", "yId", "nId"])
+    expect(config.tipAttributes).toEqual([{attributeID: "xId", role: "x"},
+      {attributeID: "yId", role: "y"}, {attributeID: "nId", role: "caption"}])
+    expect(config.uniqueTipAttributes).toEqual([{attributeID: "xId", role: "x"},
+      {attributeID: "yId", role: "y"}, {attributeID: "nId", role: "caption"}])
     expect(config.caseDataArray).toEqual([{plotNum: 0, caseID: "c1"}])
 
     // behaves as expected after removing x axis attribute
@@ -126,8 +131,10 @@ describe("DataConfigurationModel", () => {
     expect(config.places).toEqual(["caption", "y"])
     expect(config.attributes).toEqual(["nId", "yId"])
     expect(config.uniqueAttributes).toEqual(["nId", "yId"])
-    expect(config.tipAttributes).toEqual(["yId", "nId"])
-    expect(config.uniqueTipAttributes).toEqual(["yId", "nId"])
+    expect(config.tipAttributes).toEqual([{attributeID: "yId", role: "y"},
+      {attributeID: "nId", role: "caption"}])
+    expect(config.uniqueTipAttributes).toEqual([{attributeID: "yId", role: "y"},
+      {attributeID: "nId", role: "caption"}])
     expect(config.caseDataArray).toEqual([
       {plotNum: 0, caseID: "c1"},
       {plotNum: 0, caseID: "c3"}

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -22,10 +22,7 @@ export const AttributeDescription = types
     }
   }))
 
-/*
-export interface IAttributeDescription extends Instance<typeof AttributeDescription> {
-}
-*/
+export type RoleAttrIDPair = { role: GraphAttrRole, attributeID: string }
 
 export interface IAttributeDescriptionSnapshot extends SnapshotIn<typeof AttributeDescription> {
 }
@@ -59,28 +56,45 @@ export const DataConfigurationModel = types
     pointsNeedUpdating: false
   }))
   .views(self => ({
+    get y2AttributeDescriptionIsPresent() {
+      return !!self._attributeDescriptions.get('y2')
+    },
+    // Includes y2 if present
     get yAttributeDescriptions() {
-      return self._yAttributeDescriptions
+      const descriptions = self._yAttributeDescriptions,
+        y2Description = self._attributeDescriptions.get('y2') ?? null
+      return descriptions.concat(y2Description ? [y2Description] : [])
     },
+    // Includes y2 if present
     get yAttributeIDs() {
-      return self._yAttributeDescriptions.map(d => d.attributeID)
+      return this.yAttributeDescriptions.map((d: IAttributeDescriptionSnapshot) => d.attributeID)
     },
+    /**
+     * No attribute descriptions beyond the first for y are returned.
+     * The y2 attribute description is also not returned.
+     */
     get attributeDescriptions() {
-      return self._yAttributeDescriptions.reduce((acc, yAttrDesc, index: number) => {
-        const key = index === 0 ? 'y' : `y${index}`
-        acc[key] = yAttrDesc
-        return acc
-      }, {...getSnapshot(self._attributeDescriptions)})
+      const descriptions = {...getSnapshot(self._attributeDescriptions)}
+      delete descriptions.y2
+      if (self._yAttributeDescriptions.length > 1) {
+        descriptions.y = self._yAttributeDescriptions[0]
+      }
+      return descriptions
     },
     get defaultCaptionAttributeID() {
       // In v2, the caption is the attribute left-most in the child-most collection among plotted attributes
       // Until we have better support for hierarchical attributes, we just return the left-most attribute.
       return self.dataset?.attributes[0]?.id
     },
+    /**
+     * For the 'y' role we return the first y-attribute, for 'y2' we return the last y-attribute.
+     * For the 'yPlus' we do not return anything.
+     * For all other roles we return the attribute description for the role.
+     */
     attributeDescriptionForRole(role: GraphAttrRole) {
       return role === 'y' ? this.yAttributeDescriptions[0]
-        : role === 'yPlus' ? this.yAttributeDescriptions[1]
-          : this.attributeDescriptions[role]
+        : role === 'y2' ? self._attributeDescriptions.get('y2')
+        : this.attributeDescriptions[role]
     },
     attributeID(role: GraphAttrRole) {
       let attrID = this.attributeDescriptionForRole(role)?.attributeID
@@ -134,11 +148,21 @@ export const DataConfigurationModel = types
     }
   }))
   .views(self => ({
-    filterCase(data: IDataSet, caseID: string) {
-      return Object.entries(self.attributeDescriptions).every(([place, {attributeID}]) => {
+    filterCase(data: IDataSet, caseID: string, caseArrayNumber: number) {
+      const hasY2 = !!self._attributeDescriptions.get('y2'),
+        numY = self._yAttributeDescriptions.length,
+        descriptions = self.attributeDescriptions
+      if (hasY2 && caseArrayNumber === self._yAttributeDescriptions.length) {
+        descriptions.y = self._attributeDescriptions.get('y2') ?? descriptions.y
+      }
+      else if (caseArrayNumber < numY) {
+        descriptions.y = self._yAttributeDescriptions[caseArrayNumber]
+      }
+      delete descriptions.y2
+      return Object.entries(descriptions).every(([role, {attributeID}]) => {
         // can still plot the case without a caption or a legend
-        if (["caption", "legend"].includes(place)) return true
-        switch (self.attributeType(place as GraphAttrRole)) {
+        if (["caption", "legend"].includes(role)) return true
+        switch (self.attributeType(role as GraphAttrRole)) {
           case "numeric":
             return isFinite(data.getNumeric(caseID, attributeID) ?? NaN)
           default:
@@ -197,20 +221,36 @@ export const DataConfigurationModel = types
     get uniqueAttributes() {
       return Array.from(new Set<string>(this.attributes))
     },
-    get tipAttributes() {
+    get tipAttributes():RoleAttrIDPair[] {
       return TipAttrRoles
-        .map(place => self.attributeID(place))
-        .filter(id => !!id) as string[]
+        .map(role => {
+          return {role, attributeID: self.attributeID(role) }
+        })
+        .filter(pair => !!pair.attributeID)
     },
     get uniqueTipAttributes() {
-      return Array.from(new Set<string>(this.tipAttributes))
+      const tipAttributes = this.tipAttributes,
+        idCounts: {[id: string]: number} = {}
+      tipAttributes.forEach((aPair:RoleAttrIDPair) => {
+        idCounts[aPair.attributeID] = (idCounts[aPair.attributeID] || 0) + 1
+      })
+      return tipAttributes.filter((aPair:RoleAttrIDPair) => {
+        if (idCounts[aPair.attributeID] > 1) {
+          idCounts[aPair.attributeID]--
+          return false
+        }
+        return true
+      })
     },
     get noAttributesAssigned() {
       // The first attribute is always assigned as 'caption'. So it's really no attributes assigned except for that
       return this.attributes.length <= 1
     },
     get numberOfPlots() {
-      return self._yAttributeDescriptions.length
+      return this.filteredCases.length
+    },
+    get hasY2Attribute() {
+      return !!self.attributeID('y2')
     },
     getUnsortedCaseDataArray(caseArrayNumber: number): CaseData[] {
       return self.filteredCases
@@ -284,7 +324,7 @@ export const DataConfigurationModel = types
         const allGraphCaseIds = Array.from(this.getSetOfAllGraphCaseIDs()),
           allValues: number[] = []
 
-        return self.yAttributeIDs.reduce((acc, yAttrID) => {
+        return self.yAttributeIDs.reduce((acc: number[], yAttrID: string) => {
           const values = allGraphCaseIds.map((anID: string) => Number(self.dataset?.getValue(anID, yAttrID)))
           return acc.concat(values)
         }, allValues)
@@ -406,6 +446,8 @@ export const DataConfigurationModel = types
         if (desc && desc.attributeID !== '') {
           self._yAttributeDescriptions.push(desc)
         }
+      } else if (role === 'y2') {
+        this.setY2Attribute(desc)
       } else {
         if (desc && desc.attributeID !== '') {
           self._attributeDescriptions.set(role, desc)
@@ -421,13 +463,28 @@ export const DataConfigurationModel = types
         self.invalidateQuantileScale()
       }
     },
+    _addNewFilteredCases() {
+      self.filteredCases && self.dataset && self.filteredCases
+        .push(new FilteredCases({
+          casesArrayNumber: self.filteredCases.length,
+          source: self.dataset, filter: self.filterCase,
+          onSetCaseValues: self.handleSetCaseValues
+        }))
+      self.setPointsNeedUpdating(true)
+    },
     addYAttribute(desc: IAttributeDescriptionSnapshot) {
       self._yAttributeDescriptions.push(desc)
-      self.filteredCases && self.dataset && self.filteredCases.push(new FilteredCases({
-        source: self.dataset, filter: self.filterCase,
-        onSetCaseValues: self.handleSetCaseValues
-      }))
-      self.setPointsNeedUpdating(true)
+      this._addNewFilteredCases()
+    },
+    setY2Attribute(desc: IAttributeDescriptionSnapshot) {
+      const newAttribute = !self._attributeDescriptions.get('y2')
+      self._attributeDescriptions.set('y2', desc)
+      if (newAttribute) {
+        this._addNewFilteredCases()
+      } else {
+        const existingFilteredCases = self.filteredCases?.[self.numberOfPlots - 1]
+        existingFilteredCases?.invalidateCases()
+      }
     },
     removeYAttributeWithID(id: string) {
       const index = self._yAttributeDescriptions.findIndex((aDesc) => aDesc.attributeID === id)

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -88,7 +88,6 @@ export const DataConfigurationModel = types
     },
     /**
      * For the 'y' role we return the first y-attribute, for 'y2' we return the last y-attribute.
-     * For the 'yPlus' we do not return anything.
      * For all other roles we return the attribute description for the role.
      */
     attributeDescriptionForRole(role: GraphAttrRole) {
@@ -151,7 +150,7 @@ export const DataConfigurationModel = types
     filterCase(data: IDataSet, caseID: string, caseArrayNumber: number) {
       const hasY2 = !!self._attributeDescriptions.get('y2'),
         numY = self._yAttributeDescriptions.length,
-        descriptions = self.attributeDescriptions
+        descriptions = {... self.attributeDescriptions}
       if (hasY2 && caseArrayNumber === self._yAttributeDescriptions.length) {
         descriptions.y = self._attributeDescriptions.get('y2') ?? descriptions.y
       }
@@ -230,7 +229,7 @@ export const DataConfigurationModel = types
     },
     get uniqueTipAttributes() {
       const tipAttributes = this.tipAttributes,
-        idCounts: {[id: string]: number} = {}
+        idCounts:  Record<string, number> = {}
       tipAttributes.forEach((aPair:RoleAttrIDPair) => {
         idCounts[aPair.attributeID] = (idCounts[aPair.attributeID] || 0) + 1
       })
@@ -247,7 +246,7 @@ export const DataConfigurationModel = types
       return this.attributes.length <= 1
     },
     get numberOfPlots() {
-      return this.filteredCases.length
+      return this.filteredCases.length  // filteredCases is an array of CaseArrays
     },
     get hasY2Attribute() {
       return !!self.attributeID('y2')
@@ -464,8 +463,7 @@ export const DataConfigurationModel = types
       }
     },
     _addNewFilteredCases() {
-      self.filteredCases && self.dataset && self.filteredCases
-        .push(new FilteredCases({
+      self.dataset && self.filteredCases?.push(new FilteredCases({
           casesArrayNumber: self.filteredCases.length,
           source: self.dataset, filter: self.filterCase,
           onSetCaseValues: self.handleSetCaseValues
@@ -477,9 +475,9 @@ export const DataConfigurationModel = types
       this._addNewFilteredCases()
     },
     setY2Attribute(desc: IAttributeDescriptionSnapshot) {
-      const newAttribute = !self._attributeDescriptions.get('y2')
+      const isNewAttribute = !self._attributeDescriptions.get('y2')
       self._attributeDescriptions.set('y2', desc)
-      if (newAttribute) {
+      if (isNewAttribute) {
         this._addNewFilteredCases()
       } else {
         const existingFilteredCases = self.filteredCases?.[self.numberOfPlots - 1]

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -76,7 +76,7 @@ export const DataConfigurationModel = types
     get attributeDescriptions() {
       const descriptions = {...getSnapshot(self._attributeDescriptions)}
       delete descriptions.y2
-      if (self._yAttributeDescriptions.length > 1) {
+      if (self._yAttributeDescriptions.length > 0) {
         descriptions.y = self._yAttributeDescriptions[0]
       }
       return descriptions

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -116,9 +116,10 @@ export class GraphLayout {
       leftAxisWidth = desiredExtents.get('left') ?? 20,
       bottomAxisHeight = desiredExtents.get('bottom') ?? 20,
       legendHeight = desiredExtents.get('legend') ?? 0,
+      v2AxisWidth = desiredExtents.get('v2') ?? 0,
       rightAxisWidth = desiredExtents.get('right') ?? 0,
       newBounds: Map<GraphPlace, Bounds> = new Map(),
-      plotWidth = graphWidth - leftAxisWidth - rightAxisWidth,
+      plotWidth = graphWidth - leftAxisWidth - v2AxisWidth - rightAxisWidth,
       plotHeight = graphHeight - topAxisHeight - bottomAxisHeight - legendHeight
     newBounds.set('left',
       {left: 0, top: 0, width: leftAxisWidth, height: plotHeight})
@@ -133,8 +134,11 @@ export class GraphLayout {
     newBounds.set('legend',
       {left: 6, top: graphHeight - legendHeight, width: graphWidth - 6,
         height: legendHeight})
+    newBounds.set('v2',
+      {left: leftAxisWidth + plotWidth, top: topAxisHeight, width: v2AxisWidth,
+        height: plotHeight})
     newBounds.set('right',
-      {left: rightAxisWidth + plotWidth, top: topAxisHeight, width: rightAxisWidth,
+      {left: leftAxisWidth + plotWidth, top: topAxisHeight, width: rightAxisWidth,
         height: plotHeight})
     // console.log(`newBounds.left = ${JSON.stringify(newBounds.get('left'))}`)
     return newBounds

--- a/v3/src/components/graph/models/graph-model.ts
+++ b/v3/src/components/graph/models/graph-model.ts
@@ -88,6 +88,9 @@ export const GraphModel = TileContentModel
         case "select":
           return result + pointRadiusSelectionAddend
       }
+    },
+    axisShouldShowGridLines(place: AxisPlace) {
+      return self.plotType === 'scatterPlot' && ['left', 'bottom'].includes(place)
     }
   }))
   .actions(self => ({

--- a/v3/src/models/data/filtered-cases.ts
+++ b/v3/src/models/data/filtered-cases.ts
@@ -3,7 +3,7 @@ import { ISerializedActionCall, onAction } from "mobx-state-tree"
 import { IDataSet } from "./data-set"
 import { isSetCaseValuesAction } from "./data-set-actions"
 
-export type FilterFn = (data: IDataSet, caseId: string) => boolean
+export type FilterFn = (data: IDataSet, caseId: string, casesArrayNumber?:number) => boolean
 
 export interface IFilteredChangedCases {
   added: string[]   // ids of cases that newly pass the filter
@@ -14,20 +14,24 @@ export type OnSetCaseValuesFn = (actionCall: ISerializedActionCall, cases: IFilt
 
 interface IProps {
   source: IDataSet
+  // Non-zero when there are more than one y-attribute
+  casesArrayNumber?: number
   filter?: FilterFn
   onSetCaseValues?: OnSetCaseValuesFn
 }
 
 export class FilteredCases {
   private source: IDataSet
+  private casesArrayNumber: number
   @observable private filter?: FilterFn
   private onSetCaseValues?: OnSetCaseValuesFn
 
   private prevCaseIdSet = new Set<string>()
   private onActionDisposers: Array<() => void>
 
-  constructor({ source, filter, onSetCaseValues }: IProps) {
+  constructor({ source, casesArrayNumber = 0, filter, onSetCaseValues }: IProps) {
     this.source = source
+    this.casesArrayNumber = casesArrayNumber
     this.filter = filter
     this.onSetCaseValues = onSetCaseValues
 
@@ -53,7 +57,7 @@ export class FilteredCases {
     // temptation of premature optimization, let's wait to see whether it becomes a bottleneck.
     return this.source.cases
             .map(aCase => aCase.__id__)
-            .filter(id => !this.filter || this.filter(this.source, id))
+            .filter(id => !this.filter || this.filter(this.source, id, this.casesArrayNumber))
   }
 
   @computed


### PR DESCRIPTION
[#184382193] Feature: When the user removes the attribute first added to the vertical axis of a scatterplot, any already added additional attributes adjust appropriately
* Also made it possible to import a V2 document in which the graph has multiple y-attributes on the left vertical axis
* Removed `memo`-ization of scatterdots, casedots, dotplotdots and chartdots
* Computed correct data tips in presence of y2 attribute
* Correct placement of right-vertical-axis attribute label
* Fixed problems relating to having both >1 attribute on left axis plus numeric attribute on right axis
DataConfiguration enhancements
=============
* The attribute description for a y2 attribute is stored as usual, but
  * Such an attribute is treated specially in that it is not included in the array
    of attribute descriptions _or_ of attribute ids.
    * In these arrays, y2 description or id is always the last element