### PR TITLE
fix: Percent adornment category should be remembered (PT-186016085)

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -25,15 +25,8 @@ export const CountAdornment = observer(function CountAdornment({model, cellKey}:
   useEffect(() => {
     return autorun(() => {
       prf.begin("CountAdornment.autorun")
-      const shouldShowPercentOption = dataConfig ? dataConfig.categoricalAttrCount > 0 : false
-      const shouldShowPercentTypeOptions = dataConfig?.hasExactlyTwoPerpendicularCategoricalAttrs
-
-      // set percentType to 'cell' if attributes change to a configuration that doesn't support 'row' or 'column'
-      if (!shouldShowPercentTypeOptions && model?.percentType !== "cell") {
-        model.setPercentType("cell")
-      }
-
       // set showPercent to false if attributes change to a configuration that doesn't support percent
+      const shouldShowPercentOption = dataConfig ? dataConfig.categoricalAttrCount > 0 : false
       if (!shouldShowPercentOption && model?.showPercent) {
         model.setShowPercent(false)
       }

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -26,7 +26,7 @@ export const CountAdornment = observer(function CountAdornment({model, cellKey}:
     return autorun(() => {
       prf.begin("CountAdornment.autorun")
       // set showPercent to false if attributes change to a configuration that doesn't support percent
-      const shouldShowPercentOption = dataConfig ? dataConfig.categoricalAttrCount > 0 : false
+      const shouldShowPercentOption = !!dataConfig?.categoricalAttrCount
       if (!shouldShowPercentOption && model?.showPercent) {
         model.setShowPercent(false)
       }

--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -14,9 +14,14 @@ export const CountAdornmentModel = AdornmentModel
   })
   .views(self => ({
     percentValue(casesInPlot: number, cellKey: Record<string, string>, dataConfig?: IGraphDataConfigurationModel) {
-      const divisor = self.percentType === "row"
+      // Percent type options are only available when there are exactly two categorial attributes on perpendicular
+      // axes, which creates a grid of subplots with multiple rows and columns. When percent type options are not
+      // available, we default to the "cell" percent type (i.e. use `dataConfig?.allPlottedCases.length ?? 0` as
+      // the divisor)
+      const hasPercentTypeOptions = dataConfig?.hasExactlyTwoPerpendicularCategoricalAttrs
+      const divisor = hasPercentTypeOptions && self.percentType === "row"
         ? dataConfig?.rowCases(cellKey).length ?? 0
-        : self.percentType === "column"
+        : hasPercentTypeOptions && self.percentType === "column"
           ? dataConfig?.columnCases(cellKey).length ?? 0
           : dataConfig?.allPlottedCases.length ?? 0
       const percentValue = casesInPlot / divisor


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186016085

This removes the part of the autorun in `CountAdornment` that would change the model's `percentType` property to `cell` when the graph changed to a configuration that doesn't support the `row` or `column` options. Instead, the `percentValue` model view now checks the configuration and defaults to using `cell` in all instances where that's the only supported option. That means the `percentType` property value is only changed when the user changes it via the UI, and so the previously selected option will be remembered when the graph changes from a configuration that supports the percent type options, to one that doesn't, and then back to one that does.