### PR TITLE
fix: Percent values in subplots not correct (PT-186682759)

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -15,10 +15,10 @@ export const CountAdornmentModel = AdornmentModel
   .views(self => ({
     percentValue(casesInPlot: number, cellKey: Record<string, string>, dataConfig?: IGraphDataConfigurationModel) {
       const divisor = self.percentType === "row"
-        ? dataConfig?.rowCases(cellKey)?.length ?? 0
+        ? dataConfig?.rowCases(cellKey).length ?? 0
         : self.percentType === "column"
-          ? dataConfig?.columnCases(cellKey)?.length ?? 0
-          : dataConfig?.subPlotCases(cellKey)?.length ?? 0
+          ? dataConfig?.columnCases(cellKey).length ?? 0
+          : dataConfig?.allPlottedCases.length ?? 0
       const percentValue = casesInPlot / divisor
       return isFinite(percentValue) ? percentValue : 0
     }

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -282,6 +282,19 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         if (cellKey[key] === caseData[key]) matchedValCount++
       })
       return matchedValCount === numOfKeys
+    },
+    get allPlottedCases() {
+      const casesInPlot = new Map<string, ICase>()
+      self.filteredCases?.forEach(aFilteredCases => {
+        aFilteredCases.caseIds.forEach((id) => {
+          const caseData = self.dataset?.getCase(id)
+          const caseAlreadyMatched = casesInPlot.has(id)
+          if (caseData && !caseAlreadyMatched) {
+            casesInPlot.set(caseData.__id__, caseData)
+          }
+        })
+      })
+      return Array.from(casesInPlot.values())
     }
   }))
   .views(self => ({
@@ -289,14 +302,11 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       key: (cellKey: Record<string, string>) => JSON.stringify(cellKey),
       calculate: (cellKey: Record<string, string>) => {
         const casesInPlot = new Map<string, ICase>()
-        self.filteredCases?.forEach(aFilteredCases => {
-          aFilteredCases.caseIds.forEach((id) => {
-            const caseData = self.dataset?.getCase(id)
-            const caseAlreadyMatched = casesInPlot.has(id)
-            if (caseData && !caseAlreadyMatched && self.isCaseInSubPlot(cellKey, caseData)) {
-              casesInPlot.set(caseData.__id__, caseData)
-            }
-          })
+        self.allPlottedCases.forEach((caseData) => {
+          const caseAlreadyMatched = casesInPlot.has(caseData.__id__)
+          if (!caseAlreadyMatched && self.isCaseInSubPlot(cellKey, caseData)) {
+            casesInPlot.set(caseData.__id__, caseData)
+          }
         })
         return Array.from(casesInPlot.values())
       }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186682759

Previously, the `percentValue` view in the count adornment model was dividing `casesInPlot` by `dataConfig?.subPlotCases(cellKey)` to determine the percent. In graphs with multiple subplots, that caused the percent value to be 100% for each subplot.

This change ensures the view divides `casesInPlot` by _all_ the plotted cases so there's an accurate percent value shown for each subplot.