### PR TITLE
Fix for bug where drop on one graph influences another

### DIFF
--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -6,18 +6,19 @@ import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
 import {DropHint} from "./drop-hint"
 import {GraphPlace, graphPlaceToAttrRole, PlotType} from "../graphing-types"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
+import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 
 interface IAddAttributeProps {
-  graphID: string
   place: GraphPlace
   plotType: PlotType
   onDrop: (attributeId: string) => void
 }
 
-export const DroppableAddAttribute = ({graphID, place, onDrop}: IAddAttributeProps) => {
-  const dataConfiguration = useDataConfigurationContext(),
+export const DroppableAddAttribute = ({place, onDrop}: IAddAttributeProps) => {
+  const graphID = useInstanceIdContext(),
+    dataConfiguration = useDataConfigurationContext(),
     isDropAllowed = dataConfiguration?.graphPlaceCanAcceptAttributeIDDrop,
-    droppableId = `graph-add-attribute-drop-${place}-${graphID}`,
+    droppableId = `${graphID}-add-attribute-${place}-drop`,
     role = graphPlaceToAttrRole[place],
     {active, isOver, setNodeRef} = useDroppable({id: droppableId}),
     hintString = useDropHintString({role})
@@ -49,4 +50,3 @@ export const DroppableAddAttribute = ({graphID, place, onDrop}: IAddAttributePro
     </div>
   ) : null
 }
-

--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -8,15 +8,16 @@ import {GraphPlace, graphPlaceToAttrRole, PlotType} from "../graphing-types"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 
 interface IAddAttributeProps {
+  graphID: string
   place: GraphPlace
   plotType: PlotType
   onDrop: (attributeId: string) => void
 }
 
-export const DroppableAddAttribute = ({place, onDrop}: IAddAttributeProps) => {
+export const DroppableAddAttribute = ({graphID, place, onDrop}: IAddAttributeProps) => {
   const dataConfiguration = useDataConfigurationContext(),
     isDropAllowed = dataConfiguration?.graphPlaceCanAcceptAttributeIDDrop,
-    droppableId = `graph-add-attribute-drop-${place}`,
+    droppableId = `graph-add-attribute-drop-${place}-${graphID}`,
     role = graphPlaceToAttrRole[place],
     {active, isOver, setNodeRef} = useDroppable({id: droppableId}),
     hintString = useDropHintString({role})

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -38,7 +38,7 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
   const graphModel = useGraphModelContext(),
     { enableAnimation, dotsRef } = graphController,
     {plotType} = graphModel,
-    instanceId = useInstanceIdContext(),
+    instanceId = useInstanceIdContext() || 'graph',
     marqueeState = useMemo<MarqueeState>(() => new MarqueeState(), []),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
@@ -138,6 +138,7 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
         droppables.push(
           <DroppableAddAttribute
             key={place}
+            graphID={instanceId}
             place={place}
             plotType={plotType}
             onDrop={handleChangeAttribute.bind(null, place)}

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -38,7 +38,7 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
   const graphModel = useGraphModelContext(),
     { enableAnimation, dotsRef } = graphController,
     {plotType} = graphModel,
-    instanceId = useInstanceIdContext() || 'graph',
+    instanceId = useInstanceIdContext(),
     marqueeState = useMemo<MarqueeState>(() => new MarqueeState(), []),
     dataset = useDataSetContext(),
     layout = useGraphLayoutContext(),
@@ -138,7 +138,6 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
         droppables.push(
           <DroppableAddAttribute
             key={place}
-            graphID={instanceId}
             place={place}
             plotType={plotType}
             onDrop={handleChangeAttribute.bind(null, place)}

--- a/v3/src/hooks/use-instance-id-context.ts
+++ b/v3/src/hooks/use-instance-id-context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo } from "react"
 
-export const InstanceIdContext = createContext<string | undefined>(undefined)
+export const InstanceIdContext = createContext("instance-id-not-provided")
 
 const sInstanceIds = new Map<string, number>()
 


### PR DESCRIPTION
[#184910642] Bug fix: Dragging an attribute into one graph tile influences another graph tile

* `droppableID` has to be unique from one graph to another, so we include the graph's instance id