### PR TITLE
Detect formulas incorrectly referencing parent or child attributes in hierarchical tables

### DIFF
--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -8,6 +8,9 @@
     "V3.summary.startProfiling": "Start Profiling",
     "V3.summary.stopProfiling": "Stop Profiling",
 
+    // V3 formula strings that are not present in V2 and will eventually require translation.
+    "V3.formula.error.invalidParentAttrRef": "invalid reference to parent attribute '%@' within aggregate function",
+
     // CFM/File menu
     "DG.fileMenu.menuItem.newDocument": "New",
     "DG.fileMenu.menuItem.openDocument": "Open...",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185972525

Also, related Slack discussion:
https://concord-consortium.slack.com/archives/C035J6RDAK0/p1693414962764689

This PR is a first pass on displaying formula errors to users. Two mistakes that are now handled explicitly:
1. Aggregate functions should not be able to reference attributes from parent collections. 
2. Formula in parent collection should not be able to reference child attributes without using the aggregate function

One of these errors (1.) was not handled by CODAP V2, so I had to add a new error message to the translation strings.

Also, if mathjs throws an error while evaluating a formula, it'll be displayed to the user. We won't be able to translate it, so long-term we'll probably to catch these error ourselves even before letting mathjs do it. But I think it's still a reasonable fallback mechanism for scenarios that we won't think of or forget to handle.
