### PR TITLE
fix: Graph axis not split when categorical attribute added (PT-187314590)

### DIFF
--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -151,6 +151,27 @@ context("Test graph axes with various attribute types", () => {
     ah.openAxisAttributeMenu("bottom")
     ah.removeAttributeFromAxis(arrayOfAttributes[3], "bottom")
   })
+  it("will split an axis into identical sub axes when categorical attribute is on opposite split", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[4], "bottom") // Mass => x-axis
+    cy.wait(500)
+    cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".sub-axis-wrapper").should("have.length", 1)
+    cy.dragAttributeToTarget("table", arrayOfAttributes[7], "top") // Habitat => top split
+    cy.wait(500)
+    cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".sub-axis-wrapper").should("have.length", 3)
+    cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".sub-axis-wrapper").each((wrapper) => {
+      cy.wrap(wrapper).find(".tick").should("have.length", 4)
+    })
+    cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".sub-axis-wrapper").each((wrapper) => {
+      cy.wrap(wrapper).find(".tick").each((tick, index) => {
+        const value = index * 2000
+        cy.wrap(tick).invoke("text").should("eq", value.toString())
+      })
+    })
+    ah.openAxisAttributeMenu("top")
+    ah.removeAttributeFromAxis(arrayOfAttributes[7], "top")
+    cy.wait(500)
+    cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".sub-axis-wrapper").should("have.length", 1)
+  })
   it("will adjust axis domain when points are changed to bars", () => {
     // When there are no negative numeric values, such as in the case of Height, the domain for the primary
     // axis of a univariate plot showing bars should start at zero.

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -73,8 +73,8 @@ export const useSubAxis = ({
         axis = axisPlaceToAxisFn(axisPlace),
         type = _axisModel?.type,
         axisBounds = layout.getComputedBounds(axisPlace) as AxisBounds,
-        d3Scale: AxisScaleType = multiScale.scale.copy()
-          .range(axisIsVertical ? [rangeMax, rangeMin] : [rangeMin, rangeMax]) as AxisScaleType,
+        newRange = axisIsVertical ? [rangeMax, rangeMin] : [rangeMin, rangeMax],
+        d3Scale: AxisScaleType = multiScale.scale.copy().range(newRange) as AxisScaleType,
         initialTransform = (axisPlace === 'left')
           ? `translate(${axisBounds.left + axisBounds.width}, ${axisBounds.top})`
           : (axisPlace === 'top')
@@ -95,8 +95,8 @@ export const useSubAxis = ({
         },
         renderNumericAxis = () => {
           const numericScale = multiScale.scaleType === "linear"
-                                ? multiScale.numericScale as ScaleLinear<number, number>
-                                : undefined
+                                 ? multiScale.numericScale?.range(newRange) as ScaleLinear<number, number>
+                                 : undefined
           if (!isNumericAxisModel(axisModel) || !numericScale) return
           select(subAxisElt).selectAll('*').remove()
           const axisScale = axis(numericScale).tickSizeOuter(0).tickFormat(format('.9'))
@@ -214,7 +214,7 @@ export const useSubAxis = ({
             )
         }
 
-      d3Scale.range(axisIsVertical ? [rangeMax, rangeMin] : [rangeMin, rangeMax])
+      d3Scale.range(newRange)
       switch (type) {
         case 'empty':
           renderEmptyAxis()

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -95,7 +95,7 @@ export const useSubAxis = ({
         },
         renderNumericAxis = () => {
           const numericScale = multiScale.scaleType === "linear"
-                                 ? multiScale.numericScale?.range(newRange) as ScaleLinear<number, number>
+                                 ? multiScale.numericScale?.copy().range(newRange) as ScaleLinear<number, number>
                                  : undefined
           if (!isNumericAxisModel(axisModel) || !numericScale) return
           select(subAxisElt).selectAll('*').remove()
@@ -214,7 +214,6 @@ export const useSubAxis = ({
             )
         }
 
-      d3Scale.range(newRange)
       switch (type) {
         case 'empty':
           renderEmptyAxis()


### PR DESCRIPTION
[[PT-187314590]](https://www.pivotaltracker.com/story/show/187314590)

When `renderNumericAxis` in `useSubAxis` is called, it needs to update the ~~axis'~~ axis copy's range. Otherwise the axis elements won't be sized appropriately when a categorical attribute is added to the opposite split.