### PR TITLE
V3: Fixes table scroll bug on focus change

### DIFF
--- a/v3/src/components/case-table/case-table-model.ts
+++ b/v3/src/components/case-table/case-table-model.ts
@@ -11,6 +11,7 @@ export const CaseTableModel = TileContentModel
     type: types.optional(types.literal(kCaseTableTileType), kCaseTableTileType)
   })
   .volatile(self => ({
+    scrollLeft: 0,
     // map from collection IDs to scrollTops
     scrollTopMap: observable.map<string, number>(),
   }))
@@ -26,7 +27,12 @@ export const CaseTableModel = TileContentModel
     updateAfterSharedModelChanges(sharedModel?: ISharedModel) {
       // TODO
     },
-    setScrollTopMap(collectionId: string, scrollTop?: number) {
+    // entire hierarchical table scrolls as a unit horizontally
+    setScrollLeft(scrollLeft: number) {
+      self.scrollLeft = scrollLeft
+    },
+    // each sub-table scrolls independently vertically
+    setScrollTop(collectionId: string, scrollTop?: number) {
       if (scrollTop != null) {
         self.scrollTopMap.set(collectionId, scrollTop)
       } else {

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -43,7 +43,7 @@ export const CaseTable = observer(function CaseTable({ tile, setNodeRef }: IProp
               return (
                 <ParentCollectionContext.Provider key={key} value={parent}>
                   <CollectionContext.Provider key={key} value={collection}>
-                    <CollectionTable />
+                    <CollectionTable tile={tile}/>
                   </CollectionContext.Provider>
                 </ParentCollectionContext.Provider>
               )

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -1,12 +1,14 @@
 import { useDndContext } from "@dnd-kit/core"
 import { observer } from "mobx-react-lite"
-import React, { CSSProperties } from "react"
+import React, { CSSProperties, useEffect, useRef } from "react"
 import { AttributeDragOverlay } from "./attribute-drag-overlay"
 import { kChildMostTableCollectionId, kIndexColumnKey } from "./case-table-types"
 import { CollectionTable } from "./collection-table"
+import { useCaseTableModel } from "./use-case-table-model"
 import { CollectionContext, ParentCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useInstanceIdContext } from "../../hooks/use-instance-id-context"
+import { useTileModelContext } from "../../hooks/use-tile-model-context"
 import { ICollectionPropsModel } from "../../models/data/collection"
 import { ITileModel } from "../../models/tiles/tile-model"
 import { prf } from "../../utilities/profiler"
@@ -22,21 +24,46 @@ export const CaseTable = observer(function CaseTable({ tile, setNodeRef }: IProp
   const { active } = useDndContext()
   const instanceId = useInstanceIdContext() || "case-table"
   const data = useDataSetContext()
+  const tableModel = useCaseTableModel()
+  const { isTileSelected } = useTileModelContext()
+  const isFocused = isTileSelected()
+  const contentRef = useRef<HTMLDivElement | null>(null)
+
+  function setTableRef(elt: HTMLDivElement | null) {
+    contentRef.current = elt?.querySelector((".case-table-content")) ?? null
+    setNodeRef(elt)
+  }
+
+  useEffect(function syncScrollTop() {
+    // There is a bug, seemingly in React, in which the scrollLeft property gets reset
+    // to 0 when the order of tiles is changed (which happens on selecting/focusing tiles
+    // in the free tile layout), even though the CaseTable component is not re-rendered
+    // or unmounted/mounted. Therefore, we reset the scrollLeft property from our saved
+    // cache on focus change.
+    if (isFocused && contentRef.current) {
+      contentRef.current.scrollLeft = tableModel?.scrollLeft ?? 0
+    }
+  }, [isFocused, tableModel])
+
   return prf.measure("Table.render", () => {
     // disable the overlay for the index column
     const overlayDragId = active && `${active.id}`.startsWith(instanceId) && !(`${active.id}`.endsWith(kIndexColumnKey))
                             ? `${active.id}` : undefined
 
-    if (!data) return null
+    if (!tableModel || !data) return null
 
     const collections: ICollectionPropsModel[] = data.collections.map(collection => collection)
     // add the ungrouped "collection"
     collections.push(data.ungrouped)
 
+    const handleHorizontalScroll: React.UIEventHandler<HTMLDivElement> = () => {
+      tableModel?.setScrollLeft(contentRef.current?.scrollLeft ?? 0)
+    }
+
     return (
       <>
-        <div ref={setNodeRef} className="case-table" data-testid="case-table">
-          <div className="case-table-content">
+        <div ref={setTableRef} className="case-table" data-testid="case-table">
+          <div className="case-table-content" onScroll={handleHorizontalScroll}>
             {collections.map((collection, i) => {
               const key = collection?.id || kChildMostTableCollectionId
               const parent = i > 0 ? collections[i - 1] : undefined

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -43,7 +43,7 @@ export const CaseTable = observer(function CaseTable({ tile, setNodeRef }: IProp
               return (
                 <ParentCollectionContext.Provider key={key} value={parent}>
                   <CollectionContext.Provider key={key} value={collection}>
-                    <CollectionTable tile={tile}/>
+                    <CollectionTable />
                   </CollectionContext.Provider>
                 </ParentCollectionContext.Provider>
               )

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -9,27 +9,23 @@ import { useRows } from "./use-rows"
 import { useSelectedRows } from "./use-selected-rows"
 import { useCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { useTileModelContext } from "../../hooks/use-tile-model-context"
 import { IDataSet } from "../../models/data/data-set"
 import { useCaseTableModel } from "./use-case-table-model"
 import { CollectionTitle } from './collection-title'
-import { ITileModel } from "src/models/tiles/tile-model"
-import { uiState } from "../../models/ui-state"
 
 import styles from "./case-table-shared.scss"
 import "react-data-grid/lib/styles.css"
 
-interface IProps {
-  tile?: ITileModel
-}
-
-export const CollectionTable = observer(function CollectionTable({ tile }: IProps) {
+export const CollectionTable = observer(function CollectionTable() {
   const data = useDataSetContext()
   const collection = useCollectionContext()
   const tableModel = useCaseTableModel()
   const collectionId = collection?.id || kChildMostTableCollectionId
   const gridRef = useRef<DataGridHandle>(null)
   const { selectedRows, setSelectedRows, handleCellClick } = useSelectedRows({ gridRef })
-  const isFocused = uiState.isFocusedTile(tile?.id)
+  const { isTileSelected } = useTileModelContext()
+  const isFocused = isTileSelected()
 
   useEffect(()=>{
     if (isFocused && gridRef.current?.element) {


### PR DESCRIPTION
Removes duplicate ref on the data grid
Makes grid element scroll match the table scroll top because it was getting lost on grid re-render.