### PR TITLE
fix: graph import bug [PT-187250605]

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -94,9 +94,11 @@ export const useSubAxis = ({
             .style("stroke-opacity", "0.7")
         },
         renderNumericAxis = () => {
-          if (!axisModel) return
+          const numericScale = multiScale.scaleType === "linear"
+                                ? multiScale.numericScale as ScaleLinear<number, number>
+                                : undefined
+          if (!isNumericAxisModel(axisModel) || !numericScale) return
           select(subAxisElt).selectAll('*').remove()
-          const numericScale = d3Scale as unknown as ScaleLinear<number, number>
           const axisScale = axis(numericScale).tickSizeOuter(0).tickFormat(format('.9'))
           const duration = isAnimating() ? transitionDuration : 0
           if (!axisIsVertical && displayModel.hasDraggableNumericAxis(axisModel)) {

--- a/v3/src/models/formula/base-graph-formula-adapter.ts
+++ b/v3/src/models/formula/base-graph-formula-adapter.ts
@@ -1,4 +1,4 @@
-import { makeObservable, observable } from "mobx"
+import { action, makeObservable, observable } from "mobx"
 import { ICase } from "../data/data-set-types"
 import { IFormula } from "./formula"
 import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
@@ -48,10 +48,12 @@ export class BaseGraphFormulaAdapter implements IFormulaManagerAdapter {
     this.api = api
   }
 
+  @action
   addGraphContentModel(graphContentModel: IGraphContentModel) {
     this.graphContentModels.set(graphContentModel.id, graphContentModel)
   }
 
+  @action
   removeGraphContentModel(graphContentModelId: string) {
     this.graphContentModels.delete(graphContentModelId)
   }


### PR DESCRIPTION
[[PT-187250605]](https://www.pivotaltracker.com/story/show/187250605)

The bug occurred when the `useSubAxis` hook attempted to render an axis before it was fully initialized. In particular, the correct `NumericAxisModel` had been restored from the document but the `MultiScale`'s `scaleType` hadn't been set yet -- this occurs in `GraphController.initializeGraph`. The fix is simply to have `useSubAxis`'s `renderNumericAxis` function bail if the axis model and its scale aren't appropriate (yet).

I also fixed an unrelated MobX warning that appeared in loading the same document which simply required adding the `@action` decorator to a couple of MobX class methods that needed it.