### PR TITLE
Properly import graphs with multiple y attributes

### DIFF
--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -24,7 +24,6 @@ export const CaseDots = function CaseDots(props: {
     dataset = useDataSetContext(),
     dataConfiguration = useDataConfigurationContext(),
     layout = useGraphLayoutContext(),
-    legendAttrID = dataConfiguration?.attributeID('legend'),
     randomPointsRef = useRef<Record<string, { x: number, y: number }>>({}),
     dragPointRadius = graphModel.getPointRadius('hover-drag'),
     [dragID, setDragID] = useState(''),

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -505,6 +505,15 @@ export const DataConfigurationModel = types
     }
   }))
   .actions(self => ({
+    _addNewFilteredCases() {
+      self.dataset && self.filteredCases
+        ?.push(new FilteredCases({
+          casesArrayNumber: self.filteredCases.length,
+          source: self.dataset, filter: self.filterCase,
+          onSetCaseValues: self.handleSetCaseValues
+        }))
+      self.setPointsNeedUpdating(true)
+    },
     setDataset(dataset: IDataSet | undefined) {
       self.actionHandlerDisposer?.()
       self.dataset = dataset
@@ -515,6 +524,14 @@ export const DataConfigurationModel = types
           source: dataset, filter: self.filterCase,
           onSetCaseValues: self.handleSetCaseValues
         })
+        // make sure there are enough filteredCases to hold all the y attributes
+        while( self.filteredCases.length < self._yAttributeDescriptions.length) {
+          this._addNewFilteredCases()
+        }
+        // A y2 attribute is optional, so only add a new filteredCases if there is one.
+        if( self.hasY2Attribute) {
+          this._addNewFilteredCases()
+        }
       }
       self.clearCategorySets()
       self.invalidateQuantileScale()
@@ -554,15 +571,6 @@ export const DataConfigurationModel = types
       if (role === 'legend') {
         self.invalidateQuantileScale()
       }
-    },
-    _addNewFilteredCases() {
-      self.dataset && self.filteredCases
-        ?.push(new FilteredCases({
-          casesArrayNumber: self.filteredCases.length,
-          source: self.dataset, filter: self.filterCase,
-          onSetCaseValues: self.handleSetCaseValues
-        }))
-      self.setPointsNeedUpdating(true)
     },
     addYAttribute(desc: IAttributeDescriptionSnapshot) {
       self._yAttributeDescriptions.push(desc)

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -525,11 +525,11 @@ export const DataConfigurationModel = types
           onSetCaseValues: self.handleSetCaseValues
         })
         // make sure there are enough filteredCases to hold all the y attributes
-        while( self.filteredCases.length < self._yAttributeDescriptions.length) {
+        while (self.filteredCases.length < self._yAttributeDescriptions.length) {
           this._addNewFilteredCases()
         }
         // A y2 attribute is optional, so only add a new filteredCases if there is one.
-        if( self.hasY2Attribute) {
+        if (self.hasY2Attribute) {
           this._addNewFilteredCases()
         }
       }


### PR DESCRIPTION
[#184599671] Bug fix: Graphs with multiple numeric y attributes import correctly

* The DataConfigurationModel, when assigned a new dataset, needs to make sure there are filtered cases for each of the y attributes and for the y2 attribute, if any.