### PR TITLE
Support formulas with `prev()` that references its own attribute

### DIFF
--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -40,7 +40,8 @@ const aggregateFnWithFilterFactory = (fn: (values: number[]) => number) => {
   }
 }
 
-// CODAP formulas assume that 0 is a truthy value, which is different from default JS behavior.
+// CODAP formulas assume that 0 is a truthy value, which is different from default JS behavior. So that, for instance,
+// count(attribute) will return a count of valid data values, since 0 is a valid numeric value.
 export const isValueTruthy = (value: any) => value !== "" && value !== false && value !== null && value !== undefined
 
 const UNDEF_RESULT = ""

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -161,6 +161,7 @@ export class FormulaManager {
       : dataSet.childCases()
 
     const formulaScope = new FormulaMathJsScope({
+      formulaAttrId: attributeId,
       localDataSet: dataSet,
       dataSets: this.dataSets,
       globalValueManager: this.globalValueManager,
@@ -187,6 +188,9 @@ export class FormulaManager {
       let formulaValue: FValue
       try {
         formulaValue = compiledFormula.evaluate(formulaScope)
+        // This is necessary for functions like `prev` that need to know the previous result when they reference
+        // its own attribute.
+        formulaScope.setPreviousResult(formulaValue)
       } catch (e: any) {
         formulaValue = formulaError(e.message)
       }
@@ -265,12 +269,10 @@ export class FormulaManager {
     // Check if there is a dependency cycle. Note that it needs to happen after formula is registered, so that
     // the dependency check can access all the metadata in the formula registry.
     if (this.isDependencyCyclePresent(formula.id)) {
-      window.alert(`Dependency cycle detected for "${formula.canonical}". Formula will not be evaluated.`)
-      console.error(`[formula] dependency cycle detected for "${formula.canonical}". Formula will not be evaluated.`)
-      return
+      return this.setFormulaError(formula.id, formulaError("V3.formula.error.cycle"))
     }
 
-    const formulaDependencies = getFormulaDependencies(formula.canonical)
+    const formulaDependencies = getFormulaDependencies(formula.canonical, attributeId)
     const disposeLocalAttributeObserver = this.observeLocalAttributes(formula.id, formulaDependencies)
     const disposeGlobalValueObservers = this.observeGlobalValues(formula.id, formulaDependencies)
     const disposeLookupObservers = this.observeLookup(formula.id, formulaDependencies)
@@ -459,8 +461,8 @@ export class FormulaManager {
       }
       visitedFormulas[currentFormula] = true
 
-      const { formula, dataSet } = this.getFormulaContext(currentFormula)
-      const formulaDependencies = getFormulaDependencies(formula.canonical)
+      const { formula, dataSet, attributeId } = this.getFormulaContext(currentFormula)
+      const formulaDependencies = getFormulaDependencies(formula.canonical, attributeId)
 
       const localDatasetAttributeDependencies: ILocalAttributeDependency[] =
         formulaDependencies.filter(d => d.type === "localAttribute") as ILocalAttributeDependency[]

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -184,6 +184,9 @@ export class FormulaManager {
     }
 
     dataSet.setCaseValues(casesToRecalculate.map((c) => {
+      // This is necessary for functions like `prev` that need to know the previous result when they reference
+      // its own attribute.
+      formulaScope.setPreviousCaseId(formulaScope.getCaseId())
       formulaScope.setCaseId(c.__id__)
       let formulaValue: FValue
       try {

--- a/v3/src/models/data/formula-types.ts
+++ b/v3/src/models/data/formula-types.ts
@@ -56,6 +56,9 @@ export interface IFormulaMathjsFunction {
   // Value of isRandomFunction is a boolean. When true, it means that the function is a random function.
   // Formula needs to know whether it includes random functions, so we can enable rerandomize feature.
   isRandomFunction?: boolean
+  // Self reference might be used to define a formula that calculates the cumulative value, e.g.:
+  // `CumulativeValue` attribute formula: `Value + prev(CumulativeValue, 0)`
+  selfReferenceAllowed?: boolean
   // `evaluate` function accepts arguments already processed and evaluated by mathjs.
   evaluate?: EvaluateFunc
   // `evaluateRaw` function accepts raw arguments following convention defined by mathjs.

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -10,6 +10,7 @@
 
     // V3 formula strings that are not present in V2 and will eventually require translation.
     "V3.formula.error.invalidParentAttrRef": "invalid reference to parent attribute '%@' within aggregate function",
+    "V3.formula.error.cycle": "Circular reference: formula refers to its own attribute either directly or indirectly",
 
     // CFM/File menu
     "DG.fileMenu.menuItem.newDocument": "New",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186050666

It's been a lot of work for me to develop a solution covering all the scenarios. There's a basic running sum like  `OtherAtrr + prev(FormulaAttr)`, but also other forms that caused issues in my previous approaches: `prev(round(ceil(FormulaAttr)), 0) + 1`, `prev(FormulaAttr + OtherAttr, 0) + 1`, etc. While they might not seem useful, we should not have a semi-correct implementation that works only for presumably useful scenarios. 

Finally, I had to rely on an iterative approach that is "simulated" using caching within the `prev` implementation. This differs from other aggregate or semi-aggregate functions that depend on array operations. I'm not happy we need to support that, but after talking to Dan, it seems it might be important for him and used in quite a few documents - mostly to calculate running sum like `OtherAtrr + prev(FormulaAttr)`. Here's the whole Slack thread that might be worth reading:
https://concord-consortium.slack.com/archives/C035J6RDAK0/p1695129101652899

Note that CODAP V2 also supports self-reference in `next()` - probably by reversing the order of processing cases. But my suggestion is not to implement that in V3 for now. I think the idea of not treating self-reference as circular dependency is a bit fragile - it enforces a strong assumption about the order in which the formula is evaluated. For `prev()` to work, we must iterate from 0 to N. From `next`, it needs to be from N to 0. That sounds fine at first glance, we could swap interaction order if `next` is detected, but it complicates the code even more. Plus, what happens when you combine `prev` and `next` in one formula?

Also, while I see use cases for recursive `prev`, I cannot think of any reasonable use case for self-reference in `next`. So, I'd suggest not allowing it there and justifying it by saying that formulas are always calculated in order of cases, from 0 to N (and that's why `prev` is an exception that works with self-reference).
