### PR TITLE
Initial approach/spike to handling collections in formulas

### DIFF
--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -459,7 +459,7 @@ export const DataSet = types.model("DataSet", {
     }
     return self.childCases()
   },
-  getCasesForAttributes(attributeIds: string[]) {
+  getCollectionGroupForAttributes(attributeIds: string[]) {
     // finds the child-most collection (if any) among the specified attributes
     let collectionIndex = -1
     for (const attrId of attributeIds) {
@@ -471,13 +471,22 @@ export const DataSet = types.model("DataSet", {
         }
       }
       if (attrCollectionIndex < 0) {
-        // if we get here then the attribute isn't grouped, so the regular cases can be used
-        return self.childCases()
+        // if we get here then the attribute isn't grouped, so no collection group can be returned
+        return null
       }
       collectionIndex = Math.max(collectionIndex, attrCollectionIndex)
     }
-    // return the cases from the child-most collection that included any of the attributes
-    return self.collectionGroups[collectionIndex].groups.map(group => group.pseudoCase)
+    // return the child-most collection that included any of the attributes
+    return self.collectionGroups[collectionIndex]
+  },
+  getCasesForAttributes(attributeIds: string[]) {
+    const collectionGroup = this.getCollectionGroupForAttributes(attributeIds)
+    if (collectionGroup) {
+      return collectionGroup.groups.map(group => group.pseudoCase)
+    } else {
+      // If there are no groups, regular cases can be used
+      return self.childCases()
+    }
   }
 }))
 .extend(self => {

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -43,7 +43,7 @@ export class FormulaMathJsScope {
           // - the table is flat and aggregate function is referencing another attribute
           // - the table is hierarchical and aggregate function is referencing an attribute from the same collection
           // In both cases it's enough to compare collection ids. When the table is flat, they might be equal to
-          // undefined but equality check it's gonna work anyway.
+          // undefined but equality check works anyway.
           const attrCollectionId = context.localDataSet.getCollectionForAttribute(attr.id)?.id
           const useSameLevelCases = context.formulaAttributeCollectionId === attrCollectionId
           // Note that mapping childCaseIds might look like potential performance issue / O(n^2), but it's not.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185745420

This PR adds an initial implementation that handles resolving the aggregate symbols when the tables are hierarchical.
I doubt it's complete, and many edge cases are probably missing, but I still thought it might be worth sharing before I leave for vacation.

There are two main issues so far:
- I had to disable previous caching, as obviously, we can no longer cache aggregate functions as simply as before. I have some ideas on how to deal with it, but first, I'd like to wrap up and validate the whole approach.
- There's a significant difference in how I handle aggregate functions in the child collections. [Please see my message on Slack](https://concord-consortium.slack.com/archives/C035J6RDAK0/p1692357421148309), where I included two videos clearly showing the difference. It mainly happened because I didn't realize V2 was working that way. I can adjust this behavior if necessary (I bet it is, as it's a significant difference).
- I'll need to handle a scenario when an attribute with a formula is dragged to another collection.
- I didn't even try to think what to do when the formula references an attribute from the parent collection. But I've noticed that V2 gets broken or it just doesn't render anything.
- I've also noticed a few bugs in CODAP v3 related to hierarchal parents. Initial dragging of attributes usually works, but often after a few moves back and forth, things get a bit broken. I bet you're aware of that. But I'm mentioning that as it might affect testing/demoing.

