### PR TITLE
fix: Style CFM dialog provider message

### DIFF
--- a/apps/dg/resources/dg.css
+++ b/apps/dg/resources/dg.css
@@ -228,6 +228,11 @@ html, body {
     // float: right;
 // }
 
+.tabbed-panel .workspace-tab-component .dialogTab .provider-message  {
+    color: #000;
+    font-size: 12px;
+}
+
 .navBar .sc-view {
     color: white;
     font-family: 'Montserrat-Regular', sans-serif;


### PR DESCRIPTION
Without this fix the provider message, which contains the username, is invisible as it is white on a white background.  This also sets the font-size to be the same as the provider message in SageModeler.