### PR TITLE
Reimplement basic graph features using PixiJS as the points renderer instead of D3 SVG

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-pre.1449",
+      "version": "3.0.0-pre.1455",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -91,6 +91,7 @@
         "jest": "^29.7.0",
         "jest-canvas-mock": "^2.5.2",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-webgl-canvas-mock": "^2.5.3",
         "json5-loader": "^4.0.1",
         "mini-css-extract-plugin": "^2.7.6",
         "npm-run-all": "^4.1.5",
@@ -4659,6 +4660,84 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@nicolo-ribaudo/semver-v6": {
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
@@ -7680,6 +7759,14 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -7924,6 +8011,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -7949,6 +8044,21 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -8924,6 +9034,23 @@
         }
       ]
     },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -9006,6 +9133,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -9182,6 +9320,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/color2k": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.2.tgz",
@@ -9311,6 +9460,14 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -10360,6 +10517,20 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
@@ -10585,6 +10756,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -10602,6 +10781,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -12797,6 +12987,42 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/fs-monkey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
@@ -12856,6 +13082,28 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -13174,6 +13422,14 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/hasha": {
       "version": "5.2.2",
@@ -16310,6 +16566,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-webgl-canvas-mock": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/jest-webgl-canvas-mock/-/jest-webgl-canvas-mock-2.5.3.tgz",
+      "integrity": "sha512-aE5ym/VV8hpJgsu/zzmvJ/bhD4vnfAM9TY6TRQxQAy9lo3hxtNfa2rbLFt3Qx31spQd5fhlQHO58Aey6oFDxAA==",
+      "dev": true,
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
@@ -17251,6 +17517,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -17359,6 +17639,68 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mobx": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.10.2.tgz",
@@ -17426,6 +17768,14 @@
         "multicast-dns": "cli.js"
       }
     },
+    "node_modules/nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/nanoid": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.2.tgz",
@@ -17486,6 +17836,56 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -17518,6 +17918,23 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -17660,6 +18077,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -20239,6 +20670,41 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -20865,6 +21331,33 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tar": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/terser": {
       "version": "5.17.7",
@@ -22555,6 +23048,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/wildcard": {
@@ -26109,6 +26613,68 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
+      }
+    },
     "@nicolo-ribaudo/semver-v6": {
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
@@ -28371,6 +28937,14 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -28546,6 +29120,14 @@
         "default-require-extensions": "^3.0.0"
       }
     },
+    "aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -28557,6 +29139,18 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      }
     },
     "arg": {
       "version": "4.1.3",
@@ -29272,6 +29866,19 @@
       "integrity": "sha512-/Et7DwLqpjS47JPEcz6VnxU9PwcIdVi0ciLXRWBQdj1XFye68pSQYpV0QtPTfUKWuOaEig+/Vez2l74eDc1tPQ==",
       "dev": true
     },
+    "canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      }
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -29333,6 +29940,14 @@
           }
         }
       }
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "chrome-trace-event": {
       "version": "1.0.3",
@@ -29457,6 +30072,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "color2k": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.2.tgz",
@@ -29563,6 +30186,14 @@
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
       "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
       "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -30358,6 +30989,17 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
       "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ=="
     },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
     "dedent": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
@@ -30528,6 +31170,14 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -30539,6 +31189,14 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true
+    },
+    "detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -32178,6 +32836,38 @@
         "universalify": "^2.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
+      }
+    },
     "fs-monkey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
@@ -32219,6 +32909,25 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
+    },
+    "gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -32443,6 +33152,14 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "hasha": {
       "version": "5.2.2",
@@ -34757,6 +35474,16 @@
         }
       }
     },
+    "jest-webgl-canvas-mock": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/jest-webgl-canvas-mock/-/jest-webgl-canvas-mock-2.5.3.tgz",
+      "integrity": "sha512-aE5ym/VV8hpJgsu/zzmvJ/bhD4vnfAM9TY6TRQxQAy9lo3hxtNfa2rbLFt3Qx31spQd5fhlQHO58Aey6oFDxAA==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "jest-worker": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
@@ -35479,6 +36206,14 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -35556,6 +36291,55 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
+    "minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "mobx": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.10.2.tgz",
@@ -35602,6 +36386,14 @@
         "thunky": "^1.0.2"
       }
     },
+    "nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "nanoid": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.2.tgz",
@@ -35647,6 +36439,47 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -35673,6 +36506,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
+    },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -35781,6 +36625,20 @@
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "nth-check": {
@@ -37676,6 +38534,27 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -38154,6 +39033,32 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true
+    },
+    "tar": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
+      }
     },
     "terser": {
       "version": "5.17.7",
@@ -39357,6 +40262,17 @@
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "wildcard": {

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -25,6 +25,7 @@
         "mobx-react-lite": "^4.0.5",
         "nanoid": "^5.0.2",
         "papaparse": "^5.4.1",
+        "pixi.js": "^7.3.2",
         "pluralize": "^8.0.0",
         "query-string": "^8.1.0",
         "react": "^18.2.0",
@@ -4702,6 +4703,351 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pixi/accessibility": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.3.2.tgz",
+      "integrity": "sha512-MdkU22HTauRvq9cMeWZIQGaDDa86sr+m12rKNdLV+FaDQgP/AhP+qCVpK7IKeJa9BrWGXaYMw/vueij7HkyDSA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/events": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/app": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.3.2.tgz",
+      "integrity": "sha512-3YRFSMvAxDebAz3/JJv+2jzbPkT8cHC0IHmmLRN8krDL1pZV+YjMLgMwN/Oeyv5TSbwNqnrF5su5whNkRaxeZQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/assets": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.3.2.tgz",
+      "integrity": "sha512-yteq6ptAxA09EcwU9D9hl7qr5yWIqy+c2PsXkTDkc76vTAwIamLY3KxLq2aR5y1U4L4O6aHFJd26uNhHcuTPmw==",
+      "dependencies": {
+        "@types/css-font-loading-module": "^0.0.7"
+      },
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/utils": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/color": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.3.2.tgz",
+      "integrity": "sha512-jur5PvdOtUBEUTjmPudW5qdQq6yYGlVGsi3HyhasJw14bN+GKJwiCKgIsyrsiNL5HBUXmje4ICwQohf6BqKqxA==",
+      "dependencies": {
+        "@pixi/colord": "^2.9.6"
+      }
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
+    },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.3.2.tgz",
+      "integrity": "sha512-J3ENMHDPQO6CJRei55gqI0WmiZJIK6SgsW5AEkShT0aAe5miEBSomv70pXw/58ru+4/Hx8cXjamsGt4aQB2D0Q==",
+      "peerDependencies": {
+        "@pixi/assets": "7.3.2",
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/constants": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.3.2.tgz",
+      "integrity": "sha512-Q8W3ncsFxmfgC5EtokpG92qJZabd+Dl+pbQAdHwiPY3v+8UNq77u4VN2qtl1Z04864hCcg7AStIYEDrzqTLF6Q=="
+    },
+    "node_modules/@pixi/core": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.2.tgz",
+      "integrity": "sha512-Pta3ee8MtJ3yKxGXzglBWgwbEOKMB6Eth+FpLTjL0rgxiqTB550YX6jsNEQQAzcGjCBlO3rC/IF57UZ2go/X6w==",
+      "dependencies": {
+        "@pixi/color": "7.3.2",
+        "@pixi/constants": "7.3.2",
+        "@pixi/extensions": "7.3.2",
+        "@pixi/math": "7.3.2",
+        "@pixi/runner": "7.3.2",
+        "@pixi/settings": "7.3.2",
+        "@pixi/ticker": "7.3.2",
+        "@pixi/utils": "7.3.2",
+        "@types/offscreencanvas": "^2019.6.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/@pixi/display": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.2.tgz",
+      "integrity": "sha512-cY5AnZ3TWt5GYGx4e5AQ2/2U9kP+RorBg/O30amJ+8e9bFk9rS8cjh/DDq/hc4lql96BkXAInTl40eHnAML5lQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/events": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.3.2.tgz",
+      "integrity": "sha512-Moca9epu8jk1wIQCdVYjhz2pD9Ol21m50wvWUKvpgt9yM/AjkCLSDt8HO/PmTpavDrkhx5pVVWeDDA6FyUNaGA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/extensions": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.3.2.tgz",
+      "integrity": "sha512-Qw84ADfvmVu4Mwj+zTik/IEEK9lWS5n4trbrpQCcEZ+Mb8oRAXWvKz199mi1s7+LaZXDqeCY1yr2PHQaFf1KBA=="
+    },
+    "node_modules/@pixi/extract": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.3.2.tgz",
+      "integrity": "sha512-KsoflvQZV/XD8A8xbtRnmI4reYekbI4MOi7ilwQe5tMz6O1mO7IzrSukxkSMD02f6SpbAqbi7a1EayTjvY0ECQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-alpha": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.3.2.tgz",
+      "integrity": "sha512-nZMdn310wH5ZK1slwv3X4qT8eLoAGO7SgYGCy5IsMtpCtNObzE9XA4tAfhXrjihyzPS9KvszgAbnv1Qpfh0/uw==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-blur": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.3.2.tgz",
+      "integrity": "sha512-unu3zhwHMhN+iAe7Td2rK40i2UJ2GOhzWK+6jcU3ZkMOsFCT5kgBoMRTejeQVcvCs6GoYK8imbkE7mXt05Vj6A==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-color-matrix": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.3.2.tgz",
+      "integrity": "sha512-rbyjes/9SMoV9jjPiK0sLMkmLfN8D17GoTJIfq/KLv1x9646W5fL2QSKkN04UkZ+020ndWvIOxK1S97tvRyCfg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-displacement": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.3.2.tgz",
+      "integrity": "sha512-ZHl7Sfb8JYd9Z6j96OHCC0NhMKhhXJRE5AbkSDohjEMVCK1BV5rDGAHV8WVt/2MJ/j83CXUpydzyMhdM4lMchg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-fxaa": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.3.2.tgz",
+      "integrity": "sha512-9brtlxDnQTZk2XiFBKdBK9e+8CX9LdxxcL7LRpjEyiHuAPvTlQgu9B85LrJ4GzWKqJJKaIIZBzhIoiCLUnfeXg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-noise": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.3.2.tgz",
+      "integrity": "sha512-F8GQQ20n7tCjThX6GCXckiXz2YffOCxicTJ0oat9aVDZh+sVsAxYX0aKSdHh0hhv18F0yuc6tPsSL5DYb63xFg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/graphics": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.2.tgz",
+      "integrity": "sha512-PhU6j1yub4tH/s+/gqByzgZ3mLv1mfb6iGXbquycg3+WypcxHZn0opFtI/axsazaQ9SEaWxw1m3i40WG5ANH5g==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/math": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.2.tgz",
+      "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w=="
+    },
+    "node_modules/@pixi/mesh": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.2.tgz",
+      "integrity": "sha512-LFkt7ELYXQLgbgHpjl68j6JD5ejUwma8zoPn2gqSBbY+6pK/phjvV1Wkh76muF46VvNulgXF0+qLIDdCsfrDaA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/mesh-extras": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.3.2.tgz",
+      "integrity": "sha512-s/tg9TsTZZxLEdCDKWnBChDGkc041HCTP7ykJv4fEROzb9B0lskULYyvv+/YNNKa2Ugb9WnkMknpOdOXCpjyyg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/mesh": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.3.2.tgz",
+      "integrity": "sha512-bZRlyUN5+9kCUjn67V0IFtYIrbmx9Vs4sMOmXyrX3Q4B4gPLE46IzZz3v0IVaTjp32udlQztfJalIaWbuqgb3A==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.3.2.tgz",
+      "integrity": "sha512-mbUi3WxXrkViH7qOgjk4fu2BN36NwNb7u+Fy1J5dS8Bntj57ZVKmEV9PbUy0zYjXE8rVmeAvSu/2kbn5n9UutQ==",
+      "peerDependencies": {
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/mixin-get-global-position": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.3.2.tgz",
+      "integrity": "sha512-1nhWbBgmw6rK7yQJxzeI9yjKYYEkM5i3pee8qVu4YWo3b1xWVQA7osQG7aGM/4qywDkXaA1ZvciA5hfg6f4Q5Q==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/particle-container": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.3.2.tgz",
+      "integrity": "sha512-JYc4j4z97KmxyLp+1Lg0SNi8hy6RxcBBNQGk+CSLNXeDWxx3hykT5gj/ORX1eXyzHh1ZCG1XzeVS9Yr8QhlFHA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/prepare": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.3.2.tgz",
+      "integrity": "sha512-aLPAXSYLUhMwxzJtn9m0TSZe+dQlZCt09QNBqYbSi8LZId54QMDyvfBb4zBOJZrD2xAZgYL5RIJuKHwZtFX6lQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/graphics": "7.3.2",
+        "@pixi/text": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/runner": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.3.2.tgz",
+      "integrity": "sha512-maKotoKJCQiQGBJwfM+iYdQKjrPN/Tn9+72F4WIf706zp/5vKoxW688Rsktg5BX4Mcn7ZkZvcJYTxj2Mv87lFA=="
+    },
+    "node_modules/@pixi/settings": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.3.2.tgz",
+      "integrity": "sha512-vtxzuARDTbFe0fRYSqB53B+mPpX7v+QjjnCUmVMVvZiWr3QcngMWVml6c6dQDln7IakWoKZRrNG4FpggvDgLVg==",
+      "dependencies": {
+        "@pixi/constants": "7.3.2",
+        "@types/css-font-loading-module": "^0.0.7",
+        "ismobilejs": "^1.1.0"
+      }
+    },
+    "node_modules/@pixi/sprite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.2.tgz",
+      "integrity": "sha512-IpWTKXExJNXVcY7ITopJ+JW48DahdbCo/81D2IYzBImq3jyiJM2Km5EoJgvAM5ZQ3Ev3KPPIBzYLD+HoPWcxdw==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/sprite-animated": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.3.2.tgz",
+      "integrity": "sha512-j9pyUe4cefxE9wecNfbWQyL5fBQKvCGYaOA0DE1X46ukBHrIuhA8u3jg2X3N3r4IcbVvxpWFYDrDsWXWeiBmSw==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/sprite-tiling": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.3.2.tgz",
+      "integrity": "sha512-tWVVb/rMIx5AczfUrVxa0dZaIufP5C0IOL7IGfFUDQqDu5JSAUC0mwLe4F12jAXBVsqYhCGYx5bIHbPiI5vcSQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/spritesheet": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.3.2.tgz",
+      "integrity": "sha512-UkwqrPYDqrEdK5ub9qn/9VBvt5caA8ffV5iYR6ssCvrpaQovBKmS+b5pr/BYf8xNTExDpR3OmPIo8iDEYWWLuw==",
+      "peerDependencies": {
+        "@pixi/assets": "7.3.2",
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/text": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.3.2.tgz",
+      "integrity": "sha512-LdtNj+K5tPB/0UcDcO52M/C7xhwFTGFhtdF42fPhRuJawM23M3zm1Y8PapXv+mury+IxCHT1w30YlAi0qTVpKQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/text-bitmap": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.3.2.tgz",
+      "integrity": "sha512-p8KLgtZSPowWU/Zj+GVtfsUT8uGYo4TtKKYbLoWuxkRA5Pc1+4C9/rV/EOSFfoZIdW5C+iFg5VxRgBllUQf+aA==",
+      "peerDependencies": {
+        "@pixi/assets": "7.3.2",
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/mesh": "7.3.2",
+        "@pixi/text": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/text-html": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.3.2.tgz",
+      "integrity": "sha512-IYhBWEPOvqUtlHkS5/c1Hseuricj5jrrGd21ivcvHmcnK/x2m+CRGvvzeBp1mqoYBnDbQVrD2wSXSe4Dv9tEJA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2",
+        "@pixi/text": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/ticker": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.3.2.tgz",
+      "integrity": "sha512-5kIPhBeXwDJohCzKzJJ6T7f1oAGbHAgeiwOjlTO+9lNXUX8ZPj0407V3syuF+64kFqJzIBCznBRpI+fmT4c9SA==",
+      "dependencies": {
+        "@pixi/extensions": "7.3.2",
+        "@pixi/settings": "7.3.2",
+        "@pixi/utils": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/utils": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.2.tgz",
+      "integrity": "sha512-KhNvj9YcY7Zi2dTKZgDpx8C6OxKKR541vwtG6JgdBZZYDeMBOIghN2Vi5zn4diW5BhDfHBmdSJ1wZXEtE2MDwg==",
+      "dependencies": {
+        "@pixi/color": "7.3.2",
+        "@pixi/constants": "7.3.2",
+        "@pixi/settings": "7.3.2",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
+        "url": "^0.11.0"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -5700,6 +6046,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="
+    },
     "node_modules/@types/d3": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.2.tgz",
@@ -5953,6 +6304,11 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/earcut": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ=="
+    },
     "node_modules/@types/eslint": {
       "version": "8.37.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
@@ -6192,6 +6548,11 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
     },
     "node_modules/@types/papaparse": {
       "version": "5.3.10",
@@ -8505,7 +8866,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -10425,6 +10785,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -11532,8 +11897,7 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -12516,7 +12880,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
       "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -12739,7 +13102,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -12780,7 +13142,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12792,7 +13153,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -13875,6 +14235,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -17564,7 +17929,6 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -18243,6 +18607,47 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.3.2.tgz",
+      "integrity": "sha512-GJickUrT3UcBInGT1CU6cv2oktCdocE5QM74CD3t+weiJPPWIzleNlp7zrBR5QIDdU6bEO8CUgUXH2Y9QvlCMw==",
+      "dependencies": {
+        "@pixi/accessibility": "7.3.2",
+        "@pixi/app": "7.3.2",
+        "@pixi/assets": "7.3.2",
+        "@pixi/compressed-textures": "7.3.2",
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/events": "7.3.2",
+        "@pixi/extensions": "7.3.2",
+        "@pixi/extract": "7.3.2",
+        "@pixi/filter-alpha": "7.3.2",
+        "@pixi/filter-blur": "7.3.2",
+        "@pixi/filter-color-matrix": "7.3.2",
+        "@pixi/filter-displacement": "7.3.2",
+        "@pixi/filter-fxaa": "7.3.2",
+        "@pixi/filter-noise": "7.3.2",
+        "@pixi/graphics": "7.3.2",
+        "@pixi/mesh": "7.3.2",
+        "@pixi/mesh-extras": "7.3.2",
+        "@pixi/mixin-cache-as-bitmap": "7.3.2",
+        "@pixi/mixin-get-child-by-name": "7.3.2",
+        "@pixi/mixin-get-global-position": "7.3.2",
+        "@pixi/particle-container": "7.3.2",
+        "@pixi/prepare": "7.3.2",
+        "@pixi/sprite": "7.3.2",
+        "@pixi/sprite-animated": "7.3.2",
+        "@pixi/sprite-tiling": "7.3.2",
+        "@pixi/spritesheet": "7.3.2",
+        "@pixi/text": "7.3.2",
+        "@pixi/text-bitmap": "7.3.2",
+        "@pixi/text-html": "7.3.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
       }
     },
     "node_modules/pkg-dir": {
@@ -19819,7 +20224,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -21352,6 +21756,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.11.2"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -21360,6 +21773,25 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+    },
+    "node_modules/url/node_modules/qs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/use-callback-ref": {
@@ -25709,6 +26141,259 @@
         "fastq": "^1.6.0"
       }
     },
+    "@pixi/accessibility": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.3.2.tgz",
+      "integrity": "sha512-MdkU22HTauRvq9cMeWZIQGaDDa86sr+m12rKNdLV+FaDQgP/AhP+qCVpK7IKeJa9BrWGXaYMw/vueij7HkyDSA==",
+      "requires": {}
+    },
+    "@pixi/app": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.3.2.tgz",
+      "integrity": "sha512-3YRFSMvAxDebAz3/JJv+2jzbPkT8cHC0IHmmLRN8krDL1pZV+YjMLgMwN/Oeyv5TSbwNqnrF5su5whNkRaxeZQ==",
+      "requires": {}
+    },
+    "@pixi/assets": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.3.2.tgz",
+      "integrity": "sha512-yteq6ptAxA09EcwU9D9hl7qr5yWIqy+c2PsXkTDkc76vTAwIamLY3KxLq2aR5y1U4L4O6aHFJd26uNhHcuTPmw==",
+      "requires": {
+        "@types/css-font-loading-module": "^0.0.7"
+      }
+    },
+    "@pixi/color": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.3.2.tgz",
+      "integrity": "sha512-jur5PvdOtUBEUTjmPudW5qdQq6yYGlVGsi3HyhasJw14bN+GKJwiCKgIsyrsiNL5HBUXmje4ICwQohf6BqKqxA==",
+      "requires": {
+        "@pixi/colord": "^2.9.6"
+      }
+    },
+    "@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
+    },
+    "@pixi/compressed-textures": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.3.2.tgz",
+      "integrity": "sha512-J3ENMHDPQO6CJRei55gqI0WmiZJIK6SgsW5AEkShT0aAe5miEBSomv70pXw/58ru+4/Hx8cXjamsGt4aQB2D0Q==",
+      "requires": {}
+    },
+    "@pixi/constants": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.3.2.tgz",
+      "integrity": "sha512-Q8W3ncsFxmfgC5EtokpG92qJZabd+Dl+pbQAdHwiPY3v+8UNq77u4VN2qtl1Z04864hCcg7AStIYEDrzqTLF6Q=="
+    },
+    "@pixi/core": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.2.tgz",
+      "integrity": "sha512-Pta3ee8MtJ3yKxGXzglBWgwbEOKMB6Eth+FpLTjL0rgxiqTB550YX6jsNEQQAzcGjCBlO3rC/IF57UZ2go/X6w==",
+      "requires": {
+        "@pixi/color": "7.3.2",
+        "@pixi/constants": "7.3.2",
+        "@pixi/extensions": "7.3.2",
+        "@pixi/math": "7.3.2",
+        "@pixi/runner": "7.3.2",
+        "@pixi/settings": "7.3.2",
+        "@pixi/ticker": "7.3.2",
+        "@pixi/utils": "7.3.2",
+        "@types/offscreencanvas": "^2019.6.4"
+      }
+    },
+    "@pixi/display": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.2.tgz",
+      "integrity": "sha512-cY5AnZ3TWt5GYGx4e5AQ2/2U9kP+RorBg/O30amJ+8e9bFk9rS8cjh/DDq/hc4lql96BkXAInTl40eHnAML5lQ==",
+      "requires": {}
+    },
+    "@pixi/events": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.3.2.tgz",
+      "integrity": "sha512-Moca9epu8jk1wIQCdVYjhz2pD9Ol21m50wvWUKvpgt9yM/AjkCLSDt8HO/PmTpavDrkhx5pVVWeDDA6FyUNaGA==",
+      "requires": {}
+    },
+    "@pixi/extensions": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.3.2.tgz",
+      "integrity": "sha512-Qw84ADfvmVu4Mwj+zTik/IEEK9lWS5n4trbrpQCcEZ+Mb8oRAXWvKz199mi1s7+LaZXDqeCY1yr2PHQaFf1KBA=="
+    },
+    "@pixi/extract": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.3.2.tgz",
+      "integrity": "sha512-KsoflvQZV/XD8A8xbtRnmI4reYekbI4MOi7ilwQe5tMz6O1mO7IzrSukxkSMD02f6SpbAqbi7a1EayTjvY0ECQ==",
+      "requires": {}
+    },
+    "@pixi/filter-alpha": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.3.2.tgz",
+      "integrity": "sha512-nZMdn310wH5ZK1slwv3X4qT8eLoAGO7SgYGCy5IsMtpCtNObzE9XA4tAfhXrjihyzPS9KvszgAbnv1Qpfh0/uw==",
+      "requires": {}
+    },
+    "@pixi/filter-blur": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.3.2.tgz",
+      "integrity": "sha512-unu3zhwHMhN+iAe7Td2rK40i2UJ2GOhzWK+6jcU3ZkMOsFCT5kgBoMRTejeQVcvCs6GoYK8imbkE7mXt05Vj6A==",
+      "requires": {}
+    },
+    "@pixi/filter-color-matrix": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.3.2.tgz",
+      "integrity": "sha512-rbyjes/9SMoV9jjPiK0sLMkmLfN8D17GoTJIfq/KLv1x9646W5fL2QSKkN04UkZ+020ndWvIOxK1S97tvRyCfg==",
+      "requires": {}
+    },
+    "@pixi/filter-displacement": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.3.2.tgz",
+      "integrity": "sha512-ZHl7Sfb8JYd9Z6j96OHCC0NhMKhhXJRE5AbkSDohjEMVCK1BV5rDGAHV8WVt/2MJ/j83CXUpydzyMhdM4lMchg==",
+      "requires": {}
+    },
+    "@pixi/filter-fxaa": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.3.2.tgz",
+      "integrity": "sha512-9brtlxDnQTZk2XiFBKdBK9e+8CX9LdxxcL7LRpjEyiHuAPvTlQgu9B85LrJ4GzWKqJJKaIIZBzhIoiCLUnfeXg==",
+      "requires": {}
+    },
+    "@pixi/filter-noise": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.3.2.tgz",
+      "integrity": "sha512-F8GQQ20n7tCjThX6GCXckiXz2YffOCxicTJ0oat9aVDZh+sVsAxYX0aKSdHh0hhv18F0yuc6tPsSL5DYb63xFg==",
+      "requires": {}
+    },
+    "@pixi/graphics": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.2.tgz",
+      "integrity": "sha512-PhU6j1yub4tH/s+/gqByzgZ3mLv1mfb6iGXbquycg3+WypcxHZn0opFtI/axsazaQ9SEaWxw1m3i40WG5ANH5g==",
+      "requires": {}
+    },
+    "@pixi/math": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.2.tgz",
+      "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w=="
+    },
+    "@pixi/mesh": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.2.tgz",
+      "integrity": "sha512-LFkt7ELYXQLgbgHpjl68j6JD5ejUwma8zoPn2gqSBbY+6pK/phjvV1Wkh76muF46VvNulgXF0+qLIDdCsfrDaA==",
+      "requires": {}
+    },
+    "@pixi/mesh-extras": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.3.2.tgz",
+      "integrity": "sha512-s/tg9TsTZZxLEdCDKWnBChDGkc041HCTP7ykJv4fEROzb9B0lskULYyvv+/YNNKa2Ugb9WnkMknpOdOXCpjyyg==",
+      "requires": {}
+    },
+    "@pixi/mixin-cache-as-bitmap": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.3.2.tgz",
+      "integrity": "sha512-bZRlyUN5+9kCUjn67V0IFtYIrbmx9Vs4sMOmXyrX3Q4B4gPLE46IzZz3v0IVaTjp32udlQztfJalIaWbuqgb3A==",
+      "requires": {}
+    },
+    "@pixi/mixin-get-child-by-name": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.3.2.tgz",
+      "integrity": "sha512-mbUi3WxXrkViH7qOgjk4fu2BN36NwNb7u+Fy1J5dS8Bntj57ZVKmEV9PbUy0zYjXE8rVmeAvSu/2kbn5n9UutQ==",
+      "requires": {}
+    },
+    "@pixi/mixin-get-global-position": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.3.2.tgz",
+      "integrity": "sha512-1nhWbBgmw6rK7yQJxzeI9yjKYYEkM5i3pee8qVu4YWo3b1xWVQA7osQG7aGM/4qywDkXaA1ZvciA5hfg6f4Q5Q==",
+      "requires": {}
+    },
+    "@pixi/particle-container": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.3.2.tgz",
+      "integrity": "sha512-JYc4j4z97KmxyLp+1Lg0SNi8hy6RxcBBNQGk+CSLNXeDWxx3hykT5gj/ORX1eXyzHh1ZCG1XzeVS9Yr8QhlFHA==",
+      "requires": {}
+    },
+    "@pixi/prepare": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.3.2.tgz",
+      "integrity": "sha512-aLPAXSYLUhMwxzJtn9m0TSZe+dQlZCt09QNBqYbSi8LZId54QMDyvfBb4zBOJZrD2xAZgYL5RIJuKHwZtFX6lQ==",
+      "requires": {}
+    },
+    "@pixi/runner": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.3.2.tgz",
+      "integrity": "sha512-maKotoKJCQiQGBJwfM+iYdQKjrPN/Tn9+72F4WIf706zp/5vKoxW688Rsktg5BX4Mcn7ZkZvcJYTxj2Mv87lFA=="
+    },
+    "@pixi/settings": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.3.2.tgz",
+      "integrity": "sha512-vtxzuARDTbFe0fRYSqB53B+mPpX7v+QjjnCUmVMVvZiWr3QcngMWVml6c6dQDln7IakWoKZRrNG4FpggvDgLVg==",
+      "requires": {
+        "@pixi/constants": "7.3.2",
+        "@types/css-font-loading-module": "^0.0.7",
+        "ismobilejs": "^1.1.0"
+      }
+    },
+    "@pixi/sprite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.2.tgz",
+      "integrity": "sha512-IpWTKXExJNXVcY7ITopJ+JW48DahdbCo/81D2IYzBImq3jyiJM2Km5EoJgvAM5ZQ3Ev3KPPIBzYLD+HoPWcxdw==",
+      "requires": {}
+    },
+    "@pixi/sprite-animated": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.3.2.tgz",
+      "integrity": "sha512-j9pyUe4cefxE9wecNfbWQyL5fBQKvCGYaOA0DE1X46ukBHrIuhA8u3jg2X3N3r4IcbVvxpWFYDrDsWXWeiBmSw==",
+      "requires": {}
+    },
+    "@pixi/sprite-tiling": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.3.2.tgz",
+      "integrity": "sha512-tWVVb/rMIx5AczfUrVxa0dZaIufP5C0IOL7IGfFUDQqDu5JSAUC0mwLe4F12jAXBVsqYhCGYx5bIHbPiI5vcSQ==",
+      "requires": {}
+    },
+    "@pixi/spritesheet": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.3.2.tgz",
+      "integrity": "sha512-UkwqrPYDqrEdK5ub9qn/9VBvt5caA8ffV5iYR6ssCvrpaQovBKmS+b5pr/BYf8xNTExDpR3OmPIo8iDEYWWLuw==",
+      "requires": {}
+    },
+    "@pixi/text": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.3.2.tgz",
+      "integrity": "sha512-LdtNj+K5tPB/0UcDcO52M/C7xhwFTGFhtdF42fPhRuJawM23M3zm1Y8PapXv+mury+IxCHT1w30YlAi0qTVpKQ==",
+      "requires": {}
+    },
+    "@pixi/text-bitmap": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.3.2.tgz",
+      "integrity": "sha512-p8KLgtZSPowWU/Zj+GVtfsUT8uGYo4TtKKYbLoWuxkRA5Pc1+4C9/rV/EOSFfoZIdW5C+iFg5VxRgBllUQf+aA==",
+      "requires": {}
+    },
+    "@pixi/text-html": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.3.2.tgz",
+      "integrity": "sha512-IYhBWEPOvqUtlHkS5/c1Hseuricj5jrrGd21ivcvHmcnK/x2m+CRGvvzeBp1mqoYBnDbQVrD2wSXSe4Dv9tEJA==",
+      "requires": {}
+    },
+    "@pixi/ticker": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.3.2.tgz",
+      "integrity": "sha512-5kIPhBeXwDJohCzKzJJ6T7f1oAGbHAgeiwOjlTO+9lNXUX8ZPj0407V3syuF+64kFqJzIBCznBRpI+fmT4c9SA==",
+      "requires": {
+        "@pixi/extensions": "7.3.2",
+        "@pixi/settings": "7.3.2",
+        "@pixi/utils": "7.3.2"
+      }
+    },
+    "@pixi/utils": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.2.tgz",
+      "integrity": "sha512-KhNvj9YcY7Zi2dTKZgDpx8C6OxKKR541vwtG6JgdBZZYDeMBOIghN2Vi5zn4diW5BhDfHBmdSJ1wZXEtE2MDwg==",
+      "requires": {
+        "@pixi/color": "7.3.2",
+        "@pixi/constants": "7.3.2",
+        "@pixi/settings": "7.3.2",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
+        "url": "^0.11.0"
+      }
+    },
     "@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -26352,6 +27037,11 @@
         "@types/node": "*"
       }
     },
+    "@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="
+    },
     "@types/d3": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.2.tgz",
@@ -26605,6 +27295,11 @@
         "@types/d3-selection": "*"
       }
     },
+    "@types/earcut": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ=="
+    },
     "@types/eslint": {
       "version": "8.37.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
@@ -26837,6 +27532,11 @@
       "requires": {
         "undici-types": "~5.26.4"
       }
+    },
+    "@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
     },
     "@types/papaparse": {
       "version": "5.3.10",
@@ -28540,7 +29240,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -29982,6 +30681,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -30804,8 +31508,7 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.3.0",
@@ -31533,7 +32236,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
       "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -31699,7 +32401,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -31727,14 +32428,12 @@
     "has-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
     },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -32498,6 +33197,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
     },
     "isobject": {
       "version": "3.0.1",
@@ -35287,8 +35991,7 @@
     "object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-      "dev": true
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -35786,6 +36489,43 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "dev": true
+    },
+    "pixi.js": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.3.2.tgz",
+      "integrity": "sha512-GJickUrT3UcBInGT1CU6cv2oktCdocE5QM74CD3t+weiJPPWIzleNlp7zrBR5QIDdU6bEO8CUgUXH2Y9QvlCMw==",
+      "requires": {
+        "@pixi/accessibility": "7.3.2",
+        "@pixi/app": "7.3.2",
+        "@pixi/assets": "7.3.2",
+        "@pixi/compressed-textures": "7.3.2",
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/events": "7.3.2",
+        "@pixi/extensions": "7.3.2",
+        "@pixi/extract": "7.3.2",
+        "@pixi/filter-alpha": "7.3.2",
+        "@pixi/filter-blur": "7.3.2",
+        "@pixi/filter-color-matrix": "7.3.2",
+        "@pixi/filter-displacement": "7.3.2",
+        "@pixi/filter-fxaa": "7.3.2",
+        "@pixi/filter-noise": "7.3.2",
+        "@pixi/graphics": "7.3.2",
+        "@pixi/mesh": "7.3.2",
+        "@pixi/mesh-extras": "7.3.2",
+        "@pixi/mixin-cache-as-bitmap": "7.3.2",
+        "@pixi/mixin-get-child-by-name": "7.3.2",
+        "@pixi/mixin-get-global-position": "7.3.2",
+        "@pixi/particle-container": "7.3.2",
+        "@pixi/prepare": "7.3.2",
+        "@pixi/sprite": "7.3.2",
+        "@pixi/sprite-animated": "7.3.2",
+        "@pixi/sprite-tiling": "7.3.2",
+        "@pixi/spritesheet": "7.3.2",
+        "@pixi/text": "7.3.2",
+        "@pixi/text-bitmap": "7.3.2",
+        "@pixi/text-html": "7.3.2"
+      }
     },
     "pkg-dir": {
       "version": "4.2.0",
@@ -36924,7 +37664,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -38036,6 +38775,30 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "requires": {
+        "punycode": "^1.4.1",
+        "qs": "^6.11.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+        },
+        "qs": {
+          "version": "6.11.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+          "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        }
       }
     },
     "url-parse": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -145,6 +145,7 @@
     "jest": "^29.7.0",
     "jest-canvas-mock": "^2.5.2",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-webgl-canvas-mock": "^2.5.3",
     "json5-loader": "^4.0.1",
     "mini-css-extract-plugin": "^2.7.6",
     "npm-run-all": "^4.1.5",

--- a/v3/package.json
+++ b/v3/package.json
@@ -181,6 +181,7 @@
     "mobx-react-lite": "^4.0.5",
     "nanoid": "^5.0.2",
     "papaparse": "^5.4.1",
+    "pixi.js": "^7.3.2",
     "pluralize": "^8.0.0",
     "query-string": "^8.1.0",
     "react": "^18.2.0",

--- a/v3/src/components/data-display/data-display-types.ts
+++ b/v3/src/components/data-display/data-display-types.ts
@@ -2,8 +2,10 @@ import React from "react"
 import {DotsElt} from "./d3-types"
 import {AxisPlace} from "../axis/axis-types"
 import {GraphPlace} from "../axis-graph-shared"
+import {PixiPoints} from "../graph/utilities/pixi-points"
 
 export type IDotsRef = React.MutableRefObject<DotsElt>
+export type IPixiPointsRef = React.MutableRefObject<PixiPoints | undefined>
 
 export type Point = { x: number, y: number }
 export type CPLine = { slope: number, intercept: number, pivot1?: Point, pivot2?: Point }

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -1,14 +1,19 @@
-import {format, select} from "d3"
+import {format} from "d3"
 import {measureText} from "../../hooks/use-measure-text"
 import {between} from "../../utilities/math-utils"
-import {defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeOpacity, defaultSelectedStrokeWidth,
-  defaultStrokeOpacity, defaultStrokeWidth} from "../../utilities/color-utils"
+import {
+  defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeOpacity, defaultSelectedStrokeWidth,
+  defaultStrokeOpacity, defaultStrokeWidth
+} from "../../utilities/color-utils"
 import {IDataSet} from "../../models/data/data-set"
-import {IDataConfigurationModel} from "./models/data-configuration-model"
-import {CaseData, DotsElt, selectCircles, selectDots} from "./d3-types"
-import {hoverRadiusFactor, kDataDisplayFont, Point, pointRadiusLogBase, pointRadiusMax, pointRadiusMin,
-  pointRadiusSelectionAddend, Rect, rTreeRect} from "./data-display-types"
+import {IDataConfigurationModel } from "./models/data-configuration-model"
+import {DotsElt} from "./d3-types"
+import {
+  hoverRadiusFactor, kDataDisplayFont, Point, pointRadiusLogBase, pointRadiusMax, pointRadiusMin,
+  pointRadiusSelectionAddend, Rect, rTreeRect
+} from "./data-display-types"
 import {ISetPointSelection} from "../graph/utilities/graph-utils"
+import {IPixiPointStyle, PixiPoints} from "../graph/utilities/pixi-points"
 
 export const maxWidthOfStringsD3 = (strings: Iterable<string>) => {
   let maxWidth = 0
@@ -24,8 +29,8 @@ export function ptInRect(pt: Point, iRect: Rect) {
   return between(pt.x, iRect.x, tRight) && (pt.y !== undefined ? between(pt.y, iRect.y, tBottom) : false)
 }
 
-export const computePointRadius = (numPoints:number, pointSizeMultiplier: number,
-                                   use: 'normal' | 'hover-drag' | 'select' = 'normal') => {
+export const computePointRadius = (numPoints: number, pointSizeMultiplier: number,
+  use: 'normal' | 'hover-drag' | 'select' = 'normal') => {
   let r = pointRadiusMax
   // for loop is fast equivalent to radius = max( minSize, maxSize - floor( log( logBase, max( dataLength, 1 )))
   for (let i = pointRadiusLogBase; i <= numPoints; i = i * pointRadiusLogBase) {
@@ -79,77 +84,115 @@ export interface IMatchCirclesProps {
   pointStrokeColor: string
   startAnimation: () => void
   instanceId: string | undefined
+  pixiPoints?: PixiPoints
 }
 
 export function matchCirclesToData(props: IMatchCirclesProps) {
-  const {dataConfiguration, startAnimation, instanceId,
-      dotsElement, pointRadius, pointColor, pointStrokeColor} = props,
-    id = dataConfiguration.id,
-    allCaseData = dataConfiguration.joinedCaseDataArrays,
-    caseDataKeyFunc = (d: CaseData) => `${d.plotNum}-${d.caseID}`,
-    circles = selectCircles(dotsElement, id)
-  if (!circles) return
-  startAnimation()
-  circles
-    .data(allCaseData, caseDataKeyFunc)
-    .join(
-      (enter) =>
-        enter.append('circle')
-          .attr('class', `graph-dot ${id}`)
-          .property('id', (d: CaseData) => `${instanceId}_${d.caseID}`),
-      (update) =>
-        update.attr('r', pointRadius)
-          .style('fill', pointColor)
-          .style('stroke', pointStrokeColor)
-          .style('stroke-width', defaultStrokeWidth)
-    )
-  dotsElement && select(dotsElement).on('click',
-    (event: MouseEvent) => {
-      const target = select(event.target as SVGSVGElement)
-      if (target.node()?.nodeName === 'circle') {
-        handleClickOnCase(event, (target.datum() as CaseData).caseID, dataConfiguration.dataset)
-        event.stopPropagation()
-      }
-    })
+  const { dataConfiguration, pixiPoints,
+    pointRadius, pointColor, pointStrokeColor } = props
+  const allCaseData = dataConfiguration.joinedCaseDataArrays
+  // TODO PIXI: remove old SVG code
+  //   caseDataKeyFunc = (d: CaseData) => `${d.plotNum}-${d.caseID}`,
+  //   circles = selectCircles(dotsElement, id)
+  // if (!circles) return
+  // startAnimation()
+  // circles
+  //   .data(allCaseData, caseDataKeyFunc)
+  //   .join(
+  //     (enter) =>
+  //       enter.append('circle')
+  //         .attr('class', `graph-dot ${id}`)
+  //         .property('id', (d: CaseData) => `${instanceId}_${d.caseID}`),
+  //     (update) =>
+  //       update.attr('r', pointRadius)
+  //         .style('fill', pointColor)
+  //         .style('stroke', pointStrokeColor)
+  //         .style('stroke-width', defaultStrokeWidth)
+  //   )
+  // dotsElement && select(dotsElement).on('click',
+  //   (event: MouseEvent) => {
+  //     const target = select(event.target as SVGSVGElement)
+  //     if (target.node()?.nodeName === 'circle') {
+  //       handleClickOnCase(event, (target.datum() as CaseData).caseID, dataConfiguration.dataset)
+  //       event.stopPropagation()
+  //     }
+  //   })
+
+  // TODO PIXI: add animation
+  // TODO PIXI: props.startAnimation() -> what does this do?
+  // TODO PIXI: add interactivity from the code above
+  pixiPoints?.matchPointsToData(allCaseData, {
+    radius: pointRadius,
+    fill: pointColor,
+    stroke: pointStrokeColor,
+    strokeWidth: defaultStrokeWidth
+  })
+
   dataConfiguration.setPointsNeedUpdating(false)
 }
 
 export function setPointSelection(props: ISetPointSelection) {
-  const
-    {dotsRef, dataConfiguration, pointRadius, selectedPointRadius,
-      pointColor, pointStrokeColor, getPointColorAtIndex} = props,
-    dataset = dataConfiguration.dataset,
-    dots = selectCircles(dotsRef.current, dataConfiguration.id),
-    legendID = dataConfiguration.attributeID('legend')
+  const { pixiPointsRef, dataConfiguration, pointRadius, selectedPointRadius,
+    pointColor, pointStrokeColor, getPointColorAtIndex } = props
+  const dataset = dataConfiguration.dataset
+  const legendID = dataConfiguration.attributeID('legend')
 
-  if (!(dotsRef.current && dots)) return
-
+  // TODO PIXI: remove SVG code
   // First set the class based on selection
-  dots
-    .classed('graph-dot-highlighted', (aCaseData: CaseData) => !!dataset?.isCaseSelected(aCaseData.caseID))
-    // Then set properties to defaults w/o selection
-    .attr('r', pointRadius)
-    .style('stroke', pointStrokeColor)
-    .style('fill', (aCaseData:CaseData) => {
-      return legendID
-        ? dataConfiguration?.getLegendColorForCase(aCaseData.caseID)
-        : aCaseData.plotNum && getPointColorAtIndex
-          ? getPointColorAtIndex(aCaseData.plotNum) : pointColor
-    })
-    .style('stroke-width', defaultStrokeWidth)
-    .style('stroke-opacity', defaultStrokeOpacity)
+  // dots
+  //   .classed('graph-dot-highlighted', (aCaseData: CaseData) => !!dataset?.isCaseSelected(aCaseData.caseID))
+  //   // Then set properties to defaults w/o selection
+  //   .attr('r', pointRadius)
+  //   .style('stroke', pointStrokeColor)
+  //   .style('fill', (aCaseData: CaseData) => {
+  //     return legendID
+  //       ? dataConfiguration?.getLegendColorForCase(aCaseData.caseID)
+  //       : aCaseData.plotNum && getPointColorAtIndex
+  //         ? getPointColorAtIndex(aCaseData.plotNum) : pointColor
+  //   })
+  //   .style('stroke-width', defaultStrokeWidth)
+  //   .style('stroke-opacity', defaultStrokeOpacity)
 
-  const selectedDots = selectDots(dotsRef.current, true)
-  // How we deal with this depends on whether there is a legend or not
-  if (legendID) {
-    selectedDots?.style('stroke', defaultSelectedStroke)
-      .style('stroke-width', defaultSelectedStrokeWidth)
-      .style('stroke-opacity', defaultSelectedStrokeOpacity)
-  } else {
-    selectedDots?.style('fill', defaultSelectedColor)
+  // const selectedDots = selectDots(dotsRef.current, true)
+  // // How we deal with this depends on whether there is a legend or not
+  // if (legendID) {
+  //   selectedDots?.style('stroke', defaultSelectedStroke)
+  //     .style('stroke-width', defaultSelectedStrokeWidth)
+  //     .style('stroke-opacity', defaultSelectedStrokeOpacity)
+  // } else {
+  //   selectedDots?.style('fill', defaultSelectedColor)
+  // }
+  // selectedDots?.attr('r', selectedPointRadius)
+  //   .raise()
+
+  const pixiRenderer = pixiPointsRef?.current
+  if (!pixiRenderer) {
+    return
   }
-  selectedDots?.attr('r', selectedPointRadius)
-    .raise()
+  pixiRenderer.forEachPoint((point, metadata, index) => {
+    const { caseID, plotNum } = metadata
+    const isSelected = !!dataset?.isCaseSelected(caseID)
+    const isSelectedAndLegendIsPresent = isSelected && legendID
+    // This `fill` logic is directly translated from the old D3 code.
+    let fill: string
+    if (isSelected && !legendID) {
+      fill = defaultSelectedColor
+    } else if (legendID) {
+      fill = dataConfiguration?.getLegendColorForCase(caseID)
+    } else {
+      fill = plotNum && getPointColorAtIndex ? getPointColorAtIndex(plotNum) : pointColor
+    }
+    const style: Partial<IPixiPointStyle> = {
+      fill,
+      radius: isSelected ? selectedPointRadius : pointRadius,
+      stroke: isSelectedAndLegendIsPresent ? defaultSelectedStroke : pointStrokeColor,
+      strokeWidth: isSelectedAndLegendIsPresent ? defaultSelectedStrokeWidth : defaultStrokeWidth,
+      strokeOpacity: isSelectedAndLegendIsPresent ? defaultSelectedStrokeOpacity : defaultStrokeOpacity
+    }
+    pixiRenderer.setPointStyle(index, style)
+    // TODO PIXI: is this enough? Or should be raised to a separate layer?
+    pixiRenderer.setPointRaised(index, isSelected)
+  })
 }
 
 export function rectNormalize(iRect: rTreeRect) {
@@ -227,4 +270,3 @@ export function rectToTreeRect(rect: Rect) {
     h: rect.height
   }
 }
-

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -2,7 +2,7 @@ import {randomUniform, select} from "d3"
 import {mstReaction} from "../../../utilities/mst-reaction"
 import React, {useCallback, useEffect, useRef, useState} from "react"
 import {CaseData} from "../../data-display/d3-types"
-import {IDotsRef} from "../../data-display/data-display-types"
+import {IDotsRef, IPixiPointsRef} from "../../data-display/data-display-types"
 import {handleClickOnCase, setPointSelection} from "../../data-display/data-display-utils"
 import {useDataDisplayAnimation} from "../../data-display/hooks/use-data-display-animation"
 import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
@@ -13,10 +13,11 @@ import {useGraphLayoutContext} from "../hooks/use-graph-layout-context"
 import {setPointCoordinates} from "../utilities/graph-utils"
 
 export const CaseDots = function CaseDots(props: {
-  dotsRef: IDotsRef
+  dotsRef: IDotsRef,
+  pixiPointsRef: IPixiPointsRef
 }) {
   const {
-      dotsRef
+      dotsRef, pixiPointsRef
     } = props,
     graphModel = useGraphContentModelContext(),
     {isAnimating, startAnimation, stopAnimation} = useDataDisplayAnimation(),
@@ -111,10 +112,10 @@ export const CaseDots = function CaseDots(props: {
         ? dataConfiguration?.getLegendColorForCase : undefined
 
     setPointCoordinates({
-      dataset, pointRadius, selectedPointRadius, dotsRef, selectedOnly,
+      dataset, pointRadius, selectedPointRadius, dotsRef, pixiPointsRef, selectedOnly,
       pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating
     })
-  }, [dotsRef, graphModel, layout, dataConfiguration, dataset, isAnimating])
+  }, [dotsRef, pixiPointsRef, graphModel, layout, dataConfiguration, dataset, isAnimating])
 
   useEffect(function initDistribution() {
     const cases = dataConfiguration?.caseDataArray

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -15,7 +15,7 @@ import {setPointCoordinates} from "../utilities/graph-utils"
 type BinMap = Record<string, Record<string, Record<string, Record<string, number>>>>
 
 export const ChartDots = function ChartDots(props: PlotProps) {
-  const {dotsRef} = props,
+  const {dotsRef, pixiPointsRef} = props,
     graphModel = useGraphContentModelContext(),
     {isAnimating} = useDataDisplayAnimation(),
     {pointColor, pointStrokeColor} = graphModel.pointDescription,
@@ -211,10 +211,10 @@ export const ChartDots = function ChartDots(props: PlotProps) {
 
     setPointCoordinates({
       dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),
-      dotsRef, selectedOnly, pointColor, pointStrokeColor,
+      dotsRef, pixiPointsRef, selectedOnly, pointColor, pointStrokeColor,
       getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating
     })
-  }, [dataConfiguration, primaryAxisPlace, primaryAttrRole, secondaryAttrRole, graphModel, dotsRef,
+  }, [dataConfiguration, primaryAxisPlace, primaryAttrRole, secondaryAttrRole, graphModel, dotsRef, pixiPointsRef,
     extraPrimaryAttrRole, extraSecondaryAttrRole, pointColor, isAnimating,
     primaryIsBottom, layout, pointStrokeColor, computeMaxOverAllCells, dataset])
 

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -15,7 +15,7 @@ import {ICase} from "../../../models/data/data-set-types"
 import {setPointCoordinates} from "../utilities/graph-utils"
 
 export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
-  const {dotsRef} = props,
+  const {dotsRef, pixiPointsRef} = props,
     graphModel = useGraphContentModelContext(),
     {isAnimating, startAnimation, stopAnimation} = useDataDisplayAnimation(),
     dataConfiguration = useGraphDataConfigurationContext(),
@@ -257,11 +257,11 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
       setPointCoordinates({
         dataset, pointRadius: graphModel.getPointRadius(),
         selectedPointRadius: graphModel.getPointRadius('select'),
-        dotsRef, selectedOnly, pointColor, pointStrokeColor,
+        dotsRef, pixiPointsRef, selectedOnly, pointColor, pointStrokeColor,
         getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating
       })
     },
-    [graphModel, dataConfiguration, layout, primaryAttrRole, secondaryAttrRole, dataset, dotsRef,
+    [graphModel, dataConfiguration, layout, primaryAttrRole, secondaryAttrRole, dataset, dotsRef, pixiPointsRef,
       primaryIsBottom, pointColor, pointStrokeColor, isAnimating])
 
   usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection})

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -17,9 +17,10 @@ import {isGraphContentModel} from "../models/graph-content-model"
 import {Graph} from "./graph"
 import {DotsElt} from '../../data-display/d3-types'
 import {AttributeDragOverlay} from "../../drag-drop/attribute-drag-overlay"
+import {PixiPoints} from "../utilities/pixi-points"
 import "../register-adornment-types"
 
-export const GraphComponent = observer(function GraphComponent({tile}: ITileBaseProps) {
+export const GraphComponent = observer(function GraphComponent({ tile }: ITileBaseProps) {
   const graphModel = isGraphContentModel(tile?.content) ? tile?.content : undefined
 
   const instanceId = useNextInstanceId("graph")
@@ -27,14 +28,22 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
   const layout = useInitGraphLayout(graphModel)
   // Removed debouncing, but we can bring it back if we find we need it
   const graphRef = useRef<HTMLDivElement | null>(null)
-  const {width, height} = useResizeDetector<HTMLDivElement>({ targetRef: graphRef })
+  const { width, height } = useResizeDetector<HTMLDivElement>({ targetRef: graphRef })
   const dotsRef = useRef<DotsElt>(null)
+  const pixiPointsRef = useRef<PixiPoints>()
+  // TODO PIXI: PJ: probably should be fixed and become a ref, as memoization is meant for performance optimization
+  // and it's not guaranteed to be maintained across renders.
   const graphController = useMemo(
-    () => new GraphController({layout, instanceId}),
+    () => new GraphController({ layout, instanceId }),
     [layout, instanceId]
   )
 
-  useGraphController({graphController, graphModel, dotsRef})
+  useEffect(() => {
+    pixiPointsRef.current = new PixiPoints()
+    return () => pixiPointsRef.current?.dispose()
+  }, [])
+
+  useGraphController({ graphController, graphModel, dotsRef, pixiPointsRef })
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setTileExtent(width, height)
@@ -48,7 +57,7 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
 
   // used to determine when a dragged attribute is over the graph component
   const dropId = `${instanceId}-component-drop-overlay`
-  const {setNodeRef} = useDroppable({id: dropId})
+  const { setNodeRef } = useDroppable({ id: dropId })
   setNodeRef(graphRef.current ?? null)
 
   const { active } = useDndContext()
@@ -64,7 +73,12 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
           <AxisLayoutContext.Provider value={layout}>
             <GraphContentModelContext.Provider value={graphModel}>
               <AxisProviderContext.Provider value={graphModel}>
-                <Graph graphController={graphController} graphRef={graphRef} dotsRef={dotsRef} />
+                <Graph
+                  graphController={graphController}
+                  graphRef={graphRef}
+                  dotsRef={dotsRef}
+                  pixiPointsRef={pixiPointsRef}
+                />
               </AxisProviderContext.Provider>
               <AttributeDragOverlay activeDragId={overlayDragId} />
             </GraphContentModelContext.Provider>

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -20,7 +20,7 @@ import {ISquareOfResidual} from "../adornments/shared-adornment-types"
 import {scatterPlotFuncs} from "./scatter-plot-utils"
 
 export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
-  const {dotsRef} = props,
+  const {dotsRef, pixiPointsRef} = props,
     graphModel = useGraphContentModelContext(),
     instanceId = useInstanceIdContext(),
     dataConfiguration = useGraphDataConfigurationContext(),
@@ -158,11 +158,11 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
     const {pointColor, pointStrokeColor} = graphModel.pointDescription
     dataConfiguration && setPointSelection(
       {
-        dotsRef, dataConfiguration, pointRadius: pointRadiusRef.current,
+        dotsRef, pixiPointsRef, dataConfiguration, pointRadius: pointRadiusRef.current,
         selectedPointRadius: selectedPointRadiusRef.current,
         pointColor, pointStrokeColor, getPointColorAtIndex: graphModel.pointDescription.pointColorAtIndex
       })
-  }, [dataConfiguration, dotsRef, graphModel])
+  }, [dataConfiguration, dotsRef, graphModel, pixiPointsRef])
 
   const refreshSquares = useCallback(() => {
 
@@ -207,14 +207,14 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined
 
     setPointCoordinates({
-      dataset, dotsRef, pointRadius: pointRadiusRef.current,
+      dataset, dotsRef, pixiPointsRef, pointRadius: pointRadiusRef.current,
       selectedPointRadius: selectedPointRadiusRef.current,
       selectedOnly, getScreenX, getScreenY, getLegendColor,
       getPointColorAtIndex: graphModel.pointDescription.pointColorAtIndex,
       pointColor, pointStrokeColor, getAnimationEnabled: isAnimating
     })
-
-  }, [dataConfiguration, graphModel.pointDescription, layout, legendAttrID, dataset, dotsRef, isAnimating])
+  }, [dataConfiguration, graphModel.pointDescription, layout, legendAttrID, dataset, dotsRef, pixiPointsRef,
+    isAnimating])
 
   const refreshPointPositionsSVG = useCallback((selectedOnly: boolean) => {
     const xAttrID = dataConfiguration?.attributeID('x') ?? '',

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -1,7 +1,8 @@
-import {IDotsRef} from "../data-display/data-display-types"
+import {IPixiPointsRef, IDotsRef} from "../data-display/data-display-types"
 
 export interface PlotProps {
   dotsRef: IDotsRef
+  pixiPointsRef: IPixiPointsRef
 }
 
 // One element of the data array assigned to the points

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,5 +1,5 @@
 import {useEffect} from "react"
-import {IDotsRef} from "../../data-display/data-display-types"
+import {IDotsRef, IPixiPointsRef} from "../../data-display/data-display-types"
 import {GraphController} from "../models/graph-controller"
 import {IGraphContentModel} from "../models/graph-content-model"
 
@@ -7,10 +7,11 @@ export interface IUseGraphControllerProps {
   graphController: GraphController,
   graphModel?: IGraphContentModel,
   dotsRef: IDotsRef
+  pixiPointsRef: IPixiPointsRef
 }
 
-export const useGraphController = ({graphController, graphModel, dotsRef}: IUseGraphControllerProps) => {
+export const useGraphController = ({graphController, graphModel, dotsRef, pixiPointsRef}: IUseGraphControllerProps) => {
   useEffect(() => {
-    graphModel && graphController.setProperties({graphModel, dotsRef})
-  }, [graphController, graphModel, dotsRef])
+    graphModel && graphController.setProperties({graphModel, dotsRef, pixiPointsRef})
+  }, [graphController, graphModel, dotsRef, pixiPointsRef])
 }

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -57,7 +57,8 @@ describe("GraphController", () => {
     const layout = new GraphLayout()
     const graphController = new GraphController({ layout, instanceId })
     const dotsRef = { current: {} } as any
-    graphController.setProperties({ graphModel, dotsRef })
+    const pixiPointsRef = { current: {} } as any
+    graphController.setProperties({ graphModel, dotsRef, pixiPointsRef })
     return { tree: _tree, model: graphModel, controller: graphController, data: dataSet }
   }
 
@@ -93,13 +94,13 @@ describe("GraphController", () => {
     _controller.handleAttributeAssignment("bottom", data.id, "bogusId")
     expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
 
-    _controller.setProperties({ graphModel: model, dotsRef: undefined as any })
+    _controller.setProperties({ graphModel: model, dotsRef: undefined as any, pixiPointsRef: undefined as any })
     _controller.initializeGraph()
     expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
     _controller.callMatchCirclesToData()
     expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
 
-    _controller.setProperties({ graphModel: model, dotsRef: {} as any })
+    _controller.setProperties({ graphModel: model, dotsRef: {} as any, pixiPointsRef: undefined as any })
     _controller.initializeGraph()
     expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
     _controller.callMatchCirclesToData()

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -1,5 +1,7 @@
 import {getDataSetFromId} from "../../../models/shared/shared-data-utils"
-import {IDotsRef, axisPlaceToAttrRole, graphPlaceToAttrRole} from "../../data-display/data-display-types"
+import {
+  IDotsRef, IPixiPointsRef, axisPlaceToAttrRole, graphPlaceToAttrRole
+} from "../../data-display/data-display-types"
 import {matchCirclesToData} from "../../data-display/data-display-utils"
 import {setNiceDomain} from "../utilities/graph-utils"
 import {IGraphContentModel} from "./graph-content-model"
@@ -26,11 +28,13 @@ interface IGraphControllerConstructorProps {
 interface IGraphControllerProps {
   graphModel: IGraphContentModel
   dotsRef: IDotsRef
+  pixiPointsRef: IPixiPointsRef
 }
 
 export class GraphController {
   graphModel?: IGraphContentModel
   dotsRef?: IDotsRef
+  pixiPointsRef?: IPixiPointsRef
   layout: GraphLayout
   instanceId: string
   // tracks the currently configured attribute descriptions so that we know whether
@@ -45,6 +49,7 @@ export class GraphController {
   setProperties(props: IGraphControllerProps) {
     this.graphModel = props.graphModel
     this.dotsRef = props.dotsRef
+    this.pixiPointsRef = props.pixiPointsRef
     if (this.graphModel.dataConfiguration.dataset !== this.graphModel.dataset) {
       this.graphModel.dataConfiguration.setDataset(
         this.graphModel.dataset, this.graphModel.metadata)
@@ -53,13 +58,13 @@ export class GraphController {
   }
 
   callMatchCirclesToData() {
-    const {graphModel, dotsRef, instanceId} = this
-    if (graphModel && dotsRef?.current) {
+    const {graphModel, dotsRef, pixiPointsRef, instanceId} = this
+    if (graphModel && dotsRef?.current && pixiPointsRef?.current) {
       const { dataConfiguration } = graphModel,
         {pointColor, pointStrokeColor} = graphModel.pointDescription,
         pointRadius = graphModel.getPointRadius()
       dataConfiguration && matchCirclesToData({
-        dataConfiguration, dotsElement: dotsRef.current,
+        dataConfiguration, dotsElement: dotsRef.current, pixiPoints: pixiPointsRef.current,
         pointRadius, startAnimation: graphModel.startAnimation, instanceId, pointColor, pointStrokeColor
       })
     }

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -1,8 +1,10 @@
 import {extent, format} from "d3"
 import {isInteger} from "lodash"
+import * as PIXI from "pixi.js"
+import {IPixiPointMetadata} from "./pixi-points"
 import {IDataSet} from "../../../models/data/data-set"
-import {CaseData, selectDots} from "../../data-display/d3-types"
-import {IDotsRef, Point, transitionDuration} from "../../data-display/data-display-types"
+import {CaseData,} from "../../data-display/d3-types"
+import {IPixiPointsRef, IDotsRef, Point, transitionDuration} from "../../data-display/data-display-types"
 import {IAxisModel, isNumericAxisModel} from "../../axis/models/axis-model"
 import {ScaleNumericBaseType} from "../../axis/axis-types"
 import {defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeWidth, defaultStrokeWidth}
@@ -249,6 +251,7 @@ export function getScreenCoord(dataSet: IDataSet | undefined, id: string,
 
 export interface ISetPointSelection {
   dotsRef: IDotsRef
+  pixiPointsRef?: IPixiPointsRef
   dataConfiguration: IDataConfigurationModel
   pointRadius: number,
   selectedPointRadius: number,
@@ -260,6 +263,7 @@ export interface ISetPointSelection {
 export interface ISetPointCoordinates {
   dataset?: IDataSet
   dotsRef: IDotsRef
+  pixiPointsRef: IPixiPointsRef
   selectedOnly?: boolean
   pointRadius: number
   selectedPointRadius: number
@@ -274,11 +278,10 @@ export interface ISetPointCoordinates {
 
 export function setPointCoordinates(props: ISetPointCoordinates) {
   const {
-    dataset, dotsRef, selectedOnly = false, pointRadius, selectedPointRadius, pointStrokeColor, pointColor,
-    getPointColorAtIndex, getScreenX, getScreenY, getLegendColor, getAnimationEnabled
+    dataset, pixiPointsRef, selectedOnly = false, pointRadius, selectedPointRadius, pointStrokeColor,
+    pointColor, getPointColorAtIndex, getScreenX, getScreenY, getLegendColor, getAnimationEnabled
   } = props
-  const duration = getAnimationEnabled() ? transitionDuration : 0
-  const theSelection = selectDots(dotsRef.current, selectedOnly)
+
 
   const lookupLegendColor = (caseData: CaseData): string => {
     const { caseID } = caseData
@@ -296,23 +299,45 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
   }
 
   const setPoints = () => {
-    if (theSelection?.size()) {
-      theSelection
-        .transition()
-        .duration(duration)
-        .attr('cx', (aCaseData: CaseData) => getScreenX(aCaseData.caseID))
-        .attr('cy', (aCaseData: CaseData) => {
-          return getScreenY(aCaseData.caseID, aCaseData.plotNum)
+    // TODO: Remove old SVG code
+    // if (theSelection?.size()) {
+    //   theSelection
+    //     .transition()
+    //     .duration(duration)
+    //     .attr('cx', (aCaseData: CaseData) => getScreenX(aCaseData.caseID))
+    //     .attr('cy', (aCaseData: CaseData) => {
+    //       return getScreenY(aCaseData.caseID, aCaseData.plotNum)
+    //     })
+    //     .attr('r', (aCaseData: CaseData) => dataset?.isCaseSelected(aCaseData.caseID)
+    //       ? selectedPointRadius : pointRadius)
+    //     .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData))
+    //     .style('stroke', (aCaseData: CaseData) =>
+    //       (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
+    //         ? defaultSelectedStroke : pointStrokeColor)
+    //     .style('stroke-width', (aCaseData: CaseData) =>
+    //       (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
+    //         ? defaultSelectedStrokeWidth : defaultStrokeWidth)
+    // }
+
+    // TODO: Do we really need to calculate legend color here? If this function is called both while resizing
+    // the graph and while updating legend colors, we could possibly split it into two different functions.
+    // TODO: add animation
+    // const duration = getAnimationEnabled() ? transitionDuration : 0
+    // const theSelection = selectDots(dotsRef.current, selectedOnly)
+    const pixiRenderer = pixiPointsRef?.current
+    if (pixiRenderer) {
+      pixiRenderer.forEachPoint((point: PIXI.Sprite, metadata: IPixiPointMetadata, idx: number) => {
+        const { caseID, plotNum } = metadata
+        point.position.x = getScreenX(caseID) || 0
+        point.position.y = getScreenY(caseID, plotNum) || 0
+        pixiRenderer.setPointStyle(idx, {
+          radius: dataset?.isCaseSelected(caseID) ? selectedPointRadius : pointRadius,
+          fill: lookupLegendColor(metadata),
+          stroke: getLegendColor && dataset?.isCaseSelected(caseID) ? defaultSelectedStroke : pointStrokeColor,
+          strokeWidth: getLegendColor && dataset?.isCaseSelected(caseID)
+            ? defaultSelectedStrokeWidth : defaultStrokeWidth
         })
-        .attr('r', (aCaseData: CaseData) => dataset?.isCaseSelected(aCaseData.caseID)
-          ? selectedPointRadius : pointRadius)
-        .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData))
-        .style('stroke', (aCaseData: CaseData) =>
-          (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-            ? defaultSelectedStroke : pointStrokeColor)
-        .style('stroke-width', (aCaseData: CaseData) =>
-          (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-            ? defaultSelectedStrokeWidth : defaultStrokeWidth)
+      })
     }
   }
 

--- a/v3/src/components/graph/utilities/pixi-points.ts
+++ b/v3/src/components/graph/utilities/pixi-points.ts
@@ -1,0 +1,115 @@
+import * as PIXI from "pixi.js"
+import { CaseData } from "../../data-display/d3-types"
+
+const DEFAULT_Z_INDEX = 0
+const RAISED_Z_INDEX = 1
+
+export interface IPixiPointMetadata {
+  caseID: string
+  plotNum: number
+  style: IPixiPointStyle
+}
+
+export interface IPixiPointStyle {
+  radius: number
+  fill: string
+  stroke: string
+  strokeWidth: number
+  strokeOpacity?: number
+}
+
+export class PixiPoints {
+  app: PIXI.Application = new PIXI.Application({
+    resolution: window.devicePixelRatio,
+    autoDensity: true,
+    backgroundAlpha: 0,
+    antialias: true
+  })
+  pointMetadata: IPixiPointMetadata[] = []
+  textures = new Map<string, PIXI.Texture>()
+
+  get canvas() {
+    return this.app.view as HTMLCanvasElement
+  }
+
+  get points() {
+    return this.app.stage.children as PIXI.Sprite[]
+  }
+
+  get pointsCount() {
+    return this.points.length
+  }
+
+  textureKey(style: IPixiPointStyle) {
+    return JSON.stringify(style)
+  }
+
+  cleanupUnusedTextures() {
+    // TODO PIXI
+  }
+
+  getPointTexture(style: IPixiPointStyle): PIXI.Texture {
+    const { radius, fill, stroke, strokeWidth, strokeOpacity } = style
+    const key = this.textureKey(style)
+    if (this.textures.has(key)) {
+      return this.textures.get(key) as PIXI.Texture
+    }
+    const graphics = new PIXI.Graphics()
+    graphics.beginFill(fill)
+    graphics.lineStyle(strokeWidth, stroke, strokeOpacity ?? 0.4)
+    graphics.drawCircle(0, 0, radius)
+    graphics.endFill()
+    const texture = this.app.renderer.generateTexture(graphics)
+    this.textures.set(key, texture)
+    this.cleanupUnusedTextures()
+    return texture
+  }
+
+  resize(width: number, height: number) {
+    this.app.renderer.resize(width, height)
+  }
+
+  matchPointsToData(caseData: CaseData[], style: IPixiPointStyle) {
+    // TODO PIXI: optimize this method. We don't have to remove all children and re-add them.
+    this.app.stage.removeChildren()
+    this.pointMetadata = []
+
+    for (let i = 0; i < caseData.length; i++) {
+      const texture = this.getPointTexture(style)
+      const data = caseData[i]
+      const sprite = new PIXI.Sprite(texture)
+      this.app.stage.addChild(sprite)
+      sprite.anchor.set(0.5)
+      sprite.position.x = Math.random() * this.app.renderer.width / 2
+      sprite.position.y = Math.random() * this.app.renderer.height / 2
+      sprite.zIndex = DEFAULT_Z_INDEX
+      this.pointMetadata.push({ caseID: data.caseID, plotNum: data.plotNum, style })
+    }
+  }
+
+  forEachPoint(callback: (point: PIXI.Sprite, metadata: IPixiPointMetadata, index: number) => void) {
+    for (let i = 0; i < this.points.length; i++) {
+      const point = this.points[i]
+      const metadata = this.pointMetadata[i]
+      callback(point, metadata, i)
+    }
+  }
+
+  setPointStyle(index: number, style: Partial<IPixiPointStyle>) {
+    const newStyle = { ...this.pointMetadata[index].style, ...style }
+    this.pointMetadata[index].style = newStyle
+    const texture = this.getPointTexture(newStyle)
+    const point = this.points[index]
+    point.texture = texture
+  }
+
+  setPointRaised(index: number, value: boolean) {
+    const point = this.points[index]
+    point.zIndex = value ? RAISED_Z_INDEX : DEFAULT_Z_INDEX
+  }
+
+  dispose() {
+    this.app.destroy()
+    this.textures.forEach(texture => texture.destroy())
+  }
+}

--- a/v3/src/test/setupTests.ts
+++ b/v3/src/test/setupTests.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom"
 import "jest-canvas-mock"
+import "jest-webgl-canvas-mock"
 import { isEqual, isEqualWith } from "lodash"
 import ResizeObserverPolyfill from "resize-observer-polyfill"
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186631176

This is just the first step. I've enabled rendering for basic graphs, allowing you to resize the graph tile, and the dots will re-render correctly. Additionally, I've implemented marquee selection.

To fix the Jest tests, I've included jest-webgl-canvas-mock (we already use jest-canvas-mock). This appears to be the easiest way to avoid mocking Pixi completely in the Jest environment.

There are a few `// TODO PIXI:` comments, and some may be worth reviewing. I've also temporarily kept the old SVG code for comparison purposes and for future use in implementing missing features such as animations or interactions.

In the next step, I'll be focusing on point-ID matching and animations/transitions.