### PR TITLE
perf: use value.toString() instead of JSON.stringify() in Attribute.importValueToString()

### DIFF
--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -18,7 +18,6 @@ describe("Attribute", () => {
     expect(importValueToString(3.1415926)).toBe("3.1415926")
     expect(importValueToString(1e6)).toBe("1000000")
     expect(importValueToString(1e-6)).toBe("0.000001")
-    expect(importValueToString({} as any)).toBe("{}")
     expect(importValueToString(true)).toBe("true")
     expect(importValueToString(false)).toBe("false")
 
@@ -278,6 +277,28 @@ describe("Attribute", () => {
     expect(barSnap.id).toBe(bar.id)
     expect(barSnap.name).toBe(bar.name)
     expect(barSnap.values?.length).toBe(0)
+  })
+
+  test.skip("value.toString() vs. JSON.stringify(value)", () => {
+    const values: number[] = []
+    for (let i = 0; i < 5000; ++i) {
+      const factor = Math.pow(10, Math.floor(6 * Math.random()))
+      const decimals = Math.pow(10, Math.floor(4 * Math.random()))
+      values.push(Math.round(factor * decimals * Math.random()) / decimals)
+    }
+    const start0 = performance.now()
+    const converted0 = values.map(value => JSON.stringify(value))
+    const elapsed0 = performance.now() - start0
+
+    const start1 = performance.now()
+    const converted1 = values.map(value => value.toString())
+    const elapsed1 = performance.now() - start1
+
+    expect(converted0).toEqual(converted1)
+    expect(elapsed0).toBeGreaterThan(elapsed1)
+    console.log("JSON.stringify:", `${elapsed0.toFixed(3)}ms,`,
+                "value.toString:", `${elapsed1.toFixed(3)}ms,`,
+                "% diff:", `${(100 * (elapsed0 - elapsed1) / elapsed0).toFixed(1)}%`)
   })
 
 })

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -45,7 +45,7 @@ const isDevelopment = () => process.env.NODE_ENV !== "production"
 export type IValueType = string | number | boolean | undefined
 
 export function importValueToString(value: IValueType) {
-  return value == null ? "" : typeof value === "string" ? value : JSON.stringify(value)
+  return value == null ? "" : typeof value === "string" ? value : value.toString()
 }
 
 export const attributeTypes = [


### PR DESCRIPTION
@scytacki asked a question on slack about converting values for the `DataSet` and I pointed him to the `Attribute.importValueToString()` function. His suggested alternative used `value.toString()` instead of `JSON.stringify()`, which seemed like it would probably generate the same results with better performance. I whipped up a quick test to verify that (the improvement is ~40%) which also verifies that the results are the same.