### PR TITLE
fix: Legend compresses on tile resize (PT-187450934)

### DIFF
--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -97,7 +97,7 @@ export const CategoricalLegend = observer(
           lod.maxWidth = Math.max(lod.maxWidth, measureText(cat, kDataDisplayFont))
         })
         lod.maxWidth += keySize + padding
-        lod.numColumns = Math.floor(lod.fullWidth / lod.maxWidth)
+        lod.numColumns = Math.max(Math.floor(lod.fullWidth / lod.maxWidth), 1)
         lod.columnWidth = lod.fullWidth / lod.numColumns
         lod.numRows = Math.ceil((numCategories ?? 0) / lod.numColumns)
         categoryData.current.length = 0


### PR DESCRIPTION
[#187450934](https://www.pivotaltracker.com/story/show/187450934)

Previously, when a graph tile containing a categorical legend was sized down to the smallest possible width, the calculation to determine the number of columns in the legend area could return a value of `0`. This change ensures the value is always at least `1`.