### PR TITLE
fix: Squares of Residuals option (PT-181940029)

### DIFF
--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
@@ -194,7 +194,6 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
     if (interceptLocked) return
     const lineParams = model.lines?.get(instanceKey)
     const slope = lineParams?.slope || 0
-    const intercept = lineParams?.intercept || 0
     const tWorldX = xScaleRef.current.invert(event.x)
     const tWorldY = yScaleRef.current.invert(event.y)
 
@@ -215,7 +214,7 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
     const {domain: yDomain} = yAxis
     pointsOnAxes.current = lineToAxisIntercepts(slope, newIntercept, xDomain, yDomain)
     updateLine()
-    refreshEquation(slope, intercept)
+    refreshEquation(slope, newIntercept)
 
     // Until the user releases the line, only update the model's volatile props for the slope and intercept. Once
     // the user releases the line, update the model's slope and intercept and set the volatile props to undefined.


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181940029

The Movable Line's equation box content (including the "Sum of squares" part) wasn't being updated properly when you dragged the line from the middle portion. We were previously sending the initial `intercept` value to `refreshEquation` in the Movable Line component's `handleTranslate` function. Sending the `newIntercept` value instead appears to fix the problem.