### PR TITLE
Animation during graph rescaling

### DIFF
--- a/v3/src/components/axis/components/axis.tsx
+++ b/v3/src/components/axis/components/axis.tsx
@@ -1,4 +1,4 @@
-import React, {MutableRefObject} from "react"
+import React from "react"
 import {range} from "d3"
 import {AxisPlace} from "../axis-types"
 import {useAxis} from "../hooks/use-axis"
@@ -9,14 +9,15 @@ import "./axis.scss"
 
 interface IProps {
   axisPlace: AxisPlace
-  enableAnimation: MutableRefObject<boolean>
+  getAnimationEnabled: () => boolean
+  stopAnimation: () => void
   showScatterPlotGridLines?: boolean
   centerCategoryLabels?: boolean
 }
 
 export const Axis = ({
                        axisPlace, showScatterPlotGridLines = false,
-                       enableAnimation,
+                       getAnimationEnabled, stopAnimation,
                        centerCategoryLabels = true,
                      }: IProps) => {
   const
@@ -33,7 +34,8 @@ export const Axis = ({
                       numSubAxes={numRepetitions}
                       subAxisIndex={i}
                       axisPlace={axisPlace}
-                      enableAnimation={enableAnimation}
+                      getAnimationEnabled={getAnimationEnabled}
+                      stopAnimation={stopAnimation}
                       showScatterPlotGridLines={showScatterPlotGridLines}
                       centerCategoryLabels={centerCategoryLabels}
       />

--- a/v3/src/components/axis/components/sub-axis.tsx
+++ b/v3/src/components/axis/components/sub-axis.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite"
-import React, {MutableRefObject, useRef, useState} from "react"
+import React, {useRef, useState} from "react"
 import {AxisPlace} from "../axis-types"
 import {useAxisProviderContext} from "../hooks/use-axis-provider-context"
 import {useSubAxis} from "../hooks/use-sub-axis"
@@ -12,14 +12,16 @@ interface ISubAxisProps {
   numSubAxes: number
   subAxisIndex: number
   axisPlace: AxisPlace
-  enableAnimation: MutableRefObject<boolean>
+  getAnimationEnabled: () => boolean
+  stopAnimation: () => void
   showScatterPlotGridLines?: boolean
   centerCategoryLabels?: boolean
 }
 
 export const SubAxis = observer(function SubAxis({
                                                numSubAxes, subAxisIndex, axisPlace, showScatterPlotGridLines = false,
-                                               centerCategoryLabels = true, enableAnimation/*, getCategorySet*/
+                                               centerCategoryLabels = true, getAnimationEnabled, stopAnimation
+                                                   /*, getCategorySet*/
                                              }: ISubAxisProps) {
   const
     axisProvider = useAxisProviderContext(),
@@ -28,7 +30,8 @@ export const SubAxis = observer(function SubAxis({
     [subAxisElt, setSubAxisElt] = useState<SVGGElement | null>(null)
 
   useSubAxis({
-    subAxisIndex, axisPlace, subAxisElt, enableAnimation, showScatterPlotGridLines, centerCategoryLabels
+    subAxisIndex, axisPlace, subAxisElt, getAnimationEnabled, stopAnimation,
+    showScatterPlotGridLines, centerCategoryLabels
   })
 
   return (

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -11,11 +11,6 @@ import {hoverRadiusFactor, kDataDisplayFont, Point, pointRadiusLogBase, pointRad
   pointRadiusSelectionAddend, Rect, rTreeRect} from "./data-display-types"
 import {ISetPointSelection} from "../graph/utilities/graph-utils"
 
-export const startAnimation = (enableAnimation: React.MutableRefObject<boolean>) => {
-  enableAnimation.current = true
-  timeout(() => enableAnimation.current = false, 2000)
-}
-
 export const maxWidthOfStringsD3 = (strings: Iterable<string>) => {
   let maxWidth = 0
   for (const aString of strings) {
@@ -83,19 +78,19 @@ export interface IMatchCirclesProps {
   pointRadius: number
   pointColor: string
   pointStrokeColor: string
-  enableAnimation: React.MutableRefObject<boolean>
+  startAnimation: () => void
   instanceId: string | undefined
 }
 
 export function matchCirclesToData(props: IMatchCirclesProps) {
-  const {dataConfiguration, enableAnimation, instanceId,
+  const {dataConfiguration, startAnimation, instanceId,
       dotsElement, pointRadius, pointColor, pointStrokeColor} = props,
     id = dataConfiguration.id,
     allCaseData = dataConfiguration.joinedCaseDataArrays,
     caseDataKeyFunc = (d: CaseData) => `${d.plotNum}-${d.caseID}`,
     circles = selectCircles(dotsElement, id)
   if (!circles) return
-  startAnimation(enableAnimation)
+  startAnimation()
   circles
     .data(allCaseData, caseDataKeyFunc)
     .join(

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -1,5 +1,4 @@
-import React from "react"
-import {format, select, timeout} from "d3"
+import {format, select} from "d3"
 import {measureText} from "../../hooks/use-measure-text"
 import {between} from "../../utilities/math-utils"
 import {defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeOpacity, defaultSelectedStrokeWidth,

--- a/v3/src/components/data-display/hooks/use-data-tips.ts
+++ b/v3/src/components/data-display/hooks/use-data-tips.ts
@@ -1,5 +1,5 @@
 import {select} from "d3"
-import React, {useEffect} from "react"
+import {useEffect} from "react"
 import {tip as d3tip} from "d3-v6-tip"
 import {IDataSet} from "../../../models/data/data-set"
 import {IDotsRef, transitionDuration} from "../data-display-types"
@@ -21,10 +21,9 @@ interface IUseDataTips {
   dotsRef: IDotsRef,
   dataset: IDataSet | undefined,
   displayModel: IGraphContentModel | IMapPointLayerModel,
-  enableAnimation: React.MutableRefObject<boolean>
 }
 
-export const useDataTips = ({dotsRef, dataset, displayModel, enableAnimation}: IUseDataTips) => {
+export const useDataTips = ({dotsRef, dataset, displayModel}: IUseDataTips) => {
   const hoverPointRadius = displayModel.getPointRadius('hover-drag'),
     pointRadius = displayModel.getPointRadius(),
     selectedPointRadius = displayModel.getPointRadius('select'),
@@ -35,7 +34,7 @@ export const useDataTips = ({dotsRef, dataset, displayModel, enableAnimation}: I
   useEffect(() => {
 
     function okToTransition(target: any) {
-      return !enableAnimation.current && target.node()?.nodeName === 'circle' && dataset &&
+      return !displayModel.animationEnabled && target.node()?.nodeName === 'circle' && dataset &&
         !target.property('isDragging')
     }
 
@@ -77,6 +76,6 @@ export const useDataTips = ({dotsRef, dataset, displayModel, enableAnimation}: I
         .on('mouseout', hideDataTip)
         .call(dataTip)
     }
-  }, [dotsRef, dataset, enableAnimation, yAttrIDs, hoverPointRadius, pointRadius, selectedPointRadius,
-    displayModel.dataConfiguration.uniqueTipAttributes])
+  }, [dotsRef, dataset, yAttrIDs, hoverPointRadius, pointRadius, selectedPointRadius,
+    displayModel.dataConfiguration.uniqueTipAttributes, displayModel.animationEnabled])
 }

--- a/v3/src/components/data-display/hooks/use-data-tips.ts
+++ b/v3/src/components/data-display/hooks/use-data-tips.ts
@@ -5,11 +5,11 @@ import {IDataSet} from "../../../models/data/data-set"
 import {IDotsRef, transitionDuration} from "../data-display-types"
 import {CaseData} from "../d3-types"
 import {getCaseTipText} from "../data-display-utils"
-import {IGraphContentModel} from "../../graph/models/graph-content-model"
 import {RoleAttrIDPair} from "../models/data-configuration-model"
 import {urlParams} from "../../../utilities/url-params"
-import {IMapPointLayerModel} from "../../map/models/map-point-layer-model"
 import {isGraphDataConfigurationModel} from "../../graph/models/graph-data-configuration-model"
+import {IGraphContentModel} from "../../graph/models/graph-content-model"
+import {IMapPointLayerModel} from "../../map/models/map-point-layer-model"
 
 const dataTip = d3tip().attr('class', 'graph-d3-tip')/*.attr('opacity', 0.8)*/
   .attr('data-testid', 'graph-point-data-tip')
@@ -20,10 +20,11 @@ const dataTip = d3tip().attr('class', 'graph-d3-tip')/*.attr('opacity', 0.8)*/
 interface IUseDataTips {
   dotsRef: IDotsRef,
   dataset: IDataSet | undefined,
+  getAnimationEnabled: () => boolean,
   displayModel: IGraphContentModel | IMapPointLayerModel,
 }
 
-export const useDataTips = ({dotsRef, dataset, displayModel}: IUseDataTips) => {
+export const useDataTips = ({dotsRef, dataset, getAnimationEnabled, displayModel}: IUseDataTips) => {
   const hoverPointRadius = displayModel.getPointRadius('hover-drag'),
     pointRadius = displayModel.getPointRadius(),
     selectedPointRadius = displayModel.getPointRadius('select'),
@@ -34,7 +35,7 @@ export const useDataTips = ({dotsRef, dataset, displayModel}: IUseDataTips) => {
   useEffect(() => {
 
     function okToTransition(target: any) {
-      return !displayModel.animationEnabled && target.node()?.nodeName === 'circle' && dataset &&
+      return !getAnimationEnabled() && target.node()?.nodeName === 'circle' && dataset &&
         !target.property('isDragging')
     }
 
@@ -77,5 +78,5 @@ export const useDataTips = ({dotsRef, dataset, displayModel}: IUseDataTips) => {
         .call(dataTip)
     }
   }, [dotsRef, dataset, yAttrIDs, hoverPointRadius, pointRadius, selectedPointRadius,
-    displayModel.dataConfiguration.uniqueTipAttributes, displayModel.animationEnabled])
+    displayModel.dataConfiguration.uniqueTipAttributes, getAnimationEnabled])
 }

--- a/v3/src/components/data-display/models/data-display-content-model.ts
+++ b/v3/src/components/data-display/models/data-display-content-model.ts
@@ -17,12 +17,12 @@ export const DataDisplayContentModel = TileContentModel
     animationEnabled: false,
   }))
   .actions(self => ({
-    startAnimation() {
-      self.animationEnabled = true
-      setTimeout(() => self.animationEnabled = false, 2000)
-    },
     stopAnimation() {
       self.animationEnabled = false
+    },
+    startAnimation() {
+      self.animationEnabled = true
+      setTimeout(() => this.stopAnimation(), 2000)
     },
     getAnimationEnabled() {
       return self.animationEnabled

--- a/v3/src/components/data-display/models/data-display-content-model.ts
+++ b/v3/src/components/data-display/models/data-display-content-model.ts
@@ -13,4 +13,19 @@ export const DataDisplayContentModel = TileContentModel
     layers: types.array(DataDisplayLayerModelUnion),
     pointDescription: types.optional(PointDescriptionModel, () => PointDescriptionModel.create()),
   })
+  .volatile(() => ({
+    animationEnabled: false,
+  }))
+  .actions(self => ({
+    startAnimation() {
+      self.animationEnabled = true
+      setTimeout(() => self.animationEnabled = false, 2000)
+    },
+    stopAnimation() {
+      self.animationEnabled = false
+    },
+    getAnimationEnabled() {
+      return self.animationEnabled
+    }
+  }))
 

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -139,7 +139,7 @@ export const CaseDots = function CaseDots(props: {
   }, [dataConfiguration?.caseDataArray, graphModel,
     randomlyDistributePoints, refreshPointPositions])
 
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection, getAnimationEnabled})
+  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection})
 
   return (
     <></>

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -14,7 +14,7 @@ import {setPointCoordinates} from "../utilities/graph-utils"
 type BinMap = Record<string, Record<string, Record<string, Record<string, number>>>>
 
 export const ChartDots = function ChartDots(props: PlotProps) {
-  const {dotsRef, enableAnimation} = props,
+  const {dotsRef} = props,
     graphModel = useGraphContentModelContext(),
     {pointColor, pointStrokeColor} = graphModel.pointDescription,
     dataConfiguration = useGraphDataConfigurationContext(),
@@ -210,13 +210,13 @@ export const ChartDots = function ChartDots(props: PlotProps) {
     setPointCoordinates({
       dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),
       dotsRef, selectedOnly, pointColor, pointStrokeColor,
-      getScreenX, getScreenY, getLegendColor, enableAnimation
+      getScreenX, getScreenY, getLegendColor, getAnimationEnabled: graphModel.getAnimationEnabled
     })
   }, [dataConfiguration, primaryAxisPlace, primaryAttrRole, secondaryAttrRole, graphModel, dotsRef,
     extraPrimaryAttrRole, extraSecondaryAttrRole, pointColor,
-    enableAnimation, primaryIsBottom, layout, pointStrokeColor, computeMaxOverAllCells, dataset])
+    primaryIsBottom, layout, pointStrokeColor, computeMaxOverAllCells, dataset])
 
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation})
+  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection})
 
   return (
     <></>

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -3,7 +3,7 @@ import {observer} from "mobx-react-lite"
 import React, {useCallback, useRef, useState} from "react"
 import {CaseData} from "../../data-display/d3-types"
 import {PlotProps} from "../graphing-types"
-import {handleClickOnCase, setPointSelection, startAnimation} from "../../data-display/data-display-utils"
+import {handleClickOnCase, setPointSelection} from "../../data-display/data-display-utils"
 import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {appState} from "../../../models/app-state"
 import {useGraphDataConfigurationContext} from "../hooks/use-graph-data-configuration-context"
@@ -14,7 +14,7 @@ import {ICase} from "../../../models/data/data-set-types"
 import {setPointCoordinates} from "../utilities/graph-utils"
 
 export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
-  const {dotsRef, enableAnimation} = props,
+  const {dotsRef} = props,
     graphModel = useGraphContentModelContext(),
     dataConfiguration = useGraphDataConfigurationContext(),
     dataset = useDataSetContext(),
@@ -38,7 +38,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
       didDrag.current = false
       const tItsID: string = aCaseData.caseID
       if (target.current.node()?.nodeName === 'circle') {
-        enableAnimation.current = false // We don't want to animate points until end of drag
+        graphModel.stopAnimation() // We don't want to animate points until end of drag
         appState.beginPerformance()
         target.current
           .property('isDragging', true)
@@ -58,7 +58,7 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
           }
         })
       }
-    }, [graphModel, dataConfiguration, dataset, primaryIsBottom, enableAnimation]),
+    }, [graphModel, dataConfiguration, dataset, primaryIsBottom]),
 
     onDrag = useCallback((event: MouseEvent) => {
       const primaryPlace = primaryIsBottom ? 'bottom' : 'left',
@@ -107,12 +107,12 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
               [dataConfiguration?.attributeID(primaryAttrRole) ?? '']: selectedDataObjects.current[anID]
             })
           })
-          startAnimation(enableAnimation) // So points will animate back to original positions
+          graphModel.startAnimation() // So points will animate back to original positions
           caseValues.length && dataset?.setCaseValues(caseValues)
           didDrag.current = false
         }
       }
-    }, [graphModel, dataConfiguration, primaryAttrRole, dataset, dragID, enableAnimation])
+    }, [graphModel, dataConfiguration, primaryAttrRole, dataset, dragID])
 
   useDragHandlers(dotsRef.current, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
@@ -258,13 +258,13 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
         dataset, pointRadius: graphModel.getPointRadius(),
         selectedPointRadius: graphModel.getPointRadius('select'),
         dotsRef, selectedOnly, pointColor, pointStrokeColor,
-        getScreenX, getScreenY, getLegendColor, enableAnimation
+        getScreenX, getScreenY, getLegendColor, getAnimationEnabled: graphModel.getAnimationEnabled
       })
     },
     [graphModel, dataConfiguration, layout, primaryAttrRole, secondaryAttrRole, dataset, dotsRef,
-      enableAnimation, primaryIsBottom, pointColor, pointStrokeColor])
+      primaryIsBottom, pointColor, pointStrokeColor])
 
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection, enableAnimation})
+  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection})
 
   return (
     <></>

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -1,4 +1,4 @@
-import React, {MutableRefObject, useCallback, useEffect, useRef, useState} from "react"
+import React, {useCallback, useEffect, useRef, useState} from "react"
 import {autorun} from "mobx"
 import {observer} from "mobx-react-lite"
 import {isAlive} from "mobx-state-tree"
@@ -22,14 +22,15 @@ import {AttributeLabel} from "./attribute-label"
 
 interface IProps {
   place: AxisPlace
-  enableAnimation: MutableRefObject<boolean>
+  getAnimationEnabled: () => boolean
+  stopAnimation: () => void
   onDropAttribute?: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
   onRemoveAttribute?: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
 
 export const GraphAxis = observer(function GraphAxis(
-  {place, enableAnimation, onDropAttribute, onRemoveAttribute, onTreatAttributeAs}: IProps) {
+  {place, getAnimationEnabled, stopAnimation, onDropAttribute, onRemoveAttribute, onTreatAttributeAs}: IProps) {
   const dataConfig = useGraphDataConfigurationContext(),
     isDropAllowed = dataConfig?.placeCanAcceptAttributeIDDrop ?? (() => true),
     graphModel = useGraphContentModelContext(),
@@ -95,7 +96,8 @@ export const GraphAxis = observer(function GraphAxis(
       <rect className='axis-background'/>
       {axisModel &&
         <Axis axisPlace={place}
-              enableAnimation={enableAnimation}
+              getAnimationEnabled={getAnimationEnabled}
+              stopAnimation={stopAnimation}
               showScatterPlotGridLines={graphModel.axisShouldShowGridLines(place)}
               centerCategoryLabels={graphModel.dataConfiguration.categoriesForAxisShouldBeCentered(place)}
         />}

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -28,10 +28,9 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
   // Removed debouncing, but we can bring it back if we find we need it
   const graphRef = useRef<HTMLDivElement | null>(null)
   const {width, height} = useResizeDetector<HTMLDivElement>({ targetRef: graphRef })
-  const enableAnimation = useRef(true)
   const dotsRef = useRef<DotsElt>(null)
   const graphController = useMemo(
-    () => new GraphController({layout, enableAnimation, instanceId}),
+    () => new GraphController({layout, instanceId}),
     [layout, instanceId]
   )
 

--- a/v3/src/components/graph/components/graph-inspector.tsx
+++ b/v3/src/components/graph/components/graph-inspector.tsx
@@ -52,6 +52,7 @@ export const GraphInspector = observer(({tile, show}: ITileInspectorPanelProps) 
       : graphModel?.plotType === "casePlot" ? "V3.Inspector.rescale.casePlot.toolTip" : "DG.Inspector.rescale.toolTip"
 
     const handleGraphRescale = () => {
+      graphModel?.startAnimation()
       graphModel?.applyUndoableAction(
         () => graphModel.rescale(),
         "DG.Undo.axisDilate",

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -5,7 +5,6 @@ import {select} from "d3"
 import {
   GraphAttrRole, IDotsRef, attrRoleToGraphPlace, graphPlaceToAttrRole
 } from "../../data-display/data-display-types"
-import {startAnimation} from "../../data-display/data-display-utils"
 import {AxisPlace, AxisPlaces} from "../../axis/axis-types"
 import {GraphAxis} from "./graph-axis"
 import {kGraphClass} from "../graphing-types"
@@ -49,8 +48,7 @@ interface IProps {
 
 export const Graph = observer(function Graph({graphController, graphRef, dotsRef}: IProps) {
   const graphModel = useGraphContentModelContext(),
-    {enableAnimation} = graphController,
-    {plotType} = graphModel,
+    {startAnimation, plotType} = graphModel,
     instanceId = useInstanceIdContext(),
     marqueeState = useMemo<MarqueeState>(() => new MarqueeState(), []),
     dataset = useDataSetContext(),
@@ -141,12 +139,12 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
       if (isSetAttributeIDAction(action)) {
         const [role, dataSetId, attrID] = action.args,
           graphPlace = attrRoleToGraphPlace[role]
-        startAnimation(enableAnimation)
+        startAnimation()
         graphPlace && graphController?.handleAttributeAssignment(graphPlace, dataSetId, attrID)
       }
     })
     return () => disposer?.()
-  }, [graphController, layout, enableAnimation, graphModel])
+  }, [graphController, layout, graphModel, startAnimation])
 
   const handleTreatAttrAs = (place: GraphPlace, attrId: string, treatAs: AttributeType) => {
     dataset && graphModel.applyUndoableAction(() => {
@@ -155,12 +153,10 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     }, "DG.Undo.axisAttributeChange", "DG.Redo.axisAttributeChange")
   }
 
-  useDataTips({dotsRef, dataset, displayModel: graphModel, enableAnimation})
+  useDataTips({dotsRef, dataset, displayModel: graphModel})
 
   const renderPlotComponent = () => {
-    const props = {
-        xAttrID, yAttrID, dotsRef, enableAnimation
-      },
+    const props = { xAttrID, yAttrID, dotsRef },
       typeToPlotComponentMap = {
         casePlot: <CaseDots {...props}/>,
         dotChart: <ChartDots {...props}/>,

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -2,9 +2,8 @@ import {observer} from "mobx-react-lite"
 import {addDisposer, isAlive} from "mobx-state-tree"
 import React, {MutableRefObject, useEffect, useMemo, useRef} from "react"
 import {select} from "d3"
-import {
-  GraphAttrRole, IDotsRef, attrRoleToGraphPlace, graphPlaceToAttrRole
-} from "../../data-display/data-display-types"
+import {GraphAttrRole, IDotsRef, attrRoleToGraphPlace, graphPlaceToAttrRole}
+  from "../../data-display/data-display-types"
 import {AxisPlace, AxisPlaces} from "../../axis/axis-types"
 import {GraphAxis} from "./graph-axis"
 import {kGraphClass} from "../graphing-types"
@@ -48,7 +47,7 @@ interface IProps {
 
 export const Graph = observer(function Graph({graphController, graphRef, dotsRef}: IProps) {
   const graphModel = useGraphContentModelContext(),
-    {startAnimation, plotType} = graphModel,
+    {startAnimation, getAnimationEnabled, plotType} = graphModel,
     instanceId = useInstanceIdContext(),
     marqueeState = useMemo<MarqueeState>(() => new MarqueeState(), []),
     dataset = useDataSetContext(),
@@ -153,7 +152,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     }, "DG.Undo.axisAttributeChange", "DG.Redo.axisAttributeChange")
   }
 
-  useDataTips({dotsRef, dataset, displayModel: graphModel})
+  useDataTips({dotsRef, dataset, getAnimationEnabled, displayModel: graphModel})
 
   const renderPlotComponent = () => {
     const props = { xAttrID, yAttrID, dotsRef },
@@ -173,7 +172,8 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     return places.map((place: AxisPlace) => {
       return <GraphAxis key={place}
                         place={place}
-                        enableAnimation={enableAnimation}
+                        getAnimationEnabled={graphModel.getAnimationEnabled}
+                        stopAnimation={graphModel.stopAnimation}
                         onDropAttribute={handleChangeAttribute}
                         onRemoveAttribute={handleRemoveAttribute}
                         onTreatAttributeAs={handleTreatAttrAs}
@@ -182,7 +182,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
   }
 
   const renderDroppableAddAttributes = () => {
-    const droppables: JSX.Element[] = []
+    const droppables: React.ReactElement[] = []
     if (plotType !== 'casePlot') {
       const plotPlaces: GraphPlace[] = plotType === 'scatterPlot' ? ['yPlus', 'rightNumeric'] : []
       const places: GraphPlace[] = ['top', 'rightCat', ...plotPlaces]
@@ -203,7 +203,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     return droppables
   }
 
-  useGraphModel({dotsRef, graphModel, enableAnimation, instanceId})
+  useGraphModel({dotsRef, graphModel, instanceId})
 
   if (!isAlive(graphModel)) return null
 

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -1,4 +1,3 @@
-import React from "react"
 import {IDotsRef} from "../data-display/data-display-types"
 
 export interface PlotProps {

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -3,7 +3,6 @@ import {IDotsRef} from "../data-display/data-display-types"
 
 export interface PlotProps {
   dotsRef: IDotsRef
-  enableAnimation: React.MutableRefObject<boolean>
 }
 
 // One element of the data array assigned to the points

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -40,7 +40,6 @@ describe("GraphController", () => {
     metadata: types.optional(SharedCaseMetadata, () => SharedCaseMetadata.create())
   })
 
-  const enableAnimation = { current: false } as any
   const instanceId = "Graph1"
 
   let emptyPlotSnap: SnapshotIn<typeof Tree> | undefined
@@ -56,7 +55,7 @@ describe("GraphController", () => {
     mockGetMetadata.mockRestore()
     mockGetMetadata.mockImplementation(() => metadata)
     const layout = new GraphLayout()
-    const graphController = new GraphController({ layout, enableAnimation, instanceId })
+    const graphController = new GraphController({ layout, instanceId })
     const dotsRef = { current: {} } as any
     graphController.setProperties({ graphModel, dotsRef })
     return { tree: _tree, model: graphModel, controller: graphController, data: dataSet }
@@ -81,7 +80,6 @@ describe("GraphController", () => {
     expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
     const _controller = new GraphController({
       layout: undefined as any,
-      enableAnimation,
       instanceId
     })
     _controller.initializeGraph()

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -1,4 +1,3 @@
-import React from "react"
 import {getDataSetFromId} from "../../../models/shared/shared-data-utils"
 import {IDotsRef, axisPlaceToAttrRole, graphPlaceToAttrRole} from "../../data-display/data-display-types"
 import {matchCirclesToData} from "../../data-display/data-display-utils"
@@ -21,7 +20,6 @@ const plotChoices: Record<string, Record<string, PlotType>> = {
 
 interface IGraphControllerConstructorProps {
   layout: GraphLayout
-  enableAnimation: React.MutableRefObject<boolean>
   instanceId: string
 }
 
@@ -34,16 +32,14 @@ export class GraphController {
   graphModel?: IGraphContentModel
   dotsRef?: IDotsRef
   layout: GraphLayout
-  enableAnimation: React.MutableRefObject<boolean>
   instanceId: string
   // tracks the currently configured attribute descriptions so that we know whether
   // initializeGraph needs to do anything or not, e.g. when handling undo/redo.
   attrConfigForInitGraph = ""
 
-  constructor({layout, enableAnimation, instanceId}: IGraphControllerConstructorProps) {
+  constructor({layout, instanceId}: IGraphControllerConstructorProps) {
     this.layout = layout
     this.instanceId = instanceId
-    this.enableAnimation = enableAnimation
   }
 
   setProperties(props: IGraphControllerProps) {
@@ -57,14 +53,14 @@ export class GraphController {
   }
 
   callMatchCirclesToData() {
-    const {graphModel, dotsRef, enableAnimation, instanceId} = this
+    const {graphModel, dotsRef, instanceId} = this
     if (graphModel && dotsRef?.current) {
       const { dataConfiguration } = graphModel,
         {pointColor, pointStrokeColor} = graphModel.pointDescription,
         pointRadius = graphModel.getPointRadius()
       dataConfiguration && matchCirclesToData({
         dataConfiguration, dotsElement: dotsRef.current,
-        pointRadius, enableAnimation, instanceId, pointColor, pointStrokeColor
+        pointRadius, startAnimation: graphModel.startAnimation, instanceId, pointColor, pointStrokeColor
       })
     }
   }

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -1,5 +1,4 @@
 import {extent, format} from "d3"
-import React from "react"
 import {isInteger} from "lodash"
 import {IDataSet} from "../../../models/data/data-set"
 import {CaseData, selectDots} from "../../data-display/d3-types"
@@ -228,7 +227,7 @@ export interface ISetPointCoordinates {
   getScreenX: ((anID: string) => number | null)
   getScreenY: ((anID: string, plotNum?:number) => number | null)
   getLegendColor?: ((anID: string) => string)
-  enableAnimation: React.MutableRefObject<boolean>
+  getAnimationEnabled: () => boolean
 }
 
 export function setPointCoordinates(props: ISetPointCoordinates) {
@@ -269,9 +268,9 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
     {
       dataset, dotsRef, selectedOnly = false, pointRadius, selectedPointRadius,
       pointStrokeColor, pointColor, getPointColorAtIndex,
-      getScreenX, getScreenY, getLegendColor, enableAnimation
+      getScreenX, getScreenY, getLegendColor, getAnimationEnabled
     } = props,
-    duration = enableAnimation.current ? transitionDuration : 0,
+    duration = getAnimationEnabled() ? transitionDuration : 0,
 
     theSelection = selectDots(dotsRef.current, selectedOnly)
   setPoints()
@@ -298,10 +297,10 @@ export function computeSlopeAndIntercept(xAxis?: IAxisModel, yAxis?: IAxisModel)
 
   /**
    * Returns an object that has the slope and intercept
-   * @param iCoordPairs [{x: {Number}, y: {Number}}]
    * @returns {count: {Number}, xSum: {Number}, xSumOfSquares: {Number}, xSumSquaredDeviations: { Number},
-  *          ySum: {Number}, ySumOfSquares: {Number}, ySumSquaredDeviations: {Number}, sumOfProductDiffs: {Number} }
-  */
+   *          ySum: {Number}, ySumOfSquares: {Number}, ySumSquaredDeviations: {Number}, sumOfProductDiffs: {Number} }
+   * @param iCoordPairs
+   */
  const computeBivariateStats = (iCoordPairs: Point[]) => {
    const tResult = {
      count: 0,

--- a/v3/src/components/map/components/map-component.tsx
+++ b/v3/src/components/map/components/map-component.tsx
@@ -21,10 +21,9 @@ export const MapComponent = observer(function MapComponent({tile}: ITileBaseProp
   const layout = useInitMapLayout(mapModel)
   const mapRef = useRef<HTMLDivElement | null>(null)
   const {width, height} = useResizeDetector<HTMLDivElement>({targetRef: mapRef})
-  const enableAnimation = useRef(true)
   const dotsRef = useRef<DotsElt>(null)
   const mapController = useMemo(
-    () => new MapController({layout, enableAnimation, instanceId}),
+    () => new MapController({layout, instanceId}),
     [layout, instanceId]
   )
 

--- a/v3/src/components/map/components/map-interior.tsx
+++ b/v3/src/components/map/components/map-interior.tsx
@@ -16,10 +16,9 @@ interface IProps {
 
 export const MapInterior = observer(function MapInterior({mapController, dotsElement}: IProps) {
   const mapModel = useMapModelContext(),
-    {enableAnimation} = mapController,
     instanceId = useInstanceIdContext()
 
-  useMapModel({dotsElement, mapModel, enableAnimation, instanceId})
+  useMapModel({dotsElement, mapModel, instanceId})
 
   /**
    * Note that we don't have to worry about layer order because polygons will be sent to the back
@@ -31,14 +30,12 @@ export const MapInterior = observer(function MapInterior({mapController, dotsEle
           key={`${kMapPointLayerType}-${index}`}
           mapLayerModel={layerModel}
           dotsElement={dotsElement}
-          enableAnimation={enableAnimation}
         />
       }
       else if (isMapPolygonLayerModel(layerModel)) {
         return <MapPolygonLayer
           key ={`${kMapPointLayerType}-${index}`}
           mapLayerModel={layerModel}
-          enableAnimation={enableAnimation}
         />
       }
     })

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -21,19 +21,19 @@ import {IMapPointLayerModel} from "../models/map-point-layer-model"
 export const MapPointLayer = function MapPointLayer(props: {
   mapLayerModel: IMapPointLayerModel
   dotsElement: DotsElt
-  enableAnimation: React.MutableRefObject<boolean>
 }) {
-  const {mapLayerModel, dotsElement, enableAnimation} = props,
+  const {mapLayerModel, dotsElement} = props,
     {dataConfiguration, pointDescription} = mapLayerModel,
     dataset = dataConfiguration?.dataset,
     mapModel = useMapModelContext(),
+    {getAnimationEnabled} = mapModel,
     leafletMap = useMap(),
     layout = useMapLayoutContext(),
     dotsRef = useRef(dotsElement)
 
   dotsRef.current = dotsElement
 
-  useDataTips({dotsRef, dataset, displayModel: mapLayerModel, enableAnimation})
+  useDataTips({dotsRef, dataset, getAnimationEnabled, displayModel: mapLayerModel})
 
   const refreshPointSelection = useCallback(() => {
     const {pointColor, pointStrokeColor} = pointDescription,
@@ -68,7 +68,7 @@ export const MapPointLayer = function MapPointLayer(props: {
     if (!dotsElement || !dataset) return
     const
       theSelection = selectDots(dotsElement, selectedOnly),
-      duration = enableAnimation.current ? transitionDuration : 0,
+      duration = getAnimationEnabled() ? transitionDuration : 0,
       pointRadius = computePointRadius(dataConfiguration.caseDataArray.length,
         pointDescription.pointSizeMultiplier),
       selectedPointRadius = computePointRadius(dataConfiguration.caseDataArray.length,
@@ -94,7 +94,7 @@ export const MapPointLayer = function MapPointLayer(props: {
             ? defaultSelectedStrokeWidth : defaultStrokeWidth)
     }
 
-  }, [dotsElement, dataset, enableAnimation, dataConfiguration, pointDescription, leafletMap])
+  }, [dotsElement, dataset, mapModel, dataConfiguration, pointDescription, leafletMap])
 
   // Actions in the dataset can trigger need for point updates
   useEffect(function setupResponsesToDatasetActions() {

--- a/v3/src/components/map/components/map-polygon-layer.tsx
+++ b/v3/src/components/map/components/map-polygon-layer.tsx
@@ -21,7 +21,6 @@ import {IMapPolygonLayerModel} from "../models/map-polygon-layer-model"
 
 export const MapPolygonLayer = function MapPolygonLayer(props: {
   mapLayerModel: IMapPolygonLayerModel
-  enableAnimation: React.MutableRefObject<boolean>
 }) {
   const {mapLayerModel} = props,
     {dataConfiguration} = mapLayerModel,
@@ -30,7 +29,7 @@ export const MapPolygonLayer = function MapPolygonLayer(props: {
     leafletMap = useMap(),
     layout = useMapLayoutContext()
 
-  // useDataTips({dotsRef, dataset, displayModel: mapLayerModel, enableAnimation})
+  // useDataTips({dotsRef, dataset, displayModel: mapLayerModel})
 
   const refreshPolygonStyles = useCallback(() => {
     if (!dataset) return

--- a/v3/src/components/map/hooks/use-map-model.ts
+++ b/v3/src/components/map/hooks/use-map-model.ts
@@ -1,4 +1,4 @@
-import {MutableRefObject, useEffect} from "react"
+import {useEffect} from "react"
 import {latLng} from 'leaflet'
 import {useMap} from "react-leaflet"
 import {DotsElt} from "../../data-display/d3-types"
@@ -8,7 +8,6 @@ import {fitMapBoundsToData} from "../utilities/map-utils"
 
 interface IProps {
   mapModel: IMapContentModel
-  enableAnimation: MutableRefObject<boolean>
   dotsElement: DotsElt
   instanceId: string | undefined
 }

--- a/v3/src/components/map/models/map-content-model.ts
+++ b/v3/src/components/map/models/map-content-model.ts
@@ -6,12 +6,13 @@ import {ITileContentModel} from "../../../models/tiles/tile-content"
 import {applyUndoableAction} from "../../../models/history/apply-undoable-action"
 import {IDataSet} from "../../../models/data/data-set"
 import {ISharedDataSet, kSharedDataSetType, SharedDataSet} from "../../../models/shared/shared-data-set"
+import {getSharedCaseMetadataFromDataset} from "../../../models/shared/shared-data-utils"
 import {kMapModelName, kMapTileType} from "../map-defs"
 import {datasetHasBoundaryData, datasetHasLatLongData, latLongAttributesFromDataSet} from "../utilities/map-utils"
 import {DataDisplayContentModel} from "../../data-display/models/data-display-content-model"
+import {IMapLayerModel} from "./map-layer-model"
+import {IMapPolygonLayerModel, isMapPolygonLayerModel, MapPolygonLayerModel} from "./map-polygon-layer-model"
 import {MapPointLayerModel} from "./map-point-layer-model"
-import {getSharedCaseMetadataFromDataset} from "../../../models/shared/shared-data-utils"
-import {isMapPolygonLayerModel, MapPolygonLayerModel} from "./map-polygon-layer-model"
 
 export interface MapProperties {
 }
@@ -101,7 +102,7 @@ export const MapContentModel = DataDisplayContentModel
             // Todo: We should allow both points and polygons from the same dataset
             else if (datasetHasBoundaryData(sharedDataSet.dataSet)) {
               const layer = layersToCheck.find(aLayer => aLayer.data === sharedDataSet.dataSet)
-              if (isMapPolygonLayerModel(layer)) {
+              if (layer && isMapPolygonLayerModel(layer)) {
                 layer.setDataset(sharedDataSet.dataSet)
                 layersToCheck.splice(layersToCheck.indexOf(layer), 1)
               } else {

--- a/v3/src/components/map/models/map-controller.ts
+++ b/v3/src/components/map/models/map-controller.ts
@@ -1,4 +1,3 @@
-import React from "react"
 import {DotsElt} from "../../data-display/d3-types"
 import {matchCirclesToData} from "../../data-display/data-display-utils"
 import {IMapContentModel} from "./map-content-model"
@@ -7,7 +6,6 @@ import {isMapPointLayerModel} from "./map-point-layer-model"
 
 interface IMapControllerConstructorProps {
   layout: MapLayout
-  enableAnimation: React.MutableRefObject<boolean>
   instanceId: string
 }
 
@@ -20,13 +18,11 @@ export class MapController {
   mapModel?: IMapContentModel
   dotsElement?: DotsElt
   layout: MapLayout
-  enableAnimation: React.MutableRefObject<boolean>
   instanceId: string
 
-  constructor({layout, enableAnimation, instanceId}: IMapControllerConstructorProps) {
+  constructor({layout, instanceId}: IMapControllerConstructorProps) {
     this.layout = layout
     this.instanceId = instanceId
-    this.enableAnimation = enableAnimation
   }
 
   setProperties(props: IMapControllerProps) {
@@ -48,7 +44,7 @@ export class MapController {
           dataConfiguration: aLayerModel.dataConfiguration,
           dotsElement,
           pointRadius: aLayerModel.getPointRadius(),
-          enableAnimation: this.enableAnimation,
+          startAnimation: this.mapModel?.startAnimation || (() => {}),
           instanceId: this.instanceId,
           pointColor: pointDescription?.pointColor,
           pointStrokeColor: pointDescription?.pointStrokeColor

--- a/v3/src/components/map/models/map-point-layer-model.ts
+++ b/v3/src/components/map/models/map-point-layer-model.ts
@@ -19,9 +19,6 @@ export const MapPointLayerModel = MapLayerModel
     dataConfiguration: types.optional(DataConfigurationModel, () => DataConfigurationModel.create()),
     pointDescription: types.optional(PointDescriptionModel, () => PointDescriptionModel.create()),
   })
-  .volatile(() => ({
-    animationEnabled: false,
-  }))
   .actions(self => ({
     setDataset(dataSet:IDataSet) {
       const {latId, longId} = latLongAttributesFromDataSet(dataSet)

--- a/v3/src/components/map/models/map-point-layer-model.ts
+++ b/v3/src/components/map/models/map-point-layer-model.ts
@@ -19,6 +19,9 @@ export const MapPointLayerModel = MapLayerModel
     dataConfiguration: types.optional(DataConfigurationModel, () => DataConfigurationModel.create()),
     pointDescription: types.optional(PointDescriptionModel, () => PointDescriptionModel.create()),
   })
+  .volatile(() => ({
+    animationEnabled: false,
+  }))
   .actions(self => ({
     setDataset(dataSet:IDataSet) {
       const {latId, longId} = latLongAttributesFromDataSet(dataSet)

--- a/v3/src/components/slider/slider-component.tsx
+++ b/v3/src/components/slider/slider-component.tsx
@@ -26,7 +26,6 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
   const layout = useMemo(() => new SliderAxisLayout(), [])
   const {width, height, ref: sliderRef} = useResizeDetector()
   const [running, setRunning] = useState(false)
-  const animationRef = useRef(false)
   const multiScale = layout.getAxisMultiScale("bottom")
 
   // width and positioning
@@ -84,7 +83,8 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
                 <svg className="slider-axis" data-testid="slider-axis">
                   <Axis
                     axisPlace={"bottom"}
-                    enableAnimation={animationRef}
+                    getAnimationEnabled = {() => false}
+                    stopAnimation={() => {}}
                   />
                 </svg>
                 <div className="axis-end max" />


### PR DESCRIPTION
There are a **lot** of affected files, but not so many substantive changes.

[#186448221] Bug fix: When user rescales graph axes, the rescaling is animated

* This involved a large refactoring to move the state of animation being enabled into the DataDisplayContentModel where it is a volatile boolean property and no longer a React ref held onto by the GraphController
* Getting the rescale triggered in the graph inspector to animate was then trivial