### PR TITLE
fix: Treating numeric as categorical should update count adornment correctly (PT-186016145)

### DIFF
--- a/v3/src/components/graph/components/scatter-plot-utils.ts
+++ b/v3/src/components/graph/components/scatter-plot-utils.ts
@@ -68,7 +68,7 @@ export function scatterPlotFuncs(layout: GraphLayout, dataConfiguration?: IGraph
         // If the line has a category and it does not match the categorical legend value,
         // do not render squares.
         if (category && legendValue !== category && legendType === "categorical") return
-        const fullCaseData = dataset?.getCase(caseData.__id__)
+        const fullCaseData = dataset?.getCase(caseData.__id__, { numeric: false })
         if (fullCaseData && dataConfiguration?.isCaseInSubPlot(cellKey, fullCaseData)) {
           const square = residualSquare(slope, intercept, caseData.__id__)
           if (!isFinite(square.x) || !isFinite(square.y)) return

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -285,9 +285,9 @@ describe("DataConfigurationModel", () => {
     const config = tree.config
     config.setDataset(tree.data, tree.metadata)
     expect(config.subPlotCases({})).toEqual([
-      {"__id__": "c1", "nId": "n1", "xId": 1, "yId": 1},
-      {"__id__": "c2", "nId": "", "xId": 2, "yId": ""},
-      {"__id__": "c3", "nId": "n3", "xId": "", "yId": 3}
+      {"__id__": "c1", "nId": "n1", "xId": "1", "yId": "1"},
+      {"__id__": "c2", "nId": "", "xId": "2", "yId": ""},
+      {"__id__": "c3", "nId": "n3", "xId": "", "yId": "3"}
     ])
   })
 

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -279,7 +279,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       const numOfKeys = Object.keys(cellKey).length
       let matchedValCount = 0
       Object.keys(cellKey).forEach(key => {
-        if (cellKey[key] === caseData[key]) matchedValCount++
+        if (cellKey[key] === caseData[key].toString()) matchedValCount++
       })
       return matchedValCount === numOfKeys
     },

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -279,7 +279,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       const numOfKeys = Object.keys(cellKey).length
       let matchedValCount = 0
       Object.keys(cellKey).forEach(key => {
-        if (cellKey[key] === caseData[key].toString()) matchedValCount++
+        if (cellKey[key] === caseData[key]) matchedValCount++
       })
       return matchedValCount === numOfKeys
     },
@@ -287,7 +287,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       const casesInPlot = new Map<string, ICase>()
       self.filteredCases?.forEach(aFilteredCases => {
         aFilteredCases.caseIds.forEach((id) => {
-          const caseData = self.dataset?.getCase(id)
+          const caseData = self.dataset?.getCase(id, { numeric: false })
           const caseAlreadyMatched = casesInPlot.has(id)
           if (caseData && !caseAlreadyMatched) {
             casesInPlot.set(caseData.__id__, caseData)

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -510,7 +510,7 @@ export const calculateSumOfSquares = ({ cellKey, dataConfig, intercept, slope }:
   const yAttrID = dataConfig?.attributeID("y") ?? ""
   let sumOfSquares = 0
   caseData?.forEach((datum: any) => {
-    const fullCaseData = dataConfig?.dataset?.getCase(datum.__id__)
+    const fullCaseData = dataConfig?.dataset?.getCase(datum.__id__, { numeric: false })
     if (fullCaseData && dataConfig?.isCaseInSubPlot(cellKey, fullCaseData)) {
       const x = dataset?.getNumeric(datum.__id__, xAttrID) ?? NaN
       const y = dataset?.getNumeric(datum.__id__, yAttrID) ?? NaN


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186016145

`isCaseInSubPlot` was not always identifying matches between values because the value for `cellKey[key]` is always a string whereas `caseData[key]` values can be a string or numeric. A simple fix is to compare `cellKey[key]` with `caseData[key].toString()`. I'm not sure if that's entirely safe though. I can't think of a case where it would be problematic, but I could be missing something. If I am missing something, perhaps I should look into adjusting the type for `cellKey` so its property values can be numeric as well as strings?