### PR TITLE
Correct numeric drop behavior on top and right

### DIFF
--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -39,13 +39,13 @@ export const DroppableAddAttribute = ({place, onDrop}: IAddAttributeProps) => {
   const isActive = active && handleIsActive(active),
     placeKey = ['rightNumeric', 'rightCat'].includes(place) ? 'right' : place // both use same css
   const className = clsx(`add-attribute-drop-${placeKey}`, {over: isActive && isOver, active: isActive})
-  return (
+  return isActive ? (
     <div ref={setNodeRef} id={droppableId}
          className={className}>
       {isOver && hintString &&
          <DropHint hintText={hintString}/>
       }
     </div>
-  )
+  ) : null
 }
 


### PR DESCRIPTION
[#184874124] Bug fix: Same numeric attribute plotted on right and left y axes do not plot the correct scatter plot

* There are two droppable areas on the top and two on the right. They occupy the same space. One is for splitting by a categorical attribute and the other is for adding a numeric y attribute. The categorical drop area was covering up the numeric one. We fix this by only displaying the drop area if the appropriate type of attribute is being dragged.