### PR TITLE
fix: Graphs with subplots not rendered correctly on import (PT-185577446)

### DIFF
--- a/v3/src/components/graph/hooks/use-init-graph-layout.ts
+++ b/v3/src/components/graph/hooks/use-init-graph-layout.ts
@@ -23,7 +23,7 @@ export function useInitGraphLayout(model?: IGraphContentModel) {
         (Object.keys(repetitions) as AxisPlace[]).forEach((place: AxisPlace) => {
           layout.getAxisMultiScale(place)?.setRepetitions(repetitions[place] ?? 0)
         })
-      }, { name: "useInitGraphLayout repetitions" }, dataConfiguration
+      }, { name: "useInitGraphLayout repetitions", fireImmediately: true }, dataConfiguration
     )
   }, [layout, model])
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185577446

The effect function in the `useInitGraphLayout repetitions` reaction wasn't being triggered on import, and so the number of repetitions on the axes were not being correctly set. Adding `fireImmediately: true` to the reaction's options ensures the effect function is triggered after the data function's first run.