### PR TITLE
chore: add wrapSerialization function

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -11,6 +11,7 @@ import { createCodapDocument } from "../models/codap/create-codap-document"
 import {gDataBroker} from "../models/data/data-broker"
 import {DataSet, IDataSet, toCanonical} from "../models/data/data-set"
 import { IDocumentModelSnapshot } from "../models/document/document"
+import { wrapSerialization } from "../models/shared/shared-data-utils"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { getSharedModelManager } from "../models/tiles/tile-environment"
 import { ITileModel } from "../models/tiles/tile-model"
@@ -79,9 +80,7 @@ export const App = observer(function App() {
     })
 
     // retrieve document snapshot
-    gDataBroker.prepareSnapshots()
-    const docSnapshot = getSnapshot(v3Document)
-    gDataBroker.completeSnapshots()
+    const docSnapshot = wrapSerialization(v3Document, () => getSnapshot(v3Document))
     // use document snapshot
     appState.setDocument(docSnapshot)
   }, [])

--- a/v3/src/components/menu-bar/menu-bar.tsx
+++ b/v3/src/components/menu-bar/menu-bar.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import build from "../../../build_number.json"
 import pkg from "../../../package.json"
 import { appState } from "../../models/app-state"
-import { gDataBroker } from "../../models/data/data-broker"
+import { wrapSerialization } from "../../models/shared/shared-data-utils"
 import { HamburgerIcon } from "./hamburger-icon"
 
 import "./menu-bar.scss"
@@ -46,9 +46,7 @@ function download(path: string, filename: string) {
 
 function handleExportDocument() {
   // Convert JSON to string
-  gDataBroker.prepareSnapshots()
-  const data = JSON.stringify(appState.document)
-  gDataBroker.completeSnapshots()
+  const data = wrapSerialization(appState.document, () => JSON.stringify(appState.document))
 
   // Create a Blob object
   const blob = new Blob([data], { type: 'application/json' })

--- a/v3/src/models/data/data-broker.ts
+++ b/v3/src/models/data/data-broker.ts
@@ -114,14 +114,6 @@ export class DataBroker {
   clear() {
     this.dataSets.clear()
   }
-
-  prepareSnapshots() {
-    this.dataSets.forEach(data => data.prepareSnapshot())
-  }
-
-  completeSnapshots() {
-    this.dataSets.forEach(data => data.completeSnapshot())
-  }
 }
 
 export const gDataBroker = new DataBroker({ allowMultiple: true })

--- a/v3/src/models/shared/shared-data-utils.test.ts
+++ b/v3/src/models/shared/shared-data-utils.test.ts
@@ -1,3 +1,4 @@
+import { getSnapshot } from "mobx-state-tree"
 import { createCodapDocument } from "../codap/create-codap-document"
 import { IDocumentModel } from "../document/document"
 import { TileContentModel } from "../tiles/tile-content"
@@ -8,7 +9,7 @@ import { SharedCaseMetadata } from "./shared-case-metadata"
 import { SharedDataSet } from "./shared-data-set"
 import {
   getDataSetFromId, getTileCaseMetadata, getTileDataSet, getTileSharedModels, isTileLinkedToDataSet,
-  linkTileToDataSet, unlinkTileFromDataSets
+  linkTileToDataSet, unlinkTileFromDataSets, wrapSerialization
 } from "./shared-data-utils"
 import "./shared-data-set-registration"
 import "./shared-case-metadata-registration"
@@ -111,5 +112,11 @@ describe("SharedDataUtils", () => {
     expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(true)
     expect(getTileDataSet(tile.content)).toBe(sharedDataSet2.dataSet)
     expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata2)
+  })
+
+  it("wrapSerialization calls the serialization callback", () => {
+    const serialize = jest.fn(() => getSnapshot(document))
+    wrapSerialization(document, () => serialize())
+    expect(serialize).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
- eliminate `prepareSnapshots` and `completeSnapshots` from `DataBroker`
- replace them with `wrapSerialization` function in `shared-data-utils`