### PR TITLE
Fix for bug found in prior PR for specifying num stdErrors

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-model.ts
@@ -19,9 +19,11 @@ export const StandardErrorAdornmentModel = UnivariateMeasureAdornmentModel
     setNumStErrs(numStErrs: number) {
       self._numStErrs = numStErrs
       self.dynamicNumStErrs = undefined
+      self.invalidateMeasures()
     },
     setDynamicNumStErrs(numStErrs: number | undefined) {
       self.dynamicNumStErrs = numStErrs
+      self.invalidateMeasures()
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-model.ts
@@ -38,7 +38,7 @@ export const StandardErrorAdornmentModel = UnivariateMeasureAdornmentModel
       const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
       // If there are less than two values, the adornment should not render.
       if (caseValues.length < 2) return
-      return self.numStErrs * Number(std(caseValues)) / Math.sqrt(caseValues.length)
+      return this.numStErrs * Number(std(caseValues)) / Math.sqrt(caseValues.length)
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-model.ts
@@ -38,7 +38,7 @@ export const StandardErrorAdornmentModel = UnivariateMeasureAdornmentModel
       const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
       // If there are less than two values, the adornment should not render.
       if (caseValues.length < 2) return
-      return this.numStErrs * Number(std(caseValues)) / Math.sqrt(caseValues.length)
+      return self.numStErrs * Number(std(caseValues)) / Math.sqrt(caseValues.length)
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -19,6 +19,9 @@ export const MeasureInstance = types.model("MeasureInstance", {
   setValue(value: number) {
     self.value = value
     self.isValid = true
+  },
+  setIsValid(isValid: boolean) {
+    self.isValid = isValid
   }
 }))
 
@@ -78,6 +81,9 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
     },
     setShowMeasureLabels(showLabels: boolean) {
       self.showMeasureLabels = showLabels
+    },
+    invalidateMeasures() {
+      self.measures.forEach(measure => measure.setIsValid(false))
     }
   }))
   .views(self => ({


### PR DESCRIPTION
[#187626777] Feature: User can specify how many standard errors are shown in the standard error bar

* This is a fix for a bug caught in a prior PR whereby the label and text tip for standard error was not being updated when the number of standard errors was changed. The fix is to make it possible to invalidate measures maintained by UnivariateMeasureAdornmentModels and to do this invalidatation in the StandardErrorAdornmentModel when the number of standard errors is changed.