### PR TITLE
fix: redo .csv import

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -11,6 +11,7 @@ import {gDataBroker} from "../models/data/data-broker"
 import {IDataSet} from "../models/data/data-set"
 import { IDocumentModelSnapshot } from "../models/document/document"
 import { IImportDataSetOptions } from "../models/document/document-content"
+import { ISharedDataSet } from "../models/shared/shared-data-set"
 import { getSharedModelManager } from "../models/tiles/tile-environment"
 import { DocumentContext } from "../hooks/use-document-context"
 import {useDropHandler} from "../hooks/use-drop-handler"
@@ -31,9 +32,12 @@ export const App = observer(function App() {
 
   const handleImportDataSet = useCallback(
     function handleImportDataSet(data: IDataSet, options?: IImportDataSetOptions) {
+      let sharedData: ISharedDataSet | undefined
       appState.document.content?.applyUndoableAction(() => {
-        appState.document.content?.importDataSet(data, options)
+        sharedData = appState.document.content?.importDataSet(data, options)
       }, "V3.Undo.import.data", "V3.Redo.import.data")
+      // return to "normal" after import process is complete
+      sharedData?.dataSet.completeSnapshot()
     }, [])
 
   const handleImportV3Document = useCallback((document: IDocumentModelSnapshot) => {

--- a/v3/src/hooks/use-drop-handler.ts
+++ b/v3/src/hooks/use-drop-handler.ts
@@ -25,7 +25,7 @@ function importCodapV3Document(file: File | null, onComplete: (document: IDocume
   file && reader.readAsText(file)
 }
 
-interface IDropHandler {
+export interface IDropHandler {
   selector: string
   onImportDataSet?: (data: IDataSet) => void
   onImportV2Document?: (document: CodapV2Document) => void

--- a/v3/src/models/data/data-broker.ts
+++ b/v3/src/models/data/data-broker.ts
@@ -82,6 +82,8 @@ export class DataBroker {
   addDataSet(ds: IDataSet, providerId?: string) {
     const sharedModel = SharedDataSet.create({providerId})
     sharedModel.setDataSet(ds)
+    // so values are captured in undo/redo patches
+    ds.prepareSnapshot()
     this.sharedModelManager?.addSharedModel(sharedModel)
 
     const caseMetadata = SharedCaseMetadata.create()

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -59,6 +59,7 @@ import {
 } from "./data-set-undo"
 import { applyUndoableAction } from "../history/apply-undoable-action"
 import { withCustomUndoRedo } from "../history/with-custom-undo-redo"
+import { withoutUndo } from "../history/without-undo"
 import { typedId } from "../../utilities/js-utils"
 import { prf } from "../../utilities/profiler"
 
@@ -790,11 +791,13 @@ export const DataSet = types.model("DataSet", {
       // should be called before retrieving snapshot (pre-serialization)
       prepareSnapshot() {
         // move volatile data into serializable properties
+        withoutUndo({ suppressWarning: true })
         self.attributes.forEach(attr => attr.prepareSnapshot())
       },
       // should be called after retrieving snapshot (post-serialization)
       completeSnapshot() {
         // move data back into volatile storage for efficiency
+        withoutUndo({ suppressWarning: true })
         self.attributes.forEach(attr => attr.completeSnapshot())
       },
       setName(name: string) {

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -142,6 +142,8 @@ export const DocumentContentModel = BaseDocumentContentModel
       }
       // Add dataset to the formula manager
       getFormulaManager(self)?.addDataSet(data)
+
+      return sharedData
     }
   }))
   // performs the specified action so that response actions are included and undo/redo strings assigned


### PR DESCRIPTION
The issue was that the data values weren't being captured in the redo patch because of our use of volatile storage for data values. The fix is to make sure `prepareSnapshot()` is called before the patch is created and `completeSnapshot()` is called once the action is complete. I also added a jest test to increase the patch coverage. The project coverage reports a drop in coverage of some unrelated files that shouldn't be affected at all, so I don't know what's happening there.