### PR TITLE
Normal curve for histograms

### DIFF
--- a/v3/src/components/data-display/components/background.tsx
+++ b/v3/src/components/data-display/components/background.tsx
@@ -108,7 +108,7 @@ export const Background = forwardRef<SVGGElement | HTMLDivElement, IProps>((prop
         })
       }
       marqueeState.setMarqueeRect({x: startX.current, y: startY.current, width: 0, height: 0})
-    }, [datasetsArray, marqueeState, pixiPointsArrayRef]),
+    }, [bgRef, datasetsArray, marqueeState, pixiPointsArrayRef]),
 
     onDrag = useCallback((event: { dx: number; dy: number }) => {
       if (event.dx !== 0 || event.dy !== 0 && datasetsArray.length) {


### PR DESCRIPTION
This PR covers most situations for plotting normal curves on histograms, but there are probably some wrinkles to be worked out when categorical attributes are on the top and right. These are difficult to diagnose until histograms behave better when split on top and right.

[#187751261] Feature: User can plot a normal curve on top of a histogram

Fortunately, it just takes a few tweaks to normal-curve-adornment-component.tsx to get the curve to use the count axis and histogram bin width in place of the dots and overlap to get this to work.
* Also fixed a dependency error in background.tsx