### PR TITLE
fix: simplify/fix label menu rendering

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -30,7 +30,7 @@ const removeAttrItemLabelKeys: Record<string, string> = {
   "rightSplit": "DG.DataDisplayMenu.removeAttribute_right"
 }
 
-const _AxisOrLegendAttributeMenu = ({ place, target, portal,
+export const AxisOrLegendAttributeMenu = ({ place, target, portal,
                                       onChangeAttribute, onRemoveAttribute, onTreatAttributeAs }: IProps) => {
   const data = useDataSetContext()
   const dataConfig = useDataConfigurationContext()
@@ -90,4 +90,3 @@ const _AxisOrLegendAttributeMenu = ({ place, target, portal,
     </div>
   )
 }
-export const AxisOrLegendAttributeMenu = memo(_AxisOrLegendAttributeMenu)

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -1,5 +1,5 @@
 import { Menu, MenuItem, MenuList, MenuButton, MenuDivider } from "@chakra-ui/react"
-import React, {CSSProperties, useRef, memo} from "react"
+import React, {CSSProperties, useRef} from "react"
 import t from "../../../utilities/translation/translate"
 import {GraphPlace} from "../../axis-graph-shared"
 import { graphPlaceToAttrRole } from "../../data-display/data-display-types"

--- a/v3/src/components/graph/components/attribute-label.tsx
+++ b/v3/src/components/graph/components/attribute-label.tsx
@@ -27,7 +27,7 @@ interface IAttributeLabelProps {
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
 
-export const AttributeLabel = observer(
+export const AttributeLabel =
   function AttributeLabel({place, onTreatAttributeAs, onRemoveAttribute, onChangeAttribute}: IAttributeLabelProps) {
     const graphModel = useGraphContentModelContext(),
       dataConfiguration = useGraphDataConfigurationContext(),
@@ -176,5 +176,5 @@ export const AttributeLabel = observer(
         }
       </>
     )
-  })
+  }
 AttributeLabel.displayName = "AttributeLabel"

--- a/v3/src/components/graph/components/attribute-label.tsx
+++ b/v3/src/components/graph/components/attribute-label.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback, useEffect, useRef} from "react"
 import {createPortal} from "react-dom"
 import {reaction} from "mobx"
-import {observer} from "mobx-react-lite"
 import {select} from "d3"
 import {mstReaction} from "../../../utilities/mst-reaction"
 import t from "../../../utilities/translation/translate"

--- a/v3/src/hooks/use-overlay-bounds.ts
+++ b/v3/src/hooks/use-overlay-bounds.ts
@@ -1,18 +1,41 @@
+import { useEffect, useState } from "react"
+
 interface IProps {
   target: Element | null
   portal?: Element | null
 }
 
+interface Bounds {
+  left?: number
+  top?: number
+  width?: number
+  height?: number
+}
+
+function isSameBounds(a: Bounds, b: Bounds) {
+  return a.left === b.left && a.top === b.top &&
+          a.width === b.width && a.height === b.height
+}
+
 export function useOverlayBounds({ target, portal }: IProps) {
-  const portalBounds = portal?.getBoundingClientRect()
-  const targetBounds = target?.getBoundingClientRect()
-  if (targetBounds) {
-    return {
-      left: targetBounds.x - (portalBounds?.x ?? 0),
-      top: targetBounds.y - (portalBounds?.y ?? 0),
-      width: targetBounds.width,
-      height: targetBounds.height
+  const [overlayBounds, setOverlayBounds] = useState<Bounds>({})
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const portalBounds = portal?.getBoundingClientRect()
+    const targetBounds = target?.getBoundingClientRect()
+    if (targetBounds) {
+      const bounds = {
+        left: targetBounds.x - (portalBounds?.x ?? 0),
+        top: targetBounds.y - (portalBounds?.y ?? 0),
+        width: targetBounds.width,
+        height: targetBounds.height
+      }
+      if (!isSameBounds(bounds, overlayBounds)) {
+        // triggers re-render of component using the hook
+        setOverlayBounds(bounds)
+      }
     }
-  }
-  return {}
+    // no dependencies so effect runs after every render
+  })
+  return overlayBounds
 }


### PR DESCRIPTION
Fixes several issues that led to confusing rendering issues with axis/legend attribute menus

- `Graph` wraps its callbacks in `useCallback`
- `AttributeLabel` is no longer an `observer` -- it should render when its parent re-renders
- `AxisOrLegendAttributeMenu` is no longer `memo`ized -- it should render when its parent re-renders
- `useOverlayBounds` computes the overlay bounds in a `useEffect` and calls `setState` when there is a change, thus triggering a re-render