### PR TITLE
fix: graph handling of `color` attributes

### DIFF
--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -146,7 +146,9 @@ export class GraphController {
             : attributeType === 'numeric' ? graphAttributeRole
               : otherAttributeType !== 'empty' ? otherAttrRole : graphAttributeRole
         dataConfig.setPrimaryRole(primaryRole)
-        graphModel.setPlotType(plotChoices[primaryType][otherAttributeType])
+        // TODO COLOR: treat color like categorical for now
+        const _primaryType = primaryType === 'color' ? 'categorical' : primaryType
+        graphModel.setPlotType(plotChoices[_primaryType][otherAttributeType])
       }
     }
 
@@ -170,7 +172,8 @@ export class GraphController {
           }
         }
           break
-        case 'categorical': {
+        case 'categorical':
+        case 'color': { // TODO COLOR: treat color like categorical for now
           if (currentType !== 'categorical') {
             const newAxisModel = CategoricalAxisModel.create({place})
             graphModel.setAxis(place, newAxisModel)

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -189,10 +189,16 @@ export const Attribute = types.model("Attribute", {
     if (self.userType) return self.userType
     self.changeCount  // eslint-disable-line no-unused-expressions
     if (this.length === 0) return
+
     // only infer color if all non-empty values are strict colors
-    if (self.getStrictColorCount() === this.length - self.getEmptyCount()) return "color"
+    const colorCount = self.getStrictColorCount()
+    if (colorCount > 0 && colorCount === this.length - self.getEmptyCount()) return "color"
+
     // only infer numeric if all non-empty values are numeric (CODAP2)
-    return self.getNumericCount() === this.length - self.getEmptyCount() ? "numeric" : "categorical"
+    const numCount = self.getNumericCount()
+    if (numCount > 0 && numCount === this.length - self.getEmptyCount()) return "numeric"
+
+    return "categorical"
   },
   get format() {
     return self.precision != null ? `.${self.precision}~f` : kDefaultFormatStr


### PR DESCRIPTION
[[PT-187203297]](https://www.pivotaltracker.com/story/show/187203297)

- Attributes with only empty values are incorrectly interpreted as `color` attributes.
- Attributes with color type are not handled in graph.