### PR TITLE
Handle attribute names with characters that need escaping in formula backtick strings

### DIFF
--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -1,8 +1,10 @@
 import { Instance, types } from "mobx-state-tree"
 import { parse } from "mathjs"
 import { typedId } from "../../utilities/js-utils"
-import { canonicalToDisplay, displayToCanonical, isRandomFunctionPresent, preprocessFormula } from "./formula-utils"
 import { getFormulaManager } from "../tiles/tile-environment"
+import {
+  canonicalToDisplay, displayToCanonical, isRandomFunctionPresent, preprocessDisplayFormula
+} from "./formula-utils"
 
 export const Formula = types.model("Formula", {
   id: types.optional(types.identifier, () => typedId("FORM")),
@@ -18,7 +20,7 @@ export const Formula = types.model("Formula", {
   },
   get syntaxError() {
     try {
-      parse(preprocessFormula(self.display))
+      parse(preprocessDisplayFormula(self.display))
     } catch (error: any) {
       return error.message
     }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186176018

Untypical attribute names are enclosed in backticks, following V2 pattern. Since these strings are constantly evaluated and serialized, we need to remember about unescaping or escaping some special characters. It's not exciting work, but I think it's better to have it done now while I'm in the right context. Otherwise, it's going to be difficult to come back to it.

I think that for backtick strings, we need to care only about the backtick itself (`) or backslash (\). Backslash needs to be escaped as someone can use an attribute name like "Attr \\'Name", so this backslash needs to be distinguished from the one that escapes the backtick. Does that seem accurate? Anything else we need to escape?

My test cases:
```
- Attr name: Ma`ss
V2 formula: `Ma\`ss`
V3 formula: `Ma\`ss` ✅ 
- Attr name: Ma\`ss
V2 formula: doesn’t work ❌
V3 formula: `Ma\\\`ss`  ✅
- Attr name: Ma’ss
V2 formula: `Ma’ss`
V3 formula: `Ma’ss` ✅
- Attr name: Ma”ss
V2 formula: doesn’t work ❌
V3 formula: `Ma”ss` ✅
- Attr name: Ma\”ss
V2 formula: doesn’t work ❌
V3 formula: `Ma\”ss` or `Ma\\”ss` ✅
```
For each test case, I've done two kinds of tests:
1. Set an untypical attribute name first, and then try to write a formula that references it
2. First, write a formula referencing an attribute with a regular name, and then change its name to be untypical

As the flow is different, and sometimes 1 or 2 could work while the other approach doesn't. Hopefully, this explains some of the code changes.