### PR TITLE
Add tests of numericFnFactory, numericMultiArgsFnFactory, and all the arithmetic functions

### DIFF
--- a/v3/src/models/data/formula-fn-registry.test.ts
+++ b/v3/src/models/data/formula-fn-registry.test.ts
@@ -24,7 +24,7 @@ describe("numericMultiArgsFnFactory", () => {
   const fn = (valueA: number, valueB = 0) => valueA + valueB
   const numericFn = numericMultiArgsFnFactory(fn, { numOfRequiredArgs: 1 })
 
-  it("returns a function that applies the specified function to a multiple numeric values", () => {
+  it("returns a function that applies the specified function to multiple numeric values", () => {
     const result = numericFn(10, 20)
     expect(result).toBe(30)
   })

--- a/v3/src/models/data/formula-fn-registry.test.ts
+++ b/v3/src/models/data/formula-fn-registry.test.ts
@@ -1,0 +1,210 @@
+import { UNDEF_RESULT, numericFnFactory, numericMultiArgsFnFactory, math } from "./formula-fn-registry"
+
+describe("numericFnFactory", () => {
+  const fn = (value: number) => value * 2
+  const numericFn = numericFnFactory(fn)
+
+  it("returns a function that applies the specified function to a single numeric value", () => {
+    const result = numericFn(123)
+    expect(result).toBe(246)
+  })
+
+  it("returns a function that returns undefined result (empty string) for non-numeric values", () => {
+    expect(numericFn("foo")).toEqual(UNDEF_RESULT)
+    expect(numericFn(UNDEF_RESULT)).toEqual(UNDEF_RESULT)
+  })
+
+  it("returns a function that applies the specified function to an array of numeric values", () => {
+    const result = numericFn([1, 2, "3", "4", "five", "", UNDEF_RESULT])
+    expect(result).toEqual([2, 4, 6, 8, UNDEF_RESULT, UNDEF_RESULT, UNDEF_RESULT])
+  })
+})
+
+describe("numericMultiArgsFnFactory", () => {
+  const fn = (valueA: number, valueB = 0) => valueA + valueB
+  const numericFn = numericMultiArgsFnFactory(fn, { numOfRequiredArgs: 1 })
+
+  it("returns a function that applies the specified function to a multiple numeric values", () => {
+    const result = numericFn(10, 20)
+    expect(result).toBe(30)
+  })
+
+  it("returns a function that returns undefined result (empty string) if required argument is non-numeric", () => {
+    expect(numericFn("foo", 10)).toEqual(UNDEF_RESULT)
+    expect(numericFn("", 10)).toEqual(UNDEF_RESULT)
+    expect(numericFn(UNDEF_RESULT, 10)).toEqual(UNDEF_RESULT)
+    expect(numericFn("foo", "bar")).toEqual(UNDEF_RESULT)
+    expect(numericFn(10, "foo")).toEqual(10)
+    expect(numericFn(10, "")).toEqual(10)
+  })
+
+  it("returns a function that applies the specified function to each element of provided arrays", () => {
+    const result = numericFn([1, 2, "3", "4", 5, 6, "foo", ""], [1, 2, "3", "4", "five", "", 7, 8])
+    expect(result).toEqual([2, 4, 6, 8, 5, 6, UNDEF_RESULT, UNDEF_RESULT])
+  })
+
+  it("returns a function that can handle array and single value", () => {
+    const result1 = numericFn(10, [1, 2, "3", "4", "five", "", UNDEF_RESULT])
+    expect(result1).toEqual([11, 12, 13, 14, 10, 10, 10])
+    const result2 = numericFn([1, 2, "3", "4", "five", "", UNDEF_RESULT], 10)
+    expect(result2).toEqual([11, 12, 13, 14, UNDEF_RESULT, UNDEF_RESULT, UNDEF_RESULT])
+  })
+})
+
+describe("abs", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("abs(x)")
+    expect(fn.evaluate({ x: -1 })).toEqual(1)
+    expect(fn.evaluate({ x: 1 })).toEqual(1)
+    expect(fn.evaluate({ x: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [-1, -2, -3] })).toEqual([1, 2, 3])
+  })
+})
+
+describe("ceil", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("ceil(x)")
+    expect(fn.evaluate({ x: 1.2 })).toEqual(2)
+    expect(fn.evaluate({ x: -1.2 })).toEqual(-1)
+    expect(fn.evaluate({ x: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [1.2, -1.2, 2.5, "foo"] })).toEqual([2, -1, 3, UNDEF_RESULT])
+  })
+})
+
+describe("combinations", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("combinations(x, y)")
+    expect(fn.evaluate({ x: 4, y: 2 })).toEqual(6)
+    expect(fn.evaluate({ x: 20, y: 5 })).toEqual(15504)
+    expect(fn.evaluate({ x: "", y: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: 4, y: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo", y: 4 })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [4, 20, 30], y: [2, 5, "foo"] })).toEqual([6, 15504, UNDEF_RESULT])
+    expect(fn.evaluate({ x: [4, 20], y: 2 })).toEqual([6, 190])
+  })
+})
+
+describe("exp", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("exp(x)")
+    expect(fn.evaluate({ x: 4 })).toEqual(Math.exp(4))
+    expect(fn.evaluate({ x: 20 })).toEqual(Math.exp(20))
+    expect(fn.evaluate({ x: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [4, 20, "foo"] })).toEqual([Math.exp(4), Math.exp(20), UNDEF_RESULT])
+  })
+})
+
+describe("floor", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("floor(x)")
+    expect(fn.evaluate({ x: 1.2 })).toEqual(1)
+    expect(fn.evaluate({ x: -1.2 })).toEqual(-2)
+    expect(fn.evaluate({ x: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [1.2, -1.2, 2.5, "foo"] })).toEqual([1, -2, 2, UNDEF_RESULT])
+  })
+})
+
+describe("frac", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("frac(x)")
+    expect(fn.evaluate({ x: 1.125 })).toEqual(0.125)
+    expect(fn.evaluate({ x: -1.125 })).toEqual(-0.125)
+    expect(fn.evaluate({ x: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [1.125, -1.125, 2.5, "foo"] })).toEqual([0.125, -0.125, 0.5, UNDEF_RESULT])
+  })
+})
+
+describe("ln", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("ln(x)")
+    expect(fn.evaluate({ x: 4 })).toEqual(Math.log(4))
+    expect(fn.evaluate({ x: 20 })).toEqual(Math.log(20))
+    expect(fn.evaluate({ x: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [4, 20, "foo"] })).toEqual([Math.log(4), Math.log(20), UNDEF_RESULT])
+  })
+})
+
+describe("log", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("log(x)")
+    expect(fn.evaluate({ x: 4 })).toEqual(Math.log10(4))
+    expect(fn.evaluate({ x: 20 })).toEqual(Math.log10(20))
+    expect(fn.evaluate({ x: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [4, 20, "foo"] })).toEqual([Math.log10(4), Math.log10(20), UNDEF_RESULT])
+  })
+})
+
+describe("pow", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("pow(x, y)")
+    expect(fn.evaluate({ x: 4, y: 2 })).toEqual(16)
+    expect(fn.evaluate({ x: 20, y: 5 })).toEqual(3200000)
+    expect(fn.evaluate({ x: 4, y: -4 })).toEqual(1 / 256)
+    expect(fn.evaluate({ x: "", y: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: 4, y: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo", y: 4 })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [4, 20, 30], y: [2, 5, "foo"] })).toEqual([16, 3200000, UNDEF_RESULT])
+    expect(fn.evaluate({ x: [4, 20], y: 2 })).toEqual([16, 400])
+  })
+})
+
+describe("round", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("round(x, y)")
+    expect(fn.evaluate({ x: 1.2, y: 0 })).toEqual(1)
+    expect(fn.evaluate({ x: 1.2, y: "" })).toEqual(1)
+    expect(fn.evaluate({ x: 1.2, y: "foo" })).toEqual(1)
+    expect(fn.evaluate({ x: 1.5, y: 0 })).toEqual(2)
+    expect(fn.evaluate({ x: -1.2, y: 0 })).toEqual(-1)
+    expect(fn.evaluate({ x: -1.5, y: 0 })).toEqual(-1)
+    expect(fn.evaluate({ x: 1.234, y: 2 })).toEqual(1.23)
+    expect(fn.evaluate({ x: 1.235, y: 2 })).toEqual(1.24)
+    expect(fn.evaluate({ x: -1.234, y: 2 })).toEqual(-1.23)
+    expect(fn.evaluate({ x: -1.235, y: 2 })).toEqual(-1.24)
+    expect(fn.evaluate({ x: -1.235, y: "" })).toEqual(-1)
+    expect(fn.evaluate({ x: "", y: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "", y: 2 })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo", y: 1.2 })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [1.2, 1.5, -1.2, -1.5, 2.5, "foo"], y: 0 })).toEqual([1, 2, -1, -1, 3, UNDEF_RESULT])
+    expect(fn.evaluate({ x: [1.2, 1.5, 1.234, 1.235, "foo"], y: [0, 0, 2, 2, "foo"] })).toEqual(
+      [1, 2, 1.23, 1.24, UNDEF_RESULT]
+    )
+    const fn2 = math.compile("round(x)")
+    expect(fn2.evaluate({ x: 1.2 })).toEqual(1)
+    expect(fn2.evaluate({ x: 1.5 })).toEqual(2)
+    expect(fn2.evaluate({ x: -1.2 })).toEqual(-1)
+    expect(fn2.evaluate({ x: -1.5 })).toEqual(-1)
+    expect(fn2.evaluate({ x: 1.234 })).toEqual(1)
+  })
+})
+
+describe("sqrt", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("sqrt(x)")
+    expect(fn.evaluate({ x: 4 })).toEqual(2)
+    expect(fn.evaluate({ x: 9 })).toEqual(3)
+    expect(fn.evaluate({ x: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [4, 9, 16, "foo"] })).toEqual([2, 3, 4, UNDEF_RESULT])
+  })
+})
+
+describe("trunc", () => {
+  it("returns correct value, ignores non-numeric values, and supports arrays", () => {
+    const fn = math.compile("trunc(x)")
+    expect(fn.evaluate({ x: 1.2 })).toEqual(1)
+    expect(fn.evaluate({ x: 1.5 })).toEqual(1)
+    expect(fn.evaluate({ x: -1.2 })).toEqual(-1)
+    expect(fn.evaluate({ x: -1.5 })).toEqual(-1)
+    expect(fn.evaluate({ x: "" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: "foo" })).toEqual(UNDEF_RESULT)
+    expect(fn.evaluate({ x: [1.2, 1.5, -1.2, -1.5, 2.5, "foo"] })).toEqual([1, 1, -1, -1, 2, UNDEF_RESULT])
+  })
+})


### PR DESCRIPTION
[Develop testing pattern for non-aggregate formula functions #186245948](https://www.pivotaltracker.com/story/show/186245948)

This PR is related to https://github.com/concord-consortium/codap/pull/942, but I'm opening it separately because it's the first time I've added unit tests for the actual functions.

There are a couple of options on how to approach this, but the pattern with `math.compile` and `math.evaluate` with a basic object literal scope seems to be quite clean. These tests are close to real unit tests, and there's no need to involve a custom MathJS scope (which can be tested separately). Each of the arithmetic functions tests slightly overlaps with the tests of the helper functions (handling arrays and non-numeric values). However, it's easy to do and requires only a few lines of code, so I believe it's still worth keeping this pattern (even to test whether the function actually uses the helpers or equivalent logic). If someone needs to add new functions, testing them should be straightforward as well.

Aggregate and semi-aggregate functions will require more work since they depend on our custom MathJS features. So, I'll either need to initialize it in these tests or provide some mocks. I'll leave that for later.

I also considered semi-integration tests (still written in Jest) where we use `DataSet`, `MathJSScope`, and `FormulaManager` to perform complete tests. However, these tests might be limited to just one function from each group (e.g., one arithmetic, one aggregate, etc.). Writing such tests for each new function could be tedious, and the tests would be much slower.

Also, the formula-fn-registry should be divided into smaller parts, and some helpers are spread across various files and could probably be regrouped. I'm planning to refactor all the formula files and perform some cleanup, but I'll address this cleanup work separately.

