### PR TITLE
Drop attribute on map to color points or polygons

### DIFF
--- a/v3/src/components/map/components/codap-map.tsx
+++ b/v3/src/components/map/components/codap-map.tsx
@@ -1,4 +1,3 @@
-import {observer} from "mobx-react-lite"
 import React, {MutableRefObject, useRef} from "react"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {LatLngExpression} from "leaflet"
@@ -16,7 +15,7 @@ interface IProps {
   mapRef: MutableRefObject<HTMLDivElement | null>
 }
 
-export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
+export const CodapMap = function CodapMap({mapRef}: IProps) {
   const instanceId = useInstanceIdContext(),
     mapModel = useMapModelContext(),
     interiorSvgRef = useRef<SVGSVGElement>(null)
@@ -62,4 +61,4 @@ export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
       {/*{renderLegends()}*/}
     </div>
   )
-})
+}

--- a/v3/src/components/map/models/map-content-model.ts
+++ b/v3/src/components/map/models/map-content-model.ts
@@ -1,7 +1,5 @@
 import {reaction} from "mobx"
 import {addDisposer, Instance, SnapshotIn, types} from "mobx-state-tree"
-import {ISharedModel} from "../../../models/shared/shared-model"
-import {SharedModelChangeType} from "../../../models/shared/shared-model-manager"
 import {ITileContentModel} from "../../../models/tiles/tile-content"
 import {applyUndoableAction} from "../../../models/history/apply-undoable-action"
 import {IDataSet} from "../../../models/data/data-set"
@@ -69,17 +67,18 @@ export const MapContentModel = DataDisplayContentModel
       newPolygonLayer.setDataset(dataSet)
     },
     afterAttachToDocument() {
-      // Monitor our parents and update our shared model when we have a document parent
+      // Monitor coming and going of shared datasets
       addDisposer(self, reaction(() => {
           const sharedModelManager = self.tileEnv?.sharedModelManager,
             sharedDataSets: ISharedDataSet[] = sharedModelManager?.isReady
               ? sharedModelManager?.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType) ?? []
-              : []
-          return {sharedModelManager, sharedDataSets}
+              : [],
+            leafletMap = self.leafletMap
+          return {sharedModelManager, sharedDataSets, leafletMap}
         },
         // reaction/effect
-        ({sharedModelManager, sharedDataSets}) => {
-          if (!sharedModelManager?.isReady) {
+        ({sharedModelManager, sharedDataSets, leafletMap}) => {
+          if (!sharedModelManager?.isReady || !leafletMap) {
             // We aren't added to a document yet, so we can't do anything yet
             return
           }
@@ -121,10 +120,10 @@ export const MapContentModel = DataDisplayContentModel
             layersHaveChanged = true
           })
           if (layersHaveChanged) {
-            fitMapBoundsToData(self.layers, self.leafletMap)
+            fitMapBoundsToData(self.layers, leafletMap)
           }
         },
-        {name: "sharedModelSetup", fireImmediately: true}))
+        {name: "MapContentModel.respondToSharedDatasetsChanges", fireImmediately: true}))
     },
     setLeafletMap(leafletMap: any) {
       self.leafletMap = leafletMap


### PR DESCRIPTION
This feature got broken during a recent refactor. The fix is to allow CodapMap to rerender more frequently so that the refs get updated properly.

[#186510502] Feature: User can drop an attribute on a map to color points or boundaries

* CodapMap no longer an observer so that it renders sufficiently at startup to create the legend drop zone
* Fix a bug whereby we were attempting to fit the bounds of the leaflet map before it had been assigned to the model