### PR TITLE
feat: compatibility with v2 name/title usage

### DIFF
--- a/v3/src/components/case-table/case-table-title-bar.tsx
+++ b/v3/src/components/case-table/case-table-title-bar.tsx
@@ -12,8 +12,8 @@ import "./case-table-title-bar.scss"
 
 export const CaseTableTitleBar = observer(function CaseTableTitleBar({tile, ...others}: ITileTitleBarProps) {
   const data = isCaseTableModel(tile?.content) ? tile?.content.data : undefined
-  const caseMetadata = isCaseTableModel(tile?.content) ? tile?.content.metadata  : undefined
-  const getTitle = () => caseMetadata?.title || tile?.title || data?.name
+  // case table title reflects DataSet title
+  const getTitle = () => data?.title ?? ""
   const [showSwitchMessage, setShowSwitchMessage] = useState(false)
   const [showCaseCard, setShowCaseCard] = useState(false)
   const cardTableToggleRef = useRef(null)
@@ -33,10 +33,10 @@ export const CaseTableTitleBar = observer(function CaseTableTitleBar({tile, ...o
     setShowCaseCard(!showCaseCard)
   }
 
-  const handleChangeTitle = (nextValue?: string) => {
-    if (nextValue) {
-      tile?.setTitle(nextValue)
-      caseMetadata?.setTitle(nextValue)
+  const handleChangeTitle = (newTitle?: string) => {
+    if (newTitle) {
+      // case table title reflects DataSet title
+      data?.setTitle(newTitle)
     }
   }
 

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -92,12 +92,8 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
     <>
       <MenuList>
         {datasets?.map((dataset, idx) => {
-          const model = datasets.find(m =>  m.id === dataset.id) as ISharedDataSet | undefined
-          const caseMetadata = caseMetadatas?.find(cm => cm.data?.id === model?.dataSet.id)
-          const tiles = manager?.getSharedModelTiles(model)
-          const tableTile = tiles?.find(tile => tile.content.type === kCaseTableTileType)
-          const tileTitle = caseMetadata?.title ? caseMetadata?.title
-                                                : tableTile?.title ? tableTile?.title : dataset.dataSet.name
+          // case table title reflects DataSet title
+          const tileTitle = dataset.dataSet.title
           return (
             <MenuItem key={`${dataset.dataSet.id}`} onClick={()=>handleOpenDataSetTable(dataset)}
               data-testid={`tool-shelf-table-${tileTitle}`}>

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -65,7 +65,9 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
     if (dataSet.attrFromID(attrId)) {
       dataSet.applyUndoableAction(() => {
         const collection = dataSet.moveAttributeToNewCollection(attrId, beforeCollectionId)
-        lastNewCollectionDrop.current = { newCollectionId: collection.id, beforeCollectionId }
+        if (collection) {
+          lastNewCollectionDrop.current = { newCollectionId: collection.id, beforeCollectionId }
+        }
       }, {
         undoStringKey: "DG.Undo.caseTable.createCollection",
         redoStringKey: "DG.Redo.caseTable.createCollection"

--- a/v3/src/components/case-table/collection-title.tsx
+++ b/v3/src/components/case-table/collection-title.tsx
@@ -5,11 +5,9 @@ import throttle from "lodash/throttle"
 import {useResizeDetector} from "react-resize-detector"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
-import pluralize from "pluralize"
 import { uniqueName } from "../../utilities/js-utils"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useCollectionContext } from "../../hooks/use-collection-context"
-import { getCollectionAttrs } from "../../models/data/data-set-utils"
 import { t } from "../../utilities/translation/translate"
 import AddIcon from "../../assets/icons/icon-add-circle.svg"
 import { useTileModelContext } from "../../hooks/use-tile-model-context"
@@ -19,13 +17,11 @@ export const CollectionTitle = observer(function CollectionTitle() {
   const collectionId = useCollectionContext()
   const collection = data?.getCollection(collectionId)
   const { isTileSelected } = useTileModelContext()
-  const { setTitle, displayTitle } = collection || {}
-  const defaultName = collection ? pluralize((getCollectionAttrs(collection, data)[0]?.name) ?? "") : ""
+  const { setTitle, title } = collection || {}
   const caseCount = data?.getCasesForCollection(collection?.id).length ?? 0
   const tileRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const titleRef = useRef<HTMLDivElement>(null)
-  const title = displayTitle || defaultName
   // used to trigger a render
   const [ , setTableScrollLeft] = useState(0)
   const { active } = useDndContext()
@@ -79,7 +75,7 @@ export const CollectionTitle = observer(function CollectionTitle() {
   }
 
   const handleAddNewAttribute = () => {
-    const newAttrName = uniqueName("newAttr",
+    const newAttrName = uniqueName(t("DG.CaseTable.defaultAttrName"),
       (aName: string) => !data?.attributes.find(attr => aName === attr.name)
      )
     data?.addAttribute({ name: newAttrName }, { collection: collectionId })

--- a/v3/src/components/case-table/collection-title.tsx
+++ b/v3/src/components/case-table/collection-title.tsx
@@ -16,8 +16,8 @@ export const CollectionTitle = observer(function CollectionTitle() {
   const data = useDataSetContext()
   const collectionId = useCollectionContext()
   const collection = data?.getCollection(collectionId)
+  const collectionName = collection?.name ?? ""
   const { isTileSelected } = useTileModelContext()
-  const { setTitle, title } = collection || {}
   const caseCount = data?.getCasesForCollection(collection?.id).length ?? 0
   const tileRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
@@ -68,9 +68,9 @@ export const CollectionTitle = observer(function CollectionTitle() {
     }
   }
 
-  const handleChangeTitle = (nextValue?: string) => {
-    if (nextValue) {
-      setTitle?.(nextValue)
+  const handleChangeName = (newName?: string) => {
+    if (newName) {
+      collection?.setName(newName)
     }
   }
 
@@ -87,11 +87,11 @@ export const CollectionTitle = observer(function CollectionTitle() {
   return (
     <div className="collection-title-wrapper" ref={titleRef}>
       <div className="collection-title" style={titleStyle}>
-        <Editable value={isEditing ? title : `${title} (${caseCount} ${casesStr})`}
+        <Editable value={isEditing ? collectionName : `${collectionName} (${caseCount} ${casesStr})`}
             onEdit={() => setIsEditing(true)} onSubmit={() => setIsEditing(false)} onCancel={() => setIsEditing(false)}
-            isPreviewFocusable={!dragging} submitOnBlur={true} onChange={handleChangeTitle}>
+            isPreviewFocusable={!dragging} submitOnBlur={true} onChange={handleChangeName}>
           <EditablePreview paddingY={0} />
-          <EditableInput value={title} paddingY={0} className="collection-title-input" />
+          <EditableInput value={collectionName} paddingY={0} className="collection-title-input" />
         </Editable>
       </div>
       <Button className="add-attribute-icon-button" title={t("DG.TableController.newAttributeTooltip")}

--- a/v3/src/components/case-table/column-header.tsx
+++ b/v3/src/components/case-table/column-header.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useRef, useState } from "react"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { IUseDraggableAttribute, useDraggableAttribute } from "../../hooks/use-drag-drop"
 import { useInstanceIdContext } from "../../hooks/use-instance-id-context"
-import { kDefaultAttributeName } from "../../models/data/attribute"
 import { uniqueName } from "../../utilities/js-utils"
 import { AttributeMenuList } from "./attribute-menu/attribute-menu-list"
 import { CaseTablePortal } from "./case-table-portal"
@@ -94,7 +93,7 @@ export function ColumnHeader({ column }: Pick<TRenderHeaderCellProps, "column">)
         isMenuOpen.current = isOpen
         onCloseRef.current = onClose
         return (
-          <Tooltip label={`${column.name} ${description}` || kDefaultAttributeName} h="20px" fontSize="12px"
+          <Tooltip label={`${column.name ?? ""} ${description}`} h="20px" fontSize="12px"
               color="white" openDelay={1000} placement="bottom" bottom="15px" left="15px"
               isDisabled={disableTooltip}
           >
@@ -111,7 +110,7 @@ export function ColumnHeader({ column }: Pick<TRenderHeaderCellProps, "column">)
                           fontWeight="bold" onKeyDown={handleButtonKeyDown}
                           data-testid={`codap-attribute-button ${column?.name}`}
                           aria-describedby={`sr-column-header-drag-instructions-${instanceId}`}>
-                        {column.name ? `${column?.name}${units}` : kDefaultAttributeName}
+                        {`${column?.name ?? ""}${units}`}
                       </MenuButton>
                       {column.key !== kIndexColumnKey &&
                         <VisuallyHidden id={`sr-column-header-drag-instructions-${instanceId}`}>

--- a/v3/src/components/tool-shelf/tool-shelf.test.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.test.tsx
@@ -9,6 +9,21 @@ import { IDocumentModel } from "../../models/document/document"
 const libDebug = require("../../lib/debug")
 
 describe("Tool shelf", () => {
+
+  beforeEach(() => {
+    const consoleWarn = console.warn
+    jest.spyOn(console, "warn").mockImplementation((...args: any[]) => {
+      // ignore the expected warning, but allow others
+      if (args[0] !== "Unable to load plugin data.") {
+        consoleWarn(...args)
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   const renderToolShelf = (doc?: IDocumentModel) => {
     const document = doc ?? createCodapDocument()
     render(<ToolShelf document={document}/>)

--- a/v3/src/data-interactive/handlers/attribute-handler.ts
+++ b/v3/src/data-interactive/handlers/attribute-handler.ts
@@ -1,7 +1,9 @@
 import { IAttribute, IAttributeSnapshot, isAttributeType } from "../../models/data/attribute"
 import { IDataSet } from "../../models/data/data-set"
+import { v2ModelSnapshotFromV2ModelStorage } from "../../models/data/v2-model"
 import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
 import { t } from "../../utilities/translation/translate"
+import { v3TypeFromV2TypeString } from "../../v2/codap-v2-types"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIAttribute, DIHandler, DIResources, DISingleValues, DIValues } from "../data-interactive-types"
 
@@ -41,12 +43,9 @@ function convertAttributeToV2FromResources(resources: DIResources) {
 function convertValuesToAttributeSnapshot(_values: DISingleValues): IAttributeSnapshot | undefined {
   const values = _values as DIAttribute
   if (values.name) {
-    const userType = isAttributeType(values.type) ? values.type : undefined
     return {
-      name: values.name,
-      userType,
-      title: values.title,
-      id: values.cid, // TODO Should we allow the values to specify an id at all?
+      ...v2ModelSnapshotFromV2ModelStorage(values),
+      userType: v3TypeFromV2TypeString(values.type),
       // defaultMin: values.defaultMin, // TODO defaultMin not a part of IAttribute yet
       // defaultMax: values.defaultMax, // TODO defaultMax not a part of IAttribute yet
       description: values.description ?? undefined,
@@ -56,10 +55,8 @@ function convertValuesToAttributeSnapshot(_values: DISingleValues): IAttributeSn
       // hidden is part of metadata, not the attribute model
       // renameable: values.renameable, // TODO renameable not part of IAttribute yet
       // deleteable: values.deleteable, // TODO deleteable not part of IAttribute yet
-      // formula is not part of the attribute model so it's handled separately
+      formula: values.formula ? { display: values.formula } : undefined,
       // deletedFormula: values.deletedFormula, // TODO deletedFormula not part of IAttribute. Should it be?
-      // guid is not in the attribute model
-      // id has no equivalent part of the attribute model
       precision: values.precision ?? undefined,
       units: values.unit ?? undefined
     }

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -1,10 +1,7 @@
 import { getSnapshot } from "mobx-state-tree"
 import { omitUndefined } from "../../test/test-utils"
-import { gDataBroker } from "../data/data-broker"
-import { DataSet, toCanonical } from "../data/data-set"
+import { toCanonical } from "../data/data-set"
 import { createCodapDocument } from "./create-codap-document"
-import { ISharedDataSet } from "../shared/shared-data-set"
-import { getSharedModelManager } from "../tiles/tile-environment"
 import "../shared/shared-case-metadata-registration"
 import "../shared/shared-data-set-registration"
 
@@ -48,20 +45,12 @@ describe("createCodapDocument", () => {
     })
   })
 
-  it("DataBroker adds a DataSet to the document as a shared model", () => {
+  it("createDataSet adds a DataSet to the document as a shared model", () => {
     const doc = createCodapDocument()
-    const manager = getSharedModelManager(doc)
-    const data = DataSet.create()
+    const { sharedDataSet, caseMetadata } = doc.content!.createDataSet()
+    const { dataSet: data } = sharedDataSet
     data.addAttribute({ name: "a" })
     data.addCases(toCanonical(data, [{ a: "1" }, { a: "2" }, { a: "3" }]))
-    gDataBroker.setSharedModelManager(manager!)
-    const { sharedData, caseMetadata } = gDataBroker.addDataSet(data)
-
-    const entry = doc.content?.sharedModelMap.get(sharedData.id)
-    const sharedModel = entry?.sharedModel as ISharedDataSet | undefined
-    // the DataSet is not copied -- it's a single instance
-    expect(data).toBe(gDataBroker.last)
-    expect(gDataBroker.last).toBe(sharedModel?.dataSet)
 
     // need to wrap the serialization in prepareSnapshot()/completeSnapshot() to get the data
     data.prepareSnapshot()
@@ -77,24 +66,24 @@ describe("createCodapDocument", () => {
           sharedModel: { id: "test-2", type: "GlobalValueManager", globals: {} },
           tiles: []
         },
-        [sharedData.id]: {
+        [sharedDataSet.id]: {
           sharedModel: {
             dataSet: {
+              name: "New Dataset",
               attributes: [{
                 clientKey: "",
-                id: "test-6",
+                id: "test-8",
                 name: "a",
-                title: "",
                 editable: true,
                 values: ["1", "2", "3"]
               }],
-              cases: [{ __id__: "CASEorder-7" }, { __id__: "CASEorder-8" }, { __id__: "CASEorder-9" }],
+              cases: [{ __id__: "CASEorder-9" }, { __id__: "CASEorder-10" }, { __id__: "CASEorder-11" }],
               collections: [],
-              ungrouped: { id: "test-5", name: "", title: "" },
-              id: "test-4",
+              ungrouped: { id: "test-6", name: "Cases" },
+              id: "test-5",
               snapSelection: []
             },
-            id: sharedData.id,
+            id: sharedDataSet.id,
             providerId: "",
             type: "SharedDataSet"
           },
@@ -105,7 +94,7 @@ describe("createCodapDocument", () => {
             categories: {},
             collections: {},
             columnWidths: {},
-            data: "test-4",
+            data: "test-5",
             hidden: {},
             id: caseMetadata.id,
             type: "SharedCaseMetadata"

--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -2,7 +2,7 @@ import { cloneDeep } from "lodash"
 import { reaction } from "mobx"
 import { getSnapshot } from "mobx-state-tree"
 import {
-  Attribute, IAttributeSnapshot, importValueToString, isFormulaAttr,
+  Attribute, IAttributeSnapshot, importValueToString, isAttributeType, isFormulaAttr,
   isValidFormulaAttr, kDefaultFormatStr
 } from "./attribute"
 
@@ -12,6 +12,25 @@ describe("Attribute", () => {
 
   afterEach(() => {
     process.env.NODE_ENV = origNodeEnv
+  })
+
+  test("isAttributeType", () => {
+    expect(isAttributeType()).toBe(false)
+    expect(isAttributeType("")).toBe(false)
+    expect(isAttributeType("foo")).toBe(false)
+    expect(isAttributeType("nominal")).toBe(false)
+    expect(isAttributeType("categorical")).toBe(true)
+    expect(isAttributeType("numeric")).toBe(true)
+    expect(isAttributeType("color")).toBe(true)
+  })
+
+  test("matchNameOrId", () => {
+    const a = Attribute.create({ v2Id: 1, id: "v3Id", name: "name", _title: "title" })
+    expect(a.matchNameOrId("")).toBe(false)
+    expect(a.matchNameOrId(1)).toBe(true)
+    expect(a.matchNameOrId("v3Id")).toBe(true)
+    expect(a.matchNameOrId("name")).toBe(true)
+    expect(a.matchNameOrId("title")).toBe(false)
   })
 
   test("Value conversions", () => {

--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -22,15 +22,15 @@ describe("CollectionModel", () => {
 
   it("Simple properties work as expected", () => {
     const withName = CollectionPropsModel.create({ name: "name" })
-    expect(withName.displayTitle).toBe("name")
-    withName.setName("newName")
-    expect(withName.displayTitle).toBe("newName")
+    expect(withName.title).toBe("name")
+    withName.setTitle("newName")
+    expect(withName.title).toBe("newName")
     expect(isCollectionModel(withName)).toBe(false)
 
-    const withNameAndTitle = CollectionPropsModel.create({ name: "name", title: "title" })
-    expect(withNameAndTitle.displayTitle).toBe("title")
+    const withNameAndTitle = CollectionPropsModel.create({ name: "name", _title: "title" })
+    expect(withNameAndTitle.title).toBe("title")
     withNameAndTitle.setTitle("newTitle")
-    expect(withNameAndTitle.displayTitle).toBe("newTitle")
+    expect(withNameAndTitle.title).toBe("newTitle")
     expect(isCollectionModel(withNameAndTitle)).toBe(false)
   })
 
@@ -47,6 +47,7 @@ describe("CollectionModel", () => {
     expect(collection.attributes.length).toBe(0)
     expect(collection.getAttribute("a")).toBeUndefined()
     expect(collection.getAttributeIndex("a")).toBe(-1)
+    expect(collection.getAttributeByName("a")).toBeUndefined()
     // removing a non-existent attribute is a no-op
     collection.removeAttribute("a")
     expect(collection.attributes.length).toBe(0)
@@ -70,12 +71,15 @@ describe("CollectionModel", () => {
     expect(isAlive(attrA)).toBe(true)
     expect(collection.attributes.length).toBe(1)
     expect(collection.getAttribute("a")).toBe(attrA)
+    expect(collection.getAttributeByName("a")).toBe(attrA)
     expect(collection.getAttributeIndex("a")).toBe(0)
 
     const attrB = Attribute.create({ id: "b", name: "b" })
     tree.addAttribute(attrB)
     collection.addAttribute(attrB, { before: "a" })
     expect(collection.attributes.length).toBe(2)
+    expect(collection.getAttributeByName("a")).toBe(attrA)
+    expect(collection.getAttributeByName("b")).toBe(attrB)
     expect(collection.getAttributeIndex("b")).toBe(0)
     expect(collection.getAttributeIndex("a")).toBe(1)
 

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -2,6 +2,7 @@ import { getType, IAnyStateTreeNode, Instance, SnapshotIn, types } from "mobx-st
 import { Attribute, IAttribute } from "./attribute"
 import { typedId } from "../../utilities/js-utils"
 import { IMoveAttributeOptions } from "./data-set-types"
+import { V2Model } from "./v2-model"
 
 export const CollectionLabels = types.model("CollectionLabels", {
   singleCase: "",
@@ -11,25 +12,10 @@ export const CollectionLabels = types.model("CollectionLabels", {
   setOfCasesWithArticle: ""
 })
 
-export const CollectionPropsModel = types.model("CollectionProps", {
+export const CollectionPropsModel = V2Model.named("CollectionProps").props({
   id: types.optional(types.identifier, () => typedId("COLL")),
-  name: "",
-  title: "",
   labels: types.maybe(CollectionLabels)
 })
-.views(self => ({
-  get displayTitle() {
-    return self.title || self.name
-  }
-}))
-.actions(self => ({
-  setName(name: string) {
-    self.name = name
-  },
-  setTitle(title: string) {
-    self.title = title
-  }
-}))
 export interface ICollectionPropsModel extends Instance<typeof CollectionPropsModel> {}
 
 export const CollectionModel = CollectionPropsModel

--- a/v3/src/models/data/v2-model.test.ts
+++ b/v3/src/models/data/v2-model.test.ts
@@ -1,0 +1,92 @@
+import { V2Model, V2ModelStorage, isV2ModelSnapshot, v2ModelSnapshotFromV2ModelStorage, v2NameTitleToV3Title } from "./v2-model"
+
+describe("V2Model", () => {
+  it("can be constructed without arguments", () => {
+    const m = V2Model.create()
+    expect(m.v2Id).toBeUndefined()
+    expect(m.name).toBe("")
+    expect(m._title).toBeUndefined()
+    expect(m.title).toBe("")
+    expect(m.matchNameOrId("")).toBe(false)
+
+    m.setTitle("title")
+    expect(m.v2Id).toBeUndefined()
+    expect(m.name).toBe("")
+    expect(m._title).toBe("title")
+    expect(m.title).toBe("title")
+    expect(m.matchNameOrId("title")).toBe(false)
+  })
+
+  it("can be constructed with v2Id and name", () => {
+    const m = V2Model.create({ v2Id: 1, name: "name" })
+    expect(m.v2Id).toBe(1)
+    expect(m.name).toBe("name")
+    expect(m._title).toBeUndefined()
+    expect(m.title).toBe("name")
+    expect(m.matchNameOrId(1)).toBe(true)
+    expect(m.matchNameOrId("name")).toBe(true)
+    expect(m.matchNameOrId("1")).toBe(false)
+
+    m.setTitle("title")
+    expect(m.v2Id).toBe(1)
+    expect(m.name).toBe("name")
+    expect(m._title).toBe("title")
+    expect(m.title).toBe("title")
+    expect(m.matchNameOrId(1)).toBe(true)
+    expect(m.matchNameOrId("name")).toBe(true)
+    expect(m.matchNameOrId("1")).toBe(false)
+    expect(m.matchNameOrId("title")).toBe(false)
+  })
+
+  it("can identify v2 storage objects", () => {
+    expect(isV2ModelSnapshot()).toBe(false)
+    let m: V2ModelStorage = {
+      id: 1,
+      name: "name",
+      title: "title"
+    } as V2ModelStorage
+    expect(isV2ModelSnapshot(m)).toBe(false)
+    m = {
+      id: 1,
+      guid: 1,
+      name: "name",
+      title: "title"
+    }
+    expect(isV2ModelSnapshot(m)).toBe(true)
+    m = {
+      id: 1,
+      cid: "cid",
+      name: "name",
+      title: "title"
+    } as V2ModelStorage
+    expect(isV2ModelSnapshot(m)).toBe(true)
+  })
+
+  it("can convert v2 name/title to v3 title", () => {
+    expect(v2NameTitleToV3Title("name")).toBeUndefined()
+    expect(v2NameTitleToV3Title("name", "name")).toBeUndefined()
+    expect(v2NameTitleToV3Title("name", "title")).toBe("title")
+  })
+
+  it("can be constructed from v2 storage object", () => {
+    let v2m: V2ModelStorage = {
+      guid: 1
+    } as V2ModelStorage
+    let m = V2Model.create(v2ModelSnapshotFromV2ModelStorage(v2m))
+    expect(m.v2Id).toBe(1)
+    expect(m.name).toBe("")
+    expect(m._title).toBeUndefined()
+
+    v2m = {
+      id: 1,
+      guid: 1,
+      cid: "cid",
+      name: "name",
+      title: "title"
+    }
+    m = V2Model.create(v2ModelSnapshotFromV2ModelStorage(v2m))
+    expect(m.v2Id).toBe(1)
+    expect(m.name).toBe("name")
+    expect(m._title).toBe("title")
+  })
+})

--- a/v3/src/models/data/v2-model.test.ts
+++ b/v3/src/models/data/v2-model.test.ts
@@ -1,4 +1,6 @@
-import { V2Model, V2ModelStorage, isV2ModelSnapshot, v2ModelSnapshotFromV2ModelStorage, v2NameTitleToV3Title } from "./v2-model"
+import {
+  V2Model, V2ModelStorage, isV2ModelSnapshot, v2ModelSnapshotFromV2ModelStorage, v2NameTitleToV3Title
+} from "./v2-model"
 
 describe("V2Model", () => {
   it("can be constructed without arguments", () => {
@@ -9,11 +11,21 @@ describe("V2Model", () => {
     expect(m.title).toBe("")
     expect(m.matchNameOrId("")).toBe(false)
 
+    m.setName("name")
+    expect(m.v2Id).toBeUndefined()
+    expect(m.name).toBe("name")
+    expect(m._title).toBeUndefined()
+    expect(m.title).toBe("name")
+    expect(m.matchNameOrId("")).toBe(false)
+    expect(m.matchNameOrId("name")).toBe(true)
+
     m.setTitle("title")
     expect(m.v2Id).toBeUndefined()
-    expect(m.name).toBe("")
+    expect(m.name).toBe("name")
     expect(m._title).toBe("title")
     expect(m.title).toBe("title")
+    expect(m.matchNameOrId("")).toBe(false)
+    expect(m.matchNameOrId("name")).toBe(true)
     expect(m.matchNameOrId("title")).toBe(false)
   })
 

--- a/v3/src/models/data/v2-model.ts
+++ b/v3/src/models/data/v2-model.ts
@@ -1,0 +1,56 @@
+import { Instance, SnapshotIn, types } from "mobx-state-tree"
+
+export const V2Model = types.model("V2Model", {
+  v2Id: types.maybe(types.number),
+  // required for objects in documents
+  name: "",
+  _title: types.maybe(types.string)
+})
+.views(self => ({
+  get title() {
+    return self._title ?? self.name
+  },
+  matchNameOrId(nameOrId: string | number) {
+    return (!!self.name && self.name === nameOrId) || (!!self.v2Id && self.v2Id === nameOrId)
+  }
+}))
+.actions(self => ({
+  setTitle(title: string) {
+    self._title = title
+  }
+}))
+// derived models are expected to have their own string `id` property
+export interface IV2Model extends Instance<typeof V2Model> {
+  id: string
+}
+export interface IV2ModelSnapshot extends SnapshotIn<typeof V2Model> {
+  id?: string
+}
+
+export interface V2ModelStorage {
+  id: number
+  guid: number
+  cid?: string | null
+  name: string
+  title?: string | null
+}
+
+export function isV2ModelSnapshot(snap?: any): snap is IV2ModelSnapshot {
+  return snap?.guid != null || snap?.cid != null
+}
+
+export function v2NameTitleToV3Title(name: string, v2Title?: string | null) {
+  // only store the title if it's different than name
+  return v2Title && v2Title !== name ? v2Title : undefined
+}
+
+export function v2ModelSnapshotFromV2ModelStorage(storage: Partial<V2ModelStorage>) {
+  const { id, guid, cid, name = "", title } = storage
+  const v2ModelSnapshot: IV2ModelSnapshot = {
+    id: cid ?? undefined,
+    v2Id: id ?? guid,
+    name,
+    _title: v2NameTitleToV3Title(name, title)
+  }
+  return v2ModelSnapshot
+}

--- a/v3/src/models/data/v2-model.ts
+++ b/v3/src/models/data/v2-model.ts
@@ -15,6 +15,10 @@ export const V2Model = types.model("V2Model", {
   }
 }))
 .actions(self => ({
+  // some models allow changing name
+  setName(name: string) {
+    self.name = name
+  },
   setTitle(title: string) {
     self._title = title
   }

--- a/v3/src/models/shared/shared-case-metadata.test.ts
+++ b/v3/src/models/shared/shared-case-metadata.test.ts
@@ -57,12 +57,6 @@ describe("SharedCaseMetadata", () => {
     expect(isSharedCaseMetadata(tree.metadata)).toBe(true)
   })
 
-  it("supports a title", () => {
-    expect(tree.metadata.title).toBeUndefined()
-    tree.metadata.setTitle("foo")
-    expect(tree.metadata.title).toBe("foo")
-  })
-
   it("stores column widths and hidden attributes", () => {
     expect(tree.metadata.columnWidth("foo")).toBeUndefined()
     expect(tree.metadata.isHidden("foo")).toBe(false)

--- a/v3/src/models/shared/shared-case-metadata.ts
+++ b/v3/src/models/shared/shared-case-metadata.ts
@@ -16,7 +16,6 @@ export const SharedCaseMetadata = SharedModel
   .named(kSharedCaseMetadataType)
   .props({
     type: types.optional(types.literal(kSharedCaseMetadataType), kSharedCaseMetadataType),
-    title: types.maybe(types.string),
     data: types.safeReference(DataSet),
     // key is collection id
     collections: types.map(CollectionTableMetadata),
@@ -53,9 +52,6 @@ export const SharedCaseMetadata = SharedModel
   .actions(self => ({
     setData(data?: IDataSet) {
       self.data = data
-    },
-    setTitle(title: string) {
-      self.title = title
     },
     setColumnWidth(attrId: string, width?: number) {
       if (width) {


### PR DESCRIPTION
- `V2Model` implements id, name, and title logic and is base model for `Attribute`, `Collection`, `DataSet`
- `matchNameOrId` method for use by plugins to match on name or any id
- Utility functions: `isV2ModelSnapshot`, `v2NameTitleToV3Title`, `v2ModelSnapshotFromV2ModelStorage`

Attributes, collections, and data contexts imported from v2 documents now preserve their v2 ids and names/titles so plugins that rely on v2 ids and names should continue to work. Other objects (e.g. global values and components) will require similar treatment.

Update: after further investigation of v2 behavior, v3 should now work like v2 in that:
- attributes and collections have title properties, but only ever get/set their `name` property.
- data sets _do_ maintain separate `name`/`_title` properties and user edits update the `_title` property.
- case table tiles treat their data set title as their tile title, ignoring the `title` property in `TileModel`.

@tealefristoe Requesting re-review, but note that you only need to consider the second commit, i.e. changes since the first review.