### PR TITLE
Let `next` be nested within other `next` or `prev` calls

### DIFF
--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -44,6 +44,66 @@ const aggregateFnWithFilterFactory = (fn: (values: number[]) => number) => {
 // count(attribute) will return a count of valid data values, since 0 is a valid numeric value.
 export const isValueTruthy = (value: any) => value !== "" && value !== false && value !== null && value !== undefined
 
+
+// `next` and `prev` functions can share the same implementation assuming that `next` is just reversed `prev`.
+// `next` function needs to be executed for each case in the reverse order, and it'll also have different case pointer
+// modifier. `prev` will set scope to the previous index (-1), while next to the next one (+1).
+export const prevOrNextFactory = (variant: "next" | "prev") =>
+  (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
+  interface ICachedData {
+    currentIndex: number
+    resultIndex: number
+    expressionValues: FValue[]
+    filterValues: FValue[]
+  }
+
+  const cacheKey = `${variant}(${args.toString()})-${scope.getSemiAggregateGroupId()}`
+  const [ expression, defaultValue, filter ] = args
+  const cachedData = scope.getCached(cacheKey) as ICachedData | undefined
+  let result
+
+  if (cachedData !== undefined) {
+    const { currentIndex, resultIndex, expressionValues, filterValues } = cachedData
+    // This block will resolve attribute names to previous case values.
+    scope.withCaseIndexModifier(() => {
+      const newExpressionValue = evaluateNode(expression, scope)
+      expressionValues.push(newExpressionValue)
+      if (filterValues) {
+        const newFilterValue = evaluateNode(filter, scope)
+        filterValues.push(newFilterValue)
+      }
+    }, variant === "next" ? +1 : -1)
+    // In case we don't find a new result index, we need to reuse the old one.
+    let newResultIndex = resultIndex
+    if (!filterValues || isValueTruthy(filterValues[currentIndex - 1])) {
+      // If there's no filter, prev() returns the previous case value.
+      // If there's filter, prev() returns the previous case value that matches the filter. Note that in the
+      // previous case evaluations, we already checked all the previous indices. So, it's enough to check just
+      // currentIndex - 1.
+      newResultIndex = currentIndex - 1
+    }
+    result = expressionValues[newResultIndex]
+    scope.setCached(cacheKey, {
+      currentIndex: currentIndex + 1,
+      resultIndex: newResultIndex,
+      expressionValues,
+      filterValues
+    })
+  } else {
+    // This block of code will be executed only once for each group (if there's grouping), for the very first case.
+    // The very first case can't return anything from prev() function.
+    const currentIndex = 0
+    result = undefined
+    scope.setCached(cacheKey, {
+      currentIndex: currentIndex + 1,
+      resultIndex: currentIndex - 1,
+      expressionValues: [],
+      filterValues: filter ? [] : undefined
+    })
+  }
+  return result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RESULT)
+}
+
 const UNDEF_RESULT = ""
 
 export const fnRegistry = {
@@ -225,65 +285,37 @@ export const fnRegistry = {
     }
   },
 
-  // next(expression, defaultValue, filter)
   next: {
     // expression and filter are evaluated as aggregate symbols, defaultValue is not - it depends on case index
     isSemiAggregate: [true, false, true],
     evaluateRaw: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
-      interface ICachedData {
-        currentIndex: number
-        resultIndex: number
-        expressionValues: FValue[]
-        filterValues: FValue[]
-      }
+      // `next` is in fact a special case of `prev` function, where we iterate over cases in reverse order.
+      // However, since formula manager iterates in regular order, we need to simulate reversed iteration here when
+      // the first case is evaluated. Results are cached and immediately returned for all the other cases.
+      const nextFn = prevOrNextFactory("next")
+      const resultCacheKey = `next(${args.toString()})-RESULTS`
+      type CachedResults = Record<string, FValue>
+      let cachedResults = scope.getCached(resultCacheKey) as CachedResults | undefined
 
-      const calculateResultIndex = (_currentIndex: number, _filterValues: FValue[]) => {
-        if (!filter) {
-          // If there's no filter, next() simply returns the next case value.
-          return _currentIndex + 1
-        }
-        for (let i = _currentIndex + 1; i < _filterValues.length; i++) {
-          if (isValueTruthy(_filterValues[i])) {
-            return i
-          }
-        }
-        return -1
-      }
+      if (!cachedResults) {
+        cachedResults = {}
+        const originalCasePointer = scope.baseCasePointer
+        const originalCasePointerModifier = scope.casePointerModifier
+        scope.setCasePointerModifier(0)
 
-      const cacheKey = `next(${args.toString()})-${scope.getCaseGroupId()}`
-      const [ expression, defaultValue, filter ] = args
-      const cachedData = scope.getCached(cacheKey) as ICachedData | undefined
-      let result
-
-      if (cachedData) {
-        const { currentIndex, resultIndex, expressionValues, filterValues } = cachedData
-        // In case we don't find a new result index, we need to reuse the old one.
-        let newResultIndex = resultIndex
-        if (currentIndex >= resultIndex) {
-          // Current index is equal or bigger than previously cached result index. We need to recalculate it.
-          newResultIndex = calculateResultIndex(currentIndex, filterValues)
-        }
-        result = expressionValues[newResultIndex]
-        scope.setCached(cacheKey, {
-          ...cachedData,
-          currentIndex: currentIndex + 1,
-          resultIndex: newResultIndex
+        scope.context.cases.forEach((c, idx) => {
+          scope.setBaseCasePointer(scope.context.cases.length - 1 - idx)
+          const result = nextFn(args, mathjs, scope)
+          const defaultValue = args[1]
+          cachedResults![scope.caseId] = result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RESULT)
         })
-      } else {
-        // This block of code will be executed only once for each group (if there's grouping), for the very first case.
-        const currentIndex = 0
-        const filterValues = filter && evaluateNode(filter, scope)
-        const expressionValues = evaluateNode(expression, scope)
-        const resultIndex = calculateResultIndex(currentIndex, filterValues)
-        result = expressionValues[resultIndex]
-        scope.setCached(cacheKey, {
-          currentIndex: currentIndex + 1,
-          resultIndex,
-          expressionValues,
-          filterValues
-        })
+
+        scope.setBaseCasePointer(originalCasePointer)
+        scope.setCasePointerModifier(originalCasePointerModifier)
+        scope.cache.set(resultCacheKey, cachedResults)
       }
-      return result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RESULT)
+
+      return cachedResults[scope.caseId]
     }
   },
 
@@ -294,60 +326,7 @@ export const fnRegistry = {
     selfReferenceAllowed: true,
     // expression and filter are evaluated as aggregate symbols, defaultValue is not - it depends on case index
     isSemiAggregate: [true, false, true],
-    evaluateRaw: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
-      interface ICachedData {
-        currentIndex: number
-        resultIndex: number
-        expressionValues: FValue[]
-        filterValues: FValue[]
-      }
-
-      const cacheKey = `prev(${args.toString()})-${scope.getCaseGroupId()}`
-      const [ expression, defaultValue, filter ] = args
-      const cachedData = scope.getCached(cacheKey) as ICachedData | undefined
-      let result
-
-      if (cachedData !== undefined) {
-        const { currentIndex, resultIndex, expressionValues, filterValues } = cachedData
-        // This block will resolve attribute names to previous case values.
-        scope.withPreviousCase(() => {
-          const newExpressionValue = evaluateNode(expression, scope)
-          expressionValues.push(newExpressionValue)
-          if (filterValues) {
-            const newFilterValue = evaluateNode(filter, scope)
-            filterValues.push(newFilterValue)
-          }
-        })
-        // In case we don't find a new result index, we need to reuse the old one.
-        let newResultIndex = resultIndex
-        if (!filterValues || isValueTruthy(filterValues[currentIndex - 1])) {
-          // If there's no filter, prev() returns the previous case value.
-          // If there's filter, prev() returns the previous case value that matches the filter. Note that in the
-          // previous case evaluations, we already checked all the previous indices. So, it's enough to check just
-          // currentIndex - 1.
-          newResultIndex = currentIndex - 1
-        }
-        result = expressionValues[newResultIndex]
-        scope.setCached(cacheKey, {
-          currentIndex: currentIndex + 1,
-          resultIndex: newResultIndex,
-          expressionValues,
-          filterValues
-        })
-      } else {
-        // This block of code will be executed only once for each group (if there's grouping), for the very first case.
-        // The very first case can't return anything from prev() function.
-        const currentIndex = 0
-        result = undefined
-        scope.setCached(cacheKey, {
-          currentIndex: currentIndex + 1,
-          resultIndex: currentIndex - 1,
-          expressionValues: [],
-          filterValues: filter ? [] : undefined
-        })
-      }
-      return result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RESULT)
-    }
+    evaluateRaw: prevOrNextFactory("prev")
   },
 
   // if(expression, value_if_true, value_if_false)

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -197,6 +197,7 @@ export class FormulaManager {
       // - Parent-child grouping, which is used when the table is hierarchical and the aggregate function is
       //   referencing attributes from child collections.
       useSameLevelGrouping: collectionIndex === childMostAggregateCollectionIndex,
+      cases: casesToRecalculate,
       childMostCollectionCases,
       caseGroupId: this.getCaseGroupMap(formulaId),
       caseChildrenCount: this.getCaseChildrenCountMap(formulaId)
@@ -209,11 +210,8 @@ export class FormulaManager {
       return this.setFormulaError(formulaId, formulaError(e.message))
     }
 
-    dataSet.setCaseValues(casesToRecalculate.map((c) => {
-      // This is necessary for functions like `prev` that need to know the previous result when they reference
-      // its own attribute.
-      formulaScope.savePreviousCaseId(formulaScope.getCaseId())
-      formulaScope.setCaseId(c.__id__)
+    dataSet.setCaseValues(casesToRecalculate.map((c, idx) => {
+      formulaScope.setBaseCasePointer(idx)
       let formulaValue: FValue
       try {
         formulaValue = compiledFormula.evaluate(formulaScope)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186115784

Semi-aggregate functions have made a return. Frankly, I'm struggling to reason about them and fit them into the rest of the formula's code. The problem was that `next(next(LifeSpan))` didn't work previously. Similar issues arose with other combinations, such as `prev(next(LifeSpan))` or more complex ones like `prev(next(LifeSpan, -1, Habitat = "water"), -2, Habitat = "both")`.

So, the solution I came up with is to treat `next` as the reverse of `prev`. However, since it requires a reverse iteration order, it iterates over all cases and stores results when the very first case is evaluated. Then, for each subsequent case, the cached result is returned.

There are also changes to the MathJS Scope class, allowing the casePointer to be movable (I used the term 'pointer' to avoid confusion with 'caseIndex,' which has a very specific meaning in formulas).

The drawback of this solution is that when next switches the order of iteration, nested prev with complex filters might not work as expected. But I believe this is a very rare use case, if not non-existent. I wonder how all of this worked in V2. I looked at the V2 code, but recreating the entire iteration process just from reading it was challenging.

I'm opening this PR anyway, as it still improves how `next` and `prev` are evaluated, and I don't want to get bogged down in this area for more days. Perhaps taking a break and focusing on other areas will help me come up with a better solution.
