### PR TITLE
Improve lookupByKey and lookupByIndex errors handling

### DIFF
--- a/v3/src/models/formula/attribute-formula-adapter.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.ts
@@ -258,15 +258,12 @@ export class AttributeFormulaAdapter implements IFormulaManagerAdapter {
         formulaDependencies.filter(d => d.type === "lookup") as ILookupDependency[]
       for (const dependency of lookupDependencies) {
         const externalDataSet = dataSets.get(dependency.dataSetId)
-        if (!externalDataSet) {
-          throw new Error(`External dataSet with id "${dependency.dataSetId}" not found`)
-        }
-        const dependencyAttribute = externalDataSet.attrFromID(dependency.attrId)
+        const dependencyAttribute = externalDataSet?.attrFromID(dependency.attrId)
         if (dependencyAttribute?.formula.valid) {
           stack.push(dependencyAttribute.formula.id)
         }
         if (dependency.keyAttrId) {
-          const dependencyKeyAttribute = externalDataSet.attrFromID(dependency.keyAttrId)
+          const dependencyKeyAttribute = externalDataSet?.attrFromID(dependency.keyAttrId)
           if (dependencyKeyAttribute?.formula.valid) {
             stack.push(dependencyKeyAttribute.formula.id)
           }

--- a/v3/src/models/formula/formula-observers.ts
+++ b/v3/src/models/formula/formula-observers.ts
@@ -66,9 +66,8 @@ export const observeLookupDependencies = (formulaDependencies: IFormulaDependenc
   const disposeLookupObserver = lookupDependencies.map(dependency => {
     const externalDataSet = dataSets.get(dependency.dataSetId)
     if (!externalDataSet) {
-      throw new Error(`External dataSet with id "${dependency.dataSetId}" not found`)
+      return
     }
-
     return onAnyAction(externalDataSet, mstAction => {
       let casesToRecalculate: CaseList = []
       switch (mstAction.name) {
@@ -97,7 +96,7 @@ export const observeLookupDependencies = (formulaDependencies: IFormulaDependenc
     })
   })
 
-  return () => disposeLookupObserver.forEach(dispose => dispose())
+  return () => disposeLookupObserver.forEach(dispose => dispose?.())
 }
 
 export const observeGlobalValues = (formulaDependencies: IFormulaDependency[],

--- a/v3/src/models/formula/functions/lookup-functions.ts
+++ b/v3/src/models/formula/functions/lookup-functions.ts
@@ -5,21 +5,21 @@ import { UNDEF_RESULT, equal, evaluateNode } from "./function-utils"
 import type { IDataSet } from "../../data/data-set"
 import t from "../../../utilities/translation/translate"
 
-type LookupStringContantArg = ConstantNode<string> | undefined
+type LookupStringConstantArg = ConstantNode<string> | undefined
 
 export const lookupFunctions = {
   // lookupByIndex("dataSetName", "attributeName", index)
   lookupByIndex: {
     getDependency: (args: MathNode[]): ILookupDependency => {
+      const [dataSetNameArg, attrNameArg] = args as LookupStringConstantArg[]
       return {
         type: "lookup",
-        dataSetId: rmCanonicalPrefix((args[0] as LookupStringContantArg)?.value),
-        attrId: rmCanonicalPrefix((args[1] as LookupStringContantArg)?.value),
+        dataSetId: rmCanonicalPrefix(dataSetNameArg?.value),
+        attrId: rmCanonicalPrefix(attrNameArg?.value),
       }
     },
     canonicalize: (args: MathNode[], displayNameMap: DisplayNameMap) => {
-      const dataSetNameArg = args[0] as LookupStringContantArg
-      const attrNameArg = args[1] as LookupStringContantArg
+      const [dataSetNameArg, attrNameArg] = args as LookupStringConstantArg[]
       const dataSetName = dataSetNameArg?.value || ""
       const attrName = attrNameArg?.value || ""
       if (dataSetNameArg) {
@@ -55,17 +55,16 @@ export const lookupFunctions = {
   // lookupByKey("dataSetName", "attributeName", "keyAttributeName", "keyAttributeValue" | localKeyAttribute)
   lookupByKey: {
     getDependency: (args: MathNode[]): Required<ILookupDependency> => {
+      const [dataSetNameArg, attrNameArg, keyAttrNameArg] = args as LookupStringConstantArg[]
       return {
         type: "lookup",
-        dataSetId: rmCanonicalPrefix((args[0] as LookupStringContantArg)?.value),
-        attrId: rmCanonicalPrefix((args[1] as LookupStringContantArg)?.value),
-        keyAttrId: rmCanonicalPrefix((args[2] as LookupStringContantArg)?.value)
+        dataSetId: rmCanonicalPrefix(dataSetNameArg?.value),
+        attrId: rmCanonicalPrefix(attrNameArg?.value),
+        keyAttrId: rmCanonicalPrefix(keyAttrNameArg?.value)
       }
     },
     canonicalize: (args: MathNode[], displayNameMap: DisplayNameMap) => {
-      const dataSetNameArg = args[0] as LookupStringContantArg
-      const attrNameArg = args[1] as LookupStringContantArg
-      const keyAttrNameArg = args[2] as LookupStringContantArg
+      const [dataSetNameArg, attrNameArg, keyAttrNameArg] = args as LookupStringConstantArg[]
       const dataSetName = dataSetNameArg?.value || ""
       const attrName = attrNameArg?.value || ""
       const keyAttrName = keyAttrNameArg?.value || ""

--- a/v3/src/models/formula/functions/lookup-functions.ts
+++ b/v3/src/models/formula/functions/lookup-functions.ts
@@ -3,78 +3,103 @@ import { FormulaMathJsScope } from "../formula-mathjs-scope"
 import { DisplayNameMap, ILookupDependency, isConstantStringNode, rmCanonicalPrefix } from "../formula-types"
 import { UNDEF_RESULT, equal, evaluateNode } from "./function-utils"
 import type { IDataSet } from "../../data/data-set"
+import t from "../../../utilities/translation/translate"
+
+type LookupStringContantArg = ConstantNode<string> | undefined
 
 export const lookupFunctions = {
   // lookupByIndex("dataSetName", "attributeName", index)
   lookupByIndex: {
-    validateArguments: (args: MathNode[]): [ConstantNode<string>, ConstantNode<string>, MathNode] => {
-      if (args.length !== 3) {
-        throw new Error(`lookupByIndex function expects exactly 3 arguments, but it received ${args.length}`)
-      }
-      if (!isConstantStringNode(args[0]) || !isConstantStringNode(args[1])) {
-        throw new Error("lookupByIndex function expects first two arguments to be strings " +
-          "and the third one to be numeric (or evaluate to number)")
-      }
-      return [args[0], args[1], args[2]]
-    },
     getDependency: (args: MathNode[]): ILookupDependency => {
-      const validArgs = lookupFunctions.lookupByIndex.validateArguments(args)
       return {
         type: "lookup",
-        dataSetId: rmCanonicalPrefix(validArgs[0].value),
-        attrId: rmCanonicalPrefix(validArgs[1].value),
+        dataSetId: rmCanonicalPrefix((args[0] as LookupStringContantArg)?.value),
+        attrId: rmCanonicalPrefix((args[1] as LookupStringContantArg)?.value),
       }
     },
     canonicalize: (args: MathNode[], displayNameMap: DisplayNameMap) => {
-      const validArgs = lookupFunctions.lookupByIndex.validateArguments(args)
-      const dataSetName = validArgs[0].value
-      const attrName = validArgs[1].value
-      validArgs[0].value = displayNameMap.dataSet[dataSetName]?.id
-      validArgs[1].value = displayNameMap.dataSet[dataSetName]?.attribute[attrName]
+      const dataSetNameArg = args[0] as LookupStringContantArg
+      const attrNameArg = args[1] as LookupStringContantArg
+      const dataSetName = dataSetNameArg?.value || ""
+      const attrName = attrNameArg?.value || ""
+      if (dataSetNameArg) {
+        dataSetNameArg.value = displayNameMap.dataSet[dataSetName]?.id || dataSetName
+      }
+      if (attrNameArg) {
+        attrNameArg.value = displayNameMap.dataSet[dataSetName]?.attribute[attrName] || attrName
+      }
     },
     evaluateRaw: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
+      const functionName = "lookupByIndex"
+      if (args.length !== 3) {
+        throw new Error(t("DG.Formula.FuncArgsErrorPlural.description", { vars: [ functionName, 3 ] }))
+      }
+      [0, 1].forEach(i => {
+        if (!isConstantStringNode(args[i])) {
+          throw new Error(t("V3.formula.error.stringConstantArg", { vars: [ functionName, i + 1 ] }))
+        }
+      })
       const { dataSetId, attrId } = lookupFunctions.lookupByIndex.getDependency(args)
       const zeroBasedIndex = evaluateNode(args[2], scope) - 1
-      return scope.getDataSet(dataSetId)?.getValueAtIndex(zeroBasedIndex, attrId) || UNDEF_RESULT
+      const dataSet = scope.getDataSet(dataSetId)
+      if (!dataSet) {
+        throw new Error(t("DG.Formula.LookupDataSetError.description", { vars: [ dataSetId ] }))
+      }
+      if (!dataSet.attrFromID(attrId)) {
+        throw new Error(t("DG.Formula.LookupAttrError.description", { vars: [ attrId, dataSet.name || "" ] }))
+      }
+      return dataSet.getValueAtIndex(zeroBasedIndex, attrId) || UNDEF_RESULT
     }
   },
 
   // lookupByKey("dataSetName", "attributeName", "keyAttributeName", "keyAttributeValue" | localKeyAttribute)
   lookupByKey: {
-    validateArguments: (args: MathNode[]):
-      [ConstantNode<string>, ConstantNode<string>, ConstantNode<string>, MathNode] => {
-      if (args.length !== 4) {
-        throw new Error("lookupByKey function expects exactly 4 arguments")
-      }
-      if (!isConstantStringNode(args[0]) || !isConstantStringNode(args[1]) || !isConstantStringNode(args[2])) {
-        throw new Error("lookupByKey function expects first three arguments to be strings")
-      }
-      return [args[0], args[1], args[2], args[3]]
-    },
     getDependency: (args: MathNode[]): Required<ILookupDependency> => {
-      const validArgs = lookupFunctions.lookupByKey.validateArguments(args)
       return {
         type: "lookup",
-        dataSetId: rmCanonicalPrefix(validArgs[0].value),
-        attrId: rmCanonicalPrefix(validArgs[1].value),
-        keyAttrId: rmCanonicalPrefix(validArgs[2].value),
+        dataSetId: rmCanonicalPrefix((args[0] as LookupStringContantArg)?.value),
+        attrId: rmCanonicalPrefix((args[1] as LookupStringContantArg)?.value),
+        keyAttrId: rmCanonicalPrefix((args[2] as LookupStringContantArg)?.value)
       }
     },
     canonicalize: (args: MathNode[], displayNameMap: DisplayNameMap) => {
-      const validArgs = lookupFunctions.lookupByKey.validateArguments(args)
-      const dataSetName = validArgs[0].value
-      const attrName = validArgs[1].value
-      const keyAttrName = validArgs[2].value
-      validArgs[0].value = displayNameMap.dataSet[dataSetName]?.id
-      validArgs[1].value = displayNameMap.dataSet[dataSetName]?.attribute[attrName]
-      validArgs[2].value = displayNameMap.dataSet[dataSetName]?.attribute[keyAttrName]
+      const dataSetNameArg = args[0] as LookupStringContantArg
+      const attrNameArg = args[1] as LookupStringContantArg
+      const keyAttrNameArg = args[2] as LookupStringContantArg
+      const dataSetName = dataSetNameArg?.value || ""
+      const attrName = attrNameArg?.value || ""
+      const keyAttrName = keyAttrNameArg?.value || ""
+      if (dataSetNameArg) {
+        dataSetNameArg.value = displayNameMap.dataSet[dataSetName]?.id || dataSetName
+      }
+      if (attrNameArg) {
+        attrNameArg.value = displayNameMap.dataSet[dataSetName]?.attribute[attrName] || attrName
+      }
+      if (keyAttrNameArg) {
+        keyAttrNameArg.value = displayNameMap.dataSet[dataSetName]?.attribute[keyAttrName] || keyAttrName
+      }
     },
     evaluateRaw: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
+      const functionName = "lookupByKey"
+      if (args.length !== 4) {
+        throw new Error(t("DG.Formula.FuncArgsErrorPlural.description", { vars: [ functionName, 4 ] }))
+      }
+      [0, 1, 2].forEach(i => {
+        if (!isConstantStringNode(args[i])) {
+          throw new Error(t("V3.formula.error.stringConstantArg", { vars: [ functionName, i + 1 ] }))
+        }
+      })
       const { dataSetId, attrId, keyAttrId } = lookupFunctions.lookupByKey.getDependency(args)
       const keyAttrValue = evaluateNode(args[3], scope)
       const dataSet: IDataSet | undefined = scope.getDataSet(dataSetId)
       if (!dataSet) {
-        return UNDEF_RESULT
+        throw new Error(t("DG.Formula.LookupDataSetError.description", { vars: [ dataSetId ] }))
+      }
+      if (!dataSet.attrFromID(attrId)) {
+        throw new Error(t("DG.Formula.LookupAttrError.description", { vars: [ attrId, dataSet.name || "" ] }))
+      }
+      if (!dataSet.attrFromID(keyAttrId)) {
+        throw new Error(t("DG.Formula.LookupAttrError.description", { vars: [ keyAttrId, dataSet.name || "" ] }))
       }
       for (const c of dataSet.cases) {
         const val = dataSet.getValue(c.__id__, keyAttrId)

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -16,6 +16,7 @@
     // V3 formula strings that are not present in V2 and will eventually require translation.
     "V3.formula.error.invalidParentAttrRef": "invalid reference to parent attribute '%@' within aggregate function",
     "V3.formula.error.cycle": "Circular reference: formula refers to its own attribute either directly or indirectly",
+    "V3.formula.error.stringConstantArg": "The '%@()' function expects %@ argument to be a string constant",
 
     // CFM/File menu
     "DG.fileMenu.menuItem.newDocument": "New",


### PR DESCRIPTION
So, this PR came about because of a bug reported by @bfinzer: [lookupByIndex was causing an uncaught exception #186293413](https://www.pivotaltracker.com/story/show/186293413).

The main reason for the bug was that I never really set up proper error handling for the lookup functions. So, I've added another story that goes beyond just fixing this one exception: [Dealing with user errors in lookupByIndex and lookupByKey #186354628](https://www.pivotaltracker.com/story/show/186354628).

You might have noticed that I got rid of the `validateArguments` function that I added a while back. Originally, I thought it could be used for handling errors in these functions, as some errors can be spotted before the function actually runs, like the need for string constants as arguments. I tried to stick to this idea, but it required a completely different approach compared to other functions, which usually only flag errors during evaluation. For example, "mean(Height)" only realizes that "Height" is giving unsupported values when it evaluates "Height."

So, I decided to put error handling inside the evaluation process to keep things consistent with how other functions handle incorrect arguments. This way, I don't need a separate code path or the `validateArguments` helper.

To make this work, I also had to tweak some other code to be more forgiving and not crash until the formula is actually evaluated.

Error messages attempt to reuse existing V2 strings, but I ended up adding a new one. It could look something like: "The lookupByIndex function expects one argument to be a string constant," so it doesn't include ordinal numbers. However, I skipped those on purpose to keep things simple. After all, it's just for one error message that probably won't pop up too often or for too long.

Unit tests are coming in a separate PR, as they led to some more extensive work (https://github.com/concord-consortium/codap/pull/967)