### PR TITLE
chore: Simplify updateCategories actions for graph adornments

### DIFF
--- a/v3/cypress/support/elements/component-elements.ts
+++ b/v3/cypress/support/elements/component-elements.ts
@@ -12,7 +12,7 @@ export const ComponentElements = {
     graphDisplayValuesButton: "Change what is shown along with the points",
     graphDisplayConfigButton: "Configure the display differently",
     graphDisplayStylesButton: "Change the appearance of the display",
-    graphCameraButton: "Save the image as a PNG file",
+    graphCameraButton: "Save the image",
     tableSwitchCaseCard: "Switch to case card view of the data",
     tableDatasetInfoButton: "Display information about dataset",
     tableResizeButton: "Resize all columns to fit data",

--- a/v3/src/components/graph/adornments/adornment-models.test.ts
+++ b/v3/src/components/graph/adornments/adornment-models.test.ts
@@ -70,6 +70,60 @@ describe("AdornmentModel", () => {
     const cellKey = {abc123: xCategories[0], def456: yCategories[0]}
     expect(adornment.classNameFromKey(cellKey)).toEqual("abc123-pizza-def456-red")
   })
+  it("will generate a list of all cell keys for a graph", () => {
+    const adornment = AdornmentModel.create({type: "Movable Line"})
+
+    // For a graph with no categorical attributes
+    const noCategoricalOptions = {
+      xAttrId: "abc123",
+      xCats: [],
+      yAttrId: "def456",
+      yCats: [],
+      topAttrId: "",
+      topCats: [],
+      rightAttrId: "",
+      rightCats: []
+    }
+    const noCategoricalCellKeys = adornment.getAllCellKeys(noCategoricalOptions)
+    expect(noCategoricalCellKeys.length).toEqual(1)
+    expect(noCategoricalCellKeys[0]).toEqual({})
+
+    // For a graph with one categorical attribute
+    const oneCategoricalOptions = {
+      xAttrId: "abc123",
+      xCats: [],
+      yAttrId: "def456",
+      yCats: ["small", "large"],
+      topAttrId: "",
+      topCats: [],
+      rightAttrId: "",
+      rightCats: []
+    }
+    const oneCategoricalCellKeys = adornment.getAllCellKeys(oneCategoricalOptions)
+    expect(oneCategoricalCellKeys.length).toEqual(2)
+    expect(oneCategoricalCellKeys[0]).toEqual({"def456": "small"})
+    expect(oneCategoricalCellKeys[1]).toEqual({"def456": "large"})
+
+    // For a graph with multiple categorical attributes
+    const xCategories = ["pizza", "salad"]
+    const yCategories = ["red", "green"]
+    const topCategories = ["medium", "large"]
+    const rightCategories = ["hot", "cold"]
+    const categoricalOptions = {
+      xAttrId: "abc123",
+      xCats: xCategories,
+      yAttrId: "def456",
+      yCats: yCategories,
+      topAttrId: "ghi789",
+      topCats: topCategories,
+      rightAttrId: "jkl012",
+      rightCats: rightCategories
+    }
+    const cellKeys = adornment.getAllCellKeys(categoricalOptions)
+    expect(cellKeys.length).toEqual(16)
+    expect(cellKeys[0]).toEqual({abc123: "pizza", def456: "red", ghi789: "medium", jkl012: "hot"})
+    expect(cellKeys[15]).toEqual({abc123: "salad", def456: "green", ghi789: "large", jkl012: "cold"})
+  })
 })
 
 describe("UnknownAdornmentModel", () => {

--- a/v3/src/components/graph/adornments/adornment-models.ts
+++ b/v3/src/components/graph/adornments/adornment-models.ts
@@ -103,6 +103,23 @@ export const AdornmentModel = types.model("AdornmentModel", {
       return cellKey
     }
   }))
+  .views(self => ({
+    getAllCellKeys(options: IUpdateCategoriesOptions) {
+      const { xCats, yCats, topCats, rightCats } = options
+      const topCatCount = topCats.length || 1
+      const rightCatCount = rightCats.length || 1
+      const xCatCount = xCats.length || 1
+      const yCatCount = yCats.length || 1
+      const columnCount = topCatCount * xCatCount
+      const rowCount = rightCatCount * yCatCount
+      const totalCount = rowCount * columnCount
+      const cellKeys: Record<string, string>[] = []
+      for (let i = 0; i < totalCount; ++i) {
+        cellKeys.push(self.cellKey(options, i))
+      }
+      return cellKeys
+    }
+  }))
   .actions(self => ({
     setVisibility(isVisible: boolean) {
       self.isVisible = isVisible

--- a/v3/src/components/graph/adornments/adornments-store.test.ts
+++ b/v3/src/components/graph/adornments/adornments-store.test.ts
@@ -12,6 +12,7 @@ jest.spyOn(contentInfo, "getAdornmentTypes").mockReturnValue(
 const mockAdornment = {
   cellCount: () => ({x: 1, y: 1}),
   classNameFromKey: () => "mock-count-adornment",
+  getAllCellKeys: () => ([]),
   id: "ADRN123",
   instanceKey: () => "mock-count-adornment",
   isUnivariateMeasure: false,

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
@@ -51,17 +51,13 @@ export const MovableLineAdornmentModel = AdornmentModel
 }))
 .actions(self => ({
   updateCategories(options: IUpdateCategoriesOptions) {
-    const { xAxis, yAxis, topCats, rightCats, resetPoints } = options
-    const columnCount = topCats?.length || 1
-    const rowCount = rightCats?.length || 1
-    const totalCount = rowCount * columnCount
-    for (let i = 0; i < totalCount; ++i) {
-      const cellKey = self.cellKey(options, i)
+    const { resetPoints, xAxis, yAxis } = options
+    self.getAllCellKeys(options).forEach(cellKey => {
       const instanceKey = self.instanceKey(cellKey)
       if (!self.lines.get(instanceKey) || resetPoints) {
         self.setInitialLine(xAxis, yAxis, instanceKey)
       }
-    }
+    })
   }
 }))
 

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-model.ts
@@ -30,17 +30,13 @@ export const MovablePointAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
-      const { xAxis, yAxis, topCats, rightCats, resetPoints } = options
-      const columnCount = topCats?.length || 1
-      const rowCount = rightCats?.length || 1
-      const totalCount = rowCount * columnCount
-      for (let i = 0; i < totalCount; ++i) {
-        const cellKey = self.cellKey(options, i)
+      const { resetPoints, xAxis, yAxis } = options
+      self.getAllCellKeys(options).forEach(cellKey => {
         const instanceKey = self.instanceKey(cellKey)
         if (!self.points.get(instanceKey) || resetPoints) {
           self.setInitialPoint(xAxis, yAxis, instanceKey)
         }
-      }
+      })
     }
   }))
 export interface IMovablePointAdornmentModel extends Instance<typeof MovablePointAdornmentModel> {}

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-model.ts
@@ -115,29 +115,21 @@ export const MovableValueAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
-      const { xAxis, xCats, yAxis, yCats, topCats, rightCats, resetPoints } = options
-      const topCatCount = topCats.length || 1
-      const rightCatCount = rightCats.length || 1
-      const xCatCount = xCats.length || 1
-      const yCatCount = yCats.length || 1
-      const columnCount = topCatCount * xCatCount
-      const rowCount = rightCatCount * yCatCount
-      const totalCount = rowCount * columnCount
+      const { xAxis, yAxis, resetPoints } = options
       const axisMin = xAxis?.isNumeric ? (xAxis as INumericAxisModel).min : (yAxis as INumericAxisModel).min
       const axisMax = xAxis?.isNumeric ? (xAxis as INumericAxisModel).max : (yAxis as INumericAxisModel).max
 
       self.setAxisMin(axisMin)
       self.setAxisMax(axisMax)
 
-      for (let i = 0; i < totalCount; ++i) {
-        const subPlotKey = self.cellKey(options, i)
-        const instanceKey = self.instanceKey(subPlotKey)
+      self.getAllCellKeys(options).forEach(cellKey => {
+        const instanceKey = self.instanceKey(cellKey)
         // Each array in the model's values map should have the same length as all the others. If there are no existing
         // values for the current instance key, check if there is at least one array in the map. If there is, copy those
         // values. Otherwise, set the array to []. We will add any new values to the array after the loop.
         const existingValues = self.values.get(instanceKey) || self.firstValueArray || []
         self.values.set(instanceKey, [...existingValues])
-      }
+      })
 
       // If this action was triggered by the attributes changing (i.e., resetPoints is true), do not add a new value.
       if (resetPoints) return

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
@@ -96,7 +96,7 @@ export const PlottedFunctionAdornmentComponent = observer(function PlottedFuncti
   const refreshValues = useCallback(() => {
     if (!model.isVisible) return
 
-    const measure = model?.measures.get(instanceKey)
+    const measure = model?.plottedFunctions.get(instanceKey)
     const selection = select(plottedFunctionRef.current)
 
     // Remove the previous value's elements

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.test.ts
@@ -1,4 +1,17 @@
-import { PlottedFunctionAdornmentModel } from "./plotted-function-adornment-model"
+import { PlottedFunctionInstance, PlottedFunctionAdornmentModel } from "./plotted-function-adornment-model"
+
+describe("PlottedFunctionInstance", () => {
+  it("can be created", () => {
+    const measure = PlottedFunctionInstance.create()
+    expect(measure).toBeDefined()
+  })
+  it("can have its formulaFunction set", () => {
+    const plottedFunction = PlottedFunctionInstance.create()
+    expect(plottedFunction.formulaFunction(10)).toBe(NaN) // the default returns NaN no matter what
+    plottedFunction.setValue(x => x)
+    expect(plottedFunction.formulaFunction(10)).toBe(10)
+  })
+})
 
 describe("PlottedFunctionAdornmentModel", () => {
   it("is created with its type property set to 'Plotted Function' and with its value property not defined", () => {

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
@@ -3,7 +3,7 @@ import { AdornmentModel, IAdornmentModel } from "../adornment-models"
 import { kPlottedFunctionType, kPlottedFunctionValueTitleKey, FormulaFn } from "./plotted-function-adornment-types"
 import { Formula } from "../../../../models/formula/formula"
 
-export const MeasureInstance = types.model("MeasureInstance", {})
+export const PlottedFunctionMeasureInstance = types.model("MeasureInstance", {})
   .volatile(self => ({
     formulaFunction: (x: number) => NaN,
   }))
@@ -19,7 +19,7 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
     type: types.optional(types.literal(kPlottedFunctionType), kPlottedFunctionType),
     formula: types.optional(Formula, () => Formula.create()),
     labelTitle: types.optional(types.literal(kPlottedFunctionValueTitleKey), kPlottedFunctionValueTitleKey),
-    measures: types.map(MeasureInstance),
+    measures: types.map(PlottedFunctionMeasureInstance),
     error: ""
   })
   .views(self => ({
@@ -35,7 +35,7 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
       self.error = error
     },
     addMeasure(formulaFunction: FormulaFn, key="{}") {
-      const newMeasure = MeasureInstance.create()
+      const newMeasure = PlottedFunctionMeasureInstance.create()
       newMeasure.setValue(formulaFunction)
       self.measures.set(key, newMeasure)
     },

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
@@ -3,7 +3,7 @@ import { AdornmentModel, IAdornmentModel } from "../adornment-models"
 import { kPlottedFunctionType, kPlottedFunctionValueTitleKey, FormulaFn } from "./plotted-function-adornment-types"
 import { Formula } from "../../../../models/formula/formula"
 
-export const PlottedFunctionMeasureInstance = types.model("MeasureInstance", {})
+export const PlottedFunctionInstance = types.model("PlottedFunctionInstance", {})
   .volatile(self => ({
     formulaFunction: (x: number) => NaN,
   }))
@@ -19,7 +19,7 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
     type: types.optional(types.literal(kPlottedFunctionType), kPlottedFunctionType),
     formula: types.optional(Formula, () => Formula.create()),
     labelTitle: types.optional(types.literal(kPlottedFunctionValueTitleKey), kPlottedFunctionValueTitleKey),
-    measures: types.map(PlottedFunctionMeasureInstance),
+    plottedFunctions: types.map(PlottedFunctionInstance),
     error: ""
   })
   .views(self => ({
@@ -34,19 +34,19 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
     setError(error: string) {
       self.error = error
     },
-    addMeasure(formulaFunction: FormulaFn, key="{}") {
-      const newMeasure = PlottedFunctionMeasureInstance.create()
-      newMeasure.setValue(formulaFunction)
-      self.measures.set(key, newMeasure)
+    addPlottedFunction(formulaFunction: FormulaFn, key="{}") {
+      const newPlottedFunction = PlottedFunctionInstance.create()
+      newPlottedFunction.setValue(formulaFunction)
+      self.plottedFunctions.set(key, newPlottedFunction)
     },
-    updateMeasureValue(formulaFunction: FormulaFn, key="{}") {
-      const measure = self.measures.get(key)
-      if (measure) {
-        measure.setValue(formulaFunction)
+    updatePlottedFunctionValue(formulaFunction: FormulaFn, key="{}") {
+      const plottedFunction = self.plottedFunctions.get(key)
+      if (plottedFunction) {
+        plottedFunction.setValue(formulaFunction)
       }
     },
-    removeMeasure(key: string) {
-      self.measures.delete(key)
+    removePlottedFunction(key: string) {
+      self.plottedFunctions.delete(key)
     }
   }))
 

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -97,19 +97,11 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
-      const { xAttrId, xCats, yAttrId, yCats, topCats, rightCats, resetPoints, dataConfig } = options
+      const { xAttrId, yAttrId, resetPoints, dataConfig } = options
       if (!dataConfig) return
-      const topCatCount = topCats.length || 1
-      const rightCatCount = rightCats.length || 1
-      const xCatCount = xCats.length || 1
-      const yCatCount = yCats.length || 1
-      const columnCount = topCatCount * xCatCount
-      const rowCount = rightCatCount * yCatCount
-      const totalCount = rowCount * columnCount
       const xAttrType = dataConfig.attributeType("x")
       const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
-      for (let i = 0; i < totalCount; ++i) {
-        const cellKey = self.cellKey(options, i)
+      self.getAllCellKeys(options).forEach(cellKey => {
         const instanceKey = self.instanceKey(cellKey)
         const value = Number(self.computeMeasureValue(attrId, cellKey, dataConfig))
         if (!self.measures.get(instanceKey) || resetPoints) {
@@ -117,7 +109,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
         } else {
           self.updateMeasureValue(value, instanceKey)
         }
-      }
+      })
     }
   }))
 

--- a/v3/src/models/formula/plotted-function-formula-adapter.ts
+++ b/v3/src/models/formula/plotted-function-formula-adapter.ts
@@ -49,10 +49,10 @@ export class PlottedFunctionFormulaAdapter extends BaseGraphFormulaAdapter {
       const instanceKey = adornment.instanceKey(cellKey)
       const cases = dataConfig.subPlotCases(cellKey)
       const formulaFunction = this.computeFormula(formulaContext, extraMetadata, cases)
-      if (!adornment.measures.get(instanceKey)) {
-        adornment.addMeasure(formulaFunction, instanceKey)
+      if (!adornment.plottedFunctions.get(instanceKey)) {
+        adornment.addPlottedFunction(formulaFunction, instanceKey)
       } else {
-        adornment.updateMeasureValue(formulaFunction, instanceKey)
+        adornment.updatePlottedFunctionValue(formulaFunction, instanceKey)
       }
     })
   }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186477102

These changes add a common method to `AdornmentModel` for generating a list of all adornment grid cell keys for a graph. This method (`getAllCellKeys`) can be used by all the adornments' separate `updateCategories` actions instead of doing their own cell key list generation. This simplifies all the `updateCategories` actions and will help simplify code used for adornments that support formulas.