### PR TITLE
feat: add basic formula editor modal [PT-185745389]

### DIFF
--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -1,11 +1,12 @@
 import React, { forwardRef } from "react"
 import { MenuItem, MenuList, useDisclosure, useToast } from "@chakra-ui/react"
 import { CalculatedColumn } from "react-data-grid"
-import { useCaseMetadata } from "../../hooks/use-case-metadata"
-import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { TRow } from "./case-table-types"
-import { EditAttributePropertiesModal } from "./edit-attribute-properties"
-import t from "../../utilities/translation/translate"
+import { useCaseMetadata } from "../../../hooks/use-case-metadata"
+import { useDataSetContext } from "../../../hooks/use-data-set-context"
+import { TRow } from "../case-table-types"
+import { EditAttributePropertiesModal } from "./edit-attribute-properties-modal"
+import t from "../../../utilities/translation/translate"
+import { EditFormulaModal } from "./edit-formula-modal"
 
 interface IProps {
   column: CalculatedColumn<TRow, unknown>
@@ -18,34 +19,50 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
   const toast = useToast()
   const data = useDataSetContext()
   const caseMetadata = useCaseMetadata()
-  const { isOpen, onOpen, onClose } = useDisclosure()
+  const {
+    isOpen: isEditAttributePropsOpen, onOpen: onEditAttributePropsOpen, onClose: onEditAttributePropsClose
+  } = useDisclosure()
+  const {
+    isOpen: isEditFormulaOpen, onOpen: onEditFormulaOpen, onClose: onEditFormulaClose
+  } = useDisclosure()
+  const columnName = column.name as string
 
   const handleMenuItemClick = (menuItem: string) => {
     toast({
       title: 'Menu item clicked',
-      description: `You clicked on ${menuItem} on ${column.name}`,
+      description: `You clicked on ${menuItem} on ${columnName}`,
       status: 'success',
       duration: 5000,
       isClosable: true,
     })
   }
   const handleHideAttribute = () => {
-    const attrId = data?.attrIDFromName(column.name as string)
+    const attrId = data?.attrIDFromName(columnName)
     attrId && caseMetadata?.setIsHidden(attrId, true)
   }
 
   const handleDeleteAttribute = () => {
-    const attrId = data?.attrIDFromName(column.name as string)
+    const attrId = data?.attrIDFromName(columnName)
     attrId && data?.removeAttribute(attrId)
   }
 
-  const handleEditAttributeProps = () => {
-    onOpen()
+  const handleEditAttributePropsOpen = () => {
+    onEditAttributePropsOpen()
     onModalOpen(true)
   }
 
   const handleEditAttributePropsClose = () => {
-    onClose()
+    onEditAttributePropsClose()
+    onModalOpen(false)
+  }
+
+  const handleEditFormulaOpen = () => {
+    onEditFormulaOpen()
+    onModalOpen(true)
+  }
+
+  const handleEditFormulaClose = () => {
+    onEditFormulaClose()
     onModalOpen(false)
   }
 
@@ -62,10 +79,10 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
         <MenuItem onClick={() => handleMenuItemClick("Fit width")}>
           {t("DG.TableController.headerMenuItems.resizeColumn")}
         </MenuItem>
-        <MenuItem onClick={handleEditAttributeProps}>
+        <MenuItem onClick={handleEditAttributePropsOpen}>
           {t("DG.TableController.headerMenuItems.editAttribute")}
         </MenuItem>
-        <MenuItem onClick={() => handleMenuItemClick("Edit Formula")}>
+        <MenuItem onClick={handleEditFormulaOpen}>
           {t("DG.TableController.headerMenuItems.editFormula")}
         </MenuItem>
         <MenuItem onClick={() => handleMenuItemClick("Delete Formula")}>
@@ -90,9 +107,11 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
           {t("DG.TableController.headerMenuItems.deleteAttribute")}
         </MenuItem>
       </MenuList>
-      <EditAttributePropertiesModal columnName={column.name as string} isOpen={isOpen}
+      <EditAttributePropertiesModal columnName={columnName} isOpen={isEditAttributePropsOpen}
         onClose={handleEditAttributePropsClose} />
+      <EditFormulaModal columnName={columnName} isOpen={isEditFormulaOpen} onClose={handleEditFormulaClose} />
     </>
   )
-  })
+})
+
 AttributeMenuList.displayName = "AttributeMenuList"

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -37,8 +37,7 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
     })
   }
   const handleHideAttribute = () => {
-    const attrId = data?.attrIDFromName(columnName)
-    attrId && caseMetadata?.setIsHidden(attrId, true)
+   caseMetadata?.setIsHidden(column.key, true)
   }
 
   const handleDeleteAttribute = () => {

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -41,8 +41,7 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
   }
 
   const handleDeleteAttribute = () => {
-    const attrId = data?.attrIDFromName(columnName)
-    attrId && data?.removeAttribute(attrId)
+    data?.removeAttribute(column.key)
   }
 
   const handleEditAttributePropsOpen = () => {

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -1,15 +1,14 @@
 import React, { forwardRef } from "react"
 import { MenuItem, MenuList, useDisclosure, useToast } from "@chakra-ui/react"
-import { CalculatedColumn } from "react-data-grid"
 import { useCaseMetadata } from "../../../hooks/use-case-metadata"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
-import { TRow } from "../case-table-types"
+import { TCalculatedColumn } from "../case-table-types"
 import { EditAttributePropertiesModal } from "./edit-attribute-properties-modal"
 import t from "../../../utilities/translation/translate"
 import { EditFormulaModal } from "./edit-formula-modal"
 
 interface IProps {
-  column: CalculatedColumn<TRow, unknown>
+  column: TCalculatedColumn
   onRenameAttribute: () => void
   onModalOpen: (open: boolean) => void
 }
@@ -20,12 +19,8 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
   const data = useDataSetContext()
   const caseMetadata = useCaseMetadata()
   // each use of useDisclosure() maintains its own state and callbacks so they can be used for independent dialogs
-  const {
-    isOpen: isEditAttributePropsOpen, onOpen: onEditAttributePropsOpen, onClose: onEditAttributePropsClose
-  } = useDisclosure()
-  const {
-    isOpen: isEditFormulaOpen, onOpen: onEditFormulaOpen, onClose: onEditFormulaClose
-  } = useDisclosure()
+  const attributePropsModal = useDisclosure()
+  const formulaModal = useDisclosure()
   const columnName = column.name as string
 
   const handleMenuItemClick = (menuItem: string) => {
@@ -46,22 +41,22 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
   }
 
   const handleEditAttributePropsOpen = () => {
-    onEditAttributePropsOpen()
+    attributePropsModal.onOpen()
     onModalOpen(true)
   }
 
   const handleEditAttributePropsClose = () => {
-    onEditAttributePropsClose()
+    attributePropsModal.onClose()
     onModalOpen(false)
   }
 
   const handleEditFormulaOpen = () => {
-    onEditFormulaOpen()
+    formulaModal.onOpen()
     onModalOpen(true)
   }
 
   const handleEditFormulaClose = () => {
-    onEditFormulaClose()
+    formulaModal.onClose()
     onModalOpen(false)
   }
 
@@ -106,9 +101,9 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
           {t("DG.TableController.headerMenuItems.deleteAttribute")}
         </MenuItem>
       </MenuList>
-      <EditAttributePropertiesModal columnName={columnName} isOpen={isEditAttributePropsOpen}
+      <EditAttributePropertiesModal columnName={columnName} isOpen={attributePropsModal.isOpen}
         onClose={handleEditAttributePropsClose} />
-      <EditFormulaModal columnName={columnName} isOpen={isEditFormulaOpen} onClose={handleEditFormulaClose} />
+      <EditFormulaModal columnName={columnName} isOpen={formulaModal.isOpen} onClose={handleEditFormulaClose} />
     </>
   )
 })

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -19,6 +19,7 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
   const toast = useToast()
   const data = useDataSetContext()
   const caseMetadata = useCaseMetadata()
+  // each use of useDisclosure() maintains its own state and callbacks so they can be used for independent dialogs
   const {
     isOpen: isEditAttributePropsOpen, onOpen: onEditAttributePropsOpen, onClose: onEditAttributePropsClose
   } = useDisclosure()

--- a/v3/src/components/case-table/attribute-menu/edit-attribute-properties-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-attribute-properties-modal.tsx
@@ -1,11 +1,11 @@
 import { Button, FormControl, FormLabel, HStack, Input, ModalBody, ModalCloseButton, ModalFooter, ModalHeader,
   Radio, RadioGroup, Select, Textarea, Tooltip } from "@chakra-ui/react"
 import React, { useEffect, useState } from "react"
-import { AttributeType, attributeTypes } from "../../models/data/attribute"
-import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { uniqueName } from "../../utilities/js-utils"
-import { CodapModal } from "../codap-modal"
-import t from "../../utilities/translation/translate"
+import { AttributeType, attributeTypes } from "../../../models/data/attribute"
+import { useDataSetContext } from "../../../hooks/use-data-set-context"
+import { uniqueName } from "../../../utilities/js-utils"
+import { CodapModal } from "../../codap-modal"
+import t from "../../../utilities/translation/translate"
 
 interface IProps {
   columnName: string
@@ -13,7 +13,7 @@ interface IProps {
   onClose: () => void
 }
 
-export const EditAttributePropertiesModal = ({columnName, isOpen, onClose}: IProps) => {
+export const EditAttributePropertiesModal: React.FC<IProps> = ({columnName, isOpen, onClose}) => {
   const data = useDataSetContext()
   const attribute = data?.attrFromName(columnName)
   const attrId = data?.attrIDFromName(columnName)

--- a/v3/src/components/case-table/attribute-menu/edit-attribute-properties-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-attribute-properties-modal.tsx
@@ -13,7 +13,7 @@ interface IProps {
   onClose: () => void
 }
 
-export const EditAttributePropertiesModal: React.FC<IProps> = ({columnName, isOpen, onClose}) => {
+export const EditAttributePropertiesModal = ({columnName, isOpen, onClose}: IProps) => {
   const data = useDataSetContext()
   const attribute = data?.attrFromName(columnName)
   const attrId = data?.attrIDFromName(columnName)

--- a/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
@@ -12,7 +12,7 @@ interface IProps {
   onClose: () => void
 }
 
-export const EditFormulaModal: React.FC<IProps> = ({ columnName, isOpen, onClose }) => {
+export const EditFormulaModal = ({ columnName, isOpen, onClose }: IProps) => {
   const [formula, setFormula] = useState("")
 
   const applyFormula = () => {
@@ -42,7 +42,7 @@ export const EditFormulaModal: React.FC<IProps> = ({ columnName, isOpen, onClose
     >
       <ModalHeader h="30" className="codap-modal-header" fontSize="md" data-testid="codap-modal-header">
         <div className="codap-modal-icon-container" />
-        <div className="codap-header-title">{t("DG.AttrFormView.title")}</div>
+        <div className="codap-header-title" />
         <ModalCloseButton onClick={onClose} data-testid="modal-close-button" />
       </ModalHeader>
       <ModalBody>

--- a/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
@@ -1,0 +1,74 @@
+import {
+  Button, FormControl, FormLabel, Input, ModalBody, ModalCloseButton, ModalFooter, ModalHeader,
+  Textarea, Tooltip
+} from "@chakra-ui/react"
+import React, { useState } from "react"
+import { CodapModal } from "../../codap-modal"
+import t from "../../../utilities/translation/translate"
+
+interface IProps {
+  columnName: string
+  isOpen: boolean
+  onClose: () => void
+}
+
+export const EditFormulaModal: React.FC<IProps> = ({ columnName, isOpen, onClose }) => {
+  const [formula, setFormula] = useState("")
+
+  const applyFormula = () => {
+    closeModal()
+  }
+
+  const closeModal = () => {
+    onClose()
+  }
+
+  const handleFormulaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => setFormula(e.target.value)
+
+  const buttons = [{
+    label: t("DG.AttrFormView.cancelBtnTitle"),
+    tooltip: t("DG.AttrFormView.cancelBtnTooltip"),
+    onClick: closeModal
+  }, {
+    label: t("DG.AttrFormView.applyBtnTitle"),
+    onClick: applyFormula
+  }]
+
+  return (
+    <CodapModal
+      isOpen={isOpen}
+      onClose={onClose}
+      modalWidth={"350px"}
+    >
+      <ModalHeader h="30" className="codap-modal-header" fontSize="md" data-testid="codap-modal-header">
+        <div className="codap-modal-icon-container" />
+        <div className="codap-header-title">{t("DG.AttrFormView.title")}</div>
+        <ModalCloseButton onClick={onClose} data-testid="modal-close-button" />
+      </ModalHeader>
+      <ModalBody>
+        <FormControl display="flex" flexDirection="column">
+          <FormLabel display="flex" flexDirection="row">{t("DG.AttrFormView.attrNamePrompt")}
+            <Input size="xs" ml={5} placeholder="attribute" value={columnName} data-testid="attr-name-input" disabled />
+          </FormLabel>
+          <FormLabel>{t("DG.AttrFormView.formulaPrompt")}
+            <Textarea size="xs" value={formula} onChange={handleFormulaChange}
+              onKeyDown={(e) => e.stopPropagation()} data-testid="attr-formula-input" />
+          </FormLabel>
+        </FormControl>
+      </ModalBody>
+      <ModalFooter mt="-5">
+        {
+          buttons.map((b, idx) => (
+            <Tooltip key={idx} label={b.tooltip} h="20px" fontSize="12px" color="white" openDelay={1000}
+              placement="bottom" bottom="15px" left="15px" data-testid="modal-tooltip"
+            >
+              <Button size="xs" variant="ghost" ml="5" onClick={b.onClick} data-testid={`${b.label}-button`}>
+                {b.label}
+              </Button>
+            </Tooltip>
+          ))
+        }
+      </ModalFooter>
+    </CodapModal>
+  )
+}

--- a/v3/src/components/case-table/column-header.tsx
+++ b/v3/src/components/case-table/column-header.tsx
@@ -6,7 +6,7 @@ import { IUseDraggableAttribute, useDraggableAttribute } from "../../hooks/use-d
 import { useInstanceIdContext } from "../../hooks/use-instance-id-context"
 import { kDefaultAttributeName } from "../../models/data/attribute"
 import { uniqueName } from "../../utilities/js-utils"
-import { AttributeMenuList } from "./attribute-menu"
+import { AttributeMenuList } from "./attribute-menu/attribute-menu-list"
 import { CaseTablePortal } from "./case-table-portal"
 import { kIndexColumnKey, TRenderHeaderCellProps } from "./case-table-types"
 import { ColumnHeaderDivider } from "./column-header-divider"

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -706,8 +706,9 @@
     "DG.AttributeFormat.DatePrecisionShort.millisecond": "M/D/YY HH:mm:ss.SSS",
 
     // DG.AttributeFormulaView
-    "DG.AttrFormView.attrNamePrompt": "Attribute Name:",
-    "DG.AttrFormView.formulaPrompt": "Formula:",
+    "DG.AttrFormView.title": "Edit Formula",
+    "DG.AttrFormView.attrNamePrompt": "name",
+    "DG.AttrFormView.formulaPrompt": "formula",
     "DG.AttrFormView.operandMenuTitle": "--- Insert Value ---",
     "DG.AttrFormView.functionMenuTitle": "--- Insert Function ---",
     "DG.AttrFormView.applyBtnTitle": "Apply",

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -706,9 +706,8 @@
     "DG.AttributeFormat.DatePrecisionShort.millisecond": "M/D/YY HH:mm:ss.SSS",
 
     // DG.AttributeFormulaView
-    "DG.AttrFormView.title": "Edit Formula",
-    "DG.AttrFormView.attrNamePrompt": "name",
-    "DG.AttrFormView.formulaPrompt": "formula",
+    "DG.AttrFormView.attrNamePrompt": "Attribute Name:",
+    "DG.AttrFormView.formulaPrompt": "Formula:",
     "DG.AttrFormView.operandMenuTitle": "--- Insert Value ---",
     "DG.AttrFormView.functionMenuTitle": "--- Insert Function ---",
     "DG.AttrFormView.applyBtnTitle": "Apply",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185745389

1. The new modal code is based on `EditAttributePropertiesModal` that was already existing.
2. I've moved attribute menu-related code to a new dir, as I guess there'll be more dialogs, utils, etc. related to this context menu. But I don't really feel the codebase yet, so if it doesn't feel right, I'm happy to revert, or use another dir name.
3. I was surprised I had to add `onKeyDown={(e) => e.stopPropagation()}` to Textarea, as otherwise, some unexpected things were happening to the case table. This is also done in `EditAttributePropertiesModal`. Do we understand the issue well? Maybe some more generic approach could be found.
4. I haven't looked at Charka UI docs yet, but generally it looks nice. I was slightly surprised to see all the styles defined via inline attributes (like `ml` to set margin-left, etc.). Is this a pattern you agreed on and thought it'd be the best? Or something I'm randomly copying from `EditAttributePropertiesModal`? :)
5. I was also not sure about translation files. I'm assuming all the translation JSONs are coming from CODAP v2. Should we try to reuse all the strings as much as possible? Or it's fine to add new entries and tweak existing ones? In this case I've added the missing "Edit formula" header and updated the formula prompt to match the style of the `EditAttributePropertiesModal` labels (lowercase). But I don't know if this kind of update is worth it, as it'll obviously require us to re-translate these labels.