### PR TITLE
Formulas can evaluate nested `prev` calls (e.g. prev(fib, 1) + prev(prev(fib, 1), 1))

### DIFF
--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -212,14 +212,14 @@ export class FormulaManager {
     dataSet.setCaseValues(casesToRecalculate.map((c) => {
       // This is necessary for functions like `prev` that need to know the previous result when they reference
       // its own attribute.
-      formulaScope.setPreviousCaseId(formulaScope.getCaseId())
+      formulaScope.savePreviousCaseId(formulaScope.getCaseId())
       formulaScope.setCaseId(c.__id__)
       let formulaValue: FValue
       try {
         formulaValue = compiledFormula.evaluate(formulaScope)
         // This is necessary for functions like `prev` that need to know the previous result when they reference
         // its own attribute.
-        formulaScope.setPreviousResult(formulaValue)
+        formulaScope.savePreviousResult(formulaValue)
       } catch (e: any) {
         formulaValue = formulaError(e.message)
       }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186090743

This PR adds support for nested `prev` calls. It seems to work well with the Fibonacci example, or even with a filter, e.g. `prev(prev(LifeSpan, -1, Habitat = "water"), -1, Habitat = "water")`.