### PR TITLE
V3: Fixes circle in slider icon from acting like a graph circle

### DIFF
--- a/v3/src/assets/icons/icon-slider.svg
+++ b/v3/src/assets/icons/icon-slider.svg
@@ -10,6 +10,6 @@
     <rect x="14" y="2" fill="#102633" width="1" height="7.2"/>
     <rect x="12" y="2" fill="#102633" width="1" height="7.2"/>
     <rect x="10" y="2" fill="#102633" width="1" height="7.2"/>
-    <circle fill="#102633" cx="12.5" cy="18.5" r="2.6"/>
+    <circle pointer-events="none" fill="#102633" cx="12.5" cy="18.5" r="2.6"/>
   </g>
   </svg>


### PR DESCRIPTION
The bug was a long click on the circle in the slider icon made the circle big. On pointerup, CODAP would crash with a console error that case ID could not be found, making it seem like it was confusing it with a graph circle
This PR makes the slider icon circle ignore pointer events on it, but still clickable as part of the toolshelf button.