### PR TITLE
feat: when editing color value in case table, click on swatch invokes color palette

### DIFF
--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -641,4 +641,44 @@ context("case table ui", () => {
       })
     })
   })
+
+  describe("table cell editing", () => {
+    it("edits cells", () => {
+      cy.log("checking cell contents")
+      table.getGridCell(2, 2).should("contain", "African Elephant")
+      cy.log("double-clicking the cell")
+      // double-click to initiate editing cell
+      table.getGridCell(2, 2).dblclick()
+      cy.log("check the editing cell contents")
+      table.getGridCell(2, 2).find("input").should("have.value", "African Elephant")
+      // type a color string
+      table.getGridCell(2, 2).find("input").type("#ff00ff{enter}")
+      // verify that cell shows color swatch of appropriate color
+      table.verifyCellSwatchColor(2, 2, "rgb(255, 0, 255)")
+      // double-click to begin editing cell
+      table.getGridCell(2, 2).dblclick()
+      // click color swatch to bring up color palette
+      table.getGridCell(2, 2).get(".cell-edit-color-swatch").click()
+      // click hue bar to change color
+      cy.get(`.react-colorful .react-colorful__hue [aria-label="Hue"]`).click()
+      // verify that the color actually changed
+      table.verifyEditCellSwatchColor(2, 2, "rgb(0, 255,")
+      // type escape key to dismiss color palette
+      cy.get(".react-colorful").type("{esc}")
+      // verify that cell displays original color
+      table.verifyCellSwatchColor(2, 2, "rgb(255, 0, 255)")
+      // double-click to begin editing cell
+      table.getGridCell(2, 2).dblclick()
+      // click color swatch to bring up color palette
+      table.getGridCell(2, 2).get(".cell-edit-color-swatch").click()
+      // click hue bar to change color
+      cy.get(`.react-colorful .react-colorful__hue [aria-label="Hue"]`).click()
+      // verify that the color actually changed
+      table.verifyEditCellSwatchColor(2, 2, "rgb(0, 255,")
+      // click Set Color button to dismiss color palette and change color
+      cy.get(".text-editor-color-picker .set-color-button").click()
+      // verify that the color actually changed
+      table.verifyCellSwatchColor(2, 2, "rgb(0, 255,")
+    })
+  })
 })

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -30,12 +30,12 @@ export const TableTileElements = {
   // getColumnHeaderTooltip() {
   //   return cy.get("[data-testid=case-table-attribute-tooltip]")
   // },
-  getIndexRow(rowNum, collectionIndex = 1) {
+  getIndexRow(rowNum: number, collectionIndex = 1) {
     return this.getCollection(collectionIndex).find(`[data-testid=collection-table-grid]
       [role=row][aria-rowindex="${rowNum}"]
       [data-testid=codap-index-content-button]`)
   },
-  openIndexMenuForRow(rowNum, collectionIndex = 1) {
+  openIndexMenuForRow(rowNum: number, collectionIndex = 1) {
     this.getIndexRow(rowNum, collectionIndex).click("top")
   },
   getIndexMenu() {
@@ -136,8 +136,26 @@ export const TableTileElements = {
     }
     this.getApplyButton().click()
   },
-  getCell(line, row, collectionIndex = 1) {
-    return this.getCollection(collectionIndex).find(`[aria-rowindex="${row}"] [aria-colindex="${line}"] .cell-span`)
+  getGridCell(row: number, column: number, collection = 1) {
+    return this.getCollection(collection).find(`[aria-rowindex="${row}"] [aria-colindex="${column}"]`)
+  },
+  // returns the .cell-span within the cell
+  getCell(column: number, row: number, collectionIndex = 1) {
+    return this.getCollection(collectionIndex).find(`[aria-rowindex="${row}"] [aria-colindex="${column}"] .cell-span`)
+  },
+  verifyCellSwatchColor(row: number, column: number, rgbColorStr: string, collection = 1) {
+    this.getGridCell(row, column, collection).find(".cell-color-swatch-interior").then($el => {
+      return window.getComputedStyle($el[0])
+    })
+    .invoke("getPropertyValue", "background")
+    .should("contain", rgbColorStr)
+  },
+  verifyEditCellSwatchColor(row: number, column: number, rgbColorStr: string, collection = 1) {
+    this.getGridCell(row, column, collection).find(".cell-edit-color-swatch-interior").then($el => {
+      return window.getComputedStyle($el[0])
+    })
+    .invoke("getPropertyValue", "background")
+    .should("contain", rgbColorStr)
   },
   verifyRowSelected(row) {
     cy.get(`[data-testid=case-table] [aria-rowindex="${row}"]`).invoke("attr", "aria-selected")

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -34,6 +34,7 @@
         "pluralize": "^8.0.0",
         "query-string": "^8.2.0",
         "react": "^18.2.0",
+        "react-colorful": "^5.6.1",
         "react-data-grid": "7.0.0-beta.42",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
@@ -20057,6 +20058,15 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-data-grid": {
       "version": "7.0.0-beta.42",
       "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-beta.42.tgz",
@@ -38581,6 +38591,12 @@
       "requires": {
         "@babel/runtime": "^7.12.13"
       }
+    },
+    "react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "requires": {}
     },
     "react-data-grid": {
       "version": "7.0.0-beta.42",

--- a/v3/package.json
+++ b/v3/package.json
@@ -199,6 +199,7 @@
     "pluralize": "^8.0.0",
     "query-string": "^8.2.0",
     "react": "^18.2.0",
+    "react-colorful": "^5.6.1",
     "react-data-grid": "7.0.0-beta.42",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",

--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -263,7 +263,7 @@ $table-body-font-size: 8pt;
           align-items: center;
           justify-content: center;
 
-          .cell-color-swatch-center {
+          .cell-color-swatch-interior {
             width: calc(100% - 4px);
             height: calc(100% - 8px);
             margin-top: 0.5px;
@@ -277,11 +277,11 @@ $table-body-font-size: 8pt;
         display: flex;
         padding-inline-start: 2px;
 
-        .color-swatch {
+        .cell-edit-color-swatch {
           width: 12px;
           padding: 4px 2px 3px 0;
 
-          .color-swatch-interior {
+          .cell-edit-color-swatch-interior {
             width: 100%;
             height: 100%;
           }

--- a/v3/src/components/case-table/color-cell-text-editor.tsx
+++ b/v3/src/components/case-table/color-cell-text-editor.tsx
@@ -117,17 +117,17 @@ export default function ColorCellTextEditor({ row, column, onRowChange, onClose 
             closeOnBlur={false}
           >
             <PopoverTrigger>
-              <button className="color-swatch"
+              <button className="cell-edit-color-swatch"
                 onPointerDown={handleSwatchPointerDown}
                 onClick={handleSwatchClick}>
-                <div className="color-swatch-interior" style={swatchStyle}/>
+                <div className="cell-edit-color-swatch-interior" style={swatchStyle}/>
               </button>
             </PopoverTrigger>
             <PopoverAnchor>
               { inputElt }
             </PopoverAnchor>
             <Portal>
-              <PopoverContent width={"inherit"}>
+              <PopoverContent className="text-editor-color-picker" width={"inherit"}>
                 <PopoverArrow />
                 <PopoverBody>
                   <ColorPicker color={hexColor} onChange={updateValue} />
@@ -136,10 +136,10 @@ export default function ColorCellTextEditor({ row, column, onRowChange, onClose 
                   <Flex>
                     <Spacer/>
                     <ButtonGroup>
-                      <Button size="xs" fontWeight="normal" onClick={rejectValue}>
+                      <Button className="cancel-button" size="xs" fontWeight="normal" onClick={rejectValue}>
                         {t("V3.CaseTable.colorPalette.cancel")}
                       </Button>
-                      <Button size="xs" fontWeight="normal" onClick={acceptValue}>
+                      <Button className="set-color-button" size="xs" fontWeight="normal" onClick={acceptValue}>
                         {t("V3.CaseTable.colorPalette.setColor")}
                       </Button>
                     </ButtonGroup>

--- a/v3/src/components/case-table/color-cell-text-editor.tsx
+++ b/v3/src/components/case-table/color-cell-text-editor.tsx
@@ -1,8 +1,14 @@
-import React, { useEffect, useRef, useState } from "react"
+import {
+  Button, ButtonGroup, Flex, forwardRef, Popover, PopoverAnchor, PopoverArrow, PopoverBody,
+  PopoverContent, PopoverFooter, PopoverTrigger, Portal, Spacer, useDisclosure, useMergeRefs
+} from "@chakra-ui/react"
+import React, { ChangeEvent, useCallback, useEffect, useRef, useState } from "react"
 import { textEditorClassname } from "react-data-grid"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { parseColor } from "../../utilities/color-utils"
+import { parseColor, parseColorToHex } from "../../utilities/color-utils"
+import { t } from "../../utilities/translation/translate"
 import { TRenderEditCellProps } from "./case-table-types"
+import { ColorPicker } from "./color-picker"
 
 /*
   ReactDataGrid uses Linaria CSS-in-JS for its internal styling. As with CSS Modules and other
@@ -22,52 +28,126 @@ function autoFocusAndSelect(input: HTMLInputElement | null) {
   input?.select()
 }
 
+const InputElt = forwardRef<React.InputHTMLAttributes<HTMLInputElement>, 'input'>((props, ref) => {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const mergeRefs = useMergeRefs(ref, inputRef)
+
+  useEffect(() => {
+    autoFocusAndSelect(inputRef.current)
+  }, [])
+
+  return (
+    <input data-testid="cell-text-editor" className={textEditorClassname} ref={mergeRefs} {...props} />
+  )
+})
+
 export default function ColorCellTextEditor({ row, column, onRowChange, onClose }: TRenderEditCellProps) {
   const data = useDataSetContext()
   const attributeId = column.key
   const attribute = data?.getAttribute(attributeId)
-  const initialValueRef = useRef(data?.getStrValue(row.__id__, attributeId))
-  const [inputValue, setInputValue] = useState(initialValueRef.current)
+  const [inputValue, setInputValue] = useState(() => data?.getStrValue(row.__id__, attributeId))
   // support colors if user hasn't assigned a non-color type
   const supportColors = attribute?.userType == null || attribute?.userType === "color"
   // support color names if the color type is user-assigned
   const colorNames = attribute?.userType === "color"
   const color = supportColors && inputValue ? parseColor(inputValue, { colorNames }) : undefined
+  const hexColor = color ? parseColorToHex(color, { colorNames }) : undefined
   // show the color swatch if the initial value appears to be a color (no change mid-edit)
-  const showColorSwatch = useRef(!!color)
+  const showColorSwatch = useRef(!!hexColor)
 
   useEffect(() => {
     data?.setSelectedCases([])
   }, [data])
 
-  function handleAccept() {
-    // commits the change and closes the editor
+  // commits the change and closes the editor
+  const acceptValue = useCallback(() => {
     onRowChange({ ...row, [column.key]: inputValue }, true)
+  }, [column, inputValue, onRowChange, row])
+
+  // updates the value locally without committing the changes
+  const updateValue = useCallback((value: string) => {
+    setInputValue(value)
+    onRowChange({ ...row, [column.key]: value })
+  }, [column, onRowChange, row])
+
+  // rejects any local changes and closes the editor
+  const rejectValue = useCallback(() => {
+    onClose()
+  }, [onClose])
+
+  const { isOpen: isPaletteOpen, onToggle: togglePalette } = useDisclosure()
+
+  function handleSwatchPointerDown(event: React.PointerEvent) {
+    // prevent blurring the input
+    event.preventDefault()
   }
 
-  function handleKeyDown(event: React.KeyboardEvent) {
-    if (event.key === "Enter") handleAccept()
-    if (event.key === "Escape") onClose()
+  function handleSwatchClick(event: React.MouseEvent) {
+    togglePalette()
+  }
+
+  function handleInputColorChange(event: ChangeEvent<HTMLInputElement>) {
+    updateValue(event.target.value)
+  }
+
+  function handleInputKeyDown(event: React.KeyboardEvent) {
+    if (event.key === "Enter") acceptValue()
+    if (event.key === "Escape") rejectValue()
+  }
+
+  function handleInputBlur() {
+    !isPaletteOpen && acceptValue()
   }
 
   const swatchStyle: React.CSSProperties | undefined = showColorSwatch.current ? { background: color } : undefined
-  const inputElt = <input
-                    data-testid="cell-text-editor"
-                    className={textEditorClassname}
-                    ref={autoFocusAndSelect}
+  const inputElt = <InputElt
                     value={inputValue}
-                    onKeyDown={handleKeyDown}
-                    onChange={event => setInputValue(event.target.value)}
-                    onBlur={() => handleAccept()}
+                    onKeyDown={handleInputKeyDown}
+                    onChange={handleInputColorChange}
+                    onBlur={handleInputBlur}
                   />
 
   return swatchStyle
     ? (
         <div className={"color-cell-text-editor"}>
-          <div className="color-swatch">
-            <div className="color-swatch-interior" style={swatchStyle}/>
-          </div>
-          { inputElt }
+          <Popover
+            isLazy={true}
+            isOpen={isPaletteOpen}
+            placement="right"
+            closeOnBlur={false}
+          >
+            <PopoverTrigger>
+              <button className="color-swatch"
+                onPointerDown={handleSwatchPointerDown}
+                onClick={handleSwatchClick}>
+                <div className="color-swatch-interior" style={swatchStyle}/>
+              </button>
+            </PopoverTrigger>
+            <PopoverAnchor>
+              { inputElt }
+            </PopoverAnchor>
+            <Portal>
+              <PopoverContent width={"inherit"}>
+                <PopoverArrow />
+                <PopoverBody>
+                  <ColorPicker color={hexColor} onChange={updateValue} />
+                </PopoverBody>
+                <PopoverFooter>
+                  <Flex>
+                    <Spacer/>
+                    <ButtonGroup>
+                      <Button size="xs" fontWeight="normal" onClick={rejectValue}>
+                        {t("V3.CaseTable.colorPalette.cancel")}
+                      </Button>
+                      <Button size="xs" fontWeight="normal" onClick={acceptValue}>
+                        {t("V3.CaseTable.colorPalette.setColor")}
+                      </Button>
+                    </ButtonGroup>
+                  </Flex>
+                </PopoverFooter>
+              </PopoverContent>
+            </Portal>
+          </Popover>
         </div>
       )
     // if we don't have a valid color, just a simple text editor

--- a/v3/src/components/case-table/color-picker.tsx
+++ b/v3/src/components/case-table/color-picker.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+import { HexAlphaColorPicker } from "react-colorful"
+
+// copied from react-colorful because it's not exported
+type ColorPickerHTMLAttributes =
+  Omit<React.HTMLAttributes<HTMLDivElement>, "color" | "onChange" | "onChangeCapture">
+export interface ColorPickerProps extends ColorPickerHTMLAttributes {
+    color?: string;
+    onChange?: (newColor: string) => void;
+}
+export function ColorPicker(props: ColorPickerProps) {
+  return <HexAlphaColorPicker {...props} />
+}

--- a/v3/src/components/case-table/use-columns.tsx
+++ b/v3/src/components/case-table/use-columns.tsx
@@ -36,7 +36,7 @@ export function renderValue(str = "", num = NaN, attr?: IAttribute) {
   if (color) {
     return (
       <div className="cell-color-swatch" >
-        <div className="cell-color-swatch-center" style={{ background: color }} />
+        <div className="cell-color-swatch-interior" style={{ background: color }} />
       </div>
     )
   }

--- a/v3/src/sample-data/colors.csv
+++ b/v3/src/sample-data/colors.csv
@@ -1,0 +1,7 @@
+Color
+red
+green
+blue
+"#00ffff"
+"#ff00ff"
+"#ffff00"

--- a/v3/src/sample-data/index.ts
+++ b/v3/src/sample-data/index.ts
@@ -3,16 +3,18 @@ import { convertParsedCsvToDataSet, CsvParseResult, downloadCsvFile } from "../u
 import abaloneCsv from "./abalone.csv"
 import catsCsv from "./cats.csv"
 import coastersCsv from "./roller-coasters.csv"
+import colorsCsv from "./colors.csv"
 import mammalsCsv from "./mammals.csv"
 import fourCsv from "./four.csv"
 
-export const sampleData = ["Abalone", "Cats", "Coasters", "Mammals", "Four"] as const
+export const sampleData = ["Abalone", "Cats", "Coasters", "Colors", "Four", "Mammals"] as const
 export type SampleType = typeof sampleData[number]
 
 const sampleMap: Record<SampleType, string> = {
   Abalone: abaloneCsv,
   Cats: catsCsv,
   Coasters: coastersCsv,
+  Colors: colorsCsv,
   Four: fourCsv,
   Mammals: mammalsCsv
 }

--- a/v3/src/utilities/color-utils.test.ts
+++ b/v3/src/utilities/color-utils.test.ts
@@ -1,4 +1,4 @@
-import { parseColor } from "./color-utils"
+import { parseColor, parseColorToHex } from "./color-utils"
 
 describe("Color utilities", () => {
   it("parseColor works as expected without color names", () => {
@@ -58,5 +58,64 @@ describe("Color utilities", () => {
     expect(parseColor("hsl(100, 50%, 50%, 0.5)", { colorNames: true })).toBe("#6abf4080")
     // projects out-of-range hue to valid range
     expect(parseColor("hsl(460, 50%, 50%)", { colorNames: true })).toBe("#6abf40")
+  })
+
+  it("parseColorToHex works as expected without color names", () => {
+    // ignores invalid values
+    expect(parseColorToHex("")).toBe("")
+    expect(parseColorToHex("foo")).toBe("")
+    expect(parseColorToHex("rgb()")).toBe("")
+
+    // ignores color names when not configured to support them
+    expect(parseColorToHex("red")).toBe("")
+    expect(parseColorToHex("TOMATO")).toBe("")
+    expect(parseColorToHex("papayaWhip")).toBe("")
+
+    // supports hex
+    expect(parseColorToHex("#ff0000")).toBe("#ff0000")
+    expect(parseColorToHex("#00ff0080")).toBe("#00ff0080")
+    expect(parseColorToHex("#00f")).toBe("#0000ff")
+    expect(parseColorToHex("#00f8")).toBe("#0000ff87")
+
+    // supports rgb()
+    expect(parseColorToHex("rgb(0, 255, 0)")).toBe("#00ff00")
+    expect(parseColorToHex("rgb(0, 255, 0, 0.5)")).toBe("#00ff0080")
+    // clamps out-of-range values to valid range
+    expect(parseColorToHex("rgb(0, 500, 0)")).toBe("#00ff00")
+
+    // supports hsl()
+    expect(parseColorToHex("hsl(100, 50%, 50%)")).toBe("#6abf40")
+    expect(parseColorToHex("hsl(100, 50%, 50%, 0.5)")).toBe("#6abf4080")
+    // projects out-of-range hue to valid range
+    expect(parseColorToHex("hsl(460, 50%, 50%)")).toBe("#6abf40")
+  })
+  it("parseColorToHex works as expected with color names", () => {
+    // ignores invalid values
+    expect(parseColorToHex("", { colorNames: true })).toBe("")
+    expect(parseColorToHex("foo", { colorNames: true })).toBe("")
+    expect(parseColorToHex("rgb()", { colorNames: true })).toBe("")
+
+    // returns color names when configured to support them
+    expect(parseColorToHex("red", { colorNames: true })).toBe("#ff0000")
+    expect(parseColorToHex("TOMATO", { colorNames: true })).toBe("#ff6347")
+    expect(parseColorToHex("papayaWhip", { colorNames: true })).toBe("#ffefd5")
+
+    // supports hex
+    expect(parseColorToHex("#ff0000", { colorNames: true })).toBe("#ff0000")
+    expect(parseColorToHex("#00ff0080", { colorNames: true })).toBe("#00ff0080")
+    expect(parseColorToHex("#00f", { colorNames: true })).toBe("#0000ff")
+    expect(parseColorToHex("#00f8", { colorNames: true })).toBe("#0000ff87")
+
+    // supports rgb()
+    expect(parseColorToHex("rgb(0, 255, 0)", { colorNames: true })).toBe("#00ff00")
+    expect(parseColorToHex("rgb(0, 255, 0, 0.5)", { colorNames: true })).toBe("#00ff0080")
+    // clamps out-of-range values to valid range
+    expect(parseColorToHex("rgb(0, 500, 0)", { colorNames: true })).toBe("#00ff00")
+
+    // supports hsl()
+    expect(parseColorToHex("hsl(100, 50%, 50%)", { colorNames: true })).toBe("#6abf40")
+    expect(parseColorToHex("hsl(100, 50%, 50%, 0.5)", { colorNames: true })).toBe("#6abf4080")
+    // projects out-of-range hue to valid range
+    expect(parseColorToHex("hsl(460, 50%, 50%)", { colorNames: true })).toBe("#6abf40")
   })
 })

--- a/v3/src/utilities/color-utils.ts
+++ b/v3/src/utilities/color-utils.ts
@@ -54,11 +54,28 @@ export interface ParseColorOptions {
  *
  * @param str string to be parsed for its color
  * @param options { colorNames?: boolean } whether or not to recognize color names when parsing
- * @returns canonicalized color string or empty string
+ * @returns canonicalized color name or string or empty string
  */
 export function parseColor(str: string, options?: ParseColorOptions) {
   // if it's a valid color name, return it
   if (options?.colorNames && parseColorName(str)) return str.toLowerCase()
+  // if it's a valid color string, return its hex equivalent
+  return getColorFormat(str) ? colord(str).toHex() : ""
+}
+
+/**
+ * parseColorToHex
+ *
+ * @param str string to be parsed for its color
+ * @param options { colorNames?: boolean } whether or not to recognize color names when parsing
+ * @returns canonicalized color string or empty string
+ */
+export function parseColorToHex(str: string, options?: ParseColorOptions) {
+  // if it's a valid color name, return its hex equivalent
+  if (options?.colorNames) {
+    const parsed = parseColorName(str)
+    if (parsed) return colord(parsed).toHex()
+  }
   // if it's a valid color string, return its hex equivalent
   return getColorFormat(str) ? colord(str).toHex() : ""
 }

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -29,6 +29,8 @@
 
     // V3 case table strings that are not present in V2 and will eventually require translation.
     "DG.CaseTable.attribute.type.color": "color", // used dynamically (`DG.CaseTable.attribute.type.${type}`)
+    "V3.CaseTable.colorPalette.setColor": "Set Color",
+    "V3.CaseTable.colorPalette.cancel": "Cancel",
     "V3.Undo.caseTable.create": "Undo adding case table",
     "V3.Redo.caseTable.create": "Redo adding case table",
     "V3.Undo.caseTable.delete": "Undo deleting case table",


### PR DESCRIPTION
[[PT-187020075]](https://www.pivotaltracker.com/story/show/187020075)

- Clicking on swatch brings up color picker.
- Color picker allows selection of color, including opacity.
- Changes can be accepted by `enter` key, clicking `Set Color` button, or clicking outside color picker.
- Changes can be rejected by `escape` key or clicking `Cancel` button.
- Named colors are converted to hex colors when edited.