### PR TITLE
Version 3.0.0-pre.1295 - August 10, 2023

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Version 3.0.0-pre.1295 - August 10, 2023
+
+### Features/Improvements
+- Clicking on legend category key should, if appropriate, select case(s) at the level of the legend attribute. [#185325793](https://www.pivotaltracker.com/story/show/185325793)
+- A dot chart can show counts [#181914454](https://www.pivotaltracker.com/story/show/181914454)
+- Simple attribute formula editor dialog [#185745389](https://www.pivotaltracker.com/story/show/185745389)
+- The user can create a map component using the Map icon in the tool shelf. [#185505604](https://www.pivotaltracker.com/story/show/185505604)
+- Number of points in graph is at most the number of cases in the child-most collection for the given attributes [#185447912](https://www.pivotaltracker.com/story/show/185447912)
+
+### Bug Fixes
+- Closing Edit Attribute modal using "X" button doesn't restore the previously disabled attribute tooltip [#185757174](https://www.pivotaltracker.com/story/show/185757174)
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+|  main.css |   65059 bytes |                           33.11% |
+|  index.js | 3278569 bytes |                            5.45% |
+
 ## Version 3.0.0-pre.1286 - July 31, 2023
 
 ### Features/Improvements

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1286",
+  "version": "3.0.0-pre.1295",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-pre.1286",
+      "version": "3.0.0-pre.1295",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1286",
+  "version": "3.0.0-pre.1295",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",


### PR DESCRIPTION
### Features/Improvements
- Clicking on legend category key should, if appropriate, select case(s) at the level of the legend attribute. [#185325793](https://www.pivotaltracker.com/story/show/185325793)
- A dot chart can show counts [#181914454](https://www.pivotaltracker.com/story/show/181914454)
- Simple attribute formula editor dialog [#185745389](https://www.pivotaltracker.com/story/show/185745389)
- The user can create a map component using the Map icon in the tool shelf. [#185505604](https://www.pivotaltracker.com/story/show/185505604)
- Number of points in graph is at most the number of cases in the child-most collection for the given attributes [#185447912](https://www.pivotaltracker.com/story/show/185447912)

### Bug Fixes
- Closing Edit Attribute modal using "X" button doesn't restore the previously disabled attribute tooltip [#185757174](https://www.pivotaltracker.com/story/show/185757174)