### PR TITLE
Fix for graph transparency option bug

### DIFF
--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -2,6 +2,7 @@
 
 $graph-label-font: 400 14px Montserrat-Regular, sans-serif;
 $graph-empty-label-font: 12px Montserrat-Regular, sans-serif;
+$graph-background-fill: #f9f9f9;
 
 :export {
   graphLabelFont: $graph-label-font;
@@ -18,7 +19,6 @@ $graph-empty-label-font: 12px Montserrat-Regular, sans-serif;
   position: relative;
   width: 100%;
   height: calc(100% - $title-bar-height);
-  background-color: #F9F9F9;
 
   .attribute-label {
     fill: blue;
@@ -46,13 +46,20 @@ $graph-empty-label-font: 12px Montserrat-Regular, sans-serif;
     font: 12px sans-serif;
   }
 
-  .axis {
-    background-color: white;
+  .axis-wrapper {
 
-    line {
-      stroke: #DDDDDD;
+    .axis-background {
+      fill: $graph-background-fill;
     }
+
+    .axis {
+      line {
+        stroke: #DDDDDD;
+      }
+    }
+
   }
+
   .axis-click-cue {
     fill: #999999 !important;
     font-size: 12px !important;
@@ -115,9 +122,11 @@ $graph-empty-label-font: 12px Montserrat-Regular, sans-serif;
   left: 0;
   width: 100%;
   height: 25px;
+
   &.active {
     border: 5px solid rgb(255, 216, 102);
   }
+
   &.over {
     background: yellow;
     opacity: 0.5;
@@ -130,9 +139,11 @@ $graph-empty-label-font: 12px Montserrat-Regular, sans-serif;
   left: 0;
   width: 100%;
   height: 25px;
+
   &.active {
     border: 5px solid rgb(255, 216, 102);
   }
+
   &.over {
     background: yellow;
     opacity: 0.5;
@@ -145,9 +156,11 @@ $graph-empty-label-font: 12px Montserrat-Regular, sans-serif;
   right: 0;
   width: 25px;
   height: 100%;
+
   &.active {
     border: 5px solid rgb(255, 216, 102);
   }
+
   &.over {
     background: yellow;
     opacity: 0.5;

--- a/v3/src/components/graph/components/legend/legend.scss
+++ b/v3/src/components/graph/components/legend/legend.scss
@@ -1,7 +1,15 @@
+@import "../graph";
+
 .legend-component {
   position: relative;
   width: 100%;
   height: 100%;
+
+  .legend-background {
+    fill: $graph-background-fill;
+    opacity: 1;
+    stroke: none;
+  }
 
   .legend-key {
     cursor: pointer;
@@ -10,7 +18,6 @@
   svg {
     width: 100%;
     height: 100%;
-    fill: yellow;
   }
 
   text {

--- a/v3/src/components/graph/components/legend/legend.tsx
+++ b/v3/src/components/graph/components/legend/legend.tsx
@@ -1,4 +1,6 @@
-import React, {useRef} from "react"
+import {autorun} from "mobx"
+import React, {useEffect, useRef} from "react"
+import {select} from "d3"
 import {Active} from "@dnd-kit/core"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {useGraphLayoutContext} from "../../models/graph-layout"
@@ -37,7 +39,7 @@ export const Legend = function Legend({
     hintString = useDropHintString({role})
 
   const handleIsActive = (active: Active) => {
-    const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {}
+    const {dataSet, attributeId: droppedAttrId} = getDragAttributeInfo(active) || {}
     if (isDropAllowed) {
       return isDropAllowed('legend', dataSet, droppedAttrId)
     } else {
@@ -46,17 +48,34 @@ export const Legend = function Legend({
   }
 
   useDropHandler(droppableId, active => {
-    const { dataSet, attributeId: dragAttributeID } = getDragAttributeInfo(active) || {}
+    const {dataSet, attributeId: dragAttributeID} = getDragAttributeInfo(active) || {}
     dataSet && dragAttributeID && isDropAllowed('legend', dataSet, dragAttributeID) &&
-     onDropAttribute('legend', dataSet, dragAttributeID)
+    onDropAttribute('legend', dataSet, dragAttributeID)
   })
 
   const legendBounds = layout.computedBounds.legend,
     transform = `translate(${legendBounds.left}, ${legendBounds.top})`
 
+  /**
+   * Because the interior of the graph (the plot) can be transparent, we have to put a background behind
+   * axes and legends.
+   */
+  useEffect(function installBackground() {
+    return autorun(() => {
+      if (legendRef) {
+        select(legendRef.current)
+          .selectAll<SVGRectElement, number>('.legend-background')
+          .attr('transform', `translate(0, ${legendBounds.top})`)
+          .attr('width', layout.graphWidth)
+          .attr('height', legendBounds.height)
+      }
+    })
+  }, [legendBounds, legendRef, transform])
+
   return legendAttrID ? (
     <>
       <svg ref={legendRef} className='legend-component'>
+        <rect className='legend-background'/>
         <AttributeLabel
           place={'legend'}
           onChangeAttribute={onDropAttribute}


### PR DESCRIPTION
[#185707586] Bug fix: Transparent background for graph not working

* The user specification that the graph's background be transparent applies only to the interior of the graph; i.e. the plot. The background elsewhere should remain opaque.
* A background color was being set for the entire div containing the graph. This was preventing the transparency from working. Presumably this got instituted after the initial implementation of the transparency option.
* Simply eliminating the background color didn't work because then the axes, legends, and a few other miscellaneous rectangles became transparent as well.
  * The solution is to separately place a background rectangle behind axes and the legend, being careful with the top and bottom axes to make this rectangle as wide as the graph, not just as wide as the axis.