### PR TITLE
Fix `equal` helper, add tests of the basic function helpers 

### DIFF
--- a/v3/src/models/formula/functions/function-utils.test.ts
+++ b/v3/src/models/formula/functions/function-utils.test.ts
@@ -1,0 +1,86 @@
+import { isValueNonEmpty, isNumber, isValueTruthy, equal, evaluateNode } from "./function-utils"
+import { parse } from "mathjs"
+
+describe("isValueNonEmpty", () => {
+  it("should return false for empty values", () => {
+    expect(isValueNonEmpty("")).toBe(false)
+    expect(isValueNonEmpty(null)).toBe(false)
+    expect(isValueNonEmpty(undefined)).toBe(false)
+  })
+
+  it("should return true for non-empty values", () => {
+    expect(isValueNonEmpty("non-empty")).toBe(true)
+    expect(isValueNonEmpty(0)).toBe(true)
+    expect(isValueNonEmpty(false)).toBe(true)
+  })
+})
+
+describe("isNumber", () => {
+  it("should return true for numbers", () => {
+    expect(isNumber(0)).toBe(true)
+    expect(isNumber("0")).toBe(true)
+    expect(isNumber(1.23)).toBe(true)
+    expect(isNumber("1.23")).toBe(true)
+  })
+
+  it("should return false for non-numbers", () => {
+    expect(isNumber("")).toBe(false)
+    expect(isNumber("abc")).toBe(false)
+    expect(isNumber(null)).toBe(false)
+    expect(isNumber(undefined)).toBe(false)
+  })
+})
+
+describe("isValueTruthy", () => {
+  it("should return true for truthy values", () => {
+    expect(isValueTruthy(1)).toBe(true)
+    expect(isValueTruthy("non-empty")).toBe(true)
+  })
+
+  it("should return false for falsy values", () => {
+    expect(isValueTruthy("")).toBe(false)
+    expect(isValueTruthy(null)).toBe(false)
+    expect(isValueTruthy(undefined)).toBe(false)
+    expect(isValueTruthy(false)).toBe(false)
+  })
+})
+
+describe("equal", () => {
+  it("should return true for equal values", () => {
+    expect(equal(1, 1)).toBe(true)
+    expect(equal("1", 1)).toBe(true)
+    expect(equal(1, "1")).toBe(true)
+    expect(equal("1", "1")).toBe(true)
+    expect(equal(true, "true")).toBe(true)
+    expect(equal("true", true)).toBe(true)
+  })
+
+  it("should return false for unequal values", () => {
+    expect(equal(1, 2)).toBe(false)
+    expect(equal("1", 2)).toBe(false)
+    expect(equal(1, "2")).toBe(false)
+    expect(equal("1", "2")).toBe(false)
+    expect(equal(true, "false")).toBe(false)
+    expect(equal("true", false)).toBe(false)
+    expect(equal(true, 1)).toBe(false)
+  })
+
+  it("should support array arguments", () => {
+    expect(equal([1, 2], [1, 2])).toEqual([true, true])
+    expect(equal([1, 2], [1, 3])).toEqual([true, false])
+    expect(equal([1, 2], [2, 1])).toEqual([false, false])
+
+    expect(equal([1, 2], 1)).toEqual([true, false])
+    expect(equal(1, [1, 2])).toEqual([true, false])
+
+    expect(equal([1, 2], "1")).toEqual([true, false])
+    expect(equal("1", [1, 2])).toEqual([true, false])
+  })
+})
+
+describe("evaluateNode", () => {
+  it("should evaluate math nodes correctly", () => {
+    const node = parse("1 + 2")
+    expect(evaluateNode(node)).toBe(3)
+  })
+})

--- a/v3/src/models/formula/functions/function-utils.ts
+++ b/v3/src/models/formula/functions/function-utils.ts
@@ -28,17 +28,17 @@ export const equal = (a: any, b: any): boolean | boolean[] => {
   // Note that user might still compare a string with a number unintentionally, and it makes sense to try to cast
   // values when possible, so that the comparison can be performed without forcing users to think about types.
   // Also, there's more ifs than needed, but it lets us avoid unnecessary casts.
-  if (typeof a === "number" && typeof b !== "number") {
-    return a === Number(b)
-  }
-  if (typeof a !== "number" && typeof b === "number") {
-    return Number(a) === b
-  }
   if (typeof a === "boolean" && typeof b !== "boolean") {
     return a === (b === "true")
   }
   if (typeof a !== "boolean" && typeof b === "boolean") {
     return (a === "true") === b
+  }
+  if (typeof a === "number" && typeof b !== "number") {
+    return a === Number(b)
+  }
+  if (typeof a !== "number" && typeof b === "number") {
+    return Number(a) === b
   }
   return a === b
 }


### PR DESCRIPTION
This file seemed important; however, it wasn't tested. In fact, I found a bug in the `equal` function. The previous version would return true for both `true` and `1`. Now it's fixed (simply by reordering the if statements) and has been tested.