### PR TITLE
fix: Movable line not draggable beyond plot boundaries (PT-185640617)

### DIFF
--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -3,8 +3,14 @@ import {DataSet, toCanonical} from "../../../models/data/data-set"
 import {scaleLinear} from "d3"
 
 describe("equationString", () => {
-  it("should give correct html", () => {
+  it("should return a valid equation for a given slope and intercept", () => {
     expect(equationString(1, 0, {x: "Lifespan", y: "Speed"})).toBe('<em>Speed</em> = 1 <em>Lifespan</em> + 0')
+  })
+  it("should return an equation containing only the y attribute when the slope is 0", () => {
+    expect(equationString(0, 1, {x: "Lifespan", y: "Speed"})).toBe('<em>Speed</em> = 1')
+  })
+  it("should return an equation containing only the x attribute when the slope is Infinity", () => {
+    expect(equationString(Infinity, 1, {x: "Lifespan", y: "Speed"})).toBe('<em>Lifespan</em> = 1')
   })
 })
 

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -255,12 +255,13 @@ export function lineToAxisIntercepts(iSlope: number, iIntercept: number,
   }
 }
 
-export function equationString(slope: number, intercept: number, attrNames: any) {
-  const float = format('.4~r'),
-  slopeString = slope !== Infinity && slope !== 0 ? float(slope) : undefined,
-  displaySlope = slopeString ? `${slopeString} <em>${attrNames.x}</em> +` : '',
-  kSlopeIntercept = `<em>${attrNames.y}</em> = ${displaySlope} ${float(intercept)}`
-  return kSlopeIntercept
+export function equationString(slope: number, intercept: number, attrNames: {x: string, y: string}) {
+  const float = format('.4~r')
+  if (isFinite(slope) && slope !== 0) {
+    return `<em>${attrNames.y}</em> = ${float(slope)} <em>${attrNames.x}</em> + ${float(intercept)}`
+  } else {
+    return `<em>${slope === 0 ? attrNames.y : attrNames.x}</em> = ${float(intercept)}`
+  }
 }
 
 export function valueLabelString(value: number) {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185640617

These changes prevent a movable line from being dragged beyond a plot's boundaries which renders it inaccessible. Following the behavior in V2, the movable line will be reset to its initial state if it is dragged outside of the plot boundaries while in the perfectly vertical or perfectly horizontal state.

Included is small fix for [Movable line shows wrong equation when the line is vertical](https://www.pivotaltracker.com/story/show/185638862). This was fixed with the refactoring of the `equationString` function in graph-utils.ts.