### PR TITLE
Right axis drop hint fix

### DIFF
--- a/v3/src/hooks/use-drop-hint-string.ts
+++ b/v3/src/hooks/use-drop-hint-string.ts
@@ -58,7 +58,7 @@ export function determineBaseString(role: GraphAttrRole, dropType?: AttributeTyp
     rightNumeric: {
       numeric: {
         empty: "addAttribute",
-        existing: "addAttribute"
+        existing: "replaceAttribute"
       }
     },
     topSplit: {


### PR DESCRIPTION
[#184758581] Bug fix: Duplicate droppable areas shown in right y axis

* This bug was already fixed except that the drop hint was incorrect. We fix that.