### PR TITLE
Recalculate plotted value formula on graph attribute updates

### DIFF
--- a/v3/src/models/formula/attribute-formula-adapter.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.ts
@@ -216,7 +216,8 @@ export class AttributeFormulaAdapter implements IFormulaManagerAdapter {
   }
 
   setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IAttrFormulaExtraMetadata) {
-    return observeDatasetHierarchyChanges(this.api.getDatasets(), (casesToRecalculate?: CaseList) => {
+    const { dataSet } = formulaContext
+    return observeDatasetHierarchyChanges(dataSet, (casesToRecalculate?: CaseList) => {
       this.recalculateFormula(formulaContext, extraMetadata, casesToRecalculate)
     })
   }

--- a/v3/src/models/formula/formula-mathjs-scope.ts
+++ b/v3/src/models/formula/formula-mathjs-scope.ts
@@ -82,7 +82,8 @@ export class FormulaMathJsScope {
                 cachedGroup[groupId].push(this.getLocalValue(cId, attrId))
               })
             }
-            return cachedGroup[this.getCaseAggregateGroupId()] ?? cachedGroup[NO_PARENT_KEY]
+            // If there are no cases in the group, return empty array.
+            return cachedGroup[this.getCaseAggregateGroupId()] ?? cachedGroup[NO_PARENT_KEY] ?? []
           }
         }
       })

--- a/v3/src/models/formula/formula-observers.test.ts
+++ b/v3/src/models/formula/formula-observers.test.ts
@@ -220,7 +220,7 @@ describe("observeDatasetHierarchyChanges", () => {
     dataSet.addAttribute({ id: "cId", name: "c" })
 
     const hierarchyChangedCallback = jest.fn()
-    const dispose = observeDatasetHierarchyChanges(new Map([["ds1", dataSet]]), hierarchyChangedCallback)
+    const dispose = observeDatasetHierarchyChanges(dataSet, hierarchyChangedCallback)
     dataSet.moveAttributeToNewCollection("aId")
     expect(attributesByCollection(dataSet)).toEqual([["aId"], ["bId", "cId"]])
     expect(hierarchyChangedCallback).toHaveBeenCalledTimes(1)

--- a/v3/src/models/formula/formula-observers.ts
+++ b/v3/src/models/formula/formula-observers.ts
@@ -140,13 +140,12 @@ export const observeSymbolNameChanges = (dataSets: Map<string, IDataSet>,
   }
 }
 
-export const observeDatasetHierarchyChanges = (dataSets: Map<string, IDataSet>,
+export const observeDatasetHierarchyChanges = (dataSet:IDataSet,
   recalculateCallback: (casesToRecalculate?: CaseList) => void) => {
-  const dataSetsArray = Array.from(dataSets.values())
   // When any collection is added or removed, or attribute is moved between collections,
-  // we need to recalculate all formulas.
+  // we need to recalculate the formula.
   const disposeAttrCollectionReaction = reaction(
-    () => dataSetsArray.map(ds => Object.fromEntries(ds.collections.map(c => [ c.id, c.attributes.map(a => a?.id) ]))),
+    () => Object.fromEntries(dataSet.collections.map(c => [ c.id, c.attributes.map(a => a?.id) ])),
     () => recalculateCallback("ALL_CASES"),
     {
       equals: comparer.structural,

--- a/v3/src/models/formula/formula-observers.ts
+++ b/v3/src/models/formula/formula-observers.ts
@@ -140,7 +140,7 @@ export const observeSymbolNameChanges = (dataSets: Map<string, IDataSet>,
   }
 }
 
-export const observeDatasetHierarchyChanges = (dataSet:IDataSet,
+export const observeDatasetHierarchyChanges = (dataSet: IDataSet,
   recalculateCallback: (casesToRecalculate?: CaseList) => void) => {
   // When any collection is added or removed, or attribute is moved between collections,
   // we need to recalculate the formula.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186358510

This PR ensures that plotted value formulas are recalculated when the user drags a new attribute to one of the attribute slots. Now, `extraMetadata` is also used to trigger the re-registration and recalculation of a formula. This change was necessary for default argument handling.

To handle other graph axes (e.g. user dragging a category to the top or right axis), I could add something like that:
```javascript
  setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IPlottedValueFormulaExtraMetadata) {
    const graphContentModel = this.getGraphContentModel(extraMetadata)
    return reaction(() => getGraphCellKeys(graphContentModel),
    () => {
      this.recalculateFormula(formulaContext, extraMetadata)
    })
  }
```

But we would recalculate the formula twice when the default argument is updated - once because of this reaction and once because of the extra metadata update. Of course, I could calculate the defaultArgument in the reaction and not trigger recalculation, but I've added graphCellKeys to the extra metadata just to keep things simpler and together.

The last commit is not really related to plotted value, but also related to observers, so I just added it to this PR.

