### PR TITLE
187849639 v3 DI Multidata Case Cycles

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -562,7 +562,7 @@ export const DataConfigurationModel = types
       // whether the value changes result in adding/removing any cases from the filtered set
       // a single call to setCaseValues can result in up to three calls to the handlers
       if (cases.added.length) {
-        const newCases = self.dataset?.getCases(cases.added)
+        const newCases = self.dataset?.getItems(cases.added)
         self.handlers.forEach(handler => handler({name: "addCases", args: [newCases]}))
       }
       if (cases.removed.length) {

--- a/v3/src/components/graph/components/scatter-plot-utils.ts
+++ b/v3/src/components/graph/components/scatter-plot-utils.ts
@@ -50,7 +50,7 @@ export function scatterPlotFuncs(layout: GraphLayout, dataConfiguration?: IGraph
     const xValue = getXCoord(caseID)
     const yValue = getYCoord(caseID, plotNum)
     if (isFinite(xValue) && isFinite(yValue)) {
-      const caseData = dataset?.getCase(caseID, { numeric: false })
+      const caseData = dataset?.getItem(caseID, { numeric: false })
       if (caseData) {
         const lineCoords: [number, number] = [xValue, yValue]
         return { caseData, lineCoords, plotNum }
@@ -94,7 +94,7 @@ export function scatterPlotFuncs(layout: GraphLayout, dataConfiguration?: IGraph
         // If the line has a category and it does not match the categorical legend value,
         // do not render squares.
         if (category && legendValue !== category && legendType === "categorical") return
-        const fullCaseData = dataset?.getCase(caseData.__id__, { numeric: false })
+        const fullCaseData = dataset?.getItem(caseData.__id__, { numeric: false })
         if (fullCaseData && dataConfiguration?.isCaseInSubPlot(cellKey, fullCaseData)) {
           const square = residualSquare(slope, intercept, caseData.__id__)
           if (!isFinite(square.x) || !isFinite(square.y)) return

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -428,7 +428,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       key: (cellKey: Record<string, string>) => JSON.stringify(cellKey),
       calculate: (cellKey: Record<string, string>) => {
         return self.allPlottedCases().filter((caseId) => {
-          const caseData = self.dataset?.getCase(caseId, { numeric: false }) || { __id__: caseId }
+          const caseData = self.dataset?.getItem(caseId, { numeric: false }) || { __id__: caseId }
           return self.isCaseInSubPlot(cellKey, caseData)
         })
       }
@@ -443,7 +443,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         const topValue = topAttrID ? cellKey[topAttrID] : ""
 
         return self.allPlottedCases().filter(caseId => {
-          const caseData = self.dataset?.getCase(caseId)
+          const caseData = self.dataset?.getItem(caseId)
           if (!caseData) return false
           const isRightMatch = !rightAttrID || rightValue === caseData[rightAttrID]
           const isTopMatch = !topAttrID || topAttrType !== "categorical" ||
@@ -465,7 +465,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         const topValue = topAttrID ? cellKey[topAttrID] : ""
 
         return self.allPlottedCases().filter(caseId => {
-          const caseData = self.dataset?.getCase(caseId)
+          const caseData = self.dataset?.getItem(caseId)
           if (!caseData) return false
 
           const isLeftMatch = !leftAttrID || leftAttrType !== "categorical" ||
@@ -489,7 +489,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         const rightValue = rightAttrID ? cellKey[rightAttrID] : ""
 
         return self.allPlottedCases().filter(caseId => {
-          const caseData = self.dataset?.getCase(caseId)
+          const caseData = self.dataset?.getItem(caseId)
           if (!caseData) return false
 
           const isBottomMatch = !bottomAttrID || bottomAttrType !== "categorical" ||

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -628,7 +628,7 @@ export const calculateSumOfSquares = ({ cellKey, dataConfig, intercept, slope }:
   const yAttrID = dataConfig?.attributeID("y") ?? ""
   let sumOfSquares = 0
   caseData?.forEach((datum: any) => {
-    const fullCaseData = dataConfig?.dataset?.getCase(datum.__id__, { numeric: false })
+    const fullCaseData = dataConfig?.dataset?.getItem(datum.__id__, { numeric: false })
     if (fullCaseData && dataConfig?.isCaseInSubPlot(cellKey, fullCaseData)) {
       const x = dataset?.getNumeric(datum.__id__, xAttrID) ?? NaN
       const y = dataset?.getNumeric(datum.__id__, yAttrID) ?? NaN

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -66,7 +66,7 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
     const xValue = getScreenX(caseID)
     const yValue = getScreenY(caseID)
     if (isFinite(xValue) && isFinite(yValue)) {
-      const caseData = dataset?.getCase(caseID, { numeric: false })
+      const caseData = dataset?.getItem(caseID, { numeric: false })
       if (caseData) {
         const lineCoords: [number, number] = [xValue, yValue]
         return { caseData, lineCoords }

--- a/v3/src/data-interactive/data-interactive-type-utils.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.ts
@@ -66,7 +66,7 @@ export function convertCaseToV2FullCase(c: ICase, dataContext: IDataSet) {
 
   return {
     id: maybeToV2Id(caseGroup?.groupedCase.__id__),
-    itemId: maybeToV2Id(dataContext.getCase(caseId)?.__id__),
+    itemId: maybeToV2Id(dataContext.getItem(caseId)?.__id__),
     parent,
     context,
     collection,
@@ -79,7 +79,8 @@ export function getCaseRequestResultValues(c: ICase, dataContext: IDataSet): DIG
 
   const id = toV2Id(caseId)
 
-  const collectionId = dataContext.caseGroupMap.get(caseId)?.collectionId ?? dataContext.childCollection.id
+  const caseGroup = dataContext.caseGroupMap.get(caseId)
+  const collectionId = caseGroup?.collectionId ?? dataContext.childCollection.id
 
   const parent = maybeToV2Id(dataContext.getParentCase(caseId, collectionId)?.groupedCase.__id__)
 
@@ -91,9 +92,7 @@ export function getCaseRequestResultValues(c: ICase, dataContext: IDataSet): DIG
 
   const values = getCaseValues(caseId, dataContext, collectionId)
 
-  const pseudoCase = dataContext.caseGroupMap.get(caseId)
-  const children = pseudoCase?.childCaseIds?.map(cId => toV2Id(cId)) ??
-    pseudoCase?.childItemIds?.map(cId => toV2Id(cId)) ?? []
+  const children = caseGroup?.childCaseIds?.map(cId => toV2Id(cId)) ?? []
 
   const caseIndex = dataContext.getCasesForCollection(collectionId).findIndex(aCase => aCase.__id__ === caseId)
 

--- a/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
@@ -7,30 +7,32 @@ describe("DataInteractive CaseByIDHandler", () => {
   const handler = diCaseByIDHandler
   function setup() {
     const { dataset, a3 } = setupTestDataset()
-    const aCase = dataset.getCaseAtIndex(4)
-    const caseId = aCase!.__id__
-    const pseudoCase = Array.from(dataset.caseGroupMap.values())[1].groupedCase
-    const pseudoCaseId = pseudoCase.__id__
-    return { dataContext: dataset, aCase, caseId, pseudoCase, pseudoCaseId, a3 }
+    const item = dataset.getItemAtIndex(4)!
+    const itemId = item.__id__
+    const aCase = Array.from(dataset.caseGroupMap.values())[1].groupedCase
+    const caseId = aCase.__id__
+    return { dataContext: dataset, item, itemId, aCase, caseId, a3 }
   }
 
   it("get works as expected", () => {
-    const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId } = setup()
+    const { dataContext, item, itemId, aCase, caseId } = setup()
 
     expect(handler.get?.({})?.success).toBe(false)
     expect(handler.get?.({ dataContext })?.success).toBe(false)
-    expect(handler.get?.({ caseByID: aCase })?.success).toBe(false)
+    expect(handler.get?.({ caseByID: item })?.success).toBe(false)
+
+    const itemResult = handler.get?.({ dataContext, caseByID: item })?.values as DIGetCaseResult
+    expect(itemResult.case.id).toBe(maybeToV2Id(itemId))
+    expect(itemResult.case.children?.length).toBe(0)
 
     const caseResult = handler.get?.({ dataContext, caseByID: aCase })?.values as DIGetCaseResult
     expect(caseResult.case.id).toBe(maybeToV2Id(caseId))
-
-    const pseudoCaseResult = handler.get?.({ dataContext, caseByID: pseudoCase })?.values as DIGetCaseResult
-    expect(pseudoCaseResult.case.id).toBe(maybeToV2Id(pseudoCaseId))
+    expect(caseResult.case.children?.length).toBe(2)
   })
 
   it("update works as expected", () => {
-    const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId, a3 } = setup()
-    const caseResources = { dataContext, caseByID: aCase }
+    const { dataContext, item, itemId, aCase, caseId, a3 } = setup()
+    const caseResources = { dataContext, caseByID: item }
 
     expect(handler.update?.({}).success).toBe(false)
     expect(handler.update?.({ dataContext }).success).toBe(false)
@@ -38,27 +40,27 @@ describe("DataInteractive CaseByIDHandler", () => {
     expect(handler.update?.(caseResources, {}).success).toBe(false)
 
     expect(handler.update?.(caseResources, { values: { a3: 10 } }).success).toBe(true)
-    expect(a3.numValues[dataContext.caseIndexFromID(caseId)!]).toBe(10)
+    expect(a3.numValues[dataContext.caseIndexFromID(itemId)!]).toBe(10)
 
-    expect(handler.update?.({ dataContext, caseByID: pseudoCase }, { values: { a3: 100 } }).success).toBe(true)
-    dataContext.caseGroupMap.get(pseudoCaseId)?.childItemIds.forEach(id => {
+    expect(handler.update?.({ dataContext, caseByID: aCase }, { values: { a3: 100 } }).success).toBe(true)
+    dataContext.caseGroupMap.get(caseId)?.childItemIds.forEach(id => {
       expect(a3.numValues[dataContext.caseIndexFromID(id)!]).toBe(100)
     })
   })
 
   it("delete works as expected", () => {
-    const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId } = setup()
+    const { dataContext, item, itemId, aCase, caseId } = setup()
 
     expect(handler.delete?.({}).success).toBe(false)
     expect(handler.delete?.({ dataContext }).success).toBe(false)
 
-    expect(dataContext.getCase(caseId)).toBeDefined()
-    expect(handler.delete?.({ dataContext, caseByID: aCase }).success).toBe(true)
-    expect(dataContext.getCase(caseId)).toBeUndefined()
+    expect(dataContext.getItem(itemId)).toBeDefined()
+    expect(handler.delete?.({ dataContext, caseByID: item }).success).toBe(true)
+    expect(dataContext.getItem(itemId)).toBeUndefined()
 
-    const childCaseIds = dataContext.caseGroupMap.get(pseudoCaseId)!.childItemIds
-    childCaseIds.forEach(id => expect(dataContext.getCase(id)).toBeDefined())
-    expect(handler.delete?.({ dataContext, caseByID: pseudoCase }).success).toBe(true)
-    childCaseIds.forEach(id => expect(dataContext.getCase(id)).toBeUndefined())
+    const childCaseIds = dataContext.caseGroupMap.get(caseId)!.childItemIds
+    childCaseIds.forEach(id => expect(dataContext.getItem(id)).toBeDefined())
+    expect(handler.delete?.({ dataContext, caseByID: aCase }).success).toBe(true)
+    childCaseIds.forEach(id => expect(dataContext.getItem(id)).toBeUndefined())
   })
 })

--- a/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
@@ -1,21 +1,13 @@
 import { maybeToV2Id } from "../../utilities/codap-utils"
 import { DIGetCaseResult } from "../data-interactive-types"
 import { diCaseByIDHandler } from "./case-by-id-handler"
-import { setupTestDataset } from "./handler-test-utils"
+import { setupForCaseTest } from "./handler-test-utils"
 
 describe("DataInteractive CaseByIDHandler", () => {
   const handler = diCaseByIDHandler
-  function setup() {
-    const { dataset, a3 } = setupTestDataset()
-    const item = dataset.getItemAtIndex(4)!
-    const itemId = item.__id__
-    const aCase = Array.from(dataset.caseGroupMap.values())[1].groupedCase
-    const caseId = aCase.__id__
-    return { dataContext: dataset, item, itemId, aCase, caseId, a3 }
-  }
 
   it("get works as expected", () => {
-    const { dataContext, item, itemId, aCase, caseId } = setup()
+    const { dataContext, item, itemId, aCase, caseId } = setupForCaseTest()
 
     expect(handler.get?.({})?.success).toBe(false)
     expect(handler.get?.({ dataContext })?.success).toBe(false)
@@ -31,7 +23,7 @@ describe("DataInteractive CaseByIDHandler", () => {
   })
 
   it("update works as expected", () => {
-    const { dataContext, item, itemId, aCase, caseId, a3 } = setup()
+    const { dataContext, item, itemId, aCase, caseId, a3 } = setupForCaseTest()
     const caseResources = { dataContext, caseByID: item }
 
     expect(handler.update?.({}).success).toBe(false)
@@ -49,7 +41,7 @@ describe("DataInteractive CaseByIDHandler", () => {
   })
 
   it("delete works as expected", () => {
-    const { dataContext, item, itemId, aCase, caseId } = setup()
+    const { dataContext, item, itemId, aCase, caseId } = setupForCaseTest()
 
     expect(handler.delete?.({}).success).toBe(false)
     expect(handler.delete?.({ dataContext }).success).toBe(false)

--- a/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
@@ -1,36 +1,28 @@
 import { maybeToV2Id } from "../../utilities/codap-utils"
 import { DIGetCaseResult } from "../data-interactive-types"
 import { diCaseByIndexHandler } from "./case-by-index-handler"
-import { setupTestDataset } from "./handler-test-utils"
+import { setupForCaseTest } from "./handler-test-utils"
 
 describe("DataInteractive CaseByIndexHandler", () => {
   const handler = diCaseByIndexHandler
-  function setup() {
-    const { dataset, a3 } = setupTestDataset()
-    const aCase = dataset.getItemAtIndex(4)
-    const caseId = aCase!.__id__
-    const pseudoCase = Array.from(dataset.caseGroupMap.values())[1].groupedCase
-    const pseudoCaseId = pseudoCase.__id__
-    return { dataContext: dataset, aCase, caseId, pseudoCase, pseudoCaseId, a3 }
-  }
 
   it("get works as expected", () => {
-    const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId } = setup()
+    const { dataContext, item, itemId, aCase, caseId } = setupForCaseTest()
 
     expect(handler.get?.({})?.success).toBe(false)
     expect(handler.get?.({ dataContext })?.success).toBe(false)
-    expect(handler.get?.({ caseByIndex: aCase })?.success).toBe(false)
+    expect(handler.get?.({ caseByIndex: item })?.success).toBe(false)
 
-    const caseResult = handler.get?.({ dataContext, caseByIndex: aCase })?.values as DIGetCaseResult
-    expect(caseResult.case.id).toBe(maybeToV2Id(caseId))
+    const caseResult = handler.get?.({ dataContext, caseByIndex: item })?.values as DIGetCaseResult
+    expect(caseResult.case.id).toBe(maybeToV2Id(itemId))
 
-    const pseudoCaseResult = handler.get?.({ dataContext, caseByIndex: pseudoCase })?.values as DIGetCaseResult
-    expect(pseudoCaseResult.case.id).toBe(maybeToV2Id(pseudoCaseId))
+    const pseudoCaseResult = handler.get?.({ dataContext, caseByIndex: aCase })?.values as DIGetCaseResult
+    expect(pseudoCaseResult.case.id).toBe(maybeToV2Id(caseId))
   })
 
   it("update works as expected", () => {
-    const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId, a3 } = setup()
-    const caseResources = { dataContext, caseByIndex: aCase }
+    const { dataContext, item, itemId, aCase, caseId, a3 } = setupForCaseTest()
+    const caseResources = { dataContext, caseByIndex: item }
 
     expect(handler.update?.({}).success).toBe(false)
     expect(handler.update?.({ dataContext }).success).toBe(false)
@@ -38,27 +30,27 @@ describe("DataInteractive CaseByIndexHandler", () => {
     expect(handler.update?.(caseResources, {}).success).toBe(false)
 
     expect(handler.update?.(caseResources, { values: { a3: 10 } }).success).toBe(true)
-    expect(a3.numValues[dataContext.caseIndexFromID(caseId)!]).toBe(10)
+    expect(a3.numValues[dataContext.caseIndexFromID(itemId)!]).toBe(10)
 
-    expect(handler.update?.({ dataContext, caseByIndex: pseudoCase }, { values: { a3: 100 } }).success).toBe(true)
-    dataContext.caseGroupMap.get(pseudoCaseId)?.childItemIds.forEach(id => {
+    expect(handler.update?.({ dataContext, caseByIndex: aCase }, { values: { a3: 100 } }).success).toBe(true)
+    dataContext.caseGroupMap.get(caseId)?.childItemIds.forEach(id => {
       expect(a3.numValues[dataContext.caseIndexFromID(id)!]).toBe(100)
     })
   })
 
   it("delete works as expected", () => {
-    const { dataContext, aCase, caseId, pseudoCase, pseudoCaseId } = setup()
+    const { dataContext, item, itemId, aCase, caseId } = setupForCaseTest()
 
     expect(handler.delete?.({}).success).toBe(false)
     expect(handler.delete?.({ dataContext }).success).toBe(false)
 
-    expect(dataContext.getItem(caseId)).toBeDefined()
-    expect(handler.delete?.({ dataContext, caseByIndex: aCase }).success).toBe(true)
-    expect(dataContext.getItem(caseId)).toBeUndefined()
+    expect(dataContext.getItem(itemId)).toBeDefined()
+    expect(handler.delete?.({ dataContext, caseByIndex: item }).success).toBe(true)
+    expect(dataContext.getItem(itemId)).toBeUndefined()
 
-    const childCaseIds = dataContext.caseGroupMap.get(pseudoCaseId)!.childItemIds
+    const childCaseIds = dataContext.caseGroupMap.get(caseId)!.childItemIds
     childCaseIds.forEach(id => expect(dataContext.getItem(id)).toBeDefined())
-    expect(handler.delete?.({ dataContext, caseByIndex: pseudoCase }).success).toBe(true)
+    expect(handler.delete?.({ dataContext, caseByIndex: aCase }).success).toBe(true)
     childCaseIds.forEach(id => expect(dataContext.getItem(id)).toBeUndefined())
   })
 })

--- a/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
@@ -7,7 +7,7 @@ describe("DataInteractive CaseByIndexHandler", () => {
   const handler = diCaseByIndexHandler
   function setup() {
     const { dataset, a3 } = setupTestDataset()
-    const aCase = dataset.getCaseAtIndex(4)
+    const aCase = dataset.getItemAtIndex(4)
     const caseId = aCase!.__id__
     const pseudoCase = Array.from(dataset.caseGroupMap.values())[1].groupedCase
     const pseudoCaseId = pseudoCase.__id__
@@ -52,13 +52,13 @@ describe("DataInteractive CaseByIndexHandler", () => {
     expect(handler.delete?.({}).success).toBe(false)
     expect(handler.delete?.({ dataContext }).success).toBe(false)
 
-    expect(dataContext.getCase(caseId)).toBeDefined()
+    expect(dataContext.getItem(caseId)).toBeDefined()
     expect(handler.delete?.({ dataContext, caseByIndex: aCase }).success).toBe(true)
-    expect(dataContext.getCase(caseId)).toBeUndefined()
+    expect(dataContext.getItem(caseId)).toBeUndefined()
 
     const childCaseIds = dataContext.caseGroupMap.get(pseudoCaseId)!.childItemIds
-    childCaseIds.forEach(id => expect(dataContext.getCase(id)).toBeDefined())
+    childCaseIds.forEach(id => expect(dataContext.getItem(id)).toBeDefined())
     expect(handler.delete?.({ dataContext, caseByIndex: pseudoCase }).success).toBe(true)
-    childCaseIds.forEach(id => expect(dataContext.getCase(id)).toBeUndefined())
+    childCaseIds.forEach(id => expect(dataContext.getItem(id)).toBeUndefined())
   })
 })

--- a/v3/src/data-interactive/handlers/case-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-handler.test.ts
@@ -13,7 +13,7 @@ describe("DataInteractive CaseHandler", () => {
     const confirmNewCase = (newCase: DINewCase) => {
       expect(newCase.itemID).toBeDefined()
       expect(oldCaseIds.includes(newCase.itemID!)).toBe(false)
-      expect(dataset.getCase(toV3ItemId(newCase.itemID!))).toBeDefined()
+      expect(dataset.getItem(toV3ItemId(newCase.itemID!))).toBeDefined()
 
       // TODO Check newCase.id
     }

--- a/v3/src/data-interactive/handlers/handler-functions.ts
+++ b/v3/src/data-interactive/handlers/handler-functions.ts
@@ -111,7 +111,7 @@ export function updateCasesBy(resources: DIResources, values?: DIValues, itemRet
       const v3CaseId = id ? toV3CaseId(id) : undefined
       const v3ItemId = id ? toV3ItemId(id) : undefined
       const dcCase = v3CaseId ? dataContext.caseGroupMap.get(v3CaseId) : undefined
-      const dcItem = v3ItemId ? dataContext.getCase(v3ItemId) : undefined
+      const dcItem = v3ItemId ? dataContext.getItem(v3ItemId) : undefined
       const v3Id = dcCase ? v3CaseId : v3ItemId
       if (id && aCase.values && v3Id && (dcItem || dcCase)) {
         caseIDs.push(id)

--- a/v3/src/data-interactive/handlers/handler-test-utils.ts
+++ b/v3/src/data-interactive/handlers/handler-test-utils.ts
@@ -28,3 +28,12 @@ export const setupTestDataset = (options?: ITestDatasetOptions) => {
   dataset.validateCaseGroups()
   return { dataset, c1, c2, a1, a2, a3 }
 }
+
+export function setupForCaseTest() {
+  const { dataset, a3 } = setupTestDataset()
+  const item = dataset.getItemAtIndex(4)!
+  const itemId = item.__id__
+  const aCase = Array.from(dataset.caseGroupMap.values())[1].groupedCase
+  const caseId = aCase.__id__
+  return { dataContext: dataset, item, itemId, aCase, caseId, a3 }
+}

--- a/v3/src/data-interactive/handlers/item-by-case-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-by-case-id-handler.test.ts
@@ -9,23 +9,23 @@ describe("DataInteractive ItemByCaseIDHandler", () => {
 
   it("delete works", () => {
     const { dataset: dataContext } = setupTestDataset()
-    const itemByCaseID = dataContext.getCaseAtIndex(0)!
+    const itemByCaseID = dataContext.getItemAtIndex(0)!
     const itemId = itemByCaseID.__id__
 
     expect(handler.delete?.({ dataContext }).success).toBe(false)
     expect(handler.delete?.({ itemByCaseID }).success).toBe(false)
 
-    expect(dataContext.getCase(itemId)).toBeDefined()
+    expect(dataContext.getItem(itemId)).toBeDefined()
     const result = handler.delete!({ dataContext, itemByCaseID })
     expect(result?.success).toBe(true)
     const values = result.values as number[]
     expect(values[0]).toBe(toV2Id(itemId))
-    expect(dataContext.getCase(itemId)).toBeUndefined()
+    expect(dataContext.getItem(itemId)).toBeUndefined()
   })
 
   it("get works", () => {
     const { dataset: dataContext, a1 } = setupTestDataset()
-    const itemByCaseID = dataContext.getCaseAtIndex(0)!
+    const itemByCaseID = dataContext.getItemAtIndex(0)!
 
     expect(handler.get?.({ dataContext }).success).toBe(false)
     expect(handler.get?.({ itemByCaseID }).success).toBe(false)
@@ -40,7 +40,7 @@ describe("DataInteractive ItemByCaseIDHandler", () => {
 
   it("update works", () => {
     const { dataset: dataContext, a1, } = setupTestDataset()
-    const itemByCaseID = dataContext.getCaseAtIndex(0)!
+    const itemByCaseID = dataContext.getItemAtIndex(0)!
     const itemId = itemByCaseID.__id__
     const values = { a1: "c" } as DIItem
 

--- a/v3/src/data-interactive/handlers/item-by-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-by-id-handler.test.ts
@@ -9,23 +9,23 @@ describe("DataInteractive ItemByIDHandler", () => {
 
   it("delete works", () => {
     const { dataset: dataContext } = setupTestDataset()
-    const itemByID = dataContext.getCaseAtIndex(0)!
+    const itemByID = dataContext.getItemAtIndex(0)!
     const itemId = itemByID.__id__
 
     expect(handler.delete?.({ dataContext }).success).toBe(false)
     expect(handler.delete?.({ itemByID }).success).toBe(false)
 
-    expect(dataContext.getCase(itemId)).toBeDefined()
+    expect(dataContext.getItem(itemId)).toBeDefined()
     const result = handler.delete!({ dataContext, itemByID })
     expect(result?.success).toBe(true)
     const values = result.values as number[]
     expect(values[0]).toBe(toV2Id(itemId))
-    expect(dataContext.getCase(itemId)).toBeUndefined()
+    expect(dataContext.getItem(itemId)).toBeUndefined()
   })
 
   it("get works", () => {
     const { dataset: dataContext, a1 } = setupTestDataset()
-    const itemByID = dataContext.getCaseAtIndex(0)!
+    const itemByID = dataContext.getItemAtIndex(0)!
 
     expect(handler.get?.({ dataContext }).success).toBe(false)
     expect(handler.get?.({ itemByID }).success).toBe(false)
@@ -40,7 +40,7 @@ describe("DataInteractive ItemByIDHandler", () => {
 
   it("update works", () => {
     const { dataset: dataContext, a1 } = setupTestDataset()
-    const itemByID = dataContext.getCaseAtIndex(0)!
+    const itemByID = dataContext.getItemAtIndex(0)!
     const itemId = itemByID.__id__
     const values = { a1: "c" } as DIItem
 

--- a/v3/src/data-interactive/handlers/item-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-handler.test.ts
@@ -34,23 +34,23 @@ describe("DataInteractive ItemHandler", () => {
 
   it("delete works", () => {
     const { dataset: dataContext } = setupTestDataset()
-    const item = dataContext.getCaseAtIndex(0)!
+    const item = dataContext.getItemAtIndex(0)!
     const itemId = item.__id__
 
     expect(handler.delete?.({ dataContext }).success).toBe(false)
     expect(handler.delete?.({ item }).success).toBe(false)
 
-    expect(dataContext.getCase(itemId)).toBeDefined()
+    expect(dataContext.getItem(itemId)).toBeDefined()
     const result = handler.delete!({ dataContext, item })
     expect(result?.success).toBe(true)
     const values = result.values as number[]
     expect(values[0]).toBe(toV2Id(itemId))
-    expect(dataContext.getCase(itemId)).toBeUndefined()
+    expect(dataContext.getItem(itemId)).toBeUndefined()
   })
 
   it("get works", () => {
     const { dataset: dataContext, a1 } = setupTestDataset()
-    const item = dataContext.getCaseAtIndex(0)!
+    const item = dataContext.getItemAtIndex(0)!
 
     expect(handler.get?.({ dataContext }).success).toBe(false)
     expect(handler.get?.({ item }).success).toBe(false)
@@ -65,7 +65,7 @@ describe("DataInteractive ItemHandler", () => {
 
   it("update works", () => {
     const { dataset: dataContext, a1, a2 } = setupTestDataset()
-    const item = dataContext.getCaseAtIndex(0)!
+    const item = dataContext.getItemAtIndex(0)!
     const itemId = item.__id__
     const values = { a1: "c" } as DIItem
 
@@ -81,7 +81,7 @@ describe("DataInteractive ItemHandler", () => {
     expect(singleValues.changedCases?.[0]).toBe(toV2Id(itemId))
 
     // Update multiple items by id
-    const item2 = dataContext.getCaseAtIndex(1)!
+    const item2 = dataContext.getItemAtIndex(1)!
     const item2Id = item2.__id__
     expect(a2.value(0)).toBe("x")
     expect(a2.value(1)).toBe("y")

--- a/v3/src/data-interactive/handlers/item-search-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-search-handler.test.ts
@@ -15,12 +15,12 @@ describe("DataInteractive ItemSearchHandler", () => {
     expect(handler.delete?.({ dataContext }).success).toBe(false)
     expect(handler.delete?.({ itemSearch }).success).toBe(false)
 
-    itemIds.forEach(id => expect(dataContext.getCase(id)).toBeDefined())
+    itemIds.forEach(id => expect(dataContext.getItem(id)).toBeDefined())
     expect(dataContext.items.length).toBe(6)
     const result = handler.delete!({ dataContext, itemSearch })
     expect(result?.success).toBe(true)
     expect(dataContext.items.length).toBe(3)
-    itemIds.forEach(id => expect(dataContext.getCase(id)).toBeUndefined())
+    itemIds.forEach(id => expect(dataContext.getItem(id)).toBeUndefined())
     const values = result.values as number[]
     itemIds.forEach(id => expect(values.includes(toV2Id(id))).toBe(true))
   })

--- a/v3/src/data-interactive/handlers/selection-list-handler.ts
+++ b/v3/src/data-interactive/handlers/selection-list-handler.ts
@@ -17,7 +17,7 @@ function updateSelection(
   if (!dataSet || !applySelection) return dataContextNotFoundResult
   if (!values || !Array.isArray(values)) return illegalValuesResult(action)
 
-  const caseIds = values.map(value => value.toString()).filter(caseID => !!dataSet.getCase(caseID))
+  const caseIds = values.map(value => value.toString()).filter(caseID => !!dataSet.getItem(caseID))
   // TODO Filter based on collection
   applySelection(caseIds)
   return { success: true }

--- a/v3/src/data-interactive/resource-parser.test.ts
+++ b/v3/src/data-interactive/resource-parser.test.ts
@@ -82,7 +82,7 @@ describe("DataInteractive ResourceParser", () => {
   it("finds caseByID", () => {
     expect(resolve(`dataContext[data].caseByID[unknown]`).caseByID).toBeUndefined()
 
-    const itemId = dataset.getCaseAtIndex(0)!.__id__
+    const itemId = dataset.getItemAtIndex(0)!.__id__
     expect(resolve(`dataContext[data].caseByID[${toV2Id(itemId)}]`).caseByID?.__id__).toBe(itemId)
 
     const caseId = Array.from(dataset.caseGroupMap.values())[0].groupedCase.__id__
@@ -94,7 +94,7 @@ describe("DataInteractive ResourceParser", () => {
     expect(resolve(`dataContext[data].collection[${collectionId}].caseByIndex[-1]`).caseByIndex).toBeUndefined()
     expect(resolve(`dataContext[data].collection[unknown].caseByIndex[0]`).caseByIndex).toBeUndefined()
 
-    const itemId = dataset.getCaseAtIndex(0)!.__id__
+    const itemId = dataset.getItemAtIndex(0)!.__id__
     const childCollectionId = toV2Id(dataset.childCollection.id)
     expect(resolve(`dataContext[data].collection[${childCollectionId}].caseByIndex[0]`).caseByIndex?.__id__)
       .toBe(itemId)
@@ -131,14 +131,14 @@ describe("DataInteractive ResourceParser", () => {
     expect(resolve(`dataContext[data].item[100]`).item).toBeUndefined()
     expect(resolve(`dataContext[data].item[word]`).item).toBeUndefined()
 
-    const item = dataset.getCaseAtIndex(0)
+    const item = dataset.getItemAtIndex(0)
     expect(resolve(`dataContext[data].item[0]`).item?.__id__).toBe(item?.__id__)
   })
 
   it("finds itemByID", () => {
     expect(resolve(`dataContext[data].itemByID[unknown]`).itemByID).toBeUndefined()
 
-    const itemId = dataset.getCaseAtIndex(0)!.__id__
+    const itemId = dataset.getItemAtIndex(0)!.__id__
     expect(resolve(`dataContext[data].itemByID[${toV2Id(itemId)}]`).itemByID?.__id__).toBe(itemId)
   })
 
@@ -163,7 +163,7 @@ describe("DataInteractive ResourceParser", () => {
     expect(resolve(`dataContext[data].itemByCaseID[unknown]`).itemByCaseID).toBeUndefined()
 
     const caseId = Array.from(dataset.caseGroupMap.values())[0].groupedCase.__id__
-    const itemId = dataset.getCaseAtIndex(0)!.__id__
+    const itemId = dataset.getItemAtIndex(0)!.__id__
     expect(resolve(`dataContext[data].itemByCaseID[${toV2Id(caseId)}]`).itemByCaseID?.__id__).toBe(itemId)
   })
 })

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -144,7 +144,7 @@ export function resolveResources(
   }
 
   const getCaseById = (caseId: string) =>
-    dataContext?.caseGroupMap.get(caseId)?.groupedCase ?? dataContext?.getCase(caseId)
+    dataContext?.caseGroupMap.get(caseId)?.groupedCase ?? dataContext?.getItem(caseId)
 
   if (resourceSelector.caseByID) {
     const caseId = toV3CaseId(resourceSelector.caseByID)
@@ -175,7 +175,7 @@ export function resolveResources(
       dataContext.getCasesForCollection(collection.id).forEach(caseGroup => {
         const aCase = dataContext.caseGroupMap.get(caseGroup.__id__)
         const itemId = aCase?.childItemIds[0]
-        const item = dataContext.getCase(itemId ?? caseGroup.__id__)
+        const item = dataContext.getItem(itemId ?? caseGroup.__id__)
         if (item) {
           const itemIndex = dataContext.caseIndexFromID(item.__id__)
           if (func(getOperandValue(itemIndex, left), getOperandValue(itemIndex, right))) {
@@ -193,13 +193,13 @@ export function resolveResources(
   if (resourceSelector.item) {
     const index = Number(resourceSelector.item)
     if (!isNaN(index)) {
-      result.item = dataContext?.getCaseAtIndex(index)
+      result.item = dataContext?.getItemAtIndex(index)
     }
   }
 
   if (resourceSelector.itemByID) {
     const itemId = toV3ItemId(resourceSelector.itemByID)
-    result.itemByID = dataContext?.getCase(itemId)
+    result.itemByID = dataContext?.getItem(itemId)
   }
 
   if (resourceSelector.itemSearch && dataContext) {
@@ -215,7 +215,7 @@ export function resolveResources(
   if (resourceSelector.itemByCaseID) {
     const caseId = toV3CaseId(resourceSelector.itemByCaseID)
     const itemId = dataContext?.caseGroupMap.get(caseId)?.childItemIds[0]
-    if (itemId) result.itemByCaseID = dataContext?.getCase(itemId)
+    if (itemId) result.itemByCaseID = dataContext?.getItem(itemId)
   }
 
   // DG.ObjectMap.forEach(resourceSelector, function (key, value) {

--- a/v3/src/models/data/data-set-notifications.ts
+++ b/v3/src/models/data/data-set-notifications.ts
@@ -111,7 +111,7 @@ export function selectCasesNotification(dataset: IDataSet, extend?: boolean) {
 
     const convertCaseIdsToV2FullCases = (caseIds: string[]) => {
       return caseIds.map(caseId => {
-        const c = dataset.getCase(caseId)
+        const c = dataset.getItem(caseId)
         return c && convertCaseToV2FullCase(c, dataset)
       }).filter(c => !!c)
     }

--- a/v3/src/models/data/data-set-undo.test.ts
+++ b/v3/src/models/data/data-set-undo.test.ts
@@ -73,7 +73,7 @@ describe("DataSet undo/redo", () => {
     data.applyModelChange(
       () => data.setCaseValues([{ __id__: "caseId", "aId": 2, "bId": 3 }]),
       { undoStringKey: "Undo edit value", redoStringKey: "Redo edit value" })
-    expect(data.getCase("caseId")).toEqual({ __id__: "caseId", "aId": 2, "bId": 3 })
+    expect(data.getItem("caseId")).toEqual({ __id__: "caseId", "aId": 2, "bId": 3 })
 
     let timedOut = false
     try {
@@ -89,12 +89,12 @@ describe("DataSet undo/redo", () => {
     expect(undoManager?.redoEntry?.clientData).toBeUndefined()
 
     undoManager?.undo()
-    expect(data.getCase("caseId")).toEqual({ __id__: "caseId", "aId": 1, "bId": 2 })
+    expect(data.getItem("caseId")).toEqual({ __id__: "caseId", "aId": 1, "bId": 2 })
     expect(undoManager?.undoEntry?.clientData).toBeUndefined()
     expect(undoManager?.redoEntry?.clientData).toBeDefined()
 
     undoManager?.redo()
-    expect(data.getCase("caseId")).toEqual({ __id__: "caseId", "aId": 2, "bId": 3 })
+    expect(data.getItem("caseId")).toEqual({ __id__: "caseId", "aId": 2, "bId": 3 })
     expect(undoManager?.undoEntry?.clientData).toBeDefined()
     expect(undoManager?.redoEntry?.clientData).toBeUndefined()
   })

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -270,16 +270,16 @@ test("DataSet basic functionality", () => {
     expect(dataset.attrIndexFromID(attr.id)).toBe(index)
   })
 
-  expect(dataset.getCase("")).toBeUndefined()
+  expect(dataset.getItem("")).toBeUndefined()
   dataset.setCaseValues([{ __id__: "" }])
 
   // adds cases without ids (and removes them)
   dataset.addCases(toCanonical(dataset, [{ str: "c", num: 3 }]))
   expect(dataset.items.length).toBe(1)
-  expect(dataset.getCaseAtIndex(0, { canonical: false })).toEqualExcludingIds({ str: "c", num: 3 })
+  expect(dataset.getItemAtIndex(0, { canonical: false })).toEqualExcludingIds({ str: "c", num: 3 })
   const mockConsoleWarn1 = jest.fn()
   const mockConsole1 = jest.spyOn(console, "warn").mockImplementation((...args: any[]) => mockConsoleWarn1(...args))
-  expect(dataset.getCaseAtIndex(1)).toBeUndefined()
+  expect(dataset.getItemAtIndex(1)).toBeUndefined()
   // MobX 6.7.0 no longer warns about out-of-range array accesses
   expect(mockConsoleWarn1).toHaveBeenCalledTimes(0)
   mockConsole1.mockRestore()
@@ -292,18 +292,18 @@ test("DataSet basic functionality", () => {
   // adding a case "before" a non-existent case appends the case to the end
   dataset.addCases(toCanonical(dataset, [{ str: "d", num: 4 }]), { before: "bogus" })
   expect(dataset.items.length).toBe(2)
-  expect(dataset.getCaseAtIndex(1, { canonical: false })).toEqualExcludingIds({ str: "d", num: 4 })
+  expect(dataset.getItemAtIndex(1, { canonical: false })).toEqualExcludingIds({ str: "d", num: 4 })
   dataset.removeCases([dataset.items[0].__id__, dataset.items[1].__id__])
 
   // add new case
   dataset.addCases(toCanonical(dataset, [{ str: "d", num: 4 }]))
-  expect(dataset.getCaseAtIndex(0)).toEqualExcludingIds({ [strAttrID]: "d", [numAttrID]: 4 })
+  expect(dataset.getItemAtIndex(0)).toEqualExcludingIds({ [strAttrID]: "d", [numAttrID]: 4 })
   const caseD4ID = dataset.items[0].__id__
   expect(dataset.caseIDFromIndex(0)).toBe(caseD4ID)
   expect(dataset.caseIDFromIndex(-1)).toBeUndefined()
-  expect(dataset.getCaseAtIndex(-1)).toBeUndefined()
-  expect(dataset.getCaseAtIndex(0, { canonical: false })).toEqual({ __id__: caseD4ID, str: "d", num: 4 })
-  expect(dataset.getCase(caseD4ID, { canonical: false })).toEqual({ __id__: caseD4ID, str: "d", num: 4 })
+  expect(dataset.getItemAtIndex(-1)).toBeUndefined()
+  expect(dataset.getItemAtIndex(0, { canonical: false })).toEqual({ __id__: caseD4ID, str: "d", num: 4 })
+  expect(dataset.getItem(caseD4ID, { canonical: false })).toEqual({ __id__: caseD4ID, str: "d", num: 4 })
   expect(dataset.items.length).toBe(1)
   expect(caseD4ID).toBeDefined()
   expect(dataset.attributes[0].value(0)).toBe("d")
@@ -342,13 +342,13 @@ test("DataSet basic functionality", () => {
   expect(dataset.attributes[1].value(1)).toBe("2")
   expect(dataset.getValue(caseA1ID, "foo")).toBeUndefined()
   expect(dataset.getValue("foo", "bar")).toBeUndefined()
-  expect(dataset.getCase(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "a", num: 1 })
-  expect(dataset.getCase(caseB2ID, { canonical: false })).toEqual({ __id__: caseB2ID, str: "b", num: 2 })
-  expect(dataset.getCase(caseA1ID, { canonical: true }))
+  expect(dataset.getItem(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "a", num: 1 })
+  expect(dataset.getItem(caseB2ID, { canonical: false })).toEqual({ __id__: caseB2ID, str: "b", num: 2 })
+  expect(dataset.getItem(caseA1ID, { canonical: true }))
     .toEqual({ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 })
-  expect(dataset.getCase(caseB2ID, { canonical: true }))
+  expect(dataset.getItem(caseB2ID, { canonical: true }))
     .toEqual({ __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 })
-  expect(dataset.getCases([caseA1ID, caseB2ID], { canonical: true }))
+  expect(dataset.getItems([caseA1ID, caseB2ID], { canonical: true }))
     .toEqual([{ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 },
               { __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 }])
   expect(dataset.getCasesAtIndex().length).toBe(4)
@@ -356,9 +356,9 @@ test("DataSet basic functionality", () => {
   // add null/undefined values
   dataset.addCases(toCanonical(dataset, [{ str: undefined }]))
   const nullCaseID = dataset.items[dataset.items.length - 1].__id__
-  expect(dataset.getCase(nullCaseID, { canonical: false }))
+  expect(dataset.getItem(nullCaseID, { canonical: false }))
     .toEqual({ __id__: nullCaseID, str: "", num: "" })
-  expect(dataset.getCases([""], { canonical: true })).toEqual([])
+  expect(dataset.getItems([""], { canonical: true })).toEqual([])
   // validate that caseIDMap is correct
   dataset.items.forEach((aCase: ICaseID) => {
     const caseIndex = dataset.caseIndexFromID(aCase.__id__) ?? -1
@@ -376,13 +376,13 @@ test("DataSet basic functionality", () => {
   expect(dataset.attributes[1].value(4)).toBe("2")
   expect(dataset.getValue(caseJ1ID, "foo")).toBeUndefined()
   expect(dataset.getValue("foo", "bar")).toBeUndefined()
-  expect(dataset.getCase(caseJ1ID, { canonical: false })).toEqual({ __id__: caseJ1ID, str: "j", num: 1 })
-  expect(dataset.getCase(caseK2ID, { canonical: false })).toEqual({ __id__: caseK2ID, str: "k", num: 2 })
-  expect(dataset.getCase(caseJ1ID, { canonical: true }))
+  expect(dataset.getItem(caseJ1ID, { canonical: false })).toEqual({ __id__: caseJ1ID, str: "j", num: 1 })
+  expect(dataset.getItem(caseK2ID, { canonical: false })).toEqual({ __id__: caseK2ID, str: "k", num: 2 })
+  expect(dataset.getItem(caseJ1ID, { canonical: true }))
     .toEqual({ __id__: caseJ1ID, [strAttrID]: "j", [numAttrID]: 1 })
-  expect(dataset.getCase(caseK2ID, { canonical: true }))
+  expect(dataset.getItem(caseK2ID, { canonical: true }))
     .toEqual({ __id__: caseK2ID, [strAttrID]: "k", [numAttrID]: 2 })
-  expect(dataset.getCases([caseJ1ID, caseK2ID], { canonical: true }))
+  expect(dataset.getItems([caseJ1ID, caseK2ID], { canonical: true }))
     .toEqual([{ __id__: caseJ1ID, [strAttrID]: "j", [numAttrID]: 1 },
               { __id__: caseK2ID, [strAttrID]: "k", [numAttrID]: 2 }])
   expect(dataset.getCasesAtIndex().length).toBe(7)
@@ -390,12 +390,12 @@ test("DataSet basic functionality", () => {
 
   // setCaseValues
   dataset.setCaseValues(toCanonical(dataset, [{ __id__: caseA1ID, str: "A", num: 10 }]))
-  expect(dataset.getCase(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: 10 })
+  expect(dataset.getItem(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: 10 })
   dataset.setCaseValues(toCanonical(dataset, [{ __id__: caseB2ID, str: "B", num: 20 },
                                               { __id__: caseC3ID, str: "C", num: 30 }]))
   expect(dataset.getValue(caseB2ID, strAttrID)).toBe("B")
   expect(dataset.getValue(caseB2ID, numAttrID)).toBe("20")
-  expect(dataset.getCase(caseB2ID, { canonical: false })).toEqual({ __id__: caseB2ID, str: "B", num: 20 })
+  expect(dataset.getItem(caseB2ID, { canonical: false })).toEqual({ __id__: caseB2ID, str: "B", num: 20 })
   expect(dataset.getValue(caseC3ID, strAttrID)).toBe("C")
   expect(dataset.getValue(caseC3ID, numAttrID)).toBe("30")
   const mockConsoleWarn = jest.fn()
@@ -403,11 +403,11 @@ test("DataSet basic functionality", () => {
   dataset.setCaseValues(toCanonical(dataset, [{ __id__: caseA1ID, foo: "bar" }]))
   expect(mockConsoleWarn).toHaveBeenCalledTimes(1)
   consoleSpy.mockRestore()
-  expect(dataset.getCase(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: 10 })
+  expect(dataset.getItem(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: 10 })
   dataset.setCaseValues(toCanonical(dataset, [{ __id__: caseA1ID, num: undefined }]))
-  expect(dataset.getCase(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: "" })
+  expect(dataset.getItem(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: "" })
 
-  const cases = dataset.getCases([caseB2ID, caseC3ID, ""], { canonical: false })
+  const cases = dataset.getItems([caseB2ID, caseC3ID, ""], { canonical: false })
   expect(cases.length).toBe(2)
   expect(cases[0]).toEqual({ __id__: caseB2ID, str: "B", num: 20 })
   expect(cases[1]).toEqual({ __id__: caseC3ID, str: "C", num: 30 })
@@ -494,11 +494,11 @@ test("Canonical case functionality", () => {
   // add new case
   dataset.addCases([{ [strAttrID]: "d", [numAttrID]: 4 }])
   const caseD4ID = dataset.items[0].__id__
-  expect(dataset.getCaseAtIndex(-1)).toBeUndefined()
-  expect(dataset.getCaseAtIndex(0, { canonical: true }))
+  expect(dataset.getItemAtIndex(-1)).toBeUndefined()
+  expect(dataset.getItemAtIndex(0, { canonical: true }))
     .toEqual({ __id__: caseD4ID, [strAttrID]: "d", [numAttrID]: 4 })
-  expect(dataset.getCaseAtIndex(0, { canonical: false })).toEqual({ __id__: caseD4ID, str: "d", num: 4 })
-  expect(dataset.getCase(caseD4ID, { canonical: false })).toEqual({ __id__: caseD4ID, str: "d", num: 4 })
+  expect(dataset.getItemAtIndex(0, { canonical: false })).toEqual({ __id__: caseD4ID, str: "d", num: 4 })
+  expect(dataset.getItem(caseD4ID, { canonical: false })).toEqual({ __id__: caseD4ID, str: "d", num: 4 })
   expect(dataset.items.length).toBe(1)
   expect(caseD4ID).toBeDefined()
   expect(dataset.attributes[0].value(0)).toBe("d")
@@ -526,28 +526,28 @@ test("Canonical case functionality", () => {
   expect(dataset.attributes[1].numeric(0)).toBe(1)
   expect(dataset.attributes[0].value(1)).toBe("b")
   expect(dataset.attributes[1].numeric(1)).toBe(2)
-  expect(dataset.getCase(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "a", num: 1 })
-  expect(dataset.getCase(caseB2ID, { canonical: false })).toEqual({ __id__: caseB2ID, str: "b", num: 2 })
-  expect(dataset.getCase(caseA1ID, { canonical: true }))
+  expect(dataset.getItem(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "a", num: 1 })
+  expect(dataset.getItem(caseB2ID, { canonical: false })).toEqual({ __id__: caseB2ID, str: "b", num: 2 })
+  expect(dataset.getItem(caseA1ID, { canonical: true }))
     .toEqual({ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 })
-  expect(dataset.getCase(caseB2ID, { canonical: true }))
+  expect(dataset.getItem(caseB2ID, { canonical: true }))
     .toEqual({ __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 })
-  expect(dataset.getCases([caseA1ID, caseB2ID], { canonical: true }))
+  expect(dataset.getItems([caseA1ID, caseB2ID], { canonical: true }))
     .toEqual([{ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 },
               { __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 }])
   expect(dataset.getCasesAtIndex(0, { count: 2, canonical: true }))
     .toEqual([{ __id__: caseA1ID, [strAttrID]: "a", [numAttrID]: 1 },
               { __id__: caseB2ID, [strAttrID]: "b", [numAttrID]: 2 }])
-  expect(dataset.getCaseAtIndex(-1, { canonical: true })).toBeUndefined()
+  expect(dataset.getItemAtIndex(-1, { canonical: true })).toBeUndefined()
   expect(dataset.getCasesAtIndex(undefined, { canonical: true }).length).toBe(4)
   expect(dataset.getCasesAtIndex(2, { canonical: true }).length).toBe(2)
   // add null/undefined values
   dataset.addCases([{ [strAttrID]: undefined }])
   // add invalid cases
   const nullCaseID = dataset.items[dataset.items.length - 1].__id__
-  expect(dataset.getCase(nullCaseID, { canonical: false }))
+  expect(dataset.getItem(nullCaseID, { canonical: false }))
     .toEqual({ __id__: nullCaseID, str: "", num: "" })
-  expect(dataset.getCases([""], { canonical: true })).toEqual([])
+  expect(dataset.getItems([""], { canonical: true })).toEqual([])
   // validate that caseIDMap is correct
   dataset.items.forEach((aCase: ICaseID) => {
     const caseIndex = dataset.caseIndexFromID(aCase.__id__) ?? -1
@@ -558,10 +558,10 @@ test("Canonical case functionality", () => {
 
   // setCanonicalCaseValues
   dataset.setCaseValues([{ __id__: caseA1ID, [strAttrID]: "A", [numAttrID]: 10 }])
-  expect(dataset.getCase(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: 10 })
+  expect(dataset.getItem(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: 10 })
   dataset.setCaseValues([{ __id__: caseB2ID, [strAttrID]: "B", [numAttrID]: 20 },
                          { __id__: caseC3ID, [strAttrID]: "C", [numAttrID]: 30 }])
-  expect(dataset.getCase(caseB2ID, { canonical: false })).toEqual({ __id__: caseB2ID, str: "B", num: 20 })
+  expect(dataset.getItem(caseB2ID, { canonical: false })).toEqual({ __id__: caseB2ID, str: "B", num: 20 })
   expect(dataset.getValue(caseC3ID, strAttrID)).toBe("C")
   expect(dataset.getStrValue(caseC3ID, strAttrID)).toBe("C")
   expect(dataset.getNumeric(caseC3ID, numAttrID)).toBe(30)
@@ -570,11 +570,11 @@ test("Canonical case functionality", () => {
   dataset.setCaseValues(toCanonical(dataset, [{ __id__: caseA1ID, foo: "bar" }]))
   expect(mockConsoleWarn).toHaveBeenCalledTimes(1)
   consoleSpy.mockRestore()
-  expect(dataset.getCase(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: 10 })
+  expect(dataset.getItem(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: 10 })
   dataset.setCaseValues([{ __id__: caseA1ID, [numAttrID]: undefined }])
-  expect(dataset.getCase(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: "" })
+  expect(dataset.getItem(caseA1ID, { canonical: false })).toEqual({ __id__: caseA1ID, str: "A", num: "" })
 
-  const cases = dataset.getCases([caseB2ID, caseC3ID, ""], { canonical: false })
+  const cases = dataset.getItems([caseB2ID, caseC3ID, ""], { canonical: false })
   expect(cases.length).toBe(2)
   expect(cases[0]).toEqual({ __id__: caseB2ID, str: "B", num: 20 })
   expect(cases[1]).toEqual({ __id__: caseC3ID, str: "C", num: 30 })

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -509,34 +509,34 @@ export const DataSet = V2Model.named("DataSet").props({
    */
   const attrIDFromName = (name: string) => self.attrNameMap.get(name)
 
-  function getCase(caseID: string, options?: IGetCaseOptions): ICase | undefined {
-    const index = self.itemIDMap.get(caseID)
+  function getItem(itemID: string, options?: IGetCaseOptions): ICase | undefined {
+    const index = self.itemIDMap.get(itemID)
     if (index == null) { return undefined }
 
     const { canonical = true, numeric = true } = options || {}
-    const aCase: ICase = { __id__: caseID }
+    const item: ICase = { __id__: itemID }
     self.attributes.forEach((attr) => {
       const key = canonical ? attr.id : attr.name
-      aCase[key] = numeric && attr.isNumeric(index) ? attr.numeric(index) : attr.value(index)
+      item[key] = numeric && attr.isNumeric(index) ? attr.numeric(index) : attr.value(index)
     })
-    return aCase
+    return item
   }
 
-  function getCases(caseIDs: string[], options?: IGetCaseOptions): ICase[] {
-    const cases: ICase[] = []
-    caseIDs.forEach((caseID) => {
-      const aCase = getCase(caseID, options)
-      if (aCase) {
-        cases.push(aCase)
+  function getItems(itemIDs: string[], options?: IGetCaseOptions): ICase[] {
+    const items: ICase[] = []
+    itemIDs.forEach((caseID) => {
+      const item = getItem(caseID, options)
+      if (item) {
+        items.push(item)
       }
     })
-    return cases
+    return items
   }
 
-  function getCaseAtIndex(index: number, options?: IGetCaseOptions) {
-    const aCase = self.items[index],
-          id = aCase?.__id__
-    return id ? getCase(id, options) : undefined
+  function getItemAtIndex(index: number, options?: IGetCaseOptions) {
+    const item = self.items[index],
+          id = item?.__id__
+    return id ? getItem(id, options) : undefined
   }
 
   function setCaseValues(caseValues: ICase) {
@@ -572,7 +572,7 @@ export const DataSet = V2Model.named("DataSet").props({
         return self.itemIDMap.get(id)
       },
       caseIDFromIndex(index: number) {
-        return getCaseAtIndex(index)?.__id__
+        return getItemAtIndex(index)?.__id__
       },
       nextCaseID(id: string) {
         const index = self.itemIDMap.get(id),
@@ -640,15 +640,15 @@ export const DataSet = V2Model.named("DataSet").props({
         const attr = self.getAttribute(attributeID)
         return attr?.numeric(index)
       },
-      getCase,
-      getCases,
-      getCaseAtIndex,
+      getItem,
+      getItems,
+      getItemAtIndex,
       getCasesAtIndex(start = 0, options?: IGetCasesOptions) {
         const { count = self.items.length } = options || {}
         const endIndex = Math.min(start + count, self.items.length),
               cases = []
         for (let i = start; i < endIndex; ++i) {
-          cases.push(getCaseAtIndex(i, options))
+          cases.push(getItemAtIndex(i, options))
         }
         return cases
       },
@@ -851,7 +851,7 @@ export const DataSet = V2Model.named("DataSet").props({
           }
         })
         const _cases = items.length > 0 ? items : cases
-        const before = getCases(_cases.map(({ __id__ }) => __id__))
+        const before = getItems(_cases.map(({ __id__ }) => __id__))
         if (self.isCaching()) {
           // update the cases in the cache
           _cases.forEach(aCase => {
@@ -870,7 +870,7 @@ export const DataSet = V2Model.named("DataSet").props({
           })
         }
         // custom undo/redo since values aren't observed all the way down
-        const after = getCases(_cases.map(({ __id__ }) => __id__))
+        const after = getItems(_cases.map(({ __id__ }) => __id__))
         withCustomUndoRedo<ISetCaseValuesCustomPatch>({
           type: "DataSet.setCaseValues",
           data: { dataId: self.id, before, after }

--- a/v3/src/models/formula/plotted-function-formula-adapter.ts
+++ b/v3/src/models/formula/plotted-function-formula-adapter.ts
@@ -50,7 +50,7 @@ export class PlottedFunctionFormulaAdapter extends BaseGraphFormulaAdapter {
     graphCellKeys.forEach(cellKey => {
       const instanceKey = adornment.instanceKey(cellKey)
       const caseIds = dataConfig.subPlotCases(cellKey)
-      const cases = caseIds.map(id => dataConfig.dataset?.getCase(id, { numeric: true }) || { __id__: id })
+      const cases = caseIds.map(id => dataConfig.dataset?.getItem(id, { numeric: true }) || { __id__: id })
       const formulaFunction = this.computeFormula(formulaContext, extraMetadata, cases)
       if (!adornment.plottedFunctions.get(instanceKey)) {
         adornment.addPlottedFunction(formulaFunction, instanceKey)

--- a/v3/src/models/formula/plotted-value-formula-adapter.ts
+++ b/v3/src/models/formula/plotted-value-formula-adapter.ts
@@ -46,7 +46,7 @@ export class PlottedValueFormulaAdapter extends BaseGraphFormulaAdapter {
     graphCellKeys.forEach(cellKey => {
       const instanceKey = adornment.instanceKey(cellKey)
       const caseIds = dataConfig.subPlotCases(cellKey)
-      const cases = caseIds.map(id => dataConfig.dataset?.getCase(id, { numeric: true }) || { __id__: id })
+      const cases = caseIds.map(id => dataConfig.dataset?.getItem(id, { numeric: true }) || { __id__: id })
       const value = Number(this.computeFormula(formulaContext, extraMetadata, cases))
       if (!adornment.measures.get(instanceKey)) {
         adornment.addMeasure(value, instanceKey)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187849639

This PR fixes an error introduced with the recent changes to cases and items which resulted in an infinite loop in the Multidata plugin.

The immediate issue was that cases in the child-most collection included themselves as children. This was causing Multidata to eternally request information about these cases, which caused the plugin to hang up and remain blank.

Ultimately, the problem is that cases in the child-most collection are treated differently than other cases. In the codebase, they are items, not cases, which means that any time a developer is working with a case, they must check to see if they're working with an actual case or an item. I suspect there are other bugs related to this issue, and I have no doubt it will cause confusion in the future.

I also took this opportunity to correct the names of a few `DataSet` views. We should strive to use "case" and "item" consistently throughout the code. There are still many places where "case" is incorrectly used instead of "item".