### PR TITLE
Small refactoring of plotted-function model and component

### DIFF
--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
@@ -1,15 +1,96 @@
 import React, { useCallback, useEffect, useRef } from "react"
-import { select, Selection } from "d3"
+import { select } from "d3"
 import { observer } from "mobx-react-lite"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
 import { INumericAxisModel } from "../../../axis/models/axis-model"
 import { useAxisLayoutContext } from "../../../axis/models/axis-layout-context"
 import { ScaleNumericBaseType } from "../../../axis/axis-types"
+import { Point } from "../../../data-display/data-display-types"
 import { IPlottedFunctionAdornmentModel, isPlottedFunctionAdornment } from "./plotted-function-adornment-model"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import { useGraphDataConfigurationContext } from "../../hooks/use-data-configuration-context"
+import { FormulaFn } from "./plotted-function-adornment-types"
 
 import "./plotted-function-adornment-component.scss"
+
+interface IComputePointsOptions {
+  formulaFunction: FormulaFn,
+  min: number,
+  max: number,
+  xCellCount: number,
+  yCellCount: number,
+  gap: number,
+  xScale: ScaleNumericBaseType,
+  yScale: ScaleNumericBaseType
+}
+
+const computePoints = (options: IComputePointsOptions) => {
+  const { min, max, xCellCount, yCellCount, gap, xScale, yScale, formulaFunction } = options
+  const tPoints: Point[] = []
+  for (let pixelX = min; pixelX <= max; pixelX += gap) {
+    const tX = xScale.invert(pixelX * xCellCount)
+    const tY = formulaFunction(tX)
+    if (Number.isFinite(tY)) {
+      const pixelY = yScale(tY) / yCellCount
+      tPoints.push({ x: pixelX, y: pixelY })
+    }
+  }
+  return tPoints
+}
+
+// This is a modified version of CODAP V2's SvgScene.pathBasis which was extracted from protovis
+const pathBasis = (p0: Point, p1: Point, p2: Point, p3: Point) => {
+  /**
+   * Matrix to transform basis (b-spline) control points to bezier control
+   * points. Derived from FvD 11.2.8.
+   */
+  const basis = [
+    [ 1/6, 2/3, 1/6,   0 ],
+    [   0, 2/3, 1/3,   0 ],
+    [   0, 1/3, 2/3,   0 ],
+    [   0, 1/6, 2/3, 1/6 ]
+  ]
+
+  /**
+   * Returns the point that is the weighted sum of the specified control points,
+   * using the specified weights. This method requires that there are four
+   * weights and four control points.
+   */
+  const weight = (w: number[]) => {
+    return {
+      x: w[0] * p0.x + w[1] * p1.x + w[2] * p2.x + w[3] * p3.x,
+      y: w[0] * p0.y  + w[1] * p1.y  + w[2] * p2.y  + w[3] * p3.y
+    }
+  }
+
+  const b1 = weight(basis[1])
+  const b2 = weight(basis[2])
+  const b3 = weight(basis[3])
+
+  return `C${b1.x},${b1.y},${b2.x},${b2.y},${b3.x},${b3.y}`
+}
+
+ // This is a modified version of CODAP V2's SvgScene.curveBasis which was extracted from protovis
+ const curveBasis = (points: Point[]) => {
+  if (points.length <= 2) return ""
+  let path = "",
+      p0 = points[0],
+      p1 = p0,
+      p2 = p0,
+      p3 = points[1]
+  path += pathBasis(p0, p1, p2, p3)
+  for (let i = 2; i < points.length; i++) {
+    p0 = p1
+    p1 = p2
+    p2 = p3
+    p3 = points[i]
+    path += pathBasis(p0, p1, p2, p3)
+  }
+  /* Cycle through to get the last point. */
+  path += pathBasis(p1, p2, p3, p3)
+  path += pathBasis(p2, p3, p3, p3)
+  return path
+}
 
 interface IProps {
   containerId?: string
@@ -19,10 +100,6 @@ interface IProps {
   cellKey: Record<string, string>
   xAxis?: INumericAxisModel
   yAxis?: INumericAxisModel
-}
-
-interface IValue {
-  path?: Selection<SVGPathElement, unknown, null, undefined>
 }
 
 export const PlottedFunctionAdornmentComponent = observer(function PlottedFunctionAdornment(props: IProps) {
@@ -47,18 +124,20 @@ export const PlottedFunctionAdornmentComponent = observer(function PlottedFuncti
   const path = useRef("")
   const plottedFunctionRef = useRef<SVGGElement>(null)
 
-  const addPath = useCallback((newPathObject: IValue) => {
+  const addPath = useCallback((formulaFunction: FormulaFn) => {
     if (!model.expression) return
     const xMin = xScale.domain()[0]
     const xMax = xScale.domain()[1]
     const tPixelMin = xScale(xMin)
     const tPixelMax = xScale(xMax)
     const kPixelGap = 1
-    const tPoints = model.computePoints(tPixelMin, tPixelMax, xCellCount, yCellCount, kPixelGap, xScale, yScale)
-    path.current = `M${tPoints[0].x},${tPoints[0].y},${model.curveBasis(tPoints)}`
+    const tPoints = computePoints({
+      formulaFunction, min: tPixelMin, max: tPixelMax, xCellCount, yCellCount, gap: kPixelGap, xScale, yScale
+    })
+    path.current = `M${tPoints[0].x},${tPoints[0].y},${curveBasis(tPoints)}`
 
     const selection = select(plottedFunctionRef.current)
-    newPathObject.path = selection.append("path")
+    selection.append("path")
       .attr("class", `plotted-function plotted-function-${classFromKey}`)
       .attr("data-testid", `plotted-function-path${classFromKey ? `-${classFromKey}` : ""}`)
       .attr("d", path.current)
@@ -70,14 +149,13 @@ export const PlottedFunctionAdornmentComponent = observer(function PlottedFuncti
     if (!model.isVisible) return
 
     const measure = model?.measures.get(instanceKey)
-    const newValueObject: IValue = {}
     const selection = select(plottedFunctionRef.current)
 
     // Remove the previous value's elements
     selection.html(null)
 
     if (measure) {
-      addPath(newValueObject)
+      addPath(measure.formulaFunction)
     }
   }, [model, instanceKey, addPath])
 

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
@@ -1,20 +1,16 @@
 import { Instance, types } from "mobx-state-tree"
 import { AdornmentModel, IAdornmentModel, IUpdateCategoriesOptions } from "../adornment-models"
-import { kPlottedFunctionType, kPlottedFunctionValueTitleKey } from "./plotted-function-adornment-types"
-import { ScaleNumericBaseType } from "../../../axis/axis-types"
-import { Point } from "../../../data-display/data-display-types"
+import { kPlottedFunctionType, kPlottedFunctionValueTitleKey, FormulaFn } from "./plotted-function-adornment-types"
 import { ICase } from "../../../../models/data/data-set-types"
 import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
 
 export const MeasureInstance = types.model("MeasureInstance", {})
 .volatile(self => ({
-  value: NaN,
-  isValid: false
+  formulaFunction: (x: number) => NaN,
 }))
 .actions(self => ({
-  setValue(value: number) {
-    self.value = value
-    self.isValid = true
+  setValue(formulaFunction: FormulaFn) {
+    self.formulaFunction = formulaFunction
   }
 }))
 
@@ -27,63 +23,6 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
     measures: types.map(MeasureInstance)
   })
   .views(self => ({
-    get expressionIsNumber() {
-      return Number.isFinite(Number(self.expression))
-    },
-    // This is a modified version of CODAP V2's SvgScene.pathBasis which was extracted from protovis
-    pathBasis (p0: Point, p1: Point, p2: Point, p3: Point) {
-      /**
-       * Matrix to transform basis (b-spline) control points to bezier control
-       * points. Derived from FvD 11.2.8.
-       */
-      const basis = [
-        [ 1/6, 2/3, 1/6,   0 ],
-        [   0, 2/3, 1/3,   0 ],
-        [   0, 1/3, 2/3,   0 ],
-        [   0, 1/6, 2/3, 1/6 ]
-      ]
-    
-      /**
-       * Returns the point that is the weighted sum of the specified control points,
-       * using the specified weights. This method requires that there are four
-       * weights and four control points.
-       */
-      const weight = (w: number[]) => {
-        return {
-          x: w[0] * p0.x + w[1] * p1.x + w[2] * p2.x + w[3] * p3.x,
-          y: w[0] * p0.y  + w[1] * p1.y  + w[2] * p2.y  + w[3] * p3.y
-        }
-      }
-    
-      const b1 = weight(basis[1])
-      const b2 = weight(basis[2])
-      const b3 = weight(basis[3])
-
-      return `C${b1.x},${b1.y},${b2.x},${b2.y},${b3.x},${b3.y}`
-    }
-  }))
-  .views(self => ({
-    // This is a modified version of CODAP V2's SvgScene.curveBasis which was extracted from protovis
-    curveBasis (points: Point[]) {
-        if (points.length <= 2) return ""
-        let path = "",
-            p0 = points[0],
-            p1 = p0,
-            p2 = p0,
-            p3 = points[1]
-        path += self.pathBasis(p0, p1, p2, p3)
-        for (let i = 2; i < points.length; i++) {
-          p0 = p1
-          p1 = p2
-          p2 = p3
-          p3 = points[i]
-          path += self.pathBasis(p0, p1, p2, p3)
-        }
-        /* Cycle through to get the last point. */
-        path += self.pathBasis(p1, p2, p3, p3)
-        path += self.pathBasis(p2, p3, p3, p3)
-        return path
-    },
     getCaseValues(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
       const dataset = dataConfig?.dataset
       const casesInPlot = dataConfig.subPlotCases(cellKey)
@@ -97,40 +36,19 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
       return caseValues
     }
   }))
-  .views(self => ({
-    computePoints(
-      min: number, max: number, xCellCount: number, yCellCount: number, gap: number,
-      xScale: ScaleNumericBaseType, yScale: ScaleNumericBaseType
-    ) {
-      if (!self.expression) return []
-      const tPoints: Point[] = []
-      for (let pixelX = min; pixelX <= max; pixelX += gap) {
-        const tX = xScale.invert(pixelX * xCellCount)
-        const tY = self.expressionIsNumber
-          ? Number(self.expression)
-          : tX * tX // TODO: Replace with expression evaluation
-        if (Number.isFinite(tY)) {
-          const pixelY = yScale(tY) / yCellCount
-          tPoints.push({ x: pixelX, y: pixelY })
-        }
-      }
-
-      return tPoints
-    }
-  }))
   .actions(self => ({
     setExpression(expression: string) {
       self.expression = expression
     },
-    addMeasure(value: number, key="{}") {
+    addMeasure(formulaFunction: FormulaFn, key="{}") {
       const newMeasure = MeasureInstance.create()
-      newMeasure.setValue(value)
+      newMeasure.setValue(formulaFunction)
       self.measures.set(key, newMeasure)
     },
-    updateMeasureValue(value: number, key="{}") {
+    updateMeasureValue(formulaFunction: FormulaFn, key="{}") {
       const measure = self.measures.get(key)
       if (measure) {
-        measure.setValue(value)
+        measure.setValue(formulaFunction)
       }
     },
     removeMeasure(key: string) {
@@ -140,7 +58,7 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
       // TODO: If the comment below will be true of the Plotted Function, like it's true for the Plotted Value,
-      // remove everything from this action but the comment. We could also then remove xScale and yScale as 
+      // remove everything from this action but the comment. We could also then remove xScale and yScale as
       // optional items in IUpdateCategoriesOptions and getUpdateCategoriesOptions.
 
       // Overwrite the super method to do... nothing. GraphContentModel and adornments have their own way of observing
@@ -150,10 +68,6 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
 
       const { xCats, xScale, yCats, yScale, topCats, rightCats, resetPoints, dataConfig } = options
       if (!dataConfig || !xScale || !yScale) return
-      const xMin = xScale.domain()[0]
-      const xMax = xScale.domain()[1]
-      const tPixelMin = xScale(xMin)
-      const tPixelMax = xScale(xMax)
       const topCatCount = topCats.length || 1
       const rightCatCount = rightCats.length || 1
       const xCatCount = xCats.length || 1
@@ -164,11 +78,11 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
       for (let i = 0; i < totalCount; ++i) {
         const cellKey = self.cellKey(options, i)
         const instanceKey = self.instanceKey(cellKey)
-        const value = Number(self.computePoints(tPixelMin, tPixelMax, columnCount, rowCount, 1, xScale, yScale))
+        const formulaFunction = (x: number) => x * x
         if (!self.measures.get(instanceKey) || resetPoints) {
-          self.addMeasure(value, instanceKey)
+          self.addMeasure(formulaFunction, instanceKey)
         } else {
-          self.updateMeasureValue(value, instanceKey)
+          self.updateMeasureValue(formulaFunction, instanceKey)
         }
       }
     }

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
@@ -1,18 +1,16 @@
 import { Instance, types } from "mobx-state-tree"
 import { AdornmentModel, IAdornmentModel, IUpdateCategoriesOptions } from "../adornment-models"
 import { kPlottedFunctionType, kPlottedFunctionValueTitleKey, FormulaFn } from "./plotted-function-adornment-types"
-import { ICase } from "../../../../models/data/data-set-types"
-import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
 
 export const MeasureInstance = types.model("MeasureInstance", {})
-.volatile(self => ({
-  formulaFunction: (x: number) => NaN,
-}))
-.actions(self => ({
-  setValue(formulaFunction: FormulaFn) {
-    self.formulaFunction = formulaFunction
-  }
-}))
+  .volatile(self => ({
+    formulaFunction: (x: number) => NaN,
+  }))
+  .actions(self => ({
+    setValue(formulaFunction: FormulaFn) {
+      self.formulaFunction = formulaFunction
+    }
+  }))
 
 export const PlottedFunctionAdornmentModel = AdornmentModel
   .named("PlottedFunctionAdornmentModel")
@@ -22,20 +20,6 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
     labelTitle: types.optional(types.literal(kPlottedFunctionValueTitleKey), kPlottedFunctionValueTitleKey),
     measures: types.map(MeasureInstance)
   })
-  .views(self => ({
-    getCaseValues(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
-      const dataset = dataConfig?.dataset
-      const casesInPlot = dataConfig.subPlotCases(cellKey)
-      const caseValues: number[] = []
-      casesInPlot.forEach((c: ICase) => {
-        const caseValue = Number(dataset?.getValue(c.__id__, attrId))
-        if (Number.isFinite(caseValue)) {
-          caseValues.push(caseValue)
-        }
-      })
-      return caseValues
-    }
-  }))
   .actions(self => ({
     setExpression(expression: string) {
       self.expression = expression

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-types.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-types.ts
@@ -7,3 +7,5 @@ export const kPlottedFunctionRedoAddKey = "DG.Redo.graph.showPlotFunction"
 export const kPlottedFunctionUndoRemoveKey = "DG.Undo.graph.hidePlotFunction"
 export const kPlottedFunctionRedoRemoveKey = "DG.Redo.graph.hidePlotFunction"
 export const kPlottedFunctionValueTitleKey = "DG.PlottedFunction.valueTitle"
+
+export type FormulaFn = (x: number) => number


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186437311

This PR doesn't introduce any new functionality or formula-related code. It's preparatory work for upcoming changes. It mainly involves modifications to existing code, so I believe it makes sense to have a separate PR to validate whether these changes align with your understanding.

Previously, in the PlottedFunctionAdornmentModel, `self.computePoints(...)` was called, then the resulting array was converted to a number (resulting in NaN), which was set as a MeasureInstance value. I was a bit confused about how the points were plotted. It turns out that the PlottedFunctionAdornmentComponent was calling `model.computePoints(...)` again. To streamline this process:
- I changed `MeasureInstance.value` to be an instance of `(x: number) => number` (`FormulaFn` type).
- Moved `computePoints` and all related helpers (`pathBasic`, `curveBasic`) out of the model file and defined them as pure functions in the components. They don't require access to any model state, so pure functions are always preferable to me (clarity, testability). Additionally, I believe they are more fitting for the view (component) than the actual MST model, as the actual points/coordinates are more of a view concern.
- Removed `.isValid` from `MeasureInstance` as it was never used (should we double-check if that's not necessary, as I remember seeing that in other adornments?).
- Removed `IValue` and its instances from the component file, as they didn't serve any purpose.
- Kept the naming convention like `set/addValue` even though now it's a function, assuming it might be intentional to maintain similarity with other adornments. However, we can certainly change that if nothing else depends on this particular `MeasureInstance`.