### PR TITLE
Formula observers cleanup/refactor, bug fixes, and unit tests

### DIFF
--- a/v3/src/models/data/attribute-formula-adapter.ts
+++ b/v3/src/models/data/attribute-formula-adapter.ts
@@ -5,13 +5,14 @@ import {
   formulaError, getFormulaChildMostAggregateCollectionIndex, getFormulaDependencies, getIncorrectChildAttrReference,
   getIncorrectParentAttrReference
 } from "./formula-utils"
-import { NO_PARENT_KEY, FValue, ILocalAttributeDependency, ILookupDependency } from "./formula-types"
+import { NO_PARENT_KEY, FValue, ILocalAttributeDependency, ILookupDependency, CaseList } from "./formula-types"
 import { math } from "./formula-fn-registry"
 import { IFormula } from "./formula"
 import { DEBUG_FORMULAS } from "../../lib/debug"
 import type {
   IFormulaAdapterApi, IFormulaContext, IFormulaExtraMetadata, IFormulaManagerAdapter
 } from "./formula-manager"
+import { observeDatasetHierarchyChanges } from "./formula-observers"
 
 const ATTRIBUTE_FORMULA_ADAPTER = "AttributeFormulaAdapter"
 
@@ -214,9 +215,10 @@ export class AttributeFormulaAdapter implements IFormulaManagerAdapter {
     })))
   }
 
-  setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: any) {
-    // TODO: Move dataset hierarchy observing here
-    return () => {}
+  setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IAttrFormulaExtraMetadata) {
+    return observeDatasetHierarchyChanges(this.api.getDatasets(), (casesToRecalculate?: CaseList) => {
+      this.recalculateFormula(formulaContext, extraMetadata, casesToRecalculate)
+    })
   }
 
   getFormulaError(formulaContext: IFormulaContext, extraMetadata: IAttrFormulaExtraMetadata) {

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -235,10 +235,12 @@ export class FormulaManager {
       dataSet: {}
     }
 
+    const nonEmptyName = (name: string) => name || "_empty_symbol_name_"
+
     const mapAttributeNames = (dataSet: IDataSet, localPrefix: string, _useSafeSymbolNames: boolean) => {
       const result: Record<string, string> = {}
       dataSet.attributes.forEach(attr => {
-        const key = _useSafeSymbolNames ? safeSymbolName(attr.name) : attr.name
+        const key = nonEmptyName(_useSafeSymbolNames ? safeSymbolName(attr.name) : attr.name)
         result[key] = `${CANONICAL_NAME}${localPrefix}${attr.id}`
       })
       return result
@@ -252,13 +254,13 @@ export class FormulaManager {
     }
 
     this.globalValueManager?.globals.forEach(global => {
-      const key = useSafeSymbolNames ? safeSymbolName(global.name) : global.name
+      const key = nonEmptyName(useSafeSymbolNames ? safeSymbolName(global.name) : global.name)
       displayNameMap.localNames[key] = `${CANONICAL_NAME}${GLOBAL_VALUE}${global.id}`
     })
 
     this.dataSets.forEach(dataSet => {
       if (dataSet.name) {
-        displayNameMap.dataSet[dataSet.name] = {
+        displayNameMap.dataSet[nonEmptyName(dataSet.name)] = {
           id: `${CANONICAL_NAME}${dataSet.id}`,
           // No prefix is necessary for external attributes. They always need to be resolved manually by custom
           // mathjs functions (like "lookupByIndex"). Also, it's never necessary to use safe names, as these names

--- a/v3/src/models/data/formula-manager.ts
+++ b/v3/src/models/data/formula-manager.ts
@@ -1,21 +1,20 @@
 import { comparer, makeObservable, observable, reaction } from "mobx"
 import { isAlive } from "mobx-state-tree"
 import { ICase } from "./data-set-types"
-import { onAnyAction } from "../../utilities/mst-utils"
 import {
-  getFormulaDependencies, formulaError, safeSymbolName, reverseDisplayNameMap, getLocalAttrCasesToRecalculate,
-  getLookupCasesToRecalculate
+  getFormulaDependencies, formulaError, safeSymbolName, reverseDisplayNameMap
 } from "./formula-utils"
 import {
-  DisplayNameMap, IFormulaDependency, GLOBAL_VALUE, LOCAL_ATTR, ILocalAttributeDependency, IGlobalValueDependency,
-  ILookupDependency, CASE_INDEX_FAKE_ATTR_ID, CANONICAL_NAME
+  DisplayNameMap, GLOBAL_VALUE, LOCAL_ATTR, CASE_INDEX_FAKE_ATTR_ID, CANONICAL_NAME, CaseList
 } from "./formula-types"
 import { IDataSet } from "./data-set"
-import { AddCasesAction, SetCaseValuesAction } from "./data-set-actions"
 import { IGlobalValueManager } from "../global/global-value-manager"
 import { IFormula } from "./formula"
 import { AttributeFormulaAdapter } from "./attribute-formula-adapter"
 import { PlottedValueFormulaAdapter } from "./plotted-value-formula-adapter"
+import {
+  observeGlobalValues, observeLocalAttributes, observeLookupDependencies, observeSymbolNameChanges
+} from "./formula-observers"
 
 export interface IFormulaMetadata {
   formula: IFormula
@@ -38,10 +37,6 @@ export interface IFormulaContext {
   dataSet: IDataSet
 }
 
-export interface IDataSetMetadata {
-  dispose: () => void
-}
-
 export interface IFormulaAdapterApi {
   getDatasets: () => Map<string, IDataSet>
   getGlobalValueManager: () => IGlobalValueManager | undefined
@@ -53,8 +48,8 @@ export interface IFormulaManagerAdapter {
   type: string
   getAllFormulas: () => ({ formula: IFormula, extraMetadata?: any })[]
   recalculateFormula: (formulaContext: IFormulaContext, extraMetadata: any,
-    casesToRecalculateDesc?: ICase[] | "ALL_CASES") => void
-  setupFormulaObservers: (formulaContext: IFormulaContext, extraMetadata: any, recalculate: () => void) => () => void
+    casesToRecalculateDesc?: CaseList) => void
+  setupFormulaObservers: (formulaContext: IFormulaContext, extraMetadata: any) => () => void
   getFormulaError: (formulaContext: IFormulaContext, extraMetadata: any) => undefined | string
   setFormulaError: (formulaContext: IFormulaContext, extraMetadata: any, errorMsg: string) => void
 }
@@ -64,7 +59,6 @@ export class FormulaManager {
   extraMetadata = new Map<string, IFormulaExtraMetadata>()
 
   @observable.shallow dataSets = new Map<string, IDataSet>()
-  dataSetMetadata = new Map<string, IDataSetMetadata>()
   globalValueManager?: IGlobalValueManager
 
   adapters: IFormulaManagerAdapter[] = [
@@ -87,17 +81,10 @@ export class FormulaManager {
   }
 
   addDataSet(dataSet: IDataSet) {
-    this.removeDataSet(dataSet.id)
-    this.observeDatasetChanges(dataSet)
     this.dataSets.set(dataSet.id, dataSet)
   }
 
   removeDataSet(dataSetId: string) {
-    const metadata = this.dataSetMetadata.get(dataSetId)
-    if (metadata) {
-      metadata.dispose()
-      this.dataSetMetadata.delete(dataSetId)
-    }
     this.dataSets.delete(dataSetId)
   }
 
@@ -136,12 +123,6 @@ export class FormulaManager {
       throw new Error(`Dataset ${extraMetadata.dataSetId} not available`)
     }
     return { dataSet, ...formulaMetadata }
-  }
-
-  recalculateAllFormulas() {
-    this.formulaMetadata.forEach((metadata, formulaId) => {
-      this.recalculateFormula(formulaId)
-    })
   }
 
   recalculateFormula(formulaId: string, casesToRecalculate?: ICase[] | "ALL_CASES") {
@@ -300,167 +281,44 @@ export class FormulaManager {
     const formulaMetadata = this.getFormulaMetadata(formulaId)
     const extraMetadata = this.getExtraMetadata(formulaId)
     const { formula, adapter } = formulaMetadata
+    const { dataSet } = formulaContext
     if (formula.empty) {
       return
     }
-    const formulaDependencies = getFormulaDependencies(formula.canonical, extraMetadata.attributeId)
-    const disposeLocalAttributeObserver = this.observeLocalAttributes(formulaId, formulaDependencies)
-    const disposeGlobalValueObservers = this.observeGlobalValues(formulaId, formulaDependencies)
-    const disposeLookupObservers = this.observeLookup(formulaId, formulaDependencies)
-    const disposeAdapterObservers = adapter.setupFormulaObservers(formulaContext, extraMetadata, () => {
-      this.recalculateFormula(formula.id)
-    })
+    const dependencies = getFormulaDependencies(formula.canonical, extraMetadata.attributeId)
+
+    const recalculate = (casesToRecalculate: CaseList) => {
+      this.recalculateFormula(formulaId, casesToRecalculate)
+    }
+    const updateDisplay = () => {
+      formula.updateDisplayFormula()
+      // Note that when attribute is removed or renamed, this can also affect the formula's canonical form.
+      // 1. Attribute is removed - its ID needs to be removed from the canonical form and the formula should be
+      //    recalculated (usually to show the error about undefined symbol).
+      // 2. Attribute is renamed - if the previous display form had undefined symbols, they might now be resolved
+      //    to the renamed attribute. This means that the canonical form needs to be updated.
+      const oldCanonical = formula.canonical
+      formula.updateCanonicalFormula()
+      if (oldCanonical !== formula.canonical) {
+        this.recalculateFormula(formula.id)
+      }
+    }
+
+    const disposeLocalAttributeObservers = observeLocalAttributes(dependencies, dataSet, recalculate)
+    const disposeGlobalValueObservers = observeGlobalValues(dependencies, this.globalValueManager, recalculate)
+    const disposeLookupObservers = observeLookupDependencies(dependencies, this.dataSets, recalculate)
+    const disposeNameChangeObservers = observeSymbolNameChanges(this.dataSets, this.globalValueManager, updateDisplay)
+    const disposeAdapterSpecificObservers = adapter.setupFormulaObservers(formulaContext, extraMetadata)
 
     this.formulaMetadata.set(formulaId, {
       ...formulaMetadata,
       dispose: () => {
-        disposeLocalAttributeObserver()
-        disposeGlobalValueObservers.forEach(disposeGlobalValObserver => disposeGlobalValObserver())
-        disposeLookupObservers.forEach(disposeLookupObserver => disposeLookupObserver())
-        disposeAdapterObservers()
+        disposeLocalAttributeObservers()
+        disposeGlobalValueObservers()
+        disposeLookupObservers()
+        disposeNameChangeObservers()
+        disposeAdapterSpecificObservers()
       },
     })
-  }
-
-  observeDatasetChanges(dataSet: IDataSet) {
-    // When any collection is added or removed, or attribute is moved between collections,
-    // we need to recalculate all formulas.
-    const disposeAttrCollectionReaction = reaction(
-      () => Object.fromEntries(dataSet.collections.map(c => [ c.id, c.attributes.map(a => a?.id) ])),
-      () => {
-        this.unregisterDeletedFormulas()
-        this.recalculateAllFormulas()
-      },
-      {
-        equals: comparer.structural,
-        name: "FormulaManager.observeDatasetChanges.reaction [collections]"
-      }
-    )
-    // When any attribute name is updated, we need to update display formulas. We could make this more granular,
-    // and observe only dependant attributes, but it doesn't seem necessary for now.
-    const disposeAttrNameReaction = reaction(
-      () => dataSet.attrNameMap,
-      () => {
-        this.unregisterDeletedFormulas()
-        this.formulaMetadata.forEach(({ formula }) => {
-          formula.updateDisplayFormula()
-          // Note that when attribute is removed or renamed, this can also affect the formula's canonical form.
-          // 1. Attribute is removed - its ID needs to be removed from the canonical form and the formula should be
-          //    recalculated (usually to show the error about undefined symbol).
-          // 2. Attribute is renamed - if the previous display form had undefined symbols, they might now be resolved
-          //    to the renamed attribute. This means that the canonical form needs to be updated.
-          const oldCanonical = formula.canonical
-          formula.updateCanonicalFormula()
-          if (oldCanonical !== formula.canonical) {
-            this.recalculateFormula(formula.id)
-          }
-        })
-      },
-      {
-        equals: comparer.structural,
-        name: "FormulaManager.observeDatasetChanges.reaction [attrNameMap]"
-      }
-    )
-    const dispose = () => {
-      disposeAttrCollectionReaction()
-      disposeAttrNameReaction()
-    }
-    this.dataSetMetadata.set(dataSet.id, { dispose })
-  }
-
-  observeLocalAttributes(formulaId: string, formulaDependencies: IFormulaDependency[]) {
-    const { dataSet } = this.getFormulaContext(formulaId)
-
-    const localAttrDependencies =
-      formulaDependencies.filter(d => d.type === "localAttribute") as ILocalAttributeDependency[]
-
-    // Observe local dataset attribute changes
-    const disposeDatasetObserver = onAnyAction(dataSet, mstAction => {
-      let casesToRecalculate: ICase[] | "ALL_CASES" = []
-      switch (mstAction.name) {
-        case "addCases": {
-          // recalculate all new cases
-          casesToRecalculate = (mstAction as AddCasesAction).args[0] || []
-          break
-        }
-        case "setCaseValues": {
-          // recalculate cases with dependency attribute updated
-          const cases = (mstAction as SetCaseValuesAction).args[0] || []
-          casesToRecalculate = getLocalAttrCasesToRecalculate(cases, localAttrDependencies)
-          break
-        }
-        default:
-          break
-      }
-
-      if (casesToRecalculate.length > 0) {
-        this.recalculateFormula(formulaId, casesToRecalculate)
-      }
-    })
-
-    return disposeDatasetObserver
-  }
-
-  observeGlobalValues(formulaId: string, formulaDependencies: IFormulaDependency[]) {
-    const globalValueDependencies =
-      formulaDependencies.filter(d => d.type === "globalValue") as IGlobalValueDependency[]
-
-    const disposeGlobalValueObservers = globalValueDependencies.map(dependency =>
-      [
-        // Recalculate formula when global value dependency is updated.
-        reaction(
-          () => this.globalValueManager?.getValueById(dependency.globalId)?.value,
-          () => this.recalculateFormula(formulaId),
-          { name: "FormulaManager.observeGlobalValues.reaction [globalValue]" }
-        ),
-        // Update display form of the formula when global value name is updated.
-        reaction(
-          () => this.globalValueManager?.getValueById(dependency.globalId)?.name,
-          () => this.getFormulaContext(formulaId).formula.updateDisplayFormula(),
-          { name: "FormulaManager.observeGlobalValues.reaction [globalValueName]" }
-        ),
-      ]
-    ).flat()
-
-    return disposeGlobalValueObservers
-  }
-
-  observeLookup(formulaId: string, formulaDependencies: IFormulaDependency[]) {
-    const lookupDependencies: ILookupDependency[] =
-      formulaDependencies.filter(d => d.type === "lookup") as ILookupDependency[]
-
-    const disposeLookupObservers = lookupDependencies.map(dependency => {
-      const externalDataSet = this.dataSets.get(dependency.dataSetId)
-      if (!externalDataSet) {
-        throw new Error(`External dataSet with id "${dependency.dataSetId}" not found`)
-      }
-
-      return onAnyAction(externalDataSet, mstAction => {
-        let casesToRecalculate: ICase[] | "ALL_CASES" = []
-        switch (mstAction.name) {
-          // TODO: these rules are very broad, think if there are some ways to optimize and narrow them down.
-          case "addCases": {
-            casesToRecalculate = "ALL_CASES"
-            break
-          }
-          case "removeCases": {
-            casesToRecalculate = "ALL_CASES"
-            break
-          }
-          case "setCaseValues": {
-            // recalculate cases with dependency attribute updated
-            const cases = (mstAction as SetCaseValuesAction).args[0] || []
-            casesToRecalculate = getLookupCasesToRecalculate(cases, dependency)
-            break
-          }
-          default:
-            break
-        }
-
-        this.recalculateFormula(formulaId, casesToRecalculate)
-      })
-    })
-
-    return disposeLookupObservers
   }
 }

--- a/v3/src/models/data/formula-observers.test.ts
+++ b/v3/src/models/data/formula-observers.test.ts
@@ -1,0 +1,233 @@
+import { ICase } from "./data-set-types"
+import {
+  IGlobalValueDependency,
+  ILocalAttributeDependency, ILookupDependency
+} from "./formula-types"
+import {
+  getLocalAttrCasesToRecalculate, getLookupCasesToRecalculate, isAttrDefined, observeDatasetHierarchyChanges,
+  observeGlobalValues, observeLocalAttributes, observeLookupDependencies, observeSymbolNameChanges
+} from "./formula-observers"
+import { DataSet, IDataSet } from "./data-set"
+import { GlobalValueManager } from "../global/global-value-manager"
+import { GlobalValue } from "../global/global-value"
+
+describe("isAttrDefined", () => {
+  const dataSetCase: ICase = { __id__: "1", attr1: 1, attr2: 2 }
+
+  it("returns true if the attribute is defined in the data set case", () => {
+    const attributeId = "attr1"
+    const result = isAttrDefined(dataSetCase, attributeId)
+    expect(result).toBe(true)
+  })
+
+  it("returns false if the attribute is not defined in the data set case", () => {
+    const attributeId = "attr3"
+    const result = isAttrDefined(dataSetCase, attributeId)
+    expect(result).toBe(false)
+  })
+
+  it("returns false if the attribute ID is not provided", () => {
+    const attributeId = undefined
+    const result = isAttrDefined(dataSetCase, attributeId)
+    expect(result).toBe(false)
+  })
+})
+
+describe("getLocalAttrCasesToRecalculate", () => {
+  const cases: ICase[] = [
+    { __id__: "1", attr1: 0, attr2: 1 },
+    { __id__: "2", attr1: 2, attr2: 3 },
+    { __id__: "3", attr1: "" }, // empty string should be considered as value that needs to trigger recalculation
+    { __id__: "4", attr2: 4 },
+  ]
+
+  it("returns 'ALL_CASES' if any case has an attribute that depends on an aggregate attribute", () => {
+    const formulaDependencies: ILocalAttributeDependency[] = [
+      { attrId: "attr1", type: "localAttribute", aggregate: false },
+      { attrId: "attr2", type: "localAttribute", aggregate: true },
+    ]
+    const result = getLocalAttrCasesToRecalculate(cases, formulaDependencies)
+    expect(result).toBe("ALL_CASES")
+  })
+
+  it("returns an array of cases that have an attribute that depends on a regular attribute", () => {
+    const formulaDependencies: ILocalAttributeDependency[] = [
+      { attrId: "attr1", type: "localAttribute", aggregate: false }
+    ]
+    const result = getLocalAttrCasesToRecalculate(cases, formulaDependencies)
+    expect(result).toEqual([cases[0], cases[1], cases[2]])
+  })
+
+  it("returns an empty array if no case has an attribute that depends on a regular attribute", () => {
+    const formulaDependencies: ILocalAttributeDependency[] = [
+      { attrId: "attr3", type: "localAttribute", aggregate: false }
+    ]
+    const result = getLocalAttrCasesToRecalculate(cases, formulaDependencies)
+    expect(result).toEqual([])
+  })
+})
+
+describe("getLookupCasesToRecalculate", () => {
+  const dependency: ILookupDependency = { type: "lookup", dataSetId: "ds1", attrId: "attr1", keyAttrId: "attr2" }
+
+  it("returns 'ALL_CASES' if any case has the lookup attribute or the lookup key attribute", () => {
+    expect(getLookupCasesToRecalculate([{ __id__: "1", attr1: 1 }], dependency)).toBe("ALL_CASES")
+    expect(getLookupCasesToRecalculate([{ __id__: "1", attr2: "" }], dependency)).toBe("ALL_CASES")
+  })
+
+  it("returns an empty array if no case has the lookup attribute or the lookup key attribute", () => {
+    expect(getLookupCasesToRecalculate([{ __id__: "1", attr3: 3 }], dependency)).toEqual([])
+  })
+})
+
+describe("observeLocalAttributes", () => {
+  const dataSet = DataSet.create({ id: "ds1", cases: [] })
+
+  describe("when there's no aggregate dependency", () => {
+    const formulaDependenciesWithoutAggregate: ILocalAttributeDependency[] = [
+      { type: "localAttribute", attrId: "attr1", aggregate: false },
+      { type: "localAttribute", attrId: "attr2", aggregate: false },
+    ]
+
+    it("should call recalculateCallback with newly added cases", () => {
+      const recalculateCallback = jest.fn()
+      const dispose = observeLocalAttributes(formulaDependenciesWithoutAggregate, dataSet, recalculateCallback)
+      const newCases = [{ __id__: "case1" }, { __id__: "case2" }]
+      dataSet.addCases(newCases)
+      expect(recalculateCallback).toHaveBeenCalledWith(newCases)
+
+      dispose()
+      dataSet.addCases(newCases)
+      expect(recalculateCallback).toHaveBeenCalledTimes(1)
+    })
+
+    it("should call recalculateCallback with updated cases", () => {
+      const recalculateCallback = jest.fn()
+      observeLocalAttributes(formulaDependenciesWithoutAggregate, dataSet, recalculateCallback)
+      const caseUpdates = [{ __id__: "case1", attr1: 1 }, { __id__: "case2", attr321: 2 }]
+      dataSet.setCaseValues(caseUpdates)
+      expect(recalculateCallback).toHaveBeenCalledWith([caseUpdates[0]])
+    })
+  })
+
+  describe("when there is aggregate dependency", () => {
+    const formulaDependenciesWithAggregate: ILocalAttributeDependency[] = [
+      { type: "localAttribute", attrId: "attr1", aggregate: false },
+      { type: "localAttribute", attrId: "attr2", aggregate: false },
+      { type: "localAttribute", attrId: "attr2", aggregate: true },
+    ]
+
+    it("should call recalculateCallback with ALL_CASES when new case is added", () => {
+      const recalculateCallback = jest.fn()
+      observeLocalAttributes(formulaDependenciesWithAggregate, dataSet, recalculateCallback)
+      const newCases = [{ __id__: "case1" }, { __id__: "case2" }]
+      dataSet.addCases(newCases)
+      expect(recalculateCallback).toHaveBeenCalledWith("ALL_CASES")
+    })
+
+    it("should call recalculateCallback with updated cases when no aggregate dependency attribute is updated", () => {
+      const recalculateCallback = jest.fn()
+      observeLocalAttributes(formulaDependenciesWithAggregate, dataSet, recalculateCallback)
+      const caseUpdates = [{ __id__: "case1", attr1: 1 }, { __id__: "case2", attr321: 2 }]
+      dataSet.setCaseValues(caseUpdates)
+      expect(recalculateCallback).toHaveBeenCalledWith([caseUpdates[0]])
+    })
+
+    it("should call recalculateCallback with ALL_CASES when aggregate dependency attribute is updated", () => {
+      const recalculateCallback = jest.fn()
+      observeLocalAttributes(formulaDependenciesWithAggregate, dataSet, recalculateCallback)
+      const caseUpdates = [{ __id__: "case1", attr1: 1 }, { __id__: "case2", attr2: 2 }]
+      dataSet.setCaseValues(caseUpdates)
+      expect(recalculateCallback).toHaveBeenCalledWith("ALL_CASES")
+    })
+  })
+})
+
+describe("observeLookupDependencies", () => {
+  it("should call recalculateCallback with ALL_CASES when case is added, removed or updated", () => {
+    const dataSet = DataSet.create({ id: "ds1", cases: [] })
+    const formulaDependencies: ILookupDependency[] = [
+      { type: "lookup", dataSetId: "ds1", attrId: "attr1", keyAttrId: "attr2" },
+    ]
+    const recalculateCallback = jest.fn()
+    const dispose = observeLookupDependencies(formulaDependencies, new Map([["ds1", dataSet]]), recalculateCallback)
+    const newCases = [{ __id__: "case1" }, { __id__: "case2" }]
+    dataSet.addCases(newCases)
+    expect(recalculateCallback).toHaveBeenNthCalledWith(1, "ALL_CASES")
+
+    dataSet.removeCases(["case1"])
+    expect(recalculateCallback).toHaveBeenNthCalledWith(2, "ALL_CASES")
+
+    dataSet.setCaseValues([{ __id__: "case2", attr1: 1 }])
+    expect(recalculateCallback).toHaveBeenNthCalledWith(3, "ALL_CASES")
+
+    dispose()
+    dataSet.addCases(newCases)
+    expect(recalculateCallback).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe("observeGlobalValues", () => {
+  it("should call recalculateCallback with ALL_CASES when global value is updated", () => {
+    const globalValueManager = GlobalValueManager.create()
+    const globalValue = GlobalValue.create({ name: "global1", _value: 0 })
+    globalValueManager.addValue(globalValue)
+    const formulaDependencies: IGlobalValueDependency[] = [{ type: "globalValue", globalId: globalValue.id }]
+    const recalculateCallback = jest.fn()
+    const dispose = observeGlobalValues(formulaDependencies, globalValueManager, recalculateCallback)
+    globalValueManager.getValueByName("global1")?.setValue(1)
+    expect(recalculateCallback).toHaveBeenCalledWith("ALL_CASES")
+
+    dispose()
+    globalValueManager.getValueByName("global1")?.setValue(2)
+    expect(recalculateCallback).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("observeSymbolNameChanges", () => {
+  it("should call nameUpdateCallback when symbol name is changed", () => {
+    const dataSet = DataSet.create({ id: "ds1", cases: [] })
+    dataSet.addAttribute({ id: "attr1", name: "attr1" })
+    const globalValueManager = GlobalValueManager.create()
+    const globalValue = GlobalValue.create({ name: "global1", _value: 0 })
+    globalValueManager.addValue(globalValue)
+    const nameUpdateCallback = jest.fn()
+    const dispose = observeSymbolNameChanges(new Map([["ds1", dataSet]]), globalValueManager, nameUpdateCallback)
+    dataSet.attrFromID("attr1").setName("newName")
+    expect(nameUpdateCallback).toHaveBeenCalledTimes(1)
+    globalValueManager.getValueByName("global1")?.setName("newName")
+    expect(nameUpdateCallback).toHaveBeenCalledTimes(2)
+
+    dispose()
+    dataSet.attrFromID("attr1").setName("newName2")
+    expect(nameUpdateCallback).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("observeDatasetHierarchyChanges", () => {
+  const attributesByCollection = (dataSet: IDataSet) => {
+    const attrs: string[][] = []
+    dataSet.collections.forEach(collection => {
+      attrs.push(collection.attributes.map(attr => attr!.id))
+    })
+    attrs.push(dataSet.ungroupedAttributes.map(attr => attr.id))
+    return attrs
+  }
+  it("should call recalculateCallback with ALL_CASES when attribute is moved between collections", () => {
+    const dataSet = DataSet.create({ id: "ds1", cases: [] })
+    dataSet.addAttribute({ id: "aId", name: "a" })
+    dataSet.addAttribute({ id: "bId", name: "b" })
+    dataSet.addAttribute({ id: "cId", name: "c" })
+
+    const hierarchyChangedCallback = jest.fn()
+    const dispose = observeDatasetHierarchyChanges(new Map([["ds1", dataSet]]), hierarchyChangedCallback)
+    dataSet.moveAttributeToNewCollection("aId")
+    expect(attributesByCollection(dataSet)).toEqual([["aId"], ["bId", "cId"]])
+    expect(hierarchyChangedCallback).toHaveBeenCalledTimes(1)
+
+    dispose()
+    dataSet.moveAttributeToNewCollection("bId")
+    expect(attributesByCollection(dataSet)).toEqual([["aId"], ["bId"], ["cId"]])
+    expect(hierarchyChangedCallback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/v3/src/models/data/formula-observers.ts
+++ b/v3/src/models/data/formula-observers.ts
@@ -1,0 +1,159 @@
+import { comparer, reaction } from "mobx"
+import { onAnyAction } from "../../utilities/mst-utils"
+import { IDataSet } from "./data-set"
+import { AddCasesAction, SetCaseValuesAction } from "./data-set-actions"
+import {
+  CaseList, IFormulaDependency, IGlobalValueDependency, ILocalAttributeDependency, ILookupDependency
+} from "./formula-types"
+import { IGlobalValueManager } from "../global/global-value-manager"
+import { ICase } from "./data-set-types"
+
+export const isAttrDefined = (dataSetCase: ICase, attributeId?: string) =>
+  !!attributeId && Object.prototype.hasOwnProperty.call(dataSetCase, attributeId)
+
+export const getLocalAttrCasesToRecalculate = (cases: ICase[], formulaDependencies: ILocalAttributeDependency[]) => {
+  const regularAttrDeps = formulaDependencies.filter(d => d.type === "localAttribute" && !d.aggregate)
+  const aggregateAttrDeps = formulaDependencies.filter(d => d.type === "localAttribute" && d.aggregate)
+
+  return cases.some(c => aggregateAttrDeps.some(d => isAttrDefined(c, d.attrId)))
+    ? "ALL_CASES"
+    : cases.filter(c => regularAttrDeps.some(d => isAttrDefined(c, d.attrId)))
+}
+
+export const observeLocalAttributes = (formulaDependencies: IFormulaDependency[], localDataSet: IDataSet,
+  recalculateCallback: (casesToRecalculate: CaseList) => void) => {
+  const localAttrDependencies =
+    formulaDependencies.filter(d => d.type === "localAttribute") as ILocalAttributeDependency[]
+
+  const anyAggregateDepPresent = localAttrDependencies.some(d => d.aggregate)
+
+  // Observe local dataset attribute changes
+  const disposeDatasetObserver = onAnyAction(localDataSet, mstAction => {
+    let casesToRecalculate: CaseList = []
+    switch (mstAction.name) {
+      case "addCases": {
+        // Recalculate only new cases when if there's no aggregate dependency. Otherwise, we need to update all the
+        // cases.
+        casesToRecalculate = anyAggregateDepPresent ? "ALL_CASES" : (mstAction as AddCasesAction).args[0] || []
+        break
+      }
+      case "setCaseValues": {
+        // Recalculate cases with dependency attribute updated.
+        const cases = (mstAction as SetCaseValuesAction).args[0] || []
+        casesToRecalculate = getLocalAttrCasesToRecalculate(cases, localAttrDependencies)
+        break
+      }
+      default:
+        break
+    }
+
+    if (casesToRecalculate.length > 0) {
+      recalculateCallback(casesToRecalculate)
+    }
+  })
+
+  return disposeDatasetObserver
+}
+
+export const getLookupCasesToRecalculate = (cases: ICase[], dependency: ILookupDependency) =>
+  cases.some(c => isAttrDefined(c, dependency.attrId) || isAttrDefined(c, dependency.keyAttrId)) ? "ALL_CASES" : []
+
+export const observeLookupDependencies = (formulaDependencies: IFormulaDependency[], dataSets: Map<string, IDataSet>,
+  recalculateCallback: (casesToRecalculate: CaseList) => void) => {
+  const lookupDependencies: ILookupDependency[] =
+    formulaDependencies.filter(d => d.type === "lookup") as ILookupDependency[]
+
+  const disposeLookupObserver = lookupDependencies.map(dependency => {
+    const externalDataSet = dataSets.get(dependency.dataSetId)
+    if (!externalDataSet) {
+      throw new Error(`External dataSet with id "${dependency.dataSetId}" not found`)
+    }
+
+    return onAnyAction(externalDataSet, mstAction => {
+      let casesToRecalculate: CaseList = []
+      switch (mstAction.name) {
+        // TODO: these rules are very broad, think if there are some ways to optimize and narrow them down.
+        case "addCases": {
+          casesToRecalculate = "ALL_CASES"
+          break
+        }
+        case "removeCases": {
+          casesToRecalculate = "ALL_CASES"
+          break
+        }
+        case "setCaseValues": {
+          // recalculate cases with dependency attribute updated
+          const cases = (mstAction as SetCaseValuesAction).args[0] || []
+          casesToRecalculate = getLookupCasesToRecalculate(cases, dependency)
+          break
+        }
+        default:
+          break
+      }
+
+      if (casesToRecalculate.length > 0) {
+        recalculateCallback(casesToRecalculate)
+      }
+    })
+  })
+
+  return () => disposeLookupObserver.forEach(dispose => dispose())
+}
+
+export const observeGlobalValues = (formulaDependencies: IFormulaDependency[],
+  globalValueManager: IGlobalValueManager | undefined, recalculateCallback: (casesToRecalculate: CaseList) => void) => {
+  const globalValueDependencies = formulaDependencies.filter(d => d.type === "globalValue") as IGlobalValueDependency[]
+  const disposeGlobalValueObserver = globalValueDependencies.map(dependency =>
+    // Recalculate formula when global value dependency is updated.
+    reaction(
+      () => globalValueManager?.getValueById(dependency.globalId)?.value,
+      () => recalculateCallback("ALL_CASES"),
+      { name: "observeGlobalValues reaction"  }
+    )
+  )
+  return () => disposeGlobalValueObserver.forEach(dispose => dispose())
+}
+
+export const observeSymbolNameChanges = (dataSets: Map<string, IDataSet>,
+  globalValueManager: IGlobalValueManager | undefined, nameUpdateCallback: () => void) => {
+  // When any attribute name is updated, we need to update display formulas. We could make this more granular,
+  // and observe only dependant attributes, but it doesn't seem necessary for now.
+  const disposeAttrNameReaction = reaction(
+    () => Array.from(dataSets.values()).map(ds => ds.attrNameMap),
+    () => nameUpdateCallback(),
+    {
+      equals: comparer.structural,
+      name: "observeSymbolNameChanges attribute name reaction"
+    }
+  )
+  const disposeGlobalValueManagerReaction = reaction(
+    () => Array.from(globalValueManager?.globals.values() || []).map(g => g.name),
+    () => nameUpdateCallback(),
+    {
+      equals: comparer.structural,
+      name: "observeSymbolNameChanges global value name reaction"
+    }
+  )
+
+  return () => {
+    disposeAttrNameReaction()
+    disposeGlobalValueManagerReaction()
+  }
+}
+
+export const observeDatasetHierarchyChanges = (dataSets: Map<string, IDataSet>,
+  recalculateCallback: (casesToRecalculate?: CaseList) => void) => {
+  const dataSetsArray = Array.from(dataSets.values())
+  // When any collection is added or removed, or attribute is moved between collections,
+  // we need to recalculate all formulas.
+  const disposeAttrCollectionReaction = reaction(
+    () => dataSetsArray.map(ds => Object.fromEntries(ds.collections.map(c => [ c.id, c.attributes.map(a => a?.id) ]))),
+    () => recalculateCallback("ALL_CASES"),
+    {
+      equals: comparer.structural,
+      name: "observeDatasetHierarchyChanges dataset collections reaction"
+    }
+  )
+
+  return disposeAttrCollectionReaction
+}

--- a/v3/src/models/data/formula-types.ts
+++ b/v3/src/models/data/formula-types.ts
@@ -1,5 +1,6 @@
 import { ConstantNode, MathNode, SymbolNode, isConstantNode, isFunctionNode, isSymbolNode } from "mathjs"
 import type { FormulaMathJsScope } from "./formula-mathjs-scope"
+import type { ICase } from "./data-set-types"
 
 export const CANONICAL_NAME = "__CANONICAL_NAME__"
 export const GLOBAL_VALUE = "GLOBAL_VALUE_"
@@ -56,6 +57,8 @@ export type FValue = string | number | boolean
 export type EvaluateFunc = (...args: FValue[]) => FValue | FValue[]
 
 export type EvaluateRawFunc = (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]
+
+export type CaseList = ICase[] | "ALL_CASES"
 
 export interface IFormulaMathjsFunction {
   rawArgs?: boolean

--- a/v3/src/models/data/formula-utils.test.ts
+++ b/v3/src/models/data/formula-utils.test.ts
@@ -1,11 +1,8 @@
-import { ICase } from "./data-set-types"
-import {
-  CANONICAL_NAME, DisplayNameMap, GLOBAL_VALUE, ILocalAttributeDependency, ILookupDependency, LOCAL_ATTR
-} from "./formula-types"
+import { CANONICAL_NAME, DisplayNameMap, GLOBAL_VALUE, LOCAL_ATTR } from "./formula-types"
 import {
   safeSymbolName, customizeDisplayFormula, reverseDisplayNameMap, canonicalToDisplay, makeDisplayNamesSafe,
   displayToCanonical, unescapeBacktickString, escapeBacktickString, safeSymbolNameFromDisplayFormula,
-  getLocalAttrCasesToRecalculate, getLookupCasesToRecalculate, isAttrDefined, parseBasicCanonicalName, formulaIndexOf
+  parseBasicCanonicalName, formulaIndexOf
 } from "./formula-utils"
 
 const displayNameMapExample: DisplayNameMap = {
@@ -279,74 +276,5 @@ describe("canonicalToDisplay", () => {
         reverseDisplayNameMap(displayNameMapExample)
       )).toEqual("lookupByKey('Roller Coaster', 'Park\"', 'Top\\\\Speed\\'', Order) * 2")
     })
-  })
-})
-
-describe("isAttrDefined", () => {
-  const dataSetCase: ICase = { __id__: "1", attr1: 1, attr2: 2 }
-
-  it("returns true if the attribute is defined in the data set case", () => {
-    const attributeId = "attr1"
-    const result = isAttrDefined(dataSetCase, attributeId)
-    expect(result).toBe(true)
-  })
-
-  it("returns false if the attribute is not defined in the data set case", () => {
-    const attributeId = "attr3"
-    const result = isAttrDefined(dataSetCase, attributeId)
-    expect(result).toBe(false)
-  })
-
-  it("returns false if the attribute ID is not provided", () => {
-    const attributeId = undefined
-    const result = isAttrDefined(dataSetCase, attributeId)
-    expect(result).toBe(false)
-  })
-})
-
-describe("getLocalAttrCasesToRecalculate", () => {
-  const cases: ICase[] = [
-    { __id__: "1", attr1: 0, attr2: 1 },
-    { __id__: "2", attr1: 2, attr2: 3 },
-    { __id__: "3", attr1: "" }, // empty string should be considered as value that needs to trigger recalculation
-    { __id__: "4", attr2: 4 },
-  ]
-
-  it("returns 'ALL_CASES' if any case has an attribute that depends on an aggregate attribute", () => {
-    const formulaDependencies: ILocalAttributeDependency[] = [
-      { attrId: "attr1", type: "localAttribute", aggregate: false },
-      { attrId: "attr2", type: "localAttribute", aggregate: true },
-    ]
-    const result = getLocalAttrCasesToRecalculate(cases, formulaDependencies)
-    expect(result).toBe("ALL_CASES")
-  })
-
-  it("returns an array of cases that have an attribute that depends on a regular attribute", () => {
-    const formulaDependencies: ILocalAttributeDependency[] = [
-      { attrId: "attr1", type: "localAttribute", aggregate: false }
-    ]
-    const result = getLocalAttrCasesToRecalculate(cases, formulaDependencies)
-    expect(result).toEqual([cases[0], cases[1], cases[2]])
-  })
-
-  it("returns an empty array if no case has an attribute that depends on a regular attribute", () => {
-    const formulaDependencies: ILocalAttributeDependency[] = [
-      { attrId: "attr3", type: "localAttribute", aggregate: false }
-    ]
-    const result = getLocalAttrCasesToRecalculate(cases, formulaDependencies)
-    expect(result).toEqual([])
-  })
-})
-
-describe("getLookupCasesToRecalculate", () => {
-  const dependency: ILookupDependency = { type: "lookup", dataSetId: "ds1", attrId: "attr1", keyAttrId: "attr2" }
-
-  it("returns 'ALL_CASES' if any case has the lookup attribute or the lookup key attribute", () => {
-    expect(getLookupCasesToRecalculate([{ __id__: "1", attr1: 1 }], dependency)).toBe("ALL_CASES")
-    expect(getLookupCasesToRecalculate([{ __id__: "1", attr2: "" }], dependency)).toBe("ALL_CASES")
-  })
-
-  it("returns an empty array if no case has the lookup attribute or the lookup key attribute", () => {
-    expect(getLookupCasesToRecalculate([{ __id__: "1", attr3: 3 }], dependency)).toEqual([])
   })
 })

--- a/v3/src/models/data/formula-utils.ts
+++ b/v3/src/models/data/formula-utils.ts
@@ -1,12 +1,11 @@
 import { parse, MathNode, isFunctionNode } from "mathjs"
 import {
   LOCAL_ATTR, GLOBAL_VALUE, DisplayNameMap, CanonicalNameMap, IFormulaDependency, isConstantStringNode,
-  isNonFunctionSymbolNode, ILocalAttributeDependency, ILookupDependency, isCanonicalName, rmCanonicalPrefix
+  isNonFunctionSymbolNode, isCanonicalName, rmCanonicalPrefix
 } from "./formula-types"
 import { typedFnRegistry } from "./formula-fn-registry"
 import t from "../../utilities/translation/translate"
 import type { IDataSet } from "./data-set"
-import type { ICase } from "./data-set-types"
 
 // Set of formula helpers that can be used outside FormulaManager context. It should make them easier to test.
 
@@ -328,18 +327,3 @@ export const getIncorrectChildAttrReference =
   }
   return false
 }
-
-export const isAttrDefined = (dataSetCase: ICase, attributeId?: string) =>
-  !!attributeId && Object.prototype.hasOwnProperty.call(dataSetCase, attributeId)
-
-export const getLocalAttrCasesToRecalculate = (cases: ICase[], formulaDependencies: ILocalAttributeDependency[]) => {
-  const regularAttrDeps = formulaDependencies.filter(d => d.type === "localAttribute" && !d.aggregate)
-  const aggregateAttrDeps = formulaDependencies.filter(d => d.type === "localAttribute" && d.aggregate)
-
-  return cases.some(c => aggregateAttrDeps.some(d => isAttrDefined(c, d.attrId)))
-    ? "ALL_CASES"
-    : cases.filter(c => regularAttrDeps.some(d => isAttrDefined(c, d.attrId)))
-}
-
-export const getLookupCasesToRecalculate = (cases: ICase[], dependency: ILookupDependency) =>
-  cases.some(c => isAttrDefined(c, dependency.attrId) || isAttrDefined(c, dependency.keyAttrId)) ? "ALL_CASES" : []

--- a/v3/src/models/data/plotted-value-formula-adapter.ts
+++ b/v3/src/models/data/plotted-value-formula-adapter.ts
@@ -15,10 +15,9 @@ import { IAnyStateTreeNode } from "@concord-consortium/mobx-state-tree"
 import { getFormulaManager } from "../tiles/tile-environment"
 import { FormulaMathJsScope } from "./formula-mathjs-scope"
 import { DEBUG_FORMULAS } from "../../lib/debug"
-
-// This should match type of PlottedValueAdornmentModel. Currently all these models use regular string instead of
-// enums / constants / literals, so I can only copy the value and save it here.
-const ADORNMENT_TYPE = "Plotted Value"
+import {
+  kPlottedValueType
+} from "../../components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-types"
 
 const PLOTTED_VALUE_FORMULA_ADAPTER = "PlottedValueFormulaAdapter"
 
@@ -83,9 +82,9 @@ export class PlottedValueFormulaAdapter implements IFormulaManagerAdapter {
     if (!graphContentModel) {
       throw new Error(`GraphContentModel with id "${graphContentModelId}" not found`)
     }
-    const adornment = graphContentModel.adornments.find(a => a.type === ADORNMENT_TYPE)
+    const adornment = graphContentModel.adornments.find(a => a.type === kPlottedValueType)
     if (!adornment || !isPlottedValueAdornment(adornment)) {
-      throw new Error(`Adornment of type "${ADORNMENT_TYPE}" not found`)
+      throw new Error(`Adornment of type "${kPlottedValueType}" not found`)
     }
     // This code is mostly copied from UnivariateMeasureAdornmentModel.updateCategories.
     // TODO: Is there a way to share it somehow?

--- a/v3/src/models/data/plotted-value-formula-adapter.ts
+++ b/v3/src/models/data/plotted-value-formula-adapter.ts
@@ -48,13 +48,12 @@ export class PlottedValueFormulaAdapter implements IFormulaManagerAdapter {
     this.graphContentModels.delete(graphContentModelId)
   }
 
-  setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IPlottedValueFormulaExtraMetadata,
-    recalculate: () => void) {
+  setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IPlottedValueFormulaExtraMetadata) {
     const { graphContentModelId } = extraMetadata
     const graphContentModel = this.graphContentModels.get(graphContentModelId)
     const dispose = onAnyAction(graphContentModel, mstAction => {
       if (mstAction.name === "setAttributeID") {
-        recalculate()
+        this.recalculateFormula(formulaContext, extraMetadata)
       }
     })
     return dispose


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186267057

1. The most significant change in this PR is the extraction of all formula-related observers into a separate file and converting them into regular functions, making them closer to pure functions. The primary goal was to make the FormulaManager slimmer, make these functions easier to test, and allow for composing these observers when necessary. For example, attribute formulas observe changes to the dataset hierarchy, while plotted value formulas do not. I have also added quite a few unit tests that have already helped me catch a few subtle bugs, such as the need to recalculate all cases when new cases are added and the formula includes an aggregate function.

2. Additionally, I have used a new constant, `kPlottedValueType`, added by @emcelroy.

3. Finally, I updated some code to allows us to support symbols with empty names. While it may not seem very useful, it can occur. One of Tejal's tests modifies the name of the slider global value, but first, it clears its value. The GlobalName is updated immediately, and it was causing crashes in display formula updates. This bug was previously hidden, as global value name updates were slightly buggy and incomplete. Both of these issues have now been resolved.