### PR TITLE
Version 3.0.0-pre.1449 - November 27, 2023

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Version 3.0.0-pre.1449 - November 27, 2023
+
+### Features/Improvements
+- Precalculate sub-plot cases in GraphDataConfiguationModel [#186496477](https://www.pivotaltracker.com/story/show/186496477)
+- On a scatterplot movable lines and least squares lines can have their **intercepts locked** [#181939990](https://www.pivotaltracker.com/story/show/181939990)
+- Ensure Attribute#numericCount, Attribute#emptyCount, and Attribute#type are cached (and investigate why they were not(?)) [#186496489](https://www.pivotaltracker.com/story/show/186496489)
+
+### Bug Fixes
+- Dragging movable line isn't following the mouse correctly [#186448628](https://www.pivotaltracker.com/story/show/186448628)
+- Equation box for Movable Line and LSRL "jumps" when dragged. [#186485315](https://www.pivotaltracker.com/story/show/186485315)
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+|  main.css |   72522 bytes |                               0% |
+|  index.js | 3472787 bytes |                            0.09% |
+
 ## Version 3.0.0-pre.1444 - November 20, 2023
 
 ### Features/Improvements

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1444",
+  "version": "3.0.0-pre.1449",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-pre.1444",
+      "version": "3.0.0-pre.1449",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1444",
+  "version": "3.0.0-pre.1449",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -5,6 +5,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.0.0-pre.1449](https://codap3.concord.org/version/3.0.0-pre.1449/) | November 27, 2023 |
 | [3.0.0-pre.1444](https://codap3.concord.org/version/3.0.0-pre.1444/) | November 20, 2023 |
 | [3.0.0-pre.1389](https://codap3.concord.org/version/3.0.0-pre.1389/) | October 24, 2023 |
 | [3.0.0-pre.1378](https://codap3.concord.org/version/3.0.0-pre.1378/) | October 18, 2023 |


### PR DESCRIPTION
### Features/Improvements
- Precalculate sub-plot cases in GraphDataConfiguationModel [#186496477](https://www.pivotaltracker.com/story/show/186496477)
- On a scatterplot movable lines and least squares lines can have their **intercepts locked** [#181939990](https://www.pivotaltracker.com/story/show/181939990)
- Ensure Attribute#numericCount, Attribute#emptyCount, and Attribute#type are cached (and investigate why they were not(?)) [#186496489](https://www.pivotaltracker.com/story/show/186496489)

### Bug Fixes
- Dragging movable line isn't following the mouse correctly [#186448628](https://www.pivotaltracker.com/story/show/186448628)
- Equation box for Movable Line and LSRL "jumps" when dragged. [#186485315](https://www.pivotaltracker.com/story/show/186485315)