### PR TITLE
stage build 3.0.0-pre.1517

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Version 3.0.0-pre.1517 - March 7, 2024
+
+### Features/Improvements
+- PT-181961973: The map **Layers** inspector menu gives users control over map layers
+- PT-187005635: Users can specify that an attribute has a **color** data type
+- PT-187014891: Color values are displayed in case table and case card as color swatches
+- PT-187169360: Remove `sample`/dashboard` url parameters on open/close file
+- PT-187005724: A data value in various formats is automatically recognized as a color
+- PT-187014833: When an attribute is user-assigned the color type, all 140 web color names are recognized
+
+### Asset Sizes
+|      File |          Size | % Increase from Previous Release |
+|-----------|---------------|----------------------------------|
+|  main.css |  145250 bytes |                            0.86% |
+|  index.js | 5114230 bytes |                            0.29% |
+
 ## Version 3.0.0-pre.1516 - February 28, 2024
 
 ### Features/Improvements

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1516",
+  "version": "3.0.0-pre.1517",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-pre.1516",
+      "version": "3.0.0-pre.1517",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-pre.1516",
+  "version": "3.0.0-pre.1517",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browser": {

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -5,6 +5,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.0.0-pre.1517](https://codap3.concord.org/version/3.0.0-pre.1517/) | March 7, 2024 |
 | [3.0.0-pre.1516](https://codap3.concord.org/version/3.0.0-pre.1516/) | February 28, 2024 |
 | [3.0.0-pre.1515](https://codap3.concord.org/version/3.0.0-pre.1515/) | February 13, 2024 |
 | [3.0.0-pre.1502](https://codap3.concord.org/version/3.0.0-pre.1502/) | January 29, 2024 |


### PR DESCRIPTION
This staging build includes:

### Features/Improvements
- PT-181961973: The map **Layers** inspector menu gives users control over map layers
- PT-187005635: Users can specify that an attribute has a **color** data type
- PT-187014891: Color values are displayed in case table and case card as color swatches
- PT-187169360: Remove `sample`/`dashboard` url parameters on open/close file
- PT-187005724: A data value in various formats is automatically recognized as a color
- PT-187014833: When an attribute is user-assigned the color type, all 140 web color names are recognized