### PR TITLE
Fix graph rehydration bug

### DIFF
--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -26,7 +26,8 @@ export const useAxis = ({
     isNumeric = axisModel && isNumericAxisModel(axisModel),
     place = axisModel?.place ?? 'bottom',
     multiScale = layout.getAxisMultiScale(place),
-    ordinalScale = isNumeric || axisModel?.type === 'empty' ? null : multiScale?.scale as ScaleBand<string>
+    ordinalScale = isNumeric || axisModel?.type === 'empty' ? null : multiScale?.scale as ScaleBand<string>,
+    categories = ordinalScale?.domain() ?? []
   const
     // By all rights, the following three lines should not be necessary to get installDomainSync to run when
     // GraphController:processV2Document installs a new axis model.
@@ -49,7 +50,6 @@ export const useAxis = ({
       numbersHeight = getStringBounds('0').height,
       repetitions = multiScale?.repetitions ?? 1,
       bandWidth = ((ordinalScale?.bandwidth?.()) ?? 0) / repetitions,
-      categories = ordinalScale?.domain() ?? [],
       collision = collisionExists({bandWidth, categories, centerCategoryLabels}),
       maxLabelExtent = maxWidthOfStringsD3(dataConfiguration?.categoryArrayForAttrRole(attrRole) ?? []),
       d3Scale = multiScale?.scale ?? (type === 'numeric' ? scaleLinear() : scaleOrdinal())
@@ -70,7 +70,8 @@ export const useAxis = ({
       }
     }
     return desiredExtent
-  }, [centerCategoryLabels, ordinalScale, axisPlace, attrRole, dataConfiguration, axisTitle, type, multiScale])
+  }, [dataConfiguration, axisPlace, axisTitle, multiScale?.repetitions, multiScale?.scale,
+    ordinalScale, categories, centerCategoryLabels, attrRole, type])
 
   // update d3 scale and axis when scale type changes
   useEffect(() => {

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -27,6 +27,7 @@ export const useAxis = ({
     place = axisModel?.place ?? 'bottom',
     multiScale = layout.getAxisMultiScale(place),
     ordinalScale = isNumeric || axisModel?.type === 'empty' ? null : multiScale?.scale as ScaleBand<string>,
+    // eslint-disable-next-line react-hooks/exhaustive-deps  --  see note below
     categories = ordinalScale?.domain() ?? []
   const
     // By all rights, the following three lines should not be necessary to get installDomainSync to run when
@@ -41,6 +42,17 @@ export const useAxis = ({
     attributeID = dataConfiguration?.attributeID(attrRole)
   previousAxisModel.current = axisModel
 
+  /** Todo: from Kirk
+   * Looking at the overall format of this code, the computeDesiredExtent() callback lists almost everything that
+   * could possibly change as a dependency, meaning that a new callback will be generated after nearly every change.
+   * Then there are four useEffects whose primary purpose is to call computeDesiredExtent(), meaning that nearly every
+   * change will result in four calls to something like:
+   *         layout.setDesiredExtent(axisPlace, computeDesiredExtent())
+   * Seems like a situation where a single autorun or possibly reaction would make more sense. Another approach
+   * might be to introduce something like an AxisViewModel which could encapsulate some of these computations
+   * analogous to the way the CollectionTableModel is a MobX class which encapsulates a number of table-related
+   * computations. Then the desiredExtent could be a computed property which is cached automatically.
+   */
   const computeDesiredExtent = useCallback(() => {
     if (dataConfiguration?.placeCanHaveZeroExtent(axisPlace)) {
       return 0

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -69,7 +69,19 @@ export const useSubAxis = ({
           : (place === 'top') ? `translate(${axisBounds.left}, ${axisBounds.top + axisBounds.height})`
             : `translate(${axisBounds.left}, ${axisBounds.top})`
 
-      const renderEmptyOrNumericAxis = () => {
+      const renderEmptyAxis = () => {
+          select(subAxisElt).selectAll('*').remove()
+          select(subAxisElt)
+            .attr("transform", initialTransform)
+            .append('line')
+            .attr('x1', 0)
+            .attr('x2', axisIsVertical ? 0 : subAxisLength)
+            .attr('y1', 0)
+            .attr('y2', axisIsVertical ? subAxisLength : 0)
+            .style("stroke", "lightgrey")
+            .style("stroke-opacity", "0.7")
+        },
+        renderNumericAxis = () => {
           select(subAxisElt).selectAll('*').remove()
           const numericScale = d3Scale as unknown as ScaleLinear<number, number>,
             axisScale = axis(numericScale).tickSizeOuter(0).tickFormat(format('.9')),
@@ -183,9 +195,11 @@ export const useSubAxis = ({
 
       d3Scale.range(axisIsVertical ? [rangeMax, rangeMin] : [rangeMin, rangeMax])
       switch (type) {
-        case 'numeric':
         case 'empty':
-          renderEmptyOrNumericAxis()
+          renderEmptyAxis()
+          break
+        case 'numeric':
+          renderNumericAxis()
           showScatterPlotGridLines && renderScatterPlotGridLines()
           break
         case 'categorical':
@@ -285,7 +299,7 @@ export const useSubAxis = ({
           }
         )
       categoriesSelectionRef.current.each(function () {
-        const catGroup = select(this)/*.select('g')*/
+        const catGroup = select(this)
         // ticks
         catGroup.append('line').attr('class', 'tick')
         // divider between groups

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -45,6 +45,10 @@ export const EmptyAxisModel = AxisModel
 export interface IEmptyAxisModel extends Instance<typeof CategoricalAxisModel> {}
 export interface IEmptyAxisModelSnapshot extends SnapshotIn<typeof CategoricalAxisModel> {}
 
+export function isEmptyAxisModel(axisModel: IAxisModel): axisModel is IEmptyAxisModel {
+  return axisModel.type === "empty"
+}
+
 export const CategoricalAxisModel = AxisModel
   .named("CategoricalAxisModel")
   .props({

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -4,7 +4,7 @@ import {GraphLayout} from "./graph-layout"
 import {getDataSetFromId} from "../../../models/shared/shared-data-utils"
 import {AxisPlace, AxisPlaces} from "../../axis/axis-types"
 import {
-  CategoricalAxisModel, EmptyAxisModel, isCategoricalAxisModel, isNumericAxisModel, NumericAxisModel
+  CategoricalAxisModel, EmptyAxisModel, isCategoricalAxisModel, isEmptyAxisModel, isNumericAxisModel, NumericAxisModel
 } from "../../axis/models/axis-model"
 import {axisPlaceToAttrRole, graphPlaceToAttrRole, IDotsRef, PlotType} from "../graphing-types"
 import {GraphPlace} from "../../axis-graph-shared"
@@ -72,8 +72,11 @@ export class GraphController {
         if (axisModel) {
           layout.setAxisScaleType(axisPlace, axisModel.scale)
           const axisMultiScale = layout.getAxisMultiScale(axisPlace)
+          if (isEmptyAxisModel(axisModel)) {  // EmptyAxisModel
+            axisMultiScale.setScaleType('ordinal')
+          }
           if (isCategoricalAxisModel(axisModel)) {
-            layout.getAxisMultiScale(axisPlace)?.setCategorySet(dataConfig.categorySetForAttrRole(attrRole))
+            axisMultiScale.setCategorySet(dataConfig.categorySetForAttrRole(attrRole))
           }
           if (isNumericAxisModel(axisModel)) {
             axisMultiScale.setNumericDomain(axisModel.domain)


### PR DESCRIPTION
[#185496498] Bug fix: Graph rehydration bug

See the PT story for details on how to reproduce the bug

There were two problems:
1. When the categorical axis was replaced by an empty axis the stale scale was holding onto invalid ticks.
2. The axis wasn't responding to a change in the array of categories.

* In GraphController:initializeGraph handle empty axis explicitly
* In renderSubAxis handle empty axis separately from numeric axis
* Make the array of categories and explicit dependent of useAxis:computeDesiredExtent