### PR TITLE
184814780 & 184077414

### DIFF
--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -2,7 +2,6 @@ import {useDroppable} from '@dnd-kit/core'
 import {observer} from "mobx-react-lite"
 import React, {useEffect, useMemo, useRef} from "react"
 import {useResizeDetector} from "react-resize-detector"
-import {kTitleBarHeight} from '../../constants'
 import {ITileBaseProps} from '../../tiles/tile-base-props'
 import {useDataSet} from '../../../hooks/use-data-set'
 import {DataSetContext} from '../../../hooks/use-data-set-context'
@@ -33,7 +32,7 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
   useGraphController({graphController, graphModel})
 
   useEffect(() => {
-    (width != null) && (height != null) && layout.setParentExtent(width, height - kTitleBarHeight)
+    (width != null) && (height != null) && layout.setParentExtent(width, height)
   }, [width, height, layout])
 
   // used to determine when a dragged attribute is over the graph component

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -9,7 +9,8 @@
 
   svg {
     width: 100%;
-    height: calc(100% - $title-bar-height);
+    height: 100%;
+    overflow: visible;
   }
 
   text {

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -4,7 +4,6 @@ import {createContext, useContext} from "react"
 import {AxisPlace, AxisPlaces, AxisBounds, AxisScaleType, isVertical} from "../../axis/axis-types"
 import {GraphPlace} from "../graphing-types"
 import {IScaleType} from "../../axis/models/axis-model"
-import {kTitleBarHeight} from "../../constants"
 
 export const kDefaultGraphWidth = 480
 export const kDefaultGraphHeight = 300
@@ -139,7 +138,7 @@ export class GraphLayout {
     newBounds.set('left',
       {left: 0, top: 0, width: leftAxisWidth, height: plotHeight})
     newBounds.set('top',
-      {left: leftAxisWidth, top: kTitleBarHeight, width: graphWidth - leftAxisWidth - rightAxisWidth,
+      {left: leftAxisWidth, top: 0, width: graphWidth - leftAxisWidth - rightAxisWidth,
         height: topAxisHeight})
     newBounds.set('plot',
       {left: leftAxisWidth, top: topAxisHeight, width: plotWidth, height: plotHeight})

--- a/v3/src/utilities/view-utils.ts
+++ b/v3/src/utilities/view-utils.ts
@@ -1,5 +1,4 @@
 const kCodapAppHeader = 95
-const kTitleBarHeight = 25
 const kGap = 5 // Also used to increment during search
 
 export const getPositionOfNewComponent = (iViewRect: {width: number, height: number}, iPosition = "top") => {
@@ -21,7 +20,7 @@ export const getPositionOfNewComponent = (iViewRect: {width: number, height: num
       const tRes = (!isNaN(r1.x) && !isNaN(r1.y)) && !(r2.x > r1.x + r1.width ||
           r2.x + r2.width < r1.x ||
           r2.y > r1.y + r1.height ||
-          r2.y + r2.height < r1.y - kTitleBarHeight - kGap)
+          r2.y + r2.height < r1.y - kGap)
       return tRes
     }
 
@@ -83,7 +82,7 @@ export const getPositionOfNewComponent = (iViewRect: {width: number, height: num
         if (!onTopOfViewRectTopLeft(tLoc)) {
           tSuccess = true
         } else {
-          tLoc = { x: tLoc.x + kGap, y: tLoc.y + kTitleBarHeight }
+          tLoc = { x: tLoc.x + kGap, y: tLoc.y }
         }
       }
     }


### PR DESCRIPTION
Two fixes of small, annoying bugs.
* Extra vertical space at the bottom of the graph is removed by getting rid of references to the title bar height
* By styling the svg where points are plotted with overflow: visible, we prevent clipping of points near the right edge of the plot