### PR TITLE
fix: Unable to reorder categories in legend (PT-187392421)

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -258,6 +258,9 @@ export const DataConfigurationModel = types
         const attributeID = self.attributeID(role) || ''
         return self.metadata.getCategorySet(attributeID)
       }
+    },
+    potentiallyCategoricalRoles(): AttrRole[] {
+      return ["legend"] as const
     }
   }))
   .views(self => ({
@@ -286,7 +289,7 @@ export const DataConfigurationModel = types
     }),
     getAllCategoriesForRoles() {
       const categories: Map<AttrRole, string[]> = new Map()
-      ;(["legend"] as const).forEach(role => {
+      self.potentiallyCategoricalRoles().forEach(role => {
         const categorySet = self.categorySetForAttrRole(role)
         if (categorySet) {
           categories.set(role, categorySet.valuesArray)

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -283,7 +283,17 @@ export const DataConfigurationModel = types
         })
         return orderedCategories
       }
-    })
+    }),
+    getAllCategoriesForRoles() {
+      const categories: Map<AttrRole, string[]> = new Map()
+      ;(["legend"] as const).forEach(role => {
+        const categorySet = self.categorySetForAttrRole(role)
+        if (categorySet) {
+          categories.set(role, categorySet.valuesArray)
+        }
+      })
+      return categories
+    }
   }))
   .views(self => ({
     getUnsortedCaseDataArray(caseArrayNumber: number): CaseData[] {
@@ -614,6 +624,14 @@ export const DataConfigurationModel = types
         () => self.dataset,
         data => self.handleDataSetChange(data),
         {name: "DataConfigurationModel.afterCreate.reaction [dataset]", fireImmediately: true }
+      ))
+      addDisposer(self, reaction(
+        () => self.getAllCategoriesForRoles(),
+        () => self.clearCasesCache(),
+        {
+          name: "DataConfigurationModel.afterCreate.reaction [getAllCategoriesForRoles]",
+          equals: comparer.structural
+        }
       ))
       // respond to change of legend attribute
       addDisposer(self, reaction(

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -232,6 +232,9 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       const attrTypes = self.attrTypes
       return Object.values(attrTypes).filter(a => a === "categorical").length
     },
+    potentiallyCategoricalRoles(): AttrRole[] {
+      return ["legend", "x", "y", "topSplit", "rightSplit"] as const
+    },
     get hasExactlyOneCategoricalAxis() {
       const attrTypes = self.attrTypes
       const xHasCategorical = attrTypes.bottom === "categorical" || attrTypes.top === "categorical"
@@ -253,16 +256,6 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     }
   }))
   .views(self => ({
-    getAllCategoriesForRoles() {
-      const categories: Map<AttrRole, string[]> = new Map()
-      ;(["x", "y", "topSplit", "rightSplit", "legend"] as const).forEach(role => {
-        const categorySet = self.categorySetForAttrRole(role)
-        if (categorySet) {
-          categories.set(role, categorySet.valuesArray)
-        }
-      })
-      return categories
-    },
     getCategoriesOptions() {
       // Helper used often by adornments that usually ask about the same categories and their specifics.
       const xAttrType = self.attributeType("x")

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -255,7 +255,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
   .views(self => ({
     getAllCategoriesForRoles() {
       const categories: Map<AttrRole, string[]> = new Map()
-      ;(["x", "y", "topSplit", "rightSplit"] as const).forEach(role => {
+      ;(["x", "y", "topSplit", "rightSplit", "legend"] as const).forEach(role => {
         const categorySet = self.categorySetForAttrRole(role)
         if (categorySet) {
           categories.set(role, categorySet.valuesArray)

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -649,14 +649,6 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     return {
       afterCreate() {
         addDisposer(self, reaction(
-          () => self.getAllCategoriesForRoles(),
-          () => self.clearCasesCache(),
-          {
-            name: "GraphDataConfigurationModel.afterCreate.reaction [getAllCategoriesForRoles]",
-            equals: comparer.structural
-          }
-        ))
-        addDisposer(self, reaction(
           () => self.getAllCellKeys(),
           () => self.clearGraphSpecificCasesCache(),
           {


### PR DESCRIPTION
[#187392421](https://www.pivotaltracker.com/story/show/187392421)

The `categoryData` ref used throughout the component, but perhaps most notably in the D3 code that constructs the legend element, was not being updated when the category order changed. Also, the graph data configuration model's `getAllCategoriesForRoles` view didn't include "legend". So the cached `categoryArrayForAttrRole` wasn't being invalidated in reaction to reordering the legend items.

I noticed the categorical legend reorder problem also exists in the map. So I added a `getAllCategoriesForRoles` view to `DataConfigurationModel` and moved the new reaction that uses `getAllCategoriesForRoles` as its data function from `GraphDataConfigurationModel` to `DataConfigurationModel`. I think some of the duplicate code introduced by that change could be reduced, but wanted to get thoughts on the general idea before devoting more time to that.