### PR TITLE
187637447 v3 DI caseByID and caseByIndex Requests

### DIFF
--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -2,6 +2,7 @@ import { RequireAtLeastOne } from "type-fest"
 import { IAttribute } from "../models/data/attribute"
 import { ICodapV2Attribute, ICodapV2AttributeV3, ICodapV2Collection, ICodapV2DataContext } from "../v2/codap-v2-types"
 import { IDataSet } from "../models/data/data-set"
+import { ICase } from "../models/data/data-set-types"
 import { IGlobalValue } from "../models/global/global-value"
 import { ITileModel } from "../models/tiles/tile-model"
 import { ICollectionPropsModel } from "../models/data/collection"
@@ -79,6 +80,9 @@ export interface DINewCase {
   id?: number
   itemID?: number
 }
+export interface DIUpdateCase {
+  values: DICaseValues
+}
 export interface DINotification {
   request?: string
 }
@@ -87,8 +91,8 @@ export interface DIResources {
   attribute?: IAttribute
   attributeList?: IAttribute[]
   attributeLocation?: IAttribute
-  caseByID?: DICase
-  caseByIndex?: DICase
+  caseByID?: ICase
+  caseByIndex?: ICase
   caseFormulaSearch?: DICase[]
   caseSearch?: DICase[]
   collection?: ICollectionPropsModel
@@ -107,7 +111,7 @@ export interface DIResources {
 
 // types for values accepted as inputs by the API
 export type DISingleValues = DIAttribute | DICase | DIDataContext |
-  DIGlobal | DIInteractiveFrame | DINewCase | DINotification | V2Component
+  DIGlobal | DIInteractiveFrame | DINewCase | DIUpdateCase | DINotification | V2Component
 export type DIValues = DISingleValues | DISingleValues[] | number | string[]
 
 // types returned as outputs by the API
@@ -160,6 +164,8 @@ export interface DIResourceSelector {
   attributeLocation?: string
   attributes?: string
   case?: string
+  caseByID?: string
+  caseByIndex?: string
   collection?: string
   component?: string
   dataContext?: string

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -60,6 +60,19 @@ export interface DIGlobal {
   value?: number
 }
 export type DIDataContext = Partial<ICodapV2DataContext>
+export interface DIGetCaseResult {
+  case: {
+    id?: number
+    parent?: number
+    collection?: {
+      id?: number
+      name?: string
+    }
+    values?: DICaseValues
+    children?: number[]
+  }
+  caseIndex?: number
+}
 export interface DIInteractiveFrame {
   dimensions?: {
     height?: number
@@ -116,7 +129,7 @@ export type DIValues = DISingleValues | DISingleValues[] | number | string[]
 
 // types returned as outputs by the API
 export type DIResultAttributes = { attrs: ICodapV2AttributeV3[] }
-export type DIResultSingleValues = DICase | DIComponentInfo | DIGlobal | DIInteractiveFrame
+export type DIResultSingleValues = DICase | DIComponentInfo |  DIGetCaseResult | DIGlobal | DIInteractiveFrame
 export type DIResultValues = DIResultSingleValues | DIResultSingleValues[] |
                               DIAllCases | DIResultAttributes | number
 

--- a/v3/src/data-interactive/handlers/all-cases-handler.ts
+++ b/v3/src/data-interactive/handlers/all-cases-handler.ts
@@ -2,11 +2,12 @@ import { registerDIHandler } from "../data-interactive-handler"
 import { getCaseValues } from "../data-interactive-utils"
 import { DIHandler, DIResources } from "../data-interactive-types"
 import { maybeToV2Id, toV2Id } from "../../utilities/codap-utils"
+import { collectionNotFoundResult, dataContextNotFoundResult } from "./di-results"
 
 export const diAllCasesHandler: DIHandler = {
   delete(resources: DIResources) {
     const { dataContext } = resources
-    if (!dataContext) return { success: false }
+    if (!dataContext) return dataContextNotFoundResult
 
     dataContext.applyModelChange(() => {
       dataContext.removeCases(dataContext.cases.map(c => c.__id__))
@@ -18,7 +19,8 @@ export const diAllCasesHandler: DIHandler = {
   },
   get(resources: DIResources) {
     const { collection, dataContext } = resources
-    if (!collection || !dataContext) return { success: false }
+    if (!dataContext) return dataContextNotFoundResult
+    if (!collection) return collectionNotFoundResult
 
     const cases = dataContext.getGroupsForCollection(collection.id)?.map((c, caseIndex) => {
       const id = c.pseudoCase.__id__

--- a/v3/src/data-interactive/handlers/attribute-list-handler.ts
+++ b/v3/src/data-interactive/handlers/attribute-list-handler.ts
@@ -1,12 +1,12 @@
-import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { basicAttributeInfo } from "../data-interactive-type-utils"
 import { DIHandler, DIResources } from "../data-interactive-types"
+import { collectionNotFoundResult } from "./di-results"
 
 export const diAttributeListHandler: DIHandler = {
   get(resources: DIResources) {
     const { attributeList } = resources
-    if (!attributeList) return { success: false, values: { error: t("V3.DI.Error.collectionNotFound") } }
+    if (!attributeList) return collectionNotFoundResult
 
     return {
       success: true,

--- a/v3/src/data-interactive/handlers/case-by-handler-functions.ts
+++ b/v3/src/data-interactive/handlers/case-by-handler-functions.ts
@@ -1,0 +1,50 @@
+import { ICase } from "../../models/data/data-set-types"
+import { t } from "../../utilities/translation/translate"
+import { DIResources, DIUpdateCase, DIValues } from "../data-interactive-types"
+import { getCaseRequestResultValues } from "../data-interactive-type-utils"
+import { attrNamesToIds } from "../data-interactive-utils"
+import { caseNotFoundResult, dataContextNotFoundResult } from "./di-results"
+
+export function deleteCaseBy(resources: DIResources, aCase?: ICase) {
+  const { dataContext } = resources
+  if (!dataContext) return dataContextNotFoundResult
+  if (!aCase) return caseNotFoundResult
+
+  const pseudoCase = dataContext.pseudoCaseMap.get(aCase.__id__)
+  const cases = pseudoCase?.childCaseIds ?? [aCase.__id__]
+
+  dataContext.applyModelChange(() => {
+    dataContext.removeCases(cases)
+  })
+
+  return { success: true }
+}
+
+export function getCaseBy(resources: DIResources, aCase?: ICase) {
+  const { dataContext } = resources
+  if (!dataContext) return dataContextNotFoundResult
+  if (!aCase) return caseNotFoundResult
+
+  return { success: true, values: getCaseRequestResultValues(aCase, dataContext) } as const
+}
+
+export function updateCaseBy(resources: DIResources, values?: DIValues, aCase?: ICase) {
+  const { dataContext } = resources
+  if (!dataContext) return dataContextNotFoundResult
+  if (!aCase) return caseNotFoundResult
+
+  const missingFieldResult = {
+    success: false,
+    values: { error: t("V3.DI.Error.fieldRequired", { vars: ["update", "caseByID/Index", "values.values"] }) }
+  } as const
+  if (!values) return missingFieldResult
+  const updateCase = values as DIUpdateCase
+  if (!updateCase.values) return missingFieldResult
+
+  dataContext.applyModelChange(() => {
+    const updatedAttributes = attrNamesToIds(updateCase.values, dataContext)
+    dataContext.setCaseValues([{ ...updatedAttributes, __id__: aCase.__id__ }])
+  })
+
+  return { success: true }
+}

--- a/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
@@ -7,9 +7,10 @@ describe("DataInteractive CaseByIDHandler", () => {
   const handler = diCaseByIDHandler
   function setup() {
     const { dataset, a3 } = setupTestDataset()
+    // eslint-disable-next-line no-unused-expressions
     dataset.collectionGroups
     const aCase = dataset.getCaseAtIndex(4)
-    const caseId = aCase?.__id__!
+    const caseId = aCase!.__id__
     const pseudoCase = Array.from(dataset.pseudoCaseMap.values())[1].pseudoCase
     const pseudoCaseId = pseudoCase.__id__
     return { dataContext: dataset, aCase, caseId, pseudoCase, pseudoCaseId, a3 }

--- a/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
@@ -1,0 +1,30 @@
+import { maybeToV2Id } from "../../utilities/codap-utils"
+import { DIGetCaseResult } from "../data-interactive-types"
+import { diCaseByIDHandler } from "./case-by-id-handler"
+import { setupTestDataset } from "./handler-test-utils"
+
+describe("DataInteractive CaseByIDHandler", () => {
+  const handler = diCaseByIDHandler
+  function setup() {
+    const { dataset } = setupTestDataset()
+    dataset.collectionGroups
+    const aCase = dataset.getCaseAtIndex(4)
+    const caseId = aCase?.__id__
+    const pseudoCase = Array.from(dataset.pseudoCaseMap.values())[0].pseudoCase
+    const pseudoCaseId = pseudoCase.__id__
+    return { dataContext: dataset, aCase, caseId, pseudoCase, pseudoCaseId }
+  }
+
+  it("get works as expected", () => {
+    const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId } = setup()
+    expect(handler.get?.({})?.success).toBe(false)
+    expect(handler.get?.({ dataContext })?.success).toBe(false)
+    expect(handler.get?.({ caseByID: aCase })?.success).toBe(false)
+
+    const caseResult = handler.get?.({ dataContext, caseByID: aCase })?.values as DIGetCaseResult
+    expect(caseResult.case.id).toBe(maybeToV2Id(caseId))
+
+    const pseudoCaseResult = handler.get?.({ dataContext, caseByID: pseudoCase })?.values as DIGetCaseResult
+    expect(pseudoCaseResult.case.id).toBe(maybeToV2Id(pseudoCaseId))
+  })
+})

--- a/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
@@ -6,17 +6,18 @@ import { setupTestDataset } from "./handler-test-utils"
 describe("DataInteractive CaseByIDHandler", () => {
   const handler = diCaseByIDHandler
   function setup() {
-    const { dataset } = setupTestDataset()
+    const { dataset, a3 } = setupTestDataset()
     dataset.collectionGroups
     const aCase = dataset.getCaseAtIndex(4)
-    const caseId = aCase?.__id__
-    const pseudoCase = Array.from(dataset.pseudoCaseMap.values())[0].pseudoCase
+    const caseId = aCase?.__id__!
+    const pseudoCase = Array.from(dataset.pseudoCaseMap.values())[1].pseudoCase
     const pseudoCaseId = pseudoCase.__id__
-    return { dataContext: dataset, aCase, caseId, pseudoCase, pseudoCaseId }
+    return { dataContext: dataset, aCase, caseId, pseudoCase, pseudoCaseId, a3 }
   }
 
   it("get works as expected", () => {
     const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId } = setup()
+
     expect(handler.get?.({})?.success).toBe(false)
     expect(handler.get?.({ dataContext })?.success).toBe(false)
     expect(handler.get?.({ caseByID: aCase })?.success).toBe(false)
@@ -26,5 +27,39 @@ describe("DataInteractive CaseByIDHandler", () => {
 
     const pseudoCaseResult = handler.get?.({ dataContext, caseByID: pseudoCase })?.values as DIGetCaseResult
     expect(pseudoCaseResult.case.id).toBe(maybeToV2Id(pseudoCaseId))
+  })
+
+  it("update works as expected", () => {
+    const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId, a3 } = setup()
+    const caseResources = { dataContext, caseByID: aCase }
+    
+    expect(handler.update?.({}).success).toBe(false)
+    expect(handler.update?.({ dataContext }).success).toBe(false)
+    expect(handler.update?.(caseResources).success).toBe(false)
+    expect(handler.update?.(caseResources, {}).success).toBe(false)
+
+    expect(handler.update?.(caseResources, { values: { a3: 10 } }).success).toBe(true)
+    expect(a3.numValues[dataContext.caseIndexFromID(caseId)!]).toBe(10)
+
+    expect(handler.update?.({ dataContext, caseByID: pseudoCase }, { values: { a3: 100 } }).success).toBe(true)
+    dataContext.pseudoCaseMap.get(pseudoCaseId)?.childCaseIds.forEach(id => {
+      expect(a3.numValues[dataContext.caseIndexFromID(id)!]).toBe(100)
+    })
+  })
+
+  it("delete works as expected", () => {
+    const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId } = setup()
+    
+    expect(handler.delete?.({}).success).toBe(false)
+    expect(handler.delete?.({ dataContext }).success).toBe(false)
+
+    expect(dataContext.getCase(caseId)).toBeDefined()
+    expect(handler.delete?.({ dataContext, caseByID: aCase }).success).toBe(true)
+    expect(dataContext.getCase(caseId)).toBeUndefined()
+
+    const childCaseIds = dataContext.pseudoCaseMap.get(pseudoCaseId)!.childCaseIds
+    childCaseIds.forEach(id => expect(dataContext.getCase(id)).toBeDefined())
+    expect(handler.delete?.({ dataContext, caseByID: pseudoCase }).success).toBe(true)
+    childCaseIds.forEach(id => expect(dataContext.getCase(id)).toBeUndefined())
   })
 })

--- a/v3/src/data-interactive/handlers/case-by-id-handler.ts
+++ b/v3/src/data-interactive/handlers/case-by-id-handler.ts
@@ -1,7 +1,7 @@
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DIResources, DIUpdateCase, DIValues } from "../data-interactive-types"
-import { convertCaseToV2FullCase } from "../data-interactive-type-utils"
+import { getCaseRequestResultValues } from "../data-interactive-type-utils"
 import { attrNamesToIds } from "../data-interactive-utils"
 
 const dcNotFoundResult = { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } } as const
@@ -28,7 +28,7 @@ export const diCaseByIDHandler: DIHandler = {
     if (!dataContext) return dcNotFoundResult
     if (!caseByID) return caseNotFoundResult
 
-    return { success: true, values: convertCaseToV2FullCase(caseByID, dataContext) }
+    return { success: true, values: getCaseRequestResultValues(caseByID, dataContext) }
   },
 
   update(resources: DIResources, values?: DIValues) {

--- a/v3/src/data-interactive/handlers/case-by-id-handler.ts
+++ b/v3/src/data-interactive/handlers/case-by-id-handler.ts
@@ -1,55 +1,16 @@
-import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIHandler, DIResources, DIUpdateCase, DIValues } from "../data-interactive-types"
-import { getCaseRequestResultValues } from "../data-interactive-type-utils"
-import { attrNamesToIds } from "../data-interactive-utils"
-
-const dcNotFoundResult = { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } } as const
-const caseNotFoundResult = { success: false, values: { error: t("V3.DI.Error.caseNotFound") } } as const
+import { DIHandler, DIResources, DIValues } from "../data-interactive-types"
+import { deleteCaseBy, getCaseBy, updateCaseBy } from "./case-by-handler-functions"
 
 export const diCaseByIDHandler: DIHandler = {
   delete(resources: DIResources) {
-    const { caseByID, dataContext } = resources
-    if (!dataContext) return dcNotFoundResult
-    if (!caseByID) return caseNotFoundResult
-
-    const pseudoCase = dataContext.pseudoCaseMap.get(caseByID.__id__)
-    const cases = pseudoCase?.childCaseIds ?? [caseByID.__id__]
-
-    dataContext.applyModelChange(() => {
-      dataContext.removeCases(cases)
-    })
-
-    return { success: true }
+    return deleteCaseBy(resources, resources.caseByID)
   },
-
   get(resources: DIResources) {
-    const { caseByID, dataContext } = resources
-    if (!dataContext) return dcNotFoundResult
-    if (!caseByID) return caseNotFoundResult
-
-    return { success: true, values: getCaseRequestResultValues(caseByID, dataContext) }
+    return getCaseBy(resources, resources.caseByID)
   },
-
   update(resources: DIResources, values?: DIValues) {
-    const { caseByID, dataContext } = resources
-    if (!dataContext) return dcNotFoundResult
-    if (!caseByID) return caseNotFoundResult
-
-    const missingFieldResult = {
-      success: false,
-      values: { error: t("V3.DI.Error.fieldRequired", { vars: ["update", "caseByID", "wavlues.values"] }) }
-    } as const
-    if (!values) return missingFieldResult
-    const updateCase = values as DIUpdateCase
-    if (!updateCase.values) return missingFieldResult
-
-    dataContext.applyModelChange(() => {
-      const updatedAttributes = attrNamesToIds(updateCase.values, dataContext)
-      dataContext.setCaseValues([{ ...updatedAttributes, __id__: caseByID.__id__ }])
-    })
-
-    return { success: true }
+    return updateCaseBy(resources, values, resources.caseByID)
   }
 }
 

--- a/v3/src/data-interactive/handlers/case-by-id-handler.ts
+++ b/v3/src/data-interactive/handlers/case-by-id-handler.ts
@@ -1,10 +1,56 @@
+import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIHandler, diNotImplementedYet } from "../data-interactive-types"
+import { DIHandler, DIResources, DIUpdateCase, DIValues } from "../data-interactive-types"
+import { convertCaseToV2FullCase } from "../data-interactive-type-utils"
+import { attrNamesToIds } from "../data-interactive-utils"
+
+const dcNotFoundResult = { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } } as const
+const caseNotFoundResult = { success: false, values: { error: t("V3.DI.Error.caseNotFound") } } as const
 
 export const diCaseByIDHandler: DIHandler = {
-  delete: diNotImplementedYet,
-  get: diNotImplementedYet,
-  update: diNotImplementedYet
+  delete(resources: DIResources) {
+    const { caseByID, dataContext } = resources
+    if (!dataContext) return dcNotFoundResult
+    if (!caseByID) return caseNotFoundResult
+
+    const pseudoCase = dataContext.pseudoCaseMap.get(caseByID.__id__)
+    const cases = pseudoCase?.childCaseIds ?? [caseByID.__id__]
+
+    dataContext.applyModelChange(() => {
+      dataContext.removeCases(cases)
+    })
+
+    return { success: true }
+  },
+
+  get(resources: DIResources) {
+    const { caseByID, dataContext } = resources
+    if (!dataContext) return dcNotFoundResult
+    if (!caseByID) return caseNotFoundResult
+
+    return { success: true, values: convertCaseToV2FullCase(caseByID, dataContext) }
+  },
+
+  update(resources: DIResources, values?: DIValues) {
+    const { caseByID, dataContext } = resources
+    if (!dataContext) return dcNotFoundResult
+    if (!caseByID) return caseNotFoundResult
+
+    const missingFieldResult = {
+      success: false,
+      values: { error: t("V3.DI.Error.fieldRequired", { vars: ["update", "caseByID", "wavlues.values"] }) }
+    } as const
+    if (!values) return missingFieldResult
+    const updateCase = values as DIUpdateCase
+    if (!updateCase.values) return missingFieldResult
+
+    dataContext.applyModelChange(() => {
+      const updatedAttributes = attrNamesToIds(updateCase.values, dataContext)
+      dataContext.setCaseValues([{ ...updatedAttributes, __id__: caseByID.__id__ }])
+    })
+
+    return { success: true }
+  }
 }
 
 registerDIHandler("caseByID", diCaseByIDHandler)

--- a/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
@@ -1,10 +1,10 @@
 import { maybeToV2Id } from "../../utilities/codap-utils"
 import { DIGetCaseResult } from "../data-interactive-types"
-import { diCaseByIDHandler } from "./case-by-id-handler"
+import { diCaseByIndexHandler } from "./case-by-index-handler"
 import { setupTestDataset } from "./handler-test-utils"
 
-describe("DataInteractive CaseByIDHandler", () => {
-  const handler = diCaseByIDHandler
+describe("DataInteractive CaseByIndexHandler", () => {
+  const handler = diCaseByIndexHandler
   function setup() {
     const { dataset, a3 } = setupTestDataset()
     dataset.collectionGroups
@@ -20,18 +20,18 @@ describe("DataInteractive CaseByIDHandler", () => {
 
     expect(handler.get?.({})?.success).toBe(false)
     expect(handler.get?.({ dataContext })?.success).toBe(false)
-    expect(handler.get?.({ caseByID: aCase })?.success).toBe(false)
+    expect(handler.get?.({ caseByIndex: aCase })?.success).toBe(false)
 
-    const caseResult = handler.get?.({ dataContext, caseByID: aCase })?.values as DIGetCaseResult
+    const caseResult = handler.get?.({ dataContext, caseByIndex: aCase })?.values as DIGetCaseResult
     expect(caseResult.case.id).toBe(maybeToV2Id(caseId))
 
-    const pseudoCaseResult = handler.get?.({ dataContext, caseByID: pseudoCase })?.values as DIGetCaseResult
+    const pseudoCaseResult = handler.get?.({ dataContext, caseByIndex: pseudoCase })?.values as DIGetCaseResult
     expect(pseudoCaseResult.case.id).toBe(maybeToV2Id(pseudoCaseId))
   })
 
   it("update works as expected", () => {
     const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId, a3 } = setup()
-    const caseResources = { dataContext, caseByID: aCase }
+    const caseResources = { dataContext, caseByIndex: aCase }
     
     expect(handler.update?.({}).success).toBe(false)
     expect(handler.update?.({ dataContext }).success).toBe(false)
@@ -41,7 +41,7 @@ describe("DataInteractive CaseByIDHandler", () => {
     expect(handler.update?.(caseResources, { values: { a3: 10 } }).success).toBe(true)
     expect(a3.numValues[dataContext.caseIndexFromID(caseId)!]).toBe(10)
 
-    expect(handler.update?.({ dataContext, caseByID: pseudoCase }, { values: { a3: 100 } }).success).toBe(true)
+    expect(handler.update?.({ dataContext, caseByIndex: pseudoCase }, { values: { a3: 100 } }).success).toBe(true)
     dataContext.pseudoCaseMap.get(pseudoCaseId)?.childCaseIds.forEach(id => {
       expect(a3.numValues[dataContext.caseIndexFromID(id)!]).toBe(100)
     })
@@ -54,12 +54,12 @@ describe("DataInteractive CaseByIDHandler", () => {
     expect(handler.delete?.({ dataContext }).success).toBe(false)
 
     expect(dataContext.getCase(caseId)).toBeDefined()
-    expect(handler.delete?.({ dataContext, caseByID: aCase }).success).toBe(true)
+    expect(handler.delete?.({ dataContext, caseByIndex: aCase }).success).toBe(true)
     expect(dataContext.getCase(caseId)).toBeUndefined()
 
     const childCaseIds = dataContext.pseudoCaseMap.get(pseudoCaseId)!.childCaseIds
     childCaseIds.forEach(id => expect(dataContext.getCase(id)).toBeDefined())
-    expect(handler.delete?.({ dataContext, caseByID: pseudoCase }).success).toBe(true)
+    expect(handler.delete?.({ dataContext, caseByIndex: pseudoCase }).success).toBe(true)
     childCaseIds.forEach(id => expect(dataContext.getCase(id)).toBeUndefined())
   })
 })

--- a/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
@@ -7,9 +7,10 @@ describe("DataInteractive CaseByIndexHandler", () => {
   const handler = diCaseByIndexHandler
   function setup() {
     const { dataset, a3 } = setupTestDataset()
+    // eslint-disable-next-line no-unused-expressions
     dataset.collectionGroups
     const aCase = dataset.getCaseAtIndex(4)
-    const caseId = aCase?.__id__!
+    const caseId = aCase!.__id__
     const pseudoCase = Array.from(dataset.pseudoCaseMap.values())[1].pseudoCase
     const pseudoCaseId = pseudoCase.__id__
     return { dataContext: dataset, aCase, caseId, pseudoCase, pseudoCaseId, a3 }

--- a/v3/src/data-interactive/handlers/case-by-index-handler.ts
+++ b/v3/src/data-interactive/handlers/case-by-index-handler.ts
@@ -1,10 +1,17 @@
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIHandler, diNotImplementedYet } from "../data-interactive-types"
+import { DIHandler, DIResources, DIValues } from "../data-interactive-types"
+import { deleteCaseBy, getCaseBy, updateCaseBy } from "./case-by-handler-functions"
 
 export const diCaseByIndexHandler: DIHandler = {
-  delete: diNotImplementedYet,
-  get: diNotImplementedYet,
-  update: diNotImplementedYet
+  delete(resources: DIResources) {
+    return deleteCaseBy(resources, resources.caseByIndex)
+  },
+  get(resources: DIResources) {
+    return getCaseBy(resources, resources.caseByIndex)
+  },
+  update(resources: DIResources, values?: DIValues) {
+    return updateCaseBy(resources, values, resources.caseByIndex)
+  }
 }
 
 registerDIHandler("caseByIndex", diCaseByIndexHandler)

--- a/v3/src/data-interactive/handlers/case-count-handler.ts
+++ b/v3/src/data-interactive/handlers/case-count-handler.ts
@@ -1,16 +1,12 @@
-import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DIResources } from "../data-interactive-types"
+import { collectionNotFoundResult, dataContextNotFoundResult } from "./di-results"
 
 export const diCaseCountHandler: DIHandler = {
   get(resources: DIResources) {
     const { collection, dataContext } = resources
-    if (!collection) {
-      return { success: false, values: { error: t("V3.DI.Error.collectionNotFound") } }
-    }
-    if (!dataContext) {
-      return { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } }
-    }
+    if (!collection) return collectionNotFoundResult
+    if (!dataContext) return dataContextNotFoundResult
 
     return {
       success: true,

--- a/v3/src/data-interactive/handlers/case-handler.ts
+++ b/v3/src/data-interactive/handlers/case-handler.ts
@@ -1,14 +1,14 @@
 import { ICaseCreation } from "../../models/data/data-set-types"
 import { toV2Id, toV3CaseId } from "../../utilities/codap-utils"
-import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIFullCase, DIHandler, DIResources, DIValues } from "../data-interactive-types"
 import { attrNamesToIds } from "../data-interactive-utils"
+import { dataContextNotFoundResult } from "./di-results"
 
 export const diCaseHandler: DIHandler = {
   create(resources: DIResources, values?: DIValues) {
     const { dataContext } = resources
-    if (!dataContext) return { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } }
+    if (!dataContext) return dataContextNotFoundResult
 
     let itemIds: string[] = []
     const newCaseData: ICaseCreation[] = []
@@ -30,7 +30,7 @@ export const diCaseHandler: DIHandler = {
   },
   update(resources: DIResources, values?: DIValues) {
     const { dataContext } = resources
-    if (!dataContext) return { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } }
+    if (!dataContext) return dataContextNotFoundResult
 
     const cases = (Array.isArray(values) ? values : [values]) as DIFullCase[]
     const caseIDs: number[] = []

--- a/v3/src/data-interactive/handlers/collection-handler.ts
+++ b/v3/src/data-interactive/handlers/collection-handler.ts
@@ -1,17 +1,15 @@
 import { isCollectionModel } from "../../models/data/collection"
-import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DIResources, diNotImplementedYet } from "../data-interactive-types"
 import { convertCollectionToV2, convertUngroupedCollectionToV2 } from "../data-interactive-type-utils"
-
-const collectionNotFoundResult = { success: false, values: { error: t("V3.DI.Error.collectionNotFound") } } as const
+import { collectionNotFoundResult, dataContextNotFoundResult } from "./di-results"
 
 export const diCollectionHandler: DIHandler = {
   create: diNotImplementedYet,
   delete: diNotImplementedYet,
   get(resources: DIResources) {
     const { collection, dataContext } = resources
-    if (!dataContext) return { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } }
+    if (!dataContext) return dataContextNotFoundResult
     if (!collection) return collectionNotFoundResult
 
     const v2Collection = isCollectionModel(collection)

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -9,12 +9,11 @@ import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DINotification, diNotImplementedYet, DIResources, DIValues } from "../data-interactive-types"
 import { V2Component, kV2CaseTableType } from "../data-interactive-component-types"
-
-const componentNotFoundResult = { success: false, values: { error: t("V3.DI.Error.componentNotFound") } } as const
+import { componentNotFoundResult, dataContextNotFoundResult, valuesRequiredResult } from "./di-results"
 
 export const diComponentHandler: DIHandler = {
   create(_resources: DIResources, values?: DIValues) {
-    if (!values) return { success: false, values: { error: t("V3.DI.Error.valuesRequired") } }
+    if (!values) return valuesRequiredResult
 
     const { type, dataContext } = values as V2Component
 
@@ -28,7 +27,7 @@ export const diComponentHandler: DIHandler = {
       const { document } = appState
       const sharedDataSet = getSharedDataSets(document).find(sds => sds.dataSet.name === dataContext)
       const dataSet = sharedDataSet?.dataSet
-      if (!dataSet) return { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } }
+      if (!dataSet) return dataContextNotFoundResult
 
       const manager = getSharedModelManager(document)
       const caseMetadatas = manager?.getSharedModelsByType<typeof SharedCaseMetadata>(kSharedCaseMetadataType)
@@ -79,7 +78,7 @@ export const diComponentHandler: DIHandler = {
     const { component } = resources
     if (!component) return componentNotFoundResult
 
-    if (!values) return { success: false, values: { error: t("V3.DI.Error.valuesRequired") } }
+    if (!values) return valuesRequiredResult
 
     const { request } = values as DINotification
     if (request === "select") {

--- a/v3/src/data-interactive/handlers/data-context-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.ts
@@ -3,13 +3,11 @@ import { gDataBroker } from "../../models/data/data-broker"
 import { DataSet } from "../../models/data/data-set"
 import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
 import { hasOwnProperty } from "../../utilities/js-utils"
-import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIDataContext, DIHandler, DIResources, DIValues, diNotImplementedYet } from "../data-interactive-types"
 import { basicDataSetInfo, convertDataSetToV2 } from "../data-interactive-type-utils"
 import { createCollection } from "./di-handler-utils"
-
-const contextNotFoundResult = { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } } as const
+import { dataContextNotFoundResult } from "./di-results"
 
 export const diDataContextHandler: DIHandler = {
   create(_resources: DIResources, _values?: DIValues) {
@@ -40,7 +38,7 @@ export const diDataContextHandler: DIHandler = {
 
   delete(resources: DIResources) {
     const { dataContext } = resources
-    if (!dataContext) return contextNotFoundResult
+    if (!dataContext) return dataContextNotFoundResult
 
     dataContext.applyModelChange(() => {
       gDataBroker.removeDataSet(dataContext.id)
@@ -51,7 +49,7 @@ export const diDataContextHandler: DIHandler = {
 
   get(resources: DIResources) {
     const { dataContext } = resources
-    if (!dataContext) return contextNotFoundResult
+    if (!dataContext) return dataContextNotFoundResult
 
     return { success: true, values: convertDataSetToV2(dataContext, appState.document.key) }
   },
@@ -63,7 +61,7 @@ export const diDataContextHandler: DIHandler = {
     // TODO rerandomize
     // TODO sort
     const { dataContext } = resources
-    if (!dataContext) return contextNotFoundResult
+    if (!dataContext) return dataContextNotFoundResult
 
     const values = _values as DIDataContext
     if (values) {

--- a/v3/src/data-interactive/handlers/di-results.ts
+++ b/v3/src/data-interactive/handlers/di-results.ts
@@ -1,6 +1,9 @@
 import { t } from "../../utilities/translation/translate"
 
-export const caseNotFoundResult =
-  { success: false, values: { error: t("V3.DI.Error.caseNotFound") } } as const
-export const dataContextNotFoundResult =
-  { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } } as const
+const errorResult = (error: string) => ({ success: false, values: { error } } as const)
+export const attributeNotFoundResult = errorResult(t("V3.DI.Error.attributeNotFound"))
+export const caseNotFoundResult = errorResult(t("V3.DI.Error.caseNotFound"))
+export const collectionNotFoundResult = errorResult(t("V3.DI.Error.collectionNotFound"))
+export const componentNotFoundResult = errorResult(t("V3.DI.Error.componentNotFound"))
+export const dataContextNotFoundResult = errorResult(t("V3.DI.Error.dataContextNotFound"))
+export const valuesRequiredResult = errorResult(t("V3.DI.Error.valuesRequired"))

--- a/v3/src/data-interactive/handlers/di-results.ts
+++ b/v3/src/data-interactive/handlers/di-results.ts
@@ -1,0 +1,6 @@
+import { t } from "../../utilities/translation/translate"
+
+export const caseNotFoundResult =
+  { success: false, values: { error: t("V3.DI.Error.caseNotFound") } } as const
+export const dataContextNotFoundResult =
+  { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } } as const

--- a/v3/src/data-interactive/handlers/item-count-handler.ts
+++ b/v3/src/data-interactive/handlers/item-count-handler.ts
@@ -1,11 +1,12 @@
-import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DIResources } from "../data-interactive-types"
+import { dataContextNotFoundResult } from "./di-results"
 
 export const diItemCountHandler: DIHandler = {
   get(resources: DIResources) {
     const { dataContext } = resources
-    if (!dataContext) return { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } }
+    if (!dataContext) return dataContextNotFoundResult
+    
     return { success: true, values: dataContext.cases.length }
   }
 }

--- a/v3/src/data-interactive/handlers/item-handler.ts
+++ b/v3/src/data-interactive/handlers/item-handler.ts
@@ -1,15 +1,13 @@
-import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DIItem, DIResources, DIValues, diNotImplementedYet } from "../data-interactive-types"
 import { attrNamesToIds } from "../data-interactive-utils"
-
-const dataContextNotFoundResult = { success: false, values: { error: t("V3.DI.Error.dataContextNotFound") } } as const
+import { dataContextNotFoundResult, valuesRequiredResult } from "./di-results"
 
 export const diItemHandler: DIHandler = {
   create(resources: DIResources, values?: DIValues) {
     const { dataContext } = resources
     if (!dataContext) return dataContextNotFoundResult
-    if (!values) return { success: false, values: { error: t("V3.DI.Error.valuesRequired") } }
+    if (!values) return valuesRequiredResult
 
     const items = (Array.isArray(values) ? values : [values]) as DIItem[]
     const itemIDs = dataContext.addCases(items.map(item => attrNamesToIds(item, dataContext)))

--- a/v3/src/data-interactive/handlers/selection-list-handler.ts
+++ b/v3/src/data-interactive/handlers/selection-list-handler.ts
@@ -3,9 +3,8 @@ import { toV2Id } from "../../utilities/codap-utils"
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DIResources, DIValues } from "../data-interactive-types"
+import { dataContextNotFoundResult } from "./di-results"
 
-const unknownDataContextResult =
-  { success: false, values: { error: t("V3.DI.Error.dataContextNotFound")} } as const
 function illegalValuesResult(action: string) {
   return { success: false, values: {
     error: t("V3.DI.Error.selectionListIllegalValues", { vars: [action] })
@@ -15,7 +14,7 @@ function illegalValuesResult(action: string) {
 function updateSelection(
   action: string, dataSet?: IDataSet, values?: DIValues, applySelection?: (caseIds: string[]) => void
 ) {
-  if (!dataSet || !applySelection) return unknownDataContextResult
+  if (!dataSet || !applySelection) return dataContextNotFoundResult
   if (!values || !Array.isArray(values)) return illegalValuesResult(action)
 
   const caseIds = values.map(value => value.toString()).filter(caseID => !!dataSet.getCase(caseID))
@@ -31,7 +30,7 @@ export const diSelectionListHandler: DIHandler = {
   },
   get(resources: DIResources) {
     const { dataContext } = resources
-    if (!dataContext) return unknownDataContextResult
+    if (!dataContext) return dataContextNotFoundResult
 
     const caseIds = Array.from(dataContext.selection)
     // TODO Include collectionID and collectionName

--- a/v3/src/data-interactive/resource-parser.test.ts
+++ b/v3/src/data-interactive/resource-parser.test.ts
@@ -12,7 +12,7 @@ describe("DataInteractive ResourceParser", () => {
   const { content } = appState.document
   content?.createDataSet(getSnapshot(setupTestDataset().dataset))
   const dataset = content?.getFirstSharedModelByType(SharedDataSet)?.dataSet!
-  dataset.collectionGroups
+  dataset.collectionGroups // set up the pseudoCases
   const tile = content!.createOrShowTile(kWebViewTileType)!
   const resolve = (resource: string) => resolveResources(resource, "get", tile)
   

--- a/v3/src/data-interactive/resource-parser.test.ts
+++ b/v3/src/data-interactive/resource-parser.test.ts
@@ -16,19 +16,19 @@ describe("DataInteractive ResourceParser", () => {
   const tile = content!.createOrShowTile(kWebViewTileType)!
   const resolve = (resource: string) => resolveResources(resource, "get", tile)
   
-  it("resourceParser finds dataContext properly", () => {
+  it("finds dataContext", () => {
     expect(resolve("").dataContext?.id).toBe(dataset.id)
     expect(resolve("dataContext[data]").dataContext?.id).toBe(dataset.id)
     expect(resolve(`dataContext[${toV2Id(dataset.id)}]`).dataContext?.id).toBe(dataset.id)
     expect(resolve("dataContext[unknown]").dataContext).toBeUndefined()
   })
 
-  it("resourceParser finds components properly", () => {
+  it("finds components", () => {
     expect(resolve(`component[${toV2Id(tile.id)}]`).component?.id).toBe(tile.id)
     expect(resolve("component[unknown]").component).toBeUndefined()
   })
 
-  it("resourceParser finds globals properly", () => {
+  it("finds globals", () => {
     const globalManager = getGlobalValueManager(getSharedModelManager(appState.document))
     const globalSnapshot = { name: "global1", value: 0 }
     const global = globalManager!.addValueSnapshot(globalSnapshot)
@@ -38,7 +38,7 @@ describe("DataInteractive ResourceParser", () => {
     expect(resolve("global[unknown]").global).toBeUndefined()
   })
 
-  it("resourceParser finds dataContextList properly", () => {
+  it("finds dataContextList", () => {
     const { dataContextList } = resolve("dataContextList")
     expect(dataContextList?.length).toBe(1)
     expect(dataContextList?.[0].id).toBe(dataset.id)
@@ -48,19 +48,32 @@ describe("DataInteractive ResourceParser", () => {
 
   // TODO Add tests for attribute
 
-  it("resourceParser finds attributeList properly", () => {
+  it("finds attributeList", () => {
     const resources = resolve("dataContext[data].collection[collection1].attributeList")
     expect(resources.attributeList?.length).toBe(1)
     expect(resources.attributeList?.[0].name).toBe("a1")
   })
 
-  it("resourceParser finds caseByID properly", () => {
+  it("finds caseByID", () => {
+    expect(resolve(`dataContext[data].caseByID[unknown]`).caseByID).toBeUndefined()
+
     const itemId = dataset.getCaseAtIndex(0)!.__id__
     expect(resolve(`dataContext[data].caseByID[${toV2Id(itemId)}]`).caseByID?.__id__).toBe(itemId)
 
     const caseId = Array.from(dataset.pseudoCaseMap.values())[0].pseudoCase.__id__
     expect(resolve(`dataContext[data].caseByID[${toV2Id(caseId)}]`).caseByID?.__id__).toBe(caseId)
+  })
 
-    expect(resolve(`dataContext[data].caseByID[unknown]`).caseByID).toBeUndefined()
+  it("finds caseByIndex", () => {
+    const collectionId = toV2Id(dataset.collections[0].id)
+    expect(resolve(`dataContext[data].collection[${collectionId}].caseByIndex[-1]`).caseByIndex).toBeUndefined()
+    expect(resolve(`dataContext[data].collection[unknown].caseByIndex[0]`).caseByIndex).toBeUndefined()
+
+    const itemId = dataset.getCaseAtIndex(0)!.__id__
+    const ungroupedId = toV2Id(dataset.ungrouped.id)
+    expect(resolve(`dataContext[data].collection[${ungroupedId}].caseByIndex[0]`).caseByIndex?.__id__).toBe(itemId)
+
+    const caseId = Array.from(dataset.pseudoCaseMap.values())[0].pseudoCase.__id__
+    expect(resolve(`dataContext[data].collection[${collectionId}].caseByIndex[0]`).caseByIndex?.__id__).toBe(caseId)
   })
 })

--- a/v3/src/data-interactive/resource-parser.test.ts
+++ b/v3/src/data-interactive/resource-parser.test.ts
@@ -2,11 +2,11 @@ import { getSnapshot } from "mobx-state-tree"
 import { kWebViewTileType } from "../components/web-view/web-view-defs"
 import "../components/web-view/web-view-registration"
 import { appState } from "../models/app-state"
+import { SharedDataSet } from "../models/shared/shared-data-set"
 import { getGlobalValueManager, getSharedModelManager } from "../models/tiles/tile-environment"
 import { toV2Id } from "../utilities/codap-utils"
 import { setupTestDataset } from "./handlers/handler-test-utils"
 import { resolveResources } from "./resource-parser"
-import { SharedDataSet } from "../models/shared/shared-data-set"
 
 describe("DataInteractive ResourceParser", () => {
   const { content } = appState.document

--- a/v3/src/data-interactive/resource-parser.test.ts
+++ b/v3/src/data-interactive/resource-parser.test.ts
@@ -11,7 +11,8 @@ import { SharedDataSet } from "../models/shared/shared-data-set"
 describe("DataInteractive ResourceParser", () => {
   const { content } = appState.document
   content?.createDataSet(getSnapshot(setupTestDataset().dataset))
-  const dataset = content?.getFirstSharedModelByType(SharedDataSet)?.dataSet!
+  const dataset = content!.getFirstSharedModelByType(SharedDataSet)!.dataSet
+  // eslint-disable-next-line no-unused-expressions
   dataset.collectionGroups // set up the pseudoCases
   const tile = content!.createOrShowTile(kWebViewTileType)!
   const resolve = (resource: string) => resolveResources(resource, "get", tile)

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -149,14 +149,23 @@ export function resolveResources(
     result.attributeList = attributeList
   }
 
+  const getCaseById = (caseId: string) =>
+    dataContext?.pseudoCaseMap.get(caseId)?.pseudoCase ?? dataContext?.getCase(caseId)
+  
   if (resourceSelector.caseByID) {
     const caseId = toV3CaseId(resourceSelector.caseByID)
-    result.caseByID = dataContext?.pseudoCaseMap.get(caseId)?.pseudoCase ?? dataContext?.getCase(caseId)
+    result.caseByID = getCaseById(caseId)
   }
 
-  // if (resourceSelector.caseByIndex) {
-  //   result.caseByIndex = collection && collection.getCaseAt(Number(resourceSelector.caseByIndex));
-  // }
+  if (resourceSelector.caseByIndex && collection) {
+    const index = Number(resourceSelector.caseByIndex)
+    if (!isNaN(index)) {
+      const caseId = dataContext?.getCasesForCollection(collection.id)[index]?.__id__
+      if (caseId) {
+        result.caseByIndex = getCaseById(caseId)
+      }
+    }
+  }
 
   // if (resourceSelector.caseSearch) {
   //   result.caseSearch = collection && collection.searchCases(resourceSelector.caseSearch);

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -6,7 +6,7 @@ import { GlobalValueManager } from "../models/global/global-value-manager"
 import { getSharedDataSets } from "../models/shared/shared-data-utils"
 import { getTilePrefixes } from "../models/tiles/tile-content-info"
 import { ITileModel } from "../models/tiles/tile-model"
-import { toV3AttrId, toV3CollectionId, toV3GlobalId, toV3Id, toV3TileId } from "../utilities/codap-utils"
+import { toV3AttrId, toV3CaseId, toV3CollectionId, toV3GlobalId, toV3Id, toV3TileId } from "../utilities/codap-utils"
 import { ActionName, DIResources, DIResourceSelector } from "./data-interactive-types"
 import { canonicalizeAttributeName } from "./data-interactive-utils"
 
@@ -149,9 +149,10 @@ export function resolveResources(
     result.attributeList = attributeList
   }
 
-  // if (resourceSelector.caseByID) {
-  //   result.caseByID = dataContext.getCaseByID(resourceSelector.caseByID);
-  // }
+  if (resourceSelector.caseByID) {
+    const caseId = toV3CaseId(resourceSelector.caseByID)
+    result.caseByID = dataContext?.pseudoCaseMap.get(caseId)?.pseudoCase ?? dataContext?.getCase(caseId)
+  }
 
   // if (resourceSelector.caseByIndex) {
   //   result.caseByIndex = collection && collection.getCaseAt(Number(resourceSelector.caseByIndex));

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -81,6 +81,7 @@
     "V3.DI.Error.fieldRequired": "%@1 %@2: %@3 required",
     "V3.DI.Error.dataContextNotFound": "DataContext not found",
     "V3.DI.Error.caseMetadataNotFound": "CaseMetadata not found for %@",
+    "V3.DI.Error.caseNotFound": "Case not found",
     "V3.DI.Error.collectionNotFound": "Collection not found",
     "V3.DI.Error.componentNotFound": "Component not found",
     "V3.DI.Error.globalCreation": "error creating global value",


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187637447

This PR adds handlers for `caseByID` and `caseByIndex` API requests. Both support `delete`, `get`, and `update` and are identical except for how the relevant case is referred, which takes place in `resourceParser`. Since the handlers act the same way, their functions are defined in a third file, `case-by-handler-functions.ts`, with the actual handlers just calling these functions with the proper case.

One thing worth bringing up is how similar the response to `get caseByID/Index` is to `updateCase` and `selectCases` notifications broadcast by CODAP. I originally thought I could reuse the same formatting function before realizing they are slightly different. The result is one that's extremely similar with a lot of reused code. Both functions are in `data-interactive-type-utils.ts`, with `getCaseRequestResultValues` added in this PR and `convertCaseToV2FullCase` left as is. This is the sort of inconsistency that would be great to remove from CODAP. I think it would be safe to combine the information returned, though that would result in some awkwardness, like `id`, `caseId`, and `itemId` all being included in the final result. It might also be safe to totally change what's returned in the notifications, since at least Choosy ignores the details of these notifications (perhaps other plugins care about them, though). In any case, v3 is a great opportunity to try to clean up some of these inconsistencies that most likely arose in v2 organically without much thought to the bigger picture.

Another weak point of the API is the expected `values` for `update caseByID/Index`. The expected structure is like:
```
values: {
  values: {
    attr1: val1,
    ...
  }
}
```
Having two layers of `values` is just confusing. However, I don't think this is something we can change at this point.

Other changes in this PR:
- I streamlined the standard error results for API requests. This reduced duplicate code and also made error messages more consistent across different handlers. This does make some error responses different from v2, but in most if not all cases it makes the error messages more detailed and accurate.
- I made formatting changes in some old handler files to clean them up a bit.