### PR TITLE
feat: more case table actions support undo/redo -- hide/show and attribute move/hierarchy changes

### DIFF
--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -135,7 +135,7 @@ export const TableTileElements = {
   },
   showAllAttributes() {
     cy.get("[data-testid=hide-show-button]").click()
-    cy.get("[data-testid=hide-show-menu-list]").find("button").contains("Show Hidden Attribute").click()
+    cy.get("[data-testid=hide-show-menu-list]").find("button").contains("Show 1 Hidden Attribute").click()
   },
   createNewTableFromToolshelf() {
     c.createFromToolshelf("table")

--- a/v3/src/components/app.test.tsx
+++ b/v3/src/components/app.test.tsx
@@ -4,6 +4,14 @@ import { prf } from "../utilities/profiler"
 import { setUrlParams } from "../utilities/url-params"
 import { App } from "./app"
 
+// mock the `ToolShelf` component because it generates warnings:
+//  Warning: An update to ToolShelf inside a test was not wrapped in act(...).
+// This shouldn't affect coverage because `ToolShelf` has its own jest test
+// and it's also tested by the cypress tests.
+jest.mock("./tool-shelf/tool-shelf", () => ({
+  ToolShelf: () => null
+}))
+
 describe("App component", () => {
 
   it("should render the App component with no data", () => {

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -37,7 +37,9 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
     })
   }
   const handleHideAttribute = () => {
-   caseMetadata?.setIsHidden(column.key, true)
+    caseMetadata?.applyUndoableAction(
+      () => caseMetadata?.setIsHidden(column.key, true),
+      "DG.Undo.caseTable.hideAttribute", "DG.Redo.caseTable.hideAttribute")
   }
 
   const handleDeleteAttribute = () => {

--- a/v3/src/components/case-table/case-table-types.ts
+++ b/v3/src/components/case-table/case-table-types.ts
@@ -44,6 +44,4 @@ export type OnScrollClosestRowIntoViewFn = (collectionId: string, rowIndices: nu
 // used in lieu of attribute id for index column for ReactDataGrid
 export const kIndexColumnKey = "__index__"
 
-export const kChildMostTableCollectionId = "child-most"
-
 export const kDefaultColumnWidth = 80

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -2,7 +2,7 @@ import { useDndContext } from "@dnd-kit/core"
 import { observer } from "mobx-react-lite"
 import React, { CSSProperties, useCallback, useEffect, useRef } from "react"
 import { AttributeDragOverlay } from "../drag-drop/attribute-drag-overlay"
-import { kChildMostTableCollectionId, kIndexColumnKey } from "./case-table-types"
+import { kIndexColumnKey } from "./case-table-types"
 import { CollectionTable } from "./collection-table"
 import { useCaseTableModel } from "./use-case-table-model"
 import { useSyncScrolling } from "./use-sync-scrolling"
@@ -63,8 +63,10 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
 
   const handleNewCollectionDrop = useCallback((dataSet: IDataSet, attrId: string, beforeCollectionId: string) => {
     if (dataSet.attrFromID(attrId)) {
-      const collection = dataSet.moveAttributeToNewCollection(attrId, beforeCollectionId)
-      lastNewCollectionDrop.current = { newCollectionId: collection.id, beforeCollectionId }
+      dataSet.applyUndoableAction(() => {
+        const collection = dataSet.moveAttributeToNewCollection(attrId, beforeCollectionId)
+        lastNewCollectionDrop.current = { newCollectionId: collection.id, beforeCollectionId }
+      }, "DG.Undo.caseTable.createCollection", "DG.Redo.caseTable.createCollection")
     }
   }, [])
 
@@ -85,11 +87,11 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
         <div ref={setTableRef} className="case-table" data-testid="case-table">
           <div className="case-table-content" onScroll={handleHorizontalScroll}>
             {collections.map((collection, i) => {
-              const key = collection?.id || kChildMostTableCollectionId
+              const key = collection.id
               const parent = i > 0 ? collections[i - 1] : undefined
               return (
-                <ParentCollectionContext.Provider key={key} value={parent}>
-                  <CollectionContext.Provider key={key} value={collection}>
+                <ParentCollectionContext.Provider key={key} value={parent?.id}>
+                  <CollectionContext.Provider key={key} value={collection.id}>
                     <CollectionTable onMount={handleCollectionTableMount}
                       onNewCollectionDrop={handleNewCollectionDrop} onTableScroll={handleTableScroll}
                       onScrollClosestRowIntoView={handleScrollClosestRowIntoView} />

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -91,7 +91,7 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
               const parent = i > 0 ? collections[i - 1] : undefined
               return (
                 <ParentCollectionContext.Provider key={key} value={parent?.id}>
-                  <CollectionContext.Provider key={key} value={collection.id}>
+                  <CollectionContext.Provider value={collection.id}>
                     <CollectionTable onMount={handleCollectionTableMount}
                       onNewCollectionDrop={handleNewCollectionDrop} onTableScroll={handleTableScroll}
                       onScrollClosestRowIntoView={handleScrollClosestRowIntoView} />

--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -9,7 +9,6 @@ import { measureText } from "../../hooks/use-measure-text"
 import { IDataSet } from "../../models/data/data-set"
 // import { getNumericCssVariable } from "../../utilities/css-utils"
 import t from "../../utilities/translation/translate"
-import { kChildMostTableCollectionId } from "./case-table-types"
 import { useCollectionTableModel } from "./use-collection-table-model"
 import { CurvedSpline } from "./curved-spline"
 
@@ -19,12 +18,11 @@ interface IProps {
 export const CollectionTableSpacer = observer(function CollectionTableSpacer({ onDrop }: IProps) {
   const data = useDataSetContext()
   const caseMetadata = useCaseMetadata()
-  const parentCollection = useParentCollectionContext()
-  const parentCollectionId = parentCollection?.id
+  const parentCollectionId = useParentCollectionContext()
+  const parentCollection = parentCollectionId ? data?.getCollection(parentCollectionId) : undefined
   const parentTableModel = useCollectionTableModel(parentCollectionId)
   const parentScrollTop = parentTableModel?.scrollTop ?? 0
-  const childCollection = useCollectionContext()
-  const childCollectionId = childCollection?.id || kChildMostTableCollectionId
+  const childCollectionId = useCollectionContext()
   const childTableModel = useCollectionTableModel()
   const parentMost = !parentCollection
   const { active, isOver, setNodeRef } = useTileDroppable(`new-collection-${childCollectionId}`, _active => {

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -1,7 +1,7 @@
 import { observer } from "mobx-react-lite"
 import React, { useCallback, useEffect, useRef } from "react"
 import DataGrid, { DataGridHandle } from "react-data-grid"
-import { kChildMostTableCollectionId, OnScrollClosestRowIntoViewFn, OnTableScrollFn, TRow } from "./case-table-types"
+import { OnScrollClosestRowIntoViewFn, OnTableScrollFn, TRow } from "./case-table-types"
 import { CollectionTableSpacer } from "./collection-table-spacer"
 import { CollectionTitle } from "./collection-title"
 import { useColumns } from "./use-columns"
@@ -28,8 +28,7 @@ interface IProps {
 export const CollectionTable = observer(function CollectionTable(props: IProps) {
   const { onMount, onNewCollectionDrop, onTableScroll, onScrollClosestRowIntoView } = props
   const data = useDataSetContext()
-  const collection = useCollectionContext()
-  const collectionId = collection?.id || kChildMostTableCollectionId
+  const collectionId = useCollectionContext()
   const collectionTableModel = useCollectionTableModel()
   const gridRef = useRef<DataGridHandle>(null)
   const { selectedRows, setSelectedRows, handleCellClick } = useSelectedRows({ gridRef, onScrollClosestRowIntoView })
@@ -63,8 +62,8 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
 
   const handleNewCollectionDrop = useCallback((dataSet: IDataSet, attrId: string) => {
     const attr = dataSet.attrFromID(attrId)
-    attr && onNewCollectionDrop(dataSet, attrId, collection.id)
-  }, [collection.id, onNewCollectionDrop])
+    attr && onNewCollectionDrop(dataSet, attrId, collectionId)
+  }, [collectionId, onNewCollectionDrop])
 
   const handleGridScroll = useCallback(function handleGridScroll(event: React.UIEvent<HTMLDivElement, UIEvent>) {
     const gridElt = gridRef.current?.element

--- a/v3/src/components/case-table/collection-title.tsx
+++ b/v3/src/components/case-table/collection-title.tsx
@@ -16,10 +16,11 @@ import { useTileModelContext } from "../../hooks/use-tile-model-context"
 
 export const CollectionTitle = observer(function CollectionTitle() {
   const data = useDataSetContext()
-  const collection = useCollectionContext()
+  const collectionId = useCollectionContext()
+  const collection = data?.getCollection(collectionId)
   const { isTileSelected } = useTileModelContext()
-  const { setTitle, displayTitle } = collection
-  const defaultName = pluralize((getCollectionAttrs(collection, data)[0]?.name) ?? '')
+  const { setTitle, displayTitle } = collection || {}
+  const defaultName = collection ? pluralize((getCollectionAttrs(collection, data)[0]?.name) ?? "") : ""
   const caseCount = data?.getCasesForCollection(collection?.id).length ?? 0
   const tileRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
@@ -73,7 +74,7 @@ export const CollectionTitle = observer(function CollectionTitle() {
 
   const handleChangeTitle = (nextValue?: string) => {
     if (nextValue) {
-      setTitle(nextValue)
+      setTitle?.(nextValue)
     }
   }
 
@@ -81,7 +82,7 @@ export const CollectionTitle = observer(function CollectionTitle() {
     const newAttrName = uniqueName("newAttr",
       (aName: string) => !data?.attributes.find(attr => aName === attr.name)
      )
-    data?.addAttribute({ name: newAttrName }, { collection: collection.id })
+    data?.addAttribute({ name: newAttrName }, { collection: collectionId })
   }
 
   const casesStr = t(caseCount === 1 ? "DG.DataContext.singleCaseName" : "DG.DataContext.pluralCaseName")

--- a/v3/src/components/case-table/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/case-table/inspector-panel/hide-show-menu-list.tsx
@@ -45,21 +45,23 @@ export const HideShowMenuList = () => {
   }
 
   const handleShowAllAttributes = () => {
-    caseMetadata?.showAllAttributes()
+    caseMetadata?.applyUndoableAction(
+      () => caseMetadata?.showAllAttributes(),
+      "DG.Undo.caseTable.showAllHiddenAttributes", "DG.Redo.caseTable.showAllHiddenAttributes"
+    )
   }
-
-  const hiddenAttributes = data?.attributes.filter(attr => attr && caseMetadata?.isHidden(attr.id))
-  const noHiddenAttributes = !hiddenAttributes?.length || hiddenAttributes?.length <= 0
 
   const caseCount = data?.cases.length ?? 0
   const selectionCount = data?.selection.size ?? 0
   const setAsideCount = 0 // eventually will come from DataSet
   const restoreSetAsideCasesLabel = t("DG.Inspector.setaside.restoreSetAsideCases", { vars: [setAsideCount] })
-  const showAllHiddenAttributesLabel =
-    noHiddenAttributes  ? t("DG.Inspector.attributes.showAllHiddenAttributesDisabled")
-                        : hiddenAttributes?.length > 1
-                          ? t("DG.Inspector.attributes.showAllHiddenAttributesPlural")
-                          : t("DG.Inspector.attributes.showAllHiddenAttributesSing")
+
+  const hiddenAttributeCount = data?.attributes.filter(attr => attr && caseMetadata?.isHidden(attr.id)).length ?? 0
+  const showAllHiddenAttributesKey = {
+    0: "DG.Inspector.attributes.showAllHiddenAttributesDisabled",
+    1: "DG.Inspector.attributes.showAllHiddenAttributesSing"
+  }[hiddenAttributeCount] ?? "DG.Inspector.attributes.showAllHiddenAttributesPlural"
+  const showAllHiddenAttributesLabel = t(showAllHiddenAttributesKey, { vars: [hiddenAttributeCount] })
 
   return (
     <MenuList data-testid="hide-show-menu-list">
@@ -72,7 +74,7 @@ export const HideShowMenuList = () => {
       <MenuItem isDisabled={setAsideCount === 0} onClick={handleRestoreSetAsideCases}>
         {restoreSetAsideCasesLabel}
       </MenuItem>
-      <MenuItem isDisabled={noHiddenAttributes} onClick={handleShowAllAttributes}>
+      <MenuItem isDisabled={!hiddenAttributeCount} onClick={handleShowAllAttributes}>
         {showAllHiddenAttributesLabel}
       </MenuItem>
     </MenuList>

--- a/v3/src/components/case-table/use-collection-table-model.ts
+++ b/v3/src/components/case-table/use-collection-table-model.ts
@@ -5,13 +5,13 @@ import { useCaseTableModel } from "./use-case-table-model"
 
 export function useCollectionTableModel(collectionId?: string) {
   const tableModel = useCaseTableModel()
-  const collection = useCollectionContext()
+  const collectionIdFromContext = useCollectionContext()
   const collectionTableModel = useRef<CollectionTableModel | undefined>()
 
   useEffect(() => {
     const isMismatch = collectionTableModel.current?.collectionId !== collectionId
     if (!collectionTableModel.current || isMismatch) {
-      collectionTableModel.current = tableModel?.getCollectionTableModel(collectionId ?? collection.id)
+      collectionTableModel.current = tableModel?.getCollectionTableModel(collectionId ?? collectionIdFromContext)
     }
   })
 

--- a/v3/src/components/case-table/use-columns.tsx
+++ b/v3/src/components/case-table/use-columns.tsx
@@ -32,7 +32,7 @@ interface IUseColumnsProps {
 export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
   const caseMetadata = useCaseMetadata()
   const parentCollection = useParentCollectionContext()
-  const collection = useCollectionContext()
+  const collectionId = useCollectionContext()
   const [columns, setColumns] = useState<TColumn[]>([])
 
   // cell renderer
@@ -62,7 +62,8 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
     // rebuild column definitions when referenced properties change
     const disposer = reaction(
       () => {
-        const attrs: IAttribute[] = getCollectionAttrs(collection, data)
+        const collection = data?.getCollection(collectionId)
+        const attrs: IAttribute[] = collection ? getCollectionAttrs(collection, data) : []
         const visible: IAttribute[] = attrs.filter(attr => attr && !caseMetadata?.isHidden(attr.id))
         return visible.map(({ id, name, editable }) => ({ id, name, editable }))
       },
@@ -92,7 +93,7 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
       { fireImmediately: true }
     )
     return () => disposer()
-  }, [RenderCell, caseMetadata, collection, data, indexColumn, parentCollection])
+  }, [RenderCell, caseMetadata, collectionId, data, indexColumn, parentCollection])
 
   return columns
 }

--- a/v3/src/components/case-table/use-index-column.tsx
+++ b/v3/src/components/case-table/use-index-column.tsx
@@ -37,7 +37,7 @@ function indexColumnSpan(args: TColSpanArgs, { data, metadata, collection }: ICo
 export const useIndexColumn = () => {
   const caseMetadata = useCaseMetadata()
   const data = useDataSetContext()
-  const collection = useCollectionContext()
+  const collectionId = useCollectionContext()
   // renderer
   const RenderIndexCell = useCallback(({ row }: TRenderCellProps) => {
     const { __id__, [symIndex]: _index, [symParent]: parentId } = row
@@ -53,6 +53,7 @@ export const useIndexColumn = () => {
   const indexColumn = useRef<TColumn | undefined>()
 
   useEffect(() => {
+    const collection = data?.getCollection(collectionId)
     // rebuild index column definition when necessary
     indexColumn.current = {
       key: kIndexColumnKey,
@@ -63,11 +64,11 @@ export const useIndexColumn = () => {
       renderHeaderCell: ColumnHeader,
       cellClass: "codap-index-cell",
       colSpan(args: TColSpanArgs) {
-        return indexColumnSpan(args, { data, metadata: caseMetadata, collection })
+        return collection ? indexColumnSpan(args, { data, metadata: caseMetadata, collection }) : undefined
       },
       renderCell: RenderIndexCell
     }
-  }, [caseMetadata, collection, data, RenderIndexCell])
+  }, [caseMetadata, collectionId, data, RenderIndexCell])
 
   return indexColumn.current
 }

--- a/v3/src/hooks/use-collection-context.ts
+++ b/v3/src/hooks/use-collection-context.ts
@@ -1,8 +1,7 @@
 import { createContext, useContext } from "react"
-import { ICollectionPropsModel } from "../models/data/collection"
 
-export const CollectionContext = createContext<ICollectionPropsModel>({} as ICollectionPropsModel)
+export const CollectionContext = createContext<string>("")
 export const useCollectionContext = () => useContext(CollectionContext)
 
-export const ParentCollectionContext = createContext<ICollectionPropsModel | undefined>(undefined)
+export const ParentCollectionContext = createContext<string | undefined>(undefined)
 export const useParentCollectionContext = () => useContext(ParentCollectionContext)

--- a/v3/src/models/data/data-set-types.ts
+++ b/v3/src/models/data/data-set-types.ts
@@ -51,6 +51,7 @@ export interface IAddAttributeOptions {
 export interface IMoveAttributeOptions {
   before?: string;  // id of attribute before which the moved attribute should be placed
   after?: string;   // id of attribute after which the moved attribute should be placed
+  withoutCustomUndo?: boolean;
 }
 
 export interface IMoveAttributeCollectionOptions extends IMoveAttributeOptions {

--- a/v3/src/models/data/data-set-utils.test.ts
+++ b/v3/src/models/data/data-set-utils.test.ts
@@ -1,0 +1,35 @@
+import { IAttribute } from "./attribute"
+import { CollectionModel, ICollectionPropsModel } from "./collection"
+import { DataSet, IDataSet } from "./data-set"
+import { getCollectionAttrs } from "./data-set-utils"
+
+describe("DataSetUtils", () => {
+  it("getCollectionAttrs works as expected", () => {
+    function names(attrs: IAttribute[]) {
+      return attrs.map(({ name }) => name)
+    }
+    function getCollectionAttrNames(_collection: ICollectionPropsModel, _data?: IDataSet) {
+      return names(getCollectionAttrs(_collection, _data))
+    }
+    const data = DataSet.create()
+    const collection = CollectionModel.create({ id: "cId" })
+    data.addCollection(collection)
+    data.addAttribute({ id: "aId", name: "a" })
+    data.addAttribute({ id: "bId", name: "b" })
+    expect(getCollectionAttrNames(collection, data)).toEqual([])
+    expect(getCollectionAttrNames(data.ungrouped, data)).toEqual(["a", "b"])
+
+    data.setCollectionForAttribute("aId", { collection: "cId" })
+    expect(getCollectionAttrNames(collection, data)).toEqual(["a"])
+    expect(getCollectionAttrNames(data.ungrouped, data)).toEqual(["b"])
+
+    // Moving the last attribute out of the ungrouped collection will cause the collection
+    // to be destroyed and the attributes to return to being ungrouped.
+    data.setCollectionForAttribute("bId", { collection: "cId" })
+    jestSpyConsole("warn", spy => {
+      expect(getCollectionAttrNames(collection, data)).toEqual([])
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+    expect(getCollectionAttrNames(data.ungrouped, data)).toEqual(["a", "b"])
+  })
+})

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -1,8 +1,13 @@
+import { isAlive } from "mobx-state-tree"
 import {IAttribute} from "./attribute"
 import {ICollectionPropsModel, isCollectionModel} from "./collection"
 import {IDataSet} from "./data-set"
 
 export function getCollectionAttrs(collection: ICollectionPropsModel, data?: IDataSet) {
+  if (collection && !isAlive(collection)) {
+    console.warn("DataSetUtils.getCollectionAttrs called for defunct collection")
+    return []
+  }
   return (isCollectionModel(collection)
     ? Array.from(collection.attributes) as IAttribute[]
     : data?.ungroupedAttributes) ?? []

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -584,20 +584,17 @@ test("DataSet client synchronization", (done) => {
       applyAction(dst2, action)
       if ((srcActionCount <= 0) && (dstActionCount <= 0)) {
         // eslint-disable-next-line jest/no-conditional-expect
-        expect(getSnapshot(dst2)).toEqual(getSnapshot(dst))
+        expect(getSnapshot(dst2)).toEqualWithoutIds(getSnapshot(dst))
         done()
       }
     })
   })
 
-  // TODO: PJ: I had to temporarily disable this test because it was failing when formula ID in dst and dst2 were
-  // not matching formula ID in src. Currently, I don't understand how the auto-generated formula ID could match,
-  // and how this used to work for attributes that also have the same kind of auto-generated ID.
-  // src.addAttribute({ name: "str" })
-  // src.addAttribute({ name: "num" })
+  src.addAttribute({ name: "str" })
+  src.addAttribute({ name: "num" })
   src.addCases(toCanonical(src, [{ str: "a", num: 1 }]))
   src.addCases(toCanonical(src, [{ str: "b", num: 2 }, { str: "c", num: 3 }]))
-  // src.removeAttribute(src.attributes[0].id)
+  src.removeAttribute(src.attributes[0].id)
 })
 
 test("DataSet collection helpers", () => {

--- a/v3/src/models/shared/shared-case-metadata.ts
+++ b/v3/src/models/shared/shared-case-metadata.ts
@@ -3,6 +3,7 @@ import { getSnapshot, getType, Instance, ISerializedActionCall, onAction, types 
 import { CategorySet, createProvisionalCategorySet, ICategorySet } from "../data/category-set"
 import { DataSet, IDataSet } from "../data/data-set"
 import { ISharedModel, SharedModel } from "./shared-model"
+import { applyUndoableAction } from "../history/apply-undoable-action"
 
 export const kSharedCaseMetadataType = "SharedCaseMetadata"
 
@@ -135,6 +136,8 @@ export const SharedCaseMetadata = SharedModel
       return categorySet
     }
   }))
+  .actions(applyUndoableAction)
+
 export interface ISharedCaseMetadata extends Instance<typeof SharedCaseMetadata> {}
 
 export function isSharedCaseMetadata(model?: ISharedModel): model is ISharedCaseMetadata {

--- a/v3/src/test/setupTests.ts
+++ b/v3/src/test/setupTests.ts
@@ -25,7 +25,7 @@ function removeIdsReplacer(key: string, value: any) {
   return key === "id" ? undefined : value
 }
 
-// for use with lodash's isEqualWith function to implement toEqualWithUniqueIds custom jest matcher
+// for use with lodash's isEqualWith function to implement toEqualWithoutIds custom jest matcher
 const withoutIdsCustomizer = (rec: any, exp: any) => {
   if (Array.isArray(rec) && Array.isArray(exp) && (rec?.length !== exp?.length)) {
     message = () =>
@@ -52,7 +52,7 @@ expect.extend({
     message = () => ""
     const pass = isEqualWith(received, expected, withoutIdsCustomizer)
     if (!pass && !message()) {
-      message = () => "values differed outside of geometry objects"
+      message = () => "values differed even with ids ignored"
     }
     return { pass, message }
   }

--- a/v3/src/test/setupTests.ts
+++ b/v3/src/test/setupTests.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom"
 import "jest-canvas-mock"
+import { isEqual, isEqualWith } from "lodash"
 import ResizeObserverPolyfill from "resize-observer-polyfill"
 
 import { assertIsDefined } from "./assert-is-defined"
@@ -17,3 +18,50 @@ declare global {
 }
 global.assertIsDefined = assertIsDefined
 global.jestSpyConsole = jestSpyConsole
+
+let message = () => ""
+
+function removeIdsReplacer(key: string, value: any) {
+  return key === "id" ? undefined : value
+}
+
+// for use with lodash's isEqualWith function to implement toEqualWithUniqueIds custom jest matcher
+const withoutIdsCustomizer = (rec: any, exp: any) => {
+  if (Array.isArray(rec) && Array.isArray(exp) && (rec?.length !== exp?.length)) {
+    message = () =>
+      `array lengths must be equal\n` +
+      `  Expected: ${exp.length}\n` +
+      `  Received: ${rec.length}`
+    return false
+  }
+  const _rec = JSON.parse(JSON.stringify(rec, removeIdsReplacer))
+  const _exp = JSON.parse(JSON.stringify(exp, removeIdsReplacer))
+  if (!isEqual(_rec, _exp)) {
+    message = () =>
+      `object values must match:\n` +
+      `  Expected: ${JSON.stringify(_exp)}\n` +
+      `  Received: ${JSON.stringify(_rec)}`
+  }
+  return true
+}
+
+// custom jest matcher for testing that copied objects are identical to the originals
+// except for the object ids which should all be different.
+expect.extend({
+  toEqualWithoutIds(received: any, expected: any) {
+    message = () => ""
+    const pass = isEqualWith(received, expected, withoutIdsCustomizer)
+    if (!pass && !message()) {
+      message = () => "values differed outside of geometry objects"
+    }
+    return { pass, message }
+  }
+})
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toEqualWithoutIds(expected: any): R
+    }
+  }
+}


### PR DESCRIPTION
Should be undoable as a single action with appropriate undo/redo strings:
- hiding attribute(s)
- showing attribute(s)
- moving attributes within a collection
- moving attributes to create a new collection
- moving attributes to remove a collection
