### PR TITLE
Version 3.0.0-pre.1502 - January 29, 2024

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Version 3.0.0-pre.1502 - January 29, 2024
+
+### Features/Improvements
+- PT-186631176: Try to reimplement basic graph features using PixiJS as the points renderer instead of D3 SVG
+- PT-186637668: PixiJS graph: Implement sprite-caseID matching and points animations/transitions
+- PT-186645440: PixiJS graph: add point hover effect
+- PT-186691239: PixiJS graph: avoid excessive CPU workload caused by the Pixi render loop
+- PT-186717142: PixiJS graph: Basic dragging behavior
+- PT-186730431: PixiJS map layer: reimplement map dots using PixiJS layerI 
+- PT-186725312: PixiJS graph: reimplement marquee selection
+- PT-186726231: Automation for Map component
+- PT-185315423: Automation for toolshelf menu
+- PT-186762653: Case dot size should animate smoothly when Connecting Lines are activated/deactivated
+- PT-186864009: Adornments should tell GraphLayout how much space is needed for adornment banners
+
+### Bug Fixes
+- PT-186751807: PixiJS graph: redo the transition system for better support of concurrent transitions and user actions
+- PT-186747821: PixiJS graph: fix a bug that occurs when a case is deleted during graph transition
+- PT-186747801: PixiJS graph: fix interaction with connecting lines
+- PT-186789144: Percent adornment should show subcategories with split plots
+- PT-186784214: PixiJS: fix graph rendering in Safari (incorrect offset)
+- PT-186828354: Legend Attributes with missing values causes a crash
+- PT-186874564: Counts wrong when there are multiple count instances and a top split
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+|  main.css |   72902 bytes |                           -0.28% |
+|  index.js | 3987833 bytes |                           13.46% |
+
 ## Version 3.0.0-pre.1492 - January 19, 2024
 
 ### Features/Improvements

--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -8,20 +8,28 @@
 - PT-186645440: PixiJS graph: add point hover effect
 - PT-186691239: PixiJS graph: avoid excessive CPU workload caused by the Pixi render loop
 - PT-186717142: PixiJS graph: Basic dragging behavior
+- PT-186725017: PixiJS graph: Point selection via mouse click or shift + click
+- PT-186724979: PixiJS graph: Enabling dragging of graph points outside graph boundaries, similar to V2
 - PT-186730431: PixiJS map layer: reimplement map dots using PixiJS layerI 
 - PT-186725312: PixiJS graph: reimplement marquee selection
 - PT-186726231: Automation for Map component
 - PT-185315423: Automation for toolshelf menu
+- PT-186724975: PixiJS graph: Touch support for dragging
 - PT-186762653: Case dot size should animate smoothly when Connecting Lines are activated/deactivated
 - PT-186864009: Adornments should tell GraphLayout how much space is needed for adornment banners
 
 ### Bug Fixes
 - PT-186751807: PixiJS graph: redo the transition system for better support of concurrent transitions and user actions
 - PT-186747821: PixiJS graph: fix a bug that occurs when a case is deleted during graph transition
+- PT-186828511: Adornments do not update when case values change
+- PT-186724949: PixiJS graph: Enhancing the reliability of point dragging, preventing 'lost' dragged points, unlike in the SVG version
+- PT-186724971: PixiJS graph: Fixing the animation of points returning to their initial position after dragging is completed
 - PT-186747801: PixiJS graph: fix interaction with connecting lines
+- PT-186781301: Axis not updating when graph plot is split categorically
 - PT-186789144: Percent adornment should show subcategories with split plots
 - PT-186784214: PixiJS: fix graph rendering in Safari (incorrect offset)
 - PT-186828354: Legend Attributes with missing values causes a crash
+- PT-186873056: Mean adornment not updating when case value is changed in case table
 - PT-186874564: Counts wrong when there are multiple count instances and a top split
 
 ### Asset Sizes

--- a/v3/README.md
+++ b/v3/README.md
@@ -77,7 +77,7 @@ Other branches are deployed to https://codap3.concord.org/branch/{branch-name}/,
 
 To deploy a production release:
 
-1. Run git log --reverse <last-version>...HEAD | grep '#' to see a list of PR merges and stories that include PT ids in their message. Tag the PT stories based on this list as `3.0.0-pre.<new-version>`
+1. Run `git log --reverse <last-version>...HEAD | grep '#'` to see a list of PR merges and stories that include PT ids in their message. Tag the PT stories based on this list as `3.0.0-pre.<new-version>`
 2. Update the version number in `package.json` and `package-lock.json`
     - `npm version --no-git-tag-version [patch|minor|major]`
 3. Create a new entry in `versions.md` with the new version and release date

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1492",
+  "version": "3.0.0-pre.1502",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1492",
+  "version": "3.0.0-pre.1502",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -5,6 +5,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.0.0-pre.1502](https://codap3.concord.org/version/3.0.0-pre.1502/) | January 29, 2024 |
 | [3.0.0-pre.1492](https://codap3.concord.org/version/3.0.0-pre.1492/) | January 19, 2024 |
 | [3.0.0-pre.1471](https://codap3.concord.org/version/3.0.0-pre.1471/) | January 2, 2024 |
 | [3.0.0-pre.1455](https://codap3.concord.org/version/3.0.0-pre.1455/) | December 4, 2023 |


### PR DESCRIPTION
### Features/Improvements
- PT-186631176: Try to reimplement basic graph features using PixiJS as the points renderer instead of D3 SVG
- PT-186637668: PixiJS graph: Implement sprite-caseID matching and points animations/transitions
- PT-186645440: PixiJS graph: add point hover effect
- PT-186691239: PixiJS graph: avoid excessive CPU workload caused by the Pixi render loop
- PT-186717142: PixiJS graph: Basic dragging behavior
- PT-186725017: PixiJS graph: Point selection via mouse click or shift + click
- PT-186724979: PixiJS graph: Enabling dragging of graph points outside graph boundaries, similar to V2
- PT-186730431: PixiJS map layer: reimplement map dots using PixiJS layerI 
- PT-186725312: PixiJS graph: reimplement marquee selection
- PT-186726231: Automation for Map component
- PT-185315423: Automation for toolshelf menu
- PT-186724975: PixiJS graph: Touch support for dragging
- PT-186762653: Case dot size should animate smoothly when Connecting Lines are activated/deactivated
- PT-186864009: Adornments should tell GraphLayout how much space is needed for adornment banners

### Bug Fixes
- PT-186751807: PixiJS graph: redo the transition system for better support of concurrent transitions and user actions
- PT-186747821: PixiJS graph: fix a bug that occurs when a case is deleted during graph transition
- PT-186828511: Adornments do not update when case values change
- PT-186724949: PixiJS graph: Enhancing the reliability of point dragging, preventing 'lost' dragged points, unlike in the SVG version
- PT-186724971: PixiJS graph: Fixing the animation of points returning to their initial position after dragging is completed
- PT-186747801: PixiJS graph: fix interaction with connecting lines
- PT-186781301: Axis not updating when graph plot is split categorically
- PT-186789144: Percent adornment should show subcategories with split plots
- PT-186784214: PixiJS: fix graph rendering in Safari (incorrect offset)
- PT-186828354: Legend Attributes with missing values causes a crash
- PT-186873056: Mean adornment not updating when case value is changed in case table
- PT-186874564: Counts wrong when there are multiple count instances and a top split