### PR TITLE
feat: Plotted Value should show units (PT-186681717)

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -188,13 +188,18 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       const value = model.measureValue(attrId, cellKey, dataConfig)
       if (value === undefined || isNaN(value)) return
 
+      const primaryAttrId = dataConfig?.primaryAttributeID
+      const primaryAttr = primaryAttrId ? dataConfig?.dataset?.attrFromID(primaryAttrId) : undefined
+      const primaryAttrUnits = primaryAttr?.units
       const { coords, coverClass, coverId, displayRange, displayValue, lineClass, lineId, measureRange, plotValue } =
         helper.adornmentSpecs(attrId, dataConfig, value, isVertical.current, cellCounts)
 
       const translationVars = [
         `${(measureRange.min || measureRange.min === 0) && displayRange ? `${displayRange}` : `${displayValue}`}`
       ]
-      const textContent = `${t(model.labelTitle, { vars: translationVars })}`
+      const valueContent = `${t(model.labelTitle, { vars: translationVars })}`
+      const unitContent = `${primaryAttrUnits ? ` ${primaryAttrUnits}` : ""}`
+      const textContent = `${valueContent}${unitContent}`
 
       // Add the main value line
       const lineSpecs = {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186681717

These changes will add units to labels and tool tips for the Plotted Value _and_ all other Univariate Measure adornments except the Box Plot. I believe that's fine even though the story didn't call for it since V2 shows units for all those adornments, too. 