### PR TITLE
Add FormulaManager tests, refactor Formula model

### DIFF
--- a/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
@@ -24,7 +24,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({ attributeId
   }, [attribute?.formula.display])
 
   const applyFormula = () => {
-    attribute?.setDisplayFormula(formula)
+    attribute?.setDisplayExpression(formula)
     closeModal()
   }
 

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
@@ -29,7 +29,7 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     setExpression(expression: string) {
-      self.formula.setDisplayFormula(expression)
+      self.formula.setDisplayExpression(expression)
     },
     setError(error: string) {
       self.error = error

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-model.ts
@@ -19,7 +19,7 @@ export const PlottedValueAdornmentModel = UnivariateMeasureAdornmentModel
   }))
   .actions(self => ({
     setExpression(expression: string) {
-      self.formula.setDisplayFormula(expression)
+      self.formula.setDisplayExpression(expression)
     },
     setError(error: string) {
       self.error = error

--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -291,7 +291,7 @@ describe("Attribute", () => {
   test("Serialization of an attribute with formula (development)", () => {
     process.env.NODE_ENV = "development"
     const x = Attribute.create({ name: "x", values: ["2", "4", "6"] })
-    x.setDisplayFormula("caseIndex * 2")
+    x.setDisplayExpression("caseIndex * 2")
     expect(x.values).toBeUndefined()
     expect(x.strValues).toEqual(["2", "4", "6"])
     expect(x.numValues).toEqual([2, 4, 6])
@@ -313,7 +313,7 @@ describe("Attribute", () => {
   test("Serialization of an attribute with formula (production)", () => {
     process.env.NODE_ENV = "production"
     const x = Attribute.create({ name: "x", values: ["2", "4", "6"] })
-    x.setDisplayFormula("caseIndex * 2")
+    x.setDisplayExpression("caseIndex * 2")
     expect(x.values).toBe(x.strValues)
     expect(x.strValues).toEqual(["2", "4", "6"])
     expect(x.numValues).toEqual([2, 4, 6])
@@ -337,7 +337,7 @@ describe("Attribute", () => {
     expect(attr.formula.display).toBe("")
     expect(attr.formula.canonical).toBe("")
     expect(attr.isEditable).toBe(true)
-    attr.setDisplayFormula("2 * x")
+    attr.setDisplayExpression("2 * x")
     expect(attr.formula.display).toBe("2 * x")
     expect(attr.isEditable).toBe(false)
     attr.clearFormula()

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -210,10 +210,10 @@ export const Attribute = types.model("Attribute", {
     self.editable = editable
   },
   clearFormula() {
-    this.setDisplayFormula("")
+    this.setDisplayExpression("")
   },
-  setDisplayFormula(displayFormula: string) {
-    self.formula.setDisplayFormula(displayFormula)
+  setDisplayExpression(displayFormula: string) {
+    self.formula.setDisplayExpression(displayFormula)
   },
   addValue(value: IValueType = "", beforeIndex?: number) {
     const strValue = self.importValue(value)

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -199,7 +199,7 @@ export const CategorySet = types.model("CategorySet", {
     if (isValidReference(() => self.attribute)) {
       addDisposer(self, onAnyAction(self.attribute, action => {
         const actionsInvalidatingCategories = [
-          "clearFormula", "setDisplayFormula", "addValue", "addValues", "setValue", "setValues", "removeValues"
+          "clearFormula", "setDisplayExpression", "addValue", "addValues", "setValue", "setValues", "removeValues"
         ]
         if (actionsInvalidatingCategories.includes(action.name)) {
           self.invalidate()

--- a/v3/src/models/data/data-set-collection-groups.test.ts
+++ b/v3/src/models/data/data-set-collection-groups.test.ts
@@ -219,7 +219,7 @@ describe("CollectionGroups", () => {
 
   it("doesn't take formula evaluated values into account when grouping", () => {
     const aAttr = data.attrFromID("aId")
-    aAttr.setDisplayFormula("foo * bar")
+    aAttr.setDisplayExpression("foo * bar")
     data.moveAttributeToNewCollection("aId")
     expect(data.groupedAttributes.map(attr => attr.id)).toEqual(["aId"])
     expect(data.ungroupedAttributes.map(attr => attr.id)).toEqual(["bId", "cId"])

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -4,6 +4,9 @@ import { DocumentModel, IDocumentModelSnapshot } from "./document"
 import { IDocumentEnvironment } from "./document-environment"
 import { SharedModelDocumentManager } from "./shared-model-document-manager"
 import { FormulaManager } from "../formula/formula-manager"
+import { AttributeFormulaAdapter } from "../formula/attribute-formula-adapter"
+import { PlottedValueFormulaAdapter } from "../formula/plotted-value-formula-adapter"
+import { PlottedFunctionFormulaAdapter } from "../formula/plotted-function-formula-adapter"
 import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
 
 /**
@@ -15,6 +18,12 @@ import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/sha
 export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
   const sharedModelManager = new SharedModelDocumentManager()
   const formulaManager = new FormulaManager()
+  const adapterApi = formulaManager.getAdapterApi()
+  formulaManager.addAdapters([
+    new AttributeFormulaAdapter(adapterApi),
+    new PlottedValueFormulaAdapter(adapterApi),
+    new PlottedFunctionFormulaAdapter(adapterApi)
+  ])
   const fullEnvironment: ITileEnvironment & {documentEnv: IDocumentEnvironment} = {
     sharedModelManager,
     formulaManager,

--- a/v3/src/models/formula/attribute-formula-adapter.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.ts
@@ -29,8 +29,8 @@ export class AttributeFormulaAdapter implements IFormulaManagerAdapter {
     this.api = api
   }
 
-  getActiveFormulas(): ({ formula: IFormula, extraMetadata?: IAttrFormulaExtraMetadata })[] {
-    const result: ({ formula: IFormula, extraMetadata?: IAttrFormulaExtraMetadata })[] = []
+  getActiveFormulas(): ({ formula: IFormula, extraMetadata: IAttrFormulaExtraMetadata })[] {
+    const result: ({ formula: IFormula, extraMetadata: IAttrFormulaExtraMetadata })[] = []
     this.api.getDatasets().forEach(dataSet => {
       dataSet.attributes.forEach(attr => {
         result.push({

--- a/v3/src/models/formula/base-graph-formula-adapter.ts
+++ b/v3/src/models/formula/base-graph-formula-adapter.ts
@@ -89,7 +89,7 @@ export class BaseGraphFormulaAdapter implements IFormulaManagerAdapter {
     return result
   }
 
-  getActiveFormulas(): ({ formula: IFormula, extraMetadata?: IBaseGraphFormulaExtraMetadata })[] {
+  getActiveFormulas(): ({ formula: IFormula, extraMetadata: IBaseGraphFormulaExtraMetadata })[] {
     const result: ({ formula: IFormula, extraMetadata: IBaseGraphFormulaExtraMetadata })[] = []
     this.graphContentModels.forEach(graphContentModel => {
       const adornment = this.getAdornment(graphContentModel)

--- a/v3/src/models/formula/formula-manager.test.ts
+++ b/v3/src/models/formula/formula-manager.test.ts
@@ -1,0 +1,193 @@
+import { observable, runInAction } from "mobx"
+import { DataSet, IDataSet } from "../data/data-set"
+import { Formula, IFormula } from "./formula"
+import { FormulaManager } from "./formula-manager"
+import { CASE_INDEX_FAKE_ATTR_ID, localAttrIdToCanonical } from "./utils/name-mapping-utils"
+import { AttributeFormulaAdapter } from "./attribute-formula-adapter"
+
+const formulaDisplay = "1 + 2 + foo"
+
+const getFakeAdapter = (formula: IFormula, dataSet: IDataSet) => {
+  const activeFormulas = observable.box([formula])
+  return {
+    type: "fakeAdapter",
+    getActiveFormulas: jest.fn(() => {
+      return activeFormulas.get().map(f => ({ formula: f, extraMetadata: { dataSetId: dataSet.id } }))
+    }),
+    recalculateFormula: jest.fn(),
+    setupFormulaObservers: jest.fn(),
+    setFormulaError: jest.fn(),
+    getFormulaError: jest.fn(),
+    // Custom test helpers:
+    setActiveFormulas: (formulas: IFormula[]) => {
+      runInAction(() => activeFormulas.set(formulas))
+    }
+  }
+}
+
+const getManagerWithFakeAdapter = () => {
+  const dataSet = DataSet.create({ attributes: [{ name: "foo" }] })
+  const formula = Formula.create({ display: formulaDisplay })
+  const adapter = getFakeAdapter(formula, dataSet)
+  const manager = new FormulaManager()
+  manager.addDataSet(dataSet)
+  manager.addAdapters([adapter])
+  return { manager, adapter, formula, dataSet }
+}
+
+describe("FormulaManager", () => {
+  it("should create a formula manager", () => {
+    const formulaManager = new FormulaManager()
+    expect(formulaManager).toBeDefined()
+  })
+
+  it("should add dataset and adapter, get its active formulas, canonicalize them and trigger recalculation", () => {
+    const { manager, adapter, formula, dataSet } = getManagerWithFakeAdapter()
+    expect(manager.dataSets.size).toBe(1)
+    expect(manager.adapters.length).toBe(1)
+    expect(manager.adapters[0]).toBe(adapter)
+    expect(adapter.getActiveFormulas).toHaveBeenCalled()
+    expect(adapter.setupFormulaObservers).toHaveBeenCalled()
+    expect(adapter.recalculateFormula).toHaveBeenCalled()
+    expect(adapter.setFormulaError).not.toHaveBeenCalled()
+    expect(manager.getFormulaMetadata(formula.id).isInitialized).toEqual(true)
+    expect(formula.canonical).toEqual(`1 + 2 + ${localAttrIdToCanonical(dataSet.attrFromName("foo")?.id || "")}`)
+  })
+
+  describe("when formulas has a syntax error", () => {
+    it("should set formula error", () => {
+      const { manager, adapter, formula } = getManagerWithFakeAdapter()
+      formula.setDisplayExpression("1 + 2 +")
+      expect(manager.getFormulaMetadata(formula.id).isInitialized).toEqual(false)
+      expect(adapter.setFormulaError).toHaveBeenCalled()
+      expect((adapter.setFormulaError).mock.calls[0][2]).toMatch(/Syntax error/)
+    })
+  })
+
+  describe("when formula has adapter-specific error", () => {
+    it("should set formula error", () => {
+      const { adapter, formula } = getManagerWithFakeAdapter()
+      adapter.getFormulaError.mockReturnValueOnce("Some error")
+      formula.setDisplayExpression("1 + 2 + 3") // just to trigger re-registration and error check
+      expect(adapter.setFormulaError).toHaveBeenCalled()
+      expect((adapter.setFormulaError).mock.calls[0][2]).toEqual("Some error")
+    })
+  })
+
+  describe("when formula has a circular dependency", () => {
+    it("registers formulas in a way that lets cirlcular detection algorithm to work correctly", () => {
+      // This test is a bit specific ot the attribute formula adapter, but it's pretty important as it ensures
+      // that FormulaManager.registerAllFormulas is implemented in a way that delays error detection until all
+      // the formulas are registered (necessary for circular dependency detection to work correctly).
+      const dataSet = DataSet.create({
+        attributes: [
+          { name: "foo", formula: { display: "bar + 1" } },
+          { name: "bar", formula: { display: "foo + 1" } }
+        ]
+      })
+      dataSet.addCases([{ __id__: "1" }])
+      const manager = new FormulaManager()
+      const adapter = new AttributeFormulaAdapter(manager.getAdapterApi())
+      manager.addDataSet(dataSet)
+      manager.addAdapters([adapter])
+
+      expect(dataSet.getValueAtIndex(0, dataSet.attrFromName("foo")?.id || "")).toMatch(/Circular reference/)
+      expect(dataSet.getValueAtIndex(0, dataSet.attrFromName("bar")?.id || "")).toMatch(/Circular reference/)
+    })
+  })
+
+  describe("when formula becomes inactive or it's removed", () => {
+    it("un-registers formula", () => {
+      const { manager, adapter, formula } = getManagerWithFakeAdapter()
+      expect(manager.getFormulaMetadata(formula.id)).toBeDefined()
+      adapter.setActiveFormulas([])
+      expect(() => manager.getFormulaMetadata(formula.id)).toThrow() // metadata is removed
+    })
+  })
+
+  describe("formula observers", () => {
+    // Note that formula observers are extracted to its own helpers that are tested separately. These tests just
+    // roughly check the integration between formula manager and formula observers.
+    describe("when one of the symbol value changes", () => {
+      it("recalculates the formula", () => {
+        const { adapter, dataSet } = getManagerWithFakeAdapter()
+        const attr = dataSet.attrFromName("foo")
+        expect(adapter.recalculateFormula).toHaveBeenCalledTimes(1)
+        dataSet.setCaseValues([{ __id__: "1", [attr?.id || ""]: 3 }])
+        expect(adapter.recalculateFormula).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    describe("when one of the formula symbols is renamed", () => {
+      it("updates formula display expression", () => {
+        const { formula, dataSet } = getManagerWithFakeAdapter()
+        const attr = dataSet.attrFromName("foo")
+        attr?.setName("bar")
+        expect(formula.display).toEqual("1 + 2 + bar")
+        expect(formula.canonical).toEqual(`1 + 2 + ${localAttrIdToCanonical(attr?.id || "")}`)
+      })
+    })
+
+    describe("when one of the formula symbols is removed and re-added", () => {
+      it("updates formula display and canonical expressions", () => {
+        const { formula, dataSet, adapter } = getManagerWithFakeAdapter()
+        expect(adapter.recalculateFormula).toHaveBeenCalledTimes(1)
+
+        const attr = dataSet.attrFromName("foo")
+        dataSet.removeAttribute(attr?.id || "")
+        expect(formula.display).toEqual("1 + 2 + foo")
+        expect(formula.canonical).toEqual("1 + 2 + foo")
+        expect(adapter.recalculateFormula).toHaveBeenCalledTimes(2)
+
+        // Re-add attribute
+        dataSet.addAttribute({ name: "foo" })
+        const newAttr = dataSet.attrFromName("foo")
+        expect(formula.display).toEqual("1 + 2 + foo")
+        expect(formula.canonical).toEqual(`1 + 2 + ${localAttrIdToCanonical(newAttr?.id || "")}`)
+        expect(adapter.recalculateFormula).toHaveBeenCalledTimes(3)
+      })
+    })
+  })
+
+  describe("getAdapterApi", () => {
+    it("should return functional adapter api", () => {
+      const { manager, adapter, formula, dataSet } = getManagerWithFakeAdapter()
+      const api = manager.getAdapterApi()
+      expect(api).toBeDefined()
+      expect(api.getDatasets()).toEqual(manager.dataSets)
+      expect(api.getGlobalValueManager()).toEqual(manager.globalValueManager)
+      expect(api.getFormulaExtraMetadata(formula.id)).toEqual({
+        dataSetId: dataSet.id
+      })
+      const context = api.getFormulaContext(formula.id)
+      expect(context.formula).toEqual(formula)
+      expect(context.adapter).toEqual(adapter)
+      expect(context.dataSet).toEqual(dataSet)
+      expect(context.isInitialized).toEqual(true)
+      expect(context.registeredDisplay).toEqual(formulaDisplay)
+    })
+  })
+
+  describe("getDisplayNameMap", () => {
+    it("retrieves formula context and calculates display name map", () => {
+      const { manager, formula, dataSet } = getManagerWithFakeAdapter()
+      expect(manager.getDisplayNameMap(formula.id)).toEqual({
+        dataSet: {},
+        localNames: {
+          caseIndex: localAttrIdToCanonical(CASE_INDEX_FAKE_ATTR_ID),
+          foo: localAttrIdToCanonical(dataSet.attrFromName("foo")?.id || ""),
+        }
+      })
+    })
+  })
+
+  describe("getCanonicalNameMap", () => {
+    it("retrieves formula context and calculates canonical name map", () => {
+      const { manager, formula, dataSet } = getManagerWithFakeAdapter()
+      expect(manager.getCanonicalNameMap(formula.id)).toEqual({
+        [localAttrIdToCanonical(CASE_INDEX_FAKE_ATTR_ID)]: "caseIndex",
+        [localAttrIdToCanonical(dataSet.attrFromName("foo")?.id || "")]: "foo"
+      })
+    })
+  })
+})

--- a/v3/src/models/formula/formula.ts
+++ b/v3/src/models/formula/formula.ts
@@ -2,7 +2,7 @@ import { Instance, types } from "mobx-state-tree"
 import { parse } from "mathjs"
 import { typedId } from "../../utilities/js-utils"
 import { getFormulaManager } from "../tiles/tile-environment"
-import { canonicalToDisplay, displayToCanonical, preprocessDisplayFormula } from "./utils/canonicalization-utils"
+import { preprocessDisplayFormula } from "./utils/canonicalization-utils"
 import { isRandomFunctionPresent } from "./utils/misc"
 
 export const Formula = types.model("Formula", {
@@ -33,33 +33,11 @@ export const Formula = types.model("Formula", {
   },
 }))
 .actions(self => ({
-  setDisplayFormula(displayFormula: string) {
-    self.display = displayFormula
+  setDisplayExpression(displayExpression: string) {
+    self.display = displayExpression
   },
-  updateCanonicalFormula() {
-    // This action will be called by formula manager when it detects that the display formula has changed.
-    // It can happen either as a result of user editing the formula, or when a document with display formulas is loaded.
-    self.canonical = "" // reset canonical formula immediately, in case of errors that are handled below
-    if (self.empty || !self.valid || !self.formulaManager) {
-      return
-    }
-    const displayNameMap = self.formulaManager.getDisplayNameMap(self.id)
-    self.canonical = displayToCanonical(self.display, displayNameMap)
-  },
-  updateDisplayFormula() {
-    // This action should be called when one of the attributes is renamed. The canonical form is still valid, while
-    // display form needs to be updated. The old display form is used to preserve the user's whitespace / formatting.
-    if (self.empty || !self.valid || !self.formulaManager) {
-      return
-    }
-    const canonicalNameMap = self.formulaManager.getCanonicalNameMap(self.id)
-    try {
-      self.display = canonicalToDisplay(self.canonical, self.display, canonicalNameMap)
-    } catch {
-      // If the canonical formula can't be converted to display formula, it usually means there are some unresolved
-      // canonical names. It usually happens when an attribute is removed. Nothing to do here, just keep the original
-      // display form.
-    }
+  setCanonicalExpression(canonicalExpression: string) {
+    self.canonical = canonicalExpression
   },
   rerandomize() {
     self.formulaManager?.recalculateFormula(self.id)


### PR DESCRIPTION
This PR focuses on enhancing the testability of FormulaManager and introducing Jest tests. To achieve this, I've modified the initialization process of adapters to enable the use of FakeAdapter in the tests. Additionally, I've transferred certain logic from the Formula MST model to FormulaManager. The Formula model primarily serves as a simple storage, it can't do much without access to all the context (datasets, attributes, global values, etc.).