### PR TITLE
Add support of the default argument to the formula system and use it in Plotted Value formulas

### DIFF
--- a/v3/build_number.json
+++ b/v3/build_number.json
@@ -1,1 +1,1 @@
-{"buildNumber":1405}
+{"buildNumber":1406}

--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -2,7 +2,7 @@ import { comparer, makeObservable, observable, reaction, action } from "mobx"
 import { isAlive } from "mobx-state-tree"
 import { ICase } from "../data/data-set-types"
 import {
-  getFormulaDependencies, formulaError, getDisplayNameMap, getCanonicalNameMap
+  getFormulaDependencies, formulaError, getDisplayNameMap, getCanonicalNameMap, displayToCanonical
 } from "./formula-utils"
 import { CaseList } from "./formula-types"
 import { IDataSet } from "../data/data-set"
@@ -28,6 +28,7 @@ export interface IFormulaMetadata {
 export interface IFormulaExtraMetadata {
   dataSetId: string
   attributeId?: string
+  defaultArgument?: string
 }
 
 export interface IFormulaContext {
@@ -45,11 +46,10 @@ export interface IFormulaAdapterApi {
 export interface IFormulaManagerAdapter {
   type: string
   getAllFormulas: () => ({ formula: IFormula, extraMetadata?: any })[]
-  recalculateFormula: (formulaContext: IFormulaContext, extraMetadata: any,
-    casesToRecalculateDesc?: CaseList) => void
-  setupFormulaObservers: (formulaContext: IFormulaContext, extraMetadata: any) => () => void
-  getFormulaError: (formulaContext: IFormulaContext, extraMetadata: any) => undefined | string
+  recalculateFormula: (formulaContext: IFormulaContext, extraMetadata: any, casesToRecalculateDesc?: CaseList) => void
   setFormulaError: (formulaContext: IFormulaContext, extraMetadata: any, errorMsg: string) => void
+  getFormulaError: (formulaContext: IFormulaContext, extraMetadata: any) => undefined | string
+  setupFormulaObservers?: (formulaContext: IFormulaContext, extraMetadata: any) => () => void
 }
 
 export class FormulaManager {
@@ -246,12 +246,13 @@ export class FormulaManager {
     const formulaContext = this.getFormulaContext(formulaId)
     const formulaMetadata = this.getFormulaMetadata(formulaId)
     const extraMetadata = this.getExtraMetadata(formulaId)
-    const { formula, adapter } = formulaMetadata
     const { dataSet } = formulaContext
+    const { formula, adapter } = formulaMetadata
+    const { defaultArgument } = extraMetadata
     if (formula.empty) {
       return
     }
-    const dependencies = getFormulaDependencies(formula.canonical, extraMetadata.attributeId)
+    const dependencies = getFormulaDependencies(formula.canonical, extraMetadata.attributeId, defaultArgument)
 
     const recalculate = (casesToRecalculate: CaseList) => {
       this.recalculateFormula(formulaId, casesToRecalculate)
@@ -274,7 +275,7 @@ export class FormulaManager {
     const disposeGlobalValueObservers = observeGlobalValues(dependencies, this.globalValueManager, recalculate)
     const disposeLookupObservers = observeLookupDependencies(dependencies, this.dataSets, recalculate)
     const disposeNameChangeObservers = observeSymbolNameChanges(this.dataSets, this.globalValueManager, updateDisplay)
-    const disposeAdapterSpecificObservers = adapter.setupFormulaObservers(formulaContext, extraMetadata)
+    const disposeAdapterSpecificObservers = adapter.setupFormulaObservers?.(formulaContext, extraMetadata)
 
     this.formulaMetadata.set(formulaId, {
       ...formulaMetadata,
@@ -283,7 +284,7 @@ export class FormulaManager {
         disposeGlobalValueObservers()
         disposeLookupObservers()
         disposeNameChangeObservers()
-        disposeAdapterSpecificObservers()
+        disposeAdapterSpecificObservers?.()
       },
     })
   }

--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -1,9 +1,7 @@
 import { comparer, makeObservable, observable, reaction, action } from "mobx"
 import { isAlive } from "mobx-state-tree"
 import { ICase } from "../data/data-set-types"
-import {
-  getFormulaDependencies, formulaError, getDisplayNameMap, getCanonicalNameMap, displayToCanonical
-} from "./formula-utils"
+import { getFormulaDependencies, formulaError, getDisplayNameMap, getCanonicalNameMap } from "./formula-utils"
 import { CaseList } from "./formula-types"
 import { IDataSet } from "../data/data-set"
 import { IGlobalValueManager } from "../global/global-value-manager"

--- a/v3/src/models/formula/formula-mathjs-scope.ts
+++ b/v3/src/models/formula/formula-mathjs-scope.ts
@@ -1,3 +1,4 @@
+import { MathNode, parse } from "mathjs"
 import {
   FValue, CASE_INDEX_FAKE_ATTR_ID, GLOBAL_VALUE, LOCAL_ATTR, NO_PARENT_KEY, CANONICAL_NAME
 } from "./formula-types"
@@ -22,6 +23,7 @@ export interface IFormulaMathjsScopeContext {
   childMostAggregateCollectionIndex?: number
   caseGroupId?: Record<string, string>
   caseChildrenCount?: Record<string, number>
+  defaultArgument?: string
 }
 
 // Official MathJS docs don't describe custom scopes in great detail, but there's a good example in their repo:
@@ -38,6 +40,7 @@ export class FormulaMathJsScope {
   // `previousResults` is used for calculating self-referencing, recursive functions like prev(), e.g.:
   // [CumulativeValue attribute formula]: "prev(CumulativeValue, 0) + Value"
   previousResults: FValue[] = []
+  defaultArgumentNode?: MathNode
 
   get caseId() {
     if (!this.context.caseIds) {
@@ -48,6 +51,7 @@ export class FormulaMathJsScope {
 
   constructor (context: IFormulaMathjsScopeContext) {
     this.context = context
+    this.defaultArgumentNode = context.defaultArgument ? parse(context.defaultArgument) : undefined
     this.initDataStorage(context)
   }
 

--- a/v3/src/models/formula/formula-types.ts
+++ b/v3/src/models/formula/formula-types.ts
@@ -61,6 +61,8 @@ export type EvaluateRawFunc = (args: MathNode[], mathjs: any, scope: FormulaMath
 export type CaseList = ICase[] | "ALL_CASES"
 
 export interface IFormulaMathjsFunction {
+  // Each function needs to specify number of required arguments, so the default argument can be provided if needed.
+  numOfRequiredArguments: number
   rawArgs?: boolean
   // Value of isAggregate is a boolean. When true, it means that all the arguments of the function should be resolved
   // to all cases of the attribute, not just the current case.

--- a/v3/src/models/formula/formula-utils.test.ts
+++ b/v3/src/models/formula/formula-utils.test.ts
@@ -360,7 +360,7 @@ describe("getDisplayNameMap", () => {
   })
 
   describe("when there are local attributes or globals with the name 'caseIndex'", () => {
-    it("resolves 'caseIndex' to a special value (special value take precedence over anything else)", () => {
+    it("resolves 'caseIndex' to a special value (special value takes precedence over anything else)", () => {
       const dataSet = DataSet.create({
         id: "dataSet",
         name: "dataSet",

--- a/v3/src/models/formula/formula-utils.test.ts
+++ b/v3/src/models/formula/formula-utils.test.ts
@@ -353,6 +353,10 @@ describe("getDisplayNameMap", () => {
       }
     })
   })
+
+  // it("respects order of name sources", () => {
+  //   // TODO
+  // })
 })
 
 describe("getCanonicalNameMap", () => {

--- a/v3/src/models/formula/formula-utils.test.ts
+++ b/v3/src/models/formula/formula-utils.test.ts
@@ -461,7 +461,7 @@ describe("localAttrIdToCanonical", () => {
 })
 
 describe("globalValueIdToCanonical", () => {
-  it("returns a string that is recognized parseBasicCanonicalName as a global value dependency", () => {
+  it("returns a string that is recognized by parseBasicCanonicalName as a global value dependency", () => {
     expect(parseBasicCanonicalName(globalValueIdToCanonical("foo"))).toEqual({ type: "globalValue", globalId: "foo" })
   })
 })

--- a/v3/src/models/formula/formula-utils.test.ts
+++ b/v3/src/models/formula/formula-utils.test.ts
@@ -455,7 +455,7 @@ describe("getCanonicalNameMap", () => {
 })
 
 describe("localAttrIdToCanonical", () => {
-  it("returns a string that is recognized parseBasicCanonicalName as a local attribute dependency", () => {
+  it("returns a string that is recognized by parseBasicCanonicalName as a local attribute dependency", () => {
     expect(parseBasicCanonicalName(localAttrIdToCanonical("foo"))).toEqual({ type: "localAttribute", attrId: "foo" })
   })
 })

--- a/v3/src/models/formula/formula-utils.ts
+++ b/v3/src/models/formula/formula-utils.ts
@@ -335,7 +335,7 @@ export const getFormulaDependencies = (formulaCanonical: string, formulaAttribut
           result.push(dependency)
         }
       }
-      // When default argument is provided and the function has less arguments than required, we need to visit the
+      // When default argument is provided and the function has fewer arguments than required, we need to visit the
       // the default arg node so it can become a dependency.
       if (defaultArgNode && functionInfo.numOfRequiredArguments > node.args.length) {
         visitNode(defaultArgNode, "", node)

--- a/v3/src/models/formula/formula-utils.ts
+++ b/v3/src/models/formula/formula-utils.ts
@@ -1,7 +1,7 @@
 import { parse, MathNode, isFunctionNode } from "mathjs"
 import {
   LOCAL_ATTR, GLOBAL_VALUE, DisplayNameMap, CanonicalNameMap, IFormulaDependency, isConstantStringNode,
-  isNonFunctionSymbolNode, isCanonicalName, rmCanonicalPrefix, CANONICAL_NAME, CASE_INDEX_FAKE_ATTR_ID
+  isNonFunctionSymbolNode, CANONICAL_NAME, CASE_INDEX_FAKE_ATTR_ID, isCanonicalName, rmCanonicalPrefix
 } from "./formula-types"
 import { typedFnRegistry } from "./functions/math"
 import t from "../../utilities/translation/translate"
@@ -54,7 +54,6 @@ export const safeSymbolNameFromDisplayFormula = (name: string) =>
   // Replace escaped backslash and backticks in user-generated string with a single character, so they're not replaced
   // by two underscores by safeSymbolName.
   safeSymbolName(unescapeBacktickString(name))
-
 
 export const makeDisplayNamesSafe = (formula: string) => {
   // Names between `` are symbols that require special processing, as otherwise they could not be parsed by Mathjs,

--- a/v3/src/models/formula/formula-utils.ts
+++ b/v3/src/models/formula/formula-utils.ts
@@ -97,7 +97,7 @@ export const getDisplayNameMap = (options: IDisplayNameMapOptions, useSafeSymbol
     nonEmptyName(_useSafeSymbolNames ? safeSymbolName(name) : name)
 
   // When localNames are generated, the order of processing various sources of names is important.
-  // The last last source would provide the final canonical name for the symbol. So, currently the global values
+  // The last source would provide the final canonical name for the symbol. So, currently the global values
   // have the lowest priority, then local attributes, and finally the reserved symbols like `caseIndex`.
   globalValueManager?.globals.forEach(global => {
     displayNameMap.localNames[key(global.name)] = `${CANONICAL_NAME}${GLOBAL_VALUE}${global.id}`

--- a/v3/src/models/formula/functions/aggregate-functions.ts
+++ b/v3/src/models/formula/functions/aggregate-functions.ts
@@ -36,6 +36,7 @@ const aggregateFnWithFilterFactory = (fn: (values: number[]) => FValue) => {
 export const aggregateFunctions = {
   // mean(expression, filterExpression)
   mean: {
+    numOfRequiredArguments: 1,
     isAggregate: true,
     cachedEvaluateFactory: cachedAggregateFnFactory,
     evaluateRaw: aggregateFnWithFilterFactory(mean)
@@ -43,6 +44,7 @@ export const aggregateFunctions = {
 
   // median(expression, filterExpression)
   median: {
+    numOfRequiredArguments: 1,
     isAggregate: true,
     cachedEvaluateFactory: cachedAggregateFnFactory,
     evaluateRaw: aggregateFnWithFilterFactory(median)
@@ -50,6 +52,7 @@ export const aggregateFunctions = {
 
   // mad(expression, filterExpression)
   mad: {
+    numOfRequiredArguments: 1,
     isAggregate: true,
     cachedEvaluateFactory: cachedAggregateFnFactory,
     evaluateRaw: aggregateFnWithFilterFactory(mad)
@@ -57,6 +60,7 @@ export const aggregateFunctions = {
 
   // max(expression, filterExpression)
   max: {
+    numOfRequiredArguments: 1,
     isAggregate: true,
     cachedEvaluateFactory: cachedAggregateFnFactory,
     evaluateRaw: aggregateFnWithFilterFactory(max)
@@ -64,6 +68,7 @@ export const aggregateFunctions = {
 
   // min(expression, filterExpression)
   min: {
+    numOfRequiredArguments: 1,
     isAggregate: true,
     cachedEvaluateFactory: cachedAggregateFnFactory,
     evaluateRaw: aggregateFnWithFilterFactory(min)
@@ -71,6 +76,7 @@ export const aggregateFunctions = {
 
   // sum(expression, filterExpression)
   sum: {
+    numOfRequiredArguments: 1,
     isAggregate: true,
     cachedEvaluateFactory: cachedAggregateFnFactory,
     evaluateRaw: aggregateFnWithFilterFactory(sum)
@@ -78,6 +84,7 @@ export const aggregateFunctions = {
 
   // count(expression, filterExpression)
   count: {
+    numOfRequiredArguments: 0,
     isAggregate: true,
     // Note that count is untypical aggregate function that cannot use typical caching. When count() is called without
     // arguments, the default caching method would calculate incorrect cache key. Hence, caching is implemented directly

--- a/v3/src/models/formula/functions/arithmetic-functions.ts
+++ b/v3/src/models/formula/functions/arithmetic-functions.ts
@@ -55,42 +55,52 @@ export const numericFnFactory = (fn: (value: number) => number) => {
 
 export const arithmeticFunctions = {
   abs: {
+    numOfRequiredArguments: 1,
     evaluate: numericFnFactory(Math.abs)
   },
 
   ceil: {
+    numOfRequiredArguments: 1,
     evaluate: numericFnFactory(Math.ceil)
   },
 
   combinations: {
+    numOfRequiredArguments: 2,
     evaluate: numericMultiArgsFnFactory(combinations, { numOfRequiredArgs: 2 })
   },
 
   exp: {
+    numOfRequiredArguments: 1,
     evaluate: numericFnFactory(Math.exp)
   },
 
   floor: {
+    numOfRequiredArguments: 1,
     evaluate: numericFnFactory(Math.floor)
   },
 
   frac: {
+    numOfRequiredArguments: 1,
     evaluate: numericFnFactory((v: number) => v - Math.trunc(v))
   },
 
   ln: {
+    numOfRequiredArguments: 1,
     evaluate: numericFnFactory(Math.log)
   },
 
   log: {
+    numOfRequiredArguments: 1,
     evaluate: numericFnFactory(Math.log10)
   },
 
   pow: {
+    numOfRequiredArguments: 2,
     evaluate: numericMultiArgsFnFactory(Math.pow, { numOfRequiredArgs: 2 })
   },
 
   round: {
+    numOfRequiredArguments: 1,
     evaluate: numericMultiArgsFnFactory((num: number, digits = 0): number => {
       // It works correctly for negative digits value too.
       const factor = 10 ** digits
@@ -99,10 +109,12 @@ export const arithmeticFunctions = {
   },
 
   sqrt: {
+    numOfRequiredArguments: 1,
     evaluate: numericFnFactory(Math.sqrt)
   },
 
   trunc: {
+    numOfRequiredArguments: 1,
     evaluate: numericFnFactory(Math.trunc)
   },
 }

--- a/v3/src/models/formula/functions/lookup-functions.ts
+++ b/v3/src/models/formula/functions/lookup-functions.ts
@@ -10,6 +10,7 @@ type LookupStringConstantArg = ConstantNode<string> | undefined
 export const lookupFunctions = {
   // lookupByIndex("dataSetName", "attributeName", index)
   lookupByIndex: {
+    numOfRequiredArguments: 3,
     getDependency: (args: MathNode[]): ILookupDependency => {
       const [dataSetNameArg, attrNameArg] = args as LookupStringConstantArg[]
       return {
@@ -31,8 +32,9 @@ export const lookupFunctions = {
     },
     evaluateRaw: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
       const functionName = "lookupByIndex"
-      if (args.length !== 3) {
-        throw new Error(t("DG.Formula.FuncArgsErrorPlural.description", { vars: [ functionName, 3 ] }))
+      const numOfReqArgs = lookupFunctions.lookupByIndex.numOfRequiredArguments
+      if (args.length !== numOfReqArgs) {
+        throw new Error(t("DG.Formula.FuncArgsErrorPlural.description", { vars: [ functionName, numOfReqArgs ] }))
       }
       [0, 1].forEach(i => {
         if (!isConstantStringNode(args[i])) {
@@ -54,6 +56,7 @@ export const lookupFunctions = {
 
   // lookupByKey("dataSetName", "attributeName", "keyAttributeName", "keyAttributeValue" | localKeyAttribute)
   lookupByKey: {
+    numOfRequiredArguments: 4,
     getDependency: (args: MathNode[]): Required<ILookupDependency> => {
       const [dataSetNameArg, attrNameArg, keyAttrNameArg] = args as LookupStringConstantArg[]
       return {
@@ -80,8 +83,9 @@ export const lookupFunctions = {
     },
     evaluateRaw: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
       const functionName = "lookupByKey"
-      if (args.length !== 4) {
-        throw new Error(t("DG.Formula.FuncArgsErrorPlural.description", { vars: [ functionName, 4 ] }))
+      const numOfReqArgs = lookupFunctions.lookupByKey.numOfRequiredArguments
+      if (args.length !== numOfReqArgs) {
+        throw new Error(t("DG.Formula.FuncArgsErrorPlural.description", { vars: [ functionName, numOfReqArgs ] }))
       }
       [0, 1, 2].forEach(i => {
         if (!isConstantStringNode(args[i])) {

--- a/v3/src/models/formula/functions/math.test.ts
+++ b/v3/src/models/formula/functions/math.test.ts
@@ -1,0 +1,68 @@
+import { MathNode, SymbolNode, parse } from "mathjs"
+import { FormulaMathJsScope } from "../formula-mathjs-scope"
+import { evaluateRawWithAggregateContext, evaluateRawWithDefaultArg, evaluateToEvaluateRaw } from "./math"
+import { FValue } from "../formula-types"
+
+describe("evaluateRawWithAggregateContext", () => {
+  it("should call provided function within withAggregateContext", () => {
+    const args: MathNode[] = []
+    const mathjs = {}
+    const scope = {
+      aggregateContext: false,
+      withAggregateContext: (fn: () => any) => {
+        scope.aggregateContext = true
+        fn()
+        scope.aggregateContext = false
+      }
+    }
+    let result = false
+    const mockFn = jest.fn(() => { result = scope.aggregateContext; return "" })
+
+    evaluateRawWithAggregateContext(mockFn)(args, mathjs, scope as any as FormulaMathJsScope)
+    expect(mockFn).toHaveBeenCalledWith(args, mathjs, scope)
+    expect(result).toBeTruthy()
+  })
+})
+
+describe("evaluateRawWithDefaultArg", () => {
+  it("should call provided function with default argument if not enough arguments are provided", () => {
+    const args: MathNode[] = []
+    const mathjs = {}
+    const scope = {
+      defaultArgumentNode: { name: "default" }
+    }
+    const mockFn = jest.fn((_args: MathNode[]) => (_args[0] as SymbolNode).name)
+
+    const numOfReqArgs = 1
+    const res = evaluateRawWithDefaultArg(mockFn, numOfReqArgs)(args, mathjs, scope as any as FormulaMathJsScope)
+    expect(mockFn).toHaveBeenCalledWith([scope.defaultArgumentNode], mathjs, scope)
+    expect(res).toEqual("default")
+  })
+
+  it("should call provided function without default argument if enough arguments are provided", () => {
+    const args = [ { name: "provided" } ]
+    const mathjs = {}
+    const scope = {
+      defaultArgumentNode: { name: "default" }
+    }
+    const mockFn = jest.fn((_args: MathNode[]) => (_args[0] as SymbolNode).name)
+
+    const res =
+      evaluateRawWithDefaultArg(mockFn, 1)(args as any as MathNode[], mathjs, scope as any as FormulaMathJsScope)
+    expect(mockFn).toHaveBeenCalledWith(args, mathjs, scope)
+    expect(res).toEqual("provided")
+  })
+})
+
+describe("evaluateToEvaluateRaw", () => {
+  it("should call provided function with evaluated arguments", () => {
+    const args = [ parse("1"), parse("2") ]
+    const mathjs = {}
+    const scope = {}
+    const mockFn = jest.fn((a: FValue, b: FValue) => Number(a) + Number(b))
+
+    const res = evaluateToEvaluateRaw(mockFn)(args as any as MathNode[], mathjs, scope as any as FormulaMathJsScope)
+    expect(mockFn).toHaveBeenCalledWith(1, 2)
+    expect(res).toEqual(3)
+  })
+})

--- a/v3/src/models/formula/functions/math.ts
+++ b/v3/src/models/formula/functions/math.ts
@@ -1,9 +1,7 @@
 import { create, all, MathNode } from 'mathjs'
 import { FormulaMathJsScope } from '../formula-mathjs-scope'
-import {
-  FValue, CODAPMathjsFunctionRegistry
-} from '../formula-types'
-import { equal } from './function-utils'
+import { CODAPMathjsFunctionRegistry, EvaluateFunc, EvaluateRawFunc } from '../formula-types'
+import { equal, evaluateNode } from './function-utils'
 import { arithmeticFunctions } from './arithmetic-functions'
 import { lookupFunctions } from './lookup-functions'
 import { otherFunctions } from './other-functions'
@@ -13,11 +11,25 @@ import { semiAggregateFunctions } from './semi-aggregate-functions'
 export const math = create(all)
 
 // Each aggregate function needs to be evaluated with `withAggregateContext` method.
-const evaluateRawWithAggregateContext =
-(fn: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]) => {
+const evaluateRawWithAggregateContext = (fn: EvaluateRawFunc): EvaluateRawFunc => {
   return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
     // withAggregateContext returns result of the callback function
     return scope.withAggregateContext(() => fn(args, mathjs, scope))
+  }
+}
+
+const evaluateRawWithDefaultArgument = (fn: EvaluateRawFunc, numOfRequiredArguments: number): EvaluateRawFunc => {
+  return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
+    if (scope.defaultArgumentNode && args.length < numOfRequiredArguments) {
+      return fn([...args, scope.defaultArgumentNode], mathjs, scope)
+    }
+    return fn(args, mathjs, scope)
+  }
+}
+
+const evaluateToEvaluateRaw = (fn: EvaluateFunc): EvaluateRawFunc => {
+  return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
+    return fn(...(args.map(arg => evaluateNode(arg, scope))))
   }
 }
 
@@ -26,10 +38,12 @@ export const fnRegistry = {
   // Note that we need to override default MathJs implementation so we can compare strings like "ABC" == "CDE".
   // MathJs doesn't allow that by default, as it assumes that equal operator can be used only with numbers.
   equal: {
+    numOfRequiredArguments: 2,
     evaluate: equal
   },
 
   unequal: {
+    numOfRequiredArguments: 2,
     evaluate: (a: any, b: any) => !equal(a, b)
   },
 
@@ -49,23 +63,25 @@ export const typedFnRegistry: CODAPMathjsFunctionRegistry = fnRegistry
 // import the new function in the Mathjs namespace
 Object.keys(typedFnRegistry).forEach((key) => {
   const fn = typedFnRegistry[key]
-  let evaluateRaw = fn.evaluateRaw
-  if (fn.isAggregate && !fn.evaluateRaw) {
-    throw new Error("Aggregate functions need to provide evaluateRaw")
+  let evaluateRaw = fn.evaluateRaw || (fn.evaluate && evaluateToEvaluateRaw(fn.evaluate))
+  if (!evaluateRaw) {
+    throw new Error("evaluateRaw or evaluate function must be defined")
   }
-  if (evaluateRaw) {
-    if (fn.isAggregate) {
-      evaluateRaw = evaluateRawWithAggregateContext(evaluateRaw)
-    }
-    if (fn.cachedEvaluateFactory) {
-      // Use cachedEvaluateFactory if it's defined. Currently it's defined only for aggregate functions.
-      evaluateRaw = fn.cachedEvaluateFactory(key, evaluateRaw)
-    }
-    // MathJS expects rawArgs property to be set on the evaluate function
-    (evaluateRaw as any).rawArgs = true
+  if (fn.isAggregate) {
+    evaluateRaw = evaluateRawWithAggregateContext(evaluateRaw)
   }
+  if (fn.cachedEvaluateFactory) {
+    // Use cachedEvaluateFactory if it's defined. Currently it's defined only for aggregate functions.
+    evaluateRaw = fn.cachedEvaluateFactory(key, evaluateRaw)
+  }
+  if (fn.numOfRequiredArguments > 0) {
+    evaluateRaw = evaluateRawWithDefaultArgument(evaluateRaw, fn.numOfRequiredArguments)
+  }
+
+  // MathJS expects rawArgs property to be set on the evaluate function
+  (evaluateRaw as any).rawArgs = true
   math.import({
-    [key]: evaluateRaw || fn.evaluate
+    [key]: evaluateRaw
   }, {
     override: true // override functions already defined by mathjs
   })

--- a/v3/src/models/formula/functions/math.ts
+++ b/v3/src/models/formula/functions/math.ts
@@ -11,14 +11,14 @@ import { semiAggregateFunctions } from './semi-aggregate-functions'
 export const math = create(all)
 
 // Each aggregate function needs to be evaluated with `withAggregateContext` method.
-const evaluateRawWithAggregateContext = (fn: EvaluateRawFunc): EvaluateRawFunc => {
+export const evaluateRawWithAggregateContext = (fn: EvaluateRawFunc): EvaluateRawFunc => {
   return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
     // withAggregateContext returns result of the callback function
     return scope.withAggregateContext(() => fn(args, mathjs, scope))
   }
 }
 
-const evaluateRawWithDefaultArgument = (fn: EvaluateRawFunc, numOfRequiredArguments: number): EvaluateRawFunc => {
+export const evaluateRawWithDefaultArg = (fn: EvaluateRawFunc, numOfRequiredArguments: number): EvaluateRawFunc => {
   return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
     if (scope.defaultArgumentNode && args.length < numOfRequiredArguments) {
       return fn([...args, scope.defaultArgumentNode], mathjs, scope)
@@ -27,7 +27,7 @@ const evaluateRawWithDefaultArgument = (fn: EvaluateRawFunc, numOfRequiredArgume
   }
 }
 
-const evaluateToEvaluateRaw = (fn: EvaluateFunc): EvaluateRawFunc => {
+export const evaluateToEvaluateRaw = (fn: EvaluateFunc): EvaluateRawFunc => {
   return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
     return fn(...(args.map(arg => evaluateNode(arg, scope))))
   }
@@ -75,7 +75,7 @@ Object.keys(typedFnRegistry).forEach((key) => {
     evaluateRaw = fn.cachedEvaluateFactory(key, evaluateRaw)
   }
   if (fn.numOfRequiredArguments > 0) {
-    evaluateRaw = evaluateRawWithDefaultArgument(evaluateRaw, fn.numOfRequiredArguments)
+    evaluateRaw = evaluateRawWithDefaultArg(evaluateRaw, fn.numOfRequiredArguments)
   }
 
   // MathJS expects rawArgs property to be set on the evaluate function

--- a/v3/src/models/formula/functions/other-functions.ts
+++ b/v3/src/models/formula/functions/other-functions.ts
@@ -4,11 +4,13 @@ import { FValue } from "../formula-types"
 export const otherFunctions = {
   // if(expression, value_if_true, value_if_false)
   if: {
+    numOfRequiredArguments: 3,
     evaluate: (...args: FValue[]) => args[0] ? args[1] : (args[2] ?? "")
   },
 
   // randomPick(...args)
   randomPick: {
+    numOfRequiredArguments: 1,
     isRandomFunction: true,
     // Nothing to do here, mathjs.pickRandom() has exactly the same signature as CODAP V2 randomPick() function,
     // just the name is different.
@@ -17,6 +19,7 @@ export const otherFunctions = {
 
   // random(min, max)
   random: {
+    numOfRequiredArguments: 0,
     isRandomFunction: true,
     // Nothing to do here, mathjs.random() has exactly the same signature as CODAP V2 random() function.
     evaluate: (...args: FValue[]) => random(...args as number[])

--- a/v3/src/models/formula/functions/semi-aggregate-functions.ts
+++ b/v3/src/models/formula/functions/semi-aggregate-functions.ts
@@ -5,6 +5,7 @@ import { UNDEF_RESULT, evaluateNode, isValueTruthy } from "./function-utils"
 
 export const semiAggregateFunctions = {
   next: {
+    numOfRequiredArguments: 1,
     // expression and filter are evaluated as aggregate symbols, defaultValue is not - it depends on case index
     isSemiAggregate: [true, false, true],
     evaluateRaw: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
@@ -68,6 +69,7 @@ export const semiAggregateFunctions = {
 
   // prev(expression, defaultValue, filter)
   prev: {
+    numOfRequiredArguments: 1,
     // Circular reference might be used to define a formula that calculates the cumulative value, e.g.:
     // `CumulativeValue` attribute formula: `Value + prev(CumulativeValue, 0)`
     selfReferenceAllowed: true,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186358510.

This PR introduces the concept of default arguments to the formula system and integrates them into the Plotted Value formulas.

There are two key areas where significant changes have occurred:

1. **Observers**: The default argument is now treated as a new dependency, even when it's not explicitly defined. For instance, if a user simply uses `mean()` and the default argument is set to `Height`, the system will now recalculate the formula whenever any of the Height values change.

2. **Evaluation**: This aspect is more straightforward. The default argument has become a part of the FormulaMathJSScope. Functions do not require manual handling of default arguments. This handling is automatic. The only thing each function needs to specify is the number of required arguments. Without this information, it becomes impossible to determine whether the default argument should be used. In theory, we could always push the default argument into the arguments array, which would work for evaluation, as each function could just ignore this last argument. However, it does not align well with observing. In this scenario, we wouldn't be able to determine whether the default argument needs to be observed or not.

I've also included a few new helpers, did some refactoring, and added unit tests.

However, there is one outstanding issue that can be triggered by dragging a new numeric attribute to the X-axis, essentially updating the default argument. In this situation, calculations do not proceed correctly. I'm working on a solution and will open a separate PR to address this issue.