### PR TITLE
fix: adornments not updating when case values change after loading document [PT-#186873056]

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -526,7 +526,7 @@ export const DataConfigurationModel = types
       })
     },
     handleDataSetAction(actionCall: ISerializedActionCall) {
-      const cacheClearingActions = ["setCaseValues", "addCases", "removeCases"]
+      const cacheClearingActions = ["setCaseValues", "addCases", "removeCases", "removeAttribute"]
       if (cacheClearingActions.includes(actionCall.name)) {
         self.clearCasesCache()
       }


### PR DESCRIPTION
[[PT-#186873056]](https://www.pivotaltracker.com/story/show/186873056)

The proximate cause of the bug was that the `GraphContentModel` was relying on a `DataSet` listener installed in `updateAfterSharedModelChanges` to handle updating adornments, but `updateAfterSharedModelChanges` isn't executed when loading a document, so adornments wouldn't update properly after loading a document. In looking more closely, however, it became apparent that the `GraphContentModel` shouldn't have been listening to the `DataSet` directly at all, as the `DataConfigurationModel` is already doing so. With this PR the `GraphContentModel` now simply installs a MobX autorun so that it updates the adornments whenever the `DataConfigurationModel` indicates that relevant case values have been changed.  