### PR TITLE
Add semi-aggregate functions: `prev` and `next`, implement caching support

### DIFF
--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -33,8 +33,6 @@ export const fnRegistry = {
   // Note that we need to overwrite default MathJs implementation so we can compare strings like "ABC" == "CDE".
   // MathJs doesn't allow that by default, as it assumes that equal operator can be used only with numbers.
   equal: {
-    rawArgs: false,
-    isAggregate: false,
     evaluate: (a: any, b: any) => {
       if (Array.isArray(a) && Array.isArray(b)) {
         return a.map((v, i) => v === b[i])
@@ -52,7 +50,6 @@ export const fnRegistry = {
   // lookupByIndex("dataSetName", "attributeName", index)
   lookupByIndex: {
     rawArgs: true,
-    isAggregate: false,
     validateArguments: (args: MathNode[]): [ConstantNode<string>, ConstantNode<string>, MathNode] => {
       if (args.length !== 3) {
         throw new Error(`lookupByIndex function expects exactly 3 arguments, but it received ${args.length}`)
@@ -89,7 +86,6 @@ export const fnRegistry = {
   // lookupByKey("dataSetName", "attributeName", "keyAttributeName", "keyAttributeValue" | localKeyAttribute)
   lookupByKey: {
     rawArgs: true,
-    isAggregate: false,
     validateArguments: (args: MathNode[]):
       [ConstantNode<string>, ConstantNode<string>, ConstantNode<string>, MathNode] => {
       if (args.length !== 4) {
@@ -155,10 +151,11 @@ export const fnRegistry = {
     }
   },
 
-  // next(attributeName, defaultValue, filter)
+  // next(expression, defaultValue, filter)
   next: {
     rawArgs: true,
-    isAggregate: true,
+    // expression and filter are evaluated as aggregate symbols, defaultValue is not - it depends on case index
+    isSemiAggregate: [true, false, true],
     evaluate: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
       interface ICachedData {
         resultIndex: number
@@ -224,7 +221,8 @@ export const fnRegistry = {
   // prev(expression, defaultValue, filter)
   prev: {
     rawArgs: true,
-    isAggregate: true,
+    // expression and filter are evaluated as aggregate symbols, defaultValue is not - it depends on case index
+    isSemiAggregate: [true, false, true],
     evaluate: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
       interface ICachedData {
         resultIndex: number
@@ -276,7 +274,7 @@ export const fnRegistry = {
   }
 }
 
-export const typedFnRegistry: ICODAPMathjsFunctionRegistry & typeof fnRegistry = fnRegistry
+export const typedFnRegistry: ICODAPMathjsFunctionRegistry = fnRegistry
 
 // import the new function in the Mathjs namespace
 Object.keys(typedFnRegistry).forEach((key) => {

--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -183,7 +183,7 @@ export const fnRegistry = {
       const cachedData = scope.getCached(cacheKey) as ICachedData | undefined
 
       let result
-      if (cachedData !== undefined) {
+      if (cachedData) {
         const { resultIndex, expressionValues, filterValues } = cachedData
         if (currentIndex < resultIndex) {
           // Current index is still smaller than previously cached result index. We can reuse it.

--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -253,7 +253,7 @@ export const fnRegistry = {
         }
       } else {
         // This block of code will be executed only once, for the very first case.
-        // The very fist case can't return anything from prev() function.
+        // The very first case can't return anything from prev() function.
         const filterValues = evaluateNode(filter, scope)
         const expressionValues = evaluateNode(expression, scope)
         const resultIndex = -1

--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -138,6 +138,60 @@ export const fnRegistry = {
       return mean(expressionValues)
     }
   },
+
+  // next(attributeName, defaultValue, filter)
+  next: {
+    rawArgs: true,
+    isAggregate: true,
+    evaluate: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
+      const expression = args[0]
+      const defaultValue = args[1]
+      const filter = args[2]
+      const expressionValues = evaluateNode(expression, scope)
+      const dataSet: IDataSet = scope.getLocalDataSet()
+      const currentIndex = dataSet.caseIDMap[scope.getCaseId()]
+      let resultIndex = -1
+      if (!filter) {
+        resultIndex = currentIndex + 1
+      } else {
+        const filterValues = evaluateNode(filter, scope)
+        for (let i = currentIndex + 1; i < filterValues.length; i++) {
+          if (!!filterValues[i] === true) {
+            resultIndex = i
+            break
+          }
+        }
+      }
+      return expressionValues[resultIndex] ?? (defaultValue ? evaluateNode(defaultValue, scope) : "")
+    }
+  },
+
+  // prev(expression, defaultValue, filter)
+  prev: {
+    rawArgs: true,
+    isAggregate: true,
+    evaluate: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
+      const expression = args[0]
+      const defaultValue = args[1]
+      const filter = args[2]
+      const expressionValues = evaluateNode(expression, scope)
+      const dataSet: IDataSet = scope.getLocalDataSet()
+      const currentIndex = dataSet.caseIDMap[scope.getCaseId()]
+      let resultIndex = -1
+      if (!filter) {
+        resultIndex = currentIndex - 1
+      } else {
+        const filterValues = evaluateNode(filter, scope)
+        for (let i = currentIndex - 1; i >= 0; i--) {
+          if (!!filterValues[i] === true) {
+            resultIndex = i
+            break
+          }
+        }
+      }
+      return expressionValues[resultIndex] ?? (defaultValue ? evaluateNode(defaultValue, scope) : "")
+    }
+  }
 }
 
 export const typedFnRegistry: ICODAPMathjsFunctionRegistry & typeof fnRegistry = fnRegistry

--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -26,7 +26,7 @@ const cachedAggregateFnFactory =
   }
 }
 
-const UNDEF_RES = ""
+const UNDEF_RESULT = ""
 
 export const fnRegistry = {
   // equal(a, b) or a == b
@@ -78,7 +78,7 @@ export const fnRegistry = {
       const dataSetId = evaluateNode(args[0], scope)
       const attrId = evaluateNode(args[1], scope)
       const zeroBasedIndex = evaluateNode(args[2], scope) - 1
-      return scope.getDataSet(dataSetId)?.getValueAtIndex(zeroBasedIndex, attrId) || UNDEF_RES
+      return scope.getDataSet(dataSetId)?.getValueAtIndex(zeroBasedIndex, attrId) || UNDEF_RESULT
     }
   },
 
@@ -120,15 +120,15 @@ export const fnRegistry = {
 
       const dataSet: IDataSet | undefined = scope.getDataSet(dataSetId)
       if (!dataSet) {
-        return UNDEF_RES
+        return UNDEF_RESULT
       }
       for (const c of dataSet.cases) {
         const val = dataSet.getValue(c.__id__, keyAttrId)
         if (val === keyAttrValue) {
-          return dataSet.getValue(c.__id__, attrId) || UNDEF_RES
+          return dataSet.getValue(c.__id__, attrId) || UNDEF_RESULT
         }
       }
-      return UNDEF_RES
+      return UNDEF_RESULT
     },
   },
 
@@ -210,7 +210,7 @@ export const fnRegistry = {
           filterValues
         })
       }
-      return result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RES)
+      return result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RESULT)
     }
   },
 
@@ -264,7 +264,7 @@ export const fnRegistry = {
           filterValues
         })
       }
-      return result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RES)
+      return result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RESULT)
     }
   },
 }

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -84,6 +84,14 @@ export class FormulaMathJsScope {
     this.caseId = caseId
   }
 
+  getCaseId() {
+    return this.caseId
+  }
+
+  getLocalDataSet() {
+    return this.context.localDataSet
+  }
+
   getDataSet(dataSetId: string) {
     return this.context.dataSets.get(dataSetId)
   }

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -2,6 +2,8 @@ import { AGGREGATE_SYMBOL_SUFFIX, GLOBAL_VALUE, LOCAL_ATTR } from "./formula-typ
 import type { IGlobalValueManager } from "../global/global-value-manager"
 import type { IDataSet } from "./data-set"
 
+const CACHE_ENABLED = true
+
 export interface IFormulaMathjsScopeContext {
   localDataSet: IDataSet
   dataSets: Map<string, IDataSet>
@@ -14,6 +16,7 @@ export class FormulaMathJsScope {
   context: IFormulaMathjsScopeContext
   caseId = ""
   dataStorage: Record<string, any> = {}
+  cache = new Map<string, any>()
 
   constructor (context: IFormulaMathjsScopeContext) {
     this.context = context
@@ -88,11 +91,28 @@ export class FormulaMathJsScope {
     return this.caseId
   }
 
+  getCaseIndex() {
+    return this.context.localDataSet.caseIDMap[this.caseId]
+  }
+
   getLocalDataSet() {
     return this.context.localDataSet
   }
 
   getDataSet(dataSetId: string) {
     return this.context.dataSets.get(dataSetId)
+  }
+
+  setCached(key: string, value: any) {
+    if (CACHE_ENABLED) {
+      this.cache.set(key, value)
+    }
+  }
+
+  getCached(key: string) {
+    if (CACHE_ENABLED) {
+      return this.cache.get(key)
+    }
+    return undefined
   }
 }

--- a/v3/src/models/data/formula-types.ts
+++ b/v3/src/models/data/formula-types.ts
@@ -38,7 +38,9 @@ export type IFormulaDependency = ILocalAttributeDependency | IGlobalValueDepende
 
 export type FValue = string | number | boolean
 
-export type EvaluateFunc = (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]
+export type EvaluateFunc = (...args: FValue[]) => FValue | FValue[]
+
+export type EvaluateRawFunc = (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]
 
 export interface IFormulaMathjsFunction {
   rawArgs?: boolean
@@ -47,10 +49,14 @@ export interface IFormulaMathjsFunction {
   // When true, it means that the argument is a aggregate argument, otherwise it's not. Hence the whole function
   // is semi-aggregate.
   isSemiAggregate?: boolean[]
-  evaluate: EvaluateFunc
+  // `evaluate` function accepts arguments already processed and evaluated by mathjs.
+  evaluate?: EvaluateFunc
+  // `evaluateRaw` function accepts raw arguments following convention defined by mathjs.
+  // This lets us enable custom processing of arguments, caching, etc.
+  evaluateRaw?: EvaluateRawFunc
   canonicalize?: (args: MathNode[], displayNameMap: DisplayNameMap) => void
   getDependency?: (args: MathNode[]) => IFormulaDependency
-  cachedEvaluateFactory?: (fnName: string, evaluate: EvaluateFunc) => EvaluateFunc
+  cachedEvaluateFactory?: (fnName: string, evaluate: EvaluateRawFunc) => EvaluateRawFunc
 }
 
 export type ICODAPMathjsFunctionRegistry = Record<string, IFormulaMathjsFunction>

--- a/v3/src/models/data/formula-types.ts
+++ b/v3/src/models/data/formula-types.ts
@@ -36,14 +36,17 @@ export interface ILookupDependency {
 
 export type IFormulaDependency = ILocalAttributeDependency | IGlobalValueDependency | ILookupDependency
 
-export type EvalValue = string | number | boolean
+export type FValue = string | number | boolean
+
+export type EvaluateFunc = (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]
 
 export interface IFormulaMathjsFunction {
   rawArgs: boolean
   isAggregate: boolean
-  evaluate: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => EvalValue | EvalValue[]
+  evaluate: EvaluateFunc
   canonicalize?: (args: MathNode[], displayNameMap: DisplayNameMap) => void
   getDependency?: (args: MathNode[]) => IFormulaDependency
+  cachedEvaluateFactory?: (fnName: string, evaluate: EvaluateFunc) => EvaluateFunc
 }
 
 export type ICODAPMathjsFunctionRegistry = Record<string, IFormulaMathjsFunction>

--- a/v3/src/models/data/formula-types.ts
+++ b/v3/src/models/data/formula-types.ts
@@ -46,7 +46,7 @@ export interface IFormulaMathjsFunction {
   rawArgs?: boolean
   isAggregate?: boolean
   // Value of isSemiAggregate is an array of booleans, where each boolean corresponds to an argument of the function.
-  // When true, it means that the argument is a aggregate argument, otherwise it's not. Hence the whole function
+  // When true, it means that the argument is an aggregate argument, otherwise it's not. Hence the whole function
   // is semi-aggregate.
   isSemiAggregate?: boolean[]
   // `evaluate` function accepts arguments already processed and evaluated by mathjs.

--- a/v3/src/models/data/formula-types.ts
+++ b/v3/src/models/data/formula-types.ts
@@ -41,8 +41,12 @@ export type FValue = string | number | boolean
 export type EvaluateFunc = (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]
 
 export interface IFormulaMathjsFunction {
-  rawArgs: boolean
-  isAggregate: boolean
+  rawArgs?: boolean
+  isAggregate?: boolean
+  // Value of isSemiAggregate is an array of booleans, where each boolean corresponds to an argument of the function.
+  // When true, it means that the argument is a aggregate argument, otherwise it's not. Hence the whole function
+  // is semi-aggregate.
+  isSemiAggregate?: boolean[]
   evaluate: EvaluateFunc
   canonicalize?: (args: MathNode[], displayNameMap: DisplayNameMap) => void
   getDependency?: (args: MathNode[]) => IFormulaDependency

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -58,6 +58,17 @@ export const canonicalizeExpression = (displayExpression: string, displayNameMap
     if (isFunctionNode(node) && typedFnRegistry[node.fn.name].isAggregate || parent?.isDescendantOfAggregateFunc) {
       node.isDescendantOfAggregateFunc = true
     }
+    if (isFunctionNode(node) && typedFnRegistry[node.fn.name].isSemiAggregate) {
+      // Current semi-aggregate functions usually have the following signature:
+      // fn(expression, defaultValue, filter)
+      // Symbols used in `expression` and `filter` arguments should be treated as aggregate symbols.
+      // In this case, `isSemiAggregate` would be equal to [true, false, true].
+      typedFnRegistry[node.fn.name].isSemiAggregate?.forEach((isAggregateArgument, index) => {
+        if (isAggregateArgument) {
+          (node.args[index] as IExtendedMathNode).isDescendantOfAggregateFunc = true
+        }
+      })
+    }
     const isDescendantOfAggregateFunc = !!node.isDescendantOfAggregateFunc
     if (isSymbolNode(node)) {
       const canonicalName = generateCanonicalSymbolName(node.name, isDescendantOfAggregateFunc, displayNameMap)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185745491

This PR adds basic caching to the formula evaluation scope. All the aggregate functions can use it in a very simple way. `mean` is the first aggregate func we have available, and it does use it now.

Also, I've implemented the first two semi-aggregate functions: `prev` and `next`. Their implementation heavily relies on custom caching, so I could ensure that the total execution time for all the cases is O(n).

Temporarily I've added the `CACHE_ENABLED` global flag, so I could test if the difference is visible in practice. As expected - it is, as we drop from O(n2) to O(n). For 5000 cases, only cached variants are usable. I haven't done any more precise/scientific measurements.

Demo:
https://codap3.concord.org/branch/semi-aggregate/index.html