### PR TITLE
Invalid point positions for dot plots when brought in from out of bounds

### DIFF
--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -243,7 +243,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         },
         getSecondaryScreenCoord = (anID: string) => {
           if (!binMap[anID]) {
-            return NaN
+            return null // Not NaN because NaN causes errors during transitions
           }
           const secondaryCat = binMap[anID].category,
             extraSecondaryCat = binMap[anID].extraCategory,


### PR DESCRIPTION
[#185335006] Bug fix: Plot points appear in invalid places

* NaN was being returned as a screen coordinate when points were not to be plotted because the axis had been rescaled to no longer include them. But a transition (with duration zero!) was scheduled to move the point to a valid coordinate when the axis rescale allowed. The stored NaN caused an exception during the transition that prevented the point from reaching the desired coordinate.
**Conclusion**: Don't return `NaN` for screen coordinates. Use `null` instead.