### PR TITLE
Drop attribute on map bug fix

### DIFF
--- a/v3/src/components/data-display/components/droppable-svg.tsx
+++ b/v3/src/components/data-display/components/droppable-svg.tsx
@@ -19,7 +19,8 @@ export const DroppableSvg = ({
     className, portal, target, dropId, onIsActive, hintString }: IProps) => {
   const { active, isOver, setNodeRef } = useDroppable({ id: dropId })
   const isActive = active && onIsActive?.(active)
-  const style: CSSProperties = useOverlayBounds({ target, portal })
+  // zIndex is set to 2 to ensure that the droppable area is above the map content for maps
+  const style: CSSProperties = { zIndex: 2, ...useOverlayBounds({target, portal})}
   const classes = `droppable-svg ${className} ${isActive ? "active" : ""} ${isActive && isOver ? "over" : ""}`
 
   return portal && target && createPortal(

--- a/v3/src/components/map/components/codap-map.tsx
+++ b/v3/src/components/map/components/codap-map.tsx
@@ -25,7 +25,7 @@ export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
   const mapModel = useMapModelContext(),
     layout = useDataDisplayLayout(),
     mapHeight = layout.contentHeight,
-    interiorSvgRef = useRef<SVGSVGElement>(null),
+    interiorDivRef = useRef<HTMLDivElement>(null),
     prevMapSize = useRef<{ width: number, height: number, legend: number }>({ width: 0, height: 0, legend: 0 }),
     forceUpdate = useForceUpdate()
 
@@ -46,7 +46,7 @@ export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
   // its size, rather than, for instance, after the layout has changed but before the change
   // has been rendered to the DOM.
   useEffect(() => {
-    const mapBounds = interiorSvgRef.current?.getBoundingClientRect()
+    const mapBounds = interiorDivRef.current?.getBoundingClientRect()
     if (mapBounds) {
       const { width: prevWidth, height: prevHeight, legend: prevLegend } = prevMapSize.current
       const width = Math.round(mapBounds.width)
@@ -63,7 +63,7 @@ export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
 
   return (
     <div className={clsx('map-container', kPortalClass)} ref={mapRef} data-testid="map">
-      <div className="leaflet-wrapper" style={{height: mapHeight}}>
+      <div className="leaflet-wrapper" style={{height: mapHeight}} ref={interiorDivRef}>
         <MapContainer center={kDefaultMapLocation as LatLngExpression} zoom={kDefaultMapZoom} scrollWheelZoom={false}
                       zoomSnap={0} trackResize={true}>
           <TileLayer attribution={kMapAttribution} url={kMapUrl}/>
@@ -72,7 +72,7 @@ export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
       </div>
       <DroppableMapArea
         mapElt={mapRef.current}
-        targetElt={interiorSvgRef.current}
+        targetElt={interiorDivRef.current}
         onDropAttribute={handleChangeLegendAttribute}
       />
       <MultiLegend

--- a/v3/src/components/map/components/droppable-map-area.tsx
+++ b/v3/src/components/map/components/droppable-map-area.tsx
@@ -9,7 +9,7 @@ import t from "../../../utilities/translation/translate"
 
 interface IProps {
   mapElt: HTMLDivElement | null
-  targetElt: SVGGElement | null
+  targetElt: HTMLDivElement | SVGGElement | null
   onDropAttribute: (dataSet: IDataSet, attrId: string) => void
 }
 


### PR DESCRIPTION
[#187025508] Bug fix: Dragging an attribute to a map doesn't work properly
* The `CodapMap` component was no longer passing a valid DOM ref to `DroppableMapArea`
* The drop area highlighting wasn't showing above the map, so I had to adjust the z-index (ugh!)