### PR TITLE
187485557 v3 DI Attribute Notifications

### DIFF
--- a/v3/build_number.json
+++ b/v3/build_number.json
@@ -1,1 +1,1 @@
-{"buildNumber":1619}
+{"buildNumber":1620}

--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -6,7 +6,7 @@ import { WebViewTileElements as webView } from "../support/elements/web-view-til
 
 context("codap plugins", () => {
   beforeEach(function () {
-    const url = `${Cypress.config("index")}?mouseSensor&sample=mammals&dashboard`
+    const url = `${Cypress.config("index")}?sample=mammals&dashboard`
     cy.visit(url)
   })
   const openAPITester = () => {
@@ -144,6 +144,58 @@ context("codap plugins", () => {
   it('will broadcast notifications', () => {
     openAPITester()
     webView.toggleAPITesterFilter()
+
+    cy.log("Broadcast attribute notifications")
+
+    cy.log("Broadcast hideAttribute notifications")
+    c.selectTile("table", 0)
+    table.openAttributeMenu("Mammal")
+    table.selectMenuItemFromAttributeMenu("Hide Attribute")
+    webView.confirmAPITesterResponseContains(/"operation":\s"hideAttributes/)
+    webView.clearAPITesterResponses()
+
+    cy.log("Broadcast unhideAttribute notifications")
+    table.showAllAttributes()
+    webView.confirmAPITesterResponseContains(/"operation":\s"unhideAttributes/)
+    webView.clearAPITesterResponses()
+
+    cy.log("Broadcast createAttributes notifications")
+    // + button in collection header
+    table.addNewAttribute()
+    webView.confirmAPITesterResponseContains(/"operation":\s"createAttributes/)
+    webView.clearAPITesterResponses()
+    // New Attribute button in ruler menu
+    table.getRulerButton().click()
+    table.selectItemFromRulerMenu("New Attribute")
+    webView.confirmAPITesterResponseContains(/"operation":\s"createAttributes/)
+    webView.clearAPITesterResponses()
+
+    cy.log("Broadcast deleteAttributes notifications")
+    table.deleteAttrbute("newAttr2")
+    webView.confirmAPITesterResponseContains(/"operation":\s"deleteAttributes/)
+    webView.clearAPITesterResponses()
+
+    cy.log("Broadcast updateAttributes notifications")
+    // Rename attribute
+    const newName = "newerAttr"
+    table.renameAttribute("newAttr", newName)
+    webView.confirmAPITesterResponseContains(/"operation":\s"updateAttributes/)
+    webView.clearAPITesterResponses()
+    // Edit attribute properties
+    table.editAttributeProperties(newName, "", null, null, null, null, null)
+    webView.confirmAPITesterResponseContains(/"operation":\s"updateAttributes/)
+    webView.clearAPITesterResponses()
+    // Edit formula
+    table.editFormula(newName, "Mass * 2")
+    webView.confirmAPITesterResponseContains(/"operation":\s"updateAttributes/)
+    webView.clearAPITesterResponses()
+
+    // TODO Figure out how to test moveAttribute notifications
+    // cy.log("Broadcast moveAttribute notifications")
+    // table.moveAttributeToParent("Sleep", "newCollection")
+    // table.moveAttributeToParent(newName, "targetAttribute", "Speed")
+    // webView.confirmAPITesterResponseContains(/"operation":\s"moveAttribute/)
+    // webView.clearAPITesterResponses()
 
     cy.log("Broadcast global value change notifications")
     slider.changeVariableValue(8)

--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -190,13 +190,6 @@ context("codap plugins", () => {
     webView.confirmAPITesterResponseContains(/"operation":\s"updateAttributes/)
     webView.clearAPITesterResponses()
 
-    // TODO Figure out how to test moveAttribute notifications
-    // cy.log("Broadcast moveAttribute notifications")
-    // table.moveAttributeToParent("Sleep", "newCollection")
-    // table.moveAttributeToParent(newName, "targetAttribute", "Speed")
-    // webView.confirmAPITesterResponseContains(/"operation":\s"moveAttribute/)
-    // webView.clearAPITesterResponses()
-
     cy.log("Broadcast global value change notifications")
     slider.changeVariableValue(8)
     webView.confirmAPITesterResponseContains(/"action":\s"notify",\s"resource":\s"global/)
@@ -205,6 +198,29 @@ context("codap plugins", () => {
     slider.playSliderButton()
     webView.confirmAPITesterResponseContains(/"action":\s"notify",\s"resource":\s"global/)
     slider.pauseSliderButton()
+    webView.clearAPITesterResponses()
+  })
+
+  it('will broadcast notifications involving dragging', () => {
+    const url = `${Cypress.config("index")}?mouseSensor&sample=mammals&dashboard`
+    cy.visit(url)
+
+    openAPITester()
+    webView.toggleAPITesterFilter()
+
+    cy.log("Broadcast moveAttribute notifications")
+    table.moveAttributeToParent("Sleep", "newCollection")
+    // Move attribute within the ungrouped collection
+    table.moveAttributeToParent("Diet", "headerDivider", 3)
+    webView.confirmAPITesterResponseContains(/"operation":\s"moveAttribute/)
+    webView.clearAPITesterResponses()
+    // Move attribute to a different collection
+    table.moveAttributeToParent("Diet", "prevCollection")
+    webView.confirmAPITesterResponseContains(/"operation":\s"moveAttribute/)
+    webView.clearAPITesterResponses()
+    // Move attribute within a true collection
+    table.moveAttributeToParent("Diet", "headerDivider", 3)
+    webView.confirmAPITesterResponseContains(/"operation":\s"moveAttribute/)
     webView.clearAPITesterResponses()
   })
 })

--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -147,14 +147,14 @@ context("codap plugins", () => {
 
     cy.log("Broadcast attribute notifications")
 
-    cy.log("Broadcast hideAttribute notifications")
+    cy.log("Broadcast hideAttributes notifications")
     c.selectTile("table", 0)
     table.openAttributeMenu("Mammal")
     table.selectMenuItemFromAttributeMenu("Hide Attribute")
     webView.confirmAPITesterResponseContains(/"operation":\s"hideAttributes/)
     webView.clearAPITesterResponses()
 
-    cy.log("Broadcast unhideAttribute notifications")
+    cy.log("Broadcast unhideAttributes notifications")
     table.showAllAttributes()
     webView.confirmAPITesterResponseContains(/"operation":\s"unhideAttributes/)
     webView.clearAPITesterResponses()

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -663,7 +663,7 @@ context("case table ui", () => {
       table.getHideShowButton().then($element => {
         c.checkToolTip($element, c.tooltips.tableHideShowButton)
       })
-      table.getAttributesButton().then($element => {
+      table.getRulerButton().then($element => {
         c.checkToolTip($element, c.tooltips.tableAttributesButton)
       })
     })

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -664,7 +664,7 @@ context("case table ui", () => {
         c.checkToolTip($element, c.tooltips.tableHideShowButton)
       })
       table.getRulerButton().then($element => {
-        c.checkToolTip($element, c.tooltips.tableAttributesButton)
+        c.checkToolTip($element, c.tooltips.tableRulerButton)
       })
     })
   })

--- a/v3/cypress/support/commands.ts
+++ b/v3/cypress/support/commands.ts
@@ -2,12 +2,11 @@ Cypress.Commands.add("clickMenuItem", text => {
   cy.get("button[role=menuitem]").contains(text).click()
 })
 
-Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target, targetAttribute) => {
+Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target, targetNumber) => {
   const el = {
     tableColumnHeader:
       `.codap-case-table [data-testid="codap-attribute-button ${attribute}"]`,
-    targetAttributeHeader:
-      `.codap-case-table [data-testid="codap-attribute-button ${targetAttribute}"]`,
+    headerDivider: `.codap-column-header-divider`,
     caseCardHeader: ".react-data-card-attribute",
     caseCardHeaderDropZone: ".react-data-card .data-cell-lower",
     caseCardCollectionDropZone: ".react-data-card .collection-header-row",
@@ -109,8 +108,8 @@ Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target, target
     case ("prevCollection"):
       target_el = el.prevCollection
       break
-    case ("targetAttribute"):
-      target_el = el.targetAttributeHeader
+    case ("headerDivider"):
+      target_el = el.headerDivider
       break
     default:
       target_el = el.tableColumnHeader
@@ -121,7 +120,7 @@ Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target, target
   cy.get(source_el).contains(attribute)
     .trigger("mousedown", { force: true })
     .then(() => {
-      cy.get(target_el).then($target => {
+      cy.get(target_el).eq(targetNumber ?? 0).then($target => {
         return $target[0].getBoundingClientRect()
       })
       .then($targetRect => {

--- a/v3/cypress/support/commands.ts
+++ b/v3/cypress/support/commands.ts
@@ -2,10 +2,12 @@ Cypress.Commands.add("clickMenuItem", text => {
   cy.get("button[role=menuitem]").contains(text).click()
 })
 
-Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target) => {
+Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target, targetAttribute) => {
   const el = {
     tableColumnHeader:
       `.codap-case-table [data-testid="codap-attribute-button ${attribute}"]`,
+    targetAttributeHeader:
+      `.codap-case-table [data-testid="codap-attribute-button ${targetAttribute}"]`,
     caseCardHeader: ".react-data-card-attribute",
     caseCardHeaderDropZone: ".react-data-card .data-cell-lower",
     caseCardCollectionDropZone: ".react-data-card .collection-header-row",
@@ -106,6 +108,9 @@ Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target) => {
       break
     case ("prevCollection"):
       target_el = el.prevCollection
+      break
+    case ("targetAttribute"):
+      target_el = el.targetAttributeHeader
       break
     default:
       target_el = el.tableColumnHeader

--- a/v3/cypress/support/elements/component-elements.ts
+++ b/v3/cypress/support/elements/component-elements.ts
@@ -28,7 +28,7 @@ export const ComponentElements = {
     tableResizeButton: "Resize all columns to fit data",
     tableDeleteCasesButton: "Delete selected or unselected cases",
     tableHideShowButton: "Show all cases or hide selected/unselected cases",
-    tableAttributesButton: "Make new attributes. Export case data."
+    tableRulerButton: "Make new attributes. Export case data."
   },
   getComponentSelector(component) {
     return cy.get(`.codap-component[data-testid$=${component}]`)

--- a/v3/cypress/support/elements/map-tile.ts
+++ b/v3/cypress/support/elements/map-tile.ts
@@ -12,7 +12,7 @@ export const MapTileElements = {
   },
   selectHideShowButton() {
     c.getInspectorPanel().find("[data-testid=map-hide-show-button]").click()
-    c.getInspectorPanel().find("[data-testid=trash-menu-list]").should("be.visible")
+    c.getInspectorPanel().find("[data-testid=hide-show-menu-list]").should("be.visible")
   },
   getDisplayValuesButton() {
     return c.getInspectorPanel().find("[data-testid=map-display-values-button]")
@@ -36,30 +36,30 @@ export const MapTileElements = {
     return c.getInspectorPanel().find("[data-testid=hide-selected-cases]")
   },
   selectHideSelectedCases() {
-    c.getInspectorPanel().find("[data-testid=trash-menu-list]").should("be.visible").then(() => {
+    c.getInspectorPanel().find("[data-testid=hide-show-menu-list]").should("be.visible").then(() => {
       c.getInspectorPanel().find("[data-testid=hide-selected-cases]").click()
       c.getInspectorPanel().find("[data-testid=hide-selected-cases]").should("not.exist")
-      c.getInspectorPanel().find("[data-testid=trash-menu-list]").should("not.be.visible")
+      c.getInspectorPanel().find("[data-testid=hide-show-menu-list]").should("not.be.visible")
     })
   },
   getHideUnselectedCases() {
     return c.getInspectorPanel().find("[data-testid=hide-unselected-cases]")
   },
   selectHideUnselectedCases() {
-    c.getInspectorPanel().find("[data-testid=trash-menu-list]").should("be.visible").then(() => {
+    c.getInspectorPanel().find("[data-testid=hide-show-menu-list]").should("be.visible").then(() => {
       c.getInspectorPanel().find("[data-testid=hide-unselected-cases]").click()
       c.getInspectorPanel().find("[data-testid=hide-unselected-cases]").should("not.exist")
-      c.getInspectorPanel().find("[data-testid=trash-menu-list]").should("not.be.visible")
+      c.getInspectorPanel().find("[data-testid=hide-show-menu-list]").should("not.be.visible")
     })
   },
   getShowAllCases() {
     return c.getInspectorPanel().find("[data-testid=show-all-cases]")
   },
   selectShowAllCases() {
-    c.getInspectorPanel().find("[data-testid=trash-menu-list]").should("be.visible").then(() => {
+    c.getInspectorPanel().find("[data-testid=hide-show-menu-list]").should("be.visible").then(() => {
       c.getInspectorPanel().find("[data-testid=show-all-cases]").click()
       c.getInspectorPanel().find("[data-testid=show-all-cases]").should("not.exist")
-      c.getInspectorPanel().find("[data-testid=trash-menu-list]").should("not.be.visible")
+      c.getInspectorPanel().find("[data-testid=hide-show-menu-list]").should("not.be.visible")
     })
   }
 }

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -222,8 +222,8 @@ export const TableTileElements = {
       })
     })
   },
-  moveAttributeToParent(name: string, moveType: string, targetAttribute?: string) {
-    cy.dragAttributeToTarget("table", name, moveType, targetAttribute)
+  moveAttributeToParent(name: string, moveType: string, targetNumber?: number) {
+    cy.dragAttributeToTarget("table", name, moveType, targetNumber)
   },
   getExpandAllGroupsButton(collectionIndex = 1) {
     return this.getCollection(collectionIndex).find("[title=\"expand all groups\"]")

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -195,8 +195,14 @@ export const TableTileElements = {
   getHideShowButton() {
     return c.getInspectorPanel().find("[data-testid=hide-show-button]")
   },
-  getAttributesButton() {
-    return c.getInspectorPanel().find("[data-testid=table-attributes-button]")
+  getRulerButton() {
+    return c.getInspectorPanel().find("[data-testid=ruler-button]")
+  },
+  getRulerMenuItem(item: string) {
+    return cy.get("[data-testid=ruler-menu-list] button").contains(item)
+  },
+  selectItemFromRulerMenu(item: string) {
+    this.getRulerMenuItem(item).click({ force: true })
   },
   verifyAttributeValues(attributes, values, collectionIndex = 1) {
     attributes.forEach(a => {
@@ -216,8 +222,8 @@ export const TableTileElements = {
       })
     })
   },
-  moveAttributeToParent(name, moveType) {
-    cy.dragAttributeToTarget("table", name, moveType)
+  moveAttributeToParent(name: string, moveType: string, targetAttribute?: string) {
+    cy.dragAttributeToTarget("table", name, moveType, targetAttribute)
   },
   getExpandAllGroupsButton(collectionIndex = 1) {
     return this.getCollection(collectionIndex).find("[title=\"expand all groups\"]")

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -29,6 +29,7 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
   const rerandomizeDisabled = !attribute?.formula?.isRandomFunctionPresent
 
   const handleMenuItemClick = (menuItem: string) => {
+    // TODO Don't forget to broadcast notifications as these menu items are implemented!
     toast({
       title: 'Menu item clicked',
       description: `You clicked on ${menuItem} on ${columnName}`,

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -41,7 +41,7 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
     caseMetadata?.applyModelChange(
       () => caseMetadata?.setIsHidden(column.key, true),
       {
-        notification: hideAttributeNotification([column.key], data),
+        notifications: hideAttributeNotification([column.key], data),
         undoStringKey: "DG.Undo.caseTable.hideAttribute",
         redoStringKey: "DG.Redo.caseTable.hideAttribute"
       }
@@ -58,7 +58,7 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
       data.applyModelChange(() => {
         data.removeAttribute(attrId)
       }, {
-        notification: removeAttributesNotification([attrId], data),
+        notifications: removeAttributesNotification([attrId], data),
         undoStringKey: "DG.Undo.caseTable.deleteAttribute",
         redoStringKey: "DG.Redo.caseTable.deleteAttribute"
       })

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -7,7 +7,7 @@ import { TCalculatedColumn } from "../case-table-types"
 import { EditAttributePropertiesModal } from "./edit-attribute-properties-modal"
 import { t } from "../../../utilities/translation/translate"
 import { EditFormulaModal } from "./edit-formula-modal"
-import { hideAttributeNotification } from "../../../models/data/data-set-utils"
+import { hideAttributeNotification, removeAttributesNotification } from "../../../models/data/data-set-utils"
 
 interface IProps {
   column: TCalculatedColumn
@@ -58,6 +58,7 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
       data.applyModelChange(() => {
         data.removeAttribute(attrId)
       }, {
+        notification: removeAttributesNotification([attrId], data),
         undoStringKey: "DG.Undo.caseTable.deleteAttribute",
         redoStringKey: "DG.Redo.caseTable.deleteAttribute"
       })

--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -7,6 +7,7 @@ import { TCalculatedColumn } from "../case-table-types"
 import { EditAttributePropertiesModal } from "./edit-attribute-properties-modal"
 import { t } from "../../../utilities/translation/translate"
 import { EditFormulaModal } from "./edit-formula-modal"
+import { hideAttributeNotification } from "../../../models/data/data-set-utils"
 
 interface IProps {
   column: TCalculatedColumn
@@ -40,6 +41,7 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
     caseMetadata?.applyModelChange(
       () => caseMetadata?.setIsHidden(column.key, true),
       {
+        notification: hideAttributeNotification([column.key], data),
         undoStringKey: "DG.Undo.caseTable.hideAttribute",
         redoStringKey: "DG.Redo.caseTable.hideAttribute"
       }

--- a/v3/src/components/case-table/attribute-menu/edit-attribute-properties-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-attribute-properties-modal.tsx
@@ -6,6 +6,7 @@ import { useDataSetContext } from "../../../hooks/use-data-set-context"
 import { uniqueName } from "../../../utilities/js-utils"
 import { CodapModal } from "../../codap-modal"
 import { t } from "../../../utilities/translation/translate"
+import { updateAttributesNotification } from "../../../models/data/data-set-utils"
 
 // for use in menus of attribute types
 const selectableAttributeTypes = ["none", ...attributeTypes] as const
@@ -65,6 +66,7 @@ export const EditAttributePropertiesModal = ({ attributeId, isOpen, onClose }: I
           attribute.setEditable(editable === "yes")
         }
       }, {
+        notifications: updateAttributesNotification([attribute], data),
         undoStringKey: "DG.Undo.caseTable.editAttribute",
         redoStringKey: "DG.Redo.caseTable.editAttribute"
       })

--- a/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
@@ -7,6 +7,7 @@ import { observer } from "mobx-react-lite"
 import { CodapModal } from "../../codap-modal"
 import { t } from "../../../utilities/translation/translate"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
+import { updateAttributesNotification } from "../../../models/data/data-set-utils"
 
 interface IProps {
   attributeId: string
@@ -24,7 +25,14 @@ export const EditFormulaModal = observer(function EditFormulaModal({ attributeId
   }, [attribute?.formula?.display])
 
   const applyFormula = () => {
-    attribute?.setDisplayExpression(formula)
+    if (attribute) {
+      dataSet?.applyModelChange(() => {
+        attribute?.setDisplayExpression(formula)
+      }, {
+        // TODO Should also broadcast notify component edit forumla and notify updateCases notifications
+        notifications: updateAttributesNotification([attribute], dataSet)
+      })
+    }
     closeModal()
   }
 

--- a/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
@@ -27,10 +27,12 @@ export const EditFormulaModal = observer(function EditFormulaModal({ attributeId
   const applyFormula = () => {
     if (attribute) {
       dataSet?.applyModelChange(() => {
-        attribute?.setDisplayExpression(formula)
+        attribute.setDisplayExpression(formula)
       }, {
         // TODO Should also broadcast notify component edit forumla and notify updateCases notifications
-        notifications: updateAttributesNotification([attribute], dataSet)
+        notifications: updateAttributesNotification([attribute], dataSet),
+        undoStringKey: "DG.Undo.caseTable.editAttributeFormula",
+        redoStringKey: "DG.Redo.caseTable.createAttribute"
       })
     }
     closeModal()

--- a/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-formula-modal.tsx
@@ -29,7 +29,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({ attributeId
       dataSet?.applyModelChange(() => {
         attribute.setDisplayExpression(formula)
       }, {
-        // TODO Should also broadcast notify component edit forumla and notify updateCases notifications
+        // TODO Should also broadcast notify component edit formula and notify updateCases notifications
         notifications: updateAttributesNotification([attribute], dataSet),
         undoStringKey: "DG.Undo.caseTable.editAttributeFormula",
         redoStringKey: "DG.Redo.caseTable.createAttribute"

--- a/v3/src/components/case-table/case-table-inspector.tsx
+++ b/v3/src/components/case-table/case-table-inspector.tsx
@@ -55,7 +55,7 @@ export const CaseTableInspector = ({ tile, show }: ITileInspectorPanelProps) => 
               <HideShowMenuList />
             </InspectorMenu>
             <InspectorMenu tooltip={t("DG.Inspector.attributes.toolTip")}
-              icon={<ValuesIcon className="inspector-menu-icon"/>} testId="table-attributes-button">
+              icon={<ValuesIcon className="inspector-menu-icon"/>} testId="ruler-button">
               <RulerMenuList />
             </InspectorMenu>
             {showInfoModal && <DatasetInfoModal showInfoModal={showInfoModal} setShowInfoModal={setShowInfoModal}/>}

--- a/v3/src/components/case-table/collection-title.tsx
+++ b/v3/src/components/case-table/collection-title.tsx
@@ -80,9 +80,9 @@ export const CollectionTitle = observer(function CollectionTitle() {
     let attribute: IAttribute | undefined
     data?.applyModelChange(() => {
       const newAttrName = uniqueName(t("DG.CaseTable.defaultAttrName"),
-        (aName: string) => !data?.attributes.find(attr => aName === attr.name)
+        (aName: string) => !data.attributes.find(attr => aName === attr.name)
       )
-      attribute = data?.addAttribute({ name: newAttrName }, { collection: collectionId })
+      attribute = data.addAttribute({ name: newAttrName }, { collection: collectionId })
     }, {
       notifications: () => createAttributesNotification(attribute ? [attribute] : [], data),
       undoStringKey: "DG.Undo.caseTable.createAttribute",

--- a/v3/src/components/case-table/collection-title.tsx
+++ b/v3/src/components/case-table/collection-title.tsx
@@ -84,7 +84,9 @@ export const CollectionTitle = observer(function CollectionTitle() {
       )
       attribute = data?.addAttribute({ name: newAttrName }, { collection: collectionId })
     }, {
-      notifications: () => createAttributesNotification(attribute ? [attribute] : [], data)
+      notifications: () => createAttributesNotification(attribute ? [attribute] : [], data),
+      undoStringKey: "DG.Undo.caseTable.createAttribute",
+      redoStringKey: "DG.Redo.caseTable.createAttribute"
     })
   }
 

--- a/v3/src/components/case-table/collection-title.tsx
+++ b/v3/src/components/case-table/collection-title.tsx
@@ -5,12 +5,14 @@ import throttle from "lodash/throttle"
 import {useResizeDetector} from "react-resize-detector"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
-import { uniqueName } from "../../utilities/js-utils"
-import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { useCollectionContext } from "../../hooks/use-collection-context"
-import { t } from "../../utilities/translation/translate"
 import AddIcon from "../../assets/icons/icon-add-circle.svg"
+import { useCollectionContext } from "../../hooks/use-collection-context"
+import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useTileModelContext } from "../../hooks/use-tile-model-context"
+import { IAttribute } from "../../models/data/attribute"
+import { createAttributesNotification } from "../../models/data/data-set-utils"
+import { uniqueName } from "../../utilities/js-utils"
+import { t } from "../../utilities/translation/translate"
 
 export const CollectionTitle = observer(function CollectionTitle() {
   const data = useDataSetContext()
@@ -75,10 +77,15 @@ export const CollectionTitle = observer(function CollectionTitle() {
   }
 
   const handleAddNewAttribute = () => {
-    const newAttrName = uniqueName(t("DG.CaseTable.defaultAttrName"),
-      (aName: string) => !data?.attributes.find(attr => aName === attr.name)
-     )
-    data?.addAttribute({ name: newAttrName }, { collection: collectionId })
+    let attribute: IAttribute | undefined
+    data?.applyModelChange(() => {
+      const newAttrName = uniqueName(t("DG.CaseTable.defaultAttrName"),
+        (aName: string) => !data?.attributes.find(attr => aName === attr.name)
+      )
+      attribute = data?.addAttribute({ name: newAttrName }, { collection: collectionId })
+    }, {
+      notification: () => createAttributesNotification(attribute ? [attribute] : [], data)
+    })
   }
 
   const casesStr = t(caseCount === 1 ? "DG.DataContext.singleCaseName" : "DG.DataContext.pluralCaseName")

--- a/v3/src/components/case-table/collection-title.tsx
+++ b/v3/src/components/case-table/collection-title.tsx
@@ -84,7 +84,7 @@ export const CollectionTitle = observer(function CollectionTitle() {
       )
       attribute = data?.addAttribute({ name: newAttrName }, { collection: collectionId })
     }, {
-      notification: () => createAttributesNotification(attribute ? [attribute] : [], data)
+      notifications: () => createAttributesNotification(attribute ? [attribute] : [], data)
     })
   }
 

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom"
 import { IAttribute } from "../../models/data/attribute"
 import { isCollectionModel } from "../../models/data/collection"
 import { IMoveAttributeOptions } from "../../models/data/data-set-types"
-import { getCollectionAttrs } from "../../models/data/data-set-utils"
+import { getCollectionAttrs, moveAttributeNotification } from "../../models/data/data-set-utils"
 import { useCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { getDragAttributeInfo, useTileDroppable } from "../../hooks/use-drag-drop"
@@ -32,12 +32,14 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
     const options: IMoveAttributeOptions = columnKey === kIndexColumnKey
                                             ? { before: firstAttr?.id }
                                             : { after: columnKey }
+    const notification = moveAttributeNotification(data)
     if (collection === srcCollection) {
       if (isCollectionModel(collection)) {
         // move the attribute within a collection
         data.applyModelChange(
           () => collection.moveAttribute(dragAttrId, options),
           {
+            notification,
             undoStringKey: "DG.Undo.dataContext.moveAttribute",
             redoStringKey: "DG.Redo.dataContext.moveAttribute"
           }
@@ -48,6 +50,7 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
         data.applyModelChange(
           () => data.moveAttribute(dragAttrId, options),
           {
+            notification,
             undoStringKey: "DG.Undo.dataContext.moveAttribute",
             redoStringKey: "DG.Redo.dataContext.moveAttribute"
           }
@@ -59,6 +62,7 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
       data.applyModelChange(
         () => data.setCollectionForAttribute(dragAttrId, { collection: collection?.id, ...options }),
         {
+          notification,
           undoStringKey: "DG.Undo.dataContext.moveAttribute",
           redoStringKey: "DG.Redo.dataContext.moveAttribute"
         }

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -32,14 +32,14 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
     const options: IMoveAttributeOptions = columnKey === kIndexColumnKey
                                             ? { before: firstAttr?.id }
                                             : { after: columnKey }
-    const notification = moveAttributeNotification(data)
+    const notifications = moveAttributeNotification(data)
     if (collection === srcCollection) {
       if (isCollectionModel(collection)) {
         // move the attribute within a collection
         data.applyModelChange(
           () => collection.moveAttribute(dragAttrId, options),
           {
-            notifications: notification,
+            notifications,
             undoStringKey: "DG.Undo.dataContext.moveAttribute",
             redoStringKey: "DG.Redo.dataContext.moveAttribute"
           }
@@ -50,7 +50,7 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
         data.applyModelChange(
           () => data.moveAttribute(dragAttrId, options),
           {
-            notifications: notification,
+            notifications,
             undoStringKey: "DG.Undo.dataContext.moveAttribute",
             redoStringKey: "DG.Redo.dataContext.moveAttribute"
           }
@@ -62,7 +62,7 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
       data.applyModelChange(
         () => data.setCollectionForAttribute(dragAttrId, { collection: collection?.id, ...options }),
         {
-          notifications: notification,
+          notifications,
           undoStringKey: "DG.Undo.dataContext.moveAttribute",
           redoStringKey: "DG.Redo.dataContext.moveAttribute"
         }

--- a/v3/src/components/case-table/column-header-divider.tsx
+++ b/v3/src/components/case-table/column-header-divider.tsx
@@ -39,7 +39,7 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
         data.applyModelChange(
           () => collection.moveAttribute(dragAttrId, options),
           {
-            notification,
+            notifications: notification,
             undoStringKey: "DG.Undo.dataContext.moveAttribute",
             redoStringKey: "DG.Redo.dataContext.moveAttribute"
           }
@@ -50,7 +50,7 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
         data.applyModelChange(
           () => data.moveAttribute(dragAttrId, options),
           {
-            notification,
+            notifications: notification,
             undoStringKey: "DG.Undo.dataContext.moveAttribute",
             redoStringKey: "DG.Redo.dataContext.moveAttribute"
           }
@@ -62,7 +62,7 @@ export const ColumnHeaderDivider = ({ columnKey, cellElt }: IProps) => {
       data.applyModelChange(
         () => data.setCollectionForAttribute(dragAttrId, { collection: collection?.id, ...options }),
         {
-          notification,
+          notifications: notification,
           undoStringKey: "DG.Undo.dataContext.moveAttribute",
           redoStringKey: "DG.Redo.dataContext.moveAttribute"
         }

--- a/v3/src/components/case-table/column-header.tsx
+++ b/v3/src/components/case-table/column-header.tsx
@@ -72,7 +72,7 @@ export function ColumnHeader({ column }: Pick<TRenderHeaderCellProps, "column">)
       const editingAttribute = data?.getAttribute(editingAttrId)
       const oldName = editingAttribute?.name
       data?.applyModelChange(() => {
-        data?.setAttributeName(editingAttrId, () => uniqueName(trimTitle,
+        data.setAttributeName(editingAttrId, () => uniqueName(trimTitle,
           (aName: string) => (aName === column.name) || !data.attributes.find(attr => aName === attr.name)
         ))
       }, {

--- a/v3/src/components/case-table/column-header.tsx
+++ b/v3/src/components/case-table/column-header.tsx
@@ -10,6 +10,7 @@ import { CaseTablePortal } from "./case-table-portal"
 import { kIndexColumnKey, TRenderHeaderCellProps } from "./case-table-types"
 import { ColumnHeaderDivider } from "./column-header-divider"
 import { useRdgCellFocus } from "./use-rdg-cell-focus"
+import { updateAttributesNotification } from "../../models/data/data-set-utils"
 
 export function ColumnHeader({ column }: Pick<TRenderHeaderCellProps, "column">) {
   const { active } = useDndContext()
@@ -68,9 +69,19 @@ export function ColumnHeader({ column }: Pick<TRenderHeaderCellProps, "column">)
   const handleClose = (accept: boolean) => {
     const trimTitle = editingAttrName?.trim()
     if (accept && editingAttrId && trimTitle) {
-      data?.setAttributeName(editingAttrId, () => uniqueName(trimTitle,
-        (aName: string) => (aName === column.name) || !data.attributes.find(attr => aName === attr.name)
-       ))
+      const editingAttribute = data?.getAttribute(editingAttrId)
+      const oldName = editingAttribute?.name
+      data?.applyModelChange(() => {
+        data?.setAttributeName(editingAttrId, () => uniqueName(trimTitle,
+          (aName: string) => (aName === column.name) || !data.attributes.find(attr => aName === attr.name)
+        ))
+      }, {
+        notifications: () => {
+          if (editingAttribute && editingAttribute?.name !== oldName) {
+            return updateAttributesNotification([editingAttribute], data)
+          }
+        }
+      })
     }
     setEditingAttrId("")
     setEditingAttrName("")

--- a/v3/src/components/case-table/column-header.tsx
+++ b/v3/src/components/case-table/column-header.tsx
@@ -80,7 +80,9 @@ export function ColumnHeader({ column }: Pick<TRenderHeaderCellProps, "column">)
           if (editingAttribute && editingAttribute?.name !== oldName) {
             return updateAttributesNotification([editingAttribute], data)
           }
-        }
+        },
+        undoStringKey: "DG.Undo.caseTable.editAttribute",
+        redoStringKey: "DG.Redo.caseTable.editAttribute"
       })
     }
     setEditingAttrId("")

--- a/v3/src/components/case-table/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/case-table/inspector-panel/hide-show-menu-list.tsx
@@ -46,11 +46,15 @@ export const HideShowMenuList = () => {
   }
 
   const hiddenAttributes = data?.attributes.filter(attr => attr && caseMetadata?.isHidden(attr.id))
+  const hiddenAttrIds = hiddenAttributes?.map(attr => attr.id) ?? []
   const handleShowAllAttributes = () => {
     caseMetadata?.applyModelChange(
       () => caseMetadata?.showAllAttributes(),
       {
-        notifications: hideAttributeNotification(hiddenAttributes?.map(attr => attr.id) ?? [], data, true),
+        notifications: [
+          hideAttributeNotification(hiddenAttrIds, data, "unhideAttributes"),
+          hideAttributeNotification(hiddenAttrIds, data, "showAttributes")
+        ],
         undoStringKey: "DG.Undo.caseTable.showAllHiddenAttributes",
         redoStringKey: "DG.Redo.caseTable.showAllHiddenAttributes"
       }

--- a/v3/src/components/case-table/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/case-table/inspector-panel/hide-show-menu-list.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { useCaseMetadata } from "../../../hooks/use-case-metadata"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
 import { t } from "../../../utilities/translation/translate"
+import { hideAttributeNotification } from "../../../models/data/data-set-utils"
 
 export const HideShowMenuList = () => {
   const data = useDataSetContext()
@@ -44,10 +45,12 @@ export const HideShowMenuList = () => {
     })
   }
 
+  const hiddenAttributes = data?.attributes.filter(attr => attr && caseMetadata?.isHidden(attr.id))
   const handleShowAllAttributes = () => {
     caseMetadata?.applyModelChange(
       () => caseMetadata?.showAllAttributes(),
       {
+        notification: hideAttributeNotification(hiddenAttributes?.map(attr => attr.id) ?? [], data, true),
         undoStringKey: "DG.Undo.caseTable.showAllHiddenAttributes",
         redoStringKey: "DG.Redo.caseTable.showAllHiddenAttributes"
       }
@@ -59,7 +62,7 @@ export const HideShowMenuList = () => {
   const setAsideCount = 0 // eventually will come from DataSet
   const restoreSetAsideCasesLabel = t("DG.Inspector.setaside.restoreSetAsideCases", { vars: [setAsideCount] })
 
-  const hiddenAttributeCount = data?.attributes.filter(attr => attr && caseMetadata?.isHidden(attr.id)).length ?? 0
+  const hiddenAttributeCount = hiddenAttributes?.length ?? 0
   const showAllHiddenAttributesKey = {
     0: "DG.Inspector.attributes.showAllHiddenAttributesDisabled",
     1: "DG.Inspector.attributes.showAllHiddenAttributesSing"

--- a/v3/src/components/case-table/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/case-table/inspector-panel/hide-show-menu-list.tsx
@@ -50,7 +50,7 @@ export const HideShowMenuList = () => {
     caseMetadata?.applyModelChange(
       () => caseMetadata?.showAllAttributes(),
       {
-        notification: hideAttributeNotification(hiddenAttributes?.map(attr => attr.id) ?? [], data, true),
+        notifications: hideAttributeNotification(hiddenAttributes?.map(attr => attr.id) ?? [], data, true),
         undoStringKey: "DG.Undo.caseTable.showAllHiddenAttributes",
         redoStringKey: "DG.Redo.caseTable.showAllHiddenAttributes"
       }

--- a/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
@@ -32,7 +32,7 @@ export const RulerMenuList = () => {
   }
 
   return (
-    <MenuList data-testid="trash-menu-list">
+    <MenuList data-testid="ruler-menu-list">
       <MenuItem
         onClick={handleAddNewAttribute}>{t("DG.Inspector.newAttribute", { vars: [data?.name || ""] })}
       </MenuItem>

--- a/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
@@ -23,9 +23,9 @@ export const RulerMenuList = () => {
     let attribute: IAttribute | undefined
     data?.applyModelChange(() => {
       const newAttrName = uniqueName("newAttr",
-        (aName: string) => !data?.attributes.find(attr => aName === attr.name)
+        (aName: string) => !data.attributes.find(attr => aName === attr.name)
       )
-      attribute = data?.addAttribute({name: newAttrName})
+      attribute = data.addAttribute({name: newAttrName})
     }, {
       notifications: () => createAttributesNotification(attribute ? [attribute] : [], data),
       undoStringKey: "DG.Undo.caseTable.createAttribute",

--- a/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
@@ -27,7 +27,7 @@ export const RulerMenuList = () => {
       )
       attribute = data?.addAttribute({name: newAttrName})
     }, {
-      notification: () => createAttributesNotification(attribute ? [attribute] : [], data)
+      notifications: () => createAttributesNotification(attribute ? [attribute] : [], data)
     })
   }
 

--- a/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
@@ -1,6 +1,8 @@
 import { MenuItem, MenuList, useToast } from "@chakra-ui/react"
 import React from "react"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
+import { IAttribute } from "../../../models/data/attribute"
+import { createAttributesNotification } from "../../../models/data/data-set-utils"
 import { uniqueName } from "../../../utilities/js-utils"
 import { t } from "../../../utilities/translation/translate"
 
@@ -18,10 +20,15 @@ export const RulerMenuList = () => {
   }
 
   const handleAddNewAttribute = () => {
-    const newAttrName = uniqueName("newAttr",
-      (aName: string) => !data?.attributes.find(attr => aName === attr.name)
-     )
-    data?.addAttribute({name: newAttrName})
+    let attribute: IAttribute | undefined
+    data?.applyModelChange(() => {
+      const newAttrName = uniqueName("newAttr",
+        (aName: string) => !data?.attributes.find(attr => aName === attr.name)
+      )
+      attribute = data?.addAttribute({name: newAttrName})
+    }, {
+      notification: () => createAttributesNotification(attribute ? [attribute] : [], data)
+    })
   }
 
   return (

--- a/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-table/inspector-panel/ruler-menu-list.tsx
@@ -27,7 +27,9 @@ export const RulerMenuList = () => {
       )
       attribute = data?.addAttribute({name: newAttrName})
     }, {
-      notifications: () => createAttributesNotification(attribute ? [attribute] : [], data)
+      notifications: () => createAttributesNotification(attribute ? [attribute] : [], data),
+      undoStringKey: "DG.Undo.caseTable.createAttribute",
+      redoStringKey: "DG.Redo.caseTable.createAttribute"
     })
   }
 

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -74,7 +74,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
       : t("DG.DataDisplayMenu.enableMeasuresForSelection")
 
   return (
-    <MenuList data-testid="trash-menu-list">
+    <MenuList data-testid="hide-show-menu-list">
       <MenuItem onClick={hideSelectedCases} isDisabled={hideSelectedIsDisabled} data-testid="hide-selected-cases">
         {hideSelectedString}
       </MenuItem>

--- a/v3/src/components/map/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/hide-show-menu-list.tsx
@@ -59,7 +59,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
   }
 
   return (
-    <MenuList data-testid="trash-menu-list">
+    <MenuList data-testid="hide-show-menu-list">
       <MenuItem onClick={hideSelectedCases} isDisabled={numSelected === 0} data-testid="hide-selected-cases">
         {hideSelectedString}
       </MenuItem>

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -20,7 +20,7 @@ export const SaveImageMenuList = ({tile}: IProps) => {
   }
 
   return (
-    <MenuList data-testid="trash-menu-list">
+    <MenuList data-testid="save-image-menu-list">
       <MenuItem onClick={()=>handleMenuItemClick("Open in Draw Tool")}>
         {t('DG.DataDisplayMenu.copyAsImage')}
       </MenuItem>

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -47,7 +47,7 @@ export const EditableSliderValue = observer(function EditableSliderValue({ slide
           sliderModel.setValue(inputValue)
         },
         {
-          notification: () => valueChangeNotification(sliderModel.value, sliderModel.name),
+          notifications: () => valueChangeNotification(sliderModel.value, sliderModel.name),
           undoStringKey: "DG.Undo.slider.change",
           redoStringKey: "DG.Redo.slider.change"
         }

--- a/v3/src/components/slider/slider-thumb.tsx
+++ b/v3/src/components/slider/slider-thumb.tsx
@@ -52,7 +52,7 @@ export const CodapSliderThumb = observer(function CodapSliderThumb({
       if (sliderValue != null && sliderModel) {
         sliderModel.applyModelChange(
           () => sliderModel.setDynamicValue(sliderValue),
-          { notification: () => valueChangeNotification(sliderModel.value, sliderModel.name) }
+          { notifications: () => valueChangeNotification(sliderModel.value, sliderModel.name) }
         )
       }
       e.preventDefault()

--- a/v3/src/components/slider/use-slider-animation.tsx
+++ b/v3/src/components/slider/use-slider-animation.tsx
@@ -30,13 +30,13 @@ export const useSliderAnimation = ({sliderModel, running, setRunning}: IUseSlide
     if (animationDirection === "lowToHigh" && testValue >= axisMax) {
       sliderModel.applyModelChange(
         () => sliderModel.setValue(axisMin),
-        { notification: () => valueChangeNotification(sliderModel.value, sliderModel.name) }
+        { notifications: () => valueChangeNotification(sliderModel.value, sliderModel.name) }
       )
     }
     if (animationDirection === "highToLow" && testValue <= axisMin) {
       sliderModel.applyModelChange(
         () => sliderModel.setValue(axisMax),
-        { notification: () => valueChangeNotification(sliderModel.value, sliderModel.name) }
+        { notifications: () => valueChangeNotification(sliderModel.value, sliderModel.name) }
       )
     }
     return sliderModel.value
@@ -46,7 +46,7 @@ export const useSliderAnimation = ({sliderModel, running, setRunning}: IUseSlide
     if (sliderModel) {
       sliderModel.applyModelChange(
         () => sliderModel.setValue(sliderModel.validateValue(val, min, max)),
-        { notification: () => valueChangeNotification(sliderModel.value, sliderModel.name) }
+        { notifications: () => valueChangeNotification(sliderModel.value, sliderModel.name) }
       )
     }
   }, [sliderModel])

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -3,6 +3,7 @@ import { debugLog, DEBUG_PLUGINS } from "../../lib/debug"
 import {IAttribute} from "./attribute"
 import {ICollectionPropsModel, isCollectionModel} from "./collection"
 import {IDataSet} from "./data-set"
+import { convertAttributeToV2 } from "../../data-interactive/data-interactive-type-utils"
 
 export function getCollectionAttrs(collection: ICollectionPropsModel, data?: IDataSet) {
   if (collection && !isAlive(collection)) {
@@ -43,19 +44,26 @@ export function idOfChildmostCollectionForAttributes(attrIDs: string[], data?: I
   }
 }
 
-function attributeNotification(operation: string, data?: IDataSet, attrIDs?: string[]) {
+function attributeNotification(
+  operation: string, data?: IDataSet, attrIDs?: string[], attributes?: IAttribute[]
+) {
   const action = "notify"
   const resource = `dataContextChangeNotice[${data?.name}]`
   const values = {
     operation,
     result: {
       success: true,
+      attrs: attributes?.map(attr => convertAttributeToV2(attr, data)),
       attrIDs
     }
   }
   return { message: { action, resource, values }, callback: (response: any) =>
     debugLog(DEBUG_PLUGINS, `Reply to ${action} ${operation} ${attrIDs ?? ""}`, JSON.stringify(response))
   }
+}
+
+export function createAttributesNotification(attributes: IAttribute[], data?: IDataSet) {
+  return attributeNotification("createAttributes", data, attributes.map(attr => attr.id), attributes)
 }
 
 export function hideAttributeNotification(attrIDs: string[], data?: IDataSet, unhide?: boolean) {

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -66,8 +66,7 @@ export function createAttributesNotification(attrs: IAttribute[], data?: IDataSe
   return attributeNotification("createAttributes", data, attrs.map(attr => attr.id), attrs)
 }
 
-export function hideAttributeNotification(attrIDs: string[], data?: IDataSet, unhide?: boolean) {
-  const operation = unhide ? "unhideAttributes" : "hideAttributes"
+export function hideAttributeNotification(attrIDs: string[], data?: IDataSet, operation: string = "hideAttributes") {
   return attributeNotification(operation, data, attrIDs)
 }
 

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -45,7 +45,7 @@ export function idOfChildmostCollectionForAttributes(attrIDs: string[], data?: I
 }
 
 function attributeNotification(
-  operation: string, data?: IDataSet, attrIDs?: string[], attributes?: IAttribute[]
+  operation: string, data?: IDataSet, attrIDs?: string[], attrs?: IAttribute[]
 ) {
   const action = "notify"
   const resource = `dataContextChangeNotice[${data?.name}]`
@@ -53,7 +53,7 @@ function attributeNotification(
     operation,
     result: {
       success: true,
-      attrs: attributes?.map(attr => convertAttributeToV2(attr, data)),
+      attrs: attrs?.map(attr => convertAttributeToV2(attr, data)),
       attrIDs
     }
   }
@@ -62,8 +62,8 @@ function attributeNotification(
   }
 }
 
-export function createAttributesNotification(attributes: IAttribute[], data?: IDataSet) {
-  return attributeNotification("createAttributes", data, attributes.map(attr => attr.id), attributes)
+export function createAttributesNotification(attrs: IAttribute[], data?: IDataSet) {
+  return attributeNotification("createAttributes", data, attrs.map(attr => attr.id), attrs)
 }
 
 export function hideAttributeNotification(attrIDs: string[], data?: IDataSet, unhide?: boolean) {
@@ -77,4 +77,8 @@ export function moveAttributeNotification(data?: IDataSet) {
 
 export function removeAttributesNotification(attrIDs: string[], data?: IDataSet) {
   return attributeNotification("deleteAttributes", data, attrIDs)
+}
+
+export function updateAttributesNotification(attrs: IAttribute[], data?: IDataSet) {
+  return attributeNotification("updateAttributes", data, attrs.map(attr => attr.id), attrs)
 }

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -1,4 +1,5 @@
 import { isAlive } from "mobx-state-tree"
+import { debugLog, DEBUG_PLUGINS } from "../../lib/debug"
 import {IAttribute} from "./attribute"
 import {ICollectionPropsModel, isCollectionModel} from "./collection"
 import {IDataSet} from "./data-set"
@@ -39,5 +40,21 @@ export function idOfChildmostCollectionForAttributes(attrIDs: string[], data?: I
   for (let i = collections.length - 1; i >= 0; --i) {
     const collection = collections[i]
     if (collection.attributes.some(attr => attrIDs.includes(attr?.id ?? ""))) return collection.id
+  }
+}
+
+export function hideAttributeNotification(attrIDs: string[], data?: IDataSet, unhide?: boolean) {
+  const action = "notify"
+  const resource = `dataContextChangeNotice[${data?.name}]`
+  const operation = unhide ? "unhideAttributes" : "hideAttributes"
+  const values = {
+    operation,
+    result: {
+      success: true,
+      attrIDs
+    }
+  }
+  return { message: { action, resource, values }, callback: (response: any) =>
+    debugLog(DEBUG_PLUGINS, `Reply to ${action} ${operation} ${attrIDs}:`, JSON.stringify(response))
   }
 }

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -43,10 +43,9 @@ export function idOfChildmostCollectionForAttributes(attrIDs: string[], data?: I
   }
 }
 
-export function hideAttributeNotification(attrIDs: string[], data?: IDataSet, unhide?: boolean) {
+function attributeNotification(operation: string, data?: IDataSet, attrIDs?: string[]) {
   const action = "notify"
   const resource = `dataContextChangeNotice[${data?.name}]`
-  const operation = unhide ? "unhideAttributes" : "hideAttributes"
   const values = {
     operation,
     result: {
@@ -55,21 +54,19 @@ export function hideAttributeNotification(attrIDs: string[], data?: IDataSet, un
     }
   }
   return { message: { action, resource, values }, callback: (response: any) =>
-    debugLog(DEBUG_PLUGINS, `Reply to ${action} ${operation} ${attrIDs}:`, JSON.stringify(response))
+    debugLog(DEBUG_PLUGINS, `Reply to ${action} ${operation} ${attrIDs ?? ""}`, JSON.stringify(response))
   }
 }
 
+export function hideAttributeNotification(attrIDs: string[], data?: IDataSet, unhide?: boolean) {
+  const operation = unhide ? "unhideAttributes" : "hideAttributes"
+  return attributeNotification(operation, data, attrIDs)
+}
+
 export function moveAttributeNotification(data?: IDataSet) {
-  const action = "notify"
-  const resource = `dataContextChangeNotice[${data?.name}]`
-  const operation = "moveAttribute"
-  const values = {
-    operation,
-    result: {
-      success: true
-    }
-  }
-  return { message: { action, resource, values }, callback: (response: any) =>
-    debugLog(DEBUG_PLUGINS, `Reply to ${action} ${operation}:`, JSON.stringify(response))
-  }
+  return attributeNotification("moveAttribute", data)
+}
+
+export function removeAttributesNotification(attrIDs: string[], data?: IDataSet) {
+  return attributeNotification("deleteAttributes", data, attrIDs)
 }

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -58,3 +58,18 @@ export function hideAttributeNotification(attrIDs: string[], data?: IDataSet, un
     debugLog(DEBUG_PLUGINS, `Reply to ${action} ${operation} ${attrIDs}:`, JSON.stringify(response))
   }
 }
+
+export function moveAttributeNotification(data?: IDataSet) {
+  const action = "notify"
+  const resource = `dataContextChangeNotice[${data?.name}]`
+  const operation = "moveAttribute"
+  const values = {
+    operation,
+    result: {
+      success: true
+    }
+  }
+  return { message: { action, resource, values }, callback: (response: any) =>
+    debugLog(DEBUG_PLUGINS, `Reply to ${action} ${operation}:`, JSON.stringify(response))
+  }
+}

--- a/v3/src/models/history/apply-model-change.ts
+++ b/v3/src/models/history/apply-model-change.ts
@@ -10,7 +10,7 @@ interface INotification {
   callback?: iframePhone.ListenerCallback
 }
 export interface IApplyModelChangeOptions {
-  notification?: INotification | (() => INotification)
+  notifications?: INotification | INotification[] | (() => (INotification | INotification[]))
   redoStringKey?: string
   undoStringKey?: string
 }
@@ -29,12 +29,21 @@ export function applyModelChange(self: IAnyStateTreeNode) {
         withoutUndo()
       }
 
-      // Broadcast notification to plugins
-      if (options?.notification) {
+      // Broadcast notifications to plugins
+      if (options?.notifications) {
         const tileEnv = getTileEnvironment(self)
-        const { notification } = options
-        const { message, callback } = notification instanceof Function ? notification() : notification
-        tileEnv?.notify?.(message, callback ?? (() => null))
+
+        // Convert notifications to INotification[]
+        const { notifications } = options
+        const funcNotifications = notifications instanceof Function ? notifications() : undefined
+        const eitherNotifications = funcNotifications ?? notifications as INotification | INotification[]
+        const notificationArray = Array.isArray(eitherNotifications) ? eitherNotifications : [eitherNotifications]
+
+        // Actually broadcast the notifications
+        notificationArray.forEach(_notification => {
+          const { message, callback } = _notification
+          tileEnv?.notify?.(message, callback ?? (() => null))
+        })
       }
 
       return result

--- a/v3/src/models/history/apply-model-change.ts
+++ b/v3/src/models/history/apply-model-change.ts
@@ -10,7 +10,7 @@ interface INotification {
   callback?: iframePhone.ListenerCallback
 }
 export interface IApplyModelChangeOptions {
-  notifications?: INotification | INotification[] | (() => (INotification | INotification[]))
+  notifications?: INotification | INotification[] | (() => (INotification | INotification[] | undefined))
   redoStringKey?: string
   undoStringKey?: string
 }
@@ -35,15 +35,16 @@ export function applyModelChange(self: IAnyStateTreeNode) {
 
         // Convert notifications to INotification[]
         const { notifications } = options
-        const funcNotifications = notifications instanceof Function ? notifications() : undefined
-        const eitherNotifications = funcNotifications ?? notifications as INotification | INotification[]
-        const notificationArray = Array.isArray(eitherNotifications) ? eitherNotifications : [eitherNotifications]
+        const actualNotifications = notifications instanceof Function ? notifications() : notifications
+        if (actualNotifications) {
+          const notificationArray = Array.isArray(actualNotifications) ? actualNotifications : [actualNotifications]
 
-        // Actually broadcast the notifications
-        notificationArray.forEach(_notification => {
-          const { message, callback } = _notification
-          tileEnv?.notify?.(message, callback ?? (() => null))
-        })
+          // Actually broadcast the notifications
+          notificationArray.forEach(_notification => {
+            const { message, callback } = _notification
+            tileEnv?.notify?.(message, callback ?? (() => null))
+          })
+        }
       }
 
       return result


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187516358

This PR implements attribute notifications required by the Choosy plugin in v3. The following notifications are implemented:
- createAttributes
- deleteAttributes
- hideAttributes
- moveAttribute
- unhideAttributes
  - Note that Choosy is actually listening for `showAttributes`, but CODAP v2 never broadcasts this notification. I implemented the notification that CODAP v2 does broadcast, `unhideAttributes`. It doesn't look like any plugins listen for this notification, but it is referenced by `onboarding-new-3`.
- updateAttributes
  - Currently this is broadcast when an attribute's name changes, when its properties are updated, or when its formula is edited. Two places where this is broadcast in v2, Delete Formula and Recover Deleted Formula, are not broadcast in v3 because these actions have not yet been implemented.
  
Additional changes:
- Many tile menu buttons had a copy and paste error in their `data-testid` prop, usually involving "trash". In addition to being unnecessarily derogatory, it was inaccurate, so I changed that in a number of cases, which also required changing a few cypress tests.
- I made `applyModelChange` optionally accept a list of notifications to broadcast. This isn't being used yet, but it will be necessary before too long. It did require changing `notification` to `notifications` in many places.

Issues with API documentation:
- The documentation only shows one example of `createAttribute` (note missing "s"). It also mentions `update`, `delete`, and `move` in a comment. It makes no mention of `hide` or `unhide`/`show`.
- The documentation claims the `resource` for these notifications should be `dataContext[datasetName].attribute`. CODAP v2 actually uses `dataContextChangeNotice[datasetName]`. I've set v3 up to use what v2 actually uses, but this can be changed easily if necessary.