### PR TITLE
Fix connecting lines interaction

### DIFF
--- a/v3/cypress/e2e/adornments.spec.ts
+++ b/v3/cypress/e2e/adornments.spec.ts
@@ -588,10 +588,8 @@ context("Graph adornments", () => {
     // use force: true so we don't need to figure out exactly where to click.
     cy.get("*[data-testid^=connecting-lines-graph]").find("path").click({force: true})
     cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("have.attr", "stroke-width", "4")
-    cy.get("[data-testid=graph-dot-area-graph-1]").find("circle.graph-dot-highlighted").should("exist")
     cy.get("*[data-testid^=connecting-lines-graph]").find("path").click({force: true})
     cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("have.attr", "stroke-width", "2")
-    cy.get("[data-testid=graph-dot-area-graph-1]").find("circle.graph-dot-highlighted").should("not.exist")
     graph.getDisplayValuesButton().click()
     cy.get("[data-testid=adornment-checkbox-connecting-lines]").click()
     cy.get("*[data-testid^=adornment-checkbox-connecting-lines]").find("path").should("not.exist")

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -66,6 +66,10 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
 
   if (pixiPointsRef.current != null && pixiContainerRef.current && pixiContainerRef.current.children.length === 0) {
     pixiContainerRef.current.appendChild(pixiPointsRef.current.canvas)
+    pixiPointsRef.current.setupBackgroundEventDistribution({
+      elementToHide: pixiContainerRef.current,
+      interactiveElClassName: "interactive-graph-element"
+    })
   }
 
   useEffect(function handleFilteredCasesLengthChange() {
@@ -227,8 +231,8 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
           {renderGraphAxes()}
 
           <svg ref={plotAreaSVGRef}>
-            <foreignObject ref={pixiContainerRef} x={0} y={0} width="100%" height="100%"/>
             {renderPlotComponent()}
+            <foreignObject ref={pixiContainerRef} x={0} y={0} width="100%" height="100%"/>
             <Marquee marqueeState={marqueeState}/>
           </svg>
 

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -267,6 +267,7 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
           .append("path")
           .data([allLineCoords])
           .attr("d", d => curve(d))
+          .classed("interactive-graph-element", true) // for dots canvas event passing
           .classed("selected", allCasesSelected)
           .on("click", (e) => handleConnectingLinesClick(e, lineCaseIds))
           .on("mouseover", (e) => handleConnectingLinesHover(e, lineCaseIds, parentAttrName, primaryAttrValue))

--- a/v3/src/components/graph/utilities/pixi-points.ts
+++ b/v3/src/components/graph/utilities/pixi-points.ts
@@ -35,12 +35,12 @@ export interface IPixiPointStyle {
 
 // PixiPoints layer can be setup to distribute events from background to elements laying underneath.
 export interface IBackgroundEventDistributionOptions {
-  elementToHide: HTMLElement // element which should be hidden to obtain element laying underneath
+  elementToHide: HTMLElement | SVGElement // element which should be hidden to obtain element laying underneath
   interactiveElClassName?: string // class name of elements that should receive passed events
 }
 
 export interface IPixiPointsOptions {
-  resizeTo: HTMLElement,
+  resizeTo: HTMLElement
   backgroundEventDistribution?: IBackgroundEventDistributionOptions
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186747801

This PR fixes interaction with connecting lines. That's another example of where PixiJS creates challenges. Since the canvas is covering the connecting lines, I had to use the background event redistribution mechanism added recently. However, if we have more layers that require interaction, this method might become difficult to continue and maintain.