### PR TITLE
Add formula manager adapters tests (attribute, plotted value and plotted function)

### DIFF
--- a/v3/src/models/formula/attribute-formula-adapter.test.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.test.ts
@@ -1,0 +1,111 @@
+import { DataSet, IDataSet } from "../data/data-set"
+import { AttributeFormulaAdapter } from "./attribute-formula-adapter"
+import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
+
+const getTestEnv = () => {
+  const dataSet = DataSet.create({ attributes: [{ name: "foo", formula: { display: "1 + 2", canonical: "1 + 2" } }] })
+  dataSet.addCases([{ __id__: "1" }])
+  const attribute = dataSet.attributes[0]
+  const formula = attribute.formula
+  const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+  const context = { dataSet, formula }
+  const extraMetadata = { dataSetId: dataSet.id, attributeId: attribute.id }
+  const api = {
+    getDatasets: jest.fn(() => dataSets),
+    getGlobalValueManager: jest.fn(),
+    getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+    getFormulaContext: jest.fn(() => context),
+  }
+  const adapter = new AttributeFormulaAdapter(api)
+  return { adapter, api, dataSet, attribute, formula, context, extraMetadata }
+}
+
+describe("AttributeFormulaAdapter", () => {
+  describe("getAllFormulas", () => {
+    it("should return attribute formulas and extra metadata", () => {
+      const { adapter, extraMetadata, formula } = getTestEnv()
+      const formulas = adapter.getActiveFormulas()
+      expect(formulas.length).toBe(1)
+      expect(formulas[0].formula).toBe(formula)
+      expect(formulas[0].formula.display).toBe("1 + 2")
+      expect(formulas[0].extraMetadata).toEqual(extraMetadata)
+    })
+  })
+
+  describe("recalculateFormula", () => {
+    it("should store results in DataSet case values", () => {
+      const { adapter, dataSet, attribute, context, extraMetadata } = getTestEnv()
+      adapter.recalculateFormula(context, extraMetadata, "ALL_CASES")
+      expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("3")
+    })
+  })
+
+  describe("setError", () => {
+    it("should store error in DataSet case values", () => {
+      const { adapter, attribute, dataSet, context, extraMetadata } = getTestEnv()
+      adapter.setFormulaError(context, extraMetadata, "test error")
+      expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("test error")
+    })
+  })
+
+  describe("getFormulaError", () => {
+    it("should detect dependency cycles", () => {
+      const dataSet = DataSet.create({
+        attributes: [
+          { name: "foo", formula: { display: "bar + 1" } },
+          { name: "bar", formula: { display: "foo + 1" } }
+        ]
+      })
+      dataSet.attributes[0].formula.setCanonicalExpression(
+        `${localAttrIdToCanonical(dataSet.attrIDFromName("bar"))} + 1`
+      )
+      dataSet.attributes[1].formula.setCanonicalExpression(
+        `${localAttrIdToCanonical(dataSet.attrIDFromName("foo"))} + 1`
+      )
+      dataSet.addCases([{ __id__: "1" }])
+      const attribute = dataSet.attributes[0]
+      const formula = attribute.formula
+      const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+      const context = { dataSet, formula }
+      const extraMetadata = { dataSetId: dataSet.id, attributeId: attribute.id }
+      const api = {
+        getDatasets: jest.fn(() => dataSets),
+        getGlobalValueManager: jest.fn(),
+        getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+        getFormulaContext: jest.fn(() => context),
+      }
+      const adapter = new AttributeFormulaAdapter(api)
+      const error = adapter.getFormulaError(context, extraMetadata)
+      expect(error).toMatch(/Circular reference/)
+    })
+  })
+
+  describe("setupFormulaObservers", () => {
+    it("should setup observer detecting hierarchy updates", () => {
+      const dataSet = DataSet.create({
+        attributes: [
+          { name: "foo", formula: { display: "1 + 2", canonical: "1 + 2" } },
+          { name: "bar" }
+        ]
+      })
+      dataSet.addCases([{ __id__: "1" }])
+      const attribute = dataSet.attributes[0]
+      const formula = attribute.formula
+      const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+      const context = { dataSet, formula }
+      const extraMetadata = { dataSetId: dataSet.id, attributeId: attribute.id }
+      const api = {
+        getDatasets: jest.fn(() => dataSets),
+        getGlobalValueManager: jest.fn(),
+        getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+        getFormulaContext: jest.fn(() => context),
+      }
+      const adapter = new AttributeFormulaAdapter(api)
+      adapter.setupFormulaObservers(context, extraMetadata)
+
+      expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("")
+      dataSet.moveAttributeToNewCollection(dataSet.attrIDFromName("bar"))
+      expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("3") // formula has been recalculated
+    })
+  })
+})

--- a/v3/src/models/formula/plotted-function-formula-adapter.test.ts
+++ b/v3/src/models/formula/plotted-function-formula-adapter.test.ts
@@ -1,0 +1,85 @@
+import { DataSet, IDataSet } from "../data/data-set"
+import { PlottedFunctionFormulaAdapter } from "./plotted-function-formula-adapter"
+import { IUpdateCategoriesOptions } from "../../components/graph/adornments/adornment-models"
+import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
+import { GraphDataConfigurationModel } from "../../components/graph/models/graph-data-configuration-model"
+import {
+  PlottedFunctionAdornmentModel
+} from "../../components/graph/adornments/plotted-function/plotted-function-adornment-model"
+
+const getTestEnv = () => {
+  const dataSet = DataSet.create({ attributes: [{ name: "foo" }] })
+  dataSet.addCases([{ __id__: "1" }])
+  const attribute = dataSet.attributes[0]
+  const adornment = PlottedFunctionAdornmentModel.create({ formula: { display: "1 + 2 + x", canonical: "1 + 2 + x" }})
+  const graphContentModel = {
+    id: "fake-graph-content-model-id",
+    adornments: [adornment],
+    dataset: dataSet,
+    getUpdateCategoriesOptions: (): IUpdateCategoriesOptions => ({
+      xAttrId: attribute.id,
+      xCats: [],
+      yAttrId: "fake-y-attr-id",
+      yCats: [],
+      topAttrId: "fake-size-attr-id",
+      topCats: ["small", "medium", "large"],
+      rightAttrId: "",
+      rightCats: [],
+      dataConfig: GraphDataConfigurationModel.create({ }),
+    }),
+  }
+  const formula = adornment.formula
+  const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+  const context = { dataSet, formula }
+  const extraMetadata = {
+    dataSetId: dataSet.id,
+    defaultArgument: localAttrIdToCanonical("fake-y-attr-id"),
+    graphCellKeys: [
+      {"fake-size-attr-id": "small"},
+      {"fake-size-attr-id": "medium"},
+      {"fake-size-attr-id": "large"},
+    ],
+    graphContentModelId: "fake-graph-content-model-id",
+  }
+  const api = {
+    getDatasets: jest.fn(() => dataSets),
+    getGlobalValueManager: jest.fn(),
+    getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+    getFormulaContext: jest.fn(() => context),
+  }
+  const adapter = new PlottedFunctionFormulaAdapter(api)
+  adapter.addGraphContentModel(graphContentModel as any)
+  return { adapter, adornment, graphContentModel, api, dataSet, attribute, formula, context, extraMetadata }
+}
+
+describe("PlottedFunctionFormulaAdapter", () => {
+  describe("getAllFormulas", () => {
+    it("should return attribute formulas and extra metadata", () => {
+      const { adapter, formula, extraMetadata } = getTestEnv()
+      const formulas = adapter.getActiveFormulas()
+      expect(formulas.length).toBe(1)
+      expect(formulas[0].formula).toBe(formula)
+      expect(formulas[0].formula.display).toBe("1 + 2 + x")
+      expect(formulas[0].extraMetadata).toEqual(extraMetadata)
+    })
+  })
+
+  describe("recalculateFormula", () => {
+    it("should store results in DataSet case values", () => {
+      const { adapter, adornment, context, extraMetadata } = getTestEnv()
+      adapter.recalculateFormula(context, extraMetadata)
+      extraMetadata.graphCellKeys.forEach(cellKey => {
+        const instanceKey = adornment.instanceKey(cellKey)
+        expect(adornment.measures.get(instanceKey)?.formulaFunction(3)).toBe(6) // = 1 + 2 + x=3
+      })
+    })
+  })
+
+  describe("setError", () => {
+    it("should store error in DataSet case values", () => {
+      const { adapter, adornment, context, extraMetadata } = getTestEnv()
+      adapter.setFormulaError(context, extraMetadata, "test error")
+      expect(adornment.error).toBe("test error")
+    })
+  })
+})

--- a/v3/src/models/formula/plotted-value-formula-adapter.test.ts
+++ b/v3/src/models/formula/plotted-value-formula-adapter.test.ts
@@ -1,0 +1,85 @@
+import {
+  PlottedValueAdornmentModel
+} from "../../components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-model"
+import { DataSet, IDataSet } from "../data/data-set"
+import { PlottedValueFormulaAdapter } from "./plotted-value-formula-adapter"
+import { IUpdateCategoriesOptions } from "../../components/graph/adornments/adornment-models"
+import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
+import { GraphDataConfigurationModel } from "../../components/graph/models/graph-data-configuration-model"
+
+const getTestEnv = () => {
+  const dataSet = DataSet.create({ attributes: [{ name: "foo" }] })
+  dataSet.addCases([{ __id__: "1" }])
+  const attribute = dataSet.attributes[0]
+  const adornment = PlottedValueAdornmentModel.create({ formula: { display: "1 + 2", canonical: "1 + 2" }})
+  const graphContentModel = {
+    id: "fake-graph-content-model-id",
+    adornments: [adornment],
+    dataset: dataSet,
+    getUpdateCategoriesOptions: (): IUpdateCategoriesOptions => ({
+      xAttrId: attribute.id,
+      xCats: [],
+      yAttrId: "fake-y-attr-id",
+      yCats: [],
+      topAttrId: "fake-size-attr-id",
+      topCats: ["small", "medium", "large"],
+      rightAttrId: "",
+      rightCats: [],
+      dataConfig: GraphDataConfigurationModel.create({ }),
+    }),
+  }
+  const formula = adornment.formula
+  const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+  const context = { dataSet, formula }
+  const extraMetadata = {
+    dataSetId: dataSet.id,
+    defaultArgument: localAttrIdToCanonical("fake-y-attr-id"),
+    graphCellKeys: [
+      {"fake-size-attr-id": "small"},
+      {"fake-size-attr-id": "medium"},
+      {"fake-size-attr-id": "large"},
+    ],
+    graphContentModelId: "fake-graph-content-model-id",
+  }
+  const api = {
+    getDatasets: jest.fn(() => dataSets),
+    getGlobalValueManager: jest.fn(),
+    getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+    getFormulaContext: jest.fn(() => context),
+  }
+  const adapter = new PlottedValueFormulaAdapter(api)
+  adapter.addGraphContentModel(graphContentModel as any)
+  return { adapter, adornment, graphContentModel, api, dataSet, attribute, formula, context, extraMetadata }
+}
+
+describe("PlottedValueFormulaAdapter", () => {
+  describe("getAllFormulas", () => {
+    it("should return attribute formulas and extra metadata", () => {
+      const { adapter, formula, extraMetadata } = getTestEnv()
+      const formulas = adapter.getActiveFormulas()
+      expect(formulas.length).toBe(1)
+      expect(formulas[0].formula).toBe(formula)
+      expect(formulas[0].formula.display).toBe("1 + 2")
+      expect(formulas[0].extraMetadata).toEqual(extraMetadata)
+    })
+  })
+
+  describe("recalculateFormula", () => {
+    it("should store results in DataSet case values", () => {
+      const { adapter, adornment, context, extraMetadata } = getTestEnv()
+      adapter.recalculateFormula(context, extraMetadata)
+      extraMetadata.graphCellKeys.forEach(cellKey => {
+        const instanceKey = adornment.instanceKey(cellKey)
+        expect(adornment.measures.get(instanceKey)?.value).toBe(3) // = 1 + 2
+      })
+    })
+  })
+
+  describe("setError", () => {
+    it("should store error in DataSet case values", () => {
+      const { adapter, adornment, context, extraMetadata } = getTestEnv()
+      adapter.setFormulaError(context, extraMetadata, "test error")
+      expect(adornment.error).toBe("test error")
+    })
+  })
+})


### PR DESCRIPTION
This pull request includes tests for the formula adapters. Setting this up became quite messy due to obvious dependencies on various external models. The Graph formulas adapters were particularly tricky to set up because of the GraphContentModel, which I couldn't instantiate in the required manner. However, I believe that some basic concepts are covered, and it increases coverage to 80-90%.