### PR TITLE
Slightly refactor DataSet collection-related methods (-> ungrouped col consistency)

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -119,7 +119,7 @@ export const DataConfigurationModel = types
             .filter(id => !!id) as string[],
           childmostCollectionID = idOfChildmostCollectionForAttributes(attrIDs, self.dataset)
         if (childmostCollectionID) {
-          const childmostCollection = self.dataset?.getCollection(childmostCollectionID),
+          const childmostCollection = self.dataset?.getRealCollection(childmostCollectionID),
             childmostCollectionAttributes = childmostCollection?.attributes
           if (childmostCollectionAttributes?.length) {
             const firstAttribute = childmostCollectionAttributes[0]
@@ -346,7 +346,7 @@ export const DataConfigurationModel = types
     }))
     .views(self => ({
       /**
-       * For the purpose of computing percentages, we need to know the total number of cases we're counting. 
+       * For the purpose of computing percentages, we need to know the total number of cases we're counting.
        * A "subplot" contains the cases being considered. Subplots are always defined by topSplit and/or rightSplit
        * categorical attributes rather than any categorical attributes on the left or bottom.
        * A "cell" is defined by zero or more categorical attributes within a subplot.
@@ -379,7 +379,7 @@ export const DataConfigurationModel = types
       const rightAttrID = self.attributeID("rightSplit")
       const isSubplotMatch = (!topAttrID || (topAttrID && cellKey[topAttrID] === caseData[topAttrID])) &&
         (!rightAttrID || (rightAttrID && cellKey[rightAttrID] === caseData[rightAttrID]))
-      
+
       return isSubplotMatch
     },
     isCaseInCell(cellKey: Record<string, string>, caseData: Record<string, any>) {
@@ -445,7 +445,7 @@ export const DataConfigurationModel = types
           const isBottomMatch = !bottomAttrID || bottomAttrType !== "categorical" ||
             (bottomAttrType === "categorical" && bottomValue === caseData[bottomAttrID])
           const isTopMatch = !topAttrID || topValue === caseData[topAttrID]
-      
+
           if (isBottomMatch && isTopMatch) {
             casesInCol.push(caseData)
           }

--- a/v3/src/models/data/data-set-collection-groups.test.ts
+++ b/v3/src/models/data/data-set-collection-groups.test.ts
@@ -64,7 +64,7 @@ describe("CollectionGroups", () => {
     expect(collection.id).toBe("test-6")
     expect(data.collectionGroups.length).toBe(1)
     expect(attributesByCollection()).toEqual([["aId"], ["bId", "cId"]])
-    expect(data.getCollection(collection.id)).toBe(collection)
+    expect(data.getRealCollection(collection.id)).toBe(collection)
     const aCases = data.getCasesForAttributes(["aId"])
     expect(data.getCasesForCollection(collection.id)).toEqual(aCases)
     expect(aCases.length).toBe(3)

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -599,3 +599,28 @@ test("DataSet client synchronization", (done) => {
   src.addCases(toCanonical(src, [{ str: "b", num: 2 }, { str: "c", num: 3 }]))
   // src.removeAttribute(src.attributes[0].id)
 })
+
+test("DataSet collection helpers", () => {
+  const ds = DataSet.create({ name: "data" })
+  ds.addAttribute({ name: "attr1" })
+  ds.addAttribute({ name: "attr2" })
+  expect(ds.ungrouped).toBeDefined()
+  expect(ds.collections.length).toBe(0)
+  ds.moveAttributeToNewCollection(ds.attributes[0].id)
+  expect(ds.collections.length).toBe(1)
+
+  // Test collection helpers using the "real" collection (instance of CollectionModel).
+  expect(ds.getRealCollection(ds.collections[0].id)).toBeDefined()
+  expect(ds.getCollection(ds.collections[0].id)).toBeDefined()
+  expect(ds.getCollectionIndex(ds.collections[0].id)).toEqual(0)
+  expect(ds.getCollectionForAttribute(ds.attributes[0].id)).toBe(ds.collections[0])
+
+  // Test collection helpers using the the ungrouped collection stand-in. It's not considered a "real" collection,
+  // but other collection-related helpers handle it as expected.
+  expect(ds.getRealCollection(ds.ungrouped.id)).not.toBeDefined()
+  expect(ds.getCollection(ds.ungrouped.id)).toBeDefined()
+  expect(ds.getCollectionIndex(ds.ungrouped.id)).toEqual(1)
+  expect(ds.getCollectionForAttribute(ds.attributes[1].id)).toBe(ds.ungrouped)
+
+  expect(ds.getCollectionForAttribute("non-existent-attr-ID")).toBeUndefined()
+})


### PR DESCRIPTION
I've been working a bit with DataSet's collection-related helpers and noticed some inconsistencies. Some collection methods treat "ungrouped" fake-collection as a collection and return it, while others do not.

Eg. you can receive "ungrouped" when you ask for an attribute collection, but when you ask explicitly for a collection or collection index, `ungrouped` is no longer treated as one.  

These assumptions are invisible from the outside and require some special handling in the client code (in my case, it's a formula engine). So, I thought it'd be nice to make it more consistent and always include or always exclude `ungrouped` collection.

My current idea is that unless the client explicitly asks for a "real" collection (naming suggestions welcome), `ungrouped` is included in all the logic and results.

