### PR TITLE
Graph rescale button implementation

### DIFF
--- a/v3/cypress/support/elements/component-elements.ts
+++ b/v3/cypress/support/elements/component-elements.ts
@@ -7,7 +7,7 @@ export const ComponentElements = {
     minimizeComponent: "Minimize or expand this Component",
     closeComponent: "Close this Component",
     inspectorPanel: "Change what is shown along with the points",
-    graphResizeButton: "Resize all columns to fit data",
+    graphResizeButton: "Move the points to new random positions",
     graphHideShowButton: "Show all cases or hide selected/unselected cases",
     graphDisplayValuesButton: "Change what is shown along with the points",
     graphDisplayConfigButton: "Configure the display differently",

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -29,7 +29,7 @@ export const CaseDots = function CaseDots(props: {
     currPos = useRef({x: 0, y: 0}),
     target = useRef<any>()
 
-  const randomlyDistributePoints = useCallback((cases?: CaseData[] | undefined) => {
+  const randomlyDistributePoints = useCallback((cases?: CaseData[]) => {
     const uniform = randomUniform()
       const points = randomPointsRef.current
       cases?.forEach(({caseID}) => {

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -1,8 +1,9 @@
 import {randomUniform, select} from "d3"
+import {mstReaction} from "../../../utilities/mst-reaction"
 import React, {useCallback, useEffect, useRef, useState} from "react"
 import {CaseData} from "../../data-display/d3-types"
 import {IDotsRef} from "../../data-display/data-display-types"
-import {handleClickOnDot, setPointSelection} from "../../data-display/data-display-utils"
+import {handleClickOnDot, setPointSelection, startAnimation} from "../../data-display/data-display-utils"
 import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {useGraphDataConfigurationContext} from "../hooks/use-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
@@ -28,18 +29,28 @@ export const CaseDots = function CaseDots(props: {
     currPos = useRef({x: 0, y: 0}),
     target = useRef<any>()
 
-  const onDragStart = useCallback((event: MouseEvent) => {
-      enableAnimation.current = false // We don't want to animate points until end of drag
-      target.current = select(event.target as SVGSVGElement)
-      const aCaseData: CaseData = target.current.node().__data__
-      if (aCaseData && target.current.node()?.nodeName === 'circle') {
-        target.current.transition()
-          .attr('r', dragPointRadius)
-        setDragID(aCaseData.caseID)
-        currPos.current = {x: event.clientX, y: event.clientY}
-        handleClickOnDot(event, aCaseData.caseID, dataset)
-      }
-    }, [dragPointRadius, dataset, enableAnimation]),
+  const randomlyDistributePoints = useCallback((cases?: CaseData[] | undefined) => {
+    const uniform = randomUniform()
+      const points = randomPointsRef.current
+      cases?.forEach(({caseID}) => {
+        if (!points[caseID]) {
+          points[caseID] = {x: uniform(), y: uniform()}
+        }
+      })
+  }, []),
+
+  onDragStart = useCallback((event: MouseEvent) => {
+    enableAnimation.current = false // We don't want to animate points until end of drag
+    target.current = select(event.target as SVGSVGElement)
+    const aCaseData: CaseData = target.current.node().__data__
+    if (aCaseData && target.current.node()?.nodeName === 'circle') {
+      target.current.transition()
+        .attr('r', dragPointRadius)
+      setDragID(aCaseData.caseID)
+      currPos.current = {x: event.clientX, y: event.clientY}
+      handleClickOnDot(event, aCaseData.caseID, dataset)
+    }
+  }, [dragPointRadius, dataset, enableAnimation]),
 
     onDrag = useCallback((event: MouseEvent) => {
       if (dotsRef.current && dragID !== '') {
@@ -106,26 +117,28 @@ export const CaseDots = function CaseDots(props: {
   }, [dataset, dataConfiguration, graphModel, layout, dotsRef, enableAnimation])
 
   useEffect(function initDistribution() {
-    const uniform = randomUniform(),
-      cases = dataConfiguration?.caseDataArray
-
-    const initCases = (_cases?: CaseData[] | undefined) => {
-      const points = randomPointsRef.current
-      _cases?.forEach(({caseID}) => {
-        if (!points[caseID]) {
-          points[caseID] = {x: uniform(), y: uniform()}
-        }
-      })
-    }
-
-    initCases(cases)
+    const cases = dataConfiguration?.caseDataArray
+    randomlyDistributePoints(cases)
     const disposer = dataConfiguration?.onAction(action => {
       if (['addCases', 'removeCases'].includes(action.name)) {
-        initCases(dataConfiguration?.caseDataArray)
+        randomlyDistributePoints(dataConfiguration?.caseDataArray)
       }
     }) || (() => true)
     return () => disposer?.()
-  }, [dataConfiguration, dataset])
+  }, [dataConfiguration, dataset, randomlyDistributePoints])
+
+  useEffect(function respondToModelChangeCount() {
+    return mstReaction(
+      () => graphModel.changeCount,
+      () => {
+        randomPointsRef.current = {}
+        randomlyDistributePoints(dataConfiguration?.caseDataArray)
+        startAnimation(enableAnimation)
+        refreshPointPositions(false)
+      },
+      { name: "CaseDots.respondToModelChangeCount" }, graphModel)
+  }, [dataConfiguration?.caseDataArray, enableAnimation, graphModel,
+    randomlyDistributePoints, refreshPointPositions])
 
   usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation})
 

--- a/v3/src/components/graph/components/graph-inspector.tsx
+++ b/v3/src/components/graph/components/graph-inspector.tsx
@@ -46,6 +46,7 @@ export const GraphInspector = ({ tile, show }: ITileInspectorPanelProps) => {
 
   const renderRescaleButton = () => {
 
+/*
     const getRescaleTooltip = () => {
       if (graphModel?.noPossibleRescales) {
         return "V3.Inspector.rescale.noRescale.toolTip"
@@ -55,6 +56,10 @@ export const GraphInspector = ({ tile, show }: ITileInspectorPanelProps) => {
       }
       return "DG.Inspector.rescale.toolTip"
     }
+*/
+    const rescaleTooltip = graphModel?.noPossibleRescales 
+      ? "V3.Inspector.rescale.noRescale.toolTip" 
+      : graphModel?.plotType === "casePlot" ? "V3.Inspector.rescale.casePlot.toolTip" : "DG.Inspector.rescale.toolTip"
 
     const handleGraphRescale = () => {
       graphModel?.applyUndoableAction(
@@ -64,7 +69,7 @@ export const GraphInspector = ({ tile, show }: ITileInspectorPanelProps) => {
     }
 
     return (
-      <InspectorButton tooltip={t(getRescaleTooltip())} isDisabled={graphModel?.noPossibleRescales}
+      <InspectorButton tooltip={t(rescaleTooltip)} isDisabled={graphModel?.noPossibleRescales}
                        showMoreOptions={false} testId={"graph-resize-button"} onButtonClick={handleGraphRescale}>
         <ScaleDataIcon />
       </InspectorButton>

--- a/v3/src/components/graph/components/graph-inspector.tsx
+++ b/v3/src/components/graph/components/graph-inspector.tsx
@@ -32,13 +32,6 @@ export const GraphInspector = ({ tile, show }: ITileInspectorPanelProps) => {
     setShowPalette(undefined)
   }
 
-  const handleGraphRescale = () => {
-    graphModel?.applyUndoableAction(
-      () => graphModel.rescale(),
-      "DG.Undo.axisDilate",
-      "DG.Redo.axisDilate")
-  }
-
   const handleRulerButton = () => {
     setShowPalette(showPalette === "measure" ? undefined : "measure")
   }
@@ -51,22 +44,36 @@ export const GraphInspector = ({ tile, show }: ITileInspectorPanelProps) => {
     buttonRef.current = ref.current
   }
 
-  const getRescaleTooltip = () => {
-    if (graphModel?.noPossibleRescales) {
-      return "V3.Inspector.rescale.noRescale.toolTip"
-    }
-    else if (graphModel?.plotType === 'casePlot') {
-      return "V3.Inspector.rescale.casePlot.toolTip"
-    }
-    return "DG.Inspector.rescale.toolTip"
-  }
+  const renderRescaleButton = () => {
 
-  return (
-    <InspectorPanel ref={panelRef} component="graph" show={show} setShowPalette={setShowPalette}>
+    const getRescaleTooltip = () => {
+      if (graphModel?.noPossibleRescales) {
+        return "V3.Inspector.rescale.noRescale.toolTip"
+      }
+      else if (graphModel?.plotType === 'casePlot') {
+        return "V3.Inspector.rescale.casePlot.toolTip"
+      }
+      return "DG.Inspector.rescale.toolTip"
+    }
+
+    const handleGraphRescale = () => {
+      graphModel?.applyUndoableAction(
+        () => graphModel.rescale(),
+        "DG.Undo.axisDilate",
+        "DG.Redo.axisDilate")
+    }
+
+    return (
       <InspectorButton tooltip={t(getRescaleTooltip())} isDisabled={graphModel?.noPossibleRescales}
                        showMoreOptions={false} testId={"graph-resize-button"} onButtonClick={handleGraphRescale}>
         <ScaleDataIcon />
       </InspectorButton>
+    )
+  }
+
+  return (
+    <InspectorPanel ref={panelRef} component="graph" show={show} setShowPalette={setShowPalette}>
+      {renderRescaleButton()}
       <InspectorMenu tooltip={t("DG.Inspector.hideShow.toolTip")}
         icon={<HideShowIcon />} testId={"graph-hide-show-button"} onButtonClick={handleClosePalette}>
         <HideShowMenuList tile={tile} />

--- a/v3/src/components/inspector-panel.tsx
+++ b/v3/src/components/inspector-panel.tsx
@@ -26,13 +26,14 @@ export const InspectorPanel = forwardRef(({ component, show, setShowPalette, chi
 interface IInspectorButtonProps {
   children: ReactNode
   tooltip: string
+  isDisabled?: boolean
   testId: string
   showMoreOptions: boolean
   onButtonClick?: () => void
   setButtonRef?: (ref: any) => void
 }
 
-export const InspectorButton = ({children, tooltip, testId, showMoreOptions, setButtonRef,
+export const InspectorButton = ({children, tooltip, isDisabled, testId, showMoreOptions, setButtonRef,
     onButtonClick}:IInspectorButtonProps) => {
   const buttonRef = useRef<any>()
   const _onClick = () => {
@@ -40,8 +41,8 @@ export const InspectorButton = ({children, tooltip, testId, showMoreOptions, set
     onButtonClick?.()
   }
   return (
-    <Button ref={buttonRef} className="inspector-tool-button" title={tooltip} data-testid={testId}
-      onClick={_onClick}>
+    <Button ref={buttonRef} className="inspector-tool-button" title={tooltip} isDisabled={isDisabled}
+            data-testid={testId} onClick={_onClick}>
       {children}
       {showMoreOptions && <MoreOptionsIcon className="more-options-icon"/>}
     </Button>

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -15,6 +15,9 @@
     "V3.Undo.import.data": "Undo import of data",
     "V3.Redo.import.data": "Redo import of data",
 
+    "V3.Inspector.rescale.noRescale.toolTip": "All the data are already visible",
+    "V3.Inspector.rescale.casePlot.toolTip": "Move the points to new random positions",
+
     // V3 formula strings that are not present in V2 and will eventually require translation.
     "V3.formula.error.invalidParentAttrRef": "invalid reference to parent attribute '%@' within aggregate function",
     "V3.formula.error.cycle": "Circular reference: formula refers to its own attribute either directly or indirectly",


### PR DESCRIPTION
[#186438328] Feature: Graph inspector has a rescale button that scales the axes to show all the data
[#186448224] Feature: For a case plot the graph's rescale button causes the points to rerandomize their positions
[#186448263] Feature: The graph's rescale button is disabled if the plot is not a case plot and has no numeric axes.
* Added `handleGraphRescale` in `GraphInspector`
* Implemented the rescaling in `GraphContentModel`
* CaseDots pays attention to graphModel.changeCount and rerandomizes points in response
* The rescale button gets tooltips that depend on graph state
* The rescale button is disabled when appropriate

Rescale transitions should be animated but that awaits some refactoring of enableAnimation