### PR TITLE
fix: SD hover tip values are wrong (PT-186447543)

### DIFF
--- a/v3/cypress/support/elements/component-elements.ts
+++ b/v3/cypress/support/elements/component-elements.ts
@@ -12,7 +12,7 @@ export const ComponentElements = {
     graphDisplayValuesButton: "Change what is shown along with the points",
     graphDisplayConfigButton: "Configure the display differently",
     graphDisplayStylesButton: "Change the appearance of the display",
-    graphCameraButton: "Save the image as a PNG file",
+    graphCameraButton: "Save the image",
     tableSwitchCaseCard: "Switch to case card view of the data",
     tableDatasetInfoButton: "Display information about dataset",
     tableResizeButton: "Resize all columns to fit data",

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-model.ts
@@ -18,13 +18,16 @@ export const StandardDeviationAdornmentModel = UnivariateMeasureAdornmentModel
     },
     computeMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
       const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
-      if (caseValues.length === 0) return NaN
+      // If there are less than two values, the adornment should not render.
+      if (caseValues.length < 2) return
       return mean(caseValues)
     }
   }))
   .views(self => ({
     computeMeasureRange(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
       const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
+      // If there are less than two values, the adornment should not render.
+      if (caseValues.length < 2) return
       const standardDeviation = Number(std(caseValues))
       const meanValue = Number(self.computeMeasureValue(attrId, cellKey, dataConfig))
       const min = meanValue - standardDeviation

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -163,12 +163,12 @@ export class UnivariateMeasureAdornmentHelper {
       ? this.layout.getAxisMultiScale("bottom")
       : this.layout.getAxisMultiScale("left")
     const displayValue = multiScale?.formatValueForScale(value) || valueLabelString(value)
-    const plotValue = Number(displayValue) // Is this really just `value`?
+    const plotValue = Number(displayValue)
     const measureRange: IRange | undefined = attrId && this.model.hasRange
       ? this.model.computeMeasureRange(attrId, this.cellKey, dataConfig)
       : {}
     const displayRange = measureRange.min || measureRange.min === 0
-      ? multiScale?.formatValueForScale(measureRange.min) || valueLabelString(measureRange.min)
+      ? multiScale?.formatValueForScale(value - measureRange.min) || valueLabelString(value - measureRange.min)
       : undefined
     const {x: x1, y: y1} =
       this.calculateLineCoords(plotValue, 1, isVertical, cellCounts, secondaryAxisX, secondaryAxisY)

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -46,6 +46,17 @@ export class UnivariateMeasureAdornmentHelper {
     return `${this.measureSlug}-${elementType}-${this.containerId}${this.classFromKey ? `-${this.classFromKey}` : ""}`
   }
 
+  formatValueForScale(isVertical: boolean, value: number | undefined) {
+    const multiScale = isVertical
+      ? this.layout.getAxisMultiScale("bottom")
+      : this.layout.getAxisMultiScale("left")
+    return value != null
+      ? multiScale
+        ? multiScale.formatValueForScale(value)
+        : valueLabelString(value)
+      : ""
+  }
+
   calculateLineCoords = (
     value: number, index: number, isVertical: boolean, cellCounts: Record<string, number>,
     secondaryAxisX=0, secondaryAxisY=0
@@ -159,17 +170,13 @@ export class UnivariateMeasureAdornmentHelper {
     attrId: string, dataConfig: IDataConfigurationModel, value: number, isVertical: boolean,
     cellCounts: Record<string, number>, secondaryAxisX=0, secondaryAxisY=0
   ) => {
-    const multiScale = isVertical
-      ? this.layout.getAxisMultiScale("bottom")
-      : this.layout.getAxisMultiScale("left")
-    const displayValue = multiScale?.formatValueForScale(value) || valueLabelString(value)
+    const displayValue = this.formatValueForScale(isVertical, value)
     const plotValue = Number(displayValue)
-    const measureRange: IRange | undefined = attrId && this.model.hasRange
+    const measureRange: IRange = attrId && this.model.hasRange
       ? this.model.computeMeasureRange(attrId, this.cellKey, dataConfig)
       : {}
-    const displayRange = measureRange.min || measureRange.min === 0
-      ? multiScale?.formatValueForScale(value - measureRange.min) || valueLabelString(value - measureRange.min)
-      : undefined
+      const rangeValue = measureRange.min != null ? plotValue - measureRange.min : undefined
+    const displayRange = this.formatValueForScale(isVertical, rangeValue)
     const {x: x1, y: y1} =
       this.calculateLineCoords(plotValue, 1, isVertical, cellCounts, secondaryAxisX, secondaryAxisY)
     const {x: x2, y: y2} =


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186447543

These changes ensure the Standard Deviation adornment does not render for plots with fewer than two case values, and that the correct value is shown in the hover tips and labels for the adornment when it is present.