### PR TITLE
fix: Ensure adornment appears after attribute changes

### DIFF
--- a/v3/src/components/graph/adornments/plotted-value/plotted-value-banner.scss
+++ b/v3/src/components/graph/adornments/plotted-value/plotted-value-banner.scss
@@ -5,6 +5,7 @@
   display: flex;
   font: 12px "MuseoSans-500", sans-serif;
   left: 0;
+  min-height: 22px;
   padding: 0;
   pointer-events: all;
   position: absolute;
@@ -15,6 +16,7 @@
   .plotted-value-control-label {
     background: gray;
     cursor: pointer;
+    min-height: 22px;
     padding: 1px 3px 3px;
     width: 54px;
   }
@@ -23,6 +25,7 @@
     cursor: text;
     flex: 1;
     height: 100%;
+    min-height: 22px;
     padding: 1px 3px 3px;
   }
 }

--- a/v3/src/components/graph/adornments/plotted-value/plotted-value-model.ts
+++ b/v3/src/components/graph/adornments/plotted-value/plotted-value-model.ts
@@ -23,7 +23,7 @@ export const PlottedValueModel = AdornmentModel
       const caseValues: number[] = []
       casesInPlot.forEach((c: ICase) => {
         const caseValue = Number(dataset?.getValue(c.__id__, attrId))
-        if (Number.isInteger(caseValue)) {
+        if (Number.isFinite(caseValue)) {
           caseValues.push(caseValue)
         }
       })

--- a/v3/src/components/graph/adornments/plotted-value/plotted-value-model.ts
+++ b/v3/src/components/graph/adornments/plotted-value/plotted-value-model.ts
@@ -1,7 +1,9 @@
 import { Instance, types } from "mobx-state-tree"
 import { mean } from "mathjs"
-import { AdornmentModel, IAdornmentModel, IUpdateCategoriesOptions } from "../adornment-models"
+import { AdornmentModel, IAdornmentModel } from "../adornment-models"
 import { kPlottedValueType } from "./plotted-value-types"
+import { ICase } from "../../../../models/data/data-set-types"
+import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
 
 export const PlottedValueModel = AdornmentModel
   .named("PlottedValueModel")
@@ -14,17 +16,23 @@ export const PlottedValueModel = AdornmentModel
       // This is just a proof-of-concept placeholder for function strings. It will always return
       // the mean of caseValues no matter what the string value is.
       return mean(caseValues)
+    },
+    getCaseValues(attrId: string, cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) {
+      const dataset = dataConfig?.dataset
+      const casesInPlot = dataConfig.subPlotCases(cellKey)
+      const caseValues: number[] = []
+      casesInPlot.forEach((c: ICase) => {
+        const caseValue = Number(dataset?.getValue(c.__id__, attrId))
+        if (Number.isInteger(caseValue)) {
+          caseValues.push(caseValue)
+        }
+      })
+      return caseValues
     }
   }))
   .actions(self => ({
     setValue(aValue: number | string) {
       self.value = aValue
-    }
-  }))
-  .actions(self => ({
-    updateCategories(options: IUpdateCategoriesOptions) {
-      // const { resetPoints } = options
-      // this may not be needed if it really is the case that the value will always be the same for all subplots
     }
   }))
 

--- a/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
+++ b/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
@@ -137,7 +137,7 @@ export const PlottedValue = observer(function PlottedValue (props: IProps) {
   return (
     <>
       <div className="plotted-value-container" id={`plotted-value-${containerId}`}>
-        { value && model.isVisible &&
+        { value != null && model.isVisible &&
             <svg
               className={`plotted-value-${classFromKey}`}
               data-testid={`plotted-value-${classFromKey}`}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181940090

This fixes a bug where starting from a configuration where the x attribute type is numeric and the y attribute type is categorical, to a configuration where the x attribute is numeric and the y attribute is numeric, and then switching back to the previous configuration, the adornment's line would not appear in the plot even if its checkbox was checked and a value provided.

Also included are fixes to correct some styling issues, and ensure that a formula value will use the correct case data when there are multiple subplots.