### PR TITLE
Fix handling of scenario when attribute name is the same as function name (e.g. "mean(mean)")

### DIFF
--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -332,7 +332,7 @@ export class FormulaManager {
     })
   }
 
-  getDisplayNameMapForFormula(formulaId: string) {
+  getDisplayNameMapForFormula(formulaId: string, makeSymbolNamesSafe = true) {
     const { dataSet: localDataSet } = this.getFormulaContext(formulaId)
 
     const displayNameMap: DisplayNameMap = {
@@ -343,7 +343,7 @@ export class FormulaManager {
     const mapAttributeNames = (dataSet: IDataSet, prefix: string) => {
       const result: Record<string, string> = {}
       dataSet.attributes.forEach(attr => {
-        result[safeSymbolName(attr.name)] = `${prefix}${attr.id}`
+        result[makeSymbolNamesSafe ? safeSymbolName(attr.name) : attr.name] = `${prefix}${attr.id}`
       })
       return result
     }

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -111,8 +111,8 @@ export const ifSelfReference = (dependency?: IFormulaDependency, formulaAttribut
 // can be resolved by formula context and do not rely on user-based display names.
 export const canonicalizeExpression = (displayExpression: string, displayNameMap: DisplayNameMap) => {
   const formulaTree = parse(customizeFormula(makeNamesSafe(displayExpression)))
-  const visitNode = (node: MathNode) => {
-    if (isSymbolNode(node)) {
+  const visitNode = (node: MathNode, path: string, parent: MathNode) => {
+    if (isNonFunctionSymbolNode(node, parent)) {
       const canonicalName = generateCanonicalSymbolName(node.name, displayNameMap)
       if (canonicalName) {
         node.name = canonicalName
@@ -171,7 +171,7 @@ export const getFormulaDependencies = (formulaCanonical: string, formulaAttribut
     }
     const isDescendantOfAggregateFunc = !!node.isDescendantOfAggregateFunc
     const isSelfReferenceAllowed = !!node.isSelfReferenceAllowed
-    if (isSymbolNode(node)) {
+    if (isNonFunctionSymbolNode(node, parent)) {
       const dependency = parseCanonicalSymbolName(node.name)
       if (dependency?.type === "localAttribute" && isDescendantOfAggregateFunc) {
         dependency.aggregate = true

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -109,7 +109,7 @@ export const ifSelfReference = (dependency?: IFormulaDependency, formulaAttribut
 
 // Function replaces all the symbol names typed by user (display names) with the symbol canonical names that
 // can be resolved by formula context and do not rely on user-based display names.
-export const canonicalizeExpression = (displayExpression: string, displayNameMap: DisplayNameMap) => {
+export const displayToCanonical = (displayExpression: string, displayNameMap: DisplayNameMap) => {
   const formulaTree = parse(customizeFormula(makeNamesSafe(displayExpression)))
   const visitNode = (node: MathNode, path: string, parent: MathNode) => {
     if (isNonFunctionSymbolNode(node, parent)) {

--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -1,7 +1,7 @@
 import { Instance, types } from "mobx-state-tree"
 import { parse } from "mathjs"
 import { typedId } from "../../utilities/js-utils"
-import { canonicalizeExpression, customizeFormula, isRandomFunctionPresent } from "./formula-utils"
+import { displayToCanonical, customizeFormula, isRandomFunctionPresent } from "./formula-utils"
 import { getFormulaManager } from "../tiles/tile-environment"
 
 export const Formula = types.model("Formula", {
@@ -20,7 +20,7 @@ export const Formula = types.model("Formula", {
       return ""
     }
     const displayNameMap = this.formulaManager.getDisplayNameMapForFormula(self.id)
-    return canonicalizeExpression(self.display, displayNameMap)
+    return displayToCanonical(self.display, displayNameMap)
   },
   get empty() {
     return self.display.length === 0


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186152786

`mean(mean)` is a valid formula, but it used to crash in V3. I realized this would be a problem when I added the `isNonFunctionSymbolNode` helper as part of the previous PR. This is all due to how MathJS parses expressions (function node + separate function name node).

I also renamed `canonicalizeExpression` to `displayToCanonical`, so it's the inverse of `canonicalToDisplay`.

Additionally, I've added quite a few unit tests that also cover the scenario that caused a real-life bug discussed above and in the PT story.