### PR TITLE
Fix crashing bug on graph x-y switch

### DIFF
--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -3,7 +3,7 @@ import {comparer, reaction} from "mobx"
 import {AttributeType} from "../../../models/data/attribute"
 import {IDataSet} from "../../../models/data/data-set"
 import {typedId} from "../../../utilities/js-utils"
-import {cachedFnFactory, cachedFnWithArgsFactory} from "../../../utilities/mst-utils"
+import { cachedFnFactory, cachedFnWithArgsFactory, safeGetSnapshot } from "../../../utilities/mst-utils"
 import {AxisPlace} from "../../axis/axis-types"
 import {GraphPlace} from "../../axis-graph-shared"
 import {AttributeDescription, DataConfigurationModel, IAttributeDescriptionSnapshot, IDataConfigurationModel}
@@ -67,7 +67,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         {...getSnapshot(self._attributeDescriptions)}
       delete descriptions.rightNumeric
       if (self._yAttributeDescriptions.length > 0) {
-        descriptions.y = self._yAttributeDescriptions[0]
+        descriptions.y = safeGetSnapshot(self._yAttributeDescriptions[0])
       }
       return descriptions
     },
@@ -79,7 +79,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
      * For all other roles we return the attribute description for the role.
      */
     attributeDescriptionForRole(role: GraphAttrRole) {
-      return role === 'y' ? this.yAttributeDescriptions[0]
+      return role === 'y' ? safeGetSnapshot(this.yAttributeDescriptions[0])
         : role === 'rightNumeric' ? self._attributeDescriptions.get('rightNumeric')
           : this.attributeDescriptions[role]
     },

--- a/v3/src/utilities/mst-utils.ts
+++ b/v3/src/utilities/mst-utils.ts
@@ -1,7 +1,12 @@
 import {
   IAnyStateTreeNode, IDisposer, isAlive, ISerializedActionCall, getParent, getType,
-  IOnActionOptions, onAction, hasParent, types
+  IOnActionOptions, onAction, hasParent, types, getSnapshot
 } from "mobx-state-tree"
+
+
+export function safeGetSnapshot<S>(target?: IAnyStateTreeNode): S | undefined {
+  return target ? getSnapshot(target) : undefined
+}
 
 /**
  * This creates the definition for a type field in MST.


### PR DESCRIPTION
[#187757747] Bug fix: Drag-switching x-y attributes is broken

* This bug was caused by an inconsistency in the attribute descriptions were being returned from the graph's data configuration. The claim in `attributeDescriptionForRole` was that we would return a snapshot of an `AttributeDescription`. But for y attributes, which are stored in an array, we were actually returning the `AttributeDescription` model and this was causing problems for MST in the circumstance in which the user is switching attributes between x and y. We fix this by converting the y-attribute description to a snapshot before we return it.
* As a convenience we also introduce `safeGetSnapshot` which checks for `undefined` before converting its argument to a snapshot.