### PR TITLE
fix: Percent values not always correct (PT-186822118)

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -23,7 +23,7 @@ export const CountAdornmentModel = AdornmentModel
         ? dataConfig?.rowCases(cellKey).length ?? 0
         : hasPercentTypeOptions && self.percentType === "column"
           ? dataConfig?.columnCases(cellKey).length ?? 0
-          : dataConfig?.allPlottedCases.length ?? 0
+          : dataConfig?.allPlottedCases().length ?? 0
       const percentValue = casesInPlot / divisor
       return isFinite(percentValue) ? percentValue : 0
     }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186822118

The `percentValue` view in the count adornment model was using `dataConfig?.allPlottedCases.length` to get the number of plotted cases, but that was always equal to `0`. Changing it to `dataConfig?.allPlottedCases().length` results in getting the actual number of plotted cases, and so the correct percent values.