### PR TITLE
Restore graph ability to have multiple y attributes

### DIFF
--- a/v3/src/components/data-display/models/display-item-description-model.ts
+++ b/v3/src/components/data-display/models/display-item-description-model.ts
@@ -36,19 +36,22 @@ export const DisplayItemDescriptionModel = types
     get itemStrokeSameAsFill() {
       return self._itemStrokeSameAsFill
     },
+  }))
+  .views(self => ({
     // Convenience methods referring to points, especially for use by graphs
     pointColorAtIndex(plotIndex = 0) {
-      return this.itemColorAtIndex(plotIndex)
+      return self.itemColorAtIndex(plotIndex)
     },
     get pointColor() {
-      return this.itemColor
+      return self.itemColor
     },
     get pointStrokeColor() {
-      return this.itemStrokeColor
+      return self.itemStrokeColor
     },
     get pointStrokeSameAsFill() {
-      return this.itemStrokeSameAsFill
+      return self.itemStrokeSameAsFill
     }
+
   }))
   // performs the specified action so that response actions are included and undo/redo strings assigned
   .actions(applyUndoableAction)

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -364,8 +364,8 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
       const y = yScaleRef.current &&
         getScreenCoord(dataset, caseId, secondaryAttrIDsRef.current[aCaseData.plotNum], yScaleRef.current)
       if (x != null && isFinite(x) && y != null && isFinite(y)) {
-        const point = pixiPoints.getPointByCaseId(aCaseData)
-        pixiPoints.setPointPosition(point, x, y)
+        const point = pixiPoints.getPointForCaseData(aCaseData)
+        point && pixiPoints.setPointPosition(point, x, y)
       }
     }
     if (selectedOnly) {

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -364,7 +364,7 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
       const y = yScaleRef.current &&
         getScreenCoord(dataset, caseId, secondaryAttrIDsRef.current[aCaseData.plotNum], yScaleRef.current)
       if (x != null && isFinite(x) && y != null && isFinite(y)) {
-        const point = pixiPoints.getPointByCaseId(caseId)
+        const point = pixiPoints.getPointByCaseId(aCaseData)
         pixiPoints.setPointPosition(point, x, y)
       }
     }

--- a/v3/src/components/graph/utilities/pixi-points.ts
+++ b/v3/src/components/graph/utilities/pixi-points.ts
@@ -28,9 +28,7 @@ export type IPixiPointsRef = React.MutableRefObject<PixiPoints | undefined>
 
 export type PixiPointEventHandler = (event: PointerEvent, point: PIXI.Sprite, metadata: IPixiPointMetadata) => void
 
-export interface IPixiPointMetadata {
-  caseID: string
-  plotNum: number
+export interface IPixiPointMetadata extends CaseData {
   style: IPixiPointStyle
 }
 
@@ -672,7 +670,7 @@ export class PixiPoints {
       if (!currentCaseDataSet.has(caseDataKey(caseDataItem))) {
         const sprite = this.getNewSprite(texture)
         this.pointsContainer.addChild(sprite)
-        this.pointMetadata.set(sprite, { caseID: caseDataItem.caseID, plotNum: caseDataItem.plotNum, style })
+        this.pointMetadata.set(sprite, { ...caseDataItem, style })
         this.setPointForCaseData(caseDataItem, sprite)
       }
     }


### PR DESCRIPTION
[#187286536] Bug fix: Failure to plot multiple y-attributes

* `PixiPoints` was ignoring the `plotNum` property of `CaseData` and thereby regarding cases plotted in multiple plots as duplicates. We fix this by regarding `CaseData` rather than just `caseID` as the key to points in `PixiPoints`

**Note**: In `DisplayItemDescriptionModel` I encountered the need to move the convenience getters that refer to points rather than items into a new view section. Not sure why that need occurred now.