### PR TITLE
Better support of concurrent transitions in PixiJS graphs

### DIFF
--- a/v3/.vscode/settings.json
+++ b/v3/.vscode/settings.json
@@ -14,7 +14,7 @@
     "ulid"
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": [
     "javascript",

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -124,9 +124,6 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
   }, [layout, dataConfiguration, dataset, dragID])
 
   const onDragEnd = useCallback(() => {
-    dataset?.endCaching()
-    appState.endPerformance()
-
     if (dragID !== '') {
       setDragID(() => '')
       if (didDrag.current) {
@@ -146,6 +143,10 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
         didDrag.current = false
       }
     }
+    // These calls are moved to the end to ensure that transitions are not broken by all the points being
+    // repositioned (default behavior when caching and perf mode is disabled).
+    dataset?.endCaching()
+    appState.endPerformance()
   }, [dataConfiguration, dataset, dragID, startAnimation])
 
   usePixiDragHandlers(pixiPointsRef.current, {start: onDragStart, drag: onDrag, end: onDragEnd})

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -144,7 +144,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           refreshPointSelection()
         } else if (isSetCaseValuesAction(action)) {
           // assumes that if we're caching then only selected cases are being updated
-          callRefreshPointPositions(dataset.isCaching)
+          callRefreshPointPositions(dataset.isCaching())
           // TODO: handling of add/remove cases was added specifically for the case plot.
           // Bill has expressed a desire to refactor the case plot to behave more like the
           // other plots, which already handle removal of cases (and perhaps addition of cases?)

--- a/v3/src/components/graph/utilities/pixi-points.ts
+++ b/v3/src/components/graph/utilities/pixi-points.ts
@@ -123,7 +123,7 @@ export class PixiPoints {
     if (this.anyTransitionActive) {
       PixiTransition.transitionStep(this.targetProp, this.startProp)
     } else {
-      // The only reason for ticket to run is to handle ongoing transitions. If there are no transitions, we can stop.
+      // The only reason for ticker to run is to handle ongoing transitions. If there are no transitions, we can stop.
       this.ticker.stop()
     }
     this.renderer.render(this.stage)

--- a/v3/src/components/graph/utilities/pixi-transition.ts
+++ b/v3/src/components/graph/utilities/pixi-transition.ts
@@ -45,14 +45,14 @@ export class PixiTransition {
 
       for (const [point, target] of targetProp.entries()) {
         const transition = target.transition
-        const factor = transition.getFactor(now)
+        const progress = transition.getProgress(now)
         if (!point.destroyed) {
           const start = startProp.get(point) as TransitionTarget
-          const newX = start.x + factor * (target.x - start.x)
-          const newY = start.y + factor * (target.y - start.y)
+          const newX = start.x + progress * (target.x - start.x)
+          const newY = start.y + progress * (target.y - start.y)
           point[propKey].set(newX, newY)
         }
-        if (factor === 1 || point.destroyed) {
+        if (progress === 1 || point.destroyed) {
           targetProp.delete(point)
           startProp.delete(point)
           finishedTransitions.add(transition)
@@ -70,7 +70,7 @@ export class PixiTransition {
     this.onEndCallback = onEndCallback
   }
 
-  getFactor(now: number) {
+  getProgress(now: number) {
     const time = now - this.startTime
     const timeRatio = Math.min(1, time / this.duration)
     return defaultInterpolation(timeRatio)

--- a/v3/src/components/graph/utilities/pixi-transition.ts
+++ b/v3/src/components/graph/utilities/pixi-transition.ts
@@ -10,109 +10,73 @@ const defaultInterpolation = smoother
 // const smooth2: Interpolation = (x: number) => smooth(smooth(x))
 // const pow2out: Interpolation = (x: number) => Math.pow(x - 1, 2) * (-1) + 1
 
-export type SupportedPropKey = "position" | "scale"
-export type SupportedPropValue = { x: number, y: number }
+export type TransitionProp = "position" | "scale"
+
+export type TransitionTarget = { x: number, y: number, transition: PixiTransition }
+
+export type TransitionPropMap = Partial<Record<TransitionProp, Map<PIXI.Sprite, TransitionTarget>>>
 
 export class PixiTransition {
+  startTime = performance.now()
   duration = 0
-  time = 0
-  isFinished = false
-  frameId: number | undefined
-  points: PIXI.Sprite[] = []
   onEndCallback?: () => void
 
-  targetProp: Partial<Record<SupportedPropKey, Map<PIXI.Sprite, SupportedPropValue>>> = {}
-  startProp: Partial<Record<SupportedPropKey, Map<PIXI.Sprite, SupportedPropValue>>> = {}
-
-  constructor(duration: number, points: PIXI.Sprite[]) {
-    this.duration = duration
-    this.points = points
-  }
-
-  setTargetPosition(point: PIXI.Sprite, x: number, y: number) {
-    this.setTargetXyProp("position", point, x, y)
-  }
-
-  setTargetScale(point: PIXI.Sprite, scale: number) {
-    this.setTargetXyProp("scale", point, scale, scale)
-  }
-
-  play() {
-    const transitionProps = Object.keys(this.targetProp) as SupportedPropKey[]
-    if (transitionProps.length === 0) {
-      this.handleOnEnd()
-      return
-    }
-
-    let time = 0
-    const duration = this.duration
-    const startTime = performance.now()
-
-    const transitionFrame = () => {
-      const timeRatio = Math.min(1, time / duration)
-      const factor = defaultInterpolation(timeRatio)
-
-      transitionProps.forEach(propKey => {
-        this.xyTransition(propKey, factor)
-      })
-
-      if (time < duration) {
-        this.frameId = requestAnimationFrame(transitionFrame)
-        time = performance.now() - startTime
-      } else {
-        this.frameId = undefined
-        this.handleOnEnd()
+  static anyTransitionActive(targetProps: TransitionPropMap) {
+    const transitionProps = Object.keys(targetProps) as TransitionProp[]
+    for (const propName of transitionProps) {
+      if (targetProps[propName]?.size) {
+        return true
       }
     }
+    return false
+  }
 
-    transitionFrame()
+  static transitionStep(targetProps: TransitionPropMap, startProps: TransitionPropMap) {
+    const now = performance.now()
+    const finishedTransitions = new Set<PixiTransition>()
+    const transitionProps = Object.keys(targetProps) as TransitionProp[]
+
+    transitionProps.forEach(propKey => {
+      const targetProp = targetProps[propKey]
+      const startProp = startProps[propKey]
+      if (!targetProp || !startProp) {
+        return
+      }
+
+      for (const [point, target] of targetProp.entries()) {
+        const transition = target.transition
+        const factor = transition.getFactor(now)
+        if (!point.destroyed) {
+          const start = startProp.get(point) as TransitionTarget
+          const newX = start.x + factor * (target.x - start.x)
+          const newY = start.y + factor * (target.y - start.y)
+          point[propKey].set(newX, newY)
+        }
+        if (factor === 1 || point.destroyed) {
+          targetProp.delete(point)
+          startProp.delete(point)
+          finishedTransitions.add(transition)
+        }
+      }
+    })
+
+    for (const transition of finishedTransitions) {
+      transition.handleOnEnd()
+    }
+  }
+
+  constructor(duration: number, onEndCallback?: () => void) {
+    this.duration = duration
+    this.onEndCallback = onEndCallback
+  }
+
+  getFactor(now: number) {
+    const time = now - this.startTime
+    const timeRatio = Math.min(1, time / this.duration)
+    return defaultInterpolation(timeRatio)
   }
 
   handleOnEnd() {
     this.onEndCallback?.()
-    this.isFinished = true
-  }
-
-  onEnd(callback: () => void) {
-    this.onEndCallback = callback
-    if (this.isFinished) {
-      this.onEndCallback?.()
-    }
-  }
-
-  destroy() {
-    if (this.frameId) {
-      cancelAnimationFrame(this.frameId)
-    }
-  }
-
-  setTargetXyProp(propKey: SupportedPropKey, point: PIXI.Sprite, x: number, y: number) {
-    let targetProp = this.targetProp[propKey]
-    let startProp = this.startProp[propKey]
-    if (!targetProp || !startProp) {
-      targetProp = this.targetProp[propKey] = new Map()
-      startProp = this.startProp[propKey] = new Map()
-    }
-    targetProp.set(point, { x, y })
-    startProp.set(point, { x: point[propKey].x, y: point[propKey].y })
-  }
-
-  xyTransition(propKey: SupportedPropKey, factor: number) {
-    const targetProp = this.targetProp[propKey]
-    const startProp = this.startProp[propKey]
-    if (!targetProp || !startProp) {
-      return
-    }
-    for (const [point, target] of targetProp.entries()) {
-      if (point.destroyed) {
-        // This might happen if user deletes a case while transition is still occurring.
-        targetProp.delete(point)
-        continue
-      }
-      const start = startProp.get(point) as SupportedPropValue
-      const newX = start.x + factor * (target.x - start.x)
-      const newY = start.y + factor * (target.y - start.y)
-      point[propKey].set(newX, newY)
-    }
   }
 }

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -156,7 +156,7 @@ export const MapPointLayer = function MapPointLayer(props: {
           refreshPointSelection()
         } else if (isSetCaseValuesAction(action)) {
           // assumes that if we're caching then only selected cases are being updated
-          refreshPoints(dataset.isCaching)
+          refreshPoints(dataset.isCaching())
         } else if (["addCases", "removeCases"].includes(action.name)) {
           refreshPoints(false)
         }

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -517,9 +517,9 @@ test("Caching mode", () => {
   // const bId = ds.cases[1].__id__
   // const cId = ds.cases[2].__id__
 
-  expect(ds.isCaching).toBe(false)
+  expect(ds.isCaching()).toBe(false)
   ds.beginCaching()
-  expect(ds.isCaching).toBe(true)
+  expect(ds.isCaching()).toBe(true)
 
   const actionHandler = jest.fn()
   const snapshotHandler = jest.fn()
@@ -533,7 +533,7 @@ test("Caching mode", () => {
   expect(ds.getNumeric(aId, numAttrID)).toBe(-1)
 
   ds.endCaching(true)
-  expect(ds.isCaching).toBe(false)
+  expect(ds.isCaching()).toBe(false)
 })
 
 test("snapshot processing", () => {

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -159,15 +159,17 @@ export const DataSet = types.model("DataSet", {
   pseudoCaseMap: new Map<string, CaseGroup>(),
   transactionCount: 0
 }))
-.views(self => {
+.volatile(() => {
   let cachingCount = 0
   const caseCache = new Map<string, ICase>()
   return {
-    get isCaching() {
-      return cachingCount > 0
-    },
     get caseCache() {
       return caseCache
+    },
+    isCaching() {
+      // Do not use getter here, as the result would be cached and not updated when cachingCount changes.
+      // Note that it also happens for volatile properties, not only views.
+      return cachingCount > 0
     },
     clearCache() {
       caseCache.clear()
@@ -676,7 +678,7 @@ export const DataSet = types.model("DataSet", {
         return index != null ? this.getValueAtIndex(index, attributeID) : undefined
       },
       getValueAtIndex(index: number, attributeID: string) {
-          if (self.isCaching) {
+          if (self.isCaching()) {
             const caseID = self.cases[index]?.__id__
             const cachedCase = self.caseCache.get(caseID)
             if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
@@ -696,7 +698,7 @@ export const DataSet = types.model("DataSet", {
         return index != null ? this.getStrValueAtIndex(index, attributeID) : ""
       },
       getStrValueAtIndex(index: number, attributeID: string) {
-        if (self.isCaching) {
+        if (self.isCaching()) {
           const caseID = self.cases[index]?.__id__
           const cachedCase = self.caseCache.get(caseID)
           if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
@@ -716,7 +718,7 @@ export const DataSet = types.model("DataSet", {
         return index != null ? this.getNumericAtIndex(index, attributeID) : undefined
       },
       getNumericAtIndex(index: number, attributeID: string) {
-        if (self.isCaching) {
+        if (self.isCaching()) {
           const caseID = self.cases[index]?.__id__
           const cachedCase = self.caseCache.get(caseID)
           if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
@@ -918,7 +920,7 @@ export const DataSet = types.model("DataSet", {
                         ? ungroupedCases
                         : cases
         const before = getCases(_cases.map(({ __id__ }) => __id__))
-        if (self.isCaching) {
+        if (self.isCaching()) {
           // update the cases in the cache
           _cases.forEach(aCase => {
             const cached = self.caseCache.get(aCase.__id__)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186751807

This PR significantly changes the transition implementation in the PixiJS graph. The previous version didn't work too well with multiple concurrent transitions or user interactions. This new approach should resolve those issues. It's a bit difficult to demonstrate with the default 1000ms transition time, but when I set it to 6s, the purpose becomes easier to understand:

https://github.com/concord-consortium/codap/assets/767857/74ed361b-6477-4a00-85cb-e439fb0a4750

While it might not seem that useful, this is just an example. It's relatively easy to trigger some artifacts in the previous version, and I thought I should work on it so that someone else doesn't spend a lot of time trying to track down this issue later.

Also, it includes commit from PR https://github.com/concord-consortium/codap/pull/1059, as otherwise things wouldn't work correctly. I'll deal with it while merging `main` into `pixi-main` later.

And the last thing to double-check is the update of `onDragEnd` in v3/src/components/graph/components/scatterdots.tsx. This was also necessary to make all that work, but I'm not 100% sure if I'm not breaking something else.
