### PR TITLE
187308660 v3 Correct plugin urls

### DIFF
--- a/v3/src/components/tool-shelf/plugins-button.tsx
+++ b/v3/src/components/tool-shelf/plugins-button.tsx
@@ -37,6 +37,9 @@ function PluginSelection({ pluginData }: IPluginSelectionProps) {
     documentContent?.applyUndoableAction(
       () => {
         const baseUrl = `${rootPluginUrl}${pluginData.path}`
+        // Some plugins relied on index.html being the default file loaded when pointing to a directory.
+        // This is no longer the case with our S3 hosted plugins, so we have to modify the path to point to the
+        // correct file in this case.
         const url = baseUrl.endsWith("/") ? `${baseUrl}index.html` : baseUrl
         const options = { height: pluginData.height, width: pluginData.width }
         const tile = documentContent?.createOrShowTile?.(kWebViewTileType, options)

--- a/v3/src/components/tool-shelf/plugins-button.tsx
+++ b/v3/src/components/tool-shelf/plugins-button.tsx
@@ -36,7 +36,8 @@ function PluginSelection({ pluginData }: IPluginSelectionProps) {
   function handleClick() {
     documentContent?.applyUndoableAction(
       () => {
-        const url = `${rootPluginUrl}${pluginData.path}`
+        const baseUrl = `${rootPluginUrl}${pluginData.path}`
+        const url = baseUrl.endsWith("/") ? `${baseUrl}index.html` : baseUrl
         const options = { height: pluginData.height, width: pluginData.width }
         const tile = documentContent?.createOrShowTile?.(kWebViewTileType, options)
         if (tile) (tile.content as IWebViewModel).setUrl(url)

--- a/v3/src/components/web-view/use-data-interactive-controller.ts
+++ b/v3/src/components/web-view/use-data-interactive-controller.ts
@@ -31,7 +31,10 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
     if (iframeRef.current) {
       const originUrl = extractOrigin(url) ?? ""
       const phone = new iframePhone.ParentEndpoint(iframeRef.current, originUrl,
-        () => debugLog(DEBUG_PLUGINS, "connection with iframe established"))
+        () => {
+          webViewModel?.setIsPlugin(true)
+          debugLog(DEBUG_PLUGINS, "connection with iframe established")
+        })
       const handler: iframePhone.IframePhoneRpcEndpointHandlerFn =
         (request: DIRequest, callback: (returnValue: DIRequestResponse) => void) =>
       {

--- a/v3/src/components/web-view/web-view-model.ts
+++ b/v3/src/components/web-view/web-view-model.ts
@@ -18,8 +18,8 @@ export const WebViewModel = TileContentModel
     setDataInteractiveController(controller?: iframePhone.IframePhoneRpcEndpoint) {
       self.dataInteractiveController = controller
     },
-    setIsPlugin(_isPlugin: boolean) {
-      self.isPlugin = _isPlugin
+    setIsPlugin(isPlugin: boolean) {
+      self.isPlugin = isPlugin
     },
     setSavedState(state: unknown) {
       self.state = state

--- a/v3/src/components/web-view/web-view-model.ts
+++ b/v3/src/components/web-view/web-view-model.ts
@@ -11,11 +11,15 @@ export const WebViewModel = TileContentModel
     state: types.frozen<unknown>()
   })
   .volatile(self => ({
-    dataInteractiveController: undefined as iframePhone.IframePhoneRpcEndpoint | undefined
+    dataInteractiveController: undefined as iframePhone.IframePhoneRpcEndpoint | undefined,
+    isPlugin: false
   }))
   .actions(self => ({
     setDataInteractiveController(controller?: iframePhone.IframePhoneRpcEndpoint) {
       self.dataInteractiveController = controller
+    },
+    setIsPlugin(_isPlugin: boolean) {
+      self.isPlugin = _isPlugin
     },
     setSavedState(state: unknown) {
       self.state = state

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -17,10 +17,12 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
 
   return (
     <div className="codap-web-view-body" data-testid="codap-web-view">
-      <div className="codap-web-view-backdrop">
-        <div className="codap-web-view-url">{webViewModel.url}</div>
-        <div className="codap-web-view-message">{t("DG.GameView.loadError")}</div>
-      </div>
+      {!webViewModel.dataInteractiveController && (
+        <div className="codap-web-view-backdrop">
+          <div className="codap-web-view-url">{webViewModel.url}</div>
+          <div className="codap-web-view-message">{t("DG.GameView.loadError")}</div>
+        </div>
+      )}
       <div className="codap-web-view-iframe-wrapper">
         <iframe className="codap-web-view-iframe" ref={iframeRef} src={webViewModel.url} />
       </div>

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -17,7 +17,7 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
 
   return (
     <div className="codap-web-view-body" data-testid="codap-web-view">
-      {!webViewModel.dataInteractiveController && (
+      {!webViewModel.isPlugin && (
         <div className="codap-web-view-backdrop">
           <div className="codap-web-view-url">{webViewModel.url}</div>
           <div className="codap-web-view-message">{t("DG.GameView.loadError")}</div>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187308660

This PR appends `index.html` onto the paths to plugins that just direct CODAP to their source folder. It seems like several plugins were relying on the `index.html` being the default file loaded when visiting a directory, which is no longer the case on S3 (I guess?).

The majority of this PR actually hides the web view background, which shows through if the displayed web page/plugin has no background. Multiple plugins do not have a background and look bad with this message showing behind them.