### PR TITLE
Don't consider blank cells in aggregate functions, fix equal function for arrays

### DIFF
--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -43,25 +43,35 @@ const aggregateFnWithFilterFactory = (fn: (values: number[]) => number) => {
     let expressionValues = evaluateNode(expression, scope)
     if (filter) {
       const filterValues = evaluateNode(filter, scope)
-      expressionValues = expressionValues.filter((v: any, i: number) => !!filterValues[i])
+      expressionValues = expressionValues.filter((v: any, i: number) =>
+        // Non-truthy expression values should not be part of the aggregate function result following V2 behavior.
+        // E.g. empty cells should not be counted in mean() function.
+        isValueNonEmpty(v) && isValueTruthy(filterValues[i])
+      )
+    } else {
+      // Non-truthy expression values should not be part of the aggregate function result following V2 behavior.
+      // E.g. empty cells should not be counted in mean() function.
+      expressionValues = expressionValues.filter((v: any) => isValueNonEmpty(v))
     }
-    return fn(expressionValues)
+    return expressionValues.length > 0 ? fn(expressionValues) : UNDEF_RESULT
   }
 }
 
+export const isValueNonEmpty = (value: any) => value !== "" && value !== null && value !== undefined
+
 // CODAP formulas assume that 0 is a truthy value, which is different from default JS behavior. So that, for instance,
 // count(attribute) will return a count of valid data values, since 0 is a valid numeric value.
-export const isValueTruthy = (value: any) => value !== "" && value !== false && value !== null && value !== undefined
+export const isValueTruthy = (value: any) => isValueNonEmpty(value) && value !== false
 
-export const equal = (a: any, b: any) => {
+export const equal = (a: any, b: any): boolean | boolean[] => {
   if (Array.isArray(a) && Array.isArray(b)) {
-    return a.map((v, i) => v === b[i])
+    return a.map((v, i) => equal(v, b[i])) as boolean[]
   }
   if (Array.isArray(a) && !Array.isArray(b)) {
-    return a.map((v) => v === b)
+    return a.map((v) => equal(v, b)) as boolean[]
   }
   if (!Array.isArray(a) && Array.isArray(b)) {
-    return b.map((v) => v === a)
+    return b.map((v) => equal(v, a)) as boolean[]
   }
   // Checks below might seem redundant once the data set cases start using typed values, but they are not.
   // Note that user might still compare a string with a number unintentionally, and it makes sense to try to cast

--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -44,8 +44,7 @@ const aggregateFnWithFilterFactory = (fn: (values: number[]) => number) => {
     if (filter) {
       const filterValues = evaluateNode(filter, scope)
       expressionValues = expressionValues.filter((v: any, i: number) =>
-        // Non-truthy expression values should not be part of the aggregate function result following V2 behavior.
-        // E.g. empty cells should not be counted in mean() function.
+        // Empty cells should not be included in aggregate functions.
         isValueNonEmpty(v) && isValueTruthy(filterValues[i])
       )
     } else {

--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -49,8 +49,7 @@ const aggregateFnWithFilterFactory = (fn: (values: number[]) => number) => {
         isValueNonEmpty(v) && isValueTruthy(filterValues[i])
       )
     } else {
-      // Non-truthy expression values should not be part of the aggregate function result following V2 behavior.
-      // E.g. empty cells should not be counted in mean() function.
+      // Empty cells should not be included in aggregate functions.
       expressionValues = expressionValues.filter((v: any) => isValueNonEmpty(v))
     }
     return expressionValues.length > 0 ? fn(expressionValues) : UNDEF_RESULT


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186145218

The aggregate function should filter out empty strings as MathJS resolves them to 0, while CODAP v2 ignores them.

Also, I've fixed the equal operator when arrays are compared (or when an array is compared with a single value). This happens when we deal with aggregate functions. I noticed it when I tested `mean(Mass = 80)` both in V2 and V3. Now it should work as expected.