### PR TITLE
feat: point size control disabled for bars

### DIFF
--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -71,7 +71,7 @@ context("Graph UI", () => {
     return cy.get('.codap-graph').its('length')
    }
    countCodapGraphs().then(initialCount => {
-    cy.log(`Initial CODAP Graph Count: ${initialCount}`);
+    cy.log(`Initial CODAP Graph Count: ${initialCount}`)
 
     // perform an action that gets a new graph
     c.getIconFromToolshelf("graph").click()
@@ -143,5 +143,17 @@ context("Graph UI", () => {
     cy.dragAttributeToTarget("table", "Speed", "left")
     cy.wait(500)
     graph.getDisplayConfigButton().should("not.exist")
+  })
+  it("disables Point Size control when display type is bars", () => {
+    cy.dragAttributeToTarget("table", "Sleep", "bottom")
+    cy.wait(500)
+    graph.getDisplayStylesButton().click()
+    cy.get("[data-testid=point-size-slider]").should("not.have.attr", "aria-disabled")
+    graph.getDisplayConfigButton().click()
+    cy.wait(500)
+    cy.get("[data-testid=bars-radio-button]").click()
+    cy.wait(500)
+    graph.getDisplayStylesButton().click()
+    cy.get("[data-testid=point-size-slider]").should("have.attr", "aria-disabled", "true")
   })
 })

--- a/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
+++ b/v3/src/components/graph/components/inspector-panel/point-format-panel.tsx
@@ -74,9 +74,10 @@ export const PointFormatPalette = observer(function PointFormatPalette({tile, pa
         <FormControl size="xs">
           <Flex className="palette-row">
             <FormLabel className="form-label">{t("DG.Inspector.pointSize")}</FormLabel>
-            <Slider aria-label="point-size-slider" ml="10px" min={0} max={2}
+            <Slider aria-label="point-size-slider" ml="10px" min={0} max={2} data-testid="point-size-slider"
                     defaultValue={graphModel.pointDescription.pointSizeMultiplier} step={0.01}
-                    onChange={(val) => handlePointSizeMultiplierSetting(val)}>
+                    onChange={(val) => handlePointSizeMultiplierSetting(val)}
+                    isDisabled={graphModel.pointDisplayType === "bars"}>
               <SliderTrack/>
               <SliderThumb/>
             </Slider>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187127970

When points are changed to bars, the "Point size" control is disabled so bars cannot be resized.