### PR TITLE
fix: legend issues with Display Only Selected Cases (PT-187458777)

### DIFF
--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -126,7 +126,12 @@ export const CategoricalLegend = observer(
     const refreshKeys = useCallback(() => {
       categoriesRef.current = dataConfiguration?.categoryArrayForAttrRole('legend')
       const numCategories = categoriesRef.current?.length,
+        hasCategories = !(numCategories === 1 && categoriesRef.current?.[0] === "__main__"),
         catData = categoryData.current
+      if (!hasCategories) {
+        select(keysElt.current).selectAll('g').remove()
+        return
+      }
       select(keysElt.current)
         .selectAll('g')
         .data(range(0, numCategories ?? 0))
@@ -227,40 +232,43 @@ export const CategoricalLegend = observer(
      const setupKeys = useCallback(() => {
         categoriesRef.current = dataConfiguration?.categoryArrayForAttrRole('legend')
         const numCategories = categoriesRef.current?.length
+        const hasCategories = !(numCategories === 1 && categoriesRef.current?.[0] === "__main__")
         if (keysElt.current && categoryData.current) {
           select(keysElt.current).selectAll('legend-key').remove() // start fresh
 
-          const keysSelection = select(keysElt.current)
-            .selectAll<SVGGElement, number>('g')
-            .data(range(0, numCategories ?? 0))
-            .join(
-              enter => enter
-                .append('g')
-                .attr('class', 'legend-key')
-                .attr('data-testid', 'legend-key')
-                .call(dragBehavior)
-            )
-          keysSelection.each(function () {
-            const sel = select<SVGGElement, number>(this),
-              size = sel.selectAll<SVGRectElement, number>('rect').size()
-            if (size === 0) {
-              const handleClick = (event: any, i: number) => {
-                const caseIds = dataConfiguration?.getCasesForLegendValue(categoryData.current[i].category)
-                if (caseIds) {
-                  // This is breaking the graph-legend cypress test
-                  // setOrExtendSelection(caseIds, dataConfiguration?.dataset, event.shiftKey)
-                  if (event.shiftKey) dataConfiguration?.dataset?.selectCases(caseIds)
-                  else dataConfiguration?.dataset?.setSelectedCases(caseIds)
+          if (hasCategories) {
+            const keysSelection = select(keysElt.current)
+              .selectAll<SVGGElement, number>('g')
+              .data(range(0, numCategories ?? 0))
+              .join(
+                enter => enter
+                  .append('g')
+                  .attr('class', 'legend-key')
+                  .attr('data-testid', 'legend-key')
+                  .call(dragBehavior)
+              )
+            keysSelection.each(function () {
+              const sel = select<SVGGElement, number>(this),
+                size = sel.selectAll<SVGRectElement, number>('rect').size()
+              if (size === 0) {
+                const handleClick = (event: any, i: number) => {
+                  const caseIds = dataConfiguration?.getCasesForLegendValue(categoryData.current[i].category)
+                  if (caseIds) {
+                    // This is breaking the graph-legend cypress test
+                    // setOrExtendSelection(caseIds, dataConfiguration?.dataset, event.shiftKey)
+                    if (event.shiftKey) dataConfiguration?.dataset?.selectCases(caseIds)
+                    else dataConfiguration?.dataset?.setSelectedCases(caseIds)
+                  }
                 }
+                sel.append('rect')
+                  .attr('width', keySize)
+                  .attr('height', keySize)
+                  .on('click', handleClick)
+                sel.append('text')
+                  .on('click', handleClick)
               }
-              sel.append('rect')
-                .attr('width', keySize)
-                .attr('height', keySize)
-                .on('click', handleClick)
-              sel.append('text')
-                .on('click', handleClick)
-            }
-          })
+            })
+          }
         }
       }, [dataConfiguration, dragBehavior])
 

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -627,7 +627,13 @@ export const DataConfigurationModel = types
       // Invalidate cache when selection changes.
       addDisposer(self, reaction(
         () => self.dataset?.selection.values(),
-        () => self.clearCasesCache(),
+        () => {
+          if (self.displayOnlySelectedCases) {
+            self.clearCasesCache()
+          } else {
+            self.allCasesForCategoryAreSelected.invalidateAll()
+          }
+        },
         {
           name: "DataConfigurationModel.afterCreate.reaction [allCasesForCategoryAreSelected invalidate cache]",
           equals: comparer.structural

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -627,7 +627,7 @@ export const DataConfigurationModel = types
       // Invalidate cache when selection changes.
       addDisposer(self, reaction(
         () => self.dataset?.selection.values(),
-        () =>  self.allCasesForCategoryAreSelected.invalidateAll(),
+        () => self.clearCasesCache(),
         {
           name: "DataConfigurationModel.afterCreate.reaction [allCasesForCategoryAreSelected invalidate cache]",
           equals: comparer.structural


### PR DESCRIPTION
[#187458777](https://www.pivotaltracker.com/story/show/187458777)

Fixes two bugs related to the graph's Display Only Selected Cases option when a categorical legend is present:

1) When no cases are selected, the legend would show `__main__` as the only category

2) If no cases are selected and then a case is selected, the legend would update appropriately to show that case's value for the attribute. But if you then selected another single case that had a different value for the attribute, the legend would not update to show that difference. (See [this screencast](https://somup.com/cZhj3r53e9).)