### PR TITLE
fix: graph attribute drop in presence of multiple data sets

### DIFF
--- a/v3/src/components/graph/components/droppable-plot.tsx
+++ b/v3/src/components/graph/components/droppable-plot.tsx
@@ -19,13 +19,14 @@ const _DroppablePlot = ({graphElt, plotElt, onDropAttribute}: IProps) => {
   const dataConfig = useGraphDataConfigurationContext()
   const isDropAllowed = dataConfig?.graphPlaceCanAcceptAttributeIDDrop ?? (() => true)
   const droppableId = `${instanceId}-plot-area-drop`
+  const place: GraphPlace = dataConfig?.noAttributesAssigned ? 'bottom' : 'legend'
   const role = dataConfig?.noAttributesAssigned ? 'x' : 'legend'
   const hintString = useDropHintString({role})
 
   const handleIsActive = (active: Active) => {
     const { dataSet, attributeId: droppedAttrId } = getDragAttributeInfo(active) || {}
     if (isDropAllowed) {
-      return isDropAllowed('legend', dataSet, droppedAttrId)
+      return isDropAllowed(place, dataSet, droppedAttrId)
     } else {
       return !!droppedAttrId
     }
@@ -33,8 +34,8 @@ const _DroppablePlot = ({graphElt, plotElt, onDropAttribute}: IProps) => {
 
   useDropHandler(droppableId, active => {
     const { dataSet, attributeId: dragAttributeID } = getDragAttributeInfo(active) || {}
-    dataSet && dragAttributeID && isDropAllowed('legend', dataSet, dragAttributeID) &&
-      onDropAttribute('plot', dataSet, dragAttributeID)
+    dataSet && dragAttributeID && isDropAllowed(place, dataSet, dragAttributeID) &&
+      onDropAttribute(place, dataSet, dragAttributeID)
   })
 
   return (

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -54,7 +54,7 @@ export const GraphAxis = observer(function GraphAxis(
   useDropHandler(droppableId, active => {
     const {dataSet, attributeId: droppedAttrId} = getDragAttributeInfo(active) || {}
     dataSet && droppedAttrId && isDropAllowed(place, dataSet, droppedAttrId) &&
-    onDropAttribute?.(place, dataSet, droppedAttrId)
+      onDropAttribute?.(place, dataSet, droppedAttrId)
   })
 
   /**

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -227,6 +227,9 @@ export const GraphContentModel = DataDisplayContentModel
     setAttributeID(role: GraphAttrRole, dataSetID: string, id: string) {
       const newDataSet = getDataSetFromId(self, dataSetID)
       if (newDataSet && newDataSet !== self.dataConfiguration.dataset) {
+        // update shared model manager
+        linkTileToDataSet(self, newDataSet)
+        // update data configuration
         self.dataConfiguration.clearAttributes()
         self.dataConfiguration.setDataset(newDataSet, getSharedCaseMetadataFromDataset(newDataSet))
       }

--- a/v3/src/hooks/use-drag-drop.ts
+++ b/v3/src/hooks/use-drag-drop.ts
@@ -17,7 +17,7 @@ export interface IDragData {
 
 export interface IDragAttributeData extends IDragData {
   type: "attribute"
-  dataSet?: IDataSet
+  dataSet: IDataSet | undefined
   attributeId: string
 }
 export function isDragAttributeData(data: DataRef): data is DataRef<IDragAttributeData> {

--- a/v3/src/hooks/use-drop-hint-string.ts
+++ b/v3/src/hooks/use-drop-hint-string.ts
@@ -1,6 +1,5 @@
 import {useDndContext} from "@dnd-kit/core"
 import { AttributeType } from "../models/data/attribute"
-import {useDataSetContext} from "./use-data-set-context"
 import {getDragAttributeInfo} from "./use-drag-drop"
 import {useGraphDataConfigurationContext} from "../components/graph/hooks/use-data-configuration-context"
 import {attrRoleToGraphPlace, GraphAttrRole} from "../components/graph/graphing-types"
@@ -80,16 +79,15 @@ export function determineBaseString(role: GraphAttrRole, dropType?: AttributeTyp
 }
 
 export const useDropHintString = ({role} : IUseDropHintStringProps) => {
-  const dataSet = useDataSetContext(),
-    dataConfig = useGraphDataConfigurationContext(),
+  const dataConfig = useGraphDataConfigurationContext(),
     { active } = useDndContext(),
-    { attributeId: dragAttrId = "" } = getDragAttributeInfo(active) || {},
+    { attributeId: dragAttrId = "", dataSet } = getDragAttributeInfo(active) || {},
     place = attrRoleToGraphPlace[role] as GraphPlace,
     dropAllowed = dataConfig?.graphPlaceCanAcceptAttributeIDDrop(place, dataSet, dragAttrId)
 
   if (dataSet && active?.data.current && dropAllowed) {
-    const dragAttrName = dragAttrId ? dataSet.attrFromID(dragAttrId).name : undefined,
-      dragAttrType = dragAttrId? dataSet.attrFromID(dragAttrId).type : undefined
+    const dragAttrName = dragAttrId ? dataSet.attrFromID(dragAttrId)?.name : undefined,
+      dragAttrType = dragAttrId ? dataSet.attrFromID(dragAttrId)?.type : undefined
 
     const
       priorAttrId = dataConfig?.attributeID(role),


### PR DESCRIPTION
Alternative to #959 as a fix for [[#186316077]](https://www.pivotaltracker.com/story/show/186316077).

Ultimately, the issue is that we have global mechanisms (e.g. the shared model manager) and local mechanisms (e.g. `DataConfigurationModel.dataset`) for tracking which tiles are connected to which data sets and the two weren't being kept in sync. #959 proposed fixing it by eliminating all references to the global mechanisms and relying entirely on the local mechanisms, which allows the graph to work despite the two being out of sync. In this PR we propose to actually keep the two in sync.