### PR TITLE
[#186316077] Bug fix: Unable to add attribute to graph in presence of two datasets

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -634,8 +634,8 @@ export const DataConfigurationModel = types
           typeToDropIsNumeric = !!idToDrop && dataSet?.attrFromID(idToDrop)?.type === 'numeric',
           xIsNumeric = self.attributeType('x') === 'numeric',
           existingID = self.attributeID(role)
-        // only drops on left/bottom axes can change data set
-        if (dataSet?.id !== self.dataset?.id && !['left', 'bottom'].includes(place)) {
+        // If we have a dataset, only drops on left/bottom axes can change it
+        if (self.dataset && dataSet?.id !== self.dataset?.id && !['left', 'bottom'].includes(place)) {
           return false
         }
         if (place === 'yPlus') {

--- a/v3/src/components/graph/components/background.tsx
+++ b/v3/src/components/graph/components/background.tsx
@@ -9,7 +9,6 @@ import {MarqueeState} from "../models/marquee-state"
 import {rectangleSubtract, rectNormalize} from "../utilities/graph-utils"
 import {appState} from "../../../models/app-state"
 import {useCurrent} from "../../../hooks/use-current"
-import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {useGraphContentModelContext} from "../hooks/use-graph-content-model-context"
 import {InternalizedData} from "../graphing-types"
@@ -47,9 +46,9 @@ const prepareTree = (areaSelector: string, circleSelector: string): RTree => {
 export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
   const {marqueeState} = props,
     instanceId = useInstanceIdContext() || 'background',
-    dataset = useCurrent(useDataSetContext()),
     layout = useGraphLayoutContext(),
     graphModel = useGraphContentModelContext(),
+    dataset = useCurrent(graphModel.dataConfiguration?.dataset ?? undefined),
     bgRef = ref as MutableRefObject<SVGGElement | null>,
     startX = useRef(0),
     startY = useRef(0),

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -4,7 +4,6 @@ import {CaseData} from "../../data-display/d3-types"
 import {IDotsRef} from "../../data-display/data-display-types"
 import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
-import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphContentModelContext} from "../hooks/use-graph-content-model-context"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {handleClickOnDot, setPointCoordinates, setPointSelection} from "../utilities/graph-utils"
@@ -18,8 +17,8 @@ export const CaseDots = function CaseDots(props: {
       enableAnimation
     } = props,
     graphModel = useGraphContentModelContext(),
-    dataset = useDataSetContext(),
     dataConfiguration = useDataConfigurationContext(),
+    dataset = dataConfiguration?.dataset ?? undefined,
     layout = useGraphLayoutContext(),
     randomPointsRef = useRef<Record<string, { x: number, y: number }>>({}),
     dragPointRadius = graphModel.getPointRadius('hover-drag'),

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -4,7 +4,6 @@ import {CaseData, selectDots} from "../../data-display/d3-types"
 import {attrRoleToAxisPlace, PlotProps} from "../graphing-types"
 import {usePlotResponders} from "../hooks/use-plot"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
-import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphContentModelContext} from "../hooks/use-graph-content-model-context"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {setPointCoordinates, setPointSelection} from "../utilities/graph-utils"
@@ -16,7 +15,7 @@ export const ChartDots = function ChartDots(props: PlotProps) {
     graphModel = useGraphContentModelContext(),
     {pointColor, pointStrokeColor} = graphModel,
     dataConfiguration = useDataConfigurationContext(),
-    dataset = useDataSetContext(),
+    dataset = dataConfiguration?.dataset ?? undefined,
     layout = useGraphLayoutContext(),
     primaryAttrRole = dataConfiguration?.primaryRole ?? 'x',
     primaryAxisPlace = attrRoleToAxisPlace[primaryAttrRole] ?? 'bottom',

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -6,7 +6,6 @@ import {PlotProps} from "../graphing-types"
 import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {appState} from "../../../models/app-state"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
-import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphContentModelContext} from "../hooks/use-graph-content-model-context"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {ICase} from "../../../models/data/data-set-types"
@@ -16,7 +15,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
   const {dotsRef, enableAnimation} = props,
     graphModel = useGraphContentModelContext(),
     dataConfiguration = useDataConfigurationContext(),
-    dataset = useDataSetContext(),
+    dataset = dataConfiguration?.dataset ?? undefined,
     layout = useGraphLayoutContext(),
     primaryAttrRole = dataConfiguration?.primaryRole ?? 'x',
     primaryIsBottom = primaryAttrRole === 'x',

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -17,7 +17,6 @@ import {ChartDots} from "./chartdots"
 import {Marquee} from "./marquee"
 import {useGraphContentModelContext} from "../hooks/use-graph-content-model-context"
 import {DataConfigurationContext} from "../hooks/use-data-configuration-context"
-import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphModel} from "../hooks/use-graph-model"
 import {setNiceDomain, startAnimation} from "../utilities/graph-utils"
 import {IAxisModel} from "../../axis/models/axis-model"
@@ -47,7 +46,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     {plotType} = graphModel,
     instanceId = useInstanceIdContext(),
     marqueeState = useMemo<MarqueeState>(() => new MarqueeState(), []),
-    dataset = useDataSetContext(),
+    dataset = graphModel.dataConfiguration?.dataset ?? undefined,
     layout = useGraphLayoutContext(),
     xScale = layout.getAxisScale("bottom"),
     svgRef = useRef<SVGSVGElement>(null),

--- a/v3/src/components/graph/components/legend/numeric-legend.tsx
+++ b/v3/src/components/graph/components/legend/numeric-legend.tsx
@@ -1,6 +1,5 @@
 import React, {memo, useCallback, useEffect, useRef, useState} from "react"
 import {reaction} from "mobx"
-import {useDataSetContext} from "../../../../hooks/use-data-set-context"
 import {ScaleQuantile, scaleQuantile, schemeBlues} from "d3"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {isSelectionAction} from "../../../../models/data/data-set-actions"
@@ -20,7 +19,7 @@ interface INumericLegendProps {
 export const NumericLegend = memo(function NumericLegend({legendAttrID}: INumericLegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
     layout = useGraphLayoutContext(),
-    dataset = useDataSetContext(),
+    dataset = dataConfiguration?.dataset ?? undefined,
     quantileScale = useRef<ScaleQuantile<string>>(scaleQuantile()),
     [choroplethElt, setChoroplethElt] = useState<SVGGElement | null>(null),
     valuesRef = useRef<number[]>([]),

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -7,7 +7,6 @@ import {PlotProps} from "../graphing-types"
 import {useGraphContentModelContext} from "../hooks/use-graph-content-model-context"
 import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {useDataConfigurationContext} from "../hooks/use-data-configuration-context"
-import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {useGraphLayoutContext} from "../models/graph-layout"
 import {ICase} from "../../../models/data/data-set-types"
@@ -19,7 +18,7 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
     graphModel = useGraphContentModelContext(),
     instanceId = useInstanceIdContext(),
     dataConfiguration = useDataConfigurationContext(),
-    dataset = useDataSetContext(),
+    dataset = dataConfiguration?.dataset ?? undefined,
     secondaryAttrIDsRef = useRef<string[]>([]),
     pointRadiusRef = useRef(0),
     selectedPointRadiusRef = useRef(0),


### PR DESCRIPTION
There were two problems:
* Plots were attempting to obtain the relevant dataset using useDataSetContext, but when the document contains more than one dataset, this provider returns undefined.
* DataConfigurationModel:graphPlaceCanAcceptAttributeIDDrop was now allowing a drop in the middle of the graph because it was comparing the dropped dataset to its undefined current dataset. Instead, if the current dataset is undefined, the drop should be allowed.