### PR TITLE
Fix misc issues related to formulas showing while importing V2 document

### DIFF
--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -1,7 +1,7 @@
 import { Instance, types } from "mobx-state-tree"
 import { parse } from "mathjs"
 import { typedId } from "../../utilities/js-utils"
-import { canonicalizeExpression, isRandomFunctionPresent } from "./formula-utils"
+import { canonicalizeExpression, customizeFormula, isRandomFunctionPresent } from "./formula-utils"
 import { getFormulaManager } from "../tiles/tile-environment"
 
 export const Formula = types.model("Formula", {
@@ -27,7 +27,7 @@ export const Formula = types.model("Formula", {
   },
   get syntaxError() {
     try {
-      parse(self.display)
+      parse(customizeFormula(self.display))
     } catch (error: any) {
       return error.message
     }


### PR DESCRIPTION
1. Before checking for syntax errors, we need to apply formula transformations (e.g. \`\` replacement)
2. All formulas need to be registered (=> metadata with parent attribute, dataset, etc.) before we can check for errors and dependency cycles. The previous implementation was working with import only if formulas were registered in the "right" order, so it was pretty random. Now, it should always work - even when the formula is referencing another formula that is registered later.