### PR TITLE
Fix for graph rehydration bug

### DIFF
--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -87,6 +87,10 @@ export class GraphController {
             axisMultiScale.setNumericDomain(axisModel.domain)
           }
         }
+        else {
+          // During rehydration we need to reset each axis scale
+          layout.resetAxisScale(axisPlace)
+        }
       })
       this.callMatchCirclesToData()
       this.attrConfigForInitGraph = dataConfig.attributeDescriptionsStr

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -111,6 +111,13 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
     this.getAxisMultiScale(place)?.setLength(length)
   }
 
+  @action resetAxisScale(place: AxisPlace) {
+    const multiScale = this.getAxisMultiScale(place)
+    multiScale.setCategorySet(undefined)
+    multiScale.setScaleType("ordinal")
+    multiScale.setRepetitions(1)
+  }
+
   @override setDesiredExtent(place: GraphExtentsPlace, extent: number) {
     this.desiredExtents.set(place, extent)
     this.updateScaleRanges(this.plotWidth, this.plotHeight)


### PR DESCRIPTION
[#187757811] Bug fix: Rehydrating graph problem

* The symptom was an axis that retained multiple sub-axes when a document was loaded that had a variation on the instance of the graph tile present. The fix is to reset any `GraphLayout` axis scales that aren't being set up by an axis model that is brought in.