### PR TITLE
V3: 185024367 slider NaN on load

### DIFF
--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -1,6 +1,6 @@
 import {NumberInput, NumberInputField} from "@chakra-ui/react"
 import {observer} from "mobx-react-lite"
-import React, {useState, useEffect, useCallback} from "react"
+import React, {useState, useEffect} from "react"
 import {ISliderModel} from "./slider-model"
 import {MultiScale} from "../axis/models/multi-scale"
 import { AxisBounds } from "../axis/axis-types"

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -5,6 +5,7 @@ import {ISliderModel} from "./slider-model"
 import {MultiScale} from "../axis/models/multi-scale"
 
 import './slider.scss'
+import { autorun } from "mobx"
 
 interface IProps {
   sliderModel: ISliderModel
@@ -13,16 +14,17 @@ interface IProps {
 
 export const EditableSliderValue = observer(function EditableSliderValue({ sliderModel, multiScale}: IProps) {
   const [candidate, setCandidate] = useState("")
-  const axisModel = sliderModel.axis
-  const axisMin = axisModel?.min
-  const axisMax = axisModel?.max
 
-  // when `multiScale.cellLength` is not included in the dependency, slider value shows NaN
   useEffect(() => {
-    if (sliderModel) {
-      setCandidate(multiScale.formatValueForScale(sliderModel.value))
-    }
-  }, [axisMin, axisMax, multiScale.cellLength, multiScale, sliderModel, sliderModel.value])
+    return autorun(() => {
+      // trigger update on domain change
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const domain = sliderModel.domain
+      if (sliderModel) {
+        setCandidate(multiScale.formatValueForScale(sliderModel.value))
+      }
+    })
+  }, [multiScale, sliderModel])
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const {key} = e
@@ -40,7 +42,6 @@ export const EditableSliderValue = observer(function EditableSliderValue({ slide
     if (isFinite(inputValue)) {
       sliderModel.encompassValue(inputValue)
       sliderModel.setValue(inputValue)
-      setCandidate(multiScale.formatValueForScale(sliderModel.value))
     }
   }
 

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -3,25 +3,26 @@ import {observer} from "mobx-react-lite"
 import React, {useState, useEffect} from "react"
 import {ISliderModel} from "./slider-model"
 import {MultiScale} from "../axis/models/multi-scale"
-import { AxisBounds } from "../axis/axis-types"
 
 import './slider.scss'
 
 interface IProps {
   sliderModel: ISliderModel
-  domain: AxisBounds | undefined
   multiScale: MultiScale
 }
 
-export const EditableSliderValue = observer(function EditableSliderValue({ sliderModel, domain, multiScale}: IProps) {
+export const EditableSliderValue = observer(function EditableSliderValue({ sliderModel, multiScale}: IProps) {
   const [candidate, setCandidate] = useState("")
+  const axisModel = sliderModel.axis
+  const axisMin = axisModel?.min
+  const axisMax = axisModel?.max
 
-  // when `domain` and `multiScale.cellLength` are not included in the dependency, slider value shows NaN
+  // when `multiScale.cellLength` is not included in the dependency, slider value shows NaN
   useEffect(() => {
     if (sliderModel) {
       setCandidate(multiScale.formatValueForScale(sliderModel.value))
     }
-  }, [domain, multiScale.cellLength, multiScale, sliderModel, sliderModel.axis, sliderModel.value])
+  }, [axisMin, axisMax, multiScale.cellLength, multiScale, sliderModel, sliderModel.value])
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const {key} = e

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -1,6 +1,6 @@
 import {NumberInput, NumberInputField} from "@chakra-ui/react"
 import {observer} from "mobx-react-lite"
-import React, {useState, useEffect} from "react"
+import React, {useState, useEffect, useCallback} from "react"
 import {ISliderModel} from "./slider-model"
 import {MultiScale} from "../axis/models/multi-scale"
 import { AxisBounds } from "../axis/axis-types"
@@ -16,12 +16,12 @@ interface IProps {
 export const EditableSliderValue = observer(function EditableSliderValue({ sliderModel, domain, multiScale}: IProps) {
   const [candidate, setCandidate] = useState("")
 
-  // when `domain` is not included in the dependency, slider value shows NaN
+  // when `domain` and `multiScale.cellLength` are not included in the dependency, slider value shows NaN
   useEffect(() => {
     if (sliderModel) {
       setCandidate(multiScale.formatValueForScale(sliderModel.value))
     }
-  }, [domain, multiScale, sliderModel, sliderModel.axis, sliderModel.value])
+  }, [domain, multiScale.cellLength, multiScale, sliderModel, sliderModel.axis, sliderModel.value])
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const {key} = e
@@ -38,8 +38,8 @@ export const EditableSliderValue = observer(function EditableSliderValue({ slide
     const inputValue = parseFloat(e.target.value)
     if (isFinite(inputValue)) {
       sliderModel.encompassValue(inputValue)
-      setCandidate(multiScale.formatValueForScale(sliderModel.value))
       sliderModel.setValue(inputValue)
+      setCandidate(multiScale.formatValueForScale(sliderModel.value))
     }
   }
 

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -1,11 +1,11 @@
 import {NumberInput, NumberInputField} from "@chakra-ui/react"
 import {observer} from "mobx-react-lite"
+import { autorun } from "mobx"
 import React, {useState, useEffect} from "react"
 import {ISliderModel} from "./slider-model"
 import {MultiScale} from "../axis/models/multi-scale"
 
 import './slider.scss'
-import { autorun } from "mobx"
 
 interface IProps {
   sliderModel: ISliderModel
@@ -20,9 +20,7 @@ export const EditableSliderValue = observer(function EditableSliderValue({ slide
       // trigger update on domain change
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const domain = sliderModel.domain
-      if (sliderModel) {
-        setCandidate(multiScale.formatValueForScale(sliderModel.value))
-      }
+      setCandidate(multiScale.formatValueForScale(sliderModel.value))
     })
   }, [multiScale, sliderModel])
 

--- a/v3/src/components/slider/slider-component.tsx
+++ b/v3/src/components/slider/slider-component.tsx
@@ -26,7 +26,6 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
   const [running, setRunning] = useState(false)
   const animationRef = useRef(false)
   const multiScale = layout.getAxisMultiScale("bottom")
-  const domain = layout.getAxisBounds("bottom")
 
   // width and positioning
   useEffect(() => {
@@ -69,7 +68,7 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
                 <EditableInput className="name-text-input text-input"/>
               </Editable>
               <span className="equals-sign">&nbsp;=&nbsp;</span>
-              <EditableSliderValue sliderModel={sliderModel} domain={domain} multiScale={multiScale} />
+              <EditableSliderValue sliderModel={sliderModel} multiScale={multiScale} />
             </Flex>
           </Flex>
           <div className="slider">


### PR DESCRIPTION
Changes the dependencies to the useEffect for updating the value formatting. The useEffect was not running after component mount and so didn't update the format when the slider model gets its final axis max and min.