### PR TITLE
chore: cleanup references to IDotsRef and replace it with PixiPointsRef

### DIFF
--- a/v3/cypress/support/elements/point-elements.ts
+++ b/v3/cypress/support/elements/point-elements.ts
@@ -42,18 +42,6 @@ export const PointElements = {
       return $style.substring($style.indexOf("stroke:") + 1, $style.indexOf(")"))
     })
   },
-  verifyPointIsSelected(index) {
-    this.getPointOnGraph(index).invoke("attr", "class").should("contain", "graph-dot-highlighted")
-    this.getPointColor(index).should("contain", "rgb(70, 130, 180)")
-  },
-  verifyPointIsSelectedFromLegend(index) {
-    this.getPointOnGraph(index).invoke("attr", "class").should("contain", "graph-dot-highlighted")
-    this.getPointStroke(index).should("contain", "rgb(255, 0, 0)")
-  },
-  verifyHighlightedPoint(tooltip) {
-    this.getGraphTile().find("[data-testid=graph-dot].graph-dot-highlighted").click()
-    cy.get("[data-testid=graph-point-data-tip]").should("have.text", tooltip)
-  },
   verifyGraphPointDataToolTip(tooltip) {
     cy.get("[data-testid=graph-point-data-tip]").should("have.text", tooltip)
   }

--- a/v3/src/components/data-display/data-display-types.ts
+++ b/v3/src/components/data-display/data-display-types.ts
@@ -1,9 +1,6 @@
 import React from "react"
-import {DotsElt} from "./d3-types"
 import {AxisPlace} from "../axis/axis-types"
 import {GraphPlace} from "../axis-graph-shared"
-
-export type IDotsRef = React.MutableRefObject<DotsElt>
 
 export type Point = { x: number, y: number }
 export type CPLine = { slope: number, intercept: number, pivot1?: Point, pivot2?: Point }

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -7,7 +7,6 @@ import {
 } from "../../utilities/color-utils"
 import {IDataSet} from "../../models/data/data-set"
 import {IDataConfigurationModel } from "./models/data-configuration-model"
-import {DotsElt} from "./d3-types"
 import {
   hoverRadiusFactor, kDataDisplayFont, Point, pointRadiusLogBase, pointRadiusMax, pointRadiusMin,
   pointRadiusSelectionAddend, Rect, rTreeRect
@@ -78,7 +77,6 @@ export function handleClickOnCase(event: MouseEvent, caseID: string, dataset?: I
 
 export interface IMatchCirclesProps {
   dataConfiguration: IDataConfigurationModel
-  dotsElement: DotsElt
   pointRadius: number
   pointColor: string
   pointStrokeColor: string
@@ -88,37 +86,8 @@ export interface IMatchCirclesProps {
 }
 
 export function matchCirclesToData(props: IMatchCirclesProps) {
-  // TODO PIXI: remove old SVG code
-  //   caseDataKeyFunc = (d: CaseData) => `${d.plotNum}-${d.caseID}`,
-  //   circles = selectCircles(dotsElement, id)
-  // if (!circles) return
-  // startAnimation()
-  // circles
-  //   .data(allCaseData, caseDataKeyFunc)
-  //   .join(
-  //     (enter) =>
-  //       enter.append('circle')
-  //         .attr('class', `graph-dot ${id}`)
-  //         .property('id', (d: CaseData) => `${instanceId}_${d.caseID}`),
-  //     (update) =>
-  //       update.attr('r', pointRadius)
-  //         .style('fill', pointColor)
-  //         .style('stroke', pointStrokeColor)
-  //         .style('stroke-width', defaultStrokeWidth)
-  //   )
-  // dotsElement && select(dotsElement).on('click',
-  //   (event: MouseEvent) => {
-  //     const target = select(event.target as SVGSVGElement)
-  //     if (target.node()?.nodeName === 'circle') {
-  //       handleClickOnCase(event, (target.datum() as CaseData).caseID, dataConfiguration.dataset)
-  //       event.stopPropagation()
-  //     }
-  //   })
-
-  // TODO PIXI: add interactivity from the code above
   const { dataConfiguration, pixiPoints, startAnimation, pointRadius, pointColor, pointStrokeColor } = props
   const allCaseData = dataConfiguration.joinedCaseDataArrays
-
   if (!pixiPoints) {
     return
   }
@@ -140,35 +109,6 @@ export function setPointSelection(props: ISetPointSelection) {
     pointColor, pointStrokeColor, getPointColorAtIndex } = props
   const dataset = dataConfiguration.dataset
   const legendID = dataConfiguration.attributeID('legend')
-
-  // TODO PIXI: remove SVG code
-  // First set the class based on selection
-  // dots
-  //   .classed('graph-dot-highlighted', (aCaseData: CaseData) => !!dataset?.isCaseSelected(aCaseData.caseID))
-  //   // Then set properties to defaults w/o selection
-  //   .attr('r', pointRadius)
-  //   .style('stroke', pointStrokeColor)
-  //   .style('fill', (aCaseData: CaseData) => {
-  //     return legendID
-  //       ? dataConfiguration?.getLegendColorForCase(aCaseData.caseID)
-  //       : aCaseData.plotNum && getPointColorAtIndex
-  //         ? getPointColorAtIndex(aCaseData.plotNum) : pointColor
-  //   })
-  //   .style('stroke-width', defaultStrokeWidth)
-  //   .style('stroke-opacity', defaultStrokeOpacity)
-
-  // const selectedDots = selectDots(dotsRef.current, true)
-  // // How we deal with this depends on whether there is a legend or not
-  // if (legendID) {
-  //   selectedDots?.style('stroke', defaultSelectedStroke)
-  //     .style('stroke-width', defaultSelectedStrokeWidth)
-  //     .style('stroke-opacity', defaultSelectedStrokeOpacity)
-  // } else {
-  //   selectedDots?.style('fill', defaultSelectedColor)
-  // }
-  // selectedDots?.attr('r', selectedPointRadius)
-  //   .raise()
-
   const pixiRenderer = pixiPointsRef?.current
   if (!pixiRenderer) {
     return
@@ -194,7 +134,6 @@ export function setPointSelection(props: ISetPointSelection) {
       strokeOpacity: isSelectedAndLegendIsPresent ? defaultSelectedStrokeOpacity : defaultStrokeOpacity
     }
     pixiRenderer.setPointStyle(point, style)
-    // TODO PIXI: is this enough? Or should be raised to a separate layer?
     pixiRenderer.setPointRaised(point, isSelected)
   })
 }

--- a/v3/src/components/data-display/hooks/use-data-tips.ts
+++ b/v3/src/components/data-display/hooks/use-data-tips.ts
@@ -2,7 +2,7 @@ import {select} from "d3"
 import {useEffect} from "react"
 import {tip as d3tip} from "d3-v6-tip"
 import {IDataSet} from "../../../models/data/data-set"
-import {IDotsRef, transitionDuration} from "../data-display-types"
+import {transitionDuration} from "../data-display-types"
 import {CaseData} from "../d3-types"
 import {getCaseTipText} from "../data-display-utils"
 import {RoleAttrIDPair} from "../models/data-configuration-model"
@@ -11,6 +11,7 @@ import {isGraphDataConfigurationModel} from "../../graph/models/graph-data-confi
 import {IGraphContentModel} from "../../graph/models/graph-content-model"
 import {IMapPointLayerModel} from "../../map/models/map-point-layer-model"
 import {useDataDisplayAnimation} from "./use-data-display-animation"
+import {IPixiPointsRef} from "../../graph/utilities/pixi-points"
 
 const dataTip = d3tip().attr('class', 'graph-d3-tip')/*.attr('opacity', 0.8)*/
   .attr('data-testid', 'graph-point-data-tip')
@@ -19,12 +20,12 @@ const dataTip = d3tip().attr('class', 'graph-d3-tip')/*.attr('opacity', 0.8)*/
   })
 
 interface IUseDataTips {
-  dotsRef: IDotsRef,
+  pixiPointsRef?: IPixiPointsRef,
   dataset: IDataSet | undefined,
   displayModel: IGraphContentModel | IMapPointLayerModel,
 }
 
-export const useDataTips = ({dotsRef, dataset, displayModel}: IUseDataTips) => {
+export const useDataTips = ({dataset, displayModel}: IUseDataTips) => {
   const { isAnimating } = useDataDisplayAnimation(),
     hoverPointRadius = displayModel.getPointRadius('hover-drag'),
     pointRadius = displayModel.getPointRadius(),
@@ -73,11 +74,12 @@ export const useDataTips = ({dotsRef, dataset, displayModel}: IUseDataTips) => {
 
     // support disabling data tips via url parameter for jest tests
     if (urlParams.noDataTips === undefined) {
-      dotsRef.current && select(dotsRef.current)
-        .on('mouseover', showDataTip)
-        .on('mouseout', hideDataTip)
-        .call(dataTip)
+      // TODO PIXI: reimplement data tips
+      // dotsRef.current && select(dotsRef.current)
+      //   .on('mouseover', showDataTip)
+      //   .on('mouseout', hideDataTip)
+      //   .call(dataTip)
     }
-  }, [dotsRef, dataset, yAttrIDs, hoverPointRadius, pointRadius, selectedPointRadius,
+  }, [dataset, yAttrIDs, hoverPointRadius, pointRadius, selectedPointRadius,
     displayModel.dataConfiguration.uniqueTipAttributes, isAnimating])
 }

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -3,7 +3,6 @@ import {mstReaction} from "../../../utilities/mst-reaction"
 import React, {useCallback, useEffect, useRef, useState} from "react"
 import * as PIXI from "pixi.js"
 import {CaseData} from "../../data-display/d3-types"
-import {IDotsRef} from "../../data-display/data-display-types"
 import {handleClickOnCase, setPointSelection} from "../../data-display/data-display-utils"
 import {useDataDisplayAnimation} from "../../data-display/hooks/use-data-display-animation"
 import {usePixiDragHandlers, usePlotResponders} from "../hooks/use-plot"
@@ -15,11 +14,10 @@ import {setPointCoordinates} from "../utilities/graph-utils"
 import {IPixiPointMetadata, IPixiPointsRef} from "../utilities/pixi-points"
 
 export const CaseDots = function CaseDots(props: {
-  dotsRef: IDotsRef,
   pixiPointsRef: IPixiPointsRef
 }) {
   const {
-      dotsRef, pixiPointsRef
+      pixiPointsRef
     } = props,
     graphModel = useGraphContentModelContext(),
     {isAnimating, startAnimation, stopAnimation} = useDataDisplayAnimation(),
@@ -75,10 +73,10 @@ export const CaseDots = function CaseDots(props: {
     const {pointColor, pointStrokeColor} = graphModel.pointDescription,
       selectedPointRadius = graphModel.getPointRadius('select')
     dataConfiguration && setPointSelection({
-      dotsRef, pixiPointsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(), selectedPointRadius,
+      pixiPointsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(), selectedPointRadius,
       pointColor, pointStrokeColor
     })
-  }, [graphModel, dataConfiguration, dotsRef, pixiPointsRef])
+  }, [graphModel, dataConfiguration, pixiPointsRef])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
     const
@@ -97,10 +95,10 @@ export const CaseDots = function CaseDots(props: {
         ? dataConfiguration?.getLegendColorForCase : undefined
 
     setPointCoordinates({
-      dataset, pointRadius, selectedPointRadius, dotsRef, pixiPointsRef, selectedOnly,
+      dataset, pointRadius, selectedPointRadius, pixiPointsRef, selectedOnly,
       pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating
     })
-  }, [dotsRef, pixiPointsRef, graphModel, layout, dataConfiguration, dataset, isAnimating])
+  }, [pixiPointsRef, graphModel, layout, dataConfiguration, dataset, isAnimating])
 
   useEffect(function initDistribution() {
     const cases = dataConfiguration?.caseDataArray
@@ -126,7 +124,7 @@ export const CaseDots = function CaseDots(props: {
   }, [dataConfiguration?.caseDataArray, graphModel,
       randomlyDistributePoints, refreshPointPositions, startAnimation])
 
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection})
+  usePlotResponders({pixiPointsRef, refreshPointPositions, refreshPointSelection})
 
   return (
     <></>

--- a/v3/src/components/graph/components/chartdots.tsx
+++ b/v3/src/components/graph/components/chartdots.tsx
@@ -1,6 +1,6 @@
 import {ScaleBand} from "d3"
 import React, {useCallback} from "react"
-import {CaseData, selectDots} from "../../data-display/d3-types"
+import {CaseData} from "../../data-display/d3-types"
 import {PlotProps} from "../graphing-types"
 import {usePlotResponders} from "../hooks/use-plot"
 import {useGraphDataConfigurationContext} from "../hooks/use-graph-data-configuration-context"
@@ -15,7 +15,7 @@ import {setPointCoordinates} from "../utilities/graph-utils"
 type BinMap = Record<string, Record<string, Record<string, Record<string, number>>>>
 
 export const ChartDots = function ChartDots(props: PlotProps) {
-  const {dotsRef, pixiPointsRef} = props,
+  const {pixiPointsRef} = props,
     graphModel = useGraphContentModelContext(),
     {isAnimating} = useDataDisplayAnimation(),
     {pointColor, pointStrokeColor} = graphModel.pointDescription,
@@ -78,10 +78,10 @@ export const ChartDots = function ChartDots(props: PlotProps) {
 
   const refreshPointSelection = useCallback(() => {
     dataConfiguration && setPointSelection({
-      pointColor, pointStrokeColor, dotsRef, dataConfiguration,
+      pointColor, pointStrokeColor, dataConfiguration,
       pointRadius: graphModel.getPointRadius(), selectedPointRadius: graphModel.getPointRadius('select')
     })
-  }, [dataConfiguration, dotsRef, graphModel, pointColor, pointStrokeColor])
+  }, [dataConfiguration, graphModel, pointColor, pointStrokeColor])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
     // We're pretending that the primaryRole is the bottom just to help understand the naming
@@ -100,7 +100,6 @@ export const ChartDots = function ChartDots(props: PlotProps) {
       extraSecCatsArray: string[] = (dataConfiguration && extraSecondaryAttrRole)
         ? Array.from(dataConfiguration.categoryArrayForAttrRole(extraSecondaryAttrRole)) : [],
       pointDiameter = 2 * graphModel.getPointRadius(),
-      selection = selectDots(dotsRef.current, selectedOnly),
       primOrdinalScale = layout.getAxisScale(primaryAxisPlace) as ScaleBand<string>,
       secOrdinalScale = layout.getAxisScale(secondaryAxisPlace) as ScaleBand<string>,
       extraPrimOrdinalScale = layout.getAxisScale(extraPrimaryAxisPlace) as ScaleBand<string>,
@@ -116,8 +115,6 @@ export const ChartDots = function ChartDots(props: PlotProps) {
         { cell: { p: number, s: number, ep: number, es: number }, numSoFar: number }>>>> = {},
       legendAttrID = dataConfiguration?.attributeID('legend'),
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined
-
-    if (!selection) return
 
     const computeCellParams = () => {
         primCatsArray.forEach((primeCat, i) => {
@@ -211,14 +208,14 @@ export const ChartDots = function ChartDots(props: PlotProps) {
 
     setPointCoordinates({
       dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),
-      dotsRef, pixiPointsRef, selectedOnly, pointColor, pointStrokeColor,
+      pixiPointsRef, selectedOnly, pointColor, pointStrokeColor,
       getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating
     })
-  }, [dataConfiguration, primaryAxisPlace, primaryAttrRole, secondaryAttrRole, graphModel, dotsRef, pixiPointsRef,
+  }, [dataConfiguration, primaryAxisPlace, primaryAttrRole, secondaryAttrRole, graphModel, pixiPointsRef,
     extraPrimaryAttrRole, extraSecondaryAttrRole, pointColor, isAnimating,
     primaryIsBottom, layout, pointStrokeColor, computeMaxOverAllCells, dataset])
 
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection})
+  usePlotResponders({pixiPointsRef, refreshPointPositions, refreshPointSelection})
 
   return (
     <></>

--- a/v3/src/components/graph/components/dotplotdots.tsx
+++ b/v3/src/components/graph/components/dotplotdots.tsx
@@ -17,7 +17,7 @@ import {setPointCoordinates} from "../utilities/graph-utils"
 import {IPixiPointMetadata} from "../utilities/pixi-points"
 
 export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
-  const {dotsRef, pixiPointsRef} = props,
+  const {pixiPointsRef} = props,
     graphModel = useGraphContentModelContext(),
     {isAnimating, startAnimation, stopAnimation} = useDataDisplayAnimation(),
     dataConfiguration = useGraphDataConfigurationContext(),
@@ -103,10 +103,10 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
 
   const refreshPointSelection = useCallback(() => {
     dataConfiguration && setPointSelection({
-      pixiPointsRef, dotsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(),
+      pixiPointsRef, dataConfiguration, pointRadius: graphModel.getPointRadius(),
       pointColor, pointStrokeColor, selectedPointRadius: graphModel.getPointRadius('select')
     })
-  }, [dataConfiguration, dotsRef, graphModel, pixiPointsRef, pointColor, pointStrokeColor])
+  }, [dataConfiguration, graphModel, pixiPointsRef, pointColor, pointStrokeColor])
 
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
       const primaryPlace = primaryIsBottom ? 'bottom' : 'left',
@@ -240,14 +240,14 @@ export const DotPlotDots = observer(function DotPlotDots(props: PlotProps) {
       setPointCoordinates({
         dataset, pointRadius: graphModel.getPointRadius(),
         selectedPointRadius: graphModel.getPointRadius('select'),
-        dotsRef, pixiPointsRef, selectedOnly, pointColor, pointStrokeColor,
+        pixiPointsRef, selectedOnly, pointColor, pointStrokeColor,
         getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating
       })
     },
-    [graphModel, dataConfiguration, layout, primaryAttrRole, secondaryAttrRole, dataset, dotsRef, pixiPointsRef,
+    [graphModel, dataConfiguration, layout, primaryAttrRole, secondaryAttrRole, dataset, pixiPointsRef,
       primaryIsBottom, pointColor, pointStrokeColor, isAnimating])
 
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection})
+  usePlotResponders({pixiPointsRef, refreshPointPositions, refreshPointSelection})
 
   return (
     <></>

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -15,7 +15,6 @@ import {AxisLayoutContext} from "../../axis/models/axis-layout-context"
 import {GraphController} from "../models/graph-controller"
 import {isGraphContentModel} from "../models/graph-content-model"
 import {Graph} from "./graph"
-import {DotsElt} from '../../data-display/d3-types'
 import {AttributeDragOverlay} from "../../drag-drop/attribute-drag-overlay"
 import {PixiPoints} from "../utilities/pixi-points"
 import "../register-adornment-types"
@@ -29,7 +28,6 @@ export const GraphComponent = observer(function GraphComponent({ tile }: ITileBa
   // Removed debouncing, but we can bring it back if we find we need it
   const graphRef = useRef<HTMLDivElement | null>(null)
   const { width, height } = useResizeDetector<HTMLDivElement>({ targetRef: graphRef })
-  const dotsRef = useRef<DotsElt>(null)
   const pixiPointsRef = useRef<PixiPoints>()
   // TODO PIXI: PJ: probably should be fixed and become a ref, as memoization is meant for performance optimization
   // and it's not guaranteed to be maintained across renders.
@@ -43,7 +41,7 @@ export const GraphComponent = observer(function GraphComponent({ tile }: ITileBa
     return () => pixiPointsRef.current?.dispose()
   }, [])
 
-  useGraphController({ graphController, graphModel, dotsRef, pixiPointsRef })
+  useGraphController({ graphController, graphModel, pixiPointsRef })
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setTileExtent(width, height)
@@ -76,7 +74,6 @@ export const GraphComponent = observer(function GraphComponent({ tile }: ITileBa
                 <Graph
                   graphController={graphController}
                   graphRef={graphRef}
-                  dotsRef={dotsRef}
                   pixiPointsRef={pixiPointsRef}
                 />
               </AxisProviderContext.Provider>

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -84,18 +84,6 @@
   fill: white;
 }
 
-.graph-dot {
-  pointer-events: auto;
-  fill: rgba(230, 128, 91);
-  stroke: white;
-  cursor: pointer;
-  stroke-opacity: 0.4;
-  fill-opacity: 0.85;
-}
-
-.graph-dot-highlighted {
-  //fill: steelblue;
-}
 
 .graph-d3-tip {
   font-size: small;

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -3,7 +3,7 @@ import {addDisposer, isAlive} from "mobx-state-tree"
 import React, {MutableRefObject, useCallback, useEffect, useMemo, useRef} from "react"
 import {select} from "d3"
 import {clsx} from "clsx"
-import {GraphAttrRole, IDotsRef, attrRoleToGraphPlace, graphPlaceToAttrRole, kPortalClass}
+import {GraphAttrRole, attrRoleToGraphPlace, graphPlaceToAttrRole, kPortalClass}
   from "../../data-display/data-display-types"
 import {AxisPlace, AxisPlaces} from "../../axis/axis-types"
 import {GraphAxis} from "./graph-axis"
@@ -45,11 +45,10 @@ import "./graph.scss"
 interface IProps {
   graphController: GraphController
   graphRef: MutableRefObject<HTMLDivElement | null>
-  dotsRef: IDotsRef
   pixiPointsRef: IPixiPointsRef
 }
 
-export const Graph = observer(function Graph({graphController, graphRef, dotsRef, pixiPointsRef}: IProps) {
+export const Graph = observer(function Graph({graphController, graphRef, pixiPointsRef}: IProps) {
   const graphModel = useGraphContentModelContext(),
     {plotType} = graphModel,
     {startAnimation} = useDataDisplayAnimation(),
@@ -162,10 +161,10 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     return () => disposer?.()
   }, [graphController, layout, graphModel, startAnimation])
 
-  useDataTips({dotsRef, dataset, displayModel: graphModel})
+  useDataTips({pixiPointsRef, dataset, displayModel: graphModel})
 
   const renderPlotComponent = () => {
-    const props = {xAttrID, yAttrID, dotsRef, pixiPointsRef},
+    const props = {xAttrID, yAttrID, pixiPointsRef},
       typeToPlotComponentMap = {
         casePlot: <CaseDots {...props}/>,
         dotChart: <ChartDots {...props}/>,
@@ -211,7 +210,7 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
     return droppables
   }
 
-  useGraphModel({dotsRef, graphModel, instanceId})
+  useGraphModel({pixiPointsRef, graphModel, instanceId})
 
   if (!isAlive(graphModel)) return null
 
@@ -228,11 +227,8 @@ export const Graph = observer(function Graph({graphController, graphRef, dotsRef
           {renderGraphAxes()}
 
           <svg ref={plotAreaSVGRef} className="plot-area-svg">
-
-            <svg ref={dotsRef} className={`graph-dot-area ${instanceId}`}>
             <foreignObject ref={pixiContainerRef} x={0} y={0} width="100%" height="100%"/>
               {renderPlotComponent()}
-            </svg>
             <Marquee marqueeState={marqueeState}/>
           </svg>
 

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -22,7 +22,7 @@ import {scatterPlotFuncs} from "./scatter-plot-utils"
 import { IPixiPointMetadata } from "../utilities/pixi-points"
 
 export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
-  const {dotsRef, pixiPointsRef} = props,
+  const {pixiPointsRef} = props,
     graphModel = useGraphContentModelContext(),
     instanceId = useInstanceIdContext(),
     dataConfiguration = useGraphDataConfigurationContext(),
@@ -144,11 +144,11 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
     const {pointColor, pointStrokeColor} = graphModel.pointDescription
     dataConfiguration && setPointSelection(
       {
-        dotsRef, pixiPointsRef, dataConfiguration, pointRadius: pointRadiusRef.current,
+        pixiPointsRef, dataConfiguration, pointRadius: pointRadiusRef.current,
         selectedPointRadius: selectedPointRadiusRef.current,
         pointColor, pointStrokeColor, getPointColorAtIndex: graphModel.pointDescription.pointColorAtIndex
       })
-  }, [dataConfiguration, dotsRef, graphModel, pixiPointsRef])
+  }, [dataConfiguration, graphModel, pixiPointsRef])
 
   const refreshSquares = useCallback(() => {
 
@@ -193,13 +193,13 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined
 
     setPointCoordinates({
-      dataset, dotsRef, pixiPointsRef, pointRadius: pointRadiusRef.current,
+      dataset, pixiPointsRef, pointRadius: pointRadiusRef.current,
       selectedPointRadius: selectedPointRadiusRef.current,
       selectedOnly, getScreenX, getScreenY, getLegendColor,
       getPointColorAtIndex: graphModel.pointDescription.pointColorAtIndex,
       pointColor, pointStrokeColor, getAnimationEnabled: isAnimating
     })
-  }, [dataConfiguration, graphModel.pointDescription, layout, legendAttrID, dataset, dotsRef, pixiPointsRef,
+  }, [dataConfiguration, graphModel.pointDescription, layout, legendAttrID, dataset, pixiPointsRef,
     isAnimating])
 
   const refreshPointPositionsPerfMode = useCallback((selectedOnly: boolean) => {
@@ -245,7 +245,7 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
   }, [refreshSquares, showSquares])
 
   // TODO PIXI: pass pixi points here, adapt this hook?
-  usePlotResponders({dotsRef, refreshPointPositions, refreshPointSelection})
+  usePlotResponders({pixiPointsRef, refreshPointPositions, refreshPointSelection})
 
   return (
     <>

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -1,8 +1,6 @@
-import { IDotsRef } from "../data-display/data-display-types"
 import { IPixiPointsRef } from "./utilities/pixi-points"
 
 export interface PlotProps {
-  dotsRef: IDotsRef
   pixiPointsRef: IPixiPointsRef
 }
 

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,5 +1,4 @@
 import {useEffect} from "react"
-import {IDotsRef} from "../../data-display/data-display-types"
 import {GraphController} from "../models/graph-controller"
 import {IGraphContentModel} from "../models/graph-content-model"
 import {IPixiPointsRef} from "../utilities/pixi-points"
@@ -7,12 +6,11 @@ import {IPixiPointsRef} from "../utilities/pixi-points"
 export interface IUseGraphControllerProps {
   graphController: GraphController,
   graphModel?: IGraphContentModel,
-  dotsRef: IDotsRef
   pixiPointsRef: IPixiPointsRef
 }
 
-export const useGraphController = ({graphController, graphModel, dotsRef, pixiPointsRef}: IUseGraphControllerProps) => {
+export const useGraphController = ({graphController, graphModel, pixiPointsRef}: IUseGraphControllerProps) => {
   useEffect(() => {
-    graphModel && graphController.setProperties({graphModel, dotsRef, pixiPointsRef})
-  }, [graphController, graphModel, dotsRef, pixiPointsRef])
+    graphModel && graphController.setProperties({graphModel, pixiPointsRef})
+  }, [graphController, graphModel, pixiPointsRef])
 }

--- a/v3/src/components/graph/hooks/use-graph-model.ts
+++ b/v3/src/components/graph/hooks/use-graph-model.ts
@@ -1,20 +1,20 @@
 import {useCallback, useEffect} from "react"
 import {onAnyAction} from "../../../utilities/mst-utils"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
-import {IDotsRef} from "../../data-display/data-display-types"
 import {matchCirclesToData} from "../../data-display/data-display-utils"
 import {setNiceDomain} from "../utilities/graph-utils"
+import {IPixiPointsRef} from "../utilities/pixi-points"
 import {IGraphContentModel, isGraphVisualPropsAction} from "../models/graph-content-model"
 import {INumericAxisModel} from "../../axis/models/axis-model"
 
 interface IProps {
   graphModel: IGraphContentModel
-  dotsRef: IDotsRef
+  pixiPointsRef: IPixiPointsRef
   instanceId: string | undefined
 }
 
 export function useGraphModel(props: IProps) {
-  const {graphModel, dotsRef, instanceId} = props,
+  const {graphModel, instanceId, pixiPointsRef} = props,
     dataConfig = graphModel.dataConfiguration,
     yAxisModel = graphModel.getAxis('left'),
     yAttrID = graphModel.getAttributeID('y'),
@@ -24,13 +24,13 @@ export function useGraphModel(props: IProps) {
   const callMatchCirclesToData = useCallback(() => {
     dataConfig && matchCirclesToData({
       dataConfiguration: dataConfig,
+      pixiPoints: pixiPointsRef.current,
       pointRadius: graphModel.getPointRadius(),
       pointColor: graphModel.pointDescription.pointColor,
       pointStrokeColor: graphModel.pointDescription.pointStrokeColor,
-      dotsElement: dotsRef.current,
       startAnimation, instanceId
     })
-  }, [dataConfig, graphModel, dotsRef, startAnimation, instanceId])
+  }, [dataConfig, pixiPointsRef, graphModel, startAnimation, instanceId])
 
   // respond to change in plotType
   useEffect(function installPlotTypeAction() {

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -6,13 +6,13 @@ import {mstAutorun} from "../../../utilities/mst-autorun"
 import {mstReaction} from "../../../utilities/mst-reaction"
 import {useCurrent} from "../../../hooks/use-current"
 import {isSelectionAction, isSetCaseValuesAction} from "../../../models/data/data-set-actions"
-import {GraphAttrRoles, IDotsRef} from "../../data-display/data-display-types"
+import {GraphAttrRoles} from "../../data-display/data-display-types"
 import {matchCirclesToData} from "../../data-display/data-display-utils"
 import {useGraphContentModelContext} from "./use-graph-content-model-context"
 import {useGraphLayoutContext} from "./use-graph-layout-context"
 import {IAxisModel} from "../../axis/models/axis-model"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
-import { DragHandler, PixiPoints } from "../utilities/pixi-points"
+import { DragHandler, IPixiPointsRef, PixiPoints } from "../utilities/pixi-points"
 
 export interface IPixiDragHandlers {
   start: DragHandler
@@ -39,7 +39,7 @@ export const usePixiDragHandlers = (pixiPoints: PixiPoints | undefined, {start, 
 export interface IPlotResponderProps {
   refreshPointPositions: (selectedOnly: boolean) => void
   refreshPointSelection: () => void
-  dotsRef: IDotsRef
+  pixiPointsRef: IPixiPointsRef
 }
 
 function isDefunctAxisModel(axisModel?: IAxisModel) {
@@ -47,7 +47,7 @@ function isDefunctAxisModel(axisModel?: IAxisModel) {
 }
 
 export const usePlotResponders = (props: IPlotResponderProps) => {
-  const { refreshPointPositions, refreshPointSelection, dotsRef} = props,
+  const { refreshPointPositions, refreshPointSelection, pixiPointsRef} = props,
     graphModel = useGraphContentModelContext(),
     startAnimation = graphModel.startAnimation,
     layout = useGraphLayoutContext(),
@@ -140,14 +140,14 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           pointRadius: graphModel.getPointRadius(),
           pointColor: graphModel.pointDescription.pointColor,
           pointStrokeColor: graphModel.pointDescription.pointStrokeColor,
-          dotsElement: dotsRef.current,
+          pixiPoints: pixiPointsRef.current,
           startAnimation, instanceId
         })
         callRefreshPointPositions(false)
       }, { name: "respondToHiddenCasesChange" }, dataConfiguration
     )
     return () => disposer()
-  }, [callRefreshPointPositions, dataConfiguration, dotsRef, graphModel, instanceId, startAnimation])
+  }, [callRefreshPointPositions, dataConfiguration, graphModel, instanceId, pixiPointsRef, startAnimation])
 
   // respond to axis range changes (e.g. component resizing)
   useEffect(() => {
@@ -190,14 +190,14 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           pointRadius: graphModel.getPointRadius(),
           pointColor: graphModel.pointDescription.pointColor,
           pointStrokeColor: graphModel.pointDescription.pointStrokeColor,
-          dotsElement: dotsRef.current,
+          pixiPoints: pixiPointsRef.current,
           startAnimation, instanceId
         })
         callRefreshPointPositions(false)
       }
     }) || (() => true)
     return () => disposer()
-  }, [dataset, dataConfiguration, startAnimation, graphModel, callRefreshPointPositions, dotsRef, instanceId])
+  }, [dataset, dataConfiguration, startAnimation, graphModel, callRefreshPointPositions, instanceId, pixiPointsRef])
 
   // respond to pointsNeedUpdating becoming false; that is when the points have been updated
   // Happens when the number of plots has changed for now. Possibly other situations in the future.

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -56,9 +56,8 @@ describe("GraphController", () => {
     mockGetMetadata.mockImplementation(() => metadata)
     const layout = new GraphLayout()
     const graphController = new GraphController({ layout, instanceId })
-    const dotsRef = { current: {} } as any
     const pixiPointsRef = { current: {} } as any
-    graphController.setProperties({ graphModel, dotsRef, pixiPointsRef })
+    graphController.setProperties({ graphModel, pixiPointsRef })
     return { tree: _tree, model: graphModel, controller: graphController, data: dataSet }
   }
 
@@ -94,13 +93,13 @@ describe("GraphController", () => {
     _controller.handleAttributeAssignment("bottom", data.id, "bogusId")
     expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
 
-    _controller.setProperties({ graphModel: model, dotsRef: undefined as any, pixiPointsRef: undefined as any })
+    _controller.setProperties({ graphModel: model, pixiPointsRef: undefined as any })
     _controller.initializeGraph()
     expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
     _controller.callMatchCirclesToData()
     expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
 
-    _controller.setProperties({ graphModel: model, dotsRef: {} as any, pixiPointsRef: undefined as any })
+    _controller.setProperties({ graphModel: model, pixiPointsRef: undefined as any })
     _controller.initializeGraph()
     expect(mockMatchCirclesToData).toHaveBeenCalledTimes(1)
     _controller.callMatchCirclesToData()

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -1,5 +1,5 @@
 import {getDataSetFromId} from "../../../models/shared/shared-data-utils"
-import {IDotsRef, axisPlaceToAttrRole, graphPlaceToAttrRole} from "../../data-display/data-display-types"
+import {axisPlaceToAttrRole, graphPlaceToAttrRole} from "../../data-display/data-display-types"
 import {matchCirclesToData} from "../../data-display/data-display-utils"
 import {IPixiPointsRef} from "../utilities/pixi-points"
 import {setNiceDomain} from "../utilities/graph-utils"
@@ -26,13 +26,11 @@ interface IGraphControllerConstructorProps {
 
 interface IGraphControllerProps {
   graphModel: IGraphContentModel
-  dotsRef: IDotsRef
   pixiPointsRef: IPixiPointsRef
 }
 
 export class GraphController {
   graphModel?: IGraphContentModel
-  dotsRef?: IDotsRef
   pixiPointsRef?: IPixiPointsRef
   layout: GraphLayout
   instanceId: string
@@ -47,7 +45,6 @@ export class GraphController {
 
   setProperties(props: IGraphControllerProps) {
     this.graphModel = props.graphModel
-    this.dotsRef = props.dotsRef
     this.pixiPointsRef = props.pixiPointsRef
     if (this.graphModel.dataConfiguration.dataset !== this.graphModel.dataset) {
       this.graphModel.dataConfiguration.setDataset(
@@ -57,13 +54,13 @@ export class GraphController {
   }
 
   callMatchCirclesToData() {
-    const {graphModel, dotsRef, pixiPointsRef, instanceId} = this
-    if (graphModel && dotsRef?.current && pixiPointsRef?.current) {
+    const {graphModel, pixiPointsRef, instanceId} = this
+    if (graphModel && pixiPointsRef?.current) {
       const { dataConfiguration } = graphModel,
         {pointColor, pointStrokeColor} = graphModel.pointDescription,
         pointRadius = graphModel.getPointRadius()
       dataConfiguration && matchCirclesToData({
-        dataConfiguration, dotsElement: dotsRef.current, pixiPoints: pixiPointsRef.current,
+        dataConfiguration, pixiPoints: pixiPointsRef.current,
         pointRadius, startAnimation: graphModel.startAnimation, instanceId, pointColor, pointStrokeColor
       })
     }
@@ -72,10 +69,9 @@ export class GraphController {
   // Called after restore from document or undo/redo, i.e. the models are all configured
   // appropriately but the scales and other non-serialized properties need to be synced.
   initializeGraph() {
-    const {graphModel, dotsRef, layout} = this,
+    const {graphModel, layout} = this,
       dataConfig = graphModel?.dataConfiguration
-    if (dataConfig && layout && dotsRef?.current &&
-        this.attrConfigForInitGraph !== dataConfig.attributeDescriptionsStr) {
+    if (dataConfig && layout && this.attrConfigForInitGraph !== dataConfig.attributeDescriptionsStr) {
       AxisPlaces.forEach((axisPlace: AxisPlace) => {
         const axisModel = graphModel.getAxis(axisPlace),
           attrRole = axisPlaceToAttrRole[axisPlace]

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -4,7 +4,7 @@ import * as PIXI from "pixi.js"
 import {IPixiPointMetadata, IPixiPointsRef} from "./pixi-points"
 import {IDataSet} from "../../../models/data/data-set"
 import {CaseData} from "../../data-display/d3-types"
-import {IDotsRef, Point, transitionDuration} from "../../data-display/data-display-types"
+import {Point, transitionDuration} from "../../data-display/data-display-types"
 import {IAxisModel, isNumericAxisModel} from "../../axis/models/axis-model"
 import {ScaleNumericBaseType} from "../../axis/axis-types"
 import {defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeWidth, defaultStrokeWidth}
@@ -250,7 +250,6 @@ export function getScreenCoord(dataSet: IDataSet | undefined, id: string,
 }
 
 export interface ISetPointSelection {
-  dotsRef: IDotsRef
   pixiPointsRef?: IPixiPointsRef
   dataConfiguration: IDataConfigurationModel
   pointRadius: number,
@@ -262,7 +261,6 @@ export interface ISetPointSelection {
 
 export interface ISetPointCoordinates {
   dataset?: IDataSet
-  dotsRef: IDotsRef
   pixiPointsRef: IPixiPointsRef
   selectedOnly?: boolean
   pointRadius: number
@@ -299,27 +297,7 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
   }
 
   const setPoints = () => {
-    // TODO: Remove old SVG code
-    // if (theSelection?.size()) {
-    //   theSelection
-    //     .transition()
-    //     .duration(duration)
-    //     .attr('cx', (aCaseData: CaseData) => getScreenX(aCaseData.caseID))
-    //     .attr('cy', (aCaseData: CaseData) => {
-    //       return getScreenY(aCaseData.caseID, aCaseData.plotNum)
-    //     })
-    //     .attr('r', (aCaseData: CaseData) => dataset?.isCaseSelected(aCaseData.caseID)
-    //       ? selectedPointRadius : pointRadius)
-    //     .style('fill', (aCaseData: CaseData) => lookupLegendColor(aCaseData))
-    //     .style('stroke', (aCaseData: CaseData) =>
-    //       (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-    //         ? defaultSelectedStroke : pointStrokeColor)
-    //     .style('stroke-width', (aCaseData: CaseData) =>
-    //       (getLegendColor && dataset?.isCaseSelected(aCaseData.caseID))
-    //         ? defaultSelectedStrokeWidth : defaultStrokeWidth)
-    // }
-
-    // TODO PIXI: Do we really need to calculate legend color here? If this function is called both while resizing
+    // Do we really need to calculate legend color here? If this function is called both while resizing
     // the graph and while updating legend colors, we could possibly split it into two different functions.
     const pixiRenderer = pixiPointsRef?.current
     if (pixiRenderer) {

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -27,13 +27,13 @@ export const MapPointLayer = function MapPointLayer(props: {
     layout = useDataDisplayLayout(),
     dotsRef = useRef<DotsElt>(null)
 
-  useDataTips({dotsRef, dataset, displayModel: mapLayerModel})
+  useDataTips({dataset, displayModel: mapLayerModel})
 
   const refreshPointSelection = useCallback(() => {
     const {pointColor, pointStrokeColor} = pointDescription,
       selectedPointRadius = mapLayerModel.getPointRadius('select')
     dataConfiguration && setPointSelection({
-      dotsRef, dataConfiguration, pointRadius: mapLayerModel.getPointRadius(), selectedPointRadius,
+      dataConfiguration, pointRadius: mapLayerModel.getPointRadius(), selectedPointRadius,
       pointColor, pointStrokeColor
     })
   }, [pointDescription, mapLayerModel, dataConfiguration])
@@ -144,7 +144,6 @@ export const MapPointLayer = function MapPointLayer(props: {
     if (mapLayerModel && dataConfiguration && layout && dotsRef.current) {
       matchCirclesToData({
         dataConfiguration,
-        dotsElement: dotsRef.current,
         pointRadius: mapLayerModel.getPointRadius(),
         instanceId: dataConfiguration.id,
         pointColor: pointDescription?.pointColor,


### PR DESCRIPTION
[PT-186730431]

This PR removes references to IDotsRef and the commented-out SVG code, as I believe it is no longer necessary. This is also the first step towards reimplementing map dots that are currently not functioning.