### PR TITLE
Version 3.0.0-pre.1471 - January 2, 2024

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Version 3.0.0-pre.1471 - January 2, 2024
+
+### Features/Improvements
+- PT-186556758: Compare various rendering methods in a test repository (e.g. SVG vs D3 vs Canvas/3D, impact of MobX, etc.)
+- PT-186548730: Add MST caching helper for multi args methods and cache expensive methods in data configuration model
+- PT-181939990: On a scatterplot movable lines and least squares lines can have their **intercepts locked**
+- PT-186547994: Optimize methods used to retrieve dataset case values
+- PT-181940029: The **Squares of Residuals** option shows a square for each point
+- PT-186521999: Maps show a legend for each layer with a legend attribute
+- PT-186510502: User can drop an attribute on a map to color points or boundaries
+- PT-186647000: Eyeball icon for map component allows hiding and showing of cases
+- PT-186437311: Evaluate plotted function adornment formula
+- PT-186641108: Map inspector rescale button brings all map data into view
+- PT-186631176: Try to reimplement basic graph features using PixiJS as the points renderer instead of D3 SVG
+- PT-186479532: Add automated tests of function utils and "other" functions (random, pickRandom, etc.)
+- PT-186305230: Graphs with > 20K cases perform well
+- PT-181922446: A scatterplot can have **Connecting Lines** between the points
+- PT-186637668: PixiJS graph: Implement sprite-caseID matching and points animations/transitions
+- PT-186645440: PixiJS graph: add point hover effect
+- PT-186691239: PixiJS graph: avoid excessive CPU workload caused by the Pixi render loop
+
+### Bug Fixes
+- PT-186580777: Full length of movable line is not returned and it doesn't span entire graph area after the plot is split and unsplit
+- PT-186682759: Percent values in subplots not correct
+- PT-185577446: Graphs with subplots not rendered correctly on import
+- PT-186016145: Treating numeric attribute to categorical should update count and percent adornments correctly
+- PT-186648806: Legend is not responding to cases being hidden
+- PT-186485885: Some functions don't work within aggregate context (e.g. `mean(lookupByIndex("Mammals", "LifeSpan", caseIndex))`, `mean(if(LifeSpan < 30, 1, 2))`)
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+|  main.css |   72714 bytes |                            0.12% |
+|  index.js | 3499653 bytes |                            0.65% |
+
 ## Version 3.0.0-pre.1455 - December 4, 2023
 
 ### Features/Improvements

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1455",
+  "version": "3.0.0-pre.1471",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-pre.1455",
+      "version": "3.0.0-pre.1471",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1455",
+  "version": "3.0.0-pre.1471",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -5,6 +5,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.0.0-pre.1471](https://codap3.concord.org/version/3.0.0-pre.1471/) | January 2, 2024 |
 | [3.0.0-pre.1455](https://codap3.concord.org/version/3.0.0-pre.1455/) | December 4, 2023 |
 | [3.0.0-pre.1449](https://codap3.concord.org/version/3.0.0-pre.1449/) | November 27, 2023 |
 | [3.0.0-pre.1444](https://codap3.concord.org/version/3.0.0-pre.1444/) | November 20, 2023 |


### PR DESCRIPTION
### Features/Improvements
- PT-186556758: Compare various rendering methods in a test repository (e.g. SVG vs D3 vs Canvas/3D, impact of MobX, etc.)
- PT-186548730: Add MST caching helper for multi args methods and cache expensive methods in data configuration model
- PT-181939990: On a scatterplot movable lines and least squares lines can have their **intercepts locked**
- PT-186547994: Optimize methods used to retrieve dataset case values
- PT-181940029: The **Squares of Residuals** option shows a square for each point
- PT-186521999: Maps show a legend for each layer with a legend attribute
- PT-186510502: User can drop an attribute on a map to color points or boundaries
- PT-186647000: Eyeball icon for map component allows hiding and showing of cases
- PT-186437311: Evaluate plotted function adornment formula
- PT-186641108: Map inspector rescale button brings all map data into view
- PT-186631176: Try to reimplement basic graph features using PixiJS as the points renderer instead of D3 SVG
- PT-186479532: Add automated tests of function utils and "other" functions (random, pickRandom, etc.)
- PT-186305230: Graphs with > 20K cases perform well
- PT-181922446: A scatterplot can have **Connecting Lines** between the points
- PT-186637668: PixiJS graph: Implement sprite-caseID matching and points animations/transitions
- PT-186645440: PixiJS graph: add point hover effect
- PT-186691239: PixiJS graph: avoid excessive CPU workload caused by the Pixi render loop

### Bug Fixes
- PT-186580777: Full length of movable line is not returned and it doesn't span entire graph area after the plot is split and unsplit
- PT-186682759: Percent values in subplots not correct
- PT-185577446: Graphs with subplots not rendered correctly on import
- PT-186016145: Treating numeric attribute to categorical should update count and percent adornments correctly
- PT-186648806: Legend is not responding to cases being hidden
- PT-186485885: Some functions don't work within aggregate context (e.g. `mean(lookupByIndex("Mammals", "LifeSpan", caseIndex))`, `mean(if(LifeSpan < 30, 1, 2))`)