### PR TITLE
V3: Close inspector palette on escape key press

### DIFF
--- a/v3/src/components/inspector-panel.tsx
+++ b/v3/src/components/inspector-panel.tsx
@@ -117,6 +117,7 @@ export const InspectorPalette = ({children, Icon, title, panelRect, buttonRect,
   useEffect(() => {
     if (paletteRef.current) {
       setPaletteWidth(paletteRef.current.offsetWidth)
+      paletteRef.current.focus()
     }
   }, [])
 


### PR DESCRIPTION
Focuses inspector palette on open so it closes when Escape key is pressed