### PR TITLE
feat: restore caching in aggregate functions that works with hierarchical tables [PT-185947550]

### DIFF
--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -15,13 +15,20 @@ const evaluateNode = (node: MathNode, scope?: FormulaMathJsScope) => {
 const cachedAggregateFnFactory =
 (fnName: string, fn: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]) => {
   return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
-    const cacheKey = `${fnName}(${args.toString()})`
+    const cacheKey = `${fnName}(${args.toString()})-${scope.getCaseGroupId()}`
     const cachedValue = scope.getCached(cacheKey)
     if (cachedValue !== undefined) {
       return cachedValue
     }
     const result = fn(args, mathjs, scope)
-    scope.setCached(cacheKey, result)
+    // In practice, the cacheability is defined by the fact whether the function accesses attributes from the same
+    // collection only or not. It can be checked while the expression is calculated for the first time. `scope` object
+    // keeps track of that. Each scope is cacheable by default, but once it accesses an attribute from a different
+    // collection, it becomes not cacheable (and propagates this update to the parent scopes). Note that a new scope
+    // is created for each function call (and each instance keeps reference to its parent).
+    if (scope.isCacheable()) {
+      scope.setCached(cacheKey, result)
+    }
     return result
   }
 }

--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -21,8 +21,8 @@ const cachedAggregateFnFactory =
       return cachedValue
     }
     const result = fn(args, mathjs, scope)
-    // In practice, the cacheability is defined by the fact whether the function accesses attributes from the same
-    // collection only or not. It can be checked while the expression is calculated for the first time. `scope` object
+    // In practice, the cacheability is defined by whether or not the function accesses attributes from the same
+    // collection only. It can be checked while the expression is calculated for the first time. `scope` object
     // keeps track of that. Each scope is cacheable by default, but once it accesses an attribute from a different
     // collection, it becomes not cacheable (and propagates this update to the parent scopes). Note that a new scope
     // is created for each function call (and each instance keeps reference to its parent).

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -40,7 +40,7 @@ export class FormulaMathJsScope {
     // Cacheability does not depend on the parent. It's actually defined the other way - parent is not cacheable if
     // any of its children is not cacheable (see setNotCacheable() method).
     this.cacheable = true
-    // Note that dataStorage cannot be reused, as it relies on closures and bounding to correct `this` instance.
+    // Note that dataStorage cannot be reused, as it relies on closures and binding to correct `this` instance.
     // It needs to be recreated, but it is not be a costly operation. Make sure that all the caching and
     // case processing is done lazily, only for attributes that are actually referenced by the formula.
     this.initDataStorage(context)

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -3,7 +3,7 @@ import type { IGlobalValueManager } from "../global/global-value-manager"
 import type { IDataSet } from "./data-set"
 import type { IValueType } from "./attribute"
 
-const CACHE_ENABLED = false
+const CACHE_ENABLED = true
 
 export interface IFormulaMathjsScopeContext {
   localDataSet: IDataSet
@@ -16,20 +16,45 @@ export interface IFormulaMathjsScopeContext {
 // Official MathJS docs don't describe custom scopes in great detail, but there's a good example in their repo:
 // https://github.com/josdejong/mathjs/blob/develop/examples/advanced/custom_scope_objects.js
 export class FormulaMathJsScope {
+  parent?: FormulaMathJsScope
   context: IFormulaMathjsScopeContext
   caseId = ""
   dataStorage: Record<string, any> = {}
   cache = new Map<string, any>()
+  // Expression is meant to be cacheable by default. Once it references a value that makes it not cacheable, this
+  // state property will be updated (e.g. when it references a case-dependent attribute).
+  cacheable = true
 
-  constructor (context: IFormulaMathjsScopeContext) {
+  constructor (context: IFormulaMathjsScopeContext, parent?: FormulaMathJsScope) {
     this.context = context
 
+    // In regular MathJS use case, a subscope is used to create a new scope for a function call. It needs to ensure
+    // that variables from subscope cannot overwrite variables from the parent scope. However, since we don't allow
+    // any variables to be set in the formula scope, we can reuse multiple data structures for simplicity and
+    // performance reasons.
+    if (parent) {
+      this.parent = parent
+      this.caseId = parent.caseId
+      this.cache = parent.cache
+    }
+    // Cacheability does not depend on the parent. It's actually defined the other way - parent is not cacheable if
+    // any of its children is not cacheable (see setNotCacheable() method).
+    this.cacheable = true
+    // Note that dataStorage cannot be reused, as it relies on closures and bounding to correct `this` instance.
+    // It needs to be recreated, but it is not be a costly operation. Make sure that all the caching and
+    // case processing is done lazily, only for attributes that are actually referenced by the formula.
+    this.initDataStorage(context)
+  }
+
+  initDataStorage(context: IFormulaMathjsScopeContext) {
     // We could parse symbol name in get() function, but this should theoretically be faster, as it's done only once,
     // and no parsing is needed when the symbol is accessed for each dataset case.
     // First, provide local dataset attribute symbols.
     context.localDataSet.attributes.forEach(attr => {
       Object.defineProperty(this.dataStorage, `${LOCAL_ATTR}${attr.id}`, {
         get: () => {
+          // Any expression that depends on case-dependent attribute is not cacheable.
+          this.setNotCacheable()
           return context.localDataSet.getValue(this.caseId, attr.id)
         }
       })
@@ -62,9 +87,12 @@ export class FormulaMathJsScope {
             })
             cacheInitialized = true
           }
-
           // Same-level grouping uses parent ID as a group ID, parent-child grouping uses case ID as a group ID.
           const groupParentId = useSameLevelGrouping ? context.caseGroupId[this.caseId] : this.caseId
+          if (!useSameLevelGrouping) {
+            // Any expression that depends on parent-child grouping is not cacheable.
+            this.setNotCacheable()
+          }
           return cachedGroup[groupParentId] || cachedGroup[NO_PARENT_KEY]
         }
       })
@@ -106,15 +134,23 @@ export class FormulaMathJsScope {
     throw new Error("It's not allowed to clear values in the formula scope.")
   }
 
-  // In regular MathJS use case, a subscope is used to create a new scope for a function call. It needs to ensure
-  // that variables from subscope cannot overwrite variables from the parent scope. However, since we don't allow
-  // any variables to be set in the formula scope, we can just return the same scope for simplicity and
-  // performance reasons.
+  // MathJS creates a separate subscope for every parsed and evaluated function call.
   createSubScope () {
-    return this
+    return new FormulaMathJsScope(this.context, this)
   }
 
   // --- Custom functions used by our formulas or formula manager --
+  setNotCacheable() {
+    if (this.cacheable) {
+      this.parent?.setNotCacheable()
+      this.cacheable = false
+    }
+  }
+
+  isCacheable() {
+    return this.cacheable
+  }
+
   setCaseId(caseId: string) {
     this.caseId = caseId
   }
@@ -133,6 +169,10 @@ export class FormulaMathJsScope {
 
   getDataSet(dataSetId: string) {
     return this.context.dataSets.get(dataSetId)
+  }
+
+  getCaseGroupId() {
+    return this.context.caseGroupId[this.caseId]
   }
 
   setCached(key: string, value: any) {

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -41,7 +41,7 @@ export class FormulaMathJsScope {
     // any of its children is not cacheable (see setNotCacheable() method).
     this.cacheable = true
     // Note that dataStorage cannot be reused, as it relies on closures and binding to correct `this` instance.
-    // It needs to be recreated, but it is not be a costly operation. Make sure that all the caching and
+    // It needs to be recreated, but it is not a costly operation. Make sure that all the caching and
     // case processing is done lazily, only for attributes that are actually referenced by the formula.
     this.initDataStorage(context)
   }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185947550

Hierarchical tables complicated everything quite a lot.
This is an approach that seems to support two cases when the aggregate function needs to be cached:
- aggregate function referencing another attribute in a flat table
- aggregate function referencing another attribute from the same collection in a hierarchical tables

When the aggregate function references an attribute from a child collection, caching is impossible and unnecessary.
Does it cover all the use cases for caching or am I missing something?

Semi-aggregate functions work only within the flat tables or the same collection, so they should be easier to handle.

