### PR TITLE
V3: 184771920 blank default document

### DIFF
--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -20,7 +20,7 @@ const arrayOfValues = [
 
 context("Test graph axes with various attribute types", () => {
     beforeEach(function () {
-        const queryParams = "?sample=mammals&mouseSensor"
+        const queryParams = "?sample=mammals&dashboard&mouseSensor"
         const url = `${Cypress.config("index")}${queryParams}`
         cy.visit(url)
         cy.wait(2500)

--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -155,7 +155,7 @@ context("Test graph axes with various attribute types", () => {
 
 context("Test graph axes attribute menu", () => {
     beforeEach(function () {
-        const queryParams = "?sample=mammals&mouseSensor"
+        const queryParams = "?sample=mammals&dashboard&mouseSensor"
         const url = `${Cypress.config("index")}${queryParams}`
         cy.visit(url)
         cy.wait(2500)

--- a/v3/cypress/e2e/calculator.spec.ts
+++ b/v3/cypress/e2e/calculator.spec.ts
@@ -2,7 +2,7 @@ import { CalculatorTileElements as calc } from "../support/elements/calculator-t
 
 context("Data summary UI", () => {
     beforeEach(function () {
-        const queryParams = "?sample=mammals&mouseSensor"
+        const queryParams = "?sample=mammals&dashboard&mouseSensor"
         const url = `${Cypress.config("index")}${queryParams}`
         cy.visit(url)
         cy.wait(2500)

--- a/v3/cypress/e2e/data-summary.spec.ts
+++ b/v3/cypress/e2e/data-summary.spec.ts
@@ -2,7 +2,7 @@ import { DataSummaryTileElements as dataSummary } from "../support/elements/data
 
 context("Data summary UI", () => {
     beforeEach(function () {
-        const queryParams = "?sample=mammals&mouseSensor"
+        const queryParams = "?sample=mammals&dashboard&mouseSensor"
         const url = `${Cypress.config("index")}${queryParams}`
         cy.visit(url)
         cy.wait(2500)

--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -14,7 +14,7 @@ const arrayOfPlots = [
 
 context("Test graph plot transitions", () => {
     beforeEach(function () {
-        const queryParams = "?sample=mammals&mouseSensor"
+        const queryParams = "?sample=mammals&dashboard&mouseSensor"
         const url = `${Cypress.config("index")}${queryParams}`
         cy.visit(url)
         cy.wait(2500)

--- a/v3/cypress/e2e/legend.spec.ts
+++ b/v3/cypress/e2e/legend.spec.ts
@@ -122,7 +122,7 @@ context("Test legend with various attribute types", () => {
 
 context("Test drawing legend on existing legend", () => {
     beforeEach(function () {
-        const queryParams = "?sample=mammals&mouseSensor"
+        const queryParams = "?sample=mammals&dashboard&mouseSensor"
         const url = `${Cypress.config("index")}${queryParams}`
         cy.visit(url)
         cy.wait(2500)
@@ -196,7 +196,7 @@ context("Test drawing legend on existing legend", () => {
 })
 context("Test selecting and selecting categories in legend", () => {
     beforeEach(function () {
-        const queryParams = "?sample=mammals&mouseSensor"
+        const queryParams = "?sample=mammals&dashboard&mouseSensor"
         const url = `${Cypress.config("index")}${queryParams}`
         cy.visit(url)
         cy.wait(2500)

--- a/v3/cypress/e2e/legend.spec.ts
+++ b/v3/cypress/e2e/legend.spec.ts
@@ -17,7 +17,7 @@ const arrayOfValues = [
 
 context("Test legend with various attribute types", () => {
     beforeEach(function () {
-        const queryParams = "?sample=mammals&mouseSensor"
+        const queryParams = "?sample=mammals&dashboard&mouseSensor"
         const url = `${Cypress.config("index")}${queryParams}`
         cy.visit(url)
         cy.wait(2500)

--- a/v3/cypress/e2e/slider.spec.ts
+++ b/v3/cypress/e2e/slider.spec.ts
@@ -2,7 +2,7 @@ import { SliderTileElements as slider } from "../support/elements/slider-tile"
 
 context("Slider UI", () => {
     beforeEach(function () {
-        const queryParams = "?sample=mammals&mouseSensor"
+        const queryParams = "?sample=mammals&dashboard&mouseSensor"
         const url = `${Cypress.config("index")}${queryParams}`
         cy.visit(url)
         cy.wait(2500)

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -7,7 +7,7 @@ let middleRowIndex = undefined
 let numOfCases = undefined
 
 beforeEach(()=> {
-    const queryParams = "?sample=mammals"
+    const queryParams = "?sample=mammals&dashboard"
     const url = `${Cypress.config("index")}${queryParams}`
     cy.visit(url)
     cy.wait(2000)

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -122,11 +122,9 @@ export const App = observer(function App() {
     if (gDataBroker.dataSets.size === 0) {
       const sample = sampleData.find(name => urlParams.sample === name.toLowerCase())
       if (sample) {
-        console.log("in if sample")
         importSample(sample, handleImportDataSet)
-        addDefaultComponents()
       }
-      else if (getSearchParams().includes("dashboard")) {
+      if (urlParams.dashboard !== undefined) {
         createNewStarterDataset()
         addDefaultComponents()
       }

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -115,9 +115,10 @@ export const App = observer(function App() {
       const sample = sampleData.find(name => urlParams.sample === name.toLowerCase())
       if (sample) {
         importSample(sample, handleImportDataSet)
+      } else {
+        createNewStarterDataset()
       }
       if (urlParams.dashboard !== undefined) {
-        createNewStarterDataset()
         addDefaultComponents()
       }
     }

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -19,7 +19,7 @@ import {useDropHandler} from "../hooks/use-drop-handler"
 import { useKeyStates } from "../hooks/use-key-states"
 import { registerTileTypes } from "../register-tile-types"
 import { importSample, sampleData } from "../sample-data"
-import { getSearchParams, urlParams } from "../utilities/url-params"
+import { urlParams } from "../utilities/url-params"
 import { CodapV2Document } from "../v2/codap-v2-document"
 import { importV2Component } from "../v2/codap-v2-tile-importers"
 import "../models/shared/shared-case-metadata-registration"
@@ -32,14 +32,6 @@ registerTileTypes([])
 export function handleImportDataSet(data: IDataSet) {
   // add data set
   gDataBroker.addDataSet(data)
-}
-
-export function createNewStarterDataset() {
-  const newData = [{AttributeName: ""}]
-  const ds = DataSet.create({name: "New Dataset"})
-  ds.addAttribute({name: "AttributeName"})
-  ds.addCases(toCanonical(ds, newData))
-  gDataBroker.addDataSet(ds)
 }
 
 export const App = observer(function App() {
@@ -103,13 +95,13 @@ export const App = observer(function App() {
     onImportV3Document: handleImportV3Document
   })
 
-  // function createNewStarterDataset() {
-  //   const newData = [{AttributeName: ""}]
-  //   const ds = DataSet.create({name: "New Dataset"})
-  //   ds.addAttribute({name: "AttributeName"})
-  //   ds.addCases(toCanonical(ds, newData))
-  //   gDataBroker.addDataSet(ds)
-  // }
+  function createNewStarterDataset() {
+    const newData = [{AttributeName: ""}]
+    const ds = DataSet.create({name: "New Dataset"})
+    ds.addAttribute({name: "AttributeName"})
+    ds.addCases(toCanonical(ds, newData))
+    gDataBroker.addDataSet(ds)
+  }
 
   useEffect(() => {
     // connect the data broker to the shared model manager

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -19,7 +19,7 @@ import {useDropHandler} from "../hooks/use-drop-handler"
 import { useKeyStates } from "../hooks/use-key-states"
 import { registerTileTypes } from "../register-tile-types"
 import { importSample, sampleData } from "../sample-data"
-import { urlParams } from "../utilities/url-params"
+import { getSearchParams, urlParams } from "../utilities/url-params"
 import { CodapV2Document } from "../v2/codap-v2-document"
 import { importV2Component } from "../v2/codap-v2-tile-importers"
 import "../models/shared/shared-case-metadata-registration"
@@ -29,11 +29,17 @@ import "./app.scss"
 
 registerTileTypes([])
 
-addDefaultComponents()
-
 export function handleImportDataSet(data: IDataSet) {
   // add data set
   gDataBroker.addDataSet(data)
+}
+
+export function createNewStarterDataset() {
+  const newData = [{AttributeName: ""}]
+  const ds = DataSet.create({name: "New Dataset"})
+  ds.addAttribute({name: "AttributeName"})
+  ds.addCases(toCanonical(ds, newData))
+  gDataBroker.addDataSet(ds)
 }
 
 export const App = observer(function App() {
@@ -97,13 +103,13 @@ export const App = observer(function App() {
     onImportV3Document: handleImportV3Document
   })
 
-  function createNewStarterDataset() {
-    const newData = [{AttributeName: ""}]
-    const ds = DataSet.create({name: "New Dataset"})
-    ds.addAttribute({name: "AttributeName"})
-    ds.addCases(toCanonical(ds, newData))
-    gDataBroker.addDataSet(ds)
-  }
+  // function createNewStarterDataset() {
+  //   const newData = [{AttributeName: ""}]
+  //   const ds = DataSet.create({name: "New Dataset"})
+  //   ds.addAttribute({name: "AttributeName"})
+  //   ds.addCases(toCanonical(ds, newData))
+  //   gDataBroker.addDataSet(ds)
+  // }
 
   useEffect(() => {
     // connect the data broker to the shared model manager
@@ -116,9 +122,13 @@ export const App = observer(function App() {
     if (gDataBroker.dataSets.size === 0) {
       const sample = sampleData.find(name => urlParams.sample === name.toLowerCase())
       if (sample) {
+        console.log("in if sample")
         importSample(sample, handleImportDataSet)
-      } else {
+        addDefaultComponents()
+      }
+      else if (getSearchParams().includes("dashboard")) {
         createNewStarterDataset()
+        addDefaultComponents()
       }
     }
   }, [])


### PR DESCRIPTION
Adds ability to open a blank document, and opens to specified document based on URL parameters.
By default, CODAP will load a blank document with no data set.
If `dashboard` query param is added, then CODAP will load with an empty data set, and all components open.
If `sample=[sample-dataset-name]` query param is added, CODAP will load a blank document, but the specified data set is attached to the document. Currently, we have no way of opening a case table for the dataset, but can verify the dataset exist by opening a graph.
If `sample=[sample-dataset-name]&dashboard` query param is added, CODAP will load dataset with all the components opened.