### PR TITLE
feat: add GlobalValueManager; fix slider

### DIFF
--- a/v3/cypress/e2e/slider.spec.ts
+++ b/v3/cypress/e2e/slider.spec.ts
@@ -8,7 +8,7 @@ context("Slider UI", () => {
         cy.wait(2500)
     })
     it("does not populate title bar from sample data", () => {
-      const collectionName = "Slider"
-      slider.getCollectionTitle().should("contain", collectionName)
+      const sliderName = "v1"
+      slider.getComponentTitle().should("contain", sliderName)
     })
 })

--- a/v3/cypress/support/elements/slider-tile.ts
+++ b/v3/cypress/support/elements/slider-tile.ts
@@ -2,7 +2,7 @@ export const SliderTileElements = {
   getSliderTile() {
     return cy.get(".codap-slider")
   },
-  getCollectionTitle() {
+  getComponentTitle() {
     return this.getSliderTile().find("[data-testid=editable-component-title]")
   }
 }

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -7,12 +7,12 @@ import {Container} from "./container"
 import { MenuBar } from "./menu-bar/menu-bar"
 import { appState } from "../models/app-state"
 import { addDefaultComponents } from "../models/codap/add-default-content"
-import { createCodapDocument, getTileEnvironment } from "../models/codap/create-codap-document"
+import { createCodapDocument } from "../models/codap/create-codap-document"
 import {gDataBroker} from "../models/data/data-broker"
 import {DataSet, IDataSet, toCanonical} from "../models/data/data-set"
 import { IDocumentModelSnapshot } from "../models/document/document"
-import { ISharedModelDocumentManager } from "../models/document/shared-model-document-manager"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
+import { getSharedModelManager } from "../models/tiles/tile-environment"
 import { ITileModel } from "../models/tiles/tile-model"
 import { DocumentContext } from "../hooks/use-document-context"
 import {useDropHandler} from "../hooks/use-drop-handler"
@@ -47,7 +47,7 @@ export const App = observer(function App() {
 
   const handleImportV2Document = useCallback((v2Document: CodapV2Document) => {
     const v3Document = createCodapDocument(undefined, "free")
-    const sharedModelManager = getTileEnvironment(v3Document)?.sharedModelManager
+    const sharedModelManager = getSharedModelManager(v3Document)
     sharedModelManager && gDataBroker.setSharedModelManager(sharedModelManager)
     // add shared models (data sets and case metadata)
     v2Document.datasets.forEach((data, key) => {
@@ -108,8 +108,7 @@ export const App = observer(function App() {
   useEffect(() => {
     // connect the data broker to the shared model manager
     if (!gDataBroker.sharedModelManager) {
-      const docEnv = getTileEnvironment(appState.document)
-      const sharedModelManager = docEnv?.sharedModelManager as ISharedModelDocumentManager | undefined
+      const sharedModelManager = getSharedModelManager(appState.document)
       sharedModelManager && gDataBroker.setSharedModelManager(sharedModelManager)
     }
 

--- a/v3/src/components/calculator/calculator-registration.test.ts
+++ b/v3/src/components/calculator/calculator-registration.test.ts
@@ -1,0 +1,41 @@
+import { getTileComponentInfo } from "../../models/tiles/tile-component-info"
+import { getTileContentInfo } from "../../models/tiles/tile-content-info"
+import { CodapV2Document } from "../../v2/codap-v2-document"
+import { importV2Component } from "../../v2/codap-v2-tile-importers"
+import { ICodapV2DocumentJson } from "../../v2/codap-v2-types"
+import { kCalculatorTileType } from "./calculator-defs"
+import "./calculator-registration"
+
+const fs = require("fs")
+const path = require("path")
+
+describe("Calculator registration", () => {
+  it("registers content and component info", () => {
+    const calculatorContentInfo = getTileContentInfo(kCalculatorTileType)
+    expect(calculatorContentInfo).toBeDefined()
+    expect(getTileComponentInfo(kCalculatorTileType)).toBeDefined()
+    const calculator = calculatorContentInfo?.defaultContent()
+    expect(calculator).toBeDefined()
+  })
+  it("imports v2 calculator components", () => {
+    const file = path.join(__dirname, "../../v2", "calculator.codap")
+    const calculatorJson = fs.readFileSync(file, "utf8")
+    const calculatorDoc = JSON.parse(calculatorJson) as ICodapV2DocumentJson
+    const v2Document = new CodapV2Document(calculatorDoc)
+    const mockInsertTile = jest.fn()
+    const tile = importV2Component({
+      v2Component: v2Document.components[0],
+      v2Document,
+      insertTile: mockInsertTile
+    })
+    expect(tile).toBeDefined()
+    expect(mockInsertTile).toHaveBeenCalledTimes(1)
+
+    const tileWithInvalidComponent = importV2Component({
+      v2Component: {} as any,
+      v2Document,
+      insertTile: mockInsertTile
+    })
+    expect(tileWithInvalidComponent).toBeUndefined()
+  })
+})

--- a/v3/src/components/calculator/calculator-registration.ts
+++ b/v3/src/components/calculator/calculator-registration.ts
@@ -30,7 +30,7 @@ registerTileComponentInfo({
   isFixedHeight: true
 })
 
-registerV2TileImporter("DG.Calculator", ({ v2Component, v2Document, insertTile }) => {
+registerV2TileImporter("DG.Calculator", ({ v2Component, insertTile }) => {
   if (!isV2CalculatorComponent(v2Component)) return
 
   const { name = "", title = "" } = v2Component.componentStorage
@@ -40,4 +40,6 @@ registerV2TileImporter("DG.Calculator", ({ v2Component, v2Document, insertTile }
     content: CalculatorModel.create({ name })
   })
   insertTile(calculatorTile)
+
+  return calculatorTile
 })

--- a/v3/src/components/case-table/case-table-component.test.tsx
+++ b/v3/src/components/case-table/case-table-component.test.tsx
@@ -4,14 +4,13 @@ import userEvent from '@testing-library/user-event'
 import { getSnapshot } from "mobx-state-tree"
 import React from "react"
 import { CaseTableComponent } from "./case-table-component"
-import { kCaseTableTileType } from "./case-table-defs"
 import { CaseTableModel } from "./case-table-model"
 import { DataSetContext } from "../../hooks/use-data-set-context"
 import { useKeyStates } from "../../hooks/use-key-states"
 import { DataBroker } from "../../models/data/data-broker"
 import { DataSet, toCanonical } from "../../models/data/data-set"
 import { ITileModel, TileModel } from "../../models/tiles/tile-model"
-import { registerTileTypes } from "../../register-tile-types"
+import "./case-table-registration"
 
 jest.mock("./case-table-shared.scss", () => ({
   headerRowHeight: "30",
@@ -24,8 +23,6 @@ const UseKeyStatesWrapper = () => {
 }
 
 describe("Case Table", () => {
-  registerTileTypes([kCaseTableTileType])
-
   let broker: DataBroker
   let tile: ITileModel
   beforeEach(() => {
@@ -43,7 +40,7 @@ describe("Case Table", () => {
     expect(screen.queryByTestId("case-table")).not.toBeInTheDocument()
   })
 
-  it.skip("renders table with data", () => {
+  it("renders table with data", () => {
     const data = DataSet.create()
     data.addAttribute({ name: "a"})
     data.addAttribute({ name: "b" })
@@ -58,7 +55,7 @@ describe("Case Table", () => {
     expect(screen.getByTestId("case-table")).toBeInTheDocument()
   })
 
-  it.skip("selects rows when index cell is clicked", async () => {
+  it("selects rows when index cell is clicked", async () => {
     const user = userEvent.setup()
     const data = DataSet.create()
     data.addAttribute({ name: "a"})

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -45,4 +45,6 @@ registerV2TileImporter("DG.TableView", ({ v2Component, v2Document, sharedModelMa
   const { data, metadata } = v2Document.getDataAndMetadata(contextId)
   sharedModelManager?.addTileSharedModel(tableTile.content, data, true)
   sharedModelManager?.addTileSharedModel(tableTile.content, metadata, true)
+
+  return tableTile
 })

--- a/v3/src/components/graph/graph-registration.ts
+++ b/v3/src/components/graph/graph-registration.ts
@@ -46,4 +46,6 @@ registerV2TileImporter("DG.GraphView", ({ v2Component, v2Document, sharedModelMa
   const { data, metadata } = v2Document.getDataAndMetadata(contextId)
   sharedModelManager?.addTileSharedModel(graphTile.content, data, true)
   sharedModelManager?.addTileSharedModel(graphTile.content, metadata, true)
+
+  return graphTile
 })

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -37,7 +37,7 @@ export const EditableSliderValue = observer(function EditableSliderValue({slider
   const handleBlur = () => {
     const myFloat = parseFloat(candidate)
     if (isFinite(myFloat)) {
-      sliderModel.setValueRoundedToMultipleOf(myFloat)
+      sliderModel.setValue(myFloat)
     } else {
       setCandidate(formatValue(sliderModel))
     }

--- a/v3/src/components/slider/inspector-panel/slider-settings-panel.tsx
+++ b/v3/src/components/slider/inspector-panel/slider-settings-panel.tsx
@@ -2,9 +2,10 @@ import React from "react"
 import {observer} from "mobx-react-lite"
 import {Flex, FormControl, FormLabel, NumberDecrementStepper, NumberIncrementStepper, NumberInput,
         NumberInputField, NumberInputStepper, Select} from "@chakra-ui/react"
-import t from "../../../utilities/translation/translate"
-import {ISliderModel} from "../slider-model"
 import {InspectorPalette} from "../../inspector-panel"
+import {ISliderModel} from "../slider-model"
+import {AnimationDirection, AnimationDirections, AnimationMode, AnimationModes} from "../slider-types"
+import t from "../../../utilities/translation/translate"
 import ValuesIcon from "../../../assets/icons/icon-values.svg"
 
 import "./slider-settings-panel.scss"
@@ -73,11 +74,11 @@ export const SliderSettingsPalette =
         <FormControl>
           <Flex className="palette-row">
             <FormLabel className="form-label">{t("DG.Slider.direction")}
-              <Select className="slider-select direction" value={sliderModel.direction}
-                      onChange={e => sliderModel.setDirection(e.target.value)}>
-                <option value={"lowToHigh"}>{t("DG.Slider.lowToHigh")}</option>
-                <option value={"backAndForth"}>{t("DG.Slider.backAndForth")}</option>
-                <option value={"hightToLow"}>{t("DG.Slider.highToLow")}</option>
+              <Select className="slider-select direction" value={sliderModel.animationDirection}
+                      onChange={e => sliderModel.setAnimationDirection(e.target.value as AnimationDirection)}>
+                {AnimationDirections.map(direction => (
+                  <option key={direction} value={direction}>{t(`DG.Slider.${direction}`)}</option>
+                ))}
               </Select>
             </FormLabel>
           </Flex>
@@ -85,10 +86,11 @@ export const SliderSettingsPalette =
         <FormControl>
           <Flex className="palette-row">
             <FormLabel className="form-label">{t("DG.Slider.mode")}
-              <Select className="slider-select mode" value={sliderModel.repetition}
-                      onChange={e => sliderModel.setRepetition(e.target.value)}>
-                <option value={"nonStop"}>{t("DG.Slider.nonStop")}</option>
-                <option value={"onceOnly"}>{t("DG.Slider.onceOnly")}</option>
+              <Select className="slider-select mode" value={sliderModel.animationMode}
+                      onChange={e => sliderModel.setAnimationMode(e.target.value as AnimationMode)}>
+                {AnimationModes.map(mode => (
+                  <option key={mode} value={mode}>{t(`DG.Slider.${mode}`)}</option>
+                ))}
               </Select>
             </FormLabel>
           </Flex>

--- a/v3/src/components/slider/slider-component.tsx
+++ b/v3/src/components/slider/slider-component.tsx
@@ -40,7 +40,7 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
   const axisStyle: CSSProperties = {
     position: "absolute",
     left: 0,
-    top: 70,
+    top: 52,
     width,
     height: 30
   }
@@ -64,7 +64,7 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
   if (!isSliderModel(sliderModel)) return null
 
   const incrementSliderValue = () => {
-    sliderModel.setValueRoundedToMultipleOf(sliderModel.value + sliderModel.multipleOf)
+    sliderModel.setValue(sliderModel.value + sliderModel.increment)
   }
 
   const titleM = measureText(sliderModel.name)

--- a/v3/src/components/slider/slider-model.test.ts
+++ b/v3/src/components/slider/slider-model.test.ts
@@ -1,0 +1,87 @@
+import { destroy, types } from "mobx-state-tree"
+import { GlobalValue, IGlobalValue } from "../../models/global/global-value"
+import { isSliderModel, SliderModel } from "./slider-model"
+import { kDefaultAnimationDirection, kDefaultAnimationMode, kDefaultAnimationRate } from "./slider-types"
+
+describe("SliderModel", () => {
+  const mockSharedModelManagerWithoutGlobalValueManager = {
+    isReady: true,
+    addTileSharedModel: () => null,
+    getSharedModelsByType: () => []
+  }
+  const mockSharedModelManager = {
+    removeValue: () => null
+  }
+  const mockSharedModelManagerWithGlobalValueManager = {
+    ...mockSharedModelManagerWithoutGlobalValueManager,
+    getSharedModelsByType: () => [mockSharedModelManager]
+  }
+  const Tree = types.model("Tree", {
+    globalValue: GlobalValue,
+    sliderModel: SliderModel
+  })
+  let g1: IGlobalValue
+
+  beforeEach(() => {
+    g1 = GlobalValue.create({ name: "g1", value: 0 })
+  })
+
+  it("works as expected with a shared model manager with a global value manager", () => {
+    const tree = Tree.create({
+      globalValue: g1,
+      sliderModel: { globalValue: g1.id }
+    }, { sharedModelManager: mockSharedModelManagerWithGlobalValueManager })
+    const slider = tree.sliderModel
+
+    expect(isSliderModel()).toBe(false)
+    expect(isSliderModel(slider)).toBe(true)
+    expect(slider.name).toBe("g1")
+    slider.setName("foo")
+    expect(slider.name).toBe("foo")
+    expect(slider.value).toBe(0)
+    slider.setValue(1)
+    expect(slider.value).toBe(1)
+    expect(slider.domain).toEqual([slider.axis.min, slider.axis.max])
+    expect(slider.increment).toBeCloseTo(0.1)
+    slider.setMultipleOf(2)
+    slider.setValue(2.5)
+    expect(slider.value).toBe(2)
+    expect(slider.increment).toBe(2)
+    expect(slider.animationDirection).toBe(kDefaultAnimationDirection)
+    slider.setAnimationDirection("backAndForth")
+    expect(slider.animationDirection).toBe("backAndForth")
+    expect(slider.animationMode).toBe(kDefaultAnimationMode)
+    slider.setAnimationMode("nonStop")
+    expect(slider.animationMode).toBe("nonStop")
+    expect(slider.animationRate).toBe(kDefaultAnimationRate)
+    slider.setAnimationRate(60)
+    expect(slider.animationRate).toBe(60)
+    slider.setAnimationRate(kDefaultAnimationRate)
+    expect(slider._animationRate).toBeUndefined()
+
+    destroy(tree)
+  })
+
+  it("works as expected with a shared model manager without a global value manager", () => {
+    const tree = Tree.create({
+      globalValue: g1,
+      sliderModel: { globalValue: g1.id }
+    }, { sharedModelManager: mockSharedModelManagerWithoutGlobalValueManager })
+    const slider = tree.sliderModel
+    expect(isSliderModel()).toBe(false)
+    expect(isSliderModel(slider)).toBe(true)
+    destroy(tree)
+  })
+
+  it("works as expected without a shared model manager", () => {
+    const tree = Tree.create({
+      globalValue: g1,
+      sliderModel: { globalValue: g1.id }
+    })
+    const slider = tree.sliderModel
+    expect(isSliderModel()).toBe(false)
+    expect(isSliderModel(slider)).toBe(true)
+    destroy(tree)
+  })
+
+})

--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -1,69 +1,101 @@
-import { Instance, types} from "mobx-state-tree"
+import { reaction } from "mobx"
+import { addDisposer, Instance, types} from "mobx-state-tree"
 import { NumericAxisModel } from "../axis/models/axis-model"
-import { GlobalValue } from "../../models/data/global-value"
+import { GlobalValue } from "../../models/global/global-value"
+import { IGlobalValueManager, kGlobalValueManagerType } from "../../models/global/global-value-manager"
+import { ISharedModel } from "../../models/shared/shared-model"
+import { getSharedModelManager } from "../../models/tiles/tile-environment"
 import { ITileContentModel, TileContentModel } from "../../models/tiles/tile-content"
 import { kSliderTileType } from "./slider-defs"
+import {
+  AnimationDirection, AnimationDirections, AnimationMode, AnimationModes,
+  kDefaultAnimationDirection, kDefaultAnimationMode, kDefaultAnimationRate
+} from "./slider-types"
 
 export const SliderModel = TileContentModel
   .named("SliderModel")
   .props({
     type: types.optional(types.literal(kSliderTileType), kSliderTileType),
-    multipleOf: 0.5,
-    animationRate: 1,
-    direction: types.string,
-    repetition: types.string,
-    resolution: .01,
-    globalValue: types.optional(GlobalValue, {
-      // TODO: generate unique name from registry
-      name: "slider-1",
-      value: 0.5
-    }),
-    axis: types.optional(NumericAxisModel, {
-      type: 'numeric',
-      scale: 'linear',
-      place: 'bottom',
-      min: 0,
-      max: 12
-    }),
+    globalValue: types.reference(GlobalValue),
+    multipleOf: types.maybe(types.number),
+    animationDirection: types.optional(types.enumeration([...AnimationDirections]), kDefaultAnimationDirection),
+    animationMode: types.optional(types.enumeration([...AnimationModes]), kDefaultAnimationMode),
+    // clients should use animationRate view defined below
+    _animationRate: types.maybe(types.number),  // frames per second
+    axis: types.optional(NumericAxisModel, { place: 'bottom', min: 0, max: 12 })
   })
   .views(self => ({
-    get domain() {
-      return self.axis.domain
-    },
     get name() {
       return self.globalValue.name
     },
     get value() {
       return self.globalValue.value
+    },
+    get domain() {
+      return self.axis.domain
+    },
+    get increment() {
+      // TODO: implement v2 algorithm which determines default increment from axis bounds
+      return self.multipleOf || 0.1
+    },
+    get animationRate() {
+      return self._animationRate ?? kDefaultAnimationRate
+    },
+    get globalValueManager() {
+      const sharedModelManager = getSharedModelManager(self)
+      const sharedModels = sharedModelManager?.getSharedModelsByType(kGlobalValueManagerType)
+      return sharedModels?.[0] as IGlobalValueManager | undefined
     }
   }))
   .actions(self => ({
+    afterAttach() {
+      // register our link to the global value manager when we're attached to the document
+      addDisposer(self, reaction(
+        () => {
+          const sharedModelManager = getSharedModelManager(self)
+          const globalValueManager = self.globalValueManager
+          return { sharedModelManager, globalValueManager }
+        },
+        ({ sharedModelManager, globalValueManager }) => {
+          if (sharedModelManager?.isReady) {
+            // once we're added to the document, update the shared model reference
+            globalValueManager && sharedModelManager.addTileSharedModel(self, globalValueManager)
+          }
+        }, { fireImmediately: true }
+      ))
+    },
+    beforeDestroy() {
+      // destroying the slider component removes the underlying global value
+      self.globalValueManager?.removeValue(self.globalValue)
+    },
+    updateAfterSharedModelChanges(sharedModel?: ISharedModel) {
+      // nothing to do
+    },
     setName(name: string) {
       self.globalValue.setName(name)
     },
-    setValueRoundedToMultipleOf(n: number) {
-      if (self.multipleOf !== 0) {
+    setValue(n: number) {
+      if (self.multipleOf) {
         n = Math.round(n / self.multipleOf) * self.multipleOf
       }
       self.globalValue.setValue(n)
     },
-    setValue(n: number) {
-      if (self.resolution !== 0) {
-        n = Math.round(n / self.resolution) * self.resolution
-      }
-      self.globalValue.setValue(n)
-    },
     setMultipleOf(n: number) {
-      self.multipleOf = Math.abs(n)
+      if (n) {
+        self.multipleOf = Math.abs(n)
+      }
     },
-    setAnimationRate(n: number) {
-      self.animationRate = Math.abs(n)
+    setAnimationDirection(direction: AnimationDirection) {
+      self.animationDirection = direction
     },
-    setDirection(direction: string) {
-      self.direction = direction
+    setAnimationMode(mode: AnimationMode) {
+      self.animationMode = mode
     },
-    setRepetition(repetition: string) {
-      self.repetition = repetition
+    setAnimationRate(rate: number) {
+      if (rate) {
+        // no need to store the default value
+        self._animationRate = rate === kDefaultAnimationRate ? undefined : Math.abs(rate)
+      }
     }
   }))
 

--- a/v3/src/components/slider/slider-registration.test.ts
+++ b/v3/src/components/slider/slider-registration.test.ts
@@ -1,0 +1,71 @@
+import { getTileComponentInfo } from "../../models/tiles/tile-component-info"
+import { getTileContentInfo } from "../../models/tiles/tile-content-info"
+import { CodapV2Document } from "../../v2/codap-v2-document"
+import { importV2Component } from "../../v2/codap-v2-tile-importers"
+import { ICodapV2DocumentJson } from "../../v2/codap-v2-types"
+import { kSliderTileType } from "./slider-defs"
+import "./slider-registration"
+
+const fs = require("fs")
+const path = require("path")
+
+describe("Slider registration", () => {
+  it("registers content and component info", () => {
+    const sliderContentInfo = getTileContentInfo(kSliderTileType)
+    expect(sliderContentInfo).toBeDefined()
+    expect(getTileComponentInfo(kSliderTileType)).toBeDefined()
+    const mockGlobalValueManager = {
+      addValue: jest.fn(),
+      uniqueName: jest.fn(() => "v1")
+    }
+    const mockSharedModelManager = {
+      addTileSharedModel: jest.fn(),
+      getSharedModelsByType: () => [mockGlobalValueManager]
+    }
+    const slider = sliderContentInfo?.defaultContent({
+      env: {
+        sharedModelManager: mockSharedModelManager as any
+      }
+    })
+    expect(slider).toBeDefined()
+    expect(mockGlobalValueManager.addValue).toHaveBeenCalledTimes(1)
+  })
+  it("imports v2 slider components", () => {
+    const file = path.join(__dirname, "../../v2", "slider.codap")
+    const sliderJson = fs.readFileSync(file, "utf8")
+    const sliderDoc = JSON.parse(sliderJson) as ICodapV2DocumentJson
+    const v2Document = new CodapV2Document(sliderDoc)
+    const mockGlobalValueManager = {
+      addValue: jest.fn()
+    }
+    const mockSharedModelManager = {
+      addTileSharedModel: jest.fn(),
+      getSharedModelsByType: () => [mockGlobalValueManager]
+    }
+    const mockInsertTile = jest.fn()
+    const tile = importV2Component({
+      v2Component: v2Document.components[0],
+      v2Document,
+      sharedModelManager: mockSharedModelManager as any,
+      insertTile: mockInsertTile
+    })
+    expect(tile).toBeDefined()
+    expect(mockGlobalValueManager.addValue).toHaveBeenCalledTimes(1)
+    expect(mockSharedModelManager.addTileSharedModel).toHaveBeenCalledTimes(1)
+    expect(mockInsertTile).toHaveBeenCalledTimes(1)
+
+    const tileWithInvalidDocument = importV2Component({
+      v2Component: {} as any,
+      v2Document,
+      insertTile: mockInsertTile
+    })
+    expect(tileWithInvalidDocument).toBeUndefined()
+
+    const tileWithNoSharedModel = importV2Component({
+      v2Component: v2Document.components[0],
+      v2Document,
+      insertTile: mockInsertTile
+    })
+    expect(tileWithNoSharedModel).toBeUndefined()
+  })
+})

--- a/v3/src/components/slider/slider-registration.ts
+++ b/v3/src/components/slider/slider-registration.ts
@@ -1,18 +1,40 @@
+import { NumericAxisModel } from "../axis/models/axis-model"
+import { GlobalValue } from "../../models/global/global-value"
+import { IGlobalValueManager, kGlobalValueManagerType } from "../../models/global/global-value-manager"
+import { ISharedModelManager } from "../../models/shared/shared-model-manager"
+import { TileModel } from "../../models/tiles/tile-model"
 import { registerTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { registerTileContentInfo } from "../../models/tiles/tile-content-info"
+import { typedId } from "../../utilities/js-utils"
+import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
+import { isV2SliderComponent } from "../../v2/codap-v2-types"
 import { SliderComponent } from "./slider-component"
 import { kSliderTileType, kSliderTileClass } from "./slider-defs"
 import { SliderModel } from "./slider-model"
 import { SliderTitleBar } from "./slider-title-bar"
+import { AnimationDirections, AnimationModes, kDefaultAnimationDirection, kDefaultAnimationMode } from "./slider-types"
 import SliderIcon from '../../assets/icons/icon-slider.svg'
+
+export const kSliderIdPrefix = "SLID"
+
+function getGlobalValueManager(sharedModelManager?: ISharedModelManager) {
+  const sharedModels = sharedModelManager?.getSharedModelsByType(kGlobalValueManagerType)
+  return sharedModels?.[0] as IGlobalValueManager | undefined
+}
 
 registerTileContentInfo({
   type: kSliderTileType,
-  prefix: "SLID",
+  prefix: kSliderIdPrefix,
   modelClass: SliderModel,
-  // TODO: deal with auto-incrementing global value names for uniqueness
-  defaultContent: () => SliderModel.create({ direction: "loToHigh", repetition: "once",
-                                              globalValue: { name: "v1", value: 0.5 }})
+  defaultContent: options => {
+    // create and register the global value along with the slider
+    const sharedModelManager = options?.env?.sharedModelManager
+    const globalValueManager = getGlobalValueManager(sharedModelManager)
+    const name = globalValueManager?.uniqueName() || "v1"
+    const globalValue = GlobalValue.create({ name, value: 0.5 })
+    globalValueManager?.addValue(globalValue)
+    return SliderModel.create({ globalValue: globalValue.id })
+  }
 })
 
 registerTileComponentInfo({
@@ -23,4 +45,45 @@ registerTileComponentInfo({
   Icon: SliderIcon,
   defaultWidth: 300,
   isFixedHeight: true
+})
+
+registerV2TileImporter("DG.SliderView", ({ v2Component, v2Document, sharedModelManager, insertTile }) => {
+  if (!isV2SliderComponent(v2Component)) return
+
+  const globalValueManager = getGlobalValueManager(sharedModelManager)
+  if (!sharedModelManager || !globalValueManager) return
+
+  // parse the v2 content
+  const {
+    title = "", _links_, lowerBound, upperBound, animationDirection, animationMode,
+    restrictToMultiplesOf, maxPerSecond, userTitle, userSetTitle
+  } = v2Component.componentStorage
+  const globalId = _links_.model.id
+  const v2Global = v2Document.globalValues.find(_global => _global.guid === globalId)
+  if (!v2Global) return
+
+  // create global value and add to manager
+  const { guid, ...globalSnap } = v2Global
+  const globalValue = GlobalValue.create({ ...globalSnap })
+  globalValueManager.addValue(globalValue)
+  // create slider model
+  const slider = SliderModel.create({
+    globalValue: globalValue.id,
+    multipleOf: restrictToMultiplesOf ?? undefined,
+    animationDirection: AnimationDirections[animationDirection] || kDefaultAnimationDirection,
+    animationMode: AnimationModes[animationMode] || kDefaultAnimationMode,
+    _animationRate: maxPerSecond ?? undefined,
+    axis: NumericAxisModel.create({ place: "bottom", min: lowerBound ?? 0, max: upperBound ?? 12 })
+  })
+  // create and insert tile
+  const sliderTile = TileModel.create({
+    id: typedId(kSliderIdPrefix),
+    title: title && (userTitle || userSetTitle) ? title : undefined,
+    content: slider
+  })
+  insertTile(sliderTile)
+
+  // link tile to global value manager
+  sharedModelManager.addTileSharedModel(sliderTile.content, globalValueManager)
+  return sliderTile
 })

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -40,7 +40,7 @@ export const CodapSliderThumb = observer(function CodapSliderThumb({sliderContai
       if ((containerX != null) && isDragging) {
         const pixelTarget = e.clientX + downOffset.current
         const scaledValue = scale.invert(pixelTarget - containerX)
-        sliderModel.setValueRoundedToMultipleOf(scaledValue)
+        sliderModel.setValue(scaledValue)
       }
       e.preventDefault()
       e.stopImmediatePropagation()

--- a/v3/src/components/slider/slider-title-bar.tsx
+++ b/v3/src/components/slider/slider-title-bar.tsx
@@ -5,9 +5,11 @@ import { ComponentTitleBar  } from "../component-title-bar"
 import t from "../../utilities/translation/translate"
 import MinimizeIcon from "../../assets/icons/icon-minimize.svg"
 import { ITileTitleBarProps } from "../tiles/tile-base-props"
+import { isSliderModel } from "./slider-model"
 
 export const SliderTitleBar = observer(function SliderTitleBar({ tile, onCloseTile }: ITileTitleBarProps) {
-  const title = tile?.title || t("DG.DocumentController.sliderTitle")
+  const sliderModel = isSliderModel(tile?.content) ? tile?.content : undefined
+  const title = tile?.title || sliderModel?.name || t("DG.DocumentController.sliderTitle")
   const tileId = tile?.id || ""
   const tileType = tile?.content.type
   return (

--- a/v3/src/components/slider/slider-types.ts
+++ b/v3/src/components/slider/slider-types.ts
@@ -7,3 +7,15 @@ export const kDefaultSliderHeight = 200
 export const kDefaultSliderAxisTop = 0
 export const kDefaultSliderAxisHeight = 24
 export const kDefaultSliderPadding = 10
+
+// values are translation string keys; indices are v2 values
+export const AnimationDirections = ["backAndForth", "lowToHigh", "highToLow"] as const
+export type AnimationDirection = typeof AnimationDirections[number]
+export const kDefaultAnimationDirection = "lowToHigh"
+
+// values are translation string keys; indices are v2 values
+export const AnimationModes = ["nonStop", "onceOnly"] as const
+export type AnimationMode = typeof AnimationModes[number]
+export const kDefaultAnimationMode = "onceOnly"
+
+export const kDefaultAnimationRate = 20 // frames/second

--- a/v3/src/components/slider/slider.scss
+++ b/v3/src/components/slider/slider.scss
@@ -1,18 +1,18 @@
 @import "./../vars.scss";
 
-$pseudo-inspector-width: 40px;
+$slider-component-height: 98px;
 
 .slider-wrapper {
   position: relative;
   overflow: clip;
-  height: calc(100% - $title-bar-height);
+  height: calc($slider-component-height - $title-bar-height);
   background: #fff;
   border-radius: $border-radius-bottom-corners;
 
   .slider {
     button svg, .thumb-icon {
-      width:27px;
-      height:27px;
+      width: 27px;
+      height: 27px;
     }
 
     .thumb-icon {
@@ -47,10 +47,10 @@ $pseudo-inspector-width: 40px;
 
     .slider-thumb-icon {
       position: absolute;
-      top: 60px;
+      top: 42px;
 
       &.dragging {
-        top: 59px;
+        top: 41px;
         filter: drop-shadow(3px 1px 1px #555);
       }
     }

--- a/v3/src/hooks/use-data-set.ts
+++ b/v3/src/hooks/use-data-set.ts
@@ -1,15 +1,14 @@
-import { getEnv } from "mobx-state-tree"
 import { IDataSet } from "../models/data/data-set"
 import { ISharedCaseMetadata, kSharedCaseMetadataType } from "../models/shared/shared-case-metadata"
-import { ITileEnvironment } from "../models/tiles/tile-content"
+import { getSharedModelManager } from "../models/tiles/tile-environment"
 import { useDataSetContext } from "./use-data-set-context"
 
 export function useDataSet(inData?: IDataSet, inMetadata?: ISharedCaseMetadata) {
   const _data = useDataSetContext()
   const data = inData ?? _data
   // find the metadata that corresponds to this DataSet
-  const env: ITileEnvironment | undefined = data ? getEnv(data) : undefined
-  const metadata = inMetadata ?? env?.sharedModelManager
+  const sharedModelManager = getSharedModelManager(data)
+  const metadata = inMetadata ?? sharedModelManager
                                   ?.getSharedModelsByType(kSharedCaseMetadataType)
                                   .find((model: ISharedCaseMetadata) => {
                                     return model.data?.id === data?.id

--- a/v3/src/models/app-state.ts
+++ b/v3/src/models/app-state.ts
@@ -7,12 +7,11 @@
   generally be MobX-observable.
  */
 import { action, computed, makeObservable, observable } from "mobx"
-import { getEnv } from "mobx-state-tree"
 import { createCodapDocument } from "./codap/create-codap-document"
 import { gDataBroker } from "./data/data-broker"
 import { IDocumentModel, IDocumentModelSnapshot } from "./document/document"
 import { ISharedDataSet, kSharedDataSetType } from "./shared/shared-data-set"
-import { ITileEnvironment } from "./tiles/tile-content"
+import { getSharedModelManager } from "./tiles/tile-environment"
 
 type AppMode = "normal" | "performance"
 
@@ -48,8 +47,7 @@ class AppState {
         gDataBroker.clear()
 
         // update data broker with the new data sets
-        const env: ITileEnvironment | undefined = getEnv(document)
-        const manager = env?.sharedModelManager
+        const manager = getSharedModelManager(document)
         manager?.getSharedModelsByType(kSharedDataSetType).forEach((model: ISharedDataSet) => {
           gDataBroker.addSharedDataSet(model)
         })

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -8,14 +8,16 @@ import { appState } from "../app-state"
 import { IFreeTileInRowOptions } from "../document/free-tile-row"
 import { IMosaicTileInRowOptions, isMosaicTileRow } from "../document/mosaic-tile-row"
 import { getTileContentInfo } from "../tiles/tile-content-info"
+import { getTileEnvironment } from "../tiles/tile-environment"
 import { TileModel } from "../tiles/tile-model"
 
 type ILayoutOptions = IFreeTileInRowOptions | IMosaicTileInRowOptions | undefined
 
 export function createDefaultTileOfType(tileType: string) {
+  const env = getTileEnvironment(appState.document)
   const info = getTileContentInfo(tileType)
   const id = typedId(info?.prefix || "TILE")
-  const content = info?.defaultContent()
+  const content = info?.defaultContent({ env })
   return content ? TileModel.create({ id, content }) : undefined
 }
 

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -34,6 +34,20 @@ describe("createCodapDocument", () => {
     })
   })
 
+  it("creates an empty document with mosaic layout", () => {
+    const doc = createCodapDocument(undefined, "mosaic")
+    expect(doc.key).toBe("test-1")
+    expect(doc.type).toBe("CODAP")
+    expect(omitUndefined(getSnapshot(doc.content!))).toEqual({
+      rowMap: { "test-3": { id: "test-3", type: "mosaic", nodes: {}, root: "", tiles: {} } },
+      rowOrder: ["test-3"],
+      sharedModelMap: {
+        "test-2": { sharedModel: { id: "test-2", type: "GlobalValueManager", globals: {} }, tiles: [] }
+      },
+      tileMap: {}
+    })
+  })
+
   it("DataBroker adds a DataSet to the document as a shared model", () => {
     const doc = createCodapDocument()
     const manager = getSharedModelManager(doc)

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -1,11 +1,10 @@
-import { getEnv, getSnapshot } from "mobx-state-tree"
+import { getSnapshot } from "mobx-state-tree"
 import { omitUndefined } from "../../test/test-utils"
 import { gDataBroker } from "../data/data-broker"
 import { DataSet, toCanonical } from "../data/data-set"
-import { ITileEnvironment } from "../tiles/tile-content"
 import { createCodapDocument } from "./create-codap-document"
-import { ISharedModelDocumentManager } from "../document/shared-model-document-manager"
 import { ISharedDataSet } from "../shared/shared-data-set"
+import { getSharedModelManager } from "../tiles/tile-environment"
 import "../shared/shared-case-metadata-registration"
 import "../shared/shared-data-set-registration"
 
@@ -26,23 +25,25 @@ describe("createCodapDocument", () => {
     expect(doc.key).toBe("test-1")
     expect(doc.type).toBe("CODAP")
     expect(omitUndefined(getSnapshot(doc.content!))).toEqual({
-      rowMap: { "test-2": { id: "test-2", type: "free", order: [], tiles: {} } },
-      rowOrder: ["test-2"],
-      sharedModelMap: {},
+      rowMap: { "test-3": { id: "test-3", type: "free", order: [], tiles: {} } },
+      rowOrder: ["test-3"],
+      sharedModelMap: {
+        "test-2": { sharedModel: { id: "test-2", type: "GlobalValueManager", globals: {} }, tiles: [] }
+      },
       tileMap: {}
     })
   })
 
   it("DataBroker adds a DataSet to the document as a shared model", () => {
     const doc = createCodapDocument()
-    const manager = getEnv<ITileEnvironment>(doc).sharedModelManager as ISharedModelDocumentManager
+    const manager = getSharedModelManager(doc)
     const data = DataSet.create()
     data.addAttribute({ name: "a" })
     data.addCases(toCanonical(data, [{ a: "1" }, { a: "2" }, { a: "3" }]))
-    gDataBroker.setSharedModelManager(manager)
-    gDataBroker.addDataSet(data)
+    gDataBroker.setSharedModelManager(manager!)
+    const { sharedData, caseMetadata } = gDataBroker.addDataSet(data)
 
-    const entry = doc.content?.sharedModelMap.get("test-9")
+    const entry = doc.content?.sharedModelMap.get(sharedData.id)
     const sharedModel = entry?.sharedModel as ISharedDataSet | undefined
     // the DataSet is not copied -- it's a single instance
     expect(data).toBe(gDataBroker.last)
@@ -55,40 +56,44 @@ describe("createCodapDocument", () => {
 
     // the resulting document content contains the contents of the DataSet
     expect(snapContent).toEqual({
-      rowMap: { "test-2": { id: "test-2", type: "free", order: [], tiles: {} } },
-      rowOrder: ["test-2"],
+      rowMap: { "test-3": { id: "test-3", type: "free", order: [], tiles: {} } },
+      rowOrder: ["test-3"],
       sharedModelMap: {
-        "test-9": {
+        "test-2": {
+          sharedModel: { id: "test-2", type: "GlobalValueManager", globals: {} },
+          tiles: []
+        },
+        [sharedData.id]: {
           sharedModel: {
             dataSet: {
               attributes: [{
                 clientKey: "",
                 formula: {},
-                id: "test-5",
+                id: "test-6",
                 name: "a",
                 title: "",
                 editable: true,
                 values: ["1", "2", "3"]
               }],
-              cases: [{ __id__: "CASEorder-6" }, { __id__: "CASEorder-7" }, { __id__: "CASEorder-8" }],
+              cases: [{ __id__: "CASEorder-7" }, { __id__: "CASEorder-8" }, { __id__: "CASEorder-9" }],
               collections: [],
-              ungrouped: { id: "test-4", name: "", title: "" },
-              id: "test-3",
+              ungrouped: { id: "test-5", name: "", title: "" },
+              id: "test-4",
               snapSelection: []
             },
-            id: "test-9",
+            id: sharedData.id,
             providerId: "",
             type: "SharedDataSet"
           },
           tiles: []
         },
-        "test-12": {
+        [caseMetadata.id]: {
           sharedModel: {
             collections: {},
             columnWidths: {},
-            data: "test-3",
+            data: "test-4",
             hidden: {},
-            id: "test-12",
+            id: caseMetadata.id,
             type: "SharedCaseMetadata"
           },
           tiles: []

--- a/v3/src/models/codap/create-codap-document.ts
+++ b/v3/src/models/codap/create-codap-document.ts
@@ -1,4 +1,4 @@
-import { getEnv, getSnapshot } from "mobx-state-tree"
+import { getSnapshot } from "mobx-state-tree"
 import { urlParams } from "../../utilities/url-params"
 import { createDocumentModel } from "../document/create-document-model"
 import { IDocumentModel, IDocumentModelSnapshot } from "../document/document"
@@ -7,21 +7,24 @@ import { FreeTileRow } from "../document/free-tile-row"
 import { MosaicTileRow } from "../document/mosaic-tile-row"
 import build from "../../../build_number.json"
 import pkg from "../../../package.json"
-import { ITileEnvironment } from "../tiles/tile-content"
+import { GlobalValueManager } from "../global/global-value-manager"
+import "../global/global-value-manager-registration"
 const { version } = pkg
 const { buildNumber } = build
 
 export function createCodapDocument(snapshot?: IDocumentModelSnapshot, layout?: "free" | "mosaic"): IDocumentModel {
   const document = createDocumentModel({ type: "CODAP", version, build: `${buildNumber}`, ...snapshot })
+  // create the content if there isn't any
   if (!document.content) {
     document.setContent(getSnapshot(DocumentContentModel.create()))
   }
+  // add the global value manager if there isn't one
+  if (!document.content?.getFirstSharedModelByType(GlobalValueManager)) {
+    document.content?.addSharedModel(GlobalValueManager.create())
+  }
+  // create the default tile container ("row")
   if (document.content?.rowCount === 0) {
     const isMosaicLayout = layout === "mosaic" || urlParams.layout === "mosaic"
-    // CODAP v2/v3 documents have a single "row" containing all tiles/components
-    // const rowCreator = () => FreeTileRow.create()
-    // But for now we use a mosaic to preserve the current dashboard behavior until
-    // we have the ability to create/move components.
     const rowCreator = isMosaicLayout
                         ? () => MosaicTileRow.create()
                         : () => FreeTileRow.create()
@@ -31,9 +34,4 @@ export function createCodapDocument(snapshot?: IDocumentModelSnapshot, layout?: 
     document.content.setVisibleRows([row.id])
   }
   return document
-}
-
-export function getTileEnvironment(document: IDocumentModel) {
-  const env: ITileEnvironment | undefined = getEnv(document)
-  return env
 }

--- a/v3/src/models/codap/create-codap-document.ts
+++ b/v3/src/models/codap/create-codap-document.ts
@@ -19,8 +19,8 @@ export function createCodapDocument(snapshot?: IDocumentModelSnapshot, layout?: 
     document.setContent(getSnapshot(DocumentContentModel.create()))
   }
   // add the global value manager if there isn't one
-  if (!document.content?.getFirstSharedModelByType(GlobalValueManager)) {
-    document.content?.addSharedModel(GlobalValueManager.create())
+  if (document.content && !document.content.getFirstSharedModelByType(GlobalValueManager)) {
+    document.content.addSharedModel(GlobalValueManager.create())
   }
   // create the default tile container ("row")
   if (document.content?.rowCount === 0) {

--- a/v3/src/models/data/data-broker.ts
+++ b/v3/src/models/data/data-broker.ts
@@ -3,6 +3,8 @@ import { ISharedCaseMetadata, SharedCaseMetadata } from "../shared/shared-case-m
 import { ISharedDataSet, SharedDataSet } from "../shared/shared-data-set"
 import { ISharedModelManager } from "../shared/shared-model-manager"
 import { IDataSet } from "./data-set"
+import "../shared/shared-data-set-registration"
+import "../shared/shared-case-metadata-registration"
 
 export interface IDataSetSummary {
   id: string;
@@ -82,6 +84,8 @@ export class DataBroker {
 
     !this.allowMultiple && this.dataSets.clear()
     this.addSharedDataSet(sharedModel)
+
+    return { sharedData: sharedModel, caseMetadata }
   }
 
   @action

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -1,5 +1,5 @@
 import { addDisposer, onAction } from "mobx-state-tree"
-import { ITileEnvironment } from "../tiles/tile-content"
+import { ITileEnvironment } from "../tiles/tile-environment"
 import { DocumentModel, IDocumentModelSnapshot } from "./document"
 import { IDocumentEnvironment } from "./document-environment"
 import { SharedModelDocumentManager } from "./shared-model-document-manager"

--- a/v3/src/models/document/document.test.ts
+++ b/v3/src/models/document/document.test.ts
@@ -1,10 +1,7 @@
-import { registerTileTypes } from "../../register-tile-types"
 import { ITestTileContent, TestTileContent } from "../../test/test-tile-content"
 import { createSingleTileContent } from "../../test/test-utils"
 import { createDocumentModel } from "./create-document-model"
 import { IDocumentModel } from "./document"
-
-registerTileTypes(["Test"])
 
 describe("document model", () => {
   let document: IDocumentModel

--- a/v3/src/models/document/document.ts
+++ b/v3/src/models/document/document.ts
@@ -1,8 +1,8 @@
-import { addDisposer, applySnapshot, destroy, getEnv, Instance, SnapshotIn, types } from "mobx-state-tree"
+import { addDisposer, applySnapshot, destroy, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { Tree } from "../history/tree"
 import { TreeManager } from "../history/tree-manager"
 import { TreeMonitor } from "../history/tree-monitor"
-import { ITileEnvironment } from "../tiles/tile-content"
+import { getSharedModelManager } from "../tiles/tile-environment"
 import { ITileModel } from "../tiles/tile-model"
 import { DocumentContentModel, IDocumentContentSnapshotIn } from "./document-content"
 import { IDocumentMetadata } from "./document-metadata"
@@ -88,9 +88,8 @@ export const DocumentModel = Tree.named("Document")
       }
       else {
         self.content = DocumentContentModel.create(snapshot)
-        const env: ITileEnvironment = getEnv(self)
-        const sharedModelManager = env.sharedModelManager
-        ;(sharedModelManager as ISharedModelDocumentManager).setDocument(self.content)
+        const sharedModelManager = getSharedModelManager(self)
+        ;(sharedModelManager as ISharedModelDocumentManager)?.setDocument(self.content)
       }
     },
 

--- a/v3/src/models/document/shared-model-document-manager.test.ts
+++ b/v3/src/models/document/shared-model-document-manager.test.ts
@@ -1,4 +1,4 @@
-import { destroy, Instance, types, getEnv, flow, SnapshotIn } from "mobx-state-tree"
+import { destroy, Instance, types, flow, SnapshotIn } from "mobx-state-tree"
 import { when } from "mobx"
 import { ITileBaseProps } from "../../components/tiles/tile-base-props"
 import { SharedModel, ISharedModel } from "../shared/shared-model"
@@ -6,10 +6,10 @@ import { SharedModelDocumentManager } from "./shared-model-document-manager"
 import { registerSharedModelInfo } from "../shared/shared-model-registry"
 import { registerTileComponentInfo } from "../tiles/tile-component-info"
 import { registerTileContentInfo } from "../tiles/tile-content-info"
-import { ITileEnvironment, TileContentModel } from "../tiles/tile-content"
+import { TileContentModel } from "../tiles/tile-content"
+import { getSharedModelManager } from "../tiles/tile-environment"
 import { createDocumentModel } from "./create-document-model"
 import { DocumentContentModel } from "./document-content"
-import { IDocumentModel } from "./document"
 import { TileModel } from "../tiles/tile-model"
 import { LegacyTileRowModel } from "./legacy-tile-row"
 
@@ -249,7 +249,7 @@ describe("SharedModelDocumentManager", () => {
 
     const manager = getSharedModelManager(docModel)
     const sharedModel = TestSharedModel.create({})
-    manager.addTileSharedModel(tileContent, sharedModel)
+    manager!.addTileSharedModel(tileContent, sharedModel)
 
     // The update function should be called right after it is added
     await expectUpdateToBeCalledTimes(tileContent, 1)
@@ -282,7 +282,7 @@ describe("SharedModelDocumentManager", () => {
     await expectUpdateToBeCalledTimes(tileContent, 0)
 
     const manager = getSharedModelManager(docModel)
-    manager.addTileSharedModel(tileContent, sharedModel)
+    manager!.addTileSharedModel(tileContent, sharedModel)
 
     // The update function should be called right after it is added
     await expectUpdateToBeCalledTimes(tileContent, 1)
@@ -523,7 +523,7 @@ describe("SharedModelDocumentManager", () => {
     const sharedModel = TestSharedModel.create({})
 
     // Add to the first tile (and document)
-    manager.addTileSharedModel(tileContent1, sharedModel)
+    manager!.addTileSharedModel(tileContent1, sharedModel)
     const sharedModelEntry = doc.sharedModelMap.get(sharedModel.id)
     expect(sharedModelEntry?.tiles[0]?.id).toBe("t1")
 
@@ -537,7 +537,7 @@ describe("SharedModelDocumentManager", () => {
     await expectUpdateToBeCalledTimes(tileContent2, 0)
 
     // Add to the second tile
-    manager.addTileSharedModel(tileContent2, sharedModel)
+    manager!.addTileSharedModel(tileContent2, sharedModel)
     expect(doc.sharedModelMap.get(sharedModel.id)).toBe(sharedModelEntry)
     expect(sharedModelEntry?.tiles[0]?.id).toBe("t1")
     expect(sharedModelEntry?.tiles[1]?.id).toBe("t2")
@@ -618,7 +618,7 @@ describe("SharedModelDocumentManager", () => {
 
     const manager = getSharedModelManager(docModel)
     const sharedModel1 = TestSharedModel.create({})
-    manager.addTileSharedModel(tileContent, sharedModel1)
+    manager!.addTileSharedModel(tileContent, sharedModel1)
 
     // The update function should be called right after it is added
     await expectUpdateToBeCalledTimes(tileContent, 1)
@@ -628,7 +628,7 @@ describe("SharedModelDocumentManager", () => {
     await expectUpdateToBeCalledTimes(tileContent, 2)
 
     const sharedModel2 = TestSharedModel.create({})
-    manager.addTileSharedModel(tileContent, sharedModel2)
+    manager!.addTileSharedModel(tileContent, sharedModel2)
 
     // The update function should be called right after second model is added
     await expectUpdateToBeCalledTimes(tileContent, 3)
@@ -888,9 +888,4 @@ describe("SharedModelDocumentManager", () => {
 async function expectUpdateToBeCalledTimes(testTile: TestTileType, times: number) {
   const updateCalledTimes = when(() => testTile.updateCount === times, {timeout: 100})
   return expect(updateCalledTimes).resolves.toBeUndefined()
-}
-
-function getSharedModelManager(docModel: IDocumentModel) {
-  const env: ITileEnvironment = getEnv(docModel)
-  return env.sharedModelManager!
 }

--- a/v3/src/models/global/global-value-manager-registration.ts
+++ b/v3/src/models/global/global-value-manager-registration.ts
@@ -1,0 +1,7 @@
+import { registerSharedModelInfo } from "../shared/shared-model-registry"
+import { GlobalValueManager, kGlobalValueManagerType } from "./global-value-manager"
+
+registerSharedModelInfo({
+  type: kGlobalValueManagerType,
+  modelClass: GlobalValueManager
+})

--- a/v3/src/models/global/global-value-manager.test.ts
+++ b/v3/src/models/global/global-value-manager.test.ts
@@ -1,0 +1,35 @@
+import { GlobalValue } from "./global-value"
+import { GlobalValueManager } from "./global-value-manager"
+
+describe("GlobalValueManager", () => {
+  it("works as expected", () => {
+    const m = GlobalValueManager.create()
+    expect(m.globals.size).toBe(0)
+    const v = GlobalValue.create({ name: m.uniqueName(), value: 1 })
+    expect(v.name).toBe("v1")
+    expect(v.value).toBe(1)
+    m.addValue(v)
+    expect(m.globals.size).toBe(1)
+    expect(m.getValueById("foo")).toBeUndefined()
+    expect(m.getValueById(v.id)).toBe(v)
+    expect(m.getValueByName("foo")).toBeUndefined()
+    expect(m.getValueByName("v1")).toBe(v)
+    v.setName(m.uniqueName())
+    expect(v.name).toBe("v2")
+    expect(m.getValueByName("v1")).toBeUndefined()
+    expect(m.getValueByName("v2")).toBe(v)
+    v.setValue(2)
+    expect(v.value).toBe(2)
+
+    const v2 = GlobalValue.create({ name: "v2", value: 0 })
+    jestSpyConsole("warn", spy => {
+      m.addValue(v2)
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+    expect(m.globals.size).toBe(2)
+
+    m.removeValue(v)
+    expect(m.globals.size).toBe(1)
+    expect(m.getValueByName("v2")).toBe(v2)
+  })
+})

--- a/v3/src/models/global/global-value-manager.ts
+++ b/v3/src/models/global/global-value-manager.ts
@@ -1,0 +1,54 @@
+import { Instance, types } from "mobx-state-tree"
+import { SharedModel } from "../shared/shared-model"
+import { GlobalValue, IGlobalValue, kDefaultNamePrefix } from "./global-value"
+
+export const kGlobalValueManagerType = "GlobalValueManager"
+
+// manages all of the global values in a document
+export const GlobalValueManager = SharedModel
+.named("GlobalValueManager")
+.props({
+  type: types.optional(types.literal(kGlobalValueManagerType), kGlobalValueManagerType),
+  globals: types.map(GlobalValue)
+})
+.views(self => ({
+  get nameMap() {
+    const names: Record<string, IGlobalValue> = {}
+    self.globals.forEach(global => {
+      names[global.name] = global
+    })
+    return names
+  }
+}))
+.views(self => ({
+  getValueById(id: string): IGlobalValue | undefined {
+    return self.globals.get(id)
+  },
+  getValueByName(name: string): IGlobalValue | undefined {
+    return self.nameMap[name]
+  }
+}))
+.views(self => ({
+  // returns a unique name within the context of the manager (e.g. a document)
+  uniqueName(prefix = kDefaultNamePrefix) {
+    let counter = 0
+    let name
+    do {
+      ++counter
+      name = prefix + counter
+    } while (self.getValueByName(name))
+    return name
+  }
+}))
+.actions(self => ({
+  addValue(global: IGlobalValue) {
+    if (self.getValueByName(global.name)) {
+      console.warn(`GlobalValueManager: Adding global value with conflicting name: ${global.name}`)
+    }
+    self.globals.put(global)
+  },
+  removeValue(global: IGlobalValue) {
+    self.globals.delete(global.id)
+  }
+}))
+export interface IGlobalValueManager extends Instance<typeof GlobalValueManager> {}

--- a/v3/src/models/global/global-value.ts
+++ b/v3/src/models/global/global-value.ts
@@ -1,6 +1,9 @@
 import {Instance, types} from "mobx-state-tree"
 import { typedId } from "../../utilities/js-utils"
 
+export const kDefaultNamePrefix = "v"
+
+// represents a globally accessible value, such as the value of a slider
 export const GlobalValue = types.model("GlobalValue", {
     id: types.optional(types.identifier, () => typedId("GLOB")),
     name: types.string,

--- a/v3/src/models/tiles/tile-content-info.ts
+++ b/v3/src/models/tiles/tile-content-info.ts
@@ -1,8 +1,11 @@
 import { ITileMetadataModel, TileMetadataModel } from "./tile-metadata"
 import { TileContentModel, ITileContentModel } from "./tile-content"
 import { AppConfigModelType } from "../stores/app-config-model"
+import { ITileEnvironment } from "./tile-environment"
 
 export interface IDefaultContentOptions {
+  // environment in which the tile will be created
+  env?: ITileEnvironment;
   // title is only currently used by the Geometry and Table tiles
   title?: string;
   // url is added so the CLUE core can add an image tile to the document when a user

--- a/v3/src/models/tiles/tile-content.ts
+++ b/v3/src/models/tiles/tile-content.ts
@@ -1,12 +1,8 @@
-import { getEnv, getSnapshot, Instance, types } from "mobx-state-tree"
+import { getSnapshot, Instance, types } from "mobx-state-tree"
 import { ISharedModel } from "../shared/shared-model"
-import { ISharedModelManager } from "../shared/shared-model-manager"
+import { getTileEnvironment, ITileEnvironment } from "./tile-environment"
 import { tileModelHooks } from "./tile-model-hooks"
 import { kUnknownTileType } from "./unknown-types"
-
-export interface ITileEnvironment {
-  sharedModelManager?: ISharedModelManager;
-}
 
 // Generic "super class" of all tile content models
 export const TileContentModel = types.model("TileContentModel", {
@@ -38,7 +34,7 @@ export const TileContentModel = types.model("TileContentModel", {
   })
   .views(self => ({
     get tileEnv(): ITileEnvironment | undefined {
-      return getEnv(self)
+      return getTileEnvironment(self)
     },
     // Override in specific tile content model when external data (like from SharedModels) is needed when copying
     get tileSnapshotForCopy() {

--- a/v3/src/models/tiles/tile-environment.ts
+++ b/v3/src/models/tiles/tile-environment.ts
@@ -1,0 +1,14 @@
+import { getEnv, IAnyStateTreeNode } from "mobx-state-tree"
+import { ISharedModelManager } from "../shared/shared-model-manager"
+
+export interface ITileEnvironment {
+  sharedModelManager?: ISharedModelManager;
+}
+
+export function getTileEnvironment(node?: IAnyStateTreeNode) {
+  return node ? getEnv<ITileEnvironment | undefined>(node) : undefined
+}
+
+export function getSharedModelManager(node?: IAnyStateTreeNode) {
+  return getTileEnvironment(node)?.sharedModelManager
+}

--- a/v3/src/v2/codap-v2-tile-importers.ts
+++ b/v3/src/v2/codap-v2-tile-importers.ts
@@ -16,7 +16,7 @@ export interface V2TileImportArgs {
   // function to call to insert the imported tile into the document
   insertTile: (tile: ITileModel) => void
 }
-export type V2TileImportFn = (args: V2TileImportArgs) => void
+export type V2TileImportFn = (args: V2TileImportArgs) => ITileModel | undefined
 
 // map from v2 component type to import function
 const gV2TileImporters = new Map<string, V2TileImportFn>()

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -76,7 +76,10 @@ export interface ICodapV2DataContext {
 }
 
 export interface ICodapV2GlobalValue {
-
+  // from DG.GlobalValue.toArchive
+  name: string
+  value: number
+  guid: number
 }
 
 export interface IGuidLink<T extends string> {
@@ -85,8 +88,27 @@ export interface IGuidLink<T extends string> {
 }
 
 export interface ICodapV2CalculatorStorage {
+  // from DG.Component.toArchive
   title: string
   name: string
+  userSetTitle: boolean
+  cannotClose: boolean
+}
+
+export interface ICodapV2SliderStorage {
+  // from SliderController.createComponentStorage
+  _links_: {
+    model: IGuidLink<"DG.GlobalValue">
+  },
+  lowerBound?: number
+  upperBound?: number
+  animationDirection: number
+  animationMode: number
+  restrictToMultiplesOf: number | null
+  maxPerSecond: number | null
+  userTitle: boolean
+  // from DG.Component.toArchive
+  title: string
   userSetTitle: boolean
   cannotClose: boolean
 }
@@ -149,6 +171,7 @@ export interface ICodapV2GuideStorage {
 export interface ICodapV2BaseComponent {
   type: string  // e.g. "DG.TableView", "DG.GraphView", "DG.GuideView", etc.
   guid: number
+  id: number
   componentStorage: Record<string, any>
   layout: {
     width: number
@@ -168,6 +191,12 @@ export interface ICodapV2CalculatorComponent extends ICodapV2BaseComponent {
 export const isV2CalculatorComponent = (component: ICodapV2BaseComponent): component is ICodapV2CalculatorComponent =>
   component.type === "DG.Calculator"
 
+export interface ICodapV2SliderComponent extends ICodapV2BaseComponent {
+  type: "DG.SliderView",
+  componentStorage: ICodapV2SliderStorage
+}
+export const isV2SliderComponent = (component: ICodapV2BaseComponent): component is ICodapV2SliderComponent =>
+  component.type === "DG.SliderView"
 export interface ICodapV2TableComponent extends ICodapV2BaseComponent {
   type: "DG.TableView"
   componentStorage: ICodapV2TableStorage

--- a/v3/src/v2/slider.codap
+++ b/v3/src/v2/slider.codap
@@ -1,0 +1,55 @@
+{
+  "name": "slider",
+  "guid": 1,
+  "id": 1,
+  "components": [
+    {
+      "type": "DG.SliderView",
+      "guid": 3,
+      "id": 3,
+      "componentStorage": {
+        "_links_": {
+          "model": {
+            "type": "DG.GlobalValue",
+            "id": 2
+          }
+        },
+        "lowerBound": -4.393617021276597,
+        "upperBound": 26.537806873977086,
+        "animationDirection": 1,
+        "animationMode": 1,
+        "restrictToMultiplesOf": null,
+        "maxPerSecond": null,
+        "userTitle": true,
+        "title": "mySlider",
+        "userSetTitle": true,
+        "cannotClose": false
+      },
+      "layout": {
+        "width": 750,
+        "height": 98,
+        "zIndex": 105,
+        "left": 5,
+        "top": 5,
+        "isVisible": true,
+        "right": 755,
+        "bottom": 103
+      },
+      "savedHeight": null
+    }
+  ],
+  "contexts": [],
+  "globalValues": [
+    {
+      "name": "mine",
+      "value": 3.1415926,
+      "guid": 2
+    }
+  ],
+  "appName": "DG",
+  "appVersion": "2.0",
+  "appBuildNum": "0670",
+  "lang": "en",
+  "idCount": 3,
+  "metadata": {}
+}


### PR DESCRIPTION
- define new `GlobalValueManager`
- each document has a single `GlobalValueManager` instance
- each new slider creates a new `GlobalValue` and registers it with the `GlobalValueManager`
- `GlobalValueManager` is serialized with other shared models in the document
- v3 sliders import from v2 documents correctly
- cleaned up `SliderModel`
- added tests for calculator and slider tile imports
- re-enabled `case-table-component.test.ts`
- show slider name in title bar of slider component