### PR TITLE
187718437 v3 DI Create Component Fixes

### DIFF
--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -15,6 +15,10 @@ import { CaseData } from "../../data-display/d3-types"
 
 export const kGraphDataConfigurationType = "graphDataConfigurationType"
 
+interface ILegalAttributeOptions {
+  allowSameAttr?: boolean
+}
+
 /**
  * A note about cases:
  * - For situations in which there is exactly one y-attribute, there exists one set of cases, filtered
@@ -527,23 +531,29 @@ export const GraphDataConfigurationModel = DataConfigurationModel
           primaryRole = self.primaryRole
         return primaryRole === role || !['left', 'bottom'].includes(place)
       },
-      placeCanAcceptAttributeIDDrop(place: GraphPlace, dataSet?: IDataSet, idToDrop?: string) {
+      placeCanAcceptAttributeIDDrop(
+        place: GraphPlace, dataSet?: IDataSet, idToDrop?: string, options?: ILegalAttributeOptions
+      ) {
         const role = graphPlaceToAttrRole[place],
-          typeToDropIsNumeric = !!idToDrop && dataSet?.attrFromID(idToDrop)?.type === 'numeric',
           xIsNumeric = self.attributeType('x') === 'numeric',
-          existingID = self.attributeID(role)
+          existingID = self.attributeID(role),
+          differentAttribute = options?.allowSameAttr || existingID !== idToDrop
         // only drops on left/bottom axes can change data set
         if (dataSet?.id !== self.dataset?.id && !['left', 'bottom'].includes(place)) {
           return false
         }
+
+        if (!idToDrop) return false
+
+        const typeToDropIsNumeric = dataSet?.attrFromID(idToDrop)?.type === "numeric"
         if (place === 'yPlus') {
-          return xIsNumeric && typeToDropIsNumeric && !!idToDrop && !self.yAttributeIDs.includes(idToDrop)
+          return xIsNumeric && typeToDropIsNumeric && !self.yAttributeIDs.includes(idToDrop)
         } else if (place === 'rightNumeric') {
-          return xIsNumeric && typeToDropIsNumeric && !!idToDrop && existingID !== idToDrop
+          return xIsNumeric && typeToDropIsNumeric && differentAttribute
         } else if (['top', 'rightCat'].includes(place)) {
-          return !typeToDropIsNumeric && !!idToDrop && existingID !== idToDrop
+          return !typeToDropIsNumeric && differentAttribute
         } else {
-          return !!idToDrop && existingID !== idToDrop
+          return differentAttribute
         }
       }
     }))

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -3,7 +3,7 @@ import { SetRequired } from "type-fest"
 import { kCaseCardTileType } from "../../components/case-card/case-card-defs"
 import { createOrShowTableOrCardForDataset } from "../../components/case-table-card-common/case-table-card-utils"
 import { kCaseTableTileType } from "../../components/case-table/case-table-defs"
-import { GraphAttrRole } from "../../components/data-display/data-display-types"
+import { attrRoleToGraphPlace, GraphAttrRole } from "../../components/data-display/data-display-types"
 import {
   AttributeDescriptionsMapSnapshot, IAttributeDescriptionSnapshot, kDataConfigurationType
 } from "../../components/data-display/models/data-configuration-model"
@@ -51,7 +51,7 @@ import {
 } from "../data-interactive-component-types"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DINotification, diNotImplementedYet, DIResources, DIValues } from "../data-interactive-types"
-import { componentNotFoundResult, dataContextNotFoundResult, valuesRequiredResult } from "./di-results"
+import { componentNotFoundResult, dataContextNotFoundResult, errorResult, valuesRequiredResult } from "./di-results"
 
 export const diComponentHandler: DIHandler = {
   create(_resources: DIResources, values?: DIValues) {
@@ -73,14 +73,9 @@ export const diComponentHandler: DIHandler = {
       return caseMetadatas?.find(cm => cm.data?.id === dataSetId)
     }
 
-    const dataContextRequiredResult = {
-      success: false as const,
-      values: { error: t("V3.DI.Error.fieldRequired", { vars: ["Create", type, "dataContext"] }) }
-    }
-    const componentNotCreatedResult = {
-      success: false as const,
-      values: { error: t("V3.DI.Error.componentNotCreated") }
-    }
+    const dataContextRequiredResult =
+      errorResult(t("V3.DI.Error.fieldRequired", { vars: ["Create", type, "dataContext"] }))
+    const componentNotCreatedResult = errorResult(t("V3.DI.Error.componentNotCreated"))
     return document.applyModelChange(() => {
       // Special case for caseCard and caseTable, which require a dataset
       if ([kV2CaseCardType, kV2CaseTableType].includes(type)) {
@@ -93,7 +88,7 @@ export const diComponentHandler: DIHandler = {
 
         const caseMetadata = getCaseMetadata(dataSet.id)
         if (!caseMetadata) {
-          return { success: false, values: { error: t("V3.DI.Error.caseMetadataNotFound", { vars: [dataContext] }) } }
+          return errorResult(t("V3.DI.Error.caseMetadataNotFound", { vars: [dataContext] }))
         }
 
         const title = _title ?? name
@@ -213,10 +208,34 @@ export const diComponentHandler: DIHandler = {
 
           // Layers will get mangled in the model because it's not in the same tree as the dataset,
           // so we mostly use the constructed layers. However, the primaryRole is determined in the model,
-          // so we have to copy that over into the constructed layers.
+          // so we have to copy that over into the constructed layers. We also make sure all attribute assignments
+          // are legal here.
           const finalLayers: Array<IGraphPointLayerModelSnapshot> = []
           for (let i = 0; i < layers.length; i++) {
             const dataConfiguration = graphModel.layers[i].dataConfiguration as IGraphDataConfigurationModel
+            const { dataset } = dataConfiguration
+            if (dataset && dataset.name === _dataContext) {
+              // Make sure all attributes can legally fulfill their specified roles
+              for (const attributeType in attributeNames) {
+                const attributeName = attributeNames[attributeType]
+                if (attributeName) {
+                  const attribute = dataset.getAttributeByName(attributeName)
+                  if (attribute) {
+                    const attributeRole = roleFromAttrKey[attributeType]
+                    const attributePlace = attrRoleToGraphPlace[attributeRole]
+                    if (attributePlace && !dataConfiguration.placeCanAcceptAttributeIDDrop(
+                      attributePlace, dataset, attribute.id, { allowSameAttr: true }
+                    )) {
+                      return errorResult(
+                        t("V3.DI.Error.illegalAttributeAssignment", { vars: [attributeName, attributeRole] })
+                      )
+                    }
+                  }
+                }
+              }
+            }
+
+            // Use the primaryRole found by syncModelWithAttributeConfiguration
             const primaryRole = dataConfiguration.primaryRole
             const currentLayer = layers[i]
             const currentDataConfiguration = currentLayer.dataConfiguration
@@ -302,10 +321,7 @@ export const diComponentHandler: DIHandler = {
             const globalManager = document.content?.getFirstSharedModelByType(GlobalValueManager)
             const global = globalManager?.getValueByName(globalValueName)
             if (!global) {
-              return {
-                success: false,
-                values: { error: t("V3.DI.Error.globalNotFound", { vars: [globalValueName] }) }
-              }
+              return errorResult(t("V3.DI.Error.globalNotFound", { vars: [globalValueName] }))
             }
 
             // Multiple sliders for one global value are not allowed
@@ -316,10 +332,7 @@ export const diComponentHandler: DIHandler = {
               }
             })
             if (existingTile) {
-              return {
-                success: false,
-                values: { error: t("V3.DI.Error.noMultipleSliders", { vars: [globalValueName] }) }
-              }
+              return errorResult(t("V3.DI.Error.noMultipleSliders", { vars: [globalValueName] }))
             }
 
             const animationDirection = _animationDirection != null
@@ -363,7 +376,7 @@ export const diComponentHandler: DIHandler = {
         }
       }
 
-      return { success: false, values: { error: t("V3.DI.Error.unsupportedComponent", { vars: [type] }) } }
+      return errorResult(t("V3.DI.Error.unsupportedComponent", { vars: [type] }))
     })
   },
   

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -189,7 +189,6 @@ export const diComponentHandler: DIHandler = {
                   dataset: dataset.id,
                   hiddenCases,
                   metadata: metadata.id,
-                  primaryRole: "y",
                   _attributeDescriptions,
                   _yAttributeDescriptions
                 },

--- a/v3/src/data-interactive/handlers/di-results.ts
+++ b/v3/src/data-interactive/handlers/di-results.ts
@@ -1,6 +1,6 @@
 import { t } from "../../utilities/translation/translate"
 
-const errorResult = (error: string) => ({ success: false, values: { error } } as const)
+export const errorResult = (error: string) => ({ success: false as const, values: { error } })
 export const attributeNotFoundResult = errorResult(t("V3.DI.Error.attributeNotFound"))
 export const caseNotFoundResult = errorResult(t("V3.DI.Error.caseNotFound"))
 export const collectionNotFoundResult = errorResult(t("V3.DI.Error.collectionNotFound"))

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -162,6 +162,13 @@ export const DocumentContentModel = BaseDocumentContentModel
       }
       if (tiles && tiles.length > 0) {
         const tile = tiles[0]
+
+        // Update existing tile with new settings
+        if (options?.title != null) {
+          tile.setTitle(options.title)
+        }
+        
+        // Change visibility of existing tile
         const tileLayout = self.getTileLayoutById(tile.id)
         if (isFreeTileLayout(tileLayout)) {
           tileLayout.setHidden(options?.setSingletonHidden ?? !tileLayout.isHidden)

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -84,6 +84,7 @@
     "V3.DI.Error.caseNotFound": "Case not found",
     "V3.DI.Error.collectionNotFound": "Collection not found",
     "V3.DI.Error.componentNotCreated": "Could not create component",
+    "V3.DI.Error.illegalAttributeAssignment": "Cannot assign %@1 to %@2",
     "V3.DI.Error.componentNotFound": "Component not found",
     "V3.DI.Error.unsupportedComponent": "Unsupported component type %@",
     "V3.DI.Error.globalCreation": "error creating global value",


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187718437

This PR fixes bugs with the original `create component` PR.
- New graphs now have their `primaryRoles` set properly.
- Attempting to assign an attribute to a role it can't fulfill (like a categorical attribute to `rightNumeric`) will now result in a `create component graph` request failing.
  - Note that there are many similar cases where attempts at illegal assignments are simply ignored. It would be a major undertaking to check every possible option in the API.
- Singleton tiles have their `titles` updated when they are displayed.