### PR TITLE
fix: MST warning on closing map component

### DIFF
--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useEffect, useRef} from "react"
 import {comparer, reaction} from "mobx"
 import { observer } from "mobx-react-lite"
+import { isAlive } from "mobx-state-tree"
 import * as PIXI from "pixi.js"
 import {mstReaction} from "../../../utilities/mst-reaction"
 import {onAnyAction} from "../../../utilities/mst-utils"
@@ -33,7 +34,7 @@ interface IProps {
 
 export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onSetPixiPointsForLayer}: IProps) {
   const {dataConfiguration, pointDescription} = mapLayerModel,
-    dataset = dataConfiguration?.dataset,
+    dataset = isAlive(dataConfiguration) ? dataConfiguration?.dataset : undefined,
     mapModel = useMapModelContext(),
     {isAnimating} = useDataDisplayAnimation(),
     leafletMap = useMap(),


### PR DESCRIPTION
[[PT-187628522]](https://www.pivotaltracker.com/story/show/187628522)

1. The warning indicates that the error occurs in the `selection` method at `DataConfigurationModel` line 222.
2. Adding `if (!isAlive(self)) debugger` at that line yields the stack trace in the enclosed screen shot.
3. Clicking on the `runReaction_` line in the debugger results in the following `scope` section of the debugger, as seen in the next screen shot.
4. From this, we can see that the reaction in question is named `observerMapPointLayer`.
5. This string doesn't appear in the code because that's the name given to `observer` components, so the reaction in question is the `MapPointLayer` component which is an `observer`.
6. The fix is to test `isAlive` before dereferencing the `dataConfiguration` because there isn't a good way to tell an `observer` component to stop observing.

<img width="821" alt="MSTWarning" src="https://github.com/concord-consortium/codap/assets/235234/dea1788f-4727-4310-aef9-1add9e79d90d">

<img width="458" alt="MSTWarningScope" src="https://github.com/concord-consortium/codap/assets/235234/3cb4744a-ba0e-4f09-9fce-81fc5cc1df3b">
