### PR TITLE
Open/close case table preserves position & extent

### DIFF
--- a/v3/src/components/case-table/case-table-model.ts
+++ b/v3/src/components/case-table/case-table-model.ts
@@ -1,5 +1,4 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
-import { applyUndoableAction } from "../../models/history/apply-undoable-action"
 import { getTileCaseMetadata, getTileDataSet } from "../../models/shared/shared-data-utils"
 import { ISharedModel } from "../../models/shared/shared-model"
 import { ITileContentModel, TileContentModel } from "../../models/tiles/tile-content"
@@ -58,7 +57,6 @@ export const CaseTableModel = TileContentModel
       self.scrollLeft = scrollLeft
     }
   }))
-  .actions(applyUndoableAction)
 export interface ICaseTableModel extends Instance<typeof CaseTableModel> {}
 export interface ICaseTableSnapshot extends SnapshotIn<typeof CaseTableModel> {}
 

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -19,7 +19,6 @@ registerTileContentInfo({
   type: kCaseTableTileType,
   prefix: kCaseTableIdPrefix,
   modelClass: CaseTableModel,
-  doesNotGetDestroyedOnClose: true,
   defaultContent: () => ({ type: kCaseTableTileType })
 })
 

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -14,7 +14,6 @@ import "./codap-component.scss"
 
 export interface IProps extends ITileBaseProps {
   tile: ITileModel
-  isHidden?: boolean
   isMinimized?: boolean
   onMinimizeTile?: () => void
   onCloseTile: (tileId: string) => void
@@ -26,7 +25,7 @@ export interface IProps extends ITileBaseProps {
 }
 
 export const CodapComponent = observer(function CodapComponent({
-  tile, isHidden, isMinimized, onMinimizeTile, onCloseTile, onBottomRightPointerDown, onBottomLeftPointerDown,
+  tile, isMinimized, onMinimizeTile, onCloseTile, onBottomRightPointerDown, onBottomLeftPointerDown,
   onRightPointerDown, onBottomPointerDown, onLeftPointerDown
 }: IProps) {
   const info = getTileComponentInfo(tile.content.type)
@@ -40,7 +39,7 @@ export const CodapComponent = observer(function CodapComponent({
     }
   }
 
-  if (!info || isHidden) return null
+  if (!info) return null
 
   const { TitleBar, Component, tileEltClass, isFixedWidth, isFixedHeight } = info
   const classes = clsx("codap-component", tileEltClass, { minimized: isMinimized })

--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -121,11 +121,13 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
   if (info?.isFixedWidth) delete style?.width
   if (info?.isFixedHeight) delete style?.height
   const classes = clsx("free-tile-component", { minimized: rowTile?.isMinimized })
+
+  if (!info || rowTile?.isHidden) return null
+
   return (
     <div className={classes} style={style} key={tileId} ref={setNodeRef}>
       {tile && rowTile &&
         <CodapComponent tile={tile}
-          isHidden={rowTile.isHidden}
           isMinimized={rowTile.isMinimized}
           onMinimizeTile={handleMinimizeTile}
           onCloseTile={onCloseTile}

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -52,6 +52,7 @@ export function addDefaultComponents() {
     content.insertTileInRow(tableTile, row, tableOptions)
     sharedData && manager?.addTileSharedModel(tableTile.content, sharedData, true)
     caseMetadata && manager?.addTileSharedModel(tableTile.content, caseMetadata, true)
+    caseMetadata?.setCaseTableTileId(tableTile.id)
   }
   else {
     const tableTile = createDefaultTileOfType(kCaseTableTileType)
@@ -62,6 +63,7 @@ export function addDefaultComponents() {
     content.insertTileInRow(tableTile, row, tableOptions)
     sharedData && manager?.addTileSharedModel(tableTile.content, sharedData)
     caseMetadata && manager?.addTileSharedModel(tableTile.content, caseMetadata)
+    caseMetadata?.setCaseTableTileId(tableTile.id)
 
     const calculatorTile = createDefaultTileOfType(kCalculatorTileType)
     if (!calculatorTile) return

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -96,7 +96,6 @@ describe("createCodapDocument", () => {
           sharedModel: {
             categories: {},
             collections: {},
-            columnWidths: {},
             data: "test-5",
             hidden: {},
             id: caseMetadata.id,

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -146,7 +146,6 @@ export const DocumentContentModel = BaseDocumentContentModel
   .actions(self => ({
     toggleSingletonTileVisibility(tileType: string) {
       const tiles = self?.getTilesOfType(tileType)
-      // There's supposed to be at most one tile of this type. Enforce this. (But an assert would be nice!)
       if (tiles.length > 1) {
         console.error("DocumentContent.toggleSingletonTileVisibility:",
                       `encountered ${tiles.length} tiles of type ${tileType}`)
@@ -158,6 +157,14 @@ export const DocumentContentModel = BaseDocumentContentModel
         }
       } else {
         return self.createTile(tileType)
+      }
+    },
+    toggleNonDestroyableTileVisibility(tileLayoutId: string | undefined) {
+      if (tileLayoutId) {
+        const tileLayout = self.getTileLayoutById(tileLayoutId)
+        if (isFreeTileLayout(tileLayout)) {
+          tileLayout.setHidden(!tileLayout.isHidden)
+        }
       }
     }
   }))
@@ -193,7 +200,7 @@ export const DocumentContentModel = BaseDocumentContentModel
         const newTile = self.createOrShowTile(defaultTileType)
         if (newTile) {
           // link the case table to the new data set
-          linkTileToDataSet(newTile.content, sharedData.dataSet)
+          linkTileToDataSet(newTile, sharedData.dataSet)
         }
       }
       // Add dataset to the formula manager

--- a/v3/src/models/formula/test-utils/test-doc.json
+++ b/v3/src/models/formula/test-utils/test-doc.json
@@ -605,7 +605,6 @@
           "data": "DATAJXM3nKZTmvL8",
           "collections": {},
           "categories": {},
-          "columnWidths": {},
           "hidden": {}
         },
         "tiles": [
@@ -1983,7 +1982,6 @@
           "data": "DATAlL2AlOmWYdDV",
           "collections": {},
           "categories": {},
-          "columnWidths": {},
           "hidden": {}
         },
         "tiles": [

--- a/v3/src/models/shared/shared-case-metadata.test.ts
+++ b/v3/src/models/shared/shared-case-metadata.test.ts
@@ -58,18 +58,12 @@ describe("SharedCaseMetadata", () => {
   })
 
   it("stores column widths and hidden attributes", () => {
-    expect(tree.metadata.columnWidth("foo")).toBeUndefined()
     expect(tree.metadata.isHidden("foo")).toBe(false)
-    tree.metadata.setColumnWidth("foo", 10)
     tree.metadata.setIsHidden("foo", true)
-    expect(tree.metadata.columnWidth("foo")).toBe(10)
     expect(tree.metadata.isHidden("foo")).toBe(true)
-    tree.metadata.setColumnWidth("foo")
     tree.metadata.setIsHidden("foo", false)
-    expect(tree.metadata.columnWidth("foo")).toBeUndefined()
     expect(tree.metadata.isHidden("foo")).toBe(false)
     // falsy values are removed from map
-    expect(tree.metadata.columnWidths.size).toBe(0)
     expect(tree.metadata.hidden.size).toBe(0)
     // can show all hidden attributes
     tree.metadata.setIsHidden("foo", true)

--- a/v3/src/models/shared/shared-case-metadata.ts
+++ b/v3/src/models/shared/shared-case-metadata.ts
@@ -21,10 +21,10 @@ export const SharedCaseMetadata = SharedModel
     collections: types.map(CollectionTableMetadata),
     // key is attribute id
     categories: types.map(CategorySet),
-    // key is attribute id; value is width
-    columnWidths: types.map(types.number),
     // key is attribute id; value is true (false values are deleted)
-    hidden: types.map(types.boolean)
+    hidden: types.map(types.boolean),
+    caseTableTileId: types.maybe(types.string),
+    caseCardTileId: types.maybe(types.string)
   })
   .volatile(self => ({
     // CategorySets are generated whenever CODAP needs to treat an attribute categorically.
@@ -36,9 +36,6 @@ export const SharedCaseMetadata = SharedModel
     provisionalCategories: observable.map<string, ICategorySet>()
   }))
   .views(self => ({
-    columnWidth(attrId: string) {
-      return self.columnWidths.get(attrId)
-    },
     // true if passed the id of a parent/pseudo-case whose child cases have been collapsed, false otherwise
     isCollapsed(caseId: string) {
       const { collectionId, valuesJson } = self.data?.pseudoCaseMap.get(caseId) || {}
@@ -53,13 +50,11 @@ export const SharedCaseMetadata = SharedModel
     setData(data?: IDataSet) {
       self.data = data
     },
-    setColumnWidth(attrId: string, width?: number) {
-      if (width) {
-        self.columnWidths.set(attrId, width)
-      }
-      else {
-        self.columnWidths.delete(attrId)
-      }
+    setCaseTableTileId(tileId?: string) {
+      self.caseTableTileId = tileId
+    },
+    setCaseCardTileId(tileId?: string) {
+      self.caseCardTileId = tileId
     },
     setIsCollapsed(caseId: string, isCollapsed: boolean) {
       const { collectionId, valuesJson } = self.data?.pseudoCaseMap.get(caseId) || {}

--- a/v3/src/models/shared/shared-data-utils.test.ts
+++ b/v3/src/models/shared/shared-data-utils.test.ts
@@ -54,7 +54,7 @@ describe("SharedDataUtils", () => {
     const orphan = TileModel.create({ content: TestTileContent.create() })
     expect(getTileSharedModels(orphan.content)).toEqual([])
     expect(getDataSetFromId(orphan.content, sharedDataSet.dataSet.id)).toBeUndefined()
-    linkTileToDataSet(orphan.content, sharedDataSet.dataSet)
+    linkTileToDataSet(orphan, sharedDataSet.dataSet)
     expect(isTileLinkedToDataSet(orphan.content, sharedDataSet.dataSet)).toBe(false)
     expect(getTileSharedModels(orphan.content)).toEqual([])
     unlinkTileFromDataSets(orphan.content)
@@ -76,7 +76,7 @@ describe("SharedDataUtils", () => {
   })
 
   it("can link/unlink tiles to/from data sets and shared case metadata", () => {
-    linkTileToDataSet(tile.content, sharedDataSet.dataSet)
+    linkTileToDataSet(tile, sharedDataSet.dataSet)
     expect(document.content?.sharedModelMap.size).toBe(2)
     expect(getTileSharedModels(tile.content).length).toEqual(2)
     expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(true)
@@ -99,13 +99,13 @@ describe("SharedDataUtils", () => {
     sharedMetadata2.setData(sharedDataSet2.dataSet)
     expect(document.content?.sharedModelMap.size).toBe(4)
 
-    linkTileToDataSet(tile.content, sharedDataSet.dataSet)
+    linkTileToDataSet(tile, sharedDataSet.dataSet)
     expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(true)
     expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(false)
     expect(getTileDataSet(tile.content)).toBe(sharedDataSet.dataSet)
     expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata)
 
-    linkTileToDataSet(tile.content, sharedDataSet2.dataSet)
+    linkTileToDataSet(tile, sharedDataSet2.dataSet)
     expect(getTileSharedModels(tile.content).length).toEqual(2)
     expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
     expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(true)

--- a/v3/src/models/shared/shared-data-utils.ts
+++ b/v3/src/models/shared/shared-data-utils.ts
@@ -1,6 +1,7 @@
 import { IAnyStateTreeNode } from "@concord-consortium/mobx-state-tree"
 import { IDataSet } from "../data/data-set"
 import { ITileContentModel } from "../tiles/tile-content"
+import { ITileModel } from "../tiles/tile-model"
 import { getSharedModelManager } from "../tiles/tile-environment"
 import {
   ISharedCaseMetadata, isSharedCaseMetadata, kSharedCaseMetadataType, SharedCaseMetadata
@@ -75,20 +76,22 @@ export function unlinkTileFromDataSets(tile: ITileContentModel) {
 }
 
 // adds references to the specified tile to the specified SharedDataSet and its SharedCaseMetadata
-export function linkTileToDataSet(tile: ITileContentModel, dataSet: IDataSet) {
-  if (isTileLinkedToOtherDataSet(tile, dataSet)) {
-    unlinkTileFromDataSets(tile)
+export function linkTileToDataSet(tile: ITileModel, dataSet: IDataSet) {
+  const tileContent = tile.content
+  if (isTileLinkedToOtherDataSet(tileContent, dataSet)) {
+    unlinkTileFromDataSets(tileContent)
   }
 
   const sharedModelManager = getSharedModelManager(tile)
   const sharedDataSets = sharedModelManager?.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
   const sharedDataSet = sharedDataSets?.find(model => model.dataSet.id === dataSet.id) as ISharedDataSet | undefined
   if (sharedModelManager && sharedDataSet) {
-    sharedModelManager.addTileSharedModel(tile, sharedDataSet)
+    sharedModelManager.addTileSharedModel(tileContent, sharedDataSet)
 
     const sharedMetadata = sharedModelManager.getSharedModelsByType<typeof SharedCaseMetadata>(kSharedCaseMetadataType)
     const sharedCaseMetadata: ISharedCaseMetadata | undefined =
             sharedMetadata.find(model => model.data?.id === dataSet.id)
-    sharedCaseMetadata && sharedModelManager.addTileSharedModel(tile, sharedCaseMetadata)
+    sharedCaseMetadata && sharedModelManager.addTileSharedModel(tileContent, sharedCaseMetadata)
+    sharedCaseMetadata?.setCaseTableTileId(tile.id)
   }
 }

--- a/v3/src/models/tiles/tile-content-info.ts
+++ b/v3/src/models/tiles/tile-content-info.ts
@@ -28,7 +28,6 @@ export interface ITileContentInfo {
   titleBase?: string;
   metadataClass?: typeof TileMetadataModel;
   isSingleton?: boolean; // Only one instance of a tile is open per document (calculator and guide)
-  doesNotGetDestroyedOnClose?: boolean; // Tile is not destroyed when closed (case table and card)
   addSidecarNotes?: boolean;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;

--- a/v3/src/models/tiles/tile-content-info.ts
+++ b/v3/src/models/tiles/tile-content-info.ts
@@ -27,7 +27,8 @@ export interface ITileContentInfo {
   defaultContent: (options?: IDefaultContentOptions) => ITileContentSnapshotWithType;
   titleBase?: string;
   metadataClass?: typeof TileMetadataModel;
-  isSingleton?: boolean; // Only one instance of a tile is open per document
+  isSingleton?: boolean; // Only one instance of a tile is open per document (calculator and guide)
+  doesNotGetDestroyedOnClose?: boolean; // Tile is not destroyed when closed (case table and card)
   addSidecarNotes?: boolean;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;

--- a/v3/src/models/tiles/tile-content.ts
+++ b/v3/src/models/tiles/tile-content.ts
@@ -2,6 +2,7 @@ import iframePhone from "iframe-phone"
 import { getSnapshot, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { SetRequired } from "type-fest"
 import { DIMessage } from "../../data-interactive/iframe-phone-types"
+import { applyUndoableAction } from "../history/apply-undoable-action"
 import { ISharedModel } from "../shared/shared-model"
 import { SharedModelChangeType } from "../shared/shared-model-manager"
 import { getTileEnvironment, ITileEnvironment } from "./tile-environment"
@@ -76,6 +77,7 @@ export const TileContentModel = types.model("TileContentModel", {
   }))
   // Add an empty api so the api methods can be used on this generic type
   .actions(self => tileModelHooks({}))
+  .actions(applyUndoableAction)
 
 export interface ITileContentModel extends Instance<typeof TileContentModel> {}
 export interface ITileContentSnapshot extends SnapshotIn<typeof TileContentModel> {}

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -33,8 +33,6 @@
     "V3.Redo.caseTable.create": "Redo adding case table",
     "V3.Undo.caseTable.delete": "Undo deleting case table",
     "V3.Redo.caseTable.delete": "Redo deleting case table",
-    "V3.Undo.caseTable.show": "Undo showing case table",
-    "V3.Redo.caseTable.show": "Redo showing case table",
     "V3.Undo.caseTable.hide": "Undo hiding case table",
     "V3.Redo.caseTable.hide": "Redo hiding case table",
     "V3.Undo.import.data": "Undo import of data",

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -33,6 +33,10 @@
     "V3.Redo.caseTable.create": "Redo adding case table",
     "V3.Undo.caseTable.delete": "Undo deleting case table",
     "V3.Redo.caseTable.delete": "Redo deleting case table",
+    "V3.Undo.caseTable.show": "Undo showing case table",
+    "V3.Redo.caseTable.show": "Redo showing case table",
+    "V3.Undo.caseTable.hide": "Undo hiding case table",
+    "V3.Redo.caseTable.hide": "Redo hiding case table",
     "V3.Undo.import.data": "Undo import of data",
     "V3.Redo.import.data": "Redo import of data",
 

--- a/v3/src/v2/codap-v2-document.ts
+++ b/v3/src/v2/codap-v2-document.ts
@@ -6,8 +6,7 @@ import { ISharedCaseMetadata, SharedCaseMetadata } from "../models/shared/shared
 import { ISharedDataSet, SharedDataSet } from "../models/shared/shared-data-set"
 import {
   CodapV2Component, ICodapV2Attribute, ICodapV2Case, ICodapV2Collection, ICodapV2DataContext, ICodapV2DocumentJson,
-  isCodapV2Attribute, isV2TableComponent, v3TypeFromV2TypeString
-} from "./codap-v2-types"
+  v3TypeFromV2TypeString } from "./codap-v2-types"
 
 export class CodapV2Document {
   private document: ICodapV2DocumentJson
@@ -67,22 +66,6 @@ export class CodapV2Document {
     components?.forEach(component => {
       const { guid, type } = component
       this.guidMap.set(guid, { type, object: component })
-
-      // extract table metadata (e.g. column widths)
-      if (isV2TableComponent(component)) {
-        const { _links_, attributeWidths } = component.componentStorage
-        const data = this.dataMap.get(_links_.context.id)?.dataSet
-        const metadata = this.metadataMap.get(_links_.context.id)
-        attributeWidths?.forEach(entry => {
-          const v2Attr = this.guidMap.get(entry._links_.attr.id)
-          if (isCodapV2Attribute(v2Attr)) {
-            const attrId = data?.attrIDFromName(v2Attr.name)
-            if (attrId && entry.width) {
-              metadata?.setColumnWidth(attrId, entry.width)
-            }
-          }
-        })
-      }
     })
   }
 


### PR DESCRIPTION
[#187185393] Feature: Case table position is saved and restored on close and reopen

**Chore**
* Move `columnWidths` from `SharedCaseMetadata` to `CaseTableModel`. (Not actually necessary for this feature, but it was bothering me.) This necessitated changes in case-table-registration.ts and codap-v2-document.ts to change import from v2. Then, of course, places where we were getting column widths from `SharedCaseMetadata` we now get from the `CaseTableModel`.
* I discovered that in the previous PR for the Calculator hide/show it was the `CodapComponent` whose rendering was being hidden, it should actually be the `FreeTileComponent` whose rendering should be determined.

**Feature**
* Added some undo/redo strings for hiding/showing the case table
* `CaseTableTitleBar` now has its own method for `onCloseTile`
* `SharedCaseMetadata` Now has properties `caseTableTileId` and `caseCardTileId`
* The Table menu in the toolshelf now does a bit more work to make sure any newly created dataset's case table is hooked up properly and, if a case table already exists make sure that it is visible and has focus.
* The `linkTileToDataSet` function now takes a `TileModel` instead of a `TileContentModel`.

**Note**: This PR breaks the DataSummary because `DataSummaryModel.inspect` calls `linkTileToDataSet` and doesn't have a TileModel to offer. A subsequent PR will remove the DataSummary entirely from the codebase.