### PR TITLE
fix: graph response to delete case table along with undo/redo

### DIFF
--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -47,7 +47,8 @@ jobs:
       fail-fast: false
       matrix:
         # run multiple copies of the current job in parallel
-        containers: [1, 2, 3]
+        # containers: [1, 2, 3]
+        containers: [1]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -57,7 +57,7 @@ export const useSubAxis = ({
     renderSubAxis = useCallback(() => {
       const _axisModel = axisProvider.getAxis?.(axisPlace)
       if (!isAliveSafe(_axisModel)) {
-        console.warn("useSubAxis.renderSubAxis skipping rendering of defunct axis model")
+        console.warn("useSubAxis.renderSubAxis skipping rendering of defunct axis model:", axisPlace)
         return
       }
       const

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -151,9 +151,10 @@ export const DeleteDataSetModal = ({dataSetId, isOpen, onClose, setModalOpen}: I
     setModalOpen(false)
     onClose()
     if (dataSetId) {
-      manager?.removeSharedModel(dataSetId)
-      gDataBroker.removeDataSet(dataSetId)
-      getFormulaManager(document)?.removeDataSet(dataSetId)
+      document.applyUndoableAction(() => {
+        manager?.removeSharedModel(dataSetId)
+        getFormulaManager(document)?.removeDataSet(dataSetId)
+      }, "V3.Undo.caseTable.delete", "V3.Redo.caseTable.delete")
     }
   }
 

--- a/v3/src/components/graph/hooks/use-graph-model.ts
+++ b/v3/src/components/graph/hooks/use-graph-model.ts
@@ -36,18 +36,19 @@ export function useGraphModel(props: IProps) {
   useEffect(function installPlotTypeAction() {
     const disposer = onAnyAction(graphModel, action => {
       if (action.name === 'setPlotType') {
+        const { caseDataArray } = dataConfig || {}
         const newPlotType = action.args?.[0]/*,
           attrIDs = newPlotType === 'dotPlot' ? [xAttrID] : [xAttrID, yAttrID]*/
         startAnimation(enableAnimation)
         // In case the y-values have changed we rescale
         if (newPlotType === 'scatterPlot') {
-          const values = dataConfig?.caseDataArray.map(({ caseID }) => dataset?.getNumeric(caseID, yAttrID)) as number[]
+          const values = caseDataArray?.map(({ caseID }) => dataset?.getNumeric(caseID, yAttrID)) as number[]
           setNiceDomain(values || [], yAxisModel as INumericAxisModel)
         }
       }
     })
     return () => disposer()
-  }, [dataConfig?.caseDataArray, dataset, enableAnimation, graphModel, yAttrID, yAxisModel])
+  }, [dataConfig, dataset, enableAnimation, graphModel, yAttrID, yAxisModel])
 
   // respond to point properties change
   useEffect(function respondToGraphPointVisualAction() {

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -1,0 +1,212 @@
+import { applySnapshot, getSnapshot, SnapshotIn, types } from "mobx-state-tree"
+import { GraphContentModel, IGraphContentModelSnapshot, createGraphContentModel } from "./graph-content-model"
+import { GraphController } from "./graph-controller"
+import { GraphLayout } from "./graph-layout"
+import { DataSet } from "../../../models/data/data-set"
+import { SharedCaseMetadata } from "../../../models/shared/shared-case-metadata"
+import { GraphAttrRole } from "../../data-display/data-display-types"
+import { attrRoleToGraphPlace } from "../graphing-types"
+import { isCategoricalAxisModel, isEmptyAxisModel, isNumericAxisModel } from "../../axis/models/axis-model"
+import { AxisPlace } from "../../axis/axis-types"
+
+const mockGetDataSet = jest.fn()
+const mockGetMetadata = jest.fn()
+
+jest.mock("../../../models/shared/shared-data-utils", () => ({
+  getDataSetFromId: () => mockGetDataSet(),
+  getTileDataSet: () => mockGetDataSet(),
+  getTileCaseMetadata: () => mockGetMetadata()
+}))
+
+const mockComputePointRadius = jest.fn(() => 5)
+const mockMatchCirclesToData = jest.fn()
+
+jest.mock("../../data-display/data-display-utils", () => ({
+  computePointRadius: () => mockComputePointRadius(),
+  matchCirclesToData: () => mockMatchCirclesToData()
+}))
+
+describe("GraphController", () => {
+
+  const Tree = types.model("Tree", {
+    model: types.optional(GraphContentModel, () => createGraphContentModel()),
+    data: types.optional(DataSet, () => DataSet.create({
+      attributes: [
+        { id: "xId", name: "x", values: ["1", "2", "3"] },
+        { id: "yId", name: "y", values: ["4", "5", "6"] },
+        { id: "y2Id", name: "y2", values: ["7", "8", "9"] },
+        { id: "cId", name: "c", values: ["a", "b", "c"] }
+      ]
+    })),
+    metadata: types.optional(SharedCaseMetadata, () => SharedCaseMetadata.create())
+  })
+
+  const enableAnimation = { current: false } as any
+  const instanceId = "Graph1"
+
+  let emptyPlotSnap: SnapshotIn<typeof Tree> | undefined
+  let dotPlotSnap: SnapshotIn<typeof Tree> | undefined
+  let dotChartSnap: SnapshotIn<typeof Tree> | undefined
+  let scatterPlotSnap: SnapshotIn<typeof Tree> | undefined
+
+  function setup() {
+    const _tree = Tree.create()
+    const { model: graphModel, data: dataSet, metadata: _metadata } = _tree
+    mockGetDataSet.mockRestore()
+    mockGetDataSet.mockImplementation(() => dataSet)
+    mockGetMetadata.mockRestore()
+    mockGetMetadata.mockImplementation(() => _metadata)
+    const layout = new GraphLayout()
+    const graphController = new GraphController({ layout, enableAnimation, instanceId })
+    const dotsRef = { current: {} } as any
+    graphController.setProperties({ graphModel, dotsRef })
+    return { tree: _tree, model: graphModel, controller: graphController, data: dataSet, metadata: _metadata }
+  }
+
+  let { tree, model, controller, data, metadata } = setup()
+
+  function getScaleType(place: AxisPlace) {
+    return controller.layout.getAxisMultiScale(place).scaleType
+  }
+
+  function setAttributeId(role: GraphAttrRole, attrId: string) {
+    const place = attrRoleToGraphPlace[role]
+    expect(place).toBeTruthy()
+    model.setAttributeID(role, data.id, attrId)
+    // in the full graph code, `handleAttributeAssignment` is called by a MobX reaction,
+    // but here we call it directly for testing simplicity
+    controller.handleAttributeAssignment(place!, data.id, attrId)
+  }
+
+  it("methods bail appropriately when not fully defined", () => {
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+    const _controller = new GraphController({
+      layout: undefined as any,
+      enableAnimation,
+      instanceId
+    })
+    _controller.initializeGraph()
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+    _controller.clearGraph()
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+    _controller.handleAttributeAssignment("bottom", data.id, "xId")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+    _controller.handleAttributeAssignment("bottom", "bogusId", "xId")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+    _controller.handleAttributeAssignment("bottom", data.id, "bogusId")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+
+    _controller.setProperties({ graphModel: model, dotsRef: undefined as any })
+    _controller.initializeGraph()
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+    _controller.callMatchCirclesToData()
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+
+    _controller.setProperties({ graphModel: model, dotsRef: {} as any })
+    _controller.initializeGraph()
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+    _controller.callMatchCirclesToData()
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
+
+  })
+
+  it("handles attribute assignments and deserialization correctly", () => {
+    ({ tree, model, controller, data, metadata } = setup())
+
+    let matchCirclesCount = 1
+
+    expect(controller.graphModel).toBe(model)
+    emptyPlotSnap = getSnapshot(tree)
+    expect(model.plotType).toBe("casePlot")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // case plot => dot plot
+    setAttributeId("x", "xId")
+    dotPlotSnap = getSnapshot(tree)
+    expect(model.plotType).toBe("dotPlot")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // dot plot => dot plot with legend
+    setAttributeId("legend", "yId")
+    expect(model.plotType).toBe("dotPlot")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // dot plot => case plot
+    setAttributeId("x", "")
+    expect(model.plotType).toBe("casePlot")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // case plot => dot plot
+    setAttributeId("x", "xId")
+    expect(model.plotType).toBe("dotPlot")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // dot plot => scatter plot
+    setAttributeId("y", "yId")
+    scatterPlotSnap = getSnapshot(tree)
+    expect(model.plotType).toBe("scatterPlot")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // scatter plot => y2 scatter plot
+    setAttributeId("yPlus", "y2Id")
+    expect(model.plotType).toBe("scatterPlot")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // scatter plot => empty plot
+    controller.clearGraph()
+    controller.initializeGraph()  // triggered by reaction in Graph component normally
+    expect(model.plotType).toBe("casePlot")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // empty plot => dot chart
+    setAttributeId("y", "cId")
+    dotChartSnap = getSnapshot(tree)
+    expect(model.plotType).toBe("dotChart")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // dot chart => split dot chart
+    setAttributeId("topSplit", "cId")
+    expect(model.plotType).toBe("dotChart")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    // split dot chart => dot chart
+    setAttributeId("topSplit", "")
+    expect(model.plotType).toBe("dotChart")
+    expect(mockMatchCirclesToData).toHaveBeenCalledTimes(++matchCirclesCount)
+
+    /*
+     * deserialization
+     */
+    applySnapshot(tree, emptyPlotSnap)
+    controller.initializeGraph()
+    expect(model.plotType).toBe("casePlot")
+    expect(isEmptyAxisModel(model.axes.get("bottom"))).toBe(true)
+    expect(getScaleType("bottom")).toBe("ordinal")
+    expect(isEmptyAxisModel(model.axes.get("left"))).toBe(true)
+    expect(getScaleType("left")).toBe("ordinal")
+
+    applySnapshot(tree, dotPlotSnap)
+    controller.initializeGraph()
+    expect(model.plotType).toBe("dotPlot")
+    expect(isNumericAxisModel(model.axes.get("bottom"))).toBe(true)
+    expect(getScaleType("bottom")).toBe("linear")
+    expect(isEmptyAxisModel(model.axes.get("left"))).toBe(true)
+    expect(getScaleType("left")).toBe("ordinal")
+
+    applySnapshot(tree, dotChartSnap)
+    controller.initializeGraph()
+    expect(model.plotType).toBe("dotChart")
+    expect(isEmptyAxisModel(model.axes.get("bottom"))).toBe(true)
+    expect(getScaleType("bottom")).toBe("ordinal")
+    expect(isCategoricalAxisModel(model.axes.get("left"))).toBe(true)
+    expect(getScaleType("left")).toBe("band")
+
+    applySnapshot(tree, scatterPlotSnap)
+    controller.initializeGraph()
+    expect(model.plotType).toBe("scatterPlot")
+    expect(isNumericAxisModel(model.axes.get("bottom"))).toBe(true)
+    expect(getScaleType("bottom")).toBe("linear")
+    expect(isNumericAxisModel(model.axes.get("left"))).toBe(true)
+    expect(getScaleType("left")).toBe("linear")
+  })
+})

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -1,5 +1,5 @@
 import { applySnapshot, getSnapshot, SnapshotIn, types } from "mobx-state-tree"
-import { GraphContentModel, IGraphContentModelSnapshot, createGraphContentModel } from "./graph-content-model"
+import { GraphContentModel, createGraphContentModel } from "./graph-content-model"
 import { GraphController } from "./graph-controller"
 import { GraphLayout } from "./graph-layout"
 import { DataSet } from "../../../models/data/data-set"
@@ -51,19 +51,19 @@ describe("GraphController", () => {
 
   function setup() {
     const _tree = Tree.create()
-    const { model: graphModel, data: dataSet, metadata: _metadata } = _tree
+    const { model: graphModel, data: dataSet, metadata } = _tree
     mockGetDataSet.mockRestore()
     mockGetDataSet.mockImplementation(() => dataSet)
     mockGetMetadata.mockRestore()
-    mockGetMetadata.mockImplementation(() => _metadata)
+    mockGetMetadata.mockImplementation(() => metadata)
     const layout = new GraphLayout()
     const graphController = new GraphController({ layout, enableAnimation, instanceId })
     const dotsRef = { current: {} } as any
     graphController.setProperties({ graphModel, dotsRef })
-    return { tree: _tree, model: graphModel, controller: graphController, data: dataSet, metadata: _metadata }
+    return { tree: _tree, model: graphModel, controller: graphController, data: dataSet }
   }
 
-  let { tree, model, controller, data, metadata } = setup()
+  let { tree, model, controller, data } = setup()
 
   function getScaleType(place: AxisPlace) {
     return controller.layout.getAxisMultiScale(place).scaleType
@@ -111,7 +111,7 @@ describe("GraphController", () => {
   })
 
   it("handles attribute assignments and deserialization correctly", () => {
-    ({ tree, model, controller, data, metadata } = setup())
+    ({ tree, model, controller, data } = setup())
 
     let matchCirclesCount = 1
 

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -98,6 +98,20 @@ export class GraphController {
     }
   }
 
+  clearGraph() {
+    const {graphModel} = this
+    graphModel?.setPlotType("casePlot")
+    AxisPlaces.forEach(place => {
+      if (["left", "bottom"].includes(place)) {
+        graphModel?.setAxis(place, EmptyAxisModel.create({ place }))
+      }
+      else {
+        graphModel?.removeAxis(place)
+      }
+    })
+    graphModel?.dataConfiguration.clearAttributes()
+  }
+
   handleAttributeAssignment(graphPlace: GraphPlace, dataSetID: string, attrID: string) {
     const {graphModel, layout} = this,
       dataConfig = graphModel?.dataConfiguration,

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -75,7 +75,7 @@ export class GraphController {
     const {graphModel, dotsRef, layout} = this,
       dataConfig = graphModel?.dataConfiguration
     if (dataConfig && layout && dotsRef?.current &&
-        this.attrConfigForInitGraph !== dataConfig?.attributeDescriptionsStr) {
+        this.attrConfigForInitGraph !== dataConfig.attributeDescriptionsStr) {
       AxisPlaces.forEach((axisPlace: AxisPlace) => {
         const axisModel = graphModel.getAxis(axisPlace),
           attrRole = axisPlaceToAttrRole[axisPlace]
@@ -94,7 +94,7 @@ export class GraphController {
         }
       })
       this.callMatchCirclesToData()
-      this.attrConfigForInitGraph = dataConfig?.attributeDescriptionsStr
+      this.attrConfigForInitGraph = dataConfig.attributeDescriptionsStr
     }
   }
 
@@ -120,7 +120,7 @@ export class GraphController {
       return
     }
     this.callMatchCirclesToData()
-    this.attrConfigForInitGraph = dataConfig?.attributeDescriptionsStr
+    this.attrConfigForInitGraph = dataConfig.attributeDescriptionsStr
 
     if (['plot', 'legend'].includes(graphPlace)) {
       // Since there is no axis associated with the legend and the plotType will not change, we bail
@@ -201,6 +201,6 @@ export class GraphController {
 
     setPrimaryRoleAndPlotType()
     AxisPlaces.forEach(setupAxis)
-    this.attrConfigForInitGraph = dataConfig?.attributeDescriptionsStr
+    this.attrConfigForInitGraph = dataConfig.attributeDescriptionsStr
   }
 }

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -2,7 +2,6 @@ import {getSnapshot, Instance, SnapshotIn, types} from "mobx-state-tree"
 import {AttributeType} from "../../../models/data/attribute"
 import {IDataSet} from "../../../models/data/data-set"
 import {ICase} from "../../../models/data/data-set-types"
-import {ISharedCaseMetadata} from "../../../models/shared/shared-case-metadata"
 import {typedId} from "../../../utilities/js-utils"
 import {graphPlaceToAttrRole} from "../graphing-types"
 import {AxisPlace} from "../../axis/axis-types"
@@ -380,21 +379,25 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       }
     }
   })
-  .actions(self => ({
-    setDataset(dataset: IDataSet | undefined, metadata: ISharedCaseMetadata | undefined) {
-      self._setDataset(dataset, metadata)
-      if (dataset && self.filteredCases) {
-        // make sure there are enough filteredCases to hold all the y attributes
-        while (self.filteredCases.length < self._yAttributeDescriptions.length) {
-          self._addNewFilteredCases()
-        }
-        // A y2 attribute is optional, so only add a new filteredCases if there is one.
-        if (self.hasY2Attribute) {
-          self._addNewFilteredCases()
+  .actions(self => {
+    const baseHandleDataSetChange = self.handleDataSetChange
+    return {
+      handleDataSetChange(data?: IDataSet) {
+        baseHandleDataSetChange(data)
+        if (data) {
+          // make sure there are enough filteredCases to hold all the y attributes
+          while (self.filteredCases.length < self._yAttributeDescriptions.length) {
+            self._addNewFilteredCases()
+          }
+          // A y2 attribute is optional, so only add a new filteredCases if there is one.
+          if (self.hasY2Attribute) {
+            self._addNewFilteredCases()
+          }
         }
       }
-      self.invalidateQuantileScale()
-    },
+    }
+  })
+  .actions(self => ({
     setPrimaryRole(role: GraphAttrRole) {
       if (role === 'x' || role === 'y') {
         self.primaryRole = role

--- a/v3/src/models/history/tree-types.ts
+++ b/v3/src/models/history/tree-types.ts
@@ -42,6 +42,7 @@ export function getRunningActionCall() {
 
 // returns true if the specified action is a child of an "undo" or "redo" action
 export function isChildOfUndoRedo(actionCall?: IActionContext) {
+  if (actionCall && ["undo", "redo"].includes(actionCall.name)) return true
   let parentEvent = actionCall?.parentActionEvent
   while (parentEvent) {
     if (["undo", "redo"].includes(parentEvent.name)) return true

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -8,8 +8,10 @@
     "V3.summary.startProfiling": "Start Profiling",
     "V3.summary.stopProfiling": "Stop Profiling",
 
-    "V3.Undo.caseTable.create": "Undo adding a table",
-    "V3.Redo.caseTable.create": "Redo adding a table",
+    "V3.Undo.caseTable.create": "Undo adding case table",
+    "V3.Redo.caseTable.create": "Redo adding case table",
+    "V3.Undo.caseTable.delete": "Undo deleting case table",
+    "V3.Redo.caseTable.delete": "Redo deleting case table",
     "V3.Undo.import.data": "Undo import of data",
     "V3.Redo.import.data": "Redo import of data",
 


### PR DESCRIPTION
Fix: [[#186383038]](https://www.pivotaltracker.com/story/show/186383038)

There were several aspects to getting this to work:
1. The `DataConfigurationModel` needs to update its internal state, e.g. the `filteredCases` array, when its `dataset` is changed. Previously, this was accomplished by having calls to `setDataset()` internally call `_setDataset()`, which had code to update the necessary internal state. But the `dataset` can be changed by other means than directly calling `setDataset()`, e.g. by deleting it from the shared model manager. Instead, we install a MobX `reaction` in `afterCreate()` which observes the `dataset` property and performs the necessary updates whenever it changes, thus eliminating the need to trap calls to `setDataset()` directly. @bgoldowsky This change will probably benefit the CLUE code as well.
2. The `Graph` component installs a MobX `reaction` that listens specifically to the number of elements in the `filteredCases` array. This guarantees that it responds _after_ the `DataConfigurationModel` has responded to the change in `dataset`. This `reaction` calls the new `GraphController.clearGraph()` method in the specific case that the `filteredCases` array becomes empty (and we're not in the middle of an undo/redo operation). In all other cases it calls the existing `GraphController.callMatchCirclesToData()` method, which guarantees that this critical method gets called whenever the `filteredCases` array changes.
3. The new `GraphController` method `clearGraph()` handles the case of returning a graph to its default/unlinked state. It complements the existing `initializeGraph()` (for initializing a graph whose models are up to date, e.g. after deserialization) and `handleAttributeAssignment()` (for adding/removing an attribute to/from a graph).

Aside from the obvious benefit of having graphs handle deletion of their case table/data set correctly, this has the added benefit of allowing this deletion to be undoable, which is an improvement over v2.

Along the way, this PR also fixes a smattering of other issues encountered along the way:
1. enhances a `console.warn` message in the `useSubAxis` hook.
2. adds a missing dependency array to a `useEffect` in the `Graph` component
3. removes an unnecessary dependency from another `useEffect` in the `Graph` component
4. reduces the size of the dependency array from a `useEffect` in the `useGraphModel` hook
5. fixes a bug in the `isChildOfUndoRedo()` utility function