### PR TITLE
fix: axis attribute menu placement

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -54,7 +54,7 @@ const _AxisOrLegendAttributeMenu = ({ place, target, portal,
 
   return (
     <div className={`axis-legend-attribute-menu ${place}`} ref={menuRef}>
-      <Menu>
+      <Menu boundary="scrollParent">
         {({ onClose }) => {
           onCloseRef.current = onClose
           return (


### PR DESCRIPTION
PT: [[#185495543]](https://www.pivotaltracker.com/story/show/185495543)

>Notice that the menu that comes up is clipped by the bottom of the window instead of being forced to be (as much as possible) visible in the window.

We add `boundary="scrollParent"` to the `<Menu>` component, since the Graph's `scrollParent` is the document.