### PR TITLE
Handle escaping of single quote strings in formulas

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -19,7 +19,7 @@
         "escape-string-regexp": "^5.0.0",
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
-        "mathjs": "^11.11.0",
+        "mathjs": "^11.11.2",
         "mobx": "^6.10.2",
         "mobx-react-lite": "^4.0.4",
         "nanoid": "^4.0.2",
@@ -1925,9 +1925,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
+      "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -16661,11 +16661,11 @@
       }
     },
     "node_modules/mathjs": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.11.0.tgz",
-      "integrity": "sha512-i1Ao/tv1mlNd09XlOMOUu3KMySX3S0jhHNfDPzh0sCnPf1i62x6RjxhLwZ9ytmVSs0OdhF3moI4O84VSEjmUFw==",
+      "version": "11.11.2",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.11.2.tgz",
+      "integrity": "sha512-SL4/0Fxm9X4sgovUpJTeyVeZ2Ifnk4tzLPTYWDyR3AIx9SabnXYqtCkyJtmoF3vZrDPKGkLvrhbIL4YN2YbXLQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.23.1",
         "complex.js": "^2.1.1",
         "decimal.js": "^10.4.3",
         "escape-latex": "^1.2.0",
@@ -16673,7 +16673,7 @@
         "javascript-natural-sort": "^0.7.1",
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
-        "typed-function": "^4.1.0"
+        "typed-function": "^4.1.1"
       },
       "bin": {
         "mathjs": "bin/cli.js"
@@ -21101,9 +21101,9 @@
       }
     },
     "node_modules/typed-function": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.0.tgz",
-      "integrity": "sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.1.tgz",
+      "integrity": "sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ==",
       "engines": {
         "node": ">= 14"
       }
@@ -23480,9 +23480,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
+      "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -34519,11 +34519,11 @@
       }
     },
     "mathjs": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.11.0.tgz",
-      "integrity": "sha512-i1Ao/tv1mlNd09XlOMOUu3KMySX3S0jhHNfDPzh0sCnPf1i62x6RjxhLwZ9ytmVSs0OdhF3moI4O84VSEjmUFw==",
+      "version": "11.11.2",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.11.2.tgz",
+      "integrity": "sha512-SL4/0Fxm9X4sgovUpJTeyVeZ2Ifnk4tzLPTYWDyR3AIx9SabnXYqtCkyJtmoF3vZrDPKGkLvrhbIL4YN2YbXLQ==",
       "requires": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.23.1",
         "complex.js": "^2.1.1",
         "decimal.js": "^10.4.3",
         "escape-latex": "^1.2.0",
@@ -34531,7 +34531,7 @@
         "javascript-natural-sort": "^0.7.1",
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
-        "typed-function": "^4.1.0"
+        "typed-function": "^4.1.1"
       }
     },
     "mdn-data": {
@@ -37786,9 +37786,9 @@
       }
     },
     "typed-function": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.0.tgz",
-      "integrity": "sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.1.tgz",
+      "integrity": "sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/v3/package.json
+++ b/v3/package.json
@@ -174,7 +174,7 @@
     "escape-string-regexp": "^5.0.0",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
-    "mathjs": "^11.11.0",
+    "mathjs": "^11.11.2",
     "mobx": "^6.10.2",
     "mobx-react-lite": "^4.0.4",
     "nanoid": "^4.0.2",

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -291,7 +291,8 @@ export class FormulaManager {
       // In 99% of cases, the two `if` statements above will be sufficient to detect deleted formulas. However, this
       // could serve as the ultimate check in case a formula instance was deleted in a different manner.
       if (!isAlive(metadata.formula)) {
-        console.warn("FormulaManager.unregisterDeletedFormulas unregistering a defunct formula that was not detected by the usual means.")
+        console.warn("FormulaManager.unregisterDeletedFormulas unregistering a defunct formula that " +
+          "was not detected by the usual means.")
         this.unregisterFormula(formulaId)
       }
     })


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186179035

This PR finally fixes the last missing piece of special character handling: single-quote strings.

This became possible because of the MathJS v11.11.2 fix described here: https://github.com/josdejong/mathjs/issues/3073

However, some additional handling was still required on our side. MathJS doesn't store the type of string constant, whether it's a single-quote or double-quote string. Consequently, we don't know how to escape the given string when converting it from canonical form back to the display form.

That's why the formulaIndexOf helper was added. We take advantage of the fact that there are only two string delimiters available, allowing us to search for both variants, select the one that appears first in the string, and perform the remaining processing based on this result (=> escaping).