### PR TITLE
perf: downgrade eslint-webpack-plugin due to performance degradation

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -74,7 +74,7 @@
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^5.10.2",
-        "eslint-webpack-plugin": "^4.0.0",
+        "eslint-webpack-plugin": "~3.2.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "html-webpack-plugin": "^5.5.0",
@@ -10051,26 +10051,26 @@
       }
     },
     "node_modules/eslint-webpack-plugin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-4.0.0.tgz",
-      "integrity": "sha512-eM9ccGRWkU+btBSVfABRn8CjT7jZ2Q+UV/RfErMDVCFXpihEbvajNrLltZpwTAcEoXSqESGlEPIUxl7PoDlLWw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha512-avrKcGncpPbPSUHX6B3stNGzkKFto3eL+DKM4+VyMrVnhPc3vRczVlCq3uhuFOdRvDHTVXuzwk1ZKUrqDQHQ9w==",
       "dev": true,
       "dependencies": {
-        "@types/eslint": "^8.4.10",
-        "jest-worker": "^29.4.1",
+        "@types/eslint": "^7.29.0 || ^8.4.1",
+        "jest-worker": "^28.0.2",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "schema-utils": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 12.13.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "eslint": "^8.0.0",
+        "eslint": "^7.0.0 || ^8.0.0",
         "webpack": "^5.0.0"
       }
     },
@@ -10102,6 +10102,29 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/eslint-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-webpack-plugin/node_modules/jest-worker": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
+      "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
     "node_modules/eslint-webpack-plugin/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -10125,6 +10148,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/eslint-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -126,7 +126,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^5.10.2",
-    "eslint-webpack-plugin": "^4.0.0",
+    "eslint-webpack-plugin": "~3.2.0",
     "file-loader": "^6.2.0",
     "fs-extra": "^11.1.1",
     "html-webpack-plugin": "^5.5.0",


### PR DESCRIPTION
eslint-webpack-plugin issues: [#208](https://github.com/webpack-contrib/eslint-webpack-plugin/issues/208), [#209](https://github.com/webpack-contrib/eslint-webpack-plugin/issues/209), [#210](https://github.com/webpack-contrib/eslint-webpack-plugin/issues/210).

eslint-webpack-plugin PR [#213](https://github.com/webpack-contrib/eslint-webpack-plugin/pull/213) is supposed to address these issues but hasn't landed yet.