### PR TITLE
fix: Dot plots can show mean and median (PT-181914405)

### DIFF
--- a/v3/src/components/graph/adornments/adornment-models.ts
+++ b/v3/src/components/graph/adornments/adornment-models.ts
@@ -81,8 +81,14 @@ export const AdornmentModel = types.model("AdornmentModel", {
       const columnCount = topCatCount * xCatCount
       const rowCount = rightCatCount * yCatCount
       const cellKey: Record<string, string> = {}
-      const topCat = topCats[index % topCats.length]
-      const rightCat = rightCats[index % rightCats.length]
+      const topIndex = xCatCount > 0
+        ? Math.floor(index / xCatCount) % topCatCount
+        : index % topCatCount
+      const topCat = topCats[topIndex]
+      const rightIndex = yCatCount > 0
+        ? Math.floor(index / yCatCount) % rightCats.length
+        : index % rightCats.length
+      const rightCat = rightCats[rightIndex]
       const yCat = topCats.length > 0
         ? yCats[Math.floor(index / columnCount) % yCatCount]
         : yCats[index % yCats.length]

--- a/v3/src/components/graph/adornments/movable-value/movable-value.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value.tsx
@@ -202,7 +202,7 @@ export const MovableValue = observer(function MovableValue (props: IProps) {
       adjustAllValues()
       renderFills()
     }, { name: "MovableValue.refreshAxisChange" })
-  }, [adjustAllValues, dataConfig, renderFills, xAxis.max, xAxis.min, yAxis.max, yAxis.min])
+  }, [adjustAllValues, dataConfig, renderFills, xAxis.domain, yAxis.domain])
 
   // Make the movable values and their cover segments
   useEffect(function createElements() {

--- a/v3/src/components/graph/adornments/movable-value/movable-value.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value.tsx
@@ -201,10 +201,8 @@ export const MovableValue = observer(function MovableValue (props: IProps) {
       // We observe changes to the axis domains within the autorun by extracting them from the axes below.
       // We do this instead of including domains in the useEffect dependency array to prevent domain changes
       // from triggering a reinstall of the autorun.
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { domain: xDomain } = xAxis
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { domain: yDomain } = yAxis
+      const { domain: xDomain } = xAxis // eslint-disable-line @typescript-eslint/no-unused-vars
+      const { domain: yDomain } = yAxis // eslint-disable-line @typescript-eslint/no-unused-vars
       isVertical.current = dataConfig?.attributeType("x") === "numeric"
       adjustAllValues()
       renderFills()

--- a/v3/src/components/graph/adornments/movable-value/movable-value.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value.tsx
@@ -198,7 +198,12 @@ export const MovableValue = observer(function MovableValue (props: IProps) {
   // Refresh the value when the axis changes
   useEffect(function refreshAxisChange() {
     return autorun(() => {
+      // We observe changes to the axis domains within the autorun by extracting them from the axes below.
+      // We do this instead of including domains in the useEffect dependency array to prevent domain changes
+      // from triggering a reinstall of the autorun.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { domain: xDomain } = xAxis
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { domain: yDomain } = yAxis
       isVertical.current = dataConfig?.attributeType("x") === "numeric"
       adjustAllValues()

--- a/v3/src/components/graph/adornments/movable-value/movable-value.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value.tsx
@@ -198,11 +198,13 @@ export const MovableValue = observer(function MovableValue (props: IProps) {
   // Refresh the value when the axis changes
   useEffect(function refreshAxisChange() {
     return autorun(() => {
+      const { domain: xDomain } = xAxis
+      const { domain: yDomain } = yAxis
       isVertical.current = dataConfig?.attributeType("x") === "numeric"
       adjustAllValues()
       renderFills()
     }, { name: "MovableValue.refreshAxisChange" })
-  }, [adjustAllValues, dataConfig, renderFills, xAxis.domain, yAxis.domain])
+  }, [adjustAllValues, dataConfig, renderFills, xAxis, yAxis])
 
   // Make the movable values and their cover segments
   useEffect(function createElements() {

--- a/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
+++ b/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
@@ -25,12 +25,12 @@ interface IProps {
   model: IPlottedValueModel
   plotHeight: number
   plotWidth: number
-  xAxis?: INumericAxisModel
-  yAxis?: INumericAxisModel
+  xAxis: INumericAxisModel
+  yAxis: INumericAxisModel
 }
 
 export const PlottedValue = observer(function PlottedValue (props: IProps) {
-  const {cellKey={}, containerId, model, plotHeight, plotWidth, xAxis, yAxis} = props
+  const {cellKey={}, containerId, model, plotWidth, xAxis, yAxis} = props
   const graphModel = useGraphContentModelContext()
   const value = model.value
   const layout = useAxisLayoutContext()
@@ -107,7 +107,7 @@ export const PlottedValue = observer(function PlottedValue (props: IProps) {
       .attr("y", isVertical.current ? offsetTop + 10 : yScale(plotValue) / yCellCount - 5)
 
   }, [value, dataConfig, xAttrId, yAttrId, model, cellKey, layout, xAttrType, yAttrType,
-      xScale, plotWidth, plotHeight, yScale, classFromKey, containerId])
+      xScale, plotWidth, yScale, classFromKey, containerId])
 
   // Refresh the value when it changes
   useEffect(function refreshValueChange() {
@@ -120,6 +120,8 @@ export const PlottedValue = observer(function PlottedValue (props: IProps) {
   // Refresh the value when the axis changes
   useEffect(function refreshAxisChange() {
     return autorun(() => {
+      const { domain: xDomain } = xAxis
+      const { domain: yDomain } = yAxis
       // If a Plotted Value has already been added and set, and the axis attributes are 
       // reconfigured so that both x and y are numeric whereas only one of them was
       // numeric previously, then remove the Plotted Value.
@@ -135,7 +137,7 @@ export const PlottedValue = observer(function PlottedValue (props: IProps) {
       refreshValue()
     }, { name: "PlottedValue.refreshAxisChange" })
   }, [dataConfig, graphModel, model, previousAttrTypes?.xAttrType, previousAttrTypes?.yAttrType,
-      refreshValue, xAttrType, xAxis?.domain, yAttrType, yAxis?.domain])
+      refreshValue, xAttrType, xAxis, yAttrType, yAxis])
 
   return (
     <>

--- a/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
+++ b/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
@@ -120,7 +120,12 @@ export const PlottedValue = observer(function PlottedValue (props: IProps) {
   // Refresh the value when the axis changes
   useEffect(function refreshAxisChange() {
     return autorun(() => {
+      // We observe changes to the axis domains within the autorun by extracting them from the axes below.
+      // We do this instead of including domains in the useEffect dependency array to prevent domain changes
+      // from triggering a reinstall of the autorun.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { domain: xDomain } = xAxis
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { domain: yDomain } = yAxis
       // If a Plotted Value has already been added and set, and the axis attributes are 
       // reconfigured so that both x and y are numeric whereas only one of them was

--- a/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
+++ b/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
@@ -123,10 +123,8 @@ export const PlottedValue = observer(function PlottedValue (props: IProps) {
       // We observe changes to the axis domains within the autorun by extracting them from the axes below.
       // We do this instead of including domains in the useEffect dependency array to prevent domain changes
       // from triggering a reinstall of the autorun.
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { domain: xDomain } = xAxis
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { domain: yDomain } = yAxis
+      const { domain: xDomain } = xAxis // eslint-disable-line @typescript-eslint/no-unused-vars
+      const { domain: yDomain } = yAxis // eslint-disable-line @typescript-eslint/no-unused-vars
       // If a Plotted Value has already been added and set, and the axis attributes are 
       // reconfigured so that both x and y are numeric whereas only one of them was
       // numeric previously, then remove the Plotted Value.

--- a/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
+++ b/v3/src/components/graph/adornments/plotted-value/plotted-value.tsx
@@ -64,17 +64,20 @@ export const PlottedValue = observer(function PlottedValue (props: IProps) {
     const plotValue = valueIsInteger ? finalValue : Math.round(finalValue * 10) / 10
     const newValueObject: IValueObject = {}
     const selection = select(valueRef.current)
+    const [left, right] = xScale?.range() || [0, 1]
+    const [bottom, top] = yScale?.range() || [0, 1]
     const xSubAxesCount = layout.getAxisMultiScale("bottom")?.repetitions ?? 1
+    const ySubAxesCount = layout.getAxisMultiScale("left")?.repetitions ?? 1
     const xCatSet = layout.getAxisMultiScale("bottom")?.categorySet
     const xCats = xAttrType === "categorical" && xCatSet ? Array.from(xCatSet.values) : [""]
     const yCatSet = layout.getAxisMultiScale("left")?.categorySet
     const yCats = yAttrType === "categorical" && yCatSet ? Array.from(yCatSet.values) : [""]
     const xCellCount = xCats.length * xSubAxesCount
-    const yCellCount = yCats.length
-    const x1 = isVertical.current ? xScale(plotValue) / xCellCount : 0
-    const x2 = isVertical.current ? xScale(plotValue) / xCellCount : plotWidth / xCellCount
-    const y1 = isVertical.current ? plotHeight / yCellCount : yScale(plotValue) / yCellCount
-    const y2 = isVertical.current ? offsetTop : yScale(plotValue) / yCellCount
+    const yCellCount = yCats.length * ySubAxesCount
+    const x1 = isVertical.current ? xScale(plotValue) / xCellCount : right / xCellCount
+    const x2 = isVertical.current ? xScale(plotValue) / xCellCount : left / xCellCount
+    const y1 = isVertical.current ? top / yCellCount : yScale(plotValue) / yCellCount
+    const y2 = isVertical.current ? bottom / yCellCount + offsetTop : yScale(plotValue) / yCellCount
 
     // Remove the previous value's elements
     selection.html(null)
@@ -132,7 +135,7 @@ export const PlottedValue = observer(function PlottedValue (props: IProps) {
       refreshValue()
     }, { name: "PlottedValue.refreshAxisChange" })
   }, [dataConfig, graphModel, model, previousAttrTypes?.xAttrType, previousAttrTypes?.yAttrType,
-      refreshValue, xAttrType, xAxis?.max, xAxis?.min, yAttrType, yAxis?.max, yAxis?.min])
+      refreshValue, xAttrType, xAxis?.domain, yAttrType, yAxis?.domain])
 
   return (
     <>

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-model.test.ts
@@ -19,6 +19,16 @@ describe("MeanModel", () => {
     adornment.addMeasure(10)
     expect(adornment.measures.size).toBe(1)
   })
+  it("can have an existing mean value in its measures map updated", () => {
+    const adornment = MeanAdornmentModel.create()
+    expect(adornment.measures.size).toBe(0)
+    adornment.addMeasure(10)
+    expect(adornment.measures.size).toBe(1)
+    expect(adornment.measures.get("{}")?.value).toBe(10)
+    adornment.updateMeasureValue(20, "{}")
+    expect(adornment.measures.get("{}")?.value).toBe(20)
+    expect(adornment.measures.size).toBe(1)
+  })
   it("can have an existing mean value removed from its measures map", () => {
     const adornment = MeanAdornmentModel.create()
     expect(adornment.measures.size).toBe(0)

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-model.ts
@@ -13,6 +13,7 @@ export const MeanAdornmentModel = UnivariateMeasureAdornmentModel
   .views(self => ({
     getMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) {
       const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
+      if (caseValues.length === 0) return NaN
       return mean(caseValues)
     }
   }))

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-model.ts
@@ -12,8 +12,7 @@ export const MeanAdornmentModel = UnivariateMeasureAdornmentModel
   })
   .views(self => ({
     getMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) {
-      const casesInPlot = dataConfig.subPlotCases(cellKey)
-      const caseValues = self.getCaseValues(attrId, casesInPlot, dataConfig)
+      const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
       return mean(caseValues)
     }
   }))

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-model.test.ts
@@ -19,6 +19,16 @@ describe("MedianAdornmentModel", () => {
     adornment.addMeasure(10)
     expect(adornment.measures.size).toBe(1)
   })
+  it("can have an existing median value in its measures map updated", () => {
+    const adornment = MedianAdornmentModel.create()
+    expect(adornment.measures.size).toBe(0)
+    adornment.addMeasure(10)
+    expect(adornment.measures.size).toBe(1)
+    expect(adornment.measures.get("{}")?.value).toBe(10)
+    adornment.updateMeasureValue(20, "{}")
+    expect(adornment.measures.get("{}")?.value).toBe(20)
+    expect(adornment.measures.size).toBe(1)
+  })
   it("can have an existing median value removed from its measures map", () => {
     const adornment = MedianAdornmentModel.create()
     expect(adornment.measures.size).toBe(0)

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-model.ts
@@ -13,6 +13,7 @@ export const MedianAdornmentModel = UnivariateMeasureAdornmentModel
   .views(self => ({
     getMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) {
       const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
+      if (caseValues.length === 0) return NaN
       return median(caseValues)
     }
   }))

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-model.ts
@@ -12,8 +12,7 @@ export const MedianAdornmentModel = UnivariateMeasureAdornmentModel
   })
   .views(self => ({
     getMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) {
-      const casesInPlot = dataConfig.subPlotCases(cellKey)
-      const caseValues = self.getCaseValues(attrId, casesInPlot, dataConfig)
+      const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
       return median(caseValues)
     }
   }))

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
@@ -99,17 +99,20 @@ export const UnivariateMeasureAdornmentComponent = observer(
       const multiScale = isVertical.current ? layout.getAxisMultiScale("bottom") : layout.getAxisMultiScale("left")
       const displayValue = multiScale ? multiScale.formatValueForScale(value) : valueLabelString(value)
       const plotValue = Number(displayValue)
+      const [left, right] = xScale?.range() || [0, 1]
+      const [bottom, top] = yScale?.range() || [0, 1]
       const xSubAxesCount = layout.getAxisMultiScale("bottom")?.repetitions ?? 1
+      const ySubAxesCount = layout.getAxisMultiScale("left")?.repetitions ?? 1
       const xCatSet = layout.getAxisMultiScale("bottom")?.categorySet
       const xCats = xAttrType === "categorical" && xCatSet ? Array.from(xCatSet.values) : [""]
       const yCatSet = layout.getAxisMultiScale("left")?.categorySet
       const yCats = yAttrType === "categorical" && yCatSet ? Array.from(yCatSet.values) : [""]
       const xCellCount = xCats.length * xSubAxesCount
-      const yCellCount = yCats.length
-      const x1 = isVertical.current ? xScale(plotValue) / xCellCount : 0
-      const x2 = isVertical.current ? xScale(plotValue) / xCellCount : plotWidth / xCellCount
-      const y1 = isVertical.current ? plotHeight / yCellCount : yScale(plotValue) / yCellCount
-      const y2 = isVertical.current ? 3 : yScale(plotValue) / yCellCount
+      const yCellCount = yCats.length * ySubAxesCount
+      const x1 = isVertical.current ? xScale(plotValue) / xCellCount : right / xCellCount
+      const x2 = isVertical.current ? xScale(plotValue) / xCellCount : left / xCellCount
+      const y1 = isVertical.current ? top / yCellCount : yScale(plotValue) / yCellCount
+      const y2 = isVertical.current ? bottom / yCellCount : yScale(plotValue) / yCellCount
 
       const selection = select(valueRef.current)
       const labelSelection = select(labelRef.current)
@@ -141,8 +144,8 @@ export const UnivariateMeasureAdornmentComponent = observer(
         const activeUnivariateMeasures = adornmentsStore?.activeUnivariateMeasures
         const adornmentIndex = activeUnivariateMeasures?.indexOf(model) ?? null
         const topOffset = activeUnivariateMeasures.length > 1 ? adornmentIndex * 20 : 0
-        const left = labelCoords ? labelCoords.x / xCellCount : isVertical.current ? xScale(plotValue) / xCellCount : 0
-        const top = labelCoords ? labelCoords.y : topOffset
+        const labelLeft = labelCoords ? labelCoords.x / xCellCount : isVertical.current ? xScale(plotValue) / xCellCount : 0
+        const labelTop = labelCoords ? labelCoords.y : topOffset
         const labelId = `${measureType}-measure-labels-tip-${containerId}${classFromKey ? `-${classFromKey}` : ""}`
         const labelClass = clsx("measure-labels-tip", `measure-labels-tip-${measureType}`)
         labelObj.label = labelSelection.append("div")
@@ -150,8 +153,8 @@ export const UnivariateMeasureAdornmentComponent = observer(
           .attr("id", labelId)
           .attr("class", labelClass)
           .attr("data-testid", labelId)
-          .style("left", `${left}px`)
-          .style("top", `${top}px`)
+          .style("left", `${labelLeft}px`)
+          .style("top", `${labelTop}px`)
 
         labelObj.label.call(
           drag<HTMLDivElement, unknown>()
@@ -208,7 +211,7 @@ export const UnivariateMeasureAdornmentComponent = observer(
         isVertical.current = dataConfig?.attributeType("x") === "numeric"
         refreshValues()
       }, { name: "UnivariateMeasureAdornmentComponent.refreshAxisChange" })
-    }, [dataConfig, refreshValues, xAxis?.max, xAxis?.min, yAxis?.max, yAxis?.min])
+    }, [dataConfig, refreshValues, xAxis?.domain, yAxis?.domain])
 
     return (
       <>

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
@@ -211,7 +211,12 @@ export const UnivariateMeasureAdornmentComponent = observer(
     // Refresh values on axis changes
     useEffect(function refreshAxisChange() {
       return autorun(() => {
+        // We observe changes to the axis domains within the autorun by extracting them from the axes below.
+        // We do this instead of including domains in the useEffect dependency array to prevent domain changes
+        // from triggering a reinstall of the autorun.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { domain: xDomain } = xAxis
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { domain: yDomain } = yAxis
         isVertical.current = dataConfig?.attributeType("x") === "numeric"
         refreshValues()

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
@@ -214,10 +214,8 @@ export const UnivariateMeasureAdornmentComponent = observer(
         // We observe changes to the axis domains within the autorun by extracting them from the axes below.
         // We do this instead of including domains in the useEffect dependency array to prevent domain changes
         // from triggering a reinstall of the autorun.
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { domain: xDomain } = xAxis
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { domain: yDomain } = yAxis
+        const { domain: xDomain } = xAxis // eslint-disable-line @typescript-eslint/no-unused-vars
+        const { domain: yDomain } = yAxis // eslint-disable-line @typescript-eslint/no-unused-vars
         isVertical.current = dataConfig?.attributeType("x") === "numeric"
         refreshValues()
       }, { name: "UnivariateMeasureAdornmentComponent.refreshAxisChange" })

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
@@ -32,8 +32,8 @@ interface IProps {
   model: IMeanAdornmentModel | IMedianAdornmentModel
   plotHeight: number
   plotWidth: number
-  xAxis?: INumericAxisModel
-  yAxis?: INumericAxisModel
+  xAxis: INumericAxisModel
+  yAxis: INumericAxisModel
 }
 
 export const UnivariateMeasureAdornmentComponent = observer(
@@ -203,7 +203,7 @@ export const UnivariateMeasureAdornmentComponent = observer(
       selection.html(null)
       labelSelection.html(null)
 
-      if (measure) {
+      if (measure && Number.isFinite(measure.value)) {
         addLineCoverAndLabel(newValueObj, newLabelObj, measure)
       }
     }, [model, instanceKey, addLineCoverAndLabel])
@@ -211,10 +211,12 @@ export const UnivariateMeasureAdornmentComponent = observer(
     // Refresh values on axis changes
     useEffect(function refreshAxisChange() {
       return autorun(() => {
+        const { domain: xDomain } = xAxis
+        const { domain: yDomain } = yAxis
         isVertical.current = dataConfig?.attributeType("x") === "numeric"
         refreshValues()
       }, { name: "UnivariateMeasureAdornmentComponent.refreshAxisChange" })
-    }, [dataConfig, refreshValues, xAxis?.domain, yAxis?.domain])
+    }, [dataConfig, refreshValues, xAxis, yAxis])
 
     return (
       <>

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
@@ -38,7 +38,7 @@ interface IProps {
 
 export const UnivariateMeasureAdornmentComponent = observer(
   function UnivariateMeasureAdornmentComponent (props: IProps) {
-    const {cellKey={}, containerId, model, plotHeight, plotWidth, xAxis, yAxis} = props
+    const {cellKey={}, containerId, model, plotWidth, xAxis, yAxis} = props
     const layout = useAxisLayoutContext()
     const graphModel = useGraphContentModelContext()
     const dataConfig = useDataConfigurationContext()

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
@@ -144,7 +144,10 @@ export const UnivariateMeasureAdornmentComponent = observer(
         const activeUnivariateMeasures = adornmentsStore?.activeUnivariateMeasures
         const adornmentIndex = activeUnivariateMeasures?.indexOf(model) ?? null
         const topOffset = activeUnivariateMeasures.length > 1 ? adornmentIndex * 20 : 0
-        const labelLeft = labelCoords ? labelCoords.x / xCellCount : isVertical.current ? xScale(plotValue) / xCellCount : 0
+        const labelLeft = labelCoords
+          ? labelCoords.x / xCellCount
+          : isVertical.current
+            ? xScale(plotValue) / xCellCount : 0
         const labelTop = labelCoords ? labelCoords.y : topOffset
         const labelId = `${measureType}-measure-labels-tip-${containerId}${classFromKey ? `-${classFromKey}` : ""}`
         const labelClass = clsx("measure-labels-tip", `measure-labels-tip-${measureType}`)
@@ -182,8 +185,8 @@ export const UnivariateMeasureAdornmentComponent = observer(
       }
 
     }, [adornmentsStore?.activeUnivariateMeasures, classFromKey, containerId, handleEndMoveLabel,
-        handleMoveLabel, highlightCover, highlightLabel, layout, measureType, model, plotHeight,
-        plotWidth, showLabel, xAttrType, xScale, yAttrType, yScale])
+        handleMoveLabel, highlightCover, highlightLabel, layout, measureType, model, plotWidth, showLabel,
+        xAttrType, xScale, yAttrType, yScale])
 
     // Add the lines and their associated covers and labels
     const refreshValues = useCallback(() => {

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -69,7 +69,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
-      const { xAttrId, xCats, yAttrId, yCats, topCats, rightCats, resetPoints, dataConfig } = options
+      const { xAttrId, xAxis, xCats, yAttrId, yCats, topCats, rightCats, resetPoints, dataConfig } = options
       if (!dataConfig) return
       const topCatCount = topCats.length || 1
       const rightCatCount = rightCats.length || 1
@@ -78,7 +78,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
       const columnCount = topCatCount * xCatCount
       const rowCount = rightCatCount * yCatCount
       const totalCount = rowCount * columnCount
-      const attrId = xAttrId ? xAttrId : yAttrId
+      const attrId = xAttrId && dataConfig.attributeType("x") ? xAttrId : yAttrId
       for (let i = 0; i < totalCount; ++i) {
         const cellKey = self.setCellKey(options, i)
         // If there are no cases in the cell, do not add an adornment
@@ -86,9 +86,6 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
 
         const instanceKey = self.instanceKey(cellKey) 
         const value = Number(self.getMeasureValue(attrId, cellKey, dataConfig))
-        // If the value is not a number, do not add an adornment
-        if (!Number.isFinite(value)) continue
-
         if (!self.measures.get(instanceKey) || resetPoints) {
           self.addMeasure(value, instanceKey)
         } else {

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -54,7 +54,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
       newMeasure.setValue(value)
       self.measures.set(key, newMeasure)
     },
-    setMeasureValue(value: number, key="{}") {
+    updateMeasureValue(value: number, key="{}") {
       const measure = self.measures.get(key)
       if (measure) {
         measure.setValue(value)
@@ -92,7 +92,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
         if (!self.measures.get(instanceKey) || resetPoints) {
           self.addMeasure(value, instanceKey)
         } else {
-          self.setMeasureValue(value, instanceKey)
+          self.updateMeasureValue(value, instanceKey)
         }
       }
     }

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -69,7 +69,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
-      const { xAttrId, xAxis, xCats, yAttrId, yCats, topCats, rightCats, resetPoints, dataConfig } = options
+      const { xAttrId, xCats, yAttrId, yCats, topCats, rightCats, resetPoints, dataConfig } = options
       if (!dataConfig) return
       const topCatCount = topCats.length || 1
       const rightCatCount = rightCats.length || 1
@@ -81,9 +81,6 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
       const attrId = xAttrId && dataConfig.attributeType("x") ? xAttrId : yAttrId
       for (let i = 0; i < totalCount; ++i) {
         const cellKey = self.setCellKey(options, i)
-        // If there are no cases in the cell, do not add an adornment
-        if (dataConfig.subPlotCases(cellKey).length === 0) continue
-
         const instanceKey = self.instanceKey(cellKey) 
         const value = Number(self.getMeasureValue(attrId, cellKey, dataConfig))
         if (!self.measures.get(instanceKey) || resetPoints) {

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -181,12 +181,19 @@ export const GraphContentModel = DataDisplayContentModel
           }
         },
         {name: "sharedModelSetup", fireImmediately: true}))
-    },
+    }
+  }))
+  .actions(self => ({
     updateAfterSharedModelChanges(sharedModel: ISharedModel | undefined, type: SharedModelChangeType) {
       if (type === "link") {
         self.dataConfiguration.setDataset(self.dataset, self.metadata)
       } else if (type === "unlink" && isSharedDataSet(sharedModel)) {
         self.dataConfiguration.setDataset(undefined, undefined)
+      }
+      const currDataSetId = self.dataConfiguration.dataset?.id ?? ""
+      if (self.prevDataSetId !== currDataSetId) {
+        self.setDataSetListener()
+        self.prevDataSetId = currDataSetId
       }
     }
   }))


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181914405

Various bug fixes:

1.  Prevent attempts to add adornments to subplots that don't contain case data
2. Ensure adornments adjust their height correctly when the number of subplots change
3. Make adornments respond to rescaling of axes while axes are being rescaled, not just after
4. Make adornments react to case data changes

NOTE: Fix number 2 was also applicable to the Plotted Value adornment, and fix number 3 was applicable to Plotted Value and Movable Value. Since they were relatively simple, I included the changes for those adornments, too.