### PR TITLE
Add tests of semi-aggregate functions

### DIFF
--- a/v3/src/models/formula/attribute-formula-adapter.test.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.test.ts
@@ -1,0 +1,111 @@
+import { DataSet, IDataSet } from "../data/data-set"
+import { AttributeFormulaAdapter } from "./attribute-formula-adapter"
+import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
+
+const getTestEnv = () => {
+  const dataSet = DataSet.create({ attributes: [{ name: "foo", formula: { display: "1 + 2", canonical: "1 + 2" } }] })
+  dataSet.addCases([{ __id__: "1" }])
+  const attribute = dataSet.attributes[0]
+  const formula = attribute.formula
+  const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+  const context = { dataSet, formula }
+  const extraMetadata = { dataSetId: dataSet.id, attributeId: attribute.id }
+  const api = {
+    getDatasets: jest.fn(() => dataSets),
+    getGlobalValueManager: jest.fn(),
+    getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+    getFormulaContext: jest.fn(() => context),
+  }
+  const adapter = new AttributeFormulaAdapter(api)
+  return { adapter, api, dataSet, attribute, formula, context, extraMetadata }
+}
+
+describe("AttributeFormulaAdapter", () => {
+  describe("getAllFormulas", () => {
+    it("should return attribute formulas and extra metadata", () => {
+      const { adapter, extraMetadata, formula } = getTestEnv()
+      const formulas = adapter.getActiveFormulas()
+      expect(formulas.length).toBe(1)
+      expect(formulas[0].formula).toBe(formula)
+      expect(formulas[0].formula.display).toBe("1 + 2")
+      expect(formulas[0].extraMetadata).toEqual(extraMetadata)
+    })
+  })
+
+  describe("recalculateFormula", () => {
+    it("should store results in DataSet case values", () => {
+      const { adapter, dataSet, attribute, context, extraMetadata } = getTestEnv()
+      adapter.recalculateFormula(context, extraMetadata, "ALL_CASES")
+      expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("3")
+    })
+  })
+
+  describe("setError", () => {
+    it("should store error in DataSet case values", () => {
+      const { adapter, attribute, dataSet, context, extraMetadata } = getTestEnv()
+      adapter.setFormulaError(context, extraMetadata, "test error")
+      expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("test error")
+    })
+  })
+
+  describe("getFormulaError", () => {
+    it("should detect dependency cycles", () => {
+      const dataSet = DataSet.create({
+        attributes: [
+          { name: "foo", formula: { display: "bar + 1" } },
+          { name: "bar", formula: { display: "foo + 1" } }
+        ]
+      })
+      dataSet.attributes[0].formula.setCanonicalExpression(
+        `${localAttrIdToCanonical(dataSet.attrIDFromName("bar"))} + 1`
+      )
+      dataSet.attributes[1].formula.setCanonicalExpression(
+        `${localAttrIdToCanonical(dataSet.attrIDFromName("foo"))} + 1`
+      )
+      dataSet.addCases([{ __id__: "1" }])
+      const attribute = dataSet.attributes[0]
+      const formula = attribute.formula
+      const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+      const context = { dataSet, formula }
+      const extraMetadata = { dataSetId: dataSet.id, attributeId: attribute.id }
+      const api = {
+        getDatasets: jest.fn(() => dataSets),
+        getGlobalValueManager: jest.fn(),
+        getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+        getFormulaContext: jest.fn(() => context),
+      }
+      const adapter = new AttributeFormulaAdapter(api)
+      const error = adapter.getFormulaError(context, extraMetadata)
+      expect(error).toMatch(/Circular reference/)
+    })
+  })
+
+  describe("setupFormulaObservers", () => {
+    it("should setup observer detecting hierarchy updates", () => {
+      const dataSet = DataSet.create({
+        attributes: [
+          { name: "foo", formula: { display: "1 + 2", canonical: "1 + 2" } },
+          { name: "bar" }
+        ]
+      })
+      dataSet.addCases([{ __id__: "1" }])
+      const attribute = dataSet.attributes[0]
+      const formula = attribute.formula
+      const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+      const context = { dataSet, formula }
+      const extraMetadata = { dataSetId: dataSet.id, attributeId: attribute.id }
+      const api = {
+        getDatasets: jest.fn(() => dataSets),
+        getGlobalValueManager: jest.fn(),
+        getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+        getFormulaContext: jest.fn(() => context),
+      }
+      const adapter = new AttributeFormulaAdapter(api)
+      adapter.setupFormulaObservers(context, extraMetadata)
+
+      expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("")
+      dataSet.moveAttributeToNewCollection(dataSet.attrIDFromName("bar"))
+      expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("3") // formula has been recalculated
+    })
+  })
+})

--- a/v3/src/models/formula/functions/semi-aggregate-functions.test.ts
+++ b/v3/src/models/formula/functions/semi-aggregate-functions.test.ts
@@ -1,0 +1,151 @@
+import { FormulaMathJsScope } from "../formula-mathjs-scope"
+import { evaluate, evaluateForAllCases, getFormulaTestEnv } from "../test-utils/formula-test-utils"
+import { math } from "./math"
+import { getDisplayNameMap } from "../utils/name-mapping-utils"
+import { displayToCanonical } from "../utils/canonicalization-utils"
+
+describe("semiAggregateFunctions", () => {
+  describe("prev", () => {
+    it("should returns the prev value", () => {
+      expect(evaluate("prev(LifeSpan)", 0)).toBe("")
+      expect(evaluate("prev(LifeSpan)", 1)).toBe("70")
+      expect(evaluate("prev(LifeSpan)", 2)).toBe("70")
+      expect(evaluate("prev(LifeSpan)", 3)).toBe("19")
+      expect(evaluate("prev(LifeSpan)", 4)).toBe("25")
+    })
+
+    it("supports the default value", () => {
+      expect(evaluate("prev(LifeSpan, 123)", 0)).toBe(123) // first case
+      expect(evaluate("prev(LifeSpan, 123, Diet = 'does not exist')", 12)).toBe(123) // no matching filter
+    })
+
+    it("supports the filter argument", () => {
+      // When prev is evaluated with filter, it needs to be evaluated for each case using the same scope.
+      // That's why evaluateForAllCases is used here.
+      expect(evaluateForAllCases("prev(LifeSpan, 0, Diet = 'both')")).toEqual([
+        0, 0, 0, 0, 0, 0, "40", "40", "40", "40", "40", "40", "9", "9", "3", "80", "80", "80", "80", "5", "5", "12",
+        "20", "10", "10", "10", "7",
+      ])
+    })
+
+    it("supports recursive calls", () => {
+      expect(evaluateForAllCases("prev(prev(LifeSpan))")).toEqual([
+        "", "", "70", "70", "19", "25", "14", "40", "16", "40", "25", "16", "30", "9", "25", "3", "80", "20", "50",
+        "15", "5", "10", "12", "20", "10", "10", "5"
+      ])
+    })
+
+    it("supports self reference and recursion", () => {
+      // Fibonacci sequence
+      expect(evaluateForAllCases("prev(LifeSpan, 1) + prev(prev(LifeSpan, 0))", "LifeSpan")).toEqual([
+        1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946, 17711, 28657,
+        46368, 75025, 121393, 196418
+      ])
+    })
+
+    it("implements caching that ensures O(n) complexity", () => {
+      const { dataSetsByName, dataSets, globalValueManager } = getFormulaTestEnv()
+      const localDataSet = dataSetsByName.Mammals
+      const caseIds = localDataSet.cases.map(c => c.__id__)
+      const scope = new FormulaMathJsScope({
+        localDataSet,
+        dataSets,
+        globalValueManager,
+        caseIds,
+        childMostCollectionCaseIds: caseIds,
+      })
+      scope.getLocalValue = jest.fn(scope.getLocalValue)
+
+      const displayNameMap = getDisplayNameMap({
+        localDataSet,
+        dataSets,
+        globalValueManager,
+      })
+      const formula = displayToCanonical("prev(LifeSpan, 0, caseIndex = 1)", displayNameMap)
+      const compiledFormula = math.compile(formula)
+
+      const result = caseIds.map((caseId, idx) => {
+        scope.setCasePointer(idx)
+        const formulaValue = compiledFormula.evaluate(scope)
+        scope.savePreviousResult(formulaValue)
+        return formulaValue
+      })
+
+      const expectedResult = new Array(27).fill("70")
+      expectedResult[0] = 0 // default value
+      expect(result).toEqual(expectedResult)
+
+      // Local values should be called 54 times (2 times for each case). This is a proof that prev() is evaluated
+      // in O(n) time. If it was evaluated in O(n^2) time, it would be called ~729 times (27^2).
+      expect(scope.getLocalValue).toHaveBeenCalledTimes(27 * 2)
+    })
+  })
+
+  describe("next", () => {
+    it("should returns the next value", () => {
+      expect(evaluate("next(LifeSpan)", 0)).toBe("70")
+      expect(evaluate("next(LifeSpan)", 1)).toBe("19")
+      expect(evaluate("next(LifeSpan)", 2)).toBe("25")
+      expect(evaluate("next(LifeSpan)", 25)).toBe("25")
+      expect(evaluate("next(LifeSpan)", 26)).toBe("") // last case
+    })
+
+    it("supports the default value", () => {
+      expect(evaluate("next(LifeSpan, 123)", 26)).toBe(123) // last case
+      expect(evaluate("next(LifeSpan, 123, Diet = 'does not exist')", 12)).toBe(123) // no matching filter
+    })
+
+    it("supports the filter argument", () => {
+      expect(evaluate("next(LifeSpan, 0, Diet = 'both')", 0)).toBe("40")
+      expect(evaluate("next(LifeSpan, 0, Diet = 'both')", 1)).toBe("40")
+      expect(evaluate("next(LifeSpan, 0, Diet = 'both')", 5)).toBe("9")
+      expect(evaluate("next(LifeSpan, 0, Diet = 'both')", 6)).toBe("9")
+      expect(evaluate("next(LifeSpan, 0, Diet = 'both')", 11)).toBe("3")
+      expect(evaluate("next(LifeSpan, 0, Diet = 'both')", 12)).toBe("3")
+    })
+
+    it("supports recursive calls", () => {
+      expect(evaluateForAllCases("next(next(LifeSpan))")).toEqual([
+        "19", "25", "14", "40", "16", "40", "25", "16", "30", "9", "25", "3", "80", "20", "50", "15", "5", "10", "12",
+        "20", "10", "10", "5", "7", "25", "", ""
+      ])
+    })
+  })
+
+  it("implements caching that ensures O(n) complexity", () => {
+    const { dataSetsByName, dataSets, globalValueManager } = getFormulaTestEnv()
+    const localDataSet = dataSetsByName.Mammals
+    const caseIds = localDataSet.cases.map(c => c.__id__)
+    const scope = new FormulaMathJsScope({
+      localDataSet,
+      dataSets,
+      globalValueManager,
+      caseIds,
+      childMostCollectionCaseIds: caseIds,
+    })
+    scope.getLocalValue = jest.fn(scope.getLocalValue)
+
+    const displayNameMap = getDisplayNameMap({
+      localDataSet,
+      dataSets,
+      globalValueManager,
+    })
+    const formula = displayToCanonical("next(LifeSpan, 0, caseIndex = 27)", displayNameMap)
+    const compiledFormula = math.compile(formula)
+
+    const result = caseIds.map((caseId, idx) => {
+      scope.setCasePointer(idx)
+      const formulaValue = compiledFormula.evaluate(scope)
+      scope.savePreviousResult(formulaValue)
+      return formulaValue
+    })
+
+    const expectedResult = new Array(27).fill("25")
+    expectedResult[26] = 0 // default value
+    expect(result).toEqual(expectedResult)
+
+    // Local values should be called 54 times (2 times for each case). This is a proof that next() is evaluated
+    // in O(n) time. If it was evaluated in O(n^2) time, it would be called ~729 times (27^2).
+    expect(scope.getLocalValue).toHaveBeenCalledTimes(27 * 2)
+  })
+})

--- a/v3/src/models/formula/plotted-function-formula-adapter.test.ts
+++ b/v3/src/models/formula/plotted-function-formula-adapter.test.ts
@@ -1,0 +1,85 @@
+import { DataSet, IDataSet } from "../data/data-set"
+import { PlottedFunctionFormulaAdapter } from "./plotted-function-formula-adapter"
+import { IUpdateCategoriesOptions } from "../../components/graph/adornments/adornment-models"
+import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
+import { GraphDataConfigurationModel } from "../../components/graph/models/graph-data-configuration-model"
+import {
+  PlottedFunctionAdornmentModel
+} from "../../components/graph/adornments/plotted-function/plotted-function-adornment-model"
+
+const getTestEnv = () => {
+  const dataSet = DataSet.create({ attributes: [{ name: "foo" }] })
+  dataSet.addCases([{ __id__: "1" }])
+  const attribute = dataSet.attributes[0]
+  const adornment = PlottedFunctionAdornmentModel.create({ formula: { display: "1 + 2 + x", canonical: "1 + 2 + x" }})
+  const graphContentModel = {
+    id: "fake-graph-content-model-id",
+    adornments: [adornment],
+    dataset: dataSet,
+    getUpdateCategoriesOptions: (): IUpdateCategoriesOptions => ({
+      xAttrId: attribute.id,
+      xCats: [],
+      yAttrId: "fake-y-attr-id",
+      yCats: [],
+      topAttrId: "fake-size-attr-id",
+      topCats: ["small", "medium", "large"],
+      rightAttrId: "",
+      rightCats: [],
+      dataConfig: GraphDataConfigurationModel.create({ }),
+    }),
+  }
+  const formula = adornment.formula
+  const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+  const context = { dataSet, formula }
+  const extraMetadata = {
+    dataSetId: dataSet.id,
+    defaultArgument: localAttrIdToCanonical("fake-y-attr-id"),
+    graphCellKeys: [
+      {"fake-size-attr-id": "small"},
+      {"fake-size-attr-id": "medium"},
+      {"fake-size-attr-id": "large"},
+    ],
+    graphContentModelId: "fake-graph-content-model-id",
+  }
+  const api = {
+    getDatasets: jest.fn(() => dataSets),
+    getGlobalValueManager: jest.fn(),
+    getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+    getFormulaContext: jest.fn(() => context),
+  }
+  const adapter = new PlottedFunctionFormulaAdapter(api)
+  adapter.addGraphContentModel(graphContentModel as any)
+  return { adapter, adornment, graphContentModel, api, dataSet, attribute, formula, context, extraMetadata }
+}
+
+describe("PlottedFunctionFormulaAdapter", () => {
+  describe("getAllFormulas", () => {
+    it("should return attribute formulas and extra metadata", () => {
+      const { adapter, formula, extraMetadata } = getTestEnv()
+      const formulas = adapter.getActiveFormulas()
+      expect(formulas.length).toBe(1)
+      expect(formulas[0].formula).toBe(formula)
+      expect(formulas[0].formula.display).toBe("1 + 2 + x")
+      expect(formulas[0].extraMetadata).toEqual(extraMetadata)
+    })
+  })
+
+  describe("recalculateFormula", () => {
+    it("should store results in DataSet case values", () => {
+      const { adapter, adornment, context, extraMetadata } = getTestEnv()
+      adapter.recalculateFormula(context, extraMetadata)
+      extraMetadata.graphCellKeys.forEach(cellKey => {
+        const instanceKey = adornment.instanceKey(cellKey)
+        expect(adornment.measures.get(instanceKey)?.formulaFunction(3)).toBe(6) // = 1 + 2 + x=3
+      })
+    })
+  })
+
+  describe("setError", () => {
+    it("should store error in DataSet case values", () => {
+      const { adapter, adornment, context, extraMetadata } = getTestEnv()
+      adapter.setFormulaError(context, extraMetadata, "test error")
+      expect(adornment.error).toBe("test error")
+    })
+  })
+})

--- a/v3/src/models/formula/plotted-value-formula-adapter.test.ts
+++ b/v3/src/models/formula/plotted-value-formula-adapter.test.ts
@@ -1,0 +1,85 @@
+import {
+  PlottedValueAdornmentModel
+} from "../../components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-model"
+import { DataSet, IDataSet } from "../data/data-set"
+import { PlottedValueFormulaAdapter } from "./plotted-value-formula-adapter"
+import { IUpdateCategoriesOptions } from "../../components/graph/adornments/adornment-models"
+import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
+import { GraphDataConfigurationModel } from "../../components/graph/models/graph-data-configuration-model"
+
+const getTestEnv = () => {
+  const dataSet = DataSet.create({ attributes: [{ name: "foo" }] })
+  dataSet.addCases([{ __id__: "1" }])
+  const attribute = dataSet.attributes[0]
+  const adornment = PlottedValueAdornmentModel.create({ formula: { display: "1 + 2", canonical: "1 + 2" }})
+  const graphContentModel = {
+    id: "fake-graph-content-model-id",
+    adornments: [adornment],
+    dataset: dataSet,
+    getUpdateCategoriesOptions: (): IUpdateCategoriesOptions => ({
+      xAttrId: attribute.id,
+      xCats: [],
+      yAttrId: "fake-y-attr-id",
+      yCats: [],
+      topAttrId: "fake-size-attr-id",
+      topCats: ["small", "medium", "large"],
+      rightAttrId: "",
+      rightCats: [],
+      dataConfig: GraphDataConfigurationModel.create({ }),
+    }),
+  }
+  const formula = adornment.formula
+  const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+  const context = { dataSet, formula }
+  const extraMetadata = {
+    dataSetId: dataSet.id,
+    defaultArgument: localAttrIdToCanonical("fake-y-attr-id"),
+    graphCellKeys: [
+      {"fake-size-attr-id": "small"},
+      {"fake-size-attr-id": "medium"},
+      {"fake-size-attr-id": "large"},
+    ],
+    graphContentModelId: "fake-graph-content-model-id",
+  }
+  const api = {
+    getDatasets: jest.fn(() => dataSets),
+    getGlobalValueManager: jest.fn(),
+    getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+    getFormulaContext: jest.fn(() => context),
+  }
+  const adapter = new PlottedValueFormulaAdapter(api)
+  adapter.addGraphContentModel(graphContentModel as any)
+  return { adapter, adornment, graphContentModel, api, dataSet, attribute, formula, context, extraMetadata }
+}
+
+describe("PlottedValueFormulaAdapter", () => {
+  describe("getAllFormulas", () => {
+    it("should return attribute formulas and extra metadata", () => {
+      const { adapter, formula, extraMetadata } = getTestEnv()
+      const formulas = adapter.getActiveFormulas()
+      expect(formulas.length).toBe(1)
+      expect(formulas[0].formula).toBe(formula)
+      expect(formulas[0].formula.display).toBe("1 + 2")
+      expect(formulas[0].extraMetadata).toEqual(extraMetadata)
+    })
+  })
+
+  describe("recalculateFormula", () => {
+    it("should store results in DataSet case values", () => {
+      const { adapter, adornment, context, extraMetadata } = getTestEnv()
+      adapter.recalculateFormula(context, extraMetadata)
+      extraMetadata.graphCellKeys.forEach(cellKey => {
+        const instanceKey = adornment.instanceKey(cellKey)
+        expect(adornment.measures.get(instanceKey)?.value).toBe(3) // = 1 + 2
+      })
+    })
+  })
+
+  describe("setError", () => {
+    it("should store error in DataSet case values", () => {
+      const { adapter, adornment, context, extraMetadata } = getTestEnv()
+      adapter.setFormulaError(context, extraMetadata, "test error")
+      expect(adornment.error).toBe("test error")
+    })
+  })
+})

--- a/v3/src/models/formula/test-utils/formula-test-utils.test.ts
+++ b/v3/src/models/formula/test-utils/formula-test-utils.test.ts
@@ -1,4 +1,4 @@
-import { evaluate, getFormulaTestEnv } from "./formula-test-utils"
+import { evaluate, evaluateForAllCases, getFormulaTestEnv } from "./formula-test-utils"
 
 describe("getFormulaTestEnv", () => {
   it("returns default environment with datasets and global values", () => {
@@ -38,5 +38,19 @@ describe("evaluate", () => {
 
   it("throws an error when user is trying to evaluate case-dependant formula without providing casePointer", () => {
     expect(() => evaluate("LifeSpan")).toThrow()
+  })
+})
+
+describe("evaluateForAllCases", () => {
+  it("evaluates basic formulas correctly", () => {
+    const result = new Array(27).fill(3)
+    expect(evaluateForAllCases("1 + 2")).toEqual(result)
+  })
+
+  it("can evaluate case-dependant formulas", () => {
+    expect(evaluateForAllCases("LifeSpan")).toEqual([
+      "70", "70", "19", "25", "14", "40", "16", "40", "25", "16", "30", "9", "25", "3", "80", "20", "50", "15", "5",
+      "10", "12", "20", "10", "10", "5", "7", "25"
+    ])
   })
 })


### PR DESCRIPTION
This pull request adds a test for semi-aggregate functions, increasing coverage to 95%. I have verified that the complexity is indeed O(n) by considering the most pessimistic scenarios for both functions: using `prev` with a filter that works only for the first case and using `next` with a filter that works only for the last case.