### PR TITLE
Fix count() caching

### DIFF
--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -172,18 +172,20 @@ export class FormulaMathJsScope {
   // with... methods could be replaced by more elegant approach of creating sub-scope with modified properties,
   // but it would require re-initialization of the data storage. Since this could happen multiple times for each
   // evaluated case, it could be a performance hit. So, for now with... methods seem like a reasonable compromise.
-  withCustomCasePointer(callback: () => void, casePointer: number) {
+  withCustomCasePointer(callback: () => any, casePointer: number) {
     const originalCasePointer = this.casePointer
     this.casePointer = casePointer
-    callback()
+    const result = callback()
     this.casePointer = originalCasePointer
+    return result
   }
 
-  withAggregateContext(callback: () => void) {
+  withAggregateContext(callback: () => any) {
     const originalIsAggregate = this.isAggregate
     this.isAggregate = true
-    callback()
+    const result = callback()
     this.isAggregate = originalIsAggregate
+    return result
   }
 
   getCaseChildrenCount() {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186033205

This pull request fixes formulas that included a `count()` call without an argument. It was incorrectly cached and resulted in the wrong result in most cases. This is an atypical scenario, as `count()` doesn't have any arguments from the child collection, yet it should use grouping logic / behavior / IDs, as it did. Manual caching seemed to be the easiest solution.