### PR TITLE
fix: table scrolling issues

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -27,7 +27,7 @@
         "pluralize": "^8.0.0",
         "query-string": "^8.1.0",
         "react": "^18.2.0",
-        "react-data-grid": "7.0.0-beta.40",
+        "react-data-grid": "7.0.0-beta.41",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
         "react-resize-detector": "^9.1.0",
@@ -18852,9 +18852,9 @@
       }
     },
     "node_modules/react-data-grid": {
-      "version": "7.0.0-beta.40",
-      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-beta.40.tgz",
-      "integrity": "sha512-2jgF56UfmHL9LhZ4teB+qR1WzAGGq3SL1ux8heiTYR8k8gQM1NFww6+EgKRlSU9fVR9yx+k/w3b6Y9aa+NpW0g==",
+      "version": "7.0.0-beta.41",
+      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-beta.41.tgz",
+      "integrity": "sha512-WmTP/PV+vtVjIaGVLgyG6WAhqvuPBM8I54bsR7oJZl6w43+mIasZM9rEBWjQ52XHJEy41/tjcMBIMNiWqoEbrQ==",
       "dependencies": {
         "clsx": "^2.0.0"
       },
@@ -36211,9 +36211,9 @@
       }
     },
     "react-data-grid": {
-      "version": "7.0.0-beta.40",
-      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-beta.40.tgz",
-      "integrity": "sha512-2jgF56UfmHL9LhZ4teB+qR1WzAGGq3SL1ux8heiTYR8k8gQM1NFww6+EgKRlSU9fVR9yx+k/w3b6Y9aa+NpW0g==",
+      "version": "7.0.0-beta.41",
+      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-beta.41.tgz",
+      "integrity": "sha512-WmTP/PV+vtVjIaGVLgyG6WAhqvuPBM8I54bsR7oJZl6w43+mIasZM9rEBWjQ52XHJEy41/tjcMBIMNiWqoEbrQ==",
       "requires": {
         "clsx": "^2.0.0"
       }

--- a/v3/package.json
+++ b/v3/package.json
@@ -182,7 +182,7 @@
     "pluralize": "^8.0.0",
     "query-string": "^8.1.0",
     "react": "^18.2.0",
-    "react-data-grid": "7.0.0-beta.40",
+    "react-data-grid": "7.0.0-beta.41",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
     "react-resize-detector": "^9.1.0",

--- a/v3/patches/react-data-grid+7.0.0-beta.41.patch
+++ b/v3/patches/react-data-grid+7.0.0-beta.41.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-data-grid/lib/bundle.cjs b/node_modules/react-data-grid/lib/bundle.cjs
-index 62ba483..9b912a7 100644
+index f8f8557..af63f7e 100644
 --- a/node_modules/react-data-grid/lib/bundle.cjs
 +++ b/node_modules/react-data-grid/lib/bundle.cjs
-@@ -3293,5 +3293,6 @@ exports.renderSortPriority = renderSortPriority;
+@@ -3318,5 +3318,6 @@ exports.renderSortPriority = renderSortPriority;
  exports.renderToggleGroup = renderToggleGroup;
  exports.renderValue = renderValue;
  exports.textEditor = textEditor;
@@ -10,10 +10,10 @@ index 62ba483..9b912a7 100644
  exports.useRowSelection = useRowSelection;
  //# sourceMappingURL=bundle.cjs.map
 diff --git a/node_modules/react-data-grid/lib/bundle.js b/node_modules/react-data-grid/lib/bundle.js
-index 6dd95a7..018da1a 100644
+index 82e6dbd..46eb114 100644
 --- a/node_modules/react-data-grid/lib/bundle.js
 +++ b/node_modules/react-data-grid/lib/bundle.js
-@@ -3274,5 +3274,6 @@ function textEditor({
+@@ -3299,5 +3299,6 @@ function textEditor({
    });
  }
  
@@ -22,10 +22,10 @@ index 6dd95a7..018da1a 100644
 +export { DataGridDefaultRenderersProvider, RowComponent$1 as Row, SELECT_COLUMN_KEY, SelectCellFormatter, SelectColumn, ToggleGroup, TreeDataGrid$1 as TreeDataGrid, DataGrid$1 as default, renderCheckbox, renderHeaderCell, renderSortIcon, renderSortPriority, renderToggleGroup, renderValue, textEditor, textEditorClassname, useRowSelection };
  //# sourceMappingURL=bundle.js.map
 diff --git a/node_modules/react-data-grid/lib/index.d.ts b/node_modules/react-data-grid/lib/index.d.ts
-index 9c47c25..cdd58ac 100644
+index 3234d2e..9aef4df 100644
 --- a/node_modules/react-data-grid/lib/index.d.ts
 +++ b/node_modules/react-data-grid/lib/index.d.ts
-@@ -437,6 +437,8 @@ export declare interface SortColumn {
+@@ -438,6 +438,8 @@ export declare interface SortColumn {
  
  export declare type SortDirection = 'ASC' | 'DESC';
  

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -68,7 +68,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   const handleGridScroll = useCallback(function handleGridScroll(event: React.UIEvent<HTMLDivElement, UIEvent>) {
     const gridElt = gridRef.current?.element
     if (gridElt != null) {
-      collectionTableModel?.syncScrollTopFromElement()
+      collectionTableModel?.syncScrollTopFromEvent(event)
       onTableScroll(event, collectionId, gridElt)
     }
   }, [collectionId, collectionTableModel, onTableScroll])


### PR DESCRIPTION
PT: [[#186510549]](https://www.pivotaltracker.com/story/show/186510549)

Fixes two scrolling issues in the table:
1. Scrolling to selected case would sometimes not reach the selected case, i.e. it would scroll part of the way there but wouldn't always reach the desired selected case.
2. Clicking on the table (to select it) after auto-scrolling to (or at least in the direction of) a selected case would result in a blank table being rendered, i.e. the visible rows were cleared.

The first problem resulted from the fact that the prior implementation relied on timing to distinguish between user-generated scroll events and browser-generated smooth scroll events, but these timings proved unreliable. The new implementation simply relies on whether the current scroll is heading towards the most recent target scroll position.

The second problem -- the one logged in the PT story -- was fixed by updating an earlier fix to the same bug by turning off smooth scrolling in the table when synchronizing the table scroll position to the DOM element.

Also, we take the opportunity with this PR to update to the latest version of `react-data-grid` (RDG).