### PR TITLE
chore: improve v2 attribute import and plugin typing

### DIFF
--- a/v3/doc/v2-document-format.md
+++ b/v3/doc/v2-document-format.md
@@ -1,0 +1,35 @@
+# Notes on the CODAP v2 Document Format
+
+## Introduction and Notes
+
+### Identifiers
+
+V2 uses a SproutCore inspired id-generation system in which ids are generated monotonically starting at 1 (1, 2, 3, ...). Each model object is assigned its `id` when it is registered with the `DG.Store`. The `DG.Store` maintains an internal `_idCount` property to track the next id to be generated and this value is written out to documents as the `idCount` property. When store objects are serialized, they general write out both an `id` property and a `guid` property with the same value in their `toArchive` methods. As of this writing the intended purpose of this redundant `guid` property is not clear. The plugin API allows matching by these ids, so they will need to be maintained in v3 for compatibility with existing plugins.
+
+This id-generation system works fine for generating ids that are unique within the document, but creates problems when document interchange is required. At some point, these limitations led to the introduction of a `cid` (collaboration id) property on some objects, notably attributes and "items", which are part of the representation of cases. (See the corresponding document on `hierarchical-data.md` for details on cases and items.) The `cid` property is a 16+ character id like those used in v3 by default.
+
+Q: Should v3 implement an incrementing id system like v2's in addition to its longer random ids for use by plugins or can we get away with just the longer unique ids?
+
+### Names and Titles
+
+In v2 several important classes, including `DG.DataContext`, `DG.Collection`, and `DG.Attribute` have both a `name` property and a `title` property. For these classes, the `title` property is implemented as a function which is backed by a local `_title` property such that setting the `title` property sets the underlying `_title` property, while getting the `title` retrieves the `_title` property (if it has been set) or the `name` property if it hasn't.
+
+The upshot of all of this is that the `name` and `title` properties are both potentially human-readable, but the `name` property is fixed for the life of the object while the `title` property is user-modifiable. This distinction is important to the plugin API where objects requested by name can match on the internal `name` of the object even after the `title` has been changed. Note that the API only seems to match on `name`, never on `title`. When looking up objects, the plugin API consistently checks `name` first and `id` second.
+
+For v3 we must decide whether to bring this same system forward and/or how to preserve the behavior of existing plugins with whatever system we implement in v3.
+
+## Components
+
+Components are stored in a top-level `components` array.
+
+## Data Contexts
+
+Data contexts are stored in a top-level `contexts` array.
+
+### Collections
+
+Collections are stored in a `collections` array within each `context`.
+
+### Attributes
+
+Attributes are stored in an `attrs` property within each `collection`.

--- a/v3/src/components/graph/v2-graph-importer.ts
+++ b/v3/src/components/graph/v2-graph-importer.ts
@@ -1,7 +1,7 @@
 import {ITileModelSnapshotIn} from "../../models/tiles/tile-model"
 import {typedId} from "../../utilities/js-utils"
 import {V2TileImportArgs} from "../../v2/codap-v2-tile-importers"
-import {ICodapV2GraphStorage, IGuidLink, isV2GraphComponent, v3TypeFromV2Type} from "../../v2/codap-v2-types"
+import {ICodapV2GraphStorage, IGuidLink, isV2GraphComponent, v3TypeFromV2TypeIndex} from "../../v2/codap-v2-types"
 import {GraphAttrRole, PrimaryAttrRole, axisPlaceToAttrRole} from "../data-display/data-display-types"
 import {kGraphIdPrefix, kGraphTileType} from "./graph-defs"
 import {PlotType} from "./graphing-types"
@@ -64,7 +64,7 @@ export function v2GraphImporter({v2Component, v2Document, sharedModelManager, in
           v2Role = v2Component.componentStorage[attrRoleKey],
           attrTypeKey = `${attrKey}AttributeType` as keyof ICodapV2GraphStorage,
           v2Type = v2Component.componentStorage[attrTypeKey],
-          v3Type = v3TypeFromV2Type[v2Type]
+          v3Type = v3TypeFromV2TypeIndex[v2Type]
         if (v3AttrRole && v3AttrId && v3Type) {
           const v2PrimaryNumeric = 1
           const v2PrimaryCategorical = 3

--- a/v3/src/components/map/v2-map-importer.ts
+++ b/v3/src/components/map/v2-map-importer.ts
@@ -1,7 +1,7 @@
 import {ITileModelSnapshotIn} from "../../models/tiles/tile-model"
 import {typedId} from "../../utilities/js-utils"
 import {V2TileImportArgs} from "../../v2/codap-v2-tile-importers"
-import {isV2MapComponent, v3TypeFromV2Type} from "../../v2/codap-v2-types"
+import {isV2MapComponent, v3TypeFromV2TypeIndex} from "../../v2/codap-v2-types"
 import {GraphAttrRole} from "../data-display/data-display-types"
 import {IAttributeDescriptionSnapshot, kDataConfigurationType} from "../data-display/models/data-configuration-model"
 import {IMapModelContentSnapshot} from "./models/map-content-model"
@@ -40,7 +40,7 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
         legendRole
 */
       } = v2LayerModel,
-      v3LegendType = v3TypeFromV2Type[legendAttributeType]
+      v3LegendType = v3TypeFromV2TypeIndex[legendAttributeType]
 
     if (legendAttributeId) {
       _attributeDescriptions.legend = {

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -6,8 +6,27 @@ import { IGlobalValue } from "../models/global/global-value"
 import { ITileModel } from "../models/tiles/tile-model"
 import { ICollectionPropsModel } from "../models/data/collection"
 
+export type DIAttribute = Partial<ICodapV2Attribute>
+export interface DIAttributes {
+  attrs?: DIAttribute[]
+}
 export type DICase = unknown
 export type DIComponent  = unknown
+export interface DIInteractiveFrame {
+  dimensions?: {
+    height?: number
+    width?: number
+  }
+  externalUndoAvailable?: boolean
+  id?: number
+  name?: string
+  preventBringToFront?: boolean
+  preventDataContextReorg?: boolean
+  savedState?: unknown
+  standaloneUndoModeAvailable?: boolean
+  title?: string
+  version?: string
+}
 export type DIItem = unknown
 
 export interface DIResources {
@@ -31,37 +50,7 @@ export interface DIResources {
   itemSearch?: DIItem[]
 }
 
-export interface DISingleValues {
-  attrs?: ICodapV2Attribute[]
-  blockDisplayOfEmptyCategories?: boolean
-  _categoryMap?: unknown
-  cid?: string
-  defaultMax?: number
-  defaultMin?: number
-  deleteable?: boolean
-  deletedFormula?: string
-  description?: string
-  dimensions?: {
-    height?: number
-    width?: number
-  }
-  editable?: boolean
-  externalUndoAvailable?: boolean
-  formula?: string
-  guid?: number
-  hidden?: boolean
-  id?: number
-  name?: string
-  precision?: number
-  preventBringToFront?: boolean
-  preventDataContextReorg?: boolean
-  renameable?: boolean
-  standaloneUndoModeAvailable?: boolean
-  title?: string
-  type?: string
-  unit?: string
-  version?: string
-}
+export type DISingleValues = DIAttribute | DIAttributes | DIInteractiveFrame
 
 export type DIValues = DISingleValues | DISingleValues[]
 
@@ -96,7 +85,7 @@ interface DIBaseHandler {
   notify?: DIHandlerFn
 }
 
-export type ActionName = "get" | "create" | "update" | "delete" | "notify" | "register" | "unregister"
+export type ActionName = keyof DIBaseHandler | "register" | "unregister"
 export type DIHandler = RequireAtLeastOne<DIBaseHandler, "get" | "create" | "update" | "delete" | "notify">
 
 export interface DIResourceSelector {

--- a/v3/src/data-interactive/handlers/attribute-handler.test.ts
+++ b/v3/src/data-interactive/handlers/attribute-handler.test.ts
@@ -1,6 +1,6 @@
 import { Attribute } from "../../models/data/attribute"
 import { diAttributeHandler } from "./attribute-handler"
-import { DISingleValues } from "../data-interactive-types"
+import { DIAttributes } from "../data-interactive-types"
 import { DataSet } from "../../models/data/data-set"
 
 describe("DataInteractive AttributeHandler", () => {
@@ -28,7 +28,7 @@ describe("DataInteractive AttributeHandler", () => {
     const name3 = "test3"
     const results = handler.create?.(resources, [{ name: name2 }, { name: name3 }])
     expect(results?.success).toEqual(true)
-    expect((results?.values as DISingleValues)?.attrs?.length).toBe(2)
+    expect((results?.values as DIAttributes)?.attrs?.length).toBe(2)
     expect(dataContext.attributes.length).toBe(3)
     expect(dataContext.attributes[1].name).toBe(name2)
     expect(dataContext.attributes[2].name).toBe(name3)
@@ -46,7 +46,7 @@ describe("DataInteractive AttributeHandler", () => {
     const result = handler.update?.({ attribute },
       { name, title, description, unit, formula, editable, type, precision })
     expect(result?.success).toBe(true)
-    const values = result?.values as DISingleValues
+    const values = result?.values as DIAttributes
     const resultAttr = values.attrs?.[0]
     expect(resultAttr?.name).toBe(name)
     expect(resultAttr?.title).toBe(title)
@@ -58,7 +58,7 @@ describe("DataInteractive AttributeHandler", () => {
     expect(resultAttr?.precision).toBe(precision)
 
     const result2 = handler.update?.({ attribute }, { type: "fake type" })
-    const values2 = result2?.values as DISingleValues
+    const values2 = result2?.values as DIAttributes
     const resultAttr2 = values2.attrs?.[0]
     expect(resultAttr2?.type).toBe(type)
   })

--- a/v3/src/data-interactive/handlers/interactive-frame-handler.ts
+++ b/v3/src/data-interactive/handlers/interactive-frame-handler.ts
@@ -2,7 +2,7 @@ import { isWebViewModel } from "../../components/web-view/web-view-model"
 import { withoutUndo } from "../../models/history/without-undo"
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIHandler, DIResources, diNotImplementedYet, DIValues } from "../data-interactive-types"
+import { DIHandler, DIResources, diNotImplementedYet, DIValues, DIInteractiveFrame } from "../data-interactive-types"
 
 const noIFResult = {success: false, values: {error: t("V3.DI.Error.interactiveFrameNotFound")}} as const
 
@@ -12,34 +12,33 @@ export const diInteractiveFrameHandler: DIHandler = {
     const { interactiveFrame } = resources
     if (interactiveFrame) {
       const webViewContent = isWebViewModel(interactiveFrame.content) ? interactiveFrame.content : undefined
-      return {
-        success: true,
-        values: {
-          dimensions: {
-            width: 600,
-            height: 500
-          },
-          externalUndoAvailable: true,
-          name: interactiveFrame.title,
-          preventBringToFront: false,
-          preventDataContextReorg: false,
-          savedState: webViewContent?.state,
-          standaloneUndoModeAvailable: false,
-          title: interactiveFrame.title,
-          version: "0.1",
-        }
+      const values: DIInteractiveFrame = {
+        dimensions: {
+          width: 600,
+          height: 500
+        },
+        externalUndoAvailable: true,
+        name: interactiveFrame.title,
+        preventBringToFront: false,
+        preventDataContextReorg: false,
+        savedState: webViewContent?.state,
+        standaloneUndoModeAvailable: false,
+        title: interactiveFrame.title,
+        version: "0.1",
       }
+      return { success: true, values }
     }
     return noIFResult
   },
   create: diNotImplementedYet,
-  update(resources: DIResources, values?: DIValues) {
+  update(resources: DIResources, _values?: DIValues) {
     // TODO: Expand to handle additional values
     const { interactiveFrame } = resources
     if (!interactiveFrame) return noIFResult
     // CODAP v2 seems to ignore interactiveFrame updates when an array is passed for values
-    if (Array.isArray(values)) return { success: true }
+    if (Array.isArray(_values)) return { success: true }
 
+    const values = _values as DIInteractiveFrame
     interactiveFrame.applyUndoableAction(() => {
       withoutUndo()
       if (values?.title) interactiveFrame.setTitle(values.title)

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -49,7 +49,7 @@ export const attributeTypes = [
   "categorical", "numeric", "date", "qualitative", "boundary", "checkbox", "color"
 ] as const
 export type AttributeType = typeof attributeTypes[number]
-export function isAttributeType(type?: string): type is AttributeType {
+export function isAttributeType(type?: string | null): type is AttributeType {
   return type != null && (attributeTypes as readonly string[]).includes(type)
 }
 

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -9,24 +9,36 @@ export interface ICodapV2Attribute {
   cid?: string
   defaultMin?: number
   defaultMax?: number
-  description?: string
+  description?: string | null
   categoryMap?: any
   _categoryMap?: any
   colormap?: any
   _colormap?: any
   blockDisplayOfEmptyCategories?: boolean
   editable: boolean
-  hidden?: boolean
+  hidden: boolean
   renameable?: boolean
   deleteable?: boolean
   formula?: string
   deletedFormula?: string
-  precision?: number
+  precision?: number | null
   unit?: string | null
 }
 
 export function isCodapV2Attribute(o: any): o is ICodapV2Attribute {
   return o.type === "DG.Attribute"
+}
+
+export const v3TypeFromV2TypeIndex: Array<AttributeType | undefined> = [
+  // indices are numeric values of v2 types
+  undefined, "numeric", "categorical", "date", "boundary", "color"
+  // v2 type eNone === 0 which v3 codes as undefined
+]
+
+export function v3TypeFromV2TypeString(v2Type?: string | null): AttributeType | undefined {
+  if (v2Type == null || v2Type === "none") return undefined
+  if (v2Type === "nominal") return "categorical"
+  return v2Type as AttributeType
 }
 
 export interface ICodapV2Case {
@@ -378,12 +390,6 @@ export interface ICodapV2BaseComponent {
   }
   savedHeight: number | null
 }
-
-export const v3TypeFromV2Type: Array<AttributeType | undefined> = [
-  // indices are numeric values of v2 types
-  undefined, "numeric", "categorical", "date", "boundary", "color"
-  // v2 type eNone === 0 which v3 codes as undefined
-]
 
 export interface ICodapV2CalculatorComponent extends ICodapV2BaseComponent {
   type: "DG.Calculator"


### PR DESCRIPTION
[[PT-187277525]](https://www.pivotaltracker.com/story/show/187277525)

- Improves import of v2 attributes
- Improves the TypeScript types for: `ICodapV2Attribute`, `DISingleValues`
- Adds new TypeScript types: `DIAttribute`, `DIAttributes`, `DIInteractiveFrame`
- Adds a document that starts the documentation for the v2 document format
