### PR TITLE
fix: linking of data sets

### DIFF
--- a/v3/src/components/app.test.tsx
+++ b/v3/src/components/app.test.tsx
@@ -6,7 +6,7 @@ import { prf } from "../utilities/profiler"
 import { setUrlParams } from "../utilities/url-params"
 import { App, handleImportDataSet } from "./app"
 
-describe.skip("App component", () => {
+describe("App component", () => {
   beforeEach(() => {
     gDataBroker.clear()
   })
@@ -27,8 +27,20 @@ describe.skip("App component", () => {
     expect(screen.getByTestId("app")).toBeInTheDocument()
   })
 
+  it("should render the App component with no data and dashboard", () => {
+    setUrlParams("?dashboard")
+    render(<App/>)
+    expect(screen.getByTestId("app")).toBeInTheDocument()
+  })
+
   it("should render the App component with mammals data", () => {
     setUrlParams("?sample=mammals")
+    render(<App/>)
+    expect(screen.getByTestId("app")).toBeInTheDocument()
+  })
+
+  it("should render the App component with mammals data and dashboard", () => {
+    setUrlParams("?sample=mammals&dashboard")
     render(<App/>)
     expect(screen.getByTestId("app")).toBeInTheDocument()
   })

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -113,20 +113,31 @@ export const App = observer(function App() {
       sharedModelManager && gDataBroker.setSharedModelManager(sharedModelManager)
     }
 
-    // create the initial sample data (if specified) or a new data set
-    if (gDataBroker.dataSets.size === 0) {
-      const sample = sampleData.find(name => urlParams.sample === name.toLowerCase())
-      if (sample) {
-        importSample(sample, handleImportDataSet)
-      }
-      // we have to create a new starter data set only if none is imported to show the dashboard
-      if (urlParams.dashboard !== undefined) {
-        if (!sample) {
+    async function initialize() {
+      // create the initial sample data (if specified) or a new data set
+      if (gDataBroker.dataSets.size === 0) {
+        const sample = sampleData.find(name => urlParams.sample === name.toLowerCase())
+        const isDashboard = urlParams.dashboard !== undefined
+        if (sample) {
+          try {
+            const data = await importSample(sample)
+            handleImportDataSet(data)
+          }
+          catch (e) {
+            console.warn(`Failed to import sample "${sample}"`)
+          }
+        }
+        else if (isDashboard) {
           createNewStarterDataset()
         }
-        addDefaultComponents()
+        // we have to create a new starter data set only if none is imported to show the dashboard
+        if (isDashboard) {
+          addDefaultComponents()
+        }
       }
     }
+
+    initialize()
   }, [])
 
   return (

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -1,8 +1,6 @@
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { TileModelContext } from "../hooks/use-tile-model-context"
-import { DataSetContext } from "../hooks/use-data-set-context"
-import { gDataBroker } from "../models/data/data-broker"
 import { InspectorPanelWrapper } from "./inspector-panel-wrapper"
 import { ITileBaseProps } from "./tiles/tile-base-props"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
@@ -27,7 +25,7 @@ export const CodapComponent = observer(function CodapComponent({
   onBottomLeftPointerDown, onBottomRightPointerDown
 }: IProps) {
   const info = getTileComponentInfo(tile.content.type)
-  const dataset = gDataBroker?.selectedDataSet || gDataBroker?.last
+
   function handleFocusTile() {
     uiState.setFocusedTile(tile.id)
   }
@@ -37,29 +35,27 @@ export const CodapComponent = observer(function CodapComponent({
   const { TitleBar, Component, tileEltClass, isFixedWidth, isFixedHeight } = info
   return (
     <TileModelContext.Provider value={tile}>
-      <DataSetContext.Provider value={dataset}>
-        <div className={`codap-component ${tileEltClass}`} key={tile.id}
-          onFocus={handleFocusTile} onPointerDownCapture={handleFocusTile}>
-          <TitleBar tile={tile} onCloseTile={onCloseTile}/>
-          <Component tile={tile} />
-          {onRightPointerDown && !isFixedWidth &&
-            <div className="codap-component-border right" onPointerDown={onRightPointerDown}/>}
-          {onBottomPointerDown && !isFixedHeight &&
-            <div className="codap-component-border bottom" onPointerDown={onBottomPointerDown}/>}
-          {onLeftPointerDown && !isFixedWidth &&
-            <div className="codap-component-border left" onPointerDown={onLeftPointerDown}/>}
-          {onBottomLeftPointerDown && !(isFixedWidth && isFixedHeight) &&
-            <div className="codap-component-corner bottom-left" onPointerDown={onBottomLeftPointerDown}/>
-          }
-          {onBottomRightPointerDown && !(isFixedWidth && isFixedHeight) &&
-            <div className="codap-component-corner bottom-right" onPointerDown={onBottomRightPointerDown}>
-              {uiState.isFocusedTile(tile.id) &&
-                <ResizeHandle className="component-resize-handle"/>}
-            </div>
-          }
-        </div>
-        <InspectorPanelWrapper tile={tile} />
-      </DataSetContext.Provider>
+      <div className={`codap-component ${tileEltClass}`} key={tile.id}
+        onFocus={handleFocusTile} onPointerDownCapture={handleFocusTile}>
+        <TitleBar tile={tile} onCloseTile={onCloseTile}/>
+        <Component tile={tile} />
+        {onRightPointerDown && !isFixedWidth &&
+          <div className="codap-component-border right" onPointerDown={onRightPointerDown}/>}
+        {onBottomPointerDown && !isFixedHeight &&
+          <div className="codap-component-border bottom" onPointerDown={onBottomPointerDown}/>}
+        {onLeftPointerDown && !isFixedWidth &&
+          <div className="codap-component-border left" onPointerDown={onLeftPointerDown}/>}
+        {onBottomLeftPointerDown && !(isFixedWidth && isFixedHeight) &&
+          <div className="codap-component-corner bottom-left" onPointerDown={onBottomLeftPointerDown}/>
+        }
+        {onBottomRightPointerDown && !(isFixedWidth && isFixedHeight) &&
+          <div className="codap-component-corner bottom-right" onPointerDown={onBottomRightPointerDown}>
+            {uiState.isFocusedTile(tile.id) &&
+              <ResizeHandle className="component-resize-handle"/>}
+          </div>
+        }
+      </div>
+      <InspectorPanelWrapper tile={tile} />
     </TileModelContext.Provider>
   )
 })

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,5 +1,4 @@
 import {useEffect} from "react"
-import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {IDotsRef} from "../graphing-types"
 import {GraphController} from "../models/graph-controller"
 import {IGraphModel} from "../models/graph-model"
@@ -11,9 +10,7 @@ export interface IUseGraphControllerProps {
 }
 
 export const useGraphController = ({graphController, graphModel, dotsRef}: IUseGraphControllerProps) => {
-  const dataset = useDataSetContext()
-
   useEffect(() => {
-    graphModel && graphController.setProperties({graphModel, dataset, dotsRef})
-  }, [graphController, graphModel, dataset, dotsRef])
+    graphModel && graphController.setProperties({graphModel, dotsRef})
+  }, [graphController, graphModel, dotsRef])
 }

--- a/v3/src/components/graph/models/data-configuration-model.ts
+++ b/v3/src/components/graph/models/data-configuration-model.ts
@@ -518,11 +518,12 @@ export const DataConfigurationModel = types
     },
     setDataset(dataset: IDataSet | undefined, metadata: ISharedCaseMetadata | undefined) {
       self.actionHandlerDisposer?.()
+      self.actionHandlerDisposer = undefined
       self.dataset = dataset
       self.metadata = metadata
-      self.actionHandlerDisposer = onAnyAction(self.dataset, self.handleAction)
       self.filteredCases = []
       if (dataset) {
+        self.actionHandlerDisposer = onAnyAction(self.dataset, self.handleAction)
         self.filteredCases[0] = new FilteredCases({
           source: dataset, filter: self.filterCase,
           onSetCaseValues: self.handleSetCaseValues

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -1,7 +1,6 @@
 import React from "react"
 import {IGraphModel} from "./graph-model"
 import {GraphLayout} from "./graph-layout"
-import {IDataSet} from "../../../models/data/data-set"
 import {getDataSetFromId} from "../../../models/shared/shared-data-utils"
 import {AxisPlace, AxisPlaces} from "../../axis/axis-types"
 import {
@@ -26,14 +25,12 @@ interface IGraphControllerConstructorProps {
 
 interface IGraphControllerProps {
   graphModel: IGraphModel
-  dataset: IDataSet | undefined
   dotsRef: IDotsRef
 }
 
 export class GraphController {
   graphModel?: IGraphModel
   layout: GraphLayout
-  dataset?: IDataSet
   enableAnimation: React.MutableRefObject<boolean>
   instanceId: string
 
@@ -45,9 +42,8 @@ export class GraphController {
 
   setProperties(props: IGraphControllerProps) {
     this.graphModel = props.graphModel
-    this.dataset = props.dataset
-    if (this.graphModel.config.dataset !== props.dataset) {
-      this.graphModel.config.setDataset(props.dataset, this.graphModel.metadata)
+    if (this.graphModel.config.dataset !== this.graphModel.data) {
+      this.graphModel.config.setDataset(this.graphModel.data, this.graphModel.metadata)
     }
     this.initializeGraph(props.dotsRef)
   }

--- a/v3/src/components/graph/models/graph-model.ts
+++ b/v3/src/components/graph/models/graph-model.ts
@@ -114,11 +114,12 @@ export const GraphModel = TileContentModel
       self.axes.delete(place)
     },
     setAttributeID(role: GraphAttrRole, dataSetID: string, id: string) {
-      const dataSet = getDataSetFromId(self, dataSetID)
-      if (dataSet && isTileLinkedToOtherDataSet(self, dataSet)) {
-        linkTileToDataSet(self, dataSet)
+      const currDataSet = getTileDataSet(self)
+      const newDataSet = getDataSetFromId(self, dataSetID)
+      if (newDataSet && (!currDataSet || isTileLinkedToOtherDataSet(self, newDataSet))) {
+        linkTileToDataSet(self, newDataSet)
         self.config.clearAttributes()
-        self.config.setDataset(dataSet)
+        self.config.setDataset(newDataSet, getTileCaseMetadata(self))
       }
       if (role === 'yPlus') {
         self.config.addYAttribute({attributeID: id})

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -49,12 +49,12 @@ export function addDefaultComponents() {
     if (isTableOnly) {
       const tableTile = createDefaultTileOfType(kCaseTableTileType)
       if (!tableTile) return
-      sharedData && manager?.addTileSharedModel(tableTile.content, sharedData, true)
-      caseMetadata && manager?.addTileSharedModel(tableTile.content, caseMetadata, true)
       const tableOptions: ILayoutOptions = isMosaicTileRow(row)
               ? undefined
               : { x: 2, y: 2, width: 800, height: 500 }
       content.insertTileInRow(tableTile, row, tableOptions)
+      sharedData && manager?.addTileSharedModel(tableTile.content, sharedData, true)
+      caseMetadata && manager?.addTileSharedModel(tableTile.content, caseMetadata, true)
     }
     else {
       const summaryTile = createDefaultTileOfType(kDataSummaryTileType)
@@ -63,15 +63,17 @@ export function addDefaultComponents() {
               ? undefined
               : { x: 2, y: 2, width: kFullWidth, height: kFullHeight }
       content.insertTileInRow(summaryTile, row, summaryOptions)
+      sharedData && manager?.addTileSharedModel(summaryTile.content, sharedData)
+      caseMetadata && manager?.addTileSharedModel(summaryTile.content, caseMetadata)
 
       const tableTile = createDefaultTileOfType(kCaseTableTileType)
       if (!tableTile) return
-      sharedData && manager?.addTileSharedModel(tableTile.content, sharedData, true)
-      caseMetadata && manager?.addTileSharedModel(tableTile.content, caseMetadata, true)
       const tableOptions: ILayoutOptions = isMosaicTileRow(row)
               ? { splitTileId: summaryTile.id, direction: "column" }
               : { x: 2, y: kFullHeight + kGap, width: kFullWidth, height: kFullHeight }
       content.insertTileInRow(tableTile, row, tableOptions)
+      sharedData && manager?.addTileSharedModel(tableTile.content, sharedData, true)
+      caseMetadata && manager?.addTileSharedModel(tableTile.content, caseMetadata, true)
 
       const calculatorTile = createDefaultTileOfType(kCalculatorTileType)
       if (!calculatorTile) return
@@ -92,12 +94,12 @@ export function addDefaultComponents() {
 
       const graphTile = createDefaultTileOfType(kGraphTileType)
       if (graphTile) {
-        sharedData && manager?.addTileSharedModel(graphTile.content, sharedData)
-        caseMetadata && manager?.addTileSharedModel(graphTile.content, caseMetadata)
         const graphOptions = isMosaicTileRow(row)
                 ? { splitTileId: tableTile.id, direction: "row" }
                 : { x: kFullWidth + kGap, y: kFullHeight + kGap, width: kFullWidth, height: kFullHeight }
         content.insertTileInRow(graphTile, row, graphOptions)
+        sharedData && manager?.addTileSharedModel(graphTile.content, sharedData)
+        caseMetadata && manager?.addTileSharedModel(graphTile.content, caseMetadata)
       }
     }
   })

--- a/v3/src/models/document/shared-model-document-manager.ts
+++ b/v3/src/models/document/shared-model-document-manager.ts
@@ -129,7 +129,7 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
     // the tile content model automatically by the tree monitor. However when
     // the list of shared models is changed like here addTileSharedModel, the
     // tree monitor doesn't pick that up, so we must call it directly.
-    tileContentModel.updateAfterSharedModelChanges(sharedModel)
+    tileContentModel.updateAfterSharedModelChanges(sharedModel, "link")
   }
 
   // This is not an action because it is deriving state.
@@ -183,6 +183,7 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
       return
     }
 
+    tileContentModel.updateAfterSharedModelChanges(sharedModel, "unlink")
     sharedModelEntry.removeTile(tile)
   }
 }

--- a/v3/src/models/history/tree.ts
+++ b/v3/src/models/history/tree.ts
@@ -53,7 +53,7 @@ export const Tree = types.model("Tree", {
 
     // Run update function on the tiles
     for (const tile of tiles) {
-      tile.content.updateAfterSharedModelChanges(sharedModel)
+      tile.content.updateAfterSharedModelChanges(sharedModel, "change")
     }
   }
 }))

--- a/v3/src/models/shared/shared-model-manager.ts
+++ b/v3/src/models/shared/shared-model-manager.ts
@@ -44,6 +44,8 @@ export const UnknownSharedModel = types.snapshotProcessor(_UnknownSharedModel, {
   }
 })
 
+export type SharedModelChangeType = "link" | "change" | "unlink"
+
 /**
  * An instance of this interface should be provided to tiles so they can interact
  * with shared models.

--- a/v3/src/models/tiles/tile-content.ts
+++ b/v3/src/models/tiles/tile-content.ts
@@ -1,5 +1,6 @@
 import { getSnapshot, Instance, types } from "mobx-state-tree"
 import { ISharedModel } from "../shared/shared-model"
+import { SharedModelChangeType } from "../shared/shared-model-manager"
 import { getTileEnvironment, ITileEnvironment } from "./tile-environment"
 import { tileModelHooks } from "./tile-model-hooks"
 import { kUnknownTileType } from "./unknown-types"
@@ -56,7 +57,7 @@ export const TileContentModel = types.model("TileContentModel", {
      *
      * @param sharedModel
      */
-    updateAfterSharedModelChanges(sharedModel?: ISharedModel) {
+    updateAfterSharedModelChanges(sharedModel: ISharedModel | undefined, type: SharedModelChangeType) {
       console.warn("updateAfterSharedModelChanges not implemented for:", self.type)
     }
   }))

--- a/v3/src/sample-data/index.ts
+++ b/v3/src/sample-data/index.ts
@@ -17,10 +17,17 @@ const sampleMap: Record<SampleType, string> = {
   Mammals: mammalsCsv
 }
 
-export function importSample(sample: SampleType, onImportDataSet: (data: IDataSet) => void) {
+export function importSample(sample: SampleType): Promise<IDataSet> {
   const dataUrl = sampleMap[sample]
-  downloadCsvFile(dataUrl, (results: CsvParseResult) => {
-    const ds = convertParsedCsvToDataSet(results, sample)
-    ds && onImportDataSet(ds)
+  return new Promise((resolve, reject) => {
+    downloadCsvFile(dataUrl, (results: CsvParseResult) => {
+      const ds = convertParsedCsvToDataSet(results, sample)
+      if (ds) {
+        resolve(ds)
+      }
+      else {
+        reject()
+      }
+    })
   })
 }


### PR DESCRIPTION
@bfinzer This fixes the coasters problem we saw. There may still be something else going on, but this should be a start.

- eliminates defaulting of data set
- wait until sample data is available to create default tiles in dashboard mode
- eliminate redundant data set from graph controller
- synchronizes data configuration data set/metadata on link/unlink

Note: some of these changes were made originally in CLUE and were brought over in this PR.