### PR TITLE
fix: import of attribute precision; fixes import of v2 Roller Coasters example document

### DIFF
--- a/v3/src/data-interactive/handlers/attribute-handler.ts
+++ b/v3/src/data-interactive/handlers/attribute-handler.ts
@@ -2,6 +2,7 @@ import { IAttribute, IAttributeSnapshot, isAttributeType } from "../../models/da
 import { IDataSet } from "../../models/data/data-set"
 import { v2ModelSnapshotFromV2ModelStorage } from "../../models/data/v2-model"
 import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
+import { hasOwnProperty } from "../../utilities/js-utils"
 import { t } from "../../utilities/translation/translate"
 import { v3TypeFromV2TypeString } from "../../v2/codap-v2-types"
 import { registerDIHandler } from "../data-interactive-handler"
@@ -57,7 +58,7 @@ function convertValuesToAttributeSnapshot(_values: DISingleValues): IAttributeSn
       // deleteable: values.deleteable, // TODO deleteable not part of IAttribute yet
       formula: values.formula ? { display: values.formula } : undefined,
       // deletedFormula: values.deletedFormula, // TODO deletedFormula not part of IAttribute. Should it be?
-      precision: values.precision ?? undefined,
+      precision: values.precision == null || values.precision === "" ? undefined : values.precision,
       units: values.unit ?? undefined
     }
   }
@@ -125,7 +126,9 @@ export const diAttributeHandler: DIHandler = {
       if (values?.editable != null) attribute.setEditable(!!values.editable)
       if (values?.formula != null) attribute.setDisplayExpression(values.formula)
       if (values?.name != null) attribute.setName(values.name)
-      if (values?.precision != null) attribute.setPrecision(values.precision)
+      if (hasOwnProperty(values, "precision")) {
+        attribute.setPrecision(values.precision == null || values.precision === "" ? undefined : values.precision)
+      }
       if (values?.title != null) attribute.setTitle(values.title)
       if (isAttributeType(values?.type)) attribute.setUserType(values.type)
       if (values?.unit != null) attribute.setUnits(values.unit)

--- a/v3/src/data-interactive/handlers/attribute-handler.ts
+++ b/v3/src/data-interactive/handlers/attribute-handler.ts
@@ -58,7 +58,7 @@ function convertValuesToAttributeSnapshot(_values: DISingleValues): IAttributeSn
       // deleteable: values.deleteable, // TODO deleteable not part of IAttribute yet
       formula: values.formula ? { display: values.formula } : undefined,
       // deletedFormula: values.deletedFormula, // TODO deletedFormula not part of IAttribute. Should it be?
-      precision: values.precision == null || values.precision === "" ? undefined : values.precision,
+      precision: values.precision == null || values.precision === "" ? undefined : +values.precision,
       units: values.unit ?? undefined
     }
   }
@@ -127,7 +127,7 @@ export const diAttributeHandler: DIHandler = {
       if (values?.formula != null) attribute.setDisplayExpression(values.formula)
       if (values?.name != null) attribute.setName(values.name)
       if (hasOwnProperty(values, "precision")) {
-        attribute.setPrecision(values.precision == null || values.precision === "" ? undefined : values.precision)
+        attribute.setPrecision(values.precision == null || values.precision === "" ? undefined : +values.precision)
       }
       if (values?.title != null) attribute.setTitle(values.title)
       if (isAttributeType(values?.type)) attribute.setUserType(values.type)

--- a/v3/src/utilities/js-utils.test.ts
+++ b/v3/src/utilities/js-utils.test.ts
@@ -1,0 +1,14 @@
+import { hasOwnProperty } from "./js-utils"
+
+describe("JavaScript Utilities", () => {
+
+  test("hasOwnProperty", () => {
+    expect(hasOwnProperty({}, "")).toBe(false)
+    expect(hasOwnProperty({ foo: undefined }, "foo")).toBe(true)
+    expect(hasOwnProperty({ foo: "bar" }, "foo")).toBe(true)
+    expect(hasOwnProperty({ foo: "bar" }, "bar")).toBe(false)
+    expect(hasOwnProperty({ hasOwnProperty: true }, "foo")).toBe(false)
+    expect(hasOwnProperty({ hasOwnProperty: undefined }, "hasOwnProperty")).toBe(true)
+  })
+
+})

--- a/v3/src/utilities/js-utils.ts
+++ b/v3/src/utilities/js-utils.ts
@@ -6,6 +6,19 @@ const ulid = monotonicFactory()
 const nanoid = customAlphabet("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz", 21)
 
 /*
+ * hasOwnProperty()
+ *
+ * Replacement for Object.hasOwn -- returns true if the specified property is present
+ * on the specified object, even if its value is `undefined`. See
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn and
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
+ * for some of the subtleties here.
+ */
+export function hasOwnProperty(obj: object, property: string) {
+  return Object.prototype.hasOwnProperty.call(obj, property)
+}
+
+/*
  * castArrayCopy()
  *
  * returns an array for simple items, and a copy of the array for arrays
@@ -102,6 +115,6 @@ export function safeDomIdentifier(value: string) {
 
   // Ensure value doesn't start with a number
   const validId = sanitizedValue.replace(/^([0-9])/, "_$1")
-  
+
   return validId
 }

--- a/v3/src/v2/codap-v2-document.ts
+++ b/v3/src/v2/codap-v2-document.ts
@@ -138,7 +138,7 @@ export class CodapV2Document {
       const userType = v3TypeFromV2TypeString(v2Type)
       const formula = v2Formula ? { display: v2Formula } : undefined
       const editable = v2Editable == null || !!v2Editable
-      const precision = v2Precision ?? undefined
+      const precision = v2Precision == null || v2Precision === "" ? undefined : v2Precision
       const units = v2Unit ?? undefined
       this.guidMap.set(guid, { type: "DG.Attribute", object: v2Attr })
       const attribute = data.addAttribute({

--- a/v3/src/v2/codap-v2-document.ts
+++ b/v3/src/v2/codap-v2-document.ts
@@ -138,7 +138,7 @@ export class CodapV2Document {
       const userType = v3TypeFromV2TypeString(v2Type)
       const formula = v2Formula ? { display: v2Formula } : undefined
       const editable = v2Editable == null || !!v2Editable
-      const precision = v2Precision == null || v2Precision === "" ? undefined : v2Precision
+      const precision = v2Precision == null || v2Precision === "" ? undefined : +v2Precision
       const units = v2Unit ?? undefined
       this.guidMap.set(guid, { type: "DG.Attribute", object: v2Attr })
       const attribute = data.addAttribute({

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -22,7 +22,8 @@ export interface ICodapV2Attribute {
   deleteable?: boolean
   formula?: string
   deletedFormula?: string
-  precision?: number | null
+  // some documents have "" ¯\_(ツ)_/¯
+  precision?: number | "" | null
   unit?: string | null
 }
 

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -22,8 +22,7 @@ export interface ICodapV2Attribute {
   deleteable?: boolean
   formula?: string
   deletedFormula?: string
-  // some documents have "" ¯\_(ツ)_/¯
-  precision?: number | "" | null
+  precision?: number | string | null
   unit?: string | null
 }
 


### PR DESCRIPTION
[[PT-187296100]](https://www.pivotaltracker.com/story/show/187296100) "Roller Coasters" file fails to open in Example Docs menu

The root of the problem is that the `precision` property is declared to be an optional numeric value, but apparently sometimes a string (e.g. "" or "2") is written out 🤷. As mentioned previously, MST enforces types more stringently than v2 did, so it's important that we identify the _actual_ contents of v2 documents and make sure we support them.