### PR TITLE
V3—Stroke color crash—184077414

### DIFF
--- a/v3/src/components/graph/models/graph-model.ts
+++ b/v3/src/components/graph/models/graph-model.ts
@@ -63,7 +63,7 @@ export const GraphModel = TileContentModel
       return this.pointColorAtIndex(0)
     },
     get pointStrokeColor() {
-      return self.pointStrokeSameAsFill ? this.pointColor() : self._pointStrokeColor
+      return self.pointStrokeSameAsFill ? this.pointColor : self._pointStrokeColor
     },
     getAxis(place: AxisPlace) {
       return self.axes.get(place)


### PR DESCRIPTION
* Simple fix. pointColor is a property, not a function