### PR TITLE
fix: User can add Least Squares Line to scatterplot (PT-181939979)

### DIFF
--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -186,7 +186,12 @@ export const LSRLAdornmentModel = AdornmentModel
         const { intercept, rSquared, slope, sdResiduals } = self.computeValues(
           xAttrId, yAttrId, cellKey, dataConfig, key, false, legendCats[i]
         )
-        if (intercept == null || rSquared == null || slope == null || sdResiduals == null) return
+        if (
+          !Number.isFinite(intercept) ||
+          !Number.isFinite(rSquared) ||
+          !Number.isFinite(slope) ||
+          !Number.isFinite(sdResiduals)
+        ) return
         self.updateLines({category: legendCats[i], intercept, rSquared, slope, sdResiduals}, key, i)
       }
     })


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181939979

This fixes a bug reported by QA that caused crashes when the LSRL adornment was activated in graphs with multiple subplots. The check for valid values in the model's `getLines` view wasn't precise enough to prevent invalid values from being used when adding new lines, which would lead to many unnecessary lines being added to the model's `lines` map. This change fixes that.