### PR TITLE
fix: Counts wrong when movable values and top split present (PT-186874564)

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -74,6 +74,8 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
     const regionCountParams: IRegionCountParams = {
       cellKey,
       dataConfig,
+      plotHeight,
+      plotWidth,
       scale,
       subPlotRegionBoundaries: subPlotRegionBoundariesRef.current,
     }
@@ -93,7 +95,8 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
         })}
       </>
     )
-  }, [casesInPlot, cellKey, dataConfig, graphModel.plotType, model, primaryAttrRole, scale, textContent])
+  }, [casesInPlot, cellKey, dataConfig, graphModel.plotType, model, plotHeight, plotWidth, primaryAttrRole,
+      scale, textContent])
 
   useEffect(function resizeTextOnCellWidthChange() {
     return mstAutorun(() => {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186874564

Previously, the `regionCounts` view on `CountAdornmentModel` was using the full width and height of the plot when calculating the coordinates of the boundaries defining each region created by a Movable Value. When the plot was divided into subplots by a categorical split, that would mean those calculations were wrong, resulting in incorrect count values and placement.

These changes update `regionCounts` to use a copy of the `scale` which we modify to use a range defined by the subplots' width and height. This would be the second time we've done this in the adornment code. The first is [here in the Movable Line component](https://github.com/concord-consortium/codap/blob/230a3f958c764a09a98ee329657a1315eefefac7/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx#L67-L68). It makes me wonder if there should be a version of `scale` that takes into account the smaller dimensions of subplots? Or maybe there already is one and I'm not seeing it?