### PR TITLE
fix: childCases after adding/removing cases [#186182255]

### DIFF
--- a/v3/src/models/data/data-set-collection-groups.test.ts
+++ b/v3/src/models/data/data-set-collection-groups.test.ts
@@ -52,6 +52,21 @@ describe("CollectionGroups", () => {
     expect(data.getCasesForAttributes(["cId"])).toEqual(data.cases)
     expect(data.groupedAttributes).toEqual([])
     expect(data.ungroupedAttributes.map(attr => attr.id)).toEqual(["aId", "bId", "cId"])
+    // case caches are updated when cases are added/removed
+    const allCases = data.cases.map(({ __id__ }) => ({ __id__ }))
+    const childCases = data.childCases()
+    expect(childCases).toEqual(allCases)
+    data.addCases([{ __id__: "4-5-6", aId: 4, bId: 5, cId: 6 }])
+    const allCases2 = data.cases.map(({ __id__ }) => ({ __id__ }))
+    expect(allCases2).not.toEqual(allCases)
+    const childCases2 = data.childCases()
+    expect(childCases2).not.toEqual(childCases)
+    expect(childCases2).toEqual(allCases2)
+    data.removeCases(["4-5-6"])
+    const allCases3 = data.cases.map(({ __id__ }) => ({ __id__ }))
+    const childCases3 = data.childCases()
+    expect(childCases3).toEqual(childCases)
+    expect(childCases3).toEqual(allCases3)
   })
 
   it("handles grouping by a single attribute", () => {

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -301,6 +301,10 @@ export const DataSet = types.model("DataSet", {
       getCollectionForAttribute,
       // leaf-most child cases (i.e. those not grouped in a collection)
       childCases() {
+        if (!isValidCollectionGroups.get()) {
+          // childCases array cache is built by collectionGroups()
+          this.collectionGroups // eslint-disable-line no-unused-expressions
+        }
         return _childCases
       },
       // the resulting collection groups
@@ -877,8 +881,8 @@ export const DataSet = types.model("DataSet", {
           })
           insertCaseIDAtIndex(__id__, insertPosition)
         })
-        // invalidate collectionGroups if there's any grouping
-        self.collections.length && self.invalidateCollectionGroups()
+        // invalidate collectionGroups (including childCases)
+        self.invalidateCollectionGroups()
       },
 
       // Supports regular cases or pseudo-cases, but not mixing the two.
@@ -945,8 +949,8 @@ export const DataSet = types.model("DataSet", {
             }
           }
         })
-        // invalidate collectionGroups if there's grouping going on
-        self.collections.length && self.invalidateCollectionGroups()
+        // invalidate collectionGroups (including childCases)
+        self.invalidateCollectionGroups()
       },
 
       selectAll(select = true) {


### PR DESCRIPTION
[[#186182255]](https://www.pivotaltracker.com/story/show/186182255)

Invalidate/refresh the `childCases` cache when adding/removing cases to fix formula evaluation of newly added cases.