### PR TITLE
fix: LSRL does not retain equation location (PT-186834980)

### DIFF
--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -1,6 +1,7 @@
 import { LSRLAdornmentModel, LSRLInstance } from "./lsrl-adornment-model"
 
 const mockLSRLInstanceProps1 = {
+  equationCoords: {x: 1, y: 1},
   intercept: 1,
   interceptLocked: false,
   rSquared: 1,
@@ -8,6 +9,7 @@ const mockLSRLInstanceProps1 = {
   slope: 1
 }
 const mockLSRLInstanceProps2 = {
+  equationCoords: {x: 1, y: 1},
   intercept: 2,
   interceptLocked: false,
   rSquared: 2,

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -8,7 +8,7 @@ import { ScaleNumericBaseType } from "../../../axis/axis-types"
 import { ILineDescription } from "../shared-adornment-types"
 import { isFiniteNumber } from "../../../../utilities/math-utils"
 
-interface ILSRLLine {
+interface ILSRLine {
   category?: string
   equationCoords?: Point
   intercept?: number
@@ -140,12 +140,12 @@ export const LSRLAdornmentModel = AdornmentModel
   }
 }))
 .actions(self => ({
-  updateLines(line: ILSRLLine, key="", index?: number) {
+  updateLines(line: ILSRLine, key="", index?: number) {
     const { category, equationCoords, intercept, rSquared, sdResiduals, slope } = line
     const existingLines = self.lines.get(key)
     const newLines = existingLines ? [...existingLines] : []
     // Remove any pre-existing line in newLines at specified index, otherwise we can end up with duplicates.
-    isFiniteNumber(index) && newLines.splice(index, 1)
+    ;(index != null) && newLines.splice(index, 1)
     const newLine = LSRLInstance.create(line)
     newLine.setCategory(category)
     newLine.setIntercept(intercept)

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -8,6 +8,15 @@ import { ScaleNumericBaseType } from "../../../axis/axis-types"
 import { ILineDescription } from "../shared-adornment-types"
 import { isFiniteNumber } from "../../../../utilities/math-utils"
 
+interface ILSRLLine {
+  category?: string
+  equationCoords?: Point
+  intercept?: number
+  rSquared?: number
+  slope?: number
+  sdResiduals?: number
+}
+
 export const LSRLInstance = types.model("LSRLInstance", {
   equationCoords: types.maybe(PointModel)
 })
@@ -131,20 +140,19 @@ export const LSRLAdornmentModel = AdornmentModel
   }
 }))
 .actions(self => ({
-  updateLines(
-    line: {category?: string, intercept?: number, rSquared?: number, slope?: number, sdResiduals?: number},
-    key="", index?: number
-  ) {
+  updateLines(line: ILSRLLine, key="", index?: number) {
+    const { category, equationCoords, intercept, rSquared, sdResiduals, slope } = line
     const existingLines = self.lines.get(key)
     const newLines = existingLines ? [...existingLines] : []
     // Remove any pre-existing line in newLines at specified index, otherwise we can end up with duplicates.
-    index && newLines.splice(index, 1)
+    isFiniteNumber(index) && newLines.splice(index, 1)
     const newLine = LSRLInstance.create(line)
-    newLine.setCategory(line.category)
-    newLine.setIntercept(line.intercept)
-    newLine.setRSquared(line.rSquared)
-    newLine.setSlope(line.slope)
-    newLine.setSdResiduals(line.sdResiduals)
+    newLine.setCategory(category)
+    newLine.setIntercept(intercept)
+    newLine.setRSquared(rSquared)
+    newLine.setSlope(slope)
+    newLine.setSdResiduals(sdResiduals)
+    equationCoords && newLine.setEquationCoords(equationCoords)
     newLines.push(newLine)
     self.lines.set(key, newLines)
   },
@@ -165,15 +173,19 @@ export const LSRLAdornmentModel = AdornmentModel
     const { dataConfig, interceptLocked } = options
     const { xAttrId, yAttrId } = dataConfig.getCategoriesOptions()
     const legendCats = dataConfig?.categoryArrayForAttrRole("legend")
-    self.lines.clear()
     dataConfig.getAllCellKeys().forEach(cellKey => {
       const instanceKey = self.instanceKey(cellKey)
+      const lines = self.lines.get(instanceKey)
       for (let j = 0; j < legendCats.length; ++j) {
+        const existingLine = lines?.[j]
+        const equationCoords = existingLine?.equationCoords?.isValid()
+          ? { x: existingLine.equationCoords.x, y: existingLine.equationCoords.y }
+          : undefined
         const category = legendCats[j]
         const { intercept, rSquared, slope, sdResiduals } = self.computeValues(
           xAttrId, yAttrId, cellKey, dataConfig, interceptLocked, category
         )
-        self.updateLines({category, intercept, rSquared, slope, sdResiduals}, instanceKey, j)
+        self.updateLines({category, equationCoords, intercept, rSquared, slope, sdResiduals}, instanceKey, j)
       }
     })
   }
@@ -190,7 +202,11 @@ export const LSRLAdornmentModel = AdornmentModel
     const lines = self.lines.get(key)
     const legendCats = dataConfig?.categoryArrayForAttrRole("legend")
     lines?.forEach((line, i) => {
-      if (!line?.isValid) {
+      const existingLine = lines?.[i]
+      const equationCoords = existingLine?.equationCoords?.isValid()
+        ? { x: existingLine.equationCoords.x, y: existingLine.equationCoords.y }
+        : undefined
+      if (!line.isValid) {
         const { intercept, rSquared, slope, sdResiduals } = self.computeValues(
           xAttrId, yAttrId, cellKey, dataConfig, interceptLocked, legendCats[i]
         )
@@ -200,7 +216,7 @@ export const LSRLAdornmentModel = AdornmentModel
           !Number.isFinite(slope) ||
           !Number.isFinite(sdResiduals)
         ) return
-        self.updateLines({category: legendCats[i], intercept, rSquared, slope, sdResiduals}, key, i)
+        self.updateLines({category: legendCats[i], equationCoords, intercept, rSquared, slope, sdResiduals}, key, i)
       }
     })
     return lines


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186834980

Previously, `updateLines` wasn't setting a value for `equationCoords` when creating/updating lines. That resulted in moved equation boxes reverting to the default position when their associated lines were updated.

Model actions that can modify lines now check for a valid `equationCoord` value and pass it to `updateLines` so the information isn't lost.