### PR TITLE
187654045 csv import performance

### DIFF
--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -36,7 +36,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          working-directory: v3
           flags: jest
   cypress:
     runs-on: ubuntu-latest
@@ -88,7 +87,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          working-directory: v3
           flags: cypress
   s3-deploy:
     name: S3 Deploy

--- a/v3/src/components/case-card/case-card.v2.test.tsx
+++ b/v3/src/components/case-card/case-card.v2.test.tsx
@@ -10,6 +10,7 @@ import "./case-card.v2"
 const { CaseCard } = DG.React as any
 
 describe("CaseCard component", () => {
+  jest.setTimeout(10000)
   const user = userEvent.setup()
 
   // https://github.com/jsdom/jsdom/issues/1590#issuecomment-1379728739

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -25,7 +25,7 @@
   JavaScript engines can optimize operations on homogeneous arrays more than heterogeneous ones.
  */
 
-import {Instance, SnapshotIn, types} from "mobx-state-tree"
+import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { parseColor } from "../../utilities/color-utils"
 import { kAttrIdPrefix, typeV3Id } from "../../utilities/codap-utils"
 import { cachedFnFactory } from "../../utilities/mst-utils"
@@ -40,6 +40,10 @@ const isDevelopment = () => process.env.NODE_ENV !== "production"
 const isProduction = () => process.env.NODE_ENV === "production"
 
 export type IValueType = string | number | boolean | undefined
+
+export interface ISetValueOptions {
+  noInvalidate?: boolean
+}
 
 export function importValueToString(value: IValueType) {
   return value == null ? "" : typeof value === "string" ? value : value.toString()
@@ -299,11 +303,11 @@ export const Attribute = V2Model.named("Attribute").props({
     }
     self.incChangeCount()
   },
-  setValue(index: number, value: IValueType) {
+  setValue(index: number, value: IValueType, options?: ISetValueOptions) {
     if ((index >= 0) && (index < self.strValues.length)) {
       self.strValues[index] = self.importValue(value)
       self.numValues[index] = self.toNumeric(self.strValues[index])
-      self.incChangeCount()
+      if (!options?.noInvalidate) self.incChangeCount()
     }
   },
   setValues(indices: number[], values: IValueType[]) {

--- a/v3/src/models/data/data-set-actions.ts
+++ b/v3/src/models/data/data-set-actions.ts
@@ -1,11 +1,11 @@
 import { ISerializedActionCall } from "mobx-state-tree"
-import { IAddCaseOptions, ICase } from "./data-set-types"
+import { IAddCasesOptions, ICase } from "./data-set-types"
 
 // TODO: define the types for the rest of the actions
 
 export interface AddCasesAction extends ISerializedActionCall {
   name: "addCases"
-  args: [ICase[], IAddCaseOptions | undefined]
+  args: [ICase[], IAddCasesOptions | undefined]
 }
 export const isAddCasesAction = (action: ISerializedActionCall): action is AddCasesAction =>
               action.name === "addCases"

--- a/v3/src/models/data/data-set-types.ts
+++ b/v3/src/models/data/data-set-types.ts
@@ -31,11 +31,13 @@ export interface IGetCaseOptions {
 export interface IGetCasesOptions extends IGetCaseOptions {
   count?: number;
 }
-export interface IAddCaseOptions {
+export interface IAddCasesOptions {
   // id of case before/after which to insert new cases
   // if not specified, new cases are appended
   before?: string;
   after?: string;
+  // if true, property names are attribute names rather than ids
+  canonicalize?: boolean;
 }
 
 export interface IAddAttributeOptions {

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -67,8 +67,8 @@ test("Canonicalization", () => {
   const ds = DataSet.create({ name: "data" })
   ds.addAttribute({ name: "str" })
   ds.addAttribute({ name: "num" })
-  const strId = ds.attrIDFromName("str")
-  const numId = ds.attrIDFromName("num")
+  const strId = ds.attrIDFromName("str")!
+  const numId = ds.attrIDFromName("num")!
   const a1Case = { str: "a", num: "1" }
   const a1Canonical = { [strId]: "a", [numId]: "1" }
   expect(toCanonical(ds, a1Case)).toEqual(a1Canonical)

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -258,7 +258,7 @@ test("DataSet basic functionality", () => {
   expect(dataset.getStrValueAtIndex(0, numAttrID)).toBe("4")
 
   // add new case before first case
-  dataset.addCases(toCanonical(dataset, [{ str: "c", num: 3 }]), { before: caseD4ID })
+  dataset.addCases([{ str: "c", num: 3 }], { before: caseD4ID, canonicalize: true })
   const caseC3ID = dataset.cases[0].__id__
   expect(dataset.cases.length).toBe(2)
   expect(caseC3ID).toBeDefined()
@@ -275,7 +275,7 @@ test("DataSet basic functionality", () => {
   expect(dataset.getValueAtIndex(0, numAttrID)).toBe("3")
 
   // add multiple new cases before specified case
-  dataset.addCases(toCanonical(dataset, [{ str: "a", num: 1 }, { str: "b", num: 2 }]), { before: caseC3ID })
+  dataset.addCases([{ str: "a", num: 1 }, { str: "b", num: 2 }], { before: caseC3ID, canonicalize: true })
   const caseA1ID = dataset.cases[0].__id__,
         caseB2ID = dataset.cases[1].__id__
   expect(dataset.cases.length).toBe(4)
@@ -309,7 +309,7 @@ test("DataSet basic functionality", () => {
   })
 
   // add multiple new cases after specified case
-  dataset.addCases(toCanonical(dataset, [{ str: "j", num: 1 }, { str: "k", num: 2 }]), { after: caseC3ID })
+  dataset.addCases([{ str: "j", num: 1 }, { str: "k", num: 2 }], { after: caseC3ID, canonicalize: true })
   const caseJ1ID = dataset.cases[3].__id__,
         caseK2ID = dataset.cases[4].__id__
   expect(dataset.cases.length).toBe(7)

--- a/v3/src/models/formula/attribute-formula-adapter.test.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.test.ts
@@ -59,10 +59,10 @@ describe("AttributeFormulaAdapter", () => {
         ] as LEGACY_ATTRIBUTES_ARRAY_ANY
       })
       dataSet.attributes[0].formula!.setCanonicalExpression(
-        `${localAttrIdToCanonical(dataSet.attrIDFromName("bar"))} + 1`
+        `${localAttrIdToCanonical(dataSet.attrIDFromName("bar")!)} + 1`
       )
       dataSet.attributes[1].formula!.setCanonicalExpression(
-        `${localAttrIdToCanonical(dataSet.attrIDFromName("foo"))} + 1`
+        `${localAttrIdToCanonical(dataSet.attrIDFromName("foo")!)} + 1`
       )
       dataSet.addCases([{ __id__: "1" }])
       const attribute = dataSet.attributes[0]
@@ -106,7 +106,7 @@ describe("AttributeFormulaAdapter", () => {
       adapter.setupFormulaObservers(context, extraMetadata)
 
       expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("")
-      dataSet.moveAttributeToNewCollection(dataSet.attrIDFromName("bar"))
+      dataSet.moveAttributeToNewCollection(dataSet.attrIDFromName("bar")!)
       expect(dataSet.getValueAtIndex(0, attribute.id)).toEqual("3") // formula has been recalculated
     })
   })

--- a/v3/src/models/formula/formula-manager.test.ts
+++ b/v3/src/models/formula/formula-manager.test.ts
@@ -122,7 +122,7 @@ describe("FormulaManager", () => {
       it("updates formula display expression", () => {
         const { formula, dataSet } = getManagerWithFakeAdapter()
         const attr = dataSet.attrFromName("foo")
-        attr?.setName("bar")
+        dataSet.setAttributeName(attr!.id, "bar")
         expect(formula.display).toEqual("1 + 2 + bar")
         expect(formula.canonical).toEqual(`1 + 2 + ${localAttrIdToCanonical(attr?.id || "")}`)
       })
@@ -134,7 +134,7 @@ describe("FormulaManager", () => {
         expect(adapter.recalculateFormula).toHaveBeenCalledTimes(1)
 
         const attr = dataSet.attrFromName("foo")
-        dataSet.removeAttribute(attr?.id || "")
+        dataSet.removeAttribute(attr!.id)
         expect(formula.display).toEqual("1 + 2 + foo")
         expect(formula.canonical).toEqual("1 + 2 + foo")
         expect(adapter.recalculateFormula).toHaveBeenCalledTimes(2)

--- a/v3/src/models/formula/formula-observers.test.ts
+++ b/v3/src/models/formula/formula-observers.test.ts
@@ -193,7 +193,7 @@ describe("observeSymbolNameChanges", () => {
     globalValueManager.addValue(globalValue)
     const nameUpdateCallback = jest.fn()
     const dispose = observeSymbolNameChanges(new Map([["ds1", dataSet]]), globalValueManager, nameUpdateCallback)
-    dataSet.attrFromID("attr1")?.setName("newName")
+    dataSet.setAttributeName("attr1", "newName")
     expect(nameUpdateCallback).toHaveBeenCalledTimes(1)
     globalValueManager.getValueByName("global1")?.setName("newName")
     expect(nameUpdateCallback).toHaveBeenCalledTimes(2)

--- a/v3/src/models/formula/formula-observers.ts
+++ b/v3/src/models/formula/formula-observers.ts
@@ -32,8 +32,7 @@ export const observeLocalAttributes = (formulaDependencies: IFormulaDependency[]
     let casesToRecalculate: CaseList = []
     switch (mstAction.name) {
       case "addCases": {
-        // Recalculate only new cases when if there's no aggregate dependency. Otherwise, we need to update all the
-        // cases.
+        // Recalculate only new cases if there's no aggregate dependency. Otherwise, we need to update all the cases.
         casesToRecalculate = anyAggregateDepPresent ? "ALL_CASES" : (mstAction as AddCasesAction).args[0] || []
         break
       }
@@ -118,7 +117,7 @@ export const observeSymbolNameChanges = (dataSets: Map<string, IDataSet>,
   // When any attribute name is updated, we need to update display formulas. We could make this more granular,
   // and observe only dependant attributes, but it doesn't seem necessary for now.
   const disposeAttrNameReaction = reaction(
-    () => Array.from(dataSets.values()).map(ds => ds.attrNameMap),
+    () => Array.from(dataSets.values()).map(ds => ds.attrNameMap.toJSON()),
     () => nameUpdateCallback(),
     {
       equals: comparer.structural,

--- a/v3/src/utilities/csv-import.test.ts
+++ b/v3/src/utilities/csv-import.test.ts
@@ -1,0 +1,24 @@
+import { CsvParseResult, convertParsedCsvToDataSet } from "./csv-import"
+
+describe("CSV import", () => {
+  it("works as expected", () => {
+    const result: CsvParseResult = {
+      data: [
+        { "a1": "c1a1", "a2": "c1a2", "a3": "c1a3" },
+        { "a1": "c2a1", "a2": "c2a2", "a3": "c2a3" },
+        { "a1": "c3a1", "a2": "c3a2", "a3": "c3a3" }
+      ],
+      errors: [],
+      meta: {
+        delimiter: ",",
+        linebreak: "\n",
+        aborted: false,
+        truncated: false,
+        cursor: 0
+      }
+    }
+    const data = convertParsedCsvToDataSet(result, "Test")
+    expect(data.attributes.length).toBe(3)
+    expect(data.cases.length).toBe(3)
+  })
+})

--- a/v3/src/utilities/csv-import.ts
+++ b/v3/src/utilities/csv-import.ts
@@ -1,5 +1,5 @@
 import { parse, ParseResult } from "papaparse"
-import { DataSet, toCanonical } from "../models/data/data-set"
+import { DataSet } from "../models/data/data-set"
 
 type RowType = Record<string, string>
 export type CsvParseResult = ParseResult<RowType>
@@ -19,7 +19,7 @@ export function convertParsedCsvToDataSet(results: CsvParseResult, filename: str
     ds.addAttribute({name: pName})
   }
   // add cases
-  ds.addCases(toCanonical(ds, results.data))
+  ds.addCases(results.data, { canonicalize: true })
 
   return ds
 }


### PR DESCRIPTION
Implements several changes to the way csv files are imported to improve performance. Also fixes our code coverage reports. The performance-related changes for csv imports were:
- Re-implement `DataSet`'s `attrNameMap`.
  - At some point, this was changed to be an MST `view` method under the assumption that the result would be cached. We've learned that the circumstances under which this caching occurs are not always obvious, and this seems to have been one of the cases where caching didn't work as expected. The result was that every attribute name lookup required looping through all attributes, building up the attribute name map, and then returning the desired result from the map. Since this lookup is required for every value of every attribute of every case, the result was an `O(An^2 * Cn)` algorithm with `An` being the number of attributes and `Cn` being the number of cases. (Dan's test document had a large number of attributes as well as a large number of cases.)
  - The fix is to implement our own caching for the `attrNameMap`. Because some clients (e.g. Piotr's formula manager code) rely on being able to observe attribute name changes, the new `attrNameMap` is implemented as a volatile `observable.map`.
- Add a `noInvalidate` option to the `Attribute.setValue` method.
  - Each affected attribute needs to be invalidated when the import occurs, but it doesn't need to be invalidated for each case. The `noInvalidate` options allows the client to handle invalidation once per attribute.
- Add a `canonicalize` option to the `DataSet.addCases` method.
  - Previously, the parsed csv objects were all being converted to canonicalized case objects before being imported. This allows the canonicalization to occur within the `addCases` method obviating the need for the temporary canonicalized representation.
- in `DataSet.addCases`, use `for..in` rather than `Object.entries` to iterate over the cases during import to avoid the creation of the intermediate temporary array of entries.

The attribute name map issue was the major one. The others were just smaller enhancements. The code coverage fix was simply to remove the specification of the `working-directory` from our `codecov-action` configuration. @scytacki had speculated that it was a path-matching issue about whether to prefix src paths with `v3` or not and it seems that the `working-directory` specification was enough to confuse it.