### PR TITLE
Fix parsing of =, equality check, `lookupByKey` equality check + add custom unequal operator

### DIFF
--- a/v3/src/models/data/formula-utils.test.ts
+++ b/v3/src/models/data/formula-utils.test.ts
@@ -16,6 +16,11 @@ describe("customizeFormula", () => {
     expect(customizeFormula("a = b")).toEqual("a == b")
     expect(customizeFormula("a = b = c")).toEqual("a == b == c")
   })
+  it("doesn't replace unequality operator", () => {
+    expect(customizeFormula("a != 1")).toEqual("a != 1")
+    expect(customizeFormula("a != b")).toEqual("a != b")
+    expect(customizeFormula("a != b = c = d != e")).toEqual("a != b == c == d != e")
+  })
   it("replaces all the symbols enclosed between `` with safe symbol names", () => {
     expect(customizeFormula("mean(`Attribute Name`)")).toEqual("mean(Attribute_Name)")
     expect(customizeFormula("`Attribute Name` + `Attribute Name 2`")).toEqual("Attribute_Name + Attribute_Name_2")

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -35,7 +35,7 @@ export const customizeFormula = (formula: string) => {
   // Over time, this function might grow significantly and require more advanced parsing of the formula.
   return formula
     // Replace all the assignment operators with equality operators, as CODAP v2 uses a single "=" for equality check.
-    .replace(/=/g, "==")
+    .replace(/(?<!!)=(?!=)/g, "==")
     // Names between `` are symbols that require special processing, as otherwise they could not be parsed by Mathjs,
     // eg. names with spaces or names that start with a number.
     .replace(/`([^`]+)`/g, (_, match) => safeSymbolName(match))


### PR DESCRIPTION
This PR mostly addresses issues found during QA:
https://www.pivotaltracker.com/story/show/185745574/comments/238369011

But it also fixes a few other bugs related to equality operator.