### PR TITLE
feat: Graph option Show Measures for Selection (PT-187459320)

### DIFF
--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -283,6 +283,23 @@ context("Graph UI", () => {
     cy.wait(500)
     cy.get("[data-testid=show-parent-toggles]").should("exist").and("have.text", "Show Parent Visibility Toggles")
   })
+  // TODO: Get the tests below working. For some reason, the banner isn't being rendered in Cypress even though it
+  // seems to render fine in the browser.
+  // it("It adds a banner to the graph when Show Measures for Selection is activated", () => {
+  //   cy.dragAttributeToTarget("table", "Sleep", "bottom")
+  //   cy.get("[data-testid=measures-for-selection-banner]").should("not.exist")
+  //   graph.getHideShowButton().click()
+  //   cy.wait(500)
+  //   cy.get("[data-testid=show-selection-measures]").click()
+  //   cy.wait(500)
+  //   cy.get("[data-testid=measures-for-selection-banner]")
+  //     .should("exist").and("have.text", "Showing measures for 0 selected cases")
+  //   graph.getHideShowButton().click()
+  //   cy.wait(500)
+  //   cy.get("[data-testid=show-selection-measures]").click()
+  //   cy.wait(500)
+  //   cy.get("[data-testid=measures-for-selection-banner]").should("not.exist")
+  // })
   it("disables Point Size control when display type is bars", () => {
     cy.dragAttributeToTarget("table", "Sleep", "bottom")
     cy.wait(500)

--- a/v3/src/components/graph/adornments/adornments.tsx
+++ b/v3/src/components/graph/adornments/adornments.tsx
@@ -156,9 +156,9 @@ export const Adornments = observer(function Adornments() {
   )
   return (
     <>
-      {graphModel.showMeasuresForSelection && <MeasuresForSelectionBanner />}
       {adornmentBanners &&
         <div className="graph-adornments-banners" data-testid="graph-adornments-banners">
+          {graphModel.showMeasuresForSelection && <MeasuresForSelectionBanner />}
           {adornmentBanners}
         </div>
       }

--- a/v3/src/components/graph/adornments/adornments.tsx
+++ b/v3/src/components/graph/adornments/adornments.tsx
@@ -14,6 +14,7 @@ import { useGraphLayoutContext } from "../hooks/use-graph-layout-context"
 import { getAdornmentComponentInfo } from "./adornment-component-info"
 import { updateCellKey } from "./adornment-utils"
 import { kGraphAdornmentsBannerHeight } from "./adornment-types"
+import { MeasuresForSelectionBanner } from "./measures-for-selection-banner"
 
 import "./adornments.scss"
 
@@ -29,7 +30,8 @@ export const Adornments = observer(function Adornments() {
 
   useEffect(function handleAdornmentBannerCountChange() {
     return mstAutorun(() => {
-      const bannerCount = graphModel.adornmentsStore.activeBannerCount
+      let bannerCount = graphModel.showMeasuresForSelection ? 1 : 0
+      bannerCount += graphModel.adornmentsStore.activeBannerCount
       const bannersHeight = bannerCount * kGraphAdornmentsBannerHeight
       layout.setDesiredExtent("banners", bannersHeight)
       }, { name: "Graph.handleAdornmentBannerCountChange" }, graphModel
@@ -154,11 +156,12 @@ export const Adornments = observer(function Adornments() {
   )
   return (
     <>
-    {adornmentBanners &&
-      <div className="graph-adornments-banners" data-testid="graph-adornments-banners">
-        {adornmentBanners}
-      </div>
-    }
+      {graphModel.showMeasuresForSelection && <MeasuresForSelectionBanner />}
+      {adornmentBanners &&
+        <div className="graph-adornments-banners" data-testid="graph-adornments-banners">
+          {adornmentBanners}
+        </div>
+      }
       <div className={containerClass} data-testid={kGraphAdornmentsClass} style={outerGridStyle}>
         {outerGridCells}
       </div>

--- a/v3/src/components/graph/adornments/measures-for-selection-banner.scss
+++ b/v3/src/components/graph/adornments/measures-for-selection-banner.scss
@@ -1,0 +1,22 @@
+@use "../../vars.scss" as *;
+
+.measures-for-selection-banner {
+  background: $background-fill;
+  border: none;
+  color: #000;
+  display: flex;
+  flex-direction: column;
+  font: 12px "MuseoSans-500", sans-serif;
+  justify-content: center;
+  left: 0;
+  line-height: 1;
+  min-height: 22px;
+  overflow: hidden;
+  padding: 0 5px;
+  pointer-events: all;
+  position: absolute;
+  text-align: left;
+  top: 0;
+  width: calc(100% - 10px);
+  z-index: 5;
+}

--- a/v3/src/components/graph/adornments/measures-for-selection-banner.scss
+++ b/v3/src/components/graph/adornments/measures-for-selection-banner.scss
@@ -8,15 +8,11 @@
   flex-direction: column;
   font: 12px "MuseoSans-500", sans-serif;
   justify-content: center;
-  left: 0;
   line-height: 1;
   min-height: 22px;
   overflow: hidden;
   padding: 0 5px;
   pointer-events: all;
-  position: absolute;
   text-align: left;
-  top: 0;
   width: calc(100% - 10px);
-  z-index: 5;
 }

--- a/v3/src/components/graph/adornments/measures-for-selection-banner.tsx
+++ b/v3/src/components/graph/adornments/measures-for-selection-banner.tsx
@@ -12,7 +12,7 @@ export const MeasuresForSelectionBanner = observer(function MeasuresForSelection
                     : t("DG.SelectedInfoView.infoPlural", { vars: [dataConfig?.selection.length] })
   
   return (
-    <div className="measures-for-selection-banner" data-testid="measures-for-selection-banners">
+    <div className="measures-for-selection-banner" data-testid="measures-for-selection-banner">
       {content}
     </div>
   )

--- a/v3/src/components/graph/adornments/measures-for-selection-banner.tsx
+++ b/v3/src/components/graph/adornments/measures-for-selection-banner.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { observer } from "mobx-react-lite"
+import { t } from "../../../utilities/translation/translate"
+import { useGraphDataConfigurationContext } from "../hooks/use-graph-data-configuration-context"
+
+import "./measures-for-selection-banner.scss"
+
+export const MeasuresForSelectionBanner = observer(function MeasuresForSelectionBanner() {
+  const dataConfig = useGraphDataConfigurationContext()
+  const content = dataConfig?.selection.length === 1
+                    ? t("DG.SelectedInfoView.infoSing", { vars: [1] })
+                    : t("DG.SelectedInfoView.infoPlural", { vars: [dataConfig?.selection.length] })
+  
+  return (
+    <div className="measures-for-selection-banner" data-testid="measures-for-selection-banners">
+      {content}
+    </div>
+  )
+})

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -78,6 +78,19 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
     )
   }
 
+  const handleMeasuresForSelectionChange = () => {
+    const undoStringKey = graphModel?.showMeasuresForSelection
+                            ? "DG.Undo.disableMeasuresForSelection"
+                            : "DG.Undo.enableMeasuresForSelection"
+    const redoStringKey = graphModel?.showMeasuresForSelection
+                            ? "DG.Redo.disableMeasuresForSelection"
+                            : "DG.Redo.enableMeasuresForSelection"
+    dataConfig?.applyModelChange(
+      () => graphModel?.setShowMeasuresForSelection(!graphModel?.showMeasuresForSelection),
+      { undoStringKey, redoStringKey }
+    )
+  }
+
   const numSelected = dataConfig?.selection.length ?? 0,
     hideSelectedIsDisabled = numSelected === 0,
     hideSelectedString = (numSelected === 1) ? t("DG.DataDisplayMenu.hideSelectedSing")
@@ -113,8 +126,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
       <MenuItem onClick={handleParentTogglesChange} data-testid="show-parent-toggles">
         {parentToggleString}
       </MenuItem>
-      <MenuItem onClick={() => graphModel?.setShowMeasuresForSelection(!graphModel?.showMeasuresForSelection)}
-       data-testid="show-selection-measures">
+      <MenuItem onClick={handleMeasuresForSelectionChange} data-testid="show-selection-measures">
         {measuresForSelectionString}
       </MenuItem>
     </MenuList>

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -69,8 +69,9 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
   }
 
   const handleParentTogglesChange = () => {
-    const undoStringKey = graphModel?.showParentToggles ? "DG.Undo.disableNumberToggle" : "DG.Undo.enableNumberToggle"
-    const redoStringKey = graphModel?.showParentToggles ? "DG.Redo.disableNumberToggle" : "DG.Redo.enableNumberToggle"
+    const [undoStringKey, redoStringKey] = graphModel?.showParentToggles
+      ? ["DG.Undo.disableNumberToggle", "DG.Redo.disableNumberToggle"]
+      : ["DG.Undo.enableNumberToggle", "DG.Redo.enableNumberToggle"]
 
     dataConfig?.applyModelChange(
       () => graphModel?.setShowParentToggles(!graphModel?.showParentToggles),
@@ -79,12 +80,9 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
   }
 
   const handleMeasuresForSelectionChange = () => {
-    const undoStringKey = graphModel?.showMeasuresForSelection
-                            ? "DG.Undo.disableMeasuresForSelection"
-                            : "DG.Undo.enableMeasuresForSelection"
-    const redoStringKey = graphModel?.showMeasuresForSelection
-                            ? "DG.Redo.disableMeasuresForSelection"
-                            : "DG.Redo.enableMeasuresForSelection"
+    const [undoStringKey, redoStringKey] = graphModel?.showMeasuresForSelection
+      ? ["DG.Undo.disableMeasuresForSelection", "DG.Redo.disableMeasuresForSelection"]
+      : ["DG.Undo.enableMeasuresForSelection", "DG.Redo.enableMeasuresForSelection"]
     dataConfig?.applyModelChange(
       () => graphModel?.setShowMeasuresForSelection(!graphModel?.showMeasuresForSelection),
       { undoStringKey, redoStringKey }


### PR DESCRIPTION
[#187459320](https://www.pivotaltracker.com/story/show/187459320)

When the "Show Measures for Selection" option is activated, a banner appears near the top of the graph tile saying "Showing measures for _n_ selected cases", where _n_ is the number of selected cases.

There is now a [separate story](https://www.pivotaltracker.com/story/show/187711050) for making the adornments respond to the setting.