### PR TITLE
Using shared case metadata to access category sets for graphs

### DIFF
--- a/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
+++ b/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
@@ -27,7 +27,7 @@ export const PointFormatPalette = observer(function PointFormatPalette({tile, pa
   const graphModel = isGraphModel(tile?.content) ? tile?.content : undefined
   const legendAttrID = graphModel?.getAttributeID("legend")
   const attrType = dataConfiguration?.dataset?.attrFromID(legendAttrID ?? "")?.type
-  const categoriesRef = useRef<Set<string> | undefined>()
+  const categoriesRef = useRef<string[] | undefined>()
   categoriesRef.current = dataConfiguration?.categorySetForAttrRole('legend')
 
   if (!graphModel) return null

--- a/v3/src/components/graph/components/legend/categorical-legend.tsx
+++ b/v3/src/components/graph/components/legend/categorical-legend.tsx
@@ -42,7 +42,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
   const dataConfiguration = useDataConfigurationContext(),
     dataset = dataConfiguration?.dataset,
     layout = useGraphLayoutContext(),
-    categoriesRef = useRef<Set<string> | undefined>(),
+    categoriesRef = useRef<string[] | undefined>(),
     categoryData = useRef<Key[]>([]),
     layoutData = useRef<Layout>({
         maxWidth: 0,
@@ -58,7 +58,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
 
     computeLayout = useCallback(() => {
       categoriesRef.current = dataConfiguration?.categorySetForAttrRole('legend')
-      const numCategories = categoriesRef.current?.size,
+      const numCategories = categoriesRef.current?.length,
         lod: Layout = layoutData.current
       lod.fullWidth = layout.getAxisLength('bottom')
       lod.maxWidth = 0
@@ -93,7 +93,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
 
     setupKeys = useCallback(() => {
       categoriesRef.current = dataConfiguration?.categorySetForAttrRole('legend')
-      const numCategories = categoriesRef.current?.size
+      const numCategories = categoriesRef.current?.length
       if (keysElt && categoryData.current) {
         select(keysElt).selectAll('key').remove() // start fresh
 
@@ -126,7 +126,7 @@ export const CategoricalLegend = memo(function CategoricalLegend(
 
     refreshKeys = useCallback(() => {
       categoriesRef.current = dataConfiguration?.categorySetForAttrRole('legend')
-      const numCategories = categoriesRef.current?.size
+      const numCategories = categoriesRef.current?.length
       select(keysElt)
         .selectAll('g')
         .data(range(0, numCategories ?? 0))
@@ -168,14 +168,13 @@ export const CategoricalLegend = memo(function CategoricalLegend(
   }, [refreshKeys, dataset, computeDesiredExtent])
 
   useEffect(function respondToCategorySetsChange() {
-    const disposer = reaction(
+    return reaction(
       () => dataConfiguration?.categorySetForAttrRole('legend'),
       () => {
         layout.setDesiredExtent('legend', computeDesiredExtent())
         setupKeys()
         refreshKeys()
       })
-    return disposer
   }, [setupKeys, refreshKeys, dataConfiguration, layout, computeDesiredExtent])
 
   useEffect(function respondToLayoutChange() {

--- a/v3/src/components/graph/models/data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/data-configuration-model.test.ts
@@ -1,16 +1,27 @@
 import { reaction } from "mobx"
-import { DataSet, IDataSet, toCanonical } from "../../../models/data/data-set"
+import { DataSet, toCanonical } from "../../../models/data/data-set"
 import { DataConfigurationModel } from "./data-configuration-model"
+import {getSnapshot, Instance, types} from "mobx-state-tree"
+import {SharedCaseMetadata} from "../../../models/shared/shared-case-metadata"
+
+const TreeModel = types.model("Tree", {
+  data: DataSet,
+  metadata: SharedCaseMetadata
+})
+
+let tree: Instance<typeof TreeModel>
 
 describe("DataConfigurationModel", () => {
-  let data: IDataSet
-
   beforeEach(() => {
-    data = DataSet.create()
-    data.addAttribute({ id: "nId", name: "n" })
-    data.addAttribute({ id: "xId", name: "x" })
-    data.addAttribute({ id: "yId", name: "y" })
-    data.addCases(toCanonical(data, [
+    tree = TreeModel.create({
+      data: getSnapshot(DataSet.create()),
+      metadata: getSnapshot(SharedCaseMetadata.create())
+    })
+    tree.data.addAttribute({ id: "nId", name: "n" })
+    tree.data.addAttribute({ id: "xId", name: "x" })
+    tree.data.addAttribute({ id: "yId", name: "y" })
+    tree.metadata.setData(tree.data)
+    tree.data.addCases(toCanonical(tree.data, [
       { __id__: "c1", n: "n1", x: 1, y: 1 }, { __id__: "c2", x: 2 }, { __id__: "c3", n: "n3", y: 3 }
     ]))
   })
@@ -33,7 +44,7 @@ describe("DataConfigurationModel", () => {
 
   it("behaves as expected with empty/case plot", () => {
     const config = DataConfigurationModel.create()
-    config.setDataset(data)
+    config.setDataset(tree.data, tree.metadata)
     expect(config.defaultCaptionAttributeID).toBe("nId")
     expect(config.attributeID("x")).toBeUndefined()
     expect(config.attributeID("y")).toBeUndefined()
@@ -54,7 +65,7 @@ describe("DataConfigurationModel", () => {
 
   it("behaves as expected with dot chart on x axis", () => {
     const config = DataConfigurationModel.create()
-    config.setDataset(data)
+    config.setDataset(tree.data, tree.metadata)
     config.setAttribute("x", { attributeID: "nId" })
     expect(config.defaultCaptionAttributeID).toBe("nId")
     expect(config.attributeID("x")).toBe("nId")
@@ -76,7 +87,7 @@ describe("DataConfigurationModel", () => {
 
   it("behaves as expected with dot plot on x axis", () => {
     const config = DataConfigurationModel.create()
-    config.setDataset(data)
+    config.setDataset(tree.data, tree.metadata)
     config.setAttribute("x", { attributeID: "xId" })
     expect(config.defaultCaptionAttributeID).toBe("nId")
     expect(config.attributeID("x")).toBe("xId")
@@ -99,7 +110,7 @@ describe("DataConfigurationModel", () => {
 
   it("behaves as expected with scatter plot and explicit caption attribute", () => {
     const config = DataConfigurationModel.create()
-    config.setDataset(data)
+    config.setDataset(tree.data, tree.metadata)
     config.setAttribute("x", { attributeID: "xId" })
     config.setAttribute("y", { attributeID: "yId" })
     config.setAttribute("caption", { attributeID: "nId" })
@@ -119,7 +130,7 @@ describe("DataConfigurationModel", () => {
       {attributeID: "yId", role: "y"}, {attributeID: "nId", role: "caption"}])
     expect(config.caseDataArray).toEqual([{plotNum: 0, caseID: "c1"}])
 
-    // behaves as expected after removing x axis attribute
+    // behaves as expected after removing x-axis attribute
     config.setAttribute("x")
     expect(config.defaultCaptionAttributeID).toBe("nId")
     expect(config.attributeID("x")).toBeUndefined()
@@ -141,7 +152,7 @@ describe("DataConfigurationModel", () => {
     ])
 
     // updates cases when values change
-    data.setCaseValues([{ __id__: "c2", "yId": 2 }])
+    tree.data.setCaseValues([{ __id__: "c2", "yId": 2 }])
     expect(config.caseDataArray).toEqual([
       {plotNum: 0, caseID: "c1"},
       {plotNum: 0, caseID: "c2"},
@@ -152,13 +163,13 @@ describe("DataConfigurationModel", () => {
     const trigger = jest.fn()
     reaction(() => config.caseDataArray, () => trigger())
     expect(trigger).not.toHaveBeenCalled()
-    data.setCaseValues([{ __id__: "c2", "yId": "" }])
+    tree.data.setCaseValues([{ __id__: "c2", "yId": "" }])
     expect(trigger).toHaveBeenCalledTimes(1)
     expect(config.caseDataArray).toEqual([
       {plotNum: 0, caseID: "c1"},
       {plotNum: 0, caseID: "c3"}
     ])
-    data.setCaseValues([{ __id__: "c2", "yId": "2" }])
+    tree.data.setCaseValues([{ __id__: "c2", "yId": "2" }])
     expect(trigger).toHaveBeenCalledTimes(2)
     expect(config.caseDataArray).toEqual([
       {plotNum: 0, caseID: "c1"},
@@ -172,8 +183,8 @@ describe("DataConfigurationModel", () => {
     config.setAttribute("x", { attributeID: "xId" })
     expect(config.selection.length).toBe(0)
 
-    config.setDataset(data)
-    data.selectAll()
+    config.setDataset(tree.data, tree.metadata)
+    tree.data.selectAll()
     expect(config.selection.length).toBe(2)
 
     config.setAttribute("x", { attributeID: "xId" })
@@ -190,34 +201,34 @@ describe("DataConfigurationModel", () => {
 
   it("calls action listeners when appropriate", () => {
     const config = DataConfigurationModel.create()
-    config.setDataset(data)
+    config.setDataset(tree.data, tree.metadata)
     config.setAttribute("x", { attributeID: "xId" })
 
     const handleAction = jest.fn()
     config.onAction(handleAction)
 
-    data.setCaseValues([{ __id__: "c1", xId: 1.1 }])
+    tree.data.setCaseValues([{ __id__: "c1", xId: 1.1 }])
     expect(handleAction).toHaveBeenCalled()
     expect(handleAction.mock.lastCall[0].name).toBe("setCaseValues")
     handleAction.mockClear()
 
-    data.setCaseValues([{ __id__: "c3", xId: 3 }])
+    tree.data.setCaseValues([{ __id__: "c3", xId: 3 }])
     expect(handleAction).toHaveBeenCalled()
     expect(handleAction.mock.lastCall[0].name).toBe("addCases")
     handleAction.mockClear()
 
-    data.setCaseValues([{ __id__: "c1", xId: "" }])
+    tree.data.setCaseValues([{ __id__: "c1", xId: "" }])
     expect(handleAction).toHaveBeenCalled()
     expect(handleAction.mock.lastCall[0].name).toBe("removeCases")
     handleAction.mockClear()
 
-    data.setCaseValues([{ __id__: "c1", xId: 1 }, { __id__: "c2", xId: "" }, { __id__: "c3", xId: 3.3 }])
+    tree.data.setCaseValues([{ __id__: "c1", xId: 1 }, { __id__: "c2", xId: "" }, { __id__: "c3", xId: 3.3 }])
     expect(handleAction).toHaveBeenCalled()
   })
 
   it("only allows x and y as primary place", () => {
     const config = DataConfigurationModel.create()
-    config.setDataset(data)
+    config.setDataset(tree.data, tree.metadata)
     config.setPrimaryRole('y')
     expect(config.primaryRole).toBe("y")
     config.setPrimaryRole('caption')
@@ -225,27 +236,27 @@ describe("DataConfigurationModel", () => {
   })
 
   it("returns an attribute values array and category set that ignore empty values", () => {
-    data.addCases(toCanonical(data, [
+    tree.data.addCases(toCanonical(tree.data, [
       { __id__: "c4", n: "n1", x: 1, y: 1 },
       { __id__: "c5", n: "", x: 6, y: 1 },
       { __id__: "c6", n: "n1", x: 6, y: 6 }]))
     const config = DataConfigurationModel.create()
-    config.setDataset(data)
+    config.setDataset(tree.data, tree.metadata)
     config.setAttribute("x", { attributeID: "xId" })
     config.setAttribute("y", { attributeID: "yId" })
     config.setAttribute("caption", { attributeID: "nId" })
     expect(config.valuesForAttrRole("x")).toEqual(["1", "1", "6", "6"])
     expect(config.valuesForAttrRole("y")).toEqual(["1", "1", "1", "6"])
     expect(config.valuesForAttrRole("caption")).toEqual(["n1", "n1", "n1"])
-    expect(config.categorySetForAttrRole("x")).toEqual(new Set(["1", "6"]))
-    expect(config.categorySetForAttrRole("y")).toEqual(new Set(["1", "6"]))
-    expect(config.categorySetForAttrRole("caption")).toEqual(new Set(["n1"]))
+    expect(config.categorySetForAttrRole("x")).toEqual(["1", "6"])
+    expect(config.categorySetForAttrRole("y")).toEqual(["1", "6"])
+    expect(config.categorySetForAttrRole("caption")).toEqual(["n1"])
     expect(config.numericValuesForAttrRole("x")).toEqual([1, 1, 6, 6])
     expect(config.numericValuesForAttrRole("caption")).toEqual([])
 
     config.setAttribute("y")
     expect(config.valuesForAttrRole("y")).toEqual([])
-    expect(config.categorySetForAttrRole("y")).toEqual(new Set(["__main__"]))
+    expect(config.categorySetForAttrRole("y")).toEqual(["__main__"])
   })
 
 })

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -279,12 +279,19 @@ export const DataConfigurationModel = types
           return acc.concat(values)
         }, allValues)
       },
+      /**
+       * Todo: This method is inefficient since it has to go through all the cases in the graph to determine
+       * which categories are present. It should be replaced by some sort of functionality that allows
+       * caching of the categories that have been determined to be valid.
+       * @param role
+       */
       categorySetForAttrRole(role: GraphAttrRole): string[] {
         let categoryArray: string[] = []
         if (self.metadata) {
           const attributeID = self.attributeID(role) || '',
-            categorySet = getCategorySet(self.metadata, attributeID)
-          categoryArray = categorySet?.values || ['__main__']
+            categorySet = getCategorySet(self.metadata, attributeID),
+            validValues: Set<string> = new Set(this.valuesForAttrRole(role))
+          categoryArray = (categorySet?.values || ['__main__']).filter((aValue: string) => validValues.has(aValue))
         }
         if (categoryArray.length === 0) {
           categoryArray = ['__main__']
@@ -447,8 +454,7 @@ export const DataConfigurationModel = types
           return xIsNumeric && typeToDropIsNumeric && !!idToDrop && existingID !== idToDrop
         } else if (['top', 'rightCat'].includes(place)) {
           return !typeToDropIsNumeric && !!idToDrop && existingID !== idToDrop
-        }
-        else {
+        } else {
           return !!idToDrop && existingID !== idToDrop
         }
       }
@@ -506,7 +512,7 @@ export const DataConfigurationModel = types
         }))
       self.setPointsNeedUpdating(true)
     },
-    setDataset(dataset: IDataSet | undefined, metadata?: ISharedCaseMetadata | undefined) {
+    setDataset(dataset: IDataSet | undefined, metadata: ISharedCaseMetadata | undefined) {
       self.actionHandlerDisposer?.()
       self.dataset = dataset
       self.metadata = metadata

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -1,8 +1,8 @@
-import {observable} from "mobx"
 import {scaleQuantile, ScaleQuantile, schemeBlues} from "d3"
 import {getSnapshot, Instance, ISerializedActionCall, SnapshotIn, types} from "mobx-state-tree"
 import {AttributeType, attributeTypes} from "../../../models/data/attribute"
 import {IDataSet} from "../../../models/data/data-set"
+import {getCategorySet, ISharedCaseMetadata} from "../../../models/shared/shared-case-metadata"
 import {isSetCaseValuesAction} from "../../../models/data/data-set-actions"
 import {FilteredCases, IFilteredChangedCases} from "../../../models/data/filtered-cases"
 import {typedId, uniqueId} from "../../../utilities/js-utils"
@@ -53,10 +53,10 @@ export const DataConfigurationModel = types
   })
   .volatile(() => ({
     dataset: undefined as IDataSet | undefined,
+    metadata: undefined as ISharedCaseMetadata | undefined,
     actionHandlerDisposer: undefined as (() => void) | undefined,
     filteredCases: undefined as FilteredCases[] | undefined,
     handlers: new Map<string, (actionCall: ISerializedActionCall) => void>(),
-    categorySets: observable.map<GraphAttrRole, Set<string> | null>(),
     pointsNeedUpdating: false
   }))
   .views(self => ({
@@ -178,12 +178,6 @@ export const DataConfigurationModel = types
     }
   }))
   .actions(self => ({
-    clearCategorySets() {
-      self.categorySets.clear()
-    },
-    setCategorySetForRole(role: GraphAttrRole, set: Set<string> | null) {
-      self.categorySets.set(role, set)
-    },
     setPointsNeedUpdating(needUpdating: boolean) {
       self.pointsNeedUpdating = needUpdating
     }
@@ -285,27 +279,26 @@ export const DataConfigurationModel = types
           return acc.concat(values)
         }, allValues)
       },
-      categorySetForAttrRole(role: GraphAttrRole): Set<string> {
-        const existingSet = self.categorySets.get(role)
-        if (existingSet) {
-          return existingSet
-        } else {
-          const result: Set<string> = new Set(this.valuesForAttrRole(role).sort())
-          if (result.size === 0) {
-            result.add('__main__')
-          }
-          self.setCategorySetForRole(role, result)
-          return result
+      categorySetForAttrRole(role: GraphAttrRole): string[] {
+        let categoryArray: string[] = []
+        if (self.metadata) {
+          const attributeID = self.attributeID(role) || '',
+            categorySet = getCategorySet(self.metadata, attributeID)
+          categoryArray = categorySet?.values || ['__main__']
         }
+        if (categoryArray.length === 0) {
+          categoryArray = ['__main__']
+        }
+        return categoryArray
       },
       numRepetitionsForPlace(place: GraphPlace) {
         let numRepetitions = 1
         switch (place) {
           case 'left':
-            numRepetitions = Math.max(this.categorySetForAttrRole('rightSplit').size, 1)
+            numRepetitions = Math.max(this.categorySetForAttrRole('rightSplit').length, 1)
             break
           case 'bottom':
-            numRepetitions = Math.max(this.categorySetForAttrRole('topSplit').size, 1)
+            numRepetitions = Math.max(this.categorySetForAttrRole('topSplit').length, 1)
         }
         return numRepetitions
       }
@@ -493,14 +486,12 @@ export const DataConfigurationModel = types
       if (affectedAttrIDs) {
         for (const [key, desc] of Object.entries(self.attributeDescriptions)) {
           if (affectedAttrIDs.includes(desc.attributeID)) {
-            self.setCategorySetForRole(key as GraphAttrRole, null)
             if (key === "legend") {
               self.invalidateQuantileScale()
             }
           }
         }
       } else {
-        self.clearCategorySets()
         self.invalidateQuantileScale()
       }
     }
@@ -515,9 +506,10 @@ export const DataConfigurationModel = types
         }))
       self.setPointsNeedUpdating(true)
     },
-    setDataset(dataset: IDataSet | undefined) {
+    setDataset(dataset: IDataSet | undefined, metadata?: ISharedCaseMetadata | undefined) {
       self.actionHandlerDisposer?.()
       self.dataset = dataset
+      self.metadata = metadata
       self.actionHandlerDisposer = onAnyAction(self.dataset, self.handleAction)
       self.filteredCases = []
       if (dataset) {
@@ -534,7 +526,6 @@ export const DataConfigurationModel = types
           this._addNewFilteredCases()
         }
       }
-      self.clearCategorySets()
       self.invalidateQuantileScale()
     },
     setPrimaryRole(role: GraphAttrRole) {
@@ -552,7 +543,6 @@ export const DataConfigurationModel = types
         if (otherDesc?.attributeID === desc?.attributeID) {
           const currentDesc = self.attributeDescriptionForRole(role) ?? {attributeID: '', type: 'categorical'}
           self._setAttributeDescription(otherRole, currentDesc)
-          self.categorySets.set(otherRole, null)
         }
       }
       if (role === 'y') {
@@ -568,7 +558,6 @@ export const DataConfigurationModel = types
       self.filteredCases?.forEach((aFilteredCases) => {
         aFilteredCases.invalidateCases()
       })
-      self.categorySets.set(role, null)
       if (role === 'legend') {
         self.invalidateQuantileScale()
       }
@@ -605,7 +594,6 @@ export const DataConfigurationModel = types
       } else {
         self._attributeDescriptions.get(role)?.setType(type)
       }
-      self.categorySets.set(role, null) // We don't have to worry about y attributes except for the 0th one
       self.filteredCases?.forEach((aFilteredCases) => {
         aFilteredCases.invalidateCases()
       })

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -46,7 +46,7 @@ export class GraphController {
     this.graphModel = props.graphModel
     this.dataset = props.dataset
     if (this.graphModel.config.dataset !== props.dataset) {
-      this.graphModel.config.setDataset(props.dataset)
+      this.graphModel.config.setDataset(props.dataset, this.graphModel.metadata)
     }
     this.initializeGraph(props.dotsRef)
   }

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -65,7 +65,7 @@ export const CategorySet = types.model("CategorySet", {
       // build default category set order (order of occurrence)
       // could default to alphameric sort order if desired instead
       self.attribute.strValues.forEach(value => {
-        if (_indexMap.get(value) == null) {
+        if (value !== '' && _indexMap.get(value) == null) {
           _indexMap.set(value, _values.length)
           _values.push(value)
         }


### PR DESCRIPTION
* Prior to this PR graphs were making use of the DataConfigurationModel's own notion of category sets. The problem with this is that when category set order is changed by dragging, this change is not communicated to other components. By making use of the shared model, the change is communicated to other components (particuarly graphs).

* Most changes in this PR relate to the difference between Set as returned by the prior implementation and Array as returned by the new one.