### PR TITLE
Refactor metadata storage in PixiPoints class

### DIFF
--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -173,7 +173,7 @@ export function setPointSelection(props: ISetPointSelection) {
   if (!pixiRenderer) {
     return
   }
-  pixiRenderer.forEachPoint((point, metadata, index) => {
+  pixiRenderer.forEachPoint((point, metadata) => {
     const { caseID, plotNum } = metadata
     const isSelected = !!dataset?.isCaseSelected(caseID)
     const isSelectedAndLegendIsPresent = isSelected && legendID
@@ -193,9 +193,9 @@ export function setPointSelection(props: ISetPointSelection) {
       strokeWidth: isSelectedAndLegendIsPresent ? defaultSelectedStrokeWidth : defaultStrokeWidth,
       strokeOpacity: isSelectedAndLegendIsPresent ? defaultSelectedStrokeOpacity : defaultStrokeOpacity
     }
-    pixiRenderer.setPointStyle(index, style)
+    pixiRenderer.setPointStyle(point, style)
     // TODO PIXI: is this enough? Or should be raised to a separate layer?
-    pixiRenderer.setPointRaised(index, isSelected)
+    pixiRenderer.setPointRaised(point, isSelected)
   })
 }
 

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -324,16 +324,16 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
     const pixiRenderer = pixiPointsRef?.current
     if (pixiRenderer) {
       pixiRenderer.transition(getAnimationEnabled() ? transitionDuration : 0, () => {
-        pixiRenderer.forEachPoint((point: PIXI.Sprite, metadata: IPixiPointMetadata, idx: number) => {
+        pixiRenderer.forEachPoint((point: PIXI.Sprite, metadata: IPixiPointMetadata) => {
           const { caseID, plotNum } = metadata
-          pixiRenderer.setPointStyle(idx, {
+          pixiRenderer.setPointStyle(point, {
             radius: dataset?.isCaseSelected(caseID) ? selectedPointRadius : pointRadius,
             fill: lookupLegendColor(metadata),
             stroke: getLegendColor && dataset?.isCaseSelected(caseID) ? defaultSelectedStroke : pointStrokeColor,
             strokeWidth: getLegendColor && dataset?.isCaseSelected(caseID)
               ? defaultSelectedStrokeWidth : defaultStrokeWidth
           })
-          pixiRenderer.setPointPosition(idx, getScreenX(caseID) || 0, getScreenY(caseID, plotNum) || 0)
+          pixiRenderer.setPointPosition(point, getScreenX(caseID) || 0, getScreenY(caseID, plotNum) || 0)
         }, { selectedOnly })
       })
     }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186645440

This PR refactors how point metadata is stored and accessed in PixiPoints. Previously, I was relying on point indices, but that approach is a bit more fragile, requires recalculations, and is not so easy to use in some scenarios. Here, it's replaced with a Map that uses a Sprite reference as the key. I could also extend PIXI.Sprite and store metadata directly there, but that would most likely not work that well with TypeScript and would require quite a bit of type casting. The Map approach might be a bit more verbose, but it's also more type-friendly.