### PR TITLE
fix: MST warnings/errors on delete DataSet [#187041114]

### DIFF
--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -86,6 +86,15 @@ export class FormulaManager {
   }
 
   @action removeDataSet(dataSetId: string) {
+    // unregister all formulas associated with the removed DataSet
+    const formulasToUnregister: string[] = []
+    this.extraMetadata.forEach((extraMetadata, formulaId) => {
+      if (extraMetadata.dataSetId === dataSetId) {
+        formulasToUnregister.push(formulaId)
+      }
+    })
+    formulasToUnregister.forEach(formulaId => this.unregisterFormula(formulaId))
+
     this.dataSets.delete(dataSetId)
   }
 

--- a/v3/src/models/history/tree.ts
+++ b/v3/src/models/history/tree.ts
@@ -174,7 +174,15 @@ export const Tree = types.model("Tree", {
   handleSharedModelChanges: flow(function* handleSharedModelChanges(historyEntryId: string, exchangeId: string,
       call: any, sharedModelPath: string) {
 
-      const model = resolvePath(self, sharedModelPath)
+      let model: ISharedModel | undefined
+
+      try {
+        model = resolvePath(self, sharedModelPath)
+      }
+      catch {
+        console.warn("Tree.handleSharedModelChanges failed to find model at:", sharedModelPath)
+      }
+      if (!model) return
 
       // Note: the environment of the call will be undefined because the undoRecorder cleared
       // it out before calling this function


### PR DESCRIPTION
[[#187041114]](https://www.pivotaltracker.com/story/show/187041114)

The crash was from the history system failing to find a shared model that had been deleted. Beyond that there were still some warnings for accessing deleted models that were fixed by unregistering DataSet-dependent formulas immediately.

A couple of remaining issues are not addressed by this PR:
1. Undo of deleting the DataSet doesn't work correctly.
2. There are no formulas in the document in question, so all of the formulas being registered/unregistered are empty default formulas. Would probably be better to not create formulas for attributes without formulas.