### PR TITLE
fix: replace autorun with mstAutorun to eliminate MST warning

### DIFF
--- a/v3/src/components/data-display/components/attribute-label.tsx
+++ b/v3/src/components/data-display/components/attribute-label.tsx
@@ -1,12 +1,13 @@
-import { autorun } from "mobx"
 import React, { ForwardedRef, forwardRef, useEffect, useState } from "react"
 import { createPortal } from "react-dom"
 import { IDataSet } from "../../../models/data/data-set"
 import {kPortalClassSelector} from "../data-display-types"
 import { GraphPlace } from "../../axis-graph-shared"
 import { useDataDisplayLayout } from "../hooks/use-data-display-layout"
+import { useDataDisplayModelContext } from "../hooks/use-data-display-model"
 import { AxisOrLegendAttributeMenu } from "../../axis/components/axis-or-legend-attribute-menu"
 import { AttributeType } from "../../../models/data/attribute"
+import { mstAutorun } from "../../../utilities/mst-autorun"
 
 import "./attribute-label.scss"
 
@@ -23,11 +24,12 @@ export const AttributeLabel = forwardRef((props: IProps, labelRef: ForwardedRef<
   // labelRef must be a MutableRefObject, not a function
   const labelElt = typeof labelRef !== "function" ? labelRef?.current ?? null : null
   const portal = labelElt?.closest(kPortalClassSelector) as HTMLDivElement ?? null
+  const contentModel = useDataDisplayModelContext()
   const layout = useDataDisplayLayout()
   const [ , setLayoutBounds] = useState("")
 
   useEffect(() => {
-    return autorun(() => {
+    return mstAutorun(() => {
       // accessing layout triggers autorun on change
       const bounds = layout.getComputedBounds(place)
       const layoutBounds = JSON.stringify(bounds)
@@ -35,8 +37,8 @@ export const AttributeLabel = forwardRef((props: IProps, labelRef: ForwardedRef<
       setLayoutBounds(layoutBounds)
       // render label and trigger autorun on change to observables within
       refreshLabel()
-    }, { name: "AttributeLabel.autorun [refreshLabel]" })
-  }, [layout, place, refreshLabel])
+    }, { name: "AttributeLabel.autorun [refreshLabel]" }, contentModel)
+  }, [contentModel, layout, place, refreshLabel])
 
   return (
     <>


### PR DESCRIPTION
[[PT-187615908]](https://www.pivotaltracker.com/story/show/187615908)

Rather than trying to recall the steps, I followed them to make sure I got them right and have documented them here and in the corresponding PT story for future reference:

1. The first console warning occurs in `graph-attribute-label.tsx` line 45 in my version (47 in yours above), which is the `getClickHereCue` method.
2. I tried setting a breakpoint there, but it triggers too often, so instead I added this line at the top of the function
  - `if (!isAlive(graphModel)) debugger`
3. When the breakpoint is hit, scan the stack trace to find the autorun or reaction that is triggering after the model has been destroyed.
4. In this case, it’s the one named `AttributeLabel.autorun [refreshLabel]` in `attribute-label.tsx`.
5. We need to use `mstAutorun` so that the disposer is called when the model goes away.
6. That component doesn’t currently make use of the content model, but can get it with `useDataDisplayModelContext`.
7. Switching to `mstAutorun` and passing in the `contentModel` eliminates the warning.