### PR TITLE
Implement hover effect in PixiJS graph

### DIFF
--- a/v3/src/components/data-display/data-display-types.ts
+++ b/v3/src/components/data-display/data-display-types.ts
@@ -2,10 +2,8 @@ import React from "react"
 import {DotsElt} from "./d3-types"
 import {AxisPlace} from "../axis/axis-types"
 import {GraphPlace} from "../axis-graph-shared"
-import {PixiPoints} from "../graph/utilities/pixi-points"
 
 export type IDotsRef = React.MutableRefObject<DotsElt>
-export type IPixiPointsRef = React.MutableRefObject<PixiPoints | undefined>
 
 export type Point = { x: number, y: number }
 export type CPLine = { slope: number, intercept: number, pivot1?: Point, pivot2?: Point }

--- a/v3/src/components/graph/components/background.tsx
+++ b/v3/src/components/graph/components/background.tsx
@@ -3,9 +3,9 @@ import React, {forwardRef, MutableRefObject, useCallback, useEffect, useMemo, us
 import {drag, select, color, range} from "d3"
 import RTreeLib from 'rtree'
 import * as PIXI from "pixi.js"
-import {IPixiPointsRef, rTreeRect} from "../../data-display/data-display-types"
+import {rTreeRect} from "../../data-display/data-display-types"
 import {rectangleSubtract, rectNormalize} from "../../data-display/data-display-utils"
-import {IPixiPointMetadata, PixiPoints} from "../utilities/pixi-points"
+import {IPixiPointMetadata, IPixiPointsRef, PixiPoints} from "../utilities/pixi-points"
 import {MarqueeState} from "../models/marquee-state"
 import {appState} from "../../../models/app-state"
 import {useCurrent} from "../../../hooks/use-current"

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -2,7 +2,7 @@ import {randomUniform, select} from "d3"
 import {mstReaction} from "../../../utilities/mst-reaction"
 import React, {useCallback, useEffect, useRef, useState} from "react"
 import {CaseData} from "../../data-display/d3-types"
-import {IDotsRef, IPixiPointsRef} from "../../data-display/data-display-types"
+import {IDotsRef} from "../../data-display/data-display-types"
 import {handleClickOnCase, setPointSelection} from "../../data-display/data-display-utils"
 import {useDataDisplayAnimation} from "../../data-display/hooks/use-data-display-animation"
 import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
@@ -11,6 +11,7 @@ import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphContentModelContext} from "../hooks/use-graph-content-model-context"
 import {useGraphLayoutContext} from "../hooks/use-graph-layout-context"
 import {setPointCoordinates} from "../utilities/graph-utils"
+import {IPixiPointsRef} from "../utilities/pixi-points"
 
 export const CaseDots = function CaseDots(props: {
   dotsRef: IDotsRef,

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -3,7 +3,7 @@ import {addDisposer, isAlive} from "mobx-state-tree"
 import React, {MutableRefObject, useCallback, useEffect, useMemo, useRef} from "react"
 import {select} from "d3"
 import {clsx} from "clsx"
-import {GraphAttrRole, IPixiPointsRef, IDotsRef, attrRoleToGraphPlace, graphPlaceToAttrRole, kPortalClass}
+import {GraphAttrRole, IDotsRef, attrRoleToGraphPlace, graphPlaceToAttrRole, kPortalClass}
   from "../../data-display/data-display-types"
 import {AxisPlace, AxisPlaces} from "../../axis/axis-types"
 import {GraphAxis} from "./graph-axis"
@@ -37,6 +37,7 @@ import {useDataDisplayAnimation} from "../../data-display/hooks/use-data-display
 import {useDataTips} from "../../data-display/hooks/use-data-tips"
 import {mstReaction} from "../../../utilities/mst-reaction"
 import {onAnyAction} from "../../../utilities/mst-utils"
+import {IPixiPointsRef} from "../utilities/pixi-points"
 import {Adornments} from "../adornments/adornments"
 
 import "./graph.scss"
@@ -229,13 +230,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
           <svg ref={plotAreaSVGRef} className="plot-area-svg">
 
             <svg ref={dotsRef} className={`graph-dot-area ${instanceId}`}>
-            <foreignObject
-              ref={pixiContainerRef}
-              x={0} y={0} width="100%" height="100%"
-              // TODO PIXI: remove this to handle mouse events later, find a solution so that we can support
-              // background events too
-              style={{ pointerEvents: "none" }}
-            />
+            <foreignObject ref={pixiContainerRef} x={0} y={0} width="100%" height="100%" style={{pointerEvents: "none"}}/>
               {renderPlotComponent()}
             </svg>
             <Marquee marqueeState={marqueeState}/>

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -1,4 +1,5 @@
-import {IPixiPointsRef, IDotsRef} from "../data-display/data-display-types"
+import { IDotsRef } from "../data-display/data-display-types"
+import { IPixiPointsRef } from "./utilities/pixi-points"
 
 export interface PlotProps {
   dotsRef: IDotsRef

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,7 +1,8 @@
 import {useEffect} from "react"
-import {IDotsRef, IPixiPointsRef} from "../../data-display/data-display-types"
+import {IDotsRef} from "../../data-display/data-display-types"
 import {GraphController} from "../models/graph-controller"
 import {IGraphContentModel} from "../models/graph-content-model"
+import {IPixiPointsRef} from "../utilities/pixi-points"
 
 export interface IUseGraphControllerProps {
   graphController: GraphController,

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -1,8 +1,7 @@
 import {getDataSetFromId} from "../../../models/shared/shared-data-utils"
-import {
-  IDotsRef, IPixiPointsRef, axisPlaceToAttrRole, graphPlaceToAttrRole
-} from "../../data-display/data-display-types"
+import {IDotsRef, axisPlaceToAttrRole, graphPlaceToAttrRole} from "../../data-display/data-display-types"
 import {matchCirclesToData} from "../../data-display/data-display-utils"
+import {IPixiPointsRef} from "../utilities/pixi-points"
 import {setNiceDomain} from "../utilities/graph-utils"
 import {IGraphContentModel} from "./graph-content-model"
 import {GraphLayout} from "./graph-layout"

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -1,10 +1,10 @@
 import {extent, format} from "d3"
 import {isInteger} from "lodash"
 import * as PIXI from "pixi.js"
-import {IPixiPointMetadata} from "./pixi-points"
+import {IPixiPointMetadata, IPixiPointsRef} from "./pixi-points"
 import {IDataSet} from "../../../models/data/data-set"
 import {CaseData} from "../../data-display/d3-types"
-import {IPixiPointsRef, IDotsRef, Point, transitionDuration} from "../../data-display/data-display-types"
+import {IDotsRef, Point, transitionDuration} from "../../data-display/data-display-types"
 import {IAxisModel, isNumericAxisModel} from "../../axis/models/axis-model"
 import {ScaleNumericBaseType} from "../../axis/axis-types"
 import {defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeWidth, defaultStrokeWidth}

--- a/v3/src/components/graph/utilities/pixi-points.ts
+++ b/v3/src/components/graph/utilities/pixi-points.ts
@@ -144,7 +144,7 @@ export class PixiPoints {
     graphics.drawCircle(0, 0, radius)
     graphics.endFill()
     const texture = this.renderer.generateTexture(graphics, {
-      // A trick to make sprites/textures look still sharp when they"re scaled up (e.g. during hover effect).
+      // A trick to make sprites/textures look still sharp when they're scaled up (e.g. during hover effect).
       // The default resolution is `devicePixelRatio`, so if we multiply it by `MAX_SPRITE_SCALE`, we can scale
       // sprites up to `MAX_SPRITE_SCALE` without losing sharpness.
       resolution: devicePixelRatio * MAX_SPRITE_SCALE


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186645440

This PR implements a basic hover effect for points. Transitions can run in parallel now. Note that tooltips will be covered later. Additionally, it breaks the marquee selection. I spent far too much time attempting to pass events through the canvas to the background SVG rectangle and am still unsure about how to approach it. However, it seems to me that at this point, I should just reimplement the dragging handler using PixiJS.