### PR TITLE
fix: Count adornment does not immediately update (PT-186513124)

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -13,6 +13,9 @@ export const CountAdornmentModel = AdornmentModel
     percentType: types.optional(types.enumeration(["cell", "column", "row"]), "cell"),
   })
   .views(self => ({
+    countValue(cellKey: Record<string, string>, dataConfig?: IGraphDataConfigurationModel) {
+      return dataConfig?.subPlotCases(cellKey)?.length ?? 0
+    },
     percentValue(casesInPlot: number, cellKey: Record<string, string>, dataConfig?: IGraphDataConfigurationModel) {
       const divisor = self.percentType === "row"
         ? dataConfig?.rowCases(cellKey).length ?? 0


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186513124

These changes make Count Adornment value(s) update immediately upon changes to existing case values in the dataset. I'm not sure calling the data configuration model's `_invalidateCases` action from the count adornment component is the best thing to do, but as I understand it, [this part](https://github.com/concord-consortium/codap/blob/b8df5a48e552c8d6d19ff8a3d90d8a553e57ac9d/v3/src/components/data-display/models/data-configuration-model.ts#L525-L526) of `handleDataSetAction` makes it necessary. Currently, when a case's value is modified, `setCaseValues` is called which triggers [this call](https://github.com/concord-consortium/codap/blob/b8df5a48e552c8d6d19ff8a3d90d8a553e57ac9d/v3/src/components/data-display/models/data-configuration-model.ts#L523) to `clearCasesCache` in `handleDataSetAction`. But that doesn't appear to be enough to make the Count Adornment update (without the new code in this PR). It's not clear to me whether that's expected, so I'm wondering if instead of making changes to the Count Adornment, perhaps `handleDataSetAction` needs a little adjusting?