### PR TITLE
feat: Support symbol names enclosed in backticks (``) within formulas

### DIFF
--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -5,7 +5,7 @@ import { CaseGroup, ICase, IGroupedCase, symParent } from "./data-set-types"
 import { onAnyAction } from "../../utilities/mst-utils"
 import {
   getFormulaDependencies, formulaError, getFormulaChildMostAggregateCollectionIndex, getIncorrectChildAttrReference,
-  getIncorrectParentAttrReference
+  getIncorrectParentAttrReference, safeSymbolName
 } from "./formula-utils"
 import {
   DisplayNameMap, IFormulaDependency, GLOBAL_VALUE, LOCAL_ATTR, ILocalAttributeDependency, IGlobalValueDependency,
@@ -276,7 +276,7 @@ export class FormulaManager {
     const mapAttributeNames = (dataSet: IDataSet, prefix: string) => {
       const result: Record<string, string> = {}
       dataSet.attributes.forEach(attr => {
-        result[attr.name] = `${prefix}${attr.id}`
+        result[safeSymbolName(attr.name)] = `${prefix}${attr.id}`
       })
       return result
     }
@@ -286,7 +286,7 @@ export class FormulaManager {
     }
 
     this.globalValueManager?.globals.forEach(global => {
-      displayNameMap.localNames[global.name] = `${GLOBAL_VALUE}${global.id}`
+      displayNameMap.localNames[safeSymbolName(global.name)] = `${GLOBAL_VALUE}${global.id}`
     })
 
     this.dataSets.forEach(dataSet => {

--- a/v3/src/models/data/formula-utils.test.ts
+++ b/v3/src/models/data/formula-utils.test.ts
@@ -1,0 +1,23 @@
+import { safeSymbolName, customizeFormula } from "./formula-utils"
+
+describe("safeSymbolName", () => {
+  it("converts strings that are not parsable by Mathjs to valid symbol names", () => {
+    expect(safeSymbolName("Valid_Name_Should_Not_Be_Changed")).toEqual("Valid_Name_Should_Not_Be_Changed")
+    expect(safeSymbolName("Attribute Name")).toEqual("Attribute_Name")
+    expect(safeSymbolName("1")).toEqual("_1")
+    expect(safeSymbolName("1a")).toEqual("_1a")
+    expect(safeSymbolName("Attribute 🙃 Test")).toEqual("Attribute____Test")
+  })
+})
+
+describe("customizeFormula", () => {
+  it("replaces all the assignment operators with equality operators", () => {
+    expect(customizeFormula("a = 1")).toEqual("a == 1")
+    expect(customizeFormula("a = b")).toEqual("a == b")
+    expect(customizeFormula("a = b = c")).toEqual("a == b == c")
+  })
+  it("replaces all the symbols enclosed between `` with safe symbol names", () => {
+    expect(customizeFormula("mean(`Attribute Name`)")).toEqual("mean(Attribute_Name)")
+    expect(customizeFormula("`Attribute Name` + `Attribute Name 2`")).toEqual("Attribute_Name + Attribute_Name_2")
+  })
+})


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186033178

CODAP v2 handles special attribute names if they're enclosed in backticks. The most common use case can be attribute name with whitespace. This PR adds this feature to V3.