### PR TITLE
chore: improve adornment types

### DIFF
--- a/v3/src/components/graph/adornments/adornment-component-info.ts
+++ b/v3/src/components/graph/adornments/adornment-component-info.ts
@@ -1,9 +1,30 @@
 import React from "react"
+import { AdornmentModel, IAdornmentModel } from "./adornment-models"
+import { INumericAxisModel } from "../../axis/models/axis-model"
+
+export interface IAdornmentComponentProps {
+  cellKey: Record<string, string>
+  containerId: string
+  model: IAdornmentModel
+  plotHeight: number
+  plotWidth: number
+  xAxis?: INumericAxisModel
+  yAxis?: INumericAxisModel
+}
+
+export interface IAdornmentControlsProps {
+  adornmentModel: typeof AdornmentModel
+}
+
+export interface IAdornmentBannerComponentProps {
+  model: IAdornmentModel
+}
+
 export interface IAdornmentComponentInfo {
   adornmentEltClass: string
-  Component: React.ComponentType<any> // TODO: Create and use IAdornmentComponentProps instead of any?
-  Controls: React.ComponentType<any> // TODO: Create and use IAdornmentControlsProps instead of any?
-  BannerComponent?: React.ComponentType<any> // TODO: Create and use IAdornmentBannerComponentProps instead of any?
+  Component: React.ComponentType<IAdornmentComponentProps>
+  Controls: React.ComponentType<IAdornmentControlsProps>
+  BannerComponent?: React.ComponentType<IAdornmentBannerComponentProps>
   labelKey: string
   order: number
   type: string

--- a/v3/src/components/graph/adornments/adornment-utils.ts
+++ b/v3/src/components/graph/adornments/adornment-utils.ts
@@ -1,3 +1,12 @@
+import { INumericAxisModel } from "../../axis/models/axis-model"
+
+export function getAxisDomains(xAxis?: INumericAxisModel, yAxis?: INumericAxisModel) {
+  // establishes access to the specified axis domains for purposes of MobX observation
+  const { domain: xDomain = [0, 1] } = xAxis || {}
+  const { domain: yDomain = [0, 1] } = yAxis || {}
+  return { xDomain, yDomain }
+}
+
 export const updateCellKey = (cellKey: Record<string, string>, attrId: string, cat: string) => {
   const newCellKey = { ...cellKey }
   if (cat) {

--- a/v3/src/components/graph/adornments/adornment.tsx
+++ b/v3/src/components/graph/adornments/adornment.tsx
@@ -5,7 +5,6 @@ import { useDeepCompareMemo } from "use-deep-compare"
 import { IAdornmentModel } from "./adornment-models"
 import { useGraphContentModelContext } from "../hooks/use-graph-content-model-context"
 import { useSubplotExtent } from "../hooks/use-subplot-extent"
-import { INumericAxisModel } from "../../axis/models/axis-model"
 import { getAdornmentComponentInfo } from "./adornment-component-info"
 import { transitionDuration } from "../../data-display/data-display-types"
 
@@ -53,8 +52,8 @@ export const Adornment = observer(function Adornment({adornment, cellKey: _cellK
         model={adornment}
         plotHeight={subPlotHeight}
         plotWidth={subPlotWidth}
-        xAxis={graphModel.getAxis('bottom') as INumericAxisModel}
-        yAxis={graphModel.getAxis('left') as INumericAxisModel}
+        xAxis={graphModel.getNumericAxis('bottom')}
+        yAxis={graphModel.getNumericAxis('left')}
       />
     </div>
   )

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { observer } from "mobx-react-lite"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
+import { IAdornmentComponentProps } from "../adornment-component-info"
+import { getAxisDomains } from "../adornment-utils"
 import { ICountAdornmentModel, IRegionCount, IRegionCountParams } from "./count-adornment-model"
 import { useGraphDataConfigurationContext } from "../../hooks/use-graph-data-configuration-context"
 import { useAdornmentCells } from "../../hooks/use-adornment-cells"
@@ -10,22 +12,13 @@ import { prf } from "../../../../utilities/profiler"
 import { measureText } from "../../../../hooks/use-measure-text"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import { kDefaultFontSize } from "../adornment-types"
-import { INumericAxisModel } from "../../../axis/models/axis-model"
 
 import "./count-adornment-component.scss"
 
-interface IProps {
-  cellKey: Record<string, string>
-  model: ICountAdornmentModel
-  plotHeight: number
-  plotWidth: number
-  xAxis: INumericAxisModel
-  yAxis: INumericAxisModel
-}
-
-export const CountAdornment = observer(function CountAdornment(props: IProps) {
+export const CountAdornment = observer(function CountAdornment(props: IAdornmentComponentProps) {
   prf.begin("CountAdornment.render")
-  const { model, cellKey, plotHeight, plotWidth, xAxis, yAxis } = props
+  const { cellKey, plotHeight, plotWidth, xAxis, yAxis } = props
+  const model = props.model as ICountAdornmentModel
   const { classFromKey, instanceKey } = useAdornmentCells(model, cellKey)
   const { xScale, yScale } = useAdornmentAttributes()
   const dataConfig = useGraphDataConfigurationContext()
@@ -112,11 +105,7 @@ export const CountAdornment = observer(function CountAdornment(props: IProps) {
   useEffect(function refreshBoundariesAndCaseCounts() {
     return mstAutorun(
       () => {
-        // We observe changes to the axis domains within the autorun by extracting them from the axes below.
-        // We do this instead of including domains in the useEffect dependency array to prevent domain changes
-        // from triggering a reinstall of the autorun.
-        const { domain: xDomain } = xAxis // eslint-disable-line @typescript-eslint/no-unused-vars
-        const { domain: yDomain } = yAxis // eslint-disable-line @typescript-eslint/no-unused-vars
+        getAxisDomains(xAxis, yAxis)
         subPlotRegionBoundariesRef.current = adornmentsStore?.subPlotRegionBoundaries(instanceKey, scale) ?? []
         plotCaseCounts()
       }, { name: "Count.refreshBoundariesAndCaseCounts" }, model)

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-component.tsx
@@ -3,7 +3,7 @@ import {drag, select, Selection} from "d3"
 import {tip as d3tip} from "d3-v6-tip"
 import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
-import { INumericAxisModel } from "../../../axis/models/axis-model"
+import { IAdornmentComponentProps } from "../adornment-component-info"
 import { IMovablePointAdornmentModel } from "./movable-point-adornment-model"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
@@ -23,18 +23,9 @@ interface IPointObject {
   shadow?: Selection<SVGCircleElement, unknown, null, undefined>
 }
 
-interface IProps {
-  containerId?: string
-  model: IMovablePointAdornmentModel
-  plotHeight: number
-  plotWidth: number
-  cellKey: Record<string, string>
-  xAxis?: INumericAxisModel
-  yAxis?: INumericAxisModel
-}
-
-export const MovablePointAdornment = observer(function MovablePointAdornment(props: IProps) {
-  const {model, plotHeight, plotWidth, cellKey = {}, xAxis, yAxis} = props
+export const MovablePointAdornment = observer(function MovablePointAdornment(props: IAdornmentComponentProps) {
+  const {plotHeight, plotWidth, cellKey = {}, xAxis, yAxis} = props
+  const model = props.model as IMovablePointAdornmentModel
   const graphModel = useGraphContentModelContext()
   const { xAttrId, yAttrId, xAttrName, yAttrName, xScale, yScale } = useAdornmentAttributes()
   const { classFromKey, instanceKey } = useAdornmentCells(model, cellKey)

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
@@ -3,16 +3,16 @@ import { observer } from "mobx-react-lite"
 import { Button, useDisclosure } from "@chakra-ui/react"
 import t from "../../../../utilities/translation/translate"
 import { EditFormulaModal } from "./edit-formula-modal"
+import { IAdornmentBannerComponentProps } from "../adornment-component-info"
 import { IPlottedFunctionAdornmentModel } from "./plotted-function-adornment-model"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 
 import "./plotted-function-adornment-banner.scss"
 
-interface IProps {
-  model: IPlottedFunctionAdornmentModel
-}
-
-export const PlottedFunctionAdornmentBanner = observer(function PlottedFunctionAdornmentBanner({ model }: IProps) {
+export const PlottedFunctionAdornmentBanner = observer(function PlottedFunctionAdornmentBanner(
+  props: IAdornmentBannerComponentProps
+) {
+  const model = props.model as IPlottedFunctionAdornmentModel
   const graphModel = useGraphContentModelContext()
   const { expression, error } = model
   const formulaModal = useDisclosure()

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useEffect, useRef } from "react"
 import { select } from "d3"
 import { observer } from "mobx-react-lite"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
-import { INumericAxisModel } from "../../../axis/models/axis-model"
 import { ScaleNumericBaseType } from "../../../axis/axis-types"
 import { Point } from "../../../data-display/data-display-types"
+import { IAdornmentComponentProps } from "../adornment-component-info"
 import { IPlottedFunctionAdornmentModel, isPlottedFunctionAdornment } from "./plotted-function-adornment-model"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import { useGraphDataConfigurationContext } from "../../hooks/use-graph-data-configuration-context"
@@ -40,18 +40,11 @@ const computePoints = (options: IComputePointsOptions) => {
   return tPoints
 }
 
-interface IProps {
-  containerId?: string
-  model: IPlottedFunctionAdornmentModel
-  plotHeight: number
-  plotWidth: number
-  cellKey: Record<string, string>
-  xAxis?: INumericAxisModel
-  yAxis?: INumericAxisModel
-}
-
-export const PlottedFunctionAdornmentComponent = observer(function PlottedFunctionAdornment(props: IProps) {
-  const {model, cellKey = {}, plotWidth, plotHeight, xAxis, yAxis} = props
+export const PlottedFunctionAdornmentComponent = observer(function PlottedFunctionAdornment(
+  props: IAdornmentComponentProps
+) {
+  const {cellKey = {}, plotWidth, plotHeight, xAxis, yAxis} = props
+  const model = props.model as IPlottedFunctionAdornmentModel
   const graphModel = useGraphContentModelContext()
   const dataConfig = useGraphDataConfigurationContext()
   const { xScale, yScale } = useAdornmentAttributes()

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
@@ -3,11 +3,11 @@ import { select, Selection } from "d3"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import t from "../../../../../utilities/translation/translate"
-import { INumericAxisModel } from "../../../../axis/models/axis-model"
 import { useAxisLayoutContext } from "../../../../axis/models/axis-layout-context"
 import { useGraphDataConfigurationContext } from "../../../hooks/use-graph-data-configuration-context"
 import { useAdornmentAttributes } from "../../../hooks/use-adornment-attributes"
 import { useAdornmentCells } from "../../../hooks/use-adornment-cells"
+import { IAdornmentComponentProps } from "../../adornment-component-info"
 import { IBoxPlotAdornmentModel } from "./box-plot-adornment-model"
 import { ILabel, IRange, IValue } from "../univariate-measure-adornment-types"
 import { UnivariateMeasureAdornmentHelper } from "../univariate-measure-adornment-helper"
@@ -26,18 +26,9 @@ interface IBoxPlotValue extends IValue {
   upperOutliersCovers?: Selection<SVGRectElement, number, SVGGElement | null, unknown>
 }
 
-interface IProps {
-  cellKey: Record<string, string>
-  containerId?: string
-  model: IBoxPlotAdornmentModel
-  plotHeight: number
-  plotWidth: number
-  xAxis: INumericAxisModel
-  yAxis: INumericAxisModel
-}
-
-export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentComponent (props: IProps) {
-  const {cellKey={}, containerId, model, plotHeight, plotWidth, xAxis, yAxis} = props
+export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentComponent (props: IAdornmentComponentProps) {
+  const {cellKey={}, containerId, plotHeight, plotWidth, xAxis, yAxis} = props
+  const model = props.model as IBoxPlotAdornmentModel
   const layout = useAxisLayoutContext()
   const dataConfig = useGraphDataConfigurationContext()
   const { xAttrId, yAttrId, xAttrType } = useAdornmentAttributes()

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-banner.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-banner.tsx
@@ -2,17 +2,17 @@ import React, { useState } from "react"
 import { observer } from "mobx-react-lite"
 import { Button, useDisclosure } from "@chakra-ui/react"
 import t from "../../../../../utilities/translation/translate"
+import { IAdornmentBannerComponentProps } from "../../adornment-component-info"
 import { EditFormulaModal } from "./edit-formula-modal"
 import { IPlottedValueAdornmentModel } from "./plotted-value-adornment-model"
 import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
 
 import "./plotted-value-adornment-banner.scss"
 
-interface IProps {
-  model: IPlottedValueAdornmentModel
-}
-
-export const PlottedValueAdornmentBanner = observer(function PlottedValueAdornmentBanner({ model }: IProps) {
+export const PlottedValueAdornmentBanner = observer(function PlottedValueAdornmentBanner(
+  props: IAdornmentBannerComponentProps
+) {
+  const model = props.model as IPlottedValueAdornmentModel
   const graphModel = useGraphContentModelContext()
   const { expression, error } = model
   const formulaModal = useDisclosure()

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-component.tsx
@@ -1,23 +1,13 @@
 import React, { useEffect } from "react"
 import { observer } from "mobx-react-lite"
-import { INumericAxisModel } from "../../../../axis/models/axis-model"
 import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
-import { IPlottedValueAdornmentModel, isPlottedValueAdornment } from "./plotted-value-adornment-model"
+import { isPlottedValueAdornment } from "./plotted-value-adornment-model"
+import { IAdornmentComponentProps } from "../../adornment-component-info"
 import { mstAutorun } from "../../../../../utilities/mst-autorun"
 import { UnivariateMeasureAdornmentSimpleComponent } from "../univariate-measure-adornment-simple-component"
 
-interface IProps {
-  cellKey: Record<string, string>
-  containerId?: string
-  model: IPlottedValueAdornmentModel
-  plotHeight: number
-  plotWidth: number
-  xAxis: INumericAxisModel
-  yAxis: INumericAxisModel
-}
-
 export const PlottedValueComponent = observer(
-  function PlottedValueComponent (props: IProps) {
+  function PlottedValueComponent (props: IAdornmentComponentProps) {
     const {cellKey={}, containerId, model, plotHeight, plotWidth, xAxis, yAxis} = props
     const graphModel = useGraphContentModelContext()
 

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react"
 import { observer } from "mobx-react-lite"
 import { IUnivariateMeasureAdornmentModel } from "./univariate-measure-adornment-model"
+import { getAxisDomains } from "../adornment-utils"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
 import { useGraphDataConfigurationContext } from "../../hooks/use-graph-data-configuration-context"
 import { INumericAxisModel } from "../../../axis/models/axis-model"
@@ -15,8 +16,8 @@ interface IProps {
   model: IUnivariateMeasureAdornmentModel
   showLabel?: boolean
   valueRef: React.RefObject<SVGGElement>
-  xAxis: INumericAxisModel
-  yAxis: INumericAxisModel
+  xAxis?: INumericAxisModel
+  yAxis?: INumericAxisModel
   refreshValues: () => void
   setIsVertical: (isVertical: boolean) => void
 }
@@ -30,11 +31,7 @@ export const UnivariateMeasureAdornmentBaseComponent = observer(
     // Refresh values on axis changes
     useEffect(function refreshAxisChange() {
       return mstAutorun(() => {
-        // We observe changes to the axis domains within the autorun by extracting them from the axes below.
-        // We do this instead of including domains in the useEffect dependency array to prevent domain changes
-        // from triggering a reinstall of the autorun.
-        const { domain: xDomain } = xAxis // eslint-disable-line @typescript-eslint/no-unused-vars
-        const { domain: yDomain } = yAxis // eslint-disable-line @typescript-eslint/no-unused-vars
+        getAxisDomains(xAxis, yAxis)
         setIsVertical(dataConfig?.attributeType("x") === "numeric")
         refreshValues()
       }, { name: "UnivariateMeasureAdornmentComponent.refreshAxisChange" }, model)

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -4,31 +4,22 @@ import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import t from "../../../../utilities/translation/translate"
 import { IMeasureInstance, IUnivariateMeasureAdornmentModel } from "./univariate-measure-adornment-model"
-import { INumericAxisModel } from "../../../axis/models/axis-model"
 import { useAxisLayoutContext } from "../../../axis/models/axis-layout-context"
 import { useGraphDataConfigurationContext } from "../../hooks/use-graph-data-configuration-context"
 import { Point } from "../../../data-display/data-display-types"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import { measureText } from "../../../../hooks/use-measure-text"
+import { IAdornmentComponentProps } from "../adornment-component-info"
 import { ILabel, IValue } from "./univariate-measure-adornment-types"
 import { UnivariateMeasureAdornmentHelper } from "./univariate-measure-adornment-helper"
 import { UnivariateMeasureAdornmentBaseComponent } from "./univariate-measure-adornment-base-component"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
 import { useAdornmentCells } from "../../hooks/use-adornment-cells"
 
-interface IProps {
-  cellKey: Record<string, string>
-  containerId?: string
-  model: IUnivariateMeasureAdornmentModel
-  plotHeight: number
-  plotWidth: number
-  xAxis: INumericAxisModel
-  yAxis: INumericAxisModel
-}
-
 export const UnivariateMeasureAdornmentSimpleComponent = observer(
-  function UnivariateMeasureAdornmentSimpleComponent (props: IProps) {
-    const {cellKey={}, containerId, model, plotHeight, plotWidth, xAxis, yAxis} = props
+  function UnivariateMeasureAdornmentSimpleComponent (props: IAdornmentComponentProps) {
+    const {cellKey={}, containerId, plotHeight, plotWidth, xAxis, yAxis} = props
+    const model = props.model as IUnivariateMeasureAdornmentModel
     const layout = useAxisLayoutContext()
     const graphModel = useGraphContentModelContext()
     const dataConfig = useGraphDataConfigurationContext()

--- a/v3/src/components/graph/components/inspector-panel/graph-measure-panel.tsx
+++ b/v3/src/components/graph/components/inspector-panel/graph-measure-panel.tsx
@@ -48,7 +48,7 @@ export const GraphMeasurePalette = observer(function GraphMeasurePalette({
     >
       <Flex className="palette-form" direction="column">
         <Box className="form-title">Show ...</Box>
-        {graphModel && measures?.map((measure: Record<string, any>) => {
+        {graphModel && measures?.map(measure => {
           const { checked, clickHandler, componentInfo, componentContentInfo, disabled, title } = measure
           const titleSlug = t(title).replace(/ /g, "-").toLowerCase()
           if (componentInfo && componentContentInfo) {


### PR DESCRIPTION
In reviewing a bunch of adornment-related PRs from @emcelroy recently, I noticed a couple of different areas where the types could be improved:
1. Each adornment component was declaring its own props even though the same props are passed to all adornment components.
2. On a related note, in `IAdornmentComponentInfo`, the `Component`, `Controls`, and `BannerComponent` properties were all declared as `React.ComponentType<any>` with a `TODO` comment indicating that it should be fixed at some point.
3. This PR defines `IAdornmentComponentProps`, `IAdornmentControlsProps`, and `IAdornmentBannerComponentProps` interfaces which are then used by any implementing components that need them.
4. The `Adornment` component was casting its axes to be `NumericAxisModel`s even though not all axes are numeric. With this PR, non-numeric axes are passed as `undefined` which eliminates the potential of inadvertently accessing a categorical axis as though it were numeric.
5.  A number of different adornments were using the same inelegant code for accessing axis domains within MobX autoruns/reactions so that they would trigger when the axis domains changed. This PR adds a `getAxisDomains()` utility function which eliminates the redundant/inelegant code.
6. The `GraphMeasurePanel` contained an unnecessary cast which resulted in a loss of type information.
7. The process of standardizing the use of `IAdornmentComponentProps` (#s 1-3 above) led to the realization that the `MovableValueAdornmentComponent` claimed to be receiving (and making use of) a `transform` property that is never passed to it. This phantom property has been eliminated without any apparent ill effect.