### PR TITLE
fix: Movable line custom mouse cursors should change (PT-185631489)

### DIFF
--- a/v3/src/components/graph/adornments/movable-line/movable-line.scss
+++ b/v3/src/components/graph/adornments/movable-line/movable-line.scss
@@ -27,6 +27,10 @@ svg[class^="line-"] {
 
 .movable-line-lower-cover {
   cursor: url("../assets/pivot-bot-left-cursor.png") 8 8, grab;
+
+  &.negative-slope {
+    cursor: url("../assets/pivot-top-left-cursor.png") 8 8, grab;
+  }
 }
 
 .movable-line-middle-cover {
@@ -35,6 +39,10 @@ svg[class^="line-"] {
 
 .movable-line-upper-cover {
   cursor: url("../assets/pivot-top-right-cursor.png") 8 8, grab;
+
+  &.negative-slope {
+    cursor: url("../assets/pivot-bot-right-cursor.png") 8 8, grab;
+  }
 }
 
 .movable-line-equation-container {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185631489

In addition to making the custom cursors change appropriately when the line gets dragged/rotated, these changes consolidate the `continueRotation1` and `continueRotation2` functions into a single function.