### PR TITLE
Improve No Cases Message

### DIFF
--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -308,6 +308,15 @@ $table-body-font-size: 8pt;
   }
 }
 
+.no-cases-message {
+  font-size: 14px;
+  font-style: italic;
+  position: absolute;
+  text-align: center;
+  top: 58px;
+  width: 100%;
+}
+
 .codap-menu-list {
   width: 190px;
 

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -1,6 +1,6 @@
 import { useDndContext } from "@dnd-kit/core"
 import { observer } from "mobx-react-lite"
-import React, { CSSProperties, useCallback, useEffect, useRef } from "react"
+import React, { useCallback, useEffect, useRef } from "react"
 import { AttributeDragOverlay } from "../drag-drop/attribute-drag-overlay"
 import { kIndexColumnKey } from "./case-table-types"
 import { CollectionTable } from "./collection-table"
@@ -121,26 +121,18 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
               )
             })}
             <AttributeDragOverlay activeDragId={overlayDragId} />
+            <NoCasesMessage />
           </div>
         </div>
-        <NoCasesMessage />
       </>
     )
   })
 })
 
 // temporary until we have an input row
-export const NoCasesMessage = () => {
+const NoCasesMessage = observer(function NoCasesMessage() {
   const data = useDataSetContext()
-  const style: CSSProperties = {
-    position: "absolute",
-    top: 54,
-    width: "100%",
-    textAlign: "center",
-    fontSize: 14,
-    fontStyle: "italic"
-  }
   return !data?.cases.length
-          ? <div className="no-cases-message" style={style}>{t("V3.caseTable.noCases")}</div>
+          ? <div className="no-cases-message">{t("V3.caseTable.noCases")}</div>
           : null
-}
+})


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187309840

This PR improves the "No Cases" temporary message in a case table.
- It no longer overlaps with attribute names.
- It is now reactive, so it will immediately disappear when cases get added to the dataset.