### PR TITLE
Recalculate formula when dependant cell is set to "" 

### DIFF
--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -473,7 +473,7 @@ export class FormulaManager {
       // includes one of the regular dependency attributes needs to be recalculated.
       return cases.filter(c => {
         for (const dependency of regularDatasetAttributeDependencies) {
-          if (c[dependency.attrId]) {
+          if (Object.prototype.hasOwnProperty.call(c, dependency.attrId)) {
             return true
           }
         }

--- a/v3/src/models/data/formula-utils.test.ts
+++ b/v3/src/models/data/formula-utils.test.ts
@@ -24,7 +24,7 @@ const displayNameMapExample: DisplayNameMap = {
     "Roller Coaster": {
       "id": "DATA_ROLLER_COASTER",
       "attribute": {
-        // \, ", and " are added to test characters escaping
+        // \, ', and " are added to test characters escaping
         "Park\"": "ATTR_PARK",
         "Top\\Speed'": "ATTR_TOP_SPEED",
       }

--- a/v3/src/models/data/formula-utils.test.ts
+++ b/v3/src/models/data/formula-utils.test.ts
@@ -1,7 +1,9 @@
-import { DisplayNameMap } from "./formula-types"
+import { ICase } from "./data-set-types"
+import { DisplayNameMap, ILocalAttributeDependency, ILookupDependency } from "./formula-types"
 import {
   safeSymbolName, customizeDisplayFormula, reverseDisplayNameMap, canonicalToDisplay, makeDisplayNamesSafe,
-  displayToCanonical, unescapeBacktickString, escapeBacktickString, safeSymbolNameFromDisplayFormula
+  displayToCanonical, unescapeBacktickString, escapeBacktickString, safeSymbolNameFromDisplayFormula,
+  getLocalAttrCasesToRecalculate, getLookupCasesToRecalculate, isAttrDefined
 } from "./formula-utils"
 
 const displayNameMapExample: DisplayNameMap = {
@@ -22,7 +24,7 @@ const displayNameMapExample: DisplayNameMap = {
     "Roller Coaster": {
       "id": "DATA_ROLLER_COASTER",
       "attribute": {
-        // \, ', and " are added to test characters escaping
+        // \, ", and " are added to test characters escaping
         "Park\"": "ATTR_PARK",
         "Top\\Speed'": "ATTR_TOP_SPEED",
       }
@@ -202,5 +204,74 @@ describe("canonicalToDisplay", () => {
         reverseDisplayNameMap(displayNameMapExample)
       )).toEqual('lookupByKey("Roller Coaster", "Park\\"", "Top\\\\Speed\'", Order) * 2')
     })
+  })
+})
+
+describe("isAttrDefined", () => {
+  const dataSetCase: ICase = { __id__: "1", attr1: 1, attr2: 2 }
+
+  it("returns true if the attribute is defined in the data set case", () => {
+    const attributeId = "attr1"
+    const result = isAttrDefined(dataSetCase, attributeId)
+    expect(result).toBe(true)
+  })
+
+  it("returns false if the attribute is not defined in the data set case", () => {
+    const attributeId = "attr3"
+    const result = isAttrDefined(dataSetCase, attributeId)
+    expect(result).toBe(false)
+  })
+
+  it("returns false if the attribute ID is not provided", () => {
+    const attributeId = undefined
+    const result = isAttrDefined(dataSetCase, attributeId)
+    expect(result).toBe(false)
+  })
+})
+
+describe("getLocalAttrCasesToRecalculate", () => {
+  const cases: ICase[] = [
+    { __id__: "1", attr1: 0, attr2: 1 },
+    { __id__: "2", attr1: 2, attr2: 3 },
+    { __id__: "3", attr1: "" }, // empty string should be considered as value that needs to trigger recalculation
+    { __id__: "4", attr2: 4 },
+  ]
+
+  it("returns 'ALL_CASES' if any case has an attribute that depends on an aggregate attribute", () => {
+    const formulaDependencies: ILocalAttributeDependency[] = [
+      { attrId: "attr1", type: "localAttribute", aggregate: false },
+      { attrId: "attr2", type: "localAttribute", aggregate: true },
+    ]
+    const result = getLocalAttrCasesToRecalculate(cases, formulaDependencies)
+    expect(result).toBe("ALL_CASES")
+  })
+
+  it("returns an array of cases that have an attribute that depends on a regular attribute", () => {
+    const formulaDependencies: ILocalAttributeDependency[] = [
+      { attrId: "attr1", type: "localAttribute", aggregate: false }
+    ]
+    const result = getLocalAttrCasesToRecalculate(cases, formulaDependencies)
+    expect(result).toEqual([cases[0], cases[1], cases[2]])
+  })
+
+  it("returns an empty array if no case has an attribute that depends on a regular attribute", () => {
+    const formulaDependencies: ILocalAttributeDependency[] = [
+      { attrId: "attr3", type: "localAttribute", aggregate: false }
+    ]
+    const result = getLocalAttrCasesToRecalculate(cases, formulaDependencies)
+    expect(result).toEqual([])
+  })
+})
+
+describe("getLookupCasesToRecalculate", () => {
+  const dependency: ILookupDependency = { type: "lookup", dataSetId: "ds1", attrId: "attr1", keyAttrId: "attr2" }
+
+  it("returns 'ALL_CASES' if any case has the lookup attribute or the lookup key attribute", () => {
+    expect(getLookupCasesToRecalculate([{ __id__: "1", attr1: 1 }], dependency)).toBe("ALL_CASES")
+    expect(getLookupCasesToRecalculate([{ __id__: "1", attr2: "" }], dependency)).toBe("ALL_CASES")
+  })
+
+  it("returns an empty array if no case has the lookup attribute or the lookup key attribute", () => {
+    expect(getLookupCasesToRecalculate([{ __id__: "1", attr3: 3 }], dependency)).toEqual([])
   })
 })

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -1,10 +1,11 @@
 import { parse, MathNode, isFunctionNode } from "mathjs"
 import {
   LOCAL_ATTR, GLOBAL_VALUE, DisplayNameMap, CanonicalNameMap, IFormulaDependency, isConstantStringNode,
-  isNonFunctionSymbolNode,
+  isNonFunctionSymbolNode, ILocalAttributeDependency, ILookupDependency
 } from "./formula-types"
 import { typedFnRegistry } from "./formula-fn-registry"
 import type { IDataSet } from "./data-set"
+import type { ICase } from "./data-set-types"
 import t from "../../utilities/translation/translate"
 
 // Set of formula helpers that can be used outside FormulaManager context. It should make them easier to test.
@@ -269,3 +270,18 @@ export const getIncorrectChildAttrReference =
   }
   return false
 }
+
+export const isAttrDefined = (dataSetCase: ICase, attributeId?: string) =>
+  !!attributeId && Object.prototype.hasOwnProperty.call(dataSetCase, attributeId)
+
+export const getLocalAttrCasesToRecalculate = (cases: ICase[], formulaDependencies: ILocalAttributeDependency[]) => {
+  const regularAttrDeps = formulaDependencies.filter(d => d.type === "localAttribute" && !d.aggregate)
+  const aggregateAttrDeps = formulaDependencies.filter(d => d.type === "localAttribute" && d.aggregate)
+
+  return cases.some(c => aggregateAttrDeps.some(d => isAttrDefined(c, d.attrId)))
+    ? "ALL_CASES"
+    : cases.filter(c => regularAttrDeps.some(d => isAttrDefined(c, d.attrId)))
+}
+
+export const getLookupCasesToRecalculate = (cases: ICase[], dependency: ILookupDependency) =>
+  cases.some(c => isAttrDefined(c, dependency.attrId) || isAttrDefined(c, dependency.keyAttrId)) ? "ALL_CASES" : []


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186200846

This PR fixes a bug described in the PT story linked above. `if (c[attrId])` was not executed when `c[attrId]` was equal to `""`. I've refactored some helpers a bit and added unit tests to cover this use case.