### PR TITLE
Adding component automation tests

### DIFF
--- a/v3/cypress/e2e/attribute-types.spec.ts
+++ b/v3/cypress/e2e/attribute-types.spec.ts
@@ -1,43 +1,43 @@
-import {TableTileElements as table} from "../support/elements/table-tile"
-import {CfmElements as cfm} from "../support/elements/cfm"
+import { TableTileElements as table } from "../support/elements/table-tile"
+import { CfmElements as cfm } from "../support/elements/cfm"
 
 context("attribute types", () => {
-    beforeEach(() => {
-        const filename = "cypress/fixtures/attribute-types.codap"
-        const url = `${Cypress.config("index")}`
-        cy.visit(url)
-        cy.wait(3000)
-        cfm.openLocalDoc(filename)
-    })
+  beforeEach(() => {
+    const filename = "cypress/fixtures/attribute-types.codap"
+    const url = `${Cypress.config("index")}`
+    cy.visit(url)
+    cy.wait(3000)
+    cfm.openLocalDoc(filename)
+  })
 
-    describe("attribute types are rendered correctly", () => {
-        it("verify string", () => {
-            table.getCell("2", "2").should("contain", "Arizona")
-        })
-        it("verify numerical", () => {
-            table.getCell("3", "2").should("contain", "48")
-        })
-        it("verify date", () => {
-            table.getCell("4", "2").should("contain", "8/7/2017 12:01 PM")
-        })
-        it.skip("verify boolean", () => {
-            table.getCell("5", "2").should("contain", "false")
-        })
-        it.skip("verify qualitative", () => {
-            table.getCell("6", "2").find("span span").should("have.class", "dg-qualitative-bar")
-        })
-        it.skip("verify color", () => {
-            table.getCell("7", "2").find("span").should("have.class", "dg-color-table-cell")
-        })
-        it.skip("verify bounds", () => {
-            cy.wait(1500)
-            table.getCell("9", "2").find("span").should("have.class", "dg-boundary-thumb")
-        })
-        it.skip("verify invalid type", () => {
-            table.getCell("10", "2").should("contain", "❌: invalid type(s) for '*'")
-        })
-        it.skip("verify unrecognized", () => {
-            table.getCell("11", "2").should("contain", "❌: 'Bool|color' is unrecognized")
-        })
+  describe("attribute types are rendered correctly", () => {
+    it("verify string", () => {
+      table.getCell("2", "2").should("contain", "Arizona")
     })
+    it("verify numerical", () => {
+      table.getCell("3", "2").should("contain", "48")
+    })
+    it("verify date", () => {
+      table.getCell("4", "2").should("contain", "8/7/2017 12:01 PM")
+    })
+    it.skip("verify boolean", () => {
+      table.getCell("5", "2").should("contain", "false")
+    })
+    it.skip("verify qualitative", () => {
+      table.getCell("6", "2").find("span span").should("have.class", "dg-qualitative-bar")
+    })
+    it.skip("verify color", () => {
+      table.getCell("7", "2").find("span").should("have.class", "dg-color-table-cell")
+    })
+    it.skip("verify bounds", () => {
+      cy.wait(1500)
+      table.getCell("9", "2").find("span").should("have.class", "dg-boundary-thumb")
+    })
+    it.skip("verify invalid type", () => {
+      table.getCell("10", "2").should("contain", "❌: invalid type(s) for '*'")
+    })
+    it.skip("verify unrecognized", () => {
+      table.getCell("11", "2").should("contain", "❌: 'Bool|color' is unrecognized")
+    })
+  })
 })

--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -7,242 +7,242 @@ const arrayOfAttributes = [ "Mammal", "Order", "LifeSpan", "Height", "Mass", "Sl
 // than the left axis, recent labeling changes make that no longer the case. So now, these axis
 // labels are only correct if the attribute in question is placed on the "correct" axis.
 const arrayOfValues = [
-    { attribute: "Mammal", values: [ ]},
-    { attribute: "Order", values: [ ]},
-    { attribute: "LifeSpan", values: [...Array(21).keys()].map(i => `${5 * i - 5}`)},   // X
-    { attribute: "Height", values: [...Array(17).keys()].map(i => `${0.5 * i - 0.5}`)}, // X
-    { attribute: "Mass", values: [ "0", "1000", "2000", "3000", "4000", "5000", "6000", "7000" ]},  // Y
-    { attribute: "Sleep", values: [...Array(12).keys()].map(i => `${2 * i}`)},  // Y
-    { attribute: "Speed", values: [ ]},
-    { attribute: "Habitat", values: [ "both", "land", "water" ]},
-    { attribute: "Diet", values: [ "both", "meat", "plants" ]},
+  { attribute: "Mammal", values: [ ]},
+  { attribute: "Order", values: [ ]},
+  { attribute: "LifeSpan", values: [...Array(21).keys()].map(i => `${5 * i - 5}`)},   // X
+  { attribute: "Height", values: [...Array(17).keys()].map(i => `${0.5 * i - 0.5}`)}, // X
+  { attribute: "Mass", values: [ "0", "1000", "2000", "3000", "4000", "5000", "6000", "7000" ]},  // Y
+  { attribute: "Sleep", values: [...Array(12).keys()].map(i => `${2 * i}`)},  // Y
+  { attribute: "Speed", values: [ ]},
+  { attribute: "Habitat", values: [ "both", "land", "water" ]},
+  { attribute: "Diet", values: [ "both", "meat", "plants" ]},
 ]
 
 context("Test graph axes with various attribute types", () => {
-    beforeEach(function () {
-        const queryParams = "?sample=mammals&dashboard&mouseSensor"
-        const url = `${Cypress.config("index")}${queryParams}`
-        cy.visit(url)
-        cy.wait(2500)
-    })
-    it("will show default x axis label", () => {
-        ah.verifyDefaultAxisLabel("x")
-        ah.verifyDefaultAxisLabel("y")
-    })
-    it("will add categorical attribute to x axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[7], "x") // Habitat => x-axis
-        cy.wait(2000)
-        ah.verifyTickMarksDoNotExist("y")
-        ah.verifyGridLinesDoNotExist("y")
-        ah.verifyXAxisTickMarksNotDisplayed()
-        ah.verifyXAxisGridLinesDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[7].values)
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
-    })
-    it("will add numeric attribute to x axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // LifeSpan => x-axis
-        cy.wait(2000)
-        ah.verifyTickMarksDoNotExist("y")
-        ah.verifyGridLinesDoNotExist("y")
-        ah.verifyXAxisTickMarksDisplayed()
-        ah.verifyXAxisGridLinesNotDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[2].values)
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
-    })
-    it("will add categorical attribute to y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[8], "y") // Diet => y-axis
-        cy.wait(2000)
-        ah.verifyTickMarksDoNotExist("x")
-        ah.verifyGridLinesDoNotExist("x")
-        ah.verifyYAxisTickMarksNotDisplayed()
-        ah.verifyYAxisGridLinesDisplayed()
-        ah.verifyAxisTickLabels("y", arrayOfValues[8].values)
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[8], "y")
-    })
-    it("will add numeric attribute to y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[5], "y") // Sleep => y-axis
-        cy.wait(2000)
-        ah.verifyTickMarksDoNotExist("x")
-        ah.verifyGridLinesDoNotExist("x")
-        ah.verifyYAxisTickMarksDisplayed()
-        ah.verifyYAxisGridLinesNotDisplayed()
-        ah.verifyAxisTickLabels("y", arrayOfValues[5].values)
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[5], "y")
-    })
-    it("will add categorical attribute to x axis and categorical attribute to y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[7], "x") // Habitat => x-axis
-        cy.dragAttributeToTarget("table", arrayOfAttributes[8], "y") // Diet => x-axis
-        cy.wait(2000)
-        ah.verifyXAxisTickMarksNotDisplayed()
-        ah.verifyXAxisGridLinesDisplayed()
-        ah.verifyYAxisTickMarksNotDisplayed()
-        ah.verifyYAxisGridLinesDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[7].values)
-        ah.verifyAxisTickLabels("y", arrayOfValues[8].values)
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
-        ah.verifyTickMarksDoNotExist("x")
-        ah.verifyGridLinesDoNotExist("x")
-        ah.verifyYAxisTickMarksNotDisplayed()
-        ah.verifyYAxisGridLinesDisplayed()
-        ah.verifyAxisTickLabels("y", arrayOfValues[8].values)
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[8], "y")
-    })
-    it("will add categorical attribute to x axis and numeric attribute to y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[7], "x") // Habitat => x-axis
-        cy.dragAttributeToTarget("table", arrayOfAttributes[5], "y") // Sleep => y-axis
-        cy.wait(2000)
-        ah.verifyXAxisTickMarksNotDisplayed()
-        ah.verifyXAxisGridLinesDisplayed()
-        ah.verifyYAxisTickMarksDisplayed()
-        ah.verifyYAxisGridLinesNotDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[7].values)
-        ah.verifyAxisTickLabels("y", arrayOfValues[5].values)
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
-        ah.verifyTickMarksDoNotExist("x")
-        ah.verifyGridLinesDoNotExist("x")
-        ah.verifyYAxisTickMarksDisplayed()
-        ah.verifyYAxisGridLinesNotDisplayed()
-        ah.verifyAxisTickLabels("y", arrayOfValues[5].values)
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[5], "y")
-    })
-    it("will add numeric attribute to x axis and categorical attribute to y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[3], "x") // Height => x-axis
-        cy.dragAttributeToTarget("table", arrayOfAttributes[7], "y") // Habitat => y-axis
-        cy.wait(2000)
-        ah.verifyXAxisTickMarksDisplayed()
-        ah.verifyXAxisGridLinesNotDisplayed()
-        ah.verifyYAxisTickMarksNotDisplayed()
-        ah.verifyYAxisGridLinesDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
-        ah.verifyAxisTickLabels("y", arrayOfValues[7].values)
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[7], "y")
-        ah.verifyTickMarksDoNotExist("y")
-        ah.verifyGridLinesDoNotExist("y")
-        ah.verifyXAxisTickMarksDisplayed()
-        ah.verifyXAxisGridLinesNotDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[3], "x")
-    })
-    it("will add numeric attribute to x axis and numeric attribute to y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[3], "x") // Height => x-axis
-        cy.dragAttributeToTarget("table", arrayOfAttributes[4], "y") // Mass => y-axis
-        cy.wait(2000)
-        ah.verifyXAxisTickMarksDisplayed()
-        ah.verifyYAxisTickMarksDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
-        ah.verifyAxisTickLabels("y", arrayOfValues[4].values)
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[4], "y")
-        ah.verifyTickMarksDoNotExist("y")
-        ah.verifyGridLinesDoNotExist("y")
-        ah.verifyXAxisTickMarksDisplayed()
-        ah.verifyXAxisGridLinesNotDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[3], "x")
-    })
+  beforeEach(function () {
+    const queryParams = "?sample=mammals&dashboard&mouseSensor"
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.wait(2500)
+  })
+  it("will show default x axis label", () => {
+    ah.verifyDefaultAxisLabel("x")
+    ah.verifyDefaultAxisLabel("y")
+  })
+  it("will add categorical attribute to x axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[7], "x") // Habitat => x-axis
+    cy.wait(2000)
+    ah.verifyTickMarksDoNotExist("y")
+    ah.verifyGridLinesDoNotExist("y")
+    ah.verifyXAxisTickMarksNotDisplayed()
+    ah.verifyXAxisGridLinesDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[7].values)
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
+  })
+  it("will add numeric attribute to x axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // LifeSpan => x-axis
+    cy.wait(2000)
+    ah.verifyTickMarksDoNotExist("y")
+    ah.verifyGridLinesDoNotExist("y")
+    ah.verifyXAxisTickMarksDisplayed()
+    ah.verifyXAxisGridLinesNotDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[2].values)
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
+  })
+  it("will add categorical attribute to y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[8], "y") // Diet => y-axis
+    cy.wait(2000)
+    ah.verifyTickMarksDoNotExist("x")
+    ah.verifyGridLinesDoNotExist("x")
+    ah.verifyYAxisTickMarksNotDisplayed()
+    ah.verifyYAxisGridLinesDisplayed()
+    ah.verifyAxisTickLabels("y", arrayOfValues[8].values)
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[8], "y")
+  })
+  it("will add numeric attribute to y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[5], "y") // Sleep => y-axis
+    cy.wait(2000)
+    ah.verifyTickMarksDoNotExist("x")
+    ah.verifyGridLinesDoNotExist("x")
+    ah.verifyYAxisTickMarksDisplayed()
+    ah.verifyYAxisGridLinesNotDisplayed()
+    ah.verifyAxisTickLabels("y", arrayOfValues[5].values)
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[5], "y")
+  })
+  it("will add categorical attribute to x axis and categorical attribute to y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[7], "x") // Habitat => x-axis
+    cy.dragAttributeToTarget("table", arrayOfAttributes[8], "y") // Diet => x-axis
+    cy.wait(2000)
+    ah.verifyXAxisTickMarksNotDisplayed()
+    ah.verifyXAxisGridLinesDisplayed()
+    ah.verifyYAxisTickMarksNotDisplayed()
+    ah.verifyYAxisGridLinesDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[7].values)
+    ah.verifyAxisTickLabels("y", arrayOfValues[8].values)
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
+    ah.verifyTickMarksDoNotExist("x")
+    ah.verifyGridLinesDoNotExist("x")
+    ah.verifyYAxisTickMarksNotDisplayed()
+    ah.verifyYAxisGridLinesDisplayed()
+    ah.verifyAxisTickLabels("y", arrayOfValues[8].values)
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[8], "y")
+  })
+  it("will add categorical attribute to x axis and numeric attribute to y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[7], "x") // Habitat => x-axis
+    cy.dragAttributeToTarget("table", arrayOfAttributes[5], "y") // Sleep => y-axis
+    cy.wait(2000)
+    ah.verifyXAxisTickMarksNotDisplayed()
+    ah.verifyXAxisGridLinesDisplayed()
+    ah.verifyYAxisTickMarksDisplayed()
+    ah.verifyYAxisGridLinesNotDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[7].values)
+    ah.verifyAxisTickLabels("y", arrayOfValues[5].values)
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
+    ah.verifyTickMarksDoNotExist("x")
+    ah.verifyGridLinesDoNotExist("x")
+    ah.verifyYAxisTickMarksDisplayed()
+    ah.verifyYAxisGridLinesNotDisplayed()
+    ah.verifyAxisTickLabels("y", arrayOfValues[5].values)
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[5], "y")
+  })
+  it("will add numeric attribute to x axis and categorical attribute to y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[3], "x") // Height => x-axis
+    cy.dragAttributeToTarget("table", arrayOfAttributes[7], "y") // Habitat => y-axis
+    cy.wait(2000)
+    ah.verifyXAxisTickMarksDisplayed()
+    ah.verifyXAxisGridLinesNotDisplayed()
+    ah.verifyYAxisTickMarksNotDisplayed()
+    ah.verifyYAxisGridLinesDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
+    ah.verifyAxisTickLabels("y", arrayOfValues[7].values)
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[7], "y")
+    ah.verifyTickMarksDoNotExist("y")
+    ah.verifyGridLinesDoNotExist("y")
+    ah.verifyXAxisTickMarksDisplayed()
+    ah.verifyXAxisGridLinesNotDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[3], "x")
+  })
+  it("will add numeric attribute to x axis and numeric attribute to y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[3], "x") // Height => x-axis
+    cy.dragAttributeToTarget("table", arrayOfAttributes[4], "y") // Mass => y-axis
+    cy.wait(2000)
+    ah.verifyXAxisTickMarksDisplayed()
+    ah.verifyYAxisTickMarksDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
+    ah.verifyAxisTickLabels("y", arrayOfValues[4].values)
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[4], "y")
+    ah.verifyTickMarksDoNotExist("y")
+    ah.verifyGridLinesDoNotExist("y")
+    ah.verifyXAxisTickMarksDisplayed()
+    ah.verifyXAxisGridLinesNotDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[3], "x")
+  })
 })
 
 context("Test graph axes attribute menu", () => {
-    beforeEach(function () {
-        const queryParams = "?sample=mammals&dashboard&mouseSensor"
-        const url = `${Cypress.config("index")}${queryParams}`
-        cy.visit(url)
-        cy.wait(2500)
-    })
-    it("will open and close x axis attribute menu when clicked on default axis label", () => {
-        ah.openAxisAttributeMenu("x")
-        ah.verifyRemoveAttributeDoesNotExist("x")
-        ah.verifyTreatAsOptionDoesNotExist("x")
-        ah.openAxisAttributeMenu("x")
-        ah.verifyAxisMenuIsClosed("x")
-    })
-    it("will open and close y axis attribute menu when clicked on default axis label", () => {
-        ah.openAxisAttributeMenu("y")
-        ah.verifyRemoveAttributeDoesNotExist("y")
-        ah.verifyTreatAsOptionDoesNotExist("y")
-        ah.openAxisAttributeMenu("y")
-        ah.verifyAxisMenuIsClosed("y")
-    })
-    it("will add and remove categorical attribute to x axis from attribute menu", () => {
-        ah.openAxisAttributeMenu("x")
-        ah.addAttributeToAxis(arrayOfAttributes[7], "x") // Habitat => x-axis
-        ah.verifyTickMarksDoNotExist("y")
-        ah.verifyGridLinesDoNotExist("y")
-        ah.verifyXAxisTickMarksNotDisplayed()
-        ah.verifyXAxisGridLinesDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[7].values)
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
-    })
-    it("will add and remove numeric attribute to x axis from attribute menu", () => {
-        ah.openAxisAttributeMenu("x")
-        ah.addAttributeToAxis(arrayOfAttributes[3], "x") // Height => x-axis
-        ah.verifyTickMarksDoNotExist("y")
-        ah.verifyGridLinesDoNotExist("y")
-        ah.verifyXAxisTickMarksDisplayed()
-        ah.verifyXAxisGridLinesNotDisplayed()
-        ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[3], "x")
-    })
-    it("will add and remove categorical attribute to y axis from attribute menu", () => {
-        ah.openAxisAttributeMenu("y")
-        ah.addAttributeToAxis(arrayOfAttributes[7], "y") // Habitat => y-axis
-        ah.verifyTickMarksDoNotExist("x")
-        ah.verifyGridLinesDoNotExist("x")
-        ah.verifyYAxisTickMarksNotDisplayed()
-        ah.verifyYAxisGridLinesDisplayed()
-        ah.verifyAxisTickLabels("y", arrayOfValues[7].values)
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[7], "y")
-    })
-    it("will add and remove numeric attribute to y axis from attribute menu", () => {
-        ah.openAxisAttributeMenu("y")
-        ah.addAttributeToAxis(arrayOfAttributes[4], "y") // Mass => y-axis
-        ah.verifyTickMarksDoNotExist("x")
-        ah.verifyGridLinesDoNotExist("x")
-        ah.verifyYAxisTickMarksDisplayed()
-        ah.verifyYAxisGridLinesNotDisplayed()
-        ah.verifyAxisTickLabels("y", arrayOfValues[4].values)
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[4], "y")
-    })
-    // TODO: figure out why this test started failing on ci build (but works locally)
-    it.skip("will treat numeric attribute on x axis to categorical", () => {
-        ah.openAxisAttributeMenu("x")
-        ah.addAttributeToAxis(arrayOfAttributes[3], "x") // Height => x-axis
-        ah.openAxisAttributeMenu("x")
-        ah.treatAttributeAsCategorical("x")
-        ah.verifyTickMarksDoNotExist("y")
-        ah.verifyGridLinesDoNotExist("y")
-        ah.verifyXAxisTickMarksNotDisplayed()
-        ah.verifyXAxisGridLinesDisplayed()
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[3], "x")
-    })
-    // TODO: figure out why this test started failing on ci build (but works locally)
-    it.skip("will treat numeric attribute on y axis to categorical", () => {
-        ah.openAxisAttributeMenu("y")
-        ah.addAttributeToAxis(arrayOfAttributes[3], "y")
-        cy.wait(2000)
-        ah.openAxisAttributeMenu("y")
-        ah.treatAttributeAsCategorical("y")
-        ah.verifyTickMarksDoNotExist("x")
-        ah.verifyGridLinesDoNotExist("x")
-        ah.verifyYAxisTickMarksNotDisplayed()
-        ah.verifyYAxisGridLinesDisplayed()
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[3], "y")
-    })
+  beforeEach(function () {
+    const queryParams = "?sample=mammals&dashboard&mouseSensor"
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.wait(2500)
+  })
+  it("will open and close x axis attribute menu when clicked on default axis label", () => {
+    ah.openAxisAttributeMenu("x")
+    ah.verifyRemoveAttributeDoesNotExist("x")
+    ah.verifyTreatAsOptionDoesNotExist("x")
+    ah.openAxisAttributeMenu("x")
+    ah.verifyAxisMenuIsClosed("x")
+  })
+  it("will open and close y axis attribute menu when clicked on default axis label", () => {
+    ah.openAxisAttributeMenu("y")
+    ah.verifyRemoveAttributeDoesNotExist("y")
+    ah.verifyTreatAsOptionDoesNotExist("y")
+    ah.openAxisAttributeMenu("y")
+    ah.verifyAxisMenuIsClosed("y")
+  })
+  it("will add and remove categorical attribute to x axis from attribute menu", () => {
+    ah.openAxisAttributeMenu("x")
+    ah.addAttributeToAxis(arrayOfAttributes[7], "x") // Habitat => x-axis
+    ah.verifyTickMarksDoNotExist("y")
+    ah.verifyGridLinesDoNotExist("y")
+    ah.verifyXAxisTickMarksNotDisplayed()
+    ah.verifyXAxisGridLinesDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[7].values)
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
+  })
+  it("will add and remove numeric attribute to x axis from attribute menu", () => {
+    ah.openAxisAttributeMenu("x")
+    ah.addAttributeToAxis(arrayOfAttributes[3], "x") // Height => x-axis
+    ah.verifyTickMarksDoNotExist("y")
+    ah.verifyGridLinesDoNotExist("y")
+    ah.verifyXAxisTickMarksDisplayed()
+    ah.verifyXAxisGridLinesNotDisplayed()
+    ah.verifyAxisTickLabels("x", arrayOfValues[3].values)
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[3], "x")
+  })
+  it("will add and remove categorical attribute to y axis from attribute menu", () => {
+    ah.openAxisAttributeMenu("y")
+    ah.addAttributeToAxis(arrayOfAttributes[7], "y") // Habitat => y-axis
+    ah.verifyTickMarksDoNotExist("x")
+    ah.verifyGridLinesDoNotExist("x")
+    ah.verifyYAxisTickMarksNotDisplayed()
+    ah.verifyYAxisGridLinesDisplayed()
+    ah.verifyAxisTickLabels("y", arrayOfValues[7].values)
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[7], "y")
+  })
+  it("will add and remove numeric attribute to y axis from attribute menu", () => {
+    ah.openAxisAttributeMenu("y")
+    ah.addAttributeToAxis(arrayOfAttributes[4], "y") // Mass => y-axis
+    ah.verifyTickMarksDoNotExist("x")
+    ah.verifyGridLinesDoNotExist("x")
+    ah.verifyYAxisTickMarksDisplayed()
+    ah.verifyYAxisGridLinesNotDisplayed()
+    ah.verifyAxisTickLabels("y", arrayOfValues[4].values)
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[4], "y")
+  })
+  // TODO: figure out why this test started failing on ci build (but works locally)
+  it.skip("will treat numeric attribute on x axis to categorical", () => {
+    ah.openAxisAttributeMenu("x")
+    ah.addAttributeToAxis(arrayOfAttributes[3], "x") // Height => x-axis
+    ah.openAxisAttributeMenu("x")
+    ah.treatAttributeAsCategorical("x")
+    ah.verifyTickMarksDoNotExist("y")
+    ah.verifyGridLinesDoNotExist("y")
+    ah.verifyXAxisTickMarksNotDisplayed()
+    ah.verifyXAxisGridLinesDisplayed()
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[3], "x")
+  })
+  // TODO: figure out why this test started failing on ci build (but works locally)
+  it.skip("will treat numeric attribute on y axis to categorical", () => {
+    ah.openAxisAttributeMenu("y")
+    ah.addAttributeToAxis(arrayOfAttributes[3], "y")
+    cy.wait(2000)
+    ah.openAxisAttributeMenu("y")
+    ah.treatAttributeAsCategorical("y")
+    ah.verifyTickMarksDoNotExist("x")
+    ah.verifyGridLinesDoNotExist("x")
+    ah.verifyYAxisTickMarksNotDisplayed()
+    ah.verifyYAxisGridLinesDisplayed()
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[3], "y")
+  })
 })

--- a/v3/cypress/e2e/calculator.spec.ts
+++ b/v3/cypress/e2e/calculator.spec.ts
@@ -1,14 +1,64 @@
 import { CalculatorTileElements as calc } from "../support/elements/calculator-tile"
+import { ComponentElements as c } from "../support/elements/component-elements"
+
+const calculatorName = "Calculator"
 
 context("Data summary UI", () => {
-    beforeEach(function () {
-        const queryParams = "?sample=mammals&dashboard&mouseSensor"
-        const url = `${Cypress.config("index")}${queryParams}`
-        cy.visit(url)
-        cy.wait(2500)
+  beforeEach(function () {
+      const queryParams = "?sample=mammals&dashboard&mouseSensor"
+      const url = `${Cypress.config("index")}${queryParams}`
+      cy.visit(url)
+      cy.wait(2500)
+  })
+  it("populates default title", () => {
+    c.getComponentTitle("calculator").should("contain", calculatorName)
+  })
+  it("updates calculator title", () => {
+    const newCalculatorName = "my calc"
+    c.getComponentTitle("calculator").should("have.text", calculatorName)
+    c.changeComponentTitle("calculator", newCalculatorName)
+    c.getComponentTitle("calculator").should("have.text", newCalculatorName)
+  })
+  it("close calculator from toolshelf", () => {
+    const newCalculatorName = "my calc"
+    c.getComponentTitle("calculator").should("contain", calculatorName)
+    c.changeComponentTitle("calculator", newCalculatorName)
+    c.getComponentTitle("calculator").should("have.text", newCalculatorName)
+
+    c.createFromToolshelf("calculator")
+    c.checkComponentDoesNotExist("calculator")
+
+    c.createFromToolshelf("calculator")
+    c.checkComponentExists("calculator")
+    c.getComponentTitle("calculator").should("contain", calculatorName)
+  })
+  it("close calculator from close button", () => {
+    const newCalculatorName = "my calc"
+    c.getComponentTitle("calculator").should("contain", calculatorName)
+    c.changeComponentTitle("calculator", newCalculatorName)
+    c.getComponentTitle("calculator").should("have.text", newCalculatorName)
+
+    c.closeComponent("calculator")
+    c.checkComponentDoesNotExist("calculator")
+
+    c.createFromToolshelf("calculator")
+    c.checkComponentExists("calculator")
+    c.getComponentTitle("calculator").should("contain", calculatorName)
+  })
+  it("checks all calculator tooltips", () => {
+    c.selectTile("calculator")
+    c.getToolShelfIcon("calculator").then($element => {
+      c.checkToolTip($element, c.tooltips.calculatorToolShelfIcon)
     })
-    it("does not populate title bar from sample data", () => {
-      const collectionName = "Calculator"
-      calc.getCollectionTitle().should("contain", collectionName)
+    c.getMinimizeButton("calculator").then($element => {
+      c.checkToolTip($element, c.tooltips.minimizeComponent)
     })
+    c.getCloseButton("calculator").then($element => {
+      c.checkToolTip($element, c.tooltips.closeComponent)
+    })
+  })
+  it("can make calculations", () => {
+    calc.enterExpression("12X(1+2)=")
+    calc.checkCalculatorDisplay("36")
+  })
 })

--- a/v3/cypress/e2e/data-summary.spec.ts
+++ b/v3/cypress/e2e/data-summary.spec.ts
@@ -1,14 +1,14 @@
-import { DataSummaryTileElements as dataSummary } from "../support/elements/data-summary-tile"
+import { ComponentElements as c } from "../support/elements/component-elements"
 
 context("Data summary UI", () => {
-    beforeEach(function () {
-        const queryParams = "?sample=mammals&dashboard&mouseSensor"
-        const url = `${Cypress.config("index")}${queryParams}`
-        cy.visit(url)
-        cy.wait(2500)
-    })
-    it("populates title bar from sample data", () => {
-      const collectionName = "Mammals"
-      dataSummary.getCollectionTitle().should("contain", collectionName)
-    })
+  beforeEach(function () {
+    const queryParams = "?sample=mammals&dashboard&mouseSensor"
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.wait(2500)
+  })
+  it("populates title bar from sample data", () => {
+    const collectionName = "Mammals"
+    c.getComponentTitle("data-summary").should("contain", collectionName)
+  })
 })

--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -1,33 +1,100 @@
 import { GraphTileElements as graph } from "../support/elements/graph-tile"
+import { ComponentElements as c } from "../support/elements/component-elements"
 
+const collectionName = "Mammals"
+const newCollectionName = "Animals"
+const newGraphName = "New Dataset"
 const arrayOfPlots = [
-    { attribute: "Mammal", axis: "x", collection: "mammals" },
-    { attribute: "Order", axis: "y", collection: "mammals" },
-    { attribute: "LifeSpan", axis: "x1", collection: "mammals" },
-    { attribute: "Height", axis: "y1", collection: "mammals" },
-    { attribute: "Mass", axis: "x", collection: "mammals" },
-    { attribute: "Sleep", axis: "y", collection: "mammals" },
-    { attribute: "Speed", axis: "x1", collection: "mammals" },
-    { attribute: "Habitat", axis: "graph_plot", collection: "mammals" },
-    { attribute: "Diet", axis: "graph_plot", collection: "mammals" }
+  { attribute: "Mammal", axis: "x", collection: "mammals" },
+  { attribute: "Order", axis: "y", collection: "mammals" },
+  { attribute: "LifeSpan", axis: "x1", collection: "mammals" },
+  { attribute: "Height", axis: "y1", collection: "mammals" },
+  { attribute: "Mass", axis: "x", collection: "mammals" },
+  { attribute: "Sleep", axis: "y", collection: "mammals" },
+  { attribute: "Speed", axis: "x1", collection: "mammals" },
+  { attribute: "Habitat", axis: "graph_plot", collection: "mammals" },
+  { attribute: "Diet", axis: "graph_plot", collection: "mammals" }
 ]
 
 context("Test graph plot transitions", () => {
-    beforeEach(function () {
-        const queryParams = "?sample=mammals&dashboard&mouseSensor"
-        const url = `${Cypress.config("index")}${queryParams}`
-        cy.visit(url)
-        cy.wait(2500)
+  beforeEach(function () {
+    const queryParams = "?sample=mammals&dashboard&mouseSensor"
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.wait(2500)
+  })
+  it("populates title bar from sample data", () => {
+    c.getComponentTitle("graph").should("contain", collectionName)
+  })
+  it("will add attributes to a graph and verify plot transitions are correct", () => {
+    cy.wrap(arrayOfPlots).each((hash, index, list) => {
+      cy.dragAttributeToTarget("table", hash.attribute, hash.axis)
+      cy.wait(2000)
     })
-    it("populates title bar from sample data", () => {
-      const collectionName = "Mammals"
-      graph.getCollectionTitle().should("contain", collectionName)
+  })
+})
+
+context("Graph UI", () => {
+  beforeEach(function () {
+    const queryParams = "?sample=mammals&dashboard&mouseSensor"
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.wait(2500)
+  })
+  
+  it("updates graph title", () => {
+    c.getComponentTitle("graph").should("have.text", collectionName)
+    c.changeComponentTitle("graph", newCollectionName)
+    c.getComponentTitle("graph").should("have.text", newCollectionName)
+  })
+  it("creates graphs with new collection name", () => {
+    c.createFromToolshelf("graph")
+
+    c.getComponentTitle("graph").should("contain", collectionName)
+    c.getComponentTitle("graph", 1).should("contain", collectionName)
+
+    c.createFromToolshelf("graph")
+    c.getComponentTitle("graph", 2).should("contain", collectionName)
+  })
+  it("creates graphs with new collection names when existing ones are closed", () => {
+    c.closeComponent("graph")
+    c.checkComponentDoesNotExist("graph")
+    c.createFromToolshelf("graph")
+    c.getComponentTitle("graph").should("contain", collectionName)
+
+    c.closeComponent("graph")
+    c.checkComponentDoesNotExist("graph")
+    c.createFromToolshelf("graph")
+    c.getComponentTitle("graph").should("contain", collectionName)
+  })
+  it("checks all graph tooltips", () => {
+    c.selectTile("graph", 0)
+    c.getToolShelfIcon("graph").then($element => {
+      c.checkToolTip($element, c.tooltips.graphToolShelfIcon)
     })
-    it("will add attributes to a graph and verify plot transitions are correct", () => {
-        cy.wrap(arrayOfPlots).each((hash, index, list) => {
-            cy.dragAttributeToTarget("table", hash.attribute, hash.axis)
-            cy.wait(2000)
-            // cy.matchImageSnapshot(`${hash.attribute}_on_${hash.axis}`)
-        })
+    c.getMinimizeButton("graph").then($element => {
+      c.checkToolTip($element, c.tooltips.minimizeComponent)
     })
+    c.getCloseButton("graph").then($element => {
+      c.checkToolTip($element, c.tooltips.closeComponent)
+    })
+    graph.getResizeIcon().then($element => {
+      c.checkToolTip($element, c.tooltips.graphResizeButton)
+    })
+    graph.getHideShowButton().then($element => {
+      c.checkToolTip($element, c.tooltips.graphHideShowButton)
+    })
+    graph.getDisplayValuesButton().then($element => {
+      c.checkToolTip($element, c.tooltips.graphDisplayValuesButton)
+    })
+    graph.getDisplayConfigButton().then($element => {
+      c.checkToolTip($element, c.tooltips.graphDisplayConfigButton)
+    })
+    graph.getDisplayStylesButton().then($element => {
+      c.checkToolTip($element, c.tooltips.graphDisplayStylesButton)
+    })
+    graph.getCameraButton().then($element => {
+      c.checkToolTip($element, c.tooltips.graphCameraButton)
+    })
+  })
 })

--- a/v3/cypress/e2e/legend.spec.ts
+++ b/v3/cypress/e2e/legend.spec.ts
@@ -1,226 +1,226 @@
 import { AxisHelper as ah } from "../support/helpers/axis-helper"
 import { LegendHelper as lh } from "../support/helpers/legend-helper"
 
-const arrayOfAttributes = [ "Mammal", "Order", "LifeSpan", "Height", "Mass", "Sleep", "Speed", "Habitat", "Diet" ]
+const arrayOfAttributes = ["Mammal", "Order", "LifeSpan", "Height", "Mass", "Sleep", "Speed", "Habitat", "Diet"]
 
 const arrayOfValues = [
-    { attribute: "Mammal", values: [ ]},
-    { attribute: "Order", values: [ ]},
-    { attribute: "LifeSpan", values: [ "0", "10", "20", "30", "40", "50", "60", "70", "80", "90" ]},
-    { attribute: "Height", values: [ "0", "1", "2", "3", "4", "5", "6", "7" ]},
-    { attribute: "Mass", values: [ "0", "1000", "2000", "3000", "4000", "5000", "6000", "7000" ]},
-    { attribute: "Sleep", values: [ ]},
-    { attribute: "Speed", values: [ ]},
-    { attribute: "Habitat", values: [ "both", "land", "water" ]},
-    { attribute: "Diet", values: [ "both", "meat", "plants" ]},
+  { attribute: "Mammal", values: [] },
+  { attribute: "Order", values: [] },
+  { attribute: "LifeSpan", values: ["0", "10", "20", "30", "40", "50", "60", "70", "80", "90"] },
+  { attribute: "Height", values: ["0", "1", "2", "3", "4", "5", "6", "7"] },
+  { attribute: "Mass", values: ["0", "1000", "2000", "3000", "4000", "5000", "6000", "7000"] },
+  { attribute: "Sleep", values: [] },
+  { attribute: "Speed", values: [] },
+  { attribute: "Habitat", values: ["both", "land", "water"] },
+  { attribute: "Diet", values: ["both", "meat", "plants"] },
 ]
 
 context("Test legend with various attribute types", () => {
-    beforeEach(function () {
-        const queryParams = "?sample=mammals&dashboard&mouseSensor"
-        const url = `${Cypress.config("index")}${queryParams}`
-        cy.visit(url)
-        cy.wait(2500)
-    })
-    it("will not draw legend if plot area is empty", () => {
-        lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
-        ah.verifyAxisLabel("x", arrayOfAttributes[7]) // Habitat => plot area
-        ah.verifyDefaultAxisLabel("y")
-        lh.verifyLegendDoesNotExist()
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
-    })
-    it("will draw categorical legend with categorical attribute on x axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[8], "x") // Diet => x-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
-        ah.verifyAxisLabel("x", arrayOfAttributes[8])
-        lh.verifyLegendLabel(arrayOfAttributes[7])
-        lh.verifyCategoricalLegend()
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[8], "x")
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[7])
-    })
-    it("will draw categorical legend with categorical attribute on y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[8], "y") // Diet => y-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
-        ah.verifyAxisLabel("y", arrayOfAttributes[8])
-        lh.verifyLegendLabel(arrayOfAttributes[7])
-        lh.verifyCategoricalLegend()
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[8], "y")
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[7])
-    })
-    it("will draw categorical legend with numerical attribute on x axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // Diet => x-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
-        ah.verifyAxisLabel("x", arrayOfAttributes[2])
-        lh.verifyLegendLabel(arrayOfAttributes[7])
-        lh.verifyCategoricalLegend()
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[7])
-    })
-    it("will draw categorical legend with numerical attribute on y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[2], "y") // LifeSpan => y-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
-        ah.verifyAxisLabel("y", arrayOfAttributes[2])
-        lh.verifyLegendLabel(arrayOfAttributes[7])
-        lh.verifyCategoricalLegend()
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[2], "y")
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[7])
-    })
-    it("will draw numeric legend with categorical attribute on x axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[8], "x") // Diet => x-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
-        ah.verifyAxisLabel("x", arrayOfAttributes[8])
-        lh.verifyLegendLabel(arrayOfAttributes[3])
-        lh.verifyNumericLegend()
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[8], "x")
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[3])
-    })
-    it("will draw numeric legend with categorical attribute on y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[8], "y") // Diet => y-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
-        ah.verifyAxisLabel("y", arrayOfAttributes[8])
-        lh.verifyLegendLabel(arrayOfAttributes[3])
-        lh.verifyNumericLegend()
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[8], "y")
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[3])
-    })
-    it("will draw numeric legend with numerical attribute on x axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // LifeSpan => x-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
-        ah.verifyAxisLabel("x", arrayOfAttributes[2])
-        lh.verifyLegendLabel(arrayOfAttributes[3])
-        lh.verifyNumericLegend()
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[3])
-    })
-    it("will draw numeric legend with numerical attribute on y axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[2], "y") // LifeSpan => y-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
-        ah.verifyAxisLabel("y", arrayOfAttributes[2])
-        lh.verifyLegendLabel(arrayOfAttributes[3])
-        lh.verifyNumericLegend()
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[2], "y")
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[3])
-    })
+  beforeEach(function () {
+    const queryParams = "?sample=mammals&dashboard&mouseSensor"
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.wait(2500)
+  })
+  it("will not draw legend if plot area is empty", () => {
+    lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+    ah.verifyAxisLabel("x", arrayOfAttributes[7]) // Habitat => plot area
+    ah.verifyDefaultAxisLabel("y")
+    lh.verifyLegendDoesNotExist()
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[7], "x")
+  })
+  it("will draw categorical legend with categorical attribute on x axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[8], "x") // Diet => x-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+    ah.verifyAxisLabel("x", arrayOfAttributes[8])
+    lh.verifyLegendLabel(arrayOfAttributes[7])
+    lh.verifyCategoricalLegend()
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[8], "x")
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[7])
+  })
+  it("will draw categorical legend with categorical attribute on y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[8], "y") // Diet => y-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+    ah.verifyAxisLabel("y", arrayOfAttributes[8])
+    lh.verifyLegendLabel(arrayOfAttributes[7])
+    lh.verifyCategoricalLegend()
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[8], "y")
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[7])
+  })
+  it("will draw categorical legend with numerical attribute on x axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // Diet => x-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+    ah.verifyAxisLabel("x", arrayOfAttributes[2])
+    lh.verifyLegendLabel(arrayOfAttributes[7])
+    lh.verifyCategoricalLegend()
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[7])
+  })
+  it("will draw categorical legend with numerical attribute on y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "y") // LifeSpan => y-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+    ah.verifyAxisLabel("y", arrayOfAttributes[2])
+    lh.verifyLegendLabel(arrayOfAttributes[7])
+    lh.verifyCategoricalLegend()
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[2], "y")
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[7])
+  })
+  it("will draw numeric legend with categorical attribute on x axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[8], "x") // Diet => x-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+    ah.verifyAxisLabel("x", arrayOfAttributes[8])
+    lh.verifyLegendLabel(arrayOfAttributes[3])
+    lh.verifyNumericLegend()
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[8], "x")
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[3])
+  })
+  it("will draw numeric legend with categorical attribute on y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[8], "y") // Diet => y-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+    ah.verifyAxisLabel("y", arrayOfAttributes[8])
+    lh.verifyLegendLabel(arrayOfAttributes[3])
+    lh.verifyNumericLegend()
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[8], "y")
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[3])
+  })
+  it("will draw numeric legend with numerical attribute on x axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // LifeSpan => x-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+    ah.verifyAxisLabel("x", arrayOfAttributes[2])
+    lh.verifyLegendLabel(arrayOfAttributes[3])
+    lh.verifyNumericLegend()
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[3])
+  })
+  it("will draw numeric legend with numerical attribute on y axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "y") // LifeSpan => y-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+    ah.verifyAxisLabel("y", arrayOfAttributes[2])
+    lh.verifyLegendLabel(arrayOfAttributes[3])
+    lh.verifyNumericLegend()
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[2], "y")
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[3])
+  })
 })
 
 context("Test drawing legend on existing legend", () => {
-    beforeEach(function () {
-        const queryParams = "?sample=mammals&dashboard&mouseSensor"
-        const url = `${Cypress.config("index")}${queryParams}`
-        cy.visit(url)
-        cy.wait(2500)
-    })
-    it("will draw categorical legend on existing categorical legend", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // LifeSpan => x-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
-        ah.verifyAxisLabel("x", arrayOfAttributes[2])
-        lh.verifyLegendLabel(arrayOfAttributes[7])
-        lh.verifyCategoricalLegend()
-        lh.dragAttributeToLegend(arrayOfAttributes[8]) // Diet => plot area
-        lh.verifyLegendLabel(arrayOfAttributes[8])
-        lh.verifyCategoricalLegend()
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
-        lh.verifyLegendLabel(arrayOfAttributes[8])
-        lh.verifyCategoricalLegend()
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[8])
-    })
-    it("will draw categorical legend on existing numeric legend", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[2], "y") // LifeSpan => x-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
-        ah.verifyAxisLabel("y", arrayOfAttributes[2])
-        lh.verifyLegendLabel(arrayOfAttributes[3])
-        lh.verifyNumericLegend()
-        // Temporarily changing this because of #184764820
-        lh.dragAttributeToPlot(arrayOfAttributes[8]) // Diet => plot area
-        lh.verifyLegendLabel(arrayOfAttributes[8])
-        lh.verifyCategoricalLegend()
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[2], "y")
-        lh.verifyLegendLabel(arrayOfAttributes[8])
-        lh.verifyCategoricalLegend()
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[8])
-    })
-    it("will draw numeric legend on existing categorical legend", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // LifeSpan => x-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
-        ah.verifyAxisLabel("x", arrayOfAttributes[2])
-        lh.verifyLegendLabel(arrayOfAttributes[7])
-        lh.verifyCategoricalLegend()
-        lh.dragAttributeToLegend(arrayOfAttributes[3]) // Height => plot area
-        lh.verifyLegendLabel(arrayOfAttributes[3])
-        lh.verifyNumericLegend()
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
-        lh.verifyLegendLabel(arrayOfAttributes[3])
-        lh.verifyNumericLegend()
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[3])
-    })
-    it("will draw numeric legend on existing numeric legend", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[2], "y") // LifeSpan => x-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
-        ah.verifyAxisLabel("y", arrayOfAttributes[2])
-        lh.verifyLegendLabel(arrayOfAttributes[3])
-        lh.verifyNumericLegend()
-        // Temporarily changing this because of #184764820
-        lh.dragAttributeToPlot(arrayOfAttributes[4]) // Mass => plot area
-        lh.verifyLegendLabel(arrayOfAttributes[4])
-        lh.verifyNumericLegend()
-        ah.openAxisAttributeMenu("y")
-        ah.removeAttributeFromAxis(arrayOfAttributes[2], "y")
-        lh.verifyLegendLabel(arrayOfAttributes[4])
-        lh.verifyNumericLegend()
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[4])
-    })
+  beforeEach(function () {
+    const queryParams = "?sample=mammals&dashboard&mouseSensor"
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.wait(2500)
+  })
+  it("will draw categorical legend on existing categorical legend", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // LifeSpan => x-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+    ah.verifyAxisLabel("x", arrayOfAttributes[2])
+    lh.verifyLegendLabel(arrayOfAttributes[7])
+    lh.verifyCategoricalLegend()
+    lh.dragAttributeToLegend(arrayOfAttributes[8]) // Diet => plot area
+    lh.verifyLegendLabel(arrayOfAttributes[8])
+    lh.verifyCategoricalLegend()
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
+    lh.verifyLegendLabel(arrayOfAttributes[8])
+    lh.verifyCategoricalLegend()
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[8])
+  })
+  it("will draw categorical legend on existing numeric legend", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "y") // LifeSpan => x-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+    ah.verifyAxisLabel("y", arrayOfAttributes[2])
+    lh.verifyLegendLabel(arrayOfAttributes[3])
+    lh.verifyNumericLegend()
+    // Temporarily changing this because of #184764820
+    lh.dragAttributeToPlot(arrayOfAttributes[8]) // Diet => plot area
+    lh.verifyLegendLabel(arrayOfAttributes[8])
+    lh.verifyCategoricalLegend()
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[2], "y")
+    lh.verifyLegendLabel(arrayOfAttributes[8])
+    lh.verifyCategoricalLegend()
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[8])
+  })
+  it("will draw numeric legend on existing categorical legend", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "x") // LifeSpan => x-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+    ah.verifyAxisLabel("x", arrayOfAttributes[2])
+    lh.verifyLegendLabel(arrayOfAttributes[7])
+    lh.verifyCategoricalLegend()
+    lh.dragAttributeToLegend(arrayOfAttributes[3]) // Height => plot area
+    lh.verifyLegendLabel(arrayOfAttributes[3])
+    lh.verifyNumericLegend()
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[2], "x")
+    lh.verifyLegendLabel(arrayOfAttributes[3])
+    lh.verifyNumericLegend()
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[3])
+  })
+  it("will draw numeric legend on existing numeric legend", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "y") // LifeSpan => x-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+    ah.verifyAxisLabel("y", arrayOfAttributes[2])
+    lh.verifyLegendLabel(arrayOfAttributes[3])
+    lh.verifyNumericLegend()
+    // Temporarily changing this because of #184764820
+    lh.dragAttributeToPlot(arrayOfAttributes[4]) // Mass => plot area
+    lh.verifyLegendLabel(arrayOfAttributes[4])
+    lh.verifyNumericLegend()
+    ah.openAxisAttributeMenu("y")
+    ah.removeAttributeFromAxis(arrayOfAttributes[2], "y")
+    lh.verifyLegendLabel(arrayOfAttributes[4])
+    lh.verifyNumericLegend()
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[4])
+  })
 })
 context("Test selecting and selecting categories in legend", () => {
-    beforeEach(function () {
-        const queryParams = "?sample=mammals&dashboard&mouseSensor"
-        const url = `${Cypress.config("index")}${queryParams}`
-        cy.visit(url)
-        cy.wait(2500)
-    })
-    it("will select and unselect categories in categorical legend with categorical x axis", () => {
-        cy.dragAttributeToTarget("table", arrayOfAttributes[8], "x") // Diet => x-axis
-        lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
-        lh.selectCategoryNameForCategoricalLegend(arrayOfValues[7].values[0])
-        lh.verifyLegendCategorySelected(arrayOfValues[7].values[0])
-        lh.selectCategoryNameForCategoricalLegend(arrayOfValues[7].values[1])
-        lh.verifyLegendCategorySelected(arrayOfValues[7].values[1])
-        lh.selectCategoryNameForCategoricalLegend(arrayOfValues[7].values[2])
-        lh.verifyLegendCategorySelected(arrayOfValues[7].values[2])
-        lh.selectCategoryColorForCategoricalLegend(arrayOfValues[7].values[0])
-        lh.verifyLegendCategorySelected(arrayOfValues[7].values[0])
-        lh.selectCategoryColorForCategoricalLegend(arrayOfValues[7].values[1])
-        lh.verifyLegendCategorySelected(arrayOfValues[7].values[1])
-        lh.selectCategoryColorForCategoricalLegend(arrayOfValues[7].values[2])
-        lh.verifyLegendCategorySelected(arrayOfValues[7].values[2])
-        // lh.unselectCategoricalLegendCategory() //This doesn't work, will need to make this work
-        // lh.verifyNoLegendCategorySelectedForCategoricalLegend()
-        lh.openLegendMenu()
-        lh.removeAttributeFromLegend(arrayOfAttributes[7])
-        ah.openAxisAttributeMenu("x")
-        ah.removeAttributeFromAxis(arrayOfAttributes[8], "x")
-    })
+  beforeEach(function () {
+    const queryParams = "?sample=mammals&dashboard&mouseSensor"
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.wait(2500)
+  })
+  it("will select and unselect categories in categorical legend with categorical x axis", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[8], "x") // Diet => x-axis
+    lh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+    lh.selectCategoryNameForCategoricalLegend(arrayOfValues[7].values[0])
+    lh.verifyLegendCategorySelected(arrayOfValues[7].values[0])
+    lh.selectCategoryNameForCategoricalLegend(arrayOfValues[7].values[1])
+    lh.verifyLegendCategorySelected(arrayOfValues[7].values[1])
+    lh.selectCategoryNameForCategoricalLegend(arrayOfValues[7].values[2])
+    lh.verifyLegendCategorySelected(arrayOfValues[7].values[2])
+    lh.selectCategoryColorForCategoricalLegend(arrayOfValues[7].values[0])
+    lh.verifyLegendCategorySelected(arrayOfValues[7].values[0])
+    lh.selectCategoryColorForCategoricalLegend(arrayOfValues[7].values[1])
+    lh.verifyLegendCategorySelected(arrayOfValues[7].values[1])
+    lh.selectCategoryColorForCategoricalLegend(arrayOfValues[7].values[2])
+    lh.verifyLegendCategorySelected(arrayOfValues[7].values[2])
+    // lh.unselectCategoricalLegendCategory() //This doesn't work, will need to make this work
+    // lh.verifyNoLegendCategorySelectedForCategoricalLegend()
+    lh.openLegendMenu()
+    lh.removeAttributeFromLegend(arrayOfAttributes[7])
+    ah.openAxisAttributeMenu("x")
+    ah.removeAttributeFromAxis(arrayOfAttributes[8], "x")
+  })
 })

--- a/v3/cypress/e2e/slider.spec.ts
+++ b/v3/cypress/e2e/slider.spec.ts
@@ -1,14 +1,250 @@
 import { SliderTileElements as slider } from "../support/elements/slider-tile"
+import { ComponentElements as c } from "../support/elements/component-elements"
+
+const sliderName = "v1"
+const newName = "v2"
+const initialSliderValue = "0.5"
+const finalSliderValue = "11.5"
+const newSliderValue = "0.6"
 
 context("Slider UI", () => {
-    beforeEach(function () {
-        const queryParams = "?sample=mammals&dashboard&mouseSensor"
-        const url = `${Cypress.config("index")}${queryParams}`
-        cy.visit(url)
-        cy.wait(2500)
+  beforeEach(function () {
+    const queryParams = "?sample=mammals&dashboard&mouseSensor"
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.wait(2500)
+  })
+  it("populates default title, variable name and value", () => {
+    c.getComponentTitle("slider").should("contain", sliderName)
+    slider.getVariableName().should("have.text", sliderName)
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.checkPlayButtonIsPaused()
+    slider.getSliderThumbIcon().should("be.visible")
+    slider.getSliderAxis().should("be.visible")
+  })
+  it("updates slider title", () => {
+    const newSliderName = "abc"
+    c.getComponentTitle("slider").should("have.text", sliderName)
+    c.changeComponentTitle("slider", newSliderName)
+    c.getComponentTitle("slider").should("have.text", newSliderName)
+    slider.getVariableName().should("have.text", sliderName)
+  })
+  it("updates variable name", () => {
+    slider.getVariableName().should("have.text", "v1")
+    slider.changeVariableName(newName)
+    slider.getVariableName().should("have.text", newName)
+    c.getComponentTitle("slider").should("have.text", newName)
+  })
+  it("adds new variable value", () => {
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.changeVariableValue(newSliderValue)
+    slider.getVariableValue().should("contain", newSliderValue)
+  })
+  it("plays and pauses slider", () => {
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.playSliderButton()
+    slider.checkPlayButtonIsRunning()
+    slider.pauseSliderButton()
+    slider.checkPlayButtonIsPaused()
+    slider.getVariableValue().should("not.contain", initialSliderValue)
+    slider.playSliderButton()
+    cy.wait(2500)
+    slider.checkPlayButtonIsPaused()
+    slider.getVariableValue().should("contain", finalSliderValue)
+  })
+  it("replays from initial value once it reaches the end", () => {
+    slider.setAnimationRate(3)
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.playSliderButton()
+    slider.checkPlayButtonIsRunning()
+    cy.wait(15000)
+    slider.checkPlayButtonIsPaused()
+    slider.getVariableValue().should("contain", finalSliderValue)
+    slider.playSliderButton()
+    slider.getVariableValue().should("contain", "0")
+  })
+  it("plays low to high animation direction", () => {
+    slider.setAnimationRate(3)
+    slider.setAnimationDirection("lowToHigh")
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.playSliderButton()
+    slider.checkPlayButtonIsRunning()
+    slider.getVariableValue().should("contain", finalSliderValue)
+    slider.checkPlayButtonIsPaused()
+  })
+  it("plays back and forth animation direction", () => {
+    slider.setAnimationRate(3)
+    slider.setAnimationDirection("backAndForth")
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.playSliderButton()
+    slider.checkPlayButtonIsRunning()
+    slider.getVariableValue().should("contain", finalSliderValue)
+    slider.checkPlayButtonIsRunning()
+    slider.getVariableValue().should("contain", "2.5")
+    slider.checkPlayButtonIsPaused()
+  })
+  it("plays high to low animation direction", () => {
+    slider.setAnimationRate(3)
+    slider.setAnimationDirection("highToLow")
+    slider.changeVariableValue(finalSliderValue)
+    slider.getVariableValue().should("contain", finalSliderValue)
+    slider.playSliderButton()
+    slider.checkPlayButtonIsRunning()
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.checkPlayButtonIsPaused()
+  })
+  it("plays nonstop", () => {
+    slider.setAnimationRate(3)
+    slider.setAnimationRepetition("nonStop")
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.playSliderButton()
+    slider.checkPlayButtonIsRunning()
+    slider.getVariableValue().should("contain", finalSliderValue)
+    slider.checkPlayButtonIsRunning()
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.checkPlayButtonIsRunning()
+  })
+  it("plays with restricting multiples", () => {
+    const initialValue = "0"
+    const finalValue = "60"
+    const multiple = "10"
+    const values = ["10", "20", "30", "40", "50", "60"]
+
+    slider.setAnimationRate(3)
+    slider.changeVariableValue(finalValue)
+    slider.setMultipleRestriction(multiple)
+    slider.changeVariableValue(initialValue)
+    slider.getVariableValue().should("contain", initialValue)
+    slider.playSliderButton()
+    slider.checkPlayButtonIsRunning()
+    slider.getVariableValue().should("contain", values[0])
+    slider.getVariableValue().should("contain", values[1])
+    slider.getVariableValue().should("contain", values[2])
+    slider.getVariableValue().should("contain", values[3])
+    slider.getVariableValue().should("contain", values[4])
+    slider.getVariableValue().should("contain", values[5])
+    slider.checkPlayButtonIsPaused()
+  })
+  it("creates another slider from toolshelf", () => {
+    c.createFromToolshelf("slider")
+
+    c.getComponentTitle("slider").should("contain", sliderName)
+    slider.getVariableName().should("have.text", sliderName)
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.checkPlayButtonIsPaused()
+
+    c.getComponentTitle("slider", 1).should("contain", newName)
+    slider.getVariableName(1).should("have.text", newName)
+    slider.getVariableValue(1).should("contain", initialSliderValue)
+    slider.checkPlayButtonIsPaused(1)
+  })
+  it("checks editing variable name in one slider only affects that slider", () => {
+    const newSliderName = "xyz"
+    c.createFromToolshelf("slider")
+    
+    slider.changeVariableName(newSliderName, 1)
+    c.getComponentTitle("slider", 0).should("contain", sliderName)
+    c.getComponentTitle("slider", 1).should("contain", newSliderName)
+    slider.getVariableName(0).should("have.text", sliderName)
+    slider.getVariableName(1).should("have.text", newSliderName)
+  })
+  it("checks editing variable value in one slider only affects that slider", () => {
+    const newVariableValue = "100"
+    c.createFromToolshelf("slider")
+    
+    slider.changeVariableValue(newVariableValue, 1)
+    slider.getVariableValue(0).should("contain", initialSliderValue)
+    slider.getVariableValue(1).should("contain", newVariableValue)
+  })
+  it("checks playing in one slider only plays that slider", () => {
+    c.createFromToolshelf("slider")
+    slider.setAnimationRate(3, 1)
+
+    slider.checkPlayButtonIsPaused(0)
+    slider.checkPlayButtonIsPaused(1)
+
+    slider.playSliderButton(1)
+    slider.checkPlayButtonIsPaused(0)
+    slider.checkPlayButtonIsRunning(1)
+
+    slider.pauseSliderButton(1)
+    slider.checkPlayButtonIsPaused(0)
+    slider.checkPlayButtonIsPaused(1)
+
+    slider.playSliderButton(1)
+    slider.checkPlayButtonIsPaused(0)
+    slider.checkPlayButtonIsRunning(1)
+
+    cy.wait(2500)
+    slider.checkPlayButtonIsPaused(0)
+    slider.checkPlayButtonIsPaused(1)
+  })
+  it("creates sliders with incrementing names", () => {
+    c.createFromToolshelf("slider")
+
+    c.getComponentTitle("slider").should("contain", sliderName)
+    slider.getVariableName().should("have.text", sliderName)
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.checkPlayButtonIsPaused()
+
+    c.getComponentTitle("slider", 1).should("contain", "v2")
+    slider.getVariableName(1).should("have.text", "v2")
+    slider.getVariableValue(1).should("contain", initialSliderValue)
+    slider.checkPlayButtonIsPaused(1)
+
+    c.createFromToolshelf("slider")
+    c.getComponentTitle("slider", 2).should("contain", "v3")
+    slider.getVariableName(2).should("have.text", "v3")
+    slider.getVariableValue(2).should("contain", initialSliderValue)
+    slider.checkPlayButtonIsPaused(2)
+  })
+  it("creates sliders with incrementing names when existing ones are closed", () => {
+    c.closeComponent("slider")
+    c.checkComponentDoesNotExist("slider")
+    c.createFromToolshelf("slider")
+
+    c.getComponentTitle("slider").should("contain", "v2")
+    slider.getVariableName().should("have.text", "v2")
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.checkPlayButtonIsPaused()
+
+    c.closeComponent("slider")
+    c.checkComponentDoesNotExist("slider")
+    c.createFromToolshelf("slider")
+
+    c.getComponentTitle("slider").should("contain", "v3")
+    slider.getVariableName().should("have.text", "v3")
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.checkPlayButtonIsPaused()
+
+  })
+  it("checks all slider tooltips", () => {
+    c.selectTile("slider", 0)
+    c.getToolShelfIcon("slider").then($element => {
+      c.checkToolTip($element, c.tooltips.sliderToolShelfIcon)
     })
-    it("does not populate title bar from sample data", () => {
-      const sliderName = "v1"
-      slider.getComponentTitle().should("contain", sliderName)
+    c.getMinimizeButton("slider").then($element => {
+      c.checkToolTip($element, c.tooltips.minimizeComponent)
     })
+    c.getCloseButton("slider").then($element => {
+      c.checkToolTip($element, c.tooltips.closeComponent)
+    })
+    slider.getInspectorIcon().then($element => {
+      c.checkToolTip($element, c.tooltips.inspectorPanel)
+    })
+  })
+  it("checks min max slider values", () => {
+    slider.getVariableValue().should("contain", initialSliderValue)
+    slider.changeVariableValue("12345678901234567890")
+    slider.getVariableValue().should("contain", "1.235e+14")
+
+    // slider.changeVariableValue("0.12345678901234567890")
+    // slider.getVariableValue().should("contain", "0")
+
+    // slider.changeVariableValue("0.006")
+    // slider.getVariableValue().should("contain", "0")
+    
+    slider.changeVariableValue("abc")
+    slider.getVariableValue().should("contain", "")
+  })
 })

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -1,255 +1,322 @@
-import {TableTileElements as table} from "../support/elements/table-tile"
+import { TableTileElements as table } from "../support/elements/table-tile"
+import { ComponentElements as c } from "../support/elements/component-elements"
 
 const numOfAttributes = 10
 const firstRowIndex = 2
 let lastRowIndex = undefined
 let middleRowIndex = undefined
 let numOfCases = undefined
+const collectionName = "Mammals"
+const renamedCollectionName = "Animals"
+const newCollectionName = "New Dataset"
 
-beforeEach(()=> {
-    const queryParams = "?sample=mammals&dashboard"
-    const url = `${Cypress.config("index")}${queryParams}`
-    cy.visit(url)
-    cy.wait(2000)
-    table.getNumOfAttributes().should("equal", numOfAttributes.toString())
-    table.getNumOfCases().then($cases => {
-        numOfCases = $cases
-        lastRowIndex = Number($cases)
-        middleRowIndex = Math.floor(lastRowIndex/2)
-    })
+beforeEach(() => {
+  const queryParams = "?sample=mammals&dashboard"
+  const url = `${Cypress.config("index")}${queryParams}`
+  cy.visit(url)
+  cy.wait(2000)
+  table.getNumOfAttributes().should("equal", numOfAttributes.toString())
+  table.getNumOfCases().then($cases => {
+    numOfCases = $cases
+    lastRowIndex = Number($cases)
+    middleRowIndex = Math.floor(lastRowIndex / 2)
+  })
 })
 
 context("case table ui", () => {
-    describe("table view", () => {
-        it("populates title bar from sample data", () => {
-          const collectionName = "Mammals"
-          table.getCollectionTitle().should("contain", collectionName)
-        })
-        it("verify columns and tooltips", () => {
-            table.getColumnHeaders().should("have.length", 10)
-            table.getColumnHeader(0).invoke("text").then(columnName => {
-                const columnNameArr = columnName.split()
-                table.getColumnHeader(0).rightclick({force:true})
-                table.getColumnHeaderTooltip().should("contain", columnNameArr[0])
-            })
-            table.getColumnHeader(1).invoke("text").then(columnName => {
-                const columnNameArr = columnName.split(" ")
-                table.getColumnHeader(1).rightclick({force:true})
-                table.getColumnHeaderTooltip().should("contain", columnNameArr[0])
-            })
-        })
-        it("verify edit attribute properties", () => {
-            const name = "Tallness",
-                description = "The average height of the mammal.",
-                unit="meters",
-                newName = "Tallness (meters)",
-                type = null,
-                precision = null,
-                editable = "False"
-            table.editAttributeProperty("Height", name, description, type, unit, precision, editable)
-            table.getAttribute(name).should("have.text", newName)
-            table.getAttribute(name).rightclick({force:true})
-            table.getColumnHeaderTooltip().should("contain", `${name} : ${description}`)
-        })
-        // it("verify attribute reorder within a collection", () => {
-        // });
-        // it("verify index column cannot be reordered", () => {
-        // });
+  describe("table view", () => {
+    it("populates title bar from sample data", () => {
+      c.getComponentTitle("table").should("contain", collectionName)
     })
+    it("verify columns and tooltips", () => {
+      table.getColumnHeaders().should("have.length", 10)
+      table.getColumnHeader(0).invoke("text").then(columnName => {
+        const columnNameArr = columnName.split()
+        table.getColumnHeader(0).rightclick({ force: true })
+        table.getColumnHeaderTooltip().should("contain", columnNameArr[0])
+      })
+      table.getColumnHeader(1).invoke("text").then(columnName => {
+        const columnNameArr = columnName.split(" ")
+        table.getColumnHeader(1).rightclick({ force: true })
+        table.getColumnHeaderTooltip().should("contain", columnNameArr[0])
+      })
+    })
+    it("verify edit attribute properties", () => {
+      const name = "Tallness",
+        description = "The average height of the mammal.",
+        unit = "meters",
+        newName = "Tallness (meters)",
+        type = null,
+        precision = null,
+        editable = "False"
+      table.editAttributeProperty("Height", name, description, type, unit, precision, editable)
+      table.getAttribute(name).should("have.text", newName)
+      table.getAttribute(name).rightclick({ force: true })
+      table.getColumnHeaderTooltip().should("contain", `${name} : ${description}`)
+    })
+    // it("verify attribute reorder within a collection", () => {
+    // });
+    // it("verify index column cannot be reordered", () => {
+    // });
+  })
 
-    describe("case table header attribute menu", () => {
-        it("verify rename attribute", () => {
-            table.getColumnHeader(1).should("contain", "Mammal")
-            table.getAttribute("Mammal").should("exist")
-            table.openAttributeMenu("Mammal")
-            table.selectMenuItemFromAttributeMenu("Rename")
-            table.renameColumnName(`Animal{enter}`)
-            table.getColumnHeader(1).should("contain", "Animal")
-            table.getAttribute("Animal").should("exist")
-        })
-        it("verify hide and showAll attribute", () => {
-            table.openAttributeMenu("Mammal")
-            table.selectMenuItemFromAttributeMenu("Hide Attribute")
-            table.getColumnHeader(1).should("not.have.text", "Mammal")
-            table.getAttribute("Mammal").should("not.exist")
-            table.openInspectorPanel()
-            table.showAllAttributes()
-            table.getColumnHeader(1).should("contain", "Mammal")
-            table.getAttribute("Mammal").should("exist")
-        })
-        it("verify delete attribute", () => {
-            table.openAttributeMenu("Mammal")
-            table.selectMenuItemFromAttributeMenu("Delete Attribute")
-            table.getColumnHeader(1).should("not.have.text", "Mammal")
-            table.getAttribute("Mammal").should("not.exist")
-            table.getColumnHeaders().should("have.length", numOfAttributes-1)
-        })
+  describe("case table header attribute menu", () => {
+    it("verify rename attribute", () => {
+      table.getColumnHeader(1).should("contain", "Mammal")
+      table.getAttribute("Mammal").should("exist")
+      table.openAttributeMenu("Mammal")
+      table.selectMenuItemFromAttributeMenu("Rename")
+      table.renameColumnName(`Animal{enter}`)
+      table.getColumnHeader(1).should("contain", "Animal")
+      table.getAttribute("Animal").should("exist")
     })
+    it("verify hide and showAll attribute", () => {
+      table.openAttributeMenu("Mammal")
+      table.selectMenuItemFromAttributeMenu("Hide Attribute")
+      table.getColumnHeader(1).should("not.have.text", "Mammal")
+      table.getAttribute("Mammal").should("not.exist")
+      c.selectTile("table", 0)
+      table.showAllAttributes()
+      table.getColumnHeader(1).should("contain", "Mammal")
+      table.getAttribute("Mammal").should("exist")
+    })
+    it("verify delete attribute", () => {
+      table.openAttributeMenu("Mammal")
+      table.selectMenuItemFromAttributeMenu("Delete Attribute")
+      table.getColumnHeader(1).should("not.have.text", "Mammal")
+      table.getAttribute("Mammal").should("not.exist")
+      table.getColumnHeaders().should("have.length", numOfAttributes - 1)
+    })
+  })
 
-    describe("index menu", () => {
-        it("verify index menu insert case and delete case work", () => {
-            table.openIndexMenuForRow(2)
-            table.insertCase()
-            table.openIndexMenuForRow(2)
-            table.deleteCase()
-        })
-        it("verify insert cases before a row by typing num of cases", () => {
-            table.openIndexMenuForRow(2)
-            table.insertCases(2, "before")
-            table.openIndexMenuForRow(2)
-            table.deleteCase()
-            table.openIndexMenuForRow(2)
-            table.deleteCase()
-        })
-        it("verify insert cases after a row by typing num of cases", () => {
-            table.openIndexMenuForRow(2)
-            table.insertCases(2, "after")
-            table.openIndexMenuForRow(3)
-            table.deleteCase()
-            table.openIndexMenuForRow(3)
-            table.deleteCase()
-        })
-        it("verify index menu insert cases modal close", () => {
-            table.openIndexMenuForRow(2)
-            table.getIndexMenu().should("be.visible")
-            cy.clickMenuItem("Insert Cases...")
-            table.closeInsertCasesModal()
-            table.getInsertCasesModalHeader().should("not.exist")
-        })
-        it("verify index menu insert cases modal cancel", () => {
-            table.openIndexMenuForRow(2)
-            table.getIndexMenu().should("be.visible")
-            cy.clickMenuItem("Insert Cases...")
-            table.cancelInsertCasesModal()
-            table.getInsertCasesModalHeader().should("not.exist")
-        })
-        it("verify insert 1 case at the bottom", () => {
-            table.getCaseTableGrid().scrollTo("bottom")
-            table.openIndexMenuForRow(lastRowIndex)
-            table.insertCase()
-            table.getCaseTableGrid().scrollTo("bottom")
-            cy.wait(500)
-            table.openIndexMenuForRow(lastRowIndex)
-            table.deleteCase()
-            table.getNumOfCases().should("equal", numOfCases)
-        })
-        it("verify insert multiple cases below current case at the bottom", () => {
-            table.getCaseTableGrid().scrollTo("bottom")
-            table.openIndexMenuForRow(lastRowIndex)
-            table.insertCases(2, "after")
-            table.getCaseTableGrid().scrollTo("bottom")
-            cy.wait(500)
-            table.openIndexMenuForRow(lastRowIndex+1)
-            table.deleteCase()
-            table.openIndexMenuForRow(lastRowIndex+1)
-            table.deleteCase()
-            table.getNumOfCases().should("equal", numOfCases)
-        })
-        it("verify insert multiple cases above current case at the bottom", () => {
-            table.getCaseTableGrid().scrollTo("bottom")
-            table.openIndexMenuForRow(lastRowIndex)
-            table.insertCases(2, "before")
-            table.getCaseTableGrid().scrollTo("bottom")
-            cy.wait(500)
-            table.openIndexMenuForRow(lastRowIndex+1)
-            table.deleteCase()
-            table.openIndexMenuForRow(lastRowIndex)
-            table.deleteCase()
-            table.getNumOfCases().should("equal", numOfCases)
-        })
-        it("verify delete last case", () => {
-            table.getCaseTableGrid().scrollTo("bottom")
-            table.openIndexMenuForRow(lastRowIndex)
-            table.deleteCase()
-            numOfCases = (Number(numOfCases)-1).toString()
-        })
-        it("verify insert 1 case at the top", () => {
-            table.getCaseTableGrid().scrollTo("top")
-            table.openIndexMenuForRow(firstRowIndex)
-            table.insertCase()
-            table.getCaseTableGrid().scrollTo("top")
-            cy.wait(500)
-            table.openIndexMenuForRow(firstRowIndex)
-            table.deleteCase()
-            table.getNumOfCases().should("equal", numOfCases)
-        })
-        it("verify insert multiple cases below current case at the top", () => {
-            table.getCaseTableGrid().scrollTo("top")
-            table.openIndexMenuForRow(firstRowIndex)
-            table.insertCases(3, "after")
-            table.getCaseTableGrid().scrollTo("top")
-            cy.wait(500)
-            table.openIndexMenuForRow(firstRowIndex+1)
-            table.deleteCase()
-            table.openIndexMenuForRow(firstRowIndex+1)
-            table.deleteCase()
-            table.openIndexMenuForRow(firstRowIndex+1)
-            table.deleteCase()
-            table.getNumOfCases().should("equal", numOfCases)
-        })
-        it("verify insert multiple cases above current case at the top", () => {
-            table.getCaseTableGrid().scrollTo("top")
-            table.openIndexMenuForRow(firstRowIndex)
-            table.insertCases(3, "before")
-            table.getCaseTableGrid().scrollTo("top")
-            cy.wait(500)
-            table.openIndexMenuForRow(firstRowIndex)
-            table.deleteCase()
-            table.openIndexMenuForRow(firstRowIndex)
-            table.deleteCase()
-            table.openIndexMenuForRow(firstRowIndex)
-            table.deleteCase()
-            table.getNumOfCases().should("equal", numOfCases)
-        })
-        it("verify delete first case", () => {
-            table.getCaseTableGrid().scrollTo("top")
-            table.openIndexMenuForRow(firstRowIndex)
-            table.deleteCase()
-            numOfCases = (Number(numOfCases)-1).toString()
-        })
-        it("verify insert 1 case in the middle", () => {
-            table.getCaseTableGrid().scrollTo("top")
-            table.openIndexMenuForRow(middleRowIndex)
-            table.insertCase()
-            table.getCaseTableGrid().scrollTo("top")
-            cy.wait(500)
-            table.openIndexMenuForRow(middleRowIndex)
-            table.deleteCase()
-            table.getNumOfCases().should("equal", numOfCases)
-        })
-        it("verify insert multiple cases below current case in the middle", () => {
-            table.getCaseTableGrid().scrollTo("top")
-            table.openIndexMenuForRow(middleRowIndex)
-            table.insertCases(3, "after")
-            table.getCaseTableGrid().scrollTo("top")
-            cy.wait(500)
-            table.openIndexMenuForRow(middleRowIndex+1)
-            table.deleteCase()
-            table.openIndexMenuForRow(middleRowIndex+1)
-            table.deleteCase()
-            table.openIndexMenuForRow(middleRowIndex+1)
-            table.deleteCase()
-            table.getNumOfCases().should("equal", numOfCases)
-        })
-        it("verify insert multiple cases above current case in the middle", () => {
-            table.getCaseTableGrid().scrollTo("top")
-            table.openIndexMenuForRow(middleRowIndex)
-            table.insertCases(3, "before")
-            table.getCaseTableGrid().scrollTo("top")
-            cy.wait(500)
-            table.openIndexMenuForRow(middleRowIndex)
-            table.deleteCase()
-            table.openIndexMenuForRow(middleRowIndex)
-            table.deleteCase()
-            table.openIndexMenuForRow(middleRowIndex)
-            table.deleteCase()
-            table.getNumOfCases().should("equal", numOfCases)
-        })
-        it("verify delete case in the middle", () => {
-            table.getCaseTableGrid().scrollTo("top")
-            table.openIndexMenuForRow(middleRowIndex)
-            table.deleteCase()
-            numOfCases = (Number(numOfCases)-1).toString()
-        })
+  describe("index menu", () => {
+    it("verify index menu insert case and delete case work", () => {
+      table.openIndexMenuForRow(2)
+      table.insertCase()
+      table.openIndexMenuForRow(2)
+      table.deleteCase()
     })
+    it("verify insert cases before a row by typing num of cases", () => {
+      table.openIndexMenuForRow(2)
+      table.insertCases(2, "before")
+      table.openIndexMenuForRow(2)
+      table.deleteCase()
+      table.openIndexMenuForRow(2)
+      table.deleteCase()
+    })
+    it("verify insert cases after a row by typing num of cases", () => {
+      table.openIndexMenuForRow(2)
+      table.insertCases(2, "after")
+      table.openIndexMenuForRow(3)
+      table.deleteCase()
+      table.openIndexMenuForRow(3)
+      table.deleteCase()
+    })
+    it("verify index menu insert cases modal close", () => {
+      table.openIndexMenuForRow(2)
+      table.getIndexMenu().should("be.visible")
+      cy.clickMenuItem("Insert Cases...")
+      table.closeInsertCasesModal()
+      table.getInsertCasesModalHeader().should("not.exist")
+    })
+    it("verify index menu insert cases modal cancel", () => {
+      table.openIndexMenuForRow(2)
+      table.getIndexMenu().should("be.visible")
+      cy.clickMenuItem("Insert Cases...")
+      table.cancelInsertCasesModal()
+      table.getInsertCasesModalHeader().should("not.exist")
+    })
+    it("verify insert 1 case at the bottom", () => {
+      table.getCaseTableGrid().scrollTo("bottom")
+      table.openIndexMenuForRow(lastRowIndex)
+      table.insertCase()
+      table.getCaseTableGrid().scrollTo("bottom")
+      cy.wait(500)
+      table.openIndexMenuForRow(lastRowIndex)
+      table.deleteCase()
+      table.getNumOfCases().should("equal", numOfCases)
+    })
+    it("verify insert multiple cases below current case at the bottom", () => {
+      table.getCaseTableGrid().scrollTo("bottom")
+      table.openIndexMenuForRow(lastRowIndex)
+      table.insertCases(2, "after")
+      table.getCaseTableGrid().scrollTo("bottom")
+      cy.wait(500)
+      table.openIndexMenuForRow(lastRowIndex + 1)
+      table.deleteCase()
+      table.openIndexMenuForRow(lastRowIndex + 1)
+      table.deleteCase()
+      table.getNumOfCases().should("equal", numOfCases)
+    })
+    it("verify insert multiple cases above current case at the bottom", () => {
+      table.getCaseTableGrid().scrollTo("bottom")
+      table.openIndexMenuForRow(lastRowIndex)
+      table.insertCases(2, "before")
+      table.getCaseTableGrid().scrollTo("bottom")
+      cy.wait(500)
+      table.openIndexMenuForRow(lastRowIndex + 1)
+      table.deleteCase()
+      table.openIndexMenuForRow(lastRowIndex)
+      table.deleteCase()
+      table.getNumOfCases().should("equal", numOfCases)
+    })
+    it("verify delete last case", () => {
+      table.getCaseTableGrid().scrollTo("bottom")
+      table.openIndexMenuForRow(lastRowIndex)
+      table.deleteCase()
+      numOfCases = (Number(numOfCases) - 1).toString()
+    })
+    it("verify insert 1 case at the top", () => {
+      table.getCaseTableGrid().scrollTo("top")
+      table.openIndexMenuForRow(firstRowIndex)
+      table.insertCase()
+      table.getCaseTableGrid().scrollTo("top")
+      cy.wait(500)
+      table.openIndexMenuForRow(firstRowIndex)
+      table.deleteCase()
+      table.getNumOfCases().should("equal", numOfCases)
+    })
+    it("verify insert multiple cases below current case at the top", () => {
+      table.getCaseTableGrid().scrollTo("top")
+      table.openIndexMenuForRow(firstRowIndex)
+      table.insertCases(3, "after")
+      table.getCaseTableGrid().scrollTo("top")
+      cy.wait(500)
+      table.openIndexMenuForRow(firstRowIndex + 1)
+      table.deleteCase()
+      table.openIndexMenuForRow(firstRowIndex + 1)
+      table.deleteCase()
+      table.openIndexMenuForRow(firstRowIndex + 1)
+      table.deleteCase()
+      table.getNumOfCases().should("equal", numOfCases)
+    })
+    it("verify insert multiple cases above current case at the top", () => {
+      table.getCaseTableGrid().scrollTo("top")
+      table.openIndexMenuForRow(firstRowIndex)
+      table.insertCases(3, "before")
+      table.getCaseTableGrid().scrollTo("top")
+      cy.wait(500)
+      table.openIndexMenuForRow(firstRowIndex)
+      table.deleteCase()
+      table.openIndexMenuForRow(firstRowIndex)
+      table.deleteCase()
+      table.openIndexMenuForRow(firstRowIndex)
+      table.deleteCase()
+      table.getNumOfCases().should("equal", numOfCases)
+    })
+    it("verify delete first case", () => {
+      table.getCaseTableGrid().scrollTo("top")
+      table.openIndexMenuForRow(firstRowIndex)
+      table.deleteCase()
+      numOfCases = (Number(numOfCases) - 1).toString()
+    })
+    it("verify insert 1 case in the middle", () => {
+      table.getCaseTableGrid().scrollTo("top")
+      table.openIndexMenuForRow(middleRowIndex)
+      table.insertCase()
+      table.getCaseTableGrid().scrollTo("top")
+      cy.wait(500)
+      table.openIndexMenuForRow(middleRowIndex)
+      table.deleteCase()
+      table.getNumOfCases().should("equal", numOfCases)
+    })
+    it("verify insert multiple cases below current case in the middle", () => {
+      table.getCaseTableGrid().scrollTo("top")
+      table.openIndexMenuForRow(middleRowIndex)
+      table.insertCases(3, "after")
+      table.getCaseTableGrid().scrollTo("top")
+      cy.wait(500)
+      table.openIndexMenuForRow(middleRowIndex + 1)
+      table.deleteCase()
+      table.openIndexMenuForRow(middleRowIndex + 1)
+      table.deleteCase()
+      table.openIndexMenuForRow(middleRowIndex + 1)
+      table.deleteCase()
+      table.getNumOfCases().should("equal", numOfCases)
+    })
+    it("verify insert multiple cases above current case in the middle", () => {
+      table.getCaseTableGrid().scrollTo("top")
+      table.openIndexMenuForRow(middleRowIndex)
+      table.insertCases(3, "before")
+      table.getCaseTableGrid().scrollTo("top")
+      cy.wait(500)
+      table.openIndexMenuForRow(middleRowIndex)
+      table.deleteCase()
+      table.openIndexMenuForRow(middleRowIndex)
+      table.deleteCase()
+      table.openIndexMenuForRow(middleRowIndex)
+      table.deleteCase()
+      table.getNumOfCases().should("equal", numOfCases)
+    })
+    it("verify delete case in the middle", () => {
+      table.getCaseTableGrid().scrollTo("top")
+      table.openIndexMenuForRow(middleRowIndex)
+      table.deleteCase()
+      numOfCases = (Number(numOfCases) - 1).toString()
+    })
+  })
+
+  describe("table component", () => {
+    it("updates table title", () => {
+      c.getComponentTitle("table").should("have.text", collectionName)
+      c.changeComponentTitle("table", renamedCollectionName)
+      c.getComponentTitle("table").should("have.text", renamedCollectionName)
+    })
+    it("creates tables with new collection name", () => {
+      table.createNewTableFromToolshelf()
+
+      c.getComponentTitle("table").should("contain", collectionName)
+      c.getComponentTitle("table", 1).should("contain", newCollectionName)
+
+      table.createNewTableFromToolshelf()
+      c.getComponentTitle("table", 2).should("contain", newCollectionName)
+    })
+    it("creates tables with new collection names when existing ones are closed", () => {
+      c.closeComponent("table")
+      c.checkComponentDoesNotExist("table")
+      table.createNewTableFromToolshelf()
+      c.getComponentTitle("table").should("contain", newCollectionName)
+
+      c.closeComponent("table")
+      c.checkComponentDoesNotExist("table")
+      table.createNewTableFromToolshelf()
+      c.getComponentTitle("table").should("contain", newCollectionName)
+    })
+    it("closes and reopens existing case tables", () => {
+      c.closeComponent("table")
+      c.checkComponentDoesNotExist("table")
+      table.openExistingTableFromToolshelf(collectionName)
+      c.getComponentTitle("table").should("contain", collectionName)
+    })
+    it("checks all table tooltips", () => {
+      c.selectTile("table", 0)
+      c.getToolShelfIcon("table").then($element => {
+        c.checkToolTip($element, c.tooltips.tableToolShelfIcon)
+      })
+      c.getMinimizeButton("table").then($element => {
+        c.checkToolTip($element, c.tooltips.minimizeComponent)
+      })
+      c.getCloseButton("table").then($element => {
+        c.checkToolTip($element, c.tooltips.closeComponent)
+      })
+      table.getToggleCardView().then($element => {
+        c.checkToolTip($element, c.tooltips.tableSwitchCaseCard)
+      })
+      table.getDatasetInfoButton().then($element => {
+        c.checkToolTip($element, c.tooltips.tableDatasetInfoButton)
+      })
+      table.getResizeButton().then($element => {
+        c.checkToolTip($element, c.tooltips.tableResizeButton)
+      })
+      table.getDeleteCasesButton().then($element => {
+        c.checkToolTip($element, c.tooltips.tableDeleteCasesButton)
+      })
+      table.getHideShowButton().then($element => {
+        c.checkToolTip($element, c.tooltips.tableHideShowButton)
+      })
+      table.getAttributesButton().then($element => {
+        c.checkToolTip($element, c.tooltips.tableAttributesButton)
+      })
+    })
+  })
 })

--- a/v3/cypress/support/commands.ts
+++ b/v3/cypress/support/commands.ts
@@ -1,101 +1,101 @@
 Cypress.Commands.add("clickMenuItem", text => {
-    cy.get("button[role=menuitem]").contains(text).click()
+  cy.get("button[role=menuitem]").contains(text).click()
 })
 
 Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target, num = 0) => {
-    const el = {
-        tableHeader: ".codap-data-summary .data-attributes .draggable-attribute",
-        tableColumnHeader:
-        `.codap-case-table [data-testid="codap-attribute-button ${target}"]`,
-        caseCardHeader: ".react-data-card-attribute",
-        caseCardHeaderDropZone: ".react-data-card .data-cell-lower",
-        caseCardCollectionDropZone: ".react-data-card .collection-header-row",
-        graphTile: ".graph-plot svg",
-        legend: ".graph-plot .droppable-legend",
-        x_axis: ".codap-graph .droppable-axis.droppable-svg.bottom",
-        x_axis_label: ".codap-graph .axis-legend-attribute-menu.bottom>button",
-        y_axis: ".codap-graph .droppable-axis.droppable-svg.left",
-        y_axis_label: ".codap-graph .axis-legend-attribute-menu.left>button",
-        mapTile: ".dg.leaflet-container",
-        newCollection: ".dg-table-drop-target"
-    }
+  const el = {
+    tableHeader: ".codap-data-summary .data-attributes .draggable-attribute",
+    tableColumnHeader:
+      `.codap-case-table [data-testid="codap-attribute-button ${target}"]`,
+    caseCardHeader: ".react-data-card-attribute",
+    caseCardHeaderDropZone: ".react-data-card .data-cell-lower",
+    caseCardCollectionDropZone: ".react-data-card .collection-header-row",
+    graphTile: ".graph-plot svg",
+    legend: ".graph-plot .droppable-legend",
+    x_axis: ".codap-graph .droppable-axis.droppable-svg.bottom",
+    x_axis_label: ".codap-graph .axis-legend-attribute-menu.bottom>button",
+    y_axis: ".codap-graph .droppable-axis.droppable-svg.left",
+    y_axis_label: ".codap-graph .axis-legend-attribute-menu.left>button",
+    mapTile: ".dg.leaflet-container",
+    newCollection: ".dg-table-drop-target"
+  }
 
-    let source_el = "", target_el = ""
+  let source_el = "", target_el = ""
 
-    switch (source) {
-        case ("table"):
-            source_el = el.tableHeader
-            break
-        case ("attribute"):
-            source_el = el.tableHeader
-            break
-        case ("card"):
-            source_el = el.caseCardHeader
-            break
-        case ("x1"):
-            source_el = el.x_axis
-            break
-        case ("x"):
-            source_el = el.x_axis_label
-            break
-        case ("y1"):
-            source_el = el.y_axis
-            break
-        case ("y"):
-            source_el = el.y_axis_label
-            break
-    }
+  switch (source) {
+    case ("table"):
+      source_el = el.tableHeader
+      break
+    case ("attribute"):
+      source_el = el.tableHeader
+      break
+    case ("card"):
+      source_el = el.caseCardHeader
+      break
+    case ("x1"):
+      source_el = el.x_axis
+      break
+    case ("x"):
+      source_el = el.x_axis_label
+      break
+    case ("y1"):
+      source_el = el.y_axis
+      break
+    case ("y"):
+      source_el = el.y_axis_label
+      break
+  }
 
-    switch (target) {
-        case ("table"):
-            target_el = el.tableHeader
-            break
-        case ("card"):
-            target_el = el.caseCardHeaderDropZone
-            break
-        case ("card collection"):
-            target_el = el.caseCardCollectionDropZone
-            break
-        case ("graph_plot"):
-            target_el = el.graphTile
-            break
-        case ("legend"):
-            target_el = el.legend
-            break
-        case ("map"):
-            target_el = el.mapTile
-            break
-        case ("x1"):
-        case ("x"):
-            target_el = el.x_axis
-            break
-        case ("y1"):
-        case ("y"):
-            target_el = el.y_axis
-            break
-        case ("newCollection"):
-            target_el = el.newCollection
-            break
-        default:
-            target_el = el.tableColumnHeader
-            break
-    }
-    cy.get(target_el).then($target => {
-        return $target[0].getBoundingClientRect()
-    }).then($targetRect => {
-        cy.get(source_el).contains(attribute).then($subject => {
-            cy.mouseMoveBy($subject, $targetRect, { delay: 100 })
-        })
+  switch (target) {
+    case ("table"):
+      target_el = el.tableHeader
+      break
+    case ("card"):
+      target_el = el.caseCardHeaderDropZone
+      break
+    case ("card collection"):
+      target_el = el.caseCardCollectionDropZone
+      break
+    case ("graph_plot"):
+      target_el = el.graphTile
+      break
+    case ("legend"):
+      target_el = el.legend
+      break
+    case ("map"):
+      target_el = el.mapTile
+      break
+    case ("x1"):
+    case ("x"):
+      target_el = el.x_axis
+      break
+    case ("y1"):
+    case ("y"):
+      target_el = el.y_axis
+      break
+    case ("newCollection"):
+      target_el = el.newCollection
+      break
+    default:
+      target_el = el.tableColumnHeader
+      break
+  }
+  cy.get(target_el).then($target => {
+    return $target[0].getBoundingClientRect()
+  }).then($targetRect => {
+    cy.get(source_el).contains(attribute).then($subject => {
+      cy.mouseMoveBy($subject, $targetRect, { delay: 100 })
     })
-    cy.wait(2000)
+  })
+  cy.wait(2000)
 })
 
 Cypress.Commands.add("clickToUnselect", (subject, options?: { delay: number }) => {
-    cy.wrap(subject)
+  cy.wrap(subject)
     .trigger("pointerdown", {
-        force: true,
-        clientX: Math.floor(subject[0].x + 10),
-        clientY: Math.floor(subject[0].y + 10),
+      force: true,
+      clientX: Math.floor(subject[0].x + 10),
+      clientY: Math.floor(subject[0].y + 10),
     })
     .wait(options?.delay || 0, { log: Boolean(options?.delay) })
     .trigger("pointerup", { force: true })
@@ -103,32 +103,32 @@ Cypress.Commands.add("clickToUnselect", (subject, options?: { delay: number }) =
 })
 
 Cypress.Commands.add("mouseMoveBy",
-    (subject, targetRect, options?: { delay: number }) => {
-        cy.wrap(subject)
-            .trigger("mousedown", { force: true })
-            .wait(options?.delay || 0, { log: Boolean(options?.delay) })
-            .trigger("mousemove", {
-                force: true,
-                clientX: Math.floor(targetRect.x + targetRect.width / 2),
-                clientY: Math.floor(targetRect.y + targetRect.height / 2),
-            })
-            .wait(options?.delay || 0, { log: Boolean(options?.delay) })
-            .trigger("mouseup", { force: true })
-            .wait(options?.delay || 0, { log: Boolean(options?.delay) })
-    })
+  (subject, targetRect, options?: { delay: number }) => {
+    cy.wrap(subject)
+      .trigger("mousedown", { force: true })
+      .wait(options?.delay || 0, { log: Boolean(options?.delay) })
+      .trigger("mousemove", {
+        force: true,
+        clientX: Math.floor(targetRect.x + targetRect.width / 2),
+        clientY: Math.floor(targetRect.y + targetRect.height / 2),
+      })
+      .wait(options?.delay || 0, { log: Boolean(options?.delay) })
+      .trigger("mouseup", { force: true })
+      .wait(options?.delay || 0, { log: Boolean(options?.delay) })
+  })
 
 // analogous to mouseMoveBy but doesn't seem to trigger the PointerSensor as expected
 Cypress.Commands.add("pointerMoveBy",
-    (subject, targetRect, options?: { delay: number }) => {
-        cy.wrap(subject)
-            .trigger("pointerdown", { force: true })
-            .wait(options?.delay || 0, { log: Boolean(options?.delay) })
-            .trigger("pointermove", {
-                force: true,
-                clientX: Math.floor(targetRect.x + targetRect.width / 2),
-                clientY: Math.floor(targetRect.y + targetRect.height / 2),
-            })
-            .wait(options?.delay || 0, { log: Boolean(options?.delay) })
-            .trigger("pointerup", { force: true })
-            .wait(options?.delay || 0, { log: Boolean(options?.delay) })
-    })
+  (subject, targetRect, options?: { delay: number }) => {
+    cy.wrap(subject)
+      .trigger("pointerdown", { force: true })
+      .wait(options?.delay || 0, { log: Boolean(options?.delay) })
+      .trigger("pointermove", {
+        force: true,
+        clientX: Math.floor(targetRect.x + targetRect.width / 2),
+        clientY: Math.floor(targetRect.y + targetRect.height / 2),
+      })
+      .wait(options?.delay || 0, { log: Boolean(options?.delay) })
+      .trigger("pointerup", { force: true })
+      .wait(options?.delay || 0, { log: Boolean(options?.delay) })
+  })

--- a/v3/cypress/support/elements/axis-elements.ts
+++ b/v3/cypress/support/elements/axis-elements.ts
@@ -1,69 +1,69 @@
 export const AxisElements = {
-    getGraphTile() {
-        return cy.get(".codap-graph")
-    },
-    getAxisElement(axis) {
-        switch (axis) {
-            case "X":
-            case "x":
-            default:
-                return this.getGraphTile().find("[data-testid=axis-bottom]").parent()
-            case "Y":
-            case "y":
-                return this.getGraphTile().find("[data-testid=axis-left]").parent()
-            case "legend":
-                return this.getGraphTile().find(".axis-legend-attribute-menu.legend>button")
-        }
-    },
-    getAxisLabel(axis) {
-        return this.getAxisElement(axis).find(".attribute-label")
-    },
-    getDefaultAxisLabel(axis) {
-        return this.getAxisElement(axis).find(".empty-label")
-    },
-    getTickMarks(axis) {
-        return this.getAxisElement(axis).find(".tick line")
-    },
-    getTickMark(axis, index) {
-        return this.getAxisElement(axis).find(".tick line").eq(index)
-    },
-    getTickLength(axis, attr) {
-        return this.getTickMark(axis, 0).invoke("attr", attr).then(tickLength => {
-            return parseInt(tickLength, 10)
-        })
-    },
-    getGridLines(axis) {
-        return this.getAxisElement(axis).find(".tick line")
-    },
-    getGridLine(axis, index) {
-        return this.getAxisElement(axis).find(".tick line").eq(index)
-    },
-    getAxisTickLabels(axis) {
-        return this.getAxisElement(axis).find(".tick text")
-    },
-    getAxisTickLabel(axis, index) {
-        return this.getAxisElement(axis).find(".tick text").eq(index)
-    },
-    isAxisTickLabelOrientationTransformed(axis, index) {
-        return this.getAxisElement(axis).find(".tick text").eq(index).invoke("attr", "transform").should("exist")
-    },
-    dragAttributeToAxis(name, axis) {
-        cy.dragAttributeToTarget("graph", name, axis)
-    },
-    getAxisAttributeMenu(axis) {
-        switch (axis) {
-            case "X":
-            case "x":
-            default:
-                return this.getGraphTile().find(".axis-legend-attribute-menu.bottom>button")
-            case "Y":
-            case "y":
-                return this.getGraphTile().find(".axis-legend-attribute-menu.left>button")
-            case "legend":
-                return this.getGraphTile().find(".axis-legend-attribute-menu.legend>button")
-        }
-    },
-    getAttributeFromAttributeMenu(axis) {
-        return this.getAxisAttributeMenu(axis).parent()
+  getGraphTile() {
+    return cy.get(".codap-graph")
+  },
+  getAxisElement(axis) {
+    switch (axis) {
+      case "X":
+      case "x":
+      default:
+        return this.getGraphTile().find("[data-testid=axis-bottom]").parent()
+      case "Y":
+      case "y":
+        return this.getGraphTile().find("[data-testid=axis-left]").parent()
+      case "legend":
+        return this.getGraphTile().find(".axis-legend-attribute-menu.legend>button")
     }
+  },
+  getAxisLabel(axis) {
+    return this.getAxisElement(axis).find(".attribute-label")
+  },
+  getDefaultAxisLabel(axis) {
+    return this.getAxisElement(axis).find(".empty-label")
+  },
+  getTickMarks(axis) {
+    return this.getAxisElement(axis).find(".tick line")
+  },
+  getTickMark(axis, index) {
+    return this.getAxisElement(axis).find(".tick line").eq(index)
+  },
+  getTickLength(axis, attr) {
+    return this.getTickMark(axis, 0).invoke("attr", attr).then(tickLength => {
+      return parseInt(tickLength, 10)
+    })
+  },
+  getGridLines(axis) {
+    return this.getAxisElement(axis).find(".tick line")
+  },
+  getGridLine(axis, index) {
+    return this.getAxisElement(axis).find(".tick line").eq(index)
+  },
+  getAxisTickLabels(axis) {
+    return this.getAxisElement(axis).find(".tick text")
+  },
+  getAxisTickLabel(axis, index) {
+    return this.getAxisElement(axis).find(".tick text").eq(index)
+  },
+  isAxisTickLabelOrientationTransformed(axis, index) {
+    return this.getAxisElement(axis).find(".tick text").eq(index).invoke("attr", "transform").should("exist")
+  },
+  dragAttributeToAxis(name, axis) {
+    cy.dragAttributeToTarget("graph", name, axis)
+  },
+  getAxisAttributeMenu(axis) {
+    switch (axis) {
+      case "X":
+      case "x":
+      default:
+        return this.getGraphTile().find(".axis-legend-attribute-menu.bottom>button")
+      case "Y":
+      case "y":
+        return this.getGraphTile().find(".axis-legend-attribute-menu.left>button")
+      case "legend":
+        return this.getGraphTile().find(".axis-legend-attribute-menu.legend>button")
+    }
+  },
+  getAttributeFromAttributeMenu(axis) {
+    return this.getAxisAttributeMenu(axis).parent()
+  }
 }

--- a/v3/cypress/support/elements/calculator-tile.ts
+++ b/v3/cypress/support/elements/calculator-tile.ts
@@ -1,8 +1,18 @@
+import { ComponentElements as c } from "./component-elements"
+
 export const CalculatorTileElements = {
   getCalculatorTile() {
-    return cy.get(".codap-component.calculator")
+    return c.getComponentTile("calculator")
   },
-  getCollectionTitle() {
-    return this.getCalculatorTile().find("[data-testid=editable-component-title]")
+  getCalcButton(button) {
+    return this.getCalculatorTile().find("[data-testid=calc-button]").contains(button)
+  },
+  enterExpression(expression) {
+    Array.from(expression).forEach(char => {
+      this.getCalcButton(char).click()
+    })
+  },
+  checkCalculatorDisplay(answer) {
+    this.getCalculatorTile().find("[data-testid=calc-input]").should("have.text", answer)
   }
 }

--- a/v3/cypress/support/elements/cfm.ts
+++ b/v3/cypress/support/elements/cfm.ts
@@ -1,5 +1,5 @@
 export const CfmElements = {
-    openLocalDoc(filename) {
-        cy.get('#app').selectFile(filename, { action: 'drag-drop' })
-    }
+  openLocalDoc(filename) {
+    cy.get('#app').selectFile(filename, { action: 'drag-drop' })
+  }
 }

--- a/v3/cypress/support/elements/component-elements.ts
+++ b/v3/cypress/support/elements/component-elements.ts
@@ -1,0 +1,104 @@
+export const ComponentElements = {
+  tooltips: {
+    tableToolShelfIcon: "Open a case table for each data set(ctrl-alt-t)",
+    graphToolShelfIcon: "Make a graph (ctrl-alt-g)",
+    sliderToolShelfIcon: "Make a slider (ctrl-alt-s)",
+    calculatorToolShelfIcon: "Open/close the calculator (ctrl-alt-c)",
+    minimizeComponent: "Minimize or expand this Component",
+    closeComponent: "Close this Component",
+    inspectorPanel: "Change what is shown along with the points",
+    graphResizeButton: "Resize all columns to fit data",
+    graphHideShowButton: "Show all cases or hide selected/unselected cases",
+    graphDisplayValuesButton: "Change what is shown along with the points",
+    graphDisplayConfigButton: "Configure the display differently",
+    graphDisplayStylesButton: "Change the appearance of the display",
+    graphCameraButton: "Save the image as a PNG file",
+    tableSwitchCaseCard: "Switch to case card view of the data",
+    tableDatasetInfoButton: "Display information about dataset",
+    tableResizeButton: "Resize all columns to fit data",
+    tableDeleteCasesButton: "Delete selected or unselected cases",
+    tableHideShowButton: "Show all cases or hide selected/unselected cases",
+    tableAttributesButton: "Make new attributes. Export case data."
+  },
+  getComponentSelector(component) {
+    let el = ""
+    switch (component) {
+      case "graph":
+        el = ".codap-graph"
+        break
+      case "slider":
+        el = ".codap-slider"
+        break
+      case "calculator":
+        el = ".codap-component.calculator"
+        break
+      case "table":
+        el = ".codap-case-table"
+        break
+      case "data-summary":
+        el = ".codap-data-summary"
+        break
+    }
+    return cy.get(el)
+  },
+  getToolshelfSelector(component) {
+    let el = ""
+    switch (component) {
+      case "graph":
+        el = "[data-testid=tool-shelf-button-Graph]"
+        break
+      case "slider":
+        el = "[data-testid=tool-shelf-button-Slider]"
+        break
+      case "calculator":
+        el = "[data-testid=tool-shelf-button-Calc]"
+        break
+      case "table":
+        el = "[data-testid=tool-shelf-button-table]"
+        break
+    }
+    return cy.get(el)
+  },
+  getComponentTile(component, index = 0) {
+    return this.getComponentSelector(component).then(element => {
+      return element.eq(index)
+    })
+  },
+  getComponentTitle(component, index = 0) {
+    return this.getComponentTile(component, index).find("[data-testid=editable-component-title]")
+  },
+  changeComponentTitle(component, title, index = 0) {
+    this.getComponentTitle(component, index).click().find("input").type(`${title}{enter}`)
+  },
+  getInspectorPanel() {
+    return cy.get("[data-testid=inspector-panel]")
+  },
+  getMinimizeButton(component, index = 0) {
+    return this.getComponentTile(component, index).find("[data-testid=component-minimize-icon]")
+  },
+  getCloseButton(component, index = 0) {
+    return this.getComponentTile(component, index).find("[data-testid=component-close-button]")
+  },
+  checkToolTip(element, tooltipText) {
+    cy.wrap(element).invoke("attr", "title").should("contain", tooltipText)
+  },
+  createFromToolshelf(component) {
+    this.getToolShelfIcon(component).click()
+  },
+  getToolShelfIcon(component) {
+    return this.getToolshelfSelector(component)
+  },
+  selectTile(component, index = 0) {
+    this.getComponentTile(component, index).click()
+  },
+  checkComponentDoesNotExist(component) {
+    this.getComponentSelector(component).should("not.exist")
+  },
+  checkComponentExists(component) {
+    this.getComponentSelector(component).should("exist")
+  },
+  closeComponent(component, index = 0) {
+    this.selectTile(component, index)
+    this.getCloseButton(component, index).click({ force: true })
+  }
+}

--- a/v3/cypress/support/elements/graph-tile.ts
+++ b/v3/cypress/support/elements/graph-tile.ts
@@ -1,8 +1,25 @@
+import { ComponentElements as c } from "./component-elements"
+
 export const GraphTileElements = {
-  getGraphTile() {
-    return cy.get(".codap-graph")
+  getGraphTile(index = 0) {
+    return c.getComponentTile("graph", index)
   },
-  getCollectionTitle() {
-    return this.getGraphTile().find("[data-testid=editable-component-title]")
-  }
+  getResizeIcon() {
+    return c.getInspectorPanel().find("[data-testid=graph-resize-button]")
+  },
+  getHideShowButton() {
+    return c.getInspectorPanel().find("[data-testid=graph-hide-show-button]")
+  },
+  getDisplayValuesButton() {
+    return c.getInspectorPanel().find("[data-testid=graph-display-values-button]")
+  },
+  getDisplayConfigButton() {
+    return c.getInspectorPanel().find("[data-testid=graph-display-config-button]")
+  },
+  getDisplayStylesButton() {
+    return c.getInspectorPanel().find("[data-testid=graph-display-styles-button]")
+  },
+  getCameraButton() {
+    return c.getInspectorPanel().find("[data-testid=graph-camera-button]")
+  },
 }

--- a/v3/cypress/support/elements/legend-elements.ts
+++ b/v3/cypress/support/elements/legend-elements.ts
@@ -1,26 +1,26 @@
 export const LegendElements = {
-    getGraphTile() {
-        return cy.get(".codap-graph")
-    },
-    getLegend() {
-        return this.getGraphTile().find(".graph-plot .legend-component")
-    },
-    getLegendName() {
-        return this.getLegend().find(".attribute-label")
-    },
-    getCategoricalLegendCategories() {
-        return this.getLegend().find(".legend-categories>.key")
-    },
-    getCategoricalLegendCategory(name) {
-        return this.getCategoricalLegendCategories().contains(name)
-    },
-    getNumericalLegendCategories() {
-        return this.getLegend().find(".legend-categories>svg rect")
-    },
-    getLegendAttributeMenu() {
-        return this.getGraphTile().find(".axis-legend-attribute-menu.legend>button")
-    },
-    getAttributeFromLegendMenu() {
-        return this.getLegendAttributeMenu().parent()
-    }
+  getGraphTile() {
+    return cy.get(".codap-graph")
+  },
+  getLegend() {
+    return this.getGraphTile().find(".graph-plot .legend-component")
+  },
+  getLegendName() {
+    return this.getLegend().find(".attribute-label")
+  },
+  getCategoricalLegendCategories() {
+    return this.getLegend().find(".legend-categories>.key")
+  },
+  getCategoricalLegendCategory(name) {
+    return this.getCategoricalLegendCategories().contains(name)
+  },
+  getNumericalLegendCategories() {
+    return this.getLegend().find(".legend-categories>svg rect")
+  },
+  getLegendAttributeMenu() {
+    return this.getGraphTile().find(".axis-legend-attribute-menu.legend>button")
+  },
+  getAttributeFromLegendMenu() {
+    return this.getLegendAttributeMenu().parent()
+  }
 }

--- a/v3/cypress/support/elements/point-elements.ts
+++ b/v3/cypress/support/elements/point-elements.ts
@@ -1,60 +1,60 @@
 export const PointElements = {
-    getGraphTile() {
-        return cy.get(".codap-graph")
-    },
-    getPointOnGraph(index) {
-        return this.getGraphTile().find(".graph-dot-area circle").eq(index)
-    },
-    selectPointOnGraph(index) {
-        this.getPointOnGraph(index).click()
-    },
-    unselectPointOnGraph() {
-        this.getGraphTile().find(".graph-dot-area").click()
-    },
-    hoverOverPointOnGraph(index) {
-        this.getPointOnGraph(index).trigger('mouseover')
-    },
-    getPointDataTip() {
-        return cy.get("[data-testid=graph-point-data-tip")
-    },
-    // selectPointsOnGraph() {
-        
-    // },
-    unselectPointsOnGraph() {
-        this.getGraphTile().find(".graph-dot-area").click()
-    },
-    // selectAllPointsOnGraph() {
-        
-    // },
-    unselectAllPointsOnGraph() {
-        this.getGraphTile().find(".graph-dot-area").click()
-    },
-    getPointSize(index) {
-        return this.getPointOnGraph(index).invoke("attr", "r")
-    },
-    getPointColor(index) {
-        return this.getPointOnGraph(index).invoke("attr", "style").then($style => {
-            return $style.substring($style.indexOf("fill:")+1, $style.indexOf(")"))
-        })
-    },
-    getPointStroke(index) {
-        return this.getPointOnGraph(index).invoke("attr", "style").then($style => {
-            return $style.substring($style.indexOf("stroke:")+1, $style.indexOf(")"))
-        })
-    },
-    verifyPointIsSelected(index) {
-        this.getPointOnGraph(index).invoke("attr", "class").should("contain", "graph-dot-highlighted")
-        this.getPointColor(index).should("contain", "rgb(70, 130, 180)")
-    },
-    verifyPointIsSelectedFromLegend(index) {
-        this.getPointOnGraph(index).invoke("attr", "class").should("contain", "graph-dot-highlighted")
-        this.getPointStroke(index).should("contain", "rgb(255, 0, 0)")
-    },
-    verifyHighlightedPoint(tooltip) {
-        this.getGraphTile().find(".graph-dot-area .graph-dot.graph-dot-highlighted").click()
-        cy.get("[data-testid=graph-point-data-tip]").should("have.text", tooltip)
-    },
-    verifyGraphPointDataToolTip(tooltip) {
-        cy.get("[data-testid=graph-point-data-tip]").should("have.text", tooltip)
-    }
+  getGraphTile() {
+    return cy.get(".codap-graph")
+  },
+  getPointOnGraph(index) {
+    return this.getGraphTile().find(".graph-dot-area circle").eq(index)
+  },
+  selectPointOnGraph(index) {
+    this.getPointOnGraph(index).click()
+  },
+  unselectPointOnGraph() {
+    this.getGraphTile().find(".graph-dot-area").click()
+  },
+  hoverOverPointOnGraph(index) {
+    this.getPointOnGraph(index).trigger('mouseover')
+  },
+  getPointDataTip() {
+    return cy.get("[data-testid=graph-point-data-tip")
+  },
+  // selectPointsOnGraph() {
+
+  // },
+  unselectPointsOnGraph() {
+    this.getGraphTile().find(".graph-dot-area").click()
+  },
+  // selectAllPointsOnGraph() {
+
+  // },
+  unselectAllPointsOnGraph() {
+    this.getGraphTile().find(".graph-dot-area").click()
+  },
+  getPointSize(index) {
+    return this.getPointOnGraph(index).invoke("attr", "r")
+  },
+  getPointColor(index) {
+    return this.getPointOnGraph(index).invoke("attr", "style").then($style => {
+      return $style.substring($style.indexOf("fill:") + 1, $style.indexOf(")"))
+    })
+  },
+  getPointStroke(index) {
+    return this.getPointOnGraph(index).invoke("attr", "style").then($style => {
+      return $style.substring($style.indexOf("stroke:") + 1, $style.indexOf(")"))
+    })
+  },
+  verifyPointIsSelected(index) {
+    this.getPointOnGraph(index).invoke("attr", "class").should("contain", "graph-dot-highlighted")
+    this.getPointColor(index).should("contain", "rgb(70, 130, 180)")
+  },
+  verifyPointIsSelectedFromLegend(index) {
+    this.getPointOnGraph(index).invoke("attr", "class").should("contain", "graph-dot-highlighted")
+    this.getPointStroke(index).should("contain", "rgb(255, 0, 0)")
+  },
+  verifyHighlightedPoint(tooltip) {
+    this.getGraphTile().find(".graph-dot-area .graph-dot.graph-dot-highlighted").click()
+    cy.get("[data-testid=graph-point-data-tip]").should("have.text", tooltip)
+  },
+  verifyGraphPointDataToolTip(tooltip) {
+    cy.get("[data-testid=graph-point-data-tip]").should("have.text", tooltip)
+  }
 }

--- a/v3/cypress/support/elements/slider-tile.ts
+++ b/v3/cypress/support/elements/slider-tile.ts
@@ -1,8 +1,104 @@
+import { ComponentElements as c } from "./component-elements"
+
 export const SliderTileElements = {
-  getSliderTile() {
-    return cy.get(".codap-slider")
+  getSliderTile(index = 0) {
+    return c.getComponentTile("slider", index)
   },
-  getComponentTitle() {
-    return this.getSliderTile().find("[data-testid=editable-component-title]")
+  getVariableName(index = 0) {
+    return this.getSliderTile(index).find("[data-testid=slider-variable-name-text]")
+  },
+  getVariableNameInput(index = 0) {
+    return this.getSliderTile(index).find("[data-testid=slider-variable-name-text-input]")
+  },
+  changeVariableName(name, index = 0) {
+    this.getVariableName(index).click()
+    this.getVariableNameInput(index).clear()
+    this.getVariableNameInput(index).type(`${name}{enter}`)
+  },
+  getVariableValue(index = 0) {
+    return this.getSliderTile(index).find("[data-testid=slider-variable-value-text-input]").invoke("attr", "value")
+  },
+  getVariableValueInput(index = 0) {
+    return this.getSliderTile(index).find("[data-testid=slider-variable-value-text-input]")
+  },
+  changeVariableValue(value, index = 0) {
+    this.getVariableValueInput(index).click()
+    this.getVariableValueInput(index).clear()
+    this.getVariableValueInput(index).type(`${value}{enter})`)
+  },
+  getPlayButton(index = 0) {
+    return this.getSliderTile(index).find("[data-testid=slider-play-pause]")
+  },
+  playSliderButton(index = 0) {
+    this.checkPlayButtonIsPaused(index)
+    this.getPlayButton(index).click()
+  },
+  pauseSliderButton(index = 0) {
+    this.checkPlayButtonIsRunning(index)
+    this.getPlayButton(index).click()
+  },
+  checkPlayButtonIsPaused(index = 0) {
+    this.getPlayButton(index).invoke("attr", "class").should("contain", "paused")
+  },
+  checkPlayButtonIsRunning(index = 0) {
+    this.getPlayButton(index).invoke("attr", "class").should("contain", "running")
+  },
+  getSliderThumbIcon(index = 0) {
+    return this.getSliderTile(index).find("[data-testid=slider-thumb-icon]")
+  },
+  getSliderAxis(index = 0) {
+    return this.getSliderTile(index).find("[data-testid=slider-axis]")
+  },
+  getInspectorIcon() {
+    return c.getInspectorPanel().find("[data-testid=slider-values-button]")
+  },
+  clickInspectorPanel() {
+    this.getInspectorIcon().click()
+  },
+  getMultipleRestriction() {
+    return c.getInspectorPanel().find("[data-testid=slider-restrict-multiples]")
+  },
+  setMultipleRestriction(multiple, index = 0) {
+    c.selectTile("slider", index)
+    this.clickInspectorPanel()
+    this.getMultipleRestriction().find("input").type(`${multiple}{enter}`)
+  },
+  checkMultipleRestriction(multiple, index = 0) {
+    c.selectTile("slider", index)
+    this.clickInspectorPanel()
+    this.getMultipleRestriction().find("input").invoke("attr", "value").should("contain", multiple)
+    this.clickInspectorPanel()
+  },
+  getAnimationRate() {
+    return c.getInspectorPanel().find("[data-testid=slider-animation-rate]")
+  },
+  setAnimationRate(rate, index = 0) {
+    c.selectTile("slider", index)
+    this.clickInspectorPanel()
+    this.getAnimationRate().find("input").type(`${rate}{enter}`)
+  },
+  checkAnimationRate(rate, index = 0) {
+    c.selectTile("slider", index)
+    this.clickInspectorPanel()
+    this.getAnimationRate().find("input").invoke("attr", "value").should("contain", rate)
+    this.clickInspectorPanel()
+  },
+  getAnimationDirection() {
+    return c.getInspectorPanel().find("[data-testid=slider-animation-direction]")
+  },
+  setAnimationDirection(direction, index = 0) {
+    c.selectTile("slider", index)
+    this.clickInspectorPanel()
+    this.getAnimationDirection().select(direction)
+    this.clickInspectorPanel()
+  },
+  getAnimationRepetition() {
+    return c.getInspectorPanel().find("[data-testid=slider-animation-repetition]")
+  },
+  setAnimationRepetition(repetition, index = 0) {
+    c.selectTile("slider", index)
+    this.clickInspectorPanel()
+    this.getAnimationRepetition().select(repetition)
+    this.clickInspectorPanel()
   }
 }

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -1,140 +1,169 @@
-export const TableTileElements = {
-    getTableTile() {
-        return cy.get(".codap-case-table")
-    },
-    getCaseTableGrid() {
-        return cy.get("[data-testid=case-table] [role=grid]")
-    },
-    getNumOfAttributes() {
-        return cy.get("[data-testid=case-table] [role=grid]").invoke("attr", "aria-colcount")
-    },
-    getNumOfCases() {
-        return cy.get("[data-testid=case-table] [role=grid]").invoke("attr", "aria-rowcount")
-    },
-    getCollectionTitle() {
-        return this.getTableTile().find("[data-testid=editable-component-title]")
-    },
-    getColumnHeaders() {
-        return cy.get("[data-testid=case-table] [role=columnheader]")
-    },
-    getColumnHeader(index) {
-        return cy.get(".codap-column-header-content").eq(index)
-    },
-    getColumnHeaderTooltip() {
-        return cy.get("[data-testid=case-table-attribute-tooltip]")
-    },
-    openIndexMenuForRow(rowNum) {
-        cy.get(`[data-testid=case-table] [role=grid] [role=row][aria-rowindex="${rowNum}"]
-            [data-testid=codap-index-content-button]`).click()
-    },
-    getIndexMenu() {
-        return cy.get("[data-testid=index-menu-list]")
-    },
-    insertCase() {
-        this.getIndexMenu().should("be.visible")
-        cy.clickMenuItem("Insert Case")
-        cy.wait(500)
-    },
-    insertCases(num_of_cases, location) {
-        this.getIndexMenu().should("be.visible")
-        cy.clickMenuItem("Insert Cases...")
-        cy.get("[data-testid=num-case-input] input").type(num_of_cases)
-        cy.get(`[data-testid="add-${location}"]`).click()
-        cy.get("[data-testid=\"Insert Cases-button\"]").contains("Insert Cases").click()
-    },
-    deleteCase() {
-        this.getIndexMenu().should("be.visible")
-        cy.clickMenuItem("Delete Case")
-        cy.wait(500)
-    },
-    getInsertCasesModalHeader() {
-        return cy.get("[data-testid=codap-modal-header]")
-    },
-    closeInsertCasesModal() {
-        cy.get("[data-testid=modal-close-button]").click()
-    },
-    cancelInsertCasesModal() {
-        cy.get("[data-testid=Cancel-button]").click()
-    },
-    getAttributeHeader() {
-        return cy.get("[data-testid^=codap-attribute-button]")
-    },
-    getAttribute(name) {
-        return cy.get(`[data-testid^="codap-attribute-button ${name}"]`)
-    },
-    openAttributeMenu(name) {
-        this.getAttribute(name).click()
-    },
-    getAttributeMenuItem(item) {
-        return cy.get("[data-testid=attribute-menu-list] button").contains(item)
-    },
-    selectMenuItemFromAttributeMenu(item) {
-        this.getAttributeMenuItem(item).click({force:true})
-    },
-    renameColumnName(newName) {
-        cy.get("[data-testid=column-name-input").type(newName)
-    },
-    // Edit Attribute Property Dialog
-    enterAttributeName(name) {
-        cy.get("[data-testid=attr-name-input]").type(name)
-    },
-    enterAttributeDescription(text) {
-        cy.get("[data-testid=attr-description-input]").type(text)
-    },
-    selectAttributeType(type) {
-        cy.get("[data-testid=attr-type-select]").select(type)
-    },
-    enterAttributeUnit(unit) {
-        cy.get("[data-testid=attr-unit-input]").type(unit)
-    },
-    selectAttributePrecision(number) {
-        cy.get("[data-testid=attr-precision-select]").select(number)
-    },
-    selectAttributeEditableState(state) {
-        cy.get("[data-testid=attr-editable-radio] span").contains(state).click()
-    },
-    getApplyButton() {
-        return cy.get("[data-testid=Apply-button]")
-    },
-    editAttributeProperty(attr, name, description, type, unit, precision, editable) {
-        this.openAttributeMenu(attr)
-        this.selectMenuItemFromAttributeMenu("Edit Attribute Properties...")
-        if (name!=="") {
-            this.enterAttributeName(`{selectAll}{backspace}${name}`)
-        }
-        if (description!=null) {
-            this.enterAttributeDescription(`{selectAll}{backspace}${description}`)
-        }
-        if (type!=null) {
-            this.selectAttributeType(type)
-        }
-        if (unit!=null) {
-            this.enterAttributeUnit(`{selectAll}{backspace}${unit}`)
-        }
-        if (precision!=null) {
-            this.selectAttributePrecision(precision)
-        }
-        if (editable!=null) {
-            this.selectAttributeEditableState(editable)
-        }
-        this.getApplyButton().click()
+import { ComponentElements as c } from "./component-elements"
 
-    },
-    getCell(line, row) {
-        return cy.get(`[data-testid=case-table] [aria-rowindex="${row}"] [aria-colindex="${line}"] .cell-span`)
-    },
-    verifyRowSelected(row) {
-        cy.get(`[data-testid=case-table] [aria-rowindex="${row}"]`).invoke("attr", "aria-selected")
-        .should("contain", true)
-    },
-    verifyRowSelectedWithCellValue(cell) {
-        cy.get(`[data-testid=case-table] [aria-selected=true]`).should("contain", cell)
-    },
-    openInspectorPanel() {
-      this.getTableTile().click()
-    },
-    showAllAttributes() {
-      cy.get("[data-testid=hide-show-button]").click()
-      cy.get("[data-testid=hide-show-menu-list").find("button").contains("Show Hidden Attribute").click()
+export const TableTileElements = {
+  getTableTile(index = 0) {
+    return c.getComponentTile("table", index)
+  },
+  getCaseTableGrid() {
+    return cy.get("[data-testid=case-table] [role=grid]")
+  },
+  getNumOfAttributes() {
+    return cy.get("[data-testid=case-table] [role=grid]").invoke("attr", "aria-colcount")
+  },
+  getNumOfCases() {
+    return cy.get("[data-testid=case-table] [role=grid]").invoke("attr", "aria-rowcount")
+  },
+  getCollectionTitle() {
+    return this.getTableTile().find("[data-testid=editable-component-title]")
+  },
+  getColumnHeaders() {
+    return cy.get("[data-testid=case-table] [role=columnheader]")
+  },
+  getColumnHeader(index) {
+    return cy.get(".codap-column-header-content").eq(index)
+  },
+  getColumnHeaderTooltip() {
+    return cy.get("[data-testid=case-table-attribute-tooltip]")
+  },
+  openIndexMenuForRow(rowNum) {
+    cy.get(`[data-testid=case-table] [role=grid] [role=row][aria-rowindex="${rowNum}"]
+            [data-testid=codap-index-content-button]`).click()
+  },
+  getIndexMenu() {
+    return cy.get("[data-testid=index-menu-list]")
+  },
+  insertCase() {
+    this.getIndexMenu().should("be.visible")
+    cy.clickMenuItem("Insert Case")
+    cy.wait(500)
+  },
+  insertCases(num_of_cases, location) {
+    this.getIndexMenu().should("be.visible")
+    cy.clickMenuItem("Insert Cases...")
+    cy.get("[data-testid=num-case-input] input").type(num_of_cases)
+    cy.get(`[data-testid="add-${location}"]`).click()
+    cy.get("[data-testid=\"Insert Cases-button\"]").contains("Insert Cases").click()
+  },
+  deleteCase() {
+    this.getIndexMenu().should("be.visible")
+    cy.clickMenuItem("Delete Case")
+    cy.wait(500)
+  },
+  getInsertCasesModalHeader() {
+    return cy.get("[data-testid=codap-modal-header]")
+  },
+  closeInsertCasesModal() {
+    cy.get("[data-testid=modal-close-button]").click()
+  },
+  cancelInsertCasesModal() {
+    cy.get("[data-testid=Cancel-button]").click()
+  },
+  getAttributeHeader() {
+    return cy.get("[data-testid^=codap-attribute-button]")
+  },
+  getAttribute(name) {
+    return cy.get(`[data-testid^="codap-attribute-button ${name}"]`)
+  },
+  openAttributeMenu(name) {
+    this.getAttribute(name).click()
+  },
+  getAttributeMenuItem(item) {
+    return cy.get("[data-testid=attribute-menu-list] button").contains(item)
+  },
+  selectMenuItemFromAttributeMenu(item) {
+    this.getAttributeMenuItem(item).click({ force: true })
+  },
+  renameColumnName(newName) {
+    cy.get("[data-testid=column-name-input").type(newName)
+  },
+  // Edit Attribute Property Dialog
+  enterAttributeName(name) {
+    cy.get("[data-testid=attr-name-input]").type(name)
+  },
+  enterAttributeDescription(text) {
+    cy.get("[data-testid=attr-description-input]").type(text)
+  },
+  selectAttributeType(type) {
+    cy.get("[data-testid=attr-type-select]").select(type)
+  },
+  enterAttributeUnit(unit) {
+    cy.get("[data-testid=attr-unit-input]").type(unit)
+  },
+  selectAttributePrecision(number) {
+    cy.get("[data-testid=attr-precision-select]").select(number)
+  },
+  selectAttributeEditableState(state) {
+    cy.get("[data-testid=attr-editable-radio] span").contains(state).click()
+  },
+  getApplyButton() {
+    return cy.get("[data-testid=Apply-button]")
+  },
+  editAttributeProperty(attr, name, description, type, unit, precision, editable) {
+    this.openAttributeMenu(attr)
+    this.selectMenuItemFromAttributeMenu("Edit Attribute Properties...")
+    if (name !== "") {
+      this.enterAttributeName(`{selectAll}{backspace}${name}`)
     }
+    if (description != null) {
+      this.enterAttributeDescription(`{selectAll}{backspace}${description}`)
+    }
+    if (type != null) {
+      this.selectAttributeType(type)
+    }
+    if (unit != null) {
+      this.enterAttributeUnit(`{selectAll}{backspace}${unit}`)
+    }
+    if (precision != null) {
+      this.selectAttributePrecision(precision)
+    }
+    if (editable != null) {
+      this.selectAttributeEditableState(editable)
+    }
+    this.getApplyButton().click()
+
+  },
+  getCell(line, row) {
+    return cy.get(`[data-testid=case-table] [aria-rowindex="${row}"] [aria-colindex="${line}"] .cell-span`)
+  },
+  verifyRowSelected(row) {
+    cy.get(`[data-testid=case-table] [aria-rowindex="${row}"]`).invoke("attr", "aria-selected")
+      .should("contain", true)
+  },
+  verifyRowSelectedWithCellValue(cell) {
+    cy.get(`[data-testid=case-table] [aria-selected=true]`).should("contain", cell)
+  },
+  showAllAttributes() {
+    cy.get("[data-testid=hide-show-button]").click()
+    cy.get("[data-testid=hide-show-menu-list]").find("button").contains("Show Hidden Attribute").click()
+  },
+  createNewTableFromToolshelf() {
+    c.createFromToolshelf("table")
+    cy.get("[data-testid=toolshelf-table-new]").click()
+  },
+  createNewClipboardTableFromToolshelf() {
+    c.createFromToolshelf("table")
+    cy.get("[data-testid=toolshelf-table-new-clipboard]").click()
+  },
+  openExistingTableFromToolshelf(name) {
+    c.createFromToolshelf("table")
+    cy.get(`[data-testid=toolshelf-table-${name}]`).click()
+  },
+  getToggleCardView() {
+    return cy.get("[data-testid=case-table-toggle-view]")
+  },
+  getDatasetInfoButton() {
+    return c.getInspectorPanel().find("[data-testid=dataset-info-button]")
+  },
+  getResizeButton() {
+    return c.getInspectorPanel().find("[data-testid=resize-table-button]")
+  },
+  getDeleteCasesButton() {
+    return c.getInspectorPanel().find("[data-testid=delete-cases-button]")
+  },
+  getHideShowButton() {
+    return c.getInspectorPanel().find("[data-testid=hide-show-button]")
+  },
+  getAttributesButton() {
+    return c.getInspectorPanel().find("[data-testid=table-attributes-button]")
+  }
 }

--- a/v3/cypress/support/helpers/axis-helper.ts
+++ b/v3/cypress/support/helpers/axis-helper.ts
@@ -1,100 +1,100 @@
 import { AxisElements as ae } from "../elements/axis-elements"
 
 export const AxisHelper = {
-    verifyDefaultAxisLabel(axis) {
-        ae.getDefaultAxisLabel(axis).should("have.text", "Click here, or drag an attribute here.")
-    },
-    verifyAxisLabel(axis, name) {
-        ae.getAxisLabel(axis).should("have.text", name)
-    },
-    verifyTickMarksDoNotExist(axis) {
-        cy.log(`Check no tick marks for axis ${axis}`)
-        ae.getTickMarks(axis).should("not.exist")
-    },
-    verifyGridLinesDoNotExist(axis) {
-        cy.log(`Check no grid lines for axis ${axis}`)
-        ae.getTickMarks(axis).should("not.exist")
-    },
-    verifyXAxisTickMarksNotDisplayed() {
-        cy.log(`Check tick marks not displayed for x axis`)
-        ae.getTickLength("x", "y2").then($length => {
-            expect($length).to.be.lessThan(0)
-        })
-    },
-    verifyXAxisTickMarksDisplayed() {
-        cy.log(`Check tick marks displayed for x axis`)
-        ae.getTickLength("x", "y2").then($length => {
-            expect($length).to.be.greaterThan(0)
-        })
-    },
-    verifyYAxisTickMarksNotDisplayed() {
-        cy.log(`Check tick marks not displayed for y axis`)
-        ae.getTickLength("y", "x2").then($length => {
-            expect($length).to.be.greaterThan(0)
-        })
-    },
-    verifyYAxisTickMarksDisplayed() {
-        cy.log(`Check tick marks displayed for y axis`)
-        ae.getTickLength("y", "x2").then($length => {
-            expect($length).to.be.lessThan(0)
-        })
-    },
-    verifyXAxisGridLinesNotDisplayed() {
-        cy.log(`Check grid lines not displayed for x axis`)
-        ae.getTickLength("x", "y2").then($length => {
-            expect($length).to.be.greaterThan(0)
-        })
-    },
-    verifyXAxisGridLinesDisplayed() {
-        cy.log(`Check grid lines displayed for x axis`)
-        ae.getTickLength("x", "y2").then($length => {
-            expect($length).to.be.lessThan(0)
-        })
-    },
-    verifyYAxisGridLinesNotDisplayed() {
-        cy.log(`Check grid lines not displayed for y axis`)
-        ae.getTickLength("y", "x2").then($length => {
-            expect($length).to.be.lessThan(0)
-        })
-    },
-    verifyYAxisGridLinesDisplayed() {
-        cy.log(`Check grid lines displayed for y axis`)
-        ae.getTickLength("y", "x2").then($length => {
-            expect($length).to.be.greaterThan(0)
-        })
-    },
-    verifyAxisTickLabels(axis, attributeValues) {
-        ae.getAxisTickLabels(axis).should('have.length', attributeValues.length)
-        for (let index = 0; index < attributeValues; index++) {
-            this.verifyAxisTickLabel(axis, attributeValues[index], index)
-        }
-    },
-    verifyAxisTickLabel(axis, attributeValue, index) {
-        ae.getAxisTickLabel(axis, index).invoke("text").should("eq", attributeValue)
-    },
-    verifyRemoveAttributeDoesNotExist(axis) {
-        ae.getAttributeFromAttributeMenu(axis).contains(`Remove`).should("not.exist")
-    },
-    verifyTreatAsOptionDoesNotExist(axis) {
-        ae.getAttributeFromAttributeMenu(axis).contains(`Treat as`).should("not.exist")
-    },
-    verifyAxisMenuIsClosed(axis) {
-        ae.getAttributeFromAttributeMenu(axis).find("div>div").should("not.be.visible")
-    },
-    openAxisAttributeMenu(axis) {
-        ae.getAxisAttributeMenu(axis).click()
-    },
-    addAttributeToAxis(name, axis) {
-        ae.getAttributeFromAttributeMenu(axis).contains(name).click()
-        cy.wait(2000)
-    },
-    removeAttributeFromAxis(name, axis) {
-        ae.getAttributeFromAttributeMenu(axis).contains(`Remove`).click()
-    },
-    treatAttributeAsCategorical(axis) {
-        ae.getAttributeFromAttributeMenu(axis).contains("Treat as Categorical").click()
-    },
-    treatAttributeAsNumeric(axis) {
-        ae.getAttributeFromAttributeMenu(axis).contains("Treat as Numeric").click()
+  verifyDefaultAxisLabel(axis) {
+    ae.getDefaultAxisLabel(axis).should("have.text", "Click here, or drag an attribute here.")
+  },
+  verifyAxisLabel(axis, name) {
+    ae.getAxisLabel(axis).should("have.text", name)
+  },
+  verifyTickMarksDoNotExist(axis) {
+    cy.log(`Check no tick marks for axis ${axis}`)
+    ae.getTickMarks(axis).should("not.exist")
+  },
+  verifyGridLinesDoNotExist(axis) {
+    cy.log(`Check no grid lines for axis ${axis}`)
+    ae.getTickMarks(axis).should("not.exist")
+  },
+  verifyXAxisTickMarksNotDisplayed() {
+    cy.log(`Check tick marks not displayed for x axis`)
+    ae.getTickLength("x", "y2").then($length => {
+      expect($length).to.be.lessThan(0)
+    })
+  },
+  verifyXAxisTickMarksDisplayed() {
+    cy.log(`Check tick marks displayed for x axis`)
+    ae.getTickLength("x", "y2").then($length => {
+      expect($length).to.be.greaterThan(0)
+    })
+  },
+  verifyYAxisTickMarksNotDisplayed() {
+    cy.log(`Check tick marks not displayed for y axis`)
+    ae.getTickLength("y", "x2").then($length => {
+      expect($length).to.be.greaterThan(0)
+    })
+  },
+  verifyYAxisTickMarksDisplayed() {
+    cy.log(`Check tick marks displayed for y axis`)
+    ae.getTickLength("y", "x2").then($length => {
+      expect($length).to.be.lessThan(0)
+    })
+  },
+  verifyXAxisGridLinesNotDisplayed() {
+    cy.log(`Check grid lines not displayed for x axis`)
+    ae.getTickLength("x", "y2").then($length => {
+      expect($length).to.be.greaterThan(0)
+    })
+  },
+  verifyXAxisGridLinesDisplayed() {
+    cy.log(`Check grid lines displayed for x axis`)
+    ae.getTickLength("x", "y2").then($length => {
+      expect($length).to.be.lessThan(0)
+    })
+  },
+  verifyYAxisGridLinesNotDisplayed() {
+    cy.log(`Check grid lines not displayed for y axis`)
+    ae.getTickLength("y", "x2").then($length => {
+      expect($length).to.be.lessThan(0)
+    })
+  },
+  verifyYAxisGridLinesDisplayed() {
+    cy.log(`Check grid lines displayed for y axis`)
+    ae.getTickLength("y", "x2").then($length => {
+      expect($length).to.be.greaterThan(0)
+    })
+  },
+  verifyAxisTickLabels(axis, attributeValues) {
+    ae.getAxisTickLabels(axis).should('have.length', attributeValues.length)
+    for (let index = 0; index < attributeValues; index++) {
+      this.verifyAxisTickLabel(axis, attributeValues[index], index)
     }
+  },
+  verifyAxisTickLabel(axis, attributeValue, index) {
+    ae.getAxisTickLabel(axis, index).invoke("text").should("eq", attributeValue)
+  },
+  verifyRemoveAttributeDoesNotExist(axis) {
+    ae.getAttributeFromAttributeMenu(axis).contains(`Remove`).should("not.exist")
+  },
+  verifyTreatAsOptionDoesNotExist(axis) {
+    ae.getAttributeFromAttributeMenu(axis).contains(`Treat as`).should("not.exist")
+  },
+  verifyAxisMenuIsClosed(axis) {
+    ae.getAttributeFromAttributeMenu(axis).find("div>div").should("not.be.visible")
+  },
+  openAxisAttributeMenu(axis) {
+    ae.getAxisAttributeMenu(axis).click()
+  },
+  addAttributeToAxis(name, axis) {
+    ae.getAttributeFromAttributeMenu(axis).contains(name).click()
+    cy.wait(2000)
+  },
+  removeAttributeFromAxis(name, axis) {
+    ae.getAttributeFromAttributeMenu(axis).contains(`Remove`).click()
+  },
+  treatAttributeAsCategorical(axis) {
+    ae.getAttributeFromAttributeMenu(axis).contains("Treat as Categorical").click()
+  },
+  treatAttributeAsNumeric(axis) {
+    ae.getAttributeFromAttributeMenu(axis).contains("Treat as Numeric").click()
+  }
 }

--- a/v3/cypress/support/helpers/legend-helper.ts
+++ b/v3/cypress/support/helpers/legend-helper.ts
@@ -1,72 +1,72 @@
 import { LegendElements as le } from "../elements/legend-elements"
 
 export const LegendHelper = {
-    verifyLegendDoesNotExist() {
-        le.getLegend().should("not.exist")
-    },
-    verifyLegendLabel(name) {
-        le.getLegendName().should("have.text", name)
-    },
-    verifyCategoricalLegend() {
-        le.getCategoricalLegendCategories().should("exist")
-    },
-    verifyNumericLegend() {
-        le.getNumericalLegendCategories().should("exist")
-    },
-    selectCategoryNameForCategoricalLegend(name) {
-        le.getCategoricalLegendCategory(name).click()
-    },
-    selectCategoryColorForCategoricalLegend(name) {
-        le.getCategoricalLegendCategory(name).parent().find("rect").click()
-    },
-    unselectCategoricalLegendCategory() {
-        le.getGraphTile().find(".graph-background").eq(0).then($subject => {
-            cy.clickToUnselect($subject, { delay: 100 })
-        })
-    },
-    verifyLegendCategorySelected(name) {
-        le.getCategoricalLegendCategory(name).parent().find("rect").should("have.class", "legend-rect-selected")
-    },
-    verifyNoLegendCategorySelectedForCategoricalLegend() {
-        le.getCategoricalLegendCategories().each($category => {
-            cy.wrap($category).find("rect").should("not.have.class", "legend-rect-selected")
-        })
-    },
-    verifyNoLegendCategorySelectedForNumericLegend() {
-        le.getNumericalLegendCategories().then($categories => {
-            $categories.forEach($category => {
-                cy.wrap($category).should("not.have.class", "legend-rect-selected")
-            })
-        })
-    },
-    selectNumericalLegendCategory(index) {
-        le.getNumericalLegendCategories().eq(index).click()
-    },
-    unselectNumericalLegendCategory() {
-        le.getGraphTile().find(".graph-dot-area").click()
-    },
-    verifyLegendQuintileSelected(index) {
-        le.getNumericalLegendCategories().eq(index).should("have.class", "legend-rect-selected")
-    },
-    dragAttributeToPlot(name) {
-        cy.dragAttributeToTarget("table", name, "graph_plot")
-    },
-    dragAttributeToLegend(name) {
-        cy.dragAttributeToTarget("table", name, "legend")
-    },
-    openLegendMenu() {
-        le.getLegendAttributeMenu().click()
-    },
-    addAttributeToLegeend(name) {
-        le.getAttributeFromLegendMenu().contains(name).click()
-    },
-    removeAttributeFromLegend(name) {
-        le.getAttributeFromLegendMenu().contains(`Remove Legend: ${name}`).click()
-    },
-    treatLegendAttributeAsCategorical() {
-        le.getAttributeFromLegendMenu().contains("Treat as Categorical").click()
-    },
-    treatAttributeAsNumeric() {
-        le.getAttributeFromLegendMenu().contains("Treat as Numeric").click()
-    }
+  verifyLegendDoesNotExist() {
+    le.getLegend().should("not.exist")
+  },
+  verifyLegendLabel(name) {
+    le.getLegendName().should("have.text", name)
+  },
+  verifyCategoricalLegend() {
+    le.getCategoricalLegendCategories().should("exist")
+  },
+  verifyNumericLegend() {
+    le.getNumericalLegendCategories().should("exist")
+  },
+  selectCategoryNameForCategoricalLegend(name) {
+    le.getCategoricalLegendCategory(name).click()
+  },
+  selectCategoryColorForCategoricalLegend(name) {
+    le.getCategoricalLegendCategory(name).parent().find("rect").click()
+  },
+  unselectCategoricalLegendCategory() {
+    le.getGraphTile().find(".graph-background").eq(0).then($subject => {
+      cy.clickToUnselect($subject, { delay: 100 })
+    })
+  },
+  verifyLegendCategorySelected(name) {
+    le.getCategoricalLegendCategory(name).parent().find("rect").should("have.class", "legend-rect-selected")
+  },
+  verifyNoLegendCategorySelectedForCategoricalLegend() {
+    le.getCategoricalLegendCategories().each($category => {
+      cy.wrap($category).find("rect").should("not.have.class", "legend-rect-selected")
+    })
+  },
+  verifyNoLegendCategorySelectedForNumericLegend() {
+    le.getNumericalLegendCategories().then($categories => {
+      $categories.forEach($category => {
+        cy.wrap($category).should("not.have.class", "legend-rect-selected")
+      })
+    })
+  },
+  selectNumericalLegendCategory(index) {
+    le.getNumericalLegendCategories().eq(index).click()
+  },
+  unselectNumericalLegendCategory() {
+    le.getGraphTile().find(".graph-dot-area").click()
+  },
+  verifyLegendQuintileSelected(index) {
+    le.getNumericalLegendCategories().eq(index).should("have.class", "legend-rect-selected")
+  },
+  dragAttributeToPlot(name) {
+    cy.dragAttributeToTarget("table", name, "graph_plot")
+  },
+  dragAttributeToLegend(name) {
+    cy.dragAttributeToTarget("table", name, "legend")
+  },
+  openLegendMenu() {
+    le.getLegendAttributeMenu().click()
+  },
+  addAttributeToLegeend(name) {
+    le.getAttributeFromLegendMenu().contains(name).click()
+  },
+  removeAttributeFromLegend(name) {
+    le.getAttributeFromLegendMenu().contains(`Remove Legend: ${name}`).click()
+  },
+  treatLegendAttributeAsCategorical() {
+    le.getAttributeFromLegendMenu().contains("Treat as Categorical").click()
+  },
+  treatAttributeAsNumeric() {
+    le.getAttributeFromLegendMenu().contains("Treat as Numeric").click()
+  }
 }

--- a/v3/src/components/calculator/calculator.tsx
+++ b/v3/src/components/calculator/calculator.tsx
@@ -71,7 +71,8 @@ export const CalculatorComponent = ({ tile }: ITileBaseProps) => {
   calcButtonsArr.forEach((button:Record<string, any>) => {
     for (const key in button) {
       calcButtons.push(
-        <Button key={key} className="calc-button" onClick={button[key]}>
+        <Button key={key} className="calc-button" onClick={button[key]}
+        data-testid="calc-button">
          {key}
         </Button>
       )
@@ -80,10 +81,13 @@ export const CalculatorComponent = ({ tile }: ITileBaseProps) => {
   return (
     <Flex className="calculator-wrapper">
       <Flex className="calculator" data-testid="codap-calculator">
-        <Text className="calc-input">{calcValue}</Text>
+        <Text className="calc-input" data-testid="calc-input">{calcValue}</Text>
         <Flex className="calc-buttons">
             {calcButtons}
-            <Button className="calc-button wide" onClick={handleEvaluateButtonPress}>=</Button>
+            <Button className="calc-button wide" onClick={handleEvaluateButtonPress} 
+            data-testid="calc-button">
+              =
+            </Button>
         </Flex>
       </Flex>
     </Flex>

--- a/v3/src/components/case-table/case-table-title-bar.tsx
+++ b/v3/src/components/case-table/case-table-title-bar.tsx
@@ -49,7 +49,8 @@ export const CaseTableTitleBar = observer(function CaseTableTitleBar({tile, onCl
         onHandleTitleChange={handleChangeTitle}>
       <div className="header-left"
             title={cardTableToggleString}
-            onClick={handleShowCardTableToggleMessage}>
+            onClick={handleShowCardTableToggleMessage}
+            data-testid={"case-table-toggle-view"}>
         {showCaseCard
           ? <TableIcon className="table-icon" />
           : <CardIcon className="card-icon"/>

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -91,15 +91,20 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
           const tileTitle = caseMetadata?.title ? caseMetadata?.title
                                                 : tableTile?.title ? tableTile?.title : dataset.dataSet.name
           return (
-            <MenuItem key={`${dataset.dataSet.id}`} onClick={()=>handleOpenDataSetTable(dataset)}>
+            <MenuItem key={`${dataset.dataSet.id}`} onClick={()=>handleOpenDataSetTable(dataset)}
+              data-testid={`toolshelf-table-${tileTitle}`}>
               {tileTitle}
-              <TrashIcon className="tool-shelf-menu-trash-icon"
+              <TrashIcon className="toolshelf-menu-trash-icon"
                   onClick={() => handleOpenRemoveDataSetModal(dataset.dataSet.id)} />
             </MenuItem>
           )
         })}
-        <MenuItem>{t("DG.AppController.caseTableMenu.clipboardDataset")}</MenuItem>
-        <MenuItem onClick={handleCreateNewDataSet}>{t("DG.AppController.caseTableMenu.newDataSet")}</MenuItem>
+        <MenuItem data-testid="toolshelf-table-new-clipboard">
+          {t("DG.AppController.caseTableMenu.clipboardDataset")}
+        </MenuItem>
+        <MenuItem onClick={handleCreateNewDataSet} data-testid="toolshelf-table-new">
+          {t("DG.AppController.caseTableMenu.newDataSet")}
+        </MenuItem>
       </MenuList>
       {modalOpen &&
         <DeleteDataSetModal dataSetId={dataSetIdToDeleteId} isOpen={isOpen} onClose={onClose}

--- a/v3/src/components/component-title-bar.tsx
+++ b/v3/src/components/component-title-bar.tsx
@@ -43,10 +43,11 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(
       </Editable>
       <Flex className="header-right">
         <Button className="component-minimize-button">
-          <MinimizeIcon className="component-minimize-icon" title={t("DG.Component.minimizeComponent.toolTip")}/>
+          <MinimizeIcon className="component-minimize-icon" title={t("DG.Component.minimizeComponent.toolTip")}
+          data-testid="component-minimize-icon"/>
         </Button>
         <CloseButton className="component-close-button" title={t("DG.Component.closeComponent.toolTip")}
-          onPointerDown={()=>onCloseTile?.(tileId)}/>
+          onPointerDown={()=>onCloseTile?.(tileId)} data-testid="component-close-button"/>
       </Flex>
     </Flex>
   )

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -46,7 +46,8 @@ export const EditableSliderValue = observer(function EditableSliderValue({ slide
   return (
     <NumberInput value={candidate} className="value-input"
         onChange={handleValueChange} data-testid="slider-variable-value">
-      <NumberInputField className="value-text-input text-input" maxLength={15}
+      <NumberInputField className="value-text-input text-input" 
+        data-testid="slider-variable-value-text-input" maxLength={15}
         onKeyDown={handleKeyDown} onBlur={handleSubmitValue} />
     </NumberInput>
   )

--- a/v3/src/components/slider/inspector-panel/slider-settings-panel.tsx
+++ b/v3/src/components/slider/inspector-panel/slider-settings-panel.tsx
@@ -46,7 +46,7 @@ export const SliderSettingsPalette =
           <Flex className="palette-row">
             <FormLabel className="form-label">{t("DG.Slider.multiples")}
               <NumberInput className="slider-input multiples" size="xs" defaultValue={sliderModel.multipleOf}
-                  step={0.5} onChange={handleMultiplesOfChange}>
+                  step={0.5} onChange={handleMultiplesOfChange} data-testid="slider-restrict-multiples">
                 <NumberInputField />
                 <NumberInputStepper>
                   <NumberIncrementStepper />
@@ -60,7 +60,8 @@ export const SliderSettingsPalette =
           <Flex className="palette-row">
             <FormLabel className="form-label">{t("DG.Slider.maxPerSecond")}
               <NumberInput className="slider-input animation-rate" size="xs"
-                  step={0.1} defaultValue={sliderModel._animationRate} onChange={handleAnimationRateChange}>
+                  step={0.1} defaultValue={sliderModel._animationRate} 
+                  onChange={handleAnimationRateChange} data-testid="slider-animation-rate">
                 <NumberInputField />
                   <NumberInputStepper>
                     <NumberIncrementStepper />
@@ -74,7 +75,8 @@ export const SliderSettingsPalette =
           <Flex className="palette-row">
             <FormLabel className="form-label">{t("DG.Slider.direction")}
               <Select className="slider-select direction" value={sliderModel.animationDirection}
-                      onChange={e => sliderModel.setAnimationDirection(e.target.value as AnimationDirection)}>
+                      onChange={e => sliderModel.setAnimationDirection(e.target.value as AnimationDirection)}
+                      data-testid="slider-animation-direction">
                 {AnimationDirections.map(direction => (
                   <option key={direction} value={direction}>{t(`DG.Slider.${direction}`)}</option>
                 ))}
@@ -86,7 +88,8 @@ export const SliderSettingsPalette =
           <Flex className="palette-row">
             <FormLabel className="form-label">{t("DG.Slider.mode")}
               <Select className="slider-select mode" value={sliderModel.animationMode}
-                      onChange={e => sliderModel.setAnimationMode(e.target.value as AnimationMode)}>
+                      onChange={e => sliderModel.setAnimationMode(e.target.value as AnimationMode)}
+                      data-testid="slider-animation-repetition">
                 {AnimationModes.map(mode => (
                   <option key={mode} value={mode}>{t(`DG.Slider.${mode}`)}</option>
                 ))}

--- a/v3/src/components/slider/slider-component.tsx
+++ b/v3/src/components/slider/slider-component.tsx
@@ -58,14 +58,15 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
       <AxisLayoutContext.Provider value={layout}>
         <div className={kSliderClass} ref={sliderRef}>
           <Flex className="slider-control">
-            <Button className={`play-pause ${ running ? "running" : "paused"}`} onClick={toggleRunning}>
+            <Button className={`play-pause ${ running ? "running" : "paused"}`} onClick={toggleRunning} 
+              data-testid="slider-play-pause">
               { running ? <PauseIcon /> : <PlayIcon /> }
             </Button>
             <Flex className="slider-inputs">
               <Editable value={sliderModel.name} className="name-input" submitOnBlur={true}
                   onChange={handleSliderNameInput} data-testid="slider-variable-name">
-                <EditablePreview className="name-text"/>
-                <EditableInput className="name-text-input text-input"/>
+                <EditablePreview className="name-text" data-testid="slider-variable-name-text"/>
+                <EditableInput className="name-text-input text-input" data-testid="slider-variable-name-text-input"/>
               </Editable>
               <span className="equals-sign">&nbsp;=&nbsp;</span>
               <EditableSliderValue sliderModel={sliderModel} multiScale={multiScale} />
@@ -77,7 +78,7 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
             />
             <div className="slider-axis-wrapper" style={axisStyle}>
               <div className="axis-end min" />
-              <svg className="slider-axis">
+              <svg className="slider-axis" data-testid="slider-axis">
                 <Axis
                   getAxisModel={() => sliderModel.axis}
                   enableAnimation={animationRef}

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -80,6 +80,7 @@ export const CodapSliderThumb = observer(function CodapSliderThumb({sliderContai
       className={clsx("slider-thumb-icon", { dragging: isDragging })}
       onPointerDown={handlePointerDown}
       style={thumbStyle}
+      data-testid="slider-thumb-icon"
     />
   )
 })


### PR DESCRIPTION
This PR has the following changes:
1. Adding component level tests like closing, opening, changing title, checking tooltips, etc
2. Adding tests for Calculator and Slider tiles
3. Adding component level tests for Graph and Case table tiles
4. Adding `data-testids` for some elements used by the tests
5. Formatting cypress files so they use 2-space indentation used everywhere else in the project instead of 4-space indentation