### PR TITLE
Ensure New Collections Have Unique Names

### DIFF
--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -464,6 +464,10 @@ test("hierarchical collection support", () => {
   const parentAttr = data.addAttribute({ name: "parentAttr" }, { collection: parentCollectionId })
   expect(parentCollection.getAttribute(childAttr.id)).toBeUndefined()
   expect(parentCollection.getAttribute(parentAttr.id)).toBe(parentAttr)
+  
+  // Names must be unique
+  const parentCollection2 = data.addCollection({ name: "ParentCollection" })
+  expect(parentCollection2.name).toBe("ParentCollection1")
 
   destroy(data)
   jestSpyConsole("warn", spy => {

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -308,6 +308,13 @@ export const DataSet = V2Model.named("DataSet").props({
     return self.collections.find(coll => coll.hasCase(caseId))
   }
 
+  function getUniqueCollectionName(name: string) {
+    let suffix = 1
+    let collectionName = name
+    while (getCollectionByName(collectionName)) collectionName = `${name}${suffix++}`
+    return collectionName
+  }
+
   return {
     views: {
       // get collection from id
@@ -320,6 +327,7 @@ export const DataSet = V2Model.named("DataSet").props({
       // undefined => attribute not present in dataset
       getCollectionForAttribute,
       getCollectionForCase,
+      getUniqueCollectionName,
       // leaf-most child cases (i.e. those not grouped in a collection)
       childCases() {
         if (!isValidCollectionGroups.get()) {
@@ -464,7 +472,12 @@ export const DataSet = V2Model.named("DataSet").props({
       invalidateCollectionGroups() {
         isValidCollectionGroups.set(false)
       },
-      addCollection(collection: ICollectionModelSnapshot, options?: IAddCollectionOptions) {
+      addCollection(collectionSnap: ICollectionModelSnapshot, options?: IAddCollectionOptions) {
+        // ensure collection has a unique name
+        const { name, ...rest } = collectionSnap
+        const _name = getUniqueCollectionName(name ?? "")
+        const collection = { name: _name, ...rest }
+        
         // place the collection in the correct location
         let beforeIndex = options?.before ? getCollectionIndex(options.before) : -1
         if (beforeIndex < 0 && options?.after) {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187638145

This PR ensures new collections have unique names by appending a number to the end of a new collection's name if it shares a name with an existing collection. This is the same way v2 handles this problem.

Allowing duplicate names was causing a bug in the Choosy plugin, which was the motivation for fixing this issue.

I made it so whenever an attribute is added to a dataset, its name is ensured to be unique. But I wasn't sure if this was the correct place to make this intervention, so something to think about when looking over this PR.