### PR TITLE
Formulas: handle non-numeric args correctly, add all the CODAP V2 arithmetic functions 

### DIFF
--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -175,7 +175,7 @@ export const fnRegistry = {
   },
 
   frac: {
-    evaluate: numericFnFactory((v: number) => v - (v < 0 ? Math.ceil(v) : Math.floor(v)))
+    evaluate: numericFnFactory((v: number) => v - Math.trunc(v))
   },
 
   ln: {

--- a/v3/src/models/data/formula-fn-registry.ts
+++ b/v3/src/models/data/formula-fn-registry.ts
@@ -79,7 +79,7 @@ export const numericMultiArgsFnFactory = (fn: (...values: number[]) => number, o
   return (...args: (FValue | FValue[])[]) => {
     const array = args.find((a) => Array.isArray(a)) as FValue[]
     if (array) {
-      // One of the arguments is an array. In means the context of the expression is aggregate function.
+      // One of the arguments is an array. It means the context of the expression is aggregate function.
       // Other arguments can be arrays, but they don't have to (e.g. if user provided constants as arguments).
       return array.map((v, idx) => calculateCaseValue(args, idx))
     }


### PR DESCRIPTION
This PR was initially supposed to address only this story:
[numeric attribute formulas should ignore non-numeric case values](https://www.pivotaltracker.com/story/show/186235751)

When I began delving into it, I realized that all the arithmetic functions would also require that, and they could share common helpers (`numericFnFactory` and `numericMultiArgsFnFactory`). So, I proceeded to implement all the V2 arithmetic functions and added this PT story to track this work:
[V3 formulas support all the arithmetic functions from V2](https://www.pivotaltracker.com/story/show/186245938)

`numericMultiArgsFnFactory` might look a bit overcomplicated, but it makes the implementation of any arithmetic function quite simple.

Related PR with unit test: https://github.com/concord-consortium/codap/pull/943

While I was working on the "numeric attribute formulas should ignore non-numeric case values" story, I learned that CODAP v2 has two features that affect this area:
1. Formula functions that expect numbers will ignore everything that is not a number (a string that can be parsed is also considered to be a number).
2. Each attribute can have a type, and one of them is numeric. In this case, all the attribute values will be cast to numbers, more aggressively than what the first feature does (e.g. "aaa1.5aa5a" becomes 1.55 in V2).

For example, if the attribute "Height" has no explicit type set, and you type "1.5aaa" there, a formula like round(Height) will not return anything (as "1.5aaa" is not a number). However, if you set the "Height" type to "numeric", right after you type "1.5aaa", you'll see that the case table displays only 1.5, and round(Height) returns 2.

This PR addresses only the first feature. In other words, formula functions should not care about the attribute type but should work with whatever dataset returns. The second feature should be another story where the dataset starts to cast string values to user-selected types (aggressively or very forgiving). I'm assuming it should be on the dataset level, as probably graphs and other consumers of dataset data can be affected by that too.
