### PR TITLE
Make undo/redo of point size change discrete

### DIFF
--- a/v3/src/components/data-display/inspector/display-item-format-control.tsx
+++ b/v3/src/components/data-display/inspector/display-item-format-control.tsx
@@ -73,7 +73,8 @@ export const DisplayItemFormatControl = observer(function PointFormatControl(pro
             <FormLabel className="form-label">{t("DG.Inspector.pointSize")}</FormLabel>
             <Slider aria-label="point-size-slider" ml="10px" min={0} max={2} data-testid="point-size-slider"
                     defaultValue={displayItemDescription.pointSizeMultiplier} step={0.01}
-                    onChange={(val) => {
+                    onChange={(val) => displayItemDescription.setDynamicPointSizeMultiplier(val)}
+                    onChangeEnd={(val) => {
                       displayItemDescription.applyUndoableAction(
                         () => displayItemDescription.setPointSizeMultiplier(val),
                         {

--- a/v3/src/components/data-display/models/display-item-description-model.ts
+++ b/v3/src/components/data-display/models/display-item-description-model.ts
@@ -7,8 +7,11 @@ export const DisplayItemDescriptionModel = types
     _itemColors: types.optional(types.array(types.string), [defaultPointColor]),
     _itemStrokeColor: defaultStrokeColor,
     _itemStrokeSameAsFill: false,
-    pointSizeMultiplier: 1, // Not used when item is a polygon in which case it is set to -1
+    _pointSizeMultiplier: 1, // Not used when item is a polygon in which case it is set to -1
   })
+  .volatile(() => ({
+    _dynamicPointSizeMultiplier: undefined as number | undefined  // Used during slider drag
+  }))
   .actions(self => ({
     setPointColor(color: string, plotIndex = 0) {
       self._itemColors[plotIndex] = color
@@ -20,10 +23,17 @@ export const DisplayItemDescriptionModel = types
       self._itemStrokeSameAsFill = isSame
     },
     setPointSizeMultiplier(multiplier: number) {
-      self.pointSizeMultiplier = multiplier
+      self._pointSizeMultiplier = multiplier
+      self._dynamicPointSizeMultiplier = undefined
+    },
+    setDynamicPointSizeMultiplier(multiplier: number) {
+      self._dynamicPointSizeMultiplier = multiplier
     }
   }))
   .views(self => ({
+    get pointSizeMultiplier() {
+      return self._dynamicPointSizeMultiplier ?? self._pointSizeMultiplier
+    },
     itemColorAtIndex(plotIndex = 0) {
       return self._itemColors[plotIndex] ?? kellyColors[plotIndex % kellyColors.length]
     },

--- a/v3/src/components/graph/v2-graph-importer.ts
+++ b/v3/src/components/graph/v2-graph-importer.ts
@@ -150,7 +150,7 @@ export function v2GraphImporter({v2Component, v2Document, sharedModelManager, in
     pointDescription: {
       _itemColors: pointColor ? [pointColor] : [],
       _itemStrokeColor: strokeColor,
-      pointSizeMultiplier,
+      _pointSizeMultiplier: pointSizeMultiplier,
       /*transparency, strokeTransparency*/
       _itemStrokeSameAsFill: strokeSameAsFill
     },

--- a/v3/src/components/map/v2-map-importer.ts
+++ b/v3/src/components/map/v2-map-importer.ts
@@ -72,7 +72,7 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
         displayItemDescription: {
           _itemColors: pointColor ? [pointColor] : [],
           _itemStrokeColor: strokeColor,
-          pointSizeMultiplier
+          _pointSizeMultiplier: pointSizeMultiplier,
         }
       }
       layers.push(pointLayerSnapshot)


### PR DESCRIPTION
[#187128104] Bug fix: Changes in point size aren't discrete wrt undo/redo

* Followed the usual pattern of introducing a volatile dynamic property in `DisplayItemDescriptionModel` so that `DisplayItemFormatControl` can set the dynamic property during a drag and wait until the drag ends to set the non-volatile property with an undoable action.
* Graph and map V2 importers needed a tweak to accommodate the change.