### PR TITLE
Fix dataset caching

### DIFF
--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -140,7 +140,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           refreshPointSelection()
         } else if (isSetCaseValuesAction(action)) {
           // assumes that if we're caching then only selected cases are being updated
-          callRefreshPointPositions(dataset.isCaching)
+          callRefreshPointPositions(dataset.isCaching())
           // TODO: handling of add/remove cases was added specifically for the case plot.
           // Bill has expressed a desire to refactor the case plot to behave more like the
           // other plots, which already handle removal of cases (and perhaps addition of cases?)

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -114,7 +114,7 @@ export const MapPointLayer = function MapPointLayer(props: {
           refreshPointSelection()
         } else if (isSetCaseValuesAction(action)) {
           // assumes that if we're caching then only selected cases are being updated
-          refreshPoints(dataset.isCaching)
+          refreshPoints(dataset.isCaching())
         } else if (["addCases", "removeCases"].includes(action.name)) {
           refreshPoints(false)
         }

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -517,9 +517,9 @@ test("Caching mode", () => {
   // const bId = ds.cases[1].__id__
   // const cId = ds.cases[2].__id__
 
-  expect(ds.isCaching).toBe(false)
+  expect(ds.isCaching()).toBe(false)
   ds.beginCaching()
-  expect(ds.isCaching).toBe(true)
+  expect(ds.isCaching()).toBe(true)
 
   const actionHandler = jest.fn()
   const snapshotHandler = jest.fn()
@@ -533,7 +533,7 @@ test("Caching mode", () => {
   expect(ds.getNumeric(aId, numAttrID)).toBe(-1)
 
   ds.endCaching(true)
-  expect(ds.isCaching).toBe(false)
+  expect(ds.isCaching()).toBe(false)
 })
 
 test("snapshot processing", () => {

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -159,15 +159,17 @@ export const DataSet = types.model("DataSet", {
   pseudoCaseMap: new Map<string, CaseGroup>(),
   transactionCount: 0
 }))
-.views(self => {
+.volatile(() => {
   let cachingCount = 0
   const caseCache = new Map<string, ICase>()
   return {
-    get isCaching() {
-      return cachingCount > 0
-    },
     get caseCache() {
       return caseCache
+    },
+    isCaching() {
+      // Do not use getter here, as the result would be cached and not updated when cachingCount changes.
+      // Note that it also happens for volatile properties, not only views.
+      return cachingCount > 0
     },
     clearCache() {
       caseCache.clear()
@@ -676,7 +678,7 @@ export const DataSet = types.model("DataSet", {
         return index != null ? this.getValueAtIndex(index, attributeID) : undefined
       },
       getValueAtIndex(index: number, attributeID: string) {
-          if (self.isCaching) {
+          if (self.isCaching()) {
             const caseID = self.cases[index]?.__id__
             const cachedCase = self.caseCache.get(caseID)
             if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
@@ -696,7 +698,7 @@ export const DataSet = types.model("DataSet", {
         return index != null ? this.getStrValueAtIndex(index, attributeID) : ""
       },
       getStrValueAtIndex(index: number, attributeID: string) {
-        if (self.isCaching) {
+        if (self.isCaching()) {
           const caseID = self.cases[index]?.__id__
           const cachedCase = self.caseCache.get(caseID)
           if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
@@ -716,7 +718,7 @@ export const DataSet = types.model("DataSet", {
         return index != null ? this.getNumericAtIndex(index, attributeID) : undefined
       },
       getNumericAtIndex(index: number, attributeID: string) {
-        if (self.isCaching) {
+        if (self.isCaching()) {
           const caseID = self.cases[index]?.__id__
           const cachedCase = self.caseCache.get(caseID)
           if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
@@ -918,7 +920,7 @@ export const DataSet = types.model("DataSet", {
                         ? ungroupedCases
                         : cases
         const before = getCases(_cases.map(({ __id__ }) => __id__))
-        if (self.isCaching) {
+        if (self.isCaching()) {
           // update the cases in the cache
           _cases.forEach(aCase => {
             const cached = self.caseCache.get(aCase.__id__)


### PR DESCRIPTION
[[PT-186751983]](https://www.pivotaltracker.com/story/show/186751983)

I've found this bug while working on PixiJS and transitions, but I think we should merge it into the `main` branch. Note that `get isCaching` was actually cached in some situations, resulting in incorrect value being returned. Also, I changed `views` to `volatile`, although it doesn't really affect the functionality (caching still works within the volatile block). However, considering this set of functionalities extends beyond just views, I hope 'volatile' will be more descriptive.