### PR TITLE
fix: port graph code fixes from CLUE

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -702,6 +702,7 @@ export const DataConfigurationModel = types
         this._updateFilteredCasesCollectionID()
         self.filteredCases?.push(new FilteredCases({
           source: self.dataset,
+          casesArrayNumber: self.filteredCases.length,
           filter: self.filterCase,
           collectionID: idOfChildmostCollectionForAttributes(self.attributes, self.dataset),
           onSetCaseValues: this.handleSetCaseValues
@@ -772,7 +773,8 @@ export const DataConfigurationModel = types
       }
     },
     addYAttribute(desc: IAttributeDescriptionSnapshot) {
-      self._yAttributeDescriptions.push(desc)
+      // multiple Y only supported for numeric axes
+      self._yAttributeDescriptions.push({ ...desc, type: 'numeric' })
       self._addNewFilteredCases()
     },
     setY2Attribute(desc?: IAttributeDescriptionSnapshot) {

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -93,7 +93,7 @@ export class GraphController {
     const {graphModel, layout} = this,
       dataset = getDataSetFromId(graphModel, dataSetID),
       dataConfig = graphModel?.dataConfiguration
-    if (!(graphModel && layout && dataset && dataConfig)) {
+    if (!(graphModel && layout && dataConfig)) {
       return
     }
     this.callMatchCirclesToData()

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -142,6 +142,7 @@ export class GraphController {
           if (!currAxisModel || !isNumericAxisModel(currAxisModel)) {
             const newAxisModel = NumericAxisModel.create({place, min: 0, max: 1})
             graphModel.setAxis(place, newAxisModel)
+            dataConfig.setAttributeType(attrRole, 'numeric')
             layout.setAxisScaleType(place, 'linear')
             setNiceDomain(attr?.numValues || [], newAxisModel)
           } else {
@@ -153,6 +154,7 @@ export class GraphController {
           if (currentType !== 'categorical') {
             const newAxisModel = CategoricalAxisModel.create({place})
             graphModel.setAxis(place, newAxisModel)
+            dataConfig.setAttributeType(attrRole, 'categorical')
             layout.setAxisScaleType(place, 'band')
           }
           layout.getAxisMultiScale(place)?.setCategorySet(dataConfig.categorySetForAttrRole(attrRole))


### PR DESCRIPTION
- fix: cached attribute views recompute when values are changed
- fix: matchCirclesToData() not called when data set is deleted/unlinked [[CLUE #1983](https://github.com/concord-consortium/collaborative-learning/pull/1983)] [[PT-#186172943](https://pivotaltracker.com/story/show/186172943)]
- fix: assign types to graph roles when axis types are determined [[CLUE #1986](https://github.com/concord-consortium/collaborative-learning/pull/1986)] [[PT-#186171817](https://www.pivotaltracker.com/story/show/186171817)]
- fix: filtering of cases in multiple-Y plots (set `casesArrayNumber` correctly)

The first item is a latent bug in the `Attribute` code. Because the individual data values of an attribute are not observable (for performance reasons), we must manually trigger recomputation of cached views. This is not (currently) an issue in CLUE because CLUE doesn't have the `frozen` values optimization.

The second item is a bug in common code that is non-symptomatic in CODAP currently because there is no UI for unlinking a graph from its data set, whereas there is in CLUE.

The third item is a bug in common code that works in simple cases in CODAP since it is masked by the first bug because when the type isn't specified in the data configuration the code defaults to the type of the attribute, which wasn't being updated due to the caching bug described previously, which masked the symptom. With the fix to the first bug, the latter bug was revealed.

The fourth item was discovered while testing this PR in CODAP and now needs to be back-ported to CLUE. 🤦 