### PR TITLE
V3: Fixes table toolshelf menu to show table tile title instead of data set name when table tile title has been changed.

### DIFF
--- a/v3/src/components/case-table/case-table-title-bar.tsx
+++ b/v3/src/components/case-table/case-table-title-bar.tsx
@@ -12,7 +12,8 @@ import "./case-table-title-bar.scss"
 
 export const CaseTableTitleBar = observer(function CaseTableTitleBar({tile, onCloseTile}: ITileTitleBarProps) {
   const data = isCaseTableModel(tile?.content) ? tile?.content.data : undefined
-  const getTitle = () => tile?.title || data?.name
+  const caseMetadata = isCaseTableModel(tile?.content) ? tile?.content.metadata  : undefined
+  const getTitle = () => caseMetadata?.title || tile?.title || data?.name
   const [showSwitchMessage, setShowSwitchMessage] = useState(false)
   const [showCaseCard, setShowCaseCard] = useState(false)
   const cardTableToggleRef = useRef(null)
@@ -32,12 +33,20 @@ export const CaseTableTitleBar = observer(function CaseTableTitleBar({tile, onCl
     setShowCaseCard(!showCaseCard)
   }
 
+  const handleChangeTitle = (nextValue?: string) => {
+    if (tile != null && nextValue) {
+      tile.setTitle(nextValue)
+      caseMetadata?.setTitle(nextValue)
+    }
+  }
+
   const cardTableToggleString = showCaseCard
                                   ? t("DG.DocumentController.toggleToCaseTable")
                                   : t("DG.DocumentController.toggleToCaseCard")
 
   return (
-    <ComponentTitleBar tile={tile} getTitle={getTitle} onCloseTile={onCloseTile}>
+    <ComponentTitleBar tile={tile} getTitle={getTitle} onCloseTile={onCloseTile}
+        onHandleTitleChange={handleChangeTitle}>
       <div className="header-left"
             title={cardTableToggleString}
             onClick={handleShowCardTableToggleMessage}>

--- a/v3/src/components/case-table/case-table-title-bar.tsx
+++ b/v3/src/components/case-table/case-table-title-bar.tsx
@@ -34,8 +34,8 @@ export const CaseTableTitleBar = observer(function CaseTableTitleBar({tile, onCl
   }
 
   const handleChangeTitle = (nextValue?: string) => {
-    if (tile != null && nextValue) {
-      tile.setTitle(nextValue)
+    if (nextValue) {
+      tile?.setTitle(nextValue)
       caseMetadata?.setTitle(nextValue)
     }
   }

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -6,7 +6,8 @@ import t from "../../utilities/translation/translate"
 import { getSharedModelManager } from "../../models/tiles/tile-environment"
 import { appState } from "../../models/app-state"
 import { ISharedDataSet, kSharedDataSetType, SharedDataSet } from "../../models/shared/shared-data-set"
-import { ISharedCaseMetadata } from "../../models/shared/shared-case-metadata"
+import { ISharedCaseMetadata, kSharedCaseMetadataType, SharedCaseMetadata }
+  from "../../models/shared/shared-case-metadata"
 import { DataSet, toCanonical } from "../../models/data/data-set"
 import { gDataBroker } from "../../models/data/data-broker"
 import { createDefaultTileOfType } from "../../models/codap/add-default-content"
@@ -27,9 +28,7 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
   const content = document.content
   const manager = getSharedModelManager(document)
   const datasets = manager?.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
-  const existingTableTiles = document.content?.getTilesOfType(kCaseTableTileType)
-  const tileIds: string[] = []
-  existingTableTiles?.forEach(tile => tileIds.push(tile.id))
+  const caseMetadatas = manager?.getSharedModelsByType<typeof SharedCaseMetadata>(kSharedCaseMetadataType)
   const row = content?.getRowByIndex(0)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [modalOpen, setModalOpen] = useState(false)
@@ -64,7 +63,6 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
   const handleOpenDataSetTable = (dataset: ISharedDataSet) => {
     const model = manager?.getSharedModelsByType("SharedDataSet")
                     .find(m =>  m.id === dataset.id) as ISharedDataSet | undefined
-    const caseMetadatas = manager?.getSharedModelsByType("SharedCaseMetadata") as ISharedCaseMetadata[] | undefined
     const caseMetadata = caseMetadatas?.find(cm => cm.data?.id === model?.dataSet.id)
     if (!model || !caseMetadata) return
     const tiles = manager?.getSharedModelTiles(model)
@@ -86,12 +84,17 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
     <>
       <MenuList>
         {datasets?.map((dataset, idx) => {
+          const model = datasets.find(m =>  m.id === dataset.id) as ISharedDataSet | undefined
+          const caseMetadata = caseMetadatas?.find(cm => cm.data?.id === model?.dataSet.id)
+          const tiles = manager?.getSharedModelTiles(model)
+          const tableTile = tiles?.find(tile => tile.content.type === "CodapCaseTable")
+          const tileTitle = caseMetadata?.title ? caseMetadata?.title
+                                                : tableTile?.title ? tableTile?.title : dataset.dataSet.name
           return (
             <MenuItem key={`${dataset.dataSet.id}`} onClick={()=>handleOpenDataSetTable(dataset)}>
-              {dataset.dataSet.name}
+              {tileTitle}
               <TrashIcon className="tool-shelf-menu-trash-icon"
-                  onClick={() => handleOpenRemoveDataSetModal(dataset.dataSet.id)}
-              />
+                  onClick={() => handleOpenRemoveDataSetModal(dataset.dataSet.id)} />
             </MenuItem>
           )
         })}

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -87,7 +87,7 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
           const model = datasets.find(m =>  m.id === dataset.id) as ISharedDataSet | undefined
           const caseMetadata = caseMetadatas?.find(cm => cm.data?.id === model?.dataSet.id)
           const tiles = manager?.getSharedModelTiles(model)
-          const tableTile = tiles?.find(tile => tile.content.type === "CodapCaseTable")
+          const tableTile = tiles?.find(tile => tile.content.type === kCaseTableTileType)
           const tileTitle = caseMetadata?.title ? caseMetadata?.title
                                                 : tableTile?.title ? tableTile?.title : dataset.dataSet.name
           return (

--- a/v3/src/components/component-title-bar.tsx
+++ b/v3/src/components/component-title-bar.tsx
@@ -11,7 +11,7 @@ import t from "../utilities/translation/translate"
 import "./component-title-bar.scss"
 
 export const ComponentTitleBar = observer(function ComponentTitleBar(
-    { tile, getTitle, children, onCloseTile }: ITileTitleBarProps) {
+    { tile, getTitle, children, onCloseTile, onHandleTitleChange }: ITileTitleBarProps) {
   // perform all title-related model access here so only title is re-rendered when properties change
   const title = getTitle?.() || tile?.title || t("DG.AppController.createDataSet.name")
   const [isEditing, setIsEditing] = useState(false)
@@ -36,7 +36,7 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(
       {children}
       <Editable value={title} className="title-bar" isPreviewFocusable={!dragging} submitOnBlur={true}
           onEdit={() => setIsEditing(true)} onSubmit={() => setIsEditing(false)}
-          onChange={handleChangeTitle} onCancel={() => setIsEditing(false)}
+          onChange={onHandleTitleChange || handleChangeTitle} onCancel={() => setIsEditing(false)}
           data-testid="editable-component-title">
         <EditablePreview className="title-text"/>
         <EditableInput className="title-text-input"/>

--- a/v3/src/components/tiles/tile-base-props.ts
+++ b/v3/src/components/tiles/tile-base-props.ts
@@ -10,6 +10,7 @@ export interface ITileTitleBarProps extends ITileBaseProps {
   getTitle?: () => string | undefined
   children?: ReactNode
   onHandleTitleBarClick?: (e: React.MouseEvent) => void
+  onHandleTitleChange?: () => void
   onCloseTile?: (tileId: string) => void
 }
 

--- a/v3/src/models/shared/shared-case-metadata.ts
+++ b/v3/src/models/shared/shared-case-metadata.ts
@@ -19,6 +19,7 @@ export const SharedCaseMetadata = SharedModel
   .named(kSharedCaseMetadataType)
   .props({
     type: types.optional(types.literal(kSharedCaseMetadataType), kSharedCaseMetadataType),
+    title: types.maybe(types.string),
     data: types.safeReference(DataSet),
     // key is collection id
     collections: types.map(CollectionTableMetadata),
@@ -46,6 +47,9 @@ export const SharedCaseMetadata = SharedModel
   .actions(self => ({
     setData(data?: IDataSet) {
       self.data = data
+    },
+    setTitle(title: string) {
+      self.title = title
     },
     setColumnWidth(attrId: string, width?: number) {
       if (width) {


### PR DESCRIPTION
Saves case table tile title to caseMetadata so:
- Table toolshelf has access to it
- Table title persists after user closes table but not delete the dataset