### PR TITLE
Fix slider axis missing numeric scale bug

### DIFF
--- a/v3/src/components/data-display/hooks/use-data-display-model.ts
+++ b/v3/src/components/data-display/hooks/use-data-display-model.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext } from "react"
 import { IDataDisplayContentModel } from "../models/data-display-content-model"
+import {IAxisModel, isNumericAxisModel} from "../../axis/models/axis-model"
 
 const kDefaultDataDisplayModel = {
   // required by useDataDisplayAnimation
@@ -9,7 +10,7 @@ const kDefaultDataDisplayModel = {
   // required by AxisProviderContext
   getAxis: () => undefined,
   getNumericAxis: () => undefined,
-  hasDraggableNumericAxis: () => undefined,
+  hasDraggableNumericAxis: (axisModel: IAxisModel) => isNumericAxisModel(axisModel),
   nonDraggableAxisTicks: (formatter: (value: number) => string) => ({tickValues: [], tickLabels: []})
 } as unknown as IDataDisplayContentModel
 


### PR DESCRIPTION
[#187333857] Bug fix: Missing numbers on Slider axis

* In `useSubAxis` the displayModel must return `true` for `hasDraggableNumericAxis` in the slider context. We fix this by having the default data display model defer to a passed in axis model.