### PR TITLE
fix: SD hover tip values are wrong (PT-186447543)

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -175,7 +175,7 @@ export class UnivariateMeasureAdornmentHelper {
     const measureRange: IRange = attrId && this.model.hasRange
       ? this.model.computeMeasureRange(attrId, this.cellKey, dataConfig)
       : {}
-      const rangeValue = measureRange.min != null ? plotValue - measureRange.min : undefined
+    const rangeValue = measureRange.min != null ? value - measureRange.min : undefined
     const displayRange = this.formatValueForScale(isVertical, rangeValue)
     const {x: x1, y: y1} =
       this.calculateLineCoords(plotValue, 1, isVertical, cellCounts, secondaryAxisX, secondaryAxisY)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186447543

There was a small issue with the [previous work on this story](https://github.com/concord-consortium/codap/pull/998) in that the values being shown in the hover tips could sometimes be very slightly off when compared to V2 (e.g. 15.2 versus 15.1). To get values that match V2's exactly, this changes `adornmentSpecs` to use the unformatted `value` instead of the formatted `plotValue` in computing `rangeValue` which is used for the SD tip text.