### PR TITLE
Make case-table tile expansion have a consistent background color

### DIFF
--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -13,6 +13,7 @@ $table-body-font-size: 8pt;
     height: 100%;
     display: flex;
     overflow-x: auto;
+    background-color: #FFFFFF;
 
     .collection-table {
       display: flex;


### PR DESCRIPTION
Follow-up on #184553678, which was fixed by the scroll: auto; I added but which left a transparent background when a case table was expanded beyond its bounds.