### PR TITLE
Save/restore calculator position between invocations

### DIFF
--- a/v3/src/components/calculator/calculator-title-bar.tsx
+++ b/v3/src/components/calculator/calculator-title-bar.tsx
@@ -1,12 +1,19 @@
-import React from "react"
-import { observer } from "mobx-react-lite"
-import { ComponentTitleBar  } from "../component-title-bar"
-import { t } from "../../utilities/translation/translate"
-import { ITileTitleBarProps } from "../tiles/tile-base-props"
+import React, {useCallback} from "react"
+import {observer} from "mobx-react-lite"
+import {ComponentTitleBar} from "../component-title-bar"
+import {t} from "../../utilities/translation/translate"
+import {ITileTitleBarProps} from "../tiles/tile-base-props"
+import {useDocumentContent} from "../../hooks/use-document-content"
+import {kCalculatorTileType} from "./calculator-defs"
 
-export const CalculatorTitleBar = observer(function CalculatorTitleBar({ tile, ...others }: ITileTitleBarProps) {
-  const getTitle = () => tile?.title || t("DG.DocumentController.calculatorTitle")
-  return (
-    <ComponentTitleBar tile={tile} getTitle={getTitle} {...others} />
-  )
-})
+export const CalculatorTitleBar =
+  observer(function CalculatorTitleBar({tile, onCloseTile, ...others}: ITileTitleBarProps) {
+    const getTitle = () => tile?.title || t("DG.DocumentController.calculatorTitle")
+    const documentContent = useDocumentContent()
+    const closeCalculator = useCallback(() => {
+      documentContent?.toggleSingletonTileVisibility(kCalculatorTileType)
+    }, [documentContent])
+    return (
+      <ComponentTitleBar tile={tile} getTitle={getTitle} onCloseTile={closeCalculator} {...others} />
+    )
+  })

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -15,6 +15,7 @@ import "./codap-component.scss"
 export interface IProps extends ITileBaseProps {
   tile: ITileModel
   isMinimized?: boolean
+  isHidden?: boolean
   onMinimizeTile?: () => void
   onCloseTile: (tileId: string) => void
   onBottomRightPointerDown?: (e: React.PointerEvent) => void
@@ -25,7 +26,7 @@ export interface IProps extends ITileBaseProps {
 }
 
 export const CodapComponent = observer(function CodapComponent({
-  tile, isMinimized, onMinimizeTile, onCloseTile, onBottomRightPointerDown, onBottomLeftPointerDown,
+  tile, isMinimized, isHidden, onMinimizeTile, onCloseTile, onBottomRightPointerDown, onBottomLeftPointerDown,
   onRightPointerDown, onBottomPointerDown, onLeftPointerDown
 }: IProps) {
   const info = getTileComponentInfo(tile.content.type)
@@ -39,7 +40,7 @@ export const CodapComponent = observer(function CodapComponent({
     }
   }
 
-  if (!info) return null
+  if (!info || isHidden) return null
 
   const { TitleBar, Component, tileEltClass, isFixedWidth, isFixedHeight } = info
   const classes = clsx("codap-component", tileEltClass, { minimized: isMinimized })

--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -127,6 +127,7 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
         <CodapComponent tile={tile}
           isMinimized={rowTile.isMinimized}
           onMinimizeTile={handleMinimizeTile}
+          isHidden={rowTile.isHidden}
           onCloseTile={onCloseTile}
           onBottomRightPointerDown={handleBottomRightPointerDown}
           onBottomLeftPointerDown={handleBottomLeftPointerDown}

--- a/v3/src/models/document/base-document-content.ts
+++ b/v3/src/models/document/base-document-content.ts
@@ -1,10 +1,10 @@
-import { getType, Instance, SnapshotIn, types } from "mobx-state-tree"
-import { ISharedModel, SharedModel } from "../shared/shared-model"
-import { isPlaceholderTile } from "../tiles/placeholder/placeholder-content"
-import { ITileModel, ITileModelSnapshotIn, TileModel } from "../tiles/tile-model"
-import { ITileInRowOptions } from "./tile-row"
-import { ITileRowModelUnion, TileRowModelUnion } from "./tile-row-union"
-import { SharedModelEntry, SharedModelMap } from "./shared-model-entry"
+import {getType, Instance, SnapshotIn, types} from "mobx-state-tree"
+import {ISharedModel, SharedModel} from "../shared/shared-model"
+import {isPlaceholderTile} from "../tiles/placeholder/placeholder-content"
+import {ITileModel, ITileModelSnapshotIn, TileModel} from "../tiles/tile-model"
+import {ITileInRowOptions} from "./tile-row"
+import {ITileRowModelUnion, TileRowModelUnion} from "./tile-row-union"
+import {SharedModelEntry, SharedModelMap} from "./shared-model-entry"
 
 export const BaseDocumentContentModel = types
   .model("BaseDocumentContent", {
@@ -64,9 +64,9 @@ export const BaseDocumentContentModel = types
       // returns last visible row or last row
       if (!self.rowOrder.length) return -1
       const lastVisibleRowId = self.visibleRows.length
-                                ? self.visibleRows[self.visibleRows.length - 1]
-                                : self.rowOrder[self.rowOrder.length - 1]
-      return  self.rowOrder.indexOf(lastVisibleRowId)
+        ? self.visibleRows[self.visibleRows.length - 1]
+        : self.rowOrder[self.rowOrder.length - 1]
+      return self.rowOrder.indexOf(lastVisibleRowId)
     },
     getFirstSharedModelByType<IT extends typeof SharedModel>(
       modelType: IT, tileId?: string): IT["Type"] | undefined {
@@ -80,6 +80,16 @@ export const BaseDocumentContentModel = types
     getSharedModelsByType<IT extends typeof SharedModel>(type: string): IT["Type"][] {
       const sharedModelEntries = Array.from(self.sharedModelMap.values())
       return sharedModelEntries.map(entry => entry.sharedModel).filter(model => model.type === type)
+    },
+    getFreeTileLayoutById(tileId: string) {
+      let result: any // typeof FreeTileLayout | undefined
+      self.rowMap.forEach(row => {
+        if (result) return
+        if (row.type === "free") {
+          result = row.tiles.get(tileId)
+        }
+      })
+      return result
     }
   }))
   .views(self => ({
@@ -125,8 +135,7 @@ export const BaseDocumentContentModel = types
       self.rowMap.put(row)
       if ((rowIndex != null) && (rowIndex < self.rowOrder.length)) {
         self.rowOrder.splice(rowIndex, 0, row.id)
-      }
-      else {
+      } else {
         self.rowOrder.push(row.id)
       }
     },
@@ -223,5 +232,9 @@ export const BaseDocumentContentModel = types
       }
     }
   }))
-export interface IBaseDocumentContentModel extends Instance<typeof BaseDocumentContentModel> {}
-export interface IBaseDocumentContentSnapshotIn extends SnapshotIn<typeof BaseDocumentContentModel> {}
+
+export interface IBaseDocumentContentModel extends Instance<typeof BaseDocumentContentModel> {
+}
+
+export interface IBaseDocumentContentSnapshotIn extends SnapshotIn<typeof BaseDocumentContentModel> {
+}

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -144,11 +144,17 @@ export const DocumentContentModel = BaseDocumentContentModel
     }
   }))
   .actions(self => ({
-    toggleTileVisibility(tileType: string) {
+    toggleSingletonTileVisibility(tileType: string) {
       const tiles = self?.getTilesOfType(tileType)
-      if (tiles && tiles.length > 0) {
-        const tileId = tiles[0].id
+      // There's supposed to be at most one tile of this type. Enforce this. (But an assert would be nice!)
+      while (tiles && tiles.length > 1) {
+        const tileId = tiles[1].id
         self?.deleteTile(tileId)
+      }
+      if (tiles && tiles.length > 0) {
+        const singletonId = tiles[0].id,
+          freeTileLayout = self.getFreeTileLayoutById(singletonId)
+          freeTileLayout?.setHidden(!freeTileLayout.isHidden)
       } else {
         return self.createTile(tileType)
       }
@@ -159,7 +165,7 @@ export const DocumentContentModel = BaseDocumentContentModel
       const tileInfo = getTileContentInfo(tileType)
       if (tileInfo) {
         if (tileInfo.isSingleton) {
-          self.toggleTileVisibility(tileType)
+          self.toggleSingletonTileVisibility(tileType)
         } else {
           return self.createTile(tileType, options)
         }

--- a/v3/src/models/document/free-tile-row.ts
+++ b/v3/src/models/document/free-tile-row.ts
@@ -21,7 +21,8 @@ export const FreeTileLayout = types.model("FreeTileLayout", {
   y: types.number,
   width: types.maybe(types.number),
   height: types.maybe(types.number),
-  isMinimized: types.maybe(types.boolean)
+  isMinimized: types.maybe(types.boolean),
+  isHidden: types.maybe(types.boolean)
 })
 .views(self => ({
   get position() {
@@ -45,6 +46,10 @@ export const FreeTileLayout = types.model("FreeTileLayout", {
   setMinimized(isMinimized: boolean) {
     // only store it if it's true
     self.isMinimized = isMinimized || undefined
+  },
+  setHidden(isHidden: boolean) {
+    // only store it if it's true
+    self.isHidden = isHidden || undefined
   }
 }))
 export interface IFreeTileLayout extends Instance<typeof FreeTileLayout> {}


### PR DESCRIPTION
[#187391638] Feature: Calculator position is saved and restored on close and reopen

Note that this PR introduces a bug whereby once the calculator has been closed and opened again it can no longer be repositioned.

* Pass an `isHidden` property to `CodapComponent` so that singleton components and the case table/card pair can be hidden but retain their state.
* Include `isHidden` as a property of `FreeTileLayout`
* In `DocumentContent` when toggling visibility of a singleton, don't delete it, just mark it as hidden
* Added getFreeTileLayoutById to `BaseDocumentContent`
* In `CalculatorTitleBar` override the defaault `onCloseTile` function to instead call toggleSingletonTileVisibility