### PR TITLE
(Micro?) optimize various models, especially accessors used to retrieve case values

### DIFF
--- a/v3/src/components/case-table/use-index-column.tsx
+++ b/v3/src/components/case-table/use-index-column.tsx
@@ -43,8 +43,8 @@ export const useIndexColumn = () => {
     const { __id__, [symIndex]: _index, [symParent]: parentId } = row
     const index = _index != null ? _index : data?.caseIndexFromID(__id__)
     const collapsedCases = (data && parentId && caseMetadata?.isCollapsed(parentId))
-                            ? data.pseudoCaseMap[parentId]?.childPseudoCaseIds?.length ??
-                              data.pseudoCaseMap[parentId]?.childCaseIds.length
+                            ? data.pseudoCaseMap.get(parentId)?.childPseudoCaseIds?.length ??
+                              data.pseudoCaseMap.get(parentId)?.childCaseIds.length
                             : undefined
     return (
       <IndexCell caseId={__id__} index={index} collapsedCases={collapsedCases} />

--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -127,7 +127,11 @@ export const useRows = () => {
       if (!data?.collections.length && isRemoveCasesAction(action)) {
         const caseIds = action.args[0]
         // have to determine the lowest index before the cases are actually removed
-        lowestIndex.current = Math.min(...caseIds.map(id => data.caseIndexFromID(id)).filter(index => index != null))
+        lowestIndex.current = Math.min(
+          ...caseIds
+            .map(id => data.caseIndexFromID(id) ?? -1)
+            .filter(index => index !== -1)
+        )
       }
     }, { attachAfter: false })
     const afterAnyActionDisposer = data && onAnyAction(data, action => {
@@ -150,7 +154,7 @@ export const useRows = () => {
             lowestIndex.current = index != null ? index : data.cases.length
             const casesToUpdate = []
             for (let i=0; i<_cases.length; ++i) {
-              lowestIndex.current = Math.min(lowestIndex.current, data.caseIndexFromID(_cases[i].__id__))
+              lowestIndex.current = Math.min(lowestIndex.current, data.caseIndexFromID(_cases[i].__id__) ?? Infinity)
             }
             for (let j=lowestIndex.current; j < data.cases.length; ++j) {
               casesToUpdate.push(data.cases[j])
@@ -194,7 +198,7 @@ export const useRows = () => {
     const metadataDisposer = caseMetadata && onAnyAction(caseMetadata, action => {
       if (isSetIsCollapsedAction(action)) {
         const [caseId] = action.args
-        const caseGroup = data?.pseudoCaseMap[caseId]
+        const caseGroup = data?.pseudoCaseMap.get(caseId)
         const childCaseIds = caseGroup?.childPseudoCaseIds ?? caseGroup?.childCaseIds
         const firstChildCaseId = childCaseIds?.[0]
         if (firstChildCaseId) {

--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -91,10 +91,10 @@ export const CategoricalLegend = observer(function CategoricalLegend(
     }),
     duration = useRef(0)
 
-  const // keyFunc = (index: number) => index,
-    keysElt = useRef(null),
+  // keyFunc = (index: number) => index,
+  const keysElt = useRef(null)
 
-    computeLayout = useCallback(() => {
+  const computeLayout = useCallback(() => {
       categoriesRef.current = dataConfiguration?.categoryArrayForAttrRole('legend')
       const numCategories = categoriesRef.current?.length,
         lod: Layout = layoutData.current
@@ -118,18 +118,18 @@ export const CategoricalLegend = observer(function CategoricalLegend(
         })
       })
       layoutData.current = lod
-    }, [layout, dataConfiguration]),
+    }, [layout, dataConfiguration])
 
-    computeDesiredExtent = useCallback(() => {
+    const computeDesiredExtent = useCallback(() => {
       if (dataConfiguration?.placeCanHaveZeroExtent('legend')) {
         return 0
       }
       computeLayout()
       const lod = layoutData.current
       return lod.numRows * (keySize + padding) + labelHeight + axisGap
-    }, [computeLayout, dataConfiguration]),
+    }, [computeLayout, dataConfiguration])
 
-    refreshKeys = useCallback(() => {
+    const refreshKeys = useCallback(() => {
       categoriesRef.current = dataConfiguration?.categoryArrayForAttrRole('legend')
       const numCategories = categoriesRef.current?.length,
         catData = categoryData.current
@@ -187,9 +187,9 @@ export const CategoricalLegend = observer(function CategoricalLegend(
         dragInfo.current.indexOfCategory === index && select(this).raise()
       })
 */
-    }, [dataConfiguration, transform]),  // eslint-disable-line react-hooks/exhaustive-deps
+    }, [dataConfiguration, transform])  // eslint-disable-line react-hooks/exhaustive-deps
 
-    onDragStart = useCallback((event: { x: number; y: number }) => {
+    const onDragStart = useCallback((event: { x: number; y: number }) => {
       const dI = dragInfo.current,
         lod = layoutData.current,
         numCategories = categoriesRef.current?.length ?? 0,
@@ -227,9 +227,9 @@ export const CategoricalLegend = observer(function CategoricalLegend(
         }
         dI.currentDragPosition = newDragPosition
       }
-    }, [dataConfiguration, refreshKeys]),
+    }, [dataConfiguration, refreshKeys])
 
-    onDragEnd = useCallback(() => {
+    const onDragEnd = useCallback(() => {
       duration.current = transitionDuration
       dragInfo.current.indexOfCategory = -1
       refreshKeys()

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -28,7 +28,7 @@ export const NumericLegend = observer(function NumericLegend({legendAttrID}: INu
 
     getLabelHeight = useCallback(() => {
       const labelFont = vars.labelFont
-      return getStringBounds(dataset?.attrFromID(legendAttrID).name ?? '', labelFont).height
+      return getStringBounds(dataset?.attrFromID(legendAttrID)?.name ?? '', labelFont).height
     }, [dataset, legendAttrID]),
 
     refreshScale = useCallback(() => {

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -153,24 +153,25 @@ export const ScatterDots = function ScatterDots(props: PlotProps) {
 
   const refreshPointPositionsD3 = useCallback((selectedOnly: boolean) => {
     const getScreenX = (anID: string) => {
-      const xAttrID = dataConfiguration?.attributeID('x') ?? '',
-        xValue = dataset?.getNumeric(anID, xAttrID) ?? NaN,
-        xScale = layout.getAxisScale('bottom') as ScaleLinear<number, number>,
-        topSplitID = dataConfiguration?.attributeID('topSplit') ?? '',
-        topCoordValue = dataset?.getStrValue(anID, topSplitID) ?? '',
-        topScale = layout.getAxisScale('top') as ScaleBand<string>
+      const xAttrID = dataConfiguration?.attributeID('x') ?? ''
+      const xValue = dataset?.getNumeric(anID, xAttrID) ?? NaN
+      const xScale = layout.getAxisScale('bottom') as ScaleLinear<number, number>
+      const topSplitID = dataConfiguration?.attributeID('topSplit') ?? ''
+      const topCoordValue = dataset?.getStrValue(anID, topSplitID) ?? ''
+      const topScale = layout.getAxisScale('top') as ScaleBand<string>
       return xScale(xValue) / numExtraPrimaryBands + (topScale(topCoordValue) || 0)
     }
 
     const getScreenY = (anID: string, plotNum = 0) => {
-      const yAttrID = yAttrIDs[plotNum],
-        yValue = dataset?.getNumeric(anID, yAttrID) ?? NaN,
-        yScale = (hasY2Attribute && plotNum === numberOfPlots - 1 ? v2Scale : yScaleRef.current) as
-          ScaleLinear<number, number>,
-        rightSplitID = dataConfiguration?.attributeID('rightSplit') ?? '',
-        rightCoordValue = dataset?.getStrValue(anID, rightSplitID) ?? '',
-        rightScale = layout.getAxisScale('rightCat') as ScaleBand<string>,
-        rightScreenCoord = ((rightCoordValue && rightScale(rightCoordValue)) || 0)
+      const yAttrID = yAttrIDs[plotNum]
+      const yScale = (hasY2Attribute && plotNum === numberOfPlots - 1 ? v2Scale : yScaleRef.current) as
+          ScaleLinear<number, number>
+      const rightSplitID = dataConfiguration?.attributeID('rightSplit') ?? ''
+      const rightScale = layout.getAxisScale('rightCat') as ScaleBand<string>
+
+      const yValue = dataset?.getNumeric(anID, yAttrID) ?? NaN
+      const rightCoordValue = dataset?.getStrValue(anID, rightSplitID) ?? ''
+      const rightScreenCoord = ((rightCoordValue && rightScale(rightCoordValue)) || 0)
       return yScale(yValue) / numExtraSecondaryBands + rightScreenCoord
     }
 

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -244,48 +244,49 @@ export interface ISetPointCoordinates {
 }
 
 export function setPointCoordinates(props: ISetPointCoordinates) {
+  const {
+    dataset, dotsRef, selectedOnly = false, pointRadius, selectedPointRadius, pointStrokeColor, pointColor,
+    getPointColorAtIndex, getScreenX, getScreenY, getLegendColor, getAnimationEnabled
+  } = props
+  const duration = getAnimationEnabled() ? transitionDuration : 0
+  const theSelection = selectDots(dotsRef.current, selectedOnly)
 
-  const lookupLegendColor = (aCaseData: CaseData) => {
-      const id = aCaseData.caseID,
-        isSelected = dataset?.isCaseSelected(id),
-        legendColor = getLegendColor ? getLegendColor(id) : ''
-      return legendColor !== '' ? legendColor
-        : isSelected ? defaultSelectedColor
-          : aCaseData.plotNum && getPointColorAtIndex
-            ? getPointColorAtIndex(aCaseData.plotNum) : pointColor
-    },
-
-    setPoints = () => {
-
-      if (theSelection?.size()) {
-        theSelection
-          .transition()
-          .duration(duration)
-          .attr('cx', (aCaseData: CaseData) => getScreenX(aCaseData.caseID))
-          .attr('cy', (aCaseData: CaseData) => {
-            return getScreenY(aCaseData.caseID, aCaseData.plotNum)
-          })
-          .attr('r', (aCaseData: CaseData) => dataset?.isCaseSelected(aCaseData.caseID)
-            ? selectedPointRadius : pointRadius)
-          .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData))
-          .style('stroke', (aCaseData: CaseData) =>
-            (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-            ? defaultSelectedStroke : pointStrokeColor)
-          .style('stroke-width', (aCaseData: CaseData) =>
-            (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-            ? defaultSelectedStrokeWidth : defaultStrokeWidth)
-      }
+  const lookupLegendColor = (caseData: CaseData): string => {
+    const { caseID } = caseData
+    const legendColor = getLegendColor?.(caseID) || ''
+    if (legendColor !== '') {
+      return legendColor
     }
+    if (dataset?.isCaseSelected(caseID)) {
+      return defaultSelectedColor
+    }
+    if (caseData.plotNum && getPointColorAtIndex) {
+      return getPointColorAtIndex(caseData.plotNum)
+    }
+    return pointColor
+  }
 
-  const
-    {
-      dataset, dotsRef, selectedOnly = false, pointRadius, selectedPointRadius,
-      pointStrokeColor, pointColor, getPointColorAtIndex,
-      getScreenX, getScreenY, getLegendColor, getAnimationEnabled
-    } = props,
-    duration = getAnimationEnabled() ? transitionDuration : 0,
+  const setPoints = () => {
+    if (theSelection?.size()) {
+      theSelection
+        .transition()
+        .duration(duration)
+        .attr('cx', (aCaseData: CaseData) => getScreenX(aCaseData.caseID))
+        .attr('cy', (aCaseData: CaseData) => {
+          return getScreenY(aCaseData.caseID, aCaseData.plotNum)
+        })
+        .attr('r', (aCaseData: CaseData) => dataset?.isCaseSelected(aCaseData.caseID)
+          ? selectedPointRadius : pointRadius)
+        .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData))
+        .style('stroke', (aCaseData: CaseData) =>
+          (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
+            ? defaultSelectedStroke : pointStrokeColor)
+        .style('stroke-width', (aCaseData: CaseData) =>
+          (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
+            ? defaultSelectedStrokeWidth : defaultStrokeWidth)
+    }
+  }
 
-    theSelection = selectDots(dotsRef.current, selectedOnly)
   setPoints()
 }
 

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -189,8 +189,11 @@ export const CategorySet = types.model("CategorySet", {
   },
   colorForCategory(category: string) {
     const userColor = self.colors.get(category)
+    if (userColor) {
+      return userColor
+    }
     const catIndex = self.index(category)
-    return userColor || (catIndex != null ? kellyColors[catIndex % kellyColors.length] : undefined)
+    return catIndex != null ? kellyColors[catIndex % kellyColors.length] : undefined
   }
 }))
 .actions(self => ({

--- a/v3/src/models/data/data-set-collection-groups.test.ts
+++ b/v3/src/models/data/data-set-collection-groups.test.ts
@@ -1,3 +1,4 @@
+import { IAttribute } from "./attribute"
 import { CollectionModel } from "./collection"
 import { DataSet, IDataSet } from "./data-set"
 
@@ -71,7 +72,7 @@ describe("CollectionGroups", () => {
 
   it("handles grouping by a single attribute", () => {
     const collection = CollectionModel.create()
-    collection.addAttribute(data.attrFromID("aId"))
+    collection.addAttribute(data.attrFromID("aId") as IAttribute)
     data.addCollection(collection)
     expect(data.groupedAttributes.map(attr => attr.id)).toEqual(["aId"])
     expect(data.ungroupedAttributes.map(attr => attr.id)).toEqual(["bId", "cId"])
@@ -90,8 +91,8 @@ describe("CollectionGroups", () => {
 
   it("handles grouping by multiple attributes", () => {
     const collection = CollectionModel.create()
-    collection.addAttribute(data.attrFromID("aId"))
-    collection.addAttribute(data.attrFromID("bId"))
+    collection.addAttribute(data.attrFromID("aId") as IAttribute)
+    collection.addAttribute(data.attrFromID("bId") as IAttribute)
     data.addCollection(collection)
     expect(data.groupedAttributes.map(attr => attr.id)).toEqual(["aId", "bId"])
     expect(data.ungroupedAttributes.map(attr => attr.id)).toEqual(["cId"])
@@ -112,11 +113,11 @@ describe("CollectionGroups", () => {
 
   it("handles multiple groupings", () => {
     const collection1 = CollectionModel.create()
-    collection1.addAttribute(data.attrFromID("aId"))
+    collection1.addAttribute(data.attrFromID("aId") as IAttribute)
     data.addCollection(collection1)
     expect(data.collectionGroups.length).toBe(1)
     const collection2 = CollectionModel.create()
-    collection2.addAttribute(data.attrFromID("bId"))
+    collection2.addAttribute(data.attrFromID("bId") as IAttribute)
     data.addCollection(collection2)
     expect(data.groupedAttributes.map(attr => attr.id)).toEqual(["aId", "bId"])
     expect(data.ungroupedAttributes.map(attr => attr.id)).toEqual(["cId"])
@@ -219,7 +220,7 @@ describe("CollectionGroups", () => {
 
   it("doesn't take formula evaluated values into account when grouping", () => {
     const aAttr = data.attrFromID("aId")
-    aAttr.setDisplayExpression("foo * bar")
+    aAttr?.setDisplayExpression("foo * bar")
     data.moveAttributeToNewCollection("aId")
     expect(data.groupedAttributes.map(attr => attr.id)).toEqual(["aId"])
     expect(data.ungroupedAttributes.map(attr => attr.id)).toEqual(["bId", "cId"])

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -161,7 +161,7 @@ test("DataSet basic functionality", () => {
   const redShirtID = dataset.attributes[1].id
   expect(dataset.attributes.length).toBe(3)
   const redShirt = dataset.attrFromID(redShirtID)
-  expect(redShirt.name).toBe("redShirt")
+  expect(redShirt?.name).toBe("redShirt")
   dataset.removeAttribute(redShirtID)
   expect(dataset.attributes.length).toBe(2)
   expect(dataset.attrFromID(redShirtID)).toBeUndefined()
@@ -291,7 +291,7 @@ test("DataSet basic functionality", () => {
   expect(dataset.getCases([""], { canonical: true })).toEqual([])
   // validate that caseIDMap is correct
   dataset.cases.forEach((aCase: ICaseID) => {
-    const caseIndex = dataset.caseIndexFromID(aCase.__id__)
+    const caseIndex = dataset.caseIndexFromID(aCase.__id__) ?? -1
     expect((caseIndex >= 0) ? dataset.cases[caseIndex].__id__ : "").toBe(aCase.__id__)
   })
 
@@ -362,7 +362,7 @@ test("DataSet basic functionality", () => {
   expect(dataset.cases.length).toBe(4)
   // validate that caseIDMap is correct
   dataset.cases.forEach((aCase: ICaseID) => {
-    const caseIndex = dataset.caseIndexFromID(aCase.__id__)
+    const caseIndex = dataset.caseIndexFromID(aCase.__id__) ?? -1
     expect((caseIndex >= 0) ? dataset.cases[caseIndex].__id__ : "").toBe(aCase.__id__)
   })
   dataset.removeCases([""])
@@ -443,7 +443,7 @@ test("Canonical case functionality", () => {
   expect(dataset.getCases([""], { canonical: true })).toEqual([])
   // validate that caseIDMap is correct
   dataset.cases.forEach((aCase: ICaseID) => {
-    const caseIndex = dataset.caseIndexFromID(aCase.__id__)
+    const caseIndex = dataset.caseIndexFromID(aCase.__id__) ?? -1
     expect((caseIndex >= 0) ? dataset.cases[caseIndex].__id__ : "").toBe(aCase.__id__)
   })
   dataset.addCases([{ __id__: "12345", [strAttrID]: "e", [numAttrID]: 5 }])
@@ -477,7 +477,7 @@ test("Canonical case functionality", () => {
   expect(dataset.cases.length).toBe(2)
   // validate that caseIDMap is correct
   dataset.cases.forEach((aCase: ICaseID) => {
-    const caseIndex = dataset.caseIndexFromID(aCase.__id__)
+    const caseIndex = dataset.caseIndexFromID(aCase.__id__) ?? -1
     expect((caseIndex >= 0) ? dataset.cases[caseIndex].__id__ : "").toBe(aCase.__id__)
   })
   dataset.removeCases([""])

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -152,11 +152,11 @@ export const DataSet = types.model("DataSet", {
 })
 .volatile(self => ({
   // map from case IDs to indices
-  caseIDMap: {} as Record<string, number>,
+  caseIDMap: new Map<string, number>(),
   // MobX-observable set of selected case IDs
   selection: observable.set<string>(),
   // map from pseudo-case ID to the CaseGroup it represents
-  pseudoCaseMap: {} as Record<string, CaseGroup>,
+  pseudoCaseMap: new Map<string, CaseGroup>(),
   transactionCount: 0
 }))
 .views(self => {
@@ -183,9 +183,9 @@ export const DataSet = types.model("DataSet", {
 .views(self => ({
   // map from attribute id to attribute
   get attrIDMap() {
-    const idMap: Record<string, IAttribute> = {}
+    const idMap = new Map<string, IAttribute>()
     self.attributes.forEach(attr => {
-      idMap[attr.id] = attr
+      idMap.set(attr.id, attr)
     })
     return idMap
   },
@@ -318,7 +318,7 @@ export const DataSet = types.model("DataSet", {
 
         prf.measure("DataSet.collectionGroups", () => {
           self.cases.forEach(aCase => {
-            const index = self.caseIDMap[aCase.__id__]
+            const index = self.caseIDMap.get(aCase.__id__) ?? -1
             // parent attributes used for grouping are cumulative
             const parentAttrs: IAttribute[] = []
             newCollectionGroups.forEach(({ collection, groups, groupsMap }, collIndex) => {
@@ -426,12 +426,12 @@ export const DataSet = types.model("DataSet", {
         // clear map from pseudo-case id to pseudo-case
         // can't assign empty object because we're not an action
         for (const id in self.pseudoCaseMap) {
-          delete self.pseudoCaseMap[id]
+          self.pseudoCaseMap.delete(id)
         }
         // update map from pseudo-case id to pseudo-case
         newCollectionGroups.forEach(collectionGroup => {
           collectionGroup.groups.forEach(caseGroup => {
-            self.pseudoCaseMap[caseGroup.pseudoCase.__id__] = caseGroup
+            self.pseudoCaseMap.set(caseGroup.pseudoCase.__id__, caseGroup)
           })
         })
 
@@ -563,7 +563,7 @@ export const DataSet = types.model("DataSet", {
   const attrIDFromName = (name: string) => self.attrNameMap[name]
 
   function getCase(caseID: string, options?: IGetCaseOptions): ICase | undefined {
-    const index = self.caseIDMap[caseID]
+    const index = self.caseIDMap.get(caseID)
     if (index == null) { return undefined }
 
     const { canonical = true, numeric = true } = options || {}
@@ -595,15 +595,15 @@ export const DataSet = types.model("DataSet", {
   function beforeIndexForInsert(index: number, beforeID?: string | string[]) {
     if (!beforeID) { return self.cases.length }
     return Array.isArray(beforeID)
-            ? self.caseIDMap[beforeID[index]]
-            : self.caseIDMap[beforeID]
+            ? self.caseIDMap.get(beforeID[index])
+            : self.caseIDMap.get(beforeID)
   }
 
   function afterIndexForInsert(index: number, afterID?: string | string[]) {
     if (!afterID) { return self.cases.length }
     return Array.isArray(afterID)
-            ? self.caseIDMap[afterID[index]] + 1
-            : self.caseIDMap[afterID] + 1
+            ? (self.caseIDMap.get(afterID[index]) || 0) + 1
+            : (self.caseIDMap.get(afterID) || 0) + 1
   }
 
   function insertCaseIDAtIndex(id: string, beforeIndex: number) {
@@ -613,22 +613,26 @@ export const DataSet = types.model("DataSet", {
       // increment indices of all subsequent cases
       for (let i = beforeIndex + 1; i < self.cases.length; ++i) {
         const aCase = self.cases[i]
-        ++self.caseIDMap[aCase.__id__]
+        const currentVal = self.caseIDMap.get(aCase.__id__)
+        if (currentVal != null) {
+          self.caseIDMap.set(aCase.__id__, currentVal + 1)
+        }
       }
     }
     else {
       self.cases.push(newCase)
       beforeIndex = self.cases.length - 1
     }
-    self.caseIDMap[self.cases[beforeIndex].__id__] = beforeIndex
+    self.caseIDMap.set(self.cases[beforeIndex].__id__, beforeIndex)
+
   }
 
   function setCaseValues(caseValues: ICase) {
-    const index = self.caseIDMap[caseValues.__id__]
+    const index = self.caseIDMap.get(caseValues.__id__)
     if (index == null) { return }
     for (const key in caseValues) {
       if (key !== "__id__") {
-        const attribute = self.attrIDMap[key]
+        const attribute = self.attrIDMap.get(key)
         if (attribute) {
           const value = caseValues[key]
           attribute.setValue(index, value != null ? value : undefined)
@@ -643,21 +647,21 @@ export const DataSet = types.model("DataSet", {
      */
     views: {
       attrFromID(id: string) {
-        return self.attrIDMap[id]
+        return self.attrIDMap.get(id)
       },
       attrFromName(name: string) {
         const id = self.attrNameMap[name]
-        return id ? self.attrIDMap[id] : undefined
+        return id ? self.attrIDMap.get(id) : undefined
       },
       attrIDFromName,
       caseIndexFromID(id: string) {
-        return self.caseIDMap[id]
+        return self.caseIDMap.get(id)
       },
       caseIDFromIndex(index: number) {
         return getCaseAtIndex(index)?.__id__
       },
       nextCaseID(id: string) {
-        const index = self.caseIDMap[id],
+        const index = self.caseIDMap.get(id),
               nextCase = (index != null) && (index < self.cases.length - 1)
                           ? self.cases[index + 1] : undefined
         return nextCase?.__id__
@@ -666,61 +670,61 @@ export const DataSet = types.model("DataSet", {
         // The values of a pseudo-case are considered to be the values of the first real case.
         // For grouped attributes, these will be the grouped values. Clients shouldn't be
         // asking for ungrouped values from pseudo-cases.
-        const _caseId = self.pseudoCaseMap[caseID]
-                          ? self.pseudoCaseMap[caseID].childCaseIds[0]
-                          : caseID
-        const index = _caseId ? self.caseIDMap[_caseId] : undefined
-        return index != null
-                ? this.getValueAtIndex(self.caseIDMap[_caseId], attributeID)
-                : undefined
+        const pseudoCase = self.pseudoCaseMap.get(caseID)
+        const _caseId = pseudoCase ? pseudoCase?.childCaseIds[0] : caseID
+        const index = self.caseIDMap.get(_caseId)
+        return index !== undefined ? this.getValueAtIndex(index, attributeID) : undefined
       },
       getValueAtIndex(index: number, attributeID: string) {
-        const attr = self.attrIDMap[attributeID],
-              caseID = self.cases[index]?.__id__,
-              cachedCase = self.isCaching ? self.caseCache.get(caseID) : undefined
-        return (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID))
-                ? cachedCase[attributeID]
-                : attr && (index != null) ? attr.value(index) : undefined
+          if (self.isCaching) {
+            const caseID = self.cases[index]?.__id__
+            const cachedCase = self.caseCache.get(caseID)
+            if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
+              return cachedCase[attributeID]
+            }
+          }
+          const attr = self.attrIDMap.get(attributeID)
+          return attr?.value(index)
       },
       getStrValue(caseID: string, attributeID: string) {
         // The values of a pseudo-case are considered to be the values of the first real case.
         // For grouped attributes, these will be the grouped values. Clients shouldn't be
         // asking for ungrouped values from pseudo-cases.
-        const _caseId = self.pseudoCaseMap[caseID]
-                          ? self.pseudoCaseMap[caseID].childCaseIds[0]
-                          : caseID
-        const index = _caseId ? self.caseIDMap[_caseId] : undefined
-        return index != null
-                ? this.getStrValueAtIndex(self.caseIDMap[_caseId], attributeID)
-                : ""
+        const pseudoCase = self.pseudoCaseMap.get(caseID)
+        const _caseId = pseudoCase ? pseudoCase.childCaseIds[0] : caseID
+        const index = self.caseIDMap.get(_caseId)
+        return index !== undefined ? this.getStrValueAtIndex(index, attributeID) : ""
       },
       getStrValueAtIndex(index: number, attributeID: string) {
-        const attr = self.attrIDMap[attributeID],
-              caseID = self.cases[index]?.__id__,
-              cachedCase = self.isCaching ? self.caseCache.get(caseID) : undefined
-        return (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID))
-                ? `${cachedCase[attributeID]}`  // TODO: respect attribute formatting
-                : attr && (index != null) ? attr.value(index) : ""
+        if (self.isCaching) {
+          const caseID = self.cases[index]?.__id__
+          const cachedCase = self.caseCache.get(caseID)
+          if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
+            return cachedCase[attributeID]?.toString()
+          }
+        }
+        const attr = self.attrIDMap.get(attributeID)
+        return attr?.value(index) || ""
       },
       getNumeric(caseID: string, attributeID: string): number | undefined {
         // The values of a pseudo-case are considered to be the values of the first real case.
         // For grouped attributes, these will be the grouped values. Clients shouldn't be
         // asking for ungrouped values from pseudo-cases.
-        const _caseId = self.pseudoCaseMap[caseID]
-                          ? self.pseudoCaseMap[caseID].childCaseIds[0]
-                          : caseID
-        const index = _caseId ? self.caseIDMap[_caseId] : undefined
-        return index != null
-                ? this.getNumericAtIndex(self.caseIDMap[_caseId], attributeID)
-                : undefined
+        const pseudoCase = self.pseudoCaseMap.get(caseID)
+        const _caseId = pseudoCase ? pseudoCase.childCaseIds[0] : caseID
+        const index = _caseId ? self.caseIDMap.get(_caseId) : undefined
+        return index !== undefined ? this.getNumericAtIndex(index, attributeID) : undefined
       },
       getNumericAtIndex(index: number, attributeID: string) {
-        const attr = self.attrIDMap[attributeID],
-              caseID = self.cases[index]?.__id__,
-              cachedCase = self.isCaching ? self.caseCache.get(caseID) : undefined
-        return (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID))
-                ? Number(cachedCase[attributeID])
-                : attr && (index != null) ? attr.numeric(index) : undefined
+        if (self.isCaching) {
+          const caseID = self.cases[index]?.__id__
+          const cachedCase = self.caseCache.get(caseID)
+          if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
+            return Number(cachedCase[attributeID])
+          }
+        }
+        const attr = self.attrIDMap.get(attributeID)
+        return attr?.numeric(index)
       },
       getCase,
       getCases,
@@ -736,7 +740,7 @@ export const DataSet = types.model("DataSet", {
       },
       isCaseSelected(caseId: string) {
         // a pseudo-case is selected if all of its individual cases are selected
-        const group = self.pseudoCaseMap[caseId]
+        const group = self.pseudoCaseMap.get(caseId)
         return group
                 ? group.childCaseIds.every(id => self.selection.has(id))
                 : self.selection.has(caseId)
@@ -760,7 +764,7 @@ export const DataSet = types.model("DataSet", {
 
         // build caseIDMap
         self.cases.forEach((aCase, index) => {
-          self.caseIDMap[aCase.__id__] = index
+          self.caseIDMap.set(aCase.__id__, index)
         })
 
         if (!srcDataSet) {
@@ -839,7 +843,7 @@ export const DataSet = types.model("DataSet", {
       },
 
       setAttributeName(attributeID: string, name: string | (() => string)) {
-        const attribute = attributeID && self.attrIDMap[attributeID]
+        const attribute = attributeID && self.attrIDMap.get(attributeID)
         if (attribute) {
           const nameStr = typeof name === "string" ? name : name()
           attribute.setName(nameStr)
@@ -848,7 +852,7 @@ export const DataSet = types.model("DataSet", {
 
       applyAttributeProperties(attributeID: string, attrProps: IAttributeSnapshot) {
         (attrProps.name != null) && this.setAttributeName(attributeID, attrProps.name)
-        const attribute = attributeID && self.attrIDMap[attributeID]
+        const attribute = attributeID && self.attrIDMap.get(attributeID)
         if (!attribute) return
         ;(attrProps.description != null) && attribute.setDescription(attrProps.description)
         ;(attrProps.userType != null) && attribute.setUserType(attrProps.userType)
@@ -859,7 +863,7 @@ export const DataSet = types.model("DataSet", {
 
       removeAttribute(attributeID: string) {
         const attrIndex = self.attrIndexFromID(attributeID),
-              attribute = attributeID ? self.attrIDMap[attributeID] : undefined
+              attribute = attributeID ? self.attrIDMap.get(attributeID) : undefined
 
         if (attribute && attrIndex != null) {
           // remove attribute from any collection
@@ -888,7 +892,7 @@ export const DataSet = types.model("DataSet", {
             const value = aCase[attr.id]
             attr.addValue(value != null ? value : undefined, insertPosition)
           })
-          insertCaseIDAtIndex(__id__, insertPosition)
+          insertCaseIDAtIndex(__id__, insertPosition ?? 0)
         })
         // invalidate collectionGroups (including childCases)
         self.invalidateCollectionGroups()
@@ -905,7 +909,7 @@ export const DataSet = types.model("DataSet", {
         const ungroupedCases: ICase[] = []
         // convert each pseudo-case change to a change to each underlying case
         cases.forEach(aCase => {
-          const caseGroup = self.pseudoCaseMap[aCase.__id__]
+          const caseGroup = self.pseudoCaseMap.get(aCase.__id__)
           if (caseGroup) {
             ungroupedCases.push(...caseGroup.childCaseIds.map(id => ({ ...aCase, __id__: id })))
           }
@@ -944,17 +948,17 @@ export const DataSet = types.model("DataSet", {
 
       removeCases(caseIDs: string[]) {
         caseIDs.forEach((caseID) => {
-          const index = self.caseIDMap[caseID]
+          const index = self.caseIDMap.get(caseID)
           if (index != null) {
             self.cases.splice(index, 1)
             self.attributes.forEach((attr) => {
               attr.removeValues(index)
             })
             self.selection.delete(caseID)
-            delete self.caseIDMap[caseID]
+            self.caseIDMap.delete(caseID)
             for (let i = index; i < self.cases.length; ++i) {
               const id = self.cases[i].__id__
-              self.caseIDMap[id] = i
+              self.caseIDMap.set(id, i)
             }
           }
         })
@@ -974,7 +978,7 @@ export const DataSet = types.model("DataSet", {
       selectCases(caseIds: string[], select = true) {
         const ids: string[] = []
         caseIds.forEach(id => {
-          const pseudoCase = self.pseudoCaseMap[id]
+          const pseudoCase = self.pseudoCaseMap.get(id)
           if (pseudoCase) {
             ids.push(...pseudoCase.childCaseIds)
           } else {
@@ -994,7 +998,7 @@ export const DataSet = types.model("DataSet", {
       setSelectedCases(caseIds: string[]) {
         const ids: string[] = []
         caseIds.forEach(id => {
-          const pseudoCase = self.pseudoCaseMap[id]
+          const pseudoCase = self.pseudoCaseMap.get(id)
           if (pseudoCase) {
             ids.push(...pseudoCase.childCaseIds)
           } else {

--- a/v3/src/models/formula/attribute-formula-adapter.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.ts
@@ -149,14 +149,14 @@ export class AttributeFormulaAdapter implements IFormulaManagerAdapter {
 
     const incorrectParentAttrId = getIncorrectParentAttrReference(formula.canonical, collectionIndex, dataSet)
     if (incorrectParentAttrId) {
-      const attrName = dataSet.attrFromID(incorrectParentAttrId).name
+      const attrName = dataSet.attrFromID(incorrectParentAttrId)?.name || ""
       return this.setFormulaError(formulaContext, extraMetadata,
         formulaError("V3.formula.error.invalidParentAttrRef", [ attrName ]))
     }
 
     const incorrectChildAttrId = getIncorrectChildAttrReference(formula.canonical, collectionIndex, dataSet)
     if (incorrectChildAttrId) {
-      const attrName = dataSet.attrFromID(incorrectChildAttrId).name
+      const attrName = dataSet.attrFromID(incorrectChildAttrId)?.name || ""
       return this.setFormulaError(formulaContext, extraMetadata,
         formulaError("DG.Formula.HierReferenceError.message", [ attrName ]))
     }

--- a/v3/src/models/formula/formula-observers.test.ts
+++ b/v3/src/models/formula/formula-observers.test.ts
@@ -193,13 +193,13 @@ describe("observeSymbolNameChanges", () => {
     globalValueManager.addValue(globalValue)
     const nameUpdateCallback = jest.fn()
     const dispose = observeSymbolNameChanges(new Map([["ds1", dataSet]]), globalValueManager, nameUpdateCallback)
-    dataSet.attrFromID("attr1").setName("newName")
+    dataSet.attrFromID("attr1")?.setName("newName")
     expect(nameUpdateCallback).toHaveBeenCalledTimes(1)
     globalValueManager.getValueByName("global1")?.setName("newName")
     expect(nameUpdateCallback).toHaveBeenCalledTimes(2)
 
     dispose()
-    dataSet.attrFromID("attr1").setName("newName2")
+    dataSet.attrFromID("attr1")?.setName("newName2")
     expect(nameUpdateCallback).toHaveBeenCalledTimes(2)
   })
 

--- a/v3/src/models/shared/shared-case-metadata.ts
+++ b/v3/src/models/shared/shared-case-metadata.ts
@@ -42,7 +42,7 @@ export const SharedCaseMetadata = SharedModel
     },
     // true if passed the id of a parent/pseudo-case whose child cases have been collapsed, false otherwise
     isCollapsed(caseId: string) {
-      const { collectionId, valuesJson } = self.data?.pseudoCaseMap[caseId] || {}
+      const { collectionId, valuesJson } = self.data?.pseudoCaseMap.get(caseId) || {}
       return (collectionId && valuesJson && self.collections.get(collectionId)?.collapsed.get(valuesJson)) ?? false
     },
     // true if passed the id of a hidden attribute, false otherwise
@@ -66,7 +66,7 @@ export const SharedCaseMetadata = SharedModel
       }
     },
     setIsCollapsed(caseId: string, isCollapsed: boolean) {
-      const { collectionId, valuesJson } = self.data?.pseudoCaseMap[caseId] || {}
+      const { collectionId, valuesJson } = self.data?.pseudoCaseMap.get(caseId) || {}
       if (collectionId && valuesJson) {
         let tableCollection = self.collections.get(collectionId)
         if (isCollapsed) {


### PR DESCRIPTION
This PR includes several updates:

1. Various methods that I was investigating now have a more classic syntax, with each variable declared in its own statement (multiple `const` instead of just one). This change makes performance investigation more efficient (dev tools) and often leads to a more efficient implementation of the given method, as variables can be declared and calculated only when necessary. More details can be found [in this Slack thread](https://concord-consortium.slack.com/archives/C035J6RDAK0/p1700674913157909). While the old syntax might be optimized by the browser, there's never a guarantee it's going to happen, and we make it more challenging. 

2. This was especially important for critical methods like `Dataset#getCaseValue`, `#getValueAtIndex`, `#getStrValue`, `#getStrValueAtIndex`, etc. These methods are called so often that every inefficiency adds up quickly for a large number of cases.

3. I've also updated the volatile `caseIDMap` and `pseudoCaseMap` to be `Map` instances instead of an object literal. It was an experiment. This particular change didn't affect performance much, so it would be fine to revert it if you don't like it. Although it's generally recommended to use Maps for large dictionaries where keys are longer/complex. Also, this ensures better typing: `map = Record<string, number> = {}; map["nonExistentKey"]` will be considered a number, even though it's undefined. Proper `Map` doesn't have this problem, as the `.get()` method returns the map type or undefined (hence my changes in random files with fallback values).

Even though these changes seem small, they reduced the execution time of `setPointCoordinates` from ~420ms to ~270ms. It's a significant change, as my subsequent PR will make `setPointCoordinates` the main contributor to the poor performance of graph updates.

General benchmark progress:
```
Resizing the graph component: 2.1s -> 1.7s, 0.4s speed up
Rescaling either axis: ~0.1s speed up
Marquee select: ~0.1s speed up
Select by clicking on legend key: ~0.1s speed up
```