### PR TITLE
Maps respond to new datasets with lat/long data

### DIFF
--- a/v3/src/components/map/hooks/use-map-model.ts
+++ b/v3/src/components/map/hooks/use-map-model.ts
@@ -59,11 +59,7 @@ export function useMapModel(props: IProps) {
         )
       }
     } else {
-      // Wait for leaflet to render the map before fitting the bounds
-      // Todo: See if we can instead wait for the map to be ready
-      setTimeout(() => {
-        fitMapBoundsToData(mapModel.layers, leafletMap)
-      }, 100)
+      fitMapBoundsToData(mapModel.layers, leafletMap)
     }
     mapModel.setHasBeenInitialized()
   }, [leafletMap, mapModel, mapModel.layers])

--- a/v3/src/components/map/utilities/map-utils.ts
+++ b/v3/src/components/map/utilities/map-utils.ts
@@ -157,14 +157,17 @@ export const fitMapBoundsToData = (layers: IDataDisplayLayerModel[], leafletMap:
       }
     }
   }
-
-  layers.forEach((layer: any) => {
-    applyBounds(getLatLongBounds(layer.dataConfiguration))
-  })
-  leafletMap.eachLayer(function (iLayer: Polygon) {
-    iLayer.getBounds && applyBounds(iLayer.getBounds())
-  })
-  if (overallBounds) {
-    leafletMap.fitBounds(expandLatLngBounds(overallBounds, 1.1), {animate: true})
-  }
+  // Wait for leaflet to render the map before fitting the bounds
+  // Todo: See if we can instead wait for notification that the map is ready
+  setTimeout(() => {
+    layers.forEach((layer: any) => {
+      applyBounds(getLatLongBounds(layer.dataConfiguration))
+    })
+    leafletMap.eachLayer(function (iLayer: Polygon) {
+      iLayer.getBounds && applyBounds(iLayer.getBounds())
+    })
+    if (overallBounds) {
+      leafletMap.fitBounds(expandLatLngBounds(overallBounds, 1.1), {animate: true})
+    }
+  }, 100)
 }


### PR DESCRIPTION
[#186435138] Feature: Importing a csv with lat/long attributes should display points for the cases on existing map without further user intervention

* Move the setTimeout for fitting bounds into fitMapBoundsToData so clients don't have to deal with it
* In the reaction in MapContentModel that reacts to changes in the number of available datasets with points or boundaries, when layers have been changed, fit the bounds.