### PR TITLE
fix: Remove toast pop-ups for implemented adornments (PT-185639719)

### DIFF
--- a/v3/src/components/graph/components/inspector-panel/graph-measure-panel.tsx
+++ b/v3/src/components/graph/components/inspector-panel/graph-measure-panel.tsx
@@ -47,16 +47,20 @@ export const GraphMeasurePalette = ({tile, panelRect, buttonRect, setShowPalette
   }
 
   const handleSetting = (measure: string, val: boolean) => {
-    toast({
-      title: 'Item clicked',
-      description: `You clicked on ${measure} ${val}`,
-      status: 'success',
-      duration: 5000,
-      isClosable: true,
-    })
+    const componentContentInfo = getAdornmentContentInfo(measure)
+    // Show toast pop-ups for adornments that haven't been implemented yet.
+    // TODO: Remove pop-ups when all adornments are implemented.
+    if (!componentContentInfo) {
+      toast({
+        title: 'Item clicked',
+        description: `You clicked on ${measure} ${val}`,
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+      })
+      return null
+    }
     if (val && graphModel) {
-      const componentContentInfo = getAdornmentContentInfo(measure)
-      if (!componentContentInfo) return null
       const { modelClass } = componentContentInfo,
         adornment = modelClass.create({ type: measure })
       graphModel?.showAdornment(adornment, measure)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185639719

Updates the `GraphMeasurePalette` component's `handleSetting` function so it only shows toast pop-up messages for adornments that haven't been implemented yet.