### PR TITLE
fix: fix and simplify Edit Attribute modal closing [PT-185757174]

### DIFF
--- a/v3/src/components/case-table/attribute-menu.tsx
+++ b/v3/src/components/case-table/attribute-menu.tsx
@@ -43,6 +43,12 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
     onOpen()
     onModalOpen(true)
   }
+
+  const handleEditAttributePropsClose = () => {
+    onClose()
+    onModalOpen(false)
+  }
+
   const handleMenuKeyDown = (e: React.KeyboardEvent) => {
     e.stopPropagation()
   }
@@ -84,8 +90,8 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
           {t("DG.TableController.headerMenuItems.deleteAttribute")}
         </MenuItem>
       </MenuList>
-      <EditAttributePropertiesModal columnName={column.name as string} isOpen={isOpen} onClose={onClose}
-        onModalOpen={onModalOpen} />
+      <EditAttributePropertiesModal columnName={column.name as string} isOpen={isOpen}
+        onClose={handleEditAttributePropsClose} />
     </>
   )
   })

--- a/v3/src/components/case-table/edit-attribute-properties.tsx
+++ b/v3/src/components/case-table/edit-attribute-properties.tsx
@@ -11,10 +11,9 @@ interface IProps {
   columnName: string
   isOpen: boolean
   onClose: () => void
-  onModalOpen: (open: boolean) => void
 }
 
-export const EditAttributePropertiesModal = ({columnName, isOpen, onClose, onModalOpen}: IProps,
+export const EditAttributePropertiesModal = ({columnName, isOpen, onClose}: IProps,
     ref: any) => {
   const data = useDataSetContext()
   const attribute = data?.attrFromName(columnName)
@@ -32,7 +31,6 @@ export const EditAttributePropertiesModal = ({columnName, isOpen, onClose, onMod
 
   const editProperties = () => {
     onClose()
-    onModalOpen(false)
     if (attribute && attrId) {
       data?.setAttributeName(attrId, () => uniqueName(attributeName,
         (aName: string) => (aName === columnName) || !data.attributes.find(attr => aName === attr.name)
@@ -44,9 +42,9 @@ export const EditAttributePropertiesModal = ({columnName, isOpen, onClose, onMod
       attribute.setEditable(editable === "true")
     }
   }
+
   const closeModal = () => {
     onClose()
-    onModalOpen(false)
     setAttributeName(attribute?.name || "")
     setDescription(attribute?.description || "")
     setAttrType(attribute?.userType ? attribute?.userType : "none")

--- a/v3/src/components/case-table/edit-attribute-properties.tsx
+++ b/v3/src/components/case-table/edit-attribute-properties.tsx
@@ -13,8 +13,7 @@ interface IProps {
   onClose: () => void
 }
 
-export const EditAttributePropertiesModal = ({columnName, isOpen, onClose}: IProps,
-    ref: any) => {
+export const EditAttributePropertiesModal = ({columnName, isOpen, onClose}: IProps) => {
   const data = useDataSetContext()
   const attribute = data?.attrFromName(columnName)
   const attrId = data?.attrIDFromName(columnName)
@@ -30,7 +29,6 @@ export const EditAttributePropertiesModal = ({columnName, isOpen, onClose}: IPro
   }, [columnName])
 
   const editProperties = () => {
-    onClose()
     if (attribute && attrId) {
       data?.setAttributeName(attrId, () => uniqueName(attributeName,
         (aName: string) => (aName === columnName) || !data.attributes.find(attr => aName === attr.name)
@@ -41,6 +39,7 @@ export const EditAttributePropertiesModal = ({columnName, isOpen, onClose}: IPro
       attribute.setPrecision(precision && isFinite(+precision) ? +precision : undefined)
       attribute.setEditable(editable === "true")
     }
+    closeModal()
   }
 
   const closeModal = () => {
@@ -62,13 +61,13 @@ export const EditAttributePropertiesModal = ({columnName, isOpen, onClose}: IPro
   return (
     <CodapModal
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={closeModal}
       modalWidth={"350px"}
     >
       <ModalHeader h="30" className="codap-modal-header" fontSize="md" data-testid="codap-modal-header">
         <div className="codap-modal-icon-container" />
         <div className="codap-header-title">{t("DG.TableController.attributeEditor.title")}</div>
-        <ModalCloseButton onClick={onClose} data-testid="modal-close-button"/>
+        <ModalCloseButton onClick={closeModal} data-testid="modal-close-button"/>
       </ModalHeader>
       <ModalBody>
       <FormControl display="flex" flexDirection="column">


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185757174

Modal closing didn't seem to be implemented correctly and the attribute tooltip was never restored after the user closed the Edit Attribute modal using "X" button.  I've simplified the code, so the edit attribute props dialog needs to call just `onClose` instead of `onClose` + `onModalOpen(false)`.