### PR TITLE
V3—Remove right numeric attribute—184429108

### DIFF
--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -2,8 +2,8 @@ import { ScaleBand, ScaleContinuousNumeric, ScaleOrdinal } from "d3"
 
 export const axisGap = 5
 
-// "right" and "top" can only be categorical axes. "v2" can only be numeric
-export const AxisPlaces = ["bottom", "left", "right", "top", "v2"] as const
+// "rightCat" and "top" can only be categorical axes. "rightNumeric" can only be numeric
+export const AxisPlaces = ["bottom", "left", "rightCat", "top", "rightNumeric"] as const
 export type AxisPlace = typeof AxisPlaces[number]
 
 export function isHorizontal(place: AxisPlace) {
@@ -11,7 +11,7 @@ export function isHorizontal(place: AxisPlace) {
 }
 
 export function isVertical(place: AxisPlace) {
-  return ["left", "right", "v2"].includes(place)
+  return ["left", "rightCat", "rightNumeric"].includes(place)
 }
 
 export interface AxisBounds {

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -19,7 +19,7 @@ interface IProps {
 const removeAttrItemLabelKeys: Record<string, string> = {
   "x": "DG.DataDisplayMenu.removeAttribute_x",
   "y": "DG.DataDisplayMenu.removeAttribute_y",
-  "y2": "DG.DataDisplayMenu.removeAttribute_y2",
+  "rightNumeric": "DG.DataDisplayMenu.removeAttribute_y2",
   "legend": "DG.DataDisplayMenu.removeAttribute_legend"
 }
 

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -35,7 +35,7 @@ export const useAxis = ({
     bandWidth = ordinalScale?.bandwidth() ?? 0,
     axis = (place === 'bottom') ? axisBottom
       : (place === 'left') ? axisLeft
-        : (place === 'v2') ? axisRight
+        : (place === 'rightNumeric') ? axisRight
           : null,
     // By all rights, the following three lines should not be necessary to get installDomainSync to run when
     // GraphController:processV2Document installs a new axis model.
@@ -70,6 +70,9 @@ export const useAxis = ({
   }, [bandWidth, centerCategoryLabels, ordinalScale])
 
   const computeDesiredExtent = useCallback(() => {
+    if (dataConfiguration?.placeCanHaveZeroExtent(axisPlace)) {
+      return 0
+    }
     const labelHeight = getLabelBounds(label).height,
       collision = collisionExists(),
       maxLabelExtent = maxWidthOfStringsD3(dataConfiguration?.categorySetForAttrRole(attrRole) ?? [])
@@ -79,7 +82,7 @@ export const useAxis = ({
       case 'numeric': {
         const format = scale.tickFormat?.()
         ticks = ((scale.ticks?.()) ?? []).map(tick => format(tick))
-        desiredExtent += ['left', 'v2'].includes(axisPlace)
+        desiredExtent += ['left', 'rightNumeric'].includes(axisPlace)
           ? Math.max(getLabelBounds(ticks[0]).width, getLabelBounds(ticks[ticks.length - 1]).width) + axisGap
           : labelHeight
         break
@@ -158,7 +161,7 @@ export const useAxis = ({
         const
           titleTransform = `translate(${axisBounds.left}, ${axisBounds.top})`,
           tX = place === 'left' ? labelBounds.height
-            : place === 'v2' ? axisBounds.width - labelBounds.height / 2
+            : place === 'rightNumeric' ? axisBounds.width - labelBounds.height / 2
               : halfRange,
           tY = (place === 'bottom') ? axisBounds.height - labelBounds.height / 2 : halfRange,
           tRotation = place === 'bottom' ? '' : ` rotate(-90,${tX},${tY})`

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -22,7 +22,7 @@ export const AxisModel = types.model("AxisModel", {
   }))
   .views(self => ({
     get orientation(): AxisOrientation {
-      return self.place === "left" || self.place === "right"
+      return ['left', 'rightCat', 'rightNumeric'].includes(self.place)
         ? "vertical" : "horizontal"
     },
     get isNumeric() {

--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -6,7 +6,7 @@ import {DropHint} from "./drop-hint"
 import {PlotType} from "../graphing-types"
 
 interface IAddAttributeProps {
-  location: 'top' | 'y2'
+  location: 'top' | 'rightNumeric'
   plotType: PlotType
   onDrop: (attributeId: string) => void
 }

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -28,7 +28,7 @@ export const GraphAxis = observer((
       yAttributeDescriptions = dataConfig?.yAttributeDescriptions || []
     return place === 'left' && isScatterPlot
       ? yAttributeDescriptions.map((desc, index) => {
-        const isY2 = desc.attributeID === graphModel.getAttributeID('y2')
+        const isY2 = desc.attributeID === graphModel.getAttributeID('rightNumeric')
         return (desc.attributeID && !isY2 && dataset?.attrFromID(desc.attributeID)?.name) || ''
       }).filter(aName => aName !== '').join(', ')
       : (attrId && dataset?.attrFromID(attrId)?.name) || t('DG.AxisView.emptyGraphCue')

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -63,7 +63,7 @@
   }
 }
 
-.add-attribute-drop-y2 {
+.add-attribute-drop-rightNumeric {
   position: absolute;
   top: 0;
   right: 0;

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -125,8 +125,8 @@ export const Graph = observer((
 
   const getGraphAxes = () => {
     const places = ['left', 'bottom']
-    if (graphModel.getAxis('v2')) {
-      places.push('v2')
+    if (graphModel.getAxis('rightNumeric')) {
+      places.push('rightNumeric')
     }
     return places.map((place: AxisPlace) => {
       return <GraphAxis key={place}
@@ -176,9 +176,9 @@ export const Graph = observer((
           plotType = {plotType}
           onDrop={handleChangeAttribute.bind(null, 'yPlus')}/>
         <DroppableAddAttribute
-          location={'y2'}
+          location={'rightNumeric'}
           plotType = {plotType}
-          onDrop={handleChangeAttribute.bind(null, 'v2')}/>
+          onDrop={handleChangeAttribute.bind(null, 'rightNumeric')}/>
       </div>
       <GraphInspector graphModel={graphModel}
                       show={showInspector}

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -80,11 +80,14 @@ export const CategoricalLegend = memo(function CategoricalLegend(
     }, [layout, dataConfiguration]),
 
     computeDesiredExtent = useCallback(() => {
+      if (dataConfiguration?.placeCanHaveZeroExtent('legend')) {
+        return 0
+      }
       computeLayout()
       const lod = layoutData.current,
         labelHeight = legendLabelRef.current?.getBoundingClientRect().height ?? 0
       return lod.numRows * (keySize + padding) + labelHeight
-    }, [computeLayout, legendLabelRef]),
+    }, [computeLayout, legendLabelRef, dataConfiguration]),
 
     setupKeys = useCallback(() => {
       categoriesRef.current = dataConfiguration?.categorySetForAttrRole('legend')
@@ -159,13 +162,12 @@ export const CategoricalLegend = memo(function CategoricalLegend(
     }, [dataConfiguration, keysElt, transform])
 
   useEffect(function respondToSelectionChange() {
-    const disposer = onAction(dataset, action => {
+    return onAction(dataset, action => {
       if (isSelectionAction(action)) {
         refreshKeys()
       }
     }, true)
-    return disposer
-  }, [refreshKeys, dataset])
+  }, [refreshKeys, dataset, computeDesiredExtent])
 
   useEffect(function respondToCategorySetsChange() {
     const disposer = reaction(

--- a/v3/src/components/graph/components/legend/numeric-legend.tsx
+++ b/v3/src/components/graph/components/legend/numeric-legend.tsx
@@ -9,14 +9,9 @@ import {measureTextExtent} from "../../../../hooks/use-measure-text"
 import {useDataSetContext} from "../../../../hooks/use-data-set-context"
 import {kChoroplethHeight, kGraphFont} from "../../graphing-types"
 import {axisGap} from "../../../axis/axis-types"
-import {IDataSet} from "../../../../models/data/data-set"
 
-const computeDesiredExtent = (dataset:IDataSet | undefined, legendAttrID:string) => {
-  const labelHeight = measureTextExtent(dataset?.attrFromID(legendAttrID).name ?? '', kGraphFont).height
-  return 2 * labelHeight + kChoroplethHeight + 2 * axisGap
-}
 
-  interface INumericLegendProps {
+interface INumericLegendProps {
   legendAttrID: string
   transform: string
 }
@@ -30,9 +25,18 @@ export const NumericLegend = memo(function NumericLegend({transform, legendAttrI
     valuesRef = useRef<number[]>([]),
 
     refreshScale = useCallback(() => {
+
+      const computeDesiredExtent = () => {
+        if (dataConfiguration?.placeCanHaveZeroExtent('legend')) {
+          return 0
+        }
+        const labelHeight = measureTextExtent(dataset?.attrFromID(legendAttrID).name ?? '', kGraphFont).height
+        return 2 * labelHeight + kChoroplethHeight + 2 * axisGap
+      }
+
       if (choroplethElt) {
         valuesRef.current = dataConfiguration?.numericValuesForAttrRole('legend') ?? []
-        layout.setDesiredExtent('legend', computeDesiredExtent(dataset, legendAttrID))
+        layout.setDesiredExtent('legend', computeDesiredExtent())
         quantileScale.current.domain(valuesRef.current).range(schemeBlues[5])
         const bounds = layout.computedBounds.get('legend'),
           translate = `translate(${bounds?.left}, ${(bounds?.top ?? 0) + axisGap})`
@@ -48,7 +52,7 @@ export const NumericLegend = memo(function NumericLegend({transform, legendAttrI
             }
           })
       }
-    }, [layout, dataset, legendAttrID, choroplethElt, dataConfiguration])
+    }, [choroplethElt, dataConfiguration, layout, dataset, legendAttrID])
 
   useEffect(function refresh() {
     refreshScale()

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -140,7 +140,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
     const yAttrIDs = dataConfiguration?.yAttributeIDs || [],
       {pointColor, pointStrokeColor} = graphModel,
       hasY2Attribute = dataConfiguration?.hasY2Attribute,
-      v2Scale = layout.getAxisScale("v2") as ScaleNumericBaseType,
+      v2Scale = layout.getAxisScale("rightNumeric") as ScaleNumericBaseType,
       numberOfPlots = dataConfiguration?.numberOfPlots || 1,
       getScreenX = (anID: string) => getScreenCoord(dataset, anID, primaryAttrID, xScale),
       getScreenY = (anID: string, plotNum = 0) => {

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -7,7 +7,7 @@ export type CaseData = { plotNum: number, caseID: string }
 export const GraphPlaces = [...AxisPlaces, "yPlus", "plot", "legend"] as const
 export type GraphPlace = typeof GraphPlaces[number]
 export const PrimaryAttrRoles = ['x', 'y'] as const
-export const TipAttrRoles = [...PrimaryAttrRoles, 'legend', 'caption', 'y2'] as const
+export const TipAttrRoles = [...PrimaryAttrRoles, 'legend', 'caption', 'rightNumeric'] as const
 export const GraphAttrRoles = [
   ...TipAttrRoles, 'polygon', 'yPlus', 'topSplit', 'rightSplit'] as const
 export type GraphAttrRole = typeof GraphAttrRoles[number]
@@ -16,8 +16,8 @@ export type GraphAttrRole = typeof GraphAttrRoles[number]
 export const attrRoleToAxisPlace: Partial<Record<GraphAttrRole, AxisPlace>> = {
   x: "bottom",
   y: "left",
-  y2: "v2",
-  rightSplit: "right",
+  rightNumeric: "rightNumeric",
+  rightSplit: "rightCat",
   topSplit: "top"
 }
 export const attrRoleToGraphPlace: Partial<Record<GraphAttrRole, GraphPlace>> = {
@@ -30,8 +30,8 @@ export const axisPlaceToAttrRole: Record<AxisPlace, GraphAttrRole> = {
   bottom: "x",
   left: "y",
   top: "topSplit",
-  right: "rightSplit",
-  v2: "y2"
+  rightCat: "rightSplit",
+  rightNumeric: "rightNumeric"
 }
 
 export const graphPlaceToAttrRole: Record<GraphPlace, GraphAttrRole> = {

--- a/v3/src/components/graph/hooks/use-data-tips.ts
+++ b/v3/src/components/graph/hooks/use-data-tips.ts
@@ -35,7 +35,7 @@ export const useDataTips = (dotsRef: React.RefObject<SVGSVGElement>,
         const caseID = (target.datum() as CaseData).caseID,
           plotNum = (target.datum() as CaseData).plotNum, // Only can be non-zero for scatter plots
           attrIDsToUse = roleAttrIDPairs.filter((aPair) => {
-            return plotNum > 0 || aPair.role !== 'y2'
+            return plotNum > 0 || aPair.role !== 'rightNumeric'
           }).map((aPair) => {
             return plotNum === 0
               ? aPair.attributeID

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -50,7 +50,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     // numberOfScales = layout.axisScales.entries().size(),
     xNumeric = graphModel.getAxis('bottom') as INumericAxisModel,
     yNumeric = graphModel.getAxis('left') as INumericAxisModel,
-    v2Numeric = graphModel.getAxis('v2') as INumericAxisModel,
+    v2Numeric = graphModel.getAxis('rightNumeric') as INumericAxisModel,
     instanceId = useInstanceIdContext()
 
   /* This routine is frequently called many times in a row when something about the graph changes that requires

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -116,8 +116,8 @@ export class GraphLayout {
       leftAxisWidth = desiredExtents.get('left') ?? 20,
       bottomAxisHeight = desiredExtents.get('bottom') ?? 20,
       legendHeight = desiredExtents.get('legend') ?? 0,
-      v2AxisWidth = desiredExtents.get('v2') ?? 0,
-      rightAxisWidth = desiredExtents.get('right') ?? 0,
+      v2AxisWidth = desiredExtents.get('rightNumeric') ?? 0,
+      rightAxisWidth = desiredExtents.get('rightCat') ?? 0,
       newBounds: Map<GraphPlace, Bounds> = new Map(),
       plotWidth = graphWidth - leftAxisWidth - v2AxisWidth - rightAxisWidth,
       plotHeight = graphHeight - topAxisHeight - bottomAxisHeight - legendHeight
@@ -134,10 +134,10 @@ export class GraphLayout {
     newBounds.set('legend',
       {left: 6, top: graphHeight - legendHeight, width: graphWidth - 6,
         height: legendHeight})
-    newBounds.set('v2',
+    newBounds.set('rightNumeric',
       {left: leftAxisWidth + plotWidth, top: topAxisHeight, width: v2AxisWidth,
         height: plotHeight})
-    newBounds.set('right',
+    newBounds.set('rightCat',
       {left: leftAxisWidth + plotWidth, top: topAxisHeight, width: rightAxisWidth,
         height: plotHeight})
     // console.log(`newBounds.left = ${JSON.stringify(newBounds.get('left'))}`)


### PR DESCRIPTION
[#184429108] Feature: User can remove attribute from right vertical axis
* Improved GraphController:processV2Document to handle attribute on right vertical axis
* Now possible to remove y2 attribute
* Fixed symptom such that when importing from V2 and there is a scatterplot, the v2 axis shows up.
* Renamed `v2` AxisPlace to `y2`
* Added `placeCanHaveZeroExtent` to DataConfigurationModel and used it to make the space occupied by the y2 axis to go away on removal of y2 attribute
* Resolve conflicts from rebase onto main
* Renamed `y2` to `rightNumeric` and `right` to `rightCat`