### PR TITLE
fix: Users can plot a function on a scatterplot (PT-181940062)

### DIFF
--- a/v3/src/components/graph/adornments/adornment-utils.test.ts
+++ b/v3/src/components/graph/adornments/adornment-utils.test.ts
@@ -1,0 +1,14 @@
+import { updateCellKey } from "./adornment-utils"
+
+describe("updateCellKey", () => {
+  it("should return a new cellKey with the given attribute ID as a key and the given value as its value", () => {
+    const cellKey = {abc123: "plants"}
+    const newCellKey = updateCellKey(cellKey, "def456", "land")
+    expect(newCellKey).toEqual({abc123: "plants", def456: "land"})
+  })
+  it("should not overwrite values for existing attribute IDs, add __IMPOSSIBLE__ key instead", () => {
+    const cellKey = {abc123: "plants"}
+    const newCellKey = updateCellKey(cellKey, "abc123", "meat")
+    expect(newCellKey).toEqual({abc123: "plants", __IMPOSSIBLE__: "meat"})
+  })
+})

--- a/v3/src/components/graph/adornments/adornment-utils.ts
+++ b/v3/src/components/graph/adornments/adornment-utils.ts
@@ -1,7 +1,7 @@
 export const updateCellKey = (cellKey: Record<string, string>, attrId: string, cat: string) => {
   const newCellKey = { ...cellKey }
   if (cat) {
-    const propertyAlreadyPresent = Object.keys(newCellKey).includes(attrId)
+    const propertyAlreadyPresent = Object.prototype.hasOwnProperty.call(newCellKey, attrId)
     if (propertyAlreadyPresent && newCellKey[attrId] !== cat) {
       // When the same attribute appears on multiple axes or splits, we avoid overwriting the existing key's
       // value by using the new key "__IMPOSSIBLE__" since it's impossible for a single case to have two

--- a/v3/src/components/graph/adornments/adornment-utils.ts
+++ b/v3/src/components/graph/adornments/adornment-utils.ts
@@ -1,0 +1,15 @@
+export const updateCellKey = (cellKey: Record<string, string>, attrId: string, cat: string) => {
+  const newCellKey = { ...cellKey }
+  if (cat) {
+    const propertyAlreadyPresent = Object.keys(newCellKey).includes(attrId)
+    if (propertyAlreadyPresent && newCellKey[attrId] !== cat) {
+      // When the same attribute appears on multiple axes or splits, we avoid overwriting the existing key's
+      // value by using the new key "__IMPOSSIBLE__" since it's impossible for a single case to have two
+      // different values for the same attribute.
+      newCellKey.__IMPOSSIBLE__ = cat
+    } else {
+      newCellKey[attrId] = cat
+    }
+  }
+  return newCellKey
+}

--- a/v3/src/components/graph/adornments/adornments.tsx
+++ b/v3/src/components/graph/adornments/adornments.tsx
@@ -11,6 +11,7 @@ import { useTileModelContext } from "../../../hooks/use-tile-model-context"
 import { useGraphDataConfigurationContext } from "../hooks/use-data-configuration-context"
 import { useGraphContentModelContext } from "../hooks/use-graph-content-model-context"
 import { getAdornmentComponentInfo } from "./adornment-component-info"
+import { updateCellKey } from "./adornment-utils"
 
 import "./adornments.scss"
 
@@ -35,23 +36,6 @@ export const Adornments = observer(function Adornments() {
         <BannerComponent key={componentInfo.type} model={adornment} />
     )
   })
-
-  // The cellKey is an object that contains the attribute IDs and categorical values for the
-  // current graph cell. It's used to uniquely identify that cell. Since it's possible to have the
-  // same attribute on two axes or splits, we need to make sure the cellKey is unique. So if an
-  // attribute is on more than one axis or split, we set the value of that attribute's ID to 
-  // "__IMPOSSIBLE__" instead of overwriting the key's value because it's impossible for a single
-  // case to have two different values for the same attribute.
-  const updateCellKey = (cellKey: Record<string, string>, attrId: string, cat: string) => {
-    const newCellKey = { ...cellKey }
-    if (cat) {
-      const propertyAlreadyPresent = Object.keys(newCellKey).includes(attrId)
-      newCellKey[attrId] = propertyAlreadyPresent && newCellKey[attrId] !== cat
-        ? "__IMPOSSIBLE__"
-        : cat
-    }
-    return newCellKey
-  }
 
   const xAttrId = dataConfig?.attributeID("x"),
     xAttrType = dataConfig?.attributeType("x"),
@@ -96,6 +80,8 @@ export const Adornments = observer(function Adornments() {
       const adornmentNodes = []
       for (let yIndex = 0; yIndex < yCats.length; yIndex++) {
         for (let xIndex = 0; xIndex < xCats.length; xIndex++) {
+          // The cellKey is an object that contains the attribute IDs and categorical values for the
+          // current graph cell. It's used to uniquely identify that cell.
           let cellKey: Record<string, string> = {}
           if (topAttrId) {
             cellKey = updateCellKey(cellKey, topAttrId, topCats[topIndex])


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181940062

These changes eliminate problems causing duplicate cellKeys to be generated for graphs with multiple subplots. The duplicate cellKeys were caused by a few separate issues: 1) the adornment model's `cellKey` view wasn't always using the correct index values for getting category values, 2) the adornment model's `cellKey` view wasn't using the duplicate-preventing `__IMPOSSIBLE__` key used by the adornment component's `updateCellKey` function, and 3) the latter wasn't correctly using `__IMPOSSIBLE__` as a _key_. They also move `updateCellKey` to a new `adornment-utils.ts` file so it can be used by both the component and model.