### PR TITLE
Version 3.0.0-pre.1278 - July 24, 2023

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Version 3.0.0-pre.1278 - July 24, 2023
+
+### Bug Fixes
+- Remove placeholder green toast when movable line is selected/unselected in ruler menu [#185639719](https://www.pivotaltracker.com/story/show/185639719)
+- Removing one or more of the axes attributes from a graph with a movable line does not remove the movable line and its equation [#185639677](https://www.pivotaltracker.com/story/show/185639677)
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+| index.css |   45013 bytes |                            1.28% |
+|  index.js | 3095134 bytes |                            0.11% |
+
 ## Version 3.0.0-pre.1274 - July 18, 2023
 
 ### Features/Improvements

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1274",
+  "version": "3.0.0-pre.1278",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-pre.1270",
+      "version": "3.0.0-pre.1278",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1274",
+  "version": "3.0.0-pre.1278",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",


### PR DESCRIPTION
### Bug Fixes
- Remove placeholder green toast when movable line is selected/unselected in ruler menu [#185639719](https://www.pivotaltracker.com/story/show/185639719)
- Removing one or more of the axes attributes from a graph with a movable line does not remove the movable line and its equation [#185639677](https://www.pivotaltracker.com/story/show/185639677)