### PR TITLE
chore: refactor AxisModel to eliminate need for dispatcher

### DIFF
--- a/v3/src/components/axis/models/axis-model.test.ts
+++ b/v3/src/components/axis/models/axis-model.test.ts
@@ -79,8 +79,8 @@ describe("NumericAxisModel", () => {
   })
 })
 
-describe("deserializes axes of the appropriate type", () => {
-  it("foo", () => {
+describe("AxisModelUnion", () => {
+  it("deserializes axes of the appropriate type", () => {
     const M = types.model("Test", {
       axis: AxisModelUnion
     })
@@ -90,11 +90,25 @@ describe("deserializes axes of the appropriate type", () => {
       }
     }))
 
+    const emptyAxis = EmptyAxisModel.create({ place: "bottom" })
+    const empty = M.create({ axis : emptyAxis })
+    expect(isEmptyAxisModel(empty.axis)).toBe(true)
+    const emptySnap = getSnapshot(empty)
+    const empty2 = M.create(emptySnap)
+    expect(isEmptyAxisModel(empty2.axis)).toBe(true)
+
     const numAxis = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
     const num = M.create({ axis : numAxis })
     expect(isNumericAxisModel(num.axis) && num.axis.domain).toBeDefined()
     const snap = getSnapshot(num)
     const num2 = M.create(snap)
     expect(isNumericAxisModel(num2.axis) && num2.axis.domain).toBeDefined()
+
+    const catAxis = CategoricalAxisModel.create({ place: "bottom" })
+    const cat = M.create({ axis : catAxis })
+    expect(isCategoricalAxisModel(cat.axis)).toBe(true)
+    const catSnap = getSnapshot(cat)
+    const cat2 = M.create(catSnap)
+    expect(isCategoricalAxisModel(cat2.axis)).toBe(true)
   })
 })

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -44,7 +44,7 @@ export interface IAxisModel extends Instance<typeof AxisModel> {
 export const EmptyAxisModel = AxisModel
   .named("EmptyAxisModel")
   .props({
-    type: "empty",
+    type: types.optional(types.literal("empty"), "empty"),
     min: 0,
     max: 0
   })
@@ -58,7 +58,7 @@ export function isEmptyAxisModel(axisModel?: IAxisModel): axisModel is IEmptyAxi
 export const CategoricalAxisModel = AxisModel
   .named("CategoricalAxisModel")
   .props({
-    type: "categorical",
+    type: types.optional(types.literal("categorical"), "categorical"),
     scale: "band"
   })
 export interface ICategoricalAxisModel extends Instance<typeof CategoricalAxisModel> {}
@@ -71,7 +71,7 @@ export function isCategoricalAxisModel(axisModel?: IAxisModel): axisModel is ICa
 export const NumericAxisModel = AxisModel
   .named("NumericAxisModel")
   .props({
-    type: "numeric",
+    type: types.optional(types.literal("numeric"), "numeric"),
     scale: types.optional(types.enumeration([...ScaleTypes]), "linear"),
     min: types.number,
     max: types.number
@@ -119,16 +119,7 @@ export function isNumericAxisModel(axisModel?: IAxisModel): axisModel is INumeri
   return !!axisModel?.isNumeric
 }
 
-const axisTypeDispatcher = (axisSnap: any) => {
-  switch (axisSnap.type) {
-    case "categorical": return CategoricalAxisModel
-    case "numeric": return NumericAxisModel
-    default: return EmptyAxisModel
-  }
-}
-
-export const AxisModelUnion = types.union({ dispatcher: axisTypeDispatcher },
-  EmptyAxisModel, CategoricalAxisModel, NumericAxisModel)
+export const AxisModelUnion = types.union(EmptyAxisModel, CategoricalAxisModel, NumericAxisModel)
 export type IAxisModelUnion = IEmptyAxisModel | ICategoricalAxisModel | INumericAxisModel
 export type IAxisModelSnapshotUnion =
   IEmptyAxisModelSnapshot | ICategoricalAxisModelSnapshot | INumericAxisModelSnapshot


### PR DESCRIPTION
Doing some beginning of year house-cleaning of some branches that have been sitting around on my machine...

Using `types.literal` allows MST to infer the appropriate type from the snapshot and obviates the need for a dispatcher.