### PR TITLE
Support importing of V2 docs with formulas

### DIFF
--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react"
-
+import { observer } from "mobx-react-lite"
 import { MenuItem, MenuList, useDisclosure, useToast } from "@chakra-ui/react"
 import { useCaseMetadata } from "../../../hooks/use-case-metadata"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
@@ -7,7 +7,6 @@ import { TCalculatedColumn } from "../case-table-types"
 import { EditAttributePropertiesModal } from "./edit-attribute-properties-modal"
 import t from "../../../utilities/translation/translate"
 import { EditFormulaModal } from "./edit-formula-modal"
-import { observer } from "mobx-react-lite"
 
 interface IProps {
   column: TCalculatedColumn

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from "react"
+
 import { MenuItem, MenuList, useDisclosure, useToast } from "@chakra-ui/react"
 import { useCaseMetadata } from "../../../hooks/use-case-metadata"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
@@ -6,6 +7,7 @@ import { TCalculatedColumn } from "../case-table-types"
 import { EditAttributePropertiesModal } from "./edit-attribute-properties-modal"
 import t from "../../../utilities/translation/translate"
 import { EditFormulaModal } from "./edit-formula-modal"
+import { observer } from "mobx-react-lite"
 
 interface IProps {
   column: TCalculatedColumn
@@ -13,7 +15,7 @@ interface IProps {
   onModalOpen: (open: boolean) => void
 }
 
-export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
+const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
     ({ column, onRenameAttribute, onModalOpen }, ref) => {
   const toast = useToast()
   const data = useDataSetContext()
@@ -115,4 +117,6 @@ export const AttributeMenuList = forwardRef<HTMLDivElement, IProps>(
   )
 })
 
-AttributeMenuList.displayName = "AttributeMenuList"
+AttributeMenuListComp.displayName = "AttributeMenuList"
+
+export const AttributeMenuList = observer(AttributeMenuListComp)

--- a/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
@@ -14,7 +14,7 @@ interface IProps {
   onClose: () => void
 }
 
-export const EditFormulaModal = observer(({ attributeId, isOpen, onClose }: IProps) => {
+export const EditFormulaModal = observer(function EditFormulaModal({ attributeId, isOpen, onClose }: IProps) {
   const dataSet = useDataSetContext()
   const attribute = dataSet?.attrFromID(attributeId)
   const [formula, setFormula] = useState(attribute?.formula.display || "")

--- a/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
@@ -3,6 +3,7 @@ import {
   Textarea, Tooltip
 } from "@chakra-ui/react"
 import React, { useState } from "react"
+import { observer } from "mobx-react-lite"
 import { CodapModal } from "../../codap-modal"
 import t from "../../../utilities/translation/translate"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
@@ -13,10 +14,10 @@ interface IProps {
   onClose: () => void
 }
 
-export const EditFormulaModal = ({ attributeId, isOpen, onClose }: IProps) => {
+export const EditFormulaModal = observer(({ attributeId, isOpen, onClose }: IProps) => {
   const dataSet = useDataSetContext()
   const attribute = dataSet?.attrFromID(attributeId)
-  const [formula, setFormula] = useState("")
+  const [formula, setFormula] = useState(attribute?.formula.display || "")
 
   const applyFormula = () => {
     attribute?.setDisplayFormula(formula)
@@ -77,4 +78,4 @@ export const EditFormulaModal = ({ attributeId, isOpen, onClose }: IProps) => {
       </ModalFooter>
     </CodapModal>
   )
-}
+})

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -83,7 +83,7 @@ describe("createCodapDocument", () => {
               attributes: [{
                 clientKey: "",
                 formula: {
-                  canonical: "",
+                  display: "",
                   id: "test-7",
                 },
                 id: "test-6",

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -180,7 +180,7 @@ export const Attribute = types.model("Attribute", {
     self.editable = editable
   },
   clearFormula() {
-    self.formula.setCanonical("")
+    self.formula.setDisplayFormula("")
   },
   setDisplayFormula(displayFormula: string) {
     self.formula.setDisplayFormula(displayFormula)

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -19,7 +19,7 @@ import { IFormula } from "./formula"
 
 type IFormulaMetadata = {
   formula: IFormula
-  registeredCanonical: string
+  registeredDisplay: string
   attributeId: string
   dataSetId: string
   dispose?: () => void
@@ -190,11 +190,11 @@ export class FormulaManager {
 
   registerAllFormulas() {
     reaction(() => {
-      // Observe all the formulas (their canonical form in fact)
+      // Observe all the formulas
       let result = ""
       this.dataSets.forEach(dataSet => {
         dataSet.attributes.forEach(attr => {
-          result += `${attr.formula.id}-${attr.formula.canonical}`
+          result += `${attr.formula.id}-${attr.formula.display}`
         })
       })
       return result
@@ -205,7 +205,7 @@ export class FormulaManager {
       this.dataSets.forEach(dataSet => {
         dataSet.attributes.forEach(attr => {
           if (this.formulaMetadata.has(attr.formula.id)) {
-            if (this.formulaMetadata.get(attr.formula.id)?.registeredCanonical !== attr.formula.canonical) {
+            if (this.formulaMetadata.get(attr.formula.id)?.registeredDisplay !== attr.formula.display) {
               this.unregisterFormula(attr.formula.id)
               this.registerFormula(attr.formula, attr.id, dataSet)
             }
@@ -228,7 +228,7 @@ export class FormulaManager {
   registerFormula(formula: IFormula, attributeId: string, dataSet: IDataSet) {
     const formulaMetadata: IFormulaMetadata = {
       formula,
-      registeredCanonical: formula.canonical,
+      registeredDisplay: formula.display,
       attributeId,
       dataSetId: dataSet.id
     }

--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -5,29 +5,29 @@ import { getFormulaManager } from "../tiles/tile-environment"
 
 export const Formula = types.model("Formula", {
   id: types.optional(types.identifier, () => typedId("FORMULA")),
-  canonical: ""
+  display: ""
 })
 .views(self => ({
-  get valid() {
-    return !!self.canonical && self.canonical.length > 0
-  },
   get formulaManager() {
     return getFormulaManager(self)
   },
+  get canonical() {
+    if (!this.formulaManager || !self.display) {
+      return ""
+    }
+    const displayNameMap = this.formulaManager.getDisplayNameMapForFormula(self.id)
+    return canonicalizeExpression(self.display, displayNameMap)
+  },
+  get valid() {
+    return !!this.canonical && this.canonical.length > 0
+  },
   get isRandomFunctionPresent() {
-    return isRandomFunctionPresent(self.canonical)
+    return isRandomFunctionPresent(this.canonical)
   },
 }))
 .actions(self => ({
   setDisplayFormula(displayFormula: string) {
-    if (!self.formulaManager) {
-      return
-    }
-    const displayNameMap = self.formulaManager.getDisplayNameMapForFormula(self.id)
-    this.setCanonical(canonicalizeExpression(displayFormula, displayNameMap))
-  },
-  setCanonical(canonical: string) {
-    self.canonical = canonical
+    self.display = displayFormula
   },
   rerandomize() {
     self.formulaManager?.recalculateFormula(self.id)

--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -4,7 +4,7 @@ import { canonicalizeExpression, isRandomFunctionPresent } from "./formula-utils
 import { getFormulaManager } from "../tiles/tile-environment"
 
 export const Formula = types.model("Formula", {
-  id: types.optional(types.identifier, () => typedId("FORMULA")),
+  id: types.optional(types.identifier, () => typedId("FORM")),
   display: ""
 })
 .views(self => ({

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -4,6 +4,7 @@ import { DocumentModel, IDocumentModelSnapshot } from "./document"
 import { IDocumentEnvironment } from "./document-environment"
 import { SharedModelDocumentManager } from "./shared-model-document-manager"
 import { FormulaManager } from "../data/formula-manager"
+import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
 
 /**
  * Create a DocumentModel and add a new sharedModelManager into its environment
@@ -34,6 +35,9 @@ export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
     if (document.content) {
       sharedModelManager.setDocument(document.content)
     }
+    sharedModelManager.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
+      .forEach((model: ISharedDataSet) => formulaManager.addDataSet(model.dataSet))
+
     return document
   } catch (e) {
     // The only time we've seen this error so far is when MST fails to load the content

--- a/v3/src/v2/codap-v2-document.ts
+++ b/v3/src/v2/codap-v2-document.ts
@@ -130,7 +130,7 @@ export class CodapV2Document {
       const { guid, name = "", title = "", type, formula: _formula } = attr
       const formula = _formula ? { display: _formula } : undefined
       this.guidMap[guid] = { type: type || "DG.Attribute", object: attr }
-      this.v3AttrMap[guid] = data.addAttribute({ name, ...formula, title })
+      this.v3AttrMap[guid] = data.addAttribute({ name, formula, title })
     })
   }
 


### PR DESCRIPTION
This PR adds support for importing V2 docs with formulas.
It required a couple of fixes, but the most important one was to change the formula's source of truth to display string.
The canonical variant is computed as a derived value, so in most cases, it should be cached (that's why I've added `observer` to a few components). I bet over time, we might decide that it's better to store canonical string too, but for now, it simplifies quite a few things (no need to worry about synchronization between these two strings).
 