### PR TITLE
187057225 First Contact

### DIFF
--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -1,0 +1,17 @@
+import { ToolbarElements as toolbar } from "../support/elements/toolbar-elements"
+import { WebViewTileElements } from "../support/elements/web-view-tile"
+
+context("codap plugins", () => {
+  beforeEach(function () {
+    const url = `${Cypress.config("index")}?mouseSensor`
+    cy.visit(url)
+  })
+  it('will update web view title in response to plugin request', ()=>{
+      const url='https://concord-consortium.github.io/codap-data-interactives/DataInteractiveAPITester/index.html?lang=en'
+      toolbar.getOptionsButton().click()
+      toolbar.getWebViewButton().click()
+      WebViewTileElements.enterUrl(url)
+      cy.wait(1000)
+      WebViewTileElements.getTitle().should("contain.text", "CODAP API Tester")
+  })
+})

--- a/v3/cypress/support/elements/web-view-tile.ts
+++ b/v3/cypress/support/elements/web-view-tile.ts
@@ -32,5 +32,8 @@ export const WebViewTileElements = {
   },
   getEditUrlButton() {
     return cy.get(`[data-testid=web-view-edit-url-button]`)
+  },
+  getTitle() {
+    return cy.get(`.codap-web-view .title-bar .title-text`)
   }
 }

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -20,6 +20,7 @@
         "d3-format": "^3.1.0",
         "d3-v6-tip": "^1.0.9",
         "escape-string-regexp": "^5.0.0",
+        "iframe-phone": "^1.3.1",
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
         "mathjs": "^12.3.1",

--- a/v3/package.json
+++ b/v3/package.json
@@ -185,6 +185,7 @@
     "d3-format": "^3.1.0",
     "d3-v6-tip": "^1.0.9",
     "escape-string-regexp": "^5.0.0",
+    "iframe-phone": "^1.3.1",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
     "mathjs": "^12.3.1",

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -80,7 +80,7 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
       icon: <OptionsIcon className="icon-options"/>,
       label: t("DG.ToolButtonData.optionMenu.title"),
       hint: t("DG.ToolButtonData.optionMenu.toolTip"),
-      button: <OptionsShelfButton />
+      button: <OptionsShelfButton key={t("DG.ToolButtonData.optionMenu.title")} />
     },
     {
       icon: <HelpIcon className="icon-help"/>,

--- a/v3/src/components/web-view/use-data-interactive-controller.tsx
+++ b/v3/src/components/web-view/use-data-interactive-controller.tsx
@@ -7,10 +7,15 @@ import { isWebViewModel } from "./web-view-model"
 
 function extractOrigin(url?: string) {
   if (!url) return
-  return new URL(url).origin
+  // TODO It would probably be better to confirm that the url is legal before trying to create a URL from it
+  try {
+    return new URL(url).origin
+  } catch (e) {
+    debugLog(DEBUG_PLUGINS, `Could not determine origin from illegal url:`, url)
+  }
 }
 
-export function useDataInteractiveController(iframeRef: React.MutableRefObject<HTMLIFrameElement|null>, tile?: ITileModel) {
+export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFrameElement>, tile?: ITileModel) {
   const toast = useToast()
   const webViewModel = tile?.content
   const url = isWebViewModel(webViewModel) ? webViewModel.url : undefined

--- a/v3/src/components/web-view/use-data-interactive-controller.tsx
+++ b/v3/src/components/web-view/use-data-interactive-controller.tsx
@@ -1,0 +1,76 @@
+import { useToast } from "@chakra-ui/react"
+import iframePhone from "iframe-phone"
+import React, { useEffect } from "react"
+import { ITileModel } from "../../models/tiles/tile-model"
+import { isWebViewModel } from "./web-view-model"
+
+function extractOrigin(url?: string) {
+  if (!url) return
+  const re = /([^:]*:\/\/[^/]*)/
+  if (/^http.*/i.test(url)) {
+    return re.exec(url)?.[1]
+  }
+}
+
+export function useDataInteractiveController(iframeRef: React.MutableRefObject<null>, tile?: ITileModel) {
+  const toast = useToast()
+  const webViewModel = tile?.content
+  const url = isWebViewModel(webViewModel) ? webViewModel.url : undefined
+
+  useEffect(() => {
+    console.log(`Establishing connection to ${iframeRef.current}`)
+    if (iframeRef.current) {
+      const originUrl = extractOrigin(url) ?? ""
+      const phone = new iframePhone.ParentEndpoint(iframeRef.current, originUrl,
+        () => console.log("connection with iframe established"))
+      const handler: iframePhone.IframePhoneRpcEndpointHandlerFn = (content: any, callback: any) => {
+        // console.log(`--- Received data-interactive: ${JSON.stringify(content)}`)
+        toast({
+          title: "Web view received message",
+          description: JSON.stringify(content),
+          status: "success",
+          duration: 9000,
+          isClosable: true
+        })
+        let result: any = { success: false }
+        if (Array.isArray(content)) {
+          result = content.map((action: any) => {
+            if (action && action.resource === "interactiveFrame") {
+              if (action.action === "update") {
+                const values = action.values
+                if (values.title) {
+                  tile?.setTitle(values.title)
+                  return { success: true }
+                }
+              } else if (action.action === "get") {
+                return {
+                  success: true,
+                  values: {
+                    name: tile?.title,
+                    title: tile?.title,
+                    version: "0.1",
+                    preventBringToFront: false,
+                    preventDataContextReorg: false,
+                    dimensions: {
+                      width: 600,
+                      height: 500
+                    },
+                    externalUndoAvailable: true,
+                    standaloneUndoModeAvailable: false
+                  }
+                }
+              }
+            }
+            return { success: false }
+          })
+        }
+        // console.log(` -- Responding with`, result)
+        callback(result)
+      }
+      const rpcEndpoint = new iframePhone.IframePhoneRpcEndpoint(handler,
+        "data-interactive", iframeRef.current, originUrl, phone)
+      rpcEndpoint.call({message: "codap-present"} as any,
+        reply => console.log(`Reply to codap-present: `, JSON.stringify(reply)))
+    }
+  }, [iframeRef, tile, toast, url])
+}

--- a/v3/src/components/web-view/use-data-interactive-controller.tsx
+++ b/v3/src/components/web-view/use-data-interactive-controller.tsx
@@ -1,30 +1,28 @@
 import { useToast } from "@chakra-ui/react"
 import iframePhone from "iframe-phone"
 import React, { useEffect } from "react"
+import { DEBUG_PLUGINS, debugLog } from "../../lib/debug"
 import { ITileModel } from "../../models/tiles/tile-model"
 import { isWebViewModel } from "./web-view-model"
 
 function extractOrigin(url?: string) {
   if (!url) return
-  const re = /([^:]*:\/\/[^/]*)/
-  if (/^http.*/i.test(url)) {
-    return re.exec(url)?.[1]
-  }
+  return new URL(url).origin
 }
 
-export function useDataInteractiveController(iframeRef: React.MutableRefObject<null>, tile?: ITileModel) {
+export function useDataInteractiveController(iframeRef: React.MutableRefObject<HTMLIFrameElement|null>, tile?: ITileModel) {
   const toast = useToast()
   const webViewModel = tile?.content
   const url = isWebViewModel(webViewModel) ? webViewModel.url : undefined
 
   useEffect(() => {
-    console.log(`Establishing connection to ${iframeRef.current}`)
+    debugLog(DEBUG_PLUGINS, `Establishing connection to ${iframeRef.current}`)
     if (iframeRef.current) {
       const originUrl = extractOrigin(url) ?? ""
       const phone = new iframePhone.ParentEndpoint(iframeRef.current, originUrl,
-        () => console.log("connection with iframe established"))
+        () => debugLog(DEBUG_PLUGINS, "connection with iframe established"))
       const handler: iframePhone.IframePhoneRpcEndpointHandlerFn = (content: any, callback: any) => {
-        // console.log(`--- Received data-interactive: ${JSON.stringify(content)}`)
+        debugLog(DEBUG_PLUGINS, `--- Received data-interactive: ${JSON.stringify(content)}`)
         toast({
           title: "Web view received message",
           description: JSON.stringify(content),
@@ -64,13 +62,13 @@ export function useDataInteractiveController(iframeRef: React.MutableRefObject<n
             return { success: false }
           })
         }
-        // console.log(` -- Responding with`, result)
+        debugLog(DEBUG_PLUGINS, ` -- Responding with`, result)
         callback(result)
       }
       const rpcEndpoint = new iframePhone.IframePhoneRpcEndpoint(handler,
         "data-interactive", iframeRef.current, originUrl, phone)
       rpcEndpoint.call({message: "codap-present"} as any,
-        reply => console.log(`Reply to codap-present: `, JSON.stringify(reply)))
+        reply => debugLog(DEBUG_PLUGINS, `Reply to codap-present: `, JSON.stringify(reply)))
     }
   }, [iframeRef, tile, toast, url])
 }

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -8,7 +8,7 @@ import { isWebViewModel } from "./web-view-model"
 import "./web-view.scss"
 
 export const WebViewComponent = observer(function WebViewComponent({ tile }: ITileBaseProps) {
-  const iframeRef = useRef(null)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
   const webViewModel = tile?.content
 
   useDataInteractiveController(iframeRef, tile)

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -1,14 +1,86 @@
+import { useToast } from "@chakra-ui/react"
+import iframePhone from "iframe-phone"
 import { observer } from "mobx-react-lite"
-import React from "react"
+import React, { useEffect, useRef } from "react"
 import { ITileBaseProps } from "../tiles/tile-base-props"
 import { isWebViewModel } from "./web-view-model"
 import { t } from "../../utilities/translation/translate"
 
 import "./web-view.scss"
 
+function extractOrigin(url?: string) {
+  if (!url) return
+  const re = /([^:]*:\/\/[^/]*)/
+  if (/^http.*/i.test(url)) {
+    return re.exec(url)?.[1]
+  }
+}
+
 export const WebViewComponent = observer(function WebViewComponent({ tile }: ITileBaseProps) {
+  const iframeRef = useRef(null)
   const webViewModel = tile?.content
+  const toast = useToast()
+
+  const url = isWebViewModel(webViewModel) ? webViewModel.url : undefined
+  useEffect(() => {
+    console.log(`Establishing connection to ${iframeRef.current}`)
+    if (iframeRef.current) {
+      const originUrl = extractOrigin(url) ?? ""
+      const phone = new iframePhone.ParentEndpoint(iframeRef.current, originUrl,
+        () => console.log("connection with iframe established"))
+      const handler: iframePhone.IframePhoneRpcEndpointHandlerFn = (content: any, callback: any) => {
+        console.log(`--- Received data-interactive: ${JSON.stringify(content)}`)
+        toast({
+          title: "Web view received message",
+          description: JSON.stringify(content),
+          status: "success",
+          duration: 9000,
+          isClosable: true
+        })
+        let result: any = { success: false }
+        if (Array.isArray(content)) {
+          result = content.map((action: any) => {
+            if (action && action.resource === "interactiveFrame") {
+              if (action.action === "update") {
+                const values = action.values
+                if (values.title) {
+                  tile?.setTitle(values.title)
+                  return { success: true }
+                }
+              } else if (action.action === "get") {
+                return {
+                  success: true,
+                  values: {
+                    name: tile?.title,
+                    title: tile?.title,
+                    version: "0.1",
+                    preventBringToFront: false,
+                    preventDataContextReorg: false,
+                    dimensions: {
+                      width: 600,
+                      height: 500
+                    },
+                    externalUndoAvailable: true,
+                    standaloneUndoModeAvailable: false
+                  }
+                }
+              }
+            }
+            return { success: false }
+          })
+        }
+        console.log(` -- Responding with`, result)
+        callback(result)
+      }
+      const rpcEndpoint = new iframePhone.IframePhoneRpcEndpoint(handler,
+        "data-interactive", iframeRef.current, originUrl, phone)
+      rpcEndpoint.call({message: "codap-present"} as any,
+        reply => console.log(`Reply to codap-present: `, JSON.stringify(reply)))
+    }
+  }, [tile, toast, url])
+
   if (!isWebViewModel(webViewModel)) return null
+
 
   return (
     <div className="codap-web-view-body" data-testid="codap-web-view">
@@ -17,7 +89,7 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
         <div className="codap-web-view-message">{t("DG.GameView.loadError")}</div>
       </div>
       <div className="codap-web-view-iframe-wrapper">
-        <iframe className="codap-web-view-iframe" src={webViewModel.url} />
+        <iframe className="codap-web-view-iframe" ref={iframeRef} src={webViewModel.url} />
       </div>
     </div>
   )

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -1,86 +1,19 @@
-import { useToast } from "@chakra-ui/react"
-import iframePhone from "iframe-phone"
 import { observer } from "mobx-react-lite"
-import React, { useEffect, useRef } from "react"
-import { ITileBaseProps } from "../tiles/tile-base-props"
-import { isWebViewModel } from "./web-view-model"
+import React, { useRef } from "react"
 import { t } from "../../utilities/translation/translate"
+import { ITileBaseProps } from "../tiles/tile-base-props"
+import { useDataInteractiveController } from "./use-data-interactive-controller"
+import { isWebViewModel } from "./web-view-model"
 
 import "./web-view.scss"
-
-function extractOrigin(url?: string) {
-  if (!url) return
-  const re = /([^:]*:\/\/[^/]*)/
-  if (/^http.*/i.test(url)) {
-    return re.exec(url)?.[1]
-  }
-}
 
 export const WebViewComponent = observer(function WebViewComponent({ tile }: ITileBaseProps) {
   const iframeRef = useRef(null)
   const webViewModel = tile?.content
-  const toast = useToast()
 
-  const url = isWebViewModel(webViewModel) ? webViewModel.url : undefined
-  useEffect(() => {
-    console.log(`Establishing connection to ${iframeRef.current}`)
-    if (iframeRef.current) {
-      const originUrl = extractOrigin(url) ?? ""
-      const phone = new iframePhone.ParentEndpoint(iframeRef.current, originUrl,
-        () => console.log("connection with iframe established"))
-      const handler: iframePhone.IframePhoneRpcEndpointHandlerFn = (content: any, callback: any) => {
-        console.log(`--- Received data-interactive: ${JSON.stringify(content)}`)
-        toast({
-          title: "Web view received message",
-          description: JSON.stringify(content),
-          status: "success",
-          duration: 9000,
-          isClosable: true
-        })
-        let result: any = { success: false }
-        if (Array.isArray(content)) {
-          result = content.map((action: any) => {
-            if (action && action.resource === "interactiveFrame") {
-              if (action.action === "update") {
-                const values = action.values
-                if (values.title) {
-                  tile?.setTitle(values.title)
-                  return { success: true }
-                }
-              } else if (action.action === "get") {
-                return {
-                  success: true,
-                  values: {
-                    name: tile?.title,
-                    title: tile?.title,
-                    version: "0.1",
-                    preventBringToFront: false,
-                    preventDataContextReorg: false,
-                    dimensions: {
-                      width: 600,
-                      height: 500
-                    },
-                    externalUndoAvailable: true,
-                    standaloneUndoModeAvailable: false
-                  }
-                }
-              }
-            }
-            return { success: false }
-          })
-        }
-        console.log(` -- Responding with`, result)
-        callback(result)
-      }
-      const rpcEndpoint = new iframePhone.IframePhoneRpcEndpoint(handler,
-        "data-interactive", iframeRef.current, originUrl, phone)
-      rpcEndpoint.call({message: "codap-present"} as any,
-        reply => console.log(`Reply to codap-present: `, JSON.stringify(reply)))
-    }
-  }, [tile, toast, url])
+  useDataInteractiveController(iframeRef, tile)
 
   if (!isWebViewModel(webViewModel)) return null
-
 
   return (
     <div className="codap-web-view-body" data-testid="codap-web-view">

--- a/v3/src/lib/debug.ts
+++ b/v3/src/lib/debug.ts
@@ -16,6 +16,7 @@ export const DEBUG_MAP = debugContains("map")
 export const DEBUG_SAVE = debugContains("save")
 export const DEBUG_STORES = debugContains("stores")
 export const DEBUG_UNDO = debugContains("undo")
+export const DEBUG_PLUGINS = debugContains("plugins")
 
 export function debugLog(debugFlag: boolean, ...args: any[]) {
   // eslint-disable-next-line no-console

--- a/v3/src/lib/debug.ts
+++ b/v3/src/lib/debug.ts
@@ -13,10 +13,10 @@ export const DEBUG_HISTORY = debugContains("history")
 export const DEBUG_LISTENERS = debugContains("listeners")
 export const DEBUG_LOGGER = debugContains("logger")
 export const DEBUG_MAP = debugContains("map")
+export const DEBUG_PLUGINS = debugContains("plugins")
 export const DEBUG_SAVE = debugContains("save")
 export const DEBUG_STORES = debugContains("stores")
 export const DEBUG_UNDO = debugContains("undo")
-export const DEBUG_PLUGINS = debugContains("plugins")
 
 export function debugLog(debugFlag: boolean, ...args: any[]) {
   // eslint-disable-next-line no-console


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187057204

This PR establishes the first connection between web views in CODAP v3 and plugins. Currently, very little communication is handled, and that's hard coded in the `useDataInteractiveController` hook. In future PRs this will be greatly expanded and written in a more elegant way. In this PR, you should expect:
- CODAP to try to establish a connection with any website loaded in a web view using `iframe-phone`.
- Messages received from plugins to be logged in the console as well as displayed on a toast popup.
- CODAP to update the web view's title when a plugin requests it to do so.

The CODAP API Tester is a great plugin to test. Its url: https://concord-consortium.github.io/codap-data-interactives/DataInteractiveAPITester/index.html?lang=en

Additionally, a `key` was added to the options button in the `ToolShelf` to suppress an error that was showing up in the console from a previous PR.