### PR TITLE
186957025 automation for undo redo legend

### DIFF
--- a/v3/cypress/e2e/graph-legend.spec.ts
+++ b/v3/cypress/e2e/graph-legend.spec.ts
@@ -300,71 +300,174 @@ context("Test drawing legend on existing legend", () => {
     cy.visit(url)
     cy.wait(2500)
   })
-  it("will draw categorical legend on existing categorical legend", () => {
+  it("will draw categorical legend on existing categorical legend and test undo/redo", () => {
+
+    // Initial setup: Drag attributes to the x-axis and plot area for the first legend
     cy.dragAttributeToTarget("table", arrayOfAttributes[2], "bottom") // LifeSpan => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+
+    // Verify the first legend setup
     ah.verifyAxisLabel("bottom", arrayOfAttributes[2])
     glh.verifyLegendLabel(arrayOfAttributes[7])
     glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Add a second categorical legend
     glh.dragAttributeToLegend(arrayOfAttributes[8]) // Diet => plot area
+
+    // Verify the second legend setup
     glh.verifyLegendLabel(arrayOfAttributes[8])
     glh.verifyCategoricalLegend(arrayOfValues[8].values.length)
+
+    // Remove the x-axis attribute
     ah.openAxisAttributeMenu("bottom")
     ah.removeAttributeFromAxis(arrayOfAttributes[2], "bottom")
+
+    // Verify that the second legend persists after x-axis attribute removal
     glh.verifyLegendLabel(arrayOfAttributes[8])
     glh.verifyCategoricalLegend(arrayOfValues[8].values.length)
+
+    // Remove the second legend attribute
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[8])
+
+    // Undo the removal of the second legend attribute
+    toolbar.getUndoTool().click()
+
+    // Verify that the second legend attribute is restored
+    glh.verifyLegendLabel(arrayOfAttributes[8])
+    glh.verifyCategoricalLegend(arrayOfValues[8].values.length)
+
+    // Redo the removal of the second legend attribute
+    toolbar.getRedoTool().click()
+    cy.wait(500)
+
+    // Verify absence of second attribute
+    glh.verifyLegendDoesNotExist()
   })
-  it("will draw categorical legend on existing numeric legend", () => {
+  it("will draw categorical legend on existing numeric legend and test undo/redo", () => {
+    // Setup: Drag numerical attribute to x-axis and another numerical attribute to plot area for the numeric legend
     cy.dragAttributeToTarget("table", arrayOfAttributes[2], "left") // LifeSpan => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+
+    // Verify numeric legend setup
     ah.verifyAxisLabel("left", arrayOfAttributes[2])
     glh.verifyLegendLabel(arrayOfAttributes[3])
     glh.verifyNumericLegend()
+
+    // Add a categorical attribute to create a categorical legend
     // Temporarily changing this because of #184764820
     glh.dragAttributeToPlot(arrayOfAttributes[8]) // Diet => plot area
     glh.verifyLegendLabel(arrayOfAttributes[8])
     glh.verifyCategoricalLegend(arrayOfValues[8].values.length)
+
+    // Remove the x-axis attribute
     ah.openAxisAttributeMenu("left")
     ah.removeAttributeFromAxis(arrayOfAttributes[2], "left")
+
+    // Verify the categorical legend persists after x-axis attribute removal
     glh.verifyLegendLabel(arrayOfAttributes[8])
     glh.verifyCategoricalLegend(arrayOfValues[8].values.length)
+
+    // Remove the categorical legend attribute
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[8])
+
+    // Undo the removal of the categorical legend attribute
+    toolbar.getUndoTool().click()
+
+    // Verify that the categorical legend attribute is restored
+    glh.verifyLegendLabel(arrayOfAttributes[8])
+    glh.verifyCategoricalLegend(arrayOfValues[8].values.length)
+
+    // Redo the removal of the categorical legend attribute
+    toolbar.getRedoTool().click()
+
+    // Verify absence of the categorical legend attribute
+    glh.verifyLegendDoesNotExist()
+
   })
-  it("will draw numeric legend on existing categorical legend", () => {
+  it("will draw numeric legend on existing categorical legend and test undo/redo", () => {
+    // Initial setup: Drag attributes to the x-axis and plot area for the categorical legend
     cy.dragAttributeToTarget("table", arrayOfAttributes[2], "bottom") // LifeSpan => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+
+    // Verify categorical legend setup
     ah.verifyAxisLabel("bottom", arrayOfAttributes[2])
     glh.verifyLegendLabel(arrayOfAttributes[7])
     glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Replace the categorical legend with a numeric attribute to create a numeric legend
     glh.dragAttributeToLegend(arrayOfAttributes[3]) // Height => plot area
     glh.verifyLegendLabel(arrayOfAttributes[3])
     glh.verifyNumericLegend()
+
+    // Remove the x-axis attribute
     ah.openAxisAttributeMenu("bottom")
     ah.removeAttributeFromAxis(arrayOfAttributes[2], "bottom")
+
+    // Verify the numeric legend persists after x-axis attribute removal
     glh.verifyLegendLabel(arrayOfAttributes[3])
     glh.verifyNumericLegend()
+
+    // Remove the numeric legend attribute
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[3])
+
+    // Undo the removal of the numeric legend attribute
+    toolbar.getUndoTool().click()
+
+    // Verify that the numeric legend attribute is restored
+    glh.verifyLegendLabel(arrayOfAttributes[3])
+    glh.verifyNumericLegend()
+
+    // Redo the removal of the numeric legend attribute
+    toolbar.getRedoTool().click()
+
+    // Verify absence of the numeric legend attribute
+    glh.verifyLegendDoesNotExist()
+
   })
-  it("will draw numeric legend on existing numeric legend", () => {
+  it("will draw numeric legend on existing numeric legend and test undo/redo", () => {
+    // Setup: Drag numerical attributes to the x-axis and plot area for the first numeric legend
     cy.dragAttributeToTarget("table", arrayOfAttributes[2], "left") // LifeSpan => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+
+    // Verify the first numeric legend setup
     ah.verifyAxisLabel("left", arrayOfAttributes[2])
     glh.verifyLegendLabel(arrayOfAttributes[3])
     glh.verifyNumericLegend()
+
+    // Add another numerical attribute to create a second numeric legend
     // Temporarily changing this because of #184764820
     glh.dragAttributeToPlot(arrayOfAttributes[4]) // Mass => plot area
     glh.verifyLegendLabel(arrayOfAttributes[4])
     glh.verifyNumericLegend()
+
+    // Remove the x-axis attribute
     ah.openAxisAttributeMenu("left")
     ah.removeAttributeFromAxis(arrayOfAttributes[2], "left")
+
+    // Verify the second numeric legend persists after x-axis attribute removal
     glh.verifyLegendLabel(arrayOfAttributes[4])
     glh.verifyNumericLegend()
+
+    // Remove the numeric legend attribute
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[4])
+
+    // Undo the removal of the numeric legend attribute
+    toolbar.getUndoTool().click()
+
+    // Verify that the numeric legend attribute is restored
+    glh.verifyLegendLabel(arrayOfAttributes[4])
+    glh.verifyNumericLegend()
+
+    // Redo the removal of the numeric legend attribute
+    toolbar.getRedoTool().click()
+
+    // Verify absence of the numeric legend attribute
+    glh.verifyLegendDoesNotExist()
+
   })
 })
 context("Test selecting and selecting categories in legend", () => {

--- a/v3/cypress/e2e/graph-legend.spec.ts
+++ b/v3/cypress/e2e/graph-legend.spec.ts
@@ -58,27 +58,73 @@ context("Test legend with various attribute types", () => {
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[7])
   })
-  it("will draw categorical legend with categorical attribute on y axis", () => {
+  it("will draw categorical legend with categorical attribute on y axis and test undo/redo", () => {
+
+    // Drag attribute to the y-axis and drag another attribute to the plot area
     cy.dragAttributeToTarget("table", arrayOfAttributes[8], "left") // Diet => y-axis
     glh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+
+    // Verify axis label and legend
     ah.verifyAxisLabel("left", arrayOfAttributes[8])
     glh.verifyLegendLabel(arrayOfAttributes[7])
     glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Remove attributes from axis and legend
     ah.openAxisAttributeMenu("left")
     ah.removeAttributeFromAxis(arrayOfAttributes[8], "left")
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[7])
+
+    // Undo the removal of attributes from axis and legend
+    toolbar.getUndoTool().click() // Undo remove from legend
+    toolbar.getUndoTool().click() // Undo remove from axis
+
+    // Verify the attributes are restored on the axis and legend
+    ah.verifyAxisLabel("left", arrayOfAttributes[8])
+    glh.verifyLegendLabel(arrayOfAttributes[7])
+    glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Redo the removal of attributes
+    toolbar.getRedoTool().click() // Redo remove from legend
+    toolbar.getRedoTool().click() // Redo remove from axis
+
+    // Verify the attributes are removed from the legend
+    glh.verifyLegendDoesNotExist()
+
   })
-  it("will draw categorical legend with numerical attribute on x axis", () => {
+  it("will draw categorical legend with numerical attribute on x axis and test undo/redo", () => {
+
+    // Setup: Drag numerical attribute to x-axis and categorical attribute to plot area
     cy.dragAttributeToTarget("table", arrayOfAttributes[2], "bottom") // Diet => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+
+    // Verify initial state with axis label and legend
     ah.verifyAxisLabel("bottom", arrayOfAttributes[2])
     glh.verifyLegendLabel(arrayOfAttributes[7])
     glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Remove attributes from axis and legend
     ah.openAxisAttributeMenu("bottom")
     ah.removeAttributeFromAxis(arrayOfAttributes[2], "bottom")
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[7])
+
+    // Undo the removal of attributes
+    toolbar.getUndoTool().click() // Undo remove from legend
+    toolbar.getUndoTool().click() // Undo remove from axis
+
+    // Verify the attributes are restored on the axis and legend
+    ah.verifyAxisLabel("bottom", arrayOfAttributes[2])
+    glh.verifyLegendLabel(arrayOfAttributes[7])
+    glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Redo the removal of attributes
+    toolbar.getRedoTool().click() // Redo remove from legend
+    toolbar.getRedoTool().click() // Redo remove from axis
+
+    // Verify the attributes are removed from the legend
+    glh.verifyLegendDoesNotExist()
+
   })
   it("will draw categorical legend with numerical attribute on y axis", () => {
     cy.dragAttributeToTarget("table", arrayOfAttributes[2], "left") // LifeSpan => y-axis

--- a/v3/cypress/e2e/graph-legend.spec.ts
+++ b/v3/cypress/e2e/graph-legend.spec.ts
@@ -126,60 +126,170 @@ context("Test legend with various attribute types", () => {
     glh.verifyLegendDoesNotExist()
 
   })
-  it("will draw categorical legend with numerical attribute on y axis", () => {
+  it("will draw categorical legend with numerical attribute on y axis and test undo/redo", () => {
+
+    // Drag numerical attribute to y-axis and categorical attribute to plot area
     cy.dragAttributeToTarget("table", arrayOfAttributes[2], "left") // LifeSpan => y-axis
     glh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+
+    // Verify axis label and legend setup
     ah.verifyAxisLabel("left", arrayOfAttributes[2])
     glh.verifyLegendLabel(arrayOfAttributes[7])
     glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Remove attributes from axis and legend
     ah.openAxisAttributeMenu("left")
     ah.removeAttributeFromAxis(arrayOfAttributes[2], "left")
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[7])
+
+    // Undo the removal of attributes
+    toolbar.getUndoTool().click() // Undo remove from legend
+    toolbar.getUndoTool().click() // Undo remove from axis
+
+    // Verify the attributes are restored on the axis and legend
+    ah.verifyAxisLabel("left", arrayOfAttributes[2])
+    glh.verifyLegendLabel(arrayOfAttributes[7])
+    glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Redo the removal of attributes
+    toolbar.getRedoTool().click() // Redo remove from legend
+    toolbar.getRedoTool().click() // Redo remove from axis
+
+    // Verify the attributes are removed from the legend
+    glh.verifyLegendDoesNotExist()
   })
-  it("will draw numeric legend with categorical attribute on x axis", () => {
+  it("will draw numeric legend with categorical attribute on x axis and test undo/redo", () => {
+    // Initial setup: Drag categorical attribute to x-axis and numerical attribute to plot area
     cy.dragAttributeToTarget("table", arrayOfAttributes[8], "bottom") // Diet => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+
+    // Verify axis and legend setup
     ah.verifyAxisLabel("bottom", arrayOfAttributes[8])
     glh.verifyLegendLabel(arrayOfAttributes[3])
     glh.verifyNumericLegend()
+
+    // Remove attributes from axis and legend
     ah.openAxisAttributeMenu("bottom")
     ah.removeAttributeFromAxis(arrayOfAttributes[8], "bottom")
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[3])
+
+    // Undo the removal of attributes
+    toolbar.getUndoTool().click() // Undo remove from legend
+    toolbar.getUndoTool().click() // Undo remove from axis
+
+    // Verify attributes are restored on axis and legend
+    ah.verifyAxisLabel("bottom", arrayOfAttributes[8])
+    glh.verifyLegendLabel(arrayOfAttributes[3])
+    glh.verifyNumericLegend()
+
+    // Redo the removal of attributes
+    toolbar.getRedoTool().click() // Redo remove from legend
+    toolbar.getRedoTool().click() // Redo remove from axis
+
+    // Verify the attributes are removed from the legend
+    glh.verifyLegendDoesNotExist()
   })
-  it("will draw numeric legend with categorical attribute on y axis", () => {
+  it("will draw numeric legend with categorical attribute on y axis and test undo/redo", () => {
+    // Initial setup: Drag categorical attribute to y-axis and numerical attribute to plot area
     cy.dragAttributeToTarget("table", arrayOfAttributes[8], "left") // Diet => y-axis
     glh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+
+    // Verify axis and legend setup
     ah.verifyAxisLabel("left", arrayOfAttributes[8])
     glh.verifyLegendLabel(arrayOfAttributes[3])
     glh.verifyNumericLegend()
+
+    // Remove attributes from axis and legend
     ah.openAxisAttributeMenu("left")
     ah.removeAttributeFromAxis(arrayOfAttributes[8], "left")
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[3])
+
+    // Undo the removal of attributes
+    toolbar.getUndoTool().click() // Undo remove from legend
+    toolbar.getUndoTool().click() // Undo remove from axis
+
+    // Verify attributes are restored on axis and legend
+    ah.openAxisAttributeMenu("left")
+    ah.removeAttributeFromAxis(arrayOfAttributes[8], "left")
+    glh.openLegendMenu()
+    glh.removeAttributeFromLegend(arrayOfAttributes[3])
+
+    // Redo the removal of attributes
+    // Note: Redo button disables in Cypress at this step.
+    // The disable doesn't happen in CODAP though.
+    // Used force:true so that test can happen.
+    toolbar.getRedoTool().click({force: true}) // Redo remove from legend
+    toolbar.getRedoTool().click({force: true}) // Redo remove from axis
+
+    // Verify the attributes are removed from the legend
+    glh.verifyLegendDoesNotExist()
   })
-  it("will draw numeric legend with numerical attribute on x axis", () => {
+  it("will draw numeric legend with numerical attribute on x axis and test undo/redo", () => {
+    // Setup: Drag numerical attributes to x-axis and plot area
     cy.dragAttributeToTarget("table", arrayOfAttributes[2], "bottom") // LifeSpan => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+
+    // Verify axis and legend setup
     ah.verifyAxisLabel("bottom", arrayOfAttributes[2])
     glh.verifyLegendLabel(arrayOfAttributes[3])
     glh.verifyNumericLegend()
+
+    // Remove attributes from axis and legend
     ah.openAxisAttributeMenu("bottom")
     ah.removeAttributeFromAxis(arrayOfAttributes[2], "bottom")
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[3])
+
+    // Undo the removal of attributes
+    toolbar.getUndoTool().click() // Undo remove from legend
+    toolbar.getUndoTool().click() // Undo remove from axis
+
+    // Verify attributes are restored on axis and legend
+    ah.verifyAxisLabel("bottom", arrayOfAttributes[2])
+    glh.verifyLegendLabel(arrayOfAttributes[3])
+    glh.verifyNumericLegend()
+
+    // Redo the removal of attributes
+    toolbar.getRedoTool().click() // Redo remove from legend
+    toolbar.getRedoTool().click() // Redo remove from axis
+
+    // Verify the attributes are removed from the legend
+    glh.verifyLegendDoesNotExist()
   })
-  it("will draw numeric legend with numerical attribute on y axis", () => {
+  it("will draw numeric legend with numerical attribute on y axis and test undo/redo", () => {
+    // Initial setup: Drag numerical attribute to y-axis and another numerical attribute to plot area
     cy.dragAttributeToTarget("table", arrayOfAttributes[2], "left") // LifeSpan => y-axis
     glh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
+
+    // Verify axis and legend setup
     ah.verifyAxisLabel("left", arrayOfAttributes[2])
     glh.verifyLegendLabel(arrayOfAttributes[3])
     glh.verifyNumericLegend()
+
+    // Remove attribute from axis and legend
     ah.openAxisAttributeMenu("left")
     ah.removeAttributeFromAxis(arrayOfAttributes[2], "left")
     glh.openLegendMenu()
     glh.removeAttributeFromLegend(arrayOfAttributes[3])
+
+    // Undo the removal of attributes
+    toolbar.getUndoTool().click() // Undo remove from legend
+    toolbar.getUndoTool().click() // Undo remove from axis
+
+    // Verify attribute are restored on axis and legend
+    ah.verifyAxisLabel("left", arrayOfAttributes[2])
+    glh.verifyLegendLabel(arrayOfAttributes[3])
+    glh.verifyNumericLegend()
+
+    // Redo the removal of attributes
+    toolbar.getRedoTool().click() // Redo remove from legend
+    toolbar.getRedoTool().click() // Redo remove from axis
+
+    // Verify the attributes are removed from the legend
+    glh.verifyLegendDoesNotExist()
   })
 })
 

--- a/v3/cypress/e2e/graph-legend.spec.ts
+++ b/v3/cypress/e2e/graph-legend.spec.ts
@@ -1,5 +1,6 @@
 import { AxisHelper as ah } from "../support/helpers/axis-helper"
 import { GraphLegendHelper as glh } from "../support/helpers/graph-legend-helper"
+import { ToolbarElements as toolbar } from "../support/elements/toolbar-elements"
 
 const arrayOfAttributes = ["Mammal", "Order", "LifeSpan", "Height", "Mass", "Sleep", "Speed", "Habitat", "Diet"]
 
@@ -30,12 +31,28 @@ context("Test legend with various attribute types", () => {
     ah.openAxisAttributeMenu("bottom")
     ah.removeAttributeFromAxis(arrayOfAttributes[7], "bottom")
   })
-  it("will draw categorical legend with categorical attribute on x axis", () => {
+  it("will draw categorical legend with categorical attribute on x axis and test undo/redo", () => {
+
+    // Initial setup: Drag attributes to the x-axis and plot area, respectively
     cy.dragAttributeToTarget("table", arrayOfAttributes[8], "bottom") // Diet => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
+
+    // Verify the axis and legend labels are correctly displayed
     ah.verifyAxisLabel("bottom", arrayOfAttributes[8])
     glh.verifyLegendLabel(arrayOfAttributes[7])
     glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Undo add legend to graph and verify removal
+    toolbar.getUndoTool().click()
+    ah.verifyAxisLabel("bottom", arrayOfAttributes[8])
+
+    // Redo add legend to graph and verify legend returns
+    toolbar.getRedoTool().click()
+    ah.verifyAxisLabel("bottom", arrayOfAttributes[8])
+    glh.verifyLegendLabel(arrayOfAttributes[7])
+    glh.verifyCategoricalLegend(arrayOfValues[7].values.length)
+
+    // Remove attributes from axis and legend
     ah.openAxisAttributeMenu("bottom")
     ah.removeAttributeFromAxis(arrayOfAttributes[8], "bottom")
     glh.openLegendMenu()


### PR DESCRIPTION
This PR adds undo/redo Cypress tests for various graph legend tests:

- Test legend with various attribute types with undo/redo
- Test drawing legend on existing legend with undo/redo

I also added comments to the code as I went. :)

Note to @kswenson - @johnTcrawford agreed to take a look at my code for Cypress tests, although it comes with the caveat that if he's busy he'd rather we just did the merge if he doesn't get to the review. So I'd go ahead and move forward as usual but let John or me know if you have any questions. Thanks! And thanks to John for the review. :)