### PR TITLE
Improve Jest Performance

### DIFF
--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm run build
       - name: Run Tests
         working-directory: v3
-        run: npm run test:coverage -- --runInBand
+        run: npm run test:coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm run build
       - name: Run Tests
         working-directory: v3
-        run: npm run test:coverage
+        run: npm run test:coverage -- --maxWorkers=2
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -14,7 +14,9 @@ jobs:
       - uses: snow-actions/sparse-checkout@v1.1.0
         with:
           patterns: v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Install Dependencies
         working-directory: v3
         run: npm ci
@@ -78,7 +80,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Install Dependencies
         working-directory: v3
         run: npm ci

--- a/v3/package.json
+++ b/v3/package.json
@@ -8,7 +8,8 @@
     "preset": "ts-jest/presets/js-with-ts",
     "resolver": "<rootDir>/src/test/jest-resolver.js",
     "transform": {
-      "^.+\\.json5$": "@talabes/json5-jest"
+      "^.+\\.json5$": "@talabes/json5-jest",
+      "^.+\\.tsx?$": ["ts-jest", { "isolatedModules": true }]
     },
     "transformIgnorePatterns": [
       "/comments/ESM-only (https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) modules that should not be transformed by ts-jest",


### PR DESCRIPTION
-Uncached Jest runs are down from 60s to 15s. After the first run they go down to 3-5 seconds.
-Some files still have ~5-10s duration warnings. This is because they pull in a lot of dependencies, i.e. for data-configuration-model-test, Jest will load all of mobx and d3, among other dependencies. Some of these libraries have sub-libraries that we can pull in instead (i.e. installing "d3-scale" and changing every import of d3's scaleQuantile to import from it instead of "d3"), but that behavior needs to be consistently enforced throughout the codebase, and with our cold test runs down to 15 seconds, I don't think it's worth the added cognitive complexity. Maybe much further down the line.
-Jest should appropriately use both threads available on a GitHub Action