### PR TITLE
feat: use numeric ids for plugin compatibility

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -46,7 +46,6 @@
         "rtree": "^1.4.2",
         "tslib": "^2.6.2",
         "type-fest": "^4.10.2",
-        "ulid": "^2.3.0",
         "use-debounce": "^10.0.0",
         "use-deep-compare": "^1.2.1",
         "use-memo-one": "^1.1.3"
@@ -22602,14 +22601,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ulid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
-      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==",
-      "bin": {
-        "ulid": "bin/cli.js"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -40482,11 +40473,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
-    },
-    "ulid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
-      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/v3/package.json
+++ b/v3/package.json
@@ -212,7 +212,6 @@
     "rtree": "^1.4.2",
     "tslib": "^2.6.2",
     "type-fest": "^4.10.2",
-    "ulid": "^2.3.0",
     "use-debounce": "^10.0.0",
     "use-deep-compare": "^1.2.1",
     "use-memo-one": "^1.1.3"

--- a/v3/src/components/calculator/calculator-registration.ts
+++ b/v3/src/components/calculator/calculator-registration.ts
@@ -8,7 +8,6 @@ import CalcIcon from '../../assets/icons/icon-calc.svg'
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { isV2CalculatorComponent } from "../../v2/codap-v2-types"
 import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
-import { typedId } from "../../utilities/js-utils"
 
 export const kCalculatorIdPrefix = "CALC"
 
@@ -41,13 +40,13 @@ registerTileComponentInfo({
 registerV2TileImporter("DG.Calculator", ({ v2Component, insertTile }) => {
   if (!isV2CalculatorComponent(v2Component)) return
 
-  const { name = "", title = "" } = v2Component.componentStorage
+  const { guid, componentStorage: { name = "", title = "" } } = v2Component
 
   const content: ICalculatorSnapshot = {
     type: kCalculatorTileType,
     name
   }
-  const calculatorTileSnap: ITileModelSnapshotIn = { id: typedId(kCalculatorIdPrefix), title, content }
+  const calculatorTileSnap: ITileModelSnapshotIn = { id: `${guid}`, title, content }
   const calculatorTile = insertTile(calculatorTileSnap)
 
   return calculatorTile

--- a/v3/src/components/calculator/calculator-registration.ts
+++ b/v3/src/components/calculator/calculator-registration.ts
@@ -1,13 +1,14 @@
 import { registerTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { registerTileContentInfo } from "../../models/tiles/tile-content-info"
+import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
 import { CalculatorComponent } from "./calculator"
 import { kCalculatorTileClass, kCalculatorTileType } from "./calculator-defs"
 import { CalculatorModel, ICalculatorSnapshot } from "./calculator-model"
 import { CalculatorTitleBar } from "./calculator-title-bar"
 import CalcIcon from '../../assets/icons/icon-calc.svg'
+import { toV3Id } from "../../utilities/codap-utils"
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { isV2CalculatorComponent } from "../../v2/codap-v2-types"
-import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
 
 export const kCalculatorIdPrefix = "CALC"
 
@@ -46,7 +47,7 @@ registerV2TileImporter("DG.Calculator", ({ v2Component, insertTile }) => {
     type: kCalculatorTileType,
     name
   }
-  const calculatorTileSnap: ITileModelSnapshotIn = { id: `${guid}`, title, content }
+  const calculatorTileSnap: ITileModelSnapshotIn = { id: toV3Id(kCalculatorIdPrefix, guid), title, content }
   const calculatorTile = insertTile(calculatorTileSnap)
 
   return calculatorTile

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -7,7 +7,6 @@ import { kCaseTableTileType } from "./case-table-defs"
 import { CaseTableModel, ICaseTableSnapshot } from "./case-table-model"
 import { CaseTableCardTitleBar } from "../case-table-card-common/case-table-card-title-bar"
 import TableIcon from '../../assets/icons/icon-table.svg'
-import { typedId } from "../../utilities/js-utils"
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { isCodapV2Attribute, isV2TableComponent } from "../../v2/codap-v2-types"
 import { CaseTableInspector } from "./case-table-inspector"
@@ -43,7 +42,7 @@ registerTileComponentInfo({
 registerV2TileImporter("DG.TableView", ({ v2Component, v2Document, sharedModelManager, insertTile }) => {
   if (!isV2TableComponent(v2Component)) return
 
-  const { title = "", _links_, attributeWidths } = v2Component.componentStorage
+  const { guid, componentStorage: { title = "", _links_, attributeWidths } } = v2Component
 
   const content: SetRequired<ICaseTableSnapshot, "columnWidths"> = {
     type: kCaseTableTileType,
@@ -63,7 +62,7 @@ registerV2TileImporter("DG.TableView", ({ v2Component, v2Document, sharedModelMa
     }
   })
 
-  const tableTileSnap: ITileModelSnapshotIn = { id: typedId(kCaseTableIdPrefix), title, content }
+  const tableTileSnap: ITileModelSnapshotIn = { id: `${guid}`, title, content }
   const tableTile = insertTile(tableTileSnap)
 
   // Make sure metadata knows this is the table tile and it is the last shown

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -7,6 +7,7 @@ import { kCaseTableTileType } from "./case-table-defs"
 import { CaseTableModel, ICaseTableSnapshot } from "./case-table-model"
 import { CaseTableCardTitleBar } from "../case-table-card-common/case-table-card-title-bar"
 import TableIcon from '../../assets/icons/icon-table.svg'
+import { toV3Id } from "../../utilities/codap-utils"
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { isCodapV2Attribute, isV2TableComponent } from "../../v2/codap-v2-types"
 import { CaseTableInspector } from "./case-table-inspector"
@@ -62,7 +63,7 @@ registerV2TileImporter("DG.TableView", ({ v2Component, v2Document, sharedModelMa
     }
   })
 
-  const tableTileSnap: ITileModelSnapshotIn = { id: `${guid}`, title, content }
+  const tableTileSnap: ITileModelSnapshotIn = { id: toV3Id(kCaseTableIdPrefix, guid), title, content }
   const tableTile = insertTile(tableTileSnap)
 
   // Make sure metadata knows this is the table tile and it is the last shown

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -130,9 +130,9 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   if (!data || !rows) return null
 
   return (
-    <div className={`collection-table collection-${collectionId}`} ref={setNodeRef}>
+    <div className={`collection-table collection-${collectionId}`}>
       <CollectionTableSpacer onDrop={handleNewCollectionDrop} />
-      <div className="collection-table-and-title">
+      <div className="collection-table-and-title" ref={setNodeRef}>
         <CollectionTitle />
         <DataGrid ref={gridRef} className="rdg-light" data-testid="collection-table-grid" renderers={renderers}
           columns={columns} rows={rows} headerRowHeight={+styles.headerRowHeight} rowKeyGetter={rowKey}

--- a/v3/src/components/graph/v2-graph-importer.ts
+++ b/v3/src/components/graph/v2-graph-importer.ts
@@ -1,9 +1,8 @@
 import {ITileModelSnapshotIn} from "../../models/tiles/tile-model"
-import {typedId} from "../../utilities/js-utils"
 import {V2TileImportArgs} from "../../v2/codap-v2-tile-importers"
 import {ICodapV2GraphStorage, IGuidLink, isV2GraphComponent, v3TypeFromV2TypeIndex} from "../../v2/codap-v2-types"
 import {GraphAttrRole, PrimaryAttrRole, axisPlaceToAttrRole} from "../data-display/data-display-types"
-import {kGraphIdPrefix, kGraphTileType} from "./graph-defs"
+import {kGraphTileType} from "./graph-defs"
 import {PlotType} from "./graphing-types"
 import {IGraphContentModelSnapshot} from "./models/graph-content-model"
 import {kGraphDataConfigurationType} from "./models/graph-data-configuration-model"
@@ -18,17 +17,21 @@ export function v2GraphImporter({v2Component, v2Document, sharedModelManager, in
   if (!isV2GraphComponent(v2Component)) return
 
   const {
-    title = "", _links_: links, plotModels,
+    guid,
 
-    pointColor, strokeColor, pointSizeMultiplier,
-    strokeSameAsFill, isTransparent,
-    plotBackgroundImageLockInfo,
-/* The following are present in the componentStorage but not used in the V3 content model (yet):
-    displayOnlySelected, legendRole, legendAttributeType, numberOfLegendQuantiles,
-    legendQuantilesAreLocked, plotBackgroundImage, transparency, strokeTransparency,
-    plotBackgroundOpacity,
-*/
-  } = v2Component.componentStorage
+    componentStorage: {
+      title = "", _links_: links, plotModels,
+
+      pointColor, strokeColor, pointSizeMultiplier,
+      strokeSameAsFill, isTransparent,
+      plotBackgroundImageLockInfo,
+  /* The following are present in the componentStorage but not used in the V3 content model (yet):
+      displayOnlySelected, legendRole, legendAttributeType, numberOfLegendQuantiles,
+      legendQuantilesAreLocked, plotBackgroundImage, transparency, strokeTransparency,
+      plotBackgroundOpacity,
+  */
+    }
+  } = v2Component
   const plotBackgroundColor: string | null | undefined = v2Component.componentStorage.plotBackgroundColor ||
     defaultBackgroundColor
   type TLinksKey = keyof typeof links
@@ -167,7 +170,7 @@ export function v2GraphImporter({v2Component, v2Document, sharedModelManager, in
     }]
   }
 
-  const graphTileSnap: ITileModelSnapshotIn = { id: typedId(kGraphIdPrefix), title, content }
+  const graphTileSnap: ITileModelSnapshotIn = { id: `${guid}`, title, content }
   const graphTile = insertTile(graphTileSnap)
 
   // link shared model

--- a/v3/src/components/graph/v2-graph-importer.ts
+++ b/v3/src/components/graph/v2-graph-importer.ts
@@ -1,8 +1,9 @@
 import {ITileModelSnapshotIn} from "../../models/tiles/tile-model"
+import {toV3Id} from "../../utilities/codap-utils"
 import {V2TileImportArgs} from "../../v2/codap-v2-tile-importers"
 import {ICodapV2GraphStorage, IGuidLink, isV2GraphComponent, v3TypeFromV2TypeIndex} from "../../v2/codap-v2-types"
 import {GraphAttrRole, PrimaryAttrRole, axisPlaceToAttrRole} from "../data-display/data-display-types"
-import {kGraphTileType} from "./graph-defs"
+import {kGraphIdPrefix, kGraphTileType} from "./graph-defs"
 import {PlotType} from "./graphing-types"
 import {IGraphContentModelSnapshot} from "./models/graph-content-model"
 import {kGraphDataConfigurationType} from "./models/graph-data-configuration-model"
@@ -170,7 +171,7 @@ export function v2GraphImporter({v2Component, v2Document, sharedModelManager, in
     }]
   }
 
-  const graphTileSnap: ITileModelSnapshotIn = { id: `${guid}`, title, content }
+  const graphTileSnap: ITileModelSnapshotIn = { id: toV3Id(kGraphIdPrefix, guid), title, content }
   const graphTile = insertTile(graphTileSnap)
 
   // link shared model

--- a/v3/src/components/map/v2-map-importer.ts
+++ b/v3/src/components/map/v2-map-importer.ts
@@ -1,10 +1,11 @@
 import {ITileModelSnapshotIn} from "../../models/tiles/tile-model"
+import {toV3Id} from "../../utilities/codap-utils"
 import {V2TileImportArgs} from "../../v2/codap-v2-tile-importers"
 import {isV2MapComponent, v3TypeFromV2TypeIndex} from "../../v2/codap-v2-types"
 import {AttrRole} from "../data-display/data-display-types"
 import {IAttributeDescriptionSnapshot, kDataConfigurationType} from "../data-display/models/data-configuration-model"
 import {IMapModelContentSnapshot} from "./models/map-content-model"
-import {kMapTileType} from "./map-defs"
+import {kMapIdPrefix, kMapTileType} from "./map-defs"
 import {boundaryAttributeFromDataSet, latLongAttributesFromDataSet} from "./utilities/map-utils"
 import {IMapPointLayerModelSnapshot} from "./models/map-point-layer-model"
 import {BaseMapKey, kMapPointLayerType, kMapPolygonLayerType} from "./map-types"
@@ -127,6 +128,6 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
     center, zoom, baseMapLayerName, baseMapLayerIsVisible: true, layers
   }
 
-  const mapTileSnap: ITileModelSnapshotIn = { id: `${guid}`, title, content }
+  const mapTileSnap: ITileModelSnapshotIn = { id: toV3Id(kMapIdPrefix, guid), title, content }
   return insertTile(mapTileSnap)
 }

--- a/v3/src/components/map/v2-map-importer.ts
+++ b/v3/src/components/map/v2-map-importer.ts
@@ -1,11 +1,10 @@
 import {ITileModelSnapshotIn} from "../../models/tiles/tile-model"
-import {typedId} from "../../utilities/js-utils"
 import {V2TileImportArgs} from "../../v2/codap-v2-tile-importers"
 import {isV2MapComponent, v3TypeFromV2TypeIndex} from "../../v2/codap-v2-types"
 import {AttrRole} from "../data-display/data-display-types"
 import {IAttributeDescriptionSnapshot, kDataConfigurationType} from "../data-display/models/data-configuration-model"
 import {IMapModelContentSnapshot} from "./models/map-content-model"
-import {kMapIdPrefix, kMapTileType} from "./map-defs"
+import {kMapTileType} from "./map-defs"
 import {boundaryAttributeFromDataSet, latLongAttributesFromDataSet} from "./utilities/map-utils"
 import {IMapPointLayerModelSnapshot} from "./models/map-point-layer-model"
 import {BaseMapKey, kMapPointLayerType, kMapPolygonLayerType} from "./map-types"
@@ -15,7 +14,7 @@ import {IMapPolygonLayerModelSnapshot} from "./models/map-polygon-layer-model"
 export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImportArgs) {
   if (!isV2MapComponent(v2Component)) return
 
-  const {title = "", mapModelStorage} = v2Component.componentStorage
+  const {guid, componentStorage: {title = "", mapModelStorage}} = v2Component
   const {center, zoom, baseMapLayerName: v2BaseMapLayerName,
     layerModels: v2LayerModels} = mapModelStorage
   const baseMapKeyMap: Record<string, BaseMapKey> = { Topographic: 'topo', Streets: 'streets', Oceans: 'oceans' }
@@ -128,6 +127,6 @@ export function v2MapImporter({v2Component, v2Document, insertTile}: V2TileImpor
     center, zoom, baseMapLayerName, baseMapLayerIsVisible: true, layers
   }
 
-  const mapTileSnap: ITileModelSnapshotIn = { id: typedId(kMapIdPrefix), title, content }
+  const mapTileSnap: ITileModelSnapshotIn = { id: `${guid}`, title, content }
   return insertTile(mapTileSnap)
 }

--- a/v3/src/components/slider/slider-registration.ts
+++ b/v3/src/components/slider/slider-registration.ts
@@ -3,7 +3,6 @@ import { registerTileComponentInfo } from "../../models/tiles/tile-component-inf
 import { registerTileContentInfo } from "../../models/tiles/tile-content-info"
 import { getGlobalValueManager } from "../../models/tiles/tile-environment"
 import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
-import { typedId } from "../../utilities/js-utils"
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { isV2SliderComponent } from "../../v2/codap-v2-types"
 import { SliderComponent } from "./slider-component"
@@ -61,16 +60,19 @@ registerV2TileImporter("DG.SliderView", ({ v2Component, v2Document, sharedModelM
 
   // parse the v2 content
   const {
-    title: v2Title = "", _links_, lowerBound, upperBound, animationDirection, animationMode,
-    restrictToMultiplesOf, maxPerSecond, userTitle, userSetTitle
-  } = v2Component.componentStorage
+    guid: componentGuid,
+    componentStorage: {
+      title: v2Title = "", _links_, lowerBound, upperBound, animationDirection, animationMode,
+      restrictToMultiplesOf, maxPerSecond, userTitle, userSetTitle
+    }
+  } = v2Component
   const globalId = _links_.model.id
   const v2Global = v2Document.globalValues.find(_global => _global.guid === globalId)
   if (!v2Global) return
 
   // create global value and add to manager
   const { guid, ...globalSnap } = v2Global
-  const globalValue = globalValueManager.addValueSnapshot(globalSnap)
+  const globalValue = globalValueManager.addValueSnapshot({ id: `${guid}`, ...globalSnap })
 
   // create slider model
   const content: ISliderSnapshot = {
@@ -83,7 +85,7 @@ registerV2TileImporter("DG.SliderView", ({ v2Component, v2Document, sharedModelM
     axis: { type: "numeric", place: "bottom", min: lowerBound ?? 0, max: upperBound ?? 12 }
   }
   const title = v2Title && (userTitle || userSetTitle) ? v2Title : undefined
-  const sliderTileSnap: ITileModelSnapshotIn = { id: typedId(kSliderIdPrefix), title, content }
+  const sliderTileSnap: ITileModelSnapshotIn = { id: `${componentGuid}`, title, content }
   const sliderTile = insertTile(sliderTileSnap)
 
   // link tile to global value manager

--- a/v3/src/components/slider/slider-registration.ts
+++ b/v3/src/components/slider/slider-registration.ts
@@ -3,6 +3,7 @@ import { registerTileComponentInfo } from "../../models/tiles/tile-component-inf
 import { registerTileContentInfo } from "../../models/tiles/tile-content-info"
 import { getGlobalValueManager } from "../../models/tiles/tile-environment"
 import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
+import { toV3GlobalId, toV3Id } from "../../utilities/codap-utils"
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { isV2SliderComponent } from "../../v2/codap-v2-types"
 import { SliderComponent } from "./slider-component"
@@ -72,7 +73,7 @@ registerV2TileImporter("DG.SliderView", ({ v2Component, v2Document, sharedModelM
 
   // create global value and add to manager
   const { guid, ...globalSnap } = v2Global
-  const globalValue = globalValueManager.addValueSnapshot({ id: `${guid}`, ...globalSnap })
+  const globalValue = globalValueManager.addValueSnapshot({ id: toV3GlobalId(guid), ...globalSnap })
 
   // create slider model
   const content: ISliderSnapshot = {
@@ -85,7 +86,7 @@ registerV2TileImporter("DG.SliderView", ({ v2Component, v2Document, sharedModelM
     axis: { type: "numeric", place: "bottom", min: lowerBound ?? 0, max: upperBound ?? 12 }
   }
   const title = v2Title && (userTitle || userSetTitle) ? v2Title : undefined
-  const sliderTileSnap: ITileModelSnapshotIn = { id: `${componentGuid}`, title, content }
+  const sliderTileSnap: ITileModelSnapshotIn = { id: toV3Id(kSliderIdPrefix, componentGuid), title, content }
   const sliderTile = insertTile(sliderTileSnap)
 
   // link tile to global value manager

--- a/v3/src/components/web-view/web-view-registration.ts
+++ b/v3/src/components/web-view/web-view-registration.ts
@@ -1,7 +1,6 @@
 import { registerTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { registerTileContentInfo } from "../../models/tiles/tile-content-info"
 import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
-import { typedId } from "../../utilities/js-utils"
 import { registerV2TileImporter, V2TileImportArgs } from "../../v2/codap-v2-tile-importers"
 import { isV2WebViewComponent, isV2GameViewComponent } from "../../v2/codap-v2-types"
 import { kWebViewTileType } from "./web-view-defs"
@@ -30,7 +29,7 @@ registerTileComponentInfo({
   defaultHeight: 400
 })
 
-function addWebViewSnapshot(args: V2TileImportArgs, url?: string, state?: unknown) {
+function addWebViewSnapshot(args: V2TileImportArgs, guid: number, url?: string, state?: unknown) {
   const { v2Component, insertTile } = args
   const { title, userSetTitle } = v2Component.componentStorage
 
@@ -40,7 +39,7 @@ function addWebViewSnapshot(args: V2TileImportArgs, url?: string, state?: unknow
     url
   }
   const webViewTileSnap: ITileModelSnapshotIn = {
-    id: typedId(kWebViewIdPrefix),
+    id: `${guid}`,
     title: (userSetTitle && title) || undefined,
     content
   }
@@ -53,10 +52,10 @@ function importWebView(args: V2TileImportArgs) {
   if (!isV2WebViewComponent(v2Component)) return
 
   // parse the v2 content
-  const { URL } = v2Component.componentStorage
+  const { guid, componentStorage: { URL } } = v2Component
 
   // create webView model
-  return addWebViewSnapshot(args, URL)
+  return addWebViewSnapshot(args, guid, URL)
 }
 registerV2TileImporter("DG.WebView", importWebView)
 
@@ -65,9 +64,9 @@ function importGameView(args: V2TileImportArgs) {
   if (!isV2GameViewComponent(v2Component)) return
 
   // parse the v2 content
-  const { currentGameUrl, savedGameState} = v2Component.componentStorage
+  const { guid, componentStorage: { currentGameUrl, savedGameState} } = v2Component
 
   // create webView model
-  return addWebViewSnapshot(args, processPluginUrl(currentGameUrl), savedGameState)
+  return addWebViewSnapshot(args, guid, processPluginUrl(currentGameUrl), savedGameState)
 }
 registerV2TileImporter("DG.GameView", importGameView)

--- a/v3/src/components/web-view/web-view-registration.ts
+++ b/v3/src/components/web-view/web-view-registration.ts
@@ -1,6 +1,7 @@
 import { registerTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { registerTileContentInfo } from "../../models/tiles/tile-content-info"
 import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
+import { toV3Id } from "../../utilities/codap-utils"
 import { registerV2TileImporter, V2TileImportArgs } from "../../v2/codap-v2-tile-importers"
 import { isV2WebViewComponent, isV2GameViewComponent } from "../../v2/codap-v2-types"
 import { kWebViewTileType } from "./web-view-defs"
@@ -39,7 +40,7 @@ function addWebViewSnapshot(args: V2TileImportArgs, guid: number, url?: string, 
     url
   }
   const webViewTileSnap: ITileModelSnapshotIn = {
-    id: `${guid}`,
+    id: toV3Id(kWebViewIdPrefix, guid),
     title: (userSetTitle && title) || undefined,
     content
   }

--- a/v3/src/data-interactive/data-interactive-type-utils.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.ts
@@ -4,6 +4,7 @@ import { IDataSet } from "../models/data/data-set"
 import { ICase } from "../models/data/data-set-types"
 import { v2ModelSnapshotFromV2ModelStorage } from "../models/data/v2-model"
 import { getSharedCaseMetadataFromDataset } from "../models/shared/shared-data-utils"
+import { kAttrIdPrefix } from "../utilities/codap-utils"
 import {
   ICodapV2AttributeV3, ICodapV2CollectionV3, ICodapV2DataContextV3, v3TypeFromV2TypeString
 } from "../v2/codap-v2-types"
@@ -14,7 +15,7 @@ export function convertValuesToAttributeSnapshot(_values: DISingleValues): IAttr
   const values = _values as DIAttribute
   if (values.name) {
     return {
-      ...v2ModelSnapshotFromV2ModelStorage(values),
+      ...v2ModelSnapshotFromV2ModelStorage(kAttrIdPrefix, values),
       userType: v3TypeFromV2TypeString(values.type),
       // defaultMin: values.defaultMin, // TODO defaultMin not a part of IAttribute yet
       // defaultMax: values.defaultMax, // TODO defaultMax not a part of IAttribute yet

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -9,22 +9,22 @@ import { ICollectionPropsModel } from "../models/data/collection"
 export type DICaseValue = string | number | boolean | undefined
 export type DICaseValues = Record<string, DICaseValue>
 export interface DIFullCase {
-  children?: string[]
+  children?: number[]
   context?: {
-    id?: string
+    id?: number
     name?: string
   }
   collection?: {
-    id?: string
+    id?: number
     name?: string
     parent?: {
-      id?: string
+      id?: number
       name?: string
     }
   }
-  id?: string
-  itemId?: string
-  parent?: string
+  id?: number
+  itemId?: number
+  parent?: number
   values?: DICaseValues
 }
 export interface DIAllCases {
@@ -34,21 +34,21 @@ export interface DIAllCases {
   }[]
   collection?: {
     name?: string
-    id?: string
+    id?: number
   }
 }
 export type DIAttribute = Partial<ICodapV2Attribute>
 export interface DICase {
-  collectionID?: string
+  collectionID?: number
   collectionName?: string
-  caseID?: string
-  itemID?: string
+  caseID?: number
+  itemID?: number
 }
 export type DICollection = Partial<ICodapV2Collection>
 export type DIComponent = ITileModel
 export interface DIComponentInfo {
   hidden?: boolean
-  id?: string
+  id?: number
   name?: string
   title?: string
   type?: string
@@ -75,8 +75,8 @@ export interface DIInteractiveFrame {
 }
 export type DIItem = unknown
 export interface DINewCase {
-  id?: string
-  itemID?: string
+  id?: number
+  itemID?: number
 }
 export interface DINotification {
   request?: string
@@ -121,7 +121,7 @@ export interface DIMetadata {
 export interface DISuccessResult {
   success: true
   values?: DIResultValues
-  caseIDs?: string[]
+  caseIDs?: number[]
 }
 
 export interface DIErrorResult {

--- a/v3/src/data-interactive/handlers/all-cases-handler.test.ts
+++ b/v3/src/data-interactive/handlers/all-cases-handler.test.ts
@@ -44,7 +44,7 @@ describe("DataInteractive AllCasesHandler", () => {
     }
     const getCase = (result: GetAllCasesResult, index: number) =>
       result.values.cases![index].case!
-    const checkCase = (c: any, attribute: string, value: string, children: number, parent?: string) => {
+    const checkCase = (c: any, attribute: string, value: string, children: number, parent?: number) => {
       expect(c.values[attribute]).toBe(value)
       expect(c.children.length).toBe(children)
       expect(c.parent).toBe(parent)

--- a/v3/src/data-interactive/handlers/all-cases-handler.ts
+++ b/v3/src/data-interactive/handlers/all-cases-handler.ts
@@ -22,7 +22,8 @@ export const diAllCasesHandler: DIHandler = {
     const cases = dataContext.getGroupsForCollection(collection.id)?.map((c, caseIndex) => {
       const id = c.pseudoCase.__id__
 
-      const parent = dataContext.getParentCase(id, collection.id)?.pseudoCase.__id__
+      const _parent = dataContext.getParentCase(id, collection.id)?.pseudoCase.__id__
+      const parent = _parent ? +_parent : undefined
 
       // iphone-frame was throwing an error when Array.from() wasn't used here for some reason.
       const childPseudoCaseIds = c.childPseudoCaseIds && Array.from(c.childPseudoCaseIds)
@@ -32,7 +33,7 @@ export const diAllCasesHandler: DIHandler = {
       const values = getCaseValues(id, collection.id, dataContext)
 
       return {
-        case: { id, parent, children, values },
+        case: { id: +id, parent, children: children.map(child => +child), values },
         caseIndex
       }
     })
@@ -40,7 +41,7 @@ export const diAllCasesHandler: DIHandler = {
     return { success: true, values: {
       collection: {
         name: collection.name,
-        id: collection.id
+        id: +collection.id
       },
       cases
     } }

--- a/v3/src/data-interactive/handlers/all-cases-handler.ts
+++ b/v3/src/data-interactive/handlers/all-cases-handler.ts
@@ -1,6 +1,7 @@
 import { registerDIHandler } from "../data-interactive-handler"
 import { getCaseValues } from "../data-interactive-utils"
 import { DIHandler, DIResources } from "../data-interactive-types"
+import { toV2Id } from "../../utilities/codap-utils"
 
 export const diAllCasesHandler: DIHandler = {
   delete(resources: DIResources) {
@@ -23,7 +24,7 @@ export const diAllCasesHandler: DIHandler = {
       const id = c.pseudoCase.__id__
 
       const _parent = dataContext.getParentCase(id, collection.id)?.pseudoCase.__id__
-      const parent = _parent ? +_parent : undefined
+      const parent = _parent ? toV2Id(_parent) : undefined
 
       // iphone-frame was throwing an error when Array.from() wasn't used here for some reason.
       const childPseudoCaseIds = c.childPseudoCaseIds && Array.from(c.childPseudoCaseIds)
@@ -33,7 +34,7 @@ export const diAllCasesHandler: DIHandler = {
       const values = getCaseValues(id, collection.id, dataContext)
 
       return {
-        case: { id: +id, parent, children: children.map(child => +child), values },
+        case: { id: toV2Id(id), parent, children: children.map(child => toV2Id(child)), values },
         caseIndex
       }
     })
@@ -41,7 +42,7 @@ export const diAllCasesHandler: DIHandler = {
     return { success: true, values: {
       collection: {
         name: collection.name,
-        id: +collection.id
+        id: toV2Id(collection.id)
       },
       cases
     } }

--- a/v3/src/data-interactive/handlers/case-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-handler.test.ts
@@ -32,11 +32,11 @@ describe("DataInteractive CaseHandler", () => {
   it("create works as expected", () => {
     setupDataset()
 
-    const oldCaseIds = dataset?.cases.map(c => c.__id__)
+    const oldCaseIds = dataset?.cases.map(c => +c.__id__)
     const confirmNewCase = (newCase: DINewCase) => {
       expect(newCase.itemID).toBeDefined()
-      expect(oldCaseIds?.includes(newCase.itemID ?? "")).toBe(false)
-      expect(dataset?.getCase(newCase.itemID ?? "")).toBeDefined()
+      expect(oldCaseIds?.includes(newCase.itemID!)).toBe(false)
+      expect(dataset?.getCase(`${newCase.itemID}`)).toBeDefined()
 
       // TODO Check newCase.id
     }
@@ -60,7 +60,7 @@ describe("DataInteractive CaseHandler", () => {
     newCases.forEach(confirmNewCase)
 
     // Creating a single case
-    const result2 = handler.create?.({ dataContext: dataset }, 
+    const result2 = handler.create?.({ dataContext: dataset },
       {
         parent: dataset?.getCasesForCollection(c1!.id)[0].__id__,
         values: { a2: "d", a3: 8 }
@@ -81,24 +81,24 @@ describe("DataInteractive CaseHandler", () => {
 
     // Update single case
     const caseId0 = dataset?.cases[0].__id__
-    const result = handler.update?.({ dataContext: dataset }, { id: caseId0, values: { a3: 10 } } as DIValues)
+    const result = handler.update?.({ dataContext: dataset }, { id: +caseId0!, values: { a3: 10 } } as DIValues)
     expect(result?.success).toBe(true)
     expect(dataset?.getAttributeByName("a3")?.value(0)).toBe("10")
-    expect((result as DISuccessResult).caseIDs?.includes(caseId0!)).toBe(true)
+    expect((result as DISuccessResult).caseIDs?.includes(+caseId0!)).toBe(true)
 
     // Update multiple cases
     const caseId1 = dataset?.cases[1].__id__
     const caseId2 = dataset?.cases[2].__id__
     const result2 = handler.update?.({ dataContext: dataset }, [
-      { id: caseId1, values: { a2: "w" } },
-      { id: caseId2, values: { a1: "c", a2: "c", a3: "c" } }
+      { id: +caseId1!, values: { a2: "w" } },
+      { id: +caseId2!, values: { a1: "c", a2: "c", a3: "c" } }
     ] as DIValues)
     expect(result2?.success).toBe(true)
     expect(dataset?.getAttributeByName("a2")?.value(1)).toBe("w")
     const caseIDs = (result2 as DISuccessResult).caseIDs!
-    expect(caseIDs.includes(caseId1!)).toBe(true)
+    expect(caseIDs.includes(+caseId1!)).toBe(true)
     const attrs = ["a1", "a2", "a3"]
     attrs.forEach(attrName => expect(dataset?.getAttributeByName(attrName)?.value(2)).toBe("c"))
-    expect(caseIDs.includes(caseId2!)).toBe(true)
+    expect(caseIDs.includes(+caseId2!)).toBe(true)
   })
 })

--- a/v3/src/data-interactive/handlers/case-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-handler.test.ts
@@ -1,5 +1,6 @@
 import { CollectionModel, ICollectionModel } from "../../models/data/collection"
 import { DataSet, IDataSet, toCanonical } from "../../models/data/data-set"
+import { toV2Id, toV3CaseId } from "../../utilities/codap-utils"
 import { DINewCase, DISuccessResult, DIValues } from "../data-interactive-types"
 import { diCaseHandler } from "./case-handler"
 
@@ -32,11 +33,11 @@ describe("DataInteractive CaseHandler", () => {
   it("create works as expected", () => {
     setupDataset()
 
-    const oldCaseIds = dataset?.cases.map(c => +c.__id__)
+    const oldCaseIds = dataset!.cases.map(c => toV2Id(c.__id__))
     const confirmNewCase = (newCase: DINewCase) => {
       expect(newCase.itemID).toBeDefined()
       expect(oldCaseIds?.includes(newCase.itemID!)).toBe(false)
-      expect(dataset?.getCase(`${newCase.itemID}`)).toBeDefined()
+      expect(dataset!.getCase(toV3CaseId(newCase.itemID!))).toBeDefined()
 
       // TODO Check newCase.id
     }
@@ -46,10 +47,11 @@ describe("DataInteractive CaseHandler", () => {
     // Creating multiple cases
     expect(dataset?.cases.length).toBe(6)
     expect(dataset?.getCasesForCollection(c2!.id).length).toBe(4)
+    const targetParentCase = dataset!.getCasesForCollection(c2!.id)[0]
     const result = handler.create?.({ dataContext: dataset }, [
       { values: { a1: "c", a2: "c", a3: 7 } },
       {
-        parent: dataset?.getCasesForCollection(c2!.id)[0].__id__,
+        parent: toV2Id(targetParentCase.__id__),
         values: { a3: 8 }
       }
     ] as DIValues)
@@ -81,24 +83,24 @@ describe("DataInteractive CaseHandler", () => {
 
     // Update single case
     const caseId0 = dataset?.cases[0].__id__
-    const result = handler.update?.({ dataContext: dataset }, { id: +caseId0!, values: { a3: 10 } } as DIValues)
+    const result = handler.update?.({ dataContext: dataset }, { id: toV2Id(caseId0!), values: { a3: 10 } } as DIValues)
     expect(result?.success).toBe(true)
     expect(dataset?.getAttributeByName("a3")?.value(0)).toBe("10")
-    expect((result as DISuccessResult).caseIDs?.includes(+caseId0!)).toBe(true)
+    expect((result as DISuccessResult).caseIDs?.includes(toV2Id(caseId0!))).toBe(true)
 
     // Update multiple cases
     const caseId1 = dataset?.cases[1].__id__
     const caseId2 = dataset?.cases[2].__id__
     const result2 = handler.update?.({ dataContext: dataset }, [
-      { id: +caseId1!, values: { a2: "w" } },
-      { id: +caseId2!, values: { a1: "c", a2: "c", a3: "c" } }
+      { id: toV2Id(caseId1!), values: { a2: "w" } },
+      { id: toV2Id(caseId2!), values: { a1: "c", a2: "c", a3: "c" } }
     ] as DIValues)
     expect(result2?.success).toBe(true)
     expect(dataset?.getAttributeByName("a2")?.value(1)).toBe("w")
     const caseIDs = (result2 as DISuccessResult).caseIDs!
-    expect(caseIDs.includes(+caseId1!)).toBe(true)
+    expect(caseIDs.includes(toV2Id(caseId1!))).toBe(true)
     const attrs = ["a1", "a2", "a3"]
     attrs.forEach(attrName => expect(dataset?.getAttributeByName(attrName)?.value(2)).toBe("c"))
-    expect(caseIDs.includes(+caseId2!)).toBe(true)
+    expect(caseIDs.includes(toV2Id(caseId2!))).toBe(true)
   })
 })

--- a/v3/src/data-interactive/handlers/case-handler.ts
+++ b/v3/src/data-interactive/handlers/case-handler.ts
@@ -1,5 +1,6 @@
 import { IDataSet } from "../../models/data/data-set"
 import { ICaseCreation } from "../../models/data/data-set-types"
+import { toV2Id, toV3CaseId } from "../../utilities/codap-utils"
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DICaseValues, DIFullCase, DIHandler, DIResources, DIValues } from "../data-interactive-types"
@@ -26,7 +27,7 @@ export const diCaseHandler: DIHandler = {
       cases.forEach(aCase => {
         if (aCase.values) {
           const { parent } = aCase
-          const parentValues = parent ? dataContext.getParentValues(`${parent}`) : {}
+          const parentValues = parent ? dataContext.getParentValues(toV3CaseId(parent)) : {}
           const caseValues = attrNamesToIds(aCase.values, dataContext)
           newCaseData.push({ ...caseValues, ...parentValues })
         }
@@ -35,7 +36,7 @@ export const diCaseHandler: DIHandler = {
     })
 
     // TODO Include case ids as id in the returned values
-    return { success: true, values: itemIds.map(id => ({ itemID: +id })) }
+    return { success: true, values: itemIds.map(id => ({ itemID: toV2Id(id) })) }
   },
   update(resources: DIResources, values?: DIValues) {
     const { dataContext } = resources
@@ -46,7 +47,7 @@ export const diCaseHandler: DIHandler = {
     dataContext.applyModelChange(() => {
       cases.forEach(aCase => {
         const { id } = aCase
-        const strId = `${id}`
+        const strId = id && toV3CaseId(id)
         if (id && strId && aCase.values && (dataContext.getCase(strId) || dataContext.pseudoCaseMap.get(strId))) {
           caseIDs.push(id)
           const updatedAttributes = attrNamesToIds(aCase.values, dataContext)

--- a/v3/src/data-interactive/handlers/case-handler.ts
+++ b/v3/src/data-interactive/handlers/case-handler.ts
@@ -26,7 +26,7 @@ export const diCaseHandler: DIHandler = {
       cases.forEach(aCase => {
         if (aCase.values) {
           const { parent } = aCase
-          const parentValues = parent ? dataContext.getParentValues(parent) : {}
+          const parentValues = parent ? dataContext.getParentValues(`${parent}`) : {}
           const caseValues = attrNamesToIds(aCase.values, dataContext)
           newCaseData.push({ ...caseValues, ...parentValues })
         }
@@ -35,21 +35,22 @@ export const diCaseHandler: DIHandler = {
     })
 
     // TODO Include case ids as id in the returned values
-    return { success: true, values: itemIds.map(id => ({ itemID: id })) }
+    return { success: true, values: itemIds.map(id => ({ itemID: +id })) }
   },
   update(resources: DIResources, values?: DIValues) {
     const { dataContext } = resources
     if (!dataContext) return { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } }
 
     const cases = (Array.isArray(values) ? values : [values]) as DIFullCase[]
-    const caseIDs: string[] = []
+    const caseIDs: number[] = []
     dataContext.applyModelChange(() => {
       cases.forEach(aCase => {
         const { id } = aCase
-        if (id && aCase.values && (dataContext.getCase(id) || dataContext.pseudoCaseMap.get(id))) {
+        const strId = `${id}`
+        if (id && strId && aCase.values && (dataContext.getCase(strId) || dataContext.pseudoCaseMap.get(strId))) {
           caseIDs.push(id)
           const updatedAttributes = attrNamesToIds(aCase.values, dataContext)
-          dataContext.setCaseValues([{ ...updatedAttributes, __id__: id }])
+          dataContext.setCaseValues([{ ...updatedAttributes, __id__: strId }])
         }
       })
     })

--- a/v3/src/data-interactive/handlers/component-list-handler.ts
+++ b/v3/src/data-interactive/handlers/component-list-handler.ts
@@ -20,7 +20,7 @@ export const diComponentListHandler: DIHandler = {
         : kComponentTypeV3ToV2Map[content.type]
       const tileLayout = document.content?.getTileLayoutById(id)
       const hidden = isFreeTileLayout(tileLayout) ? !!tileLayout.isHidden : false
-      values.push({ hidden, id, title, type })
+      values.push({ hidden, id: +id, title, type })
     })
 
     return { success: true, values }

--- a/v3/src/data-interactive/handlers/component-list-handler.ts
+++ b/v3/src/data-interactive/handlers/component-list-handler.ts
@@ -1,6 +1,7 @@
 import { isWebViewModel } from "../../components/web-view/web-view-model"
 import { appState } from "../../models/app-state"
 import { isFreeTileLayout } from "../../models/document/free-tile-row"
+import { toV2Id } from "../../utilities/codap-utils"
 import { kComponentTypeV3ToV2Map, kV2GameType, kV2WebViewType } from "../data-interactive-component-types"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIComponentInfo, DIHandler, DIResources } from "../data-interactive-types"
@@ -20,7 +21,7 @@ export const diComponentListHandler: DIHandler = {
         : kComponentTypeV3ToV2Map[content.type]
       const tileLayout = document.content?.getTileLayoutById(id)
       const hidden = isFreeTileLayout(tileLayout) ? !!tileLayout.isHidden : false
-      values.push({ hidden, id: +id, title, type })
+      values.push({ hidden, id: toV2Id(id), title, type })
     })
 
     return { success: true, values }

--- a/v3/src/data-interactive/handlers/selection-list-handler.test.ts
+++ b/v3/src/data-interactive/handlers/selection-list-handler.test.ts
@@ -6,8 +6,8 @@ describe("DataInteractive SelectionListHandler", () => {
   const handler = diSelectionListHandler
 
   let dataset: IDataSet
-  const caseId1 = "case1"
-  const caseId2 = "case2"
+  const caseId1 = "1"
+  const caseId2 = "2"
   const caseIdUnused = "unused"
   beforeEach(function() {
     dataset = DataSet.create({ name: "data" })
@@ -25,7 +25,7 @@ describe("DataInteractive SelectionListHandler", () => {
     dataset.setSelectedCases([caseId1])
     const result = handler.get?.({ dataContext: dataset })
     expect(result?.values && Array.isArray(result.values) &&
-      (result.values as DICase[]).map(c => c.caseID).includes(caseId1)).toBe(true)
+      (result.values as DICase[]).map(c => c.caseID).includes(+caseId1)).toBe(true)
   })
 
   it("create works as expected", () => {

--- a/v3/src/data-interactive/handlers/selection-list-handler.test.ts
+++ b/v3/src/data-interactive/handlers/selection-list-handler.test.ts
@@ -1,4 +1,5 @@
 import { DataSet, IDataSet } from "../../models/data/data-set"
+import { toV2Id } from "../../utilities/codap-utils"
 import { DICase, DIValues } from "../data-interactive-types"
 import { diSelectionListHandler } from "./selection-list-handler"
 
@@ -6,8 +7,8 @@ describe("DataInteractive SelectionListHandler", () => {
   const handler = diSelectionListHandler
 
   let dataset: IDataSet
-  const caseId1 = "1"
-  const caseId2 = "2"
+  const caseId1 = "case1"
+  const caseId2 = "case2"
   const caseIdUnused = "unused"
   beforeEach(function() {
     dataset = DataSet.create({ name: "data" })
@@ -25,7 +26,7 @@ describe("DataInteractive SelectionListHandler", () => {
     dataset.setSelectedCases([caseId1])
     const result = handler.get?.({ dataContext: dataset })
     expect(result?.values && Array.isArray(result.values) &&
-      (result.values as DICase[]).map(c => c.caseID).includes(+caseId1)).toBe(true)
+      (result.values as DICase[]).map(c => c.caseID).includes(toV2Id(caseId1))).toBe(true)
   })
 
   it("create works as expected", () => {

--- a/v3/src/data-interactive/handlers/selection-list-handler.ts
+++ b/v3/src/data-interactive/handlers/selection-list-handler.ts
@@ -34,7 +34,7 @@ export const diSelectionListHandler: DIHandler = {
 
     const caseIds = Array.from(dataContext.selection)
     // TODO Include collectionID and collectionName
-    const values = caseIds.map(caseID => ({ caseID }))
+    const values = caseIds.map(caseID => ({ caseID: +caseID }))
     // TODO Filter based on collection
     return {
       success: true,

--- a/v3/src/data-interactive/handlers/selection-list-handler.ts
+++ b/v3/src/data-interactive/handlers/selection-list-handler.ts
@@ -1,4 +1,5 @@
 import { IDataSet } from "../../models/data/data-set"
+import { toV2Id } from "../../utilities/codap-utils"
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DIResources, DIValues } from "../data-interactive-types"
@@ -34,7 +35,7 @@ export const diSelectionListHandler: DIHandler = {
 
     const caseIds = Array.from(dataContext.selection)
     // TODO Include collectionID and collectionName
-    const values = caseIds.map(caseID => ({ caseID: +caseID }))
+    const values = caseIds.map(caseID => ({ caseID: toV2Id(caseID) }))
     // TODO Filter based on collection
     return {
       success: true,

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -3,7 +3,7 @@ import { kCaseTableTileType } from "../../components/case-table/case-table-defs"
 import { kGraphTileType } from "../../components/graph/graph-defs"
 import { isGraphContentModel } from "../../components/graph/models/graph-content-model"
 import { kSliderTileType } from "../../components/slider/slider-defs"
-import { randomCodapId } from "../../utilities/mst-utils"
+import { codapNumIdStr } from "../../utilities/mst-utils"
 import { urlParams } from "../../utilities/url-params"
 import { appState } from "../app-state"
 import { IFreeTileInRowOptions } from "../document/free-tile-row"
@@ -21,7 +21,7 @@ type ILayoutOptions = IFreeTileInRowOptions | IMosaicTileInRowOptions | undefine
 export function createDefaultTileOfType(tileType: string) {
   const env = getTileEnvironment(appState.document)
   const info = getTileContentInfo(tileType)
-  const id = randomCodapId()
+  const id = codapNumIdStr()
   const content = info?.defaultContent({ env })
   return content ? TileModel.create({ id, content }) : undefined
 }

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -3,7 +3,7 @@ import { kCaseTableTileType } from "../../components/case-table/case-table-defs"
 import { kGraphTileType } from "../../components/graph/graph-defs"
 import { isGraphContentModel } from "../../components/graph/models/graph-content-model"
 import { kSliderTileType } from "../../components/slider/slider-defs"
-import { codapNumIdStr } from "../../utilities/mst-utils"
+import { v3Id } from "../../utilities/codap-utils"
 import { urlParams } from "../../utilities/url-params"
 import { appState } from "../app-state"
 import { IFreeTileInRowOptions } from "../document/free-tile-row"
@@ -21,7 +21,7 @@ type ILayoutOptions = IFreeTileInRowOptions | IMosaicTileInRowOptions | undefine
 export function createDefaultTileOfType(tileType: string) {
   const env = getTileEnvironment(appState.document)
   const info = getTileContentInfo(tileType)
-  const id = codapNumIdStr()
+  const id = v3Id(info?.prefix || "TILE")
   const content = info?.defaultContent({ env })
   return content ? TileModel.create({ id, content }) : undefined
 }

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -3,7 +3,7 @@ import { kCaseTableTileType } from "../../components/case-table/case-table-defs"
 import { kGraphTileType } from "../../components/graph/graph-defs"
 import { isGraphContentModel } from "../../components/graph/models/graph-content-model"
 import { kSliderTileType } from "../../components/slider/slider-defs"
-import { typedId } from "../../utilities/js-utils"
+import { randomCodapId } from "../../utilities/mst-utils"
 import { urlParams } from "../../utilities/url-params"
 import { appState } from "../app-state"
 import { IFreeTileInRowOptions } from "../document/free-tile-row"
@@ -21,7 +21,7 @@ type ILayoutOptions = IFreeTileInRowOptions | IMosaicTileInRowOptions | undefine
 export function createDefaultTileOfType(tileType: string) {
   const env = getTileEnvironment(appState.document)
   const info = getTileContentInfo(tileType)
-  const id = typedId(info?.prefix || "TILE")
+  const id = randomCodapId()
   const content = info?.defaultContent({ env })
   return content ? TileModel.create({ id, content }) : undefined
 }

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -1,4 +1,4 @@
-import { getSnapshot } from "mobx-state-tree"
+import { getSnapshot, types } from "mobx-state-tree"
 import { omitUndefined } from "../../test/test-utils"
 import { toCanonical } from "../data/data-set"
 import { createCodapDocument } from "./create-codap-document"
@@ -11,6 +11,14 @@ jest.mock("../../utilities/js-utils", () => ({
   typedId: () => `test-${++mockNodeIdCount}`,
   uniqueOrderedId: () => `order-${++mockNodeIdCount}`
 }))
+jest.mock("../../utilities/mst-utils", () => {
+  const mockCodapId = () => `test-${++mockNodeIdCount}`
+  return {
+    ...jest.requireActual("../../utilities/mst-utils"),
+    typeCodapId: () => types.optional(types.identifier, () => `${mockCodapId()}`),
+    randomCodapId: mockCodapId
+  }
+})
 
 describe("createCodapDocument", () => {
   beforeEach(() => {
@@ -80,7 +88,7 @@ describe("createCodapDocument", () => {
                 }
               },
               attributes: ["test-8"],
-              cases: [{ __id__: "CASEorder-9" }, { __id__: "CASEorder-10" }, { __id__: "CASEorder-11" }],
+              cases: [{ __id__: "test-9" }, { __id__: "test-10" }, { __id__: "test-11" }],
               collections: [],
               ungrouped: { id: "test-6", name: "Cases" },
               id: "test-5",

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -11,12 +11,12 @@ jest.mock("../../utilities/js-utils", () => ({
   typedId: () => `test-${++mockNodeIdCount}`,
   uniqueOrderedId: () => `order-${++mockNodeIdCount}`
 }))
-jest.mock("../../utilities/mst-utils", () => {
-  const mockCodapId = () => `test-${++mockNodeIdCount}`
+jest.mock("../../utilities/codap-utils", () => {
+  const mockV3Id = () => `test-${++mockNodeIdCount}`
   return {
-    ...jest.requireActual("../../utilities/mst-utils"),
-    codapNumIdStr: mockCodapId,
-    typeCodapNumIdStr: () => types.optional(types.identifier, () => `${mockCodapId()}`)
+    ...jest.requireActual("../../utilities/codap-utils"),
+    v3Id: mockV3Id,
+    typeV3Id: () => types.optional(types.identifier, () => `${mockV3Id()}`)
   }
 })
 

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -15,8 +15,8 @@ jest.mock("../../utilities/mst-utils", () => {
   const mockCodapId = () => `test-${++mockNodeIdCount}`
   return {
     ...jest.requireActual("../../utilities/mst-utils"),
-    typeCodapId: () => types.optional(types.identifier, () => `${mockCodapId()}`),
-    randomCodapId: mockCodapId
+    codapNumIdStr: mockCodapId,
+    typeCodapNumIdStr: () => types.optional(types.identifier, () => `${mockCodapId()}`)
   }
 })
 

--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -25,10 +25,10 @@ describe("Attribute", () => {
   })
 
   test("matchNameOrId", () => {
-    const a = Attribute.create({ v2Id: 1, id: "v3Id", name: "name", _title: "title" })
+    const a = Attribute.create({ id: "1", name: "name", _title: "title" })
     expect(a.matchNameOrId("")).toBe(false)
     expect(a.matchNameOrId(1)).toBe(true)
-    expect(a.matchNameOrId("v3Id")).toBe(true)
+    expect(a.matchNameOrId("1")).toBe(true)
     expect(a.matchNameOrId("name")).toBe(true)
     expect(a.matchNameOrId("title")).toBe(false)
   })

--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -25,10 +25,10 @@ describe("Attribute", () => {
   })
 
   test("matchNameOrId", () => {
-    const a = Attribute.create({ id: "1", name: "name", _title: "title" })
+    const a = Attribute.create({ id: "ATTR1", name: "name", _title: "title" })
     expect(a.matchNameOrId("")).toBe(false)
     expect(a.matchNameOrId(1)).toBe(true)
-    expect(a.matchNameOrId("1")).toBe(true)
+    expect(a.matchNameOrId("ATTR1")).toBe(true)
     expect(a.matchNameOrId("name")).toBe(true)
     expect(a.matchNameOrId("title")).toBe(false)
   })

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -27,6 +27,7 @@
 
 import {Instance, SnapshotIn, types} from "mobx-state-tree"
 import { parseColor } from "../../utilities/color-utils"
+import { kAttrIdPrefix, typeV3Id } from "../../utilities/codap-utils"
 import { cachedFnFactory } from "../../utilities/mst-utils"
 import { Formula, IFormula } from "../formula/formula"
 import { applyModelChange } from "../history/apply-model-change"
@@ -53,6 +54,7 @@ export function isAttributeType(type?: string | null): type is AttributeType {
 }
 
 export const Attribute = V2Model.named("Attribute").props({
+  id: typeV3Id(kAttrIdPrefix),
   clientKey: "",
   sourceID: types.maybe(types.string),
   description: types.maybe(types.string),

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -27,7 +27,6 @@
 
 import {Instance, SnapshotIn, types} from "mobx-state-tree"
 import { parseColor } from "../../utilities/color-utils"
-import { typedId } from "../../utilities/js-utils"
 import { cachedFnFactory } from "../../utilities/mst-utils"
 import { Formula, IFormula } from "../formula/formula"
 import { applyModelChange } from "../history/apply-model-change"
@@ -54,7 +53,6 @@ export function isAttributeType(type?: string | null): type is AttributeType {
 }
 
 export const Attribute = V2Model.named("Attribute").props({
-  id: types.optional(types.identifier, () => typedId("ATTR")),
   clientKey: "",
   sourceID: types.maybe(types.string),
   description: types.maybe(types.string),

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -1,8 +1,8 @@
 import { getType, IAnyStateTreeNode, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { Attribute, IAttribute } from "./attribute"
-import { typedId } from "../../utilities/js-utils"
 import { IMoveAttributeOptions } from "./data-set-types"
 import { V2Model } from "./v2-model"
+import { typeCodapId } from "../../utilities/mst-utils"
 
 export const CollectionLabels = types.model("CollectionLabels", {
   singleCase: "",
@@ -13,7 +13,7 @@ export const CollectionLabels = types.model("CollectionLabels", {
 })
 
 export const CollectionPropsModel = V2Model.named("CollectionProps").props({
-  id: types.optional(types.identifier, () => typedId("COLL")),
+  id: typeCodapId(),
   labels: types.maybe(CollectionLabels)
 })
 export interface ICollectionPropsModel extends Instance<typeof CollectionPropsModel> {}

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -2,6 +2,7 @@ import { getType, IAnyStateTreeNode, Instance, SnapshotIn, types } from "mobx-st
 import { Attribute, IAttribute } from "./attribute"
 import { IMoveAttributeOptions } from "./data-set-types"
 import { V2Model } from "./v2-model"
+import { kCollectionIdPrefix, typeV3Id } from "../../utilities/codap-utils"
 
 export const CollectionLabels = types.model("CollectionLabels", {
   singleCase: "",
@@ -12,6 +13,7 @@ export const CollectionLabels = types.model("CollectionLabels", {
 })
 
 export const CollectionPropsModel = V2Model.named("CollectionProps").props({
+  id: typeV3Id(kCollectionIdPrefix),
   labels: types.maybe(CollectionLabels)
 })
 export interface ICollectionPropsModel extends Instance<typeof CollectionPropsModel> {}

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -2,7 +2,6 @@ import { getType, IAnyStateTreeNode, Instance, SnapshotIn, types } from "mobx-st
 import { Attribute, IAttribute } from "./attribute"
 import { IMoveAttributeOptions } from "./data-set-types"
 import { V2Model } from "./v2-model"
-import { typeCodapId } from "../../utilities/mst-utils"
 
 export const CollectionLabels = types.model("CollectionLabels", {
   singleCase: "",
@@ -13,7 +12,6 @@ export const CollectionLabels = types.model("CollectionLabels", {
 })
 
 export const CollectionPropsModel = V2Model.named("CollectionProps").props({
-  id: typeCodapId(),
   labels: types.maybe(CollectionLabels)
 })
 export interface ICollectionPropsModel extends Instance<typeof CollectionPropsModel> {}

--- a/v3/src/models/data/data-set-collection-groups.test.ts
+++ b/v3/src/models/data/data-set-collection-groups.test.ts
@@ -1,3 +1,4 @@
+import { types } from "mobx-state-tree"
 import { CollectionModel } from "./collection"
 import { DataSet, IDataSet } from "./data-set"
 
@@ -7,6 +8,14 @@ jest.mock("../../utilities/js-utils", () => ({
   typedId: () => `test-${++mockNodeIdCount}`,
   uniqueOrderedId: () => `order-${++mockNodeIdCount}`
 }))
+jest.mock("../../utilities/mst-utils", () => {
+  const mockCodapId = () => `test-${++mockNodeIdCount}`
+  return {
+    ...jest.requireActual("../../utilities/mst-utils"),
+    typeCodapId: () => types.optional(types.identifier, () => `${mockCodapId()}`),
+    randomCodapId: mockCodapId
+  }
+})
 
 describe("CollectionGroups", () => {
 

--- a/v3/src/models/data/data-set-collection-groups.test.ts
+++ b/v3/src/models/data/data-set-collection-groups.test.ts
@@ -12,8 +12,8 @@ jest.mock("../../utilities/mst-utils", () => {
   const mockCodapId = () => `test-${++mockNodeIdCount}`
   return {
     ...jest.requireActual("../../utilities/mst-utils"),
-    typeCodapId: () => types.optional(types.identifier, () => `${mockCodapId()}`),
-    randomCodapId: mockCodapId
+    codapNumIdStr: mockCodapId,
+    typeCodapNumIdStr: () => types.optional(types.identifier, () => `${mockCodapId()}`)
   }
 })
 

--- a/v3/src/models/data/data-set-collection-groups.test.ts
+++ b/v3/src/models/data/data-set-collection-groups.test.ts
@@ -4,16 +4,12 @@ import { DataSet, IDataSet } from "./data-set"
 
 // eslint-disable-next-line no-var
 var mockNodeIdCount = 0
-jest.mock("../../utilities/js-utils", () => ({
-  typedId: () => `test-${++mockNodeIdCount}`,
-  uniqueOrderedId: () => `order-${++mockNodeIdCount}`
-}))
-jest.mock("../../utilities/mst-utils", () => {
-  const mockCodapId = () => `test-${++mockNodeIdCount}`
+jest.mock("../../utilities/codap-utils", () => {
+  const mockV3Id = () => `test-${++mockNodeIdCount}`
   return {
-    ...jest.requireActual("../../utilities/mst-utils"),
-    codapNumIdStr: mockCodapId,
-    typeCodapNumIdStr: () => types.optional(types.identifier, () => `${mockCodapId()}`)
+    ...jest.requireActual("../../utilities/codap-utils"),
+    v3Id: mockV3Id,
+    typeV3Id: () => types.optional(types.identifier, () => `${mockV3Id()}`)
   }
 })
 

--- a/v3/src/models/data/data-set-types.ts
+++ b/v3/src/models/data/data-set-types.ts
@@ -1,9 +1,9 @@
 import { Instance, types } from "mobx-state-tree"
 import { IValueType } from "./attribute"
-import { codapNumIdStr } from "../../utilities/mst-utils"
+import { kCaseIdPrefix, v3Id } from "../../utilities/codap-utils"
 
 export const CaseID = types.model("CaseID", {
-  __id__: types.optional(types.string, () => codapNumIdStr())
+  __id__: types.optional(types.string, () => v3Id(kCaseIdPrefix))
 })
 export interface ICaseID extends Instance<typeof CaseID> {}
 

--- a/v3/src/models/data/data-set-types.ts
+++ b/v3/src/models/data/data-set-types.ts
@@ -1,9 +1,9 @@
 import { Instance, types } from "mobx-state-tree"
 import { IValueType } from "./attribute"
-import { randomCodapId } from "../../utilities/mst-utils"
+import { codapNumIdStr } from "../../utilities/mst-utils"
 
 export const CaseID = types.model("CaseID", {
-  __id__: types.optional(types.string, () => randomCodapId())
+  __id__: types.optional(types.string, () => codapNumIdStr())
 })
 export interface ICaseID extends Instance<typeof CaseID> {}
 

--- a/v3/src/models/data/data-set-types.ts
+++ b/v3/src/models/data/data-set-types.ts
@@ -1,11 +1,9 @@
 import { Instance, types } from "mobx-state-tree"
-import { uniqueOrderedId } from "../../utilities/js-utils"
 import { IValueType } from "./attribute"
-
-export const uniqueCaseId = () => `CASE${uniqueOrderedId()}`
+import { randomCodapId } from "../../utilities/mst-utils"
 
 export const CaseID = types.model("CaseID", {
-  __id__: types.optional(types.identifier, () => uniqueCaseId())
+  __id__: types.optional(types.string, () => randomCodapId())
 })
 export interface ICaseID extends Instance<typeof CaseID> {}
 

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -59,7 +59,7 @@ import { ISetCaseValuesCustomPatch, setCaseValuesCustomUndoRedo } from "./data-s
 import { applyModelChange } from "../history/apply-model-change"
 import { withCustomUndoRedo } from "../history/with-custom-undo-redo"
 import { withoutUndo } from "../history/without-undo"
-import { codapNumIdStr } from "../../utilities/mst-utils"
+import { kAttrIdPrefix, kCaseIdPrefix, typeV3Id, v3Id } from "../../utilities/codap-utils"
 import { prf } from "../../utilities/profiler"
 import { V2Model } from "./v2-model"
 
@@ -142,6 +142,7 @@ export interface CollectionGroup {
 }
 
 export const DataSet = V2Model.named("DataSet").props({
+  id: typeV3Id("DATA"),
   sourceID: types.maybe(types.string),
   // ordered parent-most to child-most; no explicit collection for ungrouped (child-most) attributes
   collections: types.array(CollectionModel),
@@ -197,7 +198,7 @@ export const DataSet = V2Model.named("DataSet").props({
     const attributesMap: Record<string, IAttributeSnapshot> = {}
     const attributes: string[] = []
     legacyAttributes.forEach(attr => {
-      const attrId = attr.id || codapNumIdStr()
+      const attrId = attr.id || v3Id(kAttrIdPrefix)
       attributesMap[attrId] = { id: attrId, ...attr }
       attributes.push(attrId)
     })
@@ -383,7 +384,7 @@ export const DataSet = V2Model.named("DataSet").props({
                 // start a new group with just this case (for now)
                 // note: PCAS ids are considered ephemeral and should not be stored/serialized,
                 // because they can be regenerated whenever the data changes.
-                const pseudoCase: IGroupedCase = { __id__: codapNumIdStr(), ...cumulativeValues }
+                const pseudoCase: IGroupedCase = { __id__: v3Id(kCaseIdPrefix), ...cumulativeValues }
                 groupsMap[cumulativeValuesJson] = {
                   collectionId: collection.id,
                   pseudoCase,
@@ -834,12 +835,12 @@ export const DataSet = V2Model.named("DataSet").props({
           // to derived DataSets.
           addDisposer(self, addMiddleware(self, (call, next) => {
             if (call.context === self && call.name === "addAttribute") {
-              const { id = codapNumIdStr(), ...others } = call.args[0] as IAttributeSnapshot
+              const { id = v3Id(kAttrIdPrefix), ...others } = call.args[0] as IAttributeSnapshot
               call.args[0] = { id, ...others }
             }
             else if (call.context === self && call.name === "addCases") {
               call.args[0] = (call.args[0] as ICaseCreation[]).map(iCase => {
-                const { __id__ = codapNumIdStr(), ...others } = iCase
+                const { __id__ = v3Id(kCaseIdPrefix), ...others } = iCase
                 return { __id__, ...others }
               })
             }
@@ -952,7 +953,7 @@ export const DataSet = V2Model.named("DataSet").props({
 
         // insert/append cases and empty values
         const ids: string[] = []
-        const _cases = cases.map(({ __id__ = codapNumIdStr() }) => {
+        const _cases = cases.map(({ __id__ = v3Id(kCaseIdPrefix) }) => {
           ids.push(__id__)
           return { __id__ }
         })

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -59,7 +59,7 @@ import { ISetCaseValuesCustomPatch, setCaseValuesCustomUndoRedo } from "./data-s
 import { applyModelChange } from "../history/apply-model-change"
 import { withCustomUndoRedo } from "../history/with-custom-undo-redo"
 import { withoutUndo } from "../history/without-undo"
-import { randomCodapId, typeCodapId } from "../../utilities/mst-utils"
+import { codapNumIdStr } from "../../utilities/mst-utils"
 import { prf } from "../../utilities/profiler"
 import { V2Model } from "./v2-model"
 
@@ -142,7 +142,6 @@ export interface CollectionGroup {
 }
 
 export const DataSet = V2Model.named("DataSet").props({
-  id: typeCodapId(),
   sourceID: types.maybe(types.string),
   // ordered parent-most to child-most; no explicit collection for ungrouped (child-most) attributes
   collections: types.array(CollectionModel),
@@ -198,7 +197,7 @@ export const DataSet = V2Model.named("DataSet").props({
     const attributesMap: Record<string, IAttributeSnapshot> = {}
     const attributes: string[] = []
     legacyAttributes.forEach(attr => {
-      const attrId = attr.id || randomCodapId()
+      const attrId = attr.id || codapNumIdStr()
       attributesMap[attrId] = { id: attrId, ...attr }
       attributes.push(attrId)
     })
@@ -384,7 +383,7 @@ export const DataSet = V2Model.named("DataSet").props({
                 // start a new group with just this case (for now)
                 // note: PCAS ids are considered ephemeral and should not be stored/serialized,
                 // because they can be regenerated whenever the data changes.
-                const pseudoCase: IGroupedCase = { __id__: randomCodapId(), ...cumulativeValues }
+                const pseudoCase: IGroupedCase = { __id__: codapNumIdStr(), ...cumulativeValues }
                 groupsMap[cumulativeValuesJson] = {
                   collectionId: collection.id,
                   pseudoCase,
@@ -835,12 +834,12 @@ export const DataSet = V2Model.named("DataSet").props({
           // to derived DataSets.
           addDisposer(self, addMiddleware(self, (call, next) => {
             if (call.context === self && call.name === "addAttribute") {
-              const { id = randomCodapId(), ...others } = call.args[0] as IAttributeSnapshot
+              const { id = codapNumIdStr(), ...others } = call.args[0] as IAttributeSnapshot
               call.args[0] = { id, ...others }
             }
             else if (call.context === self && call.name === "addCases") {
               call.args[0] = (call.args[0] as ICaseCreation[]).map(iCase => {
-                const { __id__ = randomCodapId(), ...others } = iCase
+                const { __id__ = codapNumIdStr(), ...others } = iCase
                 return { __id__, ...others }
               })
             }
@@ -953,7 +952,7 @@ export const DataSet = V2Model.named("DataSet").props({
 
         // insert/append cases and empty values
         const ids: string[] = []
-        const _cases = cases.map(({ __id__ = randomCodapId() }) => {
+        const _cases = cases.map(({ __id__ = codapNumIdStr() }) => {
           ids.push(__id__)
           return { __id__ }
         })

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -52,14 +52,14 @@ import {
 import {
   CaseGroup, CaseID, IAddAttributeOptions, IAddCaseOptions, IAttributeChangeResult, ICase, ICaseCreation,
   IDerivationSpec, IGetCaseOptions, IGetCasesOptions, IGroupedCase, IMoveAttributeCollectionOptions,
-  IMoveAttributeOptions, symIndex, symParent, uniqueCaseId
+  IMoveAttributeOptions, symIndex, symParent
 } from "./data-set-types"
 // eslint-disable-next-line import/no-cycle
 import { ISetCaseValuesCustomPatch, setCaseValuesCustomUndoRedo } from "./data-set-undo"
 import { applyModelChange } from "../history/apply-model-change"
 import { withCustomUndoRedo } from "../history/with-custom-undo-redo"
 import { withoutUndo } from "../history/without-undo"
-import { typedId } from "../../utilities/js-utils"
+import { randomCodapId, typeCodapId } from "../../utilities/mst-utils"
 import { prf } from "../../utilities/profiler"
 import { V2Model } from "./v2-model"
 
@@ -142,7 +142,7 @@ export interface CollectionGroup {
 }
 
 export const DataSet = V2Model.named("DataSet").props({
-  id: types.optional(types.identifier, () => typedId("DATA")),
+  id: typeCodapId(),
   sourceID: types.maybe(types.string),
   // ordered parent-most to child-most; no explicit collection for ungrouped (child-most) attributes
   collections: types.array(CollectionModel),
@@ -198,7 +198,7 @@ export const DataSet = V2Model.named("DataSet").props({
     const attributesMap: Record<string, IAttributeSnapshot> = {}
     const attributes: string[] = []
     legacyAttributes.forEach(attr => {
-      const attrId = attr.id || typedId("ATTR")
+      const attrId = attr.id || randomCodapId()
       attributesMap[attrId] = { id: attrId, ...attr }
       attributes.push(attrId)
     })
@@ -384,7 +384,7 @@ export const DataSet = V2Model.named("DataSet").props({
                 // start a new group with just this case (for now)
                 // note: PCAS ids are considered ephemeral and should not be stored/serialized,
                 // because they can be regenerated whenever the data changes.
-                const pseudoCase: IGroupedCase = { __id__: typedId("PCAS"), ...cumulativeValues }
+                const pseudoCase: IGroupedCase = { __id__: randomCodapId(), ...cumulativeValues }
                 groupsMap[cumulativeValuesJson] = {
                   collectionId: collection.id,
                   pseudoCase,
@@ -835,12 +835,12 @@ export const DataSet = V2Model.named("DataSet").props({
           // to derived DataSets.
           addDisposer(self, addMiddleware(self, (call, next) => {
             if (call.context === self && call.name === "addAttribute") {
-              const { id = typedId("ATTR"), ...others } = call.args[0] as IAttributeSnapshot
+              const { id = randomCodapId(), ...others } = call.args[0] as IAttributeSnapshot
               call.args[0] = { id, ...others }
             }
             else if (call.context === self && call.name === "addCases") {
               call.args[0] = (call.args[0] as ICaseCreation[]).map(iCase => {
-                const { __id__ = uniqueCaseId(), ...others } = iCase
+                const { __id__ = randomCodapId(), ...others } = iCase
                 return { __id__, ...others }
               })
             }
@@ -953,7 +953,7 @@ export const DataSet = V2Model.named("DataSet").props({
 
         // insert/append cases and empty values
         const ids: string[] = []
-        const _cases = cases.map(({ __id__ = uniqueCaseId() }) => {
+        const _cases = cases.map(({ __id__ = randomCodapId() }) => {
           ids.push(__id__)
           return { __id__ }
         })

--- a/v3/src/models/data/v2-model.test.ts
+++ b/v3/src/models/data/v2-model.test.ts
@@ -5,14 +5,14 @@ import {
 describe("V2Model", () => {
   it("can be constructed without arguments", () => {
     const m = V2Model.create()
-    expect(m.v2Id).toBeUndefined()
+    expect(m.id).toBeDefined()
     expect(m.name).toBe("")
     expect(m._title).toBeUndefined()
     expect(m.title).toBe("")
     expect(m.matchNameOrId("")).toBe(false)
 
     m.setName("name")
-    expect(m.v2Id).toBeUndefined()
+    expect(m.id).toBeDefined()
     expect(m.name).toBe("name")
     expect(m._title).toBeUndefined()
     expect(m.title).toBe("name")
@@ -20,7 +20,7 @@ describe("V2Model", () => {
     expect(m.matchNameOrId("name")).toBe(true)
 
     m.setTitle("title")
-    expect(m.v2Id).toBeUndefined()
+    expect(m.id).toBeDefined()
     expect(m.name).toBe("name")
     expect(m._title).toBe("title")
     expect(m.title).toBe("title")
@@ -30,23 +30,23 @@ describe("V2Model", () => {
   })
 
   it("can be constructed with v2Id and name", () => {
-    const m = V2Model.create({ v2Id: 1, name: "name" })
-    expect(m.v2Id).toBe(1)
+    const m = V2Model.create({ id: "1", name: "name" })
+    expect(m.id).toBe("1")
     expect(m.name).toBe("name")
     expect(m._title).toBeUndefined()
     expect(m.title).toBe("name")
     expect(m.matchNameOrId(1)).toBe(true)
     expect(m.matchNameOrId("name")).toBe(true)
-    expect(m.matchNameOrId("1")).toBe(false)
+    expect(m.matchNameOrId("1")).toBe(true)
 
     m.setTitle("title")
-    expect(m.v2Id).toBe(1)
+    expect(m.id).toBe("1")
     expect(m.name).toBe("name")
     expect(m._title).toBe("title")
     expect(m.title).toBe("title")
     expect(m.matchNameOrId(1)).toBe(true)
     expect(m.matchNameOrId("name")).toBe(true)
-    expect(m.matchNameOrId("1")).toBe(false)
+    expect(m.matchNameOrId("1")).toBe(true)
     expect(m.matchNameOrId("title")).toBe(false)
   })
 
@@ -85,7 +85,7 @@ describe("V2Model", () => {
       guid: 1
     } as V2ModelStorage
     let m = V2Model.create(v2ModelSnapshotFromV2ModelStorage(v2m))
-    expect(m.v2Id).toBe(1)
+    expect(m.id).toBe("1")
     expect(m.name).toBe("")
     expect(m._title).toBeUndefined()
 
@@ -97,7 +97,7 @@ describe("V2Model", () => {
       title: "title"
     }
     m = V2Model.create(v2ModelSnapshotFromV2ModelStorage(v2m))
-    expect(m.v2Id).toBe(1)
+    expect(m.id).toBe("1")
     expect(m.name).toBe("name")
     expect(m._title).toBe("title")
   })

--- a/v3/src/models/data/v2-model.test.ts
+++ b/v3/src/models/data/v2-model.test.ts
@@ -84,8 +84,8 @@ describe("V2Model", () => {
     let v2m: V2ModelStorage = {
       guid: 1
     } as V2ModelStorage
-    let m = V2Model.create(v2ModelSnapshotFromV2ModelStorage(v2m))
-    expect(m.id).toBe("1")
+    let m = V2Model.create(v2ModelSnapshotFromV2ModelStorage("MODL", v2m))
+    expect(m.id).toBe("MODL1")
     expect(m.name).toBe("")
     expect(m._title).toBeUndefined()
 
@@ -96,8 +96,8 @@ describe("V2Model", () => {
       name: "name",
       title: "title"
     }
-    m = V2Model.create(v2ModelSnapshotFromV2ModelStorage(v2m))
-    expect(m.id).toBe("1")
+    m = V2Model.create(v2ModelSnapshotFromV2ModelStorage("MODL", v2m))
+    expect(m.id).toBe("MODL1")
     expect(m.name).toBe("name")
     expect(m._title).toBe("title")
   })

--- a/v3/src/models/data/v2-model.ts
+++ b/v3/src/models/data/v2-model.ts
@@ -1,8 +1,8 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
-import { typeCodapId } from "../../utilities/mst-utils"
+import { typeCodapNumIdStr } from "../../utilities/mst-utils"
 
 export const V2Model = types.model("V2Model", {
-  id: typeCodapId(),
+  id: typeCodapNumIdStr(),
   // required for objects in documents
   name: "",
   _title: types.maybe(types.string)

--- a/v3/src/models/data/v2-model.ts
+++ b/v3/src/models/data/v2-model.ts
@@ -1,7 +1,8 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
+import { typeCodapId } from "../../utilities/mst-utils"
 
 export const V2Model = types.model("V2Model", {
-  v2Id: types.maybe(types.number),
+  id: typeCodapId(),
   // required for objects in documents
   name: "",
   _title: types.maybe(types.string)
@@ -11,7 +12,8 @@ export const V2Model = types.model("V2Model", {
     return self._title ?? self.name
   },
   matchNameOrId(nameOrId: string | number) {
-    return (!!self.name && self.name === nameOrId) || (!!self.v2Id && self.v2Id === nameOrId)
+    // eslint-disable-next-line eqeqeq
+    return (!!self.name && self.name == nameOrId) || (self.id == nameOrId)
   }
 }))
 .actions(self => ({
@@ -23,13 +25,8 @@ export const V2Model = types.model("V2Model", {
     self._title = title
   }
 }))
-// derived models are expected to have their own string `id` property
-export interface IV2Model extends Instance<typeof V2Model> {
-  id: string
-}
-export interface IV2ModelSnapshot extends SnapshotIn<typeof V2Model> {
-  id?: string
-}
+export interface IV2Model extends Instance<typeof V2Model> {}
+export interface IV2ModelSnapshot extends SnapshotIn<typeof V2Model> {}
 
 export interface V2ModelStorage {
   id: number
@@ -49,10 +46,9 @@ export function v2NameTitleToV3Title(name: string, v2Title?: string | null) {
 }
 
 export function v2ModelSnapshotFromV2ModelStorage(storage: Partial<V2ModelStorage>) {
-  const { id, guid, cid, name = "", title } = storage
+  const { id, guid, name = "", title } = storage
   const v2ModelSnapshot: IV2ModelSnapshot = {
-    id: cid ?? undefined,
-    v2Id: id ?? guid,
+    id: id ? `${id}` : guid ? `${guid}` : undefined,
     name,
     _title: v2NameTitleToV3Title(name, title)
   }

--- a/v3/src/models/data/v2-model.ts
+++ b/v3/src/models/data/v2-model.ts
@@ -1,8 +1,8 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
-import { typeCodapNumIdStr } from "../../utilities/mst-utils"
+import { toV2Id, toV3Id, typeV3Id } from "../../utilities/codap-utils"
 
 export const V2Model = types.model("V2Model", {
-  id: typeCodapNumIdStr(),
+  id: typeV3Id(""),
   // required for objects in documents
   name: "",
   _title: types.maybe(types.string)
@@ -12,8 +12,11 @@ export const V2Model = types.model("V2Model", {
     return self._title ?? self.name
   },
   matchNameOrId(nameOrId: string | number) {
-    // eslint-disable-next-line eqeqeq
-    return (!!self.name && self.name == nameOrId) || (self.id == nameOrId)
+    /* eslint-disable eqeqeq */
+    return (!!self.name && self.name == nameOrId) ||
+            (self.id == nameOrId) ||
+            (typeof nameOrId === "number" && toV2Id(self.id) === nameOrId)
+    /* eslint-enable eqeqeq */
   }
 }))
 .actions(self => ({
@@ -45,10 +48,10 @@ export function v2NameTitleToV3Title(name: string, v2Title?: string | null) {
   return v2Title && v2Title !== name ? v2Title : undefined
 }
 
-export function v2ModelSnapshotFromV2ModelStorage(storage: Partial<V2ModelStorage>) {
+export function v2ModelSnapshotFromV2ModelStorage(prefix: string, storage: Partial<V2ModelStorage>) {
   const { id, guid, name = "", title } = storage
   const v2ModelSnapshot: IV2ModelSnapshot = {
-    id: id ? `${id}` : guid ? `${guid}` : undefined,
+    id: id ? toV3Id(prefix, id) : guid ? toV3Id(prefix, guid) : undefined,
     name,
     _title: v2NameTitleToV3Title(name, title)
   }

--- a/v3/src/models/document/base-document-content.ts
+++ b/v3/src/models/document/base-document-content.ts
@@ -5,6 +5,7 @@ import { ITileModel, ITileModelSnapshotIn, TileModel } from "../tiles/tile-model
 import { ITileInRowOptions } from "./tile-row"
 import { ITileLayoutUnion, ITileRowModelUnion, TileRowModelUnion } from "./tile-row-union"
 import { SharedModelEntry, SharedModelMap } from "./shared-model-entry"
+import { toV2Id } from "../../utilities/codap-utils"
 
 export const BaseDocumentContentModel = types
   .model("BaseDocumentContent", {
@@ -24,7 +25,8 @@ export const BaseDocumentContentModel = types
       return self.tileMap.size === 0
     },
     getTile(tileId: string) {
-      return tileId && self.tileMap.has(tileId) ? self.tileMap.get(tileId) : undefined
+      return self.tileMap.get(tileId) ??
+        Array.from(self.tileMap.values()).find(tile => +tileId === toV2Id(tile.id))
     },
     getTilesOfType(type: string) {
       const tileMapEntries = Array.from(self.tileMap.values())

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -11,7 +11,7 @@ import { getFormulaManager, getSharedModelManager, getTileEnvironment } from "..
 import { getTileContentInfo } from "../tiles/tile-content-info"
 import { ITileModel, ITileModelSnapshotIn } from "../tiles/tile-model"
 import { ComponentRect } from "../../utilities/animation-utils"
-import { randomCodapId } from "../../utilities/mst-utils"
+import { codapNumIdStr } from "../../utilities/mst-utils"
 import { getPositionOfNewComponent } from "../../utilities/view-utils"
 import { DataSet, IDataSet, IDataSetSnapshot, toCanonical } from "../data/data-set"
 import { gDataBroker } from "../data/data-broker"
@@ -87,7 +87,7 @@ export const DocumentContentModel = BaseDocumentContentModel
     createDefaultTileSnapshotOfType(tileType: string): ITileModelSnapshotIn | undefined {
       const env = getTileEnvironment(self)
       const info = getTileContentInfo(tileType)
-      const id = randomCodapId()
+      const id = codapNumIdStr()
       const content = info?.defaultContent({ env })
       return content ? { id, content } : undefined
     },

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -11,7 +11,7 @@ import { getFormulaManager, getSharedModelManager, getTileEnvironment } from "..
 import { getTileContentInfo } from "../tiles/tile-content-info"
 import { ITileModel, ITileModelSnapshotIn } from "../tiles/tile-model"
 import { ComponentRect } from "../../utilities/animation-utils"
-import { codapNumIdStr } from "../../utilities/mst-utils"
+import { v3Id } from "../../utilities/codap-utils"
 import { getPositionOfNewComponent } from "../../utilities/view-utils"
 import { DataSet, IDataSet, IDataSetSnapshot, toCanonical } from "../data/data-set"
 import { gDataBroker } from "../data/data-broker"
@@ -87,7 +87,7 @@ export const DocumentContentModel = BaseDocumentContentModel
     createDefaultTileSnapshotOfType(tileType: string): ITileModelSnapshotIn | undefined {
       const env = getTileEnvironment(self)
       const info = getTileContentInfo(tileType)
-      const id = codapNumIdStr()
+      const id = v3Id(info?.prefix || "TILE")
       const content = info?.defaultContent({ env })
       return content ? { id, content } : undefined
     },

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -10,8 +10,8 @@ import { getTileComponentInfo } from "../tiles/tile-component-info"
 import { getFormulaManager, getSharedModelManager, getTileEnvironment } from "../tiles/tile-environment"
 import { getTileContentInfo } from "../tiles/tile-content-info"
 import { ITileModel, ITileModelSnapshotIn } from "../tiles/tile-model"
-import { typedId } from "../../utilities/js-utils"
 import { ComponentRect } from "../../utilities/animation-utils"
+import { randomCodapId } from "../../utilities/mst-utils"
 import { getPositionOfNewComponent } from "../../utilities/view-utils"
 import { DataSet, IDataSet, IDataSetSnapshot, toCanonical } from "../data/data-set"
 import { gDataBroker } from "../data/data-broker"
@@ -87,7 +87,7 @@ export const DocumentContentModel = BaseDocumentContentModel
     createDefaultTileSnapshotOfType(tileType: string): ITileModelSnapshotIn | undefined {
       const env = getTileEnvironment(self)
       const info = getTileContentInfo(tileType)
-      const id = typedId(info?.prefix || "TILE")
+      const id = randomCodapId()
       const content = info?.defaultContent({ env })
       return content ? { id, content } : undefined
     },

--- a/v3/src/models/global/global-value.ts
+++ b/v3/src/models/global/global-value.ts
@@ -1,11 +1,11 @@
 import {Instance, SnapshotIn, types} from "mobx-state-tree"
-import { typedId } from "../../utilities/js-utils"
+import { typeCodapId } from "../../utilities/mst-utils"
 
 export const kDefaultNamePrefix = "v"
 
 // represents a globally accessible value, such as the value of a slider
 export const GlobalValue = types.model("GlobalValue", {
-    id: types.optional(types.identifier, () => typedId("GLOB")),
+    id: typeCodapId(),
     name: types.string,
     _value: types.number
   })

--- a/v3/src/models/global/global-value.ts
+++ b/v3/src/models/global/global-value.ts
@@ -1,11 +1,11 @@
 import {Instance, SnapshotIn, types} from "mobx-state-tree"
-import { typeCodapId } from "../../utilities/mst-utils"
+import { typeCodapNumIdStr } from "../../utilities/mst-utils"
 
 export const kDefaultNamePrefix = "v"
 
 // represents a globally accessible value, such as the value of a slider
 export const GlobalValue = types.model("GlobalValue", {
-    id: typeCodapId(),
+    id: typeCodapNumIdStr(),
     name: types.string,
     _value: types.number
   })

--- a/v3/src/models/global/global-value.ts
+++ b/v3/src/models/global/global-value.ts
@@ -1,11 +1,11 @@
 import {Instance, SnapshotIn, types} from "mobx-state-tree"
-import { typeCodapNumIdStr } from "../../utilities/mst-utils"
+import { kGlobalIdPrefix, typeV3Id } from "../../utilities/codap-utils"
 
 export const kDefaultNamePrefix = "v"
 
 // represents a globally accessible value, such as the value of a slider
 export const GlobalValue = types.model("GlobalValue", {
-    id: typeCodapNumIdStr(),
+    id: typeV3Id(kGlobalIdPrefix),
     name: types.string,
     _value: types.number
   })

--- a/v3/src/models/tiles/tile-model.ts
+++ b/v3/src/models/tiles/tile-model.ts
@@ -5,9 +5,9 @@ import { findMetadata, getTileContentInfo, ITileExportOptions } from "./tile-con
 import { TileContentUnion } from "./tile-content-union"
 import { ITileContentModel } from "./tile-content"
 import { DisplayUserTypeEnum } from "../stores/user-types"
-import { typedId } from "../../utilities/js-utils"
 import { StringBuilder } from "../../utilities/string-builder"
 import { applyModelChange } from "../history/apply-model-change"
+import { randomCodapId, typeCodapId } from "../../utilities/mst-utils"
 
 // generally negotiated with app, e.g. single column width for table
 export const kDefaultMinWidth = 60
@@ -34,7 +34,7 @@ export function cloneTileSnapshotWithoutId(tile: ITileModel) {
 export function cloneTileSnapshotWithNewId(tile: ITileModel, newId?: string) {
   const content = tile.content.tileSnapshotForCopy
   const { id, display, ...copy } = cloneDeep(getSnapshot(tile))
-  return { id: newId || typedId("TILE"), ...copy, content }
+  return { id: newId || randomCodapId(), ...copy, content }
 }
 
 export function getTileModel(tileContentModel: ITileContentModel) {
@@ -58,7 +58,7 @@ export function setTileTitleFromContent(tileContentModel: ITileContentModel, tit
 export const TileModel = types
   .model("TileModel", {
     // if not provided, will be generated
-    id: types.optional(types.identifier, () => typedId("TILE")),
+    id: typeCodapId(),
     // all tiles can have a title
     title: types.maybe(types.string),
     // whether to restrict display to certain users

--- a/v3/src/models/tiles/tile-model.ts
+++ b/v3/src/models/tiles/tile-model.ts
@@ -7,7 +7,7 @@ import { ITileContentModel } from "./tile-content"
 import { DisplayUserTypeEnum } from "../stores/user-types"
 import { StringBuilder } from "../../utilities/string-builder"
 import { applyModelChange } from "../history/apply-model-change"
-import { randomCodapId, typeCodapId } from "../../utilities/mst-utils"
+import { codapNumIdStr, typeCodapNumIdStr } from "../../utilities/mst-utils"
 
 // generally negotiated with app, e.g. single column width for table
 export const kDefaultMinWidth = 60
@@ -34,7 +34,7 @@ export function cloneTileSnapshotWithoutId(tile: ITileModel) {
 export function cloneTileSnapshotWithNewId(tile: ITileModel, newId?: string) {
   const content = tile.content.tileSnapshotForCopy
   const { id, display, ...copy } = cloneDeep(getSnapshot(tile))
-  return { id: newId || randomCodapId(), ...copy, content }
+  return { id: newId || codapNumIdStr(), ...copy, content }
 }
 
 export function getTileModel(tileContentModel: ITileContentModel) {
@@ -58,7 +58,7 @@ export function setTileTitleFromContent(tileContentModel: ITileContentModel, tit
 export const TileModel = types
   .model("TileModel", {
     // if not provided, will be generated
-    id: typeCodapId(),
+    id: typeCodapNumIdStr(),
     // all tiles can have a title
     title: types.maybe(types.string),
     // whether to restrict display to certain users

--- a/v3/src/models/tiles/tile-model.ts
+++ b/v3/src/models/tiles/tile-model.ts
@@ -7,7 +7,7 @@ import { ITileContentModel } from "./tile-content"
 import { DisplayUserTypeEnum } from "../stores/user-types"
 import { StringBuilder } from "../../utilities/string-builder"
 import { applyModelChange } from "../history/apply-model-change"
-import { codapNumIdStr, typeCodapNumIdStr } from "../../utilities/mst-utils"
+import { v3Id, typeV3Id } from "../../utilities/codap-utils"
 
 // generally negotiated with app, e.g. single column width for table
 export const kDefaultMinWidth = 60
@@ -34,7 +34,7 @@ export function cloneTileSnapshotWithoutId(tile: ITileModel) {
 export function cloneTileSnapshotWithNewId(tile: ITileModel, newId?: string) {
   const content = tile.content.tileSnapshotForCopy
   const { id, display, ...copy } = cloneDeep(getSnapshot(tile))
-  return { id: newId || codapNumIdStr(), ...copy, content }
+  return { id: newId || v3Id("TILE"), ...copy, content }
 }
 
 export function getTileModel(tileContentModel: ITileContentModel) {
@@ -58,7 +58,7 @@ export function setTileTitleFromContent(tileContentModel: ITileContentModel, tit
 export const TileModel = types
   .model("TileModel", {
     // if not provided, will be generated
-    id: typeCodapNumIdStr(),
+    id: typeV3Id("TILE"),
     // all tiles can have a title
     title: types.maybe(types.string),
     // whether to restrict display to certain users

--- a/v3/src/utilities/codap-utils.test.ts
+++ b/v3/src/utilities/codap-utils.test.ts
@@ -1,0 +1,49 @@
+import { types } from "mobx-state-tree"
+import {
+  kAttrIdPrefix, kCaseIdPrefix, kCollectionIdPrefix, kDataSetIdPrefix, kGlobalIdPrefix,
+  toV2Id, toV3AttrId, toV3CaseId, toV3CollectionId, toV3DataSetId, toV3GlobalId, toV3Id, typeV3Id, v3Id
+} from "./codap-utils"
+
+const kPrefix = "PFIX"
+
+describe("codap-utils", () => {
+  it("toV3Id generates strings ids with a prefix and a numeric value and converts them appropriately", () => {
+    for (let i = 0; i < 10; ++i) {
+      const id = v3Id(kPrefix)
+      expect(id.startsWith(kPrefix)).toBe(true)
+      const idNum = toV2Id(id)
+      expect(`${kPrefix}${idNum}`).toBe(id)
+      expect(toV3Id(kPrefix, idNum)).toBe(id)
+      expect(toV3Id(kPrefix, `${idNum}`)).toBe(id)
+    }
+  })
+
+  it("provides prefix-specific conversion functions", () => {
+    expect(toV3AttrId(1234)).toBe(`${kAttrIdPrefix}1234`)
+    expect(toV3CaseId(1234)).toBe(`${kCaseIdPrefix}1234`)
+    expect(toV3CollectionId(1234)).toBe(`${kCollectionIdPrefix}1234`)
+    expect(toV3DataSetId(1234)).toBe(`${kDataSetIdPrefix}1234`)
+    expect(toV3GlobalId(1234)).toBe(`${kGlobalIdPrefix}1234`)
+  })
+
+  it("toV3Id converts v2 ids to v3 ids appropriately", () => {
+    expect(toV3Id(kPrefix, 1234)).toBe(`${kPrefix}1234`)
+    expect(toV3Id(kPrefix, "1234")).toBe(`${kPrefix}1234`)
+    expect(toV3Id(kPrefix, `${kPrefix}1234`)).toBe(`${kPrefix}1234`)
+  })
+
+  it("toV2Id converts v3 ids to v2 numeric format appropriately", () => {
+    expect(toV2Id(`${kPrefix}1234`)).toBe(1234)
+    expect(toV2Id(`1234`)).toBe(1234)
+    expect(toV2Id(kPrefix)).toBe(NaN)
+  })
+
+  it("typeV3Id can be used for an MST property", () => {
+    const Model = types.model("Model", {
+      id: typeV3Id(kPrefix)
+    })
+
+    const m = Model.create()
+    expect(m.id.startsWith(kPrefix)).toBe(true)
+  })
+})

--- a/v3/src/utilities/codap-utils.ts
+++ b/v3/src/utilities/codap-utils.ts
@@ -1,0 +1,49 @@
+import { types } from "mobx-state-tree"
+
+/**
+ * Generates a CODAP v2-compatible numeric id as a string.
+ *
+ * @returns the generated id
+ */
+export function v3Id(prefix: string) {
+  // The maximum representable integer in JavaScript is ~9e15.
+  // We lower the ceiling a bit and raise the floor to avoid conflicting with
+  // generated SproutCore ids which auto-increment from 1.
+  const kFactor = 1e15
+  const kOffset = 1e10
+  return `${prefix}${Math.floor(kFactor * Math.random()) + kOffset}`
+}
+
+export function toV3Id(prefix: string, v2Id: number | string) {
+  // If it's a non-numeric string, just return it
+  if (typeof v2Id === "string" && !isFinite(+v2Id)) return v2Id
+  return `${prefix}${v2Id}`
+}
+
+export const kAttrIdPrefix = "ATTR"
+export const kCaseIdPrefix = "CASE"
+export const kCollectionIdPrefix = "COLL"
+export const kDataSetIdPrefix = "DATA"
+export const kGlobalIdPrefix = "GLOB"
+
+export const toV3AttrId = (v2Id: number | string) => toV3Id(kAttrIdPrefix, v2Id)
+export const toV3CaseId = (v2Id: number | string) => toV3Id(kCaseIdPrefix, v2Id)
+export const toV3CollectionId = (v2Id: number | string) => toV3Id(kCollectionIdPrefix, v2Id)
+export const toV3DataSetId = (v2Id: number | string) => toV3Id(kDataSetIdPrefix, v2Id)
+export const toV3GlobalId = (v2Id: number | string) => toV3Id(kGlobalIdPrefix, v2Id)
+
+export function toV2Id(_v3Id: string) {
+  // strip any prefix and return the numeric value of the rest
+  const result = /[A-Za-z]*(\d+)/.exec(_v3Id)
+  return +(result?.[1] ?? NaN)
+}
+
+/**
+ * This creates the definition for an identifier field in MST, which generates
+ * a CODAP v2-compatible numeric id as a string if an id is not provided.
+ *
+ * @returns the generated id
+ */
+export function typeV3Id(prefix: string) {
+  return types.optional(types.identifier, () => v3Id(prefix))
+}

--- a/v3/src/utilities/js-utils.ts
+++ b/v3/src/utilities/js-utils.ts
@@ -1,6 +1,4 @@
 import { customAlphabet } from "nanoid"
-import { monotonicFactory } from "ulid"
-const ulid = monotonicFactory()
 // Use custom alphabet to avoid ambiguous characters, especially during mathematical formula evaluations.
 // By default, nanoid uses "-" sign, which is used in formulas for subtraction.
 const nanoid = customAlphabet("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz", 21)
@@ -79,15 +77,6 @@ export function typedId(type: string, idLength = 12): string {
 export function uniqueId(idLength = 16): string {
   // cf. https://zelark.github.io/nano-id-cc/
   return nanoid(idLength)
-}
-
-/*
- * uniqueOrderedId()
- *
- * returns a unique id string ordered by creation
- */
-export function uniqueOrderedId(): string {
-  return ulid()
 }
 
 /*

--- a/v3/src/utilities/mst-utils.ts
+++ b/v3/src/utilities/mst-utils.ts
@@ -16,30 +16,6 @@ export function typeField(typeName: string) {
 }
 
 /**
- * Generates a CODAP v2-compatible numeric id as a string.
- *
- * @returns the generated id
- */
-export function codapNumIdStr() {
-  // The maximum representable integer in JavaScript is ~9e15.
-  // We lower the ceiling a bit and raise the floor to avoid conflicting with
-  // generated SproutCore ids which auto-increment from 1.
-  const kFactor = 1e15
-  const kOffset = 1e10
-  return `${Math.floor(kFactor * Math.random()) + kOffset}`
-}
-
-/**
- * This creates the definition for an identifier field in MST, which generates
- * a CODAP v2-compatible numeric id as a string if an id is not provided.
- *
- * @returns the generated id
- */
-export function typeCodapNumIdStr() {
-  return types.optional(types.identifier, () => codapNumIdStr())
-}
-
-/**
  * Returns an ancestor of a node whose type name is `typeName`, if any.
  * This is like `getParentOfType(target, type)`, but allows us not to refer directly to the
  * parent type, which can cause circular reference errors in MST.

--- a/v3/src/utilities/mst-utils.ts
+++ b/v3/src/utilities/mst-utils.ts
@@ -15,6 +15,28 @@ export function typeField(typeName: string) {
   return types.optional(types.literal(typeName), typeName)
 }
 
+export function randomCodapId() {
+  // The maximum representable integer in JavaScript is ~9e15.
+  // We lower the ceiling a bit and raise the floor to avoid conflicting with
+  // generated SproutCore ids which auto-increment from 1.
+  const kFactor = 1e15
+  const kOffset = 1e10
+  return `${Math.floor(kFactor * Math.random()) + kOffset}`
+}
+
+/**
+ * This creates the definition for an identifier field in MST, which generates
+ * CODAP v2-compatible numeric ids if an id is not provided.
+ * The field is optional so it doesn't have to be specified when creating
+ * an instance.
+ *
+ * @param typeName the type
+ * @returns
+ */
+export function typeCodapId() {
+  return types.optional(types.identifier, () => `${randomCodapId()}`)
+}
+
 /**
  * Returns an ancestor of a node whose type name is `typeName`, if any.
  * This is like `getParentOfType(target, type)`, but allows us not to refer directly to the

--- a/v3/src/utilities/mst-utils.ts
+++ b/v3/src/utilities/mst-utils.ts
@@ -15,7 +15,12 @@ export function typeField(typeName: string) {
   return types.optional(types.literal(typeName), typeName)
 }
 
-export function randomCodapId() {
+/**
+ * Generates a CODAP v2-compatible numeric id as a string.
+ *
+ * @returns the generated id
+ */
+export function codapNumIdStr() {
   // The maximum representable integer in JavaScript is ~9e15.
   // We lower the ceiling a bit and raise the floor to avoid conflicting with
   // generated SproutCore ids which auto-increment from 1.
@@ -26,15 +31,12 @@ export function randomCodapId() {
 
 /**
  * This creates the definition for an identifier field in MST, which generates
- * CODAP v2-compatible numeric ids if an id is not provided.
- * The field is optional so it doesn't have to be specified when creating
- * an instance.
+ * a CODAP v2-compatible numeric id as a string if an id is not provided.
  *
- * @param typeName the type
- * @returns
+ * @returns the generated id
  */
-export function typeCodapId() {
-  return types.optional(types.identifier, () => `${randomCodapId()}`)
+export function typeCodapNumIdStr() {
+  return types.optional(types.identifier, () => codapNumIdStr())
 }
 
 /**

--- a/v3/src/v2/codap-v2-document.ts
+++ b/v3/src/v2/codap-v2-document.ts
@@ -113,7 +113,7 @@ export class CodapV2Document {
   registerAttributes(data: IDataSet, metadata: ISharedCaseMetadata, attributes: ICodapV2Attribute[], level: number) {
     attributes.forEach(v2Attr => {
       const {
-        cid, guid, description: v2Description, name = "", title: v2Title, type: v2Type, formula: v2Formula,
+        guid, description: v2Description, name = "", title: v2Title, type: v2Type, formula: v2Formula,
         editable: v2Editable, unit: v2Unit, precision: v2Precision
       } = v2Attr
       const _title = v2NameTitleToV3Title(name, v2Title)
@@ -125,7 +125,7 @@ export class CodapV2Document {
       const units = v2Unit ?? undefined
       this.guidMap.set(guid, { type: "DG.Attribute", object: v2Attr })
       const attribute = data.addAttribute({
-        id: cid, name, description, formula, _title, userType, editable, units, precision
+        id: `${guid}`, name, description, formula, _title, userType, editable, units, precision
       })
       if (attribute) {
         this.v3AttrMap.set(guid, attribute)

--- a/v3/src/v2/codap-v2-document.ts
+++ b/v3/src/v2/codap-v2-document.ts
@@ -4,6 +4,7 @@ import { IDataSet, toCanonical } from "../models/data/data-set"
 import { v2NameTitleToV3Title } from "../models/data/v2-model"
 import { ISharedCaseMetadata, SharedCaseMetadata } from "../models/shared/shared-case-metadata"
 import { ISharedDataSet, SharedDataSet } from "../models/shared/shared-data-set"
+import { toV3AttrId, toV3CaseId, toV3CollectionId, toV3DataSetId } from "../utilities/codap-utils"
 import {
   CodapV2Component, ICodapV2Attribute, ICodapV2Case, ICodapV2Collection, ICodapV2DataContext, ICodapV2DocumentJson,
   v3TypeFromV2TypeString } from "./codap-v2-types"
@@ -76,9 +77,10 @@ export class CodapV2Document {
         console.warn("CodapV2Document.registerContexts: context with invalid document guid:", context.document)
       }
       this.guidMap.set(guid, { type, object: context })
-      const sharedDataSet = SharedDataSet.create({ dataSet: { id: `${guid}`, name } })
+      const dataSetId = toV3DataSetId(guid)
+      const sharedDataSet = SharedDataSet.create({ dataSet: { id: dataSetId, name } })
       this.dataMap.set(guid, sharedDataSet)
-      const metadata = SharedCaseMetadata.create({ data: `${guid}` })
+      const metadata = SharedCaseMetadata.create({ data: dataSetId })
       this.metadataMap.set(guid, metadata)
 
       this.registerCollections(sharedDataSet.dataSet, metadata, collections)
@@ -97,7 +99,7 @@ export class CodapV2Document {
       this.registerCases(data, cases, level)
 
       if (level > 0) {
-        const collectionModel = CollectionModel.create({ id: `${guid}`, name, _title })
+        const collectionModel = CollectionModel.create({ id: toV3CollectionId(guid), name, _title })
         attrs.forEach(attr => {
           const attrModel = data.attrFromName(attr.name)
           attrModel && collectionModel.addAttribute(attrModel)
@@ -105,7 +107,7 @@ export class CodapV2Document {
         data.addCollection(collectionModel)
       }
       else {
-        data.setUngroupedCollection(CollectionPropsModel.create({ id: `${guid}`, name, _title }))
+        data.setUngroupedCollection(CollectionPropsModel.create({ id: toV3CollectionId(guid), name, _title }))
       }
     })
   }
@@ -125,7 +127,7 @@ export class CodapV2Document {
       const units = v2Unit ?? undefined
       this.guidMap.set(guid, { type: "DG.Attribute", object: v2Attr })
       const attribute = data.addAttribute({
-        id: `${guid}`, name, description, formula, _title, userType, editable, units, precision
+        id: toV3AttrId(guid), name, description, formula, _title, userType, editable, units, precision
       })
       if (attribute) {
         this.v3AttrMap.set(guid, attribute)
@@ -142,7 +144,7 @@ export class CodapV2Document {
       this.guidMap.set(guid, { type: "DG.Case", object: _case })
       // only add child/leaf cases (for now)
       if (level === 0) {
-        let caseValues = { __id__: `${guid}`, ...toCanonical(data, values) }
+        let caseValues = { __id__: toV3CaseId(guid), ...toCanonical(data, values) }
         // look up parent case attributes and add them to caseValues
         for (let parentCase = this.getParentCase(_case); parentCase; parentCase = this.getParentCase(parentCase)) {
           caseValues = { ...(parentCase.values ? toCanonical(data, parentCase.values) : undefined), ...caseValues }

--- a/v3/src/v2/codap-v2-document.ts
+++ b/v3/src/v2/codap-v2-document.ts
@@ -37,7 +37,7 @@ export class CodapV2Document {
     return this.document.globalValues
   }
 
-  get datasets() {
+  get dataSets() {
     return Array.from(this.dataMap.values())
   }
 
@@ -76,9 +76,9 @@ export class CodapV2Document {
         console.warn("CodapV2Document.registerContexts: context with invalid document guid:", context.document)
       }
       this.guidMap.set(guid, { type, object: context })
-      const sharedDataSet = SharedDataSet.create({ dataSet: { name } })
+      const sharedDataSet = SharedDataSet.create({ dataSet: { id: `${guid}`, name } })
       this.dataMap.set(guid, sharedDataSet)
-      const metadata = SharedCaseMetadata.create({ data: this.dataMap.get(guid)?.id })
+      const metadata = SharedCaseMetadata.create({ data: `${guid}` })
       this.metadataMap.set(guid, metadata)
 
       this.registerCollections(sharedDataSet.dataSet, metadata, collections)
@@ -97,7 +97,7 @@ export class CodapV2Document {
       this.registerCases(data, cases, level)
 
       if (level > 0) {
-        const collectionModel = CollectionModel.create({ name, _title })
+        const collectionModel = CollectionModel.create({ id: `${guid}`, name, _title })
         attrs.forEach(attr => {
           const attrModel = data.attrFromName(attr.name)
           attrModel && collectionModel.addAttribute(attrModel)
@@ -105,7 +105,7 @@ export class CodapV2Document {
         data.addCollection(collectionModel)
       }
       else {
-        data.setUngroupedCollection(CollectionPropsModel.create({ name, _title }))
+        data.setUngroupedCollection(CollectionPropsModel.create({ id: `${guid}`, name, _title }))
       }
     })
   }
@@ -140,9 +140,9 @@ export class CodapV2Document {
     cases.forEach(_case => {
       const { guid, values } = _case
       this.guidMap.set(guid, { type: "DG.Case", object: _case })
-      // only add child/leaf cases
+      // only add child/leaf cases (for now)
       if (level === 0) {
-        let caseValues = toCanonical(data, values)
+        let caseValues = { __id__: `${guid}`, ...toCanonical(data, values) }
         // look up parent case attributes and add them to caseValues
         for (let parentCase = this.getParentCase(_case); parentCase; parentCase = this.getParentCase(parentCase)) {
           caseValues = { ...(parentCase.values ? toCanonical(data, parentCase.values) : undefined), ...caseValues }

--- a/v3/src/v2/codap-v2-import.test.ts
+++ b/v3/src/v2/codap-v2-import.test.ts
@@ -72,12 +72,12 @@ describe(`V2 "mammals.codap"`, () => {
     const context = mammals.contexts[0]
     const collection = context.collections[0]
     const data = mammals.dataSets[0].dataSet
-    expect(data.id).toBe(`${context.guid}`)
-    expect(data.ungrouped.id).toBe(`${collection.guid}`)
+    expect(data.id).toBe(`DATA${context.guid}`)
+    expect(data.ungrouped.id).toBe(`COLL${collection.guid}`)
     expect(data.attributes.length).toBe(9)
-    expect(data.attributes[0].id).toBe(`${collection.attrs[0].guid}`)
+    expect(data.attributes[0].id).toBe(`ATTR${collection.attrs[0].guid}`)
     expect(data.cases.length).toBe(27)
-    expect(data.cases[0].__id__).toBe(`${collection.cases[0].guid}`)
+    expect(data.cases[0].__id__).toBe(`CASE${collection.cases[0].guid}`)
 
     // mammals has no parent cases
     const firstCase = collection.cases[0]
@@ -127,7 +127,7 @@ describe(`V2 "24cats.codap"`, () => {
     const v2SexAttr = v2ParentCollection.attrs?.[0]
     expect(cats.getV2Attribute(v2SexAttr.guid)).toBeDefined()
     const dsSexAttr = data.collections[0].attributes[0]
-    expect(dsSexAttr!.id).toBe(`${v2SexAttr.guid}`)
+    expect(dsSexAttr!.id).toBe(`ATTR${v2SexAttr.guid}`)
     expect(dsSexAttr!.name).toBe(v2SexAttr.name)
     expect(dsSexAttr!.title).toBe(v2SexAttr.title)
 

--- a/v3/src/v2/codap-v2-import.test.ts
+++ b/v3/src/v2/codap-v2-import.test.ts
@@ -34,13 +34,13 @@ describe(`V2 "calculator.codap"`, () => {
   })
 
   it("should be importable by CodapV2Document", () => {
-    const mammals = new CodapV2Document(calculatorDoc)
-    expect(mammals.components.length).toBe(1)
-    expect(mammals.contexts.length).toBe(0)
-    expect(mammals.globalValues.length).toBe(0)
-    expect(mammals.datasets.length).toBe(0)
+    const calculator = new CodapV2Document(calculatorDoc)
+    expect(calculator.components.length).toBe(1)
+    expect(calculator.contexts.length).toBe(0)
+    expect(calculator.globalValues.length).toBe(0)
+    expect(calculator.dataSets.length).toBe(0)
 
-    expect(mammals.components.map(c => c.type)).toEqual(["DG.Calculator"])
+    expect(calculator.components.map(c => c.type)).toEqual(["DG.Calculator"])
   })
 })
 
@@ -66,14 +66,21 @@ describe(`V2 "mammals.codap"`, () => {
     expect(mammals.components.length).toBe(5)
     expect(mammals.contexts.length).toBe(1)
     expect(mammals.globalValues.length).toBe(0)
-    expect(mammals.datasets.length).toBe(1)
+    expect(mammals.dataSets.length).toBe(1)
 
-    const data = mammals.datasets[0].dataSet
+    // numeric ids are converted to strings on import
+    const context = mammals.contexts[0]
+    const collection = context.collections[0]
+    const data = mammals.dataSets[0].dataSet
+    expect(data.id).toBe(`${context.guid}`)
+    expect(data.ungrouped.id).toBe(`${collection.guid}`)
     expect(data.attributes.length).toBe(9)
+    expect(data.attributes[0].id).toBe(`${collection.attrs[0].guid}`)
     expect(data.cases.length).toBe(27)
+    expect(data.cases[0].__id__).toBe(`${collection.cases[0].guid}`)
 
     // mammals has no parent cases
-    const firstCase = mammals.contexts[0].collections[0].cases[0]
+    const firstCase = collection.cases[0]
     expect(mammals.getParentCase(firstCase)).toBeUndefined()
 
     expect(mammals.components.map(c => c.type))
@@ -105,23 +112,27 @@ describe(`V2 "24cats.codap"`, () => {
     expect(cats.components.length).toBe(5)
     expect(cats.contexts.length).toBe(1)
     expect(cats.globalValues.length).toBe(0)
-    expect(cats.datasets.length).toBe(1)
+    expect(cats.dataSets.length).toBe(1)
 
-    const data = cats.datasets[0].dataSet
-    expect(data.collections.length).toBe(1)
+    // numeric ids are converted to strings on import
+    const context = cats.contexts[0]
+    const [v2ParentCollection, v2ChildCollection] = context.collections
+    const data = cats.dataSets[0].dataSet
+    expect(data.collections.length).toBe(1) // plus ungrouped makes two
     expect(data.collections[0].attributes.length).toBe(1)
     expect(data.attributes.length).toBe(9)
     expect(data.cases.length).toBe(24)
 
     // sex attribute should be in parent collection
-    const v2SexAttr = catsData.contexts?.[0].collections?.[0].attrs?.[0]
+    const v2SexAttr = v2ParentCollection.attrs?.[0]
     expect(cats.getV2Attribute(v2SexAttr.guid)).toBeDefined()
     const dsSexAttr = data.collections[0].attributes[0]
+    expect(dsSexAttr!.id).toBe(`${v2SexAttr.guid}`)
     expect(dsSexAttr!.name).toBe(v2SexAttr.name)
     expect(dsSexAttr!.title).toBe(v2SexAttr.title)
 
     // should be able to look up parent cases for child cases
-    const firstCase = cats.contexts[0].collections[1].cases[0]
+    const firstCase = v2ChildCollection.cases[0]
     expect(cats.getParentCase(firstCase)).toBeDefined()
 
     expect(cats.components.map(c => c.type))

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -412,7 +412,7 @@ export interface ICodapV2GuideStorage extends ICodapV2BaseComponentStorage {
 export interface ICodapV2BaseComponent {
   type: string  // e.g. "DG.TableView", "DG.GraphView", "DG.GuideView", etc.
   guid: number
-  id: number
+  id?: number
   componentStorage: Record<string, any>
   layout: {
     width: number

--- a/v3/src/v2/import-v2-document.ts
+++ b/v3/src/v2/import-v2-document.ts
@@ -14,7 +14,7 @@ export async function importV2Document(v2Document: CodapV2Document) {
   const sharedModelManager = getSharedModelManager(v3Document)
   sharedModelManager && gDataBroker.setSharedModelManager(sharedModelManager)
   // add shared models (data sets and case metadata)
-  v2Document.datasets.forEach((data, key) => {
+  v2Document.dataSets.forEach((data, key) => {
     const metadata = v2Document.metadata[key]
     gDataBroker.addDataAndMetadata(data, metadata)
   })


### PR DESCRIPTION
[[PT-187573595]](https://www.pivotaltracker.com/story/show/187573595)

The proposed solution is as follows:
- CODAP v3 continues to use string ids for all models.
- For models trafficked by the plugin API (tiles, collections, attributes, cases, etc.), auto-generated ids will be large numeric integers that are then stringified.
- CODAP v2 documents imported into v3 will have their ids stringified on import.
- The plugin API is responsible for converting between the string ids used internally and the numeric ids used by the plugin API.