### PR TITLE
chore: simplify GraphController.handleAttributeAssignment

### DIFF
--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -146,9 +146,6 @@ export class GraphController {
         dataConfig.setPrimaryRole(primaryRole)
         graphModel.setPlotType(plotChoices[primaryType][otherAttributeType])
       }
-      if (dataConfig.attributeID(graphAttributeRole) !== attrID) {
-        dataConfig.setAttribute(graphAttributeRole, {attributeID: attrID})
-      }
     }
 
     const setupAxis = (place: AxisPlace) => {


### PR DESCRIPTION
The code that is removed here was [removed in CLUE](https://github.com/concord-consortium/collaborative-learning/pull/2125) because it was causing issues in a multiple-Y scenario. I don't know that CODAP v3 can get into the precise situation that CLUE encountered, but the logical argument that was used there _does_ seem to apply to CODAP -- the only time `handleAttributeAssignment` is called is _after_ the data configuration has already been updated, so there's no circumstance under which it is appropriate for the `GraphController` to be calling `dataConfig.setAttribute`.