### PR TITLE
chore: improve eslint configuration

### DIFF
--- a/v3/.eslintrc.cjs
+++ b/v3/.eslintrc.cjs
@@ -24,7 +24,12 @@ module.exports = {
     react: {
       pragma: "React",
       version: "detect"
-    }
+    },
+    "componentWrapperFunctions": [
+      // The name of any function used to wrap components, e.g. Mobx `observer` function.
+      // If this isn't set, components wrapped by these functions will be skipped.
+      "observer"
+    ]
   },
   ignorePatterns: [
     "dist/", "node_modules/"

--- a/v3/src/components/graph/adornments/adornment-checkbox.tsx
+++ b/v3/src/components/graph/adornments/adornment-checkbox.tsx
@@ -11,7 +11,7 @@ interface IProps {
   type: string
 }
 
-export const AdornmentCheckbox = observer(({classNameValue, labelKey, type}: IProps) => {
+export const AdornmentCheckbox = observer(function AdornmentCheckbox({classNameValue, labelKey, type}: IProps) {
   const graphModel = useGraphContentModelContext()
   const adornmentsStore = graphModel?.adornmentsStore
   const existingAdornment = adornmentsStore.adornments.find(a => a.type === type)

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
@@ -11,7 +11,7 @@ import { kLSRLClass, kLSRLLabelKey, kLSRLPrefix, kLSRLRedoAddKey,
 import { LSRLAdornment } from "./lsrl-adornment-component"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 
-const Controls = observer(() => {
+const Controls = observer(function Controls() {
   const graphModel = useGraphContentModelContext()
   const adornmentsStore = graphModel.adornmentsStore
   const existingAdornment = adornmentsStore.findAdornmentOfType<ILSRLAdornmentModel>(kLSRLType)

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
@@ -10,7 +10,7 @@ import { useGraphContentModelContext } from "../../../hooks/use-graph-content-mo
 import { BoxPlotAdornmentComponent } from "./box-plot-adornment-component"
 import { observer } from "mobx-react-lite"
 
-const Controls = observer(() => {
+const Controls = observer(function Controls() {
   const graphModel = useGraphContentModelContext()
   const adornmentsStore = graphModel.adornmentsStore
   const existingAdornment = adornmentsStore.findAdornmentOfType<IBoxPlotAdornmentModel>(kBoxPlotType)

--- a/v3/src/components/graph/components/graph-inspector.tsx
+++ b/v3/src/components/graph/components/graph-inspector.tsx
@@ -16,7 +16,7 @@ import {ITileInspectorPanelProps} from "../../tiles/tile-base-props"
 import {isGraphContentModel} from "../models/graph-content-model"
 
 
-export const GraphInspector = observer(({tile, show}: ITileInspectorPanelProps) => {
+export const GraphInspector = observer(function GraphInspector({tile, show}: ITileInspectorPanelProps) {
   const graphModel = isGraphContentModel(tile?.content) ? tile?.content : undefined
   const [showPalette, setShowPalette] = useState<string | undefined>(undefined)
   const panelRef = useRef<HTMLDivElement>()

--- a/v3/src/components/graph/components/inspector-panel/graph-measure-panel.tsx
+++ b/v3/src/components/graph/components/inspector-panel/graph-measure-panel.tsx
@@ -18,7 +18,9 @@ interface IProps {
   setShowPalette: (palette: string | undefined) => void
 }
 
-export const GraphMeasurePalette = observer(({tile, panelRect, buttonRect, setShowPalette}: IProps) => {
+export const GraphMeasurePalette = observer(function GraphMeasurePalette({
+  tile, panelRect, buttonRect, setShowPalette
+}: IProps) {
   const toast = useToast()
   const graphModel = isGraphContentModel(tile?.content) ? tile?.content : undefined
   const measures = graphModel ? graphModel?.adornmentsStore.getAdornmentsMenuItems(graphModel.plotType) : undefined

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -9,7 +9,7 @@ interface IProps {
   tile?: ITileModel
 }
 
-export const HideShowMenuList = observer(({tile}: IProps) => {
+export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProps) {
   const toast = useToast()
   const graphModel = isGraphContentModel(tile?.content) ? tile?.content : undefined
   const dataConfiguration = graphModel?.dataConfiguration

--- a/v3/src/components/map/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/hide-show-menu-list.tsx
@@ -15,7 +15,7 @@ function isAliveMapContentModel(model?: ITileContentModel): model is IMapContent
   return !!model && isAlive(model) && isMapContentModel(model)
 }
 
-export const HideShowMenuList = observer(({tile}: IProps) => {
+export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProps) {
   const mapModel = isAliveMapContentModel(tile?.content) ? tile?.content : undefined
   const numSelected = mapModel?.numSelected() ?? 0
   const numUnselected = mapModel?.numUnselected() ?? 0


### PR DESCRIPTION
Added
```
    "componentWrapperFunctions": [
      // The name of any function used to wrap components, e.g. Mobx `observer` function.
      // If this isn't set, components wrapped by these functions will be skipped.
      "observer"
    ]
```
to our ESLint configuration so that components wrapped in `observer` are linted correctly.