### PR TITLE
fix: Edit Attribute Properties dialog [PT-187188045]

### DIFF
--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -49,20 +49,38 @@ context("case table ui", () => {
         description = "The average height of the mammal.",
         unit = "meters",
         newName = "Tallness (meters)",
-        type = null,
+        type = "color",
         precision = null,
-        editable = "False"
+        editable = "No"
 
       // Edit the attribute property
-      table.editAttributeProperty("Height", name, description, type, unit, precision, editable)
+      table.editAttributeProperties("Height", name, description, type, unit, precision, editable)
       // Verify the attribute has been edited
       table.getAttribute(name).should("have.text", newName)
+
+      // opening the dialog again should show the updated values
+      table.openAttributeMenu(name)
+      table.selectMenuItemFromAttributeMenu("Edit Attribute Properties...")
+      cy.get("[data-testid='attr-name-input']").should("have.value", name)
+      cy.get("[data-testid='attr-description-input']").should("have.text", description)
+      cy.get("[data-testid='attr-type-select']").should("have.value", type)
+      cy.get("[data-testid='attr-editable-radio'] input[value='no']").should("be.checked")
+      table.getCancelButton().click()
 
       // Perform Undo operation
       toolbar.getUndoTool().click()
 
       // Verify the undo reverts the edit to the original name "Height"
-      table.getAttribute("Height").should("not.have.text", newName)
+      table.getAttribute("Height").should("have.text", "Height")
+
+      // opening the dialog again should show the original values
+      table.openAttributeMenu("Height")
+      table.selectMenuItemFromAttributeMenu("Edit Attribute Properties...")
+      cy.get("[data-testid='attr-name-input']").should("have.value", "Height")
+      cy.get("[data-testid='attr-description-input']").should("have.text", "")
+      cy.get("[data-testid='attr-type-select']").should("have.value", "none")
+      cy.get("[data-testid='attr-editable-radio'] input[value='yes']").should("be.checked")
+      table.getCancelButton().click()
 
       // Perform Redo operation
       toolbar.getRedoTool().click()

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -31,7 +31,7 @@ export const TableTileElements = {
   //   return cy.get("[data-testid=case-table-attribute-tooltip]")
   // },
   getIndexRow(rowNum, collectionIndex = 1) {
-    return this.getCollection(collectionIndex).find(`[data-testid=collection-table-grid] 
+    return this.getCollection(collectionIndex).find(`[data-testid=collection-table-grid]
       [role=row][aria-rowindex="${rowNum}"]
       [data-testid=codap-index-content-button]`)
   },
@@ -110,7 +110,10 @@ export const TableTileElements = {
   getApplyButton() {
     return cy.get("[data-testid=Apply-button]")
   },
-  editAttributeProperty(attr, name, description, type, unit, precision, editable) {
+  getCancelButton() {
+    return cy.get("[data-testid=Cancel-button]")
+  },
+  editAttributeProperties(attr, name, description, type, unit, precision, editable) {
     this.openAttributeMenu(attr)
     this.selectMenuItemFromAttributeMenu("Edit Attribute Properties...")
     if (name !== "") {
@@ -132,7 +135,6 @@ export const TableTileElements = {
       this.selectAttributeEditableState(editable)
     }
     this.getApplyButton().click()
-
   },
   getCell(line, row, collectionIndex = 1) {
     return this.getCollection(collectionIndex).find(`[aria-rowindex="${row}"] [aria-colindex="${line}"] .cell-span`)

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -234,13 +234,13 @@ export const Attribute = types.model("Attribute", {
   setTitle(newTitle: string) {
     self.title = newTitle
   },
-  setUnits(units: string) {
+  setUnits(units?: string) {
     self.units = units
   },
-  setDescription(description: string) {
+  setDescription(description?: string) {
     self.description = description
   },
-  setUserType(type: AttributeType | undefined) {
+  setUserType(type?: AttributeType) {
     self.userType = type
   },
   // setUserFormat(precision: string) {
@@ -327,6 +327,7 @@ export const Attribute = types.model("Attribute", {
   }
 }))
 .actions(applyUndoableAction)
+
 export interface IAttribute extends Instance<typeof Attribute> {}
 export interface IAttributeSnapshot extends SnapshotIn<typeof Attribute> {}
 

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -876,17 +876,6 @@ export const DataSet = types.model("DataSet", {
         }
       },
 
-      applyAttributeProperties(attributeID: string, attrProps: IAttributeSnapshot) {
-        (attrProps.name != null) && this.setAttributeName(attributeID, attrProps.name)
-        const attribute = attributeID && self.attrIDMap.get(attributeID)
-        if (!attribute) return
-        ;(attrProps.description != null) && attribute.setDescription(attrProps.description)
-        ;(attrProps.userType != null) && attribute.setUserType(attrProps.userType)
-        ;(attrProps.units != null) && attribute.setUnits(attrProps.units)
-        ;(attrProps.precision != null) && attribute.setPrecision(attrProps.precision)
-        ;(attrProps.editable != null) && attribute.setEditable(attrProps.editable)
-      },
-
       removeAttribute(attributeID: string) {
         const attrIndex = self.attrIndexFromID(attributeID),
               attribute = attributeID ? self.attrIDMap.get(attributeID) : undefined

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -1,7 +1,5 @@
 {
     // CODAP V3 temporary strings (not for translation, at least not yet)
-    // code uses this dynamically, i.e. `DG.CaseTable.attribute.type.${type}`
-    "DG.CaseTable.attribute.type.color": "color",
     "V3.caseTable.noCases": "no cases",
     "V3.summary.parseResults": "Parsed \"%@1\" with %@2 %@3 (%@4 selected) and...",
     "V3.summary.noData": "No data",
@@ -9,6 +7,11 @@
     "V3.summary.attributeInspector": "Attribute Inspector",
     "V3.summary.startProfiling": "Start Profiling",
     "V3.summary.stopProfiling": "Stop Profiling",
+
+    // V3 general strings that are not present in V2 and will require translation
+    "V3.general.yes": "Yes",
+    "V3.general.no": "No",
+
     "V3.map.inspector.base": "Base",
     "V3.map.inspector.oceans": "Oceans",
     "V3.map.inspector.topo": "Topo",
@@ -20,6 +23,8 @@
     "V3.Undo.map.inspector.changeMapBaseLayer": "Undo changing base map",
     "V3.Redo.map.inspector.changeMapBaseLayer": "Redo changing base map",
 
+    // V3 case table strings that are not present in V2 and will eventually require translation.
+    "DG.CaseTable.attribute.type.color": "color", // used dynamically (`DG.CaseTable.attribute.type.${type}`)
     "V3.Undo.caseTable.create": "Undo adding case table",
     "V3.Redo.caseTable.create": "Redo adding case table",
     "V3.Undo.caseTable.delete": "Undo deleting case table",
@@ -706,7 +711,7 @@
     "DG.CaseTable.indexMenu.insertCases": "Insert Cases...",
     "DG.CaseTable.indexMenu.deleteCase": "Delete Case",
     "DG.CaseTable.indexMenu.deleteCases": "Delete Cases",
-    "DG.CaseTable.attribute.type.none": "",
+    "DG.CaseTable.attribute.type.none": "none",
     "DG.CaseTable.attribute.type.nominal": "categorical",
     "DG.CaseTable.attribute.type.categorical": "categorical",
     "DG.CaseTable.attribute.type.numeric": "numeric",


### PR DESCRIPTION
[[PT-187188045]](https://www.pivotaltracker.com/story/show/187188045)

The PT story is specifically about unselecting a user-selected attribute type, but it turned out there were several systemic problems in the dialog:
- clearing of property values generally didn't work (not just `color`)
- re-opening the dialog didn't refresh the dialog contents so that, for instance, if attribute properties were changed via undo/redo those changes weren't reflected in the dialog

In discussion with @bfinzer, some other changes were made to the v3 version of the dialog relative to v2:
- never store the `none` attribute type back to the model
- use "none" for the empty/unspecified attribute type label (rather than the empty string, i.e. nothing) 
- use "Yes"/"No" for radio button labels for editability rather than "True"/"False"
- add "Yes"/"No" to the list of translatable strings ("True"/"False" is hard-coded in v2 and neither that nor "Yes"/"No" were previously available as translatable strings).