### PR TITLE
V3: Makes slider variable name and value inputs behave more like V2

### DIFF
--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -1,3 +1,4 @@
+import { NumberInput, NumberInputField } from "@chakra-ui/react"
 import { format } from "d3"
 import { observer } from "mobx-react-lite"
 import React, {useState, useEffect} from "react"
@@ -15,36 +16,18 @@ const d3Format = format(`.${kDecimalPlaces}~f`)
 const formatValue = (model: ISliderModel) => d3Format(model.globalValue.value)
 
 export const EditableSliderValue = observer(function EditableSliderValue({sliderModel} : IProps) {
-  const [isEditing, setIsEditing] = useState(false)
   const [candidate, setCandidate] = useState("")
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const { key } = e
-    switch (key) {
-      case "Escape":
-        break
-      case "Enter":
-      case "Tab":
-        e.currentTarget.blur()
-        break
+    if (key === "Escape"  || key === "Enter") {
+      e.currentTarget.blur()
     }
   }
 
-  const handleDisplayClick = () => {
-    setIsEditing(true)
-  }
 
-  const handleBlur = () => {
-    const myFloat = parseFloat(candidate)
-    if (isFinite(myFloat)) {
-      sliderModel.setValue(myFloat)
-    } else {
-      setCandidate(formatValue(sliderModel))
-    }
-  }
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setCandidate(e.target.value)
+  const handleValueChange = (value: string) => {
+    setCandidate(value)
   }
 
   // keep display up-to-date
@@ -53,18 +36,9 @@ export const EditableSliderValue = observer(function EditableSliderValue({slider
   }, [sliderModel, sliderModel.globalValue.value])
 
   return (
-    <div className={`editable-slider-value ${isEditing ? 'editing' : 'display'}`}>
-      { isEditing
-        ? <input
-            type="text"
-            className="number-input"
-            value={candidate}
-            onKeyDown={handleKeyDown}
-            onBlur={handleBlur}
-            onChange={handleChange}
-          />
-        : <div onClick={handleDisplayClick}>{formatValue(sliderModel)}</div>
-      }
-    </div>
+    <NumberInput value={candidate} className="value-input"
+        onChange={handleValueChange}  data-testid="slider-variable-name">
+      <NumberInputField className="value-text-input text-input" onKeyDown={handleKeyDown}/>
+    </NumberInput>
   )
 })

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -73,7 +73,7 @@ export const CodapSliderThumb = observer(function CodapSliderThumb({sliderContai
   }
 
   return (
-     <ThumbIcon
+    <ThumbIcon
       className={clsx("slider-thumb-icon", { dragging: isDragging })}
       onPointerDown={handlePointerDown}
       style={thumbStyle}

--- a/v3/src/components/slider/slider.scss
+++ b/v3/src/components/slider/slider.scss
@@ -10,48 +10,88 @@ $slider-component-height: 98px;
   border-radius: $border-radius-bottom-corners;
 
   .slider {
-    button svg, .thumb-icon {
-      width: 27px;
-      height: 27px;
+    bottom: 23px;
+    position: absolute;
+
+    .slider-thumb-icon {
+      position: relative;
+      cursor: grab;
+
+      &.dragging {
+        filter: drop-shadow(3px 1px 1px #555);
+        cursor: grabbing;
+      }
     }
+  }
 
-    .thumb-icon {
-      transform: translateY(10px);
-    }
+  .slider-control {
+    align-items: center;
+    line-height: 1;
+    display: flex;
+    flex-wrap: wrap;
 
-    .paused svg {
-      stroke: white;
-      fill: rgb(10, 167, 10);
-    }
+    .play-pause {
+      border: none;
+      padding: 0;
+      line-height: 1;
+      background-color: transparent;
+      height: 24px;
+      width: 24px;
+      min-width: 0;
 
-    .running svg {
-      stroke-width: 4px;
-      stroke: rgb(226, 61, 61);
-      padding:3px;
-    }
+      &.paused svg {
+        stroke: white;
+        fill: rgb(10, 167, 10);
+        height: 24px;
+        width: 24px;
+      }
 
-    *[data-focused]{
-      outline: none;
-      outline-color: transparent;
-    }
-
-    .slider-inputs {
-      display: flex;
-
-      input, div {
-        border-radius: 3px;
-        // text-align: left;
-        // padding: 2px 0px;
+      &.running svg {
+        stroke-width: 4px;
+        stroke: rgb(226, 61, 61);
+        padding:3px;
+        height: 24px;
+        width: 24px;
       }
     }
 
-    .slider-thumb-icon {
-      position: absolute;
-      top: 42px;
+    .slider-inputs {
+      height: inherit;
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
 
-      &.dragging {
-        top: 41px;
-        filter: drop-shadow(3px 1px 1px #555);
+      .name-input {
+        border-radius: 3px;
+        border: none;
+        max-height: 40px;
+        white-space: nowrap;
+        font-family: "museo-sans", sans-serif !important;
+        font-size: 14px !important;
+
+        .text-input {
+          padding-inline-start: 0 !important;
+          padding-inline-end: 0 !important;
+          border: none !important;
+        }
+      }
+
+      .value-input {
+        overflow-wrap: normal;
+        border-radius: 3px;
+        border: none;
+        .text-input {
+          font-family: "museo-sans", sans-serif !important;
+          font-size: 14px !important;
+          padding-inline-start: 0 !important;
+          padding-inline-end: 0 !important;
+          border: none !important;
+          height: inherit !important;
+        }
+      }
+
+      .equals-sign {
+        padding-bottom: 2px;
       }
     }
   }


### PR DESCRIPTION
Refactors slider input to use Chakra inputs to handle styling and controls.
A long variable name wraps the variable value to the next line like in V2. The variable name still goes beyond the slider component like in V2
The one difference is the name and value inputs are two separate inputs instead of one. You can tab from one input to the other.