### PR TITLE
Recalculate formulas when attr is moved between collections

### DIFF
--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -22,11 +22,17 @@ type IFormulaMetadata = {
   registeredDisplay: string
   attributeId: string
   dataSetId: string
+  active: boolean
   dispose?: () => void
+}
+
+type IDataSetMetadata = {
+  dispose: () => void
 }
 
 export class FormulaManager {
   @observable dataSets = new Map<string, IDataSet>()
+  dataSetMetadata = new Map<string, IDataSetMetadata>()
   formulaMetadata = new Map<string, IFormulaMetadata>()
   globalValueManager?: IGlobalValueManager
 
@@ -36,10 +42,17 @@ export class FormulaManager {
   }
 
   addDataSet(dataSet: IDataSet) {
+    this.removeDataSet(dataSet.id)
+    this.observeDatasetChanges(dataSet)
     this.dataSets.set(dataSet.id, dataSet)
   }
 
   removeDataSet(dataSetId: string) {
+    const metadata = this.dataSetMetadata.get(dataSetId)
+    if (metadata) {
+      metadata.dispose()
+      this.dataSetMetadata.delete(dataSetId)
+    }
     this.dataSets.delete(dataSetId)
   }
 
@@ -53,6 +66,11 @@ export class FormulaManager {
       throw new Error(`Formula ${formulaId} not registered`)
     }
     return formulaMetadata
+  }
+
+  updateFormulaMetadata(formulaId: string, metadata: Partial<IFormulaMetadata>) {
+    const prevMetadata = this.getFormulaMetadata(formulaId)
+    this.formulaMetadata.set(formulaId, { ...prevMetadata, ...metadata })
   }
 
   // Retrieves formula context like its attribute, dataset, etc. It also validates correctness of the formula
@@ -129,7 +147,10 @@ export class FormulaManager {
   }
 
   recalculateFormula(formulaId: string, casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
-    const { formula, attributeId, dataSet } = this.getFormulaContext(formulaId)
+    const { formula, attributeId, dataSet, active } = this.getFormulaContext(formulaId)
+    if (!active) {
+      return
+    }
 
     let casesToRecalculate: ICase[] = []
     if (casesToRecalculateDesc === "ALL_CASES") {
@@ -249,11 +270,18 @@ export class FormulaManager {
       updatedFormulas.forEach(formulaId => {
         const errorPresent = this.registerFormulaErrors(formulaId)
         if (!errorPresent) {
+          this.updateFormulaMetadata(formulaId, { active: true })
           this.setupFormulaObservers(formulaId)
           this.recalculateFormula(formulaId)
         }
       })
     }, { fireImmediately: true })
+  }
+
+  recalculateAllFormulas() {
+    this.formulaMetadata.forEach((metadata, formulaId) => {
+      this.recalculateFormula(formulaId)
+    })
   }
 
   unregisterFormula(formulaId: string) {
@@ -269,7 +297,8 @@ export class FormulaManager {
       formula,
       registeredDisplay: formula.display,
       attributeId,
-      dataSetId: dataSet.id
+      dataSetId: dataSet.id,
+      active: false
     }
     this.formulaMetadata.set(formula.id, formulaMetadata)
   }
@@ -345,6 +374,20 @@ export class FormulaManager {
     })
 
     return displayNameMap
+  }
+
+  observeDatasetChanges(dataSet: IDataSet) {
+    const dispose = onAnyAction(dataSet, mstAction => {
+      switch (mstAction.name) {
+        // When attribute is moved to a new collection, it usually affects grouping that is respected by formulas.
+        // It'd be possible to optimize this by checking formula dependencies and limit number of updates, but
+        // for now let's keep it simple and see if we encounter
+        case "setCollectionForAttribute":
+          this.recalculateAllFormulas()
+          break
+      }
+    })
+    this.dataSetMetadata.set(dataSet.id, { dispose })
   }
 
   observeLocalAttributes(formulaId: string, formulaDependencies: IFormulaDependency[]) {

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -22,7 +22,7 @@ type IFormulaMetadata = {
   registeredDisplay: string
   attributeId: string
   dataSetId: string
-  active: boolean
+  isInitialized: boolean
   dispose?: () => void
 }
 
@@ -147,8 +147,8 @@ export class FormulaManager {
   }
 
   recalculateFormula(formulaId: string, casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
-    const { formula, attributeId, dataSet, active } = this.getFormulaContext(formulaId)
-    if (!active) {
+    const { formula, attributeId, dataSet, isInitialized } = this.getFormulaContext(formulaId)
+    if (!isInitialized) {
       return
     }
 
@@ -270,7 +270,7 @@ export class FormulaManager {
       updatedFormulas.forEach(formulaId => {
         const errorPresent = this.registerFormulaErrors(formulaId)
         if (!errorPresent) {
-          this.updateFormulaMetadata(formulaId, { active: true })
+          this.updateFormulaMetadata(formulaId, { isInitialized: true })
           this.setupFormulaObservers(formulaId)
           this.recalculateFormula(formulaId)
         }
@@ -298,7 +298,7 @@ export class FormulaManager {
       registeredDisplay: formula.display,
       attributeId,
       dataSetId: dataSet.id,
-      active: false
+      isInitialized: false
     }
     this.formulaMetadata.set(formula.id, formulaMetadata)
   }

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -381,7 +381,7 @@ export class FormulaManager {
       switch (mstAction.name) {
         // When attribute is moved to a new collection, it usually affects grouping that is respected by formulas.
         // It'd be possible to optimize this by checking formula dependencies and limit number of updates, but
-        // for now let's keep it simple and see if we encounter
+        // for now let's keep it simple and see if we encounter any problems.
         case "setCollectionForAttribute":
           this.recalculateAllFormulas()
           break


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186040941

"setCollectionForAttribute" seemed like the only action always being called for various use cases and called only once (moving between existing collections or while creating a new one). While I see some benefits of `onAnyAction`, I have a feeling that it might be quite fragile long-term. It feels like relying on the implementation details of various models, also making them harder to refactor if necessary. That makes me think that some simple event dispatcher (like basic event-emitte2) with more controlled, explicit events could be useful. But that's not a topic for this PR anyway. :wink: