### PR TITLE
Display map inspector on first creation of map

### DIFF
--- a/v3/src/components/map/components/map-inspector.tsx
+++ b/v3/src/components/map/components/map-inspector.tsx
@@ -1,4 +1,5 @@
 import React, {useRef, useEffect, useState} from "react"
+import {observer} from "mobx-react-lite"
 import {InspectorButton, InspectorMenu, InspectorPanel} from "../../inspector-panel"
 import ScaleDataIcon from "../../../assets/icons/icon-scaleData.svg"
 import HideShowIcon from "../../../assets/icons/icon-hideShow.svg"
@@ -13,7 +14,6 @@ import {isMapPointLayerModel} from "../models/map-point-layer-model"
 import {HideShowMenuList} from "./inspector-panel/hide-show-menu-list"
 import {SaveImageMenuList} from "./inspector-panel/save-image-menu-list"
 import {MapMeasurePalette} from "./inspector-panel/map-measure-palette"
-import {observer} from "mobx-react-lite"
 
 
 export const MapInspector = observer(function MapInspector({tile, show}: ITileInspectorPanelProps) {

--- a/v3/src/components/map/components/map-inspector.tsx
+++ b/v3/src/components/map/components/map-inspector.tsx
@@ -13,10 +13,10 @@ import {isMapPointLayerModel} from "../models/map-point-layer-model"
 import {HideShowMenuList} from "./inspector-panel/hide-show-menu-list"
 import {SaveImageMenuList} from "./inspector-panel/save-image-menu-list"
 import {MapMeasurePalette} from "./inspector-panel/map-measure-palette"
-import {observer} from "mobx-react-lite";
+import {observer} from "mobx-react-lite"
 
 
-export const MapInspector = observer( function MapInspector({tile, show}: ITileInspectorPanelProps) {
+export const MapInspector = observer(function MapInspector({tile, show}: ITileInspectorPanelProps) {
   const mapModel = isMapContentModel(tile?.content) ? tile?.content : undefined
   const [showPalette, setShowPalette] = useState<string | undefined>(undefined)
   const panelRef = useRef<HTMLDivElement>()

--- a/v3/src/components/map/components/map-inspector.tsx
+++ b/v3/src/components/map/components/map-inspector.tsx
@@ -13,9 +13,10 @@ import {isMapPointLayerModel} from "../models/map-point-layer-model"
 import {HideShowMenuList} from "./inspector-panel/hide-show-menu-list"
 import {SaveImageMenuList} from "./inspector-panel/save-image-menu-list"
 import {MapMeasurePalette} from "./inspector-panel/map-measure-palette"
+import {observer} from "mobx-react-lite";
 
 
-export const MapInspector = ({tile, show}: ITileInspectorPanelProps) => {
+export const MapInspector = observer( function MapInspector({tile, show}: ITileInspectorPanelProps) {
   const mapModel = isMapContentModel(tile?.content) ? tile?.content : undefined
   const [showPalette, setShowPalette] = useState<string | undefined>(undefined)
   const panelRef = useRef<HTMLDivElement>()
@@ -56,6 +57,17 @@ export const MapInspector = ({tile, show}: ITileInspectorPanelProps) => {
     }
   }
 
+  const renderLayersButton = () => {
+    if (mapModel) {
+      return (
+        <InspectorButton tooltip={t("DG.Inspector.displayLayers.toolTip")} showMoreOptions={true}
+                         testId={"map-display-config-button"}>
+          <LayersIcon/>
+        </InspectorButton>
+      )
+    }
+  }
+
   if (mapModel && mapModel.layers.length > 0) {
     return (
       <InspectorPanel ref={panelRef} component="map" show={show} setShowPalette={setShowPalette}>
@@ -68,10 +80,7 @@ export const MapInspector = ({tile, show}: ITileInspectorPanelProps) => {
           <HideShowMenuList tile={tile}/>
         </InspectorMenu>
         {renderRulerButton()}
-        <InspectorButton tooltip={t("DG.Inspector.displayLayers.toolTip")} showMoreOptions={true}
-                         testId={"map-display-config-button"}>
-          <LayersIcon/>
-        </InspectorButton>
+        {renderLayersButton()}
         <InspectorMenu tooltip={t("DG.Inspector.makeImage.toolTip")}
                        icon={<CameraIcon/>} testId={"map-camera-button"} onButtonClick={handleClosePalette}>
           <SaveImageMenuList tile={tile}/>
@@ -87,4 +96,4 @@ export const MapInspector = ({tile, show}: ITileInspectorPanelProps) => {
       </InspectorPanel>
     )
   }
-}
+})

--- a/v3/src/components/map/map-types.ts
+++ b/v3/src/components/map/map-types.ts
@@ -12,7 +12,7 @@ export interface PolygonLayerOptions extends GeoJSONOptions<any, GeoJSON.Geometr
 
 export const
   kDefaultMapWidth = 530,
-  kDefaultMapHeight = 440,
+  kDefaultMapHeight = 335,
   kMapAttribution = '&copy; <a href="https://static.arcgis.com/attribution/World_Topo_Map">USGS, NOAA</a>',
   kMapUrl = "https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
 


### PR DESCRIPTION
[#187054676] Bug fix: Map inspector not displaying on map creation
* Make the `MapInspector` and observer so it can observe changes in the layers the map model has and redisplay when the model constructs layers
* Change the default height of the map component to match that of V2
* A bit of preparation in the `MapInspector` for the layers menu