### PR TITLE
Added undo/redo functionality to the component rename test in calculator.spec

### DIFF
--- a/v3/cypress/e2e/calculator.spec.ts
+++ b/v3/cypress/e2e/calculator.spec.ts
@@ -14,21 +14,20 @@ context("Calculator", () => {
   it("populates default title", () => {
     c.getComponentTitle("calculator").should("contain", calculatorName)
   })
-  it("updates calculator title", () => {
+  it("updates calculator title with undo/redo", () => {
     const newCalculatorName = "my calc"
     c.getComponentTitle("calculator").should("have.text", calculatorName)
     c.changeComponentTitle("calculator", newCalculatorName)
     c.getComponentTitle("calculator").should("have.text", newCalculatorName)
 
-     // Undo title change
-     // Note: This title does not update. Instead it goes to "my Cal" when the undo button is pressed
-     // See PT bug #187033159
-     // toolbar.getUndoTool().click()
-     // c.getComponentTitle("calculator").should("have.text", calculatorName)
+    cy.log("Check update calculator title with undo/redo")
+    // Undo title change
+    toolbar.getUndoTool().click()
+    c.getComponentTitle("calculator").should("have.text", calculatorName)
 
-     // Redo title change
-     // toolbar.getRedoTool().click()
-     // c.getComponentTitle("calculator").should("have.text", newCalculatorName)
+    // Redo title change
+    toolbar.getRedoTool().click()
+    c.getComponentTitle("calculator").should("have.text", newCalculatorName)
   })
   it("close calculator from toolshelf with undo/redo", () => {
     const newCalculatorName = "my calc"
@@ -38,6 +37,8 @@ context("Calculator", () => {
 
     c.getIconFromToolshelf("calc").click()
     c.checkComponentDoesNotExist("calculator")
+
+    cy.log("Check undo/redo of close and open calculator component")
 
     // Undo closing calculator (Reopen)
     toolbar.getUndoTool().click()

--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -539,7 +539,7 @@ context("Graph UI", () => {
         expect(valueNum).to.be.closeTo(4, 0.1)
       })
     })
-    it("shows a bar graph with one categorical attr on primary axis and 'Fuse Dots into Bars' is checked", () => {
+    it("shows a bar graph for categorical attr on primary axis with 'Fuse Dots into Bars' checked", () => {
       cy.dragAttributeToTarget("table", "Habitat", "bottom")
       cy.get("[data-testid=bar-cover]").should("not.exist")
       graph.getDisplayConfigButton().click()
@@ -547,8 +547,9 @@ context("Graph UI", () => {
         .and("not.be.checked")
       cy.get("[data-testid=bar-chart-checkbox]").click()
       cy.get("[data-testid=bar-chart-checkbox]").find("input").should("be.checked")
-      // TODO: It would be better to check for the exact number of bars, but the number seems to vary depending
-      // on whether you're running the test locally or in CI for some mysterious reason.
+      // TODO: It would be better to check for the exact number of bars,
+      // but the number seems to vary depending on whether
+      // you're running the test locally or in CI for some mysterious reason.
       // cy.get("[data-testid=bar-cover]").should("exist").and("have.length", 3)
       cy.get("[data-testid=bar-cover]").should("exist")
       cy.get(".axis-wrapper.left").find("[data-testid=attribute-label]").should("exist").and("have.text", "Count")


### PR DESCRIPTION
**PT Stories**
[PT-187064552](https://www.pivotaltracker.com/story/show/187064552)
[PT-187278604](https://www.pivotaltracker.com/story/show/187278604)
[PT-187612773](https://www.pivotaltracker.com/story/show/187612773)

**Summary**
This pull request addresses the addition of undo/redo checks after a recent bug fix.

**Changes Made**
1. Added undo/redo functionality to the component rename test in `calculator.spec`.
2. Fixed a lint error in `graph.spec`.
