### PR TITLE
fix: axis repetitions should update when data values change

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -223,41 +223,45 @@ export const DataConfigurationModel = types
       return allGraphCaseIds.filter((caseId: string) => !selection.has(caseId))
     }
   }))
-  .views(self => (
-    {
-      // Note that we have to go through each of the filteredCases in order to return all the values
-      valuesForAttrRole: cachedFnWithArgsFactory({
-        key: (role: AttrRole) => role,
-        calculate: (role: AttrRole) => {
-          const attrID = self.attributeID(role)
-          const dataset = self.dataset
-          const allCaseIDs = Array.from(self.allCaseIDs)
-          const allValues = attrID ? allCaseIDs.map((anID: string) => dataset?.getStrValue(anID, attrID)) : []
-          return allValues.filter(aValue => aValue) as string[]
-        }
-      }),
-      numericValuesForAttrRole(role: AttrRole): number[] {
-        return this.valuesForAttrRole(role).map((aValue: string) => Number(aValue))
-          .filter((aValue: number) => isFinite(aValue))
-      },
-      categorySetForAttrRole(role: AttrRole) {
-        if (self.metadata) {
-          const attributeID = self.attributeID(role) || ''
-          return self.metadata.getCategorySet(attributeID)
-        }
-      },
-      /**
-       * @param role
-       * @param emptyCategoryArray
-       */
-      categoryArrayForAttrRole(role: AttrRole, emptyCategoryArray = ['__main__']): string[] {
-        let categoryArray = Array.from(new Set(this.valuesForAttrRole(role)))
+  .views(self => ({
+    // Note that we have to go through each of the filteredCases in order to return all the values
+    valuesForAttrRole: cachedFnWithArgsFactory({
+      key: (role: AttrRole) => role,
+      calculate: (role: AttrRole) => {
+        const attrID = self.attributeID(role)
+        const dataset = self.dataset
+        const allCaseIDs = Array.from(self.allCaseIDs)
+        const allValues = attrID ? allCaseIDs.map((anID: string) => dataset?.getStrValue(anID, attrID)) : []
+        return allValues.filter(aValue => aValue) as string[]
+      }
+    })
+  }))
+  .views(self => ({
+    numericValuesForAttrRole(role: AttrRole): number[] {
+      return self.valuesForAttrRole(role).map((aValue: string) => Number(aValue))
+        .filter((aValue: number) => isFinite(aValue))
+    },
+    categorySetForAttrRole(role: AttrRole) {
+      if (self.metadata) {
+        const attributeID = self.attributeID(role) || ''
+        return self.metadata.getCategorySet(attributeID)
+      }
+    },
+    /**
+     * @param role
+     * @param emptyCategoryArray
+     */
+    categoryArrayForAttrRole: cachedFnWithArgsFactory({
+      key: (role: AttrRole, emptyCategoryArray = ['__main__']) => JSON.stringify({ role, emptyCategoryArray }),
+      calculate: (role: AttrRole, emptyCategoryArray = ['__main__']) => {
+        let categoryArray = Array.from(new Set(self.valuesForAttrRole(role)))
         if (categoryArray.length === 0) {
           categoryArray = emptyCategoryArray
         }
         return categoryArray
-      },
-    }))
+      }
+    })
+  }))
   .views(self => ({
     getUnsortedCaseDataArray(caseArrayNumber: number): CaseData[] {
       return (self.filteredCases[caseArrayNumber]?.caseIds || []).map(id => {
@@ -418,6 +422,7 @@ export const DataConfigurationModel = types
   .actions(self => ({
     clearCasesCache() {
       self.valuesForAttrRole.invalidateAll()
+      self.categoryArrayForAttrRole.invalidateAll()
       self.allCasesForCategoryAreSelected.invalidateAll()
       // increment observable change count
       ++self.casesChangeCount

--- a/v3/src/components/graph/hooks/use-init-graph-layout.ts
+++ b/v3/src/components/graph/hooks/use-init-graph-layout.ts
@@ -1,3 +1,4 @@
+import { comparer } from "mobx"
 import { useEffect } from "react"
 import { useMemo } from "use-memo-one"
 import { mstReaction } from "../../../utilities/mst-reaction"
@@ -13,6 +14,7 @@ export function useInitGraphLayout(model?: IGraphContentModel) {
     const { dataConfiguration } = model || {}
     return mstReaction(
       () => {
+        dataConfiguration?.casesChangeCount // eslint-disable-line no-unused-expressions
         const repetitions: Partial<Record<AxisPlace, number>> = {}
         layout.axisScales.forEach((multiScale, place) => {
           repetitions[place] = dataConfiguration?.numRepetitionsForPlace(place) ?? 1
@@ -23,7 +25,9 @@ export function useInitGraphLayout(model?: IGraphContentModel) {
         (Object.keys(repetitions) as AxisPlace[]).forEach((place: AxisPlace) => {
           layout.getAxisMultiScale(place)?.setRepetitions(repetitions[place] ?? 0)
         })
-      }, { name: "useInitGraphLayout repetitions", fireImmediately: true }, dataConfiguration
+      },
+      { name: "useInitGraphLayout [repetitions]", fireImmediately: true, equals: comparer.structural },
+      dataConfiguration
     )
   }, [layout, model])
 

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -340,7 +340,7 @@ describe("DataConfigurationModel", () => {
     }
     config.attributeID = (role: string) => mockData.id[role]
     config.attributeType = (role: string) => mockData.type[role]
-    config.categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
+    ;(config as any).categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
 
     const cellKey = config.cellKey(0)
     expect(cellKey).toEqual({abc123: "pizza", def456: "red", ghi789: "small", jkl012: "new"})
@@ -351,7 +351,7 @@ describe("DataConfigurationModel", () => {
     let mockData: Record<string, Record<string, any>>
     config.attributeID = (role: string) => mockData.id[role]
     config.attributeType = (role: string) => mockData.type[role]
-    config.categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
+    ;(config as any).categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
 
     // For a graph with no categorical attributes
     mockData = {

--- a/v3/src/models/formula/plotted-function-formula-adapter.test.ts
+++ b/v3/src/models/formula/plotted-function-formula-adapter.test.ts
@@ -32,7 +32,7 @@ const getTestEnv = () => {
   }
   dataConfig.attributeID = (role: string) => mockData.id[role]
   dataConfig.attributeType = (role: string) => mockData.type[role]
-  dataConfig.categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
+  ;(dataConfig as any).categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
 
   const graphContentModel = {
     id: "fake-graph-content-model-id",

--- a/v3/src/models/formula/plotted-value-formula-adapter.test.ts
+++ b/v3/src/models/formula/plotted-value-formula-adapter.test.ts
@@ -32,7 +32,7 @@ const getTestEnv = () => {
   }
   dataConfig.attributeID = (role: string) => mockData.id[role]
   dataConfig.attributeType = (role: string) => mockData.type[role]
-  dataConfig.categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
+  ;(dataConfig as any).categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
   const graphContentModel = {
     id: "fake-graph-content-model-id",
     adornments: [adornment],


### PR DESCRIPTION
PT: [[#186781301]](https://www.pivotaltracker.com/story/show/186781301)

The main change that fixes the bug here is referencing the `casesChangeCount` inside the MobX `reaction` installed by `useInitGraphLayout()`. Along the way, I also turned `DataConfigurationModel.categoryArrayForAttrRole()` into a self-caching function, which may not have been necessary to fix the original bug but seemed like a reasonable idea nonetheless.