### PR TITLE
fix: graph update on replace of data set

### DIFF
--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -73,17 +73,17 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
     })
   }
 
-  useEffect(function handleFilteredCasesLengthChange() {
+  useEffect(function handleFilteredCasesChange() {
     return mstReaction(
-      () => graphModel.dataConfiguration.filteredCases.length,
-      length => {
+      () => graphModel.dataConfiguration.filteredCases.map(({ id }) => id),
+      filteredCasesIds => {
         // filtered cases become empty when DataSet is deleted, for instance
-        if ((length === 0) && !isUndoingOrRedoing()) {
+        if ((filteredCasesIds.length === 0) && !isUndoingOrRedoing()) {
           graphController.clearGraph()
         } else {
           graphController.callMatchCirclesToData()
         }
-      }, {name: "Graph.useEffect.handleFilteredCasesLengthChange"}, graphModel
+      }, {name: "Graph.handleFilteredCasesChange"}, graphModel
     )
   }, [graphController, graphModel])
 

--- a/v3/src/models/data/filtered-cases.ts
+++ b/v3/src/models/data/filtered-cases.ts
@@ -1,5 +1,6 @@
 import { action, computed, makeObservable, observable } from "mobx"
 import { ISerializedActionCall } from "mobx-state-tree"
+import { typedId } from "../../utilities/js-utils"
 import { onAnyAction } from "../../utilities/mst-utils"
 import { IDataSet } from "./data-set"
 import { isSetCaseValuesAction } from "./data-set-actions"
@@ -23,6 +24,7 @@ interface IProps {
 }
 
 export class FilteredCases {
+  public readonly id = typedId("FICA")
   private source: IDataSet
   private collectionID: string | undefined
   private casesArrayNumber: number


### PR DESCRIPTION
[[PT-187348852]](https://www.pivotaltracker.com/story/show/187348852)

The `Graph` component was calling `GraphController.callMatchCirclesToData` on changes to the _number_ of `filteredCases`, but not when the contents of the `filteredCases` array changed without a corresponding change to its length. With this PR we correct that oversight.