### PR TITLE
Prevent errors during graph dispose

### DIFF
--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -1,5 +1,6 @@
 import React, {MutableRefObject, useEffect} from "react"
 import {observer} from "mobx-react-lite"
+import {isAlive} from "mobx-state-tree"
 import {Active} from "@dnd-kit/core"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {AttributeType} from "../../../models/data/attribute"
@@ -15,7 +16,6 @@ import {DroppableAxis} from "../../axis/components/droppable-axis"
 import {AttributeLabel} from "./attribute-label"
 import {useDropHintString} from "../../../hooks/use-drop-hint-string"
 import {useAxisBoundsProvider} from "../../axis/hooks/use-axis-bounds"
-import {isAlive} from "mobx-state-tree";
 
 interface IProps {
   place: AxisPlace
@@ -60,7 +60,7 @@ export const GraphAxis = observer(function GraphAxis(
         layout.setDesiredExtent(place, 0)
       }
     }
-  }, [layout, place])
+  }, [layout, place, graphModel])
 
   return (
     <g className='axis-wrapper' ref={elt => setWrapperElt(elt)}>

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -15,6 +15,7 @@ import {DroppableAxis} from "../../axis/components/droppable-axis"
 import {AttributeLabel} from "./attribute-label"
 import {useDropHintString} from "../../../hooks/use-drop-hint-string"
 import {useAxisBoundsProvider} from "../../axis/hooks/use-axis-bounds"
+import {isAlive} from "mobx-state-tree";
 
 interface IProps {
   place: AxisPlace
@@ -53,7 +54,11 @@ export const GraphAxis = observer(function GraphAxis(
 
   useEffect(function cleanup () {
     return () => {
-      layout.setDesiredExtent(place, 0)
+      // This gets called when the component is unmounted, which happens when the graph is closed.
+      // In that case setting the desired extent in the layout will cause MST model errors.
+      if (isAlive(graphModel)) {
+        layout.setDesiredExtent(place, 0)
+      }
     }
   }, [layout, place])
 

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useRef} from "react"
+import React, {useRef} from "react"
 import {Active} from "@dnd-kit/core"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {useGraphLayoutContext} from "../../models/graph-layout"


### PR DESCRIPTION
* GraphAxis has a useEffect for a cleanup needed under normal circumstances. But it gets triggered when the graph component is closed as well, during which accesses to MST model properties of already disposed objects are attempted. So we test that the graphModel is still alive before making the attempt.