### PR TITLE
feat: import calculator; better support for non-resizable tiles

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -12,6 +12,7 @@ import {gDataBroker} from "../models/data/data-broker"
 import {DataSet, IDataSet, toCanonical} from "../models/data/data-set"
 import { IDocumentModelSnapshot } from "../models/document/document"
 import { ISharedModelDocumentManager } from "../models/document/shared-model-document-manager"
+import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { ITileModel } from "../models/tiles/tile-model"
 import { DocumentContext } from "../hooks/use-document-context"
 import {useDropHandler} from "../hooks/use-drop-handler"
@@ -65,8 +66,14 @@ export const App = observer(function App() {
     v2Components.forEach(v2Component => {
       const insertTile = (tile: ITileModel) => {
         if (row && tile) {
-          const { left, top, width, height } = v2Component.layout
-          content?.insertTileInRow(tile, row, { x: left, y: top, width, height })
+          const info = getTileComponentInfo(tile.content.type)
+          if (info) {
+            const { left, top, width, height } = v2Component.layout
+            // only apply imported width and height to resizable tiles
+            const _width = !info.isFixedWidth ? { width } : {}
+            const _height = !info?.isFixedHeight ? { height } : {}
+            content?.insertTileInRow(tile, row, { x: left, y: top, ..._width, ..._height })
+          }
         }
       }
       importV2Component({ v2Component, v2Document, sharedModelManager, insertTile })

--- a/v3/src/components/calculator/calculator-model.ts
+++ b/v3/src/components/calculator/calculator-model.ts
@@ -6,6 +6,7 @@ export const CalculatorModel = TileContentModel
   .named("CalculatorModel")
   .props({
     type: types.optional(types.literal(kCalculatorTileType), kCalculatorTileType),
+    name: ""
   })
 export interface ICalculatorModel extends Instance<typeof CalculatorModel> {}
 

--- a/v3/src/components/calculator/calculator-registration.ts
+++ b/v3/src/components/calculator/calculator-registration.ts
@@ -5,10 +5,16 @@ import { kCalculatorTileClass, kCalculatorTileType } from "./calculator-defs"
 import { CalculatorModel } from "./calculator-model"
 import { CalculatorTitleBar } from "./calculator-title-bar"
 import CalcIcon from '../../assets/icons/icon-calc.svg'
+import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
+import { isV2CalculatorComponent } from "../../v2/codap-v2-types"
+import { TileModel } from "../../models/tiles/tile-model"
+import { typedId } from "../../utilities/js-utils"
+
+export const kCalculatorIdPrefix = "CALC"
 
 registerTileContentInfo({
   type: kCalculatorTileType,
-  prefix: "CALC",
+  prefix: kCalculatorIdPrefix,
   modelClass: CalculatorModel,
   defaultContent: () => CalculatorModel.create()
 })
@@ -20,7 +26,18 @@ registerTileComponentInfo({
   tileEltClass: kCalculatorTileClass,
   Icon: CalcIcon,
   isSingleton: true,
-  height: 162,
-  width: 145,
-  isFixedSize: true,
+  isFixedWidth: true,
+  isFixedHeight: true
+})
+
+registerV2TileImporter("DG.Calculator", ({ v2Component, v2Document, insertTile }) => {
+  if (!isV2CalculatorComponent(v2Component)) return
+
+  const { name = "", title = "" } = v2Component.componentStorage
+  const calculatorTile = TileModel.create({
+    id: typedId(kCalculatorIdPrefix),
+    title,
+    content: CalculatorModel.create({ name })
+  })
+  insertTile(calculatorTile)
 })

--- a/v3/src/components/calculator/calculator.scss
+++ b/v3/src/components/calculator/calculator.scss
@@ -1,10 +1,17 @@
-@import "../vars.scss";
+@use "../vars.scss";
+
 $button-width: 30px;
 $button-height: 24px;
 
+// temporary until .codap-component can specify these globally
+// inspectors must be portaled first otherwise they'd be hidden
+.codap-component.calculator {
+  overflow: hidden;
+}
+
 .calculator-wrapper {
   background: #333333;
-  padding: 2px;
+  padding: 2px 4px 4px 4px;
   flex-direction: column;
   justify-content: center;
   align-items: center;
@@ -13,8 +20,6 @@ $button-height: 24px;
     flex-direction: column;
     font-family: "museo-sans", sans-serif;
     font-size: 12px;
-    height: 155px;
-    width: 127px;
     margin-top: 3px;
     background-color: #333333;
 
@@ -32,6 +37,7 @@ $button-height: 24px;
       margin-top: 3px;
       flex-direction: row;
       flex-wrap: wrap;
+      justify-content: space-evenly;
       width: 131px;
 
       .calc-button {

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -25,8 +25,8 @@ registerTileComponentInfo({
   Component: CaseTableComponent,
   tileEltClass: "codap-case-table",
   Icon: TableIcon,
-  height: 275,
-  width: 580,
+  defaultWidth: 580,
+  defaultHeight: 275
 })
 
 registerV2TileImporter("DG.TableView", ({ v2Component, v2Document, sharedModelManager, insertTile }) => {

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -39,20 +39,20 @@ export const CaseTable = observer(function CaseTable({ tile, setNodeRef }: IProp
     return (
       <>
         <div ref={setNodeRef} className="case-table" data-testid="case-table">
-              <div className="case-table-content">
-                {collections.map((collection, i) => {
-                  const key = collection?.id || kChildMostTableCollectionId
-                  const parent = i > 0 ? collections[i - 1] : undefined
-                  return (
-                    <ParentCollectionContext.Provider key={key} value={parent}>
-                      <CollectionContext.Provider key={key} value={collection}>
-                        <CollectionTable />
-                      </CollectionContext.Provider>
-                    </ParentCollectionContext.Provider>
-                  )
-                })}
-                <AttributeDragOverlay activeDragId={overlayDragId} />
-              </div>
+          <div className="case-table-content">
+            {collections.map((collection, i) => {
+              const key = collection?.id || kChildMostTableCollectionId
+              const parent = i > 0 ? collections[i - 1] : undefined
+              return (
+                <ParentCollectionContext.Provider key={key} value={parent}>
+                  <CollectionContext.Provider key={key} value={collection}>
+                    <CollectionTable />
+                  </CollectionContext.Provider>
+                </ParentCollectionContext.Provider>
+              )
+            })}
+            <AttributeDragOverlay activeDragId={overlayDragId} />
+          </div>
         </div>
         <NoCasesMessage />
         <CaseTableInspector show={uiState.isFocusedTile(tile?.id)} />

--- a/v3/src/components/codap-component.scss
+++ b/v3/src/components/codap-component.scss
@@ -6,6 +6,7 @@ $corner-drag-size: calc($border-drag-width * 2);
   position: relative;
   width: 100%;
   height: 100%;
+  border-radius: vars.$border-radius-four-corners;
 
   input {
     &:focus {

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -2,7 +2,8 @@ import { observer } from "mobx-react-lite"
 import React from "react"
 import { DataSetContext } from "../hooks/use-data-set-context"
 import { gDataBroker } from "../models/data/data-broker"
-import { ITileBaseProps, ITileTitleBarProps } from "./tiles/tile-base-props"
+import { ITileBaseProps } from "./tiles/tile-base-props"
+import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { ITileModel } from "../models/tiles/tile-model"
 import { uiState } from "../models/ui-state"
 import ResizeHandle from "../assets/icons/icon-corner-resize-handle.svg"
@@ -11,10 +12,6 @@ import "./codap-component.scss"
 
 export interface IProps extends ITileBaseProps {
   tile: ITileModel
-  TitleBar: React.ComponentType<ITileTitleBarProps>;
-  Component: React.ComponentType<ITileBaseProps>;
-  tileEltClass: string;
-  isFixedSize?: boolean;
   onCloseTile: (tileId: string) => void
   onBottomRightPointerDown?: (e: React.PointerEvent) => void
   onBottomLeftPointerDown?: (e: React.PointerEvent) => void
@@ -24,13 +21,18 @@ export interface IProps extends ITileBaseProps {
 }
 
 export const CodapComponent = observer(function CodapComponent({
-  tile, TitleBar, Component, tileEltClass,isFixedSize, onCloseTile, onBottomRightPointerDown,
-  onBottomLeftPointerDown, onBottomPointerDown, onLeftPointerDown, onRightPointerDown
+  tile, onCloseTile, onLeftPointerDown, onBottomPointerDown, onRightPointerDown,
+  onBottomLeftPointerDown, onBottomRightPointerDown
 }: IProps) {
+  const info = getTileComponentInfo(tile.content.type)
   const dataset = gDataBroker?.selectedDataSet || gDataBroker?.last
   function handleFocusTile() {
     uiState.setFocusedTile(tile.id)
   }
+
+  if (!info) return null
+
+  const { TitleBar, Component, tileEltClass, isFixedWidth, isFixedHeight } = info
 
   return (
     <DataSetContext.Provider value={dataset}>
@@ -38,16 +40,16 @@ export const CodapComponent = observer(function CodapComponent({
         onFocus={handleFocusTile} onPointerDownCapture={handleFocusTile}>
         <TitleBar tile={tile} onCloseTile={onCloseTile}/>
         <Component tile={tile} />
-        {onRightPointerDown && !isFixedSize &&
+        {onRightPointerDown && !isFixedWidth &&
           <div className="codap-component-border right" onPointerDown={onRightPointerDown}/>}
-        {onBottomPointerDown && !isFixedSize &&
+        {onBottomPointerDown && !isFixedHeight &&
           <div className="codap-component-border bottom" onPointerDown={onBottomPointerDown}/>}
-        {onLeftPointerDown && !isFixedSize &&
+        {onLeftPointerDown && !isFixedWidth &&
           <div className="codap-component-border left" onPointerDown={onLeftPointerDown}/>}
-        {onBottomLeftPointerDown && !isFixedSize &&
+        {onBottomLeftPointerDown && !(isFixedWidth && isFixedHeight) &&
           <div className="codap-component-corner bottom-left" onPointerDown={onBottomLeftPointerDown}/>
         }
-        {onBottomRightPointerDown && !isFixedSize &&
+        {onBottomRightPointerDown && !(isFixedWidth && isFixedHeight) &&
           <div className="codap-component-corner bottom-right" onPointerDown={onBottomRightPointerDown}>
             {uiState.isFocusedTile(tile.id) &&
               <ResizeHandle className="component-resize-handle"/>}

--- a/v3/src/components/constants.ts
+++ b/v3/src/components/constants.ts
@@ -6,3 +6,8 @@ export const defaultBoldFont = `bold ${defaultFont}`
 export const defaultItalicFont = `italic ${defaultFont}`
 
 export const defaultTileTitleFont = defaultItalicFont
+
+export const kTitleBarHeight = 25
+
+export const kDefaultTileWidth = 250
+export const kDefaultTileHeight = 250

--- a/v3/src/components/free-tile-component.tsx
+++ b/v3/src/components/free-tile-component.tsx
@@ -2,7 +2,6 @@ import { useDndContext } from "@dnd-kit/core"
 import React, { useState } from "react"
 import { getDragTileId, IUseDraggableTile, useDraggableTile } from "../hooks/use-drag-drop"
 import { IFreeTileLayout, IFreeTileRow, isFreeTileRow } from "../models/document/free-tile-row"
-import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { ITileModel } from "../models/tiles/tile-model"
 import { CodapComponent } from "./codap-component"
 
@@ -14,7 +13,7 @@ interface IProps {
 
 export const FreeTileComponent = ({ row, tile, onCloseTile}: IProps) => {
   const [resizingTileStyle, setResizingTileStyle] =
-    useState<{left: number, top: number, width: number, height: number}>()
+    useState<{left: number, top: number, width?: number, height?: number}>()
   const [resizingTileId, setResizingTileId] = useState("")
   const tileId = tile.id
   const tileType = tile.content.type
@@ -22,7 +21,6 @@ export const FreeTileComponent = ({ row, tile, onCloseTile}: IProps) => {
   const { x: left, y: top, width, height } = rowTile || {}
   const { active } = useDndContext()
   const tileStyle: React.CSSProperties = { left, top, width, height }
-  const info = getTileComponentInfo(tileType)
   const draggableOptions: IUseDraggableTile = { prefix: tileType || "tile", tileId }
   const {setNodeRef, transform} = useDraggableTile(draggableOptions,
     activeDrag => {
@@ -50,26 +48,17 @@ export const FreeTileComponent = ({ row, tile, onCloseTile}: IProps) => {
       setResizingTileId(mtile.tileId)
       const xDelta = pointerMoveEvent.pageX - startPosition.x
       const yDelta = pointerMoveEvent.pageY - startPosition.y
-      switch (direction) {
-        case "bottom-right":
-          resizingWidth = startWidth + xDelta
-          resizingHeight = startHeight + yDelta
-          break
-        case "bottom-left":
-          resizingWidth = startWidth - xDelta
-          resizingHeight = startHeight + yDelta
-          resizingLeft = startLeft + xDelta
-          break
-        case "left":
-          resizingWidth = startWidth - xDelta
-          resizingLeft = startLeft + xDelta
-          break
-        case "bottom":
-          resizingHeight = startHeight + yDelta
-          break
-        case "right":
-          resizingWidth = startWidth + xDelta
-          break
+      const addIfDefined = (x: number | undefined, delta: number) => x != null ? x + delta : x
+
+      if (direction.includes("left")) {
+        resizingWidth = addIfDefined(startWidth, -xDelta)
+        resizingLeft = startLeft + xDelta
+      }
+      if (direction.includes("bottom")) {
+        resizingHeight = addIfDefined(startHeight, yDelta)
+      }
+      if (direction.includes("right")) {
+        resizingWidth = addIfDefined(startWidth, xDelta)
       }
 
       setResizingTileStyle({left: resizingLeft, top: mtile.y, width: resizingWidth, height: resizingHeight})
@@ -97,15 +86,14 @@ export const FreeTileComponent = ({ row, tile, onCloseTile}: IProps) => {
                       : tileStyle
   return (
     <div className="free-tile-component" style={style} key={tileId} ref={setNodeRef}>
-      {tile && info && rowTile &&
-        <CodapComponent tile={tile} TitleBar={info.TitleBar} Component={info.Component}
-            tileEltClass={info.tileEltClass} onCloseTile={onCloseTile}
-            isFixedSize={info.isFixedSize}
-            onBottomRightPointerDown={(e)=>handleResizePointerDown(e, rowTile, "bottom-right")}
-            onBottomLeftPointerDown={(e)=>handleResizePointerDown(e, rowTile, "bottom-left")}
-            onRightPointerDown={(e)=>handleResizePointerDown(e, rowTile, "right")}
-            onBottomPointerDown={(e)=>handleResizePointerDown(e, rowTile, "bottom")}
-            onLeftPointerDown={(e)=>handleResizePointerDown(e, rowTile, "left")}
+      {tile && rowTile &&
+        <CodapComponent tile={tile}
+          onCloseTile={onCloseTile}
+          onBottomRightPointerDown={(e)=>handleResizePointerDown(e, rowTile, "bottom-right")}
+          onBottomLeftPointerDown={(e)=>handleResizePointerDown(e, rowTile, "bottom-left")}
+          onRightPointerDown={(e)=>handleResizePointerDown(e, rowTile, "right")}
+          onBottomPointerDown={(e)=>handleResizePointerDown(e, rowTile, "bottom")}
+          onLeftPointerDown={(e)=>handleResizePointerDown(e, rowTile, "left")}
         />
       }
     </div>

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -2,18 +2,18 @@ import {useDroppable} from '@dnd-kit/core'
 import {observer} from "mobx-react-lite"
 import React, {useEffect, useMemo, useRef} from "react"
 import {useResizeDetector} from "react-resize-detector"
+import {kTitleBarHeight} from '../../constants'
+import {ITileBaseProps} from '../../tiles/tile-base-props'
 import {useDataSet} from '../../../hooks/use-data-set'
 import {DataSetContext} from '../../../hooks/use-data-set-context'
 import {useGraphController} from "../hooks/use-graph-controller"
 import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-id-context"
 import {uiState} from "../../../models/ui-state"
-import {kTitleBarHeight} from "../graphing-types"
 import {AxisLayoutContext} from "../../axis/models/axis-layout-context"
 import {GraphController} from "../models/graph-controller"
 import {GraphLayout, GraphLayoutContext} from "../models/graph-layout"
 import {GraphModelContext, isGraphModel} from "../models/graph-model"
 import {Graph} from "./graph"
-import {ITileBaseProps} from '../../tiles/tile-base-props'
 
 export const GraphComponent = observer(function GraphComponent({tile}: ITileBaseProps) {
   const graphModel = isGraphModel(tile?.content) ? tile?.content : undefined

--- a/v3/src/components/graph/graph-registration.ts
+++ b/v3/src/components/graph/graph-registration.ts
@@ -25,8 +25,8 @@ registerTileComponentInfo({
   Component: GraphComponent,
   tileEltClass: kGraphTileClass,
   Icon: GraphIcon,
-  height: 300,
-  width: 300,
+  defaultWidth: 300,
+  defaultHeight: 300
 })
 
 registerV2TileImporter("DG.GraphView", ({ v2Component, v2Document, sharedModelManager, insertTile }) => {

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -69,7 +69,7 @@ export interface counterProps {
   setCounter: React.Dispatch<React.SetStateAction<number>>
 }
 
-export const kTitleBarHeight = 25,
+export const
   transitionDuration = 1000,
   pointRadiusMax = 10,
   pointRadiusMin = 3,

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -2,8 +2,9 @@ import {scaleBand, scaleLinear, scaleLog, scaleOrdinal} from "d3"
 import {action, computed, makeObservable, observable} from "mobx"
 import {createContext, useContext} from "react"
 import {AxisPlace, AxisPlaces, AxisBounds, AxisScaleType, isVertical} from "../../axis/axis-types"
-import {GraphPlace, kTitleBarHeight} from "../graphing-types"
+import {GraphPlace} from "../graphing-types"
 import {IScaleType} from "../../axis/models/axis-model"
+import {kTitleBarHeight} from "../../constants"
 
 export const kDefaultGraphWidth = 480
 export const kDefaultGraphHeight = 300

--- a/v3/src/components/mosaic-tile-row.tsx
+++ b/v3/src/components/mosaic-tile-row.tsx
@@ -112,8 +112,7 @@ export const MosaicTileComponent = observer(
   return (
     <div className="mosaic-tile-component" style={style} >
       {tile && info &&
-        <CodapComponent tile={tile} TitleBar={info.TitleBar} Component={info.Component}
-            tileEltClass={info.tileEltClass} onCloseTile={handleCloseTile}/>
+        <CodapComponent tile={tile} onCloseTile={handleCloseTile}/>
       }
     </div>
   )

--- a/v3/src/components/slider/slider-registration.ts
+++ b/v3/src/components/slider/slider-registration.ts
@@ -20,6 +20,6 @@ registerTileComponentInfo({
   Component: SliderComponent,
   tileEltClass: kSliderTileClass,
   Icon: SliderIcon,
-  height: 98,
-  width: 300,
+  defaultWidth: 300,
+  isFixedHeight: true
 })

--- a/v3/src/components/slider/slider.scss
+++ b/v3/src/components/slider/slider.scss
@@ -8,6 +8,7 @@ $pseudo-inspector-width: 40px;
   width: calc(100% - $pseudo-inspector-width);
   height: 100px;
   background: #fff;
+  border-radius: $border-radius-bottom-corners;
 
   .slider {
     button svg, .thumb-icon {

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import {Box, Flex, HStack, Tag, useToast} from "@chakra-ui/react"
+import { kDefaultTileHeight, kDefaultTileWidth } from "../constants"
 import t from "../../utilities/translation/translate"
 import { IDocumentContentModel } from "../../models/document/document-content"
 import { createDefaultTileOfType } from "../../models/codap/add-default-content"
@@ -42,8 +43,8 @@ export const ToolShelf = ({content}: IProps) => {
   }
 
   const createTile = (tileType: string, componentInfo: ITileComponentInfo) => {
-    const width = componentInfo.width || 185
-    const height = componentInfo.height || 250
+    const width = componentInfo.defaultWidth || kDefaultTileWidth
+    const height = componentInfo.defaultHeight || kDefaultTileHeight
     if (row) {
       const newTile = createDefaultTileOfType(tileType)
       if (newTile) {
@@ -53,8 +54,8 @@ export const ToolShelf = ({content}: IProps) => {
           const tileOptions = { x, y, width, height }
           content?.insertTileInRow(newTile, row, tileOptions)
           const rowTile = row.tiles.get(newTile.id)
-          if (componentInfo.width && componentInfo.height) {
-            rowTile?.setSize(componentInfo.width,  componentInfo.height + kHeaderHeight)
+          if (componentInfo.defaultWidth && componentInfo.defaultHeight) {
+            rowTile?.setSize(componentInfo.defaultWidth,  componentInfo.defaultHeight + kHeaderHeight)
             rowTile?.setPosition(tileOptions.x, tileOptions.y)
           }
         }

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -55,7 +55,7 @@ export function addDefaultComponents() {
     if (calculatorTile) {
       const calcOptions = isMosaicTileRow(row)
               ? { splitTileId: summaryTile.id, direction: "row" }
-              : { x: kFullWidth + kGap / 2, y: 2, width: kWidth25, height: kFullHeight }
+              : { x: kFullWidth + kGap, y: 2 }
       content.insertTileInRow(calculatorTile, row, calcOptions)
     }
 
@@ -70,7 +70,7 @@ export function addDefaultComponents() {
     if (sliderTile) {
       const sliderOptions = isMosaicTileRow(row)
               ? { splitTileId: helloTile.id, direction: "column" }
-              : { x: kFullWidth + kWidth25 + kGap, y: kHalfHeight + kGap / 2, width: kWidth75, height: kHalfHeight }
+              : { x: kFullWidth + kWidth25 + kGap, y: kHalfHeight + kGap, width: kWidth75 }
       content.insertTileInRow(sliderTile, row, sliderOptions)
     }
 

--- a/v3/src/models/document/free-tile-row.ts
+++ b/v3/src/models/document/free-tile-row.ts
@@ -15,8 +15,8 @@ export const FreeTileLayout = types.model("FreeTileLayout", {
   tileId: types.string,
   x: types.number,
   y: types.number,
-  width: types.number,
-  height: types.number
+  width: types.maybe(types.number),
+  height: types.maybe(types.number)
 })
 .views(self => ({
   get position() {
@@ -31,7 +31,7 @@ export const FreeTileLayout = types.model("FreeTileLayout", {
     self.x = x
     self.y = y
   },
-  setSize(width: number, height: number) {
+  setSize(width?: number, height?: number) {
     self.width = width
     self.height = height
   }
@@ -42,8 +42,8 @@ export interface IFreeTileLayoutSnapshot extends SnapshotIn<typeof FreeTileLayou
 export interface IFreeTileInRowOptions extends ITileInRowOptions {
   x: number
   y: number
-  width: number
-  height: number
+  width?: number
+  height?: number
 }
 export const isFreeTileInRowOptions = (options?: ITileInRowOptions): options is IFreeTileInRowOptions =>
               (options as any)?.x != null && (options as any)?.y != null
@@ -88,7 +88,7 @@ export const FreeTileRow = TileRowModel
   }))
   .actions(self => ({
     insertTile(tileId: string, options?: ITileInRowOptions) {
-      const { x = 50, y = 50, width = 400, height = 300 } = isFreeTileInRowOptions(options) ? options : {}
+      const { x = 50, y = 50, width = undefined, height = undefined } = isFreeTileInRowOptions(options) ? options : {}
       self.tiles.set(tileId, { tileId, x, y, width, height })
       self.order.push(tileId)
     },

--- a/v3/src/models/tiles/tile-component-info.ts
+++ b/v3/src/models/tiles/tile-component-info.ts
@@ -17,13 +17,14 @@ export interface ITileComponentInfo {
    */
   tileHandlesOwnSelection?: boolean;
   /**
-   * Components should have a default height and width. Plugins will specify their own height and width
+   * REsizable components should have a default width and height. Plugins will specify their own height and width
    */
-  width?: number;
-  height?: number;
-  /* Toolshelf specific properties */
-  isSingleton?: boolean; // Only one instance of a tile is open per documeent so toolshelf button opens and closes tile
-  isFixedSize?: boolean;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  /* Tool shelf specific properties */
+  isSingleton?: boolean; // Only one instance of a tile is open per document so tool shelf button opens and closes tile
+  isFixedWidth?: boolean;
+  isFixedHeight?: boolean;
 }
 
 const gTileComponentInfoMap = new Map<string, ITileComponentInfo>()

--- a/v3/src/v2/calculator.codap
+++ b/v3/src/v2/calculator.codap
@@ -1,0 +1,37 @@
+{
+  "name": "Calculator Sample",
+  "guid": 1,
+  "id": 1,
+  "components": [
+    {
+      "type": "DG.Calculator",
+      "guid": 2,
+      "id": 2,
+      "componentStorage": {
+        "title": "Calculator",
+        "name": "Calculator",
+        "userSetTitle": false,
+        "cannotClose": false
+      },
+      "layout": {
+        "width": 139,
+        "height": 208,
+        "zIndex": 102,
+        "left": 5,
+        "top": 5,
+        "isVisible": true,
+        "right": 144,
+        "bottom": 213
+      },
+      "savedHeight": null
+    }
+  ],
+  "contexts": [],
+  "globalValues": [],
+  "appName": "DG",
+  "appVersion": "2.0",
+  "appBuildNum": "0670",
+  "lang": "en",
+  "idCount": 2,
+  "metadata": {}
+}

--- a/v3/src/v2/codap-v2-import.test.ts
+++ b/v3/src/v2/codap-v2-import.test.ts
@@ -19,6 +19,29 @@ describe(`V2 "bogus-document.codap"`, () => {
 
 })
 
+describe(`V2 "calculator.codap"`, () => {
+  const file = path.join(__dirname, "./", "calculator.codap")
+  const calculatorJson = fs.readFileSync(file, "utf8")
+  const calculatorDoc = JSON.parse(calculatorJson) as ICodapV2DocumentJson
+
+  it("should be importable", () => {
+    expect(calculatorDoc.name).toBe("Calculator Sample")
+    expect(calculatorDoc.components?.length).toBe(1)
+    expect(calculatorDoc.contexts?.length).toBe(0)
+    expect(calculatorDoc.globalValues?.length).toBe(0)
+  })
+
+  it("should be importable by CodapV2Document", () => {
+    const mammals = new CodapV2Document(calculatorDoc)
+    expect(mammals.components.length).toBe(1)
+    expect(mammals.contexts.length).toBe(0)
+    expect(mammals.globalValues.length).toBe(0)
+    expect(mammals.datasets.length).toBe(0)
+
+    expect(mammals.components.map(c => c.type)).toEqual(["DG.Calculator"])
+  })
+})
+
 describe(`V2 "mammals.codap"`, () => {
 
   const file = path.join(__dirname, "./", "mammals.codap")

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -84,6 +84,13 @@ export interface IGuidLink<T extends string> {
   id: number
 }
 
+export interface ICodapV2CalculatorStorage {
+  title: string
+  name: string
+  userSetTitle: boolean
+  cannotCLose: boolean
+}
+
 export interface ICodapV2TableStorage {
   _links_: {
     context: IGuidLink<"DG.DataContextRecord">
@@ -153,6 +160,13 @@ export interface ICodapV2BaseComponent {
   }
   savedHeight: number | null
 }
+
+export interface ICodapV2CalculatorComponent extends ICodapV2BaseComponent {
+  type: "DG.Calculator"
+  componentStorage: ICodapV2CalculatorStorage
+}
+export const isV2CalculatorComponent = (component: ICodapV2BaseComponent): component is ICodapV2CalculatorComponent =>
+  component.type === "DG.Calculator"
 
 export interface ICodapV2TableComponent extends ICodapV2BaseComponent {
   type: "DG.TableView"

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -88,7 +88,7 @@ export interface ICodapV2CalculatorStorage {
   title: string
   name: string
   userSetTitle: boolean
-  cannotCLose: boolean
+  cannotClose: boolean
 }
 
 export interface ICodapV2TableStorage {


### PR DESCRIPTION
- supports import of calculator tiles from v2 documents
- free tile layout does not impose sizes (imported or otherwise) on non-resizable tiles
- non-resizable tiles render at their "natural" size without constraints imposed from above
