### PR TITLE
fix: Graph has option to Display Only Selected Cases (PT-187458777)

### DIFF
--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -17,6 +17,11 @@ export type ChoroplethLegendProps = {
 
 type ChoroplethScale = ScaleQuantile<string>
 export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElement, props: ChoroplethLegendProps) {
+  if (scale.domain().length === 0) {
+    select(choroplethElt).selectAll("*").remove()
+    return
+  }
+
   const {
       tickSize = 6, transform = '', width = 320, marginTop = 0, marginRight = 0, marginLeft = 0,
       ticks = 5, clickHandler, casesInQuantileSelectedHandler

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -45,13 +45,19 @@ export const NumericLegend =
       }
 
       if (choroplethElt) {
-        // If some or all cases are hidden, the legend should still reflect the full range of values for both hidden
-        // and visible cases.
-        // TODO: When all visible cases have the exact same value for the legend attribute, the legend should only
-        // reflect the values of the cases shown.
+        /**
+         *  Adjust the value range displayed by the legend based on the data configuration model's properties:
+         *  1. If `displayOnlySelectedCases` is true and not all cases are visible, the legend displays the range of all
+         *     cases, both hidden and visible.
+         *  2. If `displayOnlySelectedCases` is false, and some cases are explicitly hidden by the user, the legend
+         *     displays the range of only the visible cases.
+         *  3. If all cases are hidden, the legend displays no range.
+         */
         const allCasesCount = dataConfiguration?.dataset?.cases.length ?? 0
-        let values = dataConfiguration?.numericValuesForAttrRole("legend") ?? []
-        if (values.length < allCasesCount) {
+        const hiddenCasesCount = dataConfiguration?.hiddenCases.length ?? 0
+        const allCasesHidden = hiddenCasesCount === allCasesCount
+        let values = allCasesHidden ? [] : dataConfiguration?.numericValuesForAttrRole("legend") ?? []
+        if (dataConfiguration?.displayOnlySelectedCases && !allCasesHidden && values.length < allCasesCount) {
           const attribute = dataConfiguration?.dataset?.attrFromID(dataConfiguration?.attributeID("legend"))
           values = attribute?.numValues ?? []
         }

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -47,21 +47,26 @@ export const NumericLegend =
       if (choroplethElt) {
         /**
          *  Adjust the value range displayed by the legend based on the data configuration model's properties:
-         *  1. If `displayOnlySelectedCases` is true and not all cases are visible, the legend displays the range of all
+         *  1. If all cases are hidden, the legend displays no range.
+         *  2. If `displayOnlySelectedCases` is true and not all cases are visible, the legend displays the range of all
          *     cases, both hidden and visible.
-         *  2. If `displayOnlySelectedCases` is false, and some cases are explicitly hidden by the user, the legend
-         *     displays the range of only the visible cases.
-         *  3. If all cases are hidden, the legend displays no range.
+         *  3. Otherwise, the legend displays the range of only the visible cases.
+         *  
+         *  TODO: When `displayOnlySelectedCases` is true and all visible cases have the exact same value for the legend
+         *  attribute, the legend should only reflect the values of the case(s) shown.
          */
         const allCasesCount = dataConfiguration?.dataset?.cases.length ?? 0
         const hiddenCasesCount = dataConfiguration?.hiddenCases.length ?? 0
         const allCasesHidden = hiddenCasesCount === allCasesCount
-        let values = allCasesHidden ? [] : dataConfiguration?.numericValuesForAttrRole("legend") ?? []
-        if (dataConfiguration?.displayOnlySelectedCases && !allCasesHidden && values.length < allCasesCount) {
+        if (allCasesHidden) {
+          valuesRef.current = []
+        } else if (dataConfiguration?.displayOnlySelectedCases && hiddenCasesCount > 0) {
           const attribute = dataConfiguration?.dataset?.attrFromID(dataConfiguration?.attributeID("legend"))
-          values = attribute?.numValues ?? []
+          valuesRef.current = attribute?.numValues ?? []
+        } else {
+          valuesRef.current = dataConfiguration?.numericValuesForAttrRole("legend") ?? []
         }
-        valuesRef.current = values
+
         setDesiredExtent(layerIndex, computeDesiredExtent())
         quantileScale.current.domain(valuesRef.current).range(schemeBlues[5])
         choroplethLegend(quantileScale.current, choroplethElt,


### PR DESCRIPTION
[#187458777](https://www.pivotaltracker.com/story/show/187458777)

These changes fix two bugs:

1. In graphs with a numeric legend, if Display Only Selected Cases is activated while there are no cases selected, the legend shows `NaN` for the values. There was some offline discussion about this behavior since there is a similar bug in V2. When Display Only Selected Cases is activated, the desired behavior is that numeric legends should always reflect the full range of all case values regardless of whether some or all are displayed. The only exception is when there is either one case displayed or two or more cases displayed that all have the same value for the legend attribute. In that case, the legend should only reflect that value. The changes here do not support that exception. Adding that will be done in a [separate story](https://www.pivotaltracker.com/story/show/187605700). Note that when cases are otherwise hidden by the user (using the Hide Unselected Cases option), a numeric legend should always display the range of values for only the cases that are not hidden (i.e. not the full range).

2. In a graph tile with no attributes added, if Display Only Selected Cases is activated while there are no cases selected, and a numeric attribute is added to the x or y axis, and then a case is selected in the table cell, the axis domain does not get updated and the case dot that appears remains in the upper left corner of the plot.

[Description edited after a [comment from bfinzer](https://github.com/concord-consortium/codap/pull/1258#issuecomment-2113013945).]