### PR TITLE
feat: support category sets with user ordering

### DIFF
--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -103,6 +103,7 @@ describe("createCodapDocument", () => {
         },
         [caseMetadata.id]: {
           sharedModel: {
+            categories: {},
             collections: {},
             columnWidths: {},
             data: "test-4",

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -1,0 +1,114 @@
+import { types } from "mobx-state-tree"
+import { kellyColors } from "../../utilities/color-utils"
+import { Attribute, IAttribute } from "./attribute"
+import { CategorySet } from "./category-set"
+
+describe("CategorySet", () => {
+  const Tree = types.model("Tree", {
+    attribute: Attribute,
+    categories: CategorySet
+  })
+  .actions(self => ({
+    setAttribute(attr: IAttribute) {
+      self.attribute = attr
+    }
+  }))
+
+  it("constructs categories, allows them to be moved, and responds to changes", () => {
+    const a = Attribute.create({ name: "a", values: ["a", "b", "c", "a", "b", "c"] })
+    expect(a.strValues).toEqual(["a", "b", "c", "a", "b", "c"])
+    const tree = Tree.create({
+      attribute: a,
+      categories: { attribute: a.id }
+    })
+    const categories = tree.categories
+    const lastMove = () => categories.moves.at(-1)
+    const catKellyColors = () => categories.values.map(cat => categories.colorForCategory(cat))
+    const numKellyColors = (n: number) => kellyColors.slice(0, n)
+    expect(categories).toBeDefined()
+    expect(categories.values).toEqual(["a", "b", "c"])
+    expect(categories.index("foo")).toBeUndefined()
+    expect(categories.colorForCategory("foo")).toBeUndefined()
+    expect(catKellyColors()).toEqual(numKellyColors(3))
+    categories.move("c", "b") // ["a", "c", "b"]
+    expect(lastMove()).toEqual({ value: "c", fromIndex: 2, toIndex: 1, length: 3, after: "a", before: "b" })
+    expect(categories.values).toEqual(["a", "c", "b"])
+    expect(catKellyColors()).toEqual(numKellyColors(3))
+    categories.move("b", "a") // ["b", "a", "c"]
+    expect(lastMove()).toEqual({ value: "b", fromIndex: 2, toIndex: 0, length: 3, after: undefined, before: "a" })
+    expect(categories.values).toEqual(["b", "a", "c"])
+    expect(catKellyColors()).toEqual(numKellyColors(3))
+    categories.move("a") // ["b", "c", "a"]
+    expect(lastMove()).toEqual({ value: "a", fromIndex: 1, toIndex: 2, length: 3, after: "c", before: undefined })
+    expect(categories.values).toEqual(["b", "c", "a"])
+    expect(catKellyColors()).toEqual(numKellyColors(3))
+
+    // remove "b", so the "natural" order is ["a", "c", "b"]
+    a.removeValues(1, 1)
+    expect(categories.values).toEqual(["b", "c", "a"])
+    expect(catKellyColors()).toEqual(numKellyColors(3))
+    // remove the other "b", so the "natural" order is ["a", "c"]
+    a.removeValues(3, 1)
+    expect(categories.values).toEqual(["c", "a"])
+    expect(catKellyColors()).toEqual(numKellyColors(2))
+    // remove a's so the only category is "c"
+    a.removeValues(2, 1)
+    a.removeValues(0, 1)
+    expect(categories.values).toEqual(["c"])
+    expect(catKellyColors()).toEqual(numKellyColors(1))
+
+    // can't move a non-existent value
+    categories.move("b", "a")
+    expect(categories.moves.length).toBe(3)
+    expect(categories.values).toEqual(["c"])
+    expect(catKellyColors()).toEqual(numKellyColors(1))
+
+    // add values so the "natural" order is ["a", "x", "y", "z", "b", "c"]
+    a.addValues(["a", "x", "y", "z", "b"], 0)
+    expect(categories.values).toEqual(["b", "c", "a", "x", "y", "z"])
+    expect(catKellyColors()).toEqual(numKellyColors(6))
+
+    // specifying a bogus before value moves category to end
+    categories.move("c", "bogus")
+    expect(categories.values).toEqual(["b", "a", "x", "y", "z", "c"])
+    expect(catKellyColors()).toEqual(numKellyColors(6))
+
+    // moving to a position near the end works even if other values near the end are removed
+    categories.move("b", "c")
+    expect(categories.values).toEqual(["a", "x", "y", "z", "b", "c"])
+    expect(catKellyColors()).toEqual(numKellyColors(6))
+    // remove "c"s
+    a.removeValues(5, 2)
+    console.log(JSON.stringify(a.strValues))
+    expect(categories.values).toEqual(["a", "x", "y", "z", "b"])
+    expect(catKellyColors()).toEqual(numKellyColors(5))
+    categories.move("z", "a")
+    expect(categories.values).toEqual(["z", "a", "x", "y", "b"])
+    expect(catKellyColors()).toEqual(numKellyColors(5))
+    // remove "a"
+    a.removeValues(0, 1)
+    expect(categories.values).toEqual(["z", "x", "y", "b"])
+    expect(catKellyColors()).toEqual(numKellyColors(4))
+    categories.setColorForCategory("b", "red")
+    expect(catKellyColors()).toEqual([...numKellyColors(3), "red"])
+  })
+
+  it("supports callback on invalidation of attribute", () => {
+    const handleAttributeInvalidated = jest.fn()
+
+    // can destroy attribute without having set an invalidation handler
+    const a = Attribute.create({ name: "a" })
+    const aTree = Tree.create({ attribute: a, categories: { attribute: a.id } })
+    aTree.setAttribute(Attribute.create({ name: "b" }))
+    expect(handleAttributeInvalidated).not.toHaveBeenCalled()
+
+    // handler is called on attribute destruction if one has been specified
+    const c = Attribute.create({ name: "c" })
+    const cId = c.id
+    const cTree = Tree.create({ attribute: c, categories: { attribute: cId } })
+    cTree.categories.onAttributeInvalidated((attrId: string) => handleAttributeInvalidated(attrId))
+    cTree.setAttribute(Attribute.create({ name: "d" }))
+    expect(handleAttributeInvalidated).toHaveBeenCalledTimes(1)
+    expect(handleAttributeInvalidated).toHaveBeenCalledWith(cId)
+  })
+})

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -1,0 +1,182 @@
+import { addDisposer, Instance, isValidReference, onAction, types } from "mobx-state-tree"
+import { kellyColors } from "../../utilities/color-utils"
+import { Attribute } from "./attribute"
+
+interface ICategoryMove {
+  value: string     // category value
+  fromIndex: number // original index of category
+  toIndex: number   // new index of category
+  length: number    // number of categories at time of move
+  after?: string    // the category after which the current category was placed
+  before?: string   // the category before which the current category was placed
+}
+
+export const CategorySet = types.model("CategorySet", {
+  attribute: types.reference(Attribute, {
+    onInvalidated: ({ parent: self, invalidId }) => {
+      self.handleAttributeInvalidated?.(invalidId)
+    }
+  }),
+  // user color assignments
+  colors: types.map(types.string),
+  // user category re-orderings
+  moves: types.array(types.frozen<ICategoryMove>())
+})
+.volatile(self => ({
+  handleAttributeInvalidated: undefined as ((attrId: string) => void) | undefined
+}))
+.actions(self => ({
+  onAttributeInvalidated(handler: (attrId: string) => void) {
+    self.handleAttributeInvalidated = handler
+  }
+}))
+.extend(self => {
+  // map from category value to index
+  const _indexMap = new Map<string, number>()
+  let _values = [] as string[]
+  let _isValid = false
+
+  function rebuildIndexMap() {
+    _indexMap.clear()
+    _values.forEach((value, index) => {
+      _indexMap.set(value, index)
+    })
+  }
+
+  function moveValueToIndex(value: string, dstIndex: number) {
+    const valueIndex = _indexMap.get(value)
+    if (valueIndex != null && valueIndex !== dstIndex) {
+      const insertIndex = valueIndex < dstIndex ? dstIndex - 1 : dstIndex
+      // remove value from current position
+      _values.splice(valueIndex, 1)
+      // insert value in new position
+      _values.splice(insertIndex, 0, value)
+      // update the index map
+      rebuildIndexMap()
+    }
+  }
+
+  function refresh() {
+    if (!_isValid) {
+      _indexMap.clear()
+      _values = []
+
+      // build default category set order (order of occurrence)
+      // could default to alphameric sort order if desired instead
+      self.attribute.strValues.forEach(value => {
+        if (_indexMap.get(value) == null) {
+          _indexMap.set(value, _values.length)
+          _values.push(value)
+        }
+      })
+
+      // apply category moves
+      self.moves.forEach(move => {
+        const valueIndex = _indexMap.get(move.value)
+        // the value associated with this category move is no longer one of the categories
+        if (valueIndex == null) return
+
+        const afterIndex = move.after ? _indexMap.get(move.after) : undefined
+        const beforeIndex = move.before ? _indexMap.get(move.before) : undefined
+        // both neighboring categories still exist?
+        if ((afterIndex != null) && (beforeIndex != null)) {
+          // category is already (at least approximately) where it should be
+          if ((valueIndex >= afterIndex) && (valueIndex <= beforeIndex)) return
+
+          // move it next to the category closest to its original position
+          const moveRatio = move.toIndex / move.length
+          const afterRatio = (afterIndex + 1) / _values.length
+          const beforeRatio = beforeIndex / _values.length
+          const afterDistance = Math.abs(moveRatio - afterRatio)
+          const beforeDistance = Math.abs(moveRatio - beforeRatio)
+          const dstIndex = afterDistance < beforeDistance ? afterIndex + 1 : beforeIndex
+          moveValueToIndex(move.value, dstIndex)
+        }
+        else if (afterIndex != null) {
+          moveValueToIndex(move.value, afterIndex + 1)
+        }
+        else if (beforeIndex != null) {
+          moveValueToIndex(move.value, beforeIndex)
+        }
+        else {
+          // neither category neighbor still exists
+          const moveRatio = move.toIndex / move.length
+          // if it was moved near the beginning, put it at the beginning
+          if (moveRatio <= 0.2) {
+            moveValueToIndex(move.value, 0)
+          }
+          // if it was moved near the end, put it at the end
+          else if (moveRatio >= 0.8) {
+            moveValueToIndex(move.value, move.length - 1)
+          }
+          else {
+            // just punt for now
+          }
+        }
+      })
+
+      _isValid = true
+    }
+  }
+
+  return {
+    views: {
+      get values() {
+        refresh()
+        return _values
+      },
+      index(value: string) {
+        return _indexMap.get(value)
+      }
+    },
+    actions: {
+      invalidate() {
+        _isValid = false
+      }
+    }
+  }
+})
+.views(self => ({
+  colorForCategory(category: string) {
+    const userColor = self.colors.get(category)
+    const catIndex = self.index(category)
+    return userColor || (catIndex != null ? kellyColors[catIndex % kellyColors.length] : undefined)
+  }
+}))
+.actions(self => ({
+  afterAttach() {
+    // invalidate the cached categories when necessary
+    if (isValidReference(() => self.attribute)) {
+      addDisposer(self, onAction(self.attribute, action => {
+        const actionsInvalidatingCategories = [
+          "clearFormula", "setDisplayFormula", "addValue", "addValues", "setValue", "setValues", "removeValues"
+        ]
+        if (actionsInvalidatingCategories.includes(action.name)) {
+          self.invalidate()
+        }
+      }, true))
+    }
+  },
+  move(value: string, beforeValue?: string) {
+    const fromIndex = self.index(value)
+    if (fromIndex == null) return
+    const toIndex = (beforeValue != null) ? self.index(beforeValue) ?? self.values.length - 1 : self.values.length - 1
+    const afterIndex = toIndex === 0 ? undefined : toIndex < fromIndex ? toIndex - 1 : toIndex
+    const afterValue = afterIndex != null ? self.values[afterIndex] : undefined
+    self.moves.push({
+      value,
+      fromIndex,
+      toIndex,
+      length: self.values.length,
+      after: afterValue,
+      before: beforeValue
+    })
+    self.invalidate()
+  },
+  setColorForCategory(value: string, color: string) {
+    if (self.index(value)) {
+      self.colors.set(value, color)
+    }
+  }
+}))
+export interface ICategorySet extends Instance<typeof CategorySet> {}


### PR DESCRIPTION
New model `CategorySet` stores a reference to an attribute and any user-initiated re-orderings of the categories. Unlike v2, the entire order of categories is not saved -- only the user-initiated deltas/changes are stored. The `CategorySet` is also responsible for associating colors with categories, including allowing users to assign specific colors that override the default kelly colors. When the categories are changed by adding, removing, or changing values for the attribute, the user changes are heuristically applied to the updated categories. For now, initial order of the categories is the order in which they appear in the cases. There has been some discussion of defaulting the category order to alphameric, but that has been left as a refinement for another day.

The `SharedCaseMetadata` stores a map of `CategorySet`s with entries created upon demand.

Note that there is no user-visible UI for re-ordering categories at this time. There is another story for adding the UI for this feature in graphs.