### PR TITLE
added tests for undo/redo after renaming slider component

### DIFF
--- a/v3/cypress/e2e/slider.spec.ts
+++ b/v3/cypress/e2e/slider.spec.ts
@@ -31,7 +31,7 @@ context("Slider UI", () => {
     // slider.getSliderAxis().should("not.be.visible")
 
     // // redo should work after undo
-    // // use force:true here because undo button is incorrectly faded out here
+    // // use force:true here because redo button is incorrectly faded out here
     // toolbar.getRedoTool().click({force: true})
     // slider.getSliderAxis().should("be.visible")
 

--- a/v3/cypress/e2e/slider.spec.ts
+++ b/v3/cypress/e2e/slider.spec.ts
@@ -22,13 +22,35 @@ context("Slider UI", () => {
     slider.checkPlayButtonIsPaused()
     slider.getSliderThumbIcon().should("be.visible")
     slider.getSliderAxis().should("be.visible")
+
+    // // undo should work after opening the Slider
+    // // TODO: add back this code (blocker: #187612762)
+    // cy.log("check for undo/redo after opening Slider component")
+    // // use force:true here because undo button is incorrectly faded out here
+    // toolbar.getUndoTool().click({force: true})
+    // slider.getSliderAxis().should("not.be.visible")
+
+    // // redo should work after undo
+    // // use force:true here because undo button is incorrectly faded out here
+    // toolbar.getRedoTool().click({force: true})
+    // slider.getSliderAxis().should("be.visible")
+
   })
-  it("updates slider title", () => {
+  it("updates slider title with undo/redo", () => {
     const newSliderName = "abc"
+    const oldSliderName = "v1"
     c.getComponentTitle("slider").should("have.text", sliderName)
     c.changeComponentTitle("slider", newSliderName)
     c.getComponentTitle("slider").should("have.text", newSliderName)
     slider.getVariableName().should("have.text", sliderName)
+
+    // undo should work after renaming the component
+    cy.log("check for undo/redo after renaming Slider component")
+    toolbar.getUndoTool().click()
+    c.getComponentTitle("slider").should("have.text", oldSliderName)
+
+    toolbar.getRedoTool().click()
+    c.getComponentTitle("slider").should("have.text", newSliderName)
   })
   it("updates variable name", () => {
     slider.getVariableName().should("have.text", "v1")


### PR DESCRIPTION
[PT 186227302: Automation for Inspector menu options of slider](https://www.pivotaltracker.com/story/show/186227302)

For this story, the task as I understand it is to add checks for the Inspector Panel of the Slider.

These tests, however, seem to be covered in the following tests of `slider.spec`:
* `plays with restricting multiples`  (this changes the "Restrict to Multiples of" tool in the Inspector panel and "Set Animation Rate")
* `checks min max slider values`
* `replays from initial value once it reaches the end`
* `plays low to high animation direction`
* `plays back and forth animation direction`
* `plays high to low animation direction`
* `plays nonstop`

While in there, however, I did notice undo/redo tests were missing, so I added them where appropriate.