### PR TITLE
Add VSCode launch.json config

### DIFF
--- a/v3/.vscode/launch.json
+++ b/v3/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: current file",
+      "env": { "NODE_ENV": "test" },
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}"],
+      "console": "integratedTerminal"
+    }
+  ]
+}


### PR DESCRIPTION
This is similar to what Boris showed during the last dev day.

There's no checked-in launch.json, and we don't ignore it either. I don't think this would conflict with anyone's preferences or customizations, so it's probably nice to have it checked in and keep improving it as a group.

I'm also happy to keep it in my own user settings.json if we think it's better, as this particular configuration is very generic anyway. Not sure if there's any conclusion on what to do about launch.json.