### PR TITLE
chore: improve infrastructure for importing v2 tiles

### DIFF
--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -64,35 +64,35 @@ context("Graph UI", () => {
     // the Collection Name. Blocker: PT #187033159
 
   })
-  it("creates graphs with new collection name", () => {
+  it("tests undo/redo of creating graphs", () => {
 
     // Function to count CODAP graphs and return the count
-   const countCodapGraphs = () => {
-    return cy.get('.codap-graph').its('length')
-   }
-   countCodapGraphs().then(initialCount => {
-    cy.log(`Initial CODAP Graph Count: ${initialCount}`)
+    const countCodapGraphs = () => {
+      return cy.get('.codap-graph').its('length')
+    }
+    countCodapGraphs().then((initialCount: number) => {
+      cy.log(`Initial CODAP Graph Count: ${initialCount}`)
 
-    // perform an action that gets a new graph
-    c.getIconFromToolshelf("graph").click()
-    c.getComponentTitle("graph").should("contain", collectionName)
-    c.getComponentTitle("graph", 1).should("contain", collectionName)
-    // Assert the count increased by 1
-    countCodapGraphs().should('eq', initialCount + 1)
+      // perform an action that gets a new graph
+      c.getIconFromToolshelf("graph").click()
+      // cy.wait(1000)
+      c.getComponentTitle("graph").should("contain", collectionName)
+      c.getComponentTitle("graph", 1).should("contain", collectionName)
+      // Assert the count increased by 1
+      countCodapGraphs().should('eq', initialCount + 1)
 
-    c.getIconFromToolshelf("graph").click()
-    c.getComponentTitle("graph", 2).should("contain", collectionName)
-    // Assert the count increased by 1
-    countCodapGraphs().should('eq', initialCount + 2)
+      // tests for undo after creating a graph
+      toolbar.getUndoTool().click()
+      // cy.wait(1000)
+      // Assert the count decreased by 1
+      countCodapGraphs().should('eq', initialCount)
 
-    // tests for undo/redo after creating a second graph
-
-    toolbar.getUndoTool().click()
-    cy.wait(2500)
-    // Assert the count decreased by 1
-    countCodapGraphs().should('eq', initialCount + 1)
-
-   })
+      // tests for redo of creating a graph
+      toolbar.getRedoTool().click()
+      // cy.wait(1000)
+      // Assert the count decreased by 1
+      countCodapGraphs().should('eq', initialCount + 1)
+    })
   })
   it("creates graphs with new collection names when existing ones are closed", () => {
     c.closeComponent("graph")

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -4,7 +4,7 @@ import { CodapDndContext } from "./codap-dnd-context"
 import { Container } from "./container/container"
 import { ToolShelf } from "./tool-shelf/tool-shelf"
 import { kCodapAppElementId } from "./constants"
-import { importV2Document } from "./import-v2-document"
+import { importV2Document } from "../v2/import-v2-document"
 import { MenuBar, kMenuBarElementId } from "./menu-bar/menu-bar"
 import { useCloudFileManager } from "../lib/use-cloud-file-manager"
 import { appState } from "../models/app-state"
@@ -88,9 +88,9 @@ export const App = observer(function App() {
           }
         }
         else if (isDashboard) {
+          // we have to create a new starter data set only if none is imported to show the dashboard
           appState.document.content?.createStarterDataset()
         }
-        // we have to create a new starter data set only if none is imported to show the dashboard
         if (isDashboard) {
           addDefaultComponents()
         }

--- a/v3/src/components/calculator/calculator-model.ts
+++ b/v3/src/components/calculator/calculator-model.ts
@@ -1,4 +1,4 @@
-import { Instance, types } from "mobx-state-tree"
+import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { ITileContentModel, TileContentModel } from "../../models/tiles/tile-content"
 import { kCalculatorTileType } from "./calculator-defs"
 
@@ -9,6 +9,7 @@ export const CalculatorModel = TileContentModel
     name: ""
   })
 export interface ICalculatorModel extends Instance<typeof CalculatorModel> {}
+export interface ICalculatorSnapshot extends SnapshotIn<typeof CalculatorModel> {}
 
 export function isCalculatorModel(model?: ITileContentModel): model is ICalculatorModel {
   return model?.type === kCalculatorTileType

--- a/v3/src/components/calculator/calculator-registration.test.ts
+++ b/v3/src/components/calculator/calculator-registration.test.ts
@@ -1,5 +1,8 @@
+import { DocumentContentModel } from "../../models/document/document-content"
+import { FreeTileRow } from "../../models/document/free-tile-row"
 import { getTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { getTileContentInfo } from "../../models/tiles/tile-content-info"
+import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
 import { CodapV2Document } from "../../v2/codap-v2-document"
 import { importV2Component } from "../../v2/codap-v2-tile-importers"
 import { ICodapV2DocumentJson } from "../../v2/codap-v2-types"
@@ -22,7 +25,13 @@ describe("Calculator registration", () => {
     const calculatorJson = fs.readFileSync(file, "utf8")
     const calculatorDoc = JSON.parse(calculatorJson) as ICodapV2DocumentJson
     const v2Document = new CodapV2Document(calculatorDoc)
-    const mockInsertTile = jest.fn()
+
+    const docContent = DocumentContentModel.create()
+    docContent.setRowCreator(() => FreeTileRow.create())
+    const mockInsertTile = jest.fn((tileSnap: ITileModelSnapshotIn) => {
+      return docContent?.insertTileSnapshotInDefaultRow(tileSnap)
+    })
+
     const tile = importV2Component({
       v2Component: v2Document.components[0],
       v2Document,

--- a/v3/src/components/calculator/calculator-registration.ts
+++ b/v3/src/components/calculator/calculator-registration.ts
@@ -2,12 +2,12 @@ import { registerTileComponentInfo } from "../../models/tiles/tile-component-inf
 import { registerTileContentInfo } from "../../models/tiles/tile-content-info"
 import { CalculatorComponent } from "./calculator"
 import { kCalculatorTileClass, kCalculatorTileType } from "./calculator-defs"
-import { CalculatorModel } from "./calculator-model"
+import { CalculatorModel, ICalculatorSnapshot } from "./calculator-model"
 import { CalculatorTitleBar } from "./calculator-title-bar"
 import CalcIcon from '../../assets/icons/icon-calc.svg'
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { isV2CalculatorComponent } from "../../v2/codap-v2-types"
-import { TileModel } from "../../models/tiles/tile-model"
+import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
 import { typedId } from "../../utilities/js-utils"
 
 export const kCalculatorIdPrefix = "CALC"
@@ -16,7 +16,7 @@ registerTileContentInfo({
   type: kCalculatorTileType,
   prefix: kCalculatorIdPrefix,
   modelClass: CalculatorModel,
-  defaultContent: () => CalculatorModel.create(),
+  defaultContent: () => ({ type: kCalculatorTileType }),
   isSingleton: true
 })
 
@@ -42,12 +42,13 @@ registerV2TileImporter("DG.Calculator", ({ v2Component, insertTile }) => {
   if (!isV2CalculatorComponent(v2Component)) return
 
   const { name = "", title = "" } = v2Component.componentStorage
-  const calculatorTile = TileModel.create({
-    id: typedId(kCalculatorIdPrefix),
-    title,
-    content: CalculatorModel.create({ name })
-  })
-  insertTile(calculatorTile)
+
+  const content: ICalculatorSnapshot = {
+    type: kCalculatorTileType,
+    name
+  }
+  const calculatorTileSnap: ITileModelSnapshotIn = { id: typedId(kCalculatorIdPrefix), title, content }
+  const calculatorTile = insertTile(calculatorTileSnap)
 
   return calculatorTile
 })

--- a/v3/src/components/case-table/case-table-model.ts
+++ b/v3/src/components/case-table/case-table-model.ts
@@ -1,4 +1,4 @@
-import { Instance, types } from "mobx-state-tree"
+import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { getTileCaseMetadata, getTileDataSet } from "../../models/shared/shared-data-utils"
 import { ISharedModel } from "../../models/shared/shared-model"
 import { ITileContentModel, TileContentModel } from "../../models/tiles/tile-content"
@@ -45,6 +45,7 @@ export const CaseTableModel = TileContentModel
     }
   }))
 export interface ICaseTableModel extends Instance<typeof CaseTableModel> {}
+export interface ICaseTableSnapshot extends SnapshotIn<typeof CaseTableModel> {}
 
 export function isCaseTableModel(model?: ITileContentModel): model is ICaseTableModel {
   return model?.type === kCaseTableTileType

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -1,9 +1,9 @@
 import { registerTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { registerTileContentInfo } from "../../models/tiles/tile-content-info"
-import { TileModel } from "../../models/tiles/tile-model"
+import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
 import { CaseTableComponent } from "./case-table-component"
 import { kCaseTableTileType } from "./case-table-defs"
-import { CaseTableModel } from "./case-table-model"
+import { CaseTableModel, ICaseTableSnapshot } from "./case-table-model"
 import { CaseTableTitleBar } from "./case-table-title-bar"
 import TableIcon from '../../assets/icons/icon-table.svg'
 import { typedId } from "../../utilities/js-utils"
@@ -18,7 +18,7 @@ registerTileContentInfo({
   type: kCaseTableTileType,
   prefix: kCaseTableIdPrefix,
   modelClass: CaseTableModel,
-  defaultContent: () => CaseTableModel.create()
+  defaultContent: () => ({ type: kCaseTableTileType })
 })
 
 registerTileComponentInfo({
@@ -42,18 +42,21 @@ registerV2TileImporter("DG.TableView", ({ v2Component, v2Document, sharedModelMa
   if (!isV2TableComponent(v2Component)) return
 
   const { title = "", _links_ } = v2Component.componentStorage
-  const tableTile = TileModel.create({
-    id: typedId(kCaseTableIdPrefix),
-    title,
-    content: CaseTableModel.create()
-  })
-  insertTile(tableTile)
+
+  const content: ICaseTableSnapshot = {
+    type: kCaseTableTileType
+  }
+
+  const tableTileSnap: ITileModelSnapshotIn = { id: typedId(kCaseTableIdPrefix), title, content }
+  const tableTile = insertTile(tableTileSnap)
 
   // add links to shared models
-  const contextId = _links_.context.id
-  const { data, metadata } = v2Document.getDataAndMetadata(contextId)
-  sharedModelManager?.addTileSharedModel(tableTile.content, data, true)
-  sharedModelManager?.addTileSharedModel(tableTile.content, metadata, true)
+  if (tableTile) {
+    const contextId = _links_.context.id
+    const { data, metadata } = v2Document.getDataAndMetadata(contextId)
+    data && sharedModelManager?.addTileSharedModel(tableTile.content, data, true)
+    metadata && sharedModelManager?.addTileSharedModel(tableTile.content, metadata, true)
+  }
 
   return tableTile
 })

--- a/v3/src/components/data-display/models/data-display-content-model.ts
+++ b/v3/src/components/data-display/models/data-display-content-model.ts
@@ -2,9 +2,15 @@
  * A DataDisplayContentModel is a base model for GraphContentModel and MapContentModel.
  * It owns a vector of DataDisplayLayerModels.
  */
-import {Instance, types} from "mobx-state-tree"
+import {comparer, reaction} from "mobx"
+import {addDisposer, Instance, types} from "mobx-state-tree"
 import {TileContentModel} from "../../../models/tiles/tile-content"
 import {IDataSet} from "../../../models/data/data-set"
+import {ISharedCaseMetadata} from "../../../models/shared/shared-case-metadata"
+import {ISharedDataSet} from "../../../models/shared/shared-data-set"
+import {
+  getAllTileCaseMetadata, getAllTileDataSets, getSharedDataSetFromDataSetId
+} from "../../../models/shared/shared-data-utils"
 import {DataDisplayLayerModelUnion} from "./data-display-layer-union"
 import {DisplayItemDescriptionModel} from "./display-item-description-model"
 import {GraphPlace} from "../../axis-graph-shared"
@@ -20,7 +26,7 @@ export const DataDisplayContentModel = TileContentModel
   }))
   .views(() => ({
     placeCanAcceptAttributeIDDrop(place: GraphPlace,
-                             dataset: IDataSet | undefined, 
+                             dataset: IDataSet | undefined,
                              attributeID: string | undefined): boolean {
       return false
     }
@@ -32,6 +38,52 @@ export const DataDisplayContentModel = TileContentModel
     },
     stopAnimation() {
       self.animationEnabled = false
+    },
+    installSharedModelManagerSync() {
+      // synchronizes shared model references from layers' DataConfigurations to the sharedModelManager
+      addDisposer(self, reaction(
+        () => {
+          const layerDataSetIds = new Set<string>()
+          const layerMetadataIds = new Set<string>()
+          self.layers.forEach((layer, i) => {
+            const sharedDataSet = getSharedDataSetFromDataSetId(self, layer.data?.id ?? "")
+            if (sharedDataSet) layerDataSetIds.add(sharedDataSet.id)
+            if (layer.metadata) layerMetadataIds.add(layer.metadata.id)
+          })
+          return { layerDataSetIds, layerMetadataIds }
+        },
+        ({ layerDataSetIds, layerMetadataIds }) => {
+          const sharedModelManager = self.tileEnv?.sharedModelManager
+          if (sharedModelManager) {
+            // remove links to unconnected shared data sets
+            getAllTileDataSets(self).forEach(sharedDataSet => {
+              if (!layerDataSetIds.has(sharedDataSet.id)) {
+                sharedModelManager.removeTileSharedModel(self, sharedDataSet)
+              }
+            })
+            // add links to connected shared data sets
+            layerDataSetIds.forEach(id => {
+              const sharedDataSet = sharedModelManager.getSharedModelById<ISharedDataSet>(id)
+              sharedDataSet && sharedModelManager.addTileSharedModel(self, sharedDataSet)
+            })
+            // remove links to unconnected shared case metadata
+            getAllTileCaseMetadata(self).forEach(sharedMetadata => {
+              if (!layerMetadataIds.has(sharedMetadata.id)) {
+                sharedModelManager.removeTileSharedModel(self, sharedMetadata)
+              }
+            })
+            // add links to connected shared metadata
+            layerMetadataIds.forEach(id => {
+              const sharedMetadata = sharedModelManager.getSharedModelById<ISharedCaseMetadata>(id)
+              sharedMetadata && sharedModelManager.addTileSharedModel(self, sharedMetadata)
+            })
+          }
+        }, {
+          name: "DataDisplayContentModel.sharedModelManagerListener",
+          equals: comparer.structural,
+          fireImmediately: true
+        }
+      ))
     }
   }))
 export interface IDataDisplayContentModel extends Instance<typeof DataDisplayContentModel> {}

--- a/v3/src/components/data-summary/data-summary-registration.ts
+++ b/v3/src/components/data-summary/data-summary-registration.ts
@@ -9,7 +9,7 @@ registerTileContentInfo({
   type: kDataSummaryTileType,
   prefix: "DSUM",
   modelClass: DataSummaryModel,
-  defaultContent: () => DataSummaryModel.create()
+  defaultContent: () => ({ type: kDataSummaryTileType })
 })
 
 registerTileComponentInfo({

--- a/v3/src/components/graph/adornments/v2-adornment-importer.test.ts
+++ b/v3/src/components/graph/adornments/v2-adornment-importer.test.ts
@@ -35,7 +35,7 @@ describe("V2AdornmentImporter", () => {
 
   it("imports graphs with no adornments", () => {
     const { _links_: links, plotModels } = emptyGraph?.componentStorage as ICodapV2GraphStorage
-    const contextId = links.context.id
+    const contextId = links.context?.id
     const { data } = v2Document.getDataAndMetadata(contextId)
     const adornmentStore = v2AdornmentImporter({
       data, plotModels, attributeDescriptions: {}, yAttributeDescriptions: []
@@ -52,7 +52,7 @@ describe("V2AdornmentImporter", () => {
 
   it("imports graphs with Count/Percent adornments", () => {
     const { _links_: links, plotModels } = countGraph?.componentStorage as ICodapV2GraphStorage
-    const contextId = links.context.id
+    const contextId = links.context?.id
     const { data } = v2Document.getDataAndMetadata(contextId)
     const adornmentStore = v2AdornmentImporter({
       data, plotModels, attributeDescriptions: {}, yAttributeDescriptions: []
@@ -70,7 +70,7 @@ describe("V2AdornmentImporter", () => {
 
   it("imports graphs with Connecting Lines adornments", () => {
     const { _links_: links, plotModels } = connectingLinesGraph?.componentStorage as ICodapV2GraphStorage
-    const contextId = links.context.id
+    const contextId = links.context?.id
     const { data } = v2Document.getDataAndMetadata(contextId)
     const adornmentStore = v2AdornmentImporter({
       data, plotModels, attributeDescriptions: {}, yAttributeDescriptions: []
@@ -81,7 +81,7 @@ describe("V2AdornmentImporter", () => {
 
   it("imports graphs with Univariate Measure adornments", () => {
     const { _links_: links, plotModels } = univariateMeasureGraph?.componentStorage as ICodapV2GraphStorage
-    const contextId = links.context.id
+    const contextId = links.context?.id
     const { data } = v2Document.getDataAndMetadata(contextId)
     const adornmentStore = v2AdornmentImporter({
       data, plotModels, attributeDescriptions: {}, yAttributeDescriptions: []
@@ -116,7 +116,7 @@ describe("V2AdornmentImporter", () => {
 
   it("imports graphs with Plotted and Movable Values adornments", () => {
     const { _links_: links, plotModels } = plottedAndMovableValuesGraph?.componentStorage as ICodapV2GraphStorage
-    const contextId = links.context.id
+    const contextId = links.context?.id
     const { data } = v2Document.getDataAndMetadata(contextId)
     const adornmentStore = v2AdornmentImporter({
       data, plotModels, attributeDescriptions: {}, yAttributeDescriptions: []
@@ -135,10 +135,10 @@ describe("V2AdornmentImporter", () => {
     expect(movableValuesAdornment.id).toBeDefined()
     expect(movableValuesAdornment.isVisible).toBe(true)
   })
-  
+
   it("imports graphs with Movable Point, Line, LSRL adornments", () => {
     const { _links_: links, plotModels } = movablePointLineLSRLGraph?.componentStorage as ICodapV2GraphStorage
-    const contextId = links.context.id
+    const contextId = links.context?.id
     const { data } = v2Document.getDataAndMetadata(contextId)
     const adornmentStore = v2AdornmentImporter({
       data, plotModels, attributeDescriptions: {}, yAttributeDescriptions: []
@@ -164,7 +164,7 @@ describe("V2AdornmentImporter", () => {
 
   it("imports graphs with Plotted Function adornments", () => {
     const { _links_: links, plotModels } = plottedFunctionGraph?.componentStorage as ICodapV2GraphStorage
-    const contextId = links.context.id
+    const contextId = links.context?.id
     const { data } = v2Document.getDataAndMetadata(contextId)
     const adornmentStore = v2AdornmentImporter({
       data, plotModels, attributeDescriptions: {}, yAttributeDescriptions: []

--- a/v3/src/components/graph/adornments/v2-adornment-importer.ts
+++ b/v3/src/components/graph/adornments/v2-adornment-importer.ts
@@ -18,7 +18,7 @@ import { kPlottedValueType } from "./univariate-measures/plotted-value/plotted-v
 import { kStandardDeviationType } from "./univariate-measures/standard-deviation/standard-deviation-adornment-types"
 
 interface IProps {
-  data: Record<string, any>
+  data?: Record<string, any>
   plotModels: Record<string, any>
   attributeDescriptions: Record<string, any>
   yAttributeDescriptions: Record<string, any>
@@ -37,7 +37,7 @@ interface IInstanceKeyProps {
 }
 
 interface IInstanceKeysForAdornmentsProps {
-  data: Record<string, any>
+  data?: Record<string, any>
   attributeDescriptions: Record<string, any>
   yAttributeDescriptions: Record<string, any>
 }
@@ -61,7 +61,7 @@ const instanceKey = (props: IInstanceKeyProps) => {
   // to utilize that view instead of duplicating code here. There isn't a straightforward way to do that as part of
   // the import process. We'd need to first add the associated graph data configuration to the MobX state tree of the
   // V3 document we're creating to get accurate data from the view. That would require temporarily adding the data
-  // config to the tree before importing the graph and adornments so we could access the view, and then removing it 
+  // config to the tree before importing the graph and adornments so we could access the view, and then removing it
   // before completing the import.
   const { index, xAttrId, xCats, yAttrId, yCats, topAttrId, topCats, rightAttrId, rightCats } = props
   const rightCatCount = rightCats.length || 1
@@ -264,7 +264,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
     }
     v3Adornments.push(stDevAdornmentImport)
   }
-  
+
   // MEAN ABSOLUTE DEVIATION
   const madAdornment = v2Adornments.plottedMad
   if (madAdornment) {

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -1,6 +1,7 @@
-import React from "react"
-import {observer} from "mobx-react-lite"
 import {MenuItem, MenuList, useToast} from "@chakra-ui/react"
+import {observer} from "mobx-react-lite"
+import {isAlive} from "mobx-state-tree"
+import React from "react"
 import {ITileModel} from "../../../../models/tiles/tile-model"
 import {isGraphContentModel} from "../../models/graph-content-model"
 import { t } from "../../../../utilities/translation/translate"
@@ -11,7 +12,7 @@ interface IProps {
 
 export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProps) {
   const toast = useToast()
-  const graphModel = isGraphContentModel(tile?.content) ? tile?.content : undefined
+  const graphModel = tile && isAlive(tile) && isGraphContentModel(tile?.content) ? tile?.content : undefined
   const dataConfiguration = graphModel?.dataConfiguration
   const handleMenuItemClick = (menuItem: string) => {
     toast({

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -1,5 +1,5 @@
 import { applySnapshot, getSnapshot, SnapshotIn, types } from "mobx-state-tree"
-import { GraphContentModel, createGraphContentModel } from "./graph-content-model"
+import { GraphContentModel } from "./graph-content-model"
 import { GraphController } from "./graph-controller"
 import { GraphLayout } from "./graph-layout"
 import { DataSet } from "../../../models/data/data-set"
@@ -28,7 +28,7 @@ jest.mock("../../data-display/data-display-utils", () => ({
 describe("GraphController", () => {
 
   const Tree = types.model("Tree", {
-    model: types.optional(GraphContentModel, () => createGraphContentModel()),
+    model: types.optional(GraphContentModel, () => GraphContentModel.create()),
     data: types.optional(DataSet, () => DataSet.create({
       attributes: [
         { id: "xId", name: "x", values: ["1", "2", "3"] },

--- a/v3/src/components/graph/models/graph-model.test.ts
+++ b/v3/src/components/graph/models/graph-model.test.ts
@@ -8,7 +8,7 @@ describe('GraphContentModel', () => {
     const graphModel = GraphContentModel.create()
     expect(graphModel.type).toBe(kGraphTileType)
     expect(graphModel.adornmentsStore.adornments.length).toBe(0)
-    expect(graphModel.axes.size).toBe(0)
+    expect(graphModel.axes.size).toBe(2)
     expect(graphModel.plotType).toBe('casePlot')
     expect(graphModel.dataConfiguration).toBeTruthy()
     expect(graphModel.pointDescription._itemColors).toStrictEqual([defaultPointColor])

--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -1,5 +1,5 @@
 import { reaction } from "mobx"
-import { addDisposer, Instance, types} from "mobx-state-tree"
+import { addDisposer, Instance, SnapshotIn, types} from "mobx-state-tree"
 import { INumericAxisModel, NumericAxisModel } from "../axis/models/axis-model"
 import { GlobalValue } from "../../models/global/global-value"
 import { applyUndoableAction } from "../../models/history/apply-undoable-action"
@@ -174,6 +174,7 @@ export const SliderModel = TileContentModel
   .actions(applyUndoableAction)
 
 export interface ISliderModel extends Instance<typeof SliderModel> {}
+export interface ISliderSnapshot extends SnapshotIn<typeof SliderModel> {}
 
 export function isSliderModel(model?: ITileContentModel): model is ISliderModel {
   return model?.type === kSliderTileType

--- a/v3/src/components/text/text-registration.ts
+++ b/v3/src/components/text/text-registration.ts
@@ -10,7 +10,7 @@ export const kTextIdPrefix = "TEXT"
 //   type: "CodapText",
 //   prefix: kTextIdPrefix,
 //   modelClass: TextModel,
-//   defaultContent: () => createTextModel()
+//   defaultContent: () => ({ type: kCodapTextTileType })
 // })
 
 registerTileComponentInfo({

--- a/v3/src/components/web-view/web-view-registration.ts
+++ b/v3/src/components/web-view/web-view-registration.ts
@@ -12,7 +12,7 @@ registerTileContentInfo({
   type: kWebViewTileType,
   prefix: kWebViewIdPrefix,
   modelClass: WebViewModel,
-  defaultContent: () => WebViewModel.create()
+  defaultContent: () => ({ type: kWebViewTileType })
 })
 
 registerTileComponentInfo({

--- a/v3/src/lib/handle-cfm-event.test.ts
+++ b/v3/src/lib/handle-cfm-event.test.ts
@@ -4,7 +4,7 @@ import { handleCFMEvent } from "./handle-cfm-event"
 import { createCodapDocument, isCodapDocument } from "../models/codap/create-codap-document"
 import { appState } from "../models/app-state"
 import { ICodapV2DocumentJson } from "../v2/codap-v2-types"
-import * as ImportV2Document from "../components/import-v2-document"
+import * as ImportV2Document from "../v2/import-v2-document"
 
 describe("handleCFMEvent", () => {
 

--- a/v3/src/lib/handle-cfm-event.ts
+++ b/v3/src/lib/handle-cfm-event.ts
@@ -2,7 +2,7 @@ import { CloudFileManagerClient, CloudFileManagerClientEvent } from "@concord-co
 import { appState } from "../models/app-state"
 import { isCodapV2Document } from "../v2/codap-v2-types"
 import { CodapV2Document } from "../v2/codap-v2-document"
-import { importV2Document } from "../components/import-v2-document"
+import { importV2Document } from "../v2/import-v2-document"
 import { wrapCfmCallback } from "./cfm-utils"
 
 import build from "../../build_number.json"

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -2,6 +2,7 @@ import { kCalculatorTileType } from "../../components/calculator/calculator-defs
 import { kCaseTableTileType } from "../../components/case-table/case-table-defs"
 import { kDataSummaryTileType } from "../../components/data-summary/data-summary-defs"
 import { kGraphTileType } from "../../components/graph/graph-defs"
+import { isGraphContentModel } from "../../components/graph/models/graph-content-model"
 import { kSliderTileType } from "../../components/slider/slider-defs"
 import { typedId } from "../../utilities/js-utils"
 import { urlParams } from "../../utilities/url-params"
@@ -14,7 +15,6 @@ import { getTileContentInfo } from "../tiles/tile-content-info"
 import { getSharedModelManager, getTileEnvironment } from "../tiles/tile-environment"
 import { TileModel } from "../tiles/tile-model"
 
-// const isDashboard = urlParams.dashboard !== undefined
 const isTableOnly = urlParams.tableOnly !== undefined
 
 type ILayoutOptions = IFreeTileInRowOptions | IMosaicTileInRowOptions | undefined
@@ -27,7 +27,6 @@ export function createDefaultTileOfType(tileType: string) {
   return content ? TileModel.create({ id, content }) : undefined
 }
 
-// TODO: Eliminate (or hide behind a URL parameter) default dashboard content
 export function addDefaultComponents() {
   const content = appState.document.content
   const manager = getSharedModelManager(appState.document)
@@ -97,8 +96,10 @@ export function addDefaultComponents() {
               ? { splitTileId: tableTile.id, direction: "row" }
               : { x: kFullWidth + kGap, y: kFullHeight + kGap, width: kFullWidth, height: kFullHeight }
       content.insertTileInRow(graphTile, row, graphOptions)
-      sharedData && manager?.addTileSharedModel(graphTile.content, sharedData)
-      caseMetadata && manager?.addTileSharedModel(graphTile.content, caseMetadata)
+      if (isGraphContentModel(graphTile.content)) {
+        const dataConfiguration = graphTile.content.layers[0]?.dataConfiguration
+        dataConfiguration.setDataset(sharedData?.dataSet, caseMetadata)
+      }
     }
   }
 }

--- a/v3/src/models/document/base-document-content.ts
+++ b/v3/src/models/document/base-document-content.ts
@@ -1,7 +1,7 @@
 import { getType, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { ISharedModel, SharedModel } from "../shared/shared-model"
 import { isPlaceholderTile } from "../tiles/placeholder/placeholder-content"
-import { ITileModel, TileModel } from "../tiles/tile-model"
+import { ITileModel, ITileModelSnapshotIn, TileModel } from "../tiles/tile-model"
 import { ITileInRowOptions } from "./tile-row"
 import { ITileRowModelUnion, TileRowModelUnion } from "./tile-row-union"
 import { SharedModelEntry, SharedModelMap } from "./shared-model-entry"
@@ -123,6 +123,13 @@ export const BaseDocumentContentModel = types
       row.insertTile(tile.id, options)
       self.tileMap.put(tile)
     },
+    insertTileSnapshotInRow(
+      tileSnap: ITileModelSnapshotIn, row: ITileRowModelUnion, options?: ITileInRowOptions
+    ): ITileModel | undefined {
+      const tile = self.tileMap.put(tileSnap)
+      row.insertTile(tile.id, options)
+      return tile
+    },
     setVisibleRows(rows: string[]) {
       self.visibleRows = rows
     }
@@ -132,11 +139,23 @@ export const BaseDocumentContentModel = types
       const rowOrIndex = self.defaultInsertRow
       const requiresNewRow = typeof rowOrIndex === "number"
       const row = requiresNewRow ? self.rowCreator?.() : rowOrIndex
-      if (row) {
+      if (row != null) {
         if (requiresNewRow) {
           self.insertRow(row, rowOrIndex)
         }
         self.insertTileInRow(tile, row)
+      }
+    },
+    insertTileSnapshotInDefaultRow(tileSnap: ITileModelSnapshotIn): ITileModel | undefined {
+      const rowOrIndex = self.defaultInsertRow
+      const requiresNewRow = typeof rowOrIndex === "number"
+      const row = requiresNewRow ? self.rowCreator?.() : rowOrIndex
+      if (row != null) {
+        if (requiresNewRow) {
+          self.insertRow(row, rowOrIndex)
+        }
+        const tile = self.insertTileSnapshotInRow(tileSnap, row)
+        return tile
       }
     },
     deleteRow(rowId: string) {

--- a/v3/src/models/document/shared-model-document-manager.test.ts
+++ b/v3/src/models/document/shared-model-document-manager.test.ts
@@ -177,6 +177,7 @@ describe("SharedModelDocumentManager", () => {
 
     const sharedModel = doc.sharedModelMap.get("sm1")?.sharedModel as TestISharedModel
     expect(sharedModel).toBeDefined()
+    expect(getSharedModelManager(doc)?.getSharedModelById("sm1")).toBe(sharedModel)
 
     sharedModel.setValue("something")
 
@@ -196,6 +197,7 @@ describe("SharedModelDocumentManager", () => {
 
     const sharedModel = doc.sharedModelMap.get("sm1")?.sharedModel as TestISharedModel
     expect(sharedModel).toBeDefined()
+    expect(getSharedModelManager(doc)?.getSharedModelById("sm1")).toBe(sharedModel)
 
     // We call an async action on the tile
     // Then while the async action is running we change the sharedModel
@@ -293,6 +295,7 @@ describe("SharedModelDocumentManager", () => {
   })
 
   it("finds a shared model by type", () => {
+    const manager = new SharedModelDocumentManager()
     const doc = DocumentContentModel.create({
       sharedModelMap: {
         "sm1": {
@@ -302,15 +305,16 @@ describe("SharedModelDocumentManager", () => {
           }
         }
       },
-    })
-    const manager = new SharedModelDocumentManager()
+    }, { sharedModelManager: manager })
     manager.setDocument(doc)
 
     const sharedModel = manager.findFirstSharedModelByType(TestSharedModel)
     expect(sharedModel?.id).toBe("sm1")
+    expect(getSharedModelManager(doc)?.getSharedModelById("sm1")).toBe(sharedModel)
 
     const sharedModel2 = manager.findFirstSharedModelByType(TestSharedModel2)
     expect(sharedModel2).toBeUndefined()
+    expect(getSharedModelManager(doc)?.getSharedModelById("sm2")).toBeUndefined()
   })
 
   it("finds a snapshotProcessor shared model by the original type", () => {

--- a/v3/src/models/document/shared-model-document-manager.ts
+++ b/v3/src/models/document/shared-model-document-manager.ts
@@ -1,5 +1,5 @@
 import { action, computed, makeObservable, observable } from "mobx"
-import { getParentOfType, hasParentOfType, IAnyStateTreeNode } from "mobx-state-tree"
+import { getParentOfType, hasParentOfType, IAnyStateTreeNode, Instance } from "mobx-state-tree"
 import { IDocumentContentModel } from "./document-content"
 import { ISharedModel, SharedModel } from "../shared/shared-model"
 import { ISharedModelManager } from "../shared/shared-model-manager"
@@ -41,6 +41,10 @@ export class SharedModelDocumentManager implements ISharedModelDocumentManager {
 
   setDocument(document: IDocumentContentModel) {
     this.document = document
+  }
+
+  getSharedModelById<OT extends Instance<typeof SharedModel>>(id: string): OT | undefined {
+    return this.document?.sharedModelMap.get(id)?.sharedModel as OT | undefined
   }
 
   findFirstSharedModelByType<IT extends typeof SharedModel>(

--- a/v3/src/models/global/global-value-manager.ts
+++ b/v3/src/models/global/global-value-manager.ts
@@ -1,6 +1,6 @@
 import { Instance, types } from "mobx-state-tree"
 import { SharedModel } from "../shared/shared-model"
-import { GlobalValue, IGlobalValue, kDefaultNamePrefix } from "./global-value"
+import { GlobalValue, IGlobalValue, IGlobalValueSnapshot, kDefaultNamePrefix } from "./global-value"
 
 export const kGlobalValueManagerType = "GlobalValueManager"
 
@@ -46,6 +46,12 @@ export const GlobalValueManager = SharedModel
       console.warn(`GlobalValueManager: Adding global value with conflicting name: ${global.name}`)
     }
     self.globals.put(global)
+  },
+  addValueSnapshot(global: IGlobalValueSnapshot) {
+    if (self.getValueByName(global.name)) {
+      console.warn(`GlobalValueManager: Adding global value with conflicting name: ${global.name}`)
+    }
+    return self.globals.put(global)
   },
   removeValue(global: IGlobalValue) {
     self.globals.delete(global.id)

--- a/v3/src/models/global/global-value.ts
+++ b/v3/src/models/global/global-value.ts
@@ -1,4 +1,4 @@
-import {Instance, types} from "mobx-state-tree"
+import {Instance, SnapshotIn, types} from "mobx-state-tree"
 import { typedId } from "../../utilities/js-utils"
 
 export const kDefaultNamePrefix = "v"
@@ -38,3 +38,4 @@ export const GlobalValue = types.model("GlobalValue", {
     }
   }))
 export interface IGlobalValue extends Instance<typeof GlobalValue> {}
+export interface IGlobalValueSnapshot extends SnapshotIn<typeof GlobalValue> {}

--- a/v3/src/models/shared/shared-data-utils.ts
+++ b/v3/src/models/shared/shared-data-utils.ts
@@ -12,6 +12,11 @@ export function getSharedDataSets(node: IAnyStateTreeNode): ISharedDataSet[] {
   return sharedModelManager?.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType) ?? []
 }
 
+export function getSharedDataSetFromDataSetId(node: IAnyStateTreeNode, id: string): ISharedDataSet | undefined {
+  const sharedDataSets = getSharedDataSets(node)
+  return sharedDataSets.find(model => model.dataSet.id === id)
+}
+
 export function getDataSetFromId(node: IAnyStateTreeNode, id: string): IDataSet | undefined {
   const sharedDataSets = getSharedDataSets(node)
   const sharedDataSet = sharedDataSets.find(model => model.dataSet.id === id)
@@ -35,9 +40,17 @@ export function getTileDataSet(tile: ITileContentModel): IDataSet | undefined {
   return isSharedDataSet(sharedDataSet) ? sharedDataSet.dataSet : undefined
 }
 
+export function getAllTileDataSets(tile: ITileContentModel): ISharedDataSet[] {
+  return getTileSharedModels(tile).filter(m => isSharedDataSet(m)) as ISharedDataSet[]
+}
+
 export function getTileCaseMetadata(tile: ITileContentModel) {
   const sharedCaseMetadata = getTileSharedModels(tile).find(m => isSharedCaseMetadata(m))
   return isSharedCaseMetadata(sharedCaseMetadata) ? sharedCaseMetadata : undefined
+}
+
+export function getAllTileCaseMetadata(tile: ITileContentModel): ISharedCaseMetadata[] {
+  return getTileSharedModels(tile).filter(m => isSharedCaseMetadata(m)) as ISharedCaseMetadata[]
 }
 
 export function isTileLinkedToDataSet(tile: ITileContentModel, dataSet: IDataSet) {
@@ -50,6 +63,7 @@ export function isTileLinkedToOtherDataSet(tile: ITileContentModel, dataSet: IDa
   return !!sharedModels.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id !== dataSet.id)
 }
 
+// removes references to the specified tile from SharedDataSet and SharedCaseMetadata tiles
 export function unlinkTileFromDataSets(tile: ITileContentModel) {
   const sharedModelManager = getSharedModelManager(tile)
   const sharedModels = sharedModelManager?.getTileSharedModels(tile) ?? []
@@ -60,6 +74,7 @@ export function unlinkTileFromDataSets(tile: ITileContentModel) {
   })
 }
 
+// adds references to the specified tile to the specified SharedDataSet and its SharedCaseMetadata
 export function linkTileToDataSet(tile: ITileContentModel, dataSet: IDataSet) {
   if (isTileLinkedToOtherDataSet(tile, dataSet)) {
     unlinkTileFromDataSets(tile)

--- a/v3/src/models/shared/shared-model-manager.ts
+++ b/v3/src/models/shared/shared-model-manager.ts
@@ -1,5 +1,5 @@
 
-import { IAnyStateTreeNode, types } from "mobx-state-tree"
+import { IAnyStateTreeNode, Instance, types } from "mobx-state-tree"
 import { kUnknownSharedModel, SharedModel, ISharedModel } from "./shared-model"
 import { getSharedModelClasses, getSharedModelInfoByType } from "./shared-model-registry"
 
@@ -55,6 +55,13 @@ export interface ISharedModelManager {
    * The manager might be available, but is not ready to be used yet.
    */
   get isReady(): boolean;
+
+  /**
+   * Retrieve the shared model with the specified id.
+   *
+   * @param sharedModelType the MST model "class" of the shared model
+   */
+  getSharedModelById<OT extends Instance<typeof SharedModel>>(id: string): OT | undefined;
 
   /**
    * Find the shared model at the container level. If the tile wants to use this

--- a/v3/src/models/tiles/tile-content-info.ts
+++ b/v3/src/models/tiles/tile-content-info.ts
@@ -1,6 +1,5 @@
-import { SetRequired } from "type-fest"
 import { ITileMetadataModel, TileMetadataModel } from "./tile-metadata"
-import { TileContentModel, ITileContentSnapshot } from "./tile-content"
+import { TileContentModel, ITileContentSnapshotWithType } from "./tile-content"
 import { AppConfigModelType } from "../stores/app-config-model"
 import { ITileEnvironment } from "./tile-environment"
 
@@ -25,7 +24,7 @@ export interface ITileContentInfo {
   type: string;
   prefix: string; // conventionally four uppercase chars
   modelClass: typeof TileContentModel;
-  defaultContent: (options?: IDefaultContentOptions) => SetRequired<ITileContentSnapshot, "type">;
+  defaultContent: (options?: IDefaultContentOptions) => ITileContentSnapshotWithType;
   titleBase?: string;
   metadataClass?: typeof TileMetadataModel;
   isSingleton?: boolean; // Only one instance of a tile is open per document

--- a/v3/src/models/tiles/tile-content-info.ts
+++ b/v3/src/models/tiles/tile-content-info.ts
@@ -1,5 +1,6 @@
+import { SetRequired } from "type-fest"
 import { ITileMetadataModel, TileMetadataModel } from "./tile-metadata"
-import { TileContentModel, ITileContentModel } from "./tile-content"
+import { TileContentModel, ITileContentSnapshot } from "./tile-content"
 import { AppConfigModelType } from "../stores/app-config-model"
 import { ITileEnvironment } from "./tile-environment"
 
@@ -24,7 +25,7 @@ export interface ITileContentInfo {
   type: string;
   prefix: string; // conventionally four uppercase chars
   modelClass: typeof TileContentModel;
-  defaultContent: (options?: IDefaultContentOptions) => ITileContentModel;
+  defaultContent: (options?: IDefaultContentOptions) => SetRequired<ITileContentSnapshot, "type">;
   titleBase?: string;
   metadataClass?: typeof TileMetadataModel;
   isSingleton?: boolean; // Only one instance of a tile is open per document

--- a/v3/src/models/tiles/tile-content.ts
+++ b/v3/src/models/tiles/tile-content.ts
@@ -1,4 +1,5 @@
 import { getSnapshot, Instance, SnapshotIn, types } from "mobx-state-tree"
+import { SetRequired } from "type-fest"
 import { ISharedModel } from "../shared/shared-model"
 import { SharedModelChangeType } from "../shared/shared-model-manager"
 import { getTileEnvironment, ITileEnvironment } from "./tile-environment"
@@ -66,3 +67,4 @@ export const TileContentModel = types.model("TileContentModel", {
 
 export interface ITileContentModel extends Instance<typeof TileContentModel> {}
 export interface ITileContentSnapshot extends SnapshotIn<typeof TileContentModel> {}
+export type ITileContentSnapshotWithType = SetRequired<ITileContentSnapshot, "type">

--- a/v3/src/models/tiles/tile-content.ts
+++ b/v3/src/models/tiles/tile-content.ts
@@ -1,4 +1,4 @@
-import { getSnapshot, Instance, types } from "mobx-state-tree"
+import { getSnapshot, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { ISharedModel } from "../shared/shared-model"
 import { SharedModelChangeType } from "../shared/shared-model-manager"
 import { getTileEnvironment, ITileEnvironment } from "./tile-environment"
@@ -65,3 +65,4 @@ export const TileContentModel = types.model("TileContentModel", {
   .actions(self => tileModelHooks({}))
 
 export interface ITileContentModel extends Instance<typeof TileContentModel> {}
+export interface ITileContentSnapshot extends SnapshotIn<typeof TileContentModel> {}

--- a/v3/src/models/tiles/tile-model.test.ts
+++ b/v3/src/models/tiles/tile-model.test.ts
@@ -45,9 +45,7 @@ describe("TileModel", () => {
         content.originalType = "foo"
       }
 
-      let tile = TileModel.create({
-                      content: getSnapshot(toolDefaultContent?.())
-                    })
+      let tile = TileModel.create({ content: toolDefaultContent?.() })
       expect(tile.content.type).toBe(tileType)
 
       // can create/recognize snapshots of each type of tool

--- a/v3/src/test/test-tile-content.ts
+++ b/v3/src/test/test-tile-content.ts
@@ -19,7 +19,7 @@ registerTileContentInfo({
   type: "Test",
   prefix: "TEST",
   modelClass: TestTileContent,
-  defaultContent: () => TestTileContent.create()
+  defaultContent: () => ({ type: "Test" })
 })
 
 registerTileComponentInfo({

--- a/v3/src/test/v2/graph-no-data.codap
+++ b/v3/src/test/v2/graph-no-data.codap
@@ -1,0 +1,86 @@
+{
+  "name": "Untitled Document",
+  "guid": 1,
+  "id": 1,
+  "components": [
+    {
+      "type": "DG.GraphView",
+      "guid": 2,
+      "id": 2,
+      "componentStorage": {
+        "_links_": {
+          "hiddenCases": []
+        },
+        "displayOnlySelected": false,
+        "legendRole": 0,
+        "legendAttributeType": 0,
+        "numberOfLegendQuantiles": 5,
+        "legendQuantilesAreLocked": false,
+        "pointColor": "#e6805b",
+        "strokeColor": "white",
+        "pointSizeMultiplier": 1,
+        "transparency": 0.85,
+        "strokeTransparency": 0.4,
+        "strokeSameAsFill": false,
+        "isTransparent": false,
+        "plotBackgroundColor": null,
+        "plotBackgroundOpacity": 1,
+        "plotBackgroundImage": null,
+        "plotBackgroundImageLockInfo": null,
+        "xRole": 0,
+        "xAttributeType": 0,
+        "yRole": 0,
+        "yAttributeType": 0,
+        "y2Role": 0,
+        "y2AttributeType": 0,
+        "topRole": 0,
+        "topAttributeType": 0,
+        "rightRole": 0,
+        "rightAttributeType": 0,
+        "xAxisClass": "DG.AxisModel",
+        "yAxisClass": "DG.AxisModel",
+        "y2AxisClass": "DG.AxisModel",
+        "topAxisClass": "DG.CellAxisModel",
+        "rightAxisClass": "DG.CellAxisModel",
+        "plotModels": [
+          {
+            "plotModelStorage": {
+              "verticalAxisIsY2": false,
+              "adornments": {
+                "plottedCount": {
+                  "isVisible": false,
+                  "enableMeasuresForSelection": false,
+                  "isShowingCount": false,
+                  "isShowingPercent": false,
+                  "percentKind": 1
+                }
+              }
+            },
+            "plotClass": "DG.CasePlotModel"
+          }
+        ],
+        "userSetTitle": false,
+        "cannotClose": false
+      },
+      "layout": {
+        "width": 300,
+        "height": 300,
+        "zIndex": 102,
+        "left": 5,
+        "top": 5,
+        "isVisible": true,
+        "right": 305,
+        "bottom": 305
+      },
+      "savedHeight": null
+    }
+  ],
+  "contexts": [],
+  "globalValues": [],
+  "appName": "DG",
+  "appVersion": "2.0",
+  "appBuildNum": "0708",
+  "lang": "en",
+  "idCount": 2,
+  "metadata": {}
+}

--- a/v3/src/v2/codap-v2-tile-importers.ts
+++ b/v3/src/v2/codap-v2-tile-importers.ts
@@ -1,5 +1,5 @@
 import { ISharedModelManager } from "../models/shared/shared-model-manager"
-import { ITileModel } from "../models/tiles/tile-model"
+import { ITileModel, ITileModelSnapshotIn } from "../models/tiles/tile-model"
 import { CodapV2Document } from "./codap-v2-document"
 import { ICodapV2BaseComponent } from "./codap-v2-types"
 
@@ -14,7 +14,7 @@ export interface V2TileImportArgs {
   v2Document: CodapV2Document
   sharedModelManager?: ISharedModelManager
   // function to call to insert the imported tile into the document
-  insertTile: (tile: ITileModel) => void
+  insertTile: (tileSnap: ITileModelSnapshotIn) => ITileModel | undefined
 }
 export type V2TileImportFn = (args: V2TileImportArgs) => ITileModel | undefined
 

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -265,16 +265,16 @@ export interface ICodapV2PlotModel {
 
 export interface ICodapV2GraphStorage extends ICodapV2BaseComponentStorage {
   _links_: {
-    context: IGuidLink<"DG.DataContextRecord">
+    context?: IGuidLink<"DG.DataContextRecord">
     hiddenCases: any[]
-    xColl: IGuidLink<"DG.Collection">
-    xAttr: IGuidLink<"DG.Attribute">
-    yColl: IGuidLink<"DG.Collection">
-    yAttr: IGuidLink<"DG.Attribute"> | Array<IGuidLink<"DG.Attribute">>
-    y2Coll: IGuidLink<"DG.Collection">
-    y2Attr: IGuidLink<"DG.Attribute">
-    rightColl: IGuidLink<"DG.Collection">
-    rightAttr: IGuidLink<"DG.Attribute">
+    xColl?: IGuidLink<"DG.Collection">
+    xAttr?: IGuidLink<"DG.Attribute">
+    yColl?: IGuidLink<"DG.Collection">
+    yAttr?: IGuidLink<"DG.Attribute"> | Array<IGuidLink<"DG.Attribute">>
+    y2Coll?: IGuidLink<"DG.Collection">
+    y2Attr?: IGuidLink<"DG.Attribute">
+    rightColl?: IGuidLink<"DG.Collection">
+    rightAttr?: IGuidLink<"DG.Attribute">
   }
   displayOnlySelected: boolean
   legendRole: number

--- a/v3/src/v2/import-v2-document.ts
+++ b/v3/src/v2/import-v2-document.ts
@@ -5,9 +5,9 @@ import { gDataBroker } from "../models/data/data-broker"
 import { serializeDocument } from "../models/document/serialize-document"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { getSharedModelManager } from "../models/tiles/tile-environment"
-import { ITileModel } from "../models/tiles/tile-model"
-import { CodapV2Document } from "../v2/codap-v2-document"
-import { importV2Component } from "../v2/codap-v2-tile-importers"
+import { ITileModel, ITileModelSnapshotIn } from "../models/tiles/tile-model"
+import { CodapV2Document } from "./codap-v2-document"
+import { importV2Component } from "./codap-v2-tile-importers"
 
 export function importV2Document(v2Document: CodapV2Document) {
   const v3Document = createCodapDocument(undefined, { layout: "free" })
@@ -27,7 +27,8 @@ export function importV2Document(v2Document: CodapV2Document) {
   const { content } = v3Document
   const row = content?.firstRow
   v2Components.forEach(v2Component => {
-    const insertTile = (tile: ITileModel) => {
+    const insertTile = (tile: ITileModelSnapshotIn) => {
+      let newTile: ITileModel | undefined
       if (row && tile) {
         const info = getTileComponentInfo(tile.content.type)
         if (info) {
@@ -35,9 +36,10 @@ export function importV2Document(v2Document: CodapV2Document) {
           // only apply imported width and height to resizable tiles
           const _width = !info.isFixedWidth ? { width } : {}
           const _height = !info?.isFixedHeight ? { height } : {}
-          content?.insertTileInRow(tile, row, { x: left, y: top, ..._width, ..._height })
+          newTile = content?.insertTileSnapshotInRow(tile, row, { x: left, y: top, ..._width, ..._height })
         }
       }
+      return newTile
     }
     importV2Component({ v2Component, v2Document, sharedModelManager, insertTile })
   })


### PR DESCRIPTION
- component importers build snapshots rather than tiles to better support MST references
- component content `defaultContent()` implementations return snapshots rather than tiles 
- graphs and maps synchronize from data configurations to the shared model manager, i.e. the data configurations are the source of truth (unlike tables for which the shared model manager is the source of truth because tables don't store redundant shared model references).
- flesh out graph component unit tests
- declare some v2 document properties optional, since they're not always present
- switch from using `Record<>` to `Map<>` for some internal v2 document properties for better type safety

@bfinzer Given the size of this PR, I suggest looking it over async first and then we can do a sync review to go over the main points and answer any questions.