### PR TITLE
Restoration of proper GraphLayoutContext

### DIFF
--- a/v3/src/components/axis/hooks/use-axis-bounds.ts
+++ b/v3/src/components/axis/hooks/use-axis-bounds.ts
@@ -1,10 +1,9 @@
 import {useEffect, useState} from "react"
 import {AxisPlace} from "../axis-types"
-import {useGraphLayoutContext} from "../../graph/models/graph-layout"
 import {useAxisLayoutContext} from "../models/axis-layout-context"
 
 export const useAxisBounds = (place: AxisPlace) => {
-  const layout = useGraphLayoutContext()
+  const layout = useAxisLayoutContext()
   return layout.getAxisBounds(place)
 }
 

--- a/v3/src/components/axis/hooks/use-axis-bounds.ts
+++ b/v3/src/components/axis/hooks/use-axis-bounds.ts
@@ -1,6 +1,7 @@
 import {useEffect, useState} from "react"
 import {AxisPlace} from "../axis-types"
 import {useGraphLayoutContext} from "../../graph/models/graph-layout"
+import {useAxisLayoutContext} from "../models/axis-layout-context"
 
 export const useAxisBounds = (place: AxisPlace) => {
   const layout = useGraphLayoutContext()
@@ -8,7 +9,7 @@ export const useAxisBounds = (place: AxisPlace) => {
 }
 
 export const useAxisBoundsProvider = (place: AxisPlace, parentSelector: string) => {
-  const layout = useGraphLayoutContext()
+  const layout = useAxisLayoutContext()
   const [parentElt, setParentElt] = useState<HTMLDivElement | null>(null)
   const [wrapperElt, setWrapperElt] = useState<SVGGElement | null>(null)
 

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -22,8 +22,8 @@ export const GraphComponent = observer(({tile}: ITileBaseProps) => {
   const enableAnimation = useRef(true)
   const dotsRef = useRef<SVGSVGElement>(null)
   const graphController = useMemo(
-    () => new GraphController({enableAnimation, dotsRef, instanceId}),
-    [enableAnimation, dotsRef, instanceId]
+    () => new GraphController({layout, enableAnimation, dotsRef, instanceId}),
+    [layout, instanceId]
   )
   const [showInspector, setShowInspector] = useState(false)
 

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -6,7 +6,7 @@ import {useGraphController} from "../hooks/use-graph-controller"
 import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-id-context"
 import {kTitleBarHeight} from "../graphing-types"
 import {AxisLayoutContext} from "../../axis/models/axis-layout-context"
-import {GraphLayoutContext, useGraphLayoutContext} from "../models/graph-layout"
+import {GraphLayout, GraphLayoutContext} from "../models/graph-layout"
 import {GraphModelContext, isGraphModel} from "../models/graph-model"
 import {Graph} from "./graph"
 import {ITileBaseProps} from '../../tiles/tile-base-props'
@@ -17,7 +17,7 @@ export const GraphComponent = observer(({tile}: ITileBaseProps) => {
   if (!isGraphModel(graphModel)) return null
 
   const instanceId = useNextInstanceId("graph")
-  const layout = useGraphLayoutContext()
+  const layout = useMemo(() => new GraphLayout(), [])
   const {width, height, ref: graphRef} = useResizeDetector({refreshMode: "debounce", refreshRate: 10})
   const enableAnimation = useRef(true)
   const dotsRef = useRef<SVGSVGElement>(null)

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -2,7 +2,6 @@ import {useEffect} from "react"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useV2DocumentContext} from "../../../hooks/use-v2-document-context"
 import {GraphController} from "../models/graph-controller"
-import {useGraphLayoutContext} from "../models/graph-layout"
 import {IGraphModel} from "../models/graph-model"
 
 export interface IUseGraphControllerProps {
@@ -13,13 +12,12 @@ export interface IUseGraphControllerProps {
 export const useGraphController = ({graphController, graphModel}: IUseGraphControllerProps) => {
   const v2Document = useV2DocumentContext()
   const dataset = useDataSetContext()
-  const layout = useGraphLayoutContext()
 
   useEffect(() => {
     v2Document && graphController.processV2Document(v2Document)
   }, [graphController, v2Document])
 
   useEffect(() => {
-    graphController.setProperties({graphModel, layout, dataset})
-  }, [graphController, graphModel, layout, dataset])
+    graphController.setProperties({graphModel, dataset})
+  }, [graphController, graphModel, dataset])
 }

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -27,6 +27,7 @@ const plotChoices: Record<string, Record<string, PlotType>> = {
 }
 
 interface IGraphControllerConstructorProps {
+  layout: GraphLayout
   enableAnimation: React.MutableRefObject<boolean>
   dotsRef: React.RefObject<SVGSVGElement>
   instanceId: string
@@ -34,19 +35,19 @@ interface IGraphControllerConstructorProps {
 
 interface IGraphControllerProps {
   graphModel: IGraphModel
-  layout: GraphLayout
   dataset: IDataSet | undefined
 }
 
 export class GraphController {
   graphModel?: IGraphModel
-  layout?: GraphLayout
+  layout: GraphLayout
   dataset?: IDataSet
   enableAnimation: React.MutableRefObject<boolean>
   dotsRef: React.RefObject<SVGSVGElement>
   instanceId: string
 
-  constructor({enableAnimation, dotsRef, instanceId}: IGraphControllerConstructorProps) {
+  constructor({layout, enableAnimation, dotsRef, instanceId}: IGraphControllerConstructorProps) {
+    this.layout = layout
     this.instanceId = instanceId
     this.enableAnimation = enableAnimation
     this.dotsRef = dotsRef
@@ -54,7 +55,6 @@ export class GraphController {
 
   setProperties(props: IGraphControllerProps) {
     this.graphModel = props.graphModel
-    this.layout = props.layout
     this.dataset = props.dataset
     if (this.graphModel.config.dataset !== props.dataset) {
       this.graphModel.config.setDataset(props.dataset)

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -4,8 +4,6 @@ import {createContext, useContext} from "react"
 import {AxisPlace, AxisPlaces, AxisBounds, AxisScaleType, isVertical} from "../../axis/axis-types"
 import {GraphPlace, kTitleBarHeight} from "../graphing-types"
 import {IScaleType} from "../../axis/models/axis-model"
-import {GraphModel, IGraphModel} from "./graph-model";
-import {Instance} from "mobx-state-tree";
 
 export const kDefaultGraphWidth = 480
 export const kDefaultGraphHeight = 300

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -4,6 +4,8 @@ import {createContext, useContext} from "react"
 import {AxisPlace, AxisPlaces, AxisBounds, AxisScaleType, isVertical} from "../../axis/axis-types"
 import {GraphPlace, kTitleBarHeight} from "../graphing-types"
 import {IScaleType} from "../../axis/models/axis-model"
+import {GraphModel, IGraphModel} from "./graph-model";
+import {Instance} from "mobx-state-tree";
 
 export const kDefaultGraphWidth = 480
 export const kDefaultGraphHeight = 300
@@ -163,6 +165,7 @@ export class GraphLayout {
   }
 }
 
-export const GraphLayoutContext = createContext(new GraphLayout())
+export const GraphLayoutContext = createContext<GraphLayout>({} as GraphLayout)
+
 
 export const useGraphLayoutContext = () => useContext(GraphLayoutContext)


### PR DESCRIPTION
* We restore GraphLayoutContext as no longer returning a new GraphLayout
* In GraphComponent we properly create a new GraphLayout to be used as the value given to GraphLayoutContext.Provider
* This had some ramifications down the line