### PR TITLE
Evaluate aggregate function against the child-most collection in hierarchical tables (following V2 approach)

### DIFF
--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -21,14 +21,7 @@ const cachedAggregateFnFactory =
       return cachedValue
     }
     const result = fn(args, mathjs, scope)
-    // In practice, the cacheability is defined by whether or not the function accesses attributes from the same
-    // collection only. It can be checked while the expression is calculated for the first time. `scope` object
-    // keeps track of that. Each scope is cacheable by default, but once it accesses an attribute from a different
-    // collection, it becomes not cacheable (and propagates this update to the parent scopes). Note that a new scope
-    // is created for each function call (and each instance keeps reference to its parent).
-    if (scope.isCacheable()) {
-      scope.setCached(cacheKey, result)
-    }
+    scope.setCached(cacheKey, result)
     return result
   }
 }

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -40,7 +40,7 @@ export class FormulaMathJsScope {
         }
       })
 
-      // Make sure that all the caching and  case processing is done lazily, only for attributes that are actually
+      // Make sure that all the caching and case processing is done lazily, only for attributes that are actually
       // referenced by the formula.
       const cachedGroup: Record<string, IValueType[]> = {}
       let cacheInitialized = false

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -3,6 +3,7 @@ import {
   AGGREGATE_SYMBOL_SUFFIX, LOCAL_ATTR, GLOBAL_VALUE, DisplayNameMap, IFormulaDependency, ILocalAttributeDependency,
 } from "./formula-types"
 import { typedFnRegistry } from "./formula-fn-registry"
+import type { IDataSet } from "./data-set"
 
 // Set of formula helpers that can be used outside FormulaManager context. It should make them easier to test.
 
@@ -120,4 +121,32 @@ export const getFormulaDependencies = (formulaCanonical: string) => {
   }
   formulaTree.traverse(visitNode)
   return result
+}
+
+// This function returns the index of the child collection that contains the cases required for evaluating the given
+// formula. If the formula should only be evaluated against cases from its own collection, it returns `null`.
+// `-1` means that the formula should be evaluated against the child-most collection (aka ungrouped collection).
+// In practice, the formula needs to be evaluated against cases from child collections only in scenarios where it
+// contains aggregate functions. In such cases, the formula needs to be evaluated for cases in the child-most collection
+// that contains one of the arguments used in the aggregate functions.
+export const getFormulaChildMostCollectionIndex = (formulaCanonical: string, dataSet: IDataSet) => {
+  const dependencies = getFormulaDependencies(formulaCanonical)
+  let maxCollectionIndex = -Infinity
+  for (const dep of dependencies) {
+    if (dep.type === "localAttribute" && dep.aggregate) {
+      const depCollectionId = dataSet.getCollectionForAttribute(dep.attrId)?.id
+      const depCollectionIndex = dataSet.getCollectionIndex(depCollectionId || "")
+      // Child cases collection (aka ungrouped collection) has no collectionGroup and no index. So, getCollectionIndex()
+      // returns -1. But in fact this is the child-most collection, so we can treat it as the last collection and
+      // return the result immediately.
+      if (depCollectionIndex === -1) {
+        return -1
+      }
+      if (depCollectionIndex > maxCollectionIndex) {
+        maxCollectionIndex = depCollectionIndex
+      }
+    }
+  }
+  // null means that the client needs to use the collection where the formula is located.
+  return maxCollectionIndex === -Infinity ? null : maxCollectionIndex
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185967142

In V2, formulas with aggregate functions were evaluated against the child-most collection in hierarchical tables. This pull request introduces the same behavior in V3.

[Discussion on Slack #1](https://concord-consortium.slack.com/archives/C035J6RDAK0/p1693584036196519)
[Discussion on Slack #2](https://concord-consortium.slack.com/archives/C035J6RDAK0/p1693833564638489)

Details:
I've managed to streamline the update using an approach that still relies on arrays. Now, when encountering a formula like `mean(LifeSpan + newAttr)` (where newAttr is in a parent collection and LifeSpan is in a child one), it is resolved as follows:

- `mean([70, 70, 40, 25, ...] + [1, 1, 1, ...])`
- `mean([19, 25, 14, ...] + [2, 2, 2, ...])`
- `mean([40, 9, 3, ...] + [3, 3, 3, ...])`

We discussed this as one of the options on Friday.

I find this approach appealing because it allows us to implement aggregate functions in a self-contained and elegant manner, without diving into the details of how formulas are evaluated. Therefore, the code in the formula-fn-registry (or whatever set of files it evolves into in the future) should remain easy to read, and adding new functions, even aggregate ones, should be relatively straightforward. Let's see if it holds up as we encounter more edge cases in the future.

Additionally, this new approach has significantly simplified caching for aggregate functions. We now use a single grouping type per formula, making many aspects of our implementation much smoother.