### PR TITLE
feat: support tableOnly url parameter for allyant testing

### DIFF
--- a/v3/src/components/inspector-panel-wrapper.tsx
+++ b/v3/src/components/inspector-panel-wrapper.tsx
@@ -1,4 +1,5 @@
 import { useDndContext } from "@dnd-kit/core"
+import { observer } from "mobx-react-lite"
 import React from "react"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { ITileModel } from "../models/tiles/tile-model"
@@ -7,9 +8,9 @@ import { uiState } from "../models/ui-state"
 interface IInspectorPanelWrapper {
   tile?: ITileModel
 }
-export function InspectorPanelWrapper({ tile }: IInspectorPanelWrapper) {
+export const InspectorPanelWrapper = observer(function InspectorPanelWrapper({ tile }: IInspectorPanelWrapper) {
   const { InspectorPanel } = getTileComponentInfo(tile?.content.type) || {}
   const { active } = useDndContext()
   const show = uiState.isFocusedTile(tile?.id) && !active
   return InspectorPanel ? <InspectorPanel tile={tile} show={show} /> : null
-}
+})

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -4,12 +4,16 @@ import { kDataSummaryTileType } from "../../components/data-summary/data-summary
 import { kGraphTileType } from "../../components/graph/graph-defs"
 import { kSliderTileType } from "../../components/slider/slider-defs"
 import { typedId } from "../../utilities/js-utils"
+import { urlParams } from "../../utilities/url-params"
 import { appState } from "../app-state"
 import { IFreeTileInRowOptions } from "../document/free-tile-row"
 import { IMosaicTileInRowOptions, isMosaicTileRow } from "../document/mosaic-tile-row"
 import { getTileContentInfo } from "../tiles/tile-content-info"
 import { getTileEnvironment } from "../tiles/tile-environment"
 import { TileModel } from "../tiles/tile-model"
+
+// const isDashboard = urlParams.dashboard !== undefined
+const isTableOnly = urlParams.tableOnly !== undefined
 
 type ILayoutOptions = IFreeTileInRowOptions | IMosaicTileInRowOptions | undefined
 
@@ -36,43 +40,53 @@ export function addDefaultComponents() {
   const kGap = 10
 
   setTimeout(() => {
-    const summaryTile = createDefaultTileOfType(kDataSummaryTileType)
-    if (!summaryTile) return
-    const summaryOptions: ILayoutOptions = isMosaicTileRow(row)
-            ? undefined
-            : { x: 2, y: 2, width: kFullWidth, height: kFullHeight }
-    content.insertTileInRow(summaryTile, row, summaryOptions)
-
-    const tableTile = createDefaultTileOfType(kCaseTableTileType)
-    if (!tableTile) return
-    const tableOptions: ILayoutOptions = isMosaicTileRow(row)
-            ? { splitTileId: summaryTile.id, direction: "column" }
-            : { x: 2, y: kFullHeight + kGap, width: kFullWidth, height: kFullHeight }
-    content.insertTileInRow(tableTile, row, tableOptions)
-
-    const calculatorTile = createDefaultTileOfType(kCalculatorTileType)
-    if (!calculatorTile) return
-    if (calculatorTile) {
-      const calcOptions = isMosaicTileRow(row)
-              ? { splitTileId: summaryTile.id, direction: "row" }
-              : { x: kFullWidth + kGap, y: 2 }
-      content.insertTileInRow(calculatorTile, row, calcOptions)
+    if (isTableOnly) {
+      const tableTile = createDefaultTileOfType(kCaseTableTileType)
+      if (!tableTile) return
+      const tableOptions: ILayoutOptions = isMosaicTileRow(row)
+              ? undefined
+              : { x: 2, y: 2, width: 800, height: 500 }
+      content.insertTileInRow(tableTile, row, tableOptions)
     }
+    else {
+      const summaryTile = createDefaultTileOfType(kDataSummaryTileType)
+      if (!summaryTile) return
+      const summaryOptions: ILayoutOptions = isMosaicTileRow(row)
+              ? undefined
+              : { x: 2, y: 2, width: kFullWidth, height: kFullHeight }
+      content.insertTileInRow(summaryTile, row, summaryOptions)
 
-    const sliderTile = createDefaultTileOfType(kSliderTileType)
-    if (sliderTile) {
-      const sliderOptions = isMosaicTileRow(row)
-              ? { splitTileId: calculatorTile.id, direction: "row" }
-              : { x: kFullWidth + kWidth25 + kGap, y: 2, width: kWidth75 }
-      content.insertTileInRow(sliderTile, row, sliderOptions)
-    }
+      const tableTile = createDefaultTileOfType(kCaseTableTileType)
+      if (!tableTile) return
+      const tableOptions: ILayoutOptions = isMosaicTileRow(row)
+              ? { splitTileId: summaryTile.id, direction: "column" }
+              : { x: 2, y: kFullHeight + kGap, width: kFullWidth, height: kFullHeight }
+      content.insertTileInRow(tableTile, row, tableOptions)
 
-    const graphTile = createDefaultTileOfType(kGraphTileType)
-    if (graphTile) {
-      const graphOptions = isMosaicTileRow(row)
-              ? { splitTileId: tableTile.id, direction: "row" }
-              : { x: kFullWidth + kGap, y: kFullHeight + kGap, width: kFullWidth, height: kFullHeight }
-      content.insertTileInRow(graphTile, row, graphOptions)
+      const calculatorTile = createDefaultTileOfType(kCalculatorTileType)
+      if (!calculatorTile) return
+      if (calculatorTile) {
+        const calcOptions = isMosaicTileRow(row)
+                ? { splitTileId: summaryTile.id, direction: "row" }
+                : { x: kFullWidth + kGap, y: 2 }
+        content.insertTileInRow(calculatorTile, row, calcOptions)
+      }
+
+      const sliderTile = createDefaultTileOfType(kSliderTileType)
+      if (sliderTile) {
+        const sliderOptions = isMosaicTileRow(row)
+                ? { splitTileId: calculatorTile.id, direction: "row" }
+                : { x: kFullWidth + kWidth25 + kGap, y: 2, width: kWidth75 }
+        content.insertTileInRow(sliderTile, row, sliderOptions)
+      }
+
+      const graphTile = createDefaultTileOfType(kGraphTileType)
+      if (graphTile) {
+        const graphOptions = isMosaicTileRow(row)
+                ? { splitTileId: tableTile.id, direction: "row" }
+                : { x: kFullWidth + kGap, y: kFullHeight + kGap, width: kFullWidth, height: kFullHeight }
+        content.insertTileInRow(graphTile, row, graphOptions)
+      }
     }
   })
 }


### PR DESCRIPTION
- support `tableOnly` url parameter for allyant testing
- unrelated fix: add `observer()` to `InspectorPanelWrapper`