### PR TITLE
fix: Wrong attribute passed to formula (PT-186266057)

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-component.tsx
@@ -259,14 +259,17 @@ export const UnivariateMeasureAdornmentComponent = observer(
     }, [generateIdString, measureSlug, plotWidth, toggleTextTip, xCellCount, xScale, yCellCount, yScale])
 
     const addLineCoverAndLabel = useCallback((valueObj: IValue, labelObj: ILabel, measure: IMeasureInstance) => {
-      const attrId = dataConfig?.primaryAttributeID
-      const value = attrId ? model.measureValue(attrId, cellKey, dataConfig) : undefined
+      const xAttrId = dataConfig?.attributeID("x")
+      const yAttrId = dataConfig?.attributeID("y")
+      const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
+      if (!attrId || !dataConfig) return
+      const value = model.measureValue(attrId, cellKey, dataConfig)
       if (value === undefined || isNaN(value)) return
 
       const multiScale = isVertical.current ? layout.getAxisMultiScale("bottom") : layout.getAxisMultiScale("left")
       const displayValue = multiScale?.formatValueForScale(value) || valueLabelString(value)
       const plotValue = Number(displayValue)
-      const measureRange = attrId && model.hasRange
+      const measureRange = model.hasRange
         ? model.computeMeasureRange(attrId, cellKey, dataConfig)
         : undefined
       const displayRange = measureRange
@@ -297,7 +300,7 @@ export const UnivariateMeasureAdornmentComponent = observer(
       } else {
         addTextTip(plotValue, textContent, valueObj, range)
       }
-    }, [dataConfig, model, cellKey, layout, xScale, yScale, xCellCount, yCellCount, measureSlug,
+    }, [dataConfig, xAttrType, model, cellKey, layout, xScale, yScale, xCellCount, yCellCount, measureSlug,
         generateIdString, newLine, showLabel, addRange, addLabels, addTextTip])
 
     // Add the lines and their associated covers and labels

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -96,7 +96,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
-      const { xCats, yCats, topCats, rightCats, resetPoints, dataConfig } = options
+      const { xAttrId, xCats, yAttrId, yCats, topCats, rightCats, resetPoints, dataConfig } = options
       if (!dataConfig) return
       const topCatCount = topCats.length || 1
       const rightCatCount = rightCats.length || 1
@@ -105,7 +105,8 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
       const columnCount = topCatCount * xCatCount
       const rowCount = rightCatCount * yCatCount
       const totalCount = rowCount * columnCount
-      const attrId = dataConfig.primaryAttributeID
+      const xAttrType = dataConfig.attributeType("x")
+      const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
       for (let i = 0; i < totalCount; ++i) {
         const cellKey = self.cellKey(options, i)
         const instanceKey = self.instanceKey(cellKey)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186266057

@pjanik pointed out that the wrong attribute ID can sometimes be passed to the `computeMeasureValue` view in Plotted Value model. (See [PT story](https://www.pivotaltracker.com/story/show/186266057) for an example.)

In `UnivariateMeasureAdornmentModel` and `UnivariateMeasureAdornmentComponent` I had used `dataConfig.primaryAttributeID` to determine the attribute ID to use. In the case of the Plotted Value -- which unlike other univariate measures can be present when there are numeric attributes on both the x and y axes -- that won't work. According to [the original Plotted value story](https://www.pivotaltracker.com/story/show/181940090) description, "When functions (e.g. mean) are specified, if there is no argument, the x-attribute is assumed as the attribute over which computation should take place." So I believe the thing to do is always pass the x attribute's ID if there is a numeric attribute on x.