### PR TITLE
Version 3.0.0-pre.1220 - May 1, 2023

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Version 3.0.0-pre.1220 - May 1, 2023
+
+### Features/Improvements
+- Import Graph Legends when importing graph components [#184942564](https://www.pivotaltracker.com/story/show/184942564)
+- Resolve default document confusion [#184771920](https://www.pivotaltracker.com/story/show/184771920)
+- Slider animation [#184210591](https://www.pivotaltracker.com/story/show/184210591)
+
+### Bug Fixes
+- Graph points are not highlighting when selected [#185024369](https://www.pivotaltracker.com/story/show/185024369)
+- Legend attribute menu doesn't open for numeric legends [#184922380](https://www.pivotaltracker.com/story/show/184922380)
+- Dragging certain codap files into v3 crashes codap [#183680385](https://www.pivotaltracker.com/story/show/183680385)
+- Missing plot point for the last row in case table [#184428764](https://www.pivotaltracker.com/story/show/184428764)
+- Graph split plots do not redraw when switching some categorical variables [#184980432](https://www.pivotaltracker.com/story/show/184980432)
+- Axis rescale with abalone performs poorly [#185047664](https://www.pivotaltracker.com/story/show/185047664)
+- Plot points should not appear in x- or y-axis areas [#184083861](https://www.pivotaltracker.com/story/show/184083861)
+- Dragging CODAP docs with no graph or case plot, cases don't show in plot [#183704458](https://www.pivotaltracker.com/story/show/183704458)
+- Unable to properly display slider values < 0.01 [#184846919](https://www.pivotaltracker.com/story/show/184846919)
+- Imported jsons with graphs that have numeric attributes fail to restore graphs [#184992350](https://www.pivotaltracker.com/story/show/184992350)
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+| index.css |   38964 bytes |                               0% |
+|  index.js | 3018956 bytes |                           -0.03% |
+
 ## Version 3.0.0-pre.1208 - Apr 25, 2023
 
 ### Features/Improvements

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1208",
+  "version": "3.0.0-pre.1220",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-pre.1208",
+      "version": "3.0.0-pre.1220",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1208",
+  "version": "3.0.0-pre.1220",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",


### PR DESCRIPTION
### Features/Improvements
- Import Graph Legends when importing graph components [#184942564](https://www.pivotaltracker.com/story/show/184942564)
- Resolve default document confusion [#184771920](https://www.pivotaltracker.com/story/show/184771920)
- Slider animation [#184210591](https://www.pivotaltracker.com/story/show/184210591)

### Bug Fixes
- Graph points are not highlighting when selected [#185024369](https://www.pivotaltracker.com/story/show/185024369)
- Legend attribute menu doesn't open for numeric legends [#184922380](https://www.pivotaltracker.com/story/show/184922380)
- Dragging certain codap files into v3 crashes codap [#183680385](https://www.pivotaltracker.com/story/show/183680385)
- Missing plot point for the last row in case table [#184428764](https://www.pivotaltracker.com/story/show/184428764)
- Graph split plots do not redraw when switching some categorical variables [#184980432](https://www.pivotaltracker.com/story/show/184980432)
- Axis rescale with abalone performs poorly [#185047664](https://www.pivotaltracker.com/story/show/185047664)
- Plot points should not appear in x- or y-axis areas [#184083861](https://www.pivotaltracker.com/story/show/184083861)
- Dragging CODAP docs with no graph or case plot, cases don't show in plot [#183704458](https://www.pivotaltracker.com/story/show/183704458)
- Unable to properly display slider values < 0.01 [#184846919](https://www.pivotaltracker.com/story/show/184846919)
- Imported jsons with graphs that have numeric attributes fail to restore graphs [#184992350](https://www.pivotaltracker.com/story/show/184992350)