### PR TITLE
Implement graph point dragging and click selection using PixiJS, fix various bugs of the SVG behavior

### DIFF
--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -1,17 +1,18 @@
-import {randomUniform, select} from "d3"
+import {randomUniform} from "d3"
 import {mstReaction} from "../../../utilities/mst-reaction"
 import React, {useCallback, useEffect, useRef, useState} from "react"
+import * as PIXI from "pixi.js"
 import {CaseData} from "../../data-display/d3-types"
 import {IDotsRef} from "../../data-display/data-display-types"
 import {handleClickOnCase, setPointSelection} from "../../data-display/data-display-utils"
 import {useDataDisplayAnimation} from "../../data-display/hooks/use-data-display-animation"
-import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
+import {usePixiDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {useGraphDataConfigurationContext} from "../hooks/use-graph-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useGraphContentModelContext} from "../hooks/use-graph-content-model-context"
 import {useGraphLayoutContext} from "../hooks/use-graph-layout-context"
 import {setPointCoordinates} from "../utilities/graph-utils"
-import {IPixiPointsRef} from "../utilities/pixi-points"
+import {IPixiPointMetadata, IPixiPointsRef} from "../utilities/pixi-points"
 
 export const CaseDots = function CaseDots(props: {
   dotsRef: IDotsRef,
@@ -26,10 +27,8 @@ export const CaseDots = function CaseDots(props: {
     dataConfiguration = useGraphDataConfigurationContext(),
     layout = useGraphLayoutContext(),
     randomPointsRef = useRef<Record<string, { x: number, y: number }>>({}),
-    dragPointRadius = graphModel.getPointRadius('hover-drag'),
     [dragID, setDragID] = useState(''),
-    currPos = useRef({x: 0, y: 0}),
-    target = useRef<any>()
+    currPos = useRef({x: 0, y: 0})
 
   const randomlyDistributePoints = useCallback((cases?: CaseData[]) => {
     const uniform = randomUniform()
@@ -39,64 +38,49 @@ export const CaseDots = function CaseDots(props: {
           points[caseID] = {x: uniform(), y: uniform()}
         }
       })
-  }, []),
+  }, [])
 
-  onDragStart = useCallback((event: MouseEvent) => {
+  const onDragStart = useCallback((event: PointerEvent, point: PIXI.Sprite, metadata: IPixiPointMetadata) => {
     stopAnimation() // We don't want to animate points until end of drag
-    target.current = select(event.target as SVGSVGElement)
-    const aCaseData: CaseData = target.current.node().__data__
-    if (aCaseData && target.current.node()?.nodeName === 'circle') {
-      target.current.transition()
-        .attr('r', dragPointRadius)
-      setDragID(aCaseData.caseID)
-      currPos.current = {x: event.clientX, y: event.clientY}
-      handleClickOnCase(event, aCaseData.caseID, dataset)
+    setDragID(metadata.caseID)
+    currPos.current = { x: event.clientX, y: event.clientY }
+    handleClickOnCase(event, metadata.caseID, dataset)
+  }, [stopAnimation, dataset])
+
+  const onDrag = useCallback((event: PointerEvent, point: PIXI.Sprite, metadata: IPixiPointMetadata) => {
+    const pixiPoints = pixiPointsRef.current
+    if (pixiPoints && dragID !== '') {
+      const newPos = { x: event.clientX, y: event.clientY }
+      const dx = newPos.x - currPos.current.x
+      const dy = newPos.y - currPos.current.y
+      currPos.current = newPos
+      if (dx !== 0 || dy !== 0) {
+        pixiPoints.forEachSelectedPoint((selectedPoint) => {
+          selectedPoint.x += dx
+          selectedPoint.y += dy
+        })
+      }
     }
-  }, [stopAnimation, dragPointRadius, dataset]),
+  }, [pixiPointsRef, dragID])
 
-    onDrag = useCallback((event: MouseEvent) => {
-      if (dotsRef.current && dragID !== '') {
-        const newPos = {x: event.clientX, y: event.clientY},
-          dx = newPos.x - currPos.current.x,
-          dy = newPos.y - currPos.current.y
-        currPos.current = newPos
-        if (dx !== 0 || dy !== 0) {
-          const selectedDots = select(dotsRef.current).selectAll('.graph-dot-highlighted')
-          selectedDots
-            .each((d, i, nodes) => {
-              const element = select(nodes[i])
-              element
-                .attr('cx', Number(element.attr('cx')) + dx)
-                .attr('cy', Number(element.attr('cy')) + dy)
-            })
-        }
-      }
-    }, [dragID, dotsRef]),
+  const onDragEnd = useCallback((event: PointerEvent, point: PIXI.Sprite, metadata: IPixiPointMetadata) => {
+    if (dragID !== '') {
+      setDragID(() => '')
+    }
+  }, [dragID])
 
-    onDragEnd = useCallback(() => {
-      if (dragID !== '') {
-        target.current
-          .classed('dragging', false)
-          .transition()
-          .attr('r', graphModel.getPointRadius('select'))
-        setDragID(() => '')
-        target.current = null
-      }
-    }, [dragID, graphModel])
-
-  useDragHandlers(dotsRef.current, {start: onDragStart, drag: onDrag, end: onDragEnd})
+  usePixiDragHandlers(pixiPointsRef.current, { start: onDragStart, drag: onDrag, end: onDragEnd })
 
   const refreshPointSelection = useCallback(() => {
     const {pointColor, pointStrokeColor} = graphModel.pointDescription,
       selectedPointRadius = graphModel.getPointRadius('select')
     dataConfiguration && setPointSelection({
-      dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(), selectedPointRadius,
+      dotsRef, pixiPointsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(), selectedPointRadius,
       pointColor, pointStrokeColor
     })
-  }, [dataConfiguration, graphModel, dotsRef])
+  }, [graphModel, dataConfiguration, dotsRef, pixiPointsRef])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
-    if (!dotsRef.current) return
     const
       pointRadius = graphModel.getPointRadius(),
       selectedPointRadius = graphModel.getPointRadius('select'),

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -1,11 +1,12 @@
-import {max, range, ScaleBand, ScaleLinear, select} from "d3"
+import {max, range, ScaleBand, ScaleLinear} from "d3"
 import {observer} from "mobx-react-lite"
 import React, {useCallback, useRef, useState} from "react"
+import * as PIXI from "pixi.js"
 import {CaseData} from "../../data-display/d3-types"
 import {PlotProps} from "../graphing-types"
 import {handleClickOnCase, setPointSelection} from "../../data-display/data-display-utils"
 import {useDataDisplayAnimation} from "../../data-display/hooks/use-data-display-animation"
-import {useDragHandlers, usePlotResponders} from "../hooks/use-plot"
+import {usePixiDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {appState} from "../../../models/app-state"
 import {useGraphDataConfigurationContext} from "../hooks/use-graph-data-configuration-context"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
@@ -13,6 +14,7 @@ import {useGraphContentModelContext} from "../hooks/use-graph-content-model-cont
 import {useGraphLayoutContext} from "../hooks/use-graph-layout-context"
 import {ICase} from "../../../models/data/data-set-types"
 import {setPointCoordinates} from "../utilities/graph-utils"
+import {IPixiPointMetadata} from "../utilities/pixi-points"
 
 export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
   const {dotsRef, pixiPointsRef} = props,
@@ -29,101 +31,82 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
     [dragID, setDragID] = useState(''),
     currPos = useRef(0),
     didDrag = useRef(false),
-    target = useRef<any>(),
     selectedDataObjects = useRef<Record<string, number>>({})
 
-  const onDragStart = useCallback((event: any) => {
-      target.current = select(event.target as SVGSVGElement)
-      const aCaseData: CaseData = target.current.node().__data__
-      if (!aCaseData) return
-      dataset?.beginCaching()
-      didDrag.current = false
-      const tItsID: string = aCaseData.caseID
-      if (target.current.node()?.nodeName === 'circle') {
-        stopAnimation() // We don't want to animate points until end of drag
-        appState.beginPerformance()
-        target.current
-          .property('isDragging', true)
-          .transition()
-          .attr('r', graphModel.getPointRadius('hover-drag'))
-        setDragID(() => tItsID)
-        currPos.current = primaryIsBottom ? event.clientX : event.clientY
+  const onDragStart = useCallback((event: PointerEvent, point: PIXI.Sprite, metadata: IPixiPointMetadata) => {
+    dataset?.beginCaching()
+    didDrag.current = false
+    const tItsID: string = metadata.caseID
+    stopAnimation() // We don't want to animate points until end of drag
+    appState.beginPerformance()
+    setDragID(() => tItsID)
+    currPos.current = primaryIsBottom ? event.clientX : event.clientY
+    handleClickOnCase(event, tItsID, dataset)
+    // Record the current values, so we can change them during the drag and restore them when done
+    const {selection} = dataConfiguration || {}
+    const primaryAttrID = dataConfiguration?.attributeID(dataConfiguration?.primaryRole ?? 'x') ?? ''
+    selection?.forEach(anID => {
+      const itsValue = dataset?.getNumeric(anID, primaryAttrID) || undefined
+      if (itsValue != null) {
+        selectedDataObjects.current[anID] = itsValue
+      }
+    })
+  }, [dataset, stopAnimation, primaryIsBottom, dataConfiguration])
 
-        handleClickOnCase(event, tItsID, dataset)
-        // Record the current values, so we can change them during the drag and restore them when done
-        const {selection} = dataConfiguration || {},
-          primaryAttrID = dataConfiguration?.attributeID(dataConfiguration?.primaryRole ?? 'x') ?? ''
+  const onDrag = useCallback((event: PointerEvent) => {
+    const primaryPlace = primaryIsBottom ? 'bottom' : 'left'
+    const primaryAxisScale = layout.getAxisScale(primaryPlace) as ScaleLinear<number, number> | undefined
+    if (primaryAxisScale && dragID) {
+      const newPos = primaryIsBottom ? event.clientX : event.clientY
+      const deltaPixels = newPos - currPos.current
+      const primaryAttrID = dataConfiguration?.attributeID(primaryAttrRole) ?? ''
+      currPos.current = newPos
+      if (deltaPixels !== 0) {
+        didDrag.current = true
+        const delta = Number(primaryAxisScale.invert(deltaPixels)) - Number(primaryAxisScale.invert(0))
+        const caseValues: ICase[] = []
+        const {selection} = dataConfiguration || {}
         selection?.forEach(anID => {
-          const itsValue = dataset?.getNumeric(anID, primaryAttrID) || undefined
-          if (itsValue != null) {
-            selectedDataObjects.current[anID] = itsValue
+          const currValue = Number(dataset?.getNumeric(anID, primaryAttrID))
+          if (isFinite(currValue)) {
+            caseValues.push({__id__: anID, [primaryAttrID]: currValue + delta})
           }
         })
+        caseValues.length && dataset?.setCaseValues(caseValues, [primaryAttrID])
       }
-    }, [dataset, stopAnimation, graphModel, primaryIsBottom, dataConfiguration]),
+    }
+  }, [dataset, dragID, primaryIsBottom, dataConfiguration, layout, primaryAttrRole])
 
-    onDrag = useCallback((event: MouseEvent) => {
-      const primaryPlace = primaryIsBottom ? 'bottom' : 'left',
-        primaryAxisScale = layout.getAxisScale(primaryPlace) as ScaleLinear<number, number> | undefined
-      if (primaryAxisScale && dragID) {
-        const newPos = primaryIsBottom ? event.clientX : event.clientY,
-          deltaPixels = newPos - currPos.current,
-          primaryAttrID = dataConfiguration?.attributeID(primaryAttrRole) ?? ''
-        currPos.current = newPos
-        if (deltaPixels !== 0) {
-          didDrag.current = true
-          const delta = Number(primaryAxisScale.invert(deltaPixels)) -
-              Number(primaryAxisScale.invert(0)),
-            caseValues: ICase[] = [],
-            {selection} = dataConfiguration || {}
-          selection?.forEach(anID => {
-            const currValue = Number(dataset?.getNumeric(anID, primaryAttrID))
-            if (isFinite(currValue)) {
-              caseValues.push({__id__: anID, [primaryAttrID]: currValue + delta})
-            }
+  const onDragEnd = useCallback((event: PointerEvent, point: PIXI.Sprite, metadata: IPixiPointMetadata) => {
+    dataset?.endCaching()
+    appState.endPerformance()
+
+    if (dragID !== '') {
+      setDragID('')
+      if (didDrag.current) {
+        const caseValues: ICase[] = []
+        const {selection} = dataConfiguration || {}
+        selection?.forEach(anID => {
+          caseValues.push({
+            __id__: anID,
+            [dataConfiguration?.attributeID(primaryAttrRole) ?? '']: selectedDataObjects.current[anID]
           })
-          caseValues.length && dataset?.setCaseValues(caseValues, [primaryAttrID])
-        }
+        })
+        startAnimation() // So points will animate back to original positions
+        caseValues.length && dataset?.setCaseValues(caseValues)
+        didDrag.current = false
       }
-    }, [dataset, dragID, primaryIsBottom, dataConfiguration, layout, primaryAttrRole]),
+    }
+  }, [dataset, dragID, dataConfiguration, startAnimation, primaryAttrRole])
 
-    onDragEnd = useCallback(() => {
-      dataset?.endCaching()
-      appState.endPerformance()
-
-      if (dragID !== '') {
-        target.current
-          .classed('dragging', false)
-          .property('isDragging', false)
-          .transition()
-          .attr('r', graphModel.getPointRadius('select'))
-        setDragID('')
-        target.current = null
-
-        if (didDrag.current) {
-          const caseValues: ICase[] = [],
-            {selection} = dataConfiguration || {}
-          selection?.forEach(anID => {
-            caseValues.push({
-              __id__: anID,
-              [dataConfiguration?.attributeID(primaryAttrRole) ?? '']: selectedDataObjects.current[anID]
-            })
-          })
-          startAnimation() // So points will animate back to original positions
-          caseValues.length && dataset?.setCaseValues(caseValues)
-          didDrag.current = false
-        }
-      }
-    }, [dataset, dragID, graphModel, dataConfiguration, startAnimation, primaryAttrRole])
-
-  useDragHandlers(dotsRef.current, {start: onDragStart, drag: onDrag, end: onDragEnd})
+  usePixiDragHandlers(pixiPointsRef.current, {start: onDragStart, drag: onDrag, end: onDragEnd})
 
   const refreshPointSelection = useCallback(() => {
     dataConfiguration && setPointSelection({
-      dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(),
+      pixiPointsRef, dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(),
       pointColor, pointStrokeColor, selectedPointRadius: graphModel.getPointRadius('select')
     })
-  }, [dataConfiguration, dotsRef, graphModel, pointColor, pointStrokeColor])
+  }, [dataConfiguration, dotsRef, graphModel, pixiPointsRef, pointColor, pointStrokeColor])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
       const primaryPlace = primaryIsBottom ? 'bottom' : 'left',

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -230,7 +230,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
           <svg ref={plotAreaSVGRef} className="plot-area-svg">
 
             <svg ref={dotsRef} className={`graph-dot-area ${instanceId}`}>
-            <foreignObject ref={pixiContainerRef} x={0} y={0} width="100%" height="100%" style={{pointerEvents: "none"}}/>
+            <foreignObject ref={pixiContainerRef} x={0} y={0} width="100%" height="100%"/>
               {renderPlotComponent()}
             </svg>
             <Marquee marqueeState={marqueeState}/>

--- a/v3/src/components/graph/utilities/pixi-points.ts
+++ b/v3/src/components/graph/utilities/pixi-points.ts
@@ -4,7 +4,7 @@ import { PixiTransition } from "./pixi-transition"
 import { hoverRadiusFactor, transitionDuration } from "../../data-display/data-display-types"
 
 const DEFAULT_Z_INDEX = 0
-const RAISED_Z_INDEX = 1
+const RAISED_Z_INDEX = 100
 const MAX_SPRITE_SCALE = 2
 
 export type IPixiPointsRef = React.MutableRefObject<PixiPoints | undefined>
@@ -62,6 +62,8 @@ export class PixiPoints {
     this.ticker.add(() => this.renderer.render(this.stage))
     this.stage.addChild(this.background)
     this.stage.addChild(this.pointsContainer)
+    // Enable zIndex support
+    this.pointsContainer.sortableChildren = true
   }
 
   get canvas() {


### PR DESCRIPTION
This PR primarily focuses on implementing point dragging behavior using PixiJS. Compared to the previous SVG-based version, the current implementation addresses some issues and introduces/restores V2 features. To make QA and verification easier, I've added new PT stories:

- Basic dragging behavior [PT-186717142](https://www.pivotaltracker.com/story/show/186717142).
- Point selection via mouse click or shift + click [PT-186725017](https://www.pivotaltracker.com/story/show/186725017).
- Touch support for dragging [PT-186724975](https://www.pivotaltracker.com/story/show/186724975).
- Enabling dragging of graph points outside graph boundaries, similar to V2 [PT-186724979](https://www.pivotaltracker.com/story/show/186724979).
- Enhancing the reliability of point dragging, preventing 'lost' dragged points, unlike in the SVG version [PT-186724949](https://www.pivotaltracker.com/story/show/186724949).
- Fixing the animation of points returning to their initial position after dragging is completed [PT-186724971](https://www.pivotaltracker.com/story/show/186724971).


Additionally, dragging should now be much smoother, and the performance mode for rendering/dragging should also work better with large datasets.

Regarding the implementation details, I've tried to utilize as much of the existing drag handlers as possible to ensure no disruption of their functionality. I've also removed some radius logic, as it seems that the hover effect was already handling that (and that's now managed directly by the PixiPoints class).