### PR TITLE
fix: user can configure a numeric univariate plot to display bars (PT-186948896)

### DIFF
--- a/v3/src/components/graph/utilities/pixi-points.ts
+++ b/v3/src/components/graph/utilities/pixi-points.ts
@@ -410,7 +410,7 @@ export class PixiPoints {
 
   getRectTexture(style: IPixiPointStyle, includeDimensions = false) {
     const { radius, fill, stroke, strokeWidth, strokeOpacity, width, height } = style
-    const key = this.textureKey({ ...style, strokeOpacity }, includeDimensions)
+    const key = this.textureKey(style, includeDimensions)
 
     if (this.textures.has(key)) {
       return this.textures.get(key) as PIXI.Texture
@@ -449,7 +449,7 @@ export class PixiPoints {
 
   getCircleTexture(style: IPixiPointStyle) {
     const { radius, fill, stroke, strokeWidth, strokeOpacity } = style
-    const key = this.textureKey({ ...style })
+    const key = this.textureKey(style)
 
     if (this.textures.has(key)) {
       return this.textures.get(key) as PIXI.Texture


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186948896

These changes:

1) Correct an issue in `DotPlotDots` where categorical attributes on the secondary axis were not being handled correctly, leading to incorrect rendering of bars.

2) Make the non-value dimension of all bars the same across all subplots. This differs from V2 where the non-value dimension can vary according to the number of cases in each subplot when there is a right or top split. This difference is considered an improvement.

3) Improves the consistency of the animated transition from points to bars and vice versa. There was some bugginess with the initial implementation of that feature that would sometimes result in the bars being rendered incorrectly. The main fixes for those problems are adjustments to `PixiPoints` involving how `DisplayTypeTransitionState` is defined and used, the addition of `pointTransitionStates` for individual points' transition states, and the new `includeDimensions` that's used in certain instances to force methods to include width and height information when creating textures. That latter addition is somewhat inelegant, but I wasn't able to find a way to refactor things so it wasn't a necessary option. 