### PR TITLE
feat: Show both Mean & Median tips when overlapped (PT-186150345)

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.scss
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.scss
@@ -50,6 +50,9 @@
     &.visible {
       display: block;
     }
+    &.offset {
+      transform: translate(0, 17px)
+    }
   }
 
   .measure-cover {

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -44,6 +44,8 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
     const valueRef = useRef<SVGGElement>(null)
     const valueObjRef = useRef<IValue>({})
     const labelRef = useRef<HTMLDivElement>(null)
+    const isBlockingOtherMeasure = dataConfig &&
+      helper.blocksOtherMeasure({adornmentsStore, attrId, dataConfig, isVertical: isVertical.current})
 
     const highlightCovers = useCallback((highlight: boolean) => {
       const covers = selectAll(`#${helper.measureSlug}-${containerId} .${helper.measureSlug}-cover`)
@@ -60,7 +62,15 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       const tip = select(`#${tipId}`)
       tip.classed("visible", visible)
       highlightCovers(visible)
-    }, [highlightCovers])
+      if (isBlockingOtherMeasure) {
+        const containerNode: Element = select(`#${containerId}`).node() as Element
+        const parentContainer = containerNode.parentNode as Element
+        const blockedMeasureTips = select(parentContainer).selectAll(`.show-on-overlap-hover`).filter((d, i, nodes) => {
+          return (nodes[i] as SVGTextElement).id !== tipId
+        })
+        blockedMeasureTips.classed("visible offset", visible)
+      }
+    }, [containerId, highlightCovers, isBlockingOtherMeasure])
 
     const handleMoveLabel = useCallback((event: { x: number, y: number, dx: number, dy: number }, labelId: string) => {
       if (event.dx !== 0 || event.dy !== 0) {
@@ -142,7 +152,11 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
     const addTextTip = useCallback((plotValue: number, textContent: string, valueObj: IValue, range?: number) => {
       const selection = select(valueRef.current)
       const textId = helper.generateIdString("tip")
-      const textClass = clsx("measure-tip", `${helper.measureSlug}-tip`)
+      const textClass = clsx(
+        "measure-tip",
+        `${helper.measureSlug}-tip`,
+        { "show-on-overlap-hover": isBlockingOtherMeasure }
+      )
       const textTipWidth = measureText(textContent, "10px Lato, sans-serif")
       const lineOffset = 5
       const topOffset = plotHeight / cellCounts.y * .25 // 25% of the height of the subplot
@@ -181,7 +195,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       valueObj.rangeMaxCover?.on("mouseover", () => toggleTextTip(textId, true))
         .on("mouseout", () => toggleTextTip(textId, false))
 
-    }, [cellCounts, helper, plotHeight, plotWidth, toggleTextTip])
+    }, [cellCounts, helper, isBlockingOtherMeasure, plotHeight, plotWidth, toggleTextTip])
 
     const addAdornmentElements = useCallback((measure: IMeasureInstance, valueObj: IValue, labelObj: ILabel) => {
       if (!attrId || !dataConfig) return
@@ -258,7 +272,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       if (measure) {
         addAdornmentElements(measure, valueObjRef.current, newLabelObj)
       }
-    }, [model, helper.instanceKey, labelRef, addAdornmentElements])
+    }, [addAdornmentElements, helper.instanceKey, model])
 
     return (
       <UnivariateMeasureAdornmentBaseComponent


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186150345

Introduces a minor feature new in V3. If the Mean and Median adornments are both active and have the same value or values that result in their lines being rendered within two pixels of each other, hovering over one adornment's line will result in the other adornment's text tip appearing (in addition to its own).