### PR TITLE
chore: enable `noImplicitThis` in tsconfig.json

### DIFF
--- a/v3/src/components/axis/components/axis-drag-rects.tsx
+++ b/v3/src/components/axis/components/axis-drag-rects.tsx
@@ -39,7 +39,7 @@ export const AxisDragRects = observer(
         dilationAnchorCoord: number,
         dragging = false
 
-      const onDragStart: D3Handler = () => {
+      const onDragStart: D3Handler = function() {
           const subAxisLength = layout.getAxisLength(place) / numSubAxes,
             rangeMin = subAxisIndex * subAxisLength,
             rangeMax = (subAxisIndex + 1) * subAxisLength,
@@ -50,12 +50,12 @@ export const AxisDragRects = observer(
           d3ScaleAtStart = d3Scale.copy()
           lower = d3ScaleAtStart.domain()[0]
           upper = d3ScaleAtStart.domain()[1]
-          select(this as Element)
+          select(this)
             .classed('dragging', true)
           axisModel.setTransitionDuration(0)
         },
 
-        onDilateStart: D3Handler = (event: { x: number, y: number }) => {
+        onDilateStart: D3Handler = function(event: { x: number, y: number }) {
           select(this)
             .classed('dragging', true)
           multiScale = layout.getAxisMultiScale(place)
@@ -107,7 +107,7 @@ export const AxisDragRects = observer(
           }
         },
 
-        onDragEnd = () => {
+        onDragEnd: D3Handler = function() {
           select(this)
             .classed('dragging', false)
           dragging = false

--- a/v3/src/components/case-table/cell-text-editor.tsx
+++ b/v3/src/components/case-table/cell-text-editor.tsx
@@ -23,7 +23,7 @@ function autoFocusAndSelect(input: HTMLInputElement | null) {
 
 export default function CellTextEditor({ row, column, onRowChange, onClose }: TEditorProps) {
   const data = useDataSetContext()
-  const initialValueRef = useRef(data?.getValue(row.__id__, column.key))
+  const initialValueRef = useRef(data?.getStrValue(row.__id__, column.key))
   const valueRef = useRef(initialValueRef.current)
 
   useEffect(()=>{

--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -76,11 +76,11 @@ export const useRows = () => {
           const attr = data?.attributes[colIndex]
           const cellSpan = cell.querySelector(".cell-span")
           if (data && caseId && attr && cellSpan) {
-            const strValue = data.getValue(caseId, attr.id)
+            const strValue = data.getStrValue(caseId, attr.id)
             const numValue = data.getNumeric(caseId, attr.id)
             const formatStr = attr.format || kDefaultFormatStr
             const formatted = (numValue != null) && isFinite(numValue) ? format(formatStr)(numValue) : strValue
-            cellSpan.textContent = formatted
+            cellSpan.textContent = formatted ?? ""
             setCachedDomAttr(caseId, attr.id)
           }
         })

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -160,10 +160,10 @@ export const ChartDots = function ChartDots(props: PlotProps) {
           secondaryAttrID = dataConfiguration?.attributeID(secondaryAttrRole) ?? ''
         primaryAttrID && (dataConfiguration?.caseDataArray || []).forEach((aCaseData: CaseData) => {
           const anID = aCaseData.caseID,
-            hCat = dataset?.getValue(anID, primaryAttrID),
-            vCat = secondaryAttrID ? dataset?.getValue(anID, secondaryAttrID) : '__main__',
-            extraHCat = extraPrimaryAttrID ? dataset?.getValue(anID, extraPrimaryAttrID) : '__main__',
-            extraVCat = extraSecondaryAttrID ? dataset?.getValue(anID, extraSecondaryAttrID) : '__main__'
+            hCat = dataset?.getStrValue(anID, primaryAttrID),
+            vCat = secondaryAttrID ? dataset?.getStrValue(anID, secondaryAttrID) : '__main__',
+            extraHCat = extraPrimaryAttrID ? dataset?.getStrValue(anID, extraPrimaryAttrID) : '__main__',
+            extraVCat = extraSecondaryAttrID ? dataset?.getStrValue(anID, extraSecondaryAttrID) : '__main__'
           if (hCat && vCat && extraHCat && extraVCat &&
             catMap[hCat] && catMap[hCat][vCat] && catMap[hCat][vCat][extraHCat] &&
             catMap[hCat][vCat][extraHCat][extraVCat]) {

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -172,9 +172,9 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
               numerator = primaryAxisScale(dataset?.getNumeric(anID, primaryAttrID) ?? -1) /
                 numExtraPrimaryBands,
               bin = Math.ceil((numerator ?? 0) / binWidth),
-              category = dataset?.getValue(anID, secondaryAttrID) ?? '__main__',
-              extraCategory = dataset?.getValue(anID, extraSecondaryAttrID) ?? '__main__',
-              extraPrimaryCategory = dataset?.getValue(anID, extraPrimaryAttrID) ?? '__main__'
+              category = dataset?.getStrValue(anID, secondaryAttrID) ?? '__main__',
+              extraCategory = dataset?.getStrValue(anID, extraSecondaryAttrID) ?? '__main__',
+              extraPrimaryCategory = dataset?.getStrValue(anID, extraPrimaryAttrID) ?? '__main__'
             if (!bins[category]) {
               bins[category] = {}
             }
@@ -233,9 +233,9 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         getPrimaryScreenCoord = (anID: string) => {
           const primaryCoord = primaryAxisScale(dataset?.getNumeric(anID, primaryAttrID) ?? -1) /
               numExtraPrimaryBands,
-            extraPrimaryValue = dataset?.getValue(anID, extraPrimaryAttrID),
+            extraPrimaryValue = dataset?.getStrValue(anID, extraPrimaryAttrID),
             extraPrimaryCoord = extraPrimaryValue
-              ? extraPrimaryAxisScale(dataset?.getValue(anID, extraPrimaryAttrID) ?? '__main__') ?? 0
+              ? extraPrimaryAxisScale(extraPrimaryValue ?? '__main__') ?? 0
               : 0
           return primaryCoord + extraPrimaryCoord
         },

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -157,7 +157,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
         xValue = dataset?.getNumeric(anID, xAttrID) ?? NaN,
         xScale = layout.getAxisScale('bottom') as ScaleLinear<number, number>,
         topSplitID = dataConfiguration?.attributeID('topSplit') ?? '',
-        topCoordValue = dataset?.getValue(anID, topSplitID) ?? '',
+        topCoordValue = dataset?.getStrValue(anID, topSplitID) ?? '',
         topScale = layout.getAxisScale('top') as ScaleBand<string>
       return xScale(xValue) / numExtraPrimaryBands + (topScale(topCoordValue) || 0)
     }
@@ -168,7 +168,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
         yScale = (hasY2Attribute && plotNum === numberOfPlots - 1 ? v2Scale : yScaleRef.current) as
           ScaleLinear<number, number>,
         rightSplitID = dataConfiguration?.attributeID('rightSplit') ?? '',
-        rightCoordValue = dataset?.getValue(anID, rightSplitID) ?? '',
+        rightCoordValue = dataset?.getStrValue(anID, rightSplitID) ?? '',
         rightScale = layout.getAxisScale('rightCat') as ScaleBand<string>,
         rightScreenCoord = ((rightCoordValue && rightScale(rightCoordValue)) || 0)
       return yScale(yValue) / numExtraSecondaryBands + rightScreenCoord

--- a/v3/src/components/graph/hooks/use-graph-model.ts
+++ b/v3/src/components/graph/hooks/use-graph-model.ts
@@ -43,7 +43,7 @@ export function useGraphModel(props: IProps) {
         startAnimation(enableAnimation)
         // In case the y-values have changed we rescale
         if (newPlotType === 'scatterPlot') {
-          const values = dataConfig.caseDataArray.map((anID:string) => dataset?.getNumeric(anID, yAttrID)) as number[]
+          const values = dataConfig.caseDataArray.map(({ caseID }) => dataset?.getNumeric(caseID, yAttrID)) as number[]
           setNiceDomain(values || [], yAxisModel as INumericAxisModel)
         }
       }

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -111,17 +111,17 @@ export const DataConfigurationModel = types
         : role === 'rightNumeric' ? self._attributeDescriptions.get('rightNumeric')
           : this.attributeDescriptions[role]
     },
-    attributeID(role: GraphAttrRole): string {
+    attributeID(role: GraphAttrRole) {
       let attrID = this.attributeDescriptionForRole(role)?.attributeID
       if ((role === "caption") && !attrID) {
         attrID = this.defaultCaptionAttributeID
       }
       return attrID
     },
-    attributeType(role: GraphAttrRole):string {
+    attributeType(role: GraphAttrRole) {
       const desc = this.attributeDescriptionForRole(role)
       const attrID = this.attributeID(role)
-      const attr = attrID && self.dataset?.attrFromID(attrID)
+      const attr = attrID ? self.dataset?.attrFromID(attrID) : undefined
       return desc?.type || attr?.type
     },
     get places() {
@@ -140,29 +140,32 @@ export const DataConfigurationModel = types
     },
     get secondaryAttributeID(): string {
       return self.secondaryRole && self.attributeID(self.secondaryRole) || ''
+    },
+    get graphCaseIDs() {
+      const allGraphCaseIds = new Set<string>()
+      // todo: We're bypassing get caseDataArray to avoid infinite recursion. Is it necessary?
+      self.filteredCases?.forEach(aFilteredCases => {
+        if (aFilteredCases) {
+          aFilteredCases.caseIds.forEach(id => allGraphCaseIds.add(id))
+        }
+      })
+      return allGraphCaseIds
     }
   }))
-  .extend(() => {
-    // TODO: This is a hack to get around the fact that MST doesn't seem to cache this as expected
-    // when implemented as simple view.
-    let quantileScale: ScaleQuantile<string> | undefined = undefined
-
-    return {
-      views: {
-        get legendQuantileScale() {
-          if (!quantileScale) {
-            quantileScale = scaleQuantile(this.numericValuesForAttrRole('legend'), schemeBlues[5])
-          }
-          return quantileScale
-        },
-      },
-      actions: {
-        invalidateQuantileScale() {
-          quantileScale = undefined
+  .actions(self => ({
+    _setAttributeDescription(iRole: GraphAttrRole, iDesc?: IAttributeDescriptionSnapshot) {
+      if (iRole === 'y') {
+        self._yAttributeDescriptions.clear()
+        if (iDesc?.attributeID) {
+          self._yAttributeDescriptions.push(iDesc)
         }
+      } else if (iDesc?.attributeID) {
+        self._attributeDescriptions.set(iRole, iDesc)
+      } else {
+        self._attributeDescriptions.delete(iRole)
       }
     }
-  })
+  }))
   .actions(self => ({
     clearCategorySets() {
       self.categorySets.clear()
@@ -196,53 +199,11 @@ export const DataConfigurationModel = types
             return !!data.getValue(caseID, attributeID)
         }
       })
-    },
-    handleAction(actionCall: ISerializedActionCall) {
-      // forward all actions from dataset except "setCaseValues" which requires intervention
-      if (actionCall.name === "setCaseValues") return
-      self.handlers.forEach(handler => handler(actionCall))
-    },
-    handleSetCaseValues(actionCall: SetCaseValuesAction, cases: IFilteredChangedCases) {
-      let [affectedCases, affectedAttrIDs] = actionCall.args
-      // this is called by the FilteredCases object with additional information about
-      // whether the value changes result in adding/removing any cases from the filtered set
-      // a single call to setCaseValues can result in up to three calls to the handlers
-      if (cases.added.length) {
-        const newCases = self.dataset?.getCases(cases.added)
-        self.handlers.forEach(handler => handler({name: "addCases", args: [newCases]}))
-      }
-      if (cases.removed.length) {
-        self.handlers.forEach(handler => handler({name: "removeCases", args: [cases.removed]}))
-      }
-      if (cases.changed.length) {
-        const idSet = new Set(cases.changed)
-        const changedCases = affectedCases.filter(aCase => idSet.has(aCase.__id__))
-        self.handlers.forEach(handler => handler({name: "setCaseValues", args: [changedCases]}))
-      }
-      // Changes to case values require that existing cached categorySets be wiped.
-      // But if we know the ids of the attributes involved, we can determine whether
-      // an attribute that has a cache is involved
-      if (!affectedAttrIDs && affectedCases.length === 1) {
-        affectedAttrIDs = Object.keys(affectedCases[0])
-      }
-      if (affectedAttrIDs) {
-        for (const [key, desc] of Object.entries(self.attributeDescriptions)) {
-          if (affectedAttrIDs.includes(desc.attributeID)) {
-            self.setCategorySetForRole(key as GraphAttrRole, null)
-            if (key === "legend") {
-              self.invalidateQuantileScale()
-            }
-          }
-        }
-      } else {
-        self.clearCategorySets()
-        self.invalidateQuantileScale()
-      }
     }
   }))
   .views(self => ({
     get attributes() {
-      return self.places.map(place => self.attributeID(place))
+      return self.places.map(place => self.attributeID(place)).filter(attrID => !!attrID) as string[]
     },
     get uniqueAttributes() {
       return Array.from(new Set<string>(this.attributes))
@@ -250,7 +211,7 @@ export const DataConfigurationModel = types
     get tipAttributes(): RoleAttrIDPair[] {
       return TipAttrRoles
         .map(role => {
-          return {role, attributeID: self.attributeID(role)}
+          return {role, attributeID: self.attributeID(role) || ''}
         })
         .filter(pair => !!pair.attributeID)
     },
@@ -273,52 +234,10 @@ export const DataConfigurationModel = types
       return this.attributes.length <= 1
     },
     get numberOfPlots() {
-      return this.filteredCases.length  // filteredCases is an array of CaseArrays
+      return self.filteredCases?.length ?? 0  // filteredCases is an array of CaseArrays
     },
     get hasY2Attribute() {
       return !!self.attributeID('rightNumeric')
-    },
-    getUnsortedCaseDataArray(caseArrayNumber: number): CaseData[] {
-      return self.filteredCases
-        ? (self.filteredCases[caseArrayNumber]?.caseIds || []).map(id => {
-          return {plotNum: caseArrayNumber, caseID: id}
-        })
-        : []
-    },
-    getCaseDataArray(caseArrayNumber: number) {
-      const caseDataArray = this.getUnsortedCaseDataArray(caseArrayNumber),
-        legendAttrID = self.attributeID('legend')
-      if (legendAttrID) {
-        const categories = Array.from(this.categorySetForAttrRole('legend'))
-        caseDataArray.sort((cd1: CaseData, cd2: CaseData) => {
-          const cd1_Value = self.dataset?.getValue(cd1.caseID, legendAttrID),
-            cd2_value = self.dataset?.getValue(cd2.caseID, legendAttrID)
-          return categories.indexOf(cd1_Value) - categories.indexOf(cd2_value)
-        })
-      }
-      return caseDataArray
-    },
-    getSetOfAllGraphCaseIDs() {
-      const allGraphCaseIds = new Set<string>()
-      // todo: We're bypassing get caseDataArray to avoid infinite recursion. Is it necessary?
-      self.filteredCases?.forEach(aFilteredCases => {
-        if (aFilteredCases) {
-          aFilteredCases.caseIds.forEach(id => allGraphCaseIds.add(id))
-        }
-      })
-      return allGraphCaseIds
-    },
-    get joinedCaseDataArrays() {
-      const joinedCaseData: CaseData[] = []
-      self.filteredCases?.forEach((aFilteredCases, index) => {
-          aFilteredCases.caseIds.forEach(
-            (id) => joinedCaseData.push({plotNum: index, caseID: id}))
-        }
-      )
-      return joinedCaseData
-    },
-    get caseDataArray() {
-      return this.getCaseDataArray(0)
     },
     /**
      * Note that in order to eliminate a selected case from the graph's selection, we have to check that it is not
@@ -327,7 +246,7 @@ export const DataConfigurationModel = types
     get selection() {
       if (!self.dataset || !self.filteredCases || !self.filteredCases[0]) return []
       const selection = Array.from(self.dataset.selection),
-        allGraphCaseIds = this.getSetOfAllGraphCaseIDs()
+        allGraphCaseIds = self.graphCaseIDs
       return selection.filter((caseId: string) => allGraphCaseIds.has(caseId))
     }
   }))
@@ -337,7 +256,7 @@ export const DataConfigurationModel = types
       valuesForAttrRole(role: GraphAttrRole): string[] {
         const attrID = self.attributeID(role),
           dataset = self.dataset,
-          allGraphCaseIds = Array.from(this.getSetOfAllGraphCaseIDs()),
+          allGraphCaseIds = Array.from(self.graphCaseIDs),
           allValues = attrID ? allGraphCaseIds.map((anID: string) => String(dataset?.getValue(anID, attrID)))
             : []
         return allValues.filter(aValue => aValue !== '')
@@ -347,7 +266,7 @@ export const DataConfigurationModel = types
           .filter((aValue: number) => isFinite(aValue))
       },
       get numericValuesForYAxis() {
-        const allGraphCaseIds = Array.from(this.getSetOfAllGraphCaseIDs()),
+        const allGraphCaseIds = Array.from(self.graphCaseIDs),
           allValues: number[] = []
 
         return self.yAttributeIDs.reduce((acc: number[], yAttrID: string) => {
@@ -380,6 +299,61 @@ export const DataConfigurationModel = types
         return numRepetitions
       }
     }))
+  .views(self => ({
+    getUnsortedCaseDataArray(caseArrayNumber: number): CaseData[] {
+      return self.filteredCases
+        ? (self.filteredCases[caseArrayNumber]?.caseIds || []).map(id => {
+          return {plotNum: caseArrayNumber, caseID: id}
+        })
+        : []
+    },
+    getCaseDataArray(caseArrayNumber: number) {
+      const caseDataArray = this.getUnsortedCaseDataArray(caseArrayNumber),
+        legendAttrID = self.attributeID('legend')
+      if (legendAttrID) {
+        const categories = Array.from(self.categorySetForAttrRole('legend'))
+        caseDataArray.sort((cd1: CaseData, cd2: CaseData) => {
+          const cd1_Value = self.dataset?.getStrValue(cd1.caseID, legendAttrID) ?? '',
+            cd2_value = self.dataset?.getStrValue(cd2.caseID, legendAttrID) ?? ''
+          return categories.indexOf(cd1_Value) - categories.indexOf(cd2_value)
+        })
+      }
+      return caseDataArray
+    },
+    get joinedCaseDataArrays() {
+      const joinedCaseData: CaseData[] = []
+      self.filteredCases?.forEach((aFilteredCases, index) => {
+          aFilteredCases.caseIds.forEach(
+            (id) => joinedCaseData.push({plotNum: index, caseID: id}))
+        }
+      )
+      return joinedCaseData
+    },
+    get caseDataArray() {
+      return this.getCaseDataArray(0)
+    }
+  }))
+  .extend(self => {
+    // TODO: This is a hack to get around the fact that MST doesn't seem to cache this as expected
+    // when implemented as simple view.
+    let quantileScale: ScaleQuantile<string> | undefined = undefined
+
+    return {
+      views: {
+        get legendQuantileScale() {
+          if (!quantileScale) {
+            quantileScale = scaleQuantile(self.numericValuesForAttrRole('legend'), schemeBlues[5])
+          }
+          return quantileScale
+        },
+      },
+      actions: {
+        invalidateQuantileScale() {
+          quantileScale = undefined
+        }
+      }
+    }
+  })
   .views(self => (
     {
       getLegendColorForCategory(cat: string): string {
@@ -441,7 +415,7 @@ export const DataConfigurationModel = types
       getLegendColorForCase(id: string): string {
         const legendID = self.attributeID('legend'),
           legendType = self.attributeType('legend'),
-          legendValue = id && legendID ? self.dataset?.getValue(id, legendID) : null
+          legendValue = id && legendID ? self.dataset?.getStrValue(id, legendID) : null
         return legendValue == null ? ''
           : legendType === 'categorical' ? self.getLegendColorForCategory(legendValue)
             : legendType === 'numeric' ? self.getLegendColorForNumericValue(Number(legendValue))
@@ -476,6 +450,50 @@ export const DataConfigurationModel = types
       }
     }))
   .actions(self => ({
+    handleAction(actionCall: ISerializedActionCall) {
+      // forward all actions from dataset except "setCaseValues" which requires intervention
+      if (actionCall.name === "setCaseValues") return
+      self.handlers.forEach(handler => handler(actionCall))
+    },
+    handleSetCaseValues(actionCall: SetCaseValuesAction, cases: IFilteredChangedCases) {
+      let [affectedCases, affectedAttrIDs] = actionCall.args
+      // this is called by the FilteredCases object with additional information about
+      // whether the value changes result in adding/removing any cases from the filtered set
+      // a single call to setCaseValues can result in up to three calls to the handlers
+      if (cases.added.length) {
+        const newCases = self.dataset?.getCases(cases.added)
+        self.handlers.forEach(handler => handler({name: "addCases", args: [newCases]}))
+      }
+      if (cases.removed.length) {
+        self.handlers.forEach(handler => handler({name: "removeCases", args: [cases.removed]}))
+      }
+      if (cases.changed.length) {
+        const idSet = new Set(cases.changed)
+        const changedCases = affectedCases.filter(aCase => idSet.has(aCase.__id__))
+        self.handlers.forEach(handler => handler({name: "setCaseValues", args: [changedCases]}))
+      }
+      // Changes to case values require that existing cached categorySets be wiped.
+      // But if we know the ids of the attributes involved, we can determine whether
+      // an attribute that has a cache is involved
+      if (!affectedAttrIDs && affectedCases.length === 1) {
+        affectedAttrIDs = Object.keys(affectedCases[0])
+      }
+      if (affectedAttrIDs) {
+        for (const [key, desc] of Object.entries(self.attributeDescriptions)) {
+          if (affectedAttrIDs.includes(desc.attributeID)) {
+            self.setCategorySetForRole(key as GraphAttrRole, null)
+            if (key === "legend") {
+              self.invalidateQuantileScale()
+            }
+          }
+        }
+      } else {
+        self.clearCategorySets()
+        self.invalidateQuantileScale()
+      }
+    }
+  }))
+  .actions(self => ({
     setDataset(dataset: IDataSet | undefined) {
       self.actionHandlerDisposer?.()
       self.dataset = dataset
@@ -497,31 +515,14 @@ export const DataConfigurationModel = types
     },
     setAttribute(role: GraphAttrRole, desc?: IAttributeDescriptionSnapshot) {
 
-      const replaceYAttribute = (iDesc?: IAttributeDescriptionSnapshot) => {
-          self._yAttributeDescriptions.clear()
-          if (iDesc && iDesc.attributeID !== '') {
-            self._yAttributeDescriptions.push(iDesc)
-          }
-        },
-        setAttributeDescription = (iRole: GraphAttrRole, iDesc?: IAttributeDescriptionSnapshot) => {
-          if (iRole === 'y') {
-            replaceYAttribute(iDesc)
-          } else if (iDesc && iDesc.attributeID !== '') {
-            self._attributeDescriptions.set(iRole, iDesc)
-          } else {
-            self._attributeDescriptions.delete(iRole)
-          }
-        }
-
       // For 'x' and 'y' roles, if the given attribute is already present on the other axis, then
       // move whatever attribute is assigned to the given role to that axis.
       if (['x', 'y'].includes(role)) {
         const otherRole = role === 'x' ? 'y' : 'x',
           otherDesc = self.attributeDescriptionForRole(otherRole)
         if (otherDesc?.attributeID === desc?.attributeID) {
-          const currentDesc = self.attributeDescriptionForRole(role) ?? {attributeID: '', type: 'empty'}
-          setAttributeDescription(otherRole,
-            {attributeID: currentDesc.attributeID, type: currentDesc.attributeType})
+          const currentDesc = self.attributeDescriptionForRole(role) ?? {attributeID: '', type: 'categorical'}
+          self._setAttributeDescription(otherRole, currentDesc)
           self.categorySets.set(otherRole, null)
         }
       }
@@ -533,7 +534,7 @@ export const DataConfigurationModel = types
       } else if (role === 'rightNumeric') {
         this.setY2Attribute(desc)
       } else {
-        setAttributeDescription(role, desc)
+        self._setAttributeDescription(role, desc)
       }
       self.filteredCases?.forEach((aFilteredCases) => {
         aFilteredCases.invalidateCases()
@@ -556,10 +557,10 @@ export const DataConfigurationModel = types
       self._yAttributeDescriptions.push(desc)
       this._addNewFilteredCases()
     },
-    setY2Attribute(desc: IAttributeDescriptionSnapshot) {
+    setY2Attribute(desc?: IAttributeDescriptionSnapshot) {
       const isNewAttribute = !self._attributeDescriptions.get('rightNumeric'),
-        isEmpty = desc.attributeID === ''
-      self._attributeDescriptions.set('rightNumeric', desc)
+        isEmpty = !desc?.attributeID
+      self._setAttributeDescription('rightNumeric', desc)
       if (isNewAttribute) {
         this._addNewFilteredCases()
       } else if (isEmpty) {

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -120,7 +120,7 @@ export class GraphController {
     const setupAxis = (place: AxisPlace) => {
       const attrRole = graphPlaceToAttrRole[place],
         attributeID = dataConfig.attributeID(attrRole),
-        attr = dataset?.attrFromID(attributeID),
+        attr = attributeID ? dataset?.attrFromID(attributeID) : undefined,
         attrType = dataConfig.attributeType(attrRole) ?? 'empty',
         currAxisModel = graphModel.getAxis(place),
         currentType = currAxisModel?.type ?? 'empty'

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -103,11 +103,11 @@ export function getPointTipText(caseID: string, attributeIDs: string[], dataset?
     attrArray = (attributeIDs.map(attrID => {
       const attribute = dataset?.attrFromID(attrID),
         name = attribute?.name,
-        isNumeric = attribute?.type === 'numeric',
-        value = isNumeric
-          ? float(dataset?.getNumeric(caseID, attrID) ?? 0)
-          : dataset?.getValue(caseID, attrID)
-      return (value && (isNumeric && isFinite(value)) || (!isNumeric && value !== '')) ? `${name}: ${value}` : ''
+        numValue = dataset?.getNumeric(caseID, attrID),
+        value = numValue != null
+                  ? isFinite(numValue) ? float(numValue) : ''
+                  : dataset?.getValue(caseID, attrID)
+      return value ? `${name}: ${value}` : ''
     }))
   // Caption attribute can also be one of the plotted attributes, so we remove dups and join into html string
   return Array.from(new Set(attrArray)).filter(anEntry => anEntry !== '').join('<br>')

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -595,6 +595,26 @@ export const DataSet = types.model("DataSet", {
                 ? cachedCase[attributeID]
                 : attr && (index != null) ? attr.value(index) : undefined
       },
+      getStrValue(caseID: string, attributeID: string) {
+        // The values of a pseudo-case are considered to be the values of the first real case.
+        // For grouped attributes, these will be the grouped values. Clients shouldn't be
+        // asking for ungrouped values from pseudo-cases.
+        const _caseId = self.pseudoCaseMap[caseID]
+                          ? self.pseudoCaseMap[caseID].childCaseIds[0]
+                          : caseID
+        const index = _caseId ? self.caseIDMap[_caseId] : undefined
+        return index != null
+                ? this.getStrValueAtIndex(self.caseIDMap[_caseId], attributeID)
+                : ""
+      },
+      getStrValueAtIndex(index: number, attributeID: string) {
+        const attr = attrIDMap[attributeID],
+              caseID = self.cases[index]?.__id__,
+              cachedCase = self.isCaching ? self.caseCache.get(caseID) : undefined
+        return (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID))
+                ? `${cachedCase[attributeID]}`  // TODO: respect attribute formatting
+                : attr && (index != null) ? attr.value(index) : ""
+      },
       getNumeric(caseID: string, attributeID: string): number | undefined {
         // The values of a pseudo-case are considered to be the values of the first real case.
         // For grouped attributes, these will be the grouped values. Clients shouldn't be

--- a/v3/tsconfig.json
+++ b/v3/tsconfig.json
@@ -14,8 +14,6 @@
     "importHelpers": true,
     "strict": true,
     // todo: Figure out how to not require this
-    "noImplicitThis": false,
-    // todo: Figure out how to not require this
     "strictFunctionTypes": false,
     "types": [],
     "jsx": "react",


### PR DESCRIPTION
In porting v3 graph code from CODAP to CLUE, Ethan ran into a number of TypeScript compilation errors which turned out to be due to the `noImplicitThis` setting in `tsconfig.json`. In the early days of v3 development, we disabled this strictness setting with intention to return to it but had not done so to this point. I took this opportunity to enable the stricter setting and fixed all of the compilation issues that arose. There were ~48 initially, but a number of them boiled down to a couple of issues:
1. A number of clients were treating the return value from the `DataSet`'s `getValue()` function as a string even though it is typed to return a `string | number | boolean`. 
    - I added new `getStrValue()` and `getStrValueAtIndex()` methods to the `DataSet` API to address these clients
2. The `DataConfigurationModel` was playing fast and loose with types in a number of places and required some substantial reorganization due to methods that called methods defines later in the model definition.

I added a number of line comments explaining some of the changes that were made. @bfinzer note these comments and make sure they make sense to you.