### PR TITLE
feat: implement focused tile; title bar, inspector, and resize UI based on focused tile

### DIFF
--- a/v3/src/components/app.scss
+++ b/v3/src/components/app.scss
@@ -13,14 +13,6 @@
   .app {
     width: 100%;
     height: 100%;
-
-    .hello-codap3 {
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
   }
 }
 

--- a/v3/src/components/calculator/calculator-title-bar.tsx
+++ b/v3/src/components/calculator/calculator-title-bar.tsx
@@ -11,7 +11,7 @@ export const CalculatorTitleBar = ({tile, onCloseTile}: ITileTitleBarProps) => {
   const tileType = tile?.content.type
 
   return (
-    <ComponentTitleBar component={"calculator"} title={title}
+    <ComponentTitleBar tile={tile} component={"calculator"} title={title}
         draggableId={`${tileType}-${tileId}`}>
       <Flex className="header-right">
         <MinimizeIcon className="component-minimize-icon" title={t("DG.Component.minimizeComponent.toolTip")}/>

--- a/v3/src/components/case-table/case-table-component.tsx
+++ b/v3/src/components/case-table/case-table-component.tsx
@@ -52,7 +52,7 @@ export const CaseTableComponent = observer(function CaseTableComponent({ tile }:
       <DataSetContext.Provider value={data}>
         <CaseMetadataContext.Provider value={metadata}>
           <CaseTableModelContext.Provider value={tableModel}>
-            <CaseTable setNodeRef={setNodeRef} />
+            <CaseTable tile={tile} setNodeRef={setNodeRef} />
           </CaseTableModelContext.Provider>
         </CaseMetadataContext.Provider>
       </DataSetContext.Provider>

--- a/v3/src/components/case-table/case-table-title-bar.scss
+++ b/v3/src/components/case-table/case-table-title-bar.scss
@@ -1,6 +1,8 @@
+@use "../vars.scss";
+
 .card-icon {
   background-color: white;
-  fill: #177991;
+  fill: vars.$codap-teal-dark;
   height: 16px;
   width: 13px;
   border-radius: 2px;
@@ -14,7 +16,7 @@
 }
 
 .table-icon {
-  background-color: #177991;
+  background-color: vars.$codap-teal-dark;
   fill: white;
   color: white;
   margin-top: 2px;

--- a/v3/src/components/case-table/case-table-title-bar.tsx
+++ b/v3/src/components/case-table/case-table-title-bar.tsx
@@ -39,7 +39,7 @@ export const CaseTableTitleBar = ({tile, onCloseTile}: ITileTitleBarProps) => {
                                   : t("DG.DocumentController.toggleToCaseCard")
 
   return (
-    <ComponentTitleBar component={"case-table"} title={title}
+    <ComponentTitleBar tile={tile} component={"case-table"} title={title}
         draggableId={`${tileType}-${tileId}`}>
       <div className="header-left"
             title={cardTableToggleString}

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -1,6 +1,6 @@
 import { useDndContext } from "@dnd-kit/core"
 import { observer } from "mobx-react-lite"
-import React, { CSSProperties, useState } from "react"
+import React, { CSSProperties } from "react"
 import { AttributeDragOverlay } from "./attribute-drag-overlay"
 import { CaseTableInspector } from "./case-table-inspector"
 import { kChildMostTableCollectionId, kIndexColumnKey } from "./case-table-types"
@@ -9,19 +9,21 @@ import { CollectionContext, ParentCollectionContext } from "../../hooks/use-coll
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useInstanceIdContext } from "../../hooks/use-instance-id-context"
 import { ICollectionPropsModel } from "../../models/data/collection"
+import { ITileModel } from "../../models/tiles/tile-model"
+import { uiState } from "../../models/ui-state"
 import { prf } from "../../utilities/profiler"
 import t from "../../utilities/translation/translate"
 
 import "./case-table.scss"
 
 interface IProps {
+  tile?: ITileModel
   setNodeRef: (element: HTMLElement | null) => void
 }
-export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
+export const CaseTable = observer(function CaseTable({ tile, setNodeRef }: IProps) {
   const { active } = useDndContext()
   const instanceId = useInstanceIdContext() || "case-table"
   const data = useDataSetContext()
-  const [showInspector, setShowInspector] = useState(false)
   return prf.measure("Table.render", () => {
 
     // disable the overlay for the index column
@@ -36,8 +38,7 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
 
     return (
       <>
-        <div ref={setNodeRef} className="case-table" data-testid="case-table"
-            onClick={()=>setShowInspector(!showInspector)}>
+        <div ref={setNodeRef} className="case-table" data-testid="case-table">
               <div className="case-table-content">
                 {collections.map((collection, i) => {
                   const key = collection?.id || kChildMostTableCollectionId
@@ -54,7 +55,7 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
               </div>
         </div>
         <NoCasesMessage />
-        <CaseTableInspector show={showInspector} />
+        <CaseTableInspector show={uiState.isFocusedTile(tile?.id)} />
       </>
     )
   })

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -4,6 +4,7 @@ import { DataSetContext } from "../hooks/use-data-set-context"
 import { gDataBroker } from "../models/data/data-broker"
 import { ITileBaseProps, ITileTitleBarProps } from "./tiles/tile-base-props"
 import { ITileModel } from "../models/tiles/tile-model"
+import { uiState } from "../models/ui-state"
 import ResizeHandle from "../assets/icons/icon-corner-resize-handle.svg"
 
 import "./codap-component.scss"
@@ -21,14 +22,20 @@ export interface IProps extends ITileBaseProps {
   onLeftPointerDown?: (e: React.PointerEvent) => void
 }
 
-export const CodapComponent =
-    observer(({ tile, TitleBar, Component, tileEltClass, onCloseTile, onBottomRightPointerDown, onBottomLeftPointerDown,
-      onRightPointerDown, onBottomPointerDown, onLeftPointerDown }: IProps) => {
+export const CodapComponent = observer(function CodapComponent({
+  tile, TitleBar, Component, tileEltClass, onCloseTile, onBottomRightPointerDown, onBottomLeftPointerDown,
+  onBottomPointerDown, onLeftPointerDown, onRightPointerDown
+}: IProps) {
   const dataset = gDataBroker?.selectedDataSet || gDataBroker?.last
+
+  function handleFocusTile() {
+    uiState.setFocusedTile(tile.id)
+  }
 
   return (
     <DataSetContext.Provider value={dataset}>
-      <div className={`codap-component ${tileEltClass}`} key={tile.id}>
+      <div className={`codap-component ${tileEltClass}`} key={tile.id}
+        onFocus={handleFocusTile} onPointerDownCapture={handleFocusTile}>
         <TitleBar tile={tile} onCloseTile={onCloseTile}/>
         <Component tile={tile} />
         {onRightPointerDown && <div className="codap-component-border right" onPointerDown={onRightPointerDown}/>}
@@ -39,7 +46,8 @@ export const CodapComponent =
         }
         {onBottomRightPointerDown &&
           <div className="codap-component-corner bottom-right" onPointerDown={onBottomRightPointerDown}>
-            <ResizeHandle className="component-resize-handle"/>
+            {uiState.isFocusedTile(tile.id) &&
+              <ResizeHandle className="component-resize-handle"/>}
           </div>
         }
       </div>

--- a/v3/src/components/component-title-bar.scss
+++ b/v3/src/components/component-title-bar.scss
@@ -3,9 +3,12 @@
 .component-title-bar {
   flex-direction: row;
   height: $title-bar-height;
-  background-color: #177991;
+  background-color: $codap-teal-light;
   width: 100%;
   border-radius: $border-radius-top-corners;
+  &.focusTile {
+    background-color: $codap-teal-dark;
+  }
   &:hover {
     .header-right {
       visibility: visible;
@@ -25,7 +28,6 @@
     left: 5px;
     align-items: center;
     justify-content: center;
-    background-color: #177991;
     height: 24px;
     width: 24px;
     border-top-left-radius: 6px;
@@ -41,7 +43,6 @@
     right: 0;
     cursor: pointer;
     visibility: hidden;
-    background-color: #177991 !important;
     fill: lightgray;
     border-top-right-radius: 6px;
 
@@ -62,7 +63,6 @@
     }
 
     .component-close-button {
-      background-color: #177991 !important;
       color: lightgray;
       height: 24px;
       &:hover {

--- a/v3/src/components/component-title-bar.tsx
+++ b/v3/src/components/component-title-bar.tsx
@@ -1,18 +1,23 @@
-import React, { ReactNode, useState } from "react"
 import { Editable, EditableInput, EditablePreview, Flex } from "@chakra-ui/react"
 import { useDndContext, useDraggable } from "@dnd-kit/core"
-
+import { clsx } from "clsx"
+import { observer } from "mobx-react-lite"
+import React, { ReactNode, useState } from "react"
+import { ITileModel } from "../models/tiles/tile-model"
+import { uiState } from "../models/ui-state"
 
 import "./component-title-bar.scss"
 
 interface IProps {
+  tile?: ITileModel
   component?: string
   title: string
   draggableId: string
   children?: ReactNode
 }
 
-export const ComponentTitleBar = ({component, title, draggableId, children}: IProps) => {
+export const ComponentTitleBar = observer(function ComponentTitleBar(
+  {tile, component, title, draggableId, children}: IProps) {
   const [isEditing, setIsEditing] = useState(false)
   const [, setTitle] = useState(title|| "Dataset")
   const { active } = useDndContext()
@@ -29,9 +34,10 @@ export const ComponentTitleBar = ({component, title, draggableId, children}: IPr
 
   const draggableOptions = {id: draggableId, disabled: isEditing}
   const {attributes, listeners, setActivatorNodeRef} = useDraggable(draggableOptions)
+  const classes = clsx("component-title-bar", `${component}-title-bar`, {focusTile: uiState.isFocusedTile(tile?.id)})
 
   return (
-    <Flex className={`component-title-bar ${component}-title-bar`}
+    <Flex className={classes}
         ref={setActivatorNodeRef} {...listeners} {...attributes}>
       {children}
       <Editable defaultValue={title} className="title-bar" isPreviewFocusable={!dragging} submitOnBlur={true}
@@ -42,4 +48,4 @@ export const ComponentTitleBar = ({component, title, draggableId, children}: IPr
       </Editable>
     </Flex>
   )
-}
+})

--- a/v3/src/components/data-summary/data-summary-title-bar.tsx
+++ b/v3/src/components/data-summary/data-summary-title-bar.tsx
@@ -13,7 +13,7 @@ export const DataSummaryTitleBar = ({tile, onCloseTile}: ITileTitleBarProps) => 
   const tileType = tile?.content.type
 
   return (
-    <ComponentTitleBar component={"data-summary"} title={title}
+    <ComponentTitleBar tile={tile} component={"data-summary"} title={title}
         draggableId={`${tileType}-${tileId}`}>
       <Flex className="header-right">
         <MinimizeIcon className="component-minimize-icon" title={t("DG.Component.minimizeComponent.toolTip")}/>

--- a/v3/src/components/free-tile-row.tsx
+++ b/v3/src/components/free-tile-row.tsx
@@ -1,8 +1,10 @@
+import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
-import React from "react"
+import React, { useEffect } from "react"
 import { IDocumentContentModel } from "../models/document/document-content"
 import { IFreeTileRow } from "../models/document/free-tile-row"
 import { ITileModel } from "../models/tiles/tile-model"
+import { uiState } from "../models/ui-state"
 import { FreeTileComponent } from "./free-tile-component"
 
 import "./free-tile-row.scss"
@@ -18,6 +20,16 @@ export const FreeTileRowComponent = observer(function FreeTileRowComponent(
     if (!tileId) return
     content?.deleteTile(tileId)
   }
+
+  // focused tile should always be on top
+  useEffect(() => {
+    return autorun(() => {
+      const { focusedTile } = uiState
+      if (focusedTile && (focusedTile !== row.last)) {
+        row.moveTileToTop(focusedTile)
+      }
+    })
+  }, [row])
 
   return (
     <div className="free-tile-row">

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -1,16 +1,17 @@
 import {useDroppable} from '@dnd-kit/core'
 import {observer} from "mobx-react-lite"
-import React, {useEffect, useMemo, useRef, useState} from "react"
+import React, {useEffect, useMemo, useRef} from "react"
 import {useResizeDetector} from "react-resize-detector"
 import {useGraphController} from "../hooks/use-graph-controller"
 import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-id-context"
+import {uiState} from "../../../models/ui-state"
 import {kTitleBarHeight} from "../graphing-types"
 import {AxisLayoutContext} from "../../axis/models/axis-layout-context"
+import {GraphController} from "../models/graph-controller"
 import {GraphLayout, GraphLayoutContext} from "../models/graph-layout"
 import {GraphModelContext, isGraphModel} from "../models/graph-model"
 import {Graph} from "./graph"
 import {ITileBaseProps} from '../../tiles/tile-base-props'
-import {GraphController} from "../models/graph-controller"
 
 export const GraphComponent = observer(({tile}: ITileBaseProps) => {
   const graphModel = tile?.content
@@ -25,7 +26,6 @@ export const GraphComponent = observer(({tile}: ITileBaseProps) => {
     () => new GraphController({layout, enableAnimation, dotsRef, instanceId}),
     [layout, instanceId]
   )
-  const [showInspector, setShowInspector] = useState(false)
 
   useGraphController({graphController, graphModel})
 
@@ -45,8 +45,7 @@ export const GraphComponent = observer(({tile}: ITileBaseProps) => {
           <GraphModelContext.Provider value={graphModel}>
             <Graph graphController={graphController}
                    graphRef={graphRef}
-                   showInspector={showInspector}
-                   setShowInspector={setShowInspector}
+                   showInspector={uiState.isFocusedTile(tile?.id)}
             />
           </GraphModelContext.Provider>
         </AxisLayoutContext.Provider>

--- a/v3/src/components/graph/components/graph-title-bar.tsx
+++ b/v3/src/components/graph/components/graph-title-bar.tsx
@@ -13,7 +13,7 @@ export const GraphTitleBar = ({tile, onCloseTile}: ITileTitleBarProps) => {
   const tileType = tile?.content.type
 
   return (
-    <ComponentTitleBar component={"graph"} title={title}
+    <ComponentTitleBar tile={tile} component={"graph"} title={title}
         draggableId={`${tileType}-${tileId}`}>
       <Flex className="header-right">
         <MinimizeIcon className="component-minimize-icon" title={t("DG.Component.minimizeComponent.toolTip")}/>

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -34,14 +34,12 @@ interface IProps {
   graphController: GraphController
   graphRef: MutableRefObject<HTMLDivElement>
   showInspector: boolean
-  setShowInspector: (show: boolean) => void
 }
 
 const marqueeState = new MarqueeState()
 
 
-export const Graph = observer(function Graph(
-  {graphController, graphRef, showInspector, setShowInspector}: IProps) {
+export const Graph = observer(function Graph({graphController, graphRef, showInspector}: IProps) {
   const graphModel = useGraphModelContext(),
     { enableAnimation, dotsRef } = graphController,
     {plotType} = graphModel,
@@ -138,7 +136,7 @@ export const Graph = observer(function Graph(
 
   return (
     <DataConfigurationContext.Provider value={graphModel.config}>
-      <div className={kGraphClass} ref={graphRef} data-testid="graph" onClick={() => setShowInspector(!showInspector)}>
+      <div className={kGraphClass} ref={graphRef} data-testid="graph">
         <svg className='graph-svg' ref={svgRef}>
           <Background
             marqueeState={marqueeState}

--- a/v3/src/components/hello/hello-title-bar.tsx
+++ b/v3/src/components/hello/hello-title-bar.tsx
@@ -13,7 +13,7 @@ export const HelloTitleBar = ({tile, onCloseTile}: ITileTitleBarProps) => {
   const tileType = tile?.content.type
 
   return (
-    <ComponentTitleBar component={"hello"} title={title}
+    <ComponentTitleBar tile={tile} component={"hello"} title={title}
         draggableId={`${tileType}-${tileId}`}>
       <Flex className="header-right">
         <MinimizeIcon className="component-minimize-icon" title={t("DG.Component.minimizeComponent.toolTip")}/>

--- a/v3/src/components/hello/hello.scss
+++ b/v3/src/components/hello/hello.scss
@@ -1,0 +1,13 @@
+@use "../vars.scss";
+
+.hello-codap3 {
+  position: relative;
+  width: 100%;
+  height: calc(100% - 25px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: aliceblue;
+  border-radius: vars.$border-radius-bottom-corners;
+  overflow: hidden;
+}

--- a/v3/src/components/hello/hello.tsx
+++ b/v3/src/components/hello/hello.tsx
@@ -6,6 +6,8 @@ import t from "../../utilities/translation/translate"
 import { ITileBaseProps } from "../tiles/tile-base-props"
 import { isHelloCodapModel } from "./hello-model"
 
+import "./hello.scss"
+
 export const HelloComponent = ({ tile }: ITileBaseProps) => {
   const sampleText = useSampleText()
   const helloModel = tile?.content

--- a/v3/src/components/slider/slider-title-bar.tsx
+++ b/v3/src/components/slider/slider-title-bar.tsx
@@ -14,7 +14,7 @@ export const SliderTitleBar = observer(function SliderTitleBar({ tile, onCloseTi
   const tileType = tile?.content.type
 
   return (
-    <ComponentTitleBar component={"slider"} title={title}
+    <ComponentTitleBar tile={tile} component={"slider"} title={title}
         draggableId={`${tileType}-${tileId}`}>
       <Flex className="header-right">
         <MinimizeIcon className="component-minimize-icon" title={t("DG.Component.minimizeComponent.toolTip")}/>

--- a/v3/src/components/tiles/placeholder/placeholder-tile-title-bar.tsx
+++ b/v3/src/components/tiles/placeholder/placeholder-tile-title-bar.tsx
@@ -11,7 +11,7 @@ export const PlaceholderTileTitleBar = ({tile, onCloseTile}: ITileTitleBarProps)
   const tileType = tile?.content.type
 
   return (
-    <ComponentTitleBar component={"placeholder-tile"} title={title}
+    <ComponentTitleBar tile={tile} component={"placeholder-tile"} title={title}
         draggableId={`${tileType}-${tileId}`}>
       <Flex className="header-right">
         <MinimizeIcon className="component-minimize-icon" title={t("DG.Component.minimizeComponent.toolTip")}/>

--- a/v3/src/components/vars.scss
+++ b/v3/src/components/vars.scss
@@ -27,3 +27,6 @@ $charcoal-light-9: #f8f8f8;
 $teal-dark: #01879E;
 $teal-light1: #2BA5C1;
 $teal-light3: #93D5E4;
+
+$codap-teal-dark: #177991;
+$codap-teal-light: #72bfca;

--- a/v3/src/models/document/free-tile-row.ts
+++ b/v3/src/models/document/free-tile-row.ts
@@ -107,7 +107,7 @@ export const FreeTileRow = TileRowModel
       }
     }
   }))
-  export interface IFreeTileRow extends Instance<typeof FreeTileRow> {}
+export interface IFreeTileRow extends Instance<typeof FreeTileRow> {}
 
 export function isFreeTileRow(row?: ITileRowModel): row is IFreeTileRow {
   return row?.type === "free"

--- a/v3/src/models/ui-state.ts
+++ b/v3/src/models/ui-state.ts
@@ -1,0 +1,31 @@
+import { action, makeObservable, observable } from "mobx"
+
+/*
+  UIState represents globally accessible user-interface state that is not undoable, is not
+  automatically saved, and doesn't dirty the document (and thus trigger an auto-save).
+  It can be manually saved by copying it into the document during pre-serialization if desired.
+ */
+export class UIState {
+  // the focused tile is a singleton; in theory there can be multiple selected tiles
+  @observable
+  private focusTileId = ""
+
+  constructor() {
+    makeObservable(this)
+  }
+
+  get focusedTile() {
+    return this.focusTileId
+  }
+
+  isFocusedTile(tileId?: string) {
+    return this.focusTileId === tileId
+  }
+
+  @action
+  setFocusedTile(tileId: string) {
+    this.focusTileId = tileId
+  }
+}
+
+export const uiState = new UIState()

--- a/v3/src/theme.ts
+++ b/v3/src/theme.ts
@@ -19,7 +19,7 @@ export const theme = extendTheme({
   colors: {
     tealDark: "#01879E",
     tealLight1: "#2ba5c1",
-    teallight2: "#72bfca",
+    tealLight2: "#72bfca",
     tealLight3: "#93d5e4",
     tealLight4: "#b7e2ec",
     tealLight5: "#e2f4f8"


### PR DESCRIPTION
Implements a new `UIState` class which maintains an observable `focusTile` property which tracks the actively focused tile. Clicking on a tile or focusing an element within a tile (e.g. tabbing into a tile) sets the property accordingly. Rendering (or not) of focus-only UI such as inspectors, resize widgets, etc. is now determined by this `focusTile` property. The focused tile is also automatically brought to the front in the free tile layout. Also cleaned up the Hello tile somewhat so it works better as a potentially overlapping tile.