### PR TITLE
feat: Count labels change their font size to fit (PT-181914458)

### DIFF
--- a/v3/src/components/graph/adornments/adornment-types.ts
+++ b/v3/src/components/graph/adornments/adornment-types.ts
@@ -19,6 +19,7 @@ import { ILSRLAdornmentModel, LSRLAdornmentModel } from "./lsrl/lsrl-adornment-m
 
 export const kGraphAdornmentsClass = "graph-adornments-grid"
 export const kGraphAdornmentsClassSelector = `.${kGraphAdornmentsClass}`
+export const kDefaultFontSize = 12
 
 const adornmentTypeDispatcher = (adornmentSnap: IAdornmentModel) => {
   switch (adornmentSnap.type) {

--- a/v3/src/components/graph/adornments/adornments-store.test.ts
+++ b/v3/src/components/graph/adornments/adornments-store.test.ts
@@ -44,6 +44,13 @@ describe("AdornmentsStore", () => {
     expect(adornmentsStore).toBeDefined()
     expect(adornmentsStore.type).toEqual("Adornments Store")
   })
+
+  it("can have its defaultFontSize property set", () => {
+    const adornmentsStore = AdornmentsStore.create()
+    expect(adornmentsStore.defaultFontSize).toBe(12)
+    adornmentsStore.setDefaultFontSize(14)
+    expect(adornmentsStore.defaultFontSize).toBe(14)
+  })
   it("can have its interceptLocked property set", () => {
     const adornmentsStore = AdornmentsStore.create()
     expect(adornmentsStore.interceptLocked).toBe(false)

--- a/v3/src/components/graph/adornments/adornments-store.ts
+++ b/v3/src/components/graph/adornments/adornments-store.ts
@@ -1,7 +1,7 @@
 import { Instance, types } from "mobx-state-tree"
 import { IAdornmentContentInfo, getAdornmentContentInfo, getAdornmentTypes } from "./adornment-content-info"
 import { IAdornmentComponentInfo, getAdornmentComponentInfo } from "./adornment-component-info"
-import { AdornmentModelUnion, IMeasure, PlotTypes, measures } from "./adornment-types"
+import { AdornmentModelUnion, IMeasure, PlotTypes, kDefaultFontSize, measures } from "./adornment-types"
 import { IAdornmentModel, IUpdateCategoriesOptions } from "./adornment-models"
 import { kMovableLineType } from "./movable-line/movable-line-adornment-types"
 import { kLSRLType } from "./lsrl/lsrl-adornment-types"
@@ -19,12 +19,16 @@ interface IMeasureMenuItem {
 export const AdornmentsStore = types.model("AdornmentsStore", {
     type: "Adornments Store",
     adornments: types.array(AdornmentModelUnion),
+    defaultFontSize: kDefaultFontSize,
     interceptLocked: false,
     showConnectingLines: false,
     showMeasureLabels: false,
     showSquaresOfResiduals: false
   })
   .actions(self => ({
+    setDefaultFontSize(fontSize: number) {
+      self.defaultFontSize = fontSize
+    },
     toggleInterceptLocked() {
       self.interceptLocked = !self.interceptLocked
     },

--- a/v3/src/components/graph/adornments/count/count-adornment-component.scss
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.scss
@@ -1,7 +1,8 @@
 .graph-count {
-  font-size: 12px;
   line-height: 1;
   position: absolute;
   right: 3px;
   top: 2px;
+  white-space: nowrap;
+  width: calc(100% - 3px);
 }

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -1,31 +1,64 @@
-import React, { useEffect } from "react"
-import { autorun } from "mobx"
+import React, { useCallback, useEffect, useRef } from "react"
 import { observer } from "mobx-react-lite"
 import { ICountAdornmentModel } from "./count-adornment-model"
 import { useGraphDataConfigurationContext } from "../../hooks/use-graph-data-configuration-context"
 import { useAdornmentCells } from "../../hooks/use-adornment-cells"
 import { percentString } from "../../utilities/graph-utils"
 import { prf } from "../../../../utilities/profiler"
+import { measureText } from "../../../../hooks/use-measure-text"
+import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
+import { mstAutorun } from "../../../../utilities/mst-autorun"
+import { kDefaultFontSize } from "../adornment-types"
 
 import "./count-adornment-component.scss"
 
 interface IProps {
-  model: ICountAdornmentModel
   cellKey: Record<string, string>
+  model: ICountAdornmentModel
+  plotWidth: number
 }
 
-export const CountAdornment = observer(function CountAdornment({model, cellKey}: IProps) {
+export const CountAdornment = observer(function CountAdornment({ model, cellKey, plotWidth }: IProps) {
   prf.begin("CountAdornment.render")
   const { classFromKey } = useAdornmentCells(model, cellKey)
   const dataConfig = useGraphDataConfigurationContext()
+  const graphModel = useGraphContentModelContext()
   const casesInPlot = dataConfig?.subPlotCases(cellKey)?.length ?? 0
   const percent = model.percentValue(casesInPlot, cellKey, dataConfig)
   const displayPercent = model.showCount ? ` (${percentString(percent)})` : percentString(percent)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const rerenderOnCasesChange = dataConfig?.casesChangeCount
+  const textContent = `${model.showCount ? casesInPlot : ""}${model.showPercent ? displayPercent : ""}`
+  const defaultFontSize = graphModel.adornmentsStore.defaultFontSize
+  let fontSize = defaultFontSize
+  const prevCellWidth = useRef(plotWidth)
+
+  const resizeText = useCallback(() => {
+    const minFontSize = 3
+    const maxFontSize = kDefaultFontSize
+    const textOffset = 5
+    const textWidth = measureText(textContent, `${fontSize}px Lato, sans-serif`) + textOffset
+
+    if (prevCellWidth.current > plotWidth && textWidth > plotWidth && fontSize > minFontSize) {
+      fontSize--
+    } else if (prevCellWidth.current < plotWidth && textWidth < plotWidth && fontSize < maxFontSize) {
+      fontSize++
+    }
+
+    if (fontSize !== defaultFontSize) {
+      graphModel.adornmentsStore.setDefaultFontSize(fontSize)
+    }
+  }, [defaultFontSize, fontSize, graphModel.adornmentsStore, plotWidth, textContent])
+
+  useEffect(function resizeTextOnCellWidthChange() {
+    return mstAutorun(() => {
+      resizeText()
+      prevCellWidth.current = plotWidth
+    }, { name: "CountAdornmentComponent.resizeTextOnCellWidthChange" }, model)
+  }, [model, plotWidth, resizeText])
 
   useEffect(() => {
-    return autorun(() => {
+    return mstAutorun(function setShowPercentOption() {
       prf.begin("CountAdornment.autorun")
       // set showPercent to false if attributes change to a configuration that doesn't support percent
       const shouldShowPercentOption = !!dataConfig?.categoricalAttrCount
@@ -33,13 +66,16 @@ export const CountAdornment = observer(function CountAdornment({model, cellKey}:
         model.setShowPercent(false)
       }
       prf.end("CountAdornment.autorun")
-    })
+    }, { name: "CountAdornmentComponent.setShowPercentOption" }, model)
   }, [dataConfig, model])
   prf.end("CountAdornment.render")
   return (
-    <div className="graph-count" data-testid={`graph-count${classFromKey ? `-${classFromKey}` : ""}`}>
-      {model.showCount && casesInPlot}
-      {model.showPercent && displayPercent}
+    <div
+      className="graph-count"
+      data-testid={`graph-count${classFromKey ? `-${classFromKey}` : ""}`}
+      style={{fontSize: `${fontSize}px`}}
+    >
+      {textContent}
     </div>
   )
 })


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181914458

All instances of the count adornment need to have the same font size at all times, but it may be the case that only one instance's text is too wide for its subplot while all others fit fine. So in order to dynamically change the font size of _all_ instances at the same time, these changes add a `defaultFontSize` property to `AdornmentsStore` and have the `CountAdornment` component modify that as needed when the graph is resized.

(BTW, I was hoping there'd be a pure CSS solution for this, but I couldn't find anything that would work.)