### PR TITLE
fix: auto-scroll bugs

### DIFF
--- a/v3/patches/@dnd-kit+core+6.0.8.patch
+++ b/v3/patches/@dnd-kit+core+6.0.8.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@dnd-kit/core/dist/core.esm.js b/node_modules/@dnd-kit/core/dist/core.esm.js
+index 91671e9..2deb096 100644
+--- a/node_modules/@dnd-kit/core/dist/core.esm.js
++++ b/node_modules/@dnd-kit/core/dist/core.esm.js
+@@ -2348,7 +2348,7 @@ function useRects(elements, measure) {
+     callback: measureRects
+   });
+ 
+-  if (elements.length > 0 && rects === defaultValue$2) {
++  if (elements.length !== rects.length) { // [CC]
+     measureRects();
+   }
+ 

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -49,13 +49,14 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
     }
   })
 
-  // find the `case-table` DOM element; divider must be drawn relative
-  // to the `case-table` (via React portal) so it isn't clipped by the cell
+  // find the `case-table-content` DOM element; divider must be drawn relative
+  // to the `case-table-content` (via React portal) so it isn't clipped by the cell,
+  // but must be a child of the `case-table-content` for auto-scroll to work.
   useEffect(() => {
     if (cellElt && !tableElt) {
       let parent: HTMLElement | null
       for (parent = cellElt; parent; parent = parent.parentElement) {
-        if (parent.classList.contains("case-table")) {
+        if (parent.classList.contains("case-table-content")) {
           setTableElt(parent)
           break
         }

--- a/v3/src/components/codap-dnd-context.tsx
+++ b/v3/src/components/codap-dnd-context.tsx
@@ -1,5 +1,6 @@
 import {
-  DndContext, KeyboardCoordinateGetter, KeyboardSensor, PointerSensor, MouseSensor, useSensor, useSensors
+  AutoScrollOptions, DndContext, KeyboardCoordinateGetter, KeyboardSensor,
+  MouseSensor, PointerSensor, TraversalOrder, useSensor, useSensors
 } from "@dnd-kit/core"
 import React, { ReactNode } from "react"
 import { containerSnapToGridModifier } from "../hooks/use-drag-drop"
@@ -11,6 +12,13 @@ interface IProps {
 }
 export const CodapDndContext = ({ children }: IProps) => {
 
+  const autoScrollOptions: AutoScrollOptions = {
+    // scroll components before scrolling the document
+    order: TraversalOrder.ReversedTreeOrder,
+    // reduce the auto-scroll area to 5% (default is 20%)
+    threshold: { x: 0.05, y: 0.05 }
+  }
+
   const useMouseSensor = useSensor(MouseSensor)
   const sensors = useSensors(
                     // pointer must move three pixels before starting a drag
@@ -19,7 +27,11 @@ export const CodapDndContext = ({ children }: IProps) => {
                     // mouse sensor can be enabled for cypress tests, for instance
                     urlParams.mouseSensor !== undefined ? useMouseSensor : null)
   return (
-    <DndContext collisionDetection={dndDetectCollision} sensors={sensors} modifiers={[containerSnapToGridModifier]}>
+    <DndContext
+      autoScroll={autoScrollOptions}
+      collisionDetection={dndDetectCollision}
+      modifiers={[containerSnapToGridModifier]}
+      sensors={sensors} >
       {children}
     </DndContext>
   )

--- a/v3/src/components/codap-dnd-context.tsx
+++ b/v3/src/components/codap-dnd-context.tsx
@@ -12,6 +12,8 @@ interface IProps {
 }
 export const CodapDndContext = ({ children }: IProps) => {
 
+  // Note that as of this writing, the auto-scroll options are not documented in the official docs,
+  // but they are described in this PR: https://github.com/clauderic/dnd-kit/pull/140.
   const autoScrollOptions: AutoScrollOptions = {
     // scroll components before scrolling the document
     order: TraversalOrder.ReversedTreeOrder,


### PR DESCRIPTION
- improve document _does_ auto-scroll when trying to drag attribute to graph x-axis
- fix case table _doesn't_ auto-scroll when dragging attributes to create hierarchical table

The problem of the document auto-scrolling when trying to drag to the x-axis of the graph is improved (although not fixed entirely) by using existing `dnd-kit` configuration to reduce the size of the auto-scroll area. If we want to fine-tune the auto-scroll behavior based on the element being dragged over, for instance, we'll need to make more substantial modification to `dnd-kit` itself.

The case table bug is fixed by patching `@dnd-kit/core`. The dnd-kit auto-scroll code maintains a mapping between scrollable elements and their bounding rects. In the `useRects()` hook, this test was used to determine when to recompute the rectangles associated with the scrollable elements:

```typescript
  if (elements.length > 0 && rects === defaultValue$2) {
    measureRects();
  }
```

where `defaultValue$2` is the default empty array. This doesn't catch the situation in which the length of the elements array changes, which is the situation we were encountering. Changing the test to this fixes the bug:

```typescript
  if (elements.length !== rects.length) { // [CC]
    measureRects();
  }
```

For now, we're just using `patch-package` to deploy the fix, but I plan to submit a PR to the `dnd-kit` repo to contribute the fix back.

