### PR TITLE
186957019 undo redo graphs

### DIFF
--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -24,10 +24,10 @@ context("Test graph plot transitions", () => {
     cy.visit(url)
     cy.wait(2500)
   })
-  it("populates title bar from sample data", () => {
+  it.skip("populates title bar from sample data", () => {
     c.getComponentTitle("graph").should("contain", collectionName)
   })
-  it("will add attributes to a graph and verify plot transitions are correct", () => {
+  it.skip("will add attributes to a graph and verify plot transitions are correct", () => {
     cy.wrap(arrayOfPlots).each((hash, index, list) => {
       cy.dragAttributeToTarget("table", hash.attribute, hash.axis)
       cy.wait(2000)
@@ -43,19 +43,50 @@ context("Graph UI", () => {
     cy.wait(2500)
   })
 
-  it("updates graph title", () => {
+  it.skip("updates graph title", () => {
     c.getComponentTitle("graph").should("have.text", collectionName)
+    c.changeComponentTitle("graph", newCollectionName)
+    c.getComponentTitle("graph").should("have.text", newCollectionName)
+
+    // test for undo/redo when updating graph title
+    toolbar.getUndoTool().click()
+    c.changeComponentTitle("graph", newCollectionName)
+    c.getComponentTitle("graph").should("have.text", newCollectionName)
+
+    // use force:true so we don't have to worry about redo disabling
+    toolbar.getRedoTool().click({force: true})
     c.changeComponentTitle("graph", newCollectionName)
     c.getComponentTitle("graph").should("have.text", newCollectionName)
   })
   it("creates graphs with new collection name", () => {
-    c.getIconFromToolshelf("graph").click()
 
+    // Function to count CODAP graphs and return the count
+   const countCodapGraphs = () => {
+    return cy.get('.codap-graph').its('length')
+   }
+   countCodapGraphs().then(initialCount => {
+    cy.log(`Initial CODAP Graph Count: ${initialCount}`);
+
+    // perform an action that gets a new graph
+    c.getIconFromToolshelf("graph").click()
     c.getComponentTitle("graph").should("contain", collectionName)
     c.getComponentTitle("graph", 1).should("contain", collectionName)
+    // Assert the count increased by 1
+    countCodapGraphs().should('eq', initialCount + 1)
 
     c.getIconFromToolshelf("graph").click()
     c.getComponentTitle("graph", 2).should("contain", collectionName)
+    // Assert the count increased by 1
+    countCodapGraphs().should('eq', initialCount + 2)
+
+    // tests for undo/redo after creating a second graph
+
+    toolbar.getUndoTool().click()
+    cy.wait(2500)
+    // Assert the count decreased by 1
+    countCodapGraphs().should('eq', initialCount + 1)
+
+   })
   })
   it("creates graphs with new collection names when existing ones are closed", () => {
     c.closeComponent("graph")

--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -52,11 +52,16 @@ context("Graph UI", () => {
     toolbar.getUndoTool().click()
     c.changeComponentTitle("graph", newCollectionName)
     c.getComponentTitle("graph").should("have.text", newCollectionName)
+    // TODO: add a check after undo to make sure the title has reverted to
+    // the Collection Name. Blocker: PT #187033159
 
     // use force:true so we don't have to worry about redo disabling
     toolbar.getRedoTool().click({force: true})
     c.changeComponentTitle("graph", newCollectionName)
     c.getComponentTitle("graph").should("have.text", newCollectionName)
+    // TODO: add a check after undo to make sure the title has reverted to
+    // the Collection Name. Blocker: PT #187033159
+
   })
   it("creates graphs with new collection name", () => {
 

--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -24,10 +24,10 @@ context("Test graph plot transitions", () => {
     cy.visit(url)
     cy.wait(2500)
   })
-  it.skip("populates title bar from sample data", () => {
+  it("populates title bar from sample data", () => {
     c.getComponentTitle("graph").should("contain", collectionName)
   })
-  it.skip("will add attributes to a graph and verify plot transitions are correct", () => {
+  it("will add attributes to a graph and verify plot transitions are correct", () => {
     cy.wrap(arrayOfPlots).each((hash, index, list) => {
       cy.dragAttributeToTarget("table", hash.attribute, hash.axis)
       cy.wait(2000)
@@ -43,7 +43,7 @@ context("Graph UI", () => {
     cy.wait(2500)
   })
 
-  it.skip("updates graph title", () => {
+  it("updates graph title", () => {
     c.getComponentTitle("graph").should("have.text", collectionName)
     c.changeComponentTitle("graph", newCollectionName)
     c.getComponentTitle("graph").should("have.text", newCollectionName)


### PR DESCRIPTION
Added automation tests in Cypress to the spec graph.ts. This includes undo/redo after renaming a graph component (note the bug reported in PT [#187033159](https://www.pivotaltracker.com/story/show/187033159)) and after adding/removing multiple graph components.