### PR TITLE
Plotted function modal uses y-attribute name

### DIFF
--- a/v3/src/components/graph/adornments/plotted-function/edit-formula-modal.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/edit-formula-modal.tsx
@@ -8,12 +8,15 @@ import { t } from "../../../../utilities/translation/translate"
 
 interface IProps {
   currentValue?: string
+  leftHandSideLabel?: string
   isOpen: boolean
   onClose: (value: string) => void
 }
 
-export const EditFormulaModal = ({ currentValue="", isOpen, onClose }: IProps) => {
+export const EditFormulaModal = ({ currentValue="", isOpen, onClose, leftHandSideLabel }: IProps) => {
   const [value, setValue] = useState(currentValue)
+
+  const formulaPrompt = leftHandSideLabel || t("DG.PlottedFunction.formulaPrompt")
 
   const applyValue = () => {
     closeModal()
@@ -50,7 +53,7 @@ export const EditFormulaModal = ({ currentValue="", isOpen, onClose }: IProps) =
       <ModalBody>
         <FormControl display="flex" flexDirection="column" data-testid="edit-formula-value-form">
           <FormLabel>
-            {t("DG.PlottedFunction.formulaPrompt")}
+            {formulaPrompt}
           </FormLabel>
           <Textarea size="xs" value={value} onChange={handleValueChange}
             placeholder={t("DG.PlottedFunction.formulaHint")}

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
@@ -67,7 +67,9 @@ export const PlottedFunctionAdornmentBanner = observer(function PlottedFunctionA
          <EditFormulaModal
           isOpen={formulaModal.isOpen}
           currentValue={expression}
-          onClose={handleEditExpressionClose} />
+          onClose={handleEditExpressionClose}
+          leftHandSideLabel={`${yAttrName} =`}
+         />
       }
     </>
   )


### PR DESCRIPTION
[#187401360] Bug fix: Function Label Does Not Update to Variable Name in Graph Plot

* Pass y-attribute name to `EditFormulaModal`