### PR TITLE
Fix a bug that was causing an error when attr with formula was deleted

### DIFF
--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -290,6 +290,7 @@ export class FormulaManager {
       // In 99% of cases, the two `if` statements above will be sufficient to detect deleted formulas. However, this
       // could serve as the ultimate check in case a formula instance was deleted in a different manner.
       if (!isAlive(metadata.formula)) {
+        console.warn("FormulaManager.unregisterDeletedFormulas unregistering a defunct formula that was not detected by the usual means.")
         this.unregisterFormula(formulaId)
       }
     })

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -283,11 +283,7 @@ export class FormulaManager {
     this.formulaMetadata.forEach((metadata, formulaId) => {
       const { dataSetId, attributeId } = this.getFormulaMetadata(formulaId)
       const dataSet = this.dataSets.get(dataSetId)
-      if (!dataSet) {
-        this.unregisterFormula(formulaId)
-        return
-      }
-      if (!dataSet.attrFromID(attributeId)) {
+      if (!dataSet?.attrFromID(attributeId)) {
         this.unregisterFormula(formulaId)
         return
       }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186201130

This PR fixes a bug described in the linked PT story. Also, it fixes MST warnings when an attribute with an empty formula is deleted.

Kirk, I remember that during one of the recent arch meetings, you mentioned some issues with `isAlive`, but I can't remember exactly what that was. It'd be enough to use `isAlive` in this PR, but I've added it as a last resort to be more explicit (and potentially avoid the issues you described?).

