### PR TITLE
V3: drag/drop code refactor

### DIFF
--- a/v3/src/components/case-table/case-table-component.tsx
+++ b/v3/src/components/case-table/case-table-component.tsx
@@ -1,18 +1,24 @@
-import { useDroppable } from "@dnd-kit/core"
+import { closestCenter } from "@dnd-kit/core"
 import { observer } from "mobx-react-lite"
 import React from "react"
+import { useTileDropOverlay } from "../../hooks/use-drag-drop"
 import { InstanceIdContext, useNextInstanceId } from "../../hooks/use-instance-id-context"
+import { registerTileCollisionDetection } from "../dnd-detect-collision"
+import { ITileBaseProps } from "../tiles/tile-base-props"
 import { CaseTable } from "./case-table"
 import { isCaseTableModel } from "./case-table-model"
-import { ITileBaseProps } from "../tiles/tile-base-props"
+import { kCaseTableIdBase } from "./case-table-types"
+
+// use closestCenter inside table for column resizing
+registerTileCollisionDetection(kCaseTableIdBase, closestCenter)
 
 export const CaseTableComponent = observer(({ tile }: ITileBaseProps) => {
   const tableModel = tile?.content
   if (!isCaseTableModel(tableModel)) return null
 
-  const instanceId = useNextInstanceId("case-table")
-  const id = `${instanceId}-component-drop-overlay`
-  const { setNodeRef } = useDroppable({ id })
+  const instanceId = useNextInstanceId(kCaseTableIdBase)
+  // pass in the instance id since the context hasn't been provided yet
+  const { setNodeRef } = useTileDropOverlay(instanceId)
 
   return (
     <InstanceIdContext.Provider value={instanceId}>

--- a/v3/src/components/case-table/case-table-types.ts
+++ b/v3/src/components/case-table/case-table-types.ts
@@ -2,6 +2,8 @@ import {
   CalculatedColumn, Column, EditorProps, FormatterProps, HeaderRendererProps, RowRendererProps, RowsChangeData
 } from "react-data-grid"
 
+export const kCaseTableIdBase = "case-table"
+
 export interface TRow {
   __id__: string;
   // ids of attributes whose DOM representation have been manipulated

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -1,10 +1,8 @@
-import { useDroppable } from "@dnd-kit/core"
 import React, { CSSProperties, useEffect, useState } from "react"
 import { createPortal } from "react-dom"
 import { IMoveAttributeOptions } from "../../models/data/data-set-types"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { useDropHandler } from "../../hooks/use-drag-drop"
-import { useInstanceIdContext } from "../../hooks/use-instance-id-context"
+import { useTileDroppable } from "../../hooks/use-drag-drop"
 import { kIndexColumnKey } from "./case-table-types"
 
 interface IProps {
@@ -12,15 +10,12 @@ interface IProps {
   cellElt: HTMLElement | null
 }
 export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
-  const instanceId = useInstanceIdContext()
   const data = useDataSetContext()
   const [tableElt, setTableElt] = useState<HTMLElement | null>(null)
   const tableBounds = tableElt?.getBoundingClientRect()
   const cellBounds = cellElt?.getBoundingClientRect()
 
-  const id = `${instanceId}-attribute:${columnKey}-drop`
-  const { isOver, setNodeRef: setDropRef } = useDroppable({ id })
-  useDropHandler(id, active => {
+  const { isOver, setNodeRef: setDropRef } = useTileDroppable(`attribute:${columnKey}`, active => {
     const dragAttrId = active.data?.current?.attributeId
     const options: IMoveAttributeOptions = columnKey === kIndexColumnKey
                                             ? { before: data?.attributes[0].id }

--- a/v3/src/components/dnd-detect-collision.ts
+++ b/v3/src/components/dnd-detect-collision.ts
@@ -1,20 +1,36 @@
-import { closestCenter, CollisionDetection, pointerWithin, rectIntersection } from "@dnd-kit/core"
+import escapeStringRegexp from "escape-string-regexp"
+import { CollisionDetection, pointerWithin, rectIntersection } from "@dnd-kit/core"
+
+interface CollisionDetectionEntry {
+  baseId: string
+  overlayRegex: RegExp
+  droppableRegex: RegExp
+  detect: CollisionDetection
+}
+const gTileCollisionDetectionRegistry: CollisionDetectionEntry[] = []
+
+export const registerTileCollisionDetection = (baseId: string, detect: CollisionDetection = rectIntersection) => {
+  const escapedId = escapeStringRegexp(baseId)
+  const overlayRegex = new RegExp(`^${escapedId}.+drop-overlay$`)
+  const droppableRegex = new RegExp(`^${escapedId}.+drop$`)
+  gTileCollisionDetectionRegistry.push({ baseId, overlayRegex, droppableRegex, detect })
+}
 
 export const dndDetectCollision: CollisionDetection = (args) => {
   // first determine the component we're in using pointerWithin (for pointer sensor) or
   // rectIntersection (for keyboard sensor)
   const collisions = args.pointerCoordinates ? pointerWithin(args) : rectIntersection(args)
 
-  // if we're in the summary component, use rectangle intersection on the inspector button
-  if (collisions.find(collision => collision.id === "summary-component-drop")) {
-    const containers = args.droppableContainers.filter(({id}) => id === "summary-inspector-drop")
-    return rectIntersection({ ...args, droppableContainers: containers })
-  }
-
-  // if we're in the case table component, use closest center on the column header dividers
-  if (collisions.find(collision => /case-table.+component-drop-overlay/.test(`${collision.id}`))) {
-    const containers = args.droppableContainers.filter(({id}) => /case-table.+attribute.+-drop/.test(`${id}`))
-    return closestCenter({ ...args, droppableContainers: containers })
+  // check for registered tile-specific collision handlers
+  for (const entry of gTileCollisionDetectionRegistry) {
+    const { overlayRegex, droppableRegex, detect } = entry
+    // test the tile overlays to find the relevant tile
+    if (collisions.find(({id}) => overlayRegex.test(`${id}`))) {
+      // filter the drop zones to those appropriate for the relevant tile
+      const containers = args.droppableContainers.filter(({id}) => droppableRegex.test(`${id}`))
+      // apply the collection detection function specified by the tile
+      return detect({ ...args, droppableContainers: containers })
+    }
   }
 
   // if we're in the graph component, use rectangle intersection on the drop targets (e.g. axes, plot)

--- a/v3/src/hooks/use-drag-drop.ts
+++ b/v3/src/hooks/use-drag-drop.ts
@@ -37,14 +37,18 @@ export const useDraggableAttribute = ({ prefix, attributeId, ...others }: IUseDr
   return useDraggable({ ...others, id: `${prefix}-${attributeId}`, attributes, data })
 }
 
-// collision-detection code uses drop overlays to identify the tile that should handle the drag
+// Collision-detection code uses drop overlays to identify the tile that should handle the drag.
+// Passes its dropProps argument to useDroppable and returns an object with the return value
+// of useDroppable plus the generated id.
 export const useTileDropOverlay = (baseId?: string, dropProps?: UseDroppableArguments) => {
   const instanceId = useInstanceIdContext() || baseId
   const id = `${instanceId}-drop-overlay`
   return { id, ...useDroppable({ ...dropProps, id }) }
 }
 
-// collision-detection code keys on drop ids that match this convention
+// Collision-detection code keys on drop ids that match this convention.
+// Passes its dropProps argument to useDroppable and returns an object with the return value
+// of useDroppable plus the generated id.
 export const useTileDroppable = (
   baseId: string, onDrop: (active: Active) => void, dropProps?: UseDroppableArguments
 ) => {

--- a/v3/src/hooks/use-drag-drop.ts
+++ b/v3/src/hooks/use-drag-drop.ts
@@ -1,4 +1,7 @@
-import { Active, DataRef, useDndMonitor, useDraggable, UseDraggableArguments } from "@dnd-kit/core"
+import {
+  Active, DataRef, useDndMonitor, useDraggable, UseDraggableArguments, useDroppable, UseDroppableArguments
+} from "@dnd-kit/core"
+import { useInstanceIdContext } from "./use-instance-id-context"
 
 // list of draggable types
 const DragTypes = ["attribute"] as const
@@ -32,6 +35,23 @@ export const useDraggableAttribute = ({ prefix, attributeId, ...others }: IUseDr
   const attributes = { tabIndex: -1 }
   const data: IDragAttributeData = { type: "attribute", attributeId }
   return useDraggable({ ...others, id: `${prefix}-${attributeId}`, attributes, data })
+}
+
+// collision-detection code uses drop overlays to identify the tile that should handle the drag
+export const useTileDropOverlay = (baseId?: string, dropProps?: UseDroppableArguments) => {
+  const instanceId = useInstanceIdContext() || baseId
+  const id = `${instanceId}-drop-overlay`
+  return { id, ...useDroppable({ ...dropProps, id }) }
+}
+
+// collision-detection code keys on drop ids that match this convention
+export const useTileDroppable = (
+  baseId: string, onDrop: (active: Active) => void, dropProps?: UseDroppableArguments
+) => {
+  const instanceId = useInstanceIdContext()
+  const id = `${instanceId}-${baseId}-drop`
+  useDropHandler(id, onDrop)
+  return { id, ...useDroppable({ ...dropProps, id }) }
 }
 
 export const useDropHandler = (dropId: string, onDrop: (active: Active) => void) => {


### PR DESCRIPTION
Adds new hooks for conventional client usage by tiles:
- `useTileDropOverlay` for the overlay that identifies the tile responsible for handling a drag
- `useTileDroppable` for individual drop targets within a tile

Also implements a registration system so that tile-specific collision detection code need not be in common code.

The case table and the summary view are updated to make use of these new hooks and registration system. The graph is left for a future PR.