### PR TITLE
Point clipping fix

### DIFF
--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -8,7 +8,7 @@ import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
-import {Bounds, useGraphLayoutContext} from "../models/graph-layout"
+import {useGraphLayoutContext} from "../models/graph-layout"
 import {handleClickOnDot, setPointSelection} from "../utilities/graph-utils"
 import {defaultSelectedStroke, defaultSelectedStrokeWidth, defaultStrokeWidth} from "../../../utilities/color-utils"
 import {useGraphModelContext} from "../models/graph-model"
@@ -87,9 +87,6 @@ export const CaseDots = function CaseDots(props: {
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
     const
       pointRadius = graphModel.getPointRadius(),
-      {computedBounds} = layout,
-      bounds = computedBounds.get('plot') as Bounds,
-      transform = `translate(${bounds.left}, ${bounds.top})`,
       dotsSelection = select(dotsRef.current).selectAll(selectedOnly ? '.graph-dot-highlighted' : '.graph-dot'),
       duration = enableAnimation.current ? transitionDuration : 0,
       onComplete = enableAnimation.current ? () => {
@@ -98,7 +95,6 @@ export const CaseDots = function CaseDots(props: {
       xLength = layout.getAxisMultiScale('bottom')?.length ?? 0,
       yLength = layout.getAxisMultiScale('left')?.length ?? 0
     dotsSelection
-      .attr('transform', transform)
       .transition()
       .duration(duration)
       .on('end', (id, i) => (i === dotsSelection.size() - 1) && onComplete?.())

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -4,7 +4,7 @@ import {attrRoleToAxisPlace, CaseData, PlotProps, transitionDuration} from "../g
 import {usePlotResponders} from "../hooks/use-plot"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
-import {Bounds, useGraphLayoutContext} from "../models/graph-layout"
+import {useGraphLayoutContext} from "../models/graph-layout"
 import {setPointSelection} from "../utilities/graph-utils"
 import {useGraphModelContext} from "../models/graph-model"
 import {
@@ -197,11 +197,8 @@ export const ChartDots = function ChartDots(props: PlotProps) {
 
       setPoints = () => {
         const duration = enableAnimation.current ? transitionDuration : 0,
-          plotBounds = layout.computedBounds.get('plot') as Bounds,
-          transform = `translate(${plotBounds.left}, ${plotBounds.top})`,
           pointRadius = graphModel.getPointRadius()
         selection
-          .attr('transform', transform)
           .transition()
           .duration(duration)
           .on('end', (id, i) => (i === selection.size() - 1) && onComplete?.())

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -6,7 +6,7 @@ import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {appState} from "../../../models/app-state"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
-import {Bounds, useGraphLayoutContext} from "../models/graph-layout"
+import {useGraphLayoutContext} from "../models/graph-layout"
 import {ICase} from "../../../models/data/data-set-types"
 import {
   handleClickOnDot,
@@ -251,13 +251,12 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         getScreenX = primaryIsBottom ? getPrimaryScreenCoord : getSecondaryScreenCoord,
         getScreenY = primaryIsBottom ? getSecondaryScreenCoord : getPrimaryScreenCoord,
         getLegendColor = dataConfiguration?.attributeID('legend')
-          ? dataConfiguration?.getLegendColorForCase : undefined,
-        plotBounds = layout.computedBounds.get('plot') as Bounds
+          ? dataConfiguration?.getLegendColorForCase : undefined
 
       setPointCoordinates({
         dataset, pointRadius: graphModel.getPointRadius(), selectedPointRadius: graphModel.getPointRadius('select'),
         dotsRef, selectedOnly, pointColor, pointStrokeColor,
-        getScreenX, getScreenY, getLegendColor, enableAnimation, plotBounds
+        getScreenX, getScreenY, getLegendColor, enableAnimation
       })
     },
     [graphModel, dataConfiguration, layout, primaryAttrRole, secondaryAttrRole, dataset, dotsRef,

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -53,12 +53,10 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
 
   useEffect(function setupPlotArea() {
     if (xScale && xScale?.length > 0) {
-      const plotBounds = layout.getComputedBounds('plot'),
-        transform = `translate(${plotBounds?.left}, ${plotBounds?.top})`
+      const plotBounds = layout.getComputedBounds('plot')
       select(plotAreaSVGRef.current)
-        .attr('transform', transform)
-        .attr('x', 0 /*xScale?.length*/)
-        .attr('y', 0)
+        .attr('x', plotBounds?.left || 0)
+        .attr('y', plotBounds?.top || 0)
         .attr('width', layout.plotWidth)
         .attr('height', layout.plotHeight)
     }

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -7,7 +7,7 @@ import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
-import {Bounds, useGraphLayoutContext} from "../models/graph-layout"
+import {useGraphLayoutContext} from "../models/graph-layout"
 import {ICase} from "../../../models/data/data-set-types"
 import {
   getScreenCoord,
@@ -181,13 +181,11 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
       numExtraPrimaryBands = dataConfiguration?.numRepetitionsForPlace('bottom') ?? 1,
       numExtraSecondaryBands = dataConfiguration?.numRepetitionsForPlace('left') ?? 1,
       numberOfPlots = dataConfiguration?.numberOfPlots || 1,
-      getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined,
-      {computedBounds} = layout,
-      plotBounds = computedBounds.get('plot') as Bounds
+      getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined
 
     setPointCoordinates({
       dataset, dotsRef, pointRadius: pointRadiusRef.current, selectedPointRadius: selectedPointRadiusRef.current,
-      plotBounds, selectedOnly, getScreenX, getScreenY, getLegendColor,
+      selectedOnly, getScreenX, getScreenY, getLegendColor,
       getPointColorAtIndex: graphModel.pointColorAtIndex, enableAnimation, pointColor, pointStrokeColor
     })
   }, [dataConfiguration, dataset, dotsRef, layout, legendAttrID, enableAnimation, graphModel,

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -6,7 +6,6 @@ import {between} from "../../../utilities/math-utils"
 import {IAxisModel, INumericAxisModel} from "../../axis/models/axis-model"
 import {ScaleNumericBaseType} from "../../axis/axis-types"
 import {IDataSet} from "../../../models/data/data-set"
-import {Bounds} from "../models/graph-layout"
 import {
   defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeOpacity,
   defaultSelectedStrokeWidth, defaultStrokeOpacity, defaultStrokeWidth
@@ -409,7 +408,6 @@ export interface ISetPointCoordinates {
   pointColor: string
   pointStrokeColor: string
   getPointColorAtIndex?: (index: number) => string
-  plotBounds: Bounds
   getScreenX: ((anID: string) => number | null)
   getScreenY: ((anID: string, plotNum?:number) => number | null)
   getLegendColor?: ((anID: string) => string)
@@ -430,12 +428,10 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
     },
 
     setPoints = () => {
-      const duration = enableAnimation.current ? transitionDuration : 0,
-        transform = `translate(${plotBounds.left}, ${plotBounds.top})`
+      const duration = enableAnimation.current ? transitionDuration : 0
 
       if (theSelection.size() > 0) {
         theSelection
-          .attr('transform', transform)
           .transition()
           .duration(duration)
           .on('end', (id, i) => (i === theSelection.size() - 1) && onComplete())
@@ -459,7 +455,7 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
     {
       dataset, dotsRef, selectedOnly = false, pointRadius, selectedPointRadius,
       pointStrokeColor, pointColor, getPointColorAtIndex,
-      plotBounds, getScreenX, getScreenY, getLegendColor, enableAnimation,
+      getScreenX, getScreenY, getLegendColor, enableAnimation,
       onComplete = (() => {
         if (enableAnimation.current) {
           setPoints()


### PR DESCRIPTION
[#184083861] Bug fix: Plot points should not appear in x- or y-axis areas
* Points were showing up in the x and y axis areas because overflow was allowed to be visible so that points in the plot area would not be clipped. Setting overflow back to hidden fixed this problem.

* The clipping problem was due to setting x (left) and y (top) coordinates of the svg that contains the points to zero and (wrongly) attempting to us a translation of the svg to offset the plot area. Setting the x and y coordinates according to the computed left and top fixed this problem.

* Using the proper offset for the svg necessitated removing transforms of points in the various plot components