### PR TITLE
fix: bar for each point breaks axis (PT-187142716)

### DIFF
--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -153,23 +153,19 @@ context("Test graph axes with various attribute types", () => {
   })
   it("will adjust axis domain when points are changed to bars", () => {
     // When there are no negative numeric values, such as in the case of Height, the domain for the primary
-    // axis of a univariate plot showing bars should start at zero. So for this test we essentially subtract
-    // the first tick value from arrayOfValues[3].values (i.e. -0.5) to test that the domain starts at zero
-    // when the display type changes to bars.
-    const arrayOfBarValues = [...arrayOfValues[3].values].slice(0, 16)
+    // axis of a univariate plot showing bars should start at zero.
     cy.dragAttributeToTarget("table", arrayOfAttributes[3], "bottom") // Height => x-axis
     cy.wait(500)
     ah.verifyXAxisTickMarksDisplayed()
-    ah.verifyAxisTickLabels("bottom", arrayOfValues[3].values)
+    ah.verifyAxisTickLabel("bottom", "−0.5", 0)
     cy.get("[data-testid=graph-display-config-button").click()
     cy.wait(500)
     cy.get("[data-testid=bars-radio-button]").click()
     cy.wait(500)
-    ah.verifyAxisTickLabels("bottom", arrayOfBarValues)
-    cy.wait(500)
+    ah.verifyAxisTickLabel("bottom", "0", 0)
     cy.get("[data-testid=points-radio-button]").click()
     cy.wait(500)
-    ah.verifyAxisTickLabels("bottom", arrayOfValues[3].values)
+    ah.verifyAxisTickLabel("bottom", "−0.5", 0)
   })
 })
 

--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -151,6 +151,26 @@ context("Test graph axes with various attribute types", () => {
     ah.openAxisAttributeMenu("bottom")
     ah.removeAttributeFromAxis(arrayOfAttributes[3], "bottom")
   })
+  it("will adjust axis domain when points are changed to bars", () => {
+    // When there are no negative numeric values, such as in the case of Height, the domain for the primary
+    // axis of a univariate plot showing bars should start at zero. So for this test we essentially subtract
+    // the first tick value from arrayOfValues[3].values (i.e. -0.5) to test that the domain starts at zero
+    // when the display type changes to bars.
+    const arrayOfBarValues = [...arrayOfValues[3].values].slice(0, 16)
+    cy.dragAttributeToTarget("table", arrayOfAttributes[3], "bottom") // Height => x-axis
+    cy.wait(500)
+    ah.verifyXAxisTickMarksDisplayed()
+    ah.verifyAxisTickLabels("bottom", arrayOfValues[3].values)
+    cy.get("[data-testid=graph-display-config-button").click()
+    cy.wait(500)
+    cy.get("[data-testid=bars-radio-button]").click()
+    cy.wait(500)
+    ah.verifyAxisTickLabels("bottom", arrayOfBarValues)
+    cy.wait(500)
+    cy.get("[data-testid=points-radio-button]").click()
+    cy.wait(500)
+    ah.verifyAxisTickLabels("bottom", arrayOfValues[3].values)
+  })
 })
 
 context("Test graph axes attribute menu", () => {

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -373,7 +373,7 @@ export const useSubAxis = ({
         console.warn("useSubAxis.installDomainSync skipping sync of defunct axis model")
       }
     }, { name: "useSubAxis.installDomainSync" }, axisProvider)
-  }, [axisPlace, axisProvider, displayModel, layout, renderSubAxis])
+  }, [axisPlace, axisProvider, layout, renderSubAxis])
 
   // Refresh when category set, if any, changes
   useEffect(function installCategorySetSync() {

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -15,8 +15,6 @@ import {DragInfo, collisionExists, computeBestNumberOfTicks, getCategoricalLabel
         getCoordFunctions, IGetCoordFunctionsProps} from "../axis-utils"
 import { useAxisProviderContext } from "./use-axis-provider-context"
 import { useDataDisplayModelContext } from "../../data-display/hooks/use-data-display-model"
-import { ICaseID } from "../../../models/data/data-set-types"
-import { isGraphContentModel } from "../../graph/models/graph-content-model"
 
 export interface IUseSubAxis {
   subAxisIndex: number
@@ -36,7 +34,6 @@ export const useSubAxis = ({
                            }: IUseSubAxis) => {
   const layout = useAxisLayoutContext(),
     displayModel = useDataDisplayModelContext(),
-    pointDisplayType = displayModel?.pointDisplayType,
     {isAnimating, stopAnimation} = useDataDisplayAnimation(),
     axisProvider = useAxisProviderContext(),
     axisModel = axisProvider.getAxis?.(axisPlace),
@@ -228,8 +225,8 @@ export const useSubAxis = ({
           renderCategoricalSubAxis()
           break
       }
-    }, [axisProvider, axisPlace, layout, subAxisIndex, subAxisElt, isAnimating, centerCategoryLabels,
-        showScatterPlotGridLines]),
+    }, [axisProvider, axisPlace, layout, subAxisIndex, subAxisElt, axisModel, isAnimating, displayModel,
+        centerCategoryLabels, showScatterPlotGridLines]),
 
     onDragStart = useCallback((event: any) => {
       const dI = dragInfo.current
@@ -367,19 +364,7 @@ export const useSubAxis = ({
       const _axisModel = axisProvider?.getAxis?.(axisPlace)
       if (isAliveSafe(_axisModel)) {
         if (isNumericAxisModel(_axisModel)) {
-          let { domain } = _axisModel || {}
-          if (displayModel.pointDisplayType === "bars" && isGraphContentModel(displayModel)) {
-            // When displaying bars, the domain should start at 0 unless there are negative values.
-            const dataset = displayModel.dataConfiguration?.dataset
-            const attributeID = axisPlace === "bottom"
-              ? displayModel.getAttributeID("x")
-              : displayModel.getAttributeID("y")
-            const hasNegativeValues = dataset?.cases?.some((datum: ICaseID) => {
-              const caseValue = dataset?.getNumeric(datum.__id__, attributeID) ?? NaN
-              return caseValue < 0
-            })
-            domain = hasNegativeValues ? domain : [0, _axisModel.max]
-          }
+          const { domain } = _axisModel || {}
           layout.getAxisMultiScale(axisPlace)?.setNumericDomain(domain)
           renderSubAxis()
         }

--- a/v3/src/components/graph/components/freedotplotdots.tsx
+++ b/v3/src/components/graph/components/freedotplotdots.tsx
@@ -26,7 +26,6 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
     layout = useGraphLayoutContext(),
     primaryAttrRole = dataConfig?.primaryRole ?? 'x',
     primaryIsBottom = primaryAttrRole === 'x',
-    primaryAttrID = dataConfig?.attributeID(primaryAttrRole) ?? '',
     secondaryAttrRole = primaryAttrRole === 'x' ? 'y' : 'x',
     {pointColor, pointStrokeColor} = graphModel.pointDescription,
     pointDisplayType = graphModel.pointDisplayType
@@ -53,6 +52,7 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
         extraPrimaryAxisScale = layout.getAxisScale(extraPrimaryPlace) as ScaleBand<string>,
         secondaryAxisScale = layout.getAxisScale(secondaryPlace) as ScaleBand<string>,
         extraSecondaryAxisScale = layout.getAxisScale(extraSecondaryPlace) as ScaleBand<string>,
+        primaryAttrID = dataConfig?.attributeID(primaryAttrRole) ?? '',
         extraPrimaryAttrID = dataConfig?.attributeID(extraPrimaryRole) ?? '',
         numExtraPrimaryBands = Math.max(1, extraPrimaryAxisScale?.domain().length ?? 1),
         pointDiameter = 2 * graphModel.getPointRadius(),
@@ -184,7 +184,7 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
         pointDisplayType, getWidth, getHeight, anchor
       })
     },
-    [primaryIsBottom, layout, dataConfig, graphModel, secondaryAttrRole, dataset, primaryAttrID, pointDisplayType,
+    [primaryIsBottom, layout, dataConfig, primaryAttrRole, graphModel, secondaryAttrRole, dataset, pointDisplayType,
      pixiPoints, pointColor, pointStrokeColor, isAnimating])
 
   usePlotResponders({pixiPoints, refreshPointPositions, refreshPointSelection})
@@ -203,14 +203,13 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
   // respond to pointDisplayType changes because the axis domain may need to be updated
   useEffect(function respondToGraphPointDisplayType() {
     return mstAutorun(() => {
-      const primaryAttribute = dataset?.attrFromID(primaryAttrID)
       const primaryAxis = graphModel.getNumericAxis(primaryIsBottom ? "bottom" : "left")
       const numValues = graphModel.dataConfiguration.numericValuesForAttrRole(primaryIsBottom ? "x" : "y")
-      if (primaryAttribute && primaryAxis) {
+      if (primaryAxis) {
         setNiceDomain(numValues, primaryAxis, graphModel.axisDomainOptions)
       }
     }, {name: "respondToGraphPointDisplayType"}, graphModel)
-  }, [dataset, graphModel, primaryAttrID, primaryIsBottom])
+  }, [dataset, graphModel, primaryIsBottom])
 
   return (
     <></>

--- a/v3/src/components/graph/components/freedotplotdots.tsx
+++ b/v3/src/components/graph/components/freedotplotdots.tsx
@@ -99,7 +99,7 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
         const details: ISubPlotDetails | undefined = subPlotDetails.get(subPlotMapKey)
         return { subPlotKey, casesInCategory: details?.cases ?? [], caseIndex: details?.indices[anID] ?? -1 }
       }
-    
+
       const getBarStaticDimension = () => {
         // This function determines how much space is available for each bar on the non-primary axis by dividing the
         // length of the non-primary axis by the number of cases in the subplot containing the most cases. This keeps
@@ -107,7 +107,7 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
         const largestSubplotCount = Math.max(...Array.from(subPlotDetails.values()).map(sp => sp.cases.length))
         return largestSubplotCount ? secondaryBandwidth / largestSubplotCount : 0
       }
-    
+
       const getBarValueDimension = (anID: string) => {
         const computePrimaryCoordProps = {
           anID, dataConfig, dataset, extraPrimaryAttrID, extraPrimaryAxisScale, isBinned: false,
@@ -125,10 +125,10 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
         const extraSecondaryCoord = extraCategory && extraCategory !== '__main__'
           ? (extraSecondaryAxisScale(extraCategory) ?? 0)
           : 0
-      
+
         // Adjusted bar position accounts for the bar's index, dimension, and additional offsets.
         const adjustedBarPosition = caseIndex >= 0 ? caseIndex * barDimension + secondaryCoord + extraSecondaryCoord : 0
-      
+
         // Calculate the centered position by adjusting for the collective dimension of all bars in the subplot
         const collectiveDimension = barDimension * (casesInCategory.length ?? 0)
         return (adjustedBarPosition - collectiveDimension / 2) + secondaryBandwidth / 2
@@ -146,7 +146,7 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
         }
         return primaryCoord + extraPrimaryCoord
       }
-    
+
       const getSecondaryScreenCoord = (anID: string) => {
         // For bar graphs, the secondary coordinate will be determined simply by the order of the cases in the dataset,
         // not by any value the cases possess.
@@ -163,12 +163,12 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
           ? computeSecondaryCoord(computeSecondaryCoordProps) + onePixelOffset
           : null
       }
-      
+
       const getScreenX = primaryIsBottom ? getPrimaryScreenCoord : getSecondaryScreenCoord
       const getScreenY = primaryIsBottom ? getSecondaryScreenCoord : getPrimaryScreenCoord
       const getWidth = primaryIsBottom ? getBarValueDimension : getBarStaticDimension
       const getHeight = primaryIsBottom ? getBarStaticDimension : getBarValueDimension
-      
+
       const getLegendColor = dataConfig?.attributeID('legend')
         ? dataConfig?.getLegendColorForCase : undefined
 
@@ -205,11 +205,12 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
     return mstAutorun(() => {
       const primaryAttribute = dataset?.attrFromID(primaryAttrID)
       const primaryAxis = graphModel.getNumericAxis(primaryIsBottom ? "bottom" : "left")
+      const numValues = graphModel.dataConfiguration.numericValuesForAttrRole(primaryIsBottom ? "x" : "y")
       if (primaryAttribute && primaryAxis) {
-        setNiceDomain(primaryAttribute.numValues, primaryAxis, pointDisplayType)
+        setNiceDomain(numValues, primaryAxis, graphModel.axisDomainOptions)
       }
     }, {name: "respondToGraphPointDisplayType"}, graphModel)
-  }, [dataset, graphModel, pointDisplayType, primaryAttrID, primaryIsBottom])
+  }, [dataset, graphModel, primaryAttrID, primaryIsBottom])
 
   return (
     <></>

--- a/v3/src/components/graph/components/freedotplotdots.tsx
+++ b/v3/src/components/graph/components/freedotplotdots.tsx
@@ -66,8 +66,7 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
         secondaryBandwidth = fullSecondaryBandwidth / numExtraSecondaryBands,
         extraSecondaryBandwidth = (extraSecondaryAxisScale.bandwidth?.() ?? secondaryAxisExtent),
         secondarySign = primaryIsBottom ? -1 : 1,
-        baseCoord = primaryIsBottom ? secondaryMax : 0,
-        { plotHeight } = layout
+        baseCoord = primaryIsBottom ? secondaryMax : 0
 
       const binPlacementProps = {
         dataConfig, dataset, extraPrimaryAttrID, extraSecondaryAttrID, layout, numExtraPrimaryBands,
@@ -114,14 +113,7 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
           numExtraPrimaryBands, primaryAttrID, primaryAxisScale
         }
         const { primaryCoord } = computePrimaryCoord(computePrimaryCoordProps)
-        // If primaryIsBottom, we simply return the primaryCoord as the width. We can't use the value returned
-        // by getPrimaryScreenCoord because it adds the extraPrimaryCoord value.
-        // If primaryIsBottom is false, we return the absolute value of the difference between the plotHeight divided
-        // by the number of extra primary bands and the primaryCoord -- primaryCoord is essentially the top of
-        // the bar, and we need to return the height from there to the bottom of the plot.
-        return primaryIsBottom
-          ? primaryCoord
-          : Math.abs(plotHeight / numExtraPrimaryBands - primaryCoord)
+        return Math.abs(primaryCoord - primaryAxisScale(0) / numExtraPrimaryBands)
       }
 
       const getBarPositionInSubPlot = (anID: string) => {
@@ -146,7 +138,11 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
           anID, dataConfig, dataset, extraPrimaryAttrID, extraPrimaryAxisScale, isBinned: false,
           numExtraPrimaryBands, primaryAttrID, primaryAxisScale
         }
-        const { primaryCoord, extraPrimaryCoord } = computePrimaryCoord(computePrimaryCoordProps)
+        let { primaryCoord, extraPrimaryCoord } = computePrimaryCoord(computePrimaryCoordProps)
+        if (pointDisplayType === "bars") {
+          const zeroCoord = primaryAxisScale(0) / numExtraPrimaryBands
+          primaryCoord = primaryIsBottom ? Math.max(primaryCoord, zeroCoord) : Math.min(primaryCoord, zeroCoord)
+        }
         return primaryCoord + extraPrimaryCoord
       }
     

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -151,7 +151,7 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
       graphModel.dataConfiguration.removeYAttributeWithID(idOfAttributeToRemove)
       const yAxisModel = graphModel.getAxis('left') as IAxisModel
       const yValues = graphModel.dataConfiguration.numericValuesForAttrRole('y') ?? []
-      setNiceDomain(yValues, yAxisModel, graphModel.pointDisplayType)
+      setNiceDomain(yValues, yAxisModel, graphModel.axisDomainOptions)
     } else {
       dataset && handleChangeAttribute(place, dataset, '')
     }

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -150,7 +150,8 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
     if (place === 'left' && (graphModel.dataConfiguration.yAttributeDescriptions.length ?? 0) > 1) {
       graphModel.dataConfiguration.removeYAttributeWithID(idOfAttributeToRemove)
       const yAxisModel = graphModel.getAxis('left') as IAxisModel
-      setNiceDomain((graphModel.dataConfiguration.numericValuesForAttrRole('y') ?? []), yAxisModel)
+      const yValues = graphModel.dataConfiguration.numericValuesForAttrRole('y') ?? []
+      setNiceDomain(yValues, yAxisModel, graphModel.pointDisplayType)
     } else {
       dataset && handleChangeAttribute(place, dataset, '')
     }

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -11,6 +11,10 @@ export interface InternalizedData {
   cases:string[]
 }
 
+export interface IDomainOptions {
+  clampPosMinAtZero?: boolean
+}
+
 export const PlotTypes = ["casePlot", "dotPlot", "dotChart", "scatterPlot"] as const
 export type PlotType = typeof PlotTypes[number]
 

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -19,11 +19,10 @@ import {defaultBackgroundColor} from "../../../utilities/color-utils"
 import {IGraphDataConfigurationModel} from "./graph-data-configuration-model"
 import {DataDisplayContentModel} from "../../data-display/models/data-display-content-model"
 import {GraphPlace} from "../../axis-graph-shared"
-import {axisPlaceToAttrRole, GraphAttrRole, PointDisplayType,
-        PointDisplayTypes} from "../../data-display/data-display-types"
+import {axisPlaceToAttrRole, GraphAttrRole, PointDisplayType} from "../../data-display/data-display-types"
 import {AxisPlace, AxisPlaces, ScaleNumericBaseType} from "../../axis/axis-types"
 import {kGraphTileType} from "../graph-defs"
-import {PlotType, PlotTypes} from "../graphing-types"
+import {IDomainOptions, PlotType, PlotTypes} from "../graphing-types"
 import {setNiceDomain} from "../utilities/graph-utils"
 import {GraphPointLayerModel, IGraphPointLayerModel, kGraphPointLayerType} from "./graph-point-layer-model"
 import {IAdornmentModel, IUpdateCategoriesOptions} from "../adornments/adornment-models"
@@ -61,7 +60,6 @@ export const GraphContentModel = DataDisplayContentModel
     adornmentsStore: types.optional(AdornmentsStore, () => AdornmentsStore.create()),
     // keys are AxisPlaces
     axes: types.map(AxisModelUnion),
-    pointDisplayType: types.optional(types.enumeration([...PointDisplayTypes]), "points"),
     // TODO: should the default plot be something like "nullPlot" (which doesn't exist yet)?
     plotType: types.optional(types.enumeration([...PlotTypes]), "casePlot"),
     plotBackgroundColor: defaultBackgroundColor,
@@ -117,6 +115,12 @@ export const GraphContentModel = DataDisplayContentModel
                                   dataset: IDataSet | undefined,
                                   attributeID: string | undefined): boolean {
       return self.dataConfiguration.placeCanAcceptAttributeIDDrop(place, dataset, attributeID)
+    },
+    get axisDomainOptions(): IDomainOptions {
+      return {
+        // When displaying bars, the domain should start at 0 unless there are negative values.
+        clampPosMinAtZero: self.pointDisplayType === "bars"
+      }
     },
     nonDraggableAxisTicks(): { tickValues: number[], tickLabels: string[] } {
       const tickValues: number[] = []
@@ -208,7 +212,7 @@ export const GraphContentModel = DataDisplayContentModel
             role = axisPlaceToAttrRole[axisPlace]
           if (isNumericAxisModel(axis)) {
             const numericValues = dataConfiguration.numericValuesForAttrRole(role)
-            setNiceDomain(numericValues, axis, self.pointDisplayType)
+            setNiceDomain(numericValues, axis, self.axisDomainOptions)
           }
         })
       }

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -208,7 +208,7 @@ export const GraphContentModel = DataDisplayContentModel
             role = axisPlaceToAttrRole[axisPlace]
           if (isNumericAxisModel(axis)) {
             const numericValues = dataConfiguration.numericValuesForAttrRole(role)
-            setNiceDomain(numericValues, axis)
+            setNiceDomain(numericValues, axis, self.pointDisplayType)
           }
         })
       }

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -126,7 +126,7 @@ export class GraphController {
     } else if (graphPlace === 'yPlus') {
       // The yPlus attribute utilizes the left numeric axis for plotting but doesn't change anything else
       const yAxisModel = graphModel.getAxis('left')
-      yAxisModel && setNiceDomain(dataConfig.numericValuesForYAxis, yAxisModel, graphModel.pointDisplayType)
+      yAxisModel && setNiceDomain(dataConfig.numericValuesForYAxis, yAxisModel, graphModel.axisDomainOptions)
       return
     }
 
@@ -166,9 +166,9 @@ export class GraphController {
             graphModel.setAxis(place, newAxisModel)
             dataConfig.setAttributeType(attrRole, 'numeric')
             layout.setAxisScaleType(place, 'linear')
-            setNiceDomain(attr?.numValues || [], newAxisModel, graphModel.pointDisplayType)
+            setNiceDomain(attr?.numValues || [], newAxisModel, graphModel.axisDomainOptions)
           } else {
-            setNiceDomain(attr?.numValues || [], currAxisModel, graphModel.pointDisplayType)
+            setNiceDomain(attr?.numValues || [], currAxisModel, graphModel.axisDomainOptions)
           }
         }
           break

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -126,7 +126,7 @@ export class GraphController {
     } else if (graphPlace === 'yPlus') {
       // The yPlus attribute utilizes the left numeric axis for plotting but doesn't change anything else
       const yAxisModel = graphModel.getAxis('left')
-      yAxisModel && setNiceDomain(dataConfig.numericValuesForYAxis, yAxisModel)
+      yAxisModel && setNiceDomain(dataConfig.numericValuesForYAxis, yAxisModel, graphModel.pointDisplayType)
       return
     }
 
@@ -166,9 +166,9 @@ export class GraphController {
             graphModel.setAxis(place, newAxisModel)
             dataConfig.setAttributeType(attrRole, 'numeric')
             layout.setAxisScaleType(place, 'linear')
-            setNiceDomain(attr?.numValues || [], newAxisModel)
+            setNiceDomain(attr?.numValues || [], newAxisModel, graphModel.pointDisplayType)
           } else {
-            setNiceDomain(attr?.numValues || [], currAxisModel)
+            setNiceDomain(attr?.numValues || [], currAxisModel, graphModel.pointDisplayType)
           }
         }
           break

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -11,6 +11,7 @@ import {defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeWidth,
   from "../../../utilities/color-utils"
 import {IDataConfigurationModel} from "../../data-display/models/data-configuration-model"
 import { isFiniteNumber } from "../../../utilities/math-utils"
+import { IDomainOptions } from "../graphing-types"
 import { IGraphDataConfigurationModel } from "../models/graph-data-configuration-model"
 import { GraphLayout } from "../models/graph-layout"
 import { t } from "../../../utilities/translation/translate"
@@ -73,15 +74,13 @@ export function computeNiceNumericBounds(min: number, max: number): { min: numbe
   return bounds
 }
 
-export function setNiceDomain(values: number[], axisModel: IAxisModel, pointDisplayType?: PointDisplayType) {
+export function setNiceDomain(values: number[], axisModel: IAxisModel, options?: IDomainOptions) {
   if (isNumericAxisModel(axisModel)) {
     const [minValue, maxValue] = extent(values, d => d) as [number, number]
     let {min: niceMin, max: niceMax} = computeNiceNumericBounds(minValue, maxValue)
-    if (pointDisplayType === "bars") {
-      // When displaying bars, the domain should start at 0 unless there are negative values.
-      if (minValue >= 0) {
-        niceMin = 0
-      }
+    // When clamping, the domain should start at 0 unless there are negative values.
+    if (options?.clampPosMinAtZero && minValue >= 0) {
+      niceMin = 0
     }
     axisModel.setDomain(niceMin, niceMax)
   }

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -73,10 +73,16 @@ export function computeNiceNumericBounds(min: number, max: number): { min: numbe
   return bounds
 }
 
-export function setNiceDomain(values: number[], axisModel: IAxisModel) {
+export function setNiceDomain(values: number[], axisModel: IAxisModel, pointDisplayType?: PointDisplayType) {
   if (isNumericAxisModel(axisModel)) {
     const [minValue, maxValue] = extent(values, d => d) as [number, number]
-    const {min: niceMin, max: niceMax} = computeNiceNumericBounds(minValue, maxValue)
+    let {min: niceMin, max: niceMax} = computeNiceNumericBounds(minValue, maxValue)
+    if (pointDisplayType === "bars") {
+      // When displaying bars, the domain should start at 0 unless there are negative values.
+      if (minValue >= 0) {
+        niceMin = 0
+      }
+    }
     axisModel.setDomain(niceMin, niceMax)
   }
 }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187142716

Removes the setting of domain to static values in `useSubAxis` when the point display type changes to bars, and changes `FreeDotPlotDots` so it updates the axis to use a domain appropriate to the dataset's value range and the point display type. Includes changes to the `setNiceDomain` function in graph-utils.ts so it computes correct values according to point display type, and makes some adjustments to the `FreeDotPlotDots` component's `computePrimaryCoord` and `getBarPositionInSubPlot` functions.