### PR TITLE
chore: enable `strictFunctionTypes` in tsconfig.json

### DIFF
--- a/v3/src/components/axis/components/axis-drag-rects.tsx
+++ b/v3/src/components/axis/components/axis-drag-rects.tsx
@@ -1,7 +1,7 @@
 import {observer} from "mobx-react-lite"
 import React, {useEffect, useRef} from "react"
 import {reaction} from "mobx"
-import {drag, ScaleContinuousNumeric, select} from "d3"
+import {drag, ScaleContinuousNumeric, select, Selection} from "d3"
 import t from "../../../utilities/translation/translate"
 import {useAxisLayoutContext} from "../models/axis-layout-context"
 import {INumericAxisModel} from "../models/axis-model"
@@ -9,6 +9,21 @@ import {MultiScale} from "../models/multi-scale"
 import {isVertical} from "../axis-types"
 
 import "./axis.scss"
+
+// type arguments:
+//  SVGRectElement: type of element being selected
+//  RectIndices: type of data attached to selected element
+//  SVGGElement: type of parent element selected by initial/global select
+//  unknown: type of data attached to parent element (none in this case)
+export type RectIndices = [number, number, number]  // data signify lower, middle, upper rectangles
+export type DragRectSelection = Selection<SVGRectElement, RectIndices, SVGGElement, unknown>
+
+// selects all `.dragRect` elements, optionally with additional classes, e.g. `.dragRect.additional.classes`
+export function selectDragRects(parent: SVGGElement | null, additionalClasses = ""): DragRectSelection | null {
+  return parent
+          ? select(parent).selectAll<SVGRectElement, RectIndices>(`.dragRect${additionalClasses}`)
+          : null
+}
 
 interface IProps {
   axisModel: INumericAxisModel
@@ -25,7 +40,7 @@ const axisDragHints = [t("DG.CellLinearAxisView.lowerPanelTooltip"),
 
 export const AxisDragRects = observer(
   function AxisDragRects({axisModel, axisWrapperElt, numSubAxes = 1, subAxisIndex = 0}: IProps) {
-    const rectRef = useRef() as React.RefObject<SVGSVGElement>,
+    const rectRef = useRef() as React.RefObject<SVGGElement>,
       place = axisModel.place,
       layout = useAxisLayoutContext()
 
@@ -114,43 +129,38 @@ export const AxisDragRects = observer(
         }
 
       if (rectRef.current) {
-        const rectSelection = select(rectRef.current)
-
         // Add three rects in which the user can drag to dilate or translate the axis scale
         const
           classPrefix = place === 'bottom' ? 'h' : 'v',
-          numbering = place === 'bottom' ? [0, 1, 2] : [2, 1, 0],
+          numbering: RectIndices = place === 'bottom' ? [0, 1, 2] : [2, 1, 0],
           classPostfixes = place === 'bottom'
             ? ['lower-dilate', 'translate', 'upper-dilate']
             : ['upper-dilate', 'translate', 'lower-dilate'],
-          dragBehavior = [drag()  // lower
+          dragBehavior = [drag<SVGRectElement, RectIndices>()  // lower
             .on("start", onDilateStart)
             .on("drag", onLowerDilateDrag)
             .on("end", onDragEnd),
-            drag()  // middle
+            drag<SVGRectElement, RectIndices>()  // middle
               .on("start", onDragStart)
               .on("drag", onDragTranslate)
               .on("end", onDragEnd),
-            drag()  // upper
+            drag<SVGRectElement, RectIndices>()  // upper
               .on("start", onDilateStart)
               .on("drag", onUpperDilateDrag)
               .on("end", onDragEnd)]
-        rectSelection
-          .selectAll('.dragRect')
-          .data(numbering)// data signify lower, middle, upper rectangles
+
+        selectDragRects(rectRef.current)
+          ?.data(numbering)// data signify lower, middle, upper rectangles
           .join(
-            // @ts-expect-error void => Selection
-            (enter) => {
+            (enter) =>
               enter.append('rect')
                 .attr('class', (d) => `dragRect ${classPrefix}-${classPostfixes[d]}`)
                 .append('title')
                 .text((d: number) => axisDragHints[numbering[d]])
-            }
           )
         numbering.forEach((behaviorIndex, axisIndex) => {
-          rectSelection.select(`.dragRect.${classPrefix}-${classPostfixes[axisIndex]}`)
-            // @ts-expect-error strictFunctionTypes
-            .call(dragBehavior[behaviorIndex])
+          const indexedRects = selectDragRects(rectRef.current, `.${classPrefix}-${classPostfixes[axisIndex]}`)
+          indexedRects?.call(dragBehavior[behaviorIndex])
         })
       }
     }, [axisModel, place, layout, numSubAxes, subAxisIndex])
@@ -165,18 +175,13 @@ export const AxisDragRects = observer(
           const
             length = layout.getAxisLength(place) / numSubAxes,
             start = subAxisIndex * length,
-            rectSelection = select(rectRef.current),
             numbering = place === 'bottom' ? [0, 1, 2] : [2, 1, 0]
           if (length != null && axisBounds != null) {
-            rectSelection
-              .selectAll('.dragRect')
-              .data(numbering)// data signify lower, middle, upper rectangles
+            selectDragRects(rectRef.current)
+              ?.data(numbering)// data signify lower, middle, upper rectangles
               .join(
-                // @ts-expect-error void => Selection
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                () => {
-                },
-                (update) => {
+                enter => enter,
+                (update) =>
                   update
                     .attr('x', (d) => axisBounds.left + (place === 'bottom'
                       ? (start + d * length / 3) : 0))
@@ -184,15 +189,14 @@ export const AxisDragRects = observer(
                       ? 0 : (start + d * length / 3)))
                     .attr('width', () => (place === 'bottom' ? length / 3 : axisBounds.width))
                     .attr('height', () => (place === 'bottom' ? axisBounds.height : length / 3))
-                }
               )
-            rectSelection.selectAll('.dragRect').raise()
+            selectDragRects(rectRef.current)?.raise()
           }
         }, {fireImmediately: true}
       )
       return () => disposer()
     }, [axisModel, layout, axisWrapperElt, place, numSubAxes, subAxisIndex])
     return (
-      <g className={'dragRect'} ref={rectRef}/>
+      <g className={'dragRectWrapper'} ref={rectRef}/>
     )
   })

--- a/v3/src/components/axis/components/axis-drag-rects.tsx
+++ b/v3/src/components/axis/components/axis-drag-rects.tsx
@@ -149,6 +149,7 @@ export const AxisDragRects = observer(
           )
         numbering.forEach((behaviorIndex, axisIndex) => {
           rectSelection.select(`.dragRect.${classPrefix}-${classPostfixes[axisIndex]}`)
+            // @ts-expect-error strictFunctionTypes
             .call(dragBehavior[behaviorIndex])
         })
       }

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -5,6 +5,7 @@ import { useDataConfigurationContext } from "../../graph/hooks/use-data-configur
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
 import { useOutsidePointerDown } from "../../../hooks/use-outside-pointer-down"
 import { useOverlayBounds } from "../../../hooks/use-overlay-bounds"
+import { AttributeType } from "../../../models/data/attribute"
 import t from "../../../utilities/translation/translate"
 
 interface IProps {
@@ -13,7 +14,7 @@ interface IProps {
   portal: HTMLElement | null
   onChangeAttribute: (place: GraphPlace, attrId: string) => void
   onRemoveAttribute: (place: GraphPlace, attrId: string) => void
-  onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
+  onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
 
 const removeAttrItemLabelKeys: Record<string, string> = {

--- a/v3/src/components/axis/components/axis.tsx
+++ b/v3/src/components/axis/components/axis.tsx
@@ -12,6 +12,7 @@ import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {useAxis} from "../hooks/use-axis"
 import {useAxisLayoutContext} from "../models/axis-layout-context"
 import {IAxisModel} from "../models/axis-model"
+import {AttributeType} from "../../../models/data/attribute"
 import {AxisOrLegendAttributeMenu} from "./axis-or-legend-attribute-menu"
 import {SubAxis} from "./sub-axis"
 
@@ -27,7 +28,7 @@ interface IProps {
   isDropAllowed?: IsGraphDropAllowed
   onDropAttribute?: (place: AxisPlace, attrId: string) => void
   onRemoveAttribute?: (place: AxisPlace, attrId: string) => void
-  onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: string) => void
+  onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
 
 export const Axis = ({
@@ -93,9 +94,9 @@ export const Axis = ({
           target={titleRef.current}
           portal={parentElt}
           place={place}
-          onChangeAttribute={onDropAttribute}
-          onRemoveAttribute={onRemoveAttribute}
-          onTreatAttributeAs={onTreatAttributeAs}
+          onChangeAttribute={onDropAttribute as AnyFn}
+          onRemoveAttribute={onRemoveAttribute as AnyFn}
+          onTreatAttributeAs={onTreatAttributeAs as AnyFn}
         />, parentElt)
       }
 

--- a/v3/src/components/axis/components/axis.tsx
+++ b/v3/src/components/axis/components/axis.tsx
@@ -2,7 +2,6 @@ import {Active} from "@dnd-kit/core"
 import React, {MutableRefObject, useRef, useState} from "react"
 import {createPortal} from "react-dom"
 import {range} from "d3"
-import {AxisPlace} from "../axis-types"
 import {DroppableAxis} from "./droppable-axis"
 import {axisPlaceToAttrRole, GraphPlace, IsGraphDropAllowed} from "../../graph/graphing-types"
 import {useAxisBoundsProvider} from "../hooks/use-axis-bounds"
@@ -26,8 +25,8 @@ interface IProps {
   showScatterPlotGridLines?: boolean
   centerCategoryLabels?: boolean
   isDropAllowed?: IsGraphDropAllowed
-  onDropAttribute?: (place: AxisPlace, attrId: string) => void
-  onRemoveAttribute?: (place: AxisPlace, attrId: string) => void
+  onDropAttribute?: (place: GraphPlace, attrId: string) => void
+  onRemoveAttribute?: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
 
@@ -94,9 +93,9 @@ export const Axis = ({
           target={titleRef.current}
           portal={parentElt}
           place={place}
-          onChangeAttribute={onDropAttribute as AnyFn}
-          onRemoveAttribute={onRemoveAttribute as AnyFn}
-          onTreatAttributeAs={onTreatAttributeAs as AnyFn}
+          onChangeAttribute={onDropAttribute}
+          onRemoveAttribute={onRemoveAttribute}
+          onTreatAttributeAs={onTreatAttributeAs}
         />, parentElt)
       }
 

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -88,17 +88,14 @@ export const useAxis = ({
         .selectAll('text.axis-title')
         .data([1])
         .join(
-          // @ts-expect-error void => Selection
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          () => {
-          },
-          (update) => {
+          enter => enter,
+          (update) =>
             update
               .attr("transform", titleTransform + tRotation)
               .attr('x', tX)
               .attr('y', tY)
               .text(axisTitle)
-          })
+        )
     }
 
   }, [axisPlace, layout, place, titleRef, axisTitle, halfRange])
@@ -181,13 +178,12 @@ export const useAxis = ({
         .selectAll('text.axis-title')
         .data([1])
         .join(
-          // @ts-expect-error void => Selection
-          (enter) => {
+          (enter) =>
             enter.append('text')
               .attr('class', 'axis-title')
               .attr('text-anchor', 'middle')
               .attr('data-testid', `axis-title-${place}`)
-          })
+        )
     }
   }, [axisElt, halfRange, axisTitle, place, titleRef])
 

--- a/v3/src/components/case-table/column-header.tsx
+++ b/v3/src/components/case-table/column-header.tsx
@@ -53,7 +53,9 @@ export const ColumnHeader = ({ column }: Pick<THeaderRendererProps, "column">) =
       }
     }
 
+    // @ts-expect-error strictFunctionTypes
     parent?.addEventListener("focusin", handleFocus)
+    // @ts-expect-error strictFunctionTypes
     return () => parent?.removeEventListener("focusin", handleFocus)
   }, [cellElt, contentElt])
 

--- a/v3/src/components/case-table/use-index-column.tsx
+++ b/v3/src/components/case-table/use-index-column.tsx
@@ -126,7 +126,9 @@ export const IndexCell = ({ caseId, index, collapsedCases, onClick }: ICellProps
       }
     }
 
+    // @ts-expect-error strictFunctionTypes
     parent?.addEventListener("focusin", handleFocus)
+    // @ts-expect-error strictFunctionTypes
     return () => parent?.removeEventListener("focusin", handleFocus)
   }, [cellElt])
 

--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -33,6 +33,7 @@ export const useRows = () => {
   const resetRowCache = useCallback(() => {
     rowCache.clear()
     let prevParent: string | undefined
+    // @ts-expect-error strictFunctionTypes
     cases.forEach(({ __id__, [symIndex]: i, [symParent]: parent }: IGroupedCase) => {
       const firstChild = parent && (parent !== prevParent) ? { [symFirstChild]: true } : undefined
       rowCache.set(__id__, { __id__, [symIndex]: i, [symParent]: parent, ...firstChild })

--- a/v3/src/components/graph/components/background.tsx
+++ b/v3/src/components/graph/components/background.tsx
@@ -18,8 +18,7 @@ interface IProps {
 
 const prepareTree = (areaSelector: string, circleSelector: string): typeof RTree => {
     const selectionTree = RTree(10)
-    select(areaSelector).selectAll(circleSelector)
-      // @ts-expect-error strictFunctionTypes
+    select<HTMLDivElement, unknown>(areaSelector).selectAll<SVGCircleElement, InternalizedData>(circleSelector)
       .each((datum: InternalizedData, index, groups) => {
         const element: any = groups[index],
           rect = {
@@ -106,7 +105,7 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
         selectionTree.current = null
         appState.endPerformance()
       },
-      dragBehavior = drag()
+      dragBehavior = drag<SVGRectElement, number>()
         .on("start", onDragStart)
         .on("drag", onDrag)
         .on("end", onDragEnd),
@@ -120,14 +119,11 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
       .selectAll('rect')
       .data([1])
       .join(
-        // @ts-expect-error void => Selection
-        (enter) => {
+        (enter) =>
           enter.append('rect')
             .attr('class', 'graph-background')
-            // @ts-expect-error strictFunctionTypes
-            .call(dragBehavior)
-        },
-        (update) => {
+            .call(dragBehavior),
+        (update) =>
           update
             .attr('transform', transform)
             .attr('width', plotWidth)
@@ -136,7 +132,6 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
             .attr('y', 0)
             .style('fill', graphModel.plotBackgroundColor)
             .style('fill-opacity', graphModel.isTransparent ? 0 : 1)
-        }
       )
   }, [bgRef, instanceId, transform, dataset, plotHeight, plotWidth, graphModel, layout, marqueeState])
 

--- a/v3/src/components/graph/components/background.tsx
+++ b/v3/src/components/graph/components/background.tsx
@@ -19,6 +19,7 @@ interface IProps {
 const prepareTree = (areaSelector: string, circleSelector: string): typeof RTree => {
     const selectionTree = RTree(10)
     select(areaSelector).selectAll(circleSelector)
+      // @ts-expect-error strictFunctionTypes
       .each((datum: InternalizedData, index, groups) => {
         const element: any = groups[index],
           rect = {
@@ -123,6 +124,7 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
         (enter) => {
           enter.append('rect')
             .attr('class', 'graph-background')
+            // @ts-expect-error strictFunctionTypes
             .call(dragBehavior)
         },
         (update) => {

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -98,22 +98,22 @@ export const CaseDots = function CaseDots(props: {
       .transition()
       .duration(duration)
       .on('end', (id, i) => (i === dotsSelection.size() - 1) && onComplete?.())
-      .attr('cx', (aCaseData:CaseData) => {
+      .attr('cx', ((aCaseData: CaseData) => {
         return pointRadius + randomPointsRef.current[aCaseData.caseID].x * (xLength - 2 * pointRadius)
-      })
-      .attr('cy', (aCaseData:CaseData) => {
+      }) as AnyFn)
+      .attr('cy', ((aCaseData: CaseData) => {
         return yLength - (pointRadius + randomPointsRef.current[aCaseData.caseID].y * (yLength - 2 * pointRadius))
-      })
-      .style('fill', (aCaseData:CaseData) => {
+      }) as AnyFn)
+      .style('fill', ((aCaseData: CaseData) => {
         const anID = aCaseData.caseID
         return (legendAttrID && anID && dataConfiguration?.getLegendColorForCase(anID)) ?? graphModel.pointColor
-      })
-      .style('stroke', (aCaseData:CaseData) => (legendAttrID && dataset?.isCaseSelected(aCaseData.caseID))
-        ? defaultSelectedStroke : graphModel.pointStrokeColor)
-      .style('stroke-width', (id: string) => (legendAttrID && dataset?.isCaseSelected(id))
-        ? defaultSelectedStrokeWidth : defaultStrokeWidth)
-      .attr('r', (aCaseData:CaseData) => pointRadius + (dataset?.isCaseSelected(aCaseData.caseID)
-        ? pointRadiusSelectionAddend : 0))
+      }) as AnyFn)
+      .style('stroke', ((aCaseData: CaseData) => (legendAttrID && dataset?.isCaseSelected(aCaseData.caseID))
+        ? defaultSelectedStroke : graphModel.pointStrokeColor) as AnyFn)
+      .style('stroke-width', ((id: string) => (legendAttrID && dataset?.isCaseSelected(id))
+        ? defaultSelectedStrokeWidth : defaultStrokeWidth) as AnyFn)
+      .attr('r', ((aCaseData: CaseData) => pointRadius + (dataset?.isCaseSelected(aCaseData.caseID)
+        ? pointRadiusSelectionAddend : 0)) as AnyFn)
   }, [dataset, legendAttrID, dataConfiguration, graphModel,
     layout, dotsRef, enableAnimation])
 

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -1,6 +1,7 @@
 import {randomUniform, select} from "d3"
 import {onAction} from "mobx-state-tree"
 import React, {useCallback, useEffect, useRef, useState} from "react"
+import { selectDots } from "../d3-types"
 import {CaseData, pointRadiusSelectionAddend, transitionDuration} from "../graphing-types"
 import {ICase} from "../../../models/data/data-set-types"
 import {isAddCasesAction} from "../../../models/data/data-set-actions"
@@ -85,37 +86,38 @@ export const CaseDots = function CaseDots(props: {
   }, [dataConfiguration, graphModel, dotsRef])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
+    if (!dotsRef.current) return
     const
       pointRadius = graphModel.getPointRadius(),
-      dotsSelection = select(dotsRef.current).selectAll(selectedOnly ? '.graph-dot-highlighted' : '.graph-dot'),
+      dotsSelection = selectDots(dotsRef.current, selectedOnly),
       duration = enableAnimation.current ? transitionDuration : 0,
       onComplete = enableAnimation.current ? () => {
         enableAnimation.current = false
       } : undefined,
       xLength = layout.getAxisMultiScale('bottom')?.length ?? 0,
       yLength = layout.getAxisMultiScale('left')?.length ?? 0
+    if (!dotsSelection) return
     dotsSelection
       .transition()
       .duration(duration)
       .on('end', (id, i) => (i === dotsSelection.size() - 1) && onComplete?.())
-      .attr('cx', ((aCaseData: CaseData) => {
+      .attr('cx', (aCaseData: CaseData) => {
         return pointRadius + randomPointsRef.current[aCaseData.caseID].x * (xLength - 2 * pointRadius)
-      }) as AnyFn)
-      .attr('cy', ((aCaseData: CaseData) => {
+      })
+      .attr('cy', (aCaseData: CaseData) => {
         return yLength - (pointRadius + randomPointsRef.current[aCaseData.caseID].y * (yLength - 2 * pointRadius))
-      }) as AnyFn)
-      .style('fill', ((aCaseData: CaseData) => {
+      })
+      .style('fill', (aCaseData: CaseData) => {
         const anID = aCaseData.caseID
         return (legendAttrID && anID && dataConfiguration?.getLegendColorForCase(anID)) ?? graphModel.pointColor
-      }) as AnyFn)
-      .style('stroke', ((aCaseData: CaseData) => (legendAttrID && dataset?.isCaseSelected(aCaseData.caseID))
-        ? defaultSelectedStroke : graphModel.pointStrokeColor) as AnyFn)
-      .style('stroke-width', ((id: string) => (legendAttrID && dataset?.isCaseSelected(id))
-        ? defaultSelectedStrokeWidth : defaultStrokeWidth) as AnyFn)
-      .attr('r', ((aCaseData: CaseData) => pointRadius + (dataset?.isCaseSelected(aCaseData.caseID)
-        ? pointRadiusSelectionAddend : 0)) as AnyFn)
-  }, [dataset, legendAttrID, dataConfiguration, graphModel,
-    layout, dotsRef, enableAnimation])
+      })
+      .style('stroke', (aCaseData: CaseData) => (legendAttrID && dataset?.isCaseSelected(aCaseData.caseID))
+        ? defaultSelectedStroke : graphModel.pointStrokeColor)
+      .style('stroke-width', (aCaseData: CaseData) => (legendAttrID && dataset?.isCaseSelected(aCaseData.caseID))
+        ? defaultSelectedStrokeWidth : defaultStrokeWidth)
+      .attr('r', (aCaseData: CaseData) => pointRadius + (dataset?.isCaseSelected(aCaseData.caseID)
+        ? pointRadiusSelectionAddend : 0))
+  }, [dataset, legendAttrID, dataConfiguration, graphModel, layout, dotsRef, enableAnimation])
 
   useEffect(function initDistribution() {
     const {cases} = dataset || {}

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -1,5 +1,6 @@
-import {ScaleBand, select} from "d3"
+import {ScaleBand} from "d3"
 import React, {useCallback} from "react"
+import { selectDots } from "../d3-types"
 import {attrRoleToAxisPlace, CaseData, PlotProps, transitionDuration} from "../graphing-types"
 import {usePlotResponders} from "../hooks/use-plot"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
@@ -98,7 +99,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
       extraSecCatsArray: string[] = (dataConfiguration && extraSecondaryAttrRole)
         ? Array.from(dataConfiguration.categorySetForAttrRole(extraSecondaryAttrRole)) : [],
       pointDiameter = 2 * graphModel.getPointRadius(),
-      selection = select(dotsRef.current).selectAll(selectedOnly ? '.graph-dot-highlighted' : '.graph-dot'),
+      selection = selectDots(dotsRef.current, selectedOnly),
       primOrdinalScale = layout.getAxisScale(primaryAxisPlace) as ScaleBand<string>,
       secOrdinalScale = layout.getAxisScale(secondaryAxisPlace) as ScaleBand<string>,
       extraPrimOrdinalScale = layout.getAxisScale(extraPrimaryAxisPlace) as ScaleBand<string>,
@@ -114,6 +115,8 @@ export const ChartDots = function ChartDots(props: PlotProps) {
           { cell: { p: number, s: number, ep: number, es: number }, numSoFar: number }>>>> = {},
       legendAttrID = dataConfiguration?.attributeID('legend'),
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined
+
+    if (!selection) return
 
     const computeCellParams = () => {
         primCatsArray.forEach((primeCat, i) => {
@@ -203,7 +206,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
           .duration(duration)
           .on('end', (id, i) => (i === selection.size() - 1) && onComplete?.())
           .attr('r', pointRadius)
-          .attr(primaryCenterKey, ((aCaseData: CaseData) => {
+          .attr(primaryCenterKey, (aCaseData: CaseData) => {
             const anID = aCaseData.caseID
             if (cellIndices[anID]) {
               const {column} = cellIndices[anID],
@@ -213,8 +216,8 @@ export const ChartDots = function ChartDots(props: PlotProps) {
             } else {
               return 0
             }
-          }) as AnyFn)
-          .attr(secondaryCenterKey, ((aCaseData: CaseData) => {
+          })
+          .attr(secondaryCenterKey, (aCaseData: CaseData) => {
             const anID = aCaseData.caseID
             if (cellIndices[anID] && secOrdinalScale) {
               const {row} = cellIndices[anID],
@@ -225,14 +228,14 @@ export const ChartDots = function ChartDots(props: PlotProps) {
             } else {
               return 0
             }
-          }) as AnyFn)
-          .style('fill', ((aCaseData: CaseData) => lookupLegendColor(aCaseData.caseID)) as AnyFn)
+          })
+          .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData.caseID))
           .style('stroke', ((aCaseData: CaseData) =>
             (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-              ? defaultSelectedStroke : pointStrokeColor) as AnyFn)
+              ? defaultSelectedStroke : pointStrokeColor))
           .style('stroke-width', ((aCaseData: CaseData) =>
             (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-              ? defaultSelectedStrokeWidth : defaultStrokeWidth) as AnyFn)
+              ? defaultSelectedStrokeWidth : defaultStrokeWidth))
       }
 
     setPoints()

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -203,7 +203,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
           .duration(duration)
           .on('end', (id, i) => (i === selection.size() - 1) && onComplete?.())
           .attr('r', pointRadius)
-          .attr(primaryCenterKey, (aCaseData: CaseData) => {
+          .attr(primaryCenterKey, ((aCaseData: CaseData) => {
             const anID = aCaseData.caseID
             if (cellIndices[anID]) {
               const {column} = cellIndices[anID],
@@ -213,8 +213,8 @@ export const ChartDots = function ChartDots(props: PlotProps) {
             } else {
               return 0
             }
-          })
-          .attr(secondaryCenterKey, (aCaseData: CaseData) => {
+          }) as AnyFn)
+          .attr(secondaryCenterKey, ((aCaseData: CaseData) => {
             const anID = aCaseData.caseID
             if (cellIndices[anID] && secOrdinalScale) {
               const {row} = cellIndices[anID],
@@ -225,14 +225,14 @@ export const ChartDots = function ChartDots(props: PlotProps) {
             } else {
               return 0
             }
-          })
-          .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData.caseID))
-          .style('stroke', (aCaseData: CaseData) =>
+          }) as AnyFn)
+          .style('fill', ((aCaseData: CaseData) => lookupLegendColor(aCaseData.caseID)) as AnyFn)
+          .style('stroke', ((aCaseData: CaseData) =>
             (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-              ? defaultSelectedStroke : pointStrokeColor)
-          .style('stroke-width', (aCaseData: CaseData) =>
+              ? defaultSelectedStroke : pointStrokeColor) as AnyFn)
+          .style('stroke-width', ((aCaseData: CaseData) =>
             (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-              ? defaultSelectedStrokeWidth : defaultStrokeWidth)
+              ? defaultSelectedStrokeWidth : defaultStrokeWidth) as AnyFn)
       }
 
     setPoints()

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -230,12 +230,12 @@ export const ChartDots = function ChartDots(props: PlotProps) {
             }
           })
           .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData.caseID))
-          .style('stroke', ((aCaseData: CaseData) =>
+          .style('stroke', (aCaseData: CaseData) =>
             (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-              ? defaultSelectedStroke : pointStrokeColor))
-          .style('stroke-width', ((aCaseData: CaseData) =>
+              ? defaultSelectedStroke : pointStrokeColor)
+          .style('stroke-width', (aCaseData: CaseData) =>
             (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-              ? defaultSelectedStrokeWidth : defaultStrokeWidth))
+              ? defaultSelectedStrokeWidth : defaultStrokeWidth)
       }
 
     setPoints()

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -4,6 +4,7 @@ import {Axis} from "../../axis/components/axis"
 import {axisPlaceToAttrRole, GraphPlace, kGraphClassSelector} from "../graphing-types"
 import t from "../../../utilities/translation/translate"
 import {observer} from "mobx-react-lite"
+import {AttributeType} from "../../../models/data/attribute"
 import {useGraphModelContext} from "../models/graph-model"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 
@@ -12,7 +13,7 @@ interface IProps {
   enableAnimation: MutableRefObject<boolean>
   onDropAttribute?: (place: AxisPlace, attrId: string) => void
   onRemoveAttribute?: (place: AxisPlace, attrId: string) => void
-  onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: string) => void
+  onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
 
 export const GraphAxis = observer(function GraphAxis(

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -11,8 +11,8 @@ import {useDataConfigurationContext} from "../hooks/use-data-configuration-conte
 interface IProps {
   place: AxisPlace
   enableAnimation: MutableRefObject<boolean>
-  onDropAttribute?: (place: AxisPlace, attrId: string) => void
-  onRemoveAttribute?: (place: AxisPlace, attrId: string) => void
+  onDropAttribute?: (place: GraphPlace, attrId: string) => void
+  onRemoveAttribute?: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
 

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -133,7 +133,8 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
   const renderDroppableAddAttributes = () => {
     const droppables: JSX.Element[] = []
     if (plotType !== 'casePlot') {
-      const places = ['top', 'rightCat'].concat(plotType=== 'scatterPlot' ? ['yPlus', 'rightNumeric'] : [])
+      const plotPlaces: GraphPlace[] = plotType === 'scatterPlot' ? ['yPlus', 'rightNumeric'] : []
+      const places: GraphPlace[] = ['top', 'rightCat', ...plotPlaces]
       places.forEach((place: GraphPlace) => {
         droppables.push(
           <DroppableAddAttribute
@@ -177,7 +178,7 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
             graphElt={graphRef.current}
             onDropAttribute={handleChangeAttribute}
             onRemoveAttribute={handleRemoveAttribute}
-            onTreatAttributeAs={handleTreatAttrAs}
+            onTreatAttributeAs={handleTreatAttrAs as AnyFn}
           />
         </svg>
         {renderDroppableAddAttributes()}

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -178,7 +178,7 @@ export const Graph = observer(function Graph({graphController, graphRef}: IProps
             graphElt={graphRef.current}
             onDropAttribute={handleChangeAttribute}
             onRemoveAttribute={handleRemoveAttribute}
-            onTreatAttributeAs={handleTreatAttrAs as AnyFn}
+            onTreatAttributeAs={handleTreatAttrAs}
           />
         </svg>
         {renderDroppableAddAttributes()}

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -110,13 +110,13 @@ export const CategoricalLegend = memo(function CategoricalLegend(
             sel.append('rect')
               .attr('width', keySize)
               .attr('height', keySize)
-              .on('click',
-                (event, i: number) => {
+              // @ts-expect-error strictFunctionTypes
+              .on('click', (event, i: number) => {
                   dataConfiguration?.selectCasesForLegendValue(categoryData.current[i].category, event.shiftKey)
                 })
             sel.append('text')
-              .on('click',
-                (event, i: number) => {
+              // @ts-expect-error strictFunctionTypes
+              .on('click', (event, i: number) => {
                   dataConfiguration?.selectCasesForLegendValue(categoryData.current[i].category, event.shiftKey)
                 })
           }

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -96,7 +96,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
         select(keysElt).selectAll('key').remove() // start fresh
 
         const keysSelection = select(keysElt)
-          .selectAll('g')
+          .selectAll<SVGGElement, number>('g')
           .data(range(0, numCategories ?? 0))
           .join(
             enter => enter
@@ -104,18 +104,16 @@ export const CategoricalLegend = memo(function CategoricalLegend(
               .attr('class', 'key')
           )
         keysSelection.each(function (d, n, group) {
-          const sel = select(this),
-            size = sel.selectAll('rect').size()
+          const sel = select<SVGGElement, number>(this),
+            size = sel.selectAll<SVGRectElement, number>('rect').size()
           if (size === 0) {
             sel.append('rect')
               .attr('width', keySize)
               .attr('height', keySize)
-              // @ts-expect-error strictFunctionTypes
               .on('click', (event, i: number) => {
                   dataConfiguration?.selectCasesForLegendValue(categoryData.current[i].category, event.shiftKey)
                 })
             sel.append('text')
-              // @ts-expect-error strictFunctionTypes
               .on('click', (event, i: number) => {
                   dataConfiguration?.selectCasesForLegendValue(categoryData.current[i].category, event.shiftKey)
                 })

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -131,10 +131,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
         .selectAll('g')
         .data(range(0, numCategories ?? 0))
         .join(
-          // @ts-expect-error void => Selection
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          () => {
-          },
+          enter => enter,
           update => {
             update.select('rect')
               .classed('legend-rect-selected',
@@ -149,7 +146,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
               })
               .attr('y',
                 (index: number) => 10 + categoryData.current[index].row * (keySize + padding))
-            update.select('text')
+            return update.select('text')
               .text((index: number) => categoryData.current[index].category)
               .attr('transform', transform)
               .attr('x', (index: number) => {

--- a/v3/src/components/graph/components/legend/choroplethLegend/choroplethLegend.ts
+++ b/v3/src/components/graph/components/legend/choroplethLegend/choroplethLegend.ts
@@ -89,6 +89,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     .attr("transform", `${transform} translate(0,${kChoroplethHeight})`)
     .call(axisBottom(x)
       .ticks(ticks)
+      // @ts-expect-error strictFunctionTypes
       .tickFormat(tickFormat)
       .tickSize(tickSize)
       .tickValues(tickValues))

--- a/v3/src/components/graph/components/legend/choroplethLegend/choroplethLegend.ts
+++ b/v3/src/components/graph/components/legend/choroplethLegend/choroplethLegend.ts
@@ -100,14 +100,12 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     .selectAll('text')
     .data([Number(minValue), Number(maxValue)])
     .join(
-      // @ts-expect-error void => Selection
-      (enter) => {
+      (enter) =>
         enter.append('text')
           .attr('y', kChoroplethHeight)
           .style('text-anchor', (d, i) => i ? 'end' : 'start')
           .attr('x', (d, i) => i * width)
           .text((d, i) => format(`.${significantDigits[i === 0 ? 0 : 5]}r`)(d))
-      }
     )
 
   return svg.node()

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -10,6 +10,7 @@ import {DroppableSvg} from "../droppable-svg"
 import {useInstanceIdContext} from "../../../../hooks/use-instance-id-context"
 import {getDragAttributeId, useDropHandler} from "../../../../hooks/use-drag-drop"
 import {useDropHintString} from "../../../../hooks/use-drop-hint-string"
+import {AttributeType} from "../../../../models/data/attribute"
 import {GraphAttrRole, GraphPlace} from "../../graphing-types"
 import {AxisOrLegendAttributeMenu} from "../../../axis/components/axis-or-legend-attribute-menu"
 
@@ -18,7 +19,7 @@ interface ILegendProps {
   graphElt: HTMLDivElement | null
   onDropAttribute: (place: GraphPlace, attrId: string) => void
   onRemoveAttribute: (place: GraphPlace, attrId: string) => void
-  onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: string) => void
+  onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
 
 export const Legend = function Legend({

--- a/v3/src/components/graph/components/marquee.tsx
+++ b/v3/src/components/graph/components/marquee.tsx
@@ -13,17 +13,14 @@ export const Marquee = observer(function Marquee(props:{marqueeState: MarqueeSta
     select(marqueeRef.current).selectAll('rect')
       .data([1, 2])
       .join(
-        // @ts-expect-error void => Selection
-        (enter) => {
+        (enter) =>
           enter.append('rect')
-            .attr('class', (d: number) => d === 1 ? 'marquee-back' : 'marquee')
-        },
-        (update) => {
+            .attr('class', (d: number) => d === 1 ? 'marquee-back' : 'marquee'),
+        (update) =>
           update.attr('x', width < 0 ? x + width : x)
             .attr('y', height < 0 ? y + height : y)
             .attr('width', Math.abs(width))
             .attr('height', Math.abs(height))
-        }
       )
   }, [marqueeRect])
 

--- a/v3/src/components/graph/d3-types.ts
+++ b/v3/src/components/graph/d3-types.ts
@@ -2,6 +2,7 @@ import { select, Selection } from "d3"
 import { CaseData } from "./graphing-types"
 
 // For proper typing of D3 callbacks, the initial selection must be typed appropriately.
+
 // type arguments:
 //  SVGCircleElement: type of element being selected
 //  CaseData: type of data attached to selected element

--- a/v3/src/components/graph/d3-types.ts
+++ b/v3/src/components/graph/d3-types.ts
@@ -1,0 +1,25 @@
+import { select, Selection } from "d3"
+import { CaseData } from "./graphing-types"
+
+// For proper typing of D3 callbacks, the initial selection must be typed appropriately.
+// type arguments:
+//  SVGCircleElement: type of element being selected
+//  CaseData: type of data attached to selected element
+//  SVGSVGElement: type of parent element selected by initial/global select
+//  unknown: type of data attached to parent element (none in this case)
+export type DotSelection = Selection<SVGCircleElement, CaseData, SVGSVGElement, unknown>
+
+// selects all `circle` elements
+export function selectCircles(svg: SVGSVGElement | null): DotSelection | null {
+  return svg
+          ? select(svg).selectAll("circle")
+          : null
+}
+
+// selects all `.graph-dot` or `.graph-dot-highlighted` elements
+export function selectDots(svg: SVGSVGElement | null, selectedOnly = false): DotSelection | null {
+  const innerSelector = selectedOnly ? ".graph-dot-highlighted" : ".graph-dot"
+  return svg
+          ? select(svg).selectAll(innerSelector)
+          : null
+}

--- a/v3/src/components/graph/hooks/use-init-graph-layout.ts
+++ b/v3/src/components/graph/hooks/use-init-graph-layout.ts
@@ -12,15 +12,15 @@ export function useInitGraphLayout(model?: IGraphModel) {
     // synchronize the number of repetitions from the DataConfiguration to the layout's MultiScales
     return reaction(
       () => {
-        const repetitions: Record<string, number> = {}
+        const repetitions: Partial<Record<AxisPlace, number>> = {}
         layout.axisScales.forEach((multiScale, place) => {
           repetitions[place] = model?.config.numRepetitionsForPlace(place) ?? 1
         })
         return repetitions
       },
       (repetitions) => {
-        Object.keys(repetitions).forEach((place: AxisPlace) => {
-          layout.getAxisMultiScale(place)?.setRepetitions(repetitions[place])
+        (Object.keys(repetitions) as AxisPlace[]).forEach((place: AxisPlace) => {
+          layout.getAxisMultiScale(place)?.setRepetitions(repetitions[place] ?? 0)
         })
       }
     )

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -145,7 +145,7 @@ export function matchCirclesToData(props: IMatchCirclesProps) {
   startAnimation(enableAnimation)
   select(dotsElement)
     .selectAll('circle')
-    .data(allCaseData, caseDataKeyFunc)
+    .data(allCaseData, caseDataKeyFunc as AnyFn)
     .join(
       // @ts-expect-error void => Selection
       (enter) => {
@@ -368,17 +368,16 @@ export function setPointSelection(props: ISetPointSelection) {
     legendID = dataConfiguration.attributeID('legend')
   // First set the class based on selection
   dots.selectAll('circle')
-    .classed('graph-dot-highlighted',
-      (aCaseData: CaseData) => !!(dataset?.isCaseSelected(aCaseData.caseID)))
+    .classed('graph-dot-highlighted', ((aCaseData: CaseData) => !!dataset?.isCaseSelected(aCaseData.caseID)) as AnyFn)
     // Then set properties to defaults w/o selection
     .attr('r', pointRadius)
     .style('stroke', pointStrokeColor)
-    .style('fill', (aCaseData:CaseData) => {
+    .style('fill', ((aCaseData:CaseData) => {
       return legendID
         ? dataConfiguration?.getLegendColorForCase(aCaseData.caseID)
         : aCaseData.plotNum && getPointColorAtIndex
           ? getPointColorAtIndex(aCaseData.plotNum) : pointColor
-    })
+    }) as AnyFn)
     .style('stroke-width', defaultStrokeWidth)
     .style('stroke-opacity', defaultStrokeOpacity)
 
@@ -434,19 +433,19 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
           .transition()
           .duration(duration)
           .on('end', (id, i) => (i === theSelection.size() - 1) && onComplete())
-          .attr('cx', (aCaseData: CaseData) => getScreenX(aCaseData.caseID))
-          .attr('cy', (aCaseData: CaseData) => {
+          .attr('cx', ((aCaseData: CaseData) => getScreenX(aCaseData.caseID)) as AnyFn)
+          .attr('cy', ((aCaseData: CaseData) => {
             return getScreenY(aCaseData.caseID, aCaseData.plotNum)
-          })
-          .attr('r', (aCaseData: CaseData) => dataset?.isCaseSelected(aCaseData.caseID)
-            ? selectedPointRadius : pointRadius)
-          .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData))
-          .style('stroke', (aCaseData: CaseData) =>
+          }) as AnyFn)
+          .attr('r', ((aCaseData: CaseData) => dataset?.isCaseSelected(aCaseData.caseID)
+            ? selectedPointRadius : pointRadius) as AnyFn)
+          .style('fill', ((aCaseData: CaseData) => lookupLegendColor(aCaseData)) as AnyFn)
+          .style('stroke', ((aCaseData: CaseData) =>
             (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-            ? defaultSelectedStroke : pointStrokeColor)
-          .style('stroke-width', (aCaseData: CaseData) =>
+            ? defaultSelectedStroke : pointStrokeColor) as AnyFn)
+          .style('stroke-width', ((aCaseData: CaseData) =>
             (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-            ? defaultSelectedStrokeWidth : defaultStrokeWidth)
+            ? defaultSelectedStrokeWidth : defaultStrokeWidth) as AnyFn)
       }
     }
 

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -149,18 +149,15 @@ export function matchCirclesToData(props: IMatchCirclesProps) {
   circles
     .data(allCaseData, caseDataKeyFunc)
     .join(
-      // @ts-expect-error void => Selection
-      (enter) => {
+      (enter) =>
         enter.append('circle')
           .attr('class', 'graph-dot')
-          .property('id', (anID: string) => `${instanceId}_${anID}`)
-      },
-      (update) => {
+          .property('id', (anID: string) => `${instanceId}_${anID}`),
+      (update) =>
         update.attr('r', pointRadius)
           .style('fill', pointColor)
           .style('stroke', pointStrokeColor)
           .style('stroke-width', defaultStrokeWidth)
-      }
     )
   select(dotsElement).on('click',
     (event: MouseEvent) => {

--- a/v3/src/components/graph/v2-graph-importer.ts
+++ b/v3/src/components/graph/v2-graph-importer.ts
@@ -14,6 +14,7 @@ export function v2GraphImporter({ v2Component, v2Document, sharedModelManager, i
   if (!isV2GraphComponent(v2Component)) return
 
   const { title = "", _links_: links } = v2Component.componentStorage
+  type TLinksKey = keyof typeof links
   const contextId = links.context.id
   const { data, metadata } = v2Document.getDataAndMetadata(contextId)
 
@@ -36,7 +37,7 @@ export function v2GraphImporter({ v2Component, v2Document, sharedModelManager, i
   const _yAttributeDescriptions: IAttributeDescriptionSnapshot[] = []
 
   // configure attributes
-  Object.keys(links).forEach((aKey: keyof typeof links) => {
+  ;(Object.keys(links) as TLinksKey[]).forEach((aKey: TLinksKey) => {
     if (['xAttr', 'yAttr', 'y2Attr', 'legendAttr', 'topAttr', 'rightAttr'].includes(aKey)) {
       const attrKey = aKey.match(/[a-z2]+/)?.[0]  // matches before the "Attr"
       if (!attrKey) return
@@ -98,7 +99,7 @@ export function v2GraphImporter({ v2Component, v2Document, sharedModelManager, i
     }
   })
   // use empty axes for left/bottom if there are no other axes there
-  ;["bottom", "left"].forEach((place: AxisPlace) => {
+  ;(["bottom", "left"] as const).forEach(place => {
     if (!axes[place]) axes[place] = { place, type: "empty" }
   })
 

--- a/v3/src/components/tiles/placeholder/placeholder-tile.tsx
+++ b/v3/src/components/tiles/placeholder/placeholder-tile.tsx
@@ -4,7 +4,7 @@ import { ITileModel } from "../../../models/tiles/tile-model"
 import "./placeholder-tile.scss"
 
 interface IProps {
-  tile: ITileModel
+  tile?: ITileModel
 }
 export const PlaceholderTileComponent = ({ tile }: IProps) => {
 

--- a/v3/src/global.d.ts
+++ b/v3/src/global.d.ts
@@ -10,7 +10,3 @@ declare namespace process {
     NODE_ENV: string; // e.g. "development" or "production"
   }
 }
-
-// Temporary workaround for `strictFunctionTypes` issues
-// TODO: figure out a better solution
-declare type AnyFn = any

--- a/v3/src/global.d.ts
+++ b/v3/src/global.d.ts
@@ -10,3 +10,7 @@ declare namespace process {
     NODE_ENV: string; // e.g. "development" or "production"
   }
 }
+
+// Temporary workaround for `strictFunctionTypes` issues
+// TODO: figure out a better solution
+declare type AnyFn = any

--- a/v3/src/hooks/use-data-set.ts
+++ b/v3/src/hooks/use-data-set.ts
@@ -1,5 +1,5 @@
 import { IDataSet } from "../models/data/data-set"
-import { ISharedCaseMetadata, kSharedCaseMetadataType } from "../models/shared/shared-case-metadata"
+import { ISharedCaseMetadata, kSharedCaseMetadataType, SharedCaseMetadata } from "../models/shared/shared-case-metadata"
 import { getSharedModelManager } from "../models/tiles/tile-environment"
 import { useDataSetContext } from "./use-data-set-context"
 
@@ -9,7 +9,7 @@ export function useDataSet(inData?: IDataSet, inMetadata?: ISharedCaseMetadata) 
   // find the metadata that corresponds to this DataSet
   const sharedModelManager = getSharedModelManager(data)
   const metadata = inMetadata ?? sharedModelManager
-                                  ?.getSharedModelsByType(kSharedCaseMetadataType)
+                                  ?.getSharedModelsByType<typeof SharedCaseMetadata>(kSharedCaseMetadataType)
                                   .find((model: ISharedCaseMetadata) => {
                                     return model.data?.id === data?.id
                                   }) as ISharedCaseMetadata | undefined

--- a/v3/src/models/app-state.ts
+++ b/v3/src/models/app-state.ts
@@ -10,7 +10,7 @@ import { action, computed, makeObservable, observable } from "mobx"
 import { createCodapDocument } from "./codap/create-codap-document"
 import { gDataBroker } from "./data/data-broker"
 import { IDocumentModel, IDocumentModelSnapshot } from "./document/document"
-import { ISharedDataSet, kSharedDataSetType } from "./shared/shared-data-set"
+import { ISharedDataSet, kSharedDataSetType, SharedDataSet } from "./shared/shared-data-set"
 import { getSharedModelManager } from "./tiles/tile-environment"
 
 type AppMode = "normal" | "performance"
@@ -48,7 +48,7 @@ class AppState {
 
         // update data broker with the new data sets
         const manager = getSharedModelManager(document)
-        manager?.getSharedModelsByType(kSharedDataSetType).forEach((model: ISharedDataSet) => {
+        manager?.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType).forEach((model: ISharedDataSet) => {
           gDataBroker.addSharedDataSet(model)
         })
       }

--- a/v3/src/models/data/filtered-cases.ts
+++ b/v3/src/models/data/filtered-cases.ts
@@ -3,7 +3,7 @@ import { ISerializedActionCall, onAction } from "mobx-state-tree"
 import { IDataSet } from "./data-set"
 import { isSetCaseValuesAction } from "./data-set-actions"
 
-export type FilterFn = (data: IDataSet, caseId: string, casesArrayNumber?:number) => boolean
+export type FilterFn = (data: IDataSet, caseId: string, casesArrayNumber?: number) => boolean
 
 export interface IFilteredChangedCases {
   added: string[]   // ids of cases that newly pass the filter

--- a/v3/src/models/document/shared-model-document-manager.ts
+++ b/v3/src/models/document/shared-model-document-manager.ts
@@ -1,8 +1,8 @@
 import { action, computed, makeObservable, observable } from "mobx"
 import { getParentOfType, hasParentOfType, IAnyStateTreeNode } from "mobx-state-tree"
 import { IDocumentContentModel } from "./document-content"
-import { ISharedModel } from "../shared/shared-model"
-import { ISharedModelManager, SharedModelUnion } from "../shared/shared-model-manager"
+import { ISharedModel, SharedModel } from "../shared/shared-model"
+import { ISharedModelManager } from "../shared/shared-model-manager"
 import { ITileModel, TileModel } from "../tiles/tile-model"
 
 
@@ -40,7 +40,7 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
     this.document = document
   }
 
-  findFirstSharedModelByType<IT extends typeof SharedModelUnion>(
+  findFirstSharedModelByType<IT extends typeof SharedModel>(
     sharedModelType: IT, providerId?: string): IT["Type"] | undefined {
     if (!this.document) {
       console.warn("findFirstSharedModelByType has no document")
@@ -48,7 +48,7 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
     return this.document?.getFirstSharedModelByType(sharedModelType, providerId)
   }
 
-  getSharedModelsByType<IT extends typeof SharedModelUnion>(type: string): IT["Type"][] {
+  getSharedModelsByType<IT extends typeof SharedModel>(type: string): IT["Type"][] {
     return this.document?.getSharedModelsByType<IT>(type) || []
   }
 

--- a/v3/src/models/shared/shared-model-manager.ts
+++ b/v3/src/models/shared/shared-model-manager.ts
@@ -62,7 +62,7 @@ export interface ISharedModelManager {
    *
    * @param sharedModelType the MST model "class" of the shared model
    */
-  findFirstSharedModelByType<IT extends typeof SharedModelUnion>(
+  findFirstSharedModelByType<IT extends typeof SharedModel>(
     sharedModelType: IT, providerId?: string): IT["Type"] | undefined;
 
   /**
@@ -70,7 +70,7 @@ export interface ISharedModelManager {
    *
    * @param sharedModelType the MST model "class" of the shared model
    */
-  getSharedModelsByType<IT extends typeof SharedModelUnion>(type: string): IT["Type"][];
+  getSharedModelsByType<IT extends typeof SharedModel>(type: string): IT["Type"][];
 
   /**
    * Add a shared model to the container if it doesn't exist.

--- a/v3/tsconfig.json
+++ b/v3/tsconfig.json
@@ -13,8 +13,6 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "strict": true,
-    // todo: Figure out how to not require this
-    "strictFunctionTypes": false,
     "types": [],
     "jsx": "react",
     "lib": ["dom", "dom.iterable", "es2018"]


### PR DESCRIPTION
"Fixes" fall into three broad categories:
- actual fixes to the typing issues in question
- adding `@ts-expect-error` at the point of the call in places where the actual fix wasn't clear
- ~~adding a cast in some places where `@ts-expect-error` didn't work or was annoying~~

Update: I figured out the root of the issues we were having with D3 types. The trick is to type the initial selection correctly because that determines the types of all of the arguments from the chained callbacks. Also, the functions passed to `join()` must return the appropriate type to enable further chaining.