### PR TITLE
Count adornment calls applyModelChange for setCount and setPercent

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -168,7 +168,12 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
         const shouldShowPercentOption = !!dataConfig?.categoricalAttrCount || adornmentsStore.subPlotsHaveRegions ||
                                         graphModel.pointDisplayType === "bins"
         if (!shouldShowPercentOption && model?.showPercent) {
-          model.setShowPercent(false)
+          graphModel.applyModelChange(() => {
+            model.setShowPercent(false)
+          }, {
+            undoStringKey: "DG.Undo.graph.hidePercent",
+            redoStringKey: "DG.Redo.graph.hidePercent"
+          })
         }
      }, { name: "CountAdornment.refreshPercentOption"}, model)
   }, [adornmentsStore, dataConfig, graphModel, model])

--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -1,7 +1,6 @@
 import { Instance, types } from "mobx-state-tree"
 import { AdornmentModel, IAdornmentModel } from "../adornment-models"
 import { kCountType } from "./count-adornment-types"
-import { withUndoRedoStrings } from "../../../../models/history/codap-undo-types"
 import {IGraphDataConfigurationModel} from "../../models/graph-data-configuration-model"
 import { ScaleNumericBaseType } from "../../../axis/axis-types"
 
@@ -88,16 +87,10 @@ export const CountAdornmentModel = AdornmentModel
     setShowCount(showCount: boolean) {
       self.showCount = showCount
       self.isVisible = self.showCount || self.showPercent
-      const undoString = showCount ? "DG.Undo.graph.showCount" : "DG.Undo.graph.hideCount"
-      const redoString = showCount ? "DG.Redo.graph.showCount" : "DG.Redo.graph.hideCount"
-      withUndoRedoStrings(undoString, redoString)
     },
     setShowPercent(showPercent: boolean) {
       self.showPercent = showPercent
       self.isVisible = self.showCount || self.showPercent
-      const undoString = showPercent ? "DG.Undo.graph.showPercent" : "DG.Undo.graph.hidePercent"
-      const redoString = showPercent ? "DG.Redo.graph.showPercent" : "DG.Redo.graph.hidePercent"
-      withUndoRedoStrings(undoString, redoString)
     },
     setPercentType(percentType: string) {
       self.percentType = percentType

--- a/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
@@ -38,7 +38,15 @@ const Controls = () => {
     const redoRemoveKey = checkBoxType === "count" ? "DG.Redo.graph.hideCount" : "DG.Redo.graph.hidePercent"
 
     const setShowAdornment = checkBoxType === "count"
-      ? () => adornment.setShowCount(checked)
+      ? () => {
+        graphModel.applyModelChange(
+          () => {
+            adornment.setShowCount(checked)
+          }, {
+            undoStringKey: undoAddKey,
+            redoStringKey: redoAddKey
+          })
+      }
       : () => handleShowPercent(adornment, checked)
 
     if (checked) {

--- a/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
@@ -38,15 +38,7 @@ const Controls = () => {
     const redoRemoveKey = checkBoxType === "count" ? "DG.Redo.graph.hideCount" : "DG.Redo.graph.hidePercent"
 
     const setShowAdornment = checkBoxType === "count"
-      ? () => {
-        graphModel.applyModelChange(
-          () => {
-            adornment.setShowCount(checked)
-          }, {
-            undoStringKey: undoAddKey,
-            redoStringKey: redoAddKey
-          })
-      }
+      ? () => adornment.setShowCount(checked)
       : () => handleShowPercent(adornment, checked)
 
     if (checked) {


### PR DESCRIPTION
[#187510616] Chore: The count adornment relies on `withUndoRedoStrings` instead of going through `applyModelChange`

* Removed dependency on `withUndoRedoStrings` in `CountAdornmentModel`
* Use `applyModelChange` when calling `setCount` and `setPercent` in count-adornment-registration.tsx and count-adornment-component.tsx