### PR TITLE
fix logic for opening a blank document

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -115,10 +115,9 @@ export const App = observer(function App() {
       const sample = sampleData.find(name => urlParams.sample === name.toLowerCase())
       if (sample) {
         importSample(sample, handleImportDataSet)
-      } else {
-        createNewStarterDataset()
       }
       if (urlParams.dashboard !== undefined) {
+        createNewStarterDataset()
         addDefaultComponents()
       }
     }


### PR DESCRIPTION
We don't want a data set when CODAP is first opened unless `dashboard` query param is present