### PR TITLE
184392252-restore graph components

### DIFF
--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -6,19 +6,14 @@ export const axisGap = 5
 export const AxisPlaces = ["bottom", "left", "rightCat", "top", "rightNumeric"] as const
 export type AxisPlace = typeof AxisPlaces[number]
 
-export const axisPlaceToAxis = (place: AxisPlace) => {
-  switch (place) {
-    case "bottom":
-      return axisBottom
-    case "left":
-      return axisLeft
-    case "rightCat":
-      return axisRight
-    case "top":
-      return axisTop
-    case "rightNumeric":
-      return axisRight
-  }
+export const axisPlaceToAxisFn = (place: AxisPlace) => {
+  return {
+    bottom: axisBottom,
+    left: axisLeft,
+    rightCat: axisRight,
+    rightNumeric: axisRight,
+    top: axisTop
+  }[place]
 }
 
 export function isHorizontal(place: AxisPlace) {

--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -1,10 +1,25 @@
-import { ScaleBand, ScaleContinuousNumeric, ScaleOrdinal } from "d3"
+import {axisBottom, axisLeft, axisRight, axisTop, ScaleBand, ScaleContinuousNumeric, ScaleOrdinal} from "d3"
 
 export const axisGap = 5
 
 // "rightCat" and "top" can only be categorical axes. "rightNumeric" can only be numeric
 export const AxisPlaces = ["bottom", "left", "rightCat", "top", "rightNumeric"] as const
 export type AxisPlace = typeof AxisPlaces[number]
+
+export const axisPlaceToAxis = (place: AxisPlace) => {
+  switch (place) {
+    case "bottom":
+      return axisBottom
+    case "left":
+      return axisLeft
+    case "rightCat":
+      return axisRight
+    case "top":
+      return axisTop
+    case "rightNumeric":
+      return axisRight
+  }
+}
 
 export function isHorizontal(place: AxisPlace) {
   return ["bottom", "top"].includes(place)

--- a/v3/src/components/axis/components/axis-drag-rects.tsx
+++ b/v3/src/components/axis/components/axis-drag-rects.tsx
@@ -60,7 +60,7 @@ export const AxisDragRects = observer(({axisModel, axisWrapperElt}: IProps) => {
             ratio = (upperAtStart - x2) / (upperAtStart - dilationAnchorCoord),
             newRange = (upperAtStart - lowerAtStart) / ratio,
             newLowerBound = upperAtStart - newRange
-          axisModel.setDomain?.(newLowerBound, upperAtStart)
+          axisModel.setDomain(newLowerBound, upperAtStart)
         }
       },
 
@@ -69,7 +69,7 @@ export const AxisDragRects = observer(({axisModel, axisWrapperElt}: IProps) => {
         if (delta !== 0) {
           const worldDelta = Number(axisScale?.invert(delta)) -
             Number(axisScale?.invert(0))
-          axisModel.setDomain?.(axisModel.min + worldDelta, axisModel.max + worldDelta)
+          axisModel.setDomain(axisModel.min + worldDelta, axisModel.max + worldDelta)
         }
       },
 
@@ -81,7 +81,7 @@ export const AxisDragRects = observer(({axisModel, axisWrapperElt}: IProps) => {
             ratio = (x2 - lowerAtStart) / (dilationAnchorCoord - lowerAtStart),
             newRange = (upperAtStart - lowerAtStart) / ratio,
             newUpperBound = lowerAtStart + newRange
-          axisModel.setDomain?.(lowerAtStart, newUpperBound)
+          axisModel.setDomain(lowerAtStart, newUpperBound)
         }
       },
 

--- a/v3/src/components/axis/components/axis-drag-rects.tsx
+++ b/v3/src/components/axis/components/axis-drag-rects.tsx
@@ -1,11 +1,12 @@
 import {observer} from "mobx-react-lite"
 import React, {useEffect, useRef} from "react"
-import {drag, select} from "d3"
 import {reaction} from "mobx"
+import {drag, select} from "d3"
+import t from "../../../utilities/translation/translate"
 import {useAxisLayoutContext} from "../models/axis-layout-context"
 import {INumericAxisModel} from "../models/axis-model"
 import {ScaleNumericBaseType} from "../axis-types"
-import t from "../../../utilities/translation/translate"
+
 import "./axis.scss"
 
 interface IProps {
@@ -22,11 +23,11 @@ const axisDragHints = [ t("DG.CellLinearAxisView.lowerPanelTooltip"),
 export const AxisDragRects = observer(({axisModel, axisWrapperElt}: IProps) => {
   const rectRef = useRef() as React.RefObject<SVGSVGElement>,
     place = axisModel.place,
-    layout = useAxisLayoutContext(),
-    scale = layout.getAxisScale(place) as ScaleNumericBaseType
+    layout = useAxisLayoutContext()
 
   useEffect(function createRects() {
-    let scaleAtStart: any = null,
+    let axisScale: ScaleNumericBaseType,
+      scaleAtStart: any = null,
       lowerAtStart: number,
       upperAtStart: number,
       dilationAnchorCoord: number,
@@ -41,10 +42,12 @@ export const AxisDragRects = observer(({axisModel, axisWrapperElt}: IProps) => {
       onDilateStart: D3Handler = (event: { x: number, y: number }) => {
         select(this)
           .classed('dragging', true)
-        scaleAtStart = scale?.copy()
+        axisScale = layout.getAxisScale(place) as ScaleNumericBaseType
+        scaleAtStart = axisScale?.copy()
         lowerAtStart = scaleAtStart.domain()[0]
         upperAtStart = scaleAtStart.domain()[1]
-        dilationAnchorCoord = Number(place === 'bottom' ? scale?.invert(event.x) : scale?.invert(event.y))
+        dilationAnchorCoord = Number(place === 'bottom' ? axisScale?.invert(event.x)
+          : axisScale?.invert(event.y))
         dragging = true
         axisModel.setTransitionDuration(0)
       },
@@ -57,15 +60,16 @@ export const AxisDragRects = observer(({axisModel, axisWrapperElt}: IProps) => {
             ratio = (upperAtStart - x2) / (upperAtStart - dilationAnchorCoord),
             newRange = (upperAtStart - lowerAtStart) / ratio,
             newLowerBound = upperAtStart - newRange
-          axisModel.setDomain(newLowerBound, upperAtStart)
+          axisModel.setDomain?.(newLowerBound, upperAtStart)
         }
       },
 
       onDragTranslate = (event: { dx: number; dy: number }) => {
         const delta = -(place === 'bottom' ? event.dx : event.dy)
         if (delta !== 0) {
-          const worldDelta = Number(scale?.invert(delta)) - Number(scale?.invert(0))
-          axisModel.setDomain(axisModel.min + worldDelta, axisModel.max + worldDelta)
+          const worldDelta = Number(axisScale?.invert(delta)) -
+            Number(axisScale?.invert(0))
+          axisModel.setDomain?.(axisModel.min + worldDelta, axisModel.max + worldDelta)
         }
       },
 
@@ -77,7 +81,7 @@ export const AxisDragRects = observer(({axisModel, axisWrapperElt}: IProps) => {
             ratio = (x2 - lowerAtStart) / (dilationAnchorCoord - lowerAtStart),
             newRange = (upperAtStart - lowerAtStart) / ratio,
             newUpperBound = lowerAtStart + newRange
-          axisModel.setDomain(lowerAtStart, newUpperBound)
+          axisModel.setDomain?.(lowerAtStart, newUpperBound)
         }
       },
 
@@ -91,7 +95,7 @@ export const AxisDragRects = observer(({axisModel, axisWrapperElt}: IProps) => {
     if (rectRef.current) {
       const rectSelection = select(rectRef.current)
 
-      // Add three rects in which the user can drag to dilate or translate the scale
+      // Add three rects in which the user can drag to dilate or translate the axis scale
       const
         classPrefix = place === 'bottom' ? 'h' : 'v',
         numbering = place === 'bottom' ? [0, 1, 2] : [2, 1, 0],
@@ -127,7 +131,7 @@ export const AxisDragRects = observer(({axisModel, axisWrapperElt}: IProps) => {
           .call(dragBehavior[behaviorIndex])
       })
     }
-  }, [axisModel, place, scale])
+  }, [axisModel, place, layout])
 
   // update layout of axis drag rects when axis bounds change
   useEffect(() => {

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -1,7 +1,7 @@
 import {ScaleBand, scaleLinear, scaleLog, scaleOrdinal, select} from "d3"
 import {autorun, reaction} from "mobx"
 import {MutableRefObject, useCallback, useEffect, useRef} from "react"
-import {AxisBounds, axisGap, axisPlaceToAxis, isVertical, ScaleNumericBaseType} from "../axis-types"
+import {AxisBounds, axisGap, axisPlaceToAxisFn, isVertical, ScaleNumericBaseType} from "../axis-types"
 import {useAxisLayoutContext} from "../models/axis-layout-context"
 import {otherPlace, IAxisModel, isNumericAxisModel} from "../models/axis-model"
 import {between} from "../../../utilities/math-utils"
@@ -31,8 +31,8 @@ export const useAxis = ({
     scale = layout.getAxisScale(place) as ScaleNumericBaseType,
     ordinalScale = isNumeric || axisModel?.type === 'empty' ? null : scale as unknown as ScaleBand<string>
   const
-    bandWidth = (ordinalScale?.bandwidth && ordinalScale?.bandwidth()) ?? 0,
-    axis = axisPlaceToAxis(place),
+    bandWidth = (ordinalScale?.bandwidth?.()) ?? 0,
+    axis = axisPlaceToAxisFn(place),
     // By all rights, the following three lines should not be necessary to get installDomainSync to run when
     // GraphController:processV2Document installs a new axis model.
     // Todo: Revisit and figure out whether we can remove the workaround.

--- a/v3/src/components/axis/models/axis-model.test.ts
+++ b/v3/src/components/axis/models/axis-model.test.ts
@@ -1,4 +1,5 @@
-import { AxisModel, NumericAxisModel } from "./axis-model"
+import {AxisModel, AxisModelUnion, IAxisModelUnion, isNumericAxisModel, NumericAxisModel} from "./axis-model"
+import {getSnapshot, types} from "mobx-state-tree"
 
 describe("AxisModel", () => {
   it("should error if AxisModel is instantiated directly", () => {
@@ -23,3 +24,24 @@ describe("NumericAxisModel", () => {
     expect(aModel.max).toBe(0)
   })
 })
+
+describe("deserializes axes of the appropriate type", () => {
+  it("foo", () => {
+    const M = types.model("Test", {
+      axis: AxisModelUnion
+    })
+      .actions(self => ({
+        setAxis(axis: IAxisModelUnion) {
+          self.axis = axis
+        }
+      }))
+
+    const numAxis = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
+    const num = M.create({ axis : numAxis })
+    expect(isNumericAxisModel(num.axis) && num.axis.domain).toBeDefined()
+    const snap = getSnapshot(num)
+    const num2 = M.create(snap)
+    expect(isNumericAxisModel(num2.axis) && num2.axis.domain).toBeDefined()
+  })
+})
+

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -96,5 +96,14 @@ export function isNumericAxisModel(axisModel: IAxisModel): axisModel is INumeric
   return axisModel.isNumeric
 }
 
-export const AxisModelUnion = types.union(EmptyAxisModel, CategoricalAxisModel, NumericAxisModel)
+const axisTypeDispatcher = (axisSnap: any) => {
+  switch (axisSnap.type) {
+    case "categorical": return CategoricalAxisModel
+    case "numeric": return NumericAxisModel
+    default: return EmptyAxisModel
+  }
+}
+
+export const AxisModelUnion = types.union({ dispatcher: axisTypeDispatcher },
+  EmptyAxisModel, CategoricalAxisModel, NumericAxisModel)
 export type IAxisModelUnion = IEmptyAxisModel | ICategoricalAxisModel | INumericAxisModel

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -27,6 +27,9 @@ export const AxisModel = types.model("AxisModel", {
     },
     get isNumeric() {
       return ["linear", "log"].includes(self.scale)
+    },
+    get isCategorical() {
+      return self.type === "categorical"
     }
   }))
   .actions(self => ({
@@ -60,6 +63,10 @@ export const CategoricalAxisModel = AxisModel
   })
 
 export interface ICategoricalAxisModel extends Instance<typeof CategoricalAxisModel> {
+}
+
+export function isCategoricalAxisModel(axisModel: IAxisModel): axisModel is ICategoricalAxisModel {
+  return axisModel.isCategorical
 }
 
 export const NumericAxisModel = AxisModel

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -28,7 +28,7 @@ export const CodapComponent =
 
   return (
     <DataSetContext.Provider value={dataset}>
-      <div className={`codap-component ${tileEltClass}`}>
+      <div className={`codap-component ${tileEltClass}`} key={tile.id}>
         <TitleBar tile={tile} onCloseTile={onCloseTile}/>
         <Component tile={tile} />
         {onRightPointerDown && <div className="codap-component-border right" onPointerDown={onRightPointerDown}/>}

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -35,8 +35,8 @@ export const ChartDots = function ChartDots(props: PlotProps) {
     primaryScaleRef.current = layout.getAxisScale(primaryAxisPlace) as ScaleBand<string>
     secondaryScaleRef.current = layout.getAxisScale(secondaryAxisPlace) as ScaleBand<string>
 
-  primaryAttrIDRef.current = primaryAttrRole ? dataConfiguration?.attributeID(primaryAttrRole) : ''
-  secondaryAttrIDRef.current = secondaryAttrRole ? dataConfiguration?.attributeID(secondaryAttrRole) : ''
+  primaryAttrIDRef.current = dataConfiguration?.primaryAttributeID
+  secondaryAttrIDRef.current = dataConfiguration?.secondaryAttributeID
 
   const computeMaxOverAllCells = useCallback(() => {
     const valuePairs = (dataConfiguration?.caseDataArray || []).map((aCaseData:CaseData) => {
@@ -79,7 +79,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
         ? Array.from(dataConfiguration.categorySetForAttrRole(secondaryAttrRole)) : [],
       pointDiameter = 2 * graphModel.getPointRadius(),
       selection = select(dotsRef.current).selectAll(selectedOnly ? '.graph-dot-highlighted' : '.graph-dot'),
-      primaryCellWidth = (primaryScaleRef.current?.bandwidth && primaryScaleRef.current.bandwidth()) ?? 0,
+      primaryCellWidth = (primaryScaleRef.current?.bandwidth?.()) ?? 0,
       primaryHeight = secondaryScaleRef.current?.bandwidth ? secondaryScaleRef.current.bandwidth()
         : (secondaryAxisPlace ? layout.getAxisLength(secondaryAxisPlace) : 0),
       categoriesMap: Record<string, Record<string, { cell: { h: number, v: number }, numSoFar: number }>> = {},

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -23,16 +23,17 @@ export const ChartDots = function ChartDots(props: PlotProps) {
     dataConfiguration = useDataConfigurationContext(),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext()
-  const primaryAttrRole = dataConfiguration?.primaryRole,
-    primaryAxisPlace = primaryAttrRole ? attrRoleToAxisPlace[primaryAttrRole] : undefined,
+  const primaryAttrRole = dataConfiguration?.primaryRole ?? 'x',
+    primaryAxisPlace = attrRoleToAxisPlace[primaryAttrRole] ?? 'bottom',
     primaryIsBottom = primaryAxisPlace === 'bottom',
     primaryAttrIDRef = useRef(''),
     secondaryAttrIDRef = useRef(''),
-    secondaryAttrRole = primaryAttrRole === 'x' ? 'y'
-      : primaryAttrRole === 'y' ? 'x' : undefined,
-    secondaryAxisPlace = secondaryAttrRole ? attrRoleToAxisPlace[secondaryAttrRole] : undefined,
-    primaryScale = primaryAxisPlace ? layout.getAxisScale(primaryAxisPlace) as ScaleBand<string> : undefined,
-    secondaryScale = secondaryAxisPlace ? layout.getAxisScale(secondaryAxisPlace) as ScaleBand<string> : undefined
+    secondaryAttrRole = primaryAttrRole === 'x' ? 'y' : 'x',
+    secondaryAxisPlace = attrRoleToAxisPlace[secondaryAttrRole] ?? 'left',
+    primaryScaleRef = useRef<ScaleBand<string>>(),
+    secondaryScaleRef = useRef<ScaleBand<string>>()
+    primaryScaleRef.current = layout.getAxisScale(primaryAxisPlace) as ScaleBand<string>
+    secondaryScaleRef.current = layout.getAxisScale(secondaryAxisPlace) as ScaleBand<string>
 
   primaryAttrIDRef.current = primaryAttrRole ? dataConfiguration?.attributeID(primaryAttrRole) : ''
   secondaryAttrIDRef.current = secondaryAttrRole ? dataConfiguration?.attributeID(secondaryAttrRole) : ''
@@ -78,8 +79,8 @@ export const ChartDots = function ChartDots(props: PlotProps) {
         ? Array.from(dataConfiguration.categorySetForAttrRole(secondaryAttrRole)) : [],
       pointDiameter = 2 * graphModel.getPointRadius(),
       selection = select(dotsRef.current).selectAll(selectedOnly ? '.graph-dot-highlighted' : '.graph-dot'),
-      primaryCellWidth = primaryScale?.bandwidth() ?? 0,
-      primaryHeight = secondaryScale?.bandwidth ? secondaryScale.bandwidth()
+      primaryCellWidth = (primaryScaleRef.current?.bandwidth && primaryScaleRef.current.bandwidth()) ?? 0,
+      primaryHeight = secondaryScaleRef.current?.bandwidth ? secondaryScaleRef.current.bandwidth()
         : (secondaryAxisPlace ? layout.getAxisLength(secondaryAxisPlace) : 0),
       categoriesMap: Record<string, Record<string, { cell: { h: number, v: number }, numSoFar: number }>> = {},
       legendAttrID = dataConfiguration?.attributeID('legend'),
@@ -115,12 +116,14 @@ export const ChartDots = function ChartDots(props: PlotProps) {
         primaryAttrIDRef.current && (dataConfiguration?.caseDataArray || []).forEach((aCaseData:CaseData) => {
           const anID = aCaseData.caseID,
             hCat = dataset?.getValue(anID, primaryAttrIDRef.current),
-            vCat = secondaryAttrIDRef.current ? dataset?.getValue(anID, secondaryAttrIDRef.current) : '__main__',
-            mapEntry = categoriesMap[hCat][vCat],
-            numInCell = mapEntry.numSoFar++,
-            row = Math.floor(numInCell / cellParams.numPointsInRow),
-            column = numInCell % cellParams.numPointsInRow
-          indices[anID] = {cell: mapEntry.cell, row, column}
+            vCat = secondaryAttrIDRef.current ? dataset?.getValue(anID, secondaryAttrIDRef.current) : '__main__'
+          if (hCat && vCat && categoriesMap[hCat] && categoriesMap[hCat][vCat]) {
+            const mapEntry = categoriesMap[hCat][vCat],
+              numInCell = mapEntry.numSoFar++,
+              row = Math.floor(numInCell / cellParams.numPointsInRow),
+              column = numInCell % cellParams.numPointsInRow
+            indices[anID] = {cell: mapEntry.cell, row, column}
+          }
         })
         return indices
       },
@@ -162,18 +165,18 @@ export const ChartDots = function ChartDots(props: PlotProps) {
               return baseCoord + signForOffset * ((h + 0.5) * primaryCellWidth) + (column + 0.5) * pointDiameter -
                 cellParams.numPointsInRow * pointDiameter / 2
             } else {
-              return NaN
+              return 0
             }
           })
           .attr(secondaryCenterKey, (aCaseData: CaseData) => {
             const anID = aCaseData.caseID
-            if (cellIndices[anID] && secondaryScale) {
+            if (cellIndices[anID] && secondaryScaleRef.current) {
               const {row} = cellIndices[anID],
                 {v} = cellIndices[anID].cell
-              return secondaryScale.range()[0] -
+              return secondaryScaleRef.current.range()[0] -
                 signForOffset * (v * primaryHeight + (row + 0.5) * pointDiameter + row * cellParams.overlap)
             } else {
-              return NaN
+              return 0
             }
           })
           .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData.caseID))
@@ -187,8 +190,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
 
     setPoints()
   }, [dataConfiguration, primaryAttrRole, secondaryAttrRole, graphModel, dotsRef,
-    enableAnimation, primaryScale, primaryIsBottom, layout, secondaryAxisPlace, pointStrokeColor,
-    computeMaxOverAllCells, dataset, secondaryScale])
+    enableAnimation, primaryIsBottom, layout, secondaryAxisPlace, pointStrokeColor, computeMaxOverAllCells, dataset])
 
   usePlotResponders({
     graphModel, layout, dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation,

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -33,17 +33,11 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
     didDrag = useRef(false),
     target = useRef<any>(),
     selectedDataObjects = useRef<Record<string, number>>({}),
-    pointRadiusRef = useRef(0),
-    selectedPointRadiusRef = useRef(0),
-    dragPointRadiusRef = useRef(0),
     { pointColor, pointStrokeColor } = graphModel
 
-  primaryAttrIDRef.current = dataConfiguration?.attributeID(primaryAttrPlace) as string
+  primaryAttrIDRef.current = dataConfiguration?.primaryAttributeID
   primaryScaleRef.current = layout.getAxisScale(primaryAxisPlace) as ScaleNumericBaseType
-  secondaryAttrIDRef.current = dataConfiguration?.attributeID(secondaryAttrPlace)
-  pointRadiusRef.current =  graphModel.getPointRadius()
-  selectedPointRadiusRef.current =  graphModel.getPointRadius('select')
-  dragPointRadiusRef.current =   graphModel.getPointRadius('hover-drag')
+  secondaryAttrIDRef.current = dataConfiguration?.secondaryAttributeID
 
 
   const onDragStart = useCallback((event: any) => {
@@ -57,7 +51,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         target.current
           .property('isDragging', true)
           .transition()
-          .attr('r', dragPointRadiusRef.current)
+          .attr('r', graphModel.getPointRadius('hover-drag'))
         setDragID(() => tItsID)
         currPos.current = primaryIsBottom ? event.clientX : event.clientY
 
@@ -104,7 +98,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
           .classed('dragging', false)
           .property('isDragging', false)
           .transition()
-          .attr('r', selectedPointRadiusRef.current)
+          .attr('r', graphModel.getPointRadius('select'))
         setDragID('')
         target.current = null
 
@@ -129,13 +123,13 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
   const refreshPointSelection = useCallback(() => {
     dataConfiguration && setPointSelection({ pointColor, pointStrokeColor,
       dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(),
-      selectedPointRadius: selectedPointRadiusRef.current })
+      selectedPointRadius: graphModel.getPointRadius('select') })
   }, [dataConfiguration, dotsRef, graphModel, pointColor, pointStrokeColor])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
       const
         secondaryScale = layout.getAxisScale(secondaryAxisPlace) as ScaleBand<string>,
-        pointDiameter = 2 * pointRadiusRef.current,
+        pointDiameter = 2 * graphModel.getPointRadius(),
         secondaryRangeIndex = primaryIsBottom ? 0 : 1,
         secondaryMax = Number(secondaryScale?.range()[secondaryRangeIndex]),
         secondaryExtent = Math.abs(Number(secondaryScale?.range()[0] -
@@ -197,7 +191,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         plotBounds = layout.computedBounds.get('plot') as Bounds
 
       setPointCoordinates({
-        dataset, pointRadius: pointRadiusRef.current, selectedPointRadius: selectedPointRadiusRef.current,
+        dataset, pointRadius: graphModel.getPointRadius(), selectedPointRadius: graphModel.getPointRadius('select'),
         dotsRef, selectedOnly, pointColor, pointStrokeColor,
         getScreenX, getScreenY, getLegendColor, enableAnimation, plotBounds
       })

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -65,7 +65,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
           }
         })
       }
-    }, [dataConfiguration, dataset, primaryIsBottom, enableAnimation]),
+    }, [graphModel, dataConfiguration, dataset, primaryIsBottom, enableAnimation]),
 
     onDrag = useCallback((event: MouseEvent) => {
       if (dragID) {
@@ -116,7 +116,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
           didDrag.current = false
         }
       }
-    }, [dataConfiguration, dataset, dragID, enableAnimation])
+    }, [graphModel, dataConfiguration, dataset, dragID, enableAnimation])
 
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
@@ -196,7 +196,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         getScreenX, getScreenY, getLegendColor, enableAnimation, plotBounds
       })
     },
-    [dataConfiguration?.caseDataArray, dataset, dotsRef, enableAnimation, layout, secondaryAxisPlace,
+    [graphModel, dataConfiguration?.caseDataArray, dataset, dotsRef, enableAnimation, layout, secondaryAxisPlace,
       legendAttrID, primaryLength, primaryIsBottom,
       dataConfiguration?.getLegendColorForCase, pointColor, pointStrokeColor])
 

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -1,4 +1,4 @@
-import {max, range, ScaleBand, select} from "d3"
+import {max, range, ScaleBand, scaleLinear, select} from "d3"
 import {observer} from "mobx-react-lite"
 import React, {useCallback, useRef, useState} from "react"
 import { ScaleNumericBaseType } from "../../axis/axis-types"
@@ -26,21 +26,24 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
     secondaryAttrPlace = primaryAttrPlace === 'x' ? 'y' : 'x',
     secondaryAxisPlace = attrRoleToAxisPlace[secondaryAttrPlace] ?? 'left',
     legendAttrID = dataConfiguration?.attributeID('legend'),
-    primaryScale = layout.getAxisScale(primaryAxisPlace) as ScaleNumericBaseType,
+    primaryScaleRef = useRef<ScaleNumericBaseType>(scaleLinear()),
     primaryLength = layout.getAxisLength(primaryAxisPlace),
-    secondaryScale = layout.getAxisScale(secondaryAxisPlace) as ScaleBand<string>,
     [dragID, setDragID] = useState(''),
     currPos = useRef(0),
     didDrag = useRef(false),
     target = useRef<any>(),
     selectedDataObjects = useRef<Record<string, number>>({}),
-    pointRadius = graphModel.getPointRadius(),
-    selectedPointRadius = graphModel.getPointRadius('select'),
-    dragPointRadius = graphModel.getPointRadius('hover-drag'),
+    pointRadiusRef = useRef(0),
+    selectedPointRadiusRef = useRef(0),
+    dragPointRadiusRef = useRef(0),
     { pointColor, pointStrokeColor } = graphModel
 
   primaryAttrIDRef.current = dataConfiguration?.attributeID(primaryAttrPlace) as string
+  primaryScaleRef.current = layout.getAxisScale(primaryAxisPlace) as ScaleNumericBaseType
   secondaryAttrIDRef.current = dataConfiguration?.attributeID(secondaryAttrPlace)
+  pointRadiusRef.current =  graphModel.getPointRadius()
+  selectedPointRadiusRef.current =  graphModel.getPointRadius('select')
+  dragPointRadiusRef.current =   graphModel.getPointRadius('hover-drag')
 
 
   const onDragStart = useCallback((event: any) => {
@@ -54,7 +57,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         target.current
           .property('isDragging', true)
           .transition()
-          .attr('r', dragPointRadius)
+          .attr('r', dragPointRadiusRef.current)
         setDragID(() => tItsID)
         currPos.current = primaryIsBottom ? event.clientX : event.clientY
 
@@ -68,7 +71,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
           }
         })
       }
-    }, [dataConfiguration, dataset, dragPointRadius, primaryIsBottom, enableAnimation]),
+    }, [dataConfiguration, dataset, primaryIsBottom, enableAnimation]),
 
     onDrag = useCallback((event: MouseEvent) => {
       if (dragID) {
@@ -77,7 +80,8 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         currPos.current = newPos
         if (deltaPixels !== 0) {
           didDrag.current = true
-          const delta = Number(primaryScale?.invert(deltaPixels)) - Number(primaryScale?.invert(0)),
+          const delta = Number(primaryScaleRef.current?.invert(deltaPixels)) -
+              Number(primaryScaleRef.current?.invert(0)),
             caseValues: ICase[] = [],
             { selection } = dataConfiguration || {}
           selection?.forEach(anID => {
@@ -89,7 +93,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
           caseValues.length && dataset?.setCaseValues(caseValues, [primaryAttrIDRef.current])
         }
       }
-    }, [dataset, dragID, primaryScale, primaryIsBottom, dataConfiguration]),
+    }, [dataset, dragID, primaryIsBottom, dataConfiguration]),
 
     onDragEnd = useCallback(() => {
       dataset?.endCaching()
@@ -100,7 +104,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
           .classed('dragging', false)
           .property('isDragging', false)
           .transition()
-          .attr('r', selectedPointRadius)
+          .attr('r', selectedPointRadiusRef.current)
         setDragID('')
         target.current = null
 
@@ -118,23 +122,25 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
           didDrag.current = false
         }
       }
-    }, [dataConfiguration, dataset, selectedPointRadius, dragID, enableAnimation])
+    }, [dataConfiguration, dataset, dragID, enableAnimation])
 
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
   const refreshPointSelection = useCallback(() => {
     dataConfiguration && setPointSelection({ pointColor, pointStrokeColor,
-      dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(), selectedPointRadius
-    })
-  }, [dataConfiguration, dotsRef, graphModel, selectedPointRadius, pointColor, pointStrokeColor])
+      dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(),
+      selectedPointRadius: selectedPointRadiusRef.current })
+  }, [dataConfiguration, dotsRef, graphModel, pointColor, pointStrokeColor])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
       const
-        pointDiameter = 2 * pointRadius,
+        secondaryScale = layout.getAxisScale(secondaryAxisPlace) as ScaleBand<string>,
+        pointDiameter = 2 * pointRadiusRef.current,
         secondaryRangeIndex = primaryIsBottom ? 0 : 1,
         secondaryMax = Number(secondaryScale?.range()[secondaryRangeIndex]),
-        secondaryExtent = Math.abs(Number(secondaryScale?.range()[0] - secondaryScale?.range()[1])),
-        secondaryBandwidth = secondaryScale.bandwidth?.() ?? secondaryExtent,
+        secondaryExtent = Math.abs(Number(secondaryScale?.range()[0] -
+          secondaryScale?.range()[1])),
+        secondaryBandwidth = secondaryScale?.bandwidth?.() ?? secondaryExtent,
         secondarySign = primaryIsBottom ? -1 : 1,
         baseCoord = primaryIsBottom ? secondaryMax : 0,
         binMap: Record<string, { category: string, indexInBin: number }> = {}
@@ -147,7 +153,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
 
         dataConfiguration?.caseDataArray.forEach((aCaseData:CaseData) => {
           const anID = aCaseData.caseID,
-            numerator = primaryScale?.(dataset?.getNumeric(anID, primaryAttrIDRef.current) ?? -1),
+            numerator = primaryScaleRef.current(dataset?.getNumeric(anID, primaryAttrIDRef.current) ?? -1),
             bin = Math.ceil((numerator ?? 0) / binWidth),
             category = secondaryAttrIDRef.current ? dataset?.getValue(anID, secondaryAttrIDRef.current) : '__main__'
           if (!bins[category]) {
@@ -168,7 +174,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
       computeBinPlacements()
 
       const computeSecondaryCoord = (category: string, indexInBin: number) => {
-        let catCoord = !!category && category !== '__main__' ? secondaryScale?.(category) ?? 0 : 0
+        let catCoord = !!category && category !== '__main__' ? secondaryScale(category) ?? 0 : 0
         if (primaryIsBottom) {
           catCoord = secondaryExtent - secondaryBandwidth - catCoord
         }
@@ -180,7 +186,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         // Note that we can get null for either or both of the next two functions. It just means that we have
         // a circle for the case, but we're not plotting it.
         getPrimaryScreenCoord = (anID: string) => {
-          return getScreenCoord(dataset, anID, primaryAttrIDRef.current, primaryScale)
+          return getScreenCoord(dataset, anID, primaryAttrIDRef.current, primaryScaleRef.current)
         },
         getSecondaryScreenCoord = (anID: string) => {
           return binMap[anID] ? computeSecondaryCoord(binMap[anID].category, binMap[anID].indexInBin) : null
@@ -191,13 +197,14 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         plotBounds = layout.computedBounds.get('plot') as Bounds
 
       setPointCoordinates({
-        dataset, pointRadius, selectedPointRadius, dotsRef, selectedOnly, pointColor, pointStrokeColor,
+        dataset, pointRadius: pointRadiusRef.current, selectedPointRadius: selectedPointRadiusRef.current,
+        dotsRef, selectedOnly, pointColor, pointStrokeColor,
         getScreenX, getScreenY, getLegendColor, enableAnimation, plotBounds
       })
     },
-    [dataConfiguration?.caseDataArray, dataset, pointRadius, selectedPointRadius, dotsRef, enableAnimation,
-      legendAttrID, primaryLength, primaryIsBottom, primaryScale, secondaryScale,
-      dataConfiguration?.getLegendColorForCase, layout.computedBounds, pointColor, pointStrokeColor])
+    [dataConfiguration?.caseDataArray, dataset, dotsRef, enableAnimation, layout, secondaryAxisPlace,
+      legendAttrID, primaryLength, primaryIsBottom,
+      dataConfiguration?.getLegendColorForCase, pointColor, pointStrokeColor])
 
   usePlotResponders({
     graphModel, primaryAttrID: primaryAttrIDRef.current, secondaryAttrID: secondaryAttrIDRef.current,

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -2,24 +2,32 @@ import {useDroppable} from '@dnd-kit/core'
 import {observer} from "mobx-react-lite"
 import React, {useEffect, useMemo, useRef, useState} from "react"
 import {useResizeDetector} from "react-resize-detector"
+import {useGraphController} from "../hooks/use-graph-controller"
 import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-id-context"
 import {kTitleBarHeight} from "../graphing-types"
 import {AxisLayoutContext} from "../../axis/models/axis-layout-context"
-import {GraphLayout, GraphLayoutContext} from "../models/graph-layout"
+import {GraphLayoutContext, useGraphLayoutContext} from "../models/graph-layout"
 import {GraphModelContext, isGraphModel} from "../models/graph-model"
 import {Graph} from "./graph"
 import {ITileBaseProps} from '../../tiles/tile-base-props'
+import {GraphController} from "../models/graph-controller"
 
-export const GraphComponent = observer(({ tile }: ITileBaseProps) => {
+export const GraphComponent = observer(({tile}: ITileBaseProps) => {
   const graphModel = tile?.content
   if (!isGraphModel(graphModel)) return null
 
   const instanceId = useNextInstanceId("graph")
-  const layout = useMemo(() => new GraphLayout(), [])
+  const layout = useGraphLayoutContext()
   const {width, height, ref: graphRef} = useResizeDetector({refreshMode: "debounce", refreshRate: 10})
   const enableAnimation = useRef(true)
   const dotsRef = useRef<SVGSVGElement>(null)
+  const graphController = useMemo(
+    () => new GraphController({enableAnimation, dotsRef, instanceId}),
+    [enableAnimation, dotsRef, instanceId]
+  )
   const [showInspector, setShowInspector] = useState(false)
+
+  useGraphController({graphController, graphModel})
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setParentExtent(width, height - kTitleBarHeight)
@@ -35,11 +43,10 @@ export const GraphComponent = observer(({ tile }: ITileBaseProps) => {
       <GraphLayoutContext.Provider value={layout}>
         <AxisLayoutContext.Provider value={layout}>
           <GraphModelContext.Provider value={graphModel}>
-            <Graph graphRef={graphRef}
-                  enableAnimation={enableAnimation}
-                  dotsRef={dotsRef}
-                  showInspector={showInspector}
-                  setShowInspector={setShowInspector}
+            <Graph graphController={graphController}
+                   graphRef={graphRef}
+                   showInspector={showInspector}
+                   setShowInspector={setShowInspector}
             />
           </GraphModelContext.Provider>
         </AxisLayoutContext.Provider>

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -39,8 +39,9 @@ interface IProps {
 
 const marqueeState = new MarqueeState()
 
-export const Graph = observer((
-  {graphController, graphRef, showInspector, setShowInspector}: IProps) => {
+
+export const Graph = observer(function Graph(
+  {graphController, graphRef, showInspector, setShowInspector}: IProps) {
   const graphModel = useGraphModelContext(),
     { enableAnimation, dotsRef } = graphController,
     {plotType} = graphModel,

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -2,6 +2,7 @@ import {observer} from "mobx-react-lite"
 import {onAction} from "mobx-state-tree"
 import React, {MutableRefObject, useEffect, useRef} from "react"
 import {select} from "d3"
+import {GraphController} from "../models/graph-controller"
 import {DroppableAddAttribute} from "./droppable-add-attribute"
 import {Background} from "./background"
 import {DroppablePlot} from "./droppable-plot"
@@ -15,7 +16,6 @@ import {ChartDots} from "./chartdots"
 import {Marquee} from "./marquee"
 import {DataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
-import {useGraphController} from "../hooks/use-graph-controller"
 import {useGraphModel} from "../hooks/use-graph-model"
 import {setNiceDomain} from "../utilities/graph-utils"
 import {IAxisModel} from "../../axis/models/axis-model"
@@ -31,9 +31,8 @@ import {useDataTips} from "../hooks/use-data-tips"
 import "./graph.scss"
 
 interface IProps {
+  graphController: GraphController
   graphRef: MutableRefObject<HTMLDivElement>
-  enableAnimation: MutableRefObject<boolean>
-  dotsRef: React.RefObject<SVGSVGElement>
   showInspector: boolean
   setShowInspector: (show: boolean) => void
 }
@@ -41,8 +40,9 @@ interface IProps {
 const marqueeState = new MarqueeState()
 
 export const Graph = observer((
-  {graphRef, enableAnimation, dotsRef, showInspector, setShowInspector}: IProps) => {
+  {graphController, graphRef, showInspector, setShowInspector}: IProps) => {
   const graphModel = useGraphModelContext(),
+    { enableAnimation, dotsRef } = graphController,
     {plotType} = graphModel,
     instanceId = useInstanceIdContext(),
     dataset = useDataSetContext(),
@@ -55,8 +55,6 @@ export const Graph = observer((
     yAttrID = graphModel.getAttributeID('y')
 
   useGraphModel({dotsRef, graphModel, enableAnimation, instanceId})
-
-  const graphController = useGraphController({graphModel, enableAnimation, dotsRef})
 
   useEffect(function setupPlotArea() {
     if (xScale && xScale?.range().length > 0) {
@@ -83,8 +81,7 @@ export const Graph = observer((
       graphModel.config?.removeYAttributeWithID(idOfAttributeToRemove)
       const yAxisModel = graphModel.getAxis('left') as IAxisModel
       setNiceDomain(graphModel.config.numericValuesForAttrRole('y'), yAxisModel)
-    }
-    else {
+    } else {
       handleChangeAttribute(place, '')
     }
   }
@@ -106,11 +103,6 @@ export const Graph = observer((
     graphModel.config.setAttributeType(graphPlaceToAttrRole[place], treatAs)
     graphController?.handleAttributeAssignment(place, attrId)
   }
-
-  // We only need to make the following connection once
-  useEffect(function passDotsRefToController() {
-    graphController?.setDotsRef(dotsRef)
-  }, [dotsRef, graphController])
 
   useDataTips(dotsRef, dataset, graphModel)
 
@@ -177,11 +169,11 @@ export const Graph = observer((
         </svg>
         <DroppableAddAttribute
           location={'yPlus'}
-          plotType = {plotType}
+          plotType={plotType}
           onDrop={handleChangeAttribute.bind(null, 'yPlus')}/>
         <DroppableAddAttribute
           location={'rightNumeric'}
-          plotType = {plotType}
+          plotType={plotType}
           onDrop={handleChangeAttribute.bind(null, 'rightNumeric')}/>
       </div>
       <GraphInspector graphModel={graphModel}

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -34,7 +34,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
     selectedDataObjects = useRef<Record<string, { x: number, y: number }>>({}),
     plotNumRef = useRef(0)
 
-  primaryAttrIDRef.current = dataConfiguration?.attributeID('x') as string
+  primaryAttrIDRef.current = dataConfiguration?.primaryAttributeID
   secondaryAttrIDsRef.current = dataConfiguration?.yAttributeIDs || []
   pointRadiusRef.current = graphModel.getPointRadius()
   selectedPointRadiusRef.current = graphModel.getPointRadius('select')

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -20,13 +20,13 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
     dataset = useDataSetContext(),
     primaryAttrIDRef = useRef(''),
     secondaryAttrIDsRef = useRef<string[]>([]),
-    pointRadius = graphModel.getPointRadius(),
-    selectedPointRadius = graphModel.getPointRadius('select'),
-    dragPointRadius = graphModel.getPointRadius('hover-drag'),
+    pointRadiusRef = useRef(0),
+    selectedPointRadiusRef = useRef(0),
+    dragPointRadiusRef = useRef(0),
     layout = useGraphLayoutContext(),
     legendAttrID = dataConfiguration?.attributeID('legend') as string,
-    xScale = layout.getAxisScale("bottom") as ScaleNumericBaseType,
-    yScale = layout.getAxisScale("left") as ScaleNumericBaseType,
+    xScaleRef = useRef<ScaleNumericBaseType>(),
+    yScaleRef = useRef<ScaleNumericBaseType>(),
     [dragID, setDragID] = useState(''),
     currPos = useRef({x: 0, y: 0}),
     didDrag = useRef(false),
@@ -36,6 +36,12 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
 
   primaryAttrIDRef.current = dataConfiguration?.attributeID('x') as string
   secondaryAttrIDsRef.current = dataConfiguration?.yAttributeIDs || []
+  pointRadiusRef.current = graphModel.getPointRadius()
+  selectedPointRadiusRef.current = graphModel.getPointRadius('select')
+  dragPointRadiusRef.current = graphModel.getPointRadius('hover-drag')
+
+  xScaleRef.current = layout.getAxisScale("bottom") as ScaleNumericBaseType
+  yScaleRef.current = layout.getAxisScale("left") as ScaleNumericBaseType
 
   const onDragStart = useCallback((event: MouseEvent) => {
       dataset?.beginCaching()
@@ -50,7 +56,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
         target.current
           .property('isDragging', true)
           .transition()
-          .attr('r', dragPointRadius)
+          .attr('r', dragPointRadiusRef.current)
         setDragID(tItsID)
         currPos.current = {x: event.clientX, y: event.clientY}
 
@@ -64,7 +70,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
           }
         })
       }
-    }, [dataConfiguration, dataset, enableAnimation, dragPointRadius]),
+    }, [dataConfiguration, dataset, enableAnimation]),
 
     onDrag = useCallback((event: MouseEvent) => {
       if (dragID !== '') {
@@ -74,8 +80,8 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
         currPos.current = newPos
         if (dx !== 0 || dy !== 0) {
           didDrag.current = true
-          const deltaX = Number(xScale.invert(dx)) - Number(xScale.invert(0)),
-            deltaY = Number(yScale.invert(dy)) - Number(yScale.invert(0)),
+          const deltaX = Number(xScaleRef.current?.invert(dx)) - Number(xScaleRef.current?.invert(0)),
+            deltaY = Number(yScaleRef.current?.invert(dy)) - Number(yScaleRef.current?.invert(0)),
             caseValues: ICase[] = [],
             {selection} = dataConfiguration || {}
           selection?.forEach(anID => {
@@ -94,7 +100,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
             [primaryAttrIDRef.current, secondaryAttrIDsRef.current[plotNumRef.current]])
         }
       }
-    }, [dataConfiguration, dataset, dragID, xScale, yScale]),
+    }, [dataConfiguration, dataset, dragID]),
 
     onDragEnd = useCallback(() => {
       dataset?.endCaching()
@@ -105,7 +111,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
           .classed('dragging', false)
           .property('isDragging', false)
           .transition()
-          .attr('r', selectedPointRadius)
+          .attr('r', selectedPointRadiusRef.current)
         setDragID(() => '')
         target.current = null
 
@@ -125,8 +131,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
           didDrag.current = false
         }
       }
-    }, [dataConfiguration, dataset, dragID, enableAnimation,
-      selectedPointRadius])
+    }, [dataConfiguration, dataset, dragID, enableAnimation,])
 
   useDragHandlers(window, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
@@ -134,10 +139,11 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
     const {pointColor, pointStrokeColor} = graphModel
     dataConfiguration && setPointSelection(
       {
-        dotsRef, dataConfiguration, pointRadius, selectedPointRadius,
+        dotsRef, dataConfiguration, pointRadius: pointRadiusRef.current,
+        selectedPointRadius: selectedPointRadiusRef.current,
         pointColor, pointStrokeColor, getPointColorAtIndex: graphModel.pointColorAtIndex
       })
-  }, [dataConfiguration, dotsRef, pointRadius, selectedPointRadius, graphModel])
+  }, [dataConfiguration, dotsRef, graphModel])
 
   const refreshPointPositionsD3 = useCallback((selectedOnly: boolean) => {
     const yAttrIDs = dataConfiguration?.yAttributeIDs || [],
@@ -145,22 +151,23 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
       hasY2Attribute = dataConfiguration?.hasY2Attribute,
       v2Scale = layout.getAxisScale("rightNumeric") as ScaleNumericBaseType,
       numberOfPlots = dataConfiguration?.numberOfPlots || 1,
-      getScreenX = (anID: string) => getScreenCoord(dataset, anID, primaryAttrIDRef.current, xScale),
+      getScreenX = (anID: string) => xScaleRef.current &&
+        getScreenCoord(dataset, anID, primaryAttrIDRef.current, xScaleRef.current) || 0,
       getScreenY = (anID: string, plotNum = 0) => {
-        const verticalScale = hasY2Attribute && plotNum === numberOfPlots - 1 ? v2Scale : yScale
-        return getScreenCoord(dataset, anID, yAttrIDs[plotNum], verticalScale)
+        const verticalScale = hasY2Attribute && plotNum === numberOfPlots - 1 ? v2Scale : yScaleRef.current
+        return verticalScale && getScreenCoord(dataset, anID, yAttrIDs[plotNum], verticalScale) || 0
       },
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined,
       {computedBounds} = layout,
       plotBounds = computedBounds.get('plot') as Bounds
 
     setPointCoordinates({
-      dataset, dotsRef, pointRadius, selectedPointRadius, plotBounds, selectedOnly,
-      getScreenX, getScreenY, getLegendColor, getPointColorAtIndex: graphModel.pointColorAtIndex,
-      enableAnimation, pointColor, pointStrokeColor
+      dataset, dotsRef, pointRadius: pointRadiusRef.current, selectedPointRadius: selectedPointRadiusRef.current,
+      plotBounds, selectedOnly, getScreenX, getScreenY, getLegendColor,
+      getPointColorAtIndex: graphModel.pointColorAtIndex, enableAnimation, pointColor, pointStrokeColor
     })
-  }, [dataConfiguration, dataset, pointRadius, selectedPointRadius, dotsRef, layout,
-    xScale, legendAttrID, yScale, enableAnimation, graphModel])
+  }, [dataConfiguration, dataset, dotsRef, layout,
+    legendAttrID, enableAnimation, graphModel])
 
   const refreshPointPositionsSVG = useCallback((selectedOnly: boolean) => {
     const {joinedCaseDataArrays, selection} = dataConfiguration || {}
@@ -169,8 +176,9 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
         dot = dotsRef.current?.querySelector(`#${instanceId}_${caseId}`)
       if (dot) {
         const dotSvg = dot as SVGCircleElement
-        const x = getScreenCoord(dataset, caseId, primaryAttrIDRef.current, xScale)
-        const y = getScreenCoord(dataset, caseId, secondaryAttrIDsRef.current[aCaseData.plotNum], yScale)
+        const x = xScaleRef.current && getScreenCoord(dataset, caseId, primaryAttrIDRef.current, xScaleRef.current)
+        const y = yScaleRef.current &&
+          getScreenCoord(dataset, caseId, secondaryAttrIDsRef.current[aCaseData.plotNum], yScaleRef.current)
         if (x != null && isFinite(x) && y != null && isFinite(y)) {
           dotSvg.setAttribute("cx", `${x}`)
           dotSvg.setAttribute("cy", `${y}`)
@@ -182,7 +190,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
     } else {
       joinedCaseDataArrays?.forEach((aCaseData) => updateDot(aCaseData))
     }
-  }, [dataConfiguration, dataset, dotsRef, instanceId, xScale, yScale])
+  }, [dataConfiguration, dataset, dotsRef, instanceId])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
     if (appState.isPerformanceMode) {
@@ -193,7 +201,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
   }, [refreshPointPositionsD3, refreshPointPositionsSVG])
 
   usePlotResponders({
-    graphModel, primaryAttrID:primaryAttrIDRef.current, secondaryAttrID: secondaryAttrIDsRef.current[0],
+    graphModel, primaryAttrID: primaryAttrIDRef.current, secondaryAttrID: secondaryAttrIDsRef.current[0],
     layout, dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation
   })
 

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,29 +1,25 @@
-import {useRef, useEffect, useContext} from "react"
+import {useEffect} from "react"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
-import {InstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {useV2DocumentContext} from "../../../hooks/use-v2-document-context"
 import {GraphController} from "../models/graph-controller"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel} from "../models/graph-model"
 
 export interface IUseGraphControllerProps {
+  graphController: GraphController,
   graphModel: IGraphModel,
-  enableAnimation: React.MutableRefObject<boolean>
-  dotsRef: React.RefObject<SVGSVGElement>
 }
 
-export const useGraphController = ({ graphModel, enableAnimation, dotsRef }: IUseGraphControllerProps) => {
+export const useGraphController = ({graphController, graphModel}: IUseGraphControllerProps) => {
   const v2Document = useV2DocumentContext()
   const dataset = useDataSetContext()
   const layout = useGraphLayoutContext()
-  const graphControllerRef = useRef<GraphController>()
-  const instanceId = useContext(InstanceIdContext) as string
 
   useEffect(() => {
-    graphControllerRef.current = new GraphController({
-      graphModel, layout, dataset, enableAnimation, instanceId, dotsRef, v2Document
-    })
-  }, [graphModel, layout, dataset, enableAnimation, instanceId, dotsRef, v2Document])
+    v2Document && graphController.processV2Document(v2Document)
+  }, [graphController, v2Document])
 
-  return graphControllerRef.current
+  useEffect(() => {
+    graphController.setProperties({graphModel, layout, dataset})
+  }, [graphController, graphModel, layout, dataset])
 }

--- a/v3/src/components/graph/models/data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/data-configuration-model.test.ts
@@ -174,7 +174,7 @@ describe("DataConfigurationModel", () => {
 
     config.setDataset(data)
     data.selectAll()
-    expect(config.selection.length).toBe(3)
+    expect(config.selection.length).toBe(2)
 
     config.setAttribute("x", { attributeID: "xId" })
     expect(config.selection.length).toBe(2)

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -63,6 +63,11 @@ export const DataConfigurationModel = types
     pointsNeedUpdating: false
   }))
   .views(self => ({
+    get secondaryRole() {
+      return self.primaryRole === 'x' ? 'y'
+        : self.primaryRole === 'y' ? 'x'
+          : ''
+    },
     get y2AttributeDescriptionIsPresent() {
       return !!self._attributeDescriptions.get('rightNumeric')
     },
@@ -123,6 +128,14 @@ export const DataConfigurationModel = types
     placeCanHaveZeroExtent(place: GraphPlace) {
       return ['rightNumeric', 'legend', 'top', 'rightCat'].includes(place) &&
         this.attributeID(graphPlaceToAttrRole[place]) === ''
+    }
+  }))
+  .views(self => ({
+    get primaryAttributeID() {
+      return self.primaryRole && self.attributeID(self.primaryRole) || ''
+    },
+    get secondaryAttributeID() {
+      return self.secondaryRole && self.attributeID(self.secondaryRole) || ''
     }
   }))
   .extend(() => {
@@ -446,10 +459,6 @@ export const DataConfigurationModel = types
       self.actionHandlerDisposer?.()
       self.dataset = dataset
       self.actionHandlerDisposer = onAction(self.dataset, self.handleAction, true)
-      /*
-            self._attributeDescriptions.clear()
-            self._yAttributeDescriptions.clear()
-      */
       self.filteredCases = []
       if (dataset) {
         self.filteredCases[0] = new FilteredCases({

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -442,17 +442,22 @@ export const DataConfigurationModel = types
       }
     }))
   .actions(self => ({
-    setDataset(dataset: IDataSet) {
+    setDataset(dataset: IDataSet | undefined) {
       self.actionHandlerDisposer?.()
       self.dataset = dataset
       self.actionHandlerDisposer = onAction(self.dataset, self.handleAction, true)
-      self._attributeDescriptions.clear()
-      self._yAttributeDescriptions.clear()
+      /*
+            self._attributeDescriptions.clear()
+            self._yAttributeDescriptions.clear()
+      */
       self.filteredCases = []
-      self.filteredCases[0] = new FilteredCases({
-        source: dataset, filter: self.filterCase,
-        onSetCaseValues: self.handleSetCaseValues
-      })
+      if (dataset) {
+        self.filteredCases[0] = new FilteredCases({
+          source: dataset, filter: self.filterCase,
+          onSetCaseValues: self.handleSetCaseValues
+        })
+      }
+      self.clearCategorySets()
       self.invalidateQuantileScale()
     },
     setPrimaryRole(role: GraphAttrRole) {

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -5,7 +5,13 @@ import {GraphLayout, scaleTypeToD3Scale} from "./graph-layout"
 import {IDataSet} from "../../../models/data/data-set"
 import {AxisPlace, AxisPlaces} from "../../axis/axis-types"
 import {
-  CategoricalAxisModel, EmptyAxisModel, IEmptyAxisModel, INumericAxisModel, NumericAxisModel
+  CategoricalAxisModel,
+  EmptyAxisModel,
+  IEmptyAxisModel,
+  INumericAxisModel,
+  isCategoricalAxisModel,
+  isNumericAxisModel,
+  NumericAxisModel
 } from "../../axis/models/axis-model"
 import {
   attrRoleToAxisPlace, axisPlaceToAttrRole, GraphAttrRole, GraphPlace, graphPlaceToAttrRole, PlotType
@@ -33,9 +39,9 @@ interface IGraphControllerProps {
 }
 
 export class GraphController {
-  graphModel: IGraphModel | undefined
-  layout: GraphLayout | undefined
-  dataset: IDataSet | undefined
+  graphModel?: IGraphModel
+  layout?: GraphLayout
+  dataset?: IDataSet
   enableAnimation: React.MutableRefObject<boolean>
   dotsRef: React.RefObject<SVGSVGElement>
   instanceId: string
@@ -66,13 +72,11 @@ export class GraphController {
         if (axisModel) {
           const axisScale = scaleTypeToD3Scale(axisModel.scale)
           layout.setAxisScale(axisPlace, axisScale)
-          switch (axisModel.type) {
-            case 'numeric':
-              axisScale.domain([(axisModel as INumericAxisModel).min, (axisModel as INumericAxisModel).max])
-              break
-            case 'categorical':
-              axisScale.domain(graphModel.config.categorySetForAttrRole(attrRole))
-              break
+          if (isNumericAxisModel(axisModel)) {
+            axisScale.domain(axisModel.domain)
+          }
+          else if (isCategoricalAxisModel(axisModel)) {
+            axisScale.domain(graphModel.config.categorySetForAttrRole(attrRole))
           }
         }
       })

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -1,8 +1,9 @@
-import {scaleOrdinal} from "d3"
+import {scaleBand, scaleLinear, scaleLog, scaleOrdinal} from "d3"
 import {action, computed, makeObservable, observable} from "mobx"
 import {createContext, useContext} from "react"
 import {AxisPlace, AxisPlaces, AxisBounds, AxisScaleType, isVertical} from "../../axis/axis-types"
 import {GraphPlace, kTitleBarHeight} from "../graphing-types"
+import {IScaleType} from "../../axis/models/axis-model"
 
 export const kDefaultGraphWidth = 480
 export const kDefaultGraphHeight = 300
@@ -13,6 +14,19 @@ export interface Bounds {
   top: number
   width: number
   height: number
+}
+
+export const scaleTypeToD3Scale = (iScaleType: IScaleType) => {
+  switch (iScaleType) {
+    case "ordinal":
+      return scaleOrdinal()
+    case "band":
+      return scaleBand()
+    case "linear":
+      return scaleLinear()
+    case "log":
+      return scaleLog()
+  }
 }
 
 export const CategoricalLayouts = ["parallel", "perpendicular"] as const

--- a/v3/src/components/graph/models/graph-model.ts
+++ b/v3/src/components/graph/models/graph-model.ts
@@ -37,7 +37,7 @@ export const GraphModel = TileContentModel
   .props({
     type: types.optional(types.literal(kGraphTileType), kGraphTileType),
     // keys are AxisPlaces
-    axes: types.map(types.maybe(AxisModelUnion)),
+    axes: types.map(AxisModelUnion),
     // TODO: should the default plot be something like "nullPlot" (which doesn't exist yet)?
     plotType: types.optional(types.enumeration([...PlotTypes]), "casePlot"),
     config: types.optional(DataConfigurationModel, () => DataConfigurationModel.create()),


### PR DESCRIPTION
* Importing a saved codap3 document now (mostly) correctly reconstitutes the graph component.
* CodapComponent now gets a key, thus forcing import of a new document to throw out any old components and creating new ones. For the graph component this simplified things quite a bit.
* There was a need in the plot components for useRefs so that functions passed to other functions would be able to access the correct values.
* There is one known outstanding bug in the Background component such that the rectangle is not correctly rendered when (some) new documents are imported. This bug likely doesn't show itself for some other parts of the graph because they get rendered twice. I'm postponing further work on this bug for another time.