### PR TITLE
187793171 Prevent Automatic Action from being Undoable

### DIFF
--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -139,7 +139,8 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
   // the tile's dimensions. To prevent this, we add a transitionend handler that sets a flag on the tile model when the
   // transition completes. Child components can check this flag to avoid or counteract premature application of effects.
   useEffect(function addTransitionEndHandler() {
-    const handleTransitionEnd = () => tile.setTransitionComplete(true)
+    // applyModelChange is used to prevent an action from being added to the undo stack
+    const handleTransitionEnd = () => tile.applyModelChange(() => tile.setTransitionComplete(true))
     const element = document.getElementById(`${tileId}`)
     element?.addEventListener("transitionend", handleTransitionEnd)
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187793171

This PR prevents an automatic `setTransitionComplete` call from being undoable. This was causing a problem because the automatic call was happening after undoing an attribute assignment, wiping out the undo stack moving forward, preventing the action from being redoable.