### PR TITLE
Categorical axis refresh bug

### DIFF
--- a/v3/src/components/axis/components/axis.tsx
+++ b/v3/src/components/axis/components/axis.tsx
@@ -8,7 +8,7 @@ import {SubAxis} from "./sub-axis"
 import "./axis.scss"
 
 interface IProps {
-  getAxisModel: () => IAxisModel | undefined
+  axisModel: IAxisModel
   label?: string
   enableAnimation: MutableRefObject<boolean>
   showScatterPlotGridLines?: boolean
@@ -16,12 +16,11 @@ interface IProps {
 }
 
 export const Axis = ({
-                       label, getAxisModel, showScatterPlotGridLines = false,
+                       label, axisModel, showScatterPlotGridLines = false,
                        enableAnimation,
                        centerCategoryLabels = true,
                      }: IProps) => {
   const
-    axisModel = getAxisModel(),
     layout = useAxisLayoutContext(),
     place = axisModel?.place || 'bottom',
     [axisElt, setAxisElt] = useState<SVGGElement | null>(null)
@@ -36,7 +35,7 @@ export const Axis = ({
       return <SubAxis key={i}
                       numSubAxes={numRepetitions}
                       subAxisIndex={i}
-                      getAxisModel={getAxisModel}
+                      axisModel={axisModel}
                       enableAnimation={enableAnimation}
                       showScatterPlotGridLines={showScatterPlotGridLines}
                       centerCategoryLabels={centerCategoryLabels}

--- a/v3/src/components/axis/components/sub-axis.tsx
+++ b/v3/src/components/axis/components/sub-axis.tsx
@@ -1,4 +1,4 @@
-import React, {MutableRefObject, useRef, useState} from "react"
+import React, {memo, MutableRefObject, useRef, useState} from "react"
 import {useSubAxis} from "../hooks/use-sub-axis"
 import {IAxisModel, INumericAxisModel} from "../models/axis-model"
 import {NumericAxisDragRects} from "./numeric-axis-drag-rects"
@@ -8,20 +8,17 @@ import "./axis.scss"
 interface ISubAxisProps {
   numSubAxes: number
   subAxisIndex: number
-  getAxisModel: () => IAxisModel | undefined
+  axisModel: IAxisModel
   enableAnimation: MutableRefObject<boolean>
   showScatterPlotGridLines?: boolean
   centerCategoryLabels?: boolean
-  // getCategorySet?: () => ICategorySet | undefined  // only used for categorical axes
 }
 
-
-export const SubAxis = ({
-                          numSubAxes, subAxisIndex, getAxisModel, showScatterPlotGridLines = false,
+export const SubAxis = memo(function SubAxis({
+                          numSubAxes, subAxisIndex, axisModel, showScatterPlotGridLines = false,
                           centerCategoryLabels = true, enableAnimation/*, getCategorySet*/
-                        }: ISubAxisProps) => {
+                        }: ISubAxisProps) {
   const
-    axisModel = getAxisModel(),
     subWrapperElt = useRef<SVGGElement | null>(null),
     [subAxisElt, setSubAxisElt] = useState<SVGGElement | null>(null)
 
@@ -52,4 +49,4 @@ export const SubAxis = ({
           }
     </g>
   )
-}
+})

--- a/v3/src/components/axis/models/multi-scale.ts
+++ b/v3/src/components/axis/models/multi-scale.ts
@@ -1,4 +1,4 @@
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx"
+import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx"
 import {
   format, NumberValue, ScaleBand, scaleBand, scaleLinear, scaleLog, ScaleOrdinal, scaleOrdinal
 } from "d3"
@@ -134,12 +134,11 @@ export class MultiScale {
   }
 
   @action reactToCategorySetChange() {
-    return autorun(() => {
-      const categories = this.categorySetValues
-      if (categories?.length) {
-        this.setCategoricalDomain(categories)
-        this.incrementChangeCount()
-      }
+    return reaction(() => {
+      return Array.from(this.categorySetValues)
+    }, (categories) => {
+      this.setCategoricalDomain(categories)
+      this.incrementChangeCount()
     })
   }
 

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -30,6 +30,7 @@ export const GraphAxis = observer(function GraphAxis(
   const dataConfig = useDataConfigurationContext(),
     isDropAllowed = dataConfig?.graphPlaceCanAcceptAttributeIDDrop ?? (() => true),
     graphModel = useGraphModelContext(),
+    axisModel = graphModel?.getAxis(place),
     instanceId = useInstanceIdContext(),
     layout = useGraphLayoutContext(),
     droppableId = `${instanceId}-${place}-axis-drop`,
@@ -67,12 +68,13 @@ export const GraphAxis = observer(function GraphAxis(
 
   return (
     <g className='axis-wrapper' ref={elt => setWrapperElt(elt)}>
-      <Axis getAxisModel={() => graphModel.getAxis(place)}
-            label={''}  // Remove
-            enableAnimation={enableAnimation}
-            showScatterPlotGridLines={graphModel.axisShouldShowGridLines(place)}
-            centerCategoryLabels={graphModel.config.categoriesForAxisShouldBeCentered(place)}
-      />
+      {axisModel &&
+         <Axis axisModel={axisModel}
+             label={''}  // Remove
+             enableAnimation={enableAnimation}
+             showScatterPlotGridLines={graphModel.axisShouldShowGridLines(place)}
+             centerCategoryLabels={graphModel.config.categoriesForAxisShouldBeCentered(place)}
+      />}
       <AttributeLabel
         place={place}
         onChangeAttribute={onDropAttribute}

--- a/v3/src/components/slider/slider-component.tsx
+++ b/v3/src/components/slider/slider-component.tsx
@@ -80,7 +80,7 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
               <div className="axis-end min" />
               <svg className="slider-axis" data-testid="slider-axis">
                 <Axis
-                  getAxisModel={() => sliderModel.axis}
+                  axisModel={sliderModel.axis}
                   enableAnimation={animationRef}
                 />
               </svg>


### PR DESCRIPTION
[#185393868] Bug fix: Categorical axis failure to refresh

* Adjusting use-sub-axis to respond properly to category set changes
* Memoize SubAxis so that it only rerenders when it changes
* Define getAxisModel as a callback in GraphAxis so it won't trigger rerender of SubAxis every time
* In use-sub-axis install a useRef to be able detect when the category set reaction is specious