### PR TITLE
Graph split plot bug fix

### DIFF
--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -140,7 +140,7 @@ export const CaseDots = function CaseDots(props: {
   }, [dataset])
 
   usePlotResponders({
-    graphModel, dotsRef, legendAttrID, layout, refreshPointPositions, refreshPointSelection, enableAnimation
+    graphModel, dotsRef, layout, refreshPointPositions, refreshPointSelection, enableAnimation
   })
 
   return (

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -244,11 +244,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
     enableAnimation, primaryIsBottom, layout, pointStrokeColor, computeMaxOverAllCells, dataset])
 
   usePlotResponders({
-    graphModel, layout, dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation,
-    primaryAttrID: dataConfiguration?.attributeID(primaryAttrRole),
-    secondaryAttrID: dataConfiguration?.attributeID(secondaryAttrRole),
-    legendAttrID: dataConfiguration?.attributeID('legend')
-  })
+    graphModel, layout, dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation })
 
   return (
     <></>

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -265,10 +265,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
       enableAnimation, primaryIsBottom, pointColor, pointStrokeColor])
 
   usePlotResponders({
-    graphModel, primaryAttrID: dataConfiguration?.attributeID(primaryAttrRole) ?? '',
-    secondaryAttrID: dataConfiguration?.attributeID(secondaryAttrRole),
-    legendAttrID: dataConfiguration?.attributeID('legend'),
-    layout, dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation
+    graphModel, layout, dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation
   })
 
   return (

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useRef} from "react"
+import React, {useRef} from "react"
 import {Active} from "@dnd-kit/core"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {useGraphLayoutContext} from "../../models/graph-layout"

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -227,9 +227,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
   }, [refreshPointPositionsD3, refreshPointPositionsSVG])
 
   usePlotResponders({
-    graphModel, primaryAttrID: dataConfiguration?.attributeID('x') ?? '',
-    secondaryAttrID: secondaryAttrIDsRef.current[0],
-    layout, dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation
+    graphModel, layout, dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation
   })
 
   return (


### PR DESCRIPTION
[#184980432] Bug fix: Graph split plots do not redraw when switching some categorical variables

* Add a useEffect in usePlotResponders that responds to attribute changes to include all GraphAttrRoles
* Also get rid of a useEffect that was relying on a list attribute IDs as depedents