### PR TITLE
Fix evaluation of custom operators

### DIFF
--- a/v3/src/models/formula/formula-types.ts
+++ b/v3/src/models/formula/formula-types.ts
@@ -64,6 +64,8 @@ export interface IFormulaMathjsFunction {
   // Each function needs to specify number of required arguments, so the default argument can be provided if needed.
   numOfRequiredArguments: number
   rawArgs?: boolean
+  // Value of isOperator is a boolean. When true, it means that the function is an operator.
+  isOperator?: boolean
   // Value of isAggregate is a boolean. When true, it means that all the arguments of the function should be resolved
   // to all cases of the attribute, not just the current case.
   isAggregate?: boolean
@@ -82,6 +84,9 @@ export interface IFormulaMathjsFunction {
   // `evaluateRaw` function accepts raw arguments following convention defined by mathjs.
   // This lets us enable custom processing of arguments, caching, etc.
   evaluateRaw?: EvaluateRawFunc
+  // Custom operator overrides need to use `evaluateOperator` function instead of `evaluate` or `evaluateRaw`.
+  // MathJS evaluates operators differently than functions, so we need to handle them separately.
+  evaluateOperator?: EvaluateFunc
   canonicalize?: (args: MathNode[], displayNameMap: DisplayNameMap) => void
   getDependency?: (args: MathNode[]) => IFormulaDependency
   cachedEvaluateFactory?: (fnName: string, evaluate: EvaluateRawFunc) => EvaluateRawFunc


### PR DESCRIPTION
I didn't notice that https://github.com/concord-consortium/codap/pull/975 broke some functionality.
I thought I could completely replace `evaluate` with `evaluateRaw` but apparently MathJS is calling operator functions in a slightly different way. So, I still need to have basic evaluate function available and don't transform it into the evaluateRaw variant. To keep it more descriptive, I've called it `evaluateOperator` and added `isOperator` flag.