### PR TITLE
Fix graph data configuration model - rm risky and unnecessary caching

### DIFF
--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -146,7 +146,7 @@ export const LSRLAdornmentModel = AdornmentModel
 .actions(self => ({
   updateCategories(options: IUpdateCategoriesOptions) {
     const { dataConfig } = options
-    const { xAttrId, yAttrId } = dataConfig.categoriesOptions
+    const { xAttrId, yAttrId } = dataConfig.getCategoriesOptions()
     const legendCats = dataConfig?.categoryArrayForAttrRole("legend")
     self.lines.clear()
     dataConfig.getAllCellKeys().forEach(cellKey => {

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -98,7 +98,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
   .actions(self => ({
     updateCategories(options: IUpdateCategoriesOptions) {
       const { dataConfig, resetPoints } = options
-      const { xAttrId, yAttrId, xAttrType } = dataConfig.categoriesOptions
+      const { xAttrId, yAttrId, xAttrType } = dataConfig.getCategoriesOptions()
       const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
       dataConfig.getAllCellKeys().forEach(cellKey => {
         const instanceKey = self.instanceKey(cellKey)

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -217,7 +217,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     }
   }))
   .views(self => ({
-    get categoriesOptions() {
+    getCategoriesOptions() {
       // Helper used often by adornments that usually ask about the same categories and their specifics.
       const xAttrType = self.attributeType("x")
       const yAttrType = self.attributeType("y")
@@ -237,7 +237,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
   }))
   .views(self => ({
     cellKey(index: number) {
-      const { xAttrId, xCats, yAttrId, yCats, topAttrId, topCats, rightAttrId, rightCats } = self.categoriesOptions
+      const { xAttrId, xCats, yAttrId, yCats, topAttrId, topCats, rightAttrId, rightCats } = self.getCategoriesOptions()
       const rightCatCount = rightCats.length || 1
       const yCatCount = yCats.length || 1
       const xCatCount = xCats.length || 1
@@ -259,7 +259,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       return cellKey
     },
     getAllCellKeys() {
-      const { xCats, yCats, topCats, rightCats } = self.categoriesOptions
+      const { xCats, yCats, topCats, rightCats } = self.getCategoriesOptions()
       const topCatCount = topCats.length || 1
       const rightCatCount = rightCats.length || 1
       const xCatCount = xCats.length || 1

--- a/v3/src/models/formula/base-graph-formula-adapter.ts
+++ b/v3/src/models/formula/base-graph-formula-adapter.ts
@@ -17,7 +17,7 @@ export interface IBaseGraphFormulaExtraMetadata extends IFormulaExtraMetadata {
 }
 
 export const getDefaultArgument = (graphContentModel: IGraphContentModel) => {
-  const { xAttrId, yAttrId, xAttrType } = graphContentModel.dataConfiguration.categoriesOptions
+  const { xAttrId, yAttrId, xAttrType } = graphContentModel.dataConfiguration.getCategoriesOptions()
   const defaultArgumentId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
   return defaultArgumentId ? localAttrIdToCanonical(defaultArgumentId) : undefined
 }


### PR DESCRIPTION
This PR reverses a change that was introduced as part of https://github.com/concord-consortium/codap/pull/1010.

Initially, it didn't seem harmful, but I encountered issues when working on another feature. `.categoriesOptions` gets cached because of a reaction that uses it, and I could no longer update it in the tests where I applied some mocking techniques (not pretty, but it's not straightforward with MST).

Moreover, I believe it's worth reverting, as these category options might indeed depend on case values / properties that are not observable. Therefore, this getter could possibly require some manual invalidation. I don't think it's necessary at this point, and if one of the underlying methods needs to be cached because of the performance issues, it should probably be done lower down.