### PR TITLE
V3: Adds width styling to collection table

### DIFF
--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -29,7 +29,8 @@ context("case table ui", () => {
       c.getComponentTitle("table").should("contain", collectionName)
     })
     it("verify columns and tooltips", () => {
-      table.getColumnHeaders().should("have.length", 9)
+      // css width specification caused grid virtualization to only have 9 attributes in the DOM
+      table.getColumnHeaders().should("be.within", 9, 10)
       table.getColumnHeader(0).invoke("text").then(columnName => {
         const columnNameArr = columnName.split()
         table.getColumnHeader(0).rightclick({ force: true })

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -30,7 +30,7 @@ context("case table ui", () => {
     })
     it("verify columns and tooltips", () => {
       // css width specification caused grid virtualization to only have 9 attributes in the DOM
-      table.getColumnHeaders().should("be.within", 9, 10)
+      table.getColumnHeaders().should("have.length.be.within", 9, 10)
       table.getColumnHeader(0).invoke("text").then(columnName => {
         const columnNameArr = columnName.split()
         table.getColumnHeader(0).rightclick({ force: true })

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -26,7 +26,7 @@ context("case table ui", () => {
           table.getCollectionTitle().should("contain", collectionName)
         })
         it("verify columns and tooltips", () => {
-            table.getColumnHeaders().should("have.length", 10)
+            table.getColumnHeaders().should("have.length", 9)
             table.getColumnHeader(0).invoke("text").then(columnName => {
                 const columnNameArr = columnName.split()
                 table.getColumnHeader(0).rightclick({force:true})

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -25,7 +25,7 @@ export const TableTileElements = {
     },
     openIndexMenuForRow(rowNum) {
         cy.get(`[data-testid=case-table] [role=grid] [role=row][aria-rowindex="${rowNum}"]
-            [data-testid=codap-index-content-button]`).click()
+            [data-testid=codap-index-content-button]`).click("top")
     },
     getIndexMenu() {
         return cy.get("[data-testid=index-menu-list]")

--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -18,10 +18,12 @@ $table-body-font-size: 8pt;
     .collection-table {
       display: flex;
       align-items: stretch;
+      width: 100%;
 
       .collection-table-and-title {
         display: flex;
         flex-direction: column;
+        width: 100%;
 
         .collection-title-wrapper {
           position: relative;

--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -116,7 +116,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer(pro
   const topButtonTooltip = t(topTooltipKey)
 
   return (
-    <div className="collection-table-spacer-wrapper">
+    <div className="collection-table-spacer">
       <div className="collection-table-spacer-divider" />
       <div className={classes} ref={handleRef}>
         <div className="spacer-top">

--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -116,7 +116,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer(pro
   const topButtonTooltip = t(topTooltipKey)
 
   return (
-    <>
+    <div className="collection-table-spacer-wrapper">
       <div className="collection-table-spacer-divider" />
       <div className={classes} ref={handleRef}>
         <div className="spacer-top">
@@ -151,7 +151,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer(pro
         <div className="drop-message" style={msgStyle}>{isOver ? dropMessage : ""}</div>
       </div>
       <div className="collection-table-spacer-divider" />
-    </>
+    </div>
   )
 })
 


### PR DESCRIPTION
In Firefox, width was coming up as 0 for `collection-table` and `collection-table-spacer`. This forces the collection table to have a width of `100%`. However this breaks the collection table in Chrome, so had to wrap the `collection-table-spacer` in a `div`.
With the added width styling, had to make a couple of minor changes to table cypress test.  