### PR TITLE
Version 3.0.0-pre.1225 - May 8, 2023

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Version 3.0.0-pre.1225 - May 8, 2023
+
+### Features/Improvements
+- Hierachical case table -- sub-table titles can be edited by user [#184540405](https://www.pivotaltracker.com/story/show/184540405)
+
+### Bug Fixes
+- These elements contain a drag and drop feature that is currently inaccessible to screen reader and keyboard users [#183939719](https://www.pivotaltracker.com/story/show/183939719)
+- Slider initial value loads as NaN [#185024367](https://www.pivotaltracker.com/story/show/185024367)
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+| index.css |   38996 bytes |                            0.08% |
+|  index.js | 3019991 bytes |                            0.03% |
+
 ## Version 3.0.0-pre.1220 - May 1, 2023
 
 ### Features/Improvements

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1220",
+  "version": "3.0.0-pre.1225",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-pre.1220",
+      "version": "3.0.0-pre.1225",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1220",
+  "version": "3.0.0-pre.1225",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",


### PR DESCRIPTION
### Features/Improvements
- Hierachical case table -- sub-table titles can be edited by user [#184540405](https://www.pivotaltracker.com/story/show/184540405)

### Bug Fixes
- These elements contain a drag and drop feature that is currently inaccessible to screen reader and keyboard users [#183939719](https://www.pivotaltracker.com/story/show/183939719)
- Slider initial value loads as NaN [#185024367](https://www.pivotaltracker.com/story/show/185024367)