### PR TITLE
Inspector palette for maps

### DIFF
--- a/v3/src/components/map/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/hide-show-menu-list.tsx
@@ -1,0 +1,43 @@
+import { MenuItem, MenuList, useToast } from "@chakra-ui/react"
+import React from "react"
+import { useDataSetContext } from "../../../../hooks/use-data-set-context"
+import { ITileModel } from "../../../../models/tiles/tile-model"
+import {isMapContentModel} from "../../models/map-content-model"
+import t from "../../../../utilities/translation/translate"
+
+interface IProps {
+  tile?: ITileModel
+}
+
+export const HideShowMenuList = ({tile}: IProps) => {
+  const data = useDataSetContext()
+  const toast = useToast()
+  const mapModel = isMapContentModel(tile?.content) ? tile?.content : undefined
+  const handleMenuItemClick = (menuItem: string) => {
+    toast({
+      title: 'Menu item clicked',
+      description: `You clicked on ${menuItem}`,
+      status: 'success',
+      duration: 5000,
+      isClosable: true,
+    })
+  }
+
+  const hideSelectedString = (data?.selectCases?.length ?? 0) === 1
+                              ? t("DG.DataDisplayMenu.hideSelectedSing")
+                              : t("DG.DataDisplayMenu.hideSelectedPlural")
+  const hideUnselectedString = data && (data.cases.length - data.selectCases.length) === 1
+                              ? t("DG.DataDisplayMenu.hideUnselectedSing")
+                              : t("DG.DataDisplayMenu.hideUnselectedPlural")
+
+  return (
+    <MenuList data-testid="trash-menu-list">
+      <MenuItem onClick={()=>handleMenuItemClick("Hide selected cases")}>{hideSelectedString}</MenuItem>
+      <MenuItem onClick={()=>handleMenuItemClick("Hide unselected cases")}>{hideUnselectedString}</MenuItem>
+      <MenuItem onClick={()=>handleMenuItemClick("Show all cases")}>{t("DG.DataDisplayMenu.showAll")}</MenuItem>
+      <MenuItem onClick={()=>handleMenuItemClick("Display only selected cases")}>
+        {t("DG.DataDisplayMenu.displayOnlySelected")}
+      </MenuItem>
+    </MenuList>
+  )
+}

--- a/v3/src/components/map/components/inspector-panel/map-measure-palette.tsx
+++ b/v3/src/components/map/components/inspector-panel/map-measure-palette.tsx
@@ -1,0 +1,67 @@
+import React from "react"
+import {Box, Checkbox, Flex, FormControl, /*useToast*/} from "@chakra-ui/react"
+import t from "../../../../utilities/translation/translate"
+import {ITileModel} from "../../../../models/tiles/tile-model"
+import {InspectorPalette} from "../../../inspector-panel"
+import ValuesIcon from "../../../../assets/icons/icon-values.svg"
+// import {isMapContentModel} from "../../models/map-content-model"
+
+interface IProps {
+  tile?: ITileModel
+  panelRect?: DOMRect
+  buttonRect?: DOMRect
+  setShowPalette: (palette: string | undefined) => void
+}
+
+export const MapMeasurePalette = ({tile, panelRect, buttonRect, setShowPalette}: IProps) => {
+  // const toast = useToast()
+  // const mapModel = isMapContentModel(tile?.content) ? tile?.content : undefined
+  const titles = ["DG.Inspector.mapGrid", "DG.Inspector.mapPoints", "DG.Inspector.mapLines"]
+
+/*
+  const handleSetting = (measure: string, checked: boolean) => {
+    // Show toast pop-ups for adornments that haven't been implemented yet.
+    // TODO: Remove this once all adornments are implemented.
+    toast({
+      title: 'Item clicked',
+      description: `You clicked on ${measure} ${checked}`,
+      status: 'success',
+      duration: 5000,
+      isClosable: true,
+    })
+    return null
+  }
+*/
+
+  return (
+    <InspectorPalette
+      title={t("DG.Inspector.values")}
+      Icon={<ValuesIcon/>}
+      setShowPalette={setShowPalette}
+      panelRect={panelRect}
+      buttonRect={buttonRect}
+    >
+      <Flex className="palette-form" direction="column">
+        <Box className="form-title">Show ...</Box>
+        {
+          titles.map((title) => {
+            const titleSlug = t(title).replace(/ /g, "-").toLowerCase()
+            return (
+              <FormControl key={titleSlug}>
+                <Checkbox
+                  data-testid={`adornment-checkbox-${titleSlug}`}
+                  /*
+                  defaultChecked={checked}
+                  onChange={clickHandler ? clickHandler : e => handleSetting(t(title), e.target.checked)}
+                  */
+                >
+                  {t(title)}
+                </Checkbox>
+              </FormControl>
+            )
+          })
+        }
+      </Flex>
+    </InspectorPalette>
+  )
+}

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -1,0 +1,35 @@
+import { MenuItem, MenuList, useToast } from "@chakra-ui/react"
+import React from "react"
+import { ITileModel } from "../../../../models/tiles/tile-model"
+import t from "../../../../utilities/translation/translate"
+
+interface IProps {
+  tile?: ITileModel
+}
+
+export const SaveImageMenuList = ({tile}: IProps) => {
+  const toast = useToast()
+  const handleMenuItemClick = (menuItem: string) => {
+    toast({
+      title: 'Menu item clicked',
+      description: `You clicked on ${menuItem}`,
+      status: 'success',
+      duration: 5000,
+      isClosable: true,
+    })
+  }
+
+  return (
+    <MenuList data-testid="trash-menu-list">
+      <MenuItem onClick={()=>handleMenuItemClick("Open in Draw Tool")}>
+        {t('DG.DataDisplayMenu.copyAsImage')}
+      </MenuItem>
+      <MenuItem onClick={()=>handleMenuItemClick("Export PNG Image")}>
+        {t('DG.DataDisplayMenu.exportPngImage')}
+      </MenuItem>
+      <MenuItem onClick={()=>handleMenuItemClick("Export SVG Image")}>
+        {t('DG.DataDisplayMenu.exportSvgImage')}
+      </MenuItem>
+    </MenuList>
+  )
+}

--- a/v3/src/components/map/components/map-inspector.tsx
+++ b/v3/src/components/map/components/map-inspector.tsx
@@ -1,0 +1,93 @@
+import React, {useRef, useEffect, useState} from "react"
+import {InspectorButton, InspectorMenu, InspectorPanel} from "../../inspector-panel"
+import ScaleDataIcon from "../../../assets/icons/icon-scaleData.svg"
+import HideShowIcon from "../../../assets/icons/icon-hideShow.svg"
+import ValuesIcon from "../../../assets/icons/icon-values.svg"
+import LayersIcon from "../../../assets/icons/icon-layers.svg"
+import CameraIcon from "../../../assets/icons/icon-camera.svg"
+import t from "../../../utilities/translation/translate"
+import {useDndContext} from "@dnd-kit/core"
+import {ITileInspectorPanelProps} from "../../tiles/tile-base-props"
+import {isMapContentModel} from "../models/map-content-model"
+import {isMapPointLayerModel} from "../models/map-point-layer-model"
+import {HideShowMenuList} from "./inspector-panel/hide-show-menu-list"
+import {SaveImageMenuList} from "./inspector-panel/save-image-menu-list"
+import {MapMeasurePalette} from "./inspector-panel/map-measure-palette"
+
+
+export const MapInspector = ({tile, show}: ITileInspectorPanelProps) => {
+  const mapModel = isMapContentModel(tile?.content) ? tile?.content : undefined
+  const [showPalette, setShowPalette] = useState<string | undefined>(undefined)
+  const panelRef = useRef<HTMLDivElement>()
+  const panelRect = panelRef.current?.getBoundingClientRect()
+  const buttonRef = useRef<HTMLDivElement>()
+  const buttonRect = buttonRef.current?.getBoundingClientRect()
+  const {active} = useDndContext()
+
+  useEffect(() => {
+    !show && setShowPalette(undefined)
+  }, [active, show])
+
+  const handleClosePalette = () => {
+    setShowPalette(undefined)
+  }
+
+  const handleRulerButton = () => {
+    setShowPalette(showPalette === "measure" ? undefined : "measure")
+  }
+
+  const setButtonRef = (ref: any) => {
+    buttonRef.current = ref.current
+  }
+
+  const handleMapRescale = () => {
+    mapModel?.applyUndoableAction(
+      () => mapModel.rescale(),
+      "DG.Undo.map.fitBounds",
+      "DG.Redo.map.fitBounds")
+  }
+
+  const renderRulerButton = () => {
+    if (mapModel && mapModel?.layers.filter(layer => isMapPointLayerModel(layer)).length > 0) {
+      return (
+        <InspectorButton tooltip={t("DG.Inspector.displayValues.toolTip")} showMoreOptions={true}
+                         onButtonClick={handleRulerButton} setButtonRef={setButtonRef}
+                         testId={"map-display-values-button"}>
+          <ValuesIcon/>
+        </InspectorButton>
+      )
+    }
+  }
+
+  if (mapModel && mapModel.layers.length > 0) {
+    return (
+      <InspectorPanel ref={panelRef} component="map" show={show} setShowPalette={setShowPalette}>
+        <InspectorButton tooltip={t("DG.Inspector.rescale.toolTip")}
+                         showMoreOptions={false} testId={"map-resize-button"} onButtonClick={handleMapRescale}>
+          <ScaleDataIcon/>
+        </InspectorButton>
+        <InspectorMenu tooltip={t("DG.Inspector.hideShow.toolTip")}
+                       icon={<HideShowIcon/>} testId={"map-hide-show-button"} onButtonClick={handleClosePalette}>
+          <HideShowMenuList tile={tile}/>
+        </InspectorMenu>
+        {renderRulerButton()}
+        <InspectorButton tooltip={t("DG.Inspector.displayLayers.toolTip")} showMoreOptions={true}
+                         testId={"map-display-config-button"}>
+          <LayersIcon/>
+        </InspectorButton>
+        <InspectorMenu tooltip={t("DG.Inspector.makeImage.toolTip")}
+                       icon={<CameraIcon/>} testId={"map-camera-button"} onButtonClick={handleClosePalette}>
+          <SaveImageMenuList tile={tile}/>
+        </InspectorMenu>
+      {showPalette === "measure" &&
+         <MapMeasurePalette tile={tile} setShowPalette={setShowPalette}
+                              panelRect={panelRect} buttonRect={buttonRect}/>}
+        {/*
+      {showPalette === "format" &&
+         <PointFormatPalette tile={tile} setShowPalette={setShowPalette}
+                             panelRect={panelRect} buttonRect={buttonRect}/>}
+*/}
+      </InspectorPanel>
+    )
+  }
+}

--- a/v3/src/components/map/components/map-inspector.tsx
+++ b/v3/src/components/map/components/map-inspector.tsx
@@ -48,7 +48,7 @@ export const MapInspector = ({tile, show}: ITileInspectorPanelProps) => {
   }
 
   const renderRulerButton = () => {
-    if (mapModel && mapModel?.layers.filter(layer => isMapPointLayerModel(layer)).length > 0) {
+    if (mapModel && mapModel.layers.filter(layer => isMapPointLayerModel(layer)).length > 0) {
       return (
         <InspectorButton tooltip={t("DG.Inspector.displayValues.toolTip")} showMoreOptions={true}
                          onButtonClick={handleRulerButton} setButtonRef={setButtonRef}

--- a/v3/src/components/map/map-registration.ts
+++ b/v3/src/components/map/map-registration.ts
@@ -5,6 +5,7 @@ import MapIcon from "../../assets/icons/icon-map.svg"
 import {createMapContentModel, MapContentModel} from "./models/map-content-model"
 import {MapComponentTitleBar} from "./components/map-component-title-bar"
 import {MapComponent} from "./components/map-component"
+import {MapInspector} from "./components/map-inspector"
 
 export const kMapIdPrefix = "MAP_"
 
@@ -19,6 +20,7 @@ registerTileComponentInfo({
   type: kMapTileType,
   TitleBar: MapComponentTitleBar,
   Component: MapComponent,
+  InspectorPanel: MapInspector,
   tileEltClass: kMapTileClass,
   Icon: MapIcon,
   shelf: {

--- a/v3/src/components/map/models/map-content-model.ts
+++ b/v3/src/components/map/models/map-content-model.ts
@@ -3,6 +3,7 @@ import {addDisposer, Instance, SnapshotIn, types} from "mobx-state-tree"
 import {ISharedModel} from "../../../models/shared/shared-model"
 import {SharedModelChangeType} from "../../../models/shared/shared-model-manager"
 import {ITileContentModel} from "../../../models/tiles/tile-content"
+import {applyUndoableAction} from "../../../models/history/apply-undoable-action"
 import {IDataSet} from "../../../models/data/data-set"
 import {ISharedDataSet, kSharedDataSetType, SharedDataSet} from "../../../models/shared/shared-data-set"
 import {kMapModelName, kMapTileType} from "../map-defs"
@@ -106,8 +107,13 @@ export const MapContentModel = DataDisplayContentModel
     },
     incrementDisplayChangeCount() {
       self.displayChangeCount++
+    },
+    rescale() {
+      console.log("rescale")
     }
   }))
+  // performs the specified action so that response actions are included and undo/redo strings assigned
+  .actions(applyUndoableAction)
 
 export interface IMapContentModel extends Instance<typeof MapContentModel> {
 }

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -21,6 +21,9 @@
     "V3.formula.error.stringConstantArg": "The '%@()' function expects %@ argument to be a string constant",
     "V3.formula.error.caseDependentNotSupported": "This formula scope does not support case-dependent formulas",
 
+    // V3 map inspector strings
+//    "V3.Inspector.map.displayValues.toolTip": "Change what is shown along with the points",
+
     // CFM/File menu
     "DG.fileMenu.menuItem.newDocument": "New",
     "DG.fileMenu.menuItem.openDocument": "Open...",
@@ -855,6 +858,8 @@
     "DG.DataDisplayMenu.displayingOnlySelected": "Displaying Only Selected Cases",
     "DG.DataDisplayMenu.snapshot": "Make Snapshot",
     "DG.DataDisplayMenu.copyAsImage": "Open in Draw Tool",
+    "DG.DataDisplayMenu.exportPngImage": "Export PNG Image...",
+    "DG.DataDisplayMenu.exportSvgImage": "Export SVG Image...",
     "DG.DataDisplayMenu.exportImage": "Export Image...",
     "DG.DataDisplayMenu.imageOfTitle": "Image of %@",
     "DG.DataDisplayMenu.addBackgroundImage": "Add Background Image",
@@ -954,7 +959,7 @@
     "DG.Inspector.displayStyles.toolTip": "Change the appearance of the display",
     "DG.Inspector.displayLayers.toolTip": "Change the appearance of the map layers",
     "DG.Inspector.displayConfiguration.toolTip": "Configure the display differently",
-    "DG.Inspector.makeImage.toolTip": "Save the image as a PNG file",
+    "DG.Inspector.makeImage.toolTip": "Save the image",
     "DG.Inspector.displayShow": "Show …",
     "DG.Inspector.displayScale": "Scale …",
 


### PR DESCRIPTION
This commit just puts up the inspector palette but doesn't implement any of its functionality.

[#186459298] Feature: Maps have an inspector palette
* Register Map component as having a MapInspector
* Only display ruler icon if there is at least one point layer
* Show checkboxes in ruler icon menu
* Show a layers icon
* Show menu for export image icon

Strangely, two strings were missing from en-US.json5: 
"DG.DataDisplayMenu.exportSvgImage"
"DG.DataDisplayMenu.exportImage"
even though they were present in individual language json's