### PR TITLE
Fix PixiJS point style update

### DIFF
--- a/v3/src/components/graph/utilities/pixi-points.ts
+++ b/v3/src/components/graph/utilities/pixi-points.ts
@@ -211,9 +211,7 @@ export class PixiPoints {
   }
 
   setPointStyle(point: PIXI.Sprite, style: Partial<IPixiPointStyle>) {
-    const metadata = this.getMetadata(point)
-    const newStyle = { ...metadata.style, ...style }
-    metadata.style = newStyle
+    const newStyle = this.updatePointStyle(point, style)
     const texture = this.getPointTexture(newStyle)
     if (point.texture !== texture) {
       point.texture = texture
@@ -255,6 +253,21 @@ export class PixiPoints {
 
   textureKey(style: IPixiPointStyle) {
     return JSON.stringify(style)
+  }
+
+  updatePointStyle(point: PIXI.Sprite, style: Partial<IPixiPointStyle>) {
+    Object.keys(style).forEach((key: any) => {
+      // Sometimes, client code might provide empty strings as style values. This means that the given property
+      // should not be changed from its current value.
+      const styleAny = style as any
+      if (styleAny[key] == null || styleAny[key] === "") {
+        delete styleAny[key]
+      }
+    })
+    const metadata = this.getMetadata(point)
+    const newStyle = { ...metadata.style, ...style }
+    metadata.style = newStyle
+    return newStyle
   }
 
   getPointTexture(style: IPixiPointStyle): PIXI.Texture {


### PR DESCRIPTION
This PR fixes two bugs found by Tejal:

https://www.pivotaltracker.com/story/show/186828410
https://www.pivotaltracker.com/story/show/186828354

The problem is that `style: Partial<IPixiPointStyle>` sometimes has the `fill` property equal to an empty string, and PixiJS doesn't know how to render an empty fill color. I bet the client code meant not to update the fill. The fix might do more than necessary, but I had very limited time, and at least it should fix all the similar, possibly hidden issues.