### PR TITLE
Fix linting for root-level config files

### DIFF
--- a/v3/.eslintrc.cjs
+++ b/v3/.eslintrc.cjs
@@ -138,7 +138,8 @@ module.exports = {
       }
     },
     { // eslint configs
-      files: [".eslintrc*.js"],
+      // *.config.ts should be added after cypress.config.ts lint fixes
+      files: [".eslintrc*.cjs", "./*.config.js", "why-did-you-render.ts"],
       env: {
         node: true
       }

--- a/v3/postcss.config.js
+++ b/v3/postcss.config.js
@@ -1,5 +1,7 @@
+import autoprefixer from 'autoprefixer'
+
 module.exports = {
   plugins: [
-    require('autoprefixer')
+    autoprefixer,
   ]
-};
+}

--- a/v3/tsconfig.json
+++ b/v3/tsconfig.json
@@ -21,6 +21,11 @@
     "lib": ["dom", "dom.iterable", "es2018"]
   },
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    ".eslintrc*.cjs",
+    // cypress.config.ts will need another pass before being added
+    // "*.config.ts",
+    "*.config.js",
+    "why-did-you-render.ts"
   ]
 }

--- a/v3/webpack.config.js
+++ b/v3/webpack.config.js
@@ -11,7 +11,7 @@ const os = require('os')
 // `branch/[branch-name]/` or `version/[tag-name]/`
 // See the following documentation for more detail:
 //   https://github.com/concord-consortium/s3-deploy-action/blob/main/README.md#top-branch-example
-const DEPLOY_PATH = process.env.DEPLOY_PATH;
+const DEPLOY_PATH = process.env.DEPLOY_PATH
 
 module.exports = (env, argv) => {
   const devMode = argv.mode !== 'production'

--- a/v3/why-did-you-render.ts
+++ b/v3/why-did-you-render.ts
@@ -11,4 +11,4 @@ import React from "react"
 // Other configuration options, detailed at:
 // https://github.com/welldone-software/why-did-you-render#readme
 
-whyDidYouRender(React, { trackAllPureComponents: true });
+whyDidYouRender(React, { trackAllPureComponents: true })


### PR DESCRIPTION
Everything except cypress.config.ts should lint properly now- that file needs another pass to fix it up.