### PR TITLE
Fix marquee selection in presence of > 1 graph

### DIFF
--- a/v3/src/components/graph/components/background.tsx
+++ b/v3/src/components/graph/components/background.tsx
@@ -10,6 +10,7 @@ import {useCurrent} from "../../../hooks/use-current"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {MarqueeState} from "../models/marquee-state"
 import {useGraphModelContext} from "../models/graph-model"
+import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 
 interface IProps {
   marqueeState: MarqueeState
@@ -43,6 +44,7 @@ const prepareTree = (areaSelector: string, circleSelector: string, offset: Point
 
 export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
   const {marqueeState} = props,
+    instanceId = useInstanceIdContext() || 'background',
     dataset = useCurrent(useDataSetContext()),
     layout = useGraphLayoutContext(),
     graphModel = useGraphModelContext(),
@@ -60,10 +62,10 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
 
   useEffect(() => {
     const onDragStart = (event: { x: number; y: number; sourceEvent: { shiftKey: boolean } }) => {
-        const {computedBounds} = layout,
+      const {computedBounds} = layout,
           plotBounds = computedBounds.get('plot') as Bounds
         appState.beginPerformance()
-        selectionTree.current = prepareTree('.graph-dot-area', 'circle',
+        selectionTree.current = prepareTree(`.${instanceId}`, 'circle',
           {x: plotBounds.left, y: plotBounds.top})
         startX.current = event.x
         startY.current = event.y
@@ -135,7 +137,7 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
             .style('fill-opacity', graphModel.isTransparent ? 0 : 1)
         }
       )
-  }, [bgRef, transform, dataset, plotHeight, plotWidth, graphModel, layout, marqueeState])
+  }, [bgRef, instanceId, transform, dataset, plotHeight, plotWidth, graphModel, layout, marqueeState])
 
   // respond to point properties change
   useEffect(function respondToGraphPointVisualAction() {

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -1,6 +1,6 @@
 import {observer} from "mobx-react-lite"
 import {onAction} from "mobx-state-tree"
-import React, {MutableRefObject, useEffect, useRef} from "react"
+import React, {MutableRefObject, useEffect, useMemo, useRef} from "react"
 import {select} from "d3"
 import {GraphController} from "../models/graph-controller"
 import {DroppableAddAttribute} from "./droppable-add-attribute"
@@ -34,14 +34,12 @@ interface IProps {
   graphRef: MutableRefObject<HTMLDivElement>
 }
 
-const marqueeState = new MarqueeState()
-
-
 export const Graph = observer(function Graph({graphController, graphRef}: IProps) {
   const graphModel = useGraphModelContext(),
     { enableAnimation, dotsRef } = graphController,
     {plotType} = graphModel,
     instanceId = useInstanceIdContext(),
+    marqueeState = useMemo<MarqueeState>(() => new MarqueeState(), []),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
     xScale = layout.getAxisScale("bottom"),
@@ -161,7 +159,7 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
           {renderGraphAxes()}
 
           <svg ref={plotAreaSVGRef}>
-            <svg ref={dotsRef} className='graph-dot-area'>
+            <svg ref={dotsRef} className={`graph-dot-area ${  instanceId}`}>
               {renderPlotComponent()}
             </svg>
             <Marquee marqueeState={marqueeState}/>

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -159,7 +159,7 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
           {renderGraphAxes()}
 
           <svg ref={plotAreaSVGRef}>
-            <svg ref={dotsRef} className={`graph-dot-area ${  instanceId}`}>
+            <svg ref={dotsRef} className={`graph-dot-area ${instanceId}`}>
               {renderPlotComponent()}
             </svg>
             <Marquee marqueeState={marqueeState}/>


### PR DESCRIPTION
[#184805552] Bug fix: Marquee selection and point dragging in two separate graphs with case plots are not independent
* Each graph now gets its own instance of MarqueeState
* The graph dot area gets a class name based on the graph's instance ID to distinguish it from others for the purpose of selecting points