### PR TITLE
V3: Slider default values and precision restrictions

### DIFF
--- a/v3/src/components/slider/inspector-panel/slider-settings-panel.tsx
+++ b/v3/src/components/slider/inspector-panel/slider-settings-panel.tsx
@@ -46,7 +46,7 @@ export const SliderSettingsPalette =
           <Flex className="palette-row">
             <FormLabel className="form-label">{t("DG.Slider.multiples")}
               <NumberInput className="slider-input multiples" size="xs" defaultValue={sliderModel.multipleOf}
-                  min={0.1} precision={2} step={1} onChange={handleMultiplesOfChange}>
+                  min={0} step={0.5} onChange={handleMultiplesOfChange}>
                 <NumberInputField />
                 <NumberInputStepper>
                   <NumberIncrementStepper />
@@ -59,8 +59,8 @@ export const SliderSettingsPalette =
         <FormControl>
           <Flex className="palette-row">
             <FormLabel className="form-label">{t("DG.Slider.maxPerSecond")}
-              <NumberInput className="slider-input animation-rate" size="xs" min={0.1} precision={2} step={1}
-                  defaultValue={sliderModel._animationRate} onChange={handleAnimationRateChange}>
+              <NumberInput className="slider-input animation-rate" size="xs" min={0.1} max={1.0} precision={2}
+                  step={0.1} defaultValue={sliderModel._animationRate} onChange={handleAnimationRateChange}>
                 <NumberInputField />
                   <NumberInputStepper>
                     <NumberIncrementStepper />

--- a/v3/src/components/slider/slider-model.test.ts
+++ b/v3/src/components/slider/slider-model.test.ts
@@ -42,7 +42,7 @@ describe("SliderModel", () => {
     slider.setValue(1)
     expect(slider.value).toBe(1)
     expect(slider.domain).toEqual([slider.axis.min, slider.axis.max])
-    expect(slider.increment).toBeCloseTo(0.1)
+    expect(slider.increment).toBeCloseTo(0.5)
     slider.setMultipleOf(2)
     slider.setValue(2.5)
     expect(slider.value).toBe(2)

--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -36,7 +36,7 @@ export const SliderModel = TileContentModel
     },
     get increment() {
       // TODO: implement v2 algorithm which determines default increment from axis bounds
-      return self.multipleOf || 0.1
+      return self.multipleOf || 0.5
     },
     get animationRate() {
       return self._animationRate ?? kDefaultAnimationRate


### PR DESCRIPTION
This fixes the actual default values for the slider.
Changes default value of multiple of.
Removes precision restriction on slider value
Limits animation frames/sec to max out at 1.
Limits multiple of increments to 0.5

The previous PR just addressed the inspector palette values should be blank on initial open.