### PR TITLE
Version 3.0.0-pre.1360 - October 10, 2023

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Version 3.0.0-pre.1360 - October 10, 2023
+
+### Features/Improvements
+- Dot plots can show **mean** and **median** [#181914405](https://www.pivotaltracker.com/story/show/181914405)
+- Formula is updated when attribute name is changed [#186144182](https://www.pivotaltracker.com/story/show/186144182)
+- Formula is updated when global value name is changed [#186166594](https://www.pivotaltracker.com/story/show/186166594)
+- Handle characters that need escaping in formula backtick strings (e.g. `Attr\\` Name`) [#186176018](https://www.pivotaltracker.com/story/show/186176018)
+- Handle characters that need escaping in formula double quote strings (e.g. lookup("Attr\\" Name") + "cons\\"tant") [#186145125](https://www.pivotaltracker.com/story/show/186145125)
+- The **count** function can take an argument [#186185032](https://www.pivotaltracker.com/story/show/186185032)
+- Evaluation of formula with mean counts blank cells as 0 in mean calculation [#186145218](https://www.pivotaltracker.com/story/show/186145218)
+- Delete attribute from case table should be undoable [#186095272](https://www.pivotaltracker.com/story/show/186095272)
+
+### Bug Fixes
+- Syntax error in formula not caught [#186185461](https://www.pivotaltracker.com/story/show/186185461)
+- Hierarchical tables don't update properly [#186204753](https://www.pivotaltracker.com/story/show/186204753)
+- Formula doesn't work when attribute name is the same as one of the supported functions (e.g. "mean(mean)") [#186152786](https://www.pivotaltracker.com/story/show/186152786)
+- Case table content should resize to fill component when component is resized [#186095283](https://www.pivotaltracker.com/story/show/186095283)
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+|  main.css |   69080 bytes |                               0% |
+|  index.js | 3382101 bytes |                            0.38% |
+
 ## Version 3.0.0-pre.1342 - October 2, 2023
 
 ### Features/Improvements

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1342",
+  "version": "3.0.0-pre.1360",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-pre.1342",
+      "version": "3.0.0-pre.1360",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1342",
+  "version": "3.0.0-pre.1360",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -1,0 +1,28 @@
+### CODAP v3 Environments
+- Production (Will start being available when we release to production)
+- [Staging](https://codap3.concord.org/index-staging.html)
+
+### Versions
+|      Version    |          Release Date |
+|-----------------|-----------------------|
+| [3.0.0-pre.1360](https://codap3.concord.org/version/3.0.0-pre.1360/) | October 10, 2023 |
+| [3.0.0-pre.1342](https://codap3.concord.org/version/3.0.0-pre.1342/) | October 2, 2023 |
+| [3.0.0-pre.1331](https://codap3.concord.org/version/3.0.0-pre.1331/) | September 26, 2023 |
+| [3.0.0-pre.1307](https://codap3.concord.org/version/3.0.0-pre.1307/) | September 11, 2023 |
+| [3.0.0-pre.1295](https://codap3.concord.org/version/3.0.0-pre.1295/) | August 10, 2023 |
+| [3.0.0-pre.1286](https://codap3.concord.org/version/3.0.0-pre.1286/) | July 31, 2023 |
+| [3.0.0-pre.1278](https://codap3.concord.org/version/3.0.0-pre.1278/) | July 24, 2023 |
+| [3.0.0-pre.1274](https://codap3.concord.org/version/3.0.0-pre.1274/) | July 18, 2023 |
+| [3.0.0-pre.1270](https://codap3.concord.org/version/3.0.0-pre.1270/) | July 10, 2023 |
+| [3.0.0-pre.1262](https://codap3.concord.org/version/3.0.0-pre.1262/) | July 5, 2023 |
+| [3.0.0-pre.1258](https://codap3.concord.org/version/3.0.0-pre.1258/) | June 26, 2023 |
+| [3.0.0-pre.1248](https://codap3.concord.org/version/3.0.0-pre.1248/) | June 12, 2023 |
+| [3.0.0-pre.1240](https://codap3.concord.org/version/3.0.0-pre.1240/) | June 5, 2023 |
+| [3.0.0-pre.1236](https://codap3.concord.org/version/3.0.0-pre.1236/) | May 30, 2023 |
+| [3.0.0-pre.1225](https://codap3.concord.org/version/3.0.0-pre.1225/) | May 8, 2023 |
+| [3.0.0-pre.1220](https://codap3.concord.org/version/3.0.0-pre.1220/) | May 1, 2023 |
+| [3.0.0-pre.1208](https://codap3.concord.org/version/3.0.0-pre.1208/) | April 25, 2023 |
+| [3.0.0-pre.1198](https://codap3.concord.org/version/3.0.0-pre.1198/) | April 18, 2023 |
+| [3.0.0-pre.1190](https://codap3.concord.org/version/3.0.0-pre.1190/) | April 10, 2023 |
+| [3.0.0-pre.1089](https://codap3.concord.org/version/3.0.0-pre.1089/) | January 17, 2023 |
+| [3.0.0-pre.1085](https://codap3.concord.org/version/3.0.0-pre.1085/) | January 3, 2023 |


### PR DESCRIPTION
### Features/Improvements
- Dot plots can show **mean** and **median** [#181914405](https://www.pivotaltracker.com/story/show/181914405)
- Formula is updated when attribute name is changed [#186144182](https://www.pivotaltracker.com/story/show/186144182)
- Formula is updated when global value name is changed [#186166594](https://www.pivotaltracker.com/story/show/186166594)
- Handle characters that need escaping in formula backtick strings (e.g. `Attr\\` Name`) [#186176018](https://www.pivotaltracker.com/story/show/186176018)
- Handle characters that need escaping in formula double quote strings (e.g. lookup("Attr\\" Name") + "cons\\"tant") [#186145125](https://www.pivotaltracker.com/story/show/186145125)
- The **count** function can take an argument [#186185032](https://www.pivotaltracker.com/story/show/186185032)
- Evaluation of formula with mean counts blank cells as 0 in mean calculation [#186145218](https://www.pivotaltracker.com/story/show/186145218)
- Delete attribute from case table should be undoable [#186095272](https://www.pivotaltracker.com/story/show/186095272)

### Bug Fixes
- Syntax error in formula not caught [#186185461](https://www.pivotaltracker.com/story/show/186185461)
- Hierarchical tables don't update properly [#186204753](https://www.pivotaltracker.com/story/show/186204753)
- Formula doesn't work when attribute name is the same as one of the supported functions (e.g. "mean(mean)") [#186152786](https://www.pivotaltracker.com/story/show/186152786)
- Case table content should resize to fill component when component is resized [#186095283](https://www.pivotaltracker.com/story/show/186095283)