### PR TITLE
Fix import of V2 doc with formulas

### DIFF
--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -255,6 +255,7 @@ export class FormulaManager {
           if (!metadata || metadata.registeredDisplay !== attr.formula.display) {
             this.unregisterFormula(attr.formula.id)
             this.registerFormula(attr.formula, attr.id, dataSet)
+            attr.formula.updateCanonicalFormula()
             if (!attr.formula.empty) {
               updatedFormulas.push(attr.formula.id)
             }

--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -36,6 +36,10 @@ export const Formula = types.model("Formula", {
 .actions(self => ({
   setDisplayFormula(displayFormula: string) {
     self.display = displayFormula
+  },
+  updateCanonicalFormula() {
+    // This action will be called by formula manager when it detects that the display formula has changed.
+    // It can happen either as a result of user editing the formula, or when a document with display formulas is loaded.
     self.canonical = "" // reset canonical formula immediately, in case of errors that are handled below
     if (self.empty || !self.valid || !self.formulaManager) {
       return


### PR DESCRIPTION
This PR fixes a regression caught by Tejal:
https://www.pivotaltracker.com/story/show/186002016/comments/238700252

Now, the manager updates the canonical form when it detects the difference between the old and a new display form. This will handle both manual updates and updates via import / snapshots, etc.
