### PR TITLE
feat: make dropping an attribute on an axis undoable

### DIFF
--- a/v3/src/components/axis/components/axis.tsx
+++ b/v3/src/components/axis/components/axis.tsx
@@ -1,41 +1,38 @@
-import React, {MutableRefObject, useState} from "react"
+import React, {MutableRefObject} from "react"
 import {range} from "d3"
+import {AxisPlace} from "../axis-types"
 import {useAxis} from "../hooks/use-axis"
 import {useAxisLayoutContext} from "../models/axis-layout-context"
-import {IAxisModel} from "../models/axis-model"
 import {SubAxis} from "./sub-axis"
 
 import "./axis.scss"
 
 interface IProps {
-  axisModel: IAxisModel
-  label?: string
+  axisPlace: AxisPlace
   enableAnimation: MutableRefObject<boolean>
   showScatterPlotGridLines?: boolean
   centerCategoryLabels?: boolean
 }
 
 export const Axis = ({
-                       label, axisModel, showScatterPlotGridLines = false,
+                       axisPlace, showScatterPlotGridLines = false,
                        enableAnimation,
                        centerCategoryLabels = true,
                      }: IProps) => {
   const
-    layout = useAxisLayoutContext(),
-    place = axisModel?.place || 'bottom',
-    [axisElt, setAxisElt] = useState<SVGGElement | null>(null)
+    layout = useAxisLayoutContext()
 
   useAxis({
-    axisModel, axisElt, axisTitle: label, centerCategoryLabels
+    axisPlace, centerCategoryLabels
   })
 
-  const getSubAxes = () => {
-    const numRepetitions = layout.getAxisMultiScale(place)?.repetitions ?? 1
+  const renderSubAxes = () => {
+    const numRepetitions = layout.getAxisMultiScale(axisPlace)?.repetitions ?? 1
     return range(numRepetitions).map(i => {
       return <SubAxis key={i}
                       numSubAxes={numRepetitions}
                       subAxisIndex={i}
-                      axisModel={axisModel}
+                      axisPlace={axisPlace}
                       enableAnimation={enableAnimation}
                       showScatterPlotGridLines={showScatterPlotGridLines}
                       centerCategoryLabels={centerCategoryLabels}
@@ -45,8 +42,8 @@ export const Axis = ({
 
   return (
     <>
-      <g className='axis' ref={elt => setAxisElt(elt)} data-testid={`axis-${place}`}>
-        {getSubAxes()}
+      <g className='axis' data-testid={`axis-${axisPlace}`}>
+        {renderSubAxes()}
       </g>
     </>
   )

--- a/v3/src/components/axis/components/numeric-axis-drag-rects.tsx
+++ b/v3/src/components/axis/components/numeric-axis-drag-rects.tsx
@@ -178,7 +178,7 @@ export const NumericAxisDragRects = observer(
               )
             selectDragRects(rectRef.current)?.raise()
           }
-        }, {fireImmediately: true}
+        }, {name: "NumericAxisDragRects [axisBounds]", fireImmediately: true}
       )
       return () => disposer()
     }, [axisModel, layout, axisWrapperElt, place, numSubAxes, subAxisIndex])

--- a/v3/src/components/axis/components/sub-axis.tsx
+++ b/v3/src/components/axis/components/sub-axis.tsx
@@ -1,4 +1,5 @@
-import React, {memo, MutableRefObject, useRef, useState} from "react"
+import { observer } from "mobx-react-lite"
+import React, {MutableRefObject, useRef, useState} from "react"
 import {AxisPlace} from "../axis-types"
 import {useAxisProviderContext} from "../hooks/use-axis-provider-context"
 import {useSubAxis} from "../hooks/use-sub-axis"
@@ -16,7 +17,7 @@ interface ISubAxisProps {
   centerCategoryLabels?: boolean
 }
 
-export const SubAxis = memo(function SubAxis({
+export const SubAxis = observer(function SubAxis({
                                                numSubAxes, subAxisIndex, axisPlace, showScatterPlotGridLines = false,
                                                centerCategoryLabels = true, enableAnimation/*, getCategorySet*/
                                              }: ISubAxisProps) {
@@ -25,7 +26,6 @@ export const SubAxis = memo(function SubAxis({
     axisModel = axisProvider.getAxis?.(axisPlace),
     subWrapperElt = useRef<SVGGElement | null>(null),
     [subAxisElt, setSubAxisElt] = useState<SVGGElement | null>(null)
-
 
   useSubAxis({
     subAxisIndex, axisPlace, subAxisElt, enableAnimation, showScatterPlotGridLines, centerCategoryLabels

--- a/v3/src/components/axis/components/sub-axis.tsx
+++ b/v3/src/components/axis/components/sub-axis.tsx
@@ -1,6 +1,8 @@
 import React, {memo, MutableRefObject, useRef, useState} from "react"
+import {AxisPlace} from "../axis-types"
+import {useAxisProviderContext} from "../hooks/use-axis-provider-context"
 import {useSubAxis} from "../hooks/use-sub-axis"
-import {IAxisModel, INumericAxisModel} from "../models/axis-model"
+import {isNumericAxisModel} from "../models/axis-model"
 import {NumericAxisDragRects} from "./numeric-axis-drag-rects"
 
 import "./axis.scss"
@@ -8,31 +10,33 @@ import "./axis.scss"
 interface ISubAxisProps {
   numSubAxes: number
   subAxisIndex: number
-  axisModel: IAxisModel
+  axisPlace: AxisPlace
   enableAnimation: MutableRefObject<boolean>
   showScatterPlotGridLines?: boolean
   centerCategoryLabels?: boolean
 }
 
 export const SubAxis = memo(function SubAxis({
-                                               numSubAxes, subAxisIndex, axisModel, showScatterPlotGridLines = false,
+                                               numSubAxes, subAxisIndex, axisPlace, showScatterPlotGridLines = false,
                                                centerCategoryLabels = true, enableAnimation/*, getCategorySet*/
                                              }: ISubAxisProps) {
   const
+    axisProvider = useAxisProviderContext(),
+    axisModel = axisProvider.getAxis?.(axisPlace),
     subWrapperElt = useRef<SVGGElement | null>(null),
     [subAxisElt, setSubAxisElt] = useState<SVGGElement | null>(null)
 
 
   useSubAxis({
-    subAxisIndex, axisModel, subAxisElt, enableAnimation, showScatterPlotGridLines, centerCategoryLabels
+    subAxisIndex, axisPlace, subAxisElt, enableAnimation, showScatterPlotGridLines, centerCategoryLabels
   })
 
   return (
     <g className='sub-axis-wrapper' ref={subWrapperElt}>
       <g className='axis' ref={elt => setSubAxisElt(elt)}/>
-      {axisModel?.type === 'numeric'
+      {isNumericAxisModel(axisModel)
         ? <NumericAxisDragRects
-          axisModel={axisModel as INumericAxisModel}
+          axisModel={axisModel}
           axisWrapperElt={subWrapperElt.current}
           numSubAxes={numSubAxes}
           subAxisIndex={subAxisIndex}

--- a/v3/src/components/axis/hooks/use-axis-provider-context.ts
+++ b/v3/src/components/axis/hooks/use-axis-provider-context.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react"
+import { IAxisModel, INumericAxisModel, isNumericAxisModel } from "../models/axis-model"
+import { AxisPlace } from "../axis-types"
+
+export interface IAxisProvider {
+  getAxis: (place: AxisPlace) => IAxisModel | undefined
+  getNumericAxis: (place: AxisPlace) => INumericAxisModel | undefined
+}
+const kDefaultAxisProvider = {
+  getAxis: () => undefined,
+  getNumericAxis: () => undefined
+}
+
+export const AxisProviderContext = createContext<IAxisProvider>(kDefaultAxisProvider)
+
+export const useAxisProviderContext = () => useContext(AxisProviderContext)
+
+export function useAxisModel(place: AxisPlace) {
+  return useAxisProviderContext().getAxis(place)
+}
+
+export function useNumericAxisModel(place: AxisPlace) {
+  const axisModel = useAxisModel(place)
+  return isNumericAxisModel(axisModel) ? axisModel : undefined
+}

--- a/v3/src/components/axis/hooks/use-axis.test.tsx
+++ b/v3/src/components/axis/hooks/use-axis.test.tsx
@@ -5,28 +5,35 @@ import { SliderAxisLayout } from "../../slider/slider-layout"
 import { AxisLayoutContext } from "../models/axis-layout-context"
 import { INumericAxisModel, NumericAxisModel } from "../models/axis-model"
 import {IUseAxis, useAxis} from "./use-axis"
+import { AxisProviderContext, IAxisProvider } from "./use-axis-provider-context"
 
 describe("useNumericAxis", () => {
 
+  let provider: IAxisProvider
   let layout: SliderAxisLayout
   let axisModel: INumericAxisModel
   let axisElt: SVGGElement
   let useAxisOptions: IUseAxis
-  let titleRef: React.RefObject<SVGGElement>
 
   beforeEach(() => {
+    provider = {
+      getAxis: () => axisModel,
+      getNumericAxis: () => axisModel
+    }
     layout = new SliderAxisLayout()
     axisModel = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
     axisElt = document.createElementNS("http://www.w3.org/2000/svg", "g")
-    useAxisOptions = { axisModel, axisElt, titleRef, centerCategoryLabels: true }
+    useAxisOptions = { axisPlace: "bottom", centerCategoryLabels: true }
   })
 
   it("renders a simple horizontal axis", () => {
     renderHook(() => useAxis(useAxisOptions), {
       wrapper: ({ children }) => (
-        <AxisLayoutContext.Provider value={layout}>
-          {children}
-        </AxisLayoutContext.Provider>
+        <AxisProviderContext.Provider value={provider}>
+          <AxisLayoutContext.Provider value={layout}>
+            {children}
+          </AxisLayoutContext.Provider>
+        </AxisProviderContext.Provider>
       )
     })
     expect(axisElt.querySelector(".axis")).toBeDefined()
@@ -37,9 +44,11 @@ describe("useNumericAxis", () => {
     axisModel = NumericAxisModel.create({ place: "left", min: 0, max: 10 })
     renderHook(() => useAxis(useAxisOptions), {
       wrapper: ({ children }) => (
-        <AxisLayoutContext.Provider value={layout}>
-          {children}
-        </AxisLayoutContext.Provider>
+        <AxisProviderContext.Provider value={provider}>
+          <AxisLayoutContext.Provider value={layout}>
+            {children}
+          </AxisLayoutContext.Provider>
+        </AxisProviderContext.Provider>
       )
     })
     expect(axisElt.querySelector(".axis")).toBeDefined()
@@ -49,9 +58,11 @@ describe("useNumericAxis", () => {
   it("updates scale when axis domain changes", () => {
     renderHook(() => useAxis(useAxisOptions), {
       wrapper: ({ children }) => (
-        <AxisLayoutContext.Provider value={layout}>
-          {children}
-        </AxisLayoutContext.Provider>
+        <AxisProviderContext.Provider value={provider}>
+          <AxisLayoutContext.Provider value={layout}>
+            {children}
+          </AxisLayoutContext.Provider>
+        </AxisProviderContext.Provider>
       )
     })
     axisModel.setDomain(0, 100)
@@ -61,9 +72,11 @@ describe("useNumericAxis", () => {
   it("updates scale when axis range changes", () => {
     renderHook(() => useAxis(useAxisOptions), {
       wrapper: ({ children }) => (
-        <AxisLayoutContext.Provider value={layout}>
-          {children}
-        </AxisLayoutContext.Provider>
+        <AxisProviderContext.Provider value={provider}>
+          <AxisLayoutContext.Provider value={layout}>
+            {children}
+          </AxisLayoutContext.Provider>
+        </AxisProviderContext.Provider>
       )
     })
     layout.setParentExtent(100, 100)
@@ -73,9 +86,11 @@ describe("useNumericAxis", () => {
   it("can switch between linear/log axes", () => {
     renderHook(() => useAxis(useAxisOptions), {
       wrapper: ({ children }) => (
-        <AxisLayoutContext.Provider value={layout}>
-          {children}
-        </AxisLayoutContext.Provider>
+        <AxisProviderContext.Provider value={provider}>
+          <AxisLayoutContext.Provider value={layout}>
+            {children}
+          </AxisLayoutContext.Provider>
+        </AxisProviderContext.Provider>
       )
     })
     axisModel.setScale("log")

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -1,4 +1,4 @@
-import {Instance, SnapshotIn, types} from "mobx-state-tree"
+import {Instance, SnapshotIn, isAlive, types} from "mobx-state-tree"
 import {AxisOrientation, AxisPlaces, IScaleType, ScaleTypes} from "../axis-types"
 
 export const AxisModel = types.model("AxisModel", {
@@ -72,6 +72,10 @@ export const NumericAxisModel = AxisModel
   })
   .views(self => ({
     get domain() {
+      if (!isAlive(self)) {
+        console.warn("AxisModel.domain called for defunct axis model")
+        return [0, 1] as const
+      }
       return [self.min, self.max] as const
     }
   }))

--- a/v3/src/components/axis/models/multi-scale.ts
+++ b/v3/src/components/axis/models/multi-scale.ts
@@ -139,7 +139,7 @@ export class MultiScale {
     }, (categories) => {
       this.setCategoricalDomain(categories)
       this.incrementChangeCount()
-    })
+    }, { name: "MultiScale.reactToCategorySetChange"})
   }
 
   @action incrementChangeCount() {

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -38,7 +38,9 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
       }
       else {
         // move an ungrouped attribute within the DataSet
-        data.moveAttribute(dragAttrId, options)
+        data.applyUndoableAction(
+          () => data.moveAttribute(dragAttrId, options),
+          "DG.Undo.dataContext.moveAttribute", "DG.Redo.dataContext.moveAttribute")
       }
     }
     else {

--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -212,7 +212,9 @@ export const useRows = () => {
   const handleRowsChange = useCallback((_rows: TRow[], changes: TRowsChangeData) => {
     // when rows change, e.g. after cell edits, update the dataset
     const caseValues = changes.indexes.map(index => _rows[index] as ICase)
-    data?.setCaseValues(caseValues)
+    data?.applyUndoableAction(
+      () => data?.setCaseValues(caseValues),
+      "DG.Undo.caseTable.editCellValue", "DG.Redo.caseTable.editCellValue")
   }, [data])
 
   return { handleRowsChange }

--- a/v3/src/components/graph/components/attribute-label.tsx
+++ b/v3/src/components/graph/components/attribute-label.tsx
@@ -108,7 +108,8 @@ export const AttributeLabel = observer(
     useEffect(() => {
       const disposer = reaction(
         () => layout.getComputedBounds(place),
-        () => refreshAxisTitle()
+        () => refreshAxisTitle(),
+        { name: "AttributeLabel [layout.getComputedBounds]"}
       )
       return () => disposer()
     }, [place, layout, refreshAxisTitle])
@@ -153,7 +154,7 @@ export const AttributeLabel = observer(
           },
           () => {
             refreshAxisTitle()
-          }
+          }, { name: "AttributeLabel [attribute configuration]"}
         )
         return () => disposer()
     }, [place, dataConfiguration, refreshAxisTitle])

--- a/v3/src/components/graph/components/background.tsx
+++ b/v3/src/components/graph/components/background.tsx
@@ -140,7 +140,7 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
         .style('fill', d => (row(d) + col(d)) % 2 === 0 ? bgColor : darkBgColor)
         .style('fill-opacity', isTransparent ? 0 : 1)
         .call(dragBehavior)
-    })
+    }, { name: "Background.autorun" })
   }, [bgRef, dataset, dragBehavior, graphModel, layout])
 
   return (

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -12,7 +12,6 @@ import {IDataSet} from "../../../models/data/data-set"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {AxisPlace} from "../../axis/axis-types"
 import {Axis} from "../../axis/components/axis"
-import {AxisProviderContext} from "../../axis/hooks/use-axis-provider-context"
 import {GraphPlace} from "../../axis-graph-shared"
 import {axisPlaceToAttrRole, kGraphClassSelector} from "../graphing-types"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
@@ -91,31 +90,29 @@ export const GraphAxis = observer(function GraphAxis(
   }, [layout, place, graphModel])
 
   return (
-    <AxisProviderContext.Provider value={graphModel}>
-      <g className='axis-wrapper' ref={elt => setWrapperElt(elt)}>
-        <rect className='axis-background'/>
-        {axisModel &&
-          <Axis axisPlace={place}
-                enableAnimation={enableAnimation}
-                showScatterPlotGridLines={graphModel.axisShouldShowGridLines(place)}
-                centerCategoryLabels={graphModel.dataConfiguration.categoriesForAxisShouldBeCentered(place)}
-          />}
-        <AttributeLabel
-          place={place}
-          onChangeAttribute={onDropAttribute}
-          onRemoveAttribute={onRemoveAttribute}
-          onTreatAttributeAs={onTreatAttributeAs}
-        />
-        {onDropAttribute &&
-          <DroppableAxis
-              place={`${place}`}
-              dropId={droppableId}
-              hintString={hintString}
-              portal={parentEltRef.current}
-              target={wrapperElt}
-              onIsActive={handleIsActive}
-          />}
-      </g>
-    </AxisProviderContext.Provider>
+    <g className='axis-wrapper' ref={elt => setWrapperElt(elt)}>
+      <rect className='axis-background'/>
+      {axisModel &&
+        <Axis axisPlace={place}
+              enableAnimation={enableAnimation}
+              showScatterPlotGridLines={graphModel.axisShouldShowGridLines(place)}
+              centerCategoryLabels={graphModel.dataConfiguration.categoriesForAxisShouldBeCentered(place)}
+        />}
+      <AttributeLabel
+        place={place}
+        onChangeAttribute={onDropAttribute}
+        onRemoveAttribute={onRemoveAttribute}
+        onTreatAttributeAs={onTreatAttributeAs}
+      />
+      {onDropAttribute &&
+        <DroppableAxis
+            place={`${place}`}
+            dropId={droppableId}
+            hintString={hintString}
+            portal={parentEltRef.current}
+            target={wrapperElt}
+            onIsActive={handleIsActive}
+        />}
+    </g>
   )
 })

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -9,6 +9,7 @@ import {GraphContentModelContext} from '../hooks/use-graph-content-model-context
 import {useGraphController} from "../hooks/use-graph-controller"
 import {useInitGraphLayout} from '../hooks/use-init-graph-layout'
 import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-id-context"
+import {AxisProviderContext} from '../../axis/hooks/use-axis-provider-context'
 import {AxisLayoutContext} from "../../axis/models/axis-layout-context"
 import {GraphController} from "../models/graph-controller"
 import {isGraphContentModel} from "../models/graph-content-model"
@@ -63,10 +64,9 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
         <GraphLayoutContext.Provider value={layout}>
           <AxisLayoutContext.Provider value={layout}>
             <GraphContentModelContext.Provider value={graphModel}>
-              <Graph graphController={graphController}
-                      graphRef={graphRef}
-                      dotsRef={dotsRef}
-              />
+              <AxisProviderContext.Provider value={graphModel}>
+                <Graph graphController={graphController} graphRef={graphRef} dotsRef={dotsRef} />
+              </AxisProviderContext.Provider>
               <AttributeDragOverlay activeDragId={overlayDragId} />
             </GraphContentModelContext.Provider>
           </AxisLayoutContext.Provider>

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -69,7 +69,9 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
   const handleChangeAttribute = (place: GraphPlace, dataSet: IDataSet, attrId: string) => {
     const computedPlace = place === 'plot' && graphModel.dataConfiguration.noAttributesAssigned ? 'bottom' : place
     const attrRole = graphPlaceToAttrRole[computedPlace]
-    graphModel.setAttributeID(attrRole, dataSet.id, attrId)
+    graphModel.applyUndoableAction(
+      () => graphModel.setAttributeID(attrRole, dataSet.id, attrId),
+      "DG.Undo.axisAttributeChange", "DG.Redo.axisAttributeChange")
   }
 
   /**

--- a/v3/src/components/graph/hooks/use-graph-content-model-context.ts
+++ b/v3/src/components/graph/hooks/use-graph-content-model-context.ts
@@ -1,6 +1,11 @@
 import { createContext, useContext } from "react"
 import { IGraphContentModel } from "../models/graph-content-model"
 
-export const GraphContentModelContext = createContext<IGraphContentModel>({} as IGraphContentModel)
+const kDefaultGraphContentModel = {
+  getAxis: () => undefined,
+  getNumericAxis: () => undefined
+} as unknown as IGraphContentModel
+
+export const GraphContentModelContext = createContext<IGraphContentModel>(kDefaultGraphContentModel)
 
 export const useGraphContentModelContext = () => useContext(GraphContentModelContext)

--- a/v3/src/components/graph/hooks/use-init-graph-layout.ts
+++ b/v3/src/components/graph/hooks/use-init-graph-layout.ts
@@ -22,7 +22,7 @@ export function useInitGraphLayout(model?: IGraphContentModel) {
         (Object.keys(repetitions) as AxisPlace[]).forEach((place: AxisPlace) => {
           layout.getAxisMultiScale(place)?.setRepetitions(repetitions[place] ?? 0)
         })
-      }
+      }, { name: "useInitGraphLayout repetitions" }
     )
   }, [layout, model?.dataConfiguration])
 

--- a/v3/src/models/data/data-set-undo.test.ts
+++ b/v3/src/models/data/data-set-undo.test.ts
@@ -1,10 +1,10 @@
+import { when } from "mobx"
 import { Instance } from "mobx-state-tree"
 import { createCodapDocument } from "../codap/create-codap-document"
+import { TreeManager } from "../history/tree-manager"
 import { getSharedModelManager } from "../tiles/tile-environment"
 import { SharedDataSet } from "../shared/shared-data-set"
 import "./data-set-undo"
-import { TreeManager } from "../history/tree-manager"
-import { when } from "mobx"
 
 describe("DataSet undo/redo", () => {
 
@@ -27,7 +27,10 @@ describe("DataSet undo/redo", () => {
   it("can undo/redo moving an attribute", async () => {
     const { data, treeManager, undoManager } = setupDocument()
 
-    data.moveAttribute("bId", { before: "aId" })
+    data.applyUndoableAction(
+      () => data.moveAttribute("bId", { before: "aId" }),
+      "Undo move attribute", "Redo move attribute")
+
     expect(data.attributes.map(attr => attr.name)).toEqual(["b", "a"])
 
     let timedOut = false
@@ -50,7 +53,9 @@ describe("DataSet undo/redo", () => {
   it("can undo/redo setting case values", async () => {
     const { data, treeManager, undoManager } = setupDocument()
 
-    data.setCaseValues([{ __id__: "caseId", "aId": 2, "bId": 3 }])
+    data.applyUndoableAction(
+      () => data.setCaseValues([{ __id__: "caseId", "aId": 2, "bId": 3 }]),
+      "Undo edit value", "Redo edit value")
     expect(data.getCase("caseId")).toEqual({ __id__: "caseId", "aId": 2, "bId": 3 })
 
     let timedOut = false

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -214,7 +214,6 @@ export const DataSet = types.model("DataSet", {
         type: "DataSet.moveAttribute",
         data: { dataId: self.id, attrId: attributeID, before: { before: nextAttrId }, after: options }
       }, moveAttributeCustomUndoRedo)
-      withUndoRedoStrings("DG.Undo.dataContext.moveAttribute", "DG.Redo.dataContext.moveAttribute")
     }
   }
 }))
@@ -908,7 +907,6 @@ export const DataSet = types.model("DataSet", {
           type: "DataSet.setCaseValues",
           data: { dataId: self.id, before, after }
         }, setCaseValuesCustomUndoRedo)
-        withUndoRedoStrings("DG.Undo.caseTable.editCellValue", "DG.Redo.caseTable.editCellValue")
 
         // only changes to parent collection attributes invalidate grouping
         ungroupedCases.length > 0 && self.invalidateCollectionGroups()
@@ -978,6 +976,12 @@ export const DataSet = types.model("DataSet", {
   }
 })
 .actions(self => ({
+  // performs the specified action so that response actions are included and undo/redo strings assigned
+  applyUndoableAction<T = unknown>(actionFn: () => T, undoStringKey: string, redoStringKey: string) {
+    const result = actionFn()
+    withUndoRedoStrings(undoStringKey, redoStringKey)
+    return result
+  },
   commitCache() {
     self.setCaseValues(Array.from(self.caseCache.values()))
   },

--- a/v3/src/models/history/codap-undo-types.ts
+++ b/v3/src/models/history/codap-undo-types.ts
@@ -17,7 +17,7 @@ export function getUndoStringKey(undoStore?: IUndoManager) {
 }
 
 export function getRedoStringKey(undoStore?: IUndoManager) {
-  const clientData = undoStore?.undoEntry?.clientData
+  const clientData = undoStore?.redoEntry?.clientData
   return isCodapUndoData(clientData) ? clientData.redoStringKey : "DG.mainPage.mainPane.redoButton.toolTip"
 }
 

--- a/v3/src/models/history/tree-types.ts
+++ b/v3/src/models/history/tree-types.ts
@@ -41,6 +41,10 @@ export function getActionModelName(call: IActionTrackingMiddleware3Call<CallEnv>
   return getType(call.actionCall.context).name
 }
 
+export function getActionName(call: IActionTrackingMiddleware3Call<CallEnv>) {
+  return call.actionCall.name
+}
+
 export function getActionPath(call: IActionTrackingMiddleware3Call<CallEnv>) {
   return `${getPath(call.actionCall.context)}/${call.actionCall.name}`
 }


### PR DESCRIPTION
[[#186037220]](https://www.pivotaltracker.com/story/show/186037220)

also: fix MST errors for accessing defunct axis models

- add `applyUndoableAction()` methods to `GraphContentModel` and `DataSet` which allow clients to specify undo/redo strings and have response actions captured as part of the same undoable action.
- add `AxisProviderContext` and use it to provide access to `AxisModel`s rather than passing around the models themselves, which have a tendency to become stale when the plot type changes.
- add names to most of our `autorun`s and `reaction`s for easier debugging.
- add `isAlive()` assertions which `console.warn` when stale objects are detected because it's easier to debug warnings in our code than from MST code.