### PR TITLE
fix: undo create graph

### DIFF
--- a/v3/src/components/graph/components/attribute-label.tsx
+++ b/v3/src/components/graph/components/attribute-label.tsx
@@ -3,6 +3,7 @@ import {createPortal} from "react-dom"
 import {reaction} from "mobx"
 import {observer} from "mobx-react-lite"
 import {select} from "d3"
+import {mstReaction} from "../../../utilities/mst-reaction"
 import t from "../../../utilities/translation/translate"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useGraphContentModelContext} from "../hooks/use-graph-content-model-context"
@@ -143,7 +144,7 @@ export const AttributeLabel = observer(
 
     // Respond to changes in attributeID assigned to my place
     useEffect(() => {
-        const disposer = reaction(
+        const disposer = mstReaction(
           () => {
             if (place === 'left') {
               return dataConfiguration?.yAttributeDescriptionsExcludingY2.map((desc) => desc.attributeID)
@@ -154,7 +155,7 @@ export const AttributeLabel = observer(
           },
           () => {
             refreshAxisTitle()
-          }, { name: "AttributeLabel [attribute configuration]"}
+          }, { name: "AttributeLabel [attribute configuration]" }, dataConfiguration
         )
         return () => disposer()
     }, [place, dataConfiguration, refreshAxisTitle])

--- a/v3/src/components/graph/hooks/use-init-graph-layout.ts
+++ b/v3/src/components/graph/hooks/use-init-graph-layout.ts
@@ -1,6 +1,6 @@
-import { reaction } from "mobx"
 import { useEffect } from "react"
 import { useMemo } from "use-memo-one"
+import { mstReaction } from "../../../utilities/mst-reaction"
 import { AxisPlace } from "../../axis/axis-types"
 import {IGraphContentModel} from "../models/graph-content-model"
 import { GraphLayout } from "../models/graph-layout"
@@ -10,11 +10,12 @@ export function useInitGraphLayout(model?: IGraphContentModel) {
 
   useEffect(() => {
     // synchronize the number of repetitions from the DataConfiguration to the layout's MultiScales
-    return reaction(
+    const { dataConfiguration } = model || {}
+    return mstReaction(
       () => {
         const repetitions: Partial<Record<AxisPlace, number>> = {}
         layout.axisScales.forEach((multiScale, place) => {
-          repetitions[place] = model?.dataConfiguration.numRepetitionsForPlace(place) ?? 1
+          repetitions[place] = dataConfiguration?.numRepetitionsForPlace(place) ?? 1
         })
         return repetitions
       },
@@ -22,9 +23,9 @@ export function useInitGraphLayout(model?: IGraphContentModel) {
         (Object.keys(repetitions) as AxisPlace[]).forEach((place: AxisPlace) => {
           layout.getAxisMultiScale(place)?.setRepetitions(repetitions[place] ?? 0)
         })
-      }, { name: "useInitGraphLayout repetitions" }
+      }, { name: "useInitGraphLayout repetitions" }, dataConfiguration
     )
-  }, [layout, model?.dataConfiguration])
+  }, [layout, model])
 
   return layout
 }

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -10,6 +10,7 @@ import {useGraphLayoutContext} from "../models/graph-layout"
 import {matchCirclesToData, startAnimation} from "../utilities/graph-utils"
 import {useCurrent} from "../../../hooks/use-current"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
+import {mstReaction} from "../../../utilities/mst-reaction"
 import {onAnyAction} from "../../../utilities/mst-utils"
 
 interface IDragHandlers {
@@ -122,12 +123,12 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
 
   // respond to attribute assignment changes
   useEffect(() => {
-    const disposer = reaction(
+    const disposer = mstReaction(
       () => GraphAttrRoles.map((aRole) => dataConfiguration?.attributeID(aRole)),
       () => {
         startAnimation(enableAnimation)
         callRefreshPointPositions(false)
-      }, { name: "usePlot [attribute assignment]" }
+      }, { name: "usePlot [attribute assignment]" }, dataConfiguration
     )
     return () => disposer()
   }, [callRefreshPointPositions, dataConfiguration, enableAnimation])


### PR DESCRIPTION
Use `mstReaction` to prevent access to defunct models from `reaction`s in the graph code when undoing/redoing the creation of a graph tile.