### PR TITLE
186227299 automation inspector table

### DIFF
--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -120,22 +120,20 @@ context("case table ui", () => {
     it("select a case and delete the case from inspector menu", () => {
       let initialRowCount, postInsertRowCount
 
-       // Get initial row count
-       table.getNumOfRows().then(rowCount => {
-         initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-         })
+      // Get initial row count
+      table.getNumOfRows().then(rowCount => {
+        initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+      })
 
-       // Delete one case in table
-       //c.selectTile("table", 0)
-       table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
-       table.getDeleteCasesButton().click()
-       table.getDeleteMenuItem("Delete Selected Cases").click()
+      table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
+      table.getDeleteCasesButton().click()
+      table.getDeleteMenuItem("Delete Selected Cases").click()
 
-       // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
-       table.getNumOfRows().then(rowCount => {
-         postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-         expect(postInsertRowCount).to.eq(initialRowCount - 1)
-       })
+      // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
+      table.getNumOfRows().then(rowCount => {
+        postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+        expect(postInsertRowCount).to.eq(initialRowCount - 1)
+      })
 
        // // checks for undo/redo
        // cy.log("check for undo/redo after delete")
@@ -159,8 +157,6 @@ context("case table ui", () => {
        //  const rowCountAfterRedo = parseInt(rowCount)
        //  expect(rowCountAfterRedo).to.eq(initialRowCount)
        // })
-
-
     })
     it("select a case and delete unselected cases from inspector menu", () => {
      let initialRowCount // Declare variable to hold initial row count
@@ -533,8 +529,8 @@ context("case table ui", () => {
       table.openIndexMenuForRow(3)
       table.deleteCase()
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion of the second case")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -591,8 +587,8 @@ context("case table ui", () => {
       table.deleteCase()
       table.getNumOfRows().should("equal", numOfCases)
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion of bottom case")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -615,8 +611,8 @@ context("case table ui", () => {
       table.deleteCase()
       table.getNumOfRows().should("equal", numOfCases)
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion of last case")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -651,8 +647,8 @@ context("case table ui", () => {
       table.deleteCase()
       table.getNumOfRows().should("equal", numOfCases)
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion of top case")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -678,8 +674,8 @@ context("case table ui", () => {
       table.deleteCase()
       table.getNumOfRows().should("equal", numOfCases)
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion of top case above")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -705,8 +701,8 @@ context("case table ui", () => {
       table.deleteCase()
       table.getNumOfRows().should("equal", numOfCases)
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion of multiple cases on top")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -724,8 +720,8 @@ context("case table ui", () => {
       table.deleteCase()
       numOfCases = (Number(numOfCases) - 1).toString()
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion of first case")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -746,8 +742,8 @@ context("case table ui", () => {
       table.deleteCase()
       table.getNumOfRows().should("equal", numOfCases)
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion of insertion of middle case")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -772,8 +768,8 @@ context("case table ui", () => {
       table.deleteCase()
       table.getNumOfRows().should("equal", numOfCases)
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion below the middle case")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -798,14 +794,14 @@ context("case table ui", () => {
       table.deleteCase()
       table.getNumOfRows().should("equal", numOfCases)
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion above the middle case above current case")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
       // For example, check the number of rows or a specific row's content
 
-      // Use the toolbar to redo the last undone action (which should redo the deletion of the case)
+      // Use the toolbar to redo the last undone action
       toolbar.getRedoTool().click()
       // Add assertions here to verify the case is deleted again
       // For example, check the number of rows or a specific row's content
@@ -816,8 +812,8 @@ context("case table ui", () => {
       table.deleteCase()
       numOfCases = (Number(numOfCases) - 1).toString()
 
-      // Use the toolbar to undo the last action (which should be the deletion of the second case)
-      cy.log("check for undo/redo after delete")
+      // Use the toolbar to undo the last action
+      cy.log("check for undo/redo after deletion of case in the middle row")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -27,6 +27,22 @@ beforeEach(() => {
 })
 
 context("case table ui", () => {
+  // TODO: move this to the bottom once the tests are robust
+ // describe("case table Inspector menu options", () => {
+   // it("should open dataset information button and make changes", () => {
+     // check for dataset information to open. make changes?
+     //table.getDatasetInfoButton()
+     // .should("contain", "source").click().(`foo{enter}`)
+     // table-tile.getDatasetInfoButton().should("contain", "source").click().should("contain", "foo")
+
+//   })
+
+    // does delete cases open? can we delete cases from the inspector menu? undo/redo?
+    // does set aside cases work? can we restore set aside cases? undo/redo?
+    // from the ruler menu, can we add a new attribute? undo/redo?
+    // from the ruler menu, does rerandomize all work? undo?
+    // is it possible to export case data? (not sure how this would work)
+  // })
   describe("table view", () => {
     it("populates title bar from sample data", () => {
       c.getComponentTitle("table").should("contain", collectionName)
@@ -708,4 +724,6 @@ context("case table ui", () => {
       table.verifyCellSwatchColor(2, 2, "rgb(0, 255,")
     })
   })
+
+
 })

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -27,41 +27,6 @@ beforeEach(() => {
 })
 
 context("case table ui", () => {
-  // TODO: move this to the bottom once the tests are robust
- describe("case table Inspector menu options", () => {
-   it("should open dataset information button and make changes", () => {
-     // check for dataset information to open. make changes?
-     // Dataset info button doesn't appear in this CODAP document
-     // get the Dataset info button. Click to open the dialogue and change it.
-
-     const source = "The Internet",
-     date = "",
-     importDate = "May 4",
-     description = "All about mammals"
-
-     //infoname = "Rawr",
-
-
-     c.selectTile("table", 0)
-     table.editDatasetInformation(source, importDate, description)
-     table.getDatasetInfoButton().click()
-     cy.get("[data-testid='dataset-date-input']").should("have.value", importDate)
-
-     //.should("contain", "source").click().(`foo{enter}`)
-     // table-tile.getDatasetInfoButton().should("contain", "source").click().should("contain", "foo")
-
-   })
-
-    // does delete cases open? can we delete cases from the inspector menu? undo/redo?
-    it("Check delete cases from inspector menu with undo/redo", () => {
-      c.selectTile("table", 0)
-      table.getDeleteCasesButton()
-    })
-    // does set aside cases work? can we restore set aside cases? undo/redo?
-    // from the ruler menu, can we add a new attribute? undo/redo?
-    // from the ruler menu, does rerandomize all work? undo?
-    // is it possible to export case data? (not sure how this would work)
-   })
   describe("table view", () => {
     it("populates title bar from sample data", () => {
       c.getComponentTitle("table").should("contain", collectionName)
@@ -103,6 +68,7 @@ context("case table ui", () => {
       cy.get("[data-testid='attr-editable-radio'] input[value='no']").should("be.checked")
       table.getCancelButton().click()
 
+      cy.log("check undo/redo after verify attribute properties")
       // Perform Undo operation
       toolbar.getUndoTool().click()
 
@@ -131,7 +97,227 @@ context("case table ui", () => {
     // it("verify index column cannot be reordered", () => {
     // })
   })
+  // TODO: add tests for: Rerandomize All, Export Case Data, Copy to Clipboard,
+  // Import Case Data from Clipboard (PT: #184432150)
+  describe("case table Inspector menu options", () => {
+    it("should open dataset information button and make changes", () => {
+      const newInfoName = "Animals",
+      newSource = "The Internet",
+      importDate = "May 4",
+      newDescription = "All about mammals"
 
+      // Enter new dataset information
+      c.selectTile("table", 0)
+      table.editDatasetInformation(newInfoName, newSource, importDate, newDescription)
+      table.getDatasetInfoButton().click()
+
+      // Checks that the new description information is filled in
+      cy.get("[data-testid='dataset-name-input']").should("have.value", newInfoName)
+      cy.get("[data-testid='dataset-source-input']").should("have.value", newSource)
+      cy.get("[data-testid='dataset-date-input']").should("have.value", importDate)
+      cy.get("[data-testid=dataset-description-input]").should("have.value", newDescription)
+    })
+    it("select a case and delete the case from inspector menu", () => {
+      let initialRowCount, postInsertRowCount
+
+       // Get initial row count
+       table.getNumOfRows().then(rowCount => {
+         initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+         })
+
+       // Delete one case in table
+       //c.selectTile("table", 0)
+       table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
+       table.getDeleteCasesButton().click()
+       table.getDeleteMenuItem("Delete Selected Cases").click()
+
+       // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
+       table.getNumOfRows().then(rowCount => {
+         postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+         expect(postInsertRowCount).to.eq(initialRowCount - 1)
+       })
+
+       // // checks for undo/redo
+       // cy.log("check for undo/redo after delete")
+
+       // // Undo delete
+       // toolbar.getUndoTool().click()
+
+       // // Verify undo (check if row count is back to post-insert count)
+       // // TODO: add the check once bug is fixed (PT ##187597588)
+       // table.getNumOfRows().then(rowCount => {
+       //  const rowCountAfterUndo = parseInt(rowCount)
+       //  expect(rowCountAfterUndo).to.eq(postInsertRowCount)
+       // })
+
+       // // Redo delete
+       // toolbar.getRedoTool().click()
+
+       // // Verify redo (check if row count is back to initial count)
+       // // TODO: add the check once bug is fixed (PT ##187597588)
+       //  table.getNumOfRows().then(rowCount => {
+       //  const rowCountAfterRedo = parseInt(rowCount)
+       //  expect(rowCountAfterRedo).to.eq(initialRowCount)
+       // })
+
+
+    })
+    it("select a case and delete unselected cases from inspector menu", () => {
+     let initialRowCount, postInsertRowCount, postDeleteRowCount
+
+       // Get initial row count
+       table.getNumOfRows().then(rowCount => {
+        initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+       })
+
+       // Delete one case in table
+       //c.selectTile("table", 0)
+       table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
+       table.getDeleteCasesButton().click()
+       table.getDeleteMenuItem("Delete Unselected Cases").click()
+
+       // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
+       table.getNumOfRows().then(rowCount => {
+         postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+         expect(postInsertRowCount).to.eq(2)
+       })
+
+        // // checks for undo/redo
+        // cy.log("check for undo/redo after delete")
+
+        // // Undo delete
+        // toolbar.getUndoTool().click()
+
+        // // Verify undo (check if row count is back to post-insert count)
+        // // TODO: add the check once bug is fixed (PT ##187597588)
+        // table.getNumOfRows().then(rowCount => {
+        //  const rowCountAfterUndo = parseInt(rowCount)
+        //  expect(rowCountAfterUndo).to.eq(postInsertRowCount)
+        // })
+
+        // // Redo delete
+        // toolbar.getRedoTool().click()
+
+        // // Verify redo (check if row count is back to initial count)
+        // // TODO: add the check once bug is fixed (PT ##187597588)
+        //  table.getNumOfRows().then(rowCount => {
+        //  const rowCountAfterRedo = parseInt(rowCount)
+        //  expect(rowCountAfterRedo).to.eq(initialRowCount)
+        // })
+     })
+    it("check delete all cases from inspector menu", () => {
+     let initialRowCount, postInsertRowCount, postDeleteRowCount
+
+     // Get initial row count
+     table.getNumOfRows().then(rowCount => {
+      initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+    })
+
+     // Delete all cases in table
+     c.selectTile("table", 0)
+     table.getDeleteCasesButton().click()
+     table.getDeleteMenuItem("Delete All Cases").click()
+
+     // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
+     table.getNumOfRows().then(rowCount => {
+      postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+       expect(postInsertRowCount).to.eq(1)
+     })
+    })
+    it("check hide/show attribute from inspector menu", () => {
+     // Hide the attribute
+     table.openAttributeMenu("Mammal")
+     table.selectMenuItemFromAttributeMenu("Hide Attribute")
+
+     // Verify attribute is hidden
+     table.getColumnHeader(1).should("not.have.text", "Mammal")
+     table.getAttribute("Mammal").should("not.exist")
+
+     // Show all attributes
+     c.selectTile("table", 0)
+     table.getHideShowButton().click()
+     table.getHideShowMenuItem("Show 1 Hidden Attribute").click()
+
+     // Verify all attributes are shown
+     table.getColumnHeader(1).should("contain", "Mammal")
+     table.getAttribute("Mammal").should("exist")
+ })
+     // // does set aside cases work? can we restore set aside cases? undo/redo?
+     // TODO: implement this test (blocker: need functionality of Set Aside Cases)
+     // PT: #187597833
+     // it.skip("tests for set aside cases with undo/redo", () => {
+     //   let initialRowCount, postInsertRowCount, postDeleteRowCount
+
+     //   // Get initial row count
+     //   table.getNumOfRows().then(rowCount => {
+     //    initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+     //   })
+
+     //   table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
+     //   table.getHideShowButton().click()
+     //   table.getDeleteMenuItem("Set Aside Unselected Cases").click()
+
+     //   // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
+     //   table.getNumOfRows().then(rowCount => {
+     //     postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+     //     expect(postInsertRowCount).to.eq(initialRowCount - 1 )
+     //   })
+
+     //    // // checks for undo/redo
+     //    // cy.log("check for undo/redo after delete")
+
+     //    // // Undo delete
+     //    // toolbar.getUndoTool().click()
+
+     //    // // Verify undo (check if row count is back to post-insert count)
+     //    // // TODO: add the check once bug is fixed (PT ##187597588)
+     //    // table.getNumOfRows().then(rowCount => {
+     //    //  const rowCountAfterUndo = parseInt(rowCount)
+     //    //  expect(rowCountAfterUndo).to.eq(postInsertRowCount)
+     //    // })
+
+     //    // // Redo delete
+     //    // toolbar.getRedoTool().click()
+
+     //    // // Verify redo (check if row count is back to initial count)
+     //    // // TODO: add the check once bug is fixed (PT ##187597588)
+     //    //  table.getNumOfRows().then(rowCount => {
+     //    //  const rowCountAfterRedo = parseInt(rowCount)
+     //    //  expect(rowCountAfterRedo).to.eq(initialRowCount)
+     //    // })
+
+
+     // })
+
+     it("check New Attribute from inspector menu with undo/redo", () => {
+       c.selectTile("table", 0)
+       table.getRulerButton().click()
+       table.getRulerMenuItem("New Attribute in Mammals...").click()
+
+       // verify new attribute exists
+       table.getColumnHeaders().should("have.length.be.within", 10, 11)
+       table.getAttribute("newAttr").should("exist")
+       table.getAttribute("newAttr").click()
+       table.getAttribute("newAttr").should("have.text", "newAttr")
+
+       cy.log("check undo/redo after add new attribute")
+       // Perform Undo operation
+       toolbar.getUndoTool().click()
+
+       // Test if attribute is removed
+       table.getColumnHeaders().should("have.length.be.within", 9, 10)
+       table.getAttribute("newAttr").should("not.exist")
+
+       // Perform Redo operation
+       toolbar.getRedoTool().click()
+
+       // verify new attribute exists
+       table.getColumnHeaders().should("have.length.be.within", 10, 11)
+       table.getAttribute("newAttr").should("exist")
+       table.getAttribute("newAttr").click()
+       table.getAttribute("newAttr").should("have.text", "newAttr")
+   })
+ })
   describe("case table header attribute menu", () => {
     it("verify add attribute with undo and redo", ()=>{
       // Add new attribute using Add New Attribute button (+)
@@ -143,6 +329,7 @@ context("case table ui", () => {
       table.getAttribute("newAttr").click()
       table.getAttribute("newAttr").should("have.text", "newAttr")
 
+      cy.log("check undo/redo after add new attribute")
       // Perform Undo operation
       toolbar.getUndoTool().click()
 
@@ -174,6 +361,7 @@ context("case table ui", () => {
       table.getColumnHeader(1).should("contain", "Animal")
       table.getAttribute("Animal").should("exist")
 
+      cy.log("check undo/redo after rename attribute")
       // Undo rename
       toolbar.getUndoTool().click()
 
@@ -198,6 +386,7 @@ context("case table ui", () => {
       table.getColumnHeader(1).should("not.have.text", "Mammal")
       table.getAttribute("Mammal").should("not.exist")
 
+      cy.log("check undo/redo after hide and showAll attribute")
       // Undo hide
       toolbar.getUndoTool().click()
 
@@ -237,6 +426,7 @@ context("case table ui", () => {
       table.getAttribute("Mammal").should("not.exist")
       table.getColumnHeaders().should("have.length", numOfAttributes - 1)
 
+      cy.log("check undo/redo after delete attribute")
       // Undo delete
       toolbar.getUndoTool().click()
 
@@ -285,6 +475,7 @@ context("case table ui", () => {
         expect(postDeleteRowCount).to.eq(initialRowCount)
       })
 
+      cy.log("check undo/redo after insert case and delete case work")
       // Undo delete
       toolbar.getUndoTool().click()
 
@@ -319,6 +510,7 @@ context("case table ui", () => {
       table.deleteCase() // Delete the second inserted case
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete cases")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -338,6 +530,7 @@ context("case table ui", () => {
       table.deleteCase()
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -395,6 +588,7 @@ context("case table ui", () => {
       table.getNumOfRows().should("equal", numOfCases)
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -418,6 +612,7 @@ context("case table ui", () => {
       table.getNumOfRows().should("equal", numOfCases)
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -453,6 +648,7 @@ context("case table ui", () => {
       table.getNumOfRows().should("equal", numOfCases)
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -479,6 +675,7 @@ context("case table ui", () => {
       table.getNumOfRows().should("equal", numOfCases)
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -505,6 +702,7 @@ context("case table ui", () => {
       table.getNumOfRows().should("equal", numOfCases)
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -523,6 +721,7 @@ context("case table ui", () => {
       numOfCases = (Number(numOfCases) - 1).toString()
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -544,6 +743,7 @@ context("case table ui", () => {
       table.getNumOfRows().should("equal", numOfCases)
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -569,6 +769,7 @@ context("case table ui", () => {
       table.getNumOfRows().should("equal", numOfCases)
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -594,6 +795,7 @@ context("case table ui", () => {
       table.getNumOfRows().should("equal", numOfCases)
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -611,6 +813,7 @@ context("case table ui", () => {
       numOfCases = (Number(numOfCases) - 1).toString()
 
       // Use the toolbar to undo the last action (which should be the deletion of the second case)
+      cy.log("check for undo/redo after delete")
       toolbar.getUndoTool().click()
 
       // TODO: Add assertions here to verify the case is restored (PT ##187127871)
@@ -658,6 +861,7 @@ context("case table ui", () => {
       c.checkComponentDoesNotExist("table")
 
       // Add undo for closing table component
+      cy.log("check for undo/redo after closing table")
       toolbar.getUndoTool().click()
 
       // Asserts table has been reopened

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -28,21 +28,28 @@ beforeEach(() => {
 
 context("case table ui", () => {
   // TODO: move this to the bottom once the tests are robust
- // describe("case table Inspector menu options", () => {
-   // it("should open dataset information button and make changes", () => {
+ describe("case table Inspector menu options", () => {
+   //it("should open dataset information button and make changes", () => {
      // check for dataset information to open. make changes?
-     //table.getDatasetInfoButton()
-     // .should("contain", "source").click().(`foo{enter}`)
+     // Dataset info button doesn't appear in this CODAP document
+     // get the Dataset info button. Click to open the dialogue and change it.
+
+     // table.getDatasetInfoButton()
+
+     //.should("contain", "source").click().(`foo{enter}`)
      // table-tile.getDatasetInfoButton().should("contain", "source").click().should("contain", "foo")
 
-//   })
+  // })
 
     // does delete cases open? can we delete cases from the inspector menu? undo/redo?
+    it("Check delete cases from inspector menu with undo/redo", () => {
+      c.getComponentTitle("table").should("contain", collectionName)
+    })
     // does set aside cases work? can we restore set aside cases? undo/redo?
     // from the ruler menu, can we add a new attribute? undo/redo?
     // from the ruler menu, does rerandomize all work? undo?
     // is it possible to export case data? (not sure how this would work)
-  // })
+   })
   describe("table view", () => {
     it("populates title bar from sample data", () => {
       c.getComponentTitle("table").should("contain", collectionName)

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -34,13 +34,18 @@ context("case table ui", () => {
      // Dataset info button doesn't appear in this CODAP document
      // get the Dataset info button. Click to open the dialogue and change it.
 
-     const infoname = "Rawr",
-        source = "The Internet",
-        importdate = "May 4",
-        description = "All about mammals"
+     const source = "The Internet",
+     date = "",
+     importDate = "May 4",
+     description = "All about mammals"
+
+     //infoname = "Rawr",
+
 
      c.selectTile("table", 0)
-    //  table.getDatasetInfoButton().click()
+     table.editDatasetInformation(source, importDate, description)
+     table.getDatasetInfoButton().click()
+     cy.get("[data-testid='dataset-date-input']").should("have.value", importDate)
 
      //.should("contain", "source").click().(`foo{enter}`)
      // table-tile.getDatasetInfoButton().should("contain", "source").click().should("contain", "foo")

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -163,24 +163,26 @@ context("case table ui", () => {
 
     })
     it("select a case and delete unselected cases from inspector menu", () => {
-     let initialRowCount, postInsertRowCount, postDeleteRowCount
+     let initialRowCount // Declare variable to hold initial row count
+     let postInsertRowCount // Declare variable to hold row count after delete
 
-       // Get initial row count
-       table.getNumOfRows().then(rowCount => {
-        initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-       })
+     // Get initial row count
+     table.getNumOfRows().then(rowCount => {
+       initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+     })
 
-       // Delete one case in table
-       //c.selectTile("table", 0)
-       table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
-       table.getDeleteCasesButton().click()
-       table.getDeleteMenuItem("Delete Unselected Cases").click()
+     // Delete one case in table
+     //c.selectTile("table", 0)
+     table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
+     table.getDeleteCasesButton().click()
+     table.getDeleteMenuItem("Delete Unselected Cases").click()
 
-       // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
-       table.getNumOfRows().then(rowCount => {
-         postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-         expect(postInsertRowCount).to.eq(2)
-       })
+     // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
+     table.getNumOfRows().then(rowCount => {
+       postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+       expect(postInsertRowCount).to.eq(2)
+       expect(initialRowCount).to.be.greaterThan(postInsertRowCount) // add a check to make sure rows were deleted
+      })
 
         // // checks for undo/redo
         // cy.log("check for undo/redo after delete")
@@ -206,7 +208,8 @@ context("case table ui", () => {
         // })
      })
     it("check delete all cases from inspector menu", () => {
-     let initialRowCount, postInsertRowCount, postDeleteRowCount
+      let initialRowCount // Declare variable to hold initial row count
+      let postInsertRowCount // Declare variable to hold row count after delete
 
      // Get initial row count
      table.getNumOfRows().then(rowCount => {
@@ -222,6 +225,7 @@ context("case table ui", () => {
      table.getNumOfRows().then(rowCount => {
       postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
        expect(postInsertRowCount).to.eq(1)
+       expect(initialRowCount).to.be.greaterThan(postInsertRowCount) // add a check to make sure rows were deleted
      })
     })
     it("check hide/show attribute from inspector menu", () => {

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -29,21 +29,28 @@ beforeEach(() => {
 context("case table ui", () => {
   // TODO: move this to the bottom once the tests are robust
  describe("case table Inspector menu options", () => {
-   //it("should open dataset information button and make changes", () => {
+   it("should open dataset information button and make changes", () => {
      // check for dataset information to open. make changes?
      // Dataset info button doesn't appear in this CODAP document
      // get the Dataset info button. Click to open the dialogue and change it.
 
-     // table.getDatasetInfoButton()
+     const infoname = "Rawr",
+        source = "The Internet",
+        importdate = "May 4",
+        description = "All about mammals"
+
+     c.selectTile("table", 0)
+    //  table.getDatasetInfoButton().click()
 
      //.should("contain", "source").click().(`foo{enter}`)
      // table-tile.getDatasetInfoButton().should("contain", "source").click().should("contain", "foo")
 
-  // })
+   })
 
     // does delete cases open? can we delete cases from the inspector menu? undo/redo?
     it("Check delete cases from inspector menu with undo/redo", () => {
-      c.getComponentTitle("table").should("contain", collectionName)
+      c.selectTile("table", 0)
+      table.getDeleteCasesButton()
     })
     // does set aside cases work? can we restore set aside cases? undo/redo?
     // from the ruler menu, can we add a new attribute? undo/redo?

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -135,189 +135,189 @@ context("case table ui", () => {
         expect(postInsertRowCount).to.eq(initialRowCount - 1)
       })
 
-       // // checks for undo/redo
-       // cy.log("check for undo/redo after delete")
+      // // checks for undo/redo
+      // cy.log("check for undo/redo after delete")
 
-       // // Undo delete
-       // toolbar.getUndoTool().click()
+      // // Undo delete
+      // toolbar.getUndoTool().click()
 
-       // // Verify undo (check if row count is back to post-insert count)
-       // // TODO: add the check once bug is fixed (PT ##187597588)
-       // table.getNumOfRows().then(rowCount => {
-       //  const rowCountAfterUndo = parseInt(rowCount)
-       //  expect(rowCountAfterUndo).to.eq(postInsertRowCount)
-       // })
+      // // Verify undo (check if row count is back to post-insert count)
+      // // TODO: add the check once bug is fixed (PT ##187597588)
+      // table.getNumOfRows().then(rowCount => {
+      //  const rowCountAfterUndo = parseInt(rowCount)
+      //  expect(rowCountAfterUndo).to.eq(postInsertRowCount)
+      // })
 
-       // // Redo delete
-       // toolbar.getRedoTool().click()
+      // // Redo delete
+      // toolbar.getRedoTool().click()
 
-       // // Verify redo (check if row count is back to initial count)
-       // // TODO: add the check once bug is fixed (PT ##187597588)
-       //  table.getNumOfRows().then(rowCount => {
-       //  const rowCountAfterRedo = parseInt(rowCount)
-       //  expect(rowCountAfterRedo).to.eq(initialRowCount)
-       // })
+      // // Verify redo (check if row count is back to initial count)
+      // // TODO: add the check once bug is fixed (PT ##187597588)
+      //  table.getNumOfRows().then(rowCount => {
+      //  const rowCountAfterRedo = parseInt(rowCount)
+      //  expect(rowCountAfterRedo).to.eq(initialRowCount)
+      // })
     })
     it("select a case and delete unselected cases from inspector menu", () => {
-     let initialRowCount // Declare variable to hold initial row count
-     let postInsertRowCount // Declare variable to hold row count after delete
+      let initialRowCount // Declare variable to hold initial row count
+      let postInsertRowCount // Declare variable to hold row count after delete
 
-     // Get initial row count
-     table.getNumOfRows().then(rowCount => {
-       initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-     })
-
-     // Delete one case in table
-     //c.selectTile("table", 0)
-     table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
-     table.getDeleteCasesButton().click()
-     table.getDeleteMenuItem("Delete Unselected Cases").click()
-
-     // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
-     table.getNumOfRows().then(rowCount => {
-       postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-       expect(postInsertRowCount).to.eq(2)
-       expect(initialRowCount).to.be.greaterThan(postInsertRowCount) // add a check to make sure rows were deleted
+      // Get initial row count
+      table.getNumOfRows().then(rowCount => {
+        initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
       })
 
-        // // checks for undo/redo
-        // cy.log("check for undo/redo after delete")
+      // Delete one case in table
+      //c.selectTile("table", 0)
+      table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
+      table.getDeleteCasesButton().click()
+      table.getDeleteMenuItem("Delete Unselected Cases").click()
 
-        // // Undo delete
-        // toolbar.getUndoTool().click()
+      // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
+      table.getNumOfRows().then(rowCount => {
+        postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+        expect(postInsertRowCount).to.eq(2)
+        expect(initialRowCount).to.be.greaterThan(postInsertRowCount) // add a check to make sure rows were deleted
+      })
 
-        // // Verify undo (check if row count is back to post-insert count)
-        // // TODO: add the check once bug is fixed (PT ##187597588)
-        // table.getNumOfRows().then(rowCount => {
-        //  const rowCountAfterUndo = parseInt(rowCount)
-        //  expect(rowCountAfterUndo).to.eq(postInsertRowCount)
-        // })
+      // // checks for undo/redo
+      // cy.log("check for undo/redo after delete")
 
-        // // Redo delete
-        // toolbar.getRedoTool().click()
+      // // Undo delete
+      // toolbar.getUndoTool().click()
 
-        // // Verify redo (check if row count is back to initial count)
-        // // TODO: add the check once bug is fixed (PT ##187597588)
-        //  table.getNumOfRows().then(rowCount => {
-        //  const rowCountAfterRedo = parseInt(rowCount)
-        //  expect(rowCountAfterRedo).to.eq(initialRowCount)
-        // })
-     })
+      // // Verify undo (check if row count is back to post-insert count)
+      // // TODO: add the check once bug is fixed (PT ##187597588)
+      // table.getNumOfRows().then(rowCount => {
+      //  const rowCountAfterUndo = parseInt(rowCount)
+      //  expect(rowCountAfterUndo).to.eq(postInsertRowCount)
+      // })
+
+      // // Redo delete
+      // toolbar.getRedoTool().click()
+
+      // // Verify redo (check if row count is back to initial count)
+      // // TODO: add the check once bug is fixed (PT ##187597588)
+      //  table.getNumOfRows().then(rowCount => {
+      //  const rowCountAfterRedo = parseInt(rowCount)
+      //  expect(rowCountAfterRedo).to.eq(initialRowCount)
+      // })
+    })
     it("check delete all cases from inspector menu", () => {
       let initialRowCount // Declare variable to hold initial row count
       let postInsertRowCount // Declare variable to hold row count after delete
 
-     // Get initial row count
-     table.getNumOfRows().then(rowCount => {
-      initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-    })
+      // Get initial row count
+      table.getNumOfRows().then(rowCount => {
+        initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+      })
 
-     // Delete all cases in table
-     c.selectTile("table", 0)
-     table.getDeleteCasesButton().click()
-     table.getDeleteMenuItem("Delete All Cases").click()
+      // Delete all cases in table
+      c.selectTile("table", 0)
+      table.getDeleteCasesButton().click()
+      table.getDeleteMenuItem("Delete All Cases").click()
 
-     // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
-     table.getNumOfRows().then(rowCount => {
-      postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-       expect(postInsertRowCount).to.eq(1)
-       expect(initialRowCount).to.be.greaterThan(postInsertRowCount) // add a check to make sure rows were deleted
-     })
+      // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
+      table.getNumOfRows().then(rowCount => {
+        postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+        expect(postInsertRowCount).to.eq(1)
+        expect(initialRowCount).to.be.greaterThan(postInsertRowCount) // add a check to make sure rows were deleted
+      })
     })
     it("check hide/show attribute from inspector menu", () => {
-     // Hide the attribute
-     table.openAttributeMenu("Mammal")
-     table.selectMenuItemFromAttributeMenu("Hide Attribute")
+      // Hide the attribute
+      table.openAttributeMenu("Mammal")
+      table.selectMenuItemFromAttributeMenu("Hide Attribute")
 
-     // Verify attribute is hidden
-     table.getColumnHeader(1).should("not.have.text", "Mammal")
-     table.getAttribute("Mammal").should("not.exist")
+      // Verify attribute is hidden
+      table.getColumnHeader(1).should("not.have.text", "Mammal")
+      table.getAttribute("Mammal").should("not.exist")
 
-     // Show all attributes
-     c.selectTile("table", 0)
-     table.getHideShowButton().click()
-     table.getHideShowMenuItem("Show 1 Hidden Attribute").click()
+      // Show all attributes
+      c.selectTile("table", 0)
+      table.getHideShowButton().click()
+      table.getHideShowMenuItem("Show 1 Hidden Attribute").click()
 
-     // Verify all attributes are shown
-     table.getColumnHeader(1).should("contain", "Mammal")
-     table.getAttribute("Mammal").should("exist")
- })
-     // // does set aside cases work? can we restore set aside cases? undo/redo?
-     // TODO: implement this test (blocker: need functionality of Set Aside Cases)
-     // PT: #187597833
-     // it.skip("tests for set aside cases with undo/redo", () => {
-     //   let initialRowCount, postInsertRowCount, postDeleteRowCount
+      // Verify all attributes are shown
+      table.getColumnHeader(1).should("contain", "Mammal")
+      table.getAttribute("Mammal").should("exist")
+    })
 
-     //   // Get initial row count
-     //   table.getNumOfRows().then(rowCount => {
-     //    initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-     //   })
+    // // does set aside cases work? can we restore set aside cases? undo/redo?
+    // TODO: implement this test (blocker: need functionality of Set Aside Cases)
+    // PT: #187597833
+    // it.skip("tests for set aside cases with undo/redo", () => {
+    //   let initialRowCount, postInsertRowCount, postDeleteRowCount
 
-     //   table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
-     //   table.getHideShowButton().click()
-     //   table.getDeleteMenuItem("Set Aside Unselected Cases").click()
+    //   // Get initial row count
+    //   table.getNumOfRows().then(rowCount => {
+    //    initialRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+    //   })
 
-     //   // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
-     //   table.getNumOfRows().then(rowCount => {
-     //     postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
-     //     expect(postInsertRowCount).to.eq(initialRowCount - 1 )
-     //   })
+    //   table.getGridCell(2, 2).should("contain", "African Elephant").click({ force: true })
+    //   table.getHideShowButton().click()
+    //   table.getDeleteMenuItem("Set Aside Unselected Cases").click()
 
-     //    // // checks for undo/redo
-     //    // cy.log("check for undo/redo after delete")
+    //   // Row count after delete all cases (assuming row count is set to 1 if no cases are in the table)
+    //   table.getNumOfRows().then(rowCount => {
+    //     postInsertRowCount = parseInt(rowCount, 10) // Added radix parameter 10 for decimal
+    //     expect(postInsertRowCount).to.eq(initialRowCount - 1 )
+    //   })
 
-     //    // // Undo delete
-     //    // toolbar.getUndoTool().click()
+    //    // // checks for undo/redo
+    //    // cy.log("check for undo/redo after delete")
 
-     //    // // Verify undo (check if row count is back to post-insert count)
-     //    // // TODO: add the check once bug is fixed (PT ##187597588)
-     //    // table.getNumOfRows().then(rowCount => {
-     //    //  const rowCountAfterUndo = parseInt(rowCount)
-     //    //  expect(rowCountAfterUndo).to.eq(postInsertRowCount)
-     //    // })
+    //    // // Undo delete
+    //    // toolbar.getUndoTool().click()
 
-     //    // // Redo delete
-     //    // toolbar.getRedoTool().click()
+    //    // // Verify undo (check if row count is back to post-insert count)
+    //    // // TODO: add the check once bug is fixed (PT ##187597588)
+    //    // table.getNumOfRows().then(rowCount => {
+    //    //  const rowCountAfterUndo = parseInt(rowCount)
+    //    //  expect(rowCountAfterUndo).to.eq(postInsertRowCount)
+    //    // })
 
-     //    // // Verify redo (check if row count is back to initial count)
-     //    // // TODO: add the check once bug is fixed (PT ##187597588)
-     //    //  table.getNumOfRows().then(rowCount => {
-     //    //  const rowCountAfterRedo = parseInt(rowCount)
-     //    //  expect(rowCountAfterRedo).to.eq(initialRowCount)
-     //    // })
+    //    // // Redo delete
+    //    // toolbar.getRedoTool().click()
 
+    //    // // Verify redo (check if row count is back to initial count)
+    //    // // TODO: add the check once bug is fixed (PT ##187597588)
+    //    //  table.getNumOfRows().then(rowCount => {
+    //    //  const rowCountAfterRedo = parseInt(rowCount)
+    //    //  expect(rowCountAfterRedo).to.eq(initialRowCount)
+    //    // })
 
-     // })
+    // })
 
-     it("check New Attribute from inspector menu with undo/redo", () => {
-       c.selectTile("table", 0)
-       table.getRulerButton().click()
-       table.getRulerMenuItem("New Attribute in Mammals...").click()
+    it("check New Attribute from inspector menu with undo/redo", () => {
+      c.selectTile("table", 0)
+      table.getRulerButton().click()
+      table.getRulerMenuItem("New Attribute in Mammals...").click()
 
-       // verify new attribute exists
-       table.getColumnHeaders().should("have.length.be.within", 10, 11)
-       table.getAttribute("newAttr").should("exist")
-       table.getAttribute("newAttr").click()
-       table.getAttribute("newAttr").should("have.text", "newAttr")
+      // verify new attribute exists
+      table.getColumnHeaders().should("have.length.be.within", 10, 11)
+      table.getAttribute("newAttr").should("exist")
+      table.getAttribute("newAttr").click()
+      table.getAttribute("newAttr").should("have.text", "newAttr")
 
-       cy.log("check undo/redo after add new attribute")
-       // Perform Undo operation
-       toolbar.getUndoTool().click()
+      cy.log("check undo/redo after add new attribute")
+      // Perform Undo operation
+      toolbar.getUndoTool().click()
 
-       // Test if attribute is removed
-       table.getColumnHeaders().should("have.length.be.within", 9, 10)
-       table.getAttribute("newAttr").should("not.exist")
+      // Test if attribute is removed
+      table.getColumnHeaders().should("have.length.be.within", 9, 10)
+      table.getAttribute("newAttr").should("not.exist")
 
-       // Perform Redo operation
-       toolbar.getRedoTool().click()
+      // Perform Redo operation
+      toolbar.getRedoTool().click()
 
-       // verify new attribute exists
-       table.getColumnHeaders().should("have.length.be.within", 10, 11)
-       table.getAttribute("newAttr").should("exist")
-       table.getAttribute("newAttr").click()
-       table.getAttribute("newAttr").should("have.text", "newAttr")
-   })
- })
+      // verify new attribute exists
+      table.getColumnHeaders().should("have.length.be.within", 10, 11)
+      table.getAttribute("newAttr").should("exist")
+      table.getAttribute("newAttr").click()
+      table.getAttribute("newAttr").should("have.text", "newAttr")
+    })
+  })
   describe("case table header attribute menu", () => {
     it("verify add attribute with undo and redo", ()=>{
       // Add new attribute using Add New Attribute button (+)
@@ -495,7 +495,6 @@ context("case table ui", () => {
       //  const rowCountAfterRedo = parseInt(rowCount)
       //  expect(rowCountAfterRedo).to.eq(initialRowCount)
       // })
-
     })
     it("verify insert cases before a row by typing num of cases", () => {
 
@@ -658,7 +657,6 @@ context("case table ui", () => {
       toolbar.getRedoTool().click()
       // Add assertions here to verify the case is deleted again
       // For example, check the number of rows or a specific row's content
-
     })
     it("verify insert multiple cases below current case at the top", () => {
       table.getCaseTableGrid().scrollTo("top")
@@ -685,7 +683,6 @@ context("case table ui", () => {
       toolbar.getRedoTool().click()
       // Add assertions here to verify the case is deleted again
       // For example, check the number of rows or a specific row's content
-
     })
     it("verify insert multiple cases above current case at the top", () => {
       table.getCaseTableGrid().scrollTo("top")
@@ -712,7 +709,6 @@ context("case table ui", () => {
       toolbar.getRedoTool().click()
       // Add assertions here to verify the case is deleted again
       // For example, check the number of rows or a specific row's content
-
     })
     it("verify delete first case", () => {
       table.getCaseTableGrid().scrollTo("top")
@@ -947,6 +943,4 @@ context("case table ui", () => {
       table.verifyCellSwatchColor(2, 2, "rgb(0, 255,")
     })
   })
-
-
 })

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -159,11 +159,11 @@ export const TableTileElements = {
     }
     this.getApplyButton().click()
   },
-  editDatasetInformation(source, date, description) {
+  editDatasetInformation(name, source, date, description) {
     this.getDatasetInfoButton().click()
-   //  if (name !== "") {
-  //     this.enterInfoName(`{selectAll}{backspace}${name}`)
-  //   }
+     if (name !== "") {
+       this.enterInfoName(`{selectAll}{backspace}${name}`)
+     }
     if (source != null) {
        this.enterInfoSource(`{selectAll}{backspace}${source}`)
       }
@@ -237,8 +237,17 @@ export const TableTileElements = {
   getDeleteCasesButton() {
     return c.getInspectorPanel().find("[data-testid=delete-cases-button]")
   },
+  getDeleteMenuItem(item: string) {
+    return cy.get("[data-testid=trash-menu-list] button").contains(item)
+  },
+  selectItemFromDeleteMenu(item: string) {
+    this.getDeleteMenuItem(item).click({ force: true })
+  },
   getHideShowButton() {
     return c.getInspectorPanel().find("[data-testid=hide-show-button]")
+  },
+  getHideShowMenuItem(item: string) {
+    return cy.get("[data-testid=hide-show-menu-list] button").contains(item)
   },
   getRulerButton() {
     return c.getInspectorPanel().find("[data-testid=ruler-button]")

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -138,7 +138,7 @@ export const TableTileElements = {
   editAttributeProperties(attr, name, description, type, unit, precision, editable) {
     this.openAttributeMenu(attr)
     this.selectMenuItemFromAttributeMenu("Edit Attribute Properties...")
-    if (name != "") {
+    if (name !== "") {
       this.enterAttributeName(`{selectAll}{backspace}${name}`)
     }
     if (description != null) {
@@ -160,7 +160,7 @@ export const TableTileElements = {
   },
   editDatasetInformation(name, source, date, description) {
     this.getDatasetInfoButton().click()
-    if (name != "") {
+    if (name !== "") {
        this.enterInfoName(`{selectAll}{backspace}${name}`)
     }
     if (source != null) {

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -117,11 +117,11 @@ export const TableTileElements = {
     cy.get("[data-testid=attr-editable-radio] span").contains(state).click()
   },
   // Edit Dataset Information Dialog
-   enterInfoName(name) {
-     cy.get("[data-testid=dataset-name-input]").type(name)
-   },
-   enterInfoSource(source) {
-    cy.get("[data-testid=dataset-source-input]").type(source)
+  enterInfoName(name) {
+    cy.get("[data-testid=dataset-name-input]").type(name)
+  },
+  enterInfoSource(source) {
+   cy.get("[data-testid=dataset-source-input]").type(source)
   },
   enterInfoDate(date) {
     cy.get("[data-testid=dataset-date-input]").type(date)
@@ -138,7 +138,7 @@ export const TableTileElements = {
   editAttributeProperties(attr, name, description, type, unit, precision, editable) {
     this.openAttributeMenu(attr)
     this.selectMenuItemFromAttributeMenu("Edit Attribute Properties...")
-    if (name !== "") {
+    if (name != "") {
       this.enterAttributeName(`{selectAll}{backspace}${name}`)
     }
     if (description != null) {
@@ -160,19 +160,19 @@ export const TableTileElements = {
   },
   editDatasetInformation(name, source, date, description) {
     this.getDatasetInfoButton().click()
-     if (name !== "") {
+    if (name != "") {
        this.enterInfoName(`{selectAll}{backspace}${name}`)
-     }
+    }
     if (source != null) {
        this.enterInfoSource(`{selectAll}{backspace}${source}`)
-      }
-      if (date != null) {
+    }
+    if (date != null) {
         this.enterInfoDate(`{selectAll}{backspace}${date}`)
-      }
-     if (description != null) {
-       this.enterInfoDescription(`{selectAll}{backspace}${description}`)
-     }
-     this.getApplyButton().click()
+    }
+    if (description != null) {
+      this.enterInfoDescription(`{selectAll}{backspace}${description}`)
+    }
+    this.getApplyButton().click()
    },
   getGridCell(row: number, column: number, collection = 1) {
     return this.getCollection(collection).find(`[aria-rowindex="${row}"] [aria-colindex="${column}"]`)

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -116,6 +116,20 @@ export const TableTileElements = {
   selectAttributeEditableState(state) {
     cy.get("[data-testid=attr-editable-radio] span").contains(state).click()
   },
+  // Edit Dataset Information Dialog
+  //TODO: fill this in
+   enterInfoName(name) {
+     cy.get("[data-testid=dataset-name-input]").type(name)
+   },
+   enterInfoSource(source) {
+    cy.get("[data-testid=dataset-source-input]").type(source)
+  },
+  enterInfoDate(date) {
+    cy.get("[data-testid=dataset-date-input]").type(date)
+  },
+  enterInfoDescription(description) {
+    cy.get("[data-testid=dataset-description-input]").type(description)
+  },
   getApplyButton() {
     return cy.get("[data-testid=Apply-button]")
   },
@@ -145,6 +159,22 @@ export const TableTileElements = {
     }
     this.getApplyButton().click()
   },
+  editDatasetInformation(source, date, description) {
+    this.getDatasetInfoButton().click()
+   //  if (name !== "") {
+  //     this.enterInfoName(`{selectAll}{backspace}${name}`)
+  //   }
+    if (source != null) {
+       this.enterInfoSource(`{selectAll}{backspace}${source}`)
+      }
+      if (date != null) {
+        this.enterInfoDate(`{selectAll}{backspace}${date}`)
+      }
+     if (description != null) {
+       this.enterInfoDescription(`{selectAll}{backspace}${description}`)
+     }
+     this.getApplyButton().click()
+   },
   getGridCell(row: number, column: number, collection = 1) {
     return this.getCollection(collection).find(`[aria-rowindex="${row}"] [aria-colindex="${column}"]`)
   },

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -193,7 +193,7 @@ export const TableTileElements = {
     return cy.get("[data-testid=case-table-toggle-view]")
   },
   getDatasetInfoButton() {
-    return c.getInspectorPanel().find("[data-testid=dataset-info-button]")
+    return c.getInspectorPanel().find("[data-testid=dataset-info-button]")//.click().find("[data-testid=dataset-name-input]")
   },
   getDatasetDescriptionTextArea() {
     return cy.get("[data-testid=dataset-description-input")

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -193,7 +193,7 @@ export const TableTileElements = {
     return cy.get("[data-testid=case-table-toggle-view]")
   },
   getDatasetInfoButton() {
-    return c.getInspectorPanel().find("[data-testid=dataset-info-button]")//.click().find("[data-testid=dataset-name-input]")
+    return c.getInspectorPanel().find("[data-testid=dataset-info-button]")
   },
   getDatasetDescriptionTextArea() {
     return cy.get("[data-testid=dataset-description-input")

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -117,7 +117,6 @@ export const TableTileElements = {
     cy.get("[data-testid=attr-editable-radio] span").contains(state).click()
   },
   // Edit Dataset Information Dialog
-  //TODO: fill this in
    enterInfoName(name) {
      cy.get("[data-testid=dataset-name-input]").type(name)
    },

--- a/v3/src/components/case-table/inspector-panel/dataset-info-modal.tsx
+++ b/v3/src/components/case-table/inspector-panel/dataset-info-modal.tsx
@@ -62,14 +62,14 @@ export const DatasetInfoModal = ({showInfoModal, setShowInfoModal}: IProps) => {
           </FormLabel>
           <FormLabel display="flex" flexDirection="row">{t("DG.CaseTable.datasetMetadata.url")}
             <Input size="xs" ml={5} placeholder="source" value={sourceName} onFocus={(e) => e.target.select()}
-                  onChange={event => setSourceName(event.target.value)} data-testid="dataset-name-input"
+                  onChange={event => setSourceName(event.target.value)} data-testid="dataset-source-input"
                   onKeyDown={(e) => e.stopPropagation()}
             />
           </FormLabel>
           <FormLabel display="flex" flexDirection="row" overflow="no-wrap">
               {t("DG.CaseTable.datasetMetadata.creationDate")}
             <Input size="xs" ml={5} placeholder="date" value={importDate} onFocus={(e) => e.target.select()}
-                  onChange={event => setImportDate(event.target.value)} data-testid="dataset-name-input"
+                  onChange={event => setImportDate(event.target.value)} data-testid="dataset-date-input"
                   onKeyDown={(e) => e.stopPropagation()}
             />
           </FormLabel>


### PR DESCRIPTION
[PT 186227299](https://www.pivotaltracker.com/story/show/186227299) Automation for Inspector menu options of case table

This PR is an initial pass on Automation for Inspector menu options in the case table. The tests include:

- should open dataset information button and make changes 
- select a case and delete the case from inspector menu 
- select a case and delete unselected cases from inspector menu 
- check delete all cases from inspector menu
- check hide/show attribute from inspector menu
- check New Attribute from inspector menu with undo/redo

I also added `cy.log()` in `table.spec.ts` for the tests that include undo/redo since that wasn't there initially in the code.

Note the missing undo/redo checks due to [PT 187597588](https://www.pivotaltracker.com/story/show/187597588).

Also I noticed it looks like we haven't worked on Set Aside Cases yet? I added a PT story here for that: [PT 187597833](https://www.pivotaltracker.com/story/show/187597833)

Jest is complaining about the variables with lines like `'initialRowCount' is assigned a value but never used`. I don't know why Cypress is forcing that those variables are there, but if I take the variables out the tests stop working. ¯\_ (ツ)_/¯ Let me know if there are easy fixes here!

I've added two more data-ids to the code for opening the Information button. Please let me know if this causes any issues; otherwise, I'll assume everything is working fine.