### PR TITLE
Refactor graph categories options and subplot helpers 

### DIFF
--- a/v3/src/components/graph/adornments/adornment-models.test.ts
+++ b/v3/src/components/graph/adornments/adornment-models.test.ts
@@ -40,21 +40,6 @@ describe("AdornmentModel", () => {
     adornment.setVisibility(false)
     expect(adornment.isVisible).toBe(false)
   })
-  it("will create a cell key from given values", () => {
-    const options = {
-      xAttrId: "abc123",
-      xCats: ["pizza", "pasta", "salad"],
-      yAttrId: "def456",
-      yCats: ["red", "green", "blue"],
-      topAttrId: "ghi789",
-      topCats: ["small", "medium", "large"],
-      rightAttrId: "jkl012",
-      rightCats: ["new", "used"]
-    }
-    const adornment = AdornmentModel.create({type: "Movable Line"})
-    const cellKey = adornment.cellKey(options, 0)
-    expect(cellKey).toEqual({abc123: "pizza", def456: "red", ghi789: "small", jkl012: "new"})
-  })
   it("will create an instance key value from given category values", () => {
     const adornment = AdornmentModel.create({type: "Movable Line"})
     const xCategories = ["pizza", "pasta", "salad"]
@@ -69,60 +54,6 @@ describe("AdornmentModel", () => {
     const yCategories = ["red", "green", "blue"]
     const cellKey = {abc123: xCategories[0], def456: yCategories[0]}
     expect(adornment.classNameFromKey(cellKey)).toEqual("abc123-pizza-def456-red")
-  })
-  it("will generate a list of all cell keys for a graph", () => {
-    const adornment = AdornmentModel.create({type: "Movable Line"})
-
-    // For a graph with no categorical attributes
-    const noCategoricalOptions = {
-      xAttrId: "abc123",
-      xCats: [],
-      yAttrId: "def456",
-      yCats: [],
-      topAttrId: "",
-      topCats: [],
-      rightAttrId: "",
-      rightCats: []
-    }
-    const noCategoricalCellKeys = adornment.getAllCellKeys(noCategoricalOptions)
-    expect(noCategoricalCellKeys.length).toEqual(1)
-    expect(noCategoricalCellKeys[0]).toEqual({})
-
-    // For a graph with one categorical attribute
-    const oneCategoricalOptions = {
-      xAttrId: "abc123",
-      xCats: [],
-      yAttrId: "def456",
-      yCats: ["small", "large"],
-      topAttrId: "",
-      topCats: [],
-      rightAttrId: "",
-      rightCats: []
-    }
-    const oneCategoricalCellKeys = adornment.getAllCellKeys(oneCategoricalOptions)
-    expect(oneCategoricalCellKeys.length).toEqual(2)
-    expect(oneCategoricalCellKeys[0]).toEqual({"def456": "small"})
-    expect(oneCategoricalCellKeys[1]).toEqual({"def456": "large"})
-
-    // For a graph with multiple categorical attributes
-    const xCategories = ["pizza", "salad"]
-    const yCategories = ["red", "green"]
-    const topCategories = ["medium", "large"]
-    const rightCategories = ["hot", "cold"]
-    const categoricalOptions = {
-      xAttrId: "abc123",
-      xCats: xCategories,
-      yAttrId: "def456",
-      yCats: yCategories,
-      topAttrId: "ghi789",
-      topCats: topCategories,
-      rightAttrId: "jkl012",
-      rightCats: rightCategories
-    }
-    const cellKeys = adornment.getAllCellKeys(categoricalOptions)
-    expect(cellKeys.length).toEqual(16)
-    expect(cellKeys[0]).toEqual({abc123: "pizza", def456: "red", ghi789: "medium", jkl012: "hot"})
-    expect(cellKeys[15]).toEqual({abc123: "salad", def456: "green", ghi789: "large", jkl012: "cold"})
   })
 })
 

--- a/v3/src/components/graph/adornments/adornment-models.ts
+++ b/v3/src/components/graph/adornments/adornment-models.ts
@@ -9,7 +9,6 @@ import {Point} from "../../data-display/data-display-types"
 import {IGraphDataConfigurationModel} from "../models/graph-data-configuration-model"
 import { IAxisLayout } from "../../axis/models/axis-layout-context"
 import { ScaleNumericBaseType } from "../../axis/axis-types"
-import { updateCellKey } from "./adornment-utils"
 
 export const PointModel = types.model("Point", {
     x: types.optional(types.number, NaN),
@@ -31,18 +30,10 @@ export const PointModel = types.model("Point", {
 export const kInfinitePoint = {x:NaN, y:NaN}
 
 export interface IUpdateCategoriesOptions {
-  xAxis?: IAxisModel
-  xAttrId: string
-  xCats: string[]
-  yAxis?: IAxisModel
-  yAttrId: string
-  yCats: string[]
-  topCats: string[]
-  topAttrId: string
-  rightCats: string[]
-  rightAttrId: string
+  dataConfig: IGraphDataConfigurationModel
   resetPoints?: boolean
-  dataConfig?: IGraphDataConfigurationModel
+  xAxis?: IAxisModel
+  yAxis?: IAxisModel
   xScale?: ScaleNumericBaseType
   yScale?: ScaleNumericBaseType
 }
@@ -80,45 +71,6 @@ export const AdornmentModel = types.model("AdornmentModel", {
       const yCellCount = yCats.length * ySubAxesCount
       return {x: xCellCount, y: yCellCount}
     },
-    cellKey(options: IUpdateCategoriesOptions, index: number) {
-      const { xAttrId, xCats, yAttrId, yCats, topAttrId, topCats, rightAttrId, rightCats } = options
-      const rightCatCount = rightCats.length || 1
-      const yCatCount = yCats.length || 1
-      const xCatCount = xCats.length || 1
-      let cellKey: Record<string, string> = {}
-
-      // Determine which categories are associated with the cell's axes using the provided index value and
-      // the attributes and categories present in the graph.
-      const topIndex = Math.floor(index / (rightCatCount * yCatCount * xCatCount))
-      const topCat = topCats[topIndex]
-      cellKey = updateCellKey(cellKey, topAttrId, topCat)
-      const rightIndex = Math.floor(index / (yCatCount * xCatCount)) % rightCatCount
-      const rightCat = rightCats[rightIndex]
-      cellKey = updateCellKey(cellKey, rightAttrId, rightCat)
-      const yCat = yCats[index % yCatCount]
-      cellKey = updateCellKey(cellKey, yAttrId, yCat)
-      const xCat = xCats[index % xCatCount]
-      cellKey = updateCellKey(cellKey, xAttrId, xCat)
-
-      return cellKey
-    }
-  }))
-  .views(self => ({
-    getAllCellKeys(options: IUpdateCategoriesOptions) {
-      const { xCats, yCats, topCats, rightCats } = options
-      const topCatCount = topCats.length || 1
-      const rightCatCount = rightCats.length || 1
-      const xCatCount = xCats.length || 1
-      const yCatCount = yCats.length || 1
-      const columnCount = topCatCount * xCatCount
-      const rowCount = rightCatCount * yCatCount
-      const totalCount = rowCount * columnCount
-      const cellKeys: Record<string, string>[] = []
-      for (let i = 0; i < totalCount; ++i) {
-        cellKeys.push(self.cellKey(options, i))
-      }
-      return cellKeys
-    }
   }))
   .actions(self => ({
     setVisibility(isVisible: boolean) {

--- a/v3/src/components/graph/adornments/adornments-store.test.ts
+++ b/v3/src/components/graph/adornments/adornments-store.test.ts
@@ -1,5 +1,6 @@
 import { AdornmentsStore } from "./adornments-store"
 import * as contentInfo from "./adornment-content-info"
+import { IGraphDataConfigurationModel } from "../models/graph-data-configuration-model"
 
 jest.spyOn(contentInfo, "getAdornmentTypes").mockReturnValue(
   [
@@ -30,7 +31,8 @@ const mockUpdateCategoriesOptions = {
   xAttrId: "abc123",
   xCats: [],
   yAttrId: "def456",
-  yCats: []
+  yCats: [],
+  dataConfig: {} as IGraphDataConfigurationModel
 }
 
 describe("AdornmentsStore", () => {

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react-lite"
 import { ICountAdornmentModel } from "./count-adornment-model"
 import { useGraphDataConfigurationContext } from "../../hooks/use-graph-data-configuration-context"
 import { percentString } from "../../utilities/graph-utils"
+import { prf } from "../../../../utilities/profiler"
 
 import "./count-adornment-component.scss"
 
@@ -13,6 +14,7 @@ interface IProps {
 }
 
 export const CountAdornment = observer(function CountAdornment({model, cellKey}: IProps) {
+  prf.begin("CountAdornment.render")
   const classFromKey = model.classNameFromKey(cellKey)
   const dataConfig = useGraphDataConfigurationContext()
   const casesInPlot = dataConfig?.subPlotCases(cellKey)?.length ?? 0
@@ -21,6 +23,7 @@ export const CountAdornment = observer(function CountAdornment({model, cellKey}:
 
   useEffect(() => {
     return autorun(() => {
+      prf.begin("CountAdornment.autorun")
       const shouldShowPercentOption = dataConfig ? dataConfig.categoricalAttrCount > 0 : false
       const shouldShowPercentTypeOptions = dataConfig?.hasExactlyTwoPerpendicularCategoricalAttrs
 
@@ -33,9 +36,10 @@ export const CountAdornment = observer(function CountAdornment({model, cellKey}:
       if (!shouldShowPercentOption && model?.showPercent) {
         model.setShowPercent(false)
       }
+      prf.end("CountAdornment.autorun")
     })
   }, [dataConfig, model])
-
+  prf.end("CountAdornment.render")
   return (
     <div className="graph-count" data-testid={`graph-count${classFromKey ? `-${classFromKey}` : ""}`}>
       {model.showCount && casesInPlot}

--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -18,7 +18,7 @@ export const CountAdornmentModel = AdornmentModel
         ? dataConfig?.rowCases(cellKey)?.length ?? 0
         : self.percentType === "column"
           ? dataConfig?.columnCases(cellKey)?.length ?? 0
-          : dataConfig?.cellCases(cellKey)?.length ?? 0
+          : dataConfig?.subPlotCases(cellKey)?.length ?? 0
       const percentValue = casesInPlot / divisor
       return isFinite(percentValue) ? percentValue : 0
     }

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -140,24 +140,20 @@ export const LSRLAdornmentModel = AdornmentModel
   ) {
     const caseValues = self.getCaseValues(xAttrId, yAttrId, cellKey, dataConfig, cat)
     const { intercept, rSquared, slope, sdResiduals } = leastSquaresLinearRegression(caseValues, isInterceptLocked)
-    return { intercept, rSquared, slope, sdResiduals }  
+    return { intercept, rSquared, slope, sdResiduals }
   }
 }))
 .actions(self => ({
   updateCategories(options: IUpdateCategoriesOptions) {
-    const { xAttrId, yAttrId, topCats, rightCats, dataConfig } = options
-    if (!dataConfig) return
-    self.lines.clear()
-    const columnCount = topCats?.length || 1
-    const rowCount = rightCats?.length || 1
-    const totalCount = rowCount * columnCount
+    const { dataConfig } = options
+    const { xAttrId, yAttrId } = dataConfig.categoriesOptions
     const legendCats = dataConfig?.categoryArrayForAttrRole("legend")
-    for (let i = 0; i < totalCount; ++i) {
-      const cellKey = self.cellKey(options, i)
+    self.lines.clear()
+    dataConfig.getAllCellKeys().forEach(cellKey => {
       const instanceKey = self.instanceKey(cellKey)
       for (let j = 0; j < legendCats.length; ++j) {
         const category = legendCats[j]
-        // TODO: Once the Intercept Locked feature is implemented, we will need to pass in something like 
+        // TODO: Once the Intercept Locked feature is implemented, we will need to pass in something like
         // isInterceptLocked instead of false in the call to self.computeValues.
         const { intercept, rSquared, slope, sdResiduals } = self.computeValues(
           xAttrId, yAttrId, cellKey, dataConfig, instanceKey, false, category
@@ -165,7 +161,7 @@ export const LSRLAdornmentModel = AdornmentModel
         if (intercept == null || rSquared == null || slope == null || sdResiduals == null) continue
         self.updateLines({category, intercept, rSquared, slope, sdResiduals}, instanceKey, j)
       }
-    }
+    })
   }
 }))
 .views(self => ({
@@ -181,7 +177,7 @@ export const LSRLAdornmentModel = AdornmentModel
     lines?.forEach((line, i) => {
       if (!line?.isValid) {
 
-        // TODO: Once the Intercept Locked feature is implemented, we will need to pass in something like 
+        // TODO: Once the Intercept Locked feature is implemented, we will need to pass in something like
         // isInterceptLocked instead of false in the call to self.computeValues.
         const { intercept, rSquared, slope, sdResiduals } = self.computeValues(
           xAttrId, yAttrId, cellKey, dataConfig, key, false, legendCats[i]

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
@@ -51,8 +51,8 @@ export const MovableLineAdornmentModel = AdornmentModel
 }))
 .actions(self => ({
   updateCategories(options: IUpdateCategoriesOptions) {
-    const { resetPoints, xAxis, yAxis } = options
-    self.getAllCellKeys(options).forEach(cellKey => {
+    const { resetPoints, dataConfig, xAxis, yAxis } = options
+    dataConfig.getAllCellKeys().forEach(cellKey => {
       const instanceKey = self.instanceKey(cellKey)
       if (!self.lines.get(instanceKey) || resetPoints) {
         self.setInitialLine(xAxis, yAxis, instanceKey)

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-model.ts
@@ -30,8 +30,8 @@ export const MovablePointAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
-      const { resetPoints, xAxis, yAxis } = options
-      self.getAllCellKeys(options).forEach(cellKey => {
+      const { resetPoints, xAxis, yAxis, dataConfig } = options
+      dataConfig.getAllCellKeys().forEach(cellKey => {
         const instanceKey = self.instanceKey(cellKey)
         if (!self.points.get(instanceKey) || resetPoints) {
           self.setInitialPoint(xAxis, yAxis, instanceKey)

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-model.ts
@@ -115,14 +115,14 @@ export const MovableValueAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
-      const { xAxis, yAxis, resetPoints } = options
+      const { xAxis, yAxis, resetPoints, dataConfig } = options
       const axisMin = xAxis?.isNumeric ? (xAxis as INumericAxisModel).min : (yAxis as INumericAxisModel).min
       const axisMax = xAxis?.isNumeric ? (xAxis as INumericAxisModel).max : (yAxis as INumericAxisModel).max
 
       self.setAxisMin(axisMin)
       self.setAxisMax(axisMax)
 
-      self.getAllCellKeys(options).forEach(cellKey => {
+      dataConfig.getAllCellKeys().forEach(cellKey => {
         const instanceKey = self.instanceKey(cellKey)
         // Each array in the model's values map should have the same length as all the others. If there are no existing
         // values for the current instance key, check if there is at least one array in the map. If there is, copy those

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -82,7 +82,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
   }))
   .views(self => ({
     // Clients should call measureValue instead of accessing the measure's volatile value property directly.
-    // measureValue will compute the value in cases where the volatile property may have been reset to the 
+    // measureValue will compute the value in cases where the volatile property may have been reset to the
     // default. This can happen, for example, when the adornment is added to the graph, then removed and
     // added back again using the undo/redo feature.
     measureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) {
@@ -97,11 +97,10 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
   }))
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
-      const { xAttrId, yAttrId, resetPoints, dataConfig } = options
-      if (!dataConfig) return
-      const xAttrType = dataConfig.attributeType("x")
+      const { dataConfig, resetPoints } = options
+      const { xAttrId, yAttrId, xAttrType } = dataConfig.categoriesOptions
       const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
-      self.getAllCellKeys(options).forEach(cellKey => {
+      dataConfig.getAllCellKeys().forEach(cellKey => {
         const instanceKey = self.instanceKey(cellKey)
         const value = Number(self.computeMeasureValue(attrId, cellKey, dataConfig))
         if (!self.measures.get(instanceKey) || resetPoints) {

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -116,34 +116,11 @@ export const GraphContentModel = DataDisplayContentModel
     getUpdateCategoriesOptions(
       resetPoints = false, xScale?: ScaleNumericBaseType, yScale?: ScaleNumericBaseType
     ): IUpdateCategoriesOptions {
-      const xAttrId = self.getAttributeID("x"),
-        dataConfig = self.dataConfiguration,
-        xAttrType = dataConfig.attributeType("x"),
-        xCats = xAttrType === "categorical"
-          ? dataConfig.categoryArrayForAttrRole("x", [])
-          : [""],
-        yAttrId = self.getAttributeID("y"),
-        yAttrType = dataConfig.attributeType("y"),
-        yCats = yAttrType === "categorical"
-          ? dataConfig.categoryArrayForAttrRole("y", [])
-          : [""],
-        topAttrId = self.getAttributeID("topSplit"),
-        topCats = dataConfig.categoryArrayForAttrRole("topSplit", []) ?? [""],
-        rightAttrId = self.getAttributeID("rightSplit"),
-        rightCats = dataConfig.categoryArrayForAttrRole("rightSplit", []) ?? [""]
       return {
-        xAxis: self.getAxis("bottom"),
-        xAttrId,
-        xCats,
-        yAxis: self.getAxis("left"),
-        yAttrId,
-        yCats,
-        topAttrId,
-        topCats,
-        rightAttrId,
-        rightCats,
+        dataConfig: self.dataConfiguration,
         resetPoints,
-        dataConfig,
+        xAxis: self.getAxis("bottom"),
+        yAxis: self.getAxis("left"),
         xScale,
         yScale
       }

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -291,4 +291,111 @@ describe("DataConfigurationModel", () => {
     ])
   })
 
+  it("can create cell key", () => {
+    const config = tree.config
+    const mockData: Record<string, Record<string, any>> = {
+      id: {
+        x: "abc123",
+        y: "def456",
+        topSplit: "ghi789",
+        rightSplit: "jkl012"
+      },
+      type: {
+        x: "categorical",
+        y: "categorical",
+      },
+      categoryArrayForAttrRole: {
+        x: ["pizza", "pasta", "salad"],
+        y: ["red", "green", "blue"],
+        topSplit: ["small", "medium", "large"],
+        rightSplit: ["new", "used"]
+      }
+    }
+    config.attributeID = (role: string) => mockData.id[role]
+    config.attributeType = (role: string) => mockData.type[role]
+    config.categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
+
+    const cellKey = config.cellKey(0)
+    expect(cellKey).toEqual({abc123: "pizza", def456: "red", ghi789: "small", jkl012: "new"})
+  })
+
+  it("generates a list of all cell keys for a graph", () => {
+    const config = tree.config
+    let mockData: Record<string, Record<string, any>>
+    config.attributeID = (role: string) => mockData.id[role]
+    config.attributeType = (role: string) => mockData.type[role]
+    config.categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
+
+    // For a graph with no categorical attributes
+    mockData = {
+      id: {
+        x: "abc123",
+        y: "def456",
+        topSplit: "ghi789",
+        rightSplit: "jkl012"
+      },
+      type: {
+        x: "categorical",
+        y: "categorical",
+      },
+      categoryArrayForAttrRole: {
+        x: [],
+        y: [],
+        topSplit: [],
+        rightSplit: []
+      }
+    }
+    const noCategoricalCellKeys = config.getAllCellKeys()
+    expect(noCategoricalCellKeys.length).toEqual(1)
+    expect(noCategoricalCellKeys[0]).toEqual({})
+
+    // For a graph with one categorical attribute
+    mockData = {
+      id: {
+        x: "abc123",
+        y: "def456",
+        topSplit: "ghi789",
+        rightSplit: "jkl012"
+      },
+      type: {
+        x: "categorical",
+        y: "categorical",
+      },
+      categoryArrayForAttrRole: {
+        x: [],
+        y: ["small", "large"],
+        topSplit: [],
+        rightSplit: []
+      }
+    }
+
+    const oneCategoricalCellKeys = config.getAllCellKeys()
+    expect(oneCategoricalCellKeys.length).toEqual(2)
+    expect(oneCategoricalCellKeys[0]).toEqual({"def456": "small"})
+    expect(oneCategoricalCellKeys[1]).toEqual({"def456": "large"})
+
+    // For a graph with multiple categorical attributes
+    mockData = {
+      id: {
+        x: "abc123",
+        y: "def456",
+        topSplit: "ghi789",
+        rightSplit: "jkl012"
+      },
+      type: {
+        x: "categorical",
+        y: "categorical",
+      },
+      categoryArrayForAttrRole: {
+        x: ["pizza", "salad"],
+        y: ["red", "green"],
+        topSplit: ["medium", "large"],
+        rightSplit: ["hot", "cold"]
+      }
+    }
+    const cellKeys = config.getAllCellKeys()
+    expect(cellKeys.length).toEqual(16)
+    expect(cellKeys[0]).toEqual({abc123: "pizza", def456: "red", ghi789: "medium", jkl012: "hot"})
+    expect(cellKeys[15]).toEqual({abc123: "salad", def456: "green", ghi789: "large", jkl012: "cold"})
+  })
 })

--- a/v3/src/models/formula/base-graph-formula-adapter.ts
+++ b/v3/src/models/formula/base-graph-formula-adapter.ts
@@ -17,9 +17,7 @@ export interface IBaseGraphFormulaExtraMetadata extends IFormulaExtraMetadata {
 }
 
 export const getDefaultArgument = (graphContentModel: IGraphContentModel) => {
-  const options = graphContentModel.getUpdateCategoriesOptions()
-  const { xAttrId, yAttrId, dataConfig } = options
-  const xAttrType = dataConfig?.attributeType("x")
+  const { xAttrId, yAttrId, xAttrType } = graphContentModel.dataConfiguration.categoriesOptions
   const defaultArgumentId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
   return defaultArgumentId ? localAttrIdToCanonical(defaultArgumentId) : undefined
 }
@@ -67,28 +65,6 @@ export class BaseGraphFormulaAdapter implements IFormulaManagerAdapter {
     return graphContentModel
   }
 
-  getGraphCellKeys(graphContentModel: IGraphContentModel, adornment: IFormulaSupportingAdornment) {
-    // This code is mostly copied from UnivariateMeasureAdornmentModel.updateCategories.
-    // TODO: Is there a way to share it somehow?
-    const options = graphContentModel.getUpdateCategoriesOptions()
-    const { xCats, yCats, topCats, rightCats, dataConfig } = options
-    if (!dataConfig) {
-      return []
-    }
-    const result: GraphCellKey[] = []
-    const topCatCount = topCats.length || 1
-    const rightCatCount = rightCats.length || 1
-    const xCatCount = xCats.length || 1
-    const yCatCount = yCats.length || 1
-    const columnCount = topCatCount * xCatCount
-    const rowCount = rightCatCount * yCatCount
-    const totalCount = rowCount * columnCount
-    for (let i = 0; i < totalCount; ++i) {
-      result.push(adornment.cellKey(options, i))
-    }
-    return result
-  }
-
   getActiveFormulas(): ({ formula: IFormula, extraMetadata: IBaseGraphFormulaExtraMetadata })[] {
     const result: ({ formula: IFormula, extraMetadata: IBaseGraphFormulaExtraMetadata })[] = []
     this.graphContentModels.forEach(graphContentModel => {
@@ -101,7 +77,7 @@ export class BaseGraphFormulaAdapter implements IFormulaManagerAdapter {
             graphContentModelId: graphContentModel.id,
             dataSetId: graphContentModel.dataset.id,
             defaultArgument: getDefaultArgument(graphContentModel),
-            graphCellKeys: this.getGraphCellKeys(graphContentModel, adornment)
+            graphCellKeys: graphContentModel.dataConfiguration.getAllCellKeys()
           }
         })
       }

--- a/v3/src/models/formula/plotted-function-formula-adapter.test.ts
+++ b/v3/src/models/formula/plotted-function-formula-adapter.test.ts
@@ -1,6 +1,5 @@
 import { DataSet, IDataSet } from "../data/data-set"
 import { PlottedFunctionFormulaAdapter } from "./plotted-function-formula-adapter"
-import { IUpdateCategoriesOptions } from "../../components/graph/adornments/adornment-models"
 import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
 import { GraphDataConfigurationModel } from "../../components/graph/models/graph-data-configuration-model"
 import {
@@ -12,20 +11,36 @@ const getTestEnv = () => {
   dataSet.addCases([{ __id__: "1" }])
   const attribute = dataSet.attributes[0]
   const adornment = PlottedFunctionAdornmentModel.create({ formula: { display: "1 + 2 + x", canonical: "1 + 2 + x" }})
+  const dataConfig = GraphDataConfigurationModel.create({ })
+  const mockData: Record<string, Record<string, any>> = {
+    id: {
+      x: attribute.id,
+      y: "fake-y-attr-id",
+      topSplit: "fake-size-attr-id",
+      rightSplit: ""
+    },
+    type: {
+      x: "numeric",
+      y: "numeric",
+    },
+    categoryArrayForAttrRole: {
+      x: [],
+      y: [],
+      topSplit: ["small", "medium", "large"],
+      rightSplit: []
+    }
+  }
+  dataConfig.attributeID = (role: string) => mockData.id[role]
+  dataConfig.attributeType = (role: string) => mockData.type[role]
+  dataConfig.categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
+
   const graphContentModel = {
     id: "fake-graph-content-model-id",
     adornments: [adornment],
     dataset: dataSet,
-    getUpdateCategoriesOptions: (): IUpdateCategoriesOptions => ({
-      xAttrId: attribute.id,
-      xCats: [],
-      yAttrId: "fake-y-attr-id",
-      yCats: [],
-      topAttrId: "fake-size-attr-id",
-      topCats: ["small", "medium", "large"],
-      rightAttrId: "",
-      rightCats: [],
-      dataConfig: GraphDataConfigurationModel.create({ }),
+    dataConfiguration: dataConfig,
+    getUpdateCategoriesOptions: () => ({
+      dataConfig
     }),
   }
   const formula = adornment.formula
@@ -33,7 +48,7 @@ const getTestEnv = () => {
   const context = { dataSet, formula }
   const extraMetadata = {
     dataSetId: dataSet.id,
-    defaultArgument: localAttrIdToCanonical("fake-y-attr-id"),
+    defaultArgument: localAttrIdToCanonical(attribute.id),
     graphCellKeys: [
       {"fake-size-attr-id": "small"},
       {"fake-size-attr-id": "medium"},

--- a/v3/src/models/formula/plotted-value-formula-adapter.test.ts
+++ b/v3/src/models/formula/plotted-value-formula-adapter.test.ts
@@ -3,7 +3,6 @@ import {
 } from "../../components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-model"
 import { DataSet, IDataSet } from "../data/data-set"
 import { PlottedValueFormulaAdapter } from "./plotted-value-formula-adapter"
-import { IUpdateCategoriesOptions } from "../../components/graph/adornments/adornment-models"
 import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
 import { GraphDataConfigurationModel } from "../../components/graph/models/graph-data-configuration-model"
 
@@ -12,20 +11,35 @@ const getTestEnv = () => {
   dataSet.addCases([{ __id__: "1" }])
   const attribute = dataSet.attributes[0]
   const adornment = PlottedValueAdornmentModel.create({ formula: { display: "1 + 2", canonical: "1 + 2" }})
+  const dataConfig = GraphDataConfigurationModel.create({ })
+  const mockData: Record<string, Record<string, any>> = {
+    id: {
+      x: attribute.id,
+      y: "fake-y-attr-id",
+      topSplit: "fake-size-attr-id",
+      rightSplit: ""
+    },
+    type: {
+      x: "numeric",
+      y: "numeric",
+    },
+    categoryArrayForAttrRole: {
+      x: [],
+      y: [],
+      topSplit: ["small", "medium", "large"],
+      rightSplit: []
+    }
+  }
+  dataConfig.attributeID = (role: string) => mockData.id[role]
+  dataConfig.attributeType = (role: string) => mockData.type[role]
+  dataConfig.categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
   const graphContentModel = {
     id: "fake-graph-content-model-id",
     adornments: [adornment],
     dataset: dataSet,
-    getUpdateCategoriesOptions: (): IUpdateCategoriesOptions => ({
-      xAttrId: attribute.id,
-      xCats: [],
-      yAttrId: "fake-y-attr-id",
-      yCats: [],
-      topAttrId: "fake-size-attr-id",
-      topCats: ["small", "medium", "large"],
-      rightAttrId: "",
-      rightCats: [],
-      dataConfig: GraphDataConfigurationModel.create({ }),
+    dataConfiguration: dataConfig,
+    getUpdateCategoriesOptions: () => ({
+      dataConfig
     }),
   }
   const formula = adornment.formula
@@ -33,7 +47,7 @@ const getTestEnv = () => {
   const context = { dataSet, formula }
   const extraMetadata = {
     dataSetId: dataSet.id,
-    defaultArgument: localAttrIdToCanonical("fake-y-attr-id"),
+    defaultArgument: localAttrIdToCanonical(attribute.id),
     graphCellKeys: [
       {"fake-size-attr-id": "small"},
       {"fake-size-attr-id": "medium"},

--- a/v3/src/utilities/profiler.ts
+++ b/v3/src/utilities/profiler.ts
@@ -160,6 +160,17 @@ class Profiler {
     // eslint-disable-next-line no-console
     console.log(lines.join("\n"))
   }
+
+  // Shorter alias methods when used in dev tools console:
+  start() {
+    this.beginProfiling()
+  }
+
+  stop() {
+    this.endProfiling()
+    this.report()
+  }
 }
 
 export const prf = new Profiler()
+;(window as any).prf = prf


### PR DESCRIPTION
The goal of this PR is to clean up some elements of the `GraphDataConfigurationModel` so that it's possible to precalculate and cache subplot cases. The changes are as follows:

1. Cleaned up methods related to subplots and cells in `GraphDataConfigurationModel`. This model previously had multiple copies of methods with the same name (e.g., `isCaseInSubplot`), and two overlapping (possibly identical) concepts - graph cells and graph subplots. Following @bfinzer's suggestion, I removed redundant methods and left subplot naming. (@bfinzer, if you happen to review this PR, I'd mostly pay attention to the changes in `graph-data-configuration-model.ts`).
   
2. Moved `getAllCellKeys` to `GraphDataConfigurationModel`. This move appears to be necessary to enable the precalculation and caching of subplot cases.

3. Attempted to clean up and simplify the `IUpdateCategoriesOptions` passed around to Adornments models. This structure had significant overlap with the data available in `GraphDataConfigurationModel`. Consequently, I streamlined these options, making them slimmer and allowing adornments to rely more on data configuration (e.g., the newly added `categoriesOptions` view). This area is probably relevant to @emcelroy's work.

4. Moved some tests from Adornments to `GraphDataConfigurationModel` mainly because of item 3. Although mocking has become somewhat more complex, I hope it is acceptable.

I did some tests locally, and calculations seemed to be correct in various subplots. However, I can never be sure if I've triggered all possible divisions / subplots. :) If you have some robust smoke tests, I would appreciate checking them in this branch once it is deployed.