### PR TITLE
184514913-drop target behavior-V3

### DIFF
--- a/v3/src/components/axis/components/droppable-axis.tsx
+++ b/v3/src/components/axis/components/droppable-axis.tsx
@@ -22,7 +22,8 @@ export const DroppableAxis = observer(({ place, portal, target, dropId, hintStri
 
   // calculate the position of the overlay
   const style: CSSProperties = { ...axisBounds }
-  const classes = `droppable-axis droppable-svg ${place} ${isActive ? "active" : ""} ${isOver ? "over" : ""}`
+  const classes =
+    `droppable-axis droppable-svg ${place} ${isActive ? "active" : ""} ${isActive && isOver ? "over" : ""}`
 
   return portal && target && createPortal(
     <>

--- a/v3/src/components/axis/components/droppable-axis.tsx
+++ b/v3/src/components/axis/components/droppable-axis.tsx
@@ -2,6 +2,7 @@ import { Active, useDroppable } from "@dnd-kit/core"
 import { observer } from "mobx-react-lite"
 import React, { CSSProperties } from "react"
 import { createPortal } from "react-dom"
+import {clsx} from "clsx"
 import { AxisPlace } from "../axis-types"
 import { useAxisBounds } from "../hooks/use-axis-bounds"
 import { DropHint } from "../../graph/components/drop-hint"
@@ -23,7 +24,7 @@ export const DroppableAxis = observer(({ place, portal, target, dropId, hintStri
   // calculate the position of the overlay
   const style: CSSProperties = { ...axisBounds }
   const classes =
-    `droppable-axis droppable-svg ${place} ${isActive ? "active" : ""} ${isActive && isOver ? "over" : ""}`
+    clsx("droppable-axis", "droppable-svg", place, { active: isActive, over: isActive && isOver })
 
   return portal && target && createPortal(
     <>

--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -1,26 +1,28 @@
 import React from "react"
+import {clsx} from "clsx"
 import {Active, useDroppable} from "@dnd-kit/core"
 import {useDropHintString} from "../../../hooks/use-drop-hint-string"
 import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
 import {DropHint} from "./drop-hint"
-import {graphPlaceToAttrRole, IsGraphDropAllowed, PlotType} from "../graphing-types"
+import {graphPlaceToAttrRole, PlotType} from "../graphing-types"
+import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 
 interface IAddAttributeProps {
   location: 'yPlus' | 'top' | 'rightNumeric'
   plotType: PlotType
-  isDropAllowed?: IsGraphDropAllowed
   onDrop: (attributeId: string) => void
 }
 
-export const DroppableAddAttribute = ({location, plotType,
-                                        isDropAllowed = () => true, onDrop}: IAddAttributeProps) => {
-  const droppableId = `graph-add-attribute-drop-${location}`,
+export const DroppableAddAttribute = ({location, plotType, onDrop}: IAddAttributeProps) => {
+  const dataConfiguration = useDataConfigurationContext(),
+    isDropAllowed = dataConfiguration?.graphPlaceCanAcceptAttributeIDDrop,
+    droppableId = `graph-add-attribute-drop-${location}`,
     role = graphPlaceToAttrRole[location],
     {active, isOver, setNodeRef} = useDroppable({id: droppableId}),
     hintString = useDropHintString({ role, isDropAllowed})
 
   const handleIsActive = (iActive: Active) => {
-    const droppedAttrId = getDragAttributeId(iActive)
+    const droppedAttrId = getDragAttributeId(iActive) ?? ''
     if (isDropAllowed) {
       return isDropAllowed(location, droppedAttrId)
     } else {
@@ -35,7 +37,7 @@ export const DroppableAddAttribute = ({location, plotType,
 
   if (plotType === 'scatterPlot') {
     const isActive = active && handleIsActive(active)
-    const className = `add-attribute-drop-${location} ${isActive && isOver ? "over" : ""} ${isActive ? "active" : ""}`
+    const className = clsx(`add-attribute-drop-${location}`, { over: isActive && isOver, active: isActive })
     return (
       <div ref={setNodeRef} id={droppableId}
            className={className}>

--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -1,28 +1,41 @@
 import React from "react"
-import {useDroppable} from "@dnd-kit/core"
+import {Active, useDroppable} from "@dnd-kit/core"
 import {useDropHintString} from "../../../hooks/use-drop-hint-string"
 import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
 import {DropHint} from "./drop-hint"
-import {PlotType} from "../graphing-types"
+import {IsGraphDropAllowed, PlotType} from "../graphing-types"
 
 interface IAddAttributeProps {
   location: 'top' | 'rightNumeric'
   plotType: PlotType
+  isDropAllowed?: IsGraphDropAllowed
   onDrop: (attributeId: string) => void
 }
 
-export const DroppableAddAttribute = ({location, plotType, onDrop}: IAddAttributeProps) => {
+export const DroppableAddAttribute = ({location, plotType,
+                                        isDropAllowed = () => true, onDrop}: IAddAttributeProps) => {
   const droppableId = `graph-add-attribute-drop-${location}`,
     {active, isOver, setNodeRef} = useDroppable({id: droppableId}),
-    hintString = useDropHintString({role: 'yPlus'})
+    hintString = useDropHintString({role: 'yPlus', isDropAllowed})
+
+  const handleIsActive = (iActive: Active) => {
+    const droppedAttrId = getDragAttributeId(iActive)
+    if (isDropAllowed) {
+      return isDropAllowed('legend', droppedAttrId)
+    } else {
+      return !!droppedAttrId
+    }
+  }
+
   useDropHandler(droppableId, isActive => {
     const dragAttributeID = getDragAttributeId(isActive)
     dragAttributeID && onDrop(dragAttributeID)
   })
+
   if (plotType === 'scatterPlot') {
     return (
       <div ref={setNodeRef} id={droppableId}
-           className={`add-attribute-drop-${location} ${isOver ? "over" : ""} ${active ? "active" : ""} }`}>
+           className={`add-attribute-drop-${location} ${active && isOver ? "over" : ""} ${active ? "active" : ""} }`}>
         {isOver && hintString &&
            <DropHint hintText={hintString}/>
         }

--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -3,10 +3,10 @@ import {Active, useDroppable} from "@dnd-kit/core"
 import {useDropHintString} from "../../../hooks/use-drop-hint-string"
 import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
 import {DropHint} from "./drop-hint"
-import {IsGraphDropAllowed, PlotType} from "../graphing-types"
+import {graphPlaceToAttrRole, IsGraphDropAllowed, PlotType} from "../graphing-types"
 
 interface IAddAttributeProps {
-  location: 'top' | 'rightNumeric'
+  location: 'yPlus' | 'top' | 'rightNumeric'
   plotType: PlotType
   isDropAllowed?: IsGraphDropAllowed
   onDrop: (attributeId: string) => void
@@ -15,13 +15,14 @@ interface IAddAttributeProps {
 export const DroppableAddAttribute = ({location, plotType,
                                         isDropAllowed = () => true, onDrop}: IAddAttributeProps) => {
   const droppableId = `graph-add-attribute-drop-${location}`,
+    role = graphPlaceToAttrRole[location],
     {active, isOver, setNodeRef} = useDroppable({id: droppableId}),
-    hintString = useDropHintString({role: 'yPlus', isDropAllowed})
+    hintString = useDropHintString({ role, isDropAllowed})
 
   const handleIsActive = (iActive: Active) => {
     const droppedAttrId = getDragAttributeId(iActive)
     if (isDropAllowed) {
-      return isDropAllowed('legend', droppedAttrId)
+      return isDropAllowed(location, droppedAttrId)
     } else {
       return !!droppedAttrId
     }
@@ -33,9 +34,11 @@ export const DroppableAddAttribute = ({location, plotType,
   })
 
   if (plotType === 'scatterPlot') {
+    const isActive = active && handleIsActive(active)
+    const className = `add-attribute-drop-${location} ${isActive && isOver ? "over" : ""} ${isActive ? "active" : ""}`
     return (
       <div ref={setNodeRef} id={droppableId}
-           className={`add-attribute-drop-${location} ${active && isOver ? "over" : ""} ${active ? "active" : ""} }`}>
+           className={className}>
         {isOver && hintString &&
            <DropHint hintText={hintString}/>
         }

--- a/v3/src/components/graph/components/droppable-plot.tsx
+++ b/v3/src/components/graph/components/droppable-plot.tsx
@@ -3,24 +3,32 @@ import React, {memo} from "react"
 import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
 import {useDropHintString} from "../../../hooks/use-drop-hint-string"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
-import {GraphPlace} from "../graphing-types"
+import {GraphPlace, IsGraphDropAllowed} from "../graphing-types"
 import {DroppableSvg} from "./droppable-svg"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 
 interface IProps {
   graphElt: HTMLDivElement | null
   plotElt: SVGGElement | null
+  isDropAllowed?: IsGraphDropAllowed
   onDropAttribute: (place: GraphPlace, attrId: string) => void
 }
 
-const handleIsActive = (active: Active) => !!getDragAttributeId(active)
-
-const _DroppablePlot = ({ graphElt, plotElt, onDropAttribute }: IProps) => {
+const _DroppablePlot = ({ graphElt, plotElt, isDropAllowed, onDropAttribute }: IProps) => {
   const instanceId = useInstanceIdContext()
   const dataConfig = useDataConfigurationContext()
   const droppableId = `${instanceId}-plot-area-drop`
   const role = dataConfig?.noAttributesAssigned ? 'x' : 'legend'
   const hintString = useDropHintString({ role })
+
+  const handleIsActive = (active: Active) => {
+    const droppedAttrId = getDragAttributeId(active)
+    if (isDropAllowed) {
+      return isDropAllowed('legend', droppedAttrId)
+    } else {
+      return !!droppedAttrId
+    }
+  }
 
   useDropHandler(droppableId, active => {
     const dragAttributeID = getDragAttributeId(active)

--- a/v3/src/components/graph/components/droppable-plot.tsx
+++ b/v3/src/components/graph/components/droppable-plot.tsx
@@ -3,26 +3,26 @@ import React, {memo} from "react"
 import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
 import {useDropHintString} from "../../../hooks/use-drop-hint-string"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
-import {GraphPlace, IsGraphDropAllowed} from "../graphing-types"
+import {GraphPlace} from "../graphing-types"
 import {DroppableSvg} from "./droppable-svg"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 
 interface IProps {
   graphElt: HTMLDivElement | null
   plotElt: SVGGElement | null
-  isDropAllowed?: IsGraphDropAllowed
   onDropAttribute: (place: GraphPlace, attrId: string) => void
 }
 
-const _DroppablePlot = ({graphElt, plotElt, isDropAllowed = () => true, onDropAttribute}: IProps) => {
+const _DroppablePlot = ({graphElt, plotElt, onDropAttribute}: IProps) => {
   const instanceId = useInstanceIdContext()
   const dataConfig = useDataConfigurationContext()
+  const isDropAllowed = dataConfig?.graphPlaceCanAcceptAttributeIDDrop ?? (() => true)
   const droppableId = `${instanceId}-plot-area-drop`
   const role = dataConfig?.noAttributesAssigned ? 'x' : 'legend'
   const hintString = useDropHintString({role, isDropAllowed})
 
   const handleIsActive = (active: Active) => {
-    const droppedAttrId = getDragAttributeId(active)
+    const droppedAttrId = getDragAttributeId(active) ?? ''
     if (isDropAllowed) {
       return isDropAllowed('legend', droppedAttrId)
     } else {

--- a/v3/src/components/graph/components/droppable-plot.tsx
+++ b/v3/src/components/graph/components/droppable-plot.tsx
@@ -14,12 +14,12 @@ interface IProps {
   onDropAttribute: (place: GraphPlace, attrId: string) => void
 }
 
-const _DroppablePlot = ({ graphElt, plotElt, isDropAllowed, onDropAttribute }: IProps) => {
+const _DroppablePlot = ({graphElt, plotElt, isDropAllowed = () => true, onDropAttribute}: IProps) => {
   const instanceId = useInstanceIdContext()
   const dataConfig = useDataConfigurationContext()
   const droppableId = `${instanceId}-plot-area-drop`
   const role = dataConfig?.noAttributesAssigned ? 'x' : 'legend'
-  const hintString = useDropHintString({ role })
+  const hintString = useDropHintString({role, isDropAllowed})
 
   const handleIsActive = (active: Active) => {
     const droppedAttrId = getDragAttributeId(active)
@@ -32,7 +32,8 @@ const _DroppablePlot = ({ graphElt, plotElt, isDropAllowed, onDropAttribute }: I
 
   useDropHandler(droppableId, active => {
     const dragAttributeID = getDragAttributeId(active)
-    dragAttributeID && onDropAttribute('plot', dragAttributeID)
+    dragAttributeID && isDropAllowed('legend', dragAttributeID) &&
+    onDropAttribute('plot', dragAttributeID)
   })
 
   return (

--- a/v3/src/components/graph/components/droppable-svg.tsx
+++ b/v3/src/components/graph/components/droppable-svg.tsx
@@ -20,7 +20,7 @@ const _DroppableSvg = ({
   const { active, isOver, setNodeRef } = useDroppable({ id: dropId })
   const isActive = active && onIsActive?.(active)
   const style: CSSProperties = useOverlayBounds({ target, portal })
-  const classes = `droppable-svg ${className} ${isActive ? "active" : ""} ${isOver ? "over" : ""}`
+  const classes = `droppable-svg ${className} ${isActive ? "active" : ""} ${isActive && isOver ? "over" : ""}`
 
   return portal && target && createPortal(
     <>

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -1,7 +1,7 @@
 import React, {MutableRefObject} from "react"
 import {AxisPlace} from "../../axis/axis-types"
 import {Axis} from "../../axis/components/axis"
-import {axisPlaceToAttrRole, GraphPlace, kGraphClassSelector} from "../graphing-types"
+import {axisPlaceToAttrRole, GraphPlace, IsGraphDropAllowed, kGraphClassSelector} from "../graphing-types"
 import t from "../../../utilities/translation/translate"
 import {observer} from "mobx-react-lite"
 import {useGraphModelContext} from "../models/graph-model"
@@ -10,13 +10,14 @@ import {useDataConfigurationContext} from "../hooks/use-data-configuration-conte
 interface IProps {
   place: AxisPlace
   enableAnimation: MutableRefObject<boolean>
+  isDropAllowed?: IsGraphDropAllowed
   onDropAttribute?: (place: AxisPlace, attrId: string) => void
   onRemoveAttribute?: (place: AxisPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
 export const GraphAxis = observer((
-  {place, enableAnimation, onDropAttribute, onRemoveAttribute, onTreatAttributeAs}: IProps) => {
+  {place, enableAnimation, isDropAllowed, onDropAttribute, onRemoveAttribute, onTreatAttributeAs}: IProps) => {
   const dataConfig = useDataConfigurationContext()
   const dataset = dataConfig?.dataset
   const graphModel = useGraphModelContext()
@@ -41,6 +42,7 @@ export const GraphAxis = observer((
           enableAnimation={enableAnimation}
           showScatterPlotGridLines={graphModel.axisShouldShowGridLines(place)}
           centerCategoryLabels={graphModel.config.categoriesForAxisShouldBeCentered(place)}
+          isDropAllowed={isDropAllowed}
           onDropAttribute={onDropAttribute}
           onRemoveAttribute={onRemoveAttribute}
           onTreatAttributeAs={onTreatAttributeAs}

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -1,7 +1,7 @@
 import React, {MutableRefObject} from "react"
 import {AxisPlace} from "../../axis/axis-types"
 import {Axis} from "../../axis/components/axis"
-import {axisPlaceToAttrRole, GraphPlace, IsGraphDropAllowed, kGraphClassSelector} from "../graphing-types"
+import {axisPlaceToAttrRole, GraphPlace, kGraphClassSelector} from "../graphing-types"
 import t from "../../../utilities/translation/translate"
 import {observer} from "mobx-react-lite"
 import {useGraphModelContext} from "../models/graph-model"
@@ -10,15 +10,15 @@ import {useDataConfigurationContext} from "../hooks/use-data-configuration-conte
 interface IProps {
   place: AxisPlace
   enableAnimation: MutableRefObject<boolean>
-  isDropAllowed?: IsGraphDropAllowed
   onDropAttribute?: (place: AxisPlace, attrId: string) => void
   onRemoveAttribute?: (place: AxisPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
 export const GraphAxis = observer((
-  {place, enableAnimation, isDropAllowed, onDropAttribute, onRemoveAttribute, onTreatAttributeAs}: IProps) => {
+  {place, enableAnimation, onDropAttribute, onRemoveAttribute, onTreatAttributeAs}: IProps) => {
   const dataConfig = useDataConfigurationContext()
+  const isDropAllowed = dataConfig?.graphPlaceCanAcceptAttributeIDDrop ?? (() => true)
   const dataset = dataConfig?.dataset
   const graphModel = useGraphModelContext()
   const role = axisPlaceToAttrRole[place]

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -60,6 +60,22 @@
   }
   &.over {
     background: yellow;
+    opacity: 0.5;
+  }
+}
+
+.add-attribute-drop-yPlus {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 25px;
+  &.active {
+    border: 5px solid rgb(255, 216, 102);
+  }
+  &.over {
+    background: yellow;
+    opacity: 0.5;
   }
 }
 
@@ -74,5 +90,6 @@
   }
   &.over {
     background: yellow;
+    opacity: 0.5;
   }
 }

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -180,7 +180,7 @@ export const Graph = observer((
           />
         </svg>
         <DroppableAddAttribute
-          location={'top'}
+          location={'yPlus'}
           plotType = {plotType}
           isDropAllowed={isDropAllowed}
           onDrop={handleChangeAttribute.bind(null, 'yPlus')}/>

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -52,7 +52,8 @@ export const Graph = observer((
     plotAreaSVGRef = useRef<SVGSVGElement>(null),
     backgroundSvgRef = useRef<SVGGElement>(null),
     xAttrID = graphModel.getAttributeID('x'),
-    yAttrID = graphModel.getAttributeID('y')
+    yAttrID = graphModel.getAttributeID('y'),
+    isDropAllowed = graphModel.config.graphPlaceCanAcceptAttributeIDDrop
 
   useGraphModel({dotsRef, graphModel, enableAnimation, instanceId})
 
@@ -136,7 +137,7 @@ export const Graph = observer((
       return <GraphAxis key={place}
                         place={place}
                         enableAnimation={enableAnimation}
-                        isDropAllowed={graphModel.config.graphPlaceCanAcceptAttributeIDDrop}
+                        isDropAllowed={isDropAllowed}
                         onDropAttribute={handleChangeAttribute}
                         onRemoveAttribute={handleRemoveAttribute}
                         onTreatAttributeAs={handleTreatAttrAs}
@@ -165,13 +166,14 @@ export const Graph = observer((
           <DroppablePlot
             graphElt={graphRef.current}
             plotElt={backgroundSvgRef.current}
-            isDropAllowed={graphModel.config.graphPlaceCanAcceptAttributeIDDrop}
+            isDropAllowed={isDropAllowed}
             onDropAttribute={handleChangeAttribute}
           />
 
           <Legend
             legendAttrID={graphModel.getAttributeID('legend')}
             graphElt={graphRef.current}
+            isDropAllowed={isDropAllowed}
             onDropAttribute={handleChangeAttribute}
             onRemoveAttribute={handleRemoveAttribute}
             onTreatAttributeAs={handleTreatAttrAs}
@@ -180,10 +182,12 @@ export const Graph = observer((
         <DroppableAddAttribute
           location={'top'}
           plotType = {plotType}
+          isDropAllowed={isDropAllowed}
           onDrop={handleChangeAttribute.bind(null, 'yPlus')}/>
         <DroppableAddAttribute
           location={'rightNumeric'}
           plotType = {plotType}
+          isDropAllowed={isDropAllowed}
           onDrop={handleChangeAttribute.bind(null, 'rightNumeric')}/>
       </div>
       <GraphInspector graphModel={graphModel}

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -136,6 +136,7 @@ export const Graph = observer((
       return <GraphAxis key={place}
                         place={place}
                         enableAnimation={enableAnimation}
+                        isDropAllowed={graphModel.config.graphPlaceCanAcceptAttributeIDDrop}
                         onDropAttribute={handleChangeAttribute}
                         onRemoveAttribute={handleRemoveAttribute}
                         onTreatAttributeAs={handleTreatAttrAs}
@@ -164,6 +165,7 @@ export const Graph = observer((
           <DroppablePlot
             graphElt={graphRef.current}
             plotElt={backgroundSvgRef.current}
+            isDropAllowed={graphModel.config.graphPlaceCanAcceptAttributeIDDrop}
             onDropAttribute={handleChangeAttribute}
           />
 

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -52,8 +52,7 @@ export const Graph = observer((
     plotAreaSVGRef = useRef<SVGSVGElement>(null),
     backgroundSvgRef = useRef<SVGGElement>(null),
     xAttrID = graphModel.getAttributeID('x'),
-    yAttrID = graphModel.getAttributeID('y'),
-    isDropAllowed = graphModel.config.graphPlaceCanAcceptAttributeIDDrop
+    yAttrID = graphModel.getAttributeID('y')
 
   useGraphModel({dotsRef, graphModel, enableAnimation, instanceId})
 
@@ -137,7 +136,6 @@ export const Graph = observer((
       return <GraphAxis key={place}
                         place={place}
                         enableAnimation={enableAnimation}
-                        isDropAllowed={isDropAllowed}
                         onDropAttribute={handleChangeAttribute}
                         onRemoveAttribute={handleRemoveAttribute}
                         onTreatAttributeAs={handleTreatAttrAs}
@@ -166,14 +164,12 @@ export const Graph = observer((
           <DroppablePlot
             graphElt={graphRef.current}
             plotElt={backgroundSvgRef.current}
-            isDropAllowed={isDropAllowed}
             onDropAttribute={handleChangeAttribute}
           />
 
           <Legend
             legendAttrID={graphModel.getAttributeID('legend')}
             graphElt={graphRef.current}
-            isDropAllowed={isDropAllowed}
             onDropAttribute={handleChangeAttribute}
             onRemoveAttribute={handleRemoveAttribute}
             onTreatAttributeAs={handleTreatAttrAs}
@@ -182,12 +178,10 @@ export const Graph = observer((
         <DroppableAddAttribute
           location={'yPlus'}
           plotType = {plotType}
-          isDropAllowed={isDropAllowed}
           onDrop={handleChangeAttribute.bind(null, 'yPlus')}/>
         <DroppableAddAttribute
           location={'rightNumeric'}
           plotType = {plotType}
-          isDropAllowed={isDropAllowed}
           onDrop={handleChangeAttribute.bind(null, 'rightNumeric')}/>
       </div>
       <GraphInspector graphModel={graphModel}

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -10,23 +10,23 @@ import {DroppableSvg} from "../droppable-svg"
 import {useInstanceIdContext} from "../../../../hooks/use-instance-id-context"
 import {getDragAttributeId, useDropHandler} from "../../../../hooks/use-drag-drop"
 import {useDropHintString} from "../../../../hooks/use-drop-hint-string"
-import {GraphAttrRole, GraphPlace, IsGraphDropAllowed} from "../../graphing-types"
+import {GraphAttrRole, GraphPlace} from "../../graphing-types"
 import {AxisOrLegendAttributeMenu} from "../../../axis/components/axis-or-legend-attribute-menu"
 
 interface ILegendProps {
   legendAttrID: string
   graphElt: HTMLDivElement | null
-  isDropAllowed?: IsGraphDropAllowed
   onDropAttribute: (place: GraphPlace, attrId: string) => void
   onRemoveAttribute: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
 export const Legend = function Legend({
-                                        legendAttrID, graphElt, isDropAllowed = () => true,
+                                        legendAttrID, graphElt,
                                         onDropAttribute, onTreatAttributeAs, onRemoveAttribute
                                       }: ILegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
+    isDropAllowed = dataConfiguration?.graphPlaceCanAcceptAttributeIDDrop ?? (() => true),
     layout = useGraphLayoutContext(),
     attrType = dataConfiguration?.dataset?.attrFromID(legendAttrID ?? '')?.type,
     legendLabelRef = useRef<SVGGElement>(null),
@@ -38,7 +38,7 @@ export const Legend = function Legend({
     attributeIDs = useMemo(() => legendAttrID ? [legendAttrID] : [], [legendAttrID])
 
   const handleIsActive = (active: Active) => {
-    const droppedAttrId = getDragAttributeId(active)
+    const droppedAttrId = getDragAttributeId(active) ?? ''
     if (isDropAllowed) {
       return isDropAllowed('legend', droppedAttrId)
     } else {

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useMemo, useRef} from "react"
+import React, {useMemo, useRef} from "react"
 import {createPortal} from "react-dom"
 import {Active} from "@dnd-kit/core"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
@@ -10,22 +10,22 @@ import {DroppableSvg} from "../droppable-svg"
 import {useInstanceIdContext} from "../../../../hooks/use-instance-id-context"
 import {getDragAttributeId, useDropHandler} from "../../../../hooks/use-drag-drop"
 import {useDropHintString} from "../../../../hooks/use-drop-hint-string"
-import {GraphAttrRole, GraphPlace} from "../../graphing-types"
+import {GraphAttrRole, GraphPlace, IsGraphDropAllowed} from "../../graphing-types"
 import {AxisOrLegendAttributeMenu} from "../../../axis/components/axis-or-legend-attribute-menu"
 
 interface ILegendProps {
   legendAttrID: string
   graphElt: HTMLDivElement | null
+  isDropAllowed?: IsGraphDropAllowed
   onDropAttribute: (place: GraphPlace, attrId: string) => void
   onRemoveAttribute: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
 }
 
-const handleIsActive = (active: Active) => !!getDragAttributeId(active)
-
-export const Legend = memo(function Legend({
-  legendAttrID, graphElt, onDropAttribute, onTreatAttributeAs, onRemoveAttribute
-}: ILegendProps) {
+export const Legend = function Legend({
+                                        legendAttrID, graphElt, isDropAllowed = () => true,
+                                        onDropAttribute, onTreatAttributeAs, onRemoveAttribute
+                                      }: ILegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
     layout = useGraphLayoutContext(),
     attrType = dataConfiguration?.dataset?.attrFromID(legendAttrID ?? '')?.type,
@@ -34,12 +34,22 @@ export const Legend = memo(function Legend({
     instanceId = useInstanceIdContext(),
     droppableId = `${instanceId}-legend-area-drop`,
     role = 'legend' as GraphAttrRole,
-    hintString = useDropHintString({role}),
+    hintString = useDropHintString({role, isDropAllowed}),
     attributeIDs = useMemo(() => legendAttrID ? [legendAttrID] : [], [legendAttrID])
+
+  const handleIsActive = (active: Active) => {
+    const droppedAttrId = getDragAttributeId(active)
+    if (isDropAllowed) {
+      return isDropAllowed('legend', droppedAttrId)
+    } else {
+      return !!droppedAttrId
+    }
+  }
 
   useDropHandler(droppableId, active => {
     const dragAttributeID = getDragAttributeId(active)
-    dragAttributeID && onDropAttribute('legend', dragAttributeID)
+    dragAttributeID && isDropAllowed('legend', dragAttributeID) &&
+    onDropAttribute('legend', dragAttributeID)
   })
 
   const legendBounds = layout.computedBounds.get('legend') as Bounds,
@@ -49,14 +59,14 @@ export const Legend = memo(function Legend({
     <>
       <svg ref={legendRef} className='legend'>
         { graphElt && createPortal(
-            <AxisOrLegendAttributeMenu
-              place="legend"
-              target={legendLabelRef.current}
-              portal={graphElt}
-              onChangeAttribute={onDropAttribute}
-              onRemoveAttribute={onRemoveAttribute}
-              onTreatAttributeAs={onTreatAttributeAs}
-            />,
+          <AxisOrLegendAttributeMenu
+            place="legend"
+            target={legendLabelRef.current}
+            portal={graphElt}
+            onChangeAttribute={onDropAttribute}
+            onRemoveAttribute={onRemoveAttribute}
+            onTreatAttributeAs={onTreatAttributeAs}
+          />,
           graphElt)
         }
         <AttributeLabel
@@ -70,7 +80,7 @@ export const Legend = memo(function Legend({
           attrType === 'categorical' ? <CategoricalLegend transform={transform}
                                                           legendLabelRef={legendLabelRef}/>
             : attrType === 'numeric' ? <NumericLegend legendAttrID={legendAttrID}
-                                                    transform={transform}/> : null
+                                                      transform={transform}/> : null
         }
       </svg>
       <DroppableSvg
@@ -84,5 +94,5 @@ export const Legend = memo(function Legend({
     </>
 
   ) : null
-})
+}
 Legend.displayName = "Legend"

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -11,6 +11,7 @@ export const TipAttrRoles = [...PrimaryAttrRoles, 'legend', 'caption', 'rightNum
 export const GraphAttrRoles = [
   ...TipAttrRoles, 'polygon', 'yPlus', 'topSplit', 'rightSplit'] as const
 export type GraphAttrRole = typeof GraphAttrRoles[number]
+export type IsGraphDropAllowed = (place: GraphPlace, attrId: string | undefined) => boolean
 
 
 export const attrRoleToAxisPlace: Partial<Record<GraphAttrRole, AxisPlace>> = {

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -11,7 +11,7 @@ export const TipAttrRoles = [...PrimaryAttrRoles, 'legend', 'caption', 'rightNum
 export const GraphAttrRoles = [
   ...TipAttrRoles, 'polygon', 'yPlus', 'topSplit', 'rightSplit'] as const
 export type GraphAttrRole = typeof GraphAttrRoles[number]
-export type IsGraphDropAllowed = (place: GraphPlace, attrId: string | undefined) => boolean
+export type IsGraphDropAllowed = (place: GraphPlace, attrId?: string) => boolean
 
 
 export const attrRoleToAxisPlace: Partial<Record<GraphAttrRole, AxisPlace>> = {

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -428,6 +428,10 @@ export const DataConfigurationModel = types
         const role = graphPlaceToAttrRole[place],
           primaryRole = self.primaryRole
         return primaryRole === role
+      },
+      graphPlaceCanAcceptAttributeIDDrop(place: GraphPlace, idToDrop: string) {
+        const existingID = self.attributeID(graphPlaceToAttrRole[place])
+        return !!idToDrop && existingID !== idToDrop
       }
     }))
   .actions(self => ({

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -430,8 +430,12 @@ export const DataConfigurationModel = types
         return primaryRole === role
       },
       graphPlaceCanAcceptAttributeIDDrop(place: GraphPlace, idToDrop: string) {
-        const existingID = self.attributeID(graphPlaceToAttrRole[place])
-        return !!idToDrop && existingID !== idToDrop
+        if (place === 'yPlus') {
+          return !!idToDrop && !self.yAttributeIDs.includes(idToDrop)
+        } else {
+          const existingID = self.attributeID(graphPlaceToAttrRole[place])
+          return !!idToDrop && existingID !== idToDrop
+        }
       }
     }))
   .actions(self => ({

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -430,12 +430,13 @@ export const DataConfigurationModel = types
         return primaryRole === role
       },
       graphPlaceCanAcceptAttributeIDDrop(place: GraphPlace, idToDrop: string) {
-        const role = graphPlaceToAttrRole[place]
+        const role = graphPlaceToAttrRole[place],
+          typeToDrop = self.dataset?.attrFromID(idToDrop)?.type
         if (place === 'yPlus') {
-          return self.attributeType(role) === 'numeric' && !!idToDrop && !self.yAttributeIDs.includes(idToDrop)
+          return typeToDrop === 'numeric' && !!idToDrop && !self.yAttributeIDs.includes(idToDrop)
         } else {
           const existingID = self.attributeID(role)
-          return (place === 'rightNumeric' ? self.dataset?.attrFromID(idToDrop).type === 'numeric' : true) &&
+          return (place === 'rightNumeric' ? typeToDrop === 'numeric' : true) &&
             !!idToDrop && existingID !== idToDrop
         }
       }

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -430,11 +430,13 @@ export const DataConfigurationModel = types
         return primaryRole === role
       },
       graphPlaceCanAcceptAttributeIDDrop(place: GraphPlace, idToDrop: string) {
+        const role = graphPlaceToAttrRole[place]
         if (place === 'yPlus') {
-          return !!idToDrop && !self.yAttributeIDs.includes(idToDrop)
+          return self.attributeType(role) === 'numeric' && !!idToDrop && !self.yAttributeIDs.includes(idToDrop)
         } else {
-          const existingID = self.attributeID(graphPlaceToAttrRole[place])
-          return !!idToDrop && existingID !== idToDrop
+          const existingID = self.attributeID(role)
+          return (place === 'rightNumeric' ? self.dataset?.attrFromID(idToDrop).type === 'numeric' : true) &&
+            !!idToDrop && existingID !== idToDrop
         }
       }
     }))

--- a/v3/src/hooks/use-drop-hint-string.ts
+++ b/v3/src/hooks/use-drop-hint-string.ts
@@ -3,11 +3,12 @@ import { AttributeType } from "../models/data/attribute"
 import {useDataSetContext} from "./use-data-set-context"
 import {getDragAttributeId} from "./use-drag-drop"
 import {useDataConfigurationContext} from "../components/graph/hooks/use-data-configuration-context"
-import {GraphAttrRole} from "../components/graph/graphing-types"
+import {attrRoleToGraphPlace, GraphAttrRole, GraphPlace, IsGraphDropAllowed} from "../components/graph/graphing-types"
 import t from "../utilities/translation/translate"
 
 export interface IUseDropHintStringProps {
   role: GraphAttrRole
+  isDropAllowed?: IsGraphDropAllowed
 }
 
 interface HintMapEntry {
@@ -60,14 +61,16 @@ export function determineBaseString(role: GraphAttrRole, dropType?: AttributeTyp
   return stringKey ? `DG.GraphView.${stringKey}` : undefined
 }
 
-export const useDropHintString = ({role} : IUseDropHintStringProps) => {
+export const useDropHintString = ({role, isDropAllowed} : IUseDropHintStringProps) => {
   const dataSet = useDataSetContext(),
     dataConfig = useDataConfigurationContext(),
-    { active } = useDndContext()
+    { active } = useDndContext(),
+    dragAttrId = getDragAttributeId(active),
+    place = attrRoleToGraphPlace[role] as GraphPlace,
+    dropAllowed = isDropAllowed ?? (() => true)
 
-  if (dataSet && active?.data.current) {
-    const dragAttrId = getDragAttributeId(active),
-      dragAttrName = dragAttrId ? dataSet.attrFromID(dragAttrId).name : undefined,
+  if (dataSet && active?.data.current && dropAllowed(place, dragAttrId)) {
+    const dragAttrName = dragAttrId ? dataSet.attrFromID(dragAttrId).name : undefined,
       dragAttrType = dragAttrId? dataSet.attrFromID(dragAttrId).type : undefined
 
     const

--- a/v3/src/hooks/use-drop-hint-string.ts
+++ b/v3/src/hooks/use-drop-hint-string.ts
@@ -55,6 +55,12 @@ export function determineBaseString(role: GraphAttrRole, dropType?: AttributeTyp
         existing: "addAttribute"
       }
     },
+    rightNumeric: {
+      numeric: {
+        empty: "addAttribute",
+        existing: "addAttribute"
+      }
+    },
   }
 
   const stringKey = dropType && stringMap[role]?.[dropType]?.[priorType ? "existing" : "empty"]

--- a/v3/src/hooks/use-drop-hint-string.ts
+++ b/v3/src/hooks/use-drop-hint-string.ts
@@ -73,9 +73,9 @@ export const useDropHintString = ({role, isDropAllowed} : IUseDropHintStringProp
     { active } = useDndContext(),
     dragAttrId = getDragAttributeId(active),
     place = attrRoleToGraphPlace[role] as GraphPlace,
-    dropAllowed = isDropAllowed ?? (() => true)
+    dropAllowed = isDropAllowed ? isDropAllowed(place, dragAttrId) : true
 
-  if (dataSet && active?.data.current && dropAllowed(place, dragAttrId)) {
+  if (dataSet && active?.data.current && dropAllowed) {
     const dragAttrName = dragAttrId ? dataSet.attrFromID(dragAttrId).name : undefined,
       dragAttrType = dragAttrId? dataSet.attrFromID(dragAttrId).type : undefined
 


### PR DESCRIPTION
The meat is in DataConfigurationModel:graphPlaceCanAcceptAttributeIDDrop, but each of the different types of drop targets had to be massaged in their own way.