### PR TITLE
perf: combine category moves if possible

### DIFF
--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -22,7 +22,6 @@ describe("CategorySet", () => {
       categories: { attribute: a.id }
     })
     const categories = tree.categories
-    const lastMove = () => categories.moves.at(-1)
     const catKellyColors = () => categories.values.map(cat => categories.colorForCategory(cat))
     const numKellyColors = (n: number) => kellyColors.slice(0, n)
     expect(categories).toBeDefined()
@@ -31,15 +30,18 @@ describe("CategorySet", () => {
     expect(categories.colorForCategory("foo")).toBeUndefined()
     expect(catKellyColors()).toEqual(numKellyColors(3))
     categories.move("c", "b") // ["a", "c", "b"]
-    expect(lastMove()).toEqual({ value: "c", fromIndex: 2, toIndex: 1, length: 3, after: "a", before: "b" })
+    expect(categories.lastMove)
+      .toEqual({ value: "c", fromIndex: 2, toIndex: 1, length: 3, after: "a", before: "b" })
     expect(categories.values).toEqual(["a", "c", "b"])
     expect(catKellyColors()).toEqual(numKellyColors(3))
     categories.move("b", "a") // ["b", "a", "c"]
-    expect(lastMove()).toEqual({ value: "b", fromIndex: 2, toIndex: 0, length: 3, after: undefined, before: "a" })
+    expect(categories.lastMove)
+      .toEqual({ value: "b", fromIndex: 2, toIndex: 0, length: 3, after: undefined, before: "a" })
     expect(categories.values).toEqual(["b", "a", "c"])
     expect(catKellyColors()).toEqual(numKellyColors(3))
     categories.move("a") // ["b", "c", "a"]
-    expect(lastMove()).toEqual({ value: "a", fromIndex: 1, toIndex: 2, length: 3, after: "c", before: undefined })
+    expect(categories.lastMove)
+      .toEqual({ value: "a", fromIndex: 1, toIndex: 2, length: 3, after: "c", before: undefined })
     expect(categories.values).toEqual(["b", "c", "a"])
     expect(catKellyColors()).toEqual(numKellyColors(3))
 
@@ -79,7 +81,6 @@ describe("CategorySet", () => {
     expect(catKellyColors()).toEqual(numKellyColors(6))
     // remove "c"s
     a.removeValues(5, 2)
-    console.log(JSON.stringify(a.strValues))
     expect(categories.values).toEqual(["a", "x", "y", "z", "b"])
     expect(catKellyColors()).toEqual(numKellyColors(5))
     categories.move("z", "a")
@@ -91,6 +92,13 @@ describe("CategorySet", () => {
     expect(catKellyColors()).toEqual(numKellyColors(4))
     categories.setColorForCategory("b", "red")
     expect(catKellyColors()).toEqual([...numKellyColors(3), "red"])
+    // moving "b" before "z" combines moves
+    const originalFromIndex = categories.lastMove?.fromIndex
+    expect(categories.moves.length).toBe(6)
+    categories.move("z", "b")
+    expect(categories.values).toEqual(["x", "y", "z", "b"])
+    expect(categories.moves.length).toBe(6)
+    expect(categories.lastMove?.fromIndex).toBe(originalFromIndex)
   })
 
   it("supports callback on invalidation of attribute", () => {

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -137,6 +137,11 @@ export const CategorySet = types.model("CategorySet", {
   }
 })
 .views(self => ({
+  get lastMove() {
+    return self.moves.length > 0
+            ? self.moves[self.moves.length - 1]
+            : undefined
+  },
   colorForCategory(category: string) {
     const userColor = self.colors.get(category)
     const catIndex = self.index(category)
@@ -163,14 +168,22 @@ export const CategorySet = types.model("CategorySet", {
     const toIndex = (beforeValue != null) ? self.index(beforeValue) ?? self.values.length - 1 : self.values.length - 1
     const afterIndex = toIndex === 0 ? undefined : toIndex < fromIndex ? toIndex - 1 : toIndex
     const afterValue = afterIndex != null ? self.values[afterIndex] : undefined
-    self.moves.push({
+    const move: ICategoryMove = {
       value,
       fromIndex,
       toIndex,
       length: self.values.length,
       after: afterValue,
       before: beforeValue
-    })
+    }
+    // combine with last move if appropriate
+    if (value === self.lastMove?.value) {
+      move.fromIndex = self.lastMove.fromIndex
+      self.moves[self.moves.length - 1] = move
+    }
+    else {
+      self.moves.push(move)
+    }
     self.invalidate()
   },
   setColorForCategory(value: string, color: string) {


### PR DESCRIPTION
This optimization was discussed during sync review of #715 with @bfinzer, but not implemented at that time. If the user changes the order of a single category multiple times in succession, we combine those moves into a single move operation.