### PR TITLE
Fix formula mobx-based observing 

### DIFF
--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -191,12 +191,10 @@ export class FormulaManager {
   registerAllFormulas() {
     reaction(() => {
       // Observe all the formulas (their canonical form in fact)
-      const result: string[] = []
+      let result = ""
       this.dataSets.forEach(dataSet => {
         dataSet.attributes.forEach(attr => {
-          if (attr.formula.valid && attr.formula.canonical) {
-            result.push(attr.formula.canonical)
-          }
+          result += `${attr.formula.id}-${attr.formula.canonical}`
         })
       })
       return result
@@ -216,7 +214,7 @@ export class FormulaManager {
           }
         })
       })
-    })
+    }, { fireImmediately: true })
   }
 
   unregisterFormula(formulaId: string) {


### PR DESCRIPTION
I'm opening this fix as a separate PR because it highlights an interesting scenario worth considering when using Mobx.

Previously, I used to return a new array each time from the data callback of Mobx's `reaction`. This approach essentially triggered the side effect function to run every time, regardless of the array's content. This happened because arrays are compared by reference, not by their content. That's also the reason why things used to work without the `fireImmediately: true` option.

Furthermore, the `condition attr.formula.valid && attr.formula.canonical` should have been removed some time ago. This change was necessary because other parts of the formula manager expected every formula to be registered, not just those that were valid and non-empty. However, due to the aforementioned bug, this condition remained unaddressed.

The issue began to surface when I was working on the import code and had to add some data sets right after creating the formula manager.
