### PR TITLE
fix: new map tile points not initially rendered (PT-181962645)

### DIFF
--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -134,10 +134,12 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
     }
   }, [dataConfiguration.dataset, mapModel])
 
-  if (pixiPointsRef.current != null && pixiContainerRef.current && pixiContainerRef.current.children.length === 0) {
-    pixiContainerRef.current.appendChild(pixiPointsRef.current.canvas)
-    pixiPointsRef.current.resize(layout.contentWidth, layout.contentHeight)
-  }
+  useEffect(() => {
+    if (pixiPointsRef.current != null && pixiContainerRef.current && pixiContainerRef.current.children.length === 0) {
+      pixiContainerRef.current.appendChild(pixiPointsRef.current.canvas)
+      pixiPointsRef.current.resize(layout.contentWidth, layout.contentHeight)
+    }
+  }, [layout.contentWidth, layout.contentHeight])
 
   const refreshConnectingLines = useCallback(() => {
     if (!showConnectingLines && !connectingLinesActivatedRef.current) return


### PR DESCRIPTION
[[181962645](https://www.pivotaltracker.com/story/show/181962645)]

The addition of `observer` to `MapPointLayer` in [this PR](https://github.com/concord-consortium/codap/pull/1219) led to the periodic prevention of a re-render the component relied on to complete the addition of the `PixiPoints` canvas to the DOM. This caused [a bug where points weren't always being rendered](https://www.pivotaltracker.com/story/show/181962645/comments/241012206). Putting the addition of the `PixiPoints` canvas into a `useEffect` corrects the problem.