### PR TITLE
Reimplement semi-aggregate functions + refactor Formula MathJS scope and manager

### DIFF
--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -11,7 +11,8 @@ const evaluateNode = (node: MathNode, scope?: FormulaMathJsScope) => {
   return node.compile().evaluate(scope)
 }
 
-// Every aggregate function can be cached in the same way.
+// Every aggregate function can be cached in the same way. Also, each aggregate function needs to be evaluated
+// within `withAggregateContext` method, so that the scope can be properly set up.
 const cachedAggregateFnFactory =
 (fnName: string, fn: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]) => {
   return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
@@ -20,7 +21,10 @@ const cachedAggregateFnFactory =
     if (cachedValue !== undefined) {
       return cachedValue
     }
-    const result = fn(args, mathjs, scope)
+    let result
+    scope.withAggregateContext(() => {
+      result = fn(args, mathjs, scope)
+    })
     scope.setCached(cacheKey, result)
     return result
   }

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -1,40 +1,41 @@
-import {
-  FValue, CASE_INDEX_FAKE_ATTR_ID, GLOBAL_VALUE, LOCAL_ATTR, NO_PARENT_KEY
-} from "./formula-types"
+import { FValue, CASE_INDEX_FAKE_ATTR_ID, GLOBAL_VALUE, LOCAL_ATTR, NO_PARENT_KEY } from "./formula-types"
 import type { IGlobalValueManager } from "../global/global-value-manager"
 import type { IDataSet } from "./data-set"
 import type { IValueType } from "./attribute"
-import type { ICase } from "./data-set-types"
 
 const CACHE_ENABLED = true
 
 export interface IFormulaMathjsScopeContext {
-  formulaAttrId: string
   localDataSet: IDataSet
   dataSets: Map<string, IDataSet>
-  cases: ICase[]
-  childMostCollectionCases: ICase[]
-  useSameLevelGrouping: boolean
+  globalValueManager?: IGlobalValueManager
+  caseIds: string[]
+  formulaAttrId: string
+  formulaCollectionIndex: number
+  childMostAggregateCollectionIndex: number
+  childMostCollectionCaseIds: string[]
   caseGroupId: Record<string, string>
   caseChildrenCount: Record<string, number>
-  globalValueManager?: IGlobalValueManager
 }
 
 // Official MathJS docs don't describe custom scopes in great detail, but there's a good example in their repo:
 // https://github.com/josdejong/mathjs/blob/develop/examples/advanced/custom_scope_objects.js
 export class FormulaMathJsScope {
   context: IFormulaMathjsScopeContext
+  casePointer = 0
+  // When aggregate functions (functions working with multiple cases) are evaluated, this flag should be set to true.
   isAggregate = false
-  baseCasePointer = 0
   dataStorage: Record<string, any> = {}
   caseIndexCache?: Record<string, number>
-  // `cache` is used directly by custom formula functions like `prev`, `next` or other aggregate functions.
+  // `cache` is used directly by custom formula functions like `prev`, `next` or aggregate functions.
   cache = new Map<string, any>()
-  // Properties defined below are used for calculating recursive functions like prev() referencing itself, e.g.:
-  // prev(CumulativeValue, 0) + Value
-  casePointerModifier?: number
+  // `previousResults` is used for calculating self-referencing, recursive functions like prev(), e.g.:
+  // [CumulativeValue attribute formula]: "prev(CumulativeValue, 0) + Value"
   previousResults: FValue[] = []
-  previousCaseIds: string[] = []
+
+  get caseId() {
+    return this.context.caseIds[this.casePointer]
+  }
 
   constructor (context: IFormulaMathjsScopeContext) {
     this.context = context
@@ -60,15 +61,15 @@ export class FormulaMathJsScope {
               cachedGroup = {}
               // Cache is calculated lazily to avoid calculating it for all the attributes that are not referenced by
               // the formula. Note that each case is processed only once, so this mapping is only O(n) complexity.
-              context.childMostCollectionCases.forEach(c => {
-                const groupId = context.caseGroupId[c.__id__]
+              context.childMostCollectionCaseIds.forEach(cId => {
+                const groupId = context.caseGroupId[cId]
                 if (!cachedGroup[groupId]) {
                   cachedGroup[groupId] = []
                 }
-                cachedGroup[groupId].push(this.getLocalValue(c.__id__, attrId))
+                cachedGroup[groupId].push(this.getLocalValue(cId, attrId))
               })
             }
-            return cachedGroup[this.getCaseGroupId()] || cachedGroup[NO_PARENT_KEY]
+            return cachedGroup[this.getCaseAggregateGroupId()] || cachedGroup[NO_PARENT_KEY]
           }
         }
       })
@@ -83,16 +84,9 @@ export class FormulaMathJsScope {
     })
   }
 
-  get casePointer() {
-    return this.baseCasePointer + (this.casePointerModifier ?? 0)
-  }
-
-  get caseId() {
-    return this.context.cases[this.casePointer]?.__id__
-  }
-
   // --- Functions required by MathJS scope "interface". It doesn't seem to be defined/typed anywhere, so it's all
   //     based on: // https://github.com/josdejong/mathjs/blob/develop/examples/advanced/custom_scope_objects.js ---
+
   get(key: string): any {
     return this.dataStorage[key]
   }
@@ -126,23 +120,6 @@ export class FormulaMathJsScope {
   }
 
   // --- Custom functions used by our formulas or formula manager --
-  getCaseIndex(caseId: string) {
-    if (!this.caseIndexCache) {
-      // Cache is calculated lazily to avoid calculating when not necessary.
-      // Note that each case is processed only once, so this mapping is only O(n) complexity.
-      this.caseIndexCache = {}
-      const casesCount: Record<string, number> = {}
-      this.context.childMostCollectionCases.forEach(c => {
-        const groupId = this.context.caseGroupId[c.__id__]
-        if (!casesCount[groupId]) {
-          casesCount[groupId] = 0
-        }
-        casesCount[groupId] += 1
-        this.caseIndexCache![c.__id__] = casesCount[groupId]
-      })
-    }
-    return this.caseIndexCache[caseId]
-  }
 
   getLocalValue(caseId: string, attrId: string) {
     if (attrId === this.context.formulaAttrId) {
@@ -156,12 +133,36 @@ export class FormulaMathJsScope {
       : this.context.localDataSet.getValue(caseId, attrId)
   }
 
-  setBaseCasePointer(baseCasePointer: number) {
-    this.baseCasePointer = baseCasePointer
+  // Note that case index is what user sees in the table: 1-based index that respects grouping.
+  // It's not the same as a case pointer (index in fact) that is used internally by this class.
+  getCaseIndex(caseId: string) {
+    if (!this.caseIndexCache) {
+      // Cache is calculated lazily to avoid calculating when not necessary.
+      // Note that each case is processed only once, so this mapping is only O(n) complexity.
+      this.caseIndexCache = {}
+      const casesCount: Record<string, number> = {}
+      this.context.childMostCollectionCaseIds.forEach(cId => {
+        const groupId = this.context.caseGroupId[cId]
+        if (!casesCount[groupId]) {
+          casesCount[groupId] = 0
+        }
+        casesCount[groupId] += 1
+        this.caseIndexCache![cId] = casesCount[groupId]
+      })
+    }
+    return this.caseIndexCache[caseId]
   }
 
-  setCasePointerModifier(modifier: number | undefined) {
-    this.casePointerModifier = modifier
+  getCasePointer() {
+    return this.casePointer
+  }
+
+  setCasePointer(casePointer: number) {
+    this.casePointer = casePointer
+  }
+
+  getNumberOfCases() {
+    return this.context.caseIds.length
   }
 
   savePreviousResult(value: FValue) {
@@ -171,14 +172,11 @@ export class FormulaMathJsScope {
   // with... methods could be replaced by more elegant approach of creating sub-scope with modified properties,
   // but it would require re-initialization of the data storage. Since this could happen multiple times for each
   // evaluated case, it could be a performance hit. So, for now with... methods seem like a reasonable compromise.
-  withCasePointerModifier(callback: () => void, casePointerModifier: number) {
-    const originalCasePointerModifier = this.casePointerModifier
-    if (this.casePointerModifier === undefined) {
-      this.casePointerModifier = 0
-    }
-    this.casePointerModifier += casePointerModifier
+  withCustomCasePointer(callback: () => void, casePointer: number) {
+    const originalCasePointer = this.casePointer
+    this.casePointer = casePointer
     callback()
-    this.casePointerModifier = originalCasePointerModifier
+    this.casePointer = originalCasePointer
   }
 
   withAggregateContext(callback: () => void) {
@@ -200,15 +198,23 @@ export class FormulaMathJsScope {
     return this.context.dataSets.get(dataSetId)
   }
 
-  getCaseGroupId() {
-    // Same-level grouping uses parent ID as a group ID, parent-child grouping uses case ID as a group ID.
-    return this.context.useSameLevelGrouping ? this.context.caseGroupId[this.caseId] : this.caseId
+  getCaseAggregateGroupId() {
+    // There are two separate kinds of aggregate cases grouping:
+    // - Same-level grouping, which is used when the table is flat or when the aggregate function is referencing
+    //   attributes only from the same collection.
+    // - Parent-child grouping, which is used when the table is hierarchical and the aggregate function is
+    //   referencing attributes from child collections.
+    // When aggregate function is defined in a parent table but it references an attribute in a child table, we need to
+    // use formula's case ID as a group ID.
+    const useSameLevelGrouping = this.context.formulaCollectionIndex === this.context.childMostAggregateCollectionIndex
+    return useSameLevelGrouping ? this.getCaseGroupId() : this.caseId
   }
 
-  getSemiAggregateGroupId() {
+  getCaseGroupId() {
     return this.context.caseGroupId[this.caseId]
   }
 
+  // Basic, flexible cache used by formula's custom functions, usually aggregate or semi-aggregate.
   setCached(key: string, value: any) {
     if (CACHE_ENABLED) {
       this.cache.set(key, value)

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -178,7 +178,7 @@ export class FormulaMathJsScope {
     this.previousResults.push(value)
   }
 
-  withCaseIndexModifier(callback: () => void, casePointerModifier: number) {
+  withCasePointerModifier(callback: () => void, casePointerModifier: number) {
     const originalCasePointerModifier = this.casePointerModifier
     if (this.casePointerModifier === undefined) {
       this.casePointerModifier = 0

--- a/v3/src/models/data/formula-types.ts
+++ b/v3/src/models/data/formula-types.ts
@@ -3,7 +3,6 @@ import type { FormulaMathJsScope } from "./formula-mathjs-scope"
 
 export const GLOBAL_VALUE = "GLOBAL_VALUE_"
 export const LOCAL_ATTR = "LOCAL_ATTR_"
-export const AGGREGATE_SYMBOL_SUFFIX = "_ALL"
 export const CASE_INDEX_FAKE_ATTR_ID = "CASE_INDEX"
 
 export const NO_PARENT_KEY = "__NO_PARENT__"

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -162,7 +162,7 @@ export const getFormulaChildMostAggregateCollectionIndex = (formulaCanonical: st
   const attrId = getExtremeCollectionDependency(formulaCanonical, dataSet, { order: "max", aggregate: true })
   const collectionId = dataSet.getCollectionForAttribute(attrId || "")?.id
   const collectionIndex = dataSet.getCollectionIndex(collectionId || "")
-  return collectionIndex !== -1 ? dataSet.getCollectionIndex(collectionId || "") : null
+  return collectionIndex >= 0 ? collectionIndex : null
 }
 
 export const getIncorrectParentAttrReference =
@@ -170,7 +170,7 @@ export const getIncorrectParentAttrReference =
   const attrId = getExtremeCollectionDependency(formulaCanonical, dataSet, { order: "min", aggregate: true })
   const collectionId = dataSet.getCollectionForAttribute(attrId || "")?.id
   const collectionIndex = dataSet.getCollectionIndex(collectionId || "")
-  if (collectionIndex !== -1 && collectionIndex < formulaCollectionIndex) {
+  if (collectionIndex >= 0 && collectionIndex < formulaCollectionIndex) {
     return attrId
   }
   return false
@@ -181,7 +181,7 @@ export const getIncorrectChildAttrReference =
   const attrId = getExtremeCollectionDependency(formulaCanonical, dataSet, { order: "max", aggregate: false })
   const collectionId = dataSet.getCollectionForAttribute(attrId || "")?.id
   const collectionIndex = dataSet.getCollectionIndex(collectionId || "")
-  if (collectionIndex !== -1 && collectionIndex > formulaCollectionIndex) {
+  if (collectionIndex >= 0 && collectionIndex > formulaCollectionIndex) {
     return attrId
   }
   return false


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186115784

Yet another approach to semi-aggregates. I hope I've found a proper approach (which is also much simpler) that maintains an O(n) time complexity without the need for reverse iteration for `next`. So, we can avoid the potential O(n^2) issues that could happen in V2 (if I've correctly interpreted its code). The only trade-off is the lack of self-reference in `next()` function that we discussed before. But it works seamlessly for `prev()`, allowing us to implement the Fibonacci sequence or running sum.

This PR also includes some refactoring and simplification of the formula-related code:
- I've added or cleaned up `within...` methods in the mathjs custom scope and explained in comments why I use this approach instead of the more elegant sub-scopes. 
- I've removed the aggregate suffix (`_ALL`) from symbol names in the canonical form and replaced that with `withAggregateContext` scope method. Since I had to add `within...` method(s) anyway, this was making more sense now and simplified the scope code too.
- I've removed `casePointerModifier` and simply let the functions move the pointer as they want. This makes the scope simpler.
- Other smaller changes like changing names or moving some logic to places that are probably better suited for it.

I've tested `prev` and `next` functions using the [mammals dataset](https://codap.concord.org/app/static/dg/en/cert/index.html#file=examples:Mammals) in V2 and V3, and for each formula, I've checked both the flat table and the hierarchical one (with the "Diet" attribute moved to a new top-level collection). Results were identical for each of the formulas listed:

```
next(LifeSpan, -1)
prev(LifeSpan, -1)
next(LifeSpan, -1, Habitat = "water") 
prev(LifeSpan, -1, Habitat = "water")
prev(Height, 1) + prev(prev(Height, 1), 1) + prev(prev(prev(Height, 1), 1), 1)
prev(next(LifeSpan))
next(next(LifeSpan))
next(next(LifeSpan, -2, Habitat = "water"), -1, Habitat = "water")
next(prev(LifeSpan, -2, Habitat = "water"), -1, Habitat = "water")
prev(next(LifeSpan, -2, Habitat = "water"), -1, Habitat = "water")
next(prev(next(LifeSpan, -3, Habitat = "water"), -2, Habitat = "water"), -1, Habitat = "both")
prev(caseIndex)
next(caseIndex)
prev(prev(caseIndex))
next(next(caseIndex))
next(prev(caseIndex))
prev(next(caseIndex))
prev(LifeSpan) + mean(LifeSpan)
prev(newAttr2) + mean(LifeSpan) (in the top-level collection with Diet and newAttr2)
```

There are some scenarios where V2 and V3 would produce different results. But I think they either don’t make much sense, or v3 behavior seems to be better or logical:

1. Aggregate within next or prev: prev(mean(LifeSpan))
a. V2 returns 70, 70, 70…
b. V3 returns the actual mean of LifeSpan: 24.8, 24.8, 24.8…
2. prev/next referencing child attribute: prev(LifeSpan)  in the top-level collection with Diet
a. V2 fails quietly / renders blank fields
b. V3 returns the first value from the previous group: 70, 19
3. prev/next referencing child attribute within the aggregate function: prev(mean(LifeSpan)) in the top-level collection with Diet
a. V2 fails quietly / renders blank fields
b. V3 returns the mean of the previous group, which seems to make sense (same as combining prev and mean calls in two separate columns): 35, 21.8
