### PR TITLE
fix: Dragging categories on axis (PT-187539044)

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -267,7 +267,7 @@ export const useSubAxis = ({
           // Figure out the label of the category before which the dragged category should be placed
           const moveToGreater = newCatIndex > dI.indexOfCategory,
             catToMoveBefore = moveToGreater
-              ? (newCatIndex === numCategories - 1 ? '' : dI.categories[newCatIndex])
+              ? (newCatIndex === numCategories - 1 ? '' : dI.categories[newCatIndex + 1])
               : dI.categories[newCatIndex]
           dI.indexOfCategory = newCatIndex
           dI.categorySet?.move(dI.catName, catToMoveBefore)

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -216,7 +216,13 @@ export const CategorySet = types.model("CategorySet", {
   move(value: string, beforeValue?: string) {
     const fromIndex = self.index(value)
     if (fromIndex == null) return
-    const toIndex = (beforeValue != null) ? self.index(beforeValue) ?? self.values.length - 1 : self.values.length - 1
+    let toIndex = (beforeValue != null) ? self.index(beforeValue) : undefined
+    if (toIndex === undefined) {
+      toIndex = self.values.length - 1
+    } else if (fromIndex < toIndex) {
+      toIndex--
+    }
+
     const afterIndex = toIndex === 0 ? undefined : toIndex < fromIndex ? toIndex - 1 : toIndex
     const afterValue = afterIndex != null ? self.values[afterIndex] : undefined
     const move: ICategoryMove = {


### PR DESCRIPTION
[#187539044](https://www.pivotaltracker.com/story/show/187539044)

Although changes in [another PR](https://github.com/concord-consortium/codap/pull/1227) mostly fixed the problem identified in [this story](https://www.pivotaltracker.com/story/show/187539044), there was a remaining bug with dragging categories on an axis. In the previously-mentioned PR, we mistakenly changed the calculation of the index for the category _before which_ the dragged category should be moved if it was moved up from its initial position in the array.