### PR TITLE
Use y attribute name for function plot label

### DIFF
--- a/v3/cypress/e2e/adornments.spec.ts
+++ b/v3/cypress/e2e/adornments.spec.ts
@@ -576,7 +576,7 @@ context("Graph adornments", () => {
       .find("[data-testid=graph-adornments-grid__cell]").should("have.length", 1)
     cy.get("[data-testid=adornment-wrapper]").should("have.length", 1)
     cy.get("[data-testid=adornment-wrapper]").should("have.class", "visible")
-    cy.get("[data-testid=plotted-function-control-label]").should("exist").should("have.text", "f() =")
+    cy.get("[data-testid=plotted-function-control-label]").should("exist").should("have.text", "Mass")
     cy.get("[data-testid=plotted-function-control-value]").should("exist").should("have.text", "")
     cy.wait(250)
     graph.getInspectorPalette().find("[data-testid=adornment-checkbox-plotted-function]").click()
@@ -598,7 +598,7 @@ context("Graph adornments", () => {
       .find("[data-testid=graph-adornments-grid__cell]").should("have.length", 1)
     cy.get("[data-testid=adornment-wrapper]").should("have.length", 1)
     cy.get("[data-testid=adornment-wrapper]").should("have.class", "visible")
-    cy.get("[data-testid=plotted-function-control-label]").should("exist").should("have.text", "f() =")
+    cy.get("[data-testid=plotted-function-control-label]").should("exist").should("have.text", "Mass")
     cy.get("[data-testid=plotted-function-control-value]").should("exist").should("have.text", "")
     cy.wait(250)
 

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.scss
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.scss
@@ -26,7 +26,13 @@
     cursor: pointer;
     min-height: 22px;
     padding: 1px 3px 3px;
-    width: 54px;
+    max-width: 40%;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .equals-sign {
+    padding: 0 5px;
   }
   .plotted-function-control-value, .plotted-function-error {
     background: #fff;

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
@@ -14,6 +14,9 @@ export const PlottedFunctionAdornmentBanner = observer(function PlottedFunctionA
 ) {
   const model = props.model as IPlottedFunctionAdornmentModel
   const graphModel = useGraphContentModelContext()
+  const dataset = graphModel.dataset
+  const yAttrID = graphModel.dataConfiguration.attributeID('y')
+  const yAttrName = dataset?.attrIDMap.get(yAttrID)?.name ?? t("DG.PlottedFunction.formulaPrompt")
   const { expression, error } = model
   const formulaModal = useDisclosure()
   const [modalIsOpen, setModalIsOpen] = useState(false)
@@ -49,16 +52,19 @@ export const PlottedFunctionAdornmentBanner = observer(function PlottedFunctionA
       >
         <div className="plotted-function-control-row">
           <div className="plotted-function-control-label" data-testid="plotted-function-control-label">
-            { t("DG.PlottedFunction.formulaPrompt") }
+            {yAttrName}
+          </div>
+          <div className="equals-sign">
+            =
           </div>
           <div className="plotted-function-control-value" data-testid="plotted-function-control-value">
             {expression}
           </div>
         </div>
-        { error && <div className="plotted-function-error" data-testid="plotted-function-error">{error}</div> }
+        {error && <div className="plotted-function-error" data-testid="plotted-function-error">{error}</div>}
       </Button>
-      { modalIsOpen &&
-        <EditFormulaModal
+      {modalIsOpen &&
+         <EditFormulaModal
           isOpen={formulaModal.isOpen}
           currentValue={expression}
           onClose={handleEditExpressionClose} />


### PR DESCRIPTION
[#187152587] Feature: The label for a plotted function in a scatterplot uses the name of the attribute on the y-axis

* In `PlottedFunctionAdornmentBanner` we pull out the name of the first attribute on the y-axis to use as a label.
* We format so that the label is limited to just a portion of the function banner space and gets elided as needed.