### PR TITLE
Added CODAP app id (project id) to Google provider settings [PT-186571976]

### DIFF
--- a/apps/dg/core.js
+++ b/apps/dg/core.js
@@ -159,6 +159,7 @@ DG = SC.Application.create((function () // closure
      * version of the app. Should be overridden for end users */
     googleDriveClientID: '891260722961-81f8ic8tddobbh66p1j7nenr42hb93u1.apps.googleusercontent.com',
     googleDriveAPIKey: 'AIzaSyDici8Bs9pd6-dSxheNPTpnJlcR4YuGGQQ',
+    googleDriveAppId: '891260722961',
 
     /**
      * URL for a plugin data store.

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -435,7 +435,8 @@ DG.main = function main() {
         "name": "googleDrive",
         "mimeType": "application/json",
         "clientId": DG.get('googleDriveClientID'),
-        "apiKey": DG.get('googleDriveAPIKey')
+        "apiKey": DG.get('googleDriveAPIKey'),
+        "appId": DG.get('googleDriveAppId'),
       });
      }
     if (DG.cfmConfigurationOverride) {


### PR DESCRIPTION
The upcoming new CFM Google provider requires the app id to be set.