### PR TITLE
refactor: add CollectionTableModel

### DIFF
--- a/v3/cypress/support/commands.ts
+++ b/v3/cypress/support/commands.ts
@@ -13,9 +13,9 @@ Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target, num = 
     graphTile: ".graph-plot svg",
     legend: ".graph-plot .droppable-legend",
     x_axis: ".codap-graph .droppable-axis.droppable-svg.bottom",
-    x_axis_label: ".codap-graph .axis-legend-attribute-menu.bottom>button",
+    x_axis_label: ".codap-graph .axis-legend-attribute-menu.bottom .chakra-menu__menu-button",
     y_axis: ".codap-graph .droppable-axis.droppable-svg.left",
-    y_axis_label: ".codap-graph .axis-legend-attribute-menu.left>button",
+    y_axis_label: ".codap-graph .axis-legend-attribute-menu.left .chakra-menu__menu-button",
     mapTile: ".dg.leaflet-container",
     newCollection: ".dg-table-drop-target"
   }

--- a/v3/cypress/support/elements/axis-elements.ts
+++ b/v3/cypress/support/elements/axis-elements.ts
@@ -12,7 +12,7 @@ export const AxisElements = {
       case "y":
         return this.getGraphTile().find("[data-testid=axis-left]").parent()
       case "legend":
-        return this.getGraphTile().find(".axis-legend-attribute-menu.legend>button")
+        return this.getGraphTile().find(".axis-legend-attribute-menu.legend .chakra-menu__menu-button")
     }
   },
   getAxisLabel(axis) {
@@ -55,12 +55,12 @@ export const AxisElements = {
       case "X":
       case "x":
       default:
-        return this.getGraphTile().find(".axis-legend-attribute-menu.bottom>button")
+        return this.getGraphTile().find(".axis-legend-attribute-menu.bottom .chakra-menu__menu-button")
       case "Y":
       case "y":
-        return this.getGraphTile().find(".axis-legend-attribute-menu.left>button")
+        return this.getGraphTile().find(".axis-legend-attribute-menu.left .chakra-menu__menu-button")
       case "legend":
-        return this.getGraphTile().find(".axis-legend-attribute-menu.legend>button")
+        return this.getGraphTile().find(".axis-legend-attribute-menu.legend .chakra-menu__menu-button")
     }
   },
   getAttributeFromAttributeMenu(axis) {

--- a/v3/cypress/support/elements/legend-elements.ts
+++ b/v3/cypress/support/elements/legend-elements.ts
@@ -18,7 +18,7 @@ export const LegendElements = {
     return this.getLegend().find(".legend-categories>svg rect")
   },
   getLegendAttributeMenu() {
-    return this.getGraphTile().find(".axis-legend-attribute-menu.legend>button")
+    return this.getGraphTile().find(".axis-legend-attribute-menu.legend .chakra-menu__menu-button")
   },
   getAttributeFromLegendMenu() {
     return this.getLegendAttributeMenu().parent()

--- a/v3/src/components/case-table/case-table-model.ts
+++ b/v3/src/components/case-table/case-table-model.ts
@@ -29,6 +29,10 @@ export const CaseTableModel = TileContentModel
     updateAfterSharedModelChanges(sharedModel?: ISharedModel) {
       // TODO
     },
+    setScrollLeft(scrollLeft: number) {
+      self.scrollLeft = scrollLeft
+    },
+    // will create a new model if necessary
     getCollectionTableModel(collectionId: string) {
       let collectionTableModel = self.collectionTableModels.get(collectionId)
       if (!collectionTableModel) {
@@ -36,12 +40,28 @@ export const CaseTableModel = TileContentModel
         self.collectionTableModels.set(collectionId, collectionTableModel)
       }
       return collectionTableModel
+    }
+  }))
+  .actions(self => ({
+    // synchronize a given collection's scrollCount to the global syncScrollCount
+    syncCollectionScrollCount(collectionId: string) {
+      self.getCollectionTableModel(collectionId).syncScrollCount(self.syncScrollCount)
+    }
+  }))
+  .actions(self => ({
+    // if the specified collection has a scrollCount lower than the global syncScrollCount,
+    // then this is a response echo -- synchronize the counts and return true
+    syncTrailingCollectionScrollCount(collectionId: string) {
+      const isTrailing = self.getCollectionTableModel(collectionId).scrollCount < self.syncScrollCount
+      isTrailing && self.syncCollectionScrollCount(collectionId)
+      return isTrailing
     },
-    incScrollCount() {
-      return ++self.syncScrollCount
-    },
-    setScrollLeft(scrollLeft: number) {
-      self.scrollLeft = scrollLeft
+  }))
+  .actions(self => ({
+    // increment the global syncScrollCount and synchronize the scrollCount of the specified collection
+    incScrollCount(collectionId: string) {
+      ++self.syncScrollCount
+      self.syncCollectionScrollCount(collectionId)
     }
   }))
 export interface ICaseTableModel extends Instance<typeof CaseTableModel> {}

--- a/v3/src/components/case-table/case-table-types.ts
+++ b/v3/src/components/case-table/case-table-types.ts
@@ -25,6 +25,21 @@ export interface TRenderRowProps extends RenderRowProps<TRow> {}
 export interface TCellClickArgs extends CellClickArgs<TRow> {}
 export type TColSpanArgs = ColSpanArgs<TRow, unknown>
 
+export interface IBaseTableScrollInfo {
+  element: HTMLDivElement
+  scrollRowIntoView: (rowIndex: number) => void
+}
+export interface ISetTableScrollInfo extends IBaseTableScrollInfo {
+  collectionId: string
+}
+export interface ITableScrollInfo extends IBaseTableScrollInfo {
+  scrollCount: number
+}
+export type ScrollRowIntoViewFn = (rowIndex: number) => void
+export type SetScrollInfoFn = (scrollInfo: ISetTableScrollInfo) => void
+export type TableScrollEvent = React.UIEvent<HTMLDivElement, UIEvent>
+export type OnTableScrollFn = (event: TableScrollEvent, collectionId: string, element: HTMLDivElement) => void
+
 // used in lieu of attribute id for index column for ReactDataGrid
 export const kIndexColumnKey = "__index__"
 

--- a/v3/src/components/case-table/collection-table-model.ts
+++ b/v3/src/components/case-table/collection-table-model.ts
@@ -1,0 +1,67 @@
+import { action, makeObservable, observable } from "mobx"
+import { ITableScrollInfo, ScrollRowIntoViewFn, TRow } from "./case-table-types"
+
+export class CollectionTableModel {
+  collectionId: string
+  // RDG grid element
+  @observable element: HTMLDivElement | null = null
+  // used for controlling sync scrolling
+  @observable scrollCount = 0
+  // tracks current scrollTop value for grid
+  @observable scrollTop = 0
+
+  // rowCache contains all rows, whether collapsed or not; key is [pseudo-]case id
+  // RDG memoizes on the row, so we need to pass a new "case" object to trigger a render.
+  // Therefore, we cache each case object and update it when appropriate.
+  @observable.shallow rowCache = new Map<string, TRow>()
+
+  // rows contains only visible rows, i.e. collapsed rows are filtered out
+  // rows are passed directly to RDG for rendering
+  @observable.shallow rows: TRow[] = []
+
+  scrollRowIntoView: ScrollRowIntoViewFn = () => null
+
+  constructor(collectionId: string) {
+    this.collectionId = collectionId
+
+    makeObservable(this)
+  }
+
+  hasTrailingScrollCount(syncScrollCount: number) {
+    return this.scrollCount < syncScrollCount
+  }
+
+  @action syncScrollCount(syncScrollCount: number) {
+    this.scrollCount = syncScrollCount
+  }
+
+  @action setScrollInfo({ element, scrollCount, scrollRowIntoView }: ITableScrollInfo) {
+    this.element = element
+    this.scrollCount = scrollCount
+    this.scrollRowIntoView = scrollRowIntoView
+  }
+
+  @action setScrollTop(scrollTop?: number) {
+    this.scrollTop = scrollTop ?? 0
+  }
+
+  @action syncScrollTopFromElement() {
+    if (this.element) {
+      this.scrollTop = this.element.scrollTop
+    }
+  }
+
+  syncScrollTopToElement() {
+    if (this.element) {
+      this.element.scrollTop = this.scrollTop
+    }
+  }
+
+  @action resetRowCache(rowCache: Map<string, TRow>) {
+    this.rowCache = rowCache
+  }
+
+  @action resetRows(rows: TRow[]) {
+    this.rows = rows
+  }
+}

--- a/v3/src/components/case-table/collection-table-model.ts
+++ b/v3/src/components/case-table/collection-table-model.ts
@@ -27,10 +27,6 @@ export class CollectionTableModel {
     makeObservable(this)
   }
 
-  hasTrailingScrollCount(syncScrollCount: number) {
-    return this.scrollCount < syncScrollCount
-  }
-
   @action syncScrollCount(syncScrollCount: number) {
     this.scrollCount = syncScrollCount
   }

--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -10,7 +10,7 @@ import { IDataSet } from "../../models/data/data-set"
 // import { getNumericCssVariable } from "../../utilities/css-utils"
 import t from "../../utilities/translation/translate"
 import { kChildMostTableCollectionId, TRow } from "./case-table-types"
-import { useCaseTableModel } from "./use-case-table-model"
+import { useCollectionTableModel } from "./use-collection-table-model"
 
 const kDividerWidth = 48,
       kRelationParentMargin = 12,
@@ -27,13 +27,14 @@ interface IProps {
 }
 export const CollectionTableSpacer = observer(function CollectionTableSpacer(props: IProps) {
   const { rows, rowHeight, onDrop } = props
-  const tableModel = useCaseTableModel()
   const data = useDataSetContext()
   const caseMetadata = useCaseMetadata()
   const parentCollection = useParentCollectionContext()
   const parentCollectionId = parentCollection?.id
+  const parentTableModel = useCollectionTableModel(parentCollectionId || "")
   const childCollection = useCollectionContext()
   const childCollectionId = childCollection?.id || kChildMostTableCollectionId
+  const childTableModel = useCollectionTableModel()
   const parentMost = !parentCollection
   const { active, isOver, setNodeRef } = useTileDroppable(`new-collection-${childCollectionId}`, _active => {
     const { dataSet, attributeId: dragAttributeID } = getDragAttributeInfo(_active) || {}
@@ -50,8 +51,8 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer(pro
   const kMargin = 10
   const msgStyle: React.CSSProperties =
     { bottom: divHeight && dropMessageWidth ? (divHeight - dropMessageWidth) / 2 - kMargin : undefined }
-  const parentScrollTop = parentCollectionId && tableModel?.scrollTopMap.get(parentCollectionId) || 0
-  const childScrollTop = childCollectionId && tableModel?.scrollTopMap.get(childCollectionId) || 0
+  const parentScrollTop = parentTableModel?.scrollTop || 0
+  const childScrollTop = childTableModel?.scrollTop || 0
   const isScrollable = childGridRef.current && (childGridRef.current.scrollHeight > childGridRef.current.clientHeight)
   const parentCases = parentCollection ? data?.getCasesForCollection(parentCollection.id) : []
   const bottomsOfLastChildRowOfParent: number[] = []

--- a/v3/src/components/case-table/use-collection-table-model.ts
+++ b/v3/src/components/case-table/use-collection-table-model.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from "react"
+import { useCollectionContext } from "../../hooks/use-collection-context"
+import { CollectionTableModel } from "./collection-table-model"
+import { useCaseTableModel } from "./use-case-table-model"
+
+export function useCollectionTableModel(collectionId?: string) {
+  const tableModel = useCaseTableModel()
+  const collection = useCollectionContext()
+  const collectionTableModel = useRef<CollectionTableModel | undefined>()
+
+  useEffect(() => {
+    if (!collectionTableModel.current) {
+      collectionTableModel.current = tableModel?.getCollectionTableModel(collectionId ?? collection.id)
+    }
+  })
+
+  return collectionTableModel.current
+}

--- a/v3/src/components/case-table/use-row-scrolling.test.ts
+++ b/v3/src/components/case-table/use-row-scrolling.test.ts
@@ -27,23 +27,23 @@ describe("useRowScrolling", () => {
     rafMock.restore()
   })
 
-  describe("scrollToRow", () => {
+  describe("scrollRowToTop", () => {
     it("does nothing without a grid element", () => {
       const { result } = renderHook(() => useRowScrolling(null))
-      result.current.scrollToRow(1)
+      result.current.scrollRowToTop(1)
       expect(true).toBe(true)
     })
 
     it("doesn't scroll unnecessarily", () => {
       const { result } = renderHook(() => useRowScrolling(mockGridElt))
-      result.current.scrollToRow(0)
+      result.current.scrollRowToTop(0)
       expect(rafMock.mockRequest).toHaveBeenCalledTimes(0)
       expect(rafMock.queue.size).toBe(0)
     })
 
     it("scrolls to specified row in multiple steps", () => {
       const { result } = renderHook(() => useRowScrolling(mockGridElt))
-      result.current.scrollToRow(1)
+      result.current.scrollRowToTop(1)
       expect(rafMock.mockRequest).toHaveBeenCalledTimes(1)
       expect(rafMock.queue.size).toBe(1)
       // initial trigger -- initializes scroll
@@ -76,14 +76,14 @@ describe("useRowScrolling", () => {
 
     it("can be redirected before the scroll is complete", () => {
       const { result } = renderHook(() => useRowScrolling(mockGridElt))
-      result.current.scrollToRow(20)
+      result.current.scrollRowToTop(20)
       rafMock.triggerNext()
       // advance to half-way
       rafMock.triggerNext(250)
       expect(mockGridElt.scrollTop).toBeGreaterThan(170)
       expect(mockGridElt.scrollTop).toBeLessThan(190)
       // issue another request to a different location
-      result.current.scrollToRow(100)
+      result.current.scrollRowToTop(100)
       // still only one request queued
       expect(rafMock.queue.size).toBe(1)
       rafMock.triggerAll()

--- a/v3/src/components/case-table/use-row-scrolling.ts
+++ b/v3/src/components/case-table/use-row-scrolling.ts
@@ -35,7 +35,7 @@ export function useRowScrolling(gridElt: HTMLDivElement | null | undefined) {
   const rafRequestId = useRef(0)
 
   // smoothly scroll the grid so that the specified row is at the top
-  const scrollToRow = useCallback((rowIndex: number, options?: ScrollOptions) => {
+  const scrollRowToTop = useCallback((rowIndex: number, options?: ScrollOptions) => {
     if (!gridElt) return
 
     const { duration = kDefaultScrollDuration, throttle = kDefaultScrollThrottle } = options || {}
@@ -91,13 +91,13 @@ export function useRowScrolling(gridElt: HTMLDivElement | null | undefined) {
     if (rowTop >= viewTop && rowBottom <= viewBottom) return
     // is row above visible rows?
     if (rowTop < viewTop) {
-      scrollToRow(Math.max(0, rowIndex - 1), options)
+      scrollRowToTop(Math.max(0, rowIndex - 1), options)
     }
     // is row below visible rows
     else if (rowBottom > viewBottom) {
-      scrollToRow(Math.max(0, rowIndex - visibleRows + 2), options)
+      scrollRowToTop(Math.max(0, rowIndex - visibleRows + 2), options)
     }
-  }, [gridElt, scrollToRow])
+  }, [gridElt, scrollRowToTop])
 
   const scrollClosestRowIntoView = useCallback((rowIndices: number[], options?: ScrollOptions) => {
     if (!gridElt) return
@@ -127,5 +127,5 @@ export function useRowScrolling(gridElt: HTMLDivElement | null | undefined) {
     }
   }, [gridElt, scrollRowIntoView])
 
-  return { scrollToRow, scrollRowIntoView, scrollClosestRowIntoView }
+  return { scrollRowToTop, scrollRowIntoView, scrollClosestRowIntoView }
 }

--- a/v3/src/components/case-table/use-sync-scrolling.ts
+++ b/v3/src/components/case-table/use-sync-scrolling.ts
@@ -1,0 +1,66 @@
+import { useCallback } from "react"
+import { OnTableScrollFn } from "./case-table-types"
+import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { useCaseTableModel } from "./use-case-table-model"
+
+export function useSyncScrolling() {
+  const data = useDataSetContext()
+  const tableModel = useCaseTableModel()
+
+  /**
+   * The main job of this function is to manage propagation of scroll to the
+   * left and to the right to maintain the rule that all parent cases of
+   * a visible case should also be visible. We have gotten here from a
+   * notification from a scroll event from RDG and any scrolling
+   * of dependent tables will also produce scroll events, so we need to
+   * avoid getting into feedback loops. We do this by keeping a global scrollCount
+   * count and, in each case table, a scroll event count. We increment the
+   * global scrollCount and the event count for any case table that wasn't
+   * scrolled from propagation. When a new notification arrives if its
+   * table has a count less than the propagation count then it was a scroll
+   * event from propagation and bypasses further propagation. If it has an event
+   * count higher, it is a new event, so propagation should occur.
+   */
+  const handleTableScroll = useCallback<OnTableScrollFn>((event, collectionId, element) => {
+    const collectionTableModel = tableModel?.getCollectionTableModel(collectionId)
+    if (!tableModel || !collectionTableModel) return
+
+    // if this is a response echo, then ignore it
+    if (tableModel.syncTrailingCollectionScrollCount(collectionId)) return
+
+    /*
+     * handle this as a direct user scroll, which should trigger synchronization
+     */
+
+    // increment scroll count globally and for triggered table
+    tableModel.incScrollCount(collectionId)
+
+    // identify collections to be synchronized
+    const { collectionIds = [] } = data || {}
+    const triggerCollectionIndex = collectionIds.findIndex(id => id === collectionId)
+
+    // synchronize parent tables in succession
+    for (let i = triggerCollectionIndex - 1; i >= 0; --i) {
+      // const parentCollectionId = collectionIds[i]
+      // const childCollectionId = collectionIds[i + 1]
+      // if (!scrollParentToAlignWithChild(parentCollectionId, childCollectionId)) {
+      //   // if we didn't scroll, sync the count here
+      //   // if we did scroll, count will be synchronized in syncTrailingCollectionScrollCount
+      //   tableModel.syncCollectionScrollCount(parentCollectionId)
+      // }
+    }
+
+    // synchronize child tables in succession
+    for (let i = triggerCollectionIndex + 1; i < collectionIds.length; ++i) {
+      // const childCollectionId = collectionIds[i]
+      // const parentCollectionId = collectionIds[i - 1]
+      // if (!scrollChildToAlignWithParent(parentCollectionId, childCollectionId)) {
+      //   // if we didn't scroll, sync the count here
+      //   // if we did scroll, count will be synchronized in syncTrailingCollectionScrollCount
+      //   tableModel.syncCollectionScrollCount(childCollectionId)
+      // }
+    }
+  }, [data, tableModel])
+
+  return { handleTableScroll }
+}

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -1,5 +1,6 @@
-import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
+import { observer } from "mobx-react-lite"
+import { isAlive } from "mobx-state-tree"
 import React from "react"
 import { TileModelContext } from "../hooks/use-tile-model-context"
 import { InspectorPanelWrapper } from "./inspector-panel-wrapper"
@@ -30,7 +31,7 @@ export const CodapComponent = observer(function CodapComponent({
   const info = getTileComponentInfo(tile.content.type)
 
   function handleFocusTile() {
-    uiState.setFocusedTile(tile.id)
+    isAlive(tile) && uiState.setFocusedTile(tile.id)
   }
 
   if (!info) return null

--- a/v3/src/components/data-summary/data-summary.tsx
+++ b/v3/src/components/data-summary/data-summary.tsx
@@ -78,7 +78,7 @@ const DataSelectPopup = () => {
   const data = useDataSetContext()
   const dataSetSummaries = gDataBroker?.summaries
   const renderOption = (name: string, id: string) => {
-    return <option key={name} value={id}>{name}</option>
+    return <option key={id} value={id}>{name}</option>
   }
 
   const handleDataSetSelection = (evt: React.ChangeEvent<HTMLSelectElement>) => {

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -7,3 +7,17 @@ export function getCollectionAttrs(collection: ICollectionPropsModel, data?: IDa
             ? Array.from(collection.attributes) as IAttribute[]
             : data?.ungroupedAttributes) ?? []
 }
+
+export function collectionCaseIdFromIndex(index: number, data?: IDataSet, collectionId?: string) {
+  if (!data) return undefined
+  const cases = data.getCasesForCollection(collectionId)
+  return cases[index]?.__id__
+}
+
+export function collectionCaseIndexFromId(caseId: string, data?: IDataSet, collectionId?: string) {
+  if (!data) return undefined
+  const cases = data.getCasesForCollection(collectionId)
+  // for now, linear search through pseudo-cases; could index if performance becomes a problem.
+  const found = cases.findIndex(aCase => aCase.__id__ === caseId)
+  return found >= 0 ? found : undefined
+}

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -442,6 +442,9 @@ export const DataSet = types.model("DataSet", {
   }
 })
 .views(self => ({
+  get collectionIds() {
+    return [...self.collections.map(collection => collection.id), self.ungrouped.id]
+  },
   getCasesForCollection(collectionId?: string) {
     for (let i = self.collectionGroups.length - 1; i >= 0; --i) {
       const collectionGroup = self.collectionGroups[i]

--- a/v3/src/models/shared/shared-case-metadata.ts
+++ b/v3/src/models/shared/shared-case-metadata.ts
@@ -1,4 +1,4 @@
-import { getType, Instance, types } from "mobx-state-tree"
+import { getType, Instance, ISerializedActionCall, types } from "mobx-state-tree"
 import { CategorySet, ICategorySet } from "../data/category-set"
 import { DataSet, IDataSet } from "../data/data-set"
 import { ISharedModel, SharedModel } from "./shared-model"
@@ -111,4 +111,13 @@ export interface ISharedCaseMetadata extends Instance<typeof SharedCaseMetadata>
 
 export function isSharedCaseMetadata(model?: ISharedModel): model is ISharedCaseMetadata {
   return model ? getType(model) === SharedCaseMetadata : false
+}
+
+export interface SetIsCollapsedAction extends ISerializedActionCall {
+  name: "setIsCollapsed"
+  args: [string, boolean] // [caseId, isCollapsed]
+}
+
+export function isSetIsCollapsedAction(action: ISerializedActionCall): action is SetIsCollapsedAction {
+  return action.name === "setIsCollapsed"
 }


### PR DESCRIPTION
In preparation for implementing scroll synchronization:
- new `CollectionTableModel` contains scroll info and case/row information
- fixes graph cypress tests
- fixes summary view React warning that arose during cypress tests
- put initial pieces of code for scroll synchronization across tables
- table responds to expand/collapse of cases more efficiently