### PR TITLE
Restore marquee selection in PixiJS graphs

### DIFF
--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -67,8 +67,7 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
   if (pixiPointsRef.current != null && pixiContainerRef.current && pixiContainerRef.current.children.length === 0) {
     pixiContainerRef.current.appendChild(pixiPointsRef.current.canvas)
     pixiPointsRef.current.setupBackgroundEventDistribution({
-      elementToHide: pixiContainerRef.current,
-      interactiveElClassName: "interactive-graph-element"
+      elementToHide: pixiContainerRef.current
     })
   }
 

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -42,9 +42,7 @@ export const MapPointLayer = function MapPointLayer(props: {
       // PixiPoints background should redistribute events to the geoJSON polygons that lie underneath.
       backgroundEventDistribution: {
         // Element that needs to be "hidden" to obtain another element at the current cursor position.
-        elementToHide: pixiContainerRef.current,
-        // This is the class name of the leaflet map's interactive objects like geoJSON polygons.
-        interactiveElClassName: "leaflet-interactive"
+        elementToHide: pixiContainerRef.current
       }
     })
     return () => pixiPointsRef.current?.dispose()
@@ -68,7 +66,7 @@ export const MapPointLayer = function MapPointLayer(props: {
     pixiPointsRef.current.resize(layout.contentWidth, layout.contentHeight)
   }
 
-  useDataTips({dataset, displayModel: mapLayerModel})
+  useDataTips({pixiPointsRef, dataset, displayModel: mapLayerModel})
 
   const callMatchCirclesToData = useCallback(() => {
     if (mapLayerModel && dataConfiguration && layout && pixiPointsRef.current) {

--- a/v3/src/components/map/components/map-polygon-layer.tsx
+++ b/v3/src/components/map/components/map-polygon-layer.tsx
@@ -93,11 +93,17 @@ export const MapPolygonLayer = function MapPolygonLayer(props: {
                 tFeature.bindPopup(infoPopup).openPopup()
               }
             }, transitionDuration)
+            // Manual cursor setup is necessary when there's also the map points layer that uses PixiJS canvas.
+            // In that case, the events are redistributed from canvas and the only way to have hover cursor is to use
+            // mouseover and mouseout events.
+            leafletMap.getContainer().style.cursor = "pointer"
           },
 
           handleMouseout = () => {
             infoPopup?.close()
             infoPopup = null
+            // Manual cursor setup is necessary when there's also the map points layer that uses PixiJS canvas.
+            leafletMap.getContainer().style.cursor = ""
           }
 
         if (!jsonObject) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186725312

This PR restores the marquee selection behavior in graphs using the PixiJS dots/points layer. I was able to reuse most of the existing logic. I updated the canvas event redistribution mechanism to also pass `pointerdown` through, allowing the background to receive it. Then, I changed the drag implementation from the one provided by D3 to a custom one that listens only to `pointerdown` and then attaches listeners to window. This approach is usually recommended anyway and lets us avoid redispatching `pointermove` events from the canvas. Unfortunately, with our custom event redispatching, we need to be very careful about event handlers.

Additionally, I had to change how the pointer cursor is shown for elements lying under the canvas. It seems each layer will have to have its own approach (sometimes you can set the pointer on the canvas, other times it's necessary to set it on another element). Unfortunately, that's the cost of mixing Canvas with SVG layering.