### PR TITLE
chore: update mobx-state-tree to v6.0.0

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",
         "@concord-consortium/cloud-file-manager": "^2.0.0-pre.3",
-        "@concord-consortium/mobx-state-tree": "^5.4.0-cc.1",
+        "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@dnd-kit/core": "^6.1.0",
         "@floating-ui/react": "^0.26.9",
         "clsx": "^2.1.0",
@@ -3274,9 +3274,9 @@
       }
     },
     "node_modules/@concord-consortium/mobx-state-tree": {
-      "version": "5.4.0-cc.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-5.4.0-cc.1.tgz",
-      "integrity": "sha512-2uGA14kb7RA9/NSWAia56i+7cXlnL0v4YAnL6RY0DyxF9c/S/vfr7qVRCUetePAZGqsKLVxOSXn6Ic96Azq6FA==",
+      "version": "6.0.0-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
       "peerDependencies": {
         "mobx": "^6.3.0"
       }
@@ -26056,9 +26056,9 @@
       }
     },
     "@concord-consortium/mobx-state-tree": {
-      "version": "5.4.0-cc.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-5.4.0-cc.1.tgz",
-      "integrity": "sha512-2uGA14kb7RA9/NSWAia56i+7cXlnL0v4YAnL6RY0DyxF9c/S/vfr7qVRCUetePAZGqsKLVxOSXn6Ic96Azq6FA==",
+      "version": "6.0.0-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
       "requires": {}
     },
     "@concord-consortium/token-service": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -178,7 +178,7 @@
   "dependencies": {
     "@chakra-ui/react": "^2.8.2",
     "@concord-consortium/cloud-file-manager": "^2.0.0-pre.3",
-    "@concord-consortium/mobx-state-tree": "^5.4.0-cc.1",
+    "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
     "@dnd-kit/core": "^6.1.0",
     "@floating-ui/react": "^0.26.9",
     "clsx": "^2.1.0",

--- a/v3/src/components/case-card/nav-buttons.v2.test.tsx
+++ b/v3/src/components/case-card/nav-buttons.v2.test.tsx
@@ -7,6 +7,7 @@ import "./nav-buttons.v2"
 const { NavButtons } = DG.React.Components as any
 
 describe("Case card NavButtons", () => {
+  jest.setTimeout(10000)
   it("renders", async () => {
     const user = userEvent.setup()
     const collectionClient = {

--- a/v3/src/components/graph/components/scatterdots.tsx
+++ b/v3/src/components/graph/components/scatterdots.tsx
@@ -17,6 +17,8 @@ import {usePixiDragHandlers, usePlotResponders} from "../hooks/use-plot"
 import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {ICase} from "../../../models/data/data-set-types"
+import { ILSRLAdornmentModel } from "../adornments/lsrl/lsrl-adornment-model"
+import { IMovableLineAdornmentModel } from "../adornments/movable-line/movable-line-adornment-model"
 import {ISquareOfResidual} from "../adornments/shared-adornment-types"
 import { scatterPlotFuncs } from "./scatter-plot-utils"
 import { IPixiPointMetadata } from "../../data-display/pixi/pixi-points"
@@ -50,8 +52,8 @@ export const ScatterDots = observer(function ScatterDots(props: PlotProps) {
   // LSRL adornments, so we need to get information from those adornments as well.
   const adornmentsStore = graphModel.adornmentsStore
   const showSquares = adornmentsStore.showSquaresOfResiduals
-  const movableLine = adornmentsStore.adornments.find(a => a.type === "Movable Line")
-  const lsrl = adornmentsStore.adornments.find(a => a.type === "LSRL")
+  const movableLine = adornmentsStore.findAdornmentOfType<IMovableLineAdornmentModel>("Movable Line")
+  const lsrl = adornmentsStore.findAdornmentOfType<ILSRLAdornmentModel>("LSRL")
   const movableLineSquaresRef = useRef<SVGGElement>(null)
   const lsrlSquaresRef = useRef<SVGGElement>(null)
 

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -1,4 +1,4 @@
-import { applySnapshot, getEnv, getSnapshot, types } from "mobx-state-tree"
+import { applySnapshot, getSnapshot, types } from "mobx-state-tree"
 import { kellyColors } from "../../utilities/color-utils"
 import { Attribute, IAttribute } from "./attribute"
 import { CategorySet, ICategorySet, createProvisionalCategorySet, getProvisionalDataSet } from "./category-set"
@@ -47,7 +47,6 @@ describe("CategorySet", () => {
 
     // getProvisionalDataSet returns undefined for simple attributes and null
     const c = Attribute.create({ id: "cId", name: "c" }, undefined)
-    expect(getEnv(c)).toEqual({})
     expect(getProvisionalDataSet(c)).toBeUndefined()
     expect(getProvisionalDataSet(null)).toBeUndefined()
   })

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -1,6 +1,6 @@
 import { observable, runInAction } from "mobx"
 import {
-  addDisposer, getEnv, IAnyStateTreeNode, Instance, isValidReference, resolveIdentifier, types
+  addDisposer, getEnv, hasEnv, IAnyStateTreeNode, Instance, isValidReference, resolveIdentifier, types
 } from "mobx-state-tree"
 import { kellyColors } from "../../utilities/color-utils"
 import { onAnyAction } from "../../utilities/mst-utils"
@@ -21,7 +21,7 @@ interface IProvisionalEnvironment {
 }
 
 export function getProvisionalDataSet(node: IAnyStateTreeNode | null) {
-  const env = node ? getEnv<IProvisionalEnvironment>(node) : {}
+  const env = node && hasEnv(node) ? getEnv<IProvisionalEnvironment>(node) : {}
   return env.provisionalDataSet
 }
 

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -43,7 +43,7 @@
  */
 
 import { observable, reaction, runInAction } from "mobx"
-import { addDisposer, addMiddleware, getEnv, Instance, isAlive, SnapshotIn, types } from "mobx-state-tree"
+import { addDisposer, addMiddleware, getEnv, hasEnv, Instance, isAlive, SnapshotIn, types } from "mobx-state-tree"
 import pluralize from "pluralize"
 import { Attribute, IAttribute, IAttributeSnapshot } from "./attribute"
 import {
@@ -811,8 +811,8 @@ export const DataSet = V2Model.named("DataSet").props({
      */
     actions: {
       afterCreate() {
-        const context: IEnvContext = getEnv(self),
-              { srcDataSet, } = context
+        const context: IEnvContext | Record<string, never> = hasEnv(self) ? getEnv(self) : {},
+              { srcDataSet } = context
 
         // build attrNameMap
         self.attributesMap.forEach(attr => {

--- a/v3/src/models/tiles/tile-environment.ts
+++ b/v3/src/models/tiles/tile-environment.ts
@@ -1,5 +1,5 @@
 import iframePhone from "iframe-phone"
-import { getEnv, IAnyStateTreeNode } from "mobx-state-tree"
+import { getEnv, hasEnv, IAnyStateTreeNode } from "mobx-state-tree"
 import { DIMessage } from "../../data-interactive/iframe-phone-types"
 // There's nothing wrong in explicit ISharedModelManager interface, but probably dependency cycle could have been also
 // avoided using `import type { SharedModelManager } from ...`.
@@ -14,7 +14,7 @@ export interface ITileEnvironment {
 }
 
 export function getTileEnvironment(node?: IAnyStateTreeNode) {
-  return node ? getEnv<ITileEnvironment | undefined>(node) : undefined
+  return node && hasEnv(node) ? getEnv<ITileEnvironment | undefined>(node) : undefined
 }
 
 export function getSharedModelManager(node?: IAnyStateTreeNode) {


### PR DESCRIPTION
- Updated [our fork of mobx-state-tree](https://github.com/concord-consortium/mobx-state-tree) to the recently released v6.0.0 from upstream and published a new `6.0.0-cc.1` version.
  - I didn't create a separate PR there, but see the [v6.0.0-cc.x branch](https://github.com/concord-consortium/mobx-state-tree/tree/v6.0.0-cc.x) where I cherry-picked our local changes.
- Updated CODAP v3 to use the newly published version. Most of the code changes required resulted from these two changes in MST v6.0.0:
  - `getEnv()` now throws an exception if called in the absence of an environment (rather than returning an empty object). Requires use of `hasEnv()` to pre-flight calls to `getEnv()`.
  - Changes to union typing which required some changes to adornment clients.