### PR TITLE
Formulas: fix aggregate context support

### DIFF
--- a/v3/src/models/formula/formula-types.ts
+++ b/v3/src/models/formula/formula-types.ts
@@ -35,11 +35,13 @@ export type IFormulaDependency = ILocalAttributeDependency | IGlobalValueDepende
 
 export type FValue = string | number | boolean
 
+export type FValueOrArray = FValue | FValue[]
+
 export type EvaluateFunc = (...args: FValue[]) => FValue
 
-export type EvaluateFuncWithAggregateContextSupport = (...args: (FValue | FValue[])[]) => FValue | FValue[]
+export type EvaluateFuncWithAggregateContextSupport = (...args: (FValueOrArray)[]) => FValueOrArray
 
-export type EvaluateRawFunc = (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]
+export type EvaluateRawFunc = (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValueOrArray
 
 export type CaseList = ICase[] | "ALL_CASES"
 

--- a/v3/src/models/formula/formula-types.ts
+++ b/v3/src/models/formula/formula-types.ts
@@ -35,7 +35,9 @@ export type IFormulaDependency = ILocalAttributeDependency | IGlobalValueDepende
 
 export type FValue = string | number | boolean
 
-export type EvaluateFunc = (...args: FValue[]) => FValue | FValue[]
+export type EvaluateFunc = (...args: FValue[]) => FValue
+
+export type EvaluateFuncWithAggregateContextSupport = (...args: (FValue | FValue[])[]) => FValue | FValue[]
 
 export type EvaluateRawFunc = (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]
 

--- a/v3/src/models/formula/functions/aggregate-functions.test.ts
+++ b/v3/src/models/formula/functions/aggregate-functions.test.ts
@@ -22,6 +22,11 @@ describe("mean", () => {
   it("ignores non-numeric values", () => {
     expect(evaluate("mean(Diet)")).toEqual(UNDEF_RESULT)
   })
+
+  it("supports single value argument", () => {
+    expect(evaluate("mean(1, true)")).toEqual(1)
+    expect(evaluate("mean(1, false)")).toEqual(UNDEF_RESULT)
+  })
 })
 
 describe("median", () => {
@@ -35,6 +40,11 @@ describe("median", () => {
 
   it("ignores non-numeric values", () => {
     expect(evaluate("median(Diet)")).toEqual(UNDEF_RESULT)
+  })
+
+  it("supports single value argument", () => {
+    expect(evaluate("median(1, true)")).toEqual(1)
+    expect(evaluate("median(1, false)")).toEqual(UNDEF_RESULT)
   })
 })
 
@@ -50,6 +60,11 @@ describe("mad", () => {
   it("ignores non-numeric values", () => {
     expect(evaluate("mad(Diet)")).toEqual(UNDEF_RESULT)
   })
+
+  it("supports single value argument", () => {
+    expect(evaluate("mad(1, true)")).toEqual(0)
+    expect(evaluate("mad(1, false)")).toEqual(UNDEF_RESULT)
+  })
 })
 
 describe("max", () => {
@@ -63,6 +78,11 @@ describe("max", () => {
 
   it("ignores non-numeric values", () => {
     expect(evaluate("max(Diet)")).toEqual(UNDEF_RESULT)
+  })
+
+  it("supports single value argument", () => {
+    expect(evaluate("max(1, true)")).toEqual(1)
+    expect(evaluate("max(1, false)")).toEqual(UNDEF_RESULT)
   })
 })
 
@@ -78,6 +98,11 @@ describe("min", () => {
   it("ignores non-numeric values", () => {
     expect(evaluate("min(Diet)")).toEqual(UNDEF_RESULT)
   })
+
+  it("supports single value argument", () => {
+    expect(evaluate("min(1, true)")).toEqual(1)
+    expect(evaluate("min(1, false)")).toEqual(UNDEF_RESULT)
+  })
 })
 
 describe("sum", () => {
@@ -92,6 +117,11 @@ describe("sum", () => {
   it("ignores non-numeric values", () => {
     expect(evaluate("sum(Diet)")).toEqual(UNDEF_RESULT)
   })
+
+  it("supports single value argument", () => {
+    expect(evaluate("sum(1, true)")).toEqual(1)
+    expect(evaluate("sum(1, false)")).toEqual(UNDEF_RESULT)
+  })
 })
 
 describe("count", () => {
@@ -102,6 +132,11 @@ describe("count", () => {
 
   it("supports filter expression", () => {
     expect(evaluate("count(Speed, Diet = 'plants')")).toBe(7)
+  })
+
+  it("supports single value argument", () => {
+    expect(evaluate("count(1, true)")).toEqual(1)
+    expect(evaluate("count(1, false)")).toEqual(0)
   })
 })
 

--- a/v3/src/models/formula/functions/aggregate-functions.ts
+++ b/v3/src/models/formula/functions/aggregate-functions.ts
@@ -1,11 +1,11 @@
 import { MathNode, mad, max, mean, median, min, sum } from "mathjs"
 import { FormulaMathJsScope } from "../formula-mathjs-scope"
-import { FValue } from "../formula-types"
+import { FValue, FValueOrArray } from "../formula-types"
 import { UNDEF_RESULT, evaluateNode, isNumber, isValueTruthy } from "./function-utils"
 
 // Almost every aggregate function can be cached in the same way.
 export const cachedAggregateFnFactory =
-(fnName: string, fn: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValue | FValue[]) => {
+(fnName: string, fn: (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => FValueOrArray) => {
   return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
     const cacheKey = `${fnName}(${args.toString()})-${scope.getCaseAggregateGroupId()}`
     const cachedValue = scope.getCached(cacheKey)

--- a/v3/src/models/formula/functions/aggregate-functions.ts
+++ b/v3/src/models/formula/functions/aggregate-functions.ts
@@ -24,7 +24,13 @@ const aggregateFnWithFilterFactory = (fn: (values: number[]) => FValue) => {
   return (args: MathNode[], mathjs: any, scope: FormulaMathJsScope) => {
     const [ expression, filter ] = args
     let expressionValues = evaluateNode(expression, scope)
-    const filterValues = !!filter && evaluateNode(filter, scope)
+    if (!Array.isArray(expressionValues)) {
+      expressionValues = [ expressionValues ]
+    }
+    let filterValues = !!filter && evaluateNode(filter, scope)
+    if (!!filter && !Array.isArray(filterValues)) {
+      filterValues = [ filterValues ]
+    }
     expressionValues = expressionValues.filter((v: FValue, i: number) =>
       // Numeric aggregate functions should ignore non-numeric values.
       isNumber(v) && (filterValues ? isValueTruthy(filterValues[i]) : true)
@@ -105,8 +111,15 @@ export const aggregateFunctions = {
         return cachedValue
       }
 
-      const filterValues = filter && evaluateNode(filter, scope)
-      const validExpressionValues = evaluateNode(expression, scope).filter((v: FValue, i: number) =>
+      let expressionValues = evaluateNode(expression, scope)
+      if (!Array.isArray(expressionValues)) {
+        expressionValues = [ expressionValues ]
+      }
+      let filterValues = filter && evaluateNode(filter, scope)
+      if (filter && !Array.isArray(filterValues)) {
+        filterValues = [ filterValues ]
+      }
+      const validExpressionValues = expressionValues.filter((v: FValue, i: number) =>
         isValueTruthy(v) && (filter ? isValueTruthy(filterValues[i]) : true)
       )
       const result = validExpressionValues.length

--- a/v3/src/models/formula/functions/arithmetic-functions.test.ts
+++ b/v3/src/models/formula/functions/arithmetic-functions.test.ts
@@ -15,11 +15,6 @@ describe("numericFnFactory", () => {
     expect(numericFn("foo")).toEqual(UNDEF_RESULT)
     expect(numericFn(UNDEF_RESULT)).toEqual(UNDEF_RESULT)
   })
-
-  it("returns a function that applies the specified function to an array of numeric values", () => {
-    const result = numericFn([1, 2, "3", "4", "five", "", UNDEF_RESULT])
-    expect(result).toEqual([2, 4, 6, 8, UNDEF_RESULT, UNDEF_RESULT, UNDEF_RESULT])
-  })
 })
 
 describe("numericMultiArgsFnFactory", () => {
@@ -38,18 +33,6 @@ describe("numericMultiArgsFnFactory", () => {
     expect(numericFn("foo", "bar")).toEqual(UNDEF_RESULT)
     expect(numericFn(10, "foo")).toEqual(10)
     expect(numericFn(10, "")).toEqual(10)
-  })
-
-  it("returns a function that applies the specified function to each element of provided arrays", () => {
-    const result = numericFn([1, 2, "3", "4", 5, 6, "foo", ""], [1, 2, "3", "4", "five", "", 7, 8])
-    expect(result).toEqual([2, 4, 6, 8, 5, 6, UNDEF_RESULT, UNDEF_RESULT])
-  })
-
-  it("returns a function that can handle array and single value", () => {
-    const result1 = numericFn(10, [1, 2, "3", "4", "five", "", UNDEF_RESULT])
-    expect(result1).toEqual([11, 12, 13, 14, 10, 10, 10])
-    const result2 = numericFn([1, 2, "3", "4", "five", "", UNDEF_RESULT], 10)
-    expect(result2).toEqual([11, 12, 13, 14, UNDEF_RESULT, UNDEF_RESULT, UNDEF_RESULT])
   })
 })
 

--- a/v3/src/models/formula/functions/arithmetic-functions.ts
+++ b/v3/src/models/formula/functions/arithmetic-functions.ts
@@ -8,11 +8,10 @@ import { UNDEF_RESULT, isNumber } from "./function-utils"
 // be used within aggregate functions.
 export const numericMultiArgsFnFactory = (fn: (...values: number[]) => number, opts: { numOfRequiredArgs: number}) => {
   const { numOfRequiredArgs } = opts
-  const calculateCaseValue = (args: (FValue | FValue[])[], caseIdx?: number) => {
+  return (...args: FValue[]) => {
     const caseExpressionArguments: (number | undefined)[] = []
     for (let i = 0; i < args.length; i += 1) {
-      const arg = args[i]
-      const argValue = caseIdx !== undefined && Array.isArray(arg) ? arg[caseIdx] : arg
+      const argValue = args[i]
       if (isNumber(argValue)) {
         caseExpressionArguments.push(Number(argValue))
       } else {
@@ -29,26 +28,13 @@ export const numericMultiArgsFnFactory = (fn: (...values: number[]) => number, o
     // undefined values are ignored by fn, they're only allowed for optional arguments.
     return fn(...caseExpressionArguments as number[])
   }
-  return (...args: (FValue | FValue[])[]) => {
-    const array = args.find((a) => Array.isArray(a)) as FValue[]
-    if (array) {
-      // One of the arguments is an array. It means the context of the expression is aggregate function.
-      // Other arguments can be arrays, but they don't have to (e.g. if user provided constants as arguments).
-      return array.map((v, idx) => calculateCaseValue(args, idx))
-    }
-    // At this point we know that none of the arguments is an array.
-    return calculateCaseValue(args, undefined)
-  }
 }
 
 // Simple version of numericMultiArgsFnFactory that is used for functions with single argument, like round(number).
 // It's not necessary, as numericMultiArgsFnFactory can be used for single argument functions as well, but it can be
 // faster. Also, it's easier to read and can help to understand what happens in numericMultiArgsFnFactory.
 export const numericFnFactory = (fn: (value: number) => number) => {
-  return (expressionValue: FValue | FValue[]) => {
-    if (Array.isArray(expressionValue)) {
-      return expressionValue.map((v) => isNumber(v) ? fn(Number(v)) : UNDEF_RESULT)
-    }
+  return (expressionValue: FValue) => {
     return isNumber(expressionValue) ? fn(Number(expressionValue)) : UNDEF_RESULT
   }
 }

--- a/v3/src/models/formula/functions/function-utils.test.ts
+++ b/v3/src/models/formula/functions/function-utils.test.ts
@@ -64,18 +64,6 @@ describe("equal", () => {
     expect(equal("true", false)).toBe(false)
     expect(equal(true, 1)).toBe(false)
   })
-
-  it("should support array arguments", () => {
-    expect(equal([1, 2], [1, 2])).toEqual([true, true])
-    expect(equal([1, 2], [1, 3])).toEqual([true, false])
-    expect(equal([1, 2], [2, 1])).toEqual([false, false])
-
-    expect(equal([1, 2], 1)).toEqual([true, false])
-    expect(equal(1, [1, 2])).toEqual([true, false])
-
-    expect(equal([1, 2], "1")).toEqual([true, false])
-    expect(equal("1", [1, 2])).toEqual([true, false])
-  })
 })
 
 describe("evaluateNode", () => {

--- a/v3/src/models/formula/functions/function-utils.ts
+++ b/v3/src/models/formula/functions/function-utils.ts
@@ -14,16 +14,7 @@ export const isNumber = (v: any) => isValueNonEmpty(v) && !isNaN(Number(v))
 // count(attribute) will return a count of valid data values, since 0 is a valid numeric value.
 export const isValueTruthy = (value: any) => isValueNonEmpty(value) && value !== false
 
-export const equal = (a: any, b: any): boolean | boolean[] => {
-  if (Array.isArray(a) && Array.isArray(b)) {
-    return a.map((v, i) => equal(v, b[i])) as boolean[]
-  }
-  if (Array.isArray(a) && !Array.isArray(b)) {
-    return a.map((v) => equal(v, b)) as boolean[]
-  }
-  if (!Array.isArray(a) && Array.isArray(b)) {
-    return b.map((v) => equal(v, a)) as boolean[]
-  }
+export const equal = (a: any, b: any): boolean => {
   // Checks below might seem redundant once the data set cases start using typed values, but they are not.
   // Note that user might still compare a string with a number unintentionally, and it makes sense to try to cast
   // values when possible, so that the comparison can be performed without forcing users to think about types.

--- a/v3/src/models/formula/functions/lookup-functions.test.ts
+++ b/v3/src/models/formula/functions/lookup-functions.test.ts
@@ -13,6 +13,13 @@ describe("lookupByIndex", () => {
     expect(evaluate("lookupByIndex('Cats', 'PadColor', caseIndex)", 4)).toEqual("pink")
   })
 
+  it("can be executed in the aggregate context", () => {
+    expect(evaluate("mean(lookupByIndex('Mammals', 'LifeSpan', caseIndex))")).toBeCloseTo(24.85)
+    // This might look like it doesn't make sense, but it ensures that when a single value is returned, it doesn't
+    // cause an error when executed in the aggregate context.
+    expect(evaluate("mean(lookupByIndex('Mammals', 'LifeSpan', 1))")).toBeCloseTo(70)
+  })
+
   it("throws an error when number of arguments is wrong", () => {
     expect(() => evaluate("lookupByIndex('Mammals', 'LifeSpan')")).toThrow()
     expect(() => evaluate("lookupByIndex('Mammals', 'LifeSpan', 1, 2)")).toThrow()
@@ -44,6 +51,13 @@ describe("lookupByKey", () => {
     expect(evaluate("lookupByKey('Cats', 'Name', 'Weight', Mass)", 0)).toEqual("")
     expect(evaluate("lookupByKey('Cats', 'Name', 'Weight', Mass)", 18)).toEqual("Nancy Blue")
     expect(evaluate("lookupByKey('Cats', 'Name', 'Weight', Mass)", 19)).toEqual("Chubbs")
+  })
+
+  it("can be executed in the aggregate context", () => {
+    expect(evaluate("mean(lookupByKey('Mammals', 'LifeSpan', 'Mass', Mass))")).toBeCloseTo(21.85)
+    // This might look like it doesn't make sense, but it ensures that when a single value is returned, it doesn't
+    // cause an error when executed in the aggregate context.
+    expect(evaluate("mean(lookupByKey('Mammals', 'LifeSpan', 'Diet', 'meat'))")).toEqual(19)
   })
 
   it("throws an error when number of arguments is wrong", () => {

--- a/v3/src/models/formula/functions/math.test.ts
+++ b/v3/src/models/formula/functions/math.test.ts
@@ -3,7 +3,7 @@ import { FormulaMathJsScope } from "../formula-mathjs-scope"
 import {
   evaluateRawWithAggregateContext, evaluateRawWithDefaultArg, evaluateToEvaluateRaw, evaluateWithAggregateContextSupport
 } from "./math"
-import { FValue } from "../formula-types"
+import { FValue, FValueOrArray } from "../formula-types"
 
 describe("evaluateRawWithAggregateContext", () => {
   it("should call provided function within withAggregateContext", () => {
@@ -61,7 +61,7 @@ describe("evaluateToEvaluateRaw", () => {
     const args = [ parse("1"), parse("2") ]
     const mathjs = {}
     const scope = {}
-    const mockFn = jest.fn((a: FValue | FValue[], b: FValue | FValue[]) => Number(a) + Number(b))
+    const mockFn = jest.fn((a: FValueOrArray, b: FValueOrArray) => Number(a) + Number(b))
 
     const res = evaluateToEvaluateRaw(mockFn)(args as any as MathNode[], mathjs, scope as any as FormulaMathJsScope)
     expect(mockFn).toHaveBeenCalledWith(1, 2)

--- a/v3/src/models/formula/functions/math.ts
+++ b/v3/src/models/formula/functions/math.ts
@@ -1,7 +1,8 @@
 import { create, all, MathNode } from 'mathjs'
 import { FormulaMathJsScope } from '../formula-mathjs-scope'
 import {
-  CODAPMathjsFunctionRegistry, EvaluateFunc, EvaluateFuncWithAggregateContextSupport, EvaluateRawFunc, FValue
+  CODAPMathjsFunctionRegistry, EvaluateFunc, EvaluateFuncWithAggregateContextSupport, EvaluateRawFunc, FValue,
+  FValueOrArray
 } from '../formula-types'
 import { equal, evaluateNode } from './function-utils'
 import { arithmeticFunctions } from './arithmetic-functions'
@@ -38,7 +39,7 @@ export const evaluateToEvaluateRaw = (fn: EvaluateFuncWithAggregateContextSuppor
 export const evaluateWithAggregateContextSupport = (fn: EvaluateFunc): EvaluateFuncWithAggregateContextSupport => {
   // When regular function is called in aggregate context, its arguments will be arrays. The provided function needs to
   // be called for each element of the array.
-  return (...args: (FValue | FValue[])[]) => {
+  return (...args: (FValueOrArray)[]) => {
     // Precompute the check for array arguments and their indices.
     const isArrayArg = args.map(Array.isArray)
     const firstArrayArgIdx = isArrayArg.findIndex((isArr) => isArr)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186485885

This PR addresses the support of various functions within the aggregate context. Previously, the following formulas would fail:
- `mean(lookupByIndex("Mammals", "LifeSpan", caseIndex))`
- `mean(if(LifeSpan < 30, 1, 2))`
- `mean(1, true)`, `mean(1, false)`

Now, all should execute correctly. I believe I've streamlined the workflow for adding standard functions by introducing `evaluateWithAggregateContextSupport`, which is automatically applied. Developers no longer need to handle arrays explicitly when using the `evaluate:` variant of function implementation. However, when using `evaluateRaw:`, handling arrays remains necessary, as seen in the `prev` and `next` functions where I included it.