### PR TITLE
V3—Fixes bug involving rescaling on y-attribute removal—184382193

### DIFF
--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -17,6 +17,8 @@ import {DataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphController} from "../hooks/use-graph-controller"
 import {useGraphModel} from "../hooks/use-graph-model"
+import {setNiceDomain} from "../utilities/graph-utils"
+import {IAxisModel} from "../../axis/models/axis-model"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {isSetAttributeIDAction, useGraphModelContext} from "../models/graph-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
@@ -79,6 +81,8 @@ export const Graph = observer((
   const handleRemoveAttribute = (place: GraphPlace, idOfAttributeToRemove: string) => {
     if (place === 'left' && graphModel.config?.yAttributeDescriptions.length > 1) {
       graphModel.config?.removeYAttributeWithID(idOfAttributeToRemove)
+      const yAxisModel = graphModel.getAxis('left') as IAxisModel
+      setNiceDomain(graphModel.config.numericValuesForAttrRole('y'), yAxisModel)
     }
     else {
       handleChangeAttribute(place, '')


### PR DESCRIPTION
[#184382193] Feature: When the user removes the attribute first added to the vertical axis of a scatterplot, any already added additional attributes adjust appropriately
* Previously the y-axis would not rescale appropriately on attribute removal. This commit fixes that