### PR TITLE
fix: tile ordering on undo/redo close component

### DIFF
--- a/v3/src/components/container/free-tile-row.tsx
+++ b/v3/src/components/container/free-tile-row.tsx
@@ -1,9 +1,9 @@
-import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useRef } from "react"
 import { IFreeTileRow } from "../../models/document/free-tile-row"
 import { ITileModel } from "../../models/tiles/tile-model"
 import { uiState } from "../../models/ui-state"
+import { mstReaction } from "../../utilities/mst-reaction"
 import { FreeTileComponent } from "./free-tile-component"
 
 import "./free-tile-row.scss"
@@ -20,12 +20,24 @@ export const FreeTileRowComponent = observer(function FreeTileRowComponent(
 
   // focused tile should always be on top
   useEffect(() => {
-    return autorun(() => {
-      const { focusedTile } = uiState
-      if (focusedTile && (focusedTile !== row.last)) {
-        row.moveTileToTop(focusedTile)
-      }
-    }, { name: "FreeTileRowComponent.useEffect.autorun [uiState.focusedTile]" })
+    return mstReaction(
+      () => uiState.focusedTile,
+      focusedTileId => {
+        if (focusedTileId && (focusedTileId !== row.last)) {
+          row.moveTileToTop(focusedTileId)
+        }
+      }, { name: "FreeTileRowComponent.useEffect.autorun [uiState.focusedTile => row.last]" }, row)
+  }, [row])
+
+  // focused tile should always be on top
+  useEffect(() => {
+    return mstReaction(
+      () => row.last,
+      topTileId => {
+        if (topTileId && (topTileId !== uiState.focusedTile)) {
+          uiState.setFocusedTile(topTileId)
+        }
+      }, { name: "FreeTileRowComponent.useEffect.autorun [row.last => uiState.focusedTile]" }, row)
   }, [row])
 
   function handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {

--- a/v3/src/components/import-v2-document.ts
+++ b/v3/src/components/import-v2-document.ts
@@ -2,7 +2,7 @@ import { getSnapshot } from "mobx-state-tree"
 import { appState } from "../models/app-state"
 import { createCodapDocument } from "../models/codap/create-codap-document"
 import { gDataBroker } from "../models/data/data-broker"
-import { wrapSerialization } from "../models/shared/shared-data-utils"
+import { serializeDocument } from "../models/document/serialize-document"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { getSharedModelManager } from "../models/tiles/tile-environment"
 import { ITileModel } from "../models/tiles/tile-model"
@@ -43,7 +43,7 @@ import { importV2Component } from "../v2/codap-v2-tile-importers"
     })
 
     // retrieve document snapshot
-    const docSnapshot = wrapSerialization(v3Document, () => getSnapshot(v3Document))
+    const docSnapshot = serializeDocument(v3Document, () => getSnapshot(v3Document))
     // use document snapshot
     appState.setDocument(docSnapshot)
   }

--- a/v3/src/components/menu-bar/menu-bar.tsx
+++ b/v3/src/components/menu-bar/menu-bar.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import build from "../../../build_number.json"
 import pkg from "../../../package.json"
 import { appState } from "../../models/app-state"
-import { wrapSerialization } from "../../models/shared/shared-data-utils"
+import { serializeDocument } from "../../models/document/serialize-document"
 import { HamburgerIcon } from "./hamburger-icon"
 
 import "./menu-bar.scss"
@@ -46,7 +46,7 @@ function download(path: string, filename: string) {
 
 function handleExportDocument() {
   // Convert JSON to string
-  const data = wrapSerialization(appState.document, () => JSON.stringify(appState.document))
+  const data = serializeDocument(appState.document, () => JSON.stringify(appState.document))
 
   // Create a Blob object
   const blob = new Blob([data], { type: 'application/json' })

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -25,7 +25,7 @@ describe("createCodapDocument", () => {
     expect(doc.key).toBe("test-1")
     expect(doc.type).toBe("CODAP")
     expect(omitUndefined(getSnapshot(doc.content!))).toEqual({
-      rowMap: { "test-3": { id: "test-3", type: "free", order: [], tiles: {} } },
+      rowMap: { "test-3": { id: "test-3", type: "free", savedOrder: [], tiles: {} } },
       rowOrder: ["test-3"],
       sharedModelMap: {
         "test-2": { sharedModel: { id: "test-2", type: "GlobalValueManager", globals: {} }, tiles: [] }
@@ -70,7 +70,7 @@ describe("createCodapDocument", () => {
 
     // the resulting document content contains the contents of the DataSet
     expect(snapContent).toEqual({
-      rowMap: { "test-3": { id: "test-3", type: "free", order: [], tiles: {} } },
+      rowMap: { "test-3": { id: "test-3", type: "free", savedOrder: [], tiles: {} } },
       rowOrder: ["test-3"],
       sharedModelMap: {
         "test-2": {

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -12,7 +12,7 @@ import { getPositionOfNewComponent } from "../../utilities/view-utils"
 import { DataSet, IDataSet, toCanonical } from "../data/data-set"
 import { gDataBroker } from "../data/data-broker"
 import { applyUndoableAction } from "../history/apply-undoable-action"
-import { linkTileToDataSet } from "../shared/shared-data-utils"
+import { getSharedDataSets, linkTileToDataSet } from "../shared/shared-data-utils"
 import t from "../../utilities/translation/translate"
 
 /**
@@ -44,6 +44,22 @@ export interface IImportDataSetOptions {
 export const DocumentContentModel = BaseDocumentContentModel
   .named("DocumentContent")
   .actions(self => ({
+    prepareSnapshot() {
+      // prepare each row for serialization
+      self.rowMap.forEach(row => row.prepareSnapshot())
+
+      // prepare each data set for serialization
+      const sharedDataSets = getSharedDataSets(self)
+      sharedDataSets.forEach(model => model.dataSet.prepareSnapshot())
+    },
+    completeSnapshot() {
+      // complete serialization for each data set
+      const sharedDataSets = getSharedDataSets(self)
+      sharedDataSets.forEach(model => model.dataSet.completeSnapshot())
+
+      // complete serialization for each row
+      self.rowMap.forEach(row => row.completeSnapshot())
+    },
     createDefaultTileOfType(tileType: string) {
       const env = getTileEnvironment(self)
       const info = getTileContentInfo(tileType)

--- a/v3/src/models/document/document.ts
+++ b/v3/src/models/document/document.ts
@@ -71,6 +71,12 @@ export const DocumentModel = Tree.named("Document")
       // Destroying it will probably also free up memory
       addDisposer(self, () => destroy(manager))
     },
+    prepareSnapshot() {
+      self.content?.prepareSnapshot()
+    },
+    completeSnapshot() {
+      self.content?.completeSnapshot()
+    },
     undoLastAction() {
       if (self.canUndo) {
         withoutUndo()

--- a/v3/src/models/document/free-tile-row.test.ts
+++ b/v3/src/models/document/free-tile-row.test.ts
@@ -213,6 +213,5 @@ describe("FreeTileRow", () => {
     expect(isFreeTileInRowOptions({ x: 10 })).toBe(false)
     expect(isFreeTileInRowOptions({ y: 10 })).toBe(false)
     expect(isFreeTileInRowOptions({ x: 10, y: 10 })).toBe(true)
-
   })
 })

--- a/v3/src/models/document/free-tile-row.test.ts
+++ b/v3/src/models/document/free-tile-row.test.ts
@@ -1,14 +1,50 @@
-import { onPatch } from "mobx-state-tree"
-import { FreeTileRow } from "./free-tile-row"
+import { getSnapshot, onPatch } from "mobx-state-tree"
+import { FreeTileLayout, FreeTileRow, isFreeTileInRowOptions, isFreeTileRow } from "./free-tile-row"
 
 describe("FreeTileLayout", () => {
-  it("adds/removes rows", () => {
+  it("works as expected", () => {
+    const layout = FreeTileLayout.create({ tileId: "aTileId", x: 0, y: 0 })
+    expect(layout.position).toEqual({ x: 0, y: 0 })
+    expect(layout.size).toEqual({})
+    expect(layout.isMinimized).toBeUndefined()
+    layout.setPosition(10, 10)
+    expect(layout.position).toEqual({ x: 10, y: 10 })
+    layout.setSize(50, 50)
+    expect(layout.size).toEqual({ width: 50, height: 50 })
+    layout.setMinimized(true)
+    expect(layout.isMinimized).toBe(true)
+    layout.setMinimized(false)
+    expect(layout.isMinimized).toBeUndefined()
+  })
+})
+
+describe("FreeTileRow", () => {
+  it("is created in default state", () => {
     const row = FreeTileRow.create()
     expect(row.tiles.size).toBe(0)
+    expect(row.acceptDefaultInsert).toBe(true)
+    expect(row.removeWhenEmpty).toBe(false)
     expect(row.last).toBe("")
+    expect(row.tileCount).toBe(0)
+    expect(row.hasTile("foo")).toBe(false)
+
+    expect(isFreeTileRow(undefined)).toBe(false)
+    expect(isFreeTileRow(row)).toBe(true)
+
+    // adds tiles with default properties
+    row.insertTile("tile-1")
+    expect(row.getNode("tile-1")!.position).toEqual({ x: 50, y: 50 })
+    expect(row.getNode("tile-1")!.size).toEqual({})
+  })
+
+  it("adds/removes rows", () => {
+    const row = FreeTileRow.create()
 
     row.insertTile("tile-1", { x: 0, y: 0, width: 100, height: 100 })
     expect(row.tiles.size).toBe(1)
+    expect(row.tileCount).toBe(1)
+    expect(row.hasTile("tile-1")).toBe(true)
+    expect(row.getNode("tile-1")).toBeDefined()
     expect(row.tiles.get("tile-1")?.tileId).toBe("tile-1")
     expect(row.last).toBe("tile-1")
     expect(row.tileIds).toEqual(["tile-1"])
@@ -91,53 +127,92 @@ describe("FreeTileLayout", () => {
     reverses = []
     row.insertTile("tile-3", { x: 100, y: 100, width: 100, height: 100 })
     expect(patches).toEqual([
-      `{"op":"add","path":"/tiles/tile-3","value":{"tileId":"tile-3","x":100,"y":100,"width":100,"height":100}}`,
-      `{"op":"add","path":"/order/2","value":"tile-3"}`
+      `{"op":"add","path":"/tiles/tile-3","value":{"tileId":"tile-3","x":100,"y":100,"width":100,"height":100}}`
     ])
     expect(reverses).toEqual([
-      `{"op":"remove","path":"/tiles/tile-3"}`,
-      `{"op":"remove","path":"/order/2"}`
+      `{"op":"remove","path":"/tiles/tile-3"}`
     ])
 
     // move from middle to last (top)
     patches = []
     reverses = []
     row.moveTileToTop("tile-2")
-    expect(patches).toEqual([
-      `{"op":"remove","path":"/order/1"}`,
-      `{"op":"add","path":"/order/2","value":"tile-2"}`
-    ])
-    expect(reverses).toEqual([
-      `{"op":"add","path":"/order/1","value":"tile-2"}`,
-      `{"op":"remove","path":"/order/2"}`
-    ])
+    expect(patches).toEqual([])
+    expect(reverses).toEqual([])
 
     // move from beginning to last (top)
     patches = []
     reverses = []
     row.moveTileToTop("tile-1")
-    expect(patches).toEqual([
-      `{"op":"remove","path":"/order/0"}`,
-      `{"op":"add","path":"/order/2","value":"tile-1"}`
-    ])
-    expect(reverses).toEqual([
-      `{"op":"add","path":"/order/0","value":"tile-1"}`,
-      `{"op":"remove","path":"/order/2"}`
-    ])
+    expect(patches).toEqual([])
+    expect(reverses).toEqual([])
 
     // remove first tile
     patches = []
     reverses = []
     row.removeTile("tile-3")
     expect(patches).toEqual([
-      `{"op":"remove","path":"/order/0"}`,
       `{"op":"remove","path":"/tiles/tile-3"}`
     ])
     expect(reverses).toEqual([
-      `{"op":"add","path":"/order/0","value":"tile-3"}`,
       `{"op":"add","path":"/tiles/tile-3","value":{"tileId":"tile-3","x":100,"y":100,"width":100,"height":100}}`
     ])
 
     disposer()
+  })
+
+  it("preprocessSnapshot supports legacy and current formats", () => {
+    const legacyRow = FreeTileRow.create({
+      tiles: {
+        "tile-1": { tileId: "tile-1", x: 0, y: 0, width: 100, height: 100 }
+      },
+      order: ["tile-1"]
+    })
+    expect(legacyRow.order).toEqual(["tile-1"])
+
+    const modernRow = FreeTileRow.create({
+      tiles: {
+        "tile-1": { tileId: "tile-1", x: 0, y: 0, width: 100, height: 100 }
+      },
+      savedOrder: ["tile-1"]
+    })
+    expect(modernRow.order).toEqual(["tile-1"])
+  })
+
+  it("serializes correctly when prepareSnapshot() is called", () => {
+    const row = FreeTileRow.create()
+    row.insertTile("tile-1", { x: 0, y: 0, width: 100, height: 100 })
+    row.insertTile("tile-2", { x: 50, y: 50, width: 100, height: 100 })
+
+    // without prepareSnapshot(), savedOrder is empty
+    expect(getSnapshot(row)).toEqual({
+      id: row.id,
+      type: "free",
+      tiles: {
+        "tile-1": { tileId: "tile-1", x: 0, y: 0, width: 100, height: 100 },
+        "tile-2": { tileId: "tile-2", x: 50, y: 50, width: 100, height: 100 }
+      },
+      savedOrder: []
+    })
+
+    // after prepareSnapshot(), savedOrder is correct
+    row.prepareSnapshot()
+    expect(getSnapshot(row)).toEqual({
+      id: row.id,
+      type: "free",
+      tiles: {
+        "tile-1": { tileId: "tile-1", x: 0, y: 0, width: 100, height: 100 },
+        "tile-2": { tileId: "tile-2", x: 50, y: 50, width: 100, height: 100 }
+      },
+      savedOrder: ["tile-1", "tile-2"]
+    })
+  })
+
+  it("isFreeTileInRowOptions works as expected", () => {
+    expect(isFreeTileInRowOptions(undefined)).toBe(false)
+    expect(isFreeTileInRowOptions({ x: 10 })).toBe(false)
+    expect(isFreeTileInRowOptions({ y: 10 })).toBe(false)
+    expect(isFreeTileInRowOptions({ x: 10, y: 10 })).toBe(true)
+
   })
 })

--- a/v3/src/models/document/free-tile-row.ts
+++ b/v3/src/models/document/free-tile-row.ts
@@ -57,7 +57,7 @@ export interface IFreeTileInRowOptions extends ITileInRowOptions {
   height?: number
 }
 export const isFreeTileInRowOptions = (options?: ITileInRowOptions): options is IFreeTileInRowOptions =>
-              (options as any)?.x != null && (options as any).y != null
+              !!options && ("x" in options && options.x != null) && ("y" in options && options.y != null)
 
 /*
   Tiles are represented as a map of layouts and an array of tile ids representing the order.

--- a/v3/src/models/document/free-tile-row.ts
+++ b/v3/src/models/document/free-tile-row.ts
@@ -1,4 +1,5 @@
-import { Instance, SnapshotIn, types } from "mobx-state-tree"
+import { observable } from "mobx"
+import { Instance, SnapshotIn, addDisposer, onPatch, types } from "mobx-state-tree"
 import { ITileInRowOptions, ITileRowModel, TileRowModel } from "./tile-row"
 import { withoutUndo } from "../history/without-undo"
 import { withUndoRedoStrings } from "../history/codap-undo-types"
@@ -56,7 +57,7 @@ export interface IFreeTileInRowOptions extends ITileInRowOptions {
   height?: number
 }
 export const isFreeTileInRowOptions = (options?: ITileInRowOptions): options is IFreeTileInRowOptions =>
-              (options as any)?.x != null && (options as any)?.y != null
+              (options as any)?.x != null && (options as any).y != null
 
 /*
   Tiles are represented as a map of layouts and an array of tile ids representing the order.
@@ -67,8 +68,15 @@ export const FreeTileRow = TileRowModel
   .props({
     type: types.optional(types.literal("free"), "free"),
     tiles: types.map(FreeTileLayout), // tile id => layout
-    order: types.array(types.string)  // tile ids ordered from back to front
+    savedOrder: types.array(types.string)  // tile ids ordered from back to front
   })
+  .preProcessSnapshot((snap: any) => {
+    const { order, ...others } = snap
+    return order ? { savedOrder: order, ...others } : snap
+  })
+  .volatile(self => ({
+    order: observable.array<string>()
+  }))
   .views(self => ({
     get acceptDefaultInsert() {
       return true
@@ -97,16 +105,37 @@ export const FreeTileRow = TileRowModel
     }
   }))
   .actions(self => ({
+    afterCreate() {
+      // initialize volatile order from savedOrder on creation
+      self.order.replace([...self.savedOrder])
+
+      addDisposer(self, onPatch(self, ({ op, path }) => {
+        // update order whenever tiles are added/removed
+        if (op === "add" || op === "remove") {
+          const match = /^\/tiles\/(.+)$/.exec(path)
+          const tileId = match?.[1]
+          if (tileId) {
+            // newly added tiles should be front-most
+            if (op === "add") {
+              self.order.push(tileId)
+            }
+            // removed tiles should be removed from order
+            else {
+              self.order.remove(tileId)
+            }
+          }
+        }
+      }))
+    },
+    prepareSnapshot() {
+      withoutUndo({ suppressWarning: true })
+      self.savedOrder.replace(self.order)
+    },
     insertTile(tileId: string, options?: ITileInRowOptions) {
       const { x = 50, y = 50, width = undefined, height = undefined } = isFreeTileInRowOptions(options) ? options : {}
       self.tiles.set(tileId, { tileId, x, y, width, height })
-      self.order.push(tileId)
     },
     removeTile(tileId: string) {
-      const index = self.order.findIndex(id => id === tileId)
-      if (index >= 0) {
-        self.order.splice(index, 1)
-      }
       self.tiles.delete(tileId)
     },
     moveTileToTop(tileId: string) {

--- a/v3/src/models/document/serialize-document.ts
+++ b/v3/src/models/document/serialize-document.ts
@@ -1,0 +1,13 @@
+import { IDocumentModel } from "./document"
+
+export function serializeDocument<T>(document: IDocumentModel, serializeFn: () => T) {
+  try {
+    document.prepareSnapshot()
+
+    // perform the serialization of the prepared document
+    return serializeFn()
+  }
+  finally {
+    document.completeSnapshot()
+  }
+}

--- a/v3/src/models/document/tile-row.ts
+++ b/v3/src/models/document/tile-row.ts
@@ -50,6 +50,12 @@ export const TileRowModel = types
     }
   }))
   .actions(self => ({
+    prepareSnapshot() {
+      // derived models may override
+    },
+    completeSnapshot() {
+      // derived models may override
+    },
     // undefined height == default to content height
     setRowHeight(height?: number) {
       self.height = height

--- a/v3/src/models/history/tree-types.ts
+++ b/v3/src/models/history/tree-types.ts
@@ -50,6 +50,10 @@ export function isChildOfUndoRedo(actionCall?: IActionContext) {
   return false
 }
 
+export function isUndoingOrRedoing() {
+  return isChildOfUndoRedo(getRunningActionContext())
+}
+
 export function getActionModelName(call: IActionTrackingMiddleware3Call<CallEnv>) {
   return getType(call.actionCall.context).name
 }

--- a/v3/src/models/shared/shared-data-utils.test.ts
+++ b/v3/src/models/shared/shared-data-utils.test.ts
@@ -1,4 +1,3 @@
-import { getSnapshot } from "mobx-state-tree"
 import { createCodapDocument } from "../codap/create-codap-document"
 import { IDocumentModel } from "../document/document"
 import { TileContentModel } from "../tiles/tile-content"
@@ -9,7 +8,7 @@ import { SharedCaseMetadata } from "./shared-case-metadata"
 import { SharedDataSet } from "./shared-data-set"
 import {
   getDataSetFromId, getTileCaseMetadata, getTileDataSet, getTileSharedModels, isTileLinkedToDataSet,
-  linkTileToDataSet, unlinkTileFromDataSets, wrapSerialization
+  linkTileToDataSet, unlinkTileFromDataSets
 } from "./shared-data-utils"
 import "./shared-data-set-registration"
 import "./shared-case-metadata-registration"
@@ -112,11 +111,5 @@ describe("SharedDataUtils", () => {
     expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(true)
     expect(getTileDataSet(tile.content)).toBe(sharedDataSet2.dataSet)
     expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata2)
-  })
-
-  it("wrapSerialization calls the serialization callback", () => {
-    const serialize = jest.fn(() => getSnapshot(document))
-    wrapSerialization(document, () => serialize())
-    expect(serialize).toHaveBeenCalledTimes(1)
   })
 })

--- a/v3/src/models/shared/shared-data-utils.ts
+++ b/v3/src/models/shared/shared-data-utils.ts
@@ -77,18 +77,3 @@ export function linkTileToDataSet(tile: ITileContentModel, dataSet: IDataSet) {
     sharedCaseMetadata && sharedModelManager.addTileSharedModel(tile, sharedCaseMetadata)
   }
 }
-
-export function wrapSerialization<T>(node: IAnyStateTreeNode, serializeFn: () => T) {
-  const sharedDataSets = getSharedDataSets(node)
-  try {
-    // prepare each data set for serialization
-    sharedDataSets.forEach(model => model.dataSet.prepareSnapshot())
-
-    // perform the serialization with the prepared data sets
-    return serializeFn()
-  }
-  finally {
-    // complete the serialization process for each data set
-    sharedDataSets.forEach(model => model.dataSet.completeSnapshot())
-  }
-}


### PR DESCRIPTION
[[#186075314]](https://www.pivotaltracker.com/story/show/186075314)

@tejal-shah noted that sometimes redoing the removal of a tile would remove two tiles rather than one. This could occur when the `tiles` map and the `order` array got out of sync. The fix here is to move the `order` array to volatile storage so that the undo history doesn't attempt to apply any patches to it (we don't want simple tile ordering changes to be undoable anyway). We do want the tile order to be saved with the document, however, so that when users return to a saved document the tile order is the way they left it. To accomplish this we make use of the same `prepareSnapshot()`/`completeSnapshot()` mechanism we've used elsewhere, but now we apply it document-wide rather than just to `DataSet`s.