### PR TITLE
Avoid excessive CPU workload caused by the Pixi render loop

### DIFF
--- a/v3/src/components/graph/utilities/pixi-points.ts
+++ b/v3/src/components/graph/utilities/pixi-points.ts
@@ -231,6 +231,7 @@ export class PixiPoints {
   }
 
   dispose() {
+    this.ticker.destroy()
     this.renderer.destroy()
     this.stage.destroy()
     this.textures.forEach(texture => texture.destroy())


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186691239

This PR replaces the automatic render loop handling done by PIXI.Application with a custom one. Instead of running the loop all the time, the rendering loop is now started only when necessary (resize or transitions). This change should help with the CPU load observed by @bfinzer. While PIXI rendering is generally inexpensive, it is not necessary in our case. This might become noticeable when dealing with thousands of points or multiple graphs.