### PR TITLE
Graph point selection fix

### DIFF
--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -382,7 +382,7 @@ export function setPointSelection(props: ISetPointSelection) {
     .style('stroke-width', defaultStrokeWidth)
     .style('stroke-opacity', defaultStrokeOpacity)
 
-  const selectedDots = dots.selectAll('.graph-dot-highlighted')
+  const selectedDots = select(dotsRef.current).selectAll('.graph-dot-highlighted')
   // How we deal with this depends on whether there is a legend or not
   if (legendID) {
     selectedDots

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -382,19 +382,16 @@ export function setPointSelection(props: ISetPointSelection) {
     .style('stroke-width', defaultStrokeWidth)
     .style('stroke-opacity', defaultStrokeOpacity)
 
-  const selectedDots = select(dotsRef.current).selectAll('.graph-dot-highlighted')
+  const selectedDots = selectDots(dotsRef.current, true)
   // How we deal with this depends on whether there is a legend or not
   if (legendID) {
-    selectedDots
-      .style('stroke', defaultSelectedStroke)
+    selectedDots?.style('stroke', defaultSelectedStroke)
       .style('stroke-width', defaultSelectedStrokeWidth)
       .style('stroke-opacity', defaultSelectedStrokeOpacity)
   } else {
-    selectedDots
-      .style('fill', defaultSelectedColor)
+    selectedDots?.style('fill', defaultSelectedColor)
   }
-  selectedDots
-    .attr('r', selectedPointRadius)
+  selectedDots?.attr('r', selectedPointRadius)
     .raise()
 }
 


### PR DESCRIPTION
Starting in build 1201 selection of cases is no longer reflected by point highlighting in graphs.

This PR fixes this bug