### PR TITLE
Fix map bug where initial scale is not correct

### DIFF
--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -22,11 +22,12 @@ export interface IProps extends ITileBaseProps {
   onRightPointerDown?: (e: React.PointerEvent) => void
   onBottomPointerDown?: (e: React.PointerEvent) => void
   onLeftPointerDown?: (e: React.PointerEvent) => void
+  onEndTransitionRef: React.MutableRefObject<() => void> // Called once at close of first component size transition
 }
 
 export const CodapComponent = observer(function CodapComponent({
   tile, isMinimized, onMinimizeTile, onCloseTile, onBottomRightPointerDown, onBottomLeftPointerDown,
-  onRightPointerDown, onBottomPointerDown, onLeftPointerDown
+  onRightPointerDown, onBottomPointerDown, onLeftPointerDown, onEndTransitionRef
 }: IProps) {
   const info = getTileComponentInfo(tile.content.type)
 
@@ -48,7 +49,7 @@ export const CodapComponent = observer(function CodapComponent({
       <div className={classes} key={tile.id} data-testid={tileEltClass}
         onFocus={handleFocusTile} onPointerDownCapture={handleFocusTile}>
         <TitleBar tile={tile} onMinimizeTile={onMinimizeTile} onCloseTile={onCloseTile}/>
-        <Component tile={tile} isMinimized={isMinimized} />
+        <Component tile={tile} isMinimized={isMinimized} onEndTransitionRef = {onEndTransitionRef} />
         {onRightPointerDown && !isFixedWidth && !isMinimized &&
           <div className="codap-component-border right" onPointerDown={onRightPointerDown}/>}
         {onBottomPointerDown && !isFixedHeight && !isMinimized &&

--- a/v3/src/components/container/mosaic-tile-row.tsx
+++ b/v3/src/components/container/mosaic-tile-row.tsx
@@ -1,6 +1,6 @@
 import { clsx } from "clsx"
 import { observer } from "mobx-react-lite"
-import React from "react"
+import React, { useRef } from "react"
 import { IMosaicTileRow, IMosaicTileNode } from "../../models/document/mosaic-tile-row"
 import { getTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { ITileModel } from "../../models/tiles/tile-model"
@@ -105,11 +105,12 @@ export const MosaicTileComponent = observer(
   const style = styleFromExtent({ direction, pctExtent })
   const tileType = tile.content.type
   const info = getTileComponentInfo(tileType)
+  const onEndTransitionRef = useRef<() => void>(() => {})
 
   return (
     <div className="mosaic-tile-component" style={style} >
       {tile && info &&
-        <CodapComponent tile={tile} onCloseTile={onCloseTile}/>
+        <CodapComponent tile={tile} onCloseTile={onCloseTile} onEndTransitionRef={onEndTransitionRef}/>
       }
     </div>
   )

--- a/v3/src/components/map/components/codap-map.tsx
+++ b/v3/src/components/map/components/codap-map.tsx
@@ -23,9 +23,10 @@ import "./map.scss"
 
 interface IProps {
   mapRef: MutableRefObject<HTMLDivElement | null>
+  onEndTransitionRef?: React.MutableRefObject<() => void>
 }
 
-export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
+export const CodapMap = observer(function CodapMap({mapRef, onEndTransitionRef}: IProps) {
   const mapModel = useMapModelContext(),
     layout = useDataDisplayLayout(),
     mapHeight = layout.contentHeight,
@@ -90,7 +91,7 @@ export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
               })
             }
           </>
-          <MapInterior pixiPointsArrayRef={pixiPointsArrayRef}/>
+          <MapInterior pixiPointsArrayRef={pixiPointsArrayRef} onEndTransitionRef={onEndTransitionRef}/>
         </MapContainer>
         <MapBackground mapModel={mapModel} pixiPointsArrayRef={pixiPointsArrayRef}/>
       </div>

--- a/v3/src/components/map/components/map-component.tsx
+++ b/v3/src/components/map/components/map-component.tsx
@@ -6,13 +6,13 @@ import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-
 import { selectAllCases } from '../../../models/data/data-set-utils'
 import {DataDisplayLayoutContext} from "../../data-display/hooks/use-data-display-layout"
 import {AttributeDragOverlay} from "../../drag-drop/attribute-drag-overlay"
-import {ITileBaseProps} from '../../tiles/tile-base-props'
+import { ITileComponentBaseProps } from '../../tiles/tile-base-props'
 import {isMapContentModel} from "../models/map-content-model"
 import {MapModelContext} from "../hooks/use-map-model-context"
 import {useInitMapLayout} from "../hooks/use-init-map-layout"
 import {CodapMap} from "./codap-map"
 
-export const MapComponent = observer(function MapComponent({tile}: ITileBaseProps) {
+export const MapComponent = observer(function MapComponent({tile, onEndTransitionRef}: ITileComponentBaseProps) {
   const mapModel = isMapContentModel(tile?.content) ? tile?.content : undefined
 
   const instanceId = useNextInstanceId("map")
@@ -29,7 +29,7 @@ export const MapComponent = observer(function MapComponent({tile}: ITileBaseProp
       })
       return () => mapModel.leafletMapState.setOnClickCallback()
     }
-  }, [mapModel])
+  }, [mapModel, onEndTransitionRef])
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setTileExtent(width, height)
@@ -50,7 +50,7 @@ export const MapComponent = observer(function MapComponent({tile}: ITileBaseProp
     <InstanceIdContext.Provider value={instanceId}>
       <DataDisplayLayoutContext.Provider value={layout}>
         <MapModelContext.Provider value={mapModel}>
-          <CodapMap mapRef={mapRef}/>
+          <CodapMap mapRef={mapRef} onEndTransitionRef={onEndTransitionRef}/>
           <AttributeDragOverlay activeDragId={overlayDragId}/>
         </MapModelContext.Provider>
       </DataDisplayLayoutContext.Provider>

--- a/v3/src/components/map/components/map-interior.tsx
+++ b/v3/src/components/map/components/map-interior.tsx
@@ -12,12 +12,13 @@ import { DataConfigurationContext } from "../../data-display/hooks/use-data-conf
 
 interface IProps {
   pixiPointsArrayRef:  React.MutableRefObject<PixiPoints[]>
+  onEndTransitionRef?: React.MutableRefObject<() => void>
 }
 
-export const MapInterior = observer(function MapInterior({pixiPointsArrayRef}: IProps) {
+export const MapInterior = observer(function MapInterior({pixiPointsArrayRef, onEndTransitionRef}: IProps) {
   const mapModel = useMapModelContext()
 
-  useMapModel()
+  useMapModel(onEndTransitionRef)
 
   const onSetPixiPointsForLayer = useCallback((pixiPoints: PixiPoints, layerIndex: number) => {
     pixiPointsArrayRef.current[layerIndex] = pixiPoints

--- a/v3/src/components/map/models/leaflet-map-state.ts
+++ b/v3/src/components/map/models/leaflet-map-state.ts
@@ -86,6 +86,26 @@ export class LeafletMapState {
   }
 
   @action
+  setZoom(zoom: number) {
+    this.zoom = zoom
+  }
+
+  @action
+  setCenter(center: LatLng) {
+    this.center = center
+  }
+
+  @action
+  setIsZooming(isZooming: boolean) {
+    this.isZooming = isZooming
+  }
+
+  @action
+  setIsMoving(isMoving: boolean) {
+    this.isMoving = isMoving
+  }
+
+  @action
   setOnClickCallback(onClick?: (event: MouseEvent) => void) {
     this.onClick = onClick
   }
@@ -97,35 +117,35 @@ export class LeafletMapState {
   @action
   handleMoveStart() {
     if (!this.isChanging) this.startLeafletInteraction("DG.Undo.map.pan", "DG.Redo.map.pan")
-    this.isMoving = true
+    this.setIsMoving(true)
   }
 
   @action
   handleMove() {
-    this.center = this.leafletMap?.getCenter()
+    this.setCenter(this.leafletMap?.getCenter() ?? new LatLng(0, 0))
   }
 
   @action
   handleMoveEnd() {
     this.completeInProgressChanges()
-    this.isMoving = false
+    this.setIsMoving(false)
   }
 
   @action
   handleZoomStart() {
     if (!this.isChanging) this.startLeafletInteraction("DG.Undo.map.zoom", "DG.Redo.map.zoom")
-    this.isZooming = true
+    this.setIsZooming(true)
   }
 
   @action
   handleZoom() {
-    this.zoom = this.leafletMap?.getZoom()
+    this.setZoom(this.leafletMap?.getZoom() ?? 0)
   }
 
   @action
   handleZoomEnd() {
     this.completeInProgressChanges()
-    this.isZooming = false
+    this.setIsZooming(false)
   }
 
   installHandlers() {

--- a/v3/src/components/tiles/tile-base-props.ts
+++ b/v3/src/components/tiles/tile-base-props.ts
@@ -6,6 +6,10 @@ export interface ITileBaseProps {
   isMinimized?: boolean
 }
 
+export interface ITileComponentBaseProps extends ITileBaseProps {
+  onEndTransitionRef?: React.MutableRefObject<() => void>
+}
+
 export interface ITileTitleBarProps extends ITileBaseProps {
   // pass accessor function so that only title bar is re-rendered when title changes
   getTitle?: () => string | undefined

--- a/v3/src/models/tiles/tile-component-info.ts
+++ b/v3/src/models/tiles/tile-component-info.ts
@@ -1,5 +1,9 @@
 import React, { SVGProps } from "react"
-import { ITileBaseProps, ITileInspectorPanelProps, ITileTitleBarProps } from "../../components/tiles/tile-base-props"
+import {
+  ITileComponentBaseProps,
+  ITileInspectorPanelProps,
+  ITileTitleBarProps
+} from "../../components/tiles/tile-base-props"
 import { type IToolShelfTileButtonProps } from "../../components/tool-shelf/tool-shelf-button"
 
 export interface IToolShelfOptions {
@@ -12,7 +16,7 @@ export interface IToolShelfOptions {
 export interface ITileComponentInfo {
   type: string;
   TitleBar: React.ComponentType<ITileTitleBarProps>;
-  Component: React.ComponentType<ITileBaseProps>;
+  Component: React.ComponentType<ITileComponentBaseProps>;
   InspectorPanel?: React.ComponentType<ITileInspectorPanelProps>;
   tileEltClass: string;
   Icon?: React.FC<SVGProps<SVGSVGElement>>;


### PR DESCRIPTION
[#187620092] Bug fix: Map component zoom range not framed around dataset 

* This bug is a side effect of using animation on creation of components. The map scales according to the data before the animation but during that animation the portion of the map that is displayed becomes larger and the data points and polygons are left behind. Though there may be a more straightforward way, I found I could fix the problem as follows:
  * In `FreeTileComponent` 
    * hold onto the `<div/>` element
    * In a `useEffect`, set an event listener on the div to detect "transitionend"
    * Pass a ref to a function to call when transitionend is detected down to the component to be filled in by the component
    * In the listener, if the function ref has been filled out, call it. Regardless, remove the event listener immediately so it won't be triggered by any subsequent transitions
  * The map component is, of course, the only component that installs a function. But the map component has to pass the ref all the way down to `MapInterior` because we don't want the function installed if the map already has a zoom and/or position. It is in `useMapModel` that we can detect this condition and install the function accordingly.
  * We have to deal with properties of `MosaicTileRow` even though we don't actually use that component anywhere.
  * Maybe there's some less convoluted way to bring this about?