### PR TITLE
Version 3.0.0-pre.1274 - July 18, 2023

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -6,15 +6,12 @@
 - The box containing a movable line's equation can be repositioned by the user [#185472784](https://www.pivotaltracker.com/story/show/185472784)
 - A **movable line**'s "drag handles" should disappear if the graph is not the active component [#185473022](https://www.pivotaltracker.com/story/show/185473022)
 - The position of a movable line's equation should be saved and restored when it has become unpinned from the line [#185556213](https://www.pivotaltracker.com/story/show/185556213)
-- Hierarchical case table -- synchronized scrolling across collections [#184540561](https://www.pivotaltracker.com/story/show/184540561)
-- Eliminate (or hide behind a URL parameter) default dashboard content [#184210690](https://www.pivotaltracker.com/story/show/184210690)
 
 ### Asset Sizes
 |      File |          Size | % Increase from Previous Release |
 |-----------|---------------|----------------------------------|
 | index.css |   44443 bytes |                            0.97% |
 |  index.js | 3091787 bytes |                            0.22% |
-
 
 ## Version 3.0.0-pre.1270 - July 10, 2023
 

--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Version 3.0.0-pre.1274 - July 18, 2023
+
+### Features/Improvements
+- The box containing a movable line's equation can be repositioned by the user [#185472784](https://www.pivotaltracker.com/story/show/185472784)
+- A **movable line**'s "drag handles" should disappear if the graph is not the active component [#185473022](https://www.pivotaltracker.com/story/show/185473022)
+- The position of a movable line's equation should be saved and restored when it has become unpinned from the line [#185556213](https://www.pivotaltracker.com/story/show/185556213)
+- Hierarchical case table -- synchronized scrolling across collections [#184540561](https://www.pivotaltracker.com/story/show/184540561)
+- Eliminate (or hide behind a URL parameter) default dashboard content [#184210690](https://www.pivotaltracker.com/story/show/184210690)
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+| index.css |   44443 bytes |                            0.97% |
+|  index.js | 3091787 bytes |                            0.22% |
+
+
 ## Version 3.0.0-pre.1270 - July 10, 2023
 
 ### Features/Improvements

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1270",
+  "version": "3.0.0-pre.1274",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1270",
+  "version": "3.0.0-pre.1274",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",


### PR DESCRIPTION
### Features/Improvements
- The box containing a movable line's equation can be repositioned by the user [#185472784](https://www.pivotaltracker.com/story/show/185472784)
- A **movable line**'s "drag handles" should disappear if the graph is not the active component [#185473022](https://www.pivotaltracker.com/story/show/185473022)
- The position of a movable line's equation should be saved and restored when it has become unpinned from the line [#185556213](https://www.pivotaltracker.com/story/show/185556213)
- Hierarchical case table -- synchronized scrolling across collections [#184540561](https://www.pivotaltracker.com/story/show/184540561)
- Eliminate (or hide behind a URL parameter) default dashboard content [#184210690](https://www.pivotaltracker.com/story/show/184210690)