### PR TITLE
feat: show color swatch when editing color values

### DIFF
--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -271,6 +271,23 @@ $table-body-font-size: 8pt;
         }
       }
 
+      .color-cell-text-editor {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        padding-inline-start: 2px;
+
+        .color-swatch {
+          width: 12px;
+          padding: 4px 2px 3px 0;
+
+          .color-swatch-interior {
+            width: 100%;
+            height: 100%;
+          }
+        }
+      }
+
       // RDG.beta.17 moved all CSS inside @layers, which decreased their priority
       // so that some of Chakra's CSS takes precedence, including the gridlines.
       // These lines assert the RDG gridlines precedence ahead of Chakra's CSS.

--- a/v3/src/components/case-table/color-cell-text-editor.tsx
+++ b/v3/src/components/case-table/color-cell-text-editor.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef, useState } from "react"
+import { textEditorClassname } from "react-data-grid"
+import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { parseColor } from "../../utilities/color-utils"
+import { TRenderEditCellProps } from "./case-table-types"
+
+/*
+  ReactDataGrid uses Linaria CSS-in-JS for its internal styling. As with CSS Modules and other
+  CSS-in-JS solutions, this involves dynamically generating class names on the fly. The
+  `CellTextEditor` class below is a modified version of RDG's internal `TextEditor` class which
+  pulls its data from the DataSet, among other customizations. For the `CellTextEditor` component
+  to take advantage of the CSS of the `TextEditor` class, we must use the same classes.
+  Unfortunately, instead of tying their internal CSS to the public class names (e.g.
+  `rdg-text-editor`), RDG ties its internal CSS to the dynamically generated class names.
+  Therefore, to preserve the prior behavior we must give our instances of these components the
+  same classes as the components they're replacing, including the dynamically generated classes.
+  To enable this, patch-package has been used to export the `textEditorClassname` string.
+ */
+
+function autoFocusAndSelect(input: HTMLInputElement | null) {
+  input?.focus()
+  input?.select()
+}
+
+export default function ColorCellTextEditor({ row, column, onRowChange, onClose }: TRenderEditCellProps) {
+  const data = useDataSetContext()
+  const attributeId = column.key
+  const attribute = data?.getAttribute(attributeId)
+  const initialValueRef = useRef(data?.getStrValue(row.__id__, attributeId))
+  const [inputValue, setInputValue] = useState(initialValueRef.current)
+  // support colors if user hasn't assigned a non-color type
+  const supportColors = attribute?.userType == null || attribute?.userType === "color"
+  // support color names if the color type is user-assigned
+  const colorNames = attribute?.userType === "color"
+  const color = supportColors && inputValue ? parseColor(inputValue, { colorNames }) : undefined
+  // show the color swatch if the initial value appears to be a color (no change mid-edit)
+  const showColorSwatch = useRef(!!color)
+
+  useEffect(() => {
+    data?.setSelectedCases([])
+  }, [data])
+
+  function handleAccept() {
+    // commits the change and closes the editor
+    onRowChange({ ...row, [column.key]: inputValue }, true)
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent) {
+    if (event.key === "Enter") handleAccept()
+    if (event.key === "Escape") onClose()
+  }
+
+  const swatchStyle: React.CSSProperties | undefined = showColorSwatch.current ? { background: color } : undefined
+  const inputElt = <input
+                    data-testid="cell-text-editor"
+                    className={textEditorClassname}
+                    ref={autoFocusAndSelect}
+                    value={inputValue}
+                    onKeyDown={handleKeyDown}
+                    onChange={event => setInputValue(event.target.value)}
+                    onBlur={() => handleAccept()}
+                  />
+
+  return swatchStyle
+    ? (
+        <div className={"color-cell-text-editor"}>
+          <div className="color-swatch">
+            <div className="color-swatch-interior" style={swatchStyle}/>
+          </div>
+          { inputElt }
+        </div>
+      )
+    // if we don't have a valid color, just a simple text editor
+    : inputElt
+}

--- a/v3/src/components/case-table/use-columns.tsx
+++ b/v3/src/components/case-table/use-columns.tsx
@@ -12,6 +12,7 @@ import { parseColor } from "../../utilities/color-utils"
 import { mstReaction } from "../../utilities/mst-reaction"
 import { kDefaultColumnWidth, symDom, TColumn, TRenderCellProps } from "./case-table-types"
 import CellTextEditor from "./cell-text-editor"
+import ColorCellTextEditor from "./color-cell-text-editor"
 import { ColumnHeader } from "./column-header"
 
 // cache d3 number formatters so we don't have to generate them on every render
@@ -87,7 +88,7 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
         const collection = data?.getCollection(collectionId)
         const attrs: IAttribute[] = collection ? getCollectionAttrs(collection, data) : []
         const visible: IAttribute[] = attrs.filter(attr => attr && !caseMetadata?.isHidden(attr.id))
-        return visible.map(({ id, name, type, isEditable }) => ({ id, name, type, isEditable }))
+        return visible.map(({ id, name, type, userType, isEditable }) => ({ id, name, type, userType, isEditable }))
       },
       entries => {
         // column definitions
@@ -95,7 +96,7 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
           ? [
               ...(indexColumn ? [indexColumn] : []),
               // attribute column definitions
-              ...entries.map(({ id, name, isEditable }): TColumn => ({
+              ...entries.map(({ id, name, userType, isEditable }): TColumn => ({
                 key: id,
                 name,
                 // If a default column width isn't supplied, RDG defaults to "auto",
@@ -106,7 +107,11 @@ export const useColumns = ({ data, indexColumn }: IUseColumnsProps) => {
                 renderHeaderCell: ColumnHeader,
                 cellClass: "codap-data-cell",
                 renderCell: RenderCell,
-                renderEditCell: isEditable ? CellTextEditor : undefined
+                renderEditCell: isEditable
+                                  // if users haven't assigned a non-color type, then color swatches
+                                  // may be displayed and should be edited with swatches.
+                                  ? userType == null || userType === "color" ? ColorCellTextEditor : CellTextEditor
+                                  : undefined
               }))
           ]
           : []


### PR DESCRIPTION
- "Strict" color values (e.g. `#FF00FF` or `rgb(0, 255, 255)`) display as a color swatch in the case table and show a color swatch when editing _unless_ the user has assigned a non-color type to the attribute.
- Color names (e.g. `red`, `green`, `blue`) display as a color swatch in the case table if the user has assigned a color type  to the attribute.
- During editing, color swatch updates color dynamically and becomes blank if the value is not a valid color.
- Decision to show the swatch or not during editing is made based on the initial value at the start of editing, i.e. the space allocated for the swatch does not appear or disappear during editing.