### PR TITLE
Version 3.0.0-pre.1492 - January 19, 2024

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Version 3.0.0-pre.1492 - January 19, 2024
+
+### Features/Improvements
+- PT-186681717: **Plotted Value** should show units
+- PT-181914458: Count/percent labels change their font size to fit within their allocated space
+- PT-186683021: Adornments in exported V2 documents should be rendered when those documents are imported into V3
+- PT-186016085: Percentage adornment sub-category should be remembered when changing attributes
+- PT-186150345: Show both mean and median adornment values when hovered over a line that represents both values
+- PT-185940746: Separate *counts* should display for each region defined by **movable values**
+- PT-186035970: Graph adornment elements outside plot should not cover other elements
+
+### Bug Fixes
+- PT-186513124: Count adornment does not immediately update when case data modified
+- PT-186822118: *Percent* values not always correct
+- PT-186834980: Least Squares Line doesn't retain its equation box custom location upon graph resize or import
+- PT-186751983: Fix dataset caching
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+|  main.css |   73112 bytes |                            0.55% |
+|  index.js | 3514822 bytes |                            0.43% |
+
 ## Version 3.0.0-pre.1471 - January 2, 2024
 
 ### Features/Improvements

--- a/v3/README.md
+++ b/v3/README.md
@@ -77,20 +77,21 @@ Other branches are deployed to https://codap3.concord.org/branch/{branch-name}/,
 
 To deploy a production release:
 
-1. Update the version number in `package.json` and `package-lock.json`
+1. Run git log --reverse <last-version>...HEAD | grep '#' to see a list of PR merges and stories that include PT ids in their message. Tag the PT stories based on this list as `3.0.0-pre.<new-version>`
+2. Update the version number in `package.json` and `package-lock.json`
     - `npm version --no-git-tag-version [patch|minor|major]`
-2. Create a new entry in `versions.md` with the new version and release date
-3. Create a new entry in `CHANGELOG.md` with a description of the new version
-4. Run `git log --pretty=oneline --reverse <last release tag>...HEAD | grep '#' | grep -v Merge` and add contents (after edits if needed to CHANGELOG.md)
-5. Run `npm run build`
-6. Copy asset size markdown table from previous release and change sizes to match new sizes in `dist`
-7. Create `v3-release-<version>` branch and commit changes, push to GitHub, create PR and merge
-8. Checkout `main` and pull
-9. Make a new version tag using your local git client with the version number in the description (e.g., `git tag -a 3.0.0-pre.1085 -m "version 3.0.0-pre.1085"`) and push the tag to the remote origin (e.g., `git push origin 3.0.0-pre.1085`)
-10. Watch the GitHub actions build to see that the S3 Deploy step finished and then QA this version using the versioned URL (e.g., https://codap3.concord.org/version/3.0.0-pre.1085/) or alternatively QA the staged release in step 11
-11. Stage the release by running the [Release v3 Staging Workflow](https://github.com/concord-consortium/codap/actions/workflows/release-v3-staging.yml) and entering the version tag you just pushed
-12. Test the staged release at https://codap3.concord.org/index-staging.html
-13. Update production by running the [Release v3 Production Workflow](https://github.com/concord-consortium/codap/actions/workflows/release-v3-production.yml) and entering the release version tag
+3. Create a new entry in `versions.md` with the new version and release date
+4. Create a new entry in `CHANGELOG.md` with a description of the new version
+5. Run `git log --pretty=oneline --reverse <last release tag>...HEAD | grep '#' | grep -v Merge` and add contents (after edits if needed to CHANGELOG.md)
+6. Run `npm run build`
+7. Copy asset size markdown table from previous release and change sizes to match new sizes in `dist`
+8. Create `v3-release-<version>` branch and commit changes, push to GitHub, create PR and merge
+9. Checkout `main` and pull
+10. Make a new version tag using your local git client with the version number in the description (e.g., `git tag -a 3.0.0-pre.1085 -m "version 3.0.0-pre.1085"`) and push the tag to the remote origin (e.g., `git push origin 3.0.0-pre.1085`)
+11. Watch the GitHub actions build to see that the S3 Deploy step finished and then QA this version using the versioned URL (e.g., https://codap3.concord.org/version/3.0.0-pre.1085/) or alternatively QA the staged release in step 11
+12. Stage the release by running the [Release v3 Staging Workflow](https://github.com/concord-consortium/codap/actions/workflows/release-v3-staging.yml) and entering the version tag you just pushed
+13. Test the staged release at https://codap3.concord.org/index-staging.html
+14. Update production by running the [Release v3 Production Workflow](https://github.com/concord-consortium/codap/actions/workflows/release-v3-production.yml) and entering the release version tag
 
 ### Versions
 [Here](https://github.com/concord-consortium/codap/blob/main/v3/versions.md) is a link to the various versions of CODAP along with their release dates.

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1471",
+  "version": "3.0.0-pre.1492",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1471",
+  "version": "3.0.0-pre.1492",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -5,6 +5,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.0.0-pre.1492](https://codap3.concord.org/version/3.0.0-pre.1492/) | January 19, 2024 |
 | [3.0.0-pre.1471](https://codap3.concord.org/version/3.0.0-pre.1471/) | January 2, 2024 |
 | [3.0.0-pre.1455](https://codap3.concord.org/version/3.0.0-pre.1455/) | December 4, 2023 |
 | [3.0.0-pre.1449](https://codap3.concord.org/version/3.0.0-pre.1449/) | November 27, 2023 |


### PR DESCRIPTION
### Features/Improvements
- PT-186681717: **Plotted Value** should show units
- PT-181914458: Count/percent labels change their font size to fit within their allocated space
- PT-186683021: Adornments in exported V2 documents should be rendered when those documents are imported into V3
- PT-186016085: Percentage adornment sub-category should be remembered when changing attributes
- PT-186150345: Show both mean and median adornment values when hovered over a line that represents both values
- PT-185940746: Separate *counts* should display for each region defined by **movable values**
- PT-186035970: Graph adornment elements outside plot should not cover other elements

### Bug Fixes
- PT-186513124: Count adornment does not immediately update when case data modified
- PT-186822118: *Percent* values not always correct
- PT-186834980: Least Squares Line doesn't retain its equation box custom location upon graph resize or import
- PT-186751983: Fix dataset caching