### PR TITLE
feat: provide access to v2 `example-documents`

### DIFF
--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         # run multiple copies of the current job in parallel
-        containers: [1, 2]
+        containers: [1, 2, 3]
         # containers: [1]
     steps:
       - name: Checkout

--- a/v3/cypress/e2e/calculator.spec.ts
+++ b/v3/cypress/e2e/calculator.spec.ts
@@ -4,7 +4,7 @@ import { ToolbarElements as toolbar } from "../support/elements/toolbar-elements
 
 const calculatorName = "Calculator"
 
-context("Data summary UI", () => {
+context("Calculator", () => {
   beforeEach(function () {
       const queryParams = "?sample=mammals&dashboard&mouseSensor"
       const url = `${Cypress.config("index")}${queryParams}`

--- a/v3/cypress/e2e/cfm.spec.ts
+++ b/v3/cypress/e2e/cfm.spec.ts
@@ -1,0 +1,33 @@
+import { CfmElements as cfm } from "../support/elements/cfm"
+
+context("CloudFileManager", () => {
+  beforeEach(function () {
+      const queryParams = "" // "?sample=mammals&dashboard&mouseSensor"
+      const url = `${Cypress.config("index")}${queryParams}`
+      cy.visit(url)
+      cy.wait(2500)
+  })
+  it("Opens Mammals example document via CFM Open dialog", () => {
+    // hamburger menu is hidden initially
+    cfm.getHamburgerMenuButton().should("exist")
+    cfm.getHamburgerMenu().should("not.exist")
+    // hamburger menu is shows when button is clicked
+    cfm.getHamburgerMenuButton().click()
+    cfm.getHamburgerMenu().should("exist")
+    // clicking Open... item closes menu and shows Open dialog
+    cfm.getHamburgerMenu().contains("li", "Open...").click()
+    cfm.getHamburgerMenu().should("not.exist")
+    cfm.getModalDialog().contains(".modal-dialog-title", "Open")
+    // Example Documents should be selected by default
+    cfm.getModalDialog().contains(".tab-selected", "Example Documents")
+    cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
+    cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
+    // Selecting Mammals document should load the mammals example document
+    cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").click()
+    cfm.getModalDialog().contains(".buttons button", "Open").click()
+    cy.wait(1000)
+    // once loaded, Open dialog should be hidden and document content should be shown
+    cfm.getModalDialog().should("not.exist")
+    cy.get(".codap-component.codap-case-table").contains(".title-bar", "Mammals").should("exist")
+  })
+})

--- a/v3/cypress/e2e/cfm.spec.ts
+++ b/v3/cypress/e2e/cfm.spec.ts
@@ -2,7 +2,7 @@ import { CfmElements as cfm } from "../support/elements/cfm"
 
 context("CloudFileManager", () => {
   beforeEach(function () {
-      const queryParams = "" // "?sample=mammals&dashboard&mouseSensor"
+      const queryParams = "?mouseSensor"
       const url = `${Cypress.config("index")}${queryParams}`
       cy.visit(url)
       cy.wait(2500)

--- a/v3/cypress/support/elements/cfm.ts
+++ b/v3/cypress/support/elements/cfm.ts
@@ -1,5 +1,17 @@
 export const CfmElements = {
   openLocalDoc(filename) {
     cy.get('#codap-app-id').selectFile(filename, { action: 'drag-drop' })
+  },
+  getMenuBar() {
+    return cy.get('#codap-menu-bar-id')
+  },
+  getHamburgerMenuButton() {
+    return cy.get('#codap-menu-bar-id .cfm-menu.menu-anchor')
+  },
+  getHamburgerMenu() {
+    return cy.get('#codap-menu-bar-id .cfm-menu.menu-showing')
+  },
+  getModalDialog() {
+    return cy.get('#codap-menu-bar-id .view .modal-dialog')
   }
 }

--- a/v3/src/lib/use-cloud-file-manager.ts
+++ b/v3/src/lib/use-cloud-file-manager.ts
@@ -95,7 +95,7 @@ export function useCloudFileManager(optionsArg: CFMAppOptions) {
           "name": "readOnly",
           "displayName": t("DG.fileMenu.provider.examples.displayName"),
           "urlDisplayName": "examples",
-          "src": "https://codap-server.concord.org/app/extn/example-documents/index.json.en",
+          "src": "https://codap-resources.s3.amazonaws.com/example-documents/index.json",
           alphabetize: true
         },
         {


### PR DESCRIPTION
[[#186945881]](https://www.pivotaltracker.com/story/show/186945881)

Currently, `example-documents` are deployed to a folder alongside the v2 application as part of the CODAP v2 build process. Ultimately, there should be a GitHub Actions-based deployment process attached to the [codap-data](https://github.com/concord-consortium/codap-data) repository that is responsible for deploying the latest `example-documents` to s3. In the meantime, I have manually copied the contents of the `example-documents/src` folder in the [codap-data](https://github.com/concord-consortium/codap-data) repository to the `example-documents` folder of the `codap-resources` s3 bucket and updated the local CFM URL to point to the updated example documents.

Note that several of the documents don't load correctly in v3, but that's a topic for another PR.