### PR TITLE
Legend responds to hidden cases

### DIFF
--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -269,8 +269,9 @@ export const CategoricalLegend = observer(
     useEffect(function respondToCategorySetsChange() {
       return mstReaction(
         () => {
+          const categories = dataConfiguration?.categoryArrayForAttrRole('legend')
           const numHidden = dataConfiguration?.hiddenCases.length
-          return dataConfiguration?.categoryArrayForAttrRole('legend')
+          return { categories, numHidden }
         },
         () => {
           setDesiredExtent(layerIndex, computeDesiredExtent())

--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -1,5 +1,6 @@
 import {observer} from "mobx-react-lite"
-import {reaction} from "mobx"
+import {mstReaction} from "../../../../utilities/mst-reaction"
+import {comparer, reaction} from "mobx"
 import {drag, range, select} from "d3"
 import React, {useCallback, useEffect, useMemo, useRef} from "react"
 import {isSelectionAction} from "../../../../models/data/data-set-actions"
@@ -266,13 +267,17 @@ export const CategoricalLegend = observer(
     }, [refreshKeys, dataset, computeDesiredExtent])
 
     useEffect(function respondToCategorySetsChange() {
-      return reaction(
-        () => dataConfiguration?.categoryArrayForAttrRole('legend'),
+      return mstReaction(
+        () => {
+          const numHidden = dataConfiguration?.hiddenCases.length
+          return dataConfiguration?.categoryArrayForAttrRole('legend')
+        },
         () => {
           setDesiredExtent(layerIndex, computeDesiredExtent())
           setupKeys()
           refreshKeys()
-        })
+        }, {name: 'CategoricalLegend respondToCategorySetsChange',
+          equals: comparer.structural}, dataConfiguration)
     }, [setupKeys, refreshKeys, dataConfiguration, computeDesiredExtent, setDesiredExtent, layerIndex])
 
     useEffect(function respondToAttributeIDChange() {

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -574,6 +574,11 @@ export const DataConfigurationModel = types
           equals: comparer.structural
         }
       ))
+      // invalidate caches when hiddenCases changes
+      addDisposer(self, reaction(
+        () => self.hiddenCases.length,
+        count => self._invalidateCases()
+      ))
     },
     setDataset(dataset: IDataSet | undefined, metadata: ISharedCaseMetadata | undefined) {
       self.dataset = dataset
@@ -592,12 +597,10 @@ export const DataConfigurationModel = types
       self._setAttributeType(role, type, plotNumber)
     },
     addNewHiddenCases(hiddenCases: string[]) {
-      self.hiddenCases.replace(self.hiddenCases.concat(hiddenCases))
-      self._invalidateCases()
+      self.hiddenCases.push(...hiddenCases)
     },
     clearHiddenCases() {
       self.hiddenCases.replace([])
-      self._invalidateCases()
     }
   }))
   .actions(self => ({

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -246,21 +246,11 @@ export const DataConfigurationModel = types
         }
       },
       /**
-       * Todo: This method is inefficient since it has to go through all the cases in the graph to determine
-       * which categories are present. It should be replaced by some sort of functionality that allows
-       * caching of the categories that have been determined to be valid.
        * @param role
        * @param emptyCategoryArray
        */
       categoryArrayForAttrRole(role: AttrRole, emptyCategoryArray = ['__main__']): string[] {
-        let categoryArray: string[] = []
-        if (self.metadata) {
-          const attributeID = self.attributeID(role) || ''
-          const categorySet = self.metadata.getCategorySet(attributeID)
-          const validValues: Set<string> = new Set(this.valuesForAttrRole(role))
-          categoryArray = (categorySet?.values || emptyCategoryArray)
-            .filter((aValue: string) => validValues.has(aValue))
-        }
+        let categoryArray = Array.from(new Set(this.valuesForAttrRole(role)))
         if (categoryArray.length === 0) {
           categoryArray = emptyCategoryArray
         }
@@ -503,6 +493,7 @@ export const DataConfigurationModel = types
       self.filteredCases.forEach((aFilteredCases) => {
         aFilteredCases.invalidateCases()
       })
+      self.clearCasesCache()
     },
     _addNewFilteredCases() {
       if (self.dataset) {


### PR DESCRIPTION
This PR fixes the bug whereby when you hide all the cases belonging to a given category, the legend was not responding by hiding that category key.

The fix works for the action of hiding, but _not_ for the undo because DataConfigurationModel:clearCasesCache is not being called on undo. Perhaps @kswenson can take a look?

[#186648806] Bug fix: Legend is not responding to cases being hidden
* In CategoricalLegend:respondToCategorySetsChange improve ability to notice changes to number of categories
* In DataConfigurationModel:categoryArrayForAttrRole, simplify and streamline logic