### PR TITLE
187651946 v3 DI Fix Multidata

### DIFF
--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -114,6 +114,12 @@ export interface DIUpdateCollection {
   title?: string
   labels?: Partial<ICollectionLabels>
 }
+export interface DIUpdateDataContext extends DIDataContext {
+  sort?: {
+    attr?: string
+    isDescending?: boolean
+  }
+}
 export interface DINotification {
   request?: string
 }

--- a/v3/src/data-interactive/data-interactive-utils.ts
+++ b/v3/src/data-interactive/data-interactive-utils.ts
@@ -1,6 +1,7 @@
+import { ICollectionModel } from "../models/data/collection"
 import { IDataSet } from "../models/data/data-set"
 import { ICaseCreation } from "../models/data/data-set-types"
-import { toV2Id, toV3CollectionId } from "../utilities/codap-utils"
+import { toV2Id, toV3AttrId, toV3CollectionId } from "../utilities/codap-utils"
 import { DICaseValues } from "./data-interactive-types"
 
 export function canonicalizeAttributeName(name: string, iCanonicalize = true) {
@@ -53,4 +54,12 @@ export function getCollection(dataContext?: IDataSet, nameOrId?: string) {
 
   return dataContext?.getCollectionByName(nameOrId) ||
     dataContext?.getCollection(toV3CollectionId(nameOrId))
+}
+
+export function getAttribute(nameOrId: string, dataContext?: IDataSet, collection?: ICollectionModel) {
+  const canonicalAttrName = canonicalizeAttributeName(nameOrId)
+  // check collection first in case of ambiguous names in data set
+  return collection?.getAttributeByName(nameOrId) || collection?.getAttributeByName(canonicalAttrName) ||
+    dataContext?.getAttributeByName(nameOrId) || dataContext?.getAttributeByName(canonicalAttrName) ||
+    dataContext?.getAttribute(toV3AttrId(nameOrId)) // in case it's an id
 }

--- a/v3/src/data-interactive/handlers/attribute-location-handler.ts
+++ b/v3/src/data-interactive/handlers/attribute-location-handler.ts
@@ -33,6 +33,7 @@ export const diAttributeLocationHandler: DIHandler = {
       afterAttrId,
       attrId: attributeLocation.id,
       dataset: dataContext,
+      includeNotifications: true,
       sourceCollection,
       targetCollection
     })

--- a/v3/src/data-interactive/handlers/data-context-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.ts
@@ -4,8 +4,11 @@ import { DataSet } from "../../models/data/data-set"
 import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
 import { hasOwnProperty } from "../../utilities/js-utils"
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIDataContext, DIHandler, DIResources, DIValues, diNotImplementedYet } from "../data-interactive-types"
+import {
+  DIDataContext, DIHandler, DIResources, DIUpdateDataContext, DIValues, diNotImplementedYet
+} from "../data-interactive-types"
 import { basicDataSetInfo, convertDataSetToV2 } from "../data-interactive-type-utils"
+import { getAttribute } from "../data-interactive-utils"
 import { createCollection } from "./di-handler-utils"
 import { dataContextNotFoundResult } from "./di-results"
 
@@ -63,12 +66,19 @@ export const diDataContextHandler: DIHandler = {
     const { dataContext } = resources
     if (!dataContext) return dataContextNotFoundResult
 
-    const values = _values as DIDataContext
+    const values = _values as DIUpdateDataContext
     if (values) {
       dataContext.applyModelChange(() => {
         const { metadata, title } = values
         if (metadata && hasOwnProperty(metadata, "description")) dataContext.setDescription(metadata.description)
         if (hasOwnProperty(values, "title")) dataContext.setTitle(title)
+
+        if (values.sort?.attr) {
+          const attribute = getAttribute(values.sort.attr, dataContext)
+          if (attribute) {
+            // TODO Perform the actual sort
+          }
+        }
       })
     }
 

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -2,13 +2,12 @@ import { appState } from "../models/app-state"
 import { IAttribute } from "../models/data/attribute"
 import { isCollectionModel } from "../models/data/collection"
 import { GlobalValueManager } from "../models/global/global-value-manager"
-// import { IDataSet } from "../models/data/data-set"
 import { getSharedDataSets } from "../models/shared/shared-data-utils"
 import { getTilePrefixes } from "../models/tiles/tile-content-info"
 import { ITileModel } from "../models/tiles/tile-model"
-import { toV3AttrId, toV3CaseId, toV3GlobalId, toV3Id, toV3TileId } from "../utilities/codap-utils"
+import { toV3CaseId, toV3GlobalId, toV3Id, toV3TileId } from "../utilities/codap-utils"
 import { ActionName, DIResources, DIResourceSelector } from "./data-interactive-types"
-import { canonicalizeAttributeName, getCollection } from "./data-interactive-utils"
+import { getAttribute, getCollection } from "./data-interactive-utils"
 
 /**
  * A resource selector identifies a CODAP resource. It is either a group
@@ -137,12 +136,7 @@ export function resolveResources(
   if (resourceSelector.attribute || resourceSelector.attributeLocation) {
     const attrKey = resourceSelector.attribute ? 'attribute' : 'attributeLocation'
     const attrNameOrId = resourceSelector[attrKey] ?? ""
-    const canonicalAttrName = canonicalizeAttributeName(attrNameOrId)
-    result[attrKey] =
-      // check collection first in case of ambiguous names in data set
-      collectionModel?.getAttributeByName(attrNameOrId) || collectionModel?.getAttributeByName(canonicalAttrName) ||
-      dataContext?.getAttributeByName(attrNameOrId) || dataContext?.getAttributeByName(canonicalAttrName) ||
-      dataContext?.getAttribute(toV3AttrId(attrNameOrId)) // in case it's an id
+    result[attrKey] = getAttribute(attrNameOrId, dataContext, collectionModel)
   }
 
   if ("attributeList" in resourceSelector) {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187651946

This PR starts to address some issues with the Multidata plugin in v3 discovered during testing.
- Notifications are now broadcast when an attribute is moved in response to an API request. Multidata relies on these notifications to update its representation of the dataset when a user moves an attribute in the plugin.
- Infrastructure has been added to handle `update dataContext` requests with `sort attribute`. Since sorting attributes hasn't been implemented in v3 yet, the request isn't fully handled, but it should be easy to finish once it is possible to sort attributes. 