### PR TITLE
Do not serialize values computed by formulas, make formula attrs non-editable

### DIFF
--- a/v3/src/components/case-table/use-columns.tsx
+++ b/v3/src/components/case-table/use-columns.tsx
@@ -65,7 +65,7 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
         const collection = data?.getCollection(collectionId)
         const attrs: IAttribute[] = collection ? getCollectionAttrs(collection, data) : []
         const visible: IAttribute[] = attrs.filter(attr => attr && !caseMetadata?.isHidden(attr.id))
-        return visible.map(({ id, name, editable }) => ({ id, name, editable }))
+        return visible.map(({ id, name, isEditable }) => ({ id, name, isEditable }))
       },
       entries => {
         // column definitions
@@ -73,7 +73,7 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
           ? [
               ...(indexColumn ? [indexColumn] : []),
               // attribute column definitions
-              ...entries.map(({ id, name, editable }): TColumn => ({
+              ...entries.map(({ id, name, isEditable }): TColumn => ({
                 key: id,
                 name,
                 // If a default column width isn't supplied, RDG defaults to "auto",
@@ -84,7 +84,7 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
                 renderHeaderCell: ColumnHeader,
                 cellClass: "codap-data-cell",
                 renderCell: RenderCell,
-                renderEditCell: editable ? CellTextEditor : undefined
+                renderEditCell: isEditable ? CellTextEditor : undefined
               }))
           ]
           : []

--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -178,6 +178,7 @@ describe("Attribute", () => {
     expect(attribute.editable).toBe(true)
     attribute.setEditable(false)
     expect(attribute.editable).toBe(false)
+    expect(attribute.isEditable).toBe(false)
   })
 
   test("caching/invalidation of views based on data values works as expected", () => {
@@ -329,14 +330,14 @@ describe("Attribute", () => {
     const attr = Attribute.create({ name: "foo" })
     expect(attr.formula.display).toBe("")
     expect(attr.formula.canonical).toBe("")
-    expect(attr.editable).toBe(true)
+    expect(attr.isEditable).toBe(true)
     attr.setDisplayFormula("2 * x")
     expect(attr.formula.display).toBe("2 * x")
-    expect(attr.editable).toBe(false)
+    expect(attr.isEditable).toBe(false)
     attr.clearFormula()
     expect(attr.formula.display).toBe("")
     expect(attr.formula.canonical).toBe("")
-    expect(attr.editable).toBe(true)
+    expect(attr.isEditable).toBe(true)
   })
 
   test("Attribute derivation", () => {

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -167,6 +167,9 @@ export const Attribute = types.model("Attribute", {
   get format() {
     return self.precision != null ? `.${self.precision}~f` : kDefaultFormatStr
   },
+  get isEditable() {
+    return self.editable && self.formula.empty
+  },
   value(index: number) {
     return self.strValues[index]
   },
@@ -211,7 +214,6 @@ export const Attribute = types.model("Attribute", {
   },
   setDisplayFormula(displayFormula: string) {
     self.formula.setDisplayFormula(displayFormula)
-    this.setEditable(displayFormula === "")
   },
   addValue(value: IValueType = "", beforeIndex?: number) {
     const strValue = self.importValue(value)

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -13,8 +13,6 @@
   To enable mutability, we move the values into `volatile` storage at creation time and then
   move it back to its `frozen` location for serialization. For this to work, clients must
   call the `preSerialize()` and `postSerialize()` functions before and after serialization.
-  Luckily, this sleight-of-hand is not necessary in production and the `preSerialize()` and
-  `postSerialize()` are no-ops in that case.
 
   Like Fathom and and CODAP 2, we need to be able to store heterogeneous values, e.g. strings,
   numbers, boolean values, eventually possibly things like image URLs, etc. Unlike those prior


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186424226

This PR ensures that values computed by formulas will not be serialized in both development and production modes. I've also modified the top-level attribute file comment because, unfortunately, prepareSnapshot() and completeSnapshot() are no longer no-ops in production.

Additionally, I've added a semi-related feature (mostly due to it being overdue for a long time) - formula cells are now non-editable.
