### PR TITLE
fix: count adornment responds to data changes [#186513124]

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -50,7 +50,8 @@ export const DataConfigurationModel = types
     actionHandlerDisposer: undefined as (() => void) | undefined,
     filteredCases: [] as FilteredCases[],
     handlers: new Map<string, (actionCall: ISerializedActionCall) => void>(),
-    pointsNeedUpdating: false
+    pointsNeedUpdating: false,
+    casesChangeCount: 0
   }))
   .views(self => ({
     get isEmpty() {
@@ -418,6 +419,8 @@ export const DataConfigurationModel = types
     clearCasesCache() {
       self.valuesForAttrRole.invalidateAll()
       self.allCasesForCategoryAreSelected.invalidateAll()
+      // increment observable change count
+      ++self.casesChangeCount
     }
   }))
   .actions(self => ({

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -21,6 +21,8 @@ export const CountAdornment = observer(function CountAdornment({model, cellKey}:
   const casesInPlot = dataConfig?.subPlotCases(cellKey)?.length ?? 0
   const percent = model.percentValue(casesInPlot, cellKey, dataConfig)
   const displayPercent = model.showCount ? ` (${percentString(percent)})` : percentString(percent)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const rerenderOnCasesChange = dataConfig?.casesChangeCount
 
   useEffect(() => {
     return autorun(() => {

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -3,7 +3,6 @@ import { Point } from "../../../data-display/data-display-types"
 import { AdornmentModel, IAdornmentModel, IUpdateCategoriesOptions, PointModel } from "../adornment-models"
 import { leastSquaresLinearRegression, tAt0975ForDf } from "../../utilities/graph-utils"
 import { kLSRLType } from "./lsrl-adornment-types"
-import { ICase } from "../../../../models/data/data-set-types"
 import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
 import { ScaleNumericBaseType } from "../../../axis/axis-types"
 import { ILineDescription } from "../shared-adornment-types"
@@ -70,10 +69,10 @@ export const LSRLAdornmentModel = AdornmentModel
     const legendAttrId = dataConfig?.attributeID("legend")
     const casesInPlot = dataConfig.subPlotCases(cellKey)
     const caseValues: Point[] = []
-    casesInPlot.forEach((c: ICase) => {
-      const caseValueX = dataset?.getNumeric(c.__id__, xAttrId)
-      const caseValueY = dataset?.getNumeric(c.__id__, yAttrId)
-      const caseValueLegend = dataset?.getValue(c.__id__, legendAttrId)
+    casesInPlot.forEach(caseId => {
+      const caseValueX = dataset?.getNumeric(caseId, xAttrId)
+      const caseValueY = dataset?.getNumeric(caseId, yAttrId)
+      const caseValueLegend = dataset?.getValue(caseId, legendAttrId)
       const isValidX = caseValueX && Number.isFinite(caseValueX)
       const isValidY = caseValueY && Number.isFinite(caseValueY)
       const categoryMatch = cat === "__main__" || caseValueLegend === cat

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -3,7 +3,7 @@ import { Point } from "../../../data-display/data-display-types"
 import { AdornmentModel, IAdornmentModel, IUpdateCategoriesOptions, PointModel } from "../adornment-models"
 import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
 import {IGraphDataConfigurationModel} from "../../models/graph-data-configuration-model"
-import { ICase } from "../../../../models/data/data-set-types"
+import { isFiniteNumber } from "../../../../utilities/math-utils"
 
 export const MeasureInstance = types.model("MeasureInstance", {
   labelCoords: types.maybe(PointModel)
@@ -39,9 +39,9 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
       const dataset = dataConfig?.dataset
       const casesInPlot = dataConfig.subPlotCases(cellKey)
       const caseValues: number[] = []
-      casesInPlot.forEach((c: ICase) => {
-        const caseValue = Number(dataset?.getValue(c.__id__, attrId))
-        if (Number.isFinite(caseValue)) {
+      casesInPlot.forEach(caseId => {
+        const caseValue = dataset?.getNumeric(caseId, attrId)
+        if (isFiniteNumber(caseValue)) {
           caseValues.push(caseValue)
         }
       })

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -24,7 +24,9 @@ describe("DataConfigurationModel", () => {
     tree.data.addAttribute({ id: "yId", name: "y" })
     tree.metadata.setData(tree.data)
     tree.data.addCases(toCanonical(tree.data, [
-      { __id__: "c1", n: "n1", x: 1, y: 1 }, { __id__: "c2", x: 2 }, { __id__: "c3", n: "n3", y: 3 }
+      { __id__: "c1", n: "n1", x: 1, y: 1 },
+      { __id__: "c2", x: 2 },
+      { __id__: "c3", n: "n3", y: 3 }
     ]))
   })
 
@@ -284,11 +286,36 @@ describe("DataConfigurationModel", () => {
   it("returns an array of cases in a plot", () => {
     const config = tree.config
     config.setDataset(tree.data, tree.metadata)
-    expect(config.subPlotCases({})).toEqual([
-      {"__id__": "c1", "nId": "n1", "xId": "1", "yId": "1"},
-      {"__id__": "c2", "nId": "", "xId": "2", "yId": ""},
-      {"__id__": "c3", "nId": "n3", "xId": "", "yId": "3"}
-    ])
+    expect(config.allPlottedCases()).toEqual(["c1", "c2", "c3"])
+    expect(config.subPlotCases({})).toEqual(["c1", "c2", "c3"])
+    expect(config.rowCases({})).toEqual(["c1", "c2", "c3"])
+    expect(config.columnCases({})).toEqual(["c1", "c2", "c3"])
+
+    config.setAttribute("x", { attributeID: "xId" })
+    expect(config.allPlottedCases()).toEqual(["c1", "c2"])
+    expect(config.subPlotCases({})).toEqual(["c1", "c2"])
+    expect(config.rowCases({})).toEqual(["c1", "c2"])
+    expect(config.columnCases({})).toEqual(["c1", "c2"])
+
+    config.setAttribute("y", { attributeID: "yId" })
+    expect(config.allPlottedCases()).toEqual(["c1"])
+    expect(config.subPlotCases({})).toEqual(["c1"])
+    expect(config.rowCases({})).toEqual(["c1"])
+    expect(config.columnCases({})).toEqual(["c1"])
+
+    config.setAttribute("topSplit", { attributeID: "nId" })
+    expect(config.allPlottedCases()).toEqual(["c1"])
+    expect(config.subPlotCases({})).toEqual(["c1"])
+    expect(config.rowCases({})).toEqual(["c1"])
+    expect(config.columnCases({})).toEqual([])
+    expect(config.columnCases({ nId: "n1" })).toEqual(["c1"])
+
+    config.setAttribute("x")
+    expect(config.allPlottedCases()).toEqual(["c1", "c3"])
+    expect(config.subPlotCases({})).toEqual(["c1", "c3"])
+    expect(config.rowCases({})).toEqual(["c1", "c3"])
+    expect(config.columnCases({})).toEqual([])
+    expect(config.columnCases({ nId: "n1" })).toEqual(["c1"])
   })
 
   it("can create cell key", () => {

--- a/v3/src/models/formula/plotted-function-formula-adapter.ts
+++ b/v3/src/models/formula/plotted-function-formula-adapter.ts
@@ -49,7 +49,8 @@ export class PlottedFunctionFormulaAdapter extends BaseGraphFormulaAdapter {
     this.setFormulaError(formulaContext, extraMetadata, "")
     graphCellKeys.forEach(cellKey => {
       const instanceKey = adornment.instanceKey(cellKey)
-      const cases = dataConfig.subPlotCases(cellKey)
+      const caseIds = dataConfig.subPlotCases(cellKey)
+      const cases = caseIds.map(id => dataConfig.dataset?.getCase(id, { numeric: true }) || { __id__: id })
       const formulaFunction = this.computeFormula(formulaContext, extraMetadata, cases)
       if (!adornment.plottedFunctions.get(instanceKey)) {
         adornment.addPlottedFunction(formulaFunction, instanceKey)

--- a/v3/src/models/formula/plotted-value-formula-adapter.ts
+++ b/v3/src/models/formula/plotted-value-formula-adapter.ts
@@ -45,7 +45,8 @@ export class PlottedValueFormulaAdapter extends BaseGraphFormulaAdapter {
 
     graphCellKeys.forEach(cellKey => {
       const instanceKey = adornment.instanceKey(cellKey)
-      const cases = dataConfig.subPlotCases(cellKey)
+      const caseIds = dataConfig.subPlotCases(cellKey)
+      const cases = caseIds.map(id => dataConfig.dataset?.getCase(id, { numeric: true }) || { __id__: id })
       const value = Number(this.computeFormula(formulaContext, extraMetadata, cases))
       if (!adornment.measures.get(instanceKey)) {
         adornment.addMeasure(value, instanceKey)


### PR DESCRIPTION
[[#186513124]](https://www.pivotaltracker.com/story/show/186513124) Count adornment does not immediately update when case data modified

Alternative to the fix in #1063.
>I'm not sure calling the data configuration model's _invalidateCases action from the count adornment component is the best thing to do

@emcelroy Your misgivings were warranted. Ultimately, the problem was with the caching in the `GraphDataConfigurationModel`. `GraphDataConfigurationModel.allPlottedCases` wasn't being invalidated/updated on value changes. In addition to caching the result from `allPlottedCases` with `cachedFnFactory`, this PR also changes the caching of `allPlottedCases`, `subPlotCases`, `rowCases`, and `columnCases` so that they cache and return arrays of case ids rather than entire case objects. Many clients don't need the case data and those that do should request it themselves from the DataSet rather than caching what potentially amounts to an entire copy of the DataSet locally. Finally, we add an observable volatile `casesChangeCount` property to the `DataConfigurationModel` which is updated when `clearCasesCache` is called and reference it in the `CountAdornmentComponent` to trigger a re-render. Other adornments may need to do the same.