### PR TITLE
Add `cachedFnFactory` MST util and use it to cache Attribute props 

### DIFF
--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -81,7 +81,7 @@ describe("Attribute", () => {
 
     attribute.setUnits("m")
     expect(attribute.units).toBe("m")
-    expect(attribute.numericCount).toBe(0)
+    expect(attribute.getNumericCount()).toBe(0)
     expect(attribute.type).toBeUndefined()
 
     attribute.addValue("1")
@@ -95,7 +95,7 @@ describe("Attribute", () => {
     expect(attribute.value(2)).toBe("3")
     expect(attribute.numeric(1)).toBe(2)
     expect(attribute.numeric(2)).toBe(3)
-    expect(attribute.numericCount).toBe(3)
+    expect(attribute.getNumericCount()).toBe(3)
 
     attribute.addValue(0, 0)
     expect(attribute.length).toBe(4)
@@ -132,7 +132,7 @@ describe("Attribute", () => {
     expect(attribute.value(1)).toBe("2")
     expect(attribute.numeric(0)).toBe(0)
     expect(attribute.numeric(1)).toBe(2)
-    expect(attribute.numericCount).toBe(6)
+    expect(attribute.getNumericCount()).toBe(6)
     expect(attribute.type).toBe("numeric")
 
     // undefined/empty values are ignored when determining type
@@ -202,21 +202,21 @@ describe("Attribute", () => {
 
     // value changes should trigger emptyCount reevaluation
     const emptyCountListener = jest.fn()
-    const emptyCountDisposer = reaction(() => a.emptyCount, () => emptyCountListener())
-    expect(a.emptyCount).toBe(0)
+    const emptyCountDisposer = reaction(() => a.getEmptyCount(), () => emptyCountListener())
+    expect(a.getEmptyCount()).toBe(0)
     expect(emptyCountListener).toHaveBeenCalledTimes(0)
     a.setValue(2, "")
-    expect(a.emptyCount).toBe(1)
+    expect(a.getEmptyCount()).toBe(1)
     expect(emptyCountListener).toHaveBeenCalledTimes(1)
     emptyCountDisposer()
 
     // value changes should trigger numericCount reevaluation
     const numericCountListener = jest.fn()
-    const numericCountDisposer = reaction(() => a.numericCount, () => numericCountListener())
-    expect(a.numericCount).toBe(3)
+    const numericCountDisposer = reaction(() => a.getNumericCount(), () => numericCountListener())
+    expect(a.getNumericCount()).toBe(3)
     expect(numericCountListener).toHaveBeenCalledTimes(0)
     a.setValue(2, "3")
-    expect(a.numericCount).toBe(4)
+    expect(a.getNumericCount()).toBe(4)
     expect(numericCountListener).toHaveBeenCalledTimes(1)
     numericCountDisposer()
 

--- a/v3/src/utilities/mst-utils.test.ts
+++ b/v3/src/utilities/mst-utils.test.ts
@@ -1,0 +1,25 @@
+import { cachedFnFactory } from "./mst-utils"
+
+describe("cachedFnFactory", () => {
+  it("should return a function that lazily caches the value", () => {
+    const recalculate = jest.fn(() => "foo")
+    const cachedFn = cachedFnFactory(recalculate)
+    expect(recalculate).not.toHaveBeenCalled()
+    expect(cachedFn()).toEqual("foo")
+    expect(cachedFn()).toEqual("foo")
+    expect(recalculate).toHaveBeenCalledTimes(1)
+  })
+
+  it("should return a function that caches the value until invalidate() is called", () => {
+    const recalculate = jest.fn(() => "foo")
+    const cachedFn = cachedFnFactory(recalculate)
+    expect(cachedFn()).toEqual("foo")
+    recalculate.mockImplementation(() => "bar")
+    expect(cachedFn()).toEqual("foo")
+    expect(recalculate).toHaveBeenCalledTimes(1)
+    cachedFn.invalidate()
+    expect(cachedFn()).toEqual("bar")
+    expect(cachedFn()).toEqual("bar")
+    expect(recalculate).toHaveBeenCalledTimes(2)
+  })
+})

--- a/v3/src/utilities/mst-utils.ts
+++ b/v3/src/utilities/mst-utils.ts
@@ -76,3 +76,25 @@ export function onAnyAction(
 ): IDisposer {
     return onAction(target, listener, { attachAfter: true, allActions: true, ...options })
 }
+
+/**
+ * A function factory that returns lazily evaluated function which will return the same value until invalidate() is
+ * called. This is useful for caching values that are expensive to calculate.
+ *
+ * @param recalculate
+ * @returns a function that will return the same value until invalidate() is called.
+ */
+export function cachedFnFactory<T>(recalculate: () => T): (() => T) & { invalidate: () => void } {
+  const invalidKey = "__invalid__"
+  let cachedValue: T | "__invalid__" = invalidKey
+  const getter = () => {
+    if (cachedValue === invalidKey) {
+      cachedValue = recalculate()
+    }
+    return cachedValue
+  }
+  getter.invalidate = () => {
+    cachedValue = invalidKey
+  }
+  return getter
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186496489

This PR introduces manual caching for some of the Attribute props. I've implemented it as a small helper so that the pattern is easier to replicate in other models, making it clear that the function result is cached.

I opted not to use getters as I believe it may not be possible with this type of tool. Additionally, even if it were, there might be a conflict with Mobx caching. Developers might assume manual invalidation is sufficient, but Mobx could still cache the data.

Also, I left `self.changeCount // eslint-disable-line no-unused-expressions` as some tests were depending on this reactivity.  So, I assumed that some features might also rely on it.

As part of this task, I tried to understand the process and explore alternative options. My initial impression is that we have limited alternatives. Another potential approach could involve triggering Mobx caching using targeted observable blocks, such as by placing graph rendering in `autorun`. I experimented with this, but it seems to be a challenging task and could likely introduce other issues. You can find most of my conclusions in [this lengthy Slack thread](https://concord-consortium.slack.com/archives/C0303QUNU/p1700580463868519).