### PR TITLE
fix: intercept detached from origin on top split removal (PT-181939990)

### DIFF
--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -73,7 +73,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({ o
     // collapse the parent case
     caseMetadata?.setIsCollapsed(parentCaseId, !caseMetadata?.isCollapsed(parentCaseId))
     // scroll to the first expanded/collapsed child case (if necessary)
-    const parentPseudoCase = data?.pseudoCaseMap[parentCaseId]
+    const parentPseudoCase = data?.pseudoCaseMap.get(parentCaseId)
     const firstChildId = parentPseudoCase?.childPseudoCaseIds?.[0] || parentPseudoCase?.childCaseIds?.[0]
     const rowIndex = (firstChildId ? childTableModel?.getRowIndexOfCase(firstChildId) : -1) ?? -1
     ;(rowIndex >= 0) && childTableModel?.scrollRowIntoView(rowIndex)

--- a/v3/src/components/graph/adornments/adornment.tsx
+++ b/v3/src/components/graph/adornments/adornment.tsx
@@ -3,8 +3,7 @@ import { clsx } from "clsx"
 import { observer } from "mobx-react-lite"
 import { IAdornmentModel } from "./adornment-models"
 import { useGraphContentModelContext } from "../hooks/use-graph-content-model-context"
-import { useGraphLayoutContext } from "../hooks/use-graph-layout-context"
-import { useGraphDataConfigurationContext } from "../hooks/use-graph-data-configuration-context"
+import { useSubplotExtent } from "../hooks/use-subplot-extent"
 import { INumericAxisModel } from "../../axis/models/axis-model"
 import { getAdornmentComponentInfo } from "./adornment-component-info"
 import {transitionDuration} from "../../data-display/data-display-types"
@@ -18,12 +17,7 @@ interface IProps {
 
 export const Adornment = observer(function Adornment({adornment, cellKey}: IProps) {
   const graphModel = useGraphContentModelContext()
-  const layout = useGraphLayoutContext()
-  const dataConfig = useGraphDataConfigurationContext()
-  const numExtraPrimaryBands = dataConfig?.numRepetitionsForPlace("bottom") ?? 1
-  const numExtraSecondaryBands = dataConfig?.numRepetitionsForPlace("left") ?? 1
-  const subPlotWidth = layout.plotWidth / numExtraPrimaryBands
-  const subPlotHeight = layout.plotHeight / numExtraSecondaryBands
+  const { subPlotWidth, subPlotHeight } = useSubplotExtent()
   const classFromCellKey = adornment.classNameFromKey(cellKey)
   // The adornmentKey is a unique value used for React's key prop and for the adornment wrapper's HTML ID.
   // We can't use the cellKey because that value may be duplicated if there are multiple types of

--- a/v3/src/components/graph/adornments/adornment.tsx
+++ b/v3/src/components/graph/adornments/adornment.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react-lite"
 import { IAdornmentModel } from "./adornment-models"
 import { useGraphContentModelContext } from "../hooks/use-graph-content-model-context"
 import { useGraphLayoutContext } from "../hooks/use-graph-layout-context"
+import { useGraphDataConfigurationContext } from "../hooks/use-graph-data-configuration-context"
 import { INumericAxisModel } from "../../axis/models/axis-model"
 import { getAdornmentComponentInfo } from "./adornment-component-info"
 import {transitionDuration} from "../../data-display/data-display-types"
@@ -13,22 +14,16 @@ import "./adornment.scss"
 interface IProps {
   adornment: IAdornmentModel
   cellKey: Record<string, string>
-  topCats: string[] | number[]
-  rightCats: string[] | number[]
 }
 
-export const Adornment = observer(function Adornment(
-  {adornment, cellKey, topCats, rightCats}: IProps
-) {
-  const graphModel = useGraphContentModelContext(),
-    layout = useGraphLayoutContext(),
-    subPlotWidth = topCats.length > 0
-                     ? layout.plotWidth / topCats.length
-                     : layout.plotWidth,
-    subPlotHeight = rightCats.length > 0
-                      ? layout.plotHeight / rightCats.length
-                      : layout.plotHeight
-
+export const Adornment = observer(function Adornment({adornment, cellKey}: IProps) {
+  const graphModel = useGraphContentModelContext()
+  const layout = useGraphLayoutContext()
+  const dataConfig = useGraphDataConfigurationContext()
+  const numExtraPrimaryBands = dataConfig?.numRepetitionsForPlace("bottom") ?? 1
+  const numExtraSecondaryBands = dataConfig?.numRepetitionsForPlace("left") ?? 1
+  const subPlotWidth = layout.plotWidth / numExtraPrimaryBands
+  const subPlotHeight = layout.plotHeight / numExtraSecondaryBands
   const classFromCellKey = adornment.classNameFromKey(cellKey)
   // The adornmentKey is a unique value used for React's key prop and for the adornment wrapper's HTML ID.
   // We can't use the cellKey because that value may be duplicated if there are multiple types of

--- a/v3/src/components/graph/adornments/adornments.tsx
+++ b/v3/src/components/graph/adornments/adornments.tsx
@@ -115,8 +115,6 @@ export const Adornments = observer(function Adornments() {
                           key={`graph-adornment-${adornment.id}-${yIndex}-${xIndex}-${rightIndex}-${topIndex}`}
                           adornment={adornment}
                           cellKey={cellKey}
-                          topCats={topCats}
-                          rightCats={rightCats}
                         />
                 })
               }

--- a/v3/src/components/graph/hooks/use-subplot-extent.ts
+++ b/v3/src/components/graph/hooks/use-subplot-extent.ts
@@ -1,0 +1,12 @@
+import { useGraphDataConfigurationContext } from "./use-graph-data-configuration-context"
+import { useGraphLayoutContext } from "./use-graph-layout-context"
+
+export const useSubplotExtent = () => {
+  const layout = useGraphLayoutContext()
+  const dataConfig = useGraphDataConfigurationContext()
+  const numExtraPrimaryBands = dataConfig?.numRepetitionsForPlace("bottom") ?? 1
+  const numExtraSecondaryBands = dataConfig?.numRepetitionsForPlace("left") ?? 1
+  const subPlotWidth = layout.plotWidth / numExtraPrimaryBands
+  const subPlotHeight = layout.plotHeight / numExtraSecondaryBands
+  return { subPlotWidth, subPlotHeight }
+}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181939990

These changes fix a bug where using the Intercept Locked option with a Movable Line in a top split scatter plot, and then removing the top split attribute, the line no longer passes through the origin. I believe this also fixes [#186580777](https://www.pivotaltracker.com/story/show/186580777) and some other bugginess with the rendering of adornments and labels when top and right splits are removed.