### PR TITLE
fix: several bugs

### DIFF
--- a/v3/cypress/support/elements/legend-elements.ts
+++ b/v3/cypress/support/elements/legend-elements.ts
@@ -3,7 +3,7 @@ export const LegendElements = {
         return cy.get(".codap-graph")
     },
     getLegend() {
-        return this.getGraphTile().find(".graph-plot .legend")
+        return this.getGraphTile().find(".graph-plot .legend-component")
     },
     getLegendName() {
         return this.getLegend().find(".legend-label")

--- a/v3/src/components/case-table/case-table-inspector.scss
+++ b/v3/src/components/case-table/case-table-inspector.scss
@@ -1,0 +1,7 @@
+.inspector-panel.table {
+  .inspector-tool-button {
+    .trash-icon {
+      fill: white;
+    }
+  }
+}

--- a/v3/src/components/case-table/case-table-inspector.tsx
+++ b/v3/src/components/case-table/case-table-inspector.tsx
@@ -16,7 +16,7 @@ import { useDataSet } from "../../hooks/use-data-set"
 import { DataSetContext } from "../../hooks/use-data-set-context"
 import { CaseMetadataContext } from "../../hooks/use-case-metadata"
 import { CaseTableModelContext } from "./use-case-table-model"
-
+import "./case-table-inspector.scss"
 
 export const CaseTableInspector = ({ tile, show }: ITileInspectorPanelProps) => {
   const [showInfoModal, setShowInfoModal] = useState(false)
@@ -46,7 +46,7 @@ export const CaseTableInspector = ({ tile, show }: ITileInspectorPanelProps) => 
               <ScaleDataIcon />
             </InspectorButton>
             <InspectorMenu tooltip={t("DG.Inspector.delete.toolTip")}
-              icon={<TrashIcon className="inspector-menu-icon"/>}
+              icon={<TrashIcon className="inspector-menu-icon trash-icon"/>}
               testId="delete-cases-button">
               <TrashMenuList />
             </InspectorMenu>

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react-lite"
 import React from "react"
 import { DataSetContext } from "../hooks/use-data-set-context"
 import { gDataBroker } from "../models/data/data-broker"
+import { InspectorPanelWrapper } from "./inspector-panel-wrapper"
 import { ITileBaseProps } from "./tiles/tile-base-props"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { ITileModel } from "../models/tiles/tile-model"
@@ -32,7 +33,7 @@ export const CodapComponent = observer(function CodapComponent({
 
   if (!info) return null
 
-  const { TitleBar, Component, InspectorPanel, tileEltClass, isFixedWidth, isFixedHeight } = info
+  const { TitleBar, Component, tileEltClass, isFixedWidth, isFixedHeight } = info
   return (
     <DataSetContext.Provider value={dataset}>
       <div className={`codap-component ${tileEltClass}`} key={tile.id}
@@ -55,7 +56,7 @@ export const CodapComponent = observer(function CodapComponent({
           </div>
         }
       </div>
-      {InspectorPanel && <InspectorPanel tile={tile} show={uiState.isFocusedTile(tile?.id)}/>}
+      <InspectorPanelWrapper tile={tile} />
     </DataSetContext.Provider>
   )
 })

--- a/v3/src/components/inspector-panel-wrapper.tsx
+++ b/v3/src/components/inspector-panel-wrapper.tsx
@@ -1,0 +1,15 @@
+import { useDndContext } from "@dnd-kit/core"
+import React from "react"
+import { getTileComponentInfo } from "../models/tiles/tile-component-info"
+import { ITileModel } from "../models/tiles/tile-model"
+import { uiState } from "../models/ui-state"
+
+interface IInspectorPanelWrapper {
+  tile?: ITileModel
+}
+export function InspectorPanelWrapper({ tile }: IInspectorPanelWrapper) {
+  const { InspectorPanel } = getTileComponentInfo(tile?.content.type) || {}
+  const { active } = useDndContext()
+  const show = uiState.isFocusedTile(tile?.id) && !active
+  return InspectorPanel ? <InspectorPanel tile={tile} show={show} /> : null
+}

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -33,13 +33,9 @@ export const ToolShelf = ({content}: IProps) => {
           if (!entry) return null
           const { type, shelf: { ButtonComponent = ToolShelfButton, label, hint } } = entry
           return (
-            <>
-              {ButtonComponent &&
-                <ButtonComponent tileType={type} key={`${type}-${idx}`} label={label} hint={hint}
-                    content={content}
-                />
-              }
-            </>
+            ButtonComponent
+              ? <ButtonComponent tileType={type} key={`${type}-${idx}`} label={label} hint={hint} content={content} />
+              : null
           )
         })}
       </Flex>


### PR DESCRIPTION
- trash can icon in case table inspector should be white
- hide inspector panels during drags
- don't redraw components when inspector visibility changes (just the inspector panels)
- fix React "key" warning
- fix legend cypress tests