### PR TITLE
Improve error handling when an attribute used by formula is deleted

### DIFF
--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -1,7 +1,7 @@
 import { create, all, mean, median, mad, max, min, sum, random, pickRandom, MathNode, ConstantNode } from 'mathjs'
 import { FormulaMathJsScope } from './formula-mathjs-scope'
 import {
-  DisplayNameMap, FValue, CODAPMathjsFunctionRegistry, ILookupDependency, isConstantStringNode
+  DisplayNameMap, FValue, CODAPMathjsFunctionRegistry, ILookupDependency, isConstantStringNode, rmCanonicalPrefix
 } from './formula-types'
 import type { IDataSet } from './data-set'
 
@@ -132,8 +132,8 @@ export const fnRegistry = {
       validArgs[1].value = displayNameMap.dataSet[dataSetName]?.attribute[attrName]
     },
     evaluateRaw: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
-      const dataSetId = evaluateNode(args[0], scope)
-      const attrId = evaluateNode(args[1], scope)
+      const dataSetId = rmCanonicalPrefix(evaluateNode(args[0], scope))
+      const attrId = rmCanonicalPrefix(evaluateNode(args[1], scope))
       const zeroBasedIndex = evaluateNode(args[2], scope) - 1
       return scope.getDataSet(dataSetId)?.getValueAtIndex(zeroBasedIndex, attrId) || UNDEF_RESULT
     }
@@ -170,9 +170,9 @@ export const fnRegistry = {
       validArgs[2].value = displayNameMap.dataSet[dataSetName]?.attribute[keyAttrName]
     },
     evaluateRaw: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
-      const dataSetId = evaluateNode(args[0], scope)
-      const attrId = evaluateNode(args[1], scope)
-      const keyAttrId = evaluateNode(args[2], scope)
+      const dataSetId = rmCanonicalPrefix(evaluateNode(args[0], scope))
+      const attrId = rmCanonicalPrefix(evaluateNode(args[1], scope))
+      const keyAttrId = rmCanonicalPrefix(evaluateNode(args[2], scope))
       const keyAttrValue = evaluateNode(args[3], scope)
 
       const dataSet: IDataSet | undefined = scope.getDataSet(dataSetId)

--- a/v3/src/models/data/formula-mathjs-scope.ts
+++ b/v3/src/models/data/formula-mathjs-scope.ts
@@ -1,4 +1,6 @@
-import { FValue, CASE_INDEX_FAKE_ATTR_ID, GLOBAL_VALUE, LOCAL_ATTR, NO_PARENT_KEY } from "./formula-types"
+import {
+  FValue, CASE_INDEX_FAKE_ATTR_ID, GLOBAL_VALUE, LOCAL_ATTR, NO_PARENT_KEY, CANONICAL_NAME
+} from "./formula-types"
 import type { IGlobalValueManager } from "../global/global-value-manager"
 import type { IDataSet } from "./data-set"
 import type { IValueType } from "./attribute"
@@ -52,7 +54,7 @@ export class FormulaMathJsScope {
       // Make sure that all the caching and case processing is done lazily, only for attributes that are actually
       // referenced by the formula.
       let cachedGroup: Record<string, IValueType[]>
-      Object.defineProperty(this.dataStorage, `${LOCAL_ATTR}${attrId}`, {
+      Object.defineProperty(this.dataStorage, `${CANONICAL_NAME}${LOCAL_ATTR}${attrId}`, {
         get: () => {
           if (!this.isAggregate) {
             return this.getLocalValue(this.caseId, attrId)
@@ -76,7 +78,7 @@ export class FormulaMathJsScope {
     })
     // Global value symbols.
     context.globalValueManager?.globals.forEach(global => {
-      Object.defineProperty(this.dataStorage, `${GLOBAL_VALUE}${global.id}`, {
+      Object.defineProperty(this.dataStorage, `${CANONICAL_NAME}${GLOBAL_VALUE}${global.id}`, {
         get: () => {
           return global.value
         }

--- a/v3/src/models/data/formula-types.test.ts
+++ b/v3/src/models/data/formula-types.test.ts
@@ -1,0 +1,31 @@
+import { CANONICAL_NAME, isCanonicalName, rmCanonicalPrefix } from "./formula-types"
+
+describe("isCanonicalName", () => {
+  it("returns true if the name starts with the canonical name", () => {
+    expect(isCanonicalName(`${CANONICAL_NAME}TEST`)).toBe(true)
+  })
+  it("returns false if the name does not start with the canonical name", () => {
+    expect(isCanonicalName("FOO_BAR")).toBe(false)
+  })
+  it("returns false if the name is undefined or unexpected type", () => {
+    expect(isCanonicalName(undefined)).toBe(false)
+    expect(isCanonicalName(1)).toBe(false)
+    expect(isCanonicalName({})).toBe(false)
+    expect(isCanonicalName([])).toBe(false)
+  })
+})
+
+describe("rmCanonicalPrefix", () => {
+  it("removes the canonical prefix from the name", () => {
+    expect(rmCanonicalPrefix(`${CANONICAL_NAME}TEST`)).toBe("TEST")
+  })
+  it("returns the original name if it does not start with the canonical name", () => {
+    expect(rmCanonicalPrefix("FOO_BAR")).toBe("FOO_BAR")
+  })
+  it("returns the if the name is undefined or unexpected type", () => {
+    expect(rmCanonicalPrefix(undefined)).toEqual(undefined)
+    expect(rmCanonicalPrefix(1)).toEqual(1)
+    expect(rmCanonicalPrefix({})).toEqual({})
+    expect(rmCanonicalPrefix([])).toEqual([])
+  })
+})

--- a/v3/src/models/data/formula-types.ts
+++ b/v3/src/models/data/formula-types.ts
@@ -1,6 +1,7 @@
 import { ConstantNode, MathNode, SymbolNode, isConstantNode, isFunctionNode, isSymbolNode } from "mathjs"
 import type { FormulaMathJsScope } from "./formula-mathjs-scope"
 
+export const CANONICAL_NAME = "__CANONICAL_NAME__"
 export const GLOBAL_VALUE = "GLOBAL_VALUE_"
 export const LOCAL_ATTR = "LOCAL_ATTR_"
 export const CASE_INDEX_FAKE_ATTR_ID = "CASE_INDEX"
@@ -14,6 +15,10 @@ export const isConstantStringNode = (node: MathNode): node is ConstantNode<strin
 // name. In most cases, it's more useful to handle function node explicitly and skip the function name symbol node.
 export const isNonFunctionSymbolNode = (node: MathNode, parent: MathNode): node is SymbolNode =>
   isSymbolNode(node) && (!isFunctionNode(parent) || parent.fn !== node)
+
+export const isCanonicalName = (name: any): name is string => !!name?.startsWith?.(CANONICAL_NAME)
+
+export const rmCanonicalPrefix = (name: any) => isCanonicalName(name) ? name.substring(CANONICAL_NAME.length) : name
 
 export type DisplayNameMap = {
   localNames: Record<string, string>

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -13,7 +13,7 @@ import type { ICase } from "./data-set-types"
 export const formulaError = (message: string, vars?: string[]) => `❌ ${t(message, { vars })}`
 
 // Currently, canonical names can be "basic": they can refer to local attributes or global values.
-// Or they can be custom, like ones used by lookup functions. This helpers parses basic canonical names.
+// Or they can be custom, like ones used by lookup functions. This helper parses basic canonical names.
 export const parseBasicCanonicalName = (canonicalName: string): IFormulaDependency | undefined => {
   if (!isCanonicalName(canonicalName)) {
     return undefined

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -1,21 +1,24 @@
 import { parse, MathNode, isFunctionNode } from "mathjs"
 import {
   LOCAL_ATTR, GLOBAL_VALUE, DisplayNameMap, CanonicalNameMap, IFormulaDependency, isConstantStringNode,
-  isNonFunctionSymbolNode, ILocalAttributeDependency, ILookupDependency
+  isNonFunctionSymbolNode, ILocalAttributeDependency, ILookupDependency, isCanonicalName, rmCanonicalPrefix
 } from "./formula-types"
 import { typedFnRegistry } from "./formula-fn-registry"
+import t from "../../utilities/translation/translate"
 import type { IDataSet } from "./data-set"
 import type { ICase } from "./data-set-types"
-import t from "../../utilities/translation/translate"
 
 // Set of formula helpers that can be used outside FormulaManager context. It should make them easier to test.
 
 export const formulaError = (message: string, vars?: string[]) => `❌ ${t(message, { vars })}`
 
-export const generateCanonicalSymbolName = (name: string, displayNameMap: DisplayNameMap) =>
-  displayNameMap.localNames[name] || null
-
-export const parseCanonicalSymbolName = (canonicalName: string): IFormulaDependency | undefined => {
+// Currently, canonical names can be "basic": they can refer to local attributes or global values.
+// Or they can be custom, like ones used by lookup functions. This helpers parses basic canonical names.
+export const parseBasicCanonicalName = (canonicalName: string): IFormulaDependency | undefined => {
+  if (!isCanonicalName(canonicalName)) {
+    return undefined
+  }
+  canonicalName = rmCanonicalPrefix(canonicalName)
   if (canonicalName.startsWith(LOCAL_ATTR)) {
     const attrId = canonicalName.substring(LOCAL_ATTR.length)
     return { type: "localAttribute", attrId }
@@ -85,7 +88,17 @@ export const canonicalToDisplay = (canonical: string, originalDisplay: string, c
   // function names and constants might be identical to the symbol name. E.g. 'mean(mean) + "mean"' is a valid formula
   // if there's attribute called "mean". If we process function names and constants, it'll be handled correctly.
   originalDisplay = makeDisplayNamesSafe(originalDisplay) // so it can be parsed by MathJS
-  const getNameFromId = (id: string) => canonicalNameMap[id] || id
+  const getDisplayNameFromSymbol = (name: string) => {
+    if (isCanonicalName(name)) {
+      if (!canonicalNameMap[name]) {
+        // It'll happen when attribute has been deleted and it's no longer available.
+        throw new Error("canonicalToDisplay: canonical name not found in canonicalNameMap")
+      }
+      return canonicalNameMap[name]
+    }
+    // Not a canonical symbol (e.g. regular string or math symbol like Pi).
+    return name
+  }
   // Wrap in backticks if it's not a (MathJS) safe symbol name.
   const wrapInBackticksIfNecessary = (name: string) => name !== safeSymbolName(name) ? `\`${name}\`` : name
 
@@ -101,9 +114,9 @@ export const canonicalToDisplay = (canonical: string, originalDisplay: string, c
     // Symbol with nonstandard characters need to be wrapped in backticks, while constants don't (as they're already
     // wrapped in string quotes).
     isNonFunctionSymbolNode(node, parent) && newNames.push(
-      wrapInBackticksIfNecessary(escapeBacktickString(getNameFromId(node.name)))
+      wrapInBackticksIfNecessary(escapeBacktickString(getDisplayNameFromSymbol(node.name)))
     )
-    isConstantStringNode(node) && newNames.push(escapeDoubleQuoteString(getNameFromId(node.value)))
+    isConstantStringNode(node) && newNames.push(escapeDoubleQuoteString(getDisplayNameFromSymbol(node.value)))
     isFunctionNode(node) && newNames.push(node.fn.name)
   })
 
@@ -131,7 +144,7 @@ export const displayToCanonical = (displayExpression: string, displayNameMap: Di
   const formulaTree = parse(preprocessDisplayFormula(displayExpression))
   const visitNode = (node: MathNode, path: string, parent: MathNode) => {
     if (isNonFunctionSymbolNode(node, parent)) {
-      const canonicalName = generateCanonicalSymbolName(node.name, displayNameMap)
+      const canonicalName = displayNameMap.localNames[node.name]
       if (canonicalName) {
         node.name = canonicalName
       }
@@ -193,7 +206,7 @@ export const getFormulaDependencies = (formulaCanonical: string, formulaAttribut
     const isDescendantOfAggregateFunc = !!node.isDescendantOfAggregateFunc
     const isSelfReferenceAllowed = !!node.isSelfReferenceAllowed
     if (isNonFunctionSymbolNode(node, parent)) {
-      const dependency = parseCanonicalSymbolName(node.name)
+      const dependency = parseBasicCanonicalName(node.name)
       if (dependency?.type === "localAttribute" && isDescendantOfAggregateFunc) {
         dependency.aggregate = true
       }

--- a/v3/src/models/data/formula.ts
+++ b/v3/src/models/data/formula.ts
@@ -54,7 +54,13 @@ export const Formula = types.model("Formula", {
       return
     }
     const canonicalNameMap = self.formulaManager.getCanonicalNameMap(self.id)
-    self.display = canonicalToDisplay(self.canonical, self.display, canonicalNameMap)
+    try {
+      self.display = canonicalToDisplay(self.canonical, self.display, canonicalNameMap)
+    } catch {
+      // If the canonical formula can't be converted to display formula, it usually means there are some unresolved
+      // canonical names. It usually happens when an attribute is removed. Nothing to do here, just keep the original
+      // display form.
+    }
   },
   rerandomize() {
     self.formulaManager?.recalculateFormula(self.id)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186201910

This PR fixes the following bug:

**Test scenario**

1. Open https://codap3.concord.org/branch/main/index.html?sample=mammals
2. Add formula: `Height + Mass`
3. Remove the attribute Mass

**Current behavior**

1. The formula displays an error (as expected), but the error mentions the canonical symbol name (instead of the display one). 
2. When you open the formula dialog, you'll see: `Height + LOCAL_ATTR_ATTRHKTbQ9BF_f2w`
3. When you rename another attribute to Mass, the formula doesn't get fixed.

**Expected behavior**

1. The formula displays an error about undefined `Mass`, 
2. The formula dialog still shows `Height + Mass`.
3. When the user renames another attribute to Mass, the formula should be fixed and recalculated.

---

It took me a bit more time than expected because, initially, I wanted to avoid prefixing all the canonical names with an additional prefix. We could manage regular symbols, but things became tricky with lookup function arguments. Since they're normal strings, at some point, it becomes difficult to guess if they're canonical names or valid user-defined string constants. This new prefix makes things more explicit.