### PR TITLE
Clear case values evaluated by formula before moving attr to a different collection

### DIFF
--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -167,6 +167,12 @@ describe("Attribute", () => {
     expect(attribute.isNumeric(5)).toBe(false)
     expect(attribute.numeric(5)).toBeNaN()
 
+    attribute.clearValues()
+    expect(attribute.strValues.length).toBe(6)
+    expect(attribute.numValues.length).toBe(6)
+    expect(attribute.strValues).toEqual(["", "", "", "", "", ""])
+    expect(attribute.numValues).toEqual([NaN, NaN, NaN, NaN, NaN, NaN])
+
     expect(attribute.format).toBe(kDefaultFormatStr)
     attribute.setPrecision(2)
     expect(attribute.format).toBe(".2~f")

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -247,6 +247,12 @@ export const Attribute = types.model("Attribute", {
       self.numValues.splice(index, count)
       self.incChangeCount()
     }
+  },
+  clearValues() {
+    for (let i = self.strValues.length - 1; i >= 0; --i) {
+      self.strValues[i] = ""
+      self.numValues[i] = self.toNumeric(self.strValues[i])
+    }
   }
 }))
 export interface IAttribute extends Instance<typeof Attribute> {}

--- a/v3/src/models/data/data-set-collection-groups.test.ts
+++ b/v3/src/models/data/data-set-collection-groups.test.ts
@@ -216,4 +216,19 @@ describe("CollectionGroups", () => {
     data.removeAttribute("bId")
     expect(data.collections.length).toBe(0)
   })
+
+  it("doesn't take formula evaluated values into account when grouping", () => {
+    const aAttr = data.attrFromID("aId")
+    aAttr.setDisplayFormula("foo * bar")
+    data.moveAttributeToNewCollection("aId")
+    expect(data.groupedAttributes.map(attr => attr.id)).toEqual(["aId"])
+    expect(data.ungroupedAttributes.map(attr => attr.id)).toEqual(["bId", "cId"])
+    expect(data.collectionGroups.length).toBe(1)
+    expect(attributesByCollection()).toEqual([["aId"], ["bId", "cId"]])
+    const aCases = data.getCasesForAttributes(["aId"])
+    expect(aCases.length).toBe(1) // (!) without formula it'd be equal to 3
+    expect(aCases.map((c: any) => c.aId)).toEqual([""]) // formula needs to be re-evaluated
+    const abCases = data.getCasesForAttributes(["aId", "bId"])
+    expect(abCases.length).toBe(27)
+  })
 })

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -464,6 +464,12 @@ export const DataSet = types.model("DataSet", {
         const newCollection = options?.collection ? getGroupedCollection(options.collection) : undefined
         const oldCollection = getCollectionForAttribute(attributeId)
         if (attribute && oldCollection !== newCollection) {
+          if (!attribute.formula.empty) {
+            // If the attribute has a formula, we need to reset all the calculated values to blank values so that they
+            // are not taken into account while calculating case grouping. After the grouping is done, the formula will
+            // be re-evaluated, and the values will be updated to the correct values again.
+            attribute.clearValues()
+          }
           if (isCollectionModel(oldCollection)) {
             // remove it from previous collection (if any)
             if (oldCollection?.attributes.length > 1) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186323665

This PR resets formula-evaluated values to blank right before the attribute is moved to another collection. This prevents the grouping logic from considering cases that have been evaluated using the formula.

A simpler version of https://github.com/concord-consortium/codap/pull/986 that addresses @kswenson suggestion.