### PR TITLE
Restoration of proper GraphLayoutContext

### DIFF
--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -6,7 +6,7 @@ import {useGraphController} from "../hooks/use-graph-controller"
 import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-id-context"
 import {kTitleBarHeight} from "../graphing-types"
 import {AxisLayoutContext} from "../../axis/models/axis-layout-context"
-import {GraphLayoutContext, useGraphLayoutContext} from "../models/graph-layout"
+import {GraphLayout, GraphLayoutContext} from "../models/graph-layout"
 import {GraphModelContext, isGraphModel} from "../models/graph-model"
 import {Graph} from "./graph"
 import {ITileBaseProps} from '../../tiles/tile-base-props'
@@ -17,7 +17,7 @@ export const GraphComponent = observer(({tile}: ITileBaseProps) => {
   if (!isGraphModel(graphModel)) return null
 
   const instanceId = useNextInstanceId("graph")
-  const layout = useGraphLayoutContext()
+  const layout = useMemo(() => new GraphLayout(), [])
   const {width, height, ref: graphRef} = useResizeDetector({refreshMode: "debounce", refreshRate: 10})
   const enableAnimation = useRef(true)
   const dotsRef = useRef<SVGSVGElement>(null)

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -4,6 +4,8 @@ import {createContext, useContext} from "react"
 import {AxisPlace, AxisPlaces, AxisBounds, AxisScaleType, isVertical} from "../../axis/axis-types"
 import {GraphPlace, kTitleBarHeight} from "../graphing-types"
 import {IScaleType} from "../../axis/models/axis-model"
+import {GraphModel, IGraphModel} from "./graph-model";
+import {Instance} from "mobx-state-tree";
 
 export const kDefaultGraphWidth = 480
 export const kDefaultGraphHeight = 300
@@ -163,6 +165,7 @@ export class GraphLayout {
   }
 }
 
-export const GraphLayoutContext = createContext(new GraphLayout())
+export const GraphLayoutContext = createContext<GraphLayout>({} as GraphLayout)
+
 
 export const useGraphLayoutContext = () => useContext(GraphLayoutContext)


### PR DESCRIPTION
* We restore GraphLayoutContext as no longer returning a new GraphLayout
* In GraphComponent we properly create a new GraphLayout to be used as the value given to GraphLayoutContext.Provider