### PR TITLE
maps respond to component resize

### DIFF
--- a/v3/src/components/map/components/codap-map.tsx
+++ b/v3/src/components/map/components/codap-map.tsx
@@ -5,7 +5,6 @@ import {LatLngExpression} from "leaflet"
 import {MapContainer, TileLayer} from "react-leaflet"
 import {kDefaultMapLocation, kDefaultMapZoom, kMapAttribution, kMapUrl} from "../map-types"
 import {useMapModelContext} from "../hooks/use-map-model-context"
-import {MapController} from "../models/map-controller"
 import {MapInterior} from "./map-interior"
 import {DroppableMapArea} from "./droppable-map-area"
 import {IDataSet} from "../../../models/data/data-set"
@@ -14,11 +13,10 @@ import 'leaflet/dist/leaflet.css'
 import "./map.scss"
 
 interface IProps {
-  mapController: MapController
   mapRef: MutableRefObject<HTMLDivElement | null>
 }
 
-export const CodapMap = observer(function CodapMap({mapController, mapRef}: IProps) {
+export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
   const instanceId = useInstanceIdContext(),
     mapModel = useMapModelContext(),
     interiorSvgRef = useRef<SVGSVGElement>(null)
@@ -53,7 +51,7 @@ export const CodapMap = observer(function CodapMap({mapController, mapRef}: IPro
                     zoomSnap={0} trackResize={true}>
         <TileLayer attribution={kMapAttribution} url={kMapUrl}/>
         <svg ref={interiorSvgRef} className={`map-dot-area ${instanceId}`}>
-          <MapInterior mapController={mapController}/>
+          <MapInterior />
         </svg>
       </MapContainer>
       <DroppableMapArea

--- a/v3/src/components/map/components/map-component.tsx
+++ b/v3/src/components/map/components/map-component.tsx
@@ -1,13 +1,12 @@
 import {useDndContext, useDroppable} from '@dnd-kit/core'
 import {observer} from "mobx-react-lite"
-import React, {useEffect, useMemo, useRef} from "react"
+import React, {useEffect, useRef} from "react"
 import {useResizeDetector} from "react-resize-detector"
 import {ITileBaseProps} from '../../tiles/tile-base-props'
 import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-id-context"
 import {AttributeDragOverlay} from "../../drag-drop/attribute-drag-overlay"
 import {CodapMap} from "./codap-map"
 import {isMapContentModel} from "../models/map-content-model"
-import {MapController} from "../models/map-controller"
 import {MapLayoutContext} from "../models/map-layout"
 import {MapModelContext} from "../hooks/use-map-model-context"
 import {useInitMapLayout} from "../hooks/use-init-map-layout"
@@ -19,22 +18,10 @@ export const MapComponent = observer(function MapComponent({tile}: ITileBaseProp
   const layout = useInitMapLayout(mapModel)
   const mapRef = useRef<HTMLDivElement | null>(null)
   const {width, height} = useResizeDetector<HTMLDivElement>({targetRef: mapRef})
-  const mapController = useMemo(
-    () => new MapController({mapModel, layout, instanceId}),
-    [mapModel, layout, instanceId]
-  )
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setParentExtent(width, height)
   }, [width, height, layout])
-
-  useEffect(function cleanup() {
-    /*
-        return () => {
-          layout.cleanup()
-        }
-    */
-  }, [layout])
 
   // used to determine when a dragged attribute is over the map component
   const dropId = `${instanceId}-component-drop-overlay`
@@ -51,9 +38,7 @@ export const MapComponent = observer(function MapComponent({tile}: ITileBaseProp
     <InstanceIdContext.Provider value={instanceId}>
       <MapLayoutContext.Provider value={layout}>
         <MapModelContext.Provider value={mapModel}>
-          <CodapMap mapController={mapController}
-                    mapRef={mapRef}
-          />
+          <CodapMap mapRef={mapRef}/>
           <AttributeDragOverlay activeDragId={overlayDragId}/>
         </MapModelContext.Provider>
       </MapLayoutContext.Provider>

--- a/v3/src/components/map/components/map-interior.tsx
+++ b/v3/src/components/map/components/map-interior.tsx
@@ -1,23 +1,16 @@
 import {observer} from "mobx-react-lite"
 import React from "react"
-import {MapController} from "../models/map-controller"
 import {useMapModelContext} from "../hooks/use-map-model-context"
-import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {useMapModel} from "../hooks/use-map-model"
 import {isMapPointLayerModel, kMapPointLayerType} from "../models/map-point-layer-model"
 import {MapPointLayer} from "./map-point-layer"
 import {isMapPolygonLayerModel} from "../models/map-polygon-layer-model"
 import {MapPolygonLayer} from "./map-polygon-layer"
 
-interface IProps {
-  mapController: MapController
-}
+export const MapInterior = observer(function MapInterior() {
+  const mapModel = useMapModelContext()
 
-export const MapInterior = observer(function MapInterior({mapController}: IProps) {
-  const mapModel = useMapModelContext(),
-    instanceId = useInstanceIdContext()
-
-  useMapModel({mapModel, instanceId})
+  useMapModel()
 
   /**
    * Note that we don't have to worry about layer order because polygons will be sent to the back

--- a/v3/src/components/map/hooks/use-map-model.ts
+++ b/v3/src/components/map/hooks/use-map-model.ts
@@ -1,18 +1,16 @@
+import {reaction} from "mobx"
 import {useEffect} from "react"
 import {latLng} from 'leaflet'
 import {useMap} from "react-leaflet"
+import {useMapModelContext} from "./use-map-model-context"
+import {useMapLayoutContext} from "../models/map-layout"
 import {kDefaultMapZoomForGeoLocation} from "../map-types"
-import {IMapContentModel} from "../models/map-content-model"
 import {fitMapBoundsToData} from "../utilities/map-utils"
 
-interface IProps {
-  mapModel: IMapContentModel
-  instanceId: string | undefined
-}
-
-export function useMapModel(props: IProps) {
-  const {mapModel} = props,
-    leafletMap = useMap()
+export function useMapModel() {
+  const leafletMap = useMap(),
+    mapModel = useMapModelContext(),
+    layout = useMapLayoutContext()
 
   // Initialize
   useEffect(function initializeLeafletMapHandlers() {
@@ -68,4 +66,13 @@ export function useMapModel(props: IProps) {
     mapModel.setHasBeenInitialized()
   }, [leafletMap, mapModel, mapModel.layers])
 
+  // Respond to content width and height changes
+  useEffect(function updateMapSize() {
+    const disposer = reaction(
+      () => [layout.mapWidth, layout.mapHeight],
+      () => leafletMap.invalidateSize(),
+      {name: "updateMapSize"}
+    )
+    return () => disposer()
+  }, [leafletMap, layout])
 }

--- a/v3/src/components/map/hooks/use-map-model.ts
+++ b/v3/src/components/map/hooks/use-map-model.ts
@@ -71,7 +71,7 @@ export function useMapModel() {
     const disposer = reaction(
       () => [layout.mapWidth, layout.mapHeight],
       () => leafletMap.invalidateSize(),
-      {name: "updateMapSize"}
+      {name: "MapContentModel.updateMapSize"}
     )
     return () => disposer()
   }, [leafletMap, layout])


### PR DESCRIPTION
Previous to this PR maps would not properly bring in new portions of the base map when the map component was resized. Now they do. In a slight touchup from V2, the map shrinks and grows around the center of the map rather than the upper left corner.

[#186408583] Feature: Maps should expand when a user expands the component using the drag handle

* Set up a useEffect in use-map-model.ts to inform leafletMap that its size has changed
* Considerable cleanup on getting rid of MapController