### PR TITLE
Handle and render formula syntax errors

### DIFF
--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -455,8 +455,8 @@ export class FormulaManager {
       }
       visitedFormulas[currentFormula] = true
 
-      const { dataSet } = this.getFormulaContext(currentFormula)
-      const formulaDependencies = getFormulaDependencies(currentFormula)
+      const { formula, dataSet } = this.getFormulaContext(currentFormula)
+      const formulaDependencies = getFormulaDependencies(formula.canonical)
 
       const localDatasetAttributeDependencies: ILocalAttributeDependency[] =
         formulaDependencies.filter(d => d.type === "localAttribute") as ILocalAttributeDependency[]

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -138,20 +138,19 @@ export class FormulaManager {
     }
     console.log(`[formula] recalculate "${formula.canonical}" for ${casesToRecalculate.length} cases`)
 
-    let errorMsg = ""
     const collectionId = dataSet.getCollectionForAttribute(attributeId)?.id
     const collectionIndex = dataSet.getCollectionIndex(collectionId || "")
 
     const incorrectParentAttrId = getIncorrectParentAttrReference(formula.canonical, collectionIndex, dataSet)
     if (incorrectParentAttrId) {
       const attrName = dataSet.attrFromID(incorrectParentAttrId).name
-      errorMsg = formulaError("V3.formula.error.invalidParentAttrRef", [ attrName ])
+      return this.setFormulaError(formulaId, formulaError("V3.formula.error.invalidParentAttrRef", [ attrName ]))
     }
 
     const incorrectChildAttrId = getIncorrectChildAttrReference(formula.canonical, collectionIndex, dataSet)
     if (incorrectChildAttrId) {
       const attrName = dataSet.attrFromID(incorrectChildAttrId).name
-      errorMsg = formulaError("DG.Formula.HierReferenceError.message", [ attrName ])
+      return this.setFormulaError(formulaId, formulaError("DG.Formula.HierReferenceError.message", [ attrName ]))
     }
 
     const childMostAggregateCollectionIndex =
@@ -180,16 +179,7 @@ export class FormulaManager {
     try {
       compiledFormula = math.compile(formula.canonical)
     } catch (e: any) {
-      errorMsg = formulaError(e.message)
-    }
-
-    // Error message is set as formula output, similarly as in CODAP V2.
-    if (errorMsg) {
-      dataSet.setCaseValues(casesToRecalculate.map(c => ({
-        __id__: c.__id__,
-        [attributeId]: errorMsg
-      })))
-      return
+      return this.setFormulaError(formulaId, formulaError(e.message))
     }
 
     dataSet.setCaseValues(casesToRecalculate.map((c) => {
@@ -205,6 +195,16 @@ export class FormulaManager {
         [attributeId]: formulaValue
       }
     }))
+  }
+
+  // Error message is set as formula output, similarly as in CODAP V2.
+  setFormulaError(formulaId: string, errorMsg: string) {
+    const { attributeId, dataSet } = this.getFormulaContext(formulaId)
+    const allCases = dataSet.getCasesForAttributes([attributeId])
+    dataSet.setCaseValues(allCases.map(c => ({
+      __id__: c.__id__,
+      [attributeId]: errorMsg
+    })))
   }
 
   registerAllFormulas() {
@@ -253,9 +253,13 @@ export class FormulaManager {
     }
     this.formulaMetadata.set(formula.id, formulaMetadata)
 
-    if (!formula.valid) {
+    if (formula.empty) {
       // Nothing else to do, formula is empty.
       return
+    }
+
+    if (formula.syntaxError) {
+      return this.setFormulaError(formula.id, formulaError("DG.Formula.SyntaxErrorMiddle", [ formula.syntaxError ]))
     }
 
     // Check if there is a dependency cycle. Note that it needs to happen after formula is registered, so that

--- a/v3/src/models/data/formula.test.ts
+++ b/v3/src/models/data/formula.test.ts
@@ -1,0 +1,20 @@
+import { Formula } from "./formula"
+
+describe("Formula", () => {
+  it("should have an empty display by default", () => {
+    const formula = Formula.create()
+    expect(formula.display).toBe("")
+  })
+
+  it("should be valid when display is set to a valid expression", () => {
+    const formula = Formula.create({ display: "2 + 3 * 4" })
+    expect(formula.valid).toBe(true)
+    expect(formula.syntaxError).toBeNull()
+  })
+
+  it("should be invalid when display is set to an invalid expression", () => {
+    const formula = Formula.create({ display: "2 + * 3" })
+    expect(formula.valid).toBe(false)
+    expect(formula.syntaxError).toBeDefined()
+  })
+})

--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -1,4 +1,5 @@
 import { Instance, types } from "mobx-state-tree"
+import { parse } from "mathjs"
 import { typedId } from "../../utilities/js-utils"
 import { canonicalizeExpression, isRandomFunctionPresent } from "./formula-utils"
 import { getFormulaManager } from "../tiles/tile-environment"
@@ -12,14 +13,28 @@ export const Formula = types.model("Formula", {
     return getFormulaManager(self)
   },
   get canonical() {
+    if (!this.valid) {
+      return ""
+    }
     if (!this.formulaManager || !self.display) {
       return ""
     }
     const displayNameMap = this.formulaManager.getDisplayNameMapForFormula(self.id)
     return canonicalizeExpression(self.display, displayNameMap)
   },
+  get empty() {
+    return self.display.length === 0
+  },
+  get syntaxError() {
+    try {
+      parse(self.display)
+    } catch (error: any) {
+      return error.message
+    }
+    return null
+  },
   get valid() {
-    return !!this.canonical && this.canonical.length > 0
+    return !this.empty && !this.syntaxError
   },
   get isRandomFunctionPresent() {
     return isRandomFunctionPresent(this.canonical)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186052466

This PR cleans up the handling of syntax errors. CODAP will not crash in such a case, and the syntax error will be rendered as formula output (similarly to V2).
