### PR TITLE
187458550 v3 DI Delete Component Hides Singletons

### DIFF
--- a/v3/src/components/case-card/case-card-registration.ts
+++ b/v3/src/components/case-card/case-card-registration.ts
@@ -15,7 +15,8 @@ registerTileContentInfo({
   type: kCaseCardTileType,
   prefix: kCaseCardIdPrefix,
   modelClass: CaseCardModel,
-  defaultContent: () => ({ type: kCaseCardTileType })
+  defaultContent: () => ({ type: kCaseCardTileType }),
+  hideOnClose: true
 })
 
 registerTileComponentInfo({

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -19,7 +19,8 @@ registerTileContentInfo({
   type: kCaseTableTileType,
   prefix: kCaseTableIdPrefix,
   modelClass: CaseTableModel,
-  defaultContent: () => ({ type: kCaseTableTileType })
+  defaultContent: () => ({ type: kCaseTableTileType }),
+  hideOnClose: true
 })
 
 registerTileComponentInfo({

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -34,6 +34,7 @@ export interface DICase {
 export type DICollection = Partial<ICodapV2Collection>
 export type DIComponent = ITileModel
 export interface DIComponentInfo {
+  hidden?: boolean
   id?: string
   name?: string
   title?: string

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -13,7 +13,7 @@ export const diComponentHandler: DIHandler = {
 
     const { document } = appState
     document.applyModelChange(() => {
-      appState.document.content?.deleteOrHideTile(component.id)
+      document.content?.deleteOrHideTile(component.id)
     })
 
     return { success: true }

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -1,8 +1,8 @@
 import { t } from "../../utilities/translation/translate"
+import { appState } from "../../models/app-state"
+import { uiState } from "../../models/ui-state"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DINotification, DIResources, DIValues } from "../data-interactive-types"
-import { uiState } from "../../models/ui-state"
-import { appState } from "../../models/app-state"
 
 const componentNotFoundResult = { success: false, values: { error: t("V3.DI.Error.componentNotFound") } } as const
 
@@ -11,7 +11,10 @@ export const diComponentHandler: DIHandler = {
     const { component } = resources
     if (!component) return componentNotFoundResult
 
-    appState.document.deleteTile(component.id)
+    const { document } = appState
+    document.applyModelChange(() => {
+      appState.document.content?.deleteOrHideTile(component.id)
+    })
 
     return { success: true }
   },

--- a/v3/src/data-interactive/handlers/component-list-handler.ts
+++ b/v3/src/data-interactive/handlers/component-list-handler.ts
@@ -1,13 +1,15 @@
 import { isWebViewModel } from "../../components/web-view/web-view-model"
 import { appState } from "../../models/app-state"
+import { isFreeTileLayout } from "../../models/document/free-tile-row"
 import { kComponentTypeV3ToV2Map, kV2GameType, kV2WebViewType } from "../data-interactive-component-types"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIComponentInfo, DIHandler, DIResources } from "../data-interactive-types"
 
 export const diComponentListHandler: DIHandler = {
   get(_resources: DIResources) {
+    const { document } = appState
     const values: DIComponentInfo[] = []
-    appState.document.content?.tileMap.forEach(tile => {
+    document.content?.tileMap.forEach(tile => {
       // TODO Should we add names to tiles?
       // TODO Tiles sometimes show titles different than tile.title. Should we return those?
       const { content, id, title } = tile
@@ -16,7 +18,9 @@ export const diComponentListHandler: DIHandler = {
           ? kV2GameType
           : kV2WebViewType
         : kComponentTypeV3ToV2Map[content.type]
-      values.push({ id, title, type })
+      const tileLayout = document.content?.getTileLayoutById(id)
+      const hidden = isFreeTileLayout(tileLayout) ? !!tileLayout.isHidden : false
+      values.push({ hidden, id, title, type })
     })
 
     return { success: true, values }

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -185,20 +185,18 @@ export const DocumentContentModel = BaseDocumentContentModel
         }
       }
     },
+    // Hide the tile if it's a singleton and can be hidden. Otherwise, delete it.
     deleteOrHideTile(tileId: string) {
       const tile = self.getTile(tileId)
-      if (tile) {
-        const tileType = tile.content.type
-        const tileInfo = getTileContentInfo(tileType)
-        if (tileInfo?.isSingleton) {
-          const tileLayout = self.getTileLayoutById(tileId)
-          if (isFreeTileLayout(tileLayout)) {
-            tileLayout.setHidden(true)
-          }
-        } else {
-          self.deleteTile(tileId)
+      const tileInfo = getTileContentInfo(tile?.content.type)
+      if (tileInfo?.isSingleton) {
+        const tileLayout = self.getTileLayoutById(tileId)
+        if (isFreeTileLayout(tileLayout)) {
+          tileLayout.setHidden(true)
+          return
         }
       }
+      self.deleteTile(tileId)
     }
   }))
   .actions(self => ({

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -184,6 +184,21 @@ export const DocumentContentModel = BaseDocumentContentModel
           return self.createTile(tileType, options)
         }
       }
+    },
+    deleteOrHideTile(tileId: string) {
+      const tile = self.getTile(tileId)
+      if (tile) {
+        const tileType = tile.content.type
+        const tileInfo = getTileContentInfo(tileType)
+        if (tileInfo?.isSingleton) {
+          const tileLayout = self.getTileLayoutById(tileId)
+          if (isFreeTileLayout(tileLayout)) {
+            tileLayout.setHidden(true)
+          }
+        } else {
+          self.deleteTile(tileId)
+        }
+      }
     }
   }))
   .actions(self => ({

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -185,11 +185,11 @@ export const DocumentContentModel = BaseDocumentContentModel
         }
       }
     },
-    // Hide the tile if it's a singleton and can be hidden. Otherwise, delete it.
+    // Hide the tile if it should hide on close or is a singleton and can be hidden. Otherwise, delete it.
     deleteOrHideTile(tileId: string) {
       const tile = self.getTile(tileId)
       const tileInfo = getTileContentInfo(tile?.content.type)
-      if (tileInfo?.isSingleton) {
+      if (tileInfo?.hideOnClose || tileInfo?.isSingleton) {
         const tileLayout = self.getTileLayoutById(tileId)
         if (isFreeTileLayout(tileLayout)) {
           tileLayout.setHidden(true)

--- a/v3/src/models/tiles/tile-content-info.ts
+++ b/v3/src/models/tiles/tile-content-info.ts
@@ -28,6 +28,7 @@ export interface ITileContentInfo {
   titleBase?: string;
   metadataClass?: typeof TileMetadataModel;
   isSingleton?: boolean; // Only one instance of a tile is open per document (calculator and guide)
+  hideOnClose?: boolean;
   addSidecarNotes?: boolean;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187458550

@nstclair-cc pointed out that `delete component` on singletons (like the calculator) should not actually delete the tile, but instead should be hide it, so it reappears in the same location when recreated. This PR fixes that issue by hiding singletons rather than deleting them from the document.

It's worth noting that this is not how v2 works. But v3 also differs from v2 in that closing a singleton will actually delete it in v2, while it just hides the singleton in v3.

This PR also adds the `hidden` field to the response to `get componentList` requests.