### PR TITLE
WIP: avoiding reading of MST observables

### DIFF
--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -124,6 +124,8 @@ export function setPointSelection(props: ISetPointSelection) {
 
   if (!(dotsRef.current && dots)) return
 
+  const legendType = dataConfiguration.attributeType('legend') || ""
+  const categorySet = dataConfiguration.categorySetForAttrRole('legend')
   // First set the class based on selection
   dots
     .classed('graph-dot-highlighted', (aCaseData: CaseData) => !!dataset?.isCaseSelected(aCaseData.caseID))
@@ -132,7 +134,7 @@ export function setPointSelection(props: ISetPointSelection) {
     .style('stroke', pointStrokeColor)
     .style('fill', (aCaseData:CaseData) => {
       return legendID
-        ? dataConfiguration?.getLegendColorForCase(aCaseData.caseID)
+        ? dataConfiguration?.getLegendColorForCase(aCaseData.caseID, legendID, legendType, categorySet)
         : aCaseData.plotNum && getPointColorAtIndex
           ? getPointColorAtIndex(aCaseData.plotNum) : pointColor
     })
@@ -227,4 +229,3 @@ export function rectToTreeRect(rect: Rect) {
     h: rect.height
   }
 }
-

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -5,6 +5,7 @@ import {addDisposer, getSnapshot, Instance, ISerializedActionCall, SnapshotIn, t
 import {cachedFnWithArgsFactory, onAnyAction} from "../../../utilities/mst-utils"
 import {AttributeType, attributeTypes} from "../../../models/data/attribute"
 import {DataSet, IDataSet} from "../../../models/data/data-set"
+import {ICategorySet} from "../../../models/data/category-set"
 import {ICase} from "../../../models/data/data-set-types"
 import {idOfChildmostCollectionForAttributes} from "../../../models/data/data-set-utils"
 import {ISharedCaseMetadata, SharedCaseMetadata} from "../../../models/shared/shared-case-metadata"
@@ -322,8 +323,10 @@ export const DataConfigurationModel = types
   })
   .views(self => (
     {
-      getLegendColorForCategory(cat: string): string {
-        const categorySet = self.categorySetForAttrRole('legend')
+      getLegendColorForCategory(cat: string, categorySet?: ICategorySet): string {
+        if (!categorySet) {
+          categorySet = self.categorySetForAttrRole('legend')
+        }
         return categorySet?.colorForCategory(cat) ?? missingColor
       },
 
@@ -404,9 +407,13 @@ export const DataConfigurationModel = types
         }
         return false
       },
-      getLegendColorForCase(id: string): string {
-        const legendID = self.attributeID('legend')
-        const legendType = self.attributeType('legend')
+      getLegendColorForCase(id: string, legendID?: string, legendType?: string, categorySet?: ICategorySet): string {
+        if (!legendID) {
+          legendID = self.attributeID('legend')
+        }
+        if (!legendType) {
+          legendType = self.attributeType('legend')
+        }
         if (!id || !legendID) {
           return ''
         }
@@ -416,7 +423,7 @@ export const DataConfigurationModel = types
         }
         switch (legendType) {
           case 'categorical':
-            return self.getLegendColorForCategory(legendValue)
+            return self.getLegendColorForCategory(legendValue, categorySet)
           case 'numeric':
             return self.getLegendColorForNumericValue(Number(legendValue))
           default:


### PR DESCRIPTION
@kswenson, @bfinzer, you might find this interesting. I don't intend to merge this PR in its current form, as it can be done in a cleaner way. However, my goal was to make absolutely minimal changes and show how it affects performance.

So, essentially, extracting `legendType` and `categorySet` from the case-number-dependent loop reduced the time of `setPointSelection` from 240ms to 150ms. It's a solid difference. Note that these methods don't really perform any significant calculations. They mostly involve accessing some properties and performing simple operations.

I think it's largely due to slow MobX model access. Also, this illustrates how these little things build up. In the perfect scenario, graph rendering code (e.g., D3) could use a temporary model built using plain JS structures and classes. However, maintaining this model would be a challenge.