### PR TITLE
fix: link/unlink data sets and case metadata

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -46,7 +46,7 @@ export const App = observer(function App() {
   }, [])
 
   const handleImportV2Document = useCallback((v2Document: CodapV2Document) => {
-    const v3Document = createCodapDocument(undefined, "free")
+    const v3Document = createCodapDocument(undefined, { layout: "free" })
     const sharedModelManager = getSharedModelManager(v3Document)
     sharedModelManager && gDataBroker.setSharedModelManager(sharedModelManager)
     // add shared models (data sets and case metadata)

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -8,12 +8,13 @@ import { useDataSetContext } from "../../../hooks/use-data-set-context"
 import { useOutsidePointerDown } from "../../../hooks/use-outside-pointer-down"
 import { useOverlayBounds } from "../../../hooks/use-overlay-bounds"
 import { AttributeType } from "../../../models/data/attribute"
+import { IDataSet } from "../../../models/data/data-set"
 
 interface IProps {
   place: GraphPlace,
   target: SVGGElement | null
   portal: HTMLElement | null
-  onChangeAttribute: (place: GraphPlace, attrId: string) => void
+  onChangeAttribute: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
   onRemoveAttribute: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
@@ -54,7 +55,7 @@ const _AxisOrLegendAttributeMenu = ({ place, target, portal,
               <MenuList>
                 { data?.attributes?.map((attr) => {
                   return (
-                    <MenuItem onClick={() => onChangeAttribute(place, attr.id)} key={attr.id}>
+                    <MenuItem onClick={() => onChangeAttribute(place, data, attr.id)} key={attr.id}>
                       {attr.name}
                     </MenuItem>
                   )

--- a/v3/src/components/case-table/attribute-drag-overlay.tsx
+++ b/v3/src/components/case-table/attribute-drag-overlay.tsx
@@ -1,7 +1,6 @@
 import { DragOverlay, useDndContext } from "@dnd-kit/core"
 import React from "react"
-import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { getDragAttributeId } from "../../hooks/use-drag-drop"
+import { getDragAttributeInfo } from "../../hooks/use-drag-drop"
 
 import "./attribute-drag-overlay.scss"
 
@@ -9,10 +8,9 @@ interface IProps {
   activeDragId?: string
 }
 export const AttributeDragOverlay = ({ activeDragId }: IProps) => {
-  const data = useDataSetContext()
   const { active } = useDndContext()
-  const dragAttrId = activeDragId ? getDragAttributeId(active) : undefined
-  const attr = dragAttrId ? data?.attrFromID(dragAttrId) : undefined
+  const { dataSet, attributeId: dragAttrId } = getDragAttributeInfo(active) || {}
+  const attr = activeDragId && dragAttrId ? dataSet?.attrFromID(dragAttrId) : undefined
   return (
     <DragOverlay dropAnimation={null}>
       {dragAttrId

--- a/v3/src/components/case-table/case-table-model.ts
+++ b/v3/src/components/case-table/case-table-model.ts
@@ -1,7 +1,5 @@
 import { Instance, types } from "mobx-state-tree"
-import { IDataSet } from "../../models/data/data-set"
-import { ISharedCaseMetadata, isSharedCaseMetadata } from "../../models/shared/shared-case-metadata"
-import { isSharedDataSet } from "../../models/shared/shared-data-set"
+import { getTileCaseMetadata, getTileDataSet } from "../../models/shared/shared-data-utils"
 import { ISharedModel } from "../../models/shared/shared-model"
 import { ITileContentModel, TileContentModel } from "../../models/tiles/tile-content"
 import { kCaseTableTileType } from "./case-table-defs"
@@ -12,15 +10,11 @@ export const CaseTableModel = TileContentModel
     type: types.optional(types.literal(kCaseTableTileType), kCaseTableTileType)
   })
   .views(self => ({
-    get data(): IDataSet | undefined {
-      const sharedModelManager = self.tileEnv?.sharedModelManager
-      const sharedModel = sharedModelManager?.getTileSharedModels(self).find(m => isSharedDataSet(m))
-      return isSharedDataSet(sharedModel) ? sharedModel.dataSet : undefined
+    get data() {
+      return getTileDataSet(self)
     },
-    get metadata(): ISharedCaseMetadata | undefined {
-      const sharedModelManager = self.tileEnv?.sharedModelManager
-      const sharedModel = sharedModelManager?.getTileSharedModels(self).find(m => isSharedCaseMetadata(m))
-      return isSharedCaseMetadata(sharedModel) ? sharedModel : undefined
+    get metadata() {
+      return getTileCaseMetadata(self)
     }
   }))
   .actions(self => ({

--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -3,14 +3,15 @@ import React, { useMemo, useRef } from "react"
 import { useCaseMetadata } from "../../hooks/use-case-metadata"
 import { useCollectionContext, useParentCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { getDragAttributeId, useTileDroppable } from "../../hooks/use-drag-drop"
+import { getDragAttributeInfo, useTileDroppable } from "../../hooks/use-drag-drop"
 import { measureText } from "../../hooks/use-measure-text"
+import { IDataSet } from "../../models/data/data-set"
 // import { getNumericCssVariable } from "../../utilities/css-utils"
 import t from "../../utilities/translation/translate"
 import { kChildMostTableCollectionId } from "./case-table-types"
 
 interface IProps {
-  onDrop?: (attrId: string) => void
+  onDrop?: (dataSet: IDataSet, attrId: string) => void
 }
 export function CollectionTableSpacer({ onDrop }: IProps) {
   const data = useDataSetContext()
@@ -20,11 +21,11 @@ export function CollectionTableSpacer({ onDrop }: IProps) {
   const collectionId = collection?.id || kChildMostTableCollectionId
   const parentMost = !parentCollection
   const { active, isOver, setNodeRef } = useTileDroppable(`new-collection-${collectionId}`, _active => {
-    const dragAttributeID = getDragAttributeId(_active)
-    dragAttributeID && onDrop?.(dragAttributeID)
+    const { dataSet, attributeId: dragAttributeID } = getDragAttributeInfo(_active) || {}
+    dataSet && dragAttributeID && onDrop?.(dataSet, dragAttributeID)
   })
 
-  const classes = clsx("collection-table-spacer", { active: !!getDragAttributeId(active), over: isOver, parentMost })
+  const classes = clsx("collection-table-spacer", { active: !!getDragAttributeInfo(active), over: isOver, parentMost })
   const dropMessage = t("DG.CaseTableDropTarget.dropMessage")
   const dropMessageWidth = useMemo(() => measureText(dropMessage, "12px sans-serif"), [dropMessage])
   const parentGridRef = useRef<HTMLElement | null>(null)

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -9,6 +9,7 @@ import { useRows } from "./use-rows"
 import { useSelectedRows } from "./use-selected-rows"
 import { useCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { IDataSet } from "../../models/data/data-set"
 import { CollectionTitle } from './collection-title'
 
 import styles from "./case-table-shared.scss"
@@ -32,7 +33,7 @@ export const CollectionTable = observer(function CollectionTable() {
 
   if (!data) return null
 
-  function handleNewCollectionDrop(attrId: string) {
+  function handleNewCollectionDrop(dataSet: IDataSet, attrId: string) {
     const attr = data?.attrFromID(attrId)
     if (data && attr) {
       data.moveAttributeToNewCollection(attrId, collection.id)

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -6,7 +6,7 @@ import { IMoveAttributeOptions } from "../../models/data/data-set-types"
 import { getCollectionAttrs } from "../../models/data/data-set-utils"
 import { useCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { getDragAttributeId, useTileDroppable } from "../../hooks/use-drag-drop"
+import { getDragAttributeInfo, useTileDroppable } from "../../hooks/use-drag-drop"
 import { kIndexColumnKey } from "./case-table-types"
 
 interface IProps {
@@ -23,10 +23,10 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
   const cellBounds = cellElt?.getBoundingClientRect()
 
   const { isOver, setNodeRef: setDropRef } = useTileDroppable(droppableId, active => {
-    const dragAttrId = getDragAttributeId(active)
-    if (!data || !dragAttrId) return
+    const { dataSet, attributeId: dragAttrId } = getDragAttributeInfo(active) || {}
+    if (!dataSet || (dataSet !== data) || !dragAttrId) return
 
-    const srcCollection = data.getCollectionForAttribute(dragAttrId)
+    const srcCollection = dataSet.getCollectionForAttribute(dragAttrId)
     const firstAttr: IAttribute | undefined = getCollectionAttrs(collection, data)[0]
     const options: IMoveAttributeOptions = columnKey === kIndexColumnKey
                                             ? { before: firstAttr?.id }

--- a/v3/src/components/case-table/column-header.tsx
+++ b/v3/src/components/case-table/column-header.tsx
@@ -28,7 +28,9 @@ export const ColumnHeader = ({ column }: Pick<THeaderRendererProps, "column">) =
   const dragging = !!active
   const attribute = data?.attrFromID(column.key)
 
-  const draggableOptions: IUseDraggableAttribute = { prefix: instanceId, attributeId: column.key }
+  const draggableOptions: IUseDraggableAttribute = {
+    prefix: instanceId, dataSet: data, attributeId: column.key
+  }
   const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions)
 
   const setCellRef = (elt: HTMLDivElement | null) => {

--- a/v3/src/components/data-summary/data-summary-model.ts
+++ b/v3/src/components/data-summary/data-summary-model.ts
@@ -1,4 +1,6 @@
 import { Instance, types } from "mobx-state-tree"
+import { IDataSet } from "../../models/data/data-set"
+import { getTileCaseMetadata, getTileDataSet, linkTileToDataSet } from "../../models/shared/shared-data-utils"
 import { ITileContentModel, TileContentModel } from "../../models/tiles/tile-content"
 import { kDataSummaryTileType } from "./data-summary-defs"
 
@@ -8,8 +10,17 @@ export const DataSummaryModel = TileContentModel
     type: types.optional(types.literal(kDataSummaryTileType), kDataSummaryTileType),
     inspectedAttrId: ""
   })
+  .views(self => ({
+    get data() {
+      return getTileDataSet(self)
+    },
+    get metadata() {
+      return getTileCaseMetadata(self)
+    }
+  }))
   .actions(self => ({
-    inspect(attrId: string) {
+    inspect(dataSet: IDataSet, attrId: string) {
+      linkTileToDataSet(self, dataSet)
       self.inspectedAttrId = attrId
     }
   }))

--- a/v3/src/components/graph/components/attribute-label.tsx
+++ b/v3/src/components/graph/components/attribute-label.tsx
@@ -6,6 +6,7 @@ import {select} from "d3"
 import t from "../../../utilities/translation/translate"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {AttributeType} from "../../../models/data/attribute"
+import {IDataSet} from "../../../models/data/data-set"
 import {isSetAttributeNameAction} from "../../../models/data/data-set-actions"
 import {GraphPlace, isVertical} from "../../axis-graph-shared"
 import {graphPlaceToAttrRole, kGraphClassSelector} from "../graphing-types"
@@ -19,7 +20,7 @@ import graphVars from "./graph.scss"
 
 interface IAttributeLabelProps {
   place: GraphPlace
-  onChangeAttribute?: (place: GraphPlace, attrId: string) => void
+  onChangeAttribute?: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
   onRemoveAttribute?: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }

--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -2,17 +2,18 @@ import React from "react"
 import {clsx} from "clsx"
 import {Active, useDroppable} from "@dnd-kit/core"
 import {useDropHintString} from "../../../hooks/use-drop-hint-string"
-import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
+import {getDragAttributeInfo, useDropHandler} from "../../../hooks/use-drag-drop"
 import {DropHint} from "./drop-hint"
 import {graphPlaceToAttrRole, PlotType} from "../graphing-types"
 import {GraphPlace} from "../../axis-graph-shared"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
+import {IDataSet} from "../../../models/data/data-set"
 
 interface IAddAttributeProps {
   place: GraphPlace
   plotType: PlotType
-  onDrop: (attributeId: string) => void
+  onDrop: (dataSet: IDataSet, attributeId: string) => void
 }
 
 export const DroppableAddAttribute = ({place, onDrop}: IAddAttributeProps) => {
@@ -25,17 +26,17 @@ export const DroppableAddAttribute = ({place, onDrop}: IAddAttributeProps) => {
     hintString = useDropHintString({role})
 
   const handleIsActive = (iActive: Active) => {
-    const droppedAttrId = getDragAttributeId(iActive) ?? ''
+    const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(iActive) || {}
     if (isDropAllowed) {
-      return isDropAllowed(place, droppedAttrId)
+      return isDropAllowed(place, dataSet, droppedAttrId)
     } else {
       return !!droppedAttrId
     }
   }
 
   useDropHandler(droppableId, iActive => {
-    const dragAttributeID = getDragAttributeId(iActive)
-    dragAttributeID && onDrop(dragAttributeID)
+    const { dataSet, attributeId: dragAttributeID } = getDragAttributeInfo(active) || {}
+    dataSet && dragAttributeID && onDrop(dataSet, dragAttributeID)
   })
 
   const isActive = active && handleIsActive(active),

--- a/v3/src/components/graph/components/droppable-plot.tsx
+++ b/v3/src/components/graph/components/droppable-plot.tsx
@@ -1,16 +1,17 @@
 import {Active} from "@dnd-kit/core"
 import React, {memo} from "react"
-import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
+import {getDragAttributeInfo, useDropHandler} from "../../../hooks/use-drag-drop"
 import {useDropHintString} from "../../../hooks/use-drop-hint-string"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {DroppableSvg} from "./droppable-svg"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {GraphPlace} from "../../axis-graph-shared"
+import {IDataSet} from "../../../models/data/data-set"
 
 interface IProps {
   graphElt: HTMLDivElement | null
   plotElt: SVGGElement | null
-  onDropAttribute: (place: GraphPlace, attrId: string) => void
+  onDropAttribute: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
 }
 
 const _DroppablePlot = ({graphElt, plotElt, onDropAttribute}: IProps) => {
@@ -22,18 +23,18 @@ const _DroppablePlot = ({graphElt, plotElt, onDropAttribute}: IProps) => {
   const hintString = useDropHintString({role})
 
   const handleIsActive = (active: Active) => {
-    const droppedAttrId = getDragAttributeId(active) ?? ''
+    const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {}
     if (isDropAllowed) {
-      return isDropAllowed('legend', droppedAttrId)
+      return isDropAllowed('legend', dataSet, droppedAttrId)
     } else {
       return !!droppedAttrId
     }
   }
 
   useDropHandler(droppableId, active => {
-    const dragAttributeID = getDragAttributeId(active)
-    dragAttributeID && isDropAllowed('legend', dragAttributeID) &&
-    onDropAttribute('plot', dragAttributeID)
+    const { dataSet, attributeId: dragAttributeID } = getDragAttributeInfo(active) || {}
+    dataSet && dragAttributeID && isDropAllowed('legend', dataSet, dragAttributeID) &&
+      onDropAttribute('plot', dataSet, dragAttributeID)
   })
 
   return (

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -4,10 +4,11 @@ import {isAlive} from "mobx-state-tree"
 import {Active} from "@dnd-kit/core"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {AttributeType} from "../../../models/data/attribute"
+import {IDataSet} from "../../../models/data/data-set"
 import {useGraphModelContext} from "../models/graph-model"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useGraphLayoutContext} from "../models/graph-layout"
-import {getDragAttributeId, useDropHandler} from "../../../hooks/use-drag-drop"
+import {getDragAttributeInfo, useDropHandler} from "../../../hooks/use-drag-drop"
 import {AxisPlace} from "../../axis/axis-types"
 import {Axis} from "../../axis/components/axis"
 import {axisPlaceToAttrRole, kGraphClassSelector} from "../graphing-types"
@@ -20,7 +21,7 @@ import {useAxisBoundsProvider} from "../../axis/hooks/use-axis-bounds"
 interface IProps {
   place: AxisPlace
   enableAnimation: MutableRefObject<boolean>
-  onDropAttribute?: (place: GraphPlace, attrId: string) => void
+  onDropAttribute?: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
   onRemoveAttribute?: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
@@ -36,9 +37,9 @@ export const GraphAxis = observer(function GraphAxis(
     hintString = useDropHintString({role: axisPlaceToAttrRole[place]})
 
   const handleIsActive = (active: Active) => {
-    const droppedAttrId = getDragAttributeId(active) ?? ''
+    const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {}
     if (isDropAllowed) {
-      return isDropAllowed(place, droppedAttrId)
+      return isDropAllowed(place, dataSet, droppedAttrId)
     } else {
       return !!droppedAttrId
     }
@@ -48,8 +49,9 @@ export const GraphAxis = observer(function GraphAxis(
     setWrapperElt} = useAxisBoundsProvider(place, kGraphClassSelector)
 
   useDropHandler(droppableId, active => {
-    const droppedAttrId = getDragAttributeId(active)
-    droppedAttrId && isDropAllowed(place, droppedAttrId) && onDropAttribute?.(place, droppedAttrId)
+    const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {}
+    dataSet && droppedAttrId && isDropAllowed(place, dataSet, droppedAttrId) &&
+      onDropAttribute?.(place, dataSet, droppedAttrId)
   })
 
   useEffect(function cleanup () {

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -25,6 +25,7 @@ import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {MarqueeState} from "../models/marquee-state"
 import {Legend} from "./legend/legend"
 import {AttributeType} from "../../../models/data/attribute"
+import {IDataSet} from "../../../models/data/data-set"
 import {useDataTips} from "../hooks/use-data-tips"
 import {onAnyAction} from "../../../utilities/mst-utils"
 
@@ -62,10 +63,10 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     }
   }, [dataset, plotAreaSVGRef, layout, layout.plotHeight, layout.plotWidth, xScale])
 
-  const handleChangeAttribute = (place: GraphPlace, attrId: string) => {
+  const handleChangeAttribute = (place: GraphPlace, dataSet: IDataSet, attrId: string) => {
     const computedPlace = place === 'plot' && graphModel.config.noAttributesAssigned ? 'bottom' : place
     const attrRole = graphPlaceToAttrRole[computedPlace]
-    graphModel.setAttributeID(attrRole, attrId)
+    graphModel.setAttributeID(attrRole, dataSet.id, attrId)
   }
 
   /**
@@ -78,7 +79,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
       const yAxisModel = graphModel.getAxis('left') as IAxisModel
       setNiceDomain(graphModel.config.numericValuesForAttrRole('y'), yAxisModel)
     } else {
-      handleChangeAttribute(place, '')
+      dataset && handleChangeAttribute(place, dataset, '')
     }
   }
 
@@ -86,10 +87,10 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
   useEffect(function handleNewAttributeID() {
     const disposer = graphModel && onAnyAction(graphModel, action => {
       if (isSetAttributeIDAction(action)) {
-        const [role, attrID] = action.args,
+        const [role, dataSetId, attrID] = action.args,
           graphPlace = attrRoleToGraphPlace[role]
         startAnimation(enableAnimation)
-        graphPlace && graphController?.handleAttributeAssignment(graphPlace, attrID)
+        graphPlace && graphController?.handleAttributeAssignment(graphPlace, dataSetId, attrID)
       }
     })
     return () => disposer?.()
@@ -97,7 +98,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
 
   const handleTreatAttrAs = (place: GraphPlace, attrId: string, treatAs: AttributeType) => {
     graphModel.config.setAttributeType(graphPlaceToAttrRole[place], treatAs)
-    graphController?.handleAttributeAssignment(place, attrId)
+    dataset && graphController?.handleAttributeAssignment(place, dataset.id, attrId)
   }
 
   useDataTips({dotsRef, dataset, graphModel, enableAnimation})

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -7,16 +7,17 @@ import {CategoricalLegend} from "./categorical-legend"
 import {NumericLegend} from "./numeric-legend"
 import {DroppableSvg} from "../droppable-svg"
 import {useInstanceIdContext} from "../../../../hooks/use-instance-id-context"
-import {getDragAttributeId, useDropHandler} from "../../../../hooks/use-drag-drop"
+import {getDragAttributeInfo, useDropHandler} from "../../../../hooks/use-drag-drop"
 import {useDropHintString} from "../../../../hooks/use-drop-hint-string"
 import {AttributeType} from "../../../../models/data/attribute"
+import {IDataSet} from "../../../../models/data/data-set"
 import {GraphAttrRole} from "../../graphing-types"
 import {GraphPlace} from "../../../axis-graph-shared"
 
 interface ILegendProps {
   legendAttrID: string
   graphElt: HTMLDivElement | null
-  onDropAttribute: (place: GraphPlace, attrId: string) => void
+  onDropAttribute: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
   onRemoveAttribute: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
@@ -36,18 +37,18 @@ export const Legend = function Legend({
     hintString = useDropHintString({role})
 
   const handleIsActive = (active: Active) => {
-    const droppedAttrId = getDragAttributeId(active) ?? ''
+    const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {}
     if (isDropAllowed) {
-      return isDropAllowed('legend', droppedAttrId)
+      return isDropAllowed('legend', dataSet, droppedAttrId)
     } else {
       return !!droppedAttrId
     }
   }
 
   useDropHandler(droppableId, active => {
-    const dragAttributeID = getDragAttributeId(active)
-    dragAttributeID && isDropAllowed('legend', dragAttributeID) &&
-    onDropAttribute('legend', dragAttributeID)
+    const { dataSet, attributeId: dragAttributeID } = getDragAttributeInfo(active) || {}
+    dataSet && dragAttributeID && isDropAllowed('legend', dataSet, dragAttributeID) &&
+     onDropAttribute('legend', dataSet, dragAttributeID)
   })
 
   const legendBounds = layout.computedBounds.legend,

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -448,6 +448,10 @@ export const DataConfigurationModel = types
           typeToDropIsNumeric = !!idToDrop && dataSet?.attrFromID(idToDrop)?.type === 'numeric',
           xIsNumeric = self.attributeType('x') === 'numeric',
           existingID = self.attributeID(role)
+        // only drops on left/bottom axes can change data set
+        if (dataSet?.id !== self.dataset?.id && !['left', 'bottom'].includes(place)) {
+          return false
+        }
         if (place === 'yPlus') {
           return xIsNumeric && typeToDropIsNumeric && !!idToDrop && !self.yAttributeIDs.includes(idToDrop)
         } else if (place === 'rightNumeric') {

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -443,9 +443,9 @@ export const DataConfigurationModel = types
           primaryRole = self.primaryRole
         return primaryRole === role || !['left', 'bottom'].includes(place)
       },
-      graphPlaceCanAcceptAttributeIDDrop(place: GraphPlace, idToDrop?: string) {
+      graphPlaceCanAcceptAttributeIDDrop(place: GraphPlace, dataSet?: IDataSet, idToDrop?: string) {
         const role = graphPlaceToAttrRole[place],
-          typeToDropIsNumeric = !!idToDrop && self.dataset?.attrFromID(idToDrop)?.type === 'numeric',
+          typeToDropIsNumeric = !!idToDrop && dataSet?.attrFromID(idToDrop)?.type === 'numeric',
           xIsNumeric = self.attributeType('x') === 'numeric',
           existingID = self.attributeID(role)
         if (place === 'yPlus') {
@@ -541,6 +541,10 @@ export const DataConfigurationModel = types
       if (role === 'x' || role === 'y') {
         self.primaryRole = role
       }
+    },
+    clearAttributes() {
+      self._attributeDescriptions.clear()
+      self._yAttributeDescriptions.clear()
     },
     setAttribute(role: GraphAttrRole, desc?: IAttributeDescriptionSnapshot) {
 

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -2,6 +2,7 @@ import React from "react"
 import {IGraphModel} from "./graph-model"
 import {GraphLayout} from "./graph-layout"
 import {IDataSet} from "../../../models/data/data-set"
+import {getDataSetFromId} from "../../../models/shared/shared-data-utils"
 import {AxisPlace, AxisPlaces} from "../../axis/axis-types"
 import {
   CategoricalAxisModel, EmptyAxisModel, isCategoricalAxisModel, isNumericAxisModel, NumericAxisModel
@@ -80,8 +81,9 @@ export class GraphController {
     }
   }
 
-  handleAttributeAssignment(graphPlace: GraphPlace, attrID: string) {
-    const {graphModel, layout, dataset} = this,
+  handleAttributeAssignment(graphPlace: GraphPlace, dataSetID: string, attrID: string) {
+    const {graphModel, layout} = this,
+      dataset = getDataSetFromId(graphModel, dataSetID),
       dataConfig = graphModel?.config
     if (!(graphModel && layout && dataset && dataConfig)) {
       return

--- a/v3/src/hooks/use-drag-drop.ts
+++ b/v3/src/hooks/use-drag-drop.ts
@@ -1,5 +1,8 @@
-import { Active, DataRef, DragEndEvent, Modifier, useDndMonitor, useDraggable, UseDraggableArguments,
-    useDroppable, UseDroppableArguments} from "@dnd-kit/core"
+import {
+  Active, DataRef, DragEndEvent, Modifier, useDndMonitor,
+  useDraggable, UseDraggableArguments, useDroppable, UseDroppableArguments
+} from "@dnd-kit/core"
+import { IDataSet } from "../models/data/data-set"
 import { useInstanceIdContext } from "./use-instance-id-context"
 
 // list of draggable types
@@ -14,27 +17,30 @@ export interface IDragData {
 
 export interface IDragAttributeData extends IDragData {
   type: "attribute"
+  dataSet?: IDataSet
   attributeId: string
 }
 export function isDragAttributeData(data: DataRef): data is DataRef<IDragAttributeData> {
   return data.current?.type === "attribute"
 }
-export const getDragAttributeId = (active: Active | null) => {
-  return active && isDragAttributeData(active.data) ? active.data.current?.attributeId : undefined
+export function getDragAttributeInfo(active: Active | null): Omit<IDragAttributeData, "type"> | undefined {
+  const { dataSet, attributeId } = active?.data.current as IDragAttributeData || {}
+  return dataSet && attributeId ? { dataSet, attributeId } : undefined
 }
 
 export interface IUseDraggableAttribute extends Omit<UseDraggableArguments, "id"> {
   // should generally include instanceId to support dragging from multiple component instances
   prefix: string
+  dataSet?: IDataSet
   attributeId: string
 }
-export const useDraggableAttribute = ({ prefix, attributeId, ...others }: IUseDraggableAttribute) => {
+export const useDraggableAttribute = ({ prefix, dataSet, attributeId, ...others }: IUseDraggableAttribute) => {
   // RDG expects all cells to have tabIndex of -1 except for the selected/active/clicked cell.
   // For instance, it calls scrollIntoView(gridRef.current?.querySelector('[tabindex="0"]')).
   // DnDKit sets the tabIndex of draggable elements to 0 by default for keyboard accessibility.
   // For now we set it to -1 to meet RDG's expectations and we'll worry about keyboard drag later.
   const attributes = { tabIndex: -1 }
-  const data: IDragAttributeData = { type: "attribute", attributeId }
+  const data: IDragAttributeData = { type: "attribute", dataSet, attributeId }
   return useDraggable({ ...others, id: `${prefix}-${attributeId}`, attributes, data })
 }
 

--- a/v3/src/hooks/use-drop-hint-string.ts
+++ b/v3/src/hooks/use-drop-hint-string.ts
@@ -1,7 +1,7 @@
 import {useDndContext} from "@dnd-kit/core"
 import { AttributeType } from "../models/data/attribute"
 import {useDataSetContext} from "./use-data-set-context"
-import {getDragAttributeId} from "./use-drag-drop"
+import {getDragAttributeInfo} from "./use-drag-drop"
 import {useDataConfigurationContext} from "../components/graph/hooks/use-data-configuration-context"
 import {attrRoleToGraphPlace, GraphAttrRole} from "../components/graph/graphing-types"
 import {GraphPlace} from "../components/axis-graph-shared"
@@ -83,9 +83,9 @@ export const useDropHintString = ({role} : IUseDropHintStringProps) => {
   const dataSet = useDataSetContext(),
     dataConfig = useDataConfigurationContext(),
     { active } = useDndContext(),
-    dragAttrId = getDragAttributeId(active) ?? '',
+    { attributeId: dragAttrId = "" } = getDragAttributeInfo(active) || {},
     place = attrRoleToGraphPlace[role] as GraphPlace,
-    dropAllowed = dataConfig?.graphPlaceCanAcceptAttributeIDDrop(place, dragAttrId)
+    dropAllowed = dataConfig?.graphPlaceCanAcceptAttributeIDDrop(place, dataSet, dragAttrId)
 
   if (dataSet && active?.data.current && dropAllowed) {
     const dragAttrName = dragAttrId ? dataSet.attrFromID(dragAttrId).name : undefined,

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -35,7 +35,7 @@ describe("createCodapDocument", () => {
   })
 
   it("creates an empty document with mosaic layout", () => {
-    const doc = createCodapDocument(undefined, "mosaic")
+    const doc = createCodapDocument(undefined, { layout: "mosaic" })
     expect(doc.key).toBe("test-1")
     expect(doc.type).toBe("CODAP")
     expect(omitUndefined(getSnapshot(doc.content!))).toEqual({

--- a/v3/src/models/codap/create-codap-document.ts
+++ b/v3/src/models/codap/create-codap-document.ts
@@ -12,14 +12,19 @@ import "../global/global-value-manager-registration"
 const { version } = pkg
 const { buildNumber } = build
 
-export function createCodapDocument(snapshot?: IDocumentModelSnapshot, layout?: "free" | "mosaic"): IDocumentModel {
+interface IOptions {
+  layout?: "free" | "mosaic"
+  noGlobals?: boolean
+}
+export function createCodapDocument(snapshot?: IDocumentModelSnapshot, options?: IOptions): IDocumentModel {
+  const { layout = "free", noGlobals = false } = options || {}
   const document = createDocumentModel({ type: "CODAP", version, build: `${buildNumber}`, ...snapshot })
   // create the content if there isn't any
   if (!document.content) {
     document.setContent(getSnapshot(DocumentContentModel.create()))
   }
   // add the global value manager if there isn't one
-  if (document.content && !document.content.getFirstSharedModelByType(GlobalValueManager)) {
+  if (document.content && !noGlobals && !document.content.getFirstSharedModelByType(GlobalValueManager)) {
     document.content.addSharedModel(GlobalValueManager.create())
   }
   // create the default tile container ("row")

--- a/v3/src/models/shared/shared-data-utils.test.ts
+++ b/v3/src/models/shared/shared-data-utils.test.ts
@@ -1,0 +1,115 @@
+import { createCodapDocument } from "../codap/create-codap-document"
+import { IDocumentModel } from "../document/document"
+import { TileContentModel } from "../tiles/tile-content"
+import { registerTileContentInfo } from "../tiles/tile-content-info"
+import { getSharedModelManager } from "../tiles/tile-environment"
+import { TileModel } from "../tiles/tile-model"
+import { SharedCaseMetadata } from "./shared-case-metadata"
+import { SharedDataSet } from "./shared-data-set"
+import {
+  getDataSetFromId, getTileCaseMetadata, getTileDataSet, getTileSharedModels, isTileLinkedToDataSet,
+  linkTileToDataSet, unlinkTileFromDataSets
+} from "./shared-data-utils"
+import "./shared-data-set-registration"
+import "./shared-case-metadata-registration"
+
+const TestTileContent = TileContentModel
+  .named("TestTile")
+  .props({
+    type: "Test"
+  })
+  .actions(self => ({
+    updateAfterSharedModelChanges() {
+      // NOP
+    }
+  }))
+
+registerTileContentInfo({
+  type: "Test",
+  prefix: "TEST",
+  modelClass: TestTileContent,
+  defaultContent(options) {
+    return TestTileContent.create()
+  }
+})
+
+describe("SharedDataUtils", () => {
+  let document: IDocumentModel = createCodapDocument(undefined, { noGlobals: true })
+  let tile = TileModel.create({ content: TestTileContent.create() })
+  let sharedDataSet = SharedDataSet.create()
+  let sharedMetadata = SharedCaseMetadata.create()
+
+  beforeEach(() => {
+    document = createCodapDocument(undefined, { noGlobals: true })
+    tile = TileModel.create({ content: TestTileContent.create() })
+    document.addTile(tile)
+    sharedDataSet = SharedDataSet.create()
+    document.content?.addSharedModel(sharedDataSet)
+    sharedMetadata = SharedCaseMetadata.create()
+    document.content?.addSharedModel(sharedMetadata)
+    sharedMetadata.setData(sharedDataSet.dataSet)
+  })
+
+  it("handles tiles not connected to the document", () => {
+    const orphan = TileModel.create({ content: TestTileContent.create() })
+    expect(getTileSharedModels(orphan.content)).toEqual([])
+    expect(getDataSetFromId(orphan.content, sharedDataSet.dataSet.id)).toBeUndefined()
+    linkTileToDataSet(orphan.content, sharedDataSet.dataSet)
+    expect(isTileLinkedToDataSet(orphan.content, sharedDataSet.dataSet)).toBe(false)
+    expect(getTileSharedModels(orphan.content)).toEqual([])
+    unlinkTileFromDataSets(orphan.content)
+    expect(isTileLinkedToDataSet(orphan.content, sharedDataSet.dataSet)).toBe(false)
+    expect(getTileSharedModels(orphan.content)).toEqual([])
+  })
+
+  it("works as expected when no tiles are linked", () => {
+    expect(getSharedModelManager(document)).toBeDefined()
+    expect(getSharedModelManager(tile)).toBeDefined()
+    expect(sharedMetadata.data).toBeDefined()
+    expect(document.content?.sharedModelMap.size).toBe(2)
+    expect(getDataSetFromId(document, "foo")).toBeUndefined()
+    expect(getDataSetFromId(document, sharedDataSet.dataSet.id)).toBe(sharedDataSet.dataSet)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
+    expect(getTileSharedModels(tile.content)).toEqual([])
+    expect(getTileDataSet(tile.content)).toBeUndefined()
+    expect(getTileCaseMetadata(tile.content)).toBeUndefined()
+  })
+
+  it("can link/unlink tiles to/from data sets and shared case metadata", () => {
+    linkTileToDataSet(tile.content, sharedDataSet.dataSet)
+    expect(document.content?.sharedModelMap.size).toBe(2)
+    expect(getTileSharedModels(tile.content).length).toEqual(2)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(true)
+    expect(getTileDataSet(tile.content)).toBe(sharedDataSet.dataSet)
+    expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata)
+
+    unlinkTileFromDataSets(tile.content)
+    expect(document.content?.sharedModelMap.size).toBe(2)
+    expect(getTileSharedModels(tile.content).length).toEqual(0)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
+    expect(getTileDataSet(tile.content)).not.toBeDefined()
+    expect(getTileCaseMetadata(tile.content)).not.toBeDefined()
+  })
+
+  it("auto-unlinks previously linked data sets when linking a new data set", () => {
+    const sharedDataSet2 = SharedDataSet.create()
+    document.content?.addSharedModel(sharedDataSet2)
+    const sharedMetadata2 = SharedCaseMetadata.create()
+    document.content?.addSharedModel(sharedMetadata2)
+    sharedMetadata2.setData(sharedDataSet2.dataSet)
+    expect(document.content?.sharedModelMap.size).toBe(4)
+
+    linkTileToDataSet(tile.content, sharedDataSet.dataSet)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(true)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(false)
+    expect(getTileDataSet(tile.content)).toBe(sharedDataSet.dataSet)
+    expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata)
+
+    linkTileToDataSet(tile.content, sharedDataSet2.dataSet)
+    expect(getTileSharedModels(tile.content).length).toEqual(2)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(true)
+    expect(getTileDataSet(tile.content)).toBe(sharedDataSet2.dataSet)
+    expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata2)
+  })
+})

--- a/v3/src/models/shared/shared-data-utils.ts
+++ b/v3/src/models/shared/shared-data-utils.ts
@@ -1,0 +1,68 @@
+import { IAnyStateTreeNode } from "@concord-consortium/mobx-state-tree"
+import { IDataSet } from "../data/data-set"
+import { ITileContentModel } from "../tiles/tile-content"
+import { getSharedModelManager } from "../tiles/tile-environment"
+import {
+  ISharedCaseMetadata, isSharedCaseMetadata, kSharedCaseMetadataType, SharedCaseMetadata
+} from "./shared-case-metadata"
+import { ISharedDataSet, isSharedDataSet, kSharedDataSetType, SharedDataSet } from "./shared-data-set"
+
+export function getTileSharedModels(tile: ITileContentModel) {
+  const sharedModelManager = getSharedModelManager(tile)
+  return sharedModelManager?.getTileSharedModels(tile)
+}
+
+export function getDataSetFromId(node: IAnyStateTreeNode, id: string): IDataSet | undefined {
+  const sharedModelManager = getSharedModelManager(node)
+  const sharedDataSets = sharedModelManager?.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
+  const sharedDataSet = sharedDataSets?.find(model => model.dataSet.id === id) as ISharedDataSet | undefined
+  return sharedDataSet?.dataSet
+}
+
+export function getTileDataSet(tile: ITileContentModel): IDataSet | undefined {
+  const sharedDataSet = getTileSharedModels(tile)?.find(m => isSharedDataSet(m))
+  return isSharedDataSet(sharedDataSet) ? sharedDataSet.dataSet : undefined
+}
+
+export function getTileCaseMetadata(tile: ITileContentModel) {
+  const sharedCaseMetadata = getTileSharedModels(tile)?.find(m => isSharedCaseMetadata(m))
+  return isSharedCaseMetadata(sharedCaseMetadata) ? sharedCaseMetadata : undefined
+}
+
+export function isTileLinkedToDataSet(tile: ITileContentModel, dataSet: IDataSet) {
+  const sharedModels = getTileSharedModels(tile)
+  return !!sharedModels?.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id === dataSet.id)
+}
+
+export function isTileLinkedToOtherDataSet(tile: ITileContentModel, dataSet: IDataSet) {
+  const sharedModels = getTileSharedModels(tile)
+  return !!sharedModels?.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id !== dataSet.id)
+}
+
+export function unlinkTileFromDataSets(tile: ITileContentModel) {
+  const sharedModelManager = getSharedModelManager(tile)
+  const sharedModels = sharedModelManager?.getTileSharedModels(tile)
+  sharedModels?.forEach(sharedModel => {
+    if (sharedModel.type === kSharedDataSetType || sharedModel.type === kSharedCaseMetadataType) {
+      sharedModelManager?.removeTileSharedModel(tile, sharedModel)
+    }
+  })
+}
+
+export function linkTileToDataSet(tile: ITileContentModel, dataSet: IDataSet) {
+  if (isTileLinkedToOtherDataSet(tile, dataSet)) {
+    unlinkTileFromDataSets(tile)
+  }
+
+  const sharedModelManager = getSharedModelManager(tile)
+  const sharedDataSets = sharedModelManager?.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
+  const sharedDataSet = sharedDataSets?.find(model => model.dataSet.id === dataSet.id) as ISharedDataSet | undefined
+  if (sharedModelManager && sharedDataSet) {
+    sharedModelManager.addTileSharedModel(tile, sharedDataSet)
+
+    const sharedMetadata = sharedModelManager.getSharedModelsByType<typeof SharedCaseMetadata>(kSharedCaseMetadataType)
+    const sharedCaseMetadata: ISharedCaseMetadata | undefined =
+            sharedMetadata.find(model => model.data?.id === dataSet.id)
+    sharedCaseMetadata && sharedModelManager.addTileSharedModel(tile, sharedCaseMetadata)
+  }
+}

--- a/v3/src/models/shared/shared-data-utils.ts
+++ b/v3/src/models/shared/shared-data-utils.ts
@@ -9,7 +9,7 @@ import { ISharedDataSet, isSharedDataSet, kSharedDataSetType, SharedDataSet } fr
 
 export function getTileSharedModels(tile: ITileContentModel) {
   const sharedModelManager = getSharedModelManager(tile)
-  return sharedModelManager?.getTileSharedModels(tile)
+  return sharedModelManager?.getTileSharedModels(tile) ?? []
 }
 
 export function getDataSetFromId(node: IAnyStateTreeNode, id: string): IDataSet | undefined {
@@ -20,23 +20,23 @@ export function getDataSetFromId(node: IAnyStateTreeNode, id: string): IDataSet 
 }
 
 export function getTileDataSet(tile: ITileContentModel): IDataSet | undefined {
-  const sharedDataSet = getTileSharedModels(tile)?.find(m => isSharedDataSet(m))
+  const sharedDataSet = getTileSharedModels(tile).find(m => isSharedDataSet(m))
   return isSharedDataSet(sharedDataSet) ? sharedDataSet.dataSet : undefined
 }
 
 export function getTileCaseMetadata(tile: ITileContentModel) {
-  const sharedCaseMetadata = getTileSharedModels(tile)?.find(m => isSharedCaseMetadata(m))
+  const sharedCaseMetadata = getTileSharedModels(tile).find(m => isSharedCaseMetadata(m))
   return isSharedCaseMetadata(sharedCaseMetadata) ? sharedCaseMetadata : undefined
 }
 
 export function isTileLinkedToDataSet(tile: ITileContentModel, dataSet: IDataSet) {
   const sharedModels = getTileSharedModels(tile)
-  return !!sharedModels?.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id === dataSet.id)
+  return !!sharedModels.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id === dataSet.id)
 }
 
 export function isTileLinkedToOtherDataSet(tile: ITileContentModel, dataSet: IDataSet) {
   const sharedModels = getTileSharedModels(tile)
-  return !!sharedModels?.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id !== dataSet.id)
+  return !!sharedModels.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id !== dataSet.id)
 }
 
 export function unlinkTileFromDataSets(tile: ITileContentModel) {


### PR DESCRIPTION
- add `dataSet` to attribute drags
- use `dataSet` in attribute drags to link graphs to shared models on drops
- add a set of utility functions in `shared-data-utils.ts`