### PR TITLE
feat: add random() and randomPick() functions, implement basic rerandomization [PT-185745433]

### DIFF
--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -23,6 +23,8 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
   const formulaModal = useDisclosure()
   const columnName = column.name as string
   const columnId = column.key
+  const attribute = data?.attrFromID(columnId)
+  const rerandomizeDisabled = !attribute?.formula.isRandomFunctionPresent
 
   const handleMenuItemClick = (menuItem: string) => {
     toast({
@@ -61,6 +63,10 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
     onModalOpen(false)
   }
 
+  const handleRerandomize = () => {
+    attribute?.formula.rerandomize()
+  }
+
   const handleMenuKeyDown = (e: React.KeyboardEvent) => {
     e.stopPropagation()
   }
@@ -86,7 +92,7 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
         <MenuItem onClick={() => handleMenuItemClick("Recover Formula")}>
           {t("DG.TableController.headerMenuItems.recoverFormula")}
         </MenuItem>
-        <MenuItem onClick={() => handleMenuItemClick("Rerandomize")}>
+        <MenuItem onClick={handleRerandomize} isDisabled={rerandomizeDisabled}>
           {t("DG.TableController.headerMenuItems.randomizeAttribute")}
         </MenuItem>
         <MenuItem onClick={() => handleMenuItemClick("Sort Ascending")}>

--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -1,4 +1,4 @@
-import { create, all, mean, MathNode, ConstantNode } from 'mathjs'
+import { create, all, mean, random, pickRandom, MathNode, ConstantNode } from 'mathjs'
 import { FormulaMathJsScope } from './formula-mathjs-scope'
 import {
   DisplayNameMap, FValue, ICODAPMathjsFunctionRegistry, ILookupDependency, isConstantStringNode
@@ -267,6 +267,21 @@ export const fnRegistry = {
       return result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RES)
     }
   },
+
+  // randomPick(...args)
+  randomPick: {
+    isRandomFunction: true,
+    // Nothing to do here, mathjs.pickRandom() has exactly the same signature as CODAP V2 randomPick() function,
+    // just the name is different.
+    evaluate: (...args: FValue[]) => pickRandom(args)
+  },
+
+  // random(min, max)
+  random: {
+    isRandomFunction: true,
+    // Nothing to do here, mathjs.random() has exactly the same signature as CODAP V2 random() function.
+    evaluate: (...args: FValue[]) => random(...args as number[])
+  }
 }
 
 export const typedFnRegistry: ICODAPMathjsFunctionRegistry = fnRegistry

--- a/v3/src/models/data/formula-types.ts
+++ b/v3/src/models/data/formula-types.ts
@@ -44,11 +44,16 @@ export type EvaluateRawFunc = (args: MathNode[], mathjs: any, scope: FormulaMath
 
 export interface IFormulaMathjsFunction {
   rawArgs?: boolean
+  // Value of isAggregate is a boolean. When true, it means that all the arguments of the function should be resolved
+  // to all cases of the attribute, not just the current case.
   isAggregate?: boolean
   // Value of isSemiAggregate is an array of booleans, where each boolean corresponds to an argument of the function.
   // When true, it means that the argument is a aggregate argument, otherwise it's not. Hence the whole function
   // is semi-aggregate.
   isSemiAggregate?: boolean[]
+  // Value of isRandomFunction is a boolean. When true, it means that the function is a random function.
+  // Formula needs to know whether it includes random functions, so we can enable rerandomize feature.
+  isRandomFunction?: boolean
   // `evaluate` function accepts arguments already processed and evaluated by mathjs.
   evaluate?: EvaluateFunc
   // `evaluateRaw` function accepts raw arguments following convention defined by mathjs.

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -87,6 +87,18 @@ export const canonicalizeExpression = (displayExpression: string, displayNameMap
   return formulaTree.toString()
 }
 
+export const isRandomFunctionPresent = (formulaCanonical: string) => {
+  const formulaTree = parse(formulaCanonical)
+  let result = false
+  const visitNode = (node: MathNode) => {
+    if (isFunctionNode(node) && typedFnRegistry[node.fn.name].isRandomFunction) {
+      result = true
+    }
+  }
+  formulaTree.traverse(visitNode)
+  return result
+}
+
 export const getFormulaDependencies = (formulaCanonical: string) => {
   const formulaTree = parse(formulaCanonical)
   const result: IFormulaDependency[] = []

--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -1,6 +1,6 @@
 import { Instance, types } from "mobx-state-tree"
 import { typedId } from "../../utilities/js-utils"
-import { canonicalizeExpression } from "./formula-utils"
+import { canonicalizeExpression, isRandomFunctionPresent } from "./formula-utils"
 import { getFormulaManager } from "../tiles/tile-environment"
 
 export const Formula = types.model("Formula", {
@@ -13,7 +13,10 @@ export const Formula = types.model("Formula", {
   },
   get formulaManager() {
     return getFormulaManager(self)
-  }
+  },
+  get isRandomFunctionPresent() {
+    return isRandomFunctionPresent(self.canonical)
+  },
 }))
 .actions(self => ({
   setDisplayFormula(displayFormula: string) {
@@ -25,6 +28,12 @@ export const Formula = types.model("Formula", {
   },
   setCanonical(canonical: string) {
     self.canonical = canonical
+  },
+  rerandomize() {
+    if (!self.formulaManager) {
+      return
+    }
+    self.formulaManager.recalculateFormula(self.id)
   }
 }))
 

--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -30,10 +30,7 @@ export const Formula = types.model("Formula", {
     self.canonical = canonical
   },
   rerandomize() {
-    if (!self.formulaManager) {
-      return
-    }
-    self.formulaManager.recalculateFormula(self.id)
+    self.formulaManager?.recalculateFormula(self.id)
   }
 }))
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185745433

This PR adds two random functions: `random` and `randomPick`. Also, it implements "rerandomize" feature and makes this button disabled when there's no random function in the formula. 

The implementation is very basic, so I likely missed some quirks and challenges related to the random functions, but I still thought I could just push it and open PR.

Note that there are some differences in behavior compared to V2, but I could almost call them improvements unless there are some specific reasons for the previous behavior. An example:

CODAP V2: Open Mammals and add a new formula like `random() * Height`. Simple, non-aggregate function. Now, when I edit just one "Height" cell, all the cases get recomputed and since we use random(), they all get a new value. However, my implementation in CODAP V3 updates just the case that was edited by the user. Is that fine? From my naive perspective, it makes even more sense. 

I can find other similar scenarios - e.g., when I add a new case in V2, all the values get recomputed. V3 recomputes only the new ones. Would we consider such behavior okay and/or even an improvement? Or is there some reason to recalculate everything?

Note that differences are caused by the property observing. I guess V3 is more specific about what and when to recompute a case. Although this will depend on type of the dependency - e.g., lookup dependency probably works similarly to V2.

