### PR TITLE
rebase with main and added test for multiple y attributes

### DIFF
--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -218,6 +218,24 @@ context("Test graph axes with various attribute types", () => {
     cy.wait(500)
     cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".sub-axis-wrapper").should("have.length", 1)
   })
+  it("will test graph with numeric x-axis and two numeric y-attributes", () => {
+    cy.dragAttributeToTarget("table", arrayOfAttributes[2], "bottom") // Lifespan => x-axis
+    cy.wait(500)
+    cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".sub-axis-wrapper").should("have.length", 1)
+    cy.dragAttributeToTarget("table", arrayOfAttributes[3], "left") // Height => left split
+    cy.wait(500)
+    cy.dragAttributeToTarget("data-summary", arrayOfAttributes[5], "yplus") // Sleep => left split
+    cy.wait(500)
+
+    // checks for multiple y-axis labels
+    ah.verifyXAxisTickMarksDisplayed()
+    ah.verifyYAxisTickMarksDisplayed()
+    cy.get("[data-testid=graph]").find("[data-testid=attribute-label]").should("have.text", "LifeSpanHeight, Sleep")
+    ah.verifyAxisTickLabel("left", "0", 0)
+    cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".sub-axis-wrapper").should("have.length", 1)
+
+    // TODO: add checks for undo/redo
+  })
   it("will adjust axis domain when points are changed to bars with undo/redo", () => {
     // When there are no negative numeric values, such as in the case of Height, the domain for the primary
     // axis of a univariate plot showing bars should start at zero.


### PR DESCRIPTION
This is in follow-up to [PT story #187319504](#187319504) and [PR 1188](https://github.com/concord-consortium/codap/pull/1188). Code was fine, just needed to be updated to match main, so I'm going to move forward with the PR without review.