### PR TITLE
fix: % values in data tip incorrect when legend present (PT-181915881)

### DIFF
--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -348,7 +348,7 @@ export const GraphContentModel = DataDisplayContentModel
         ...(caseTopSplitValue && {[topSplitAttrID]: caseTopSplitValue}),
         ...(caseRightSplitValue && {[rightSplitAttrID]: caseRightSplitValue})
       }
-      const casesInSubPlot = dataConfig?.subPlotCases(cellKey).length
+      const casesInSubPlot = dataConfig?.subPlotCases(cellKey) ?? []
       const totalCases = [
         legendMatches.length,
         bothSplitMatches.length,
@@ -356,14 +356,13 @@ export const GraphContentModel = DataDisplayContentModel
         rightSplitMatches.length,
         dataset?.cases.length ?? 0
       ].find(length => length > 0) ?? 0
-      const caseCategoryString = caseLegendValue !== ""
-        ? casePrimaryValue
-        : ""
-      const caseLegendCategoryString = caseLegendValue !== ""
-        ? caseLegendValue
-        : casePrimaryValue
-      const firstCount = legendAttrID ? totalCases : casesInSubPlot
-      const secondCount = legendAttrID ? casesInSubPlot : totalCases
+      const legendMatchesInSubplot = legendAttrID 
+        ? casesInSubPlot.filter(aCaseID => dataset?.getStrValue(aCaseID, legendAttrID) === caseLegendValue).length
+        :  0
+      const caseCategoryString = caseLegendValue ? casePrimaryValue : ""
+      const caseLegendCategoryString = caseLegendValue || casePrimaryValue
+      const firstCount = legendAttrID ? legendMatchesInSubplot : casesInSubPlot.length
+      const secondCount = legendAttrID ? casesInSubPlot.length : totalCases
       const percent = float(100 * firstCount / secondCount)
       // <n> of <m> <category> (<p>%) are <legend category>
       const attrArray = [


### PR DESCRIPTION
[[#181915881](https://www.pivotaltracker.com/story/show/181915881)]

Previously when a legend was present and there was a split of the primary axis of a bar chart, the percent values shown in the bar segment data tips were incorrect. They would have values like `86 of 61 are sitdown (141%)`, for example. That was because the total number of cases matching a given legend value across the _entire_ graph plot was being used instead of just the matches inside the subplot. These changes correct that.