### PR TITLE
Fix V2 map import bug affecting adding a legend

### DIFF
--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -222,6 +222,7 @@ export const MapPointLayer = function MapPointLayer(props: {
       ({layerIsVisible, pointsAreVisible}) => {
         if (layerIsVisible && pointsAreVisible && !pixiPointsRef.current?.isVisible) {
           pixiPointsRef.current?.setVisibility(true)
+          refreshPoints(false)
         }
         else if (!(layerIsVisible && pointsAreVisible) && pixiPointsRef.current?.isVisible) {
           pixiPointsRef.current?.setVisibility(false)

--- a/v3/src/components/map/v2-map-importer.ts
+++ b/v3/src/components/map/v2-map-importer.ts
@@ -44,6 +44,7 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
 */
       } = v2LayerModel,
       v3LegendType = v3TypeFromV2TypeIndex[legendAttributeType]
+    if (!data?.dataSet) return
 
     if (legendAttributeId) {
       _attributeDescriptions.legend = {
@@ -61,7 +62,7 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
         */
       } = v2LayerModel
       // V2 point layers don't store their lat/long attributes, so we need to find them in the dataset
-      const {latId, longId} = latLongAttributesFromDataSet(data?.dataSet as IDataSet)
+      const {latId, longId} = latLongAttributesFromDataSet(data.dataSet)
       _attributeDescriptions.lat = {attributeID: latId, type: 'numeric'}
       _attributeDescriptions.long = {attributeID: longId, type: 'numeric'}
       const pointLayerSnapshot: IMapPointLayerModelSnapshot = {
@@ -97,7 +98,7 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
         */
       } = v2LayerModel
       // V2 polygon layers don't store their boundary attribute, so we need to find it in the dataset
-      _attributeDescriptions.polygon = {attributeID: boundaryAttributeFromDataSet(data?.dataSet as IDataSet)}
+      _attributeDescriptions.polygon = {attributeID: boundaryAttributeFromDataSet(data.dataSet)}
       const polygonLayerSnapshot: IMapPolygonLayerModelSnapshot = {
         type: kMapPolygonLayerType,
         layerIndex,

--- a/v3/src/components/map/v2-map-importer.ts
+++ b/v3/src/components/map/v2-map-importer.ts
@@ -2,10 +2,12 @@ import {ITileModelSnapshotIn} from "../../models/tiles/tile-model"
 import {typedId} from "../../utilities/js-utils"
 import {V2TileImportArgs} from "../../v2/codap-v2-tile-importers"
 import {isV2MapComponent, v3TypeFromV2TypeIndex} from "../../v2/codap-v2-types"
-import {GraphAttrRole} from "../data-display/data-display-types"
+import {IDataSet} from "../../models/data/data-set"
+import {AttrRole} from "../data-display/data-display-types"
 import {IAttributeDescriptionSnapshot, kDataConfigurationType} from "../data-display/models/data-configuration-model"
 import {IMapModelContentSnapshot} from "./models/map-content-model"
 import {kMapIdPrefix, kMapTileType} from "./map-defs"
+import {boundaryAttributeFromDataSet, latLongAttributesFromDataSet} from "./utilities/map-utils"
 import {IMapPointLayerModelSnapshot} from "./models/map-point-layer-model"
 import {BaseMapKey, kMapPointLayerType, kMapPolygonLayerType} from "./map-types"
 import {IMapBaseLayerModelSnapshot} from "./models/map-base-layer-model"
@@ -15,7 +17,8 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
   if (!isV2MapComponent(v2Component)) return
 
   const {title = "", mapModelStorage} = v2Component.componentStorage
-  const {center, zoom, baseMapLayerName: v2BaseMapLayerName, layerModels: v2LayerModels} = mapModelStorage
+  const {center, zoom, baseMapLayerName: v2BaseMapLayerName,
+    layerModels: v2LayerModels} = mapModelStorage
   const baseMapKeyMap: Record<string, BaseMapKey> = { Topographic: 'topo', Streets: 'streets', Oceans: 'oceans' }
   const baseMapLayerName = baseMapKeyMap[v2BaseMapLayerName]
 
@@ -24,7 +27,7 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
   v2LayerModels.forEach((v2LayerModel, layerIndex) => {
     // Pull out stuff from _links_ and decide if it's a point layer or polygon layer
     const contextId = v2LayerModel._links_.context.id,
-      _attributeDescriptions: Partial<Record<GraphAttrRole, IAttributeDescriptionSnapshot>> = {},
+      _attributeDescriptions: Partial<Record<AttrRole, IAttributeDescriptionSnapshot>> = {},
       hiddenCases = v2LayerModel._links_.hiddenCases,
       // legendCollectionId = v2LayerModel._links_.legendColl?.id,
       v2LegendAttribute = Array.isArray(v2LayerModel._links_.legendAttr)
@@ -52,12 +55,15 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
     if (isPoints) {
       const {
         pointColor, strokeColor, pointSizeMultiplier,
+        grid, pointsShouldBeVisible, connectingLines
         /* Present in v2 layer model but not yet used in V3 layer model:
-        transparency, strokeTransparency, pointsShouldBeVisible,
-        grid, connectingLines,
+        transparency, strokeTransparency
         */
       } = v2LayerModel
-
+      // V2 point layers don't store their lat/long attributes, so we need to find them in the dataset
+      const {latId, longId} = latLongAttributesFromDataSet(data?.dataSet as IDataSet)
+      _attributeDescriptions.lat = {attributeID: latId, type: 'numeric'}
+      _attributeDescriptions.long = {attributeID: longId, type: 'numeric'}
       const pointLayerSnapshot: IMapPointLayerModelSnapshot = {
         type: kMapPointLayerType,
         layerIndex,
@@ -73,7 +79,13 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
           _itemColors: pointColor ? [pointColor] : [],
           _itemStrokeColor: strokeColor,
           _pointSizeMultiplier: pointSizeMultiplier,
-        }
+        },
+        gridModel: {
+          isVisible: grid.isVisible,
+          _gridMultiplier: grid.gridMultiplier,
+        },
+        pointsAreVisible: pointsShouldBeVisible,
+        connectingLinesAreVisible: connectingLines.isVisible
       }
       layers.push(pointLayerSnapshot)
     }
@@ -84,7 +96,8 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
         areaTransparency, strokeTransparency, areaStrokeTransparency
         */
       } = v2LayerModel
-
+      // V2 polygon layers don't store their boundary attribute, so we need to find it in the dataset
+      _attributeDescriptions.polygon = {attributeID: boundaryAttributeFromDataSet(data?.dataSet as IDataSet)}
       const polygonLayerSnapshot: IMapPolygonLayerModelSnapshot = {
         type: kMapPolygonLayerType,
         layerIndex,

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -365,7 +365,7 @@ export interface ICodapV2MapLayerStorage {
   transparency?: number
   strokeTransparency?: number
   pointsShouldBeVisible?: boolean
-  grid?: { gridMultiplier: number, isVisible: boolean }
+  grid: { gridMultiplier: number, isVisible: boolean }
   connectingLines: { isVisible: boolean, enableMeasuresForSelection: boolean }
 }
 


### PR DESCRIPTION
[#187374319] Bug fix: Imported V2 maps have a problem when adding a legend

* In v2-map-importer.ts for point and polygon layers pull out the respective lat/long or polygon attribute IDs and assign them to the data configuration model for the layer
* v2MapImporter now properly imports visibility of grid, points and connecting lines. gridMultiplier is properly imported
* Also fixed a bug in MapPointLayer whereby if a map layer gets imported with points not visible, the toggle to make them visible was not working. The fix is to always call `refreshPoints` when point visibility becomes true. Though this was detected by importing from V2, it was also true of V3 restore.