### PR TITLE
187308847 Prevent webView iframes from displaying over other elements

### DIFF
--- a/v3/src/components/web-view/web-view.scss
+++ b/v3/src/components/web-view/web-view.scss
@@ -16,7 +16,6 @@
     position: absolute;
     transform: rotate(-30deg) translateY(35%);
     width: 100%;
-    z-index: 0;
 
     .codap-web-view-url {
       color: white;
@@ -35,7 +34,6 @@
     height: 100%;
     position: absolute;
     width: 100%;
-    z-index: 1;
 
     .codap-web-view-iframe {
       height: 100%;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187308847

This PR fixes a bug that caused webView iframes to display over most other CODAP elements, including other tiles and dropdown menus.

The fix is to remove `z-index` for the webView background and iframe. As far as I can tell, these weren't actually doing anything, and were most likely added in addition to other css that actually fixed a problem.