### PR TITLE
187849622 v3 DI Dataset Notifications

### DIFF
--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -162,6 +162,17 @@ context("codap plugins", () => {
     openAPITester()
     webView.toggleAPITesterFilter()
 
+    cy.log("Broadcast dataContextCountChanged notifications when dataset is added to document")
+    table.createNewTableFromToolshelf()
+    webView.confirmAPITesterResponseContains(/"operation":\s"dataContextCountChanged/)
+    webView.clearAPITesterResponses()
+
+    cy.log("Broadcast dataContextDeleted notifications when dataset is deleted")
+    table.deleteDataSetFromToolshelf(1)
+    webView.confirmAPITesterResponseContains(/"operation":\s"dataContextDeleted/)
+    webView.confirmAPITesterResponseContains(/"deletedContext":\s"New\sDataset/)
+    webView.clearAPITesterResponses()
+
     cy.log("Broadcast select cases notifications")
     table.getCell(2, 2).click()
     webView.confirmAPITesterResponseContains(/"operation":\s"selectCases/)

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -214,9 +214,14 @@ export const TableTileElements = {
     c.getIconFromToolshelf("table").click()
     cy.get("[data-testid=tool-shelf-table-new-clipboard]").click()
   },
-  openExistingTableFromToolshelf(name) {
+  openExistingTableFromToolshelf(name: string) {
     c.getIconFromToolshelf("table").click()
     cy.get(`[data-testid=tool-shelf-table-${name}]`).click()
+  },
+  deleteDataSetFromToolshelf(index = 0) {
+    c.getIconFromToolshelf("table").click()
+    cy.get(`.tool-shelf-menu-trash-icon`).eq(index).click()
+    cy.get(`.delete-data-set-button-delete`).click()
   },
   getToggleCardView() {
     return cy.get("[data-testid=case-table-toggle-view]")
@@ -380,9 +385,5 @@ export const TableTileElements = {
     for (let rowIndex = 0; rowIndex < error.cases; rowIndex++) {
       this.getAttributeValue(attribute, rowIndex+2, collectionIndex).should("have.text", error.value)
     }
-  },
-  createNewDataset() {
-    c.getIconFromToolshelf("table").click()
-    cy.get("[data-testid=tool-shelf-table-new]").click()
   }
 }

--- a/v3/cypress/support/helpers/formula-helper.ts
+++ b/v3/cypress/support/helpers/formula-helper.ts
@@ -35,7 +35,7 @@ export const FormulaHelper = {
     table.editFormula(attributeName, formula, collectionIndex)
   },
   createNewDataset() {
-    table.createNewDataset()
+    table.createNewTableFromToolshelf()
   },
   insertCases(rowIndex: number, numOfCases: number) {
     table.openIndexMenuForRow(rowIndex)

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -6,6 +6,9 @@ import { appState } from "../../models/app-state"
 import { createDefaultTileOfType } from "../../models/codap/add-default-content"
 import { gDataBroker } from "../../models/data/data-broker"
 import { DataSet, toCanonical } from "../../models/data/data-set"
+import {
+  dataContextCountChangedNotification, dataContextDeletedNotification
+} from "../../models/data/data-set-notifications"
 import { kSharedDataSetType, SharedDataSet } from "../../models/shared/shared-data-set"
 import { getFormulaManager, getSharedModelManager } from "../../models/tiles/tile-environment"
 import { t } from "../../utilities/translation/translate"
@@ -15,9 +18,10 @@ import {
 import { CodapModal } from "../codap-modal"
 import { ToolShelfButtonTag } from "../tool-shelf/tool-shelf-button"
 import { kCaseTableTileType } from "./case-table-defs"
+
+import AlertIcon from "../../assets/icons/icon-alert.svg"
 import TableIcon from "../../assets/icons/icon-table.svg"
 import TrashIcon from "../../assets/icons/icon-trash.svg"
-import AlertIcon from "../../assets/icons/icon-alert.svg"
 
 import "../tool-shelf/tool-shelf.scss"
 
@@ -45,6 +49,7 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
       getFormulaManager(document)?.addDataSet(ds)
       createTableOrCardForDataset(sharedData, caseMetadata)
     }, {
+      notifications: dataContextCountChangedNotification,
       undoStringKey: "V3.Undo.caseTable.create",
       redoStringKey: "V3.Redo.caseTable.create"
     })
@@ -122,6 +127,7 @@ export const DeleteDataSetModal = ({dataSetId, isOpen, onClose, setModalOpen}: I
         manager?.removeSharedModel(dataSetId)
         getFormulaManager(document)?.removeDataSet(dataSetId)
       }, {
+        notifications: data ? dataContextDeletedNotification(data) : undefined,
         undoStringKey: "V3.Undo.caseTable.delete",
         redoStringKey: "V3.Redo.caseTable.delete"
       })

--- a/v3/src/data-interactive/handlers/interactive-frame-handler.ts
+++ b/v3/src/data-interactive/handlers/interactive-frame-handler.ts
@@ -47,7 +47,7 @@ export const diInteractiveFrameHandler: DIHandler = {
     if (Array.isArray(_values)) return { success: true }
 
     const values = _values as DIInteractiveFrame
-    const { dimensions, preventAttributeDeletion, respectEditableItemAttribute, title } = values
+    const { dimensions, name, preventAttributeDeletion, respectEditableItemAttribute, title } = values
     interactiveFrame.applyModelChange(() => {
       if (dimensions) {
         appState.document.content?.setTileDimensions(interactiveFrame.id, dimensions)
@@ -56,6 +56,7 @@ export const diInteractiveFrameHandler: DIHandler = {
       if (respectEditableItemAttribute != null) {
         webViewContent?.setRespectEditableItemAttribute(respectEditableItemAttribute)
       }
+      if (name) interactiveFrame.setTitle(name)
       if (title) interactiveFrame.setTitle(title)
     })
     return { success: true }

--- a/v3/src/models/data/data-set-notifications.ts
+++ b/v3/src/models/data/data-set-notifications.ts
@@ -12,11 +12,20 @@ function makeCallback(operation: string, other?: any) {
     debugLog(DEBUG_PLUGINS, `Reply to ${action} ${operation} ${other ?? ""}`, JSON.stringify(response))
 }
 
-function notification(operation: string, result: any, dataSet?: IDataSet, _callback?: (result: any) => void) {
-  const resource = `dataContextChangeNotice[${dataSet?.name}]`
-  const values = { operation, result }
+function notification(
+  operation: string, result?: any, dataSet?: IDataSet, _callback?: (result: any) => void,
+  extraValues?: Record<string, any>
+) {
+  const resource = dataSet ? `dataContextChangeNotice[${dataSet.name}]` : `documentChangeNotice`
+  const values = { operation, result, ...extraValues }
   const callback = _callback ?? makeCallback(operation)
   return { message: { action, resource, values }, callback }
+}
+
+export const dataContextCountChangedNotification = notification("dataContextCountChanged")
+
+export function dataContextDeletedNotification(dataSet: IDataSet) {
+  return notification("dataContextDeleted", undefined, undefined, undefined, { deletedContext: dataSet.name })
 }
 
 export function updateDataContextNotification(dataSet: IDataSet) {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187849622

This PR fixes a couple of issues with the Multidata plugin:
- It broadcasts `dataContextCountChanged` and `dataContextDeleted` notifications, which allows the Multidata plugin to keep its dataset list up to date.
- It handles `update interactiveFrame name` API requests.
  - Technically, the plugin should probably use `update interactiveFrame title`, as `name` is not included in the documentation, but it was an easy fix and felt like less trouble than asking for a change to the plugin.

I'm not sure why these unrelated bugs were included in the same PT story, but making a second story probably would have required more time than just fixing them.

One additional minor change is removing a redundant cypress function.