### PR TITLE
Update MathJS to v12, update formula code to work with fixed special chars in MathJS, add unit tests

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -19,7 +19,7 @@
         "escape-string-regexp": "^5.0.0",
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
-        "mathjs": "~11.11.2",
+        "mathjs": "^12.0.0",
         "mobx": "^6.10.2",
         "mobx-react-lite": "^4.0.5",
         "nanoid": "^5.0.2",
@@ -16739,11 +16739,11 @@
       }
     },
     "node_modules/mathjs": {
-      "version": "11.11.2",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.11.2.tgz",
-      "integrity": "sha512-SL4/0Fxm9X4sgovUpJTeyVeZ2Ifnk4tzLPTYWDyR3AIx9SabnXYqtCkyJtmoF3vZrDPKGkLvrhbIL4YN2YbXLQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-12.0.0.tgz",
+      "integrity": "sha512-Oz3swPplNPe7taoP6WrkKhQzhDE2SwvOgLzu8H3EN+hEadw2GjEJUm6Xl+hrioHoB8g2BYb3gfw1glSzhdBKYw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.1",
+        "@babel/runtime": "^7.23.2",
         "complex.js": "^2.1.1",
         "decimal.js": "^10.4.3",
         "escape-latex": "^1.2.0",
@@ -16757,7 +16757,7 @@
         "mathjs": "bin/cli.js"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/mdn-data": {
@@ -34673,11 +34673,11 @@
       }
     },
     "mathjs": {
-      "version": "11.11.2",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.11.2.tgz",
-      "integrity": "sha512-SL4/0Fxm9X4sgovUpJTeyVeZ2Ifnk4tzLPTYWDyR3AIx9SabnXYqtCkyJtmoF3vZrDPKGkLvrhbIL4YN2YbXLQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-12.0.0.tgz",
+      "integrity": "sha512-Oz3swPplNPe7taoP6WrkKhQzhDE2SwvOgLzu8H3EN+hEadw2GjEJUm6Xl+hrioHoB8g2BYb3gfw1glSzhdBKYw==",
       "requires": {
-        "@babel/runtime": "^7.23.1",
+        "@babel/runtime": "^7.23.2",
         "complex.js": "^2.1.1",
         "decimal.js": "^10.4.3",
         "escape-latex": "^1.2.0",

--- a/v3/package.json
+++ b/v3/package.json
@@ -174,7 +174,7 @@
     "escape-string-regexp": "^5.0.0",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
-    "mathjs": "~11.11.2",
+    "mathjs": "^12.0.0",
     "mobx": "^6.10.2",
     "mobx-react-lite": "^4.0.5",
     "nanoid": "^5.0.2",

--- a/v3/src/models/formula/formula-utils.test.ts
+++ b/v3/src/models/formula/formula-utils.test.ts
@@ -114,8 +114,17 @@ describe("displayToCanonical", () => {
       )).toEqual('mean(__CANONICAL_NAME__LOCAL_ATTR_ATTR_MEAN) + "mean"')
     })
   })
+  describe("when string constant includes special characters", () => {
+    it("is converted and escaped correctly", () => {
+      expect(displayToCanonical(
+        `if(1 < 2, 'ok\\'ay', "not\\"okay")`, displayNameMapExample
+      )).toEqual(`if(1 < 2, "ok'ay", "not\\"okay")`)
+      // MathJS always uses double quotes for string constants.
+      // This is fine, as the reverse function, canonicalToDisplay, will convert them back to single quotes.
+    })
+  })
   describe("when attribute name is provided as string constant (e.g. lookup functions)", () => {
-    it("is still converted correctly and names with special characters are NOT enclosed in backticks", () => {
+    it("is still converted correctly", () => {
       expect(displayToCanonical(
         'lookupByKey("Roller Coaster", "Park\\"", "Top\\\\Speed\'", Order) * 2', displayNameMapExample
       )).toEqual(
@@ -257,8 +266,16 @@ describe("canonicalToDisplay", () => {
       )).toEqual("mean ( `new\\\\mean\\`attribute 🙃` ) + 'mean'")
     })
   })
+  describe("when string constant includes special characters", () => {
+    it("is maintained and escaped correctly", () => {
+      expect(canonicalToDisplay(
+        `if(1 < 50, "ok'ay", "not\\"okay")`,
+        `if(1 < 2, 'ok\\'ay', "not\\"okay")`, reverseDisplayNameMap(displayNameMapExample)
+      )).toEqual(`if(1 < 2, 'ok\\'ay', "not\\"okay")`)
+    })
+  })
   describe("when attribute name is provided as a double quote string constant (e.g. lookup functions)", () => {
-    it("is still converted correctly and names with special characters are NOT enclosed in backticks", () => {
+    it("is still converted correctly and is NOT enclosed in backticks", () => {
       expect(canonicalToDisplay(
         'lookupByKey("__CANONICAL_NAME__DATA_ROLLER_COASTER", "__CANONICAL_NAME__ATTR_PARK",' +
         ' "__CANONICAL_NAME__ATTR_TOP_SPEED", __CANONICAL_NAME__LOCAL_ATTR_ATTR_ORDER) * 2',
@@ -268,7 +285,7 @@ describe("canonicalToDisplay", () => {
     })
   })
   describe("when attribute name is provided as a single quote string constant (e.g. lookup functions)", () => {
-    it("is still converted correctly and names with special characters are NOT enclosed in backticks", () => {
+    it("is still converted correctly and is NOT enclosed in backticks", () => {
       expect(canonicalToDisplay(
         "lookupByKey('__CANONICAL_NAME__DATA_ROLLER_COASTER', '__CANONICAL_NAME__ATTR_PARK'," +
         " '__CANONICAL_NAME__ATTR_TOP_SPEED', __CANONICAL_NAME__LOCAL_ATTR_ATTR_ORDER) * 2",

--- a/v3/src/models/formula/formula-utils.ts
+++ b/v3/src/models/formula/formula-utils.ts
@@ -199,9 +199,6 @@ export const displayToCanonical = (displayExpression: string, displayNameMap: Di
       // Note that parseArguments will modify args array in place, because we're passing canonicalizeWith option.
       typedFnRegistry[node.fn.name].canonicalize?.(node.args, displayNameMap)
     }
-    if (isConstantStringNode(node)) {
-      node.value = escapeDoubleQuoteString(node.value)
-    }
   }
   formulaTree.traverse(visitNode)
   return formulaTree.toString()


### PR DESCRIPTION
@kswenson mentioned that MathJS v11.12.0 is causing Cypress tests to break: https://github.com/concord-consortium/codap/pull/964

This issue happened due to a recent MathJS bug fix:
- https://github.com/josdejong/mathjs/issues/3073#issuecomment-1768326862
- https://github.com/josdejong/mathjs/pull/3082

This PR removes some lines from formula-utils.ts that are no longer necessary. Additionally, I've added unit tests that would fail with MathJS < 11.12.0 and the new code, providing us with double coverage (not just relying on the Cypress tests that saved me before, thanks to @tejal-shah :wink:).