### PR TITLE
Three minor bug fixes

### DIFF
--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -102,7 +102,7 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
     graphController?.handleAttributeAssignment(place, attrId)
   }
 
-  useDataTips(dotsRef, dataset, graphModel)
+  useDataTips({dotsRef, dataset, graphModel, enableAnimation})
 
   const renderPlotComponent = () => {
     const props = {

--- a/v3/src/components/graph/components/legend/legend.scss
+++ b/v3/src/components/graph/components/legend/legend.scss
@@ -1,4 +1,4 @@
-.legend {
+.legend-component {
   position: relative;
   width: 100%;
   height: 100%;

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -57,7 +57,7 @@ export const Legend = function Legend({
 
   return legendAttrID ? (
     <>
-      <svg ref={legendRef} className='legend'>
+      <svg ref={legendRef} className='legend-component'>
         { graphElt && createPortal(
           <AxisOrLegendAttributeMenu
             place="legend"

--- a/v3/src/components/graph/hooks/use-data-tips.ts
+++ b/v3/src/components/graph/hooks/use-data-tips.ts
@@ -13,8 +13,13 @@ const dataTip = d3tip().attr('class', 'graph-d3-tip')/*.attr('opacity', 0.8)*/
     return `<p>${d}</p>`
   })
 
-export const useDataTips = (dotsRef: React.RefObject<SVGSVGElement>,
-                            dataset: IDataSet | undefined, graphModel: IGraphModel) => {
+interface IUseDataTips {
+  dotsRef: React.RefObject<SVGSVGElement>,
+  dataset: IDataSet | undefined,
+  graphModel: IGraphModel,
+  enableAnimation: React.MutableRefObject<boolean>
+}
+export const useDataTips = ({dotsRef, dataset, graphModel, enableAnimation}:IUseDataTips) => {
   const hoverPointRadius = graphModel.getPointRadius('hover-drag'),
     pointRadius = graphModel.getPointRadius(),
     selectedPointRadius = graphModel.getPointRadius('select'),
@@ -24,7 +29,7 @@ export const useDataTips = (dotsRef: React.RefObject<SVGSVGElement>,
   useEffect(() => {
 
     function okToTransition(target: any) {
-      return target.node()?.nodeName === 'circle' && dataset && /*!active(target.node()) &&*/
+      return !enableAnimation.current && target.node()?.nodeName === 'circle' && dataset &&
         !target.property('isDragging')
     }
 
@@ -62,6 +67,6 @@ export const useDataTips = (dotsRef: React.RefObject<SVGSVGElement>,
       .on('mouseover', showDataTip)
       .on('mouseout', hideDataTip)
       .call(dataTip)
-  }, [dotsRef, dataset, roleAttrIDPairs, yAttrIDs,
+  }, [dotsRef, dataset, enableAnimation, roleAttrIDPairs, yAttrIDs,
     hoverPointRadius, pointRadius, selectedPointRadius])
 }


### PR DESCRIPTION
[#184891112] Bug fix: Graph with legend shows spurious green rectangle
* Green rectangle caused by a reuse of `legend` as className

[#184891232] Bug fix: Categorical axis not getting correct size with split plot
* Categorical axis sizing fixed by adding reaction to number of repetitions of a multiscale changing

[#184814723] Bug fix: Some points don't make it all the way to their position on drop attribute
* Point animation fixed by detecting that enableAnimation.current is true and not showing the data tip if so