### PR TITLE
Fix of bar chart/histogram restore bug

### DIFF
--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -635,7 +635,7 @@ export class PixiPoints {
     // For now, the only display type values PixiPoints supports are "points" and "bars", so
     // all other display type values passed to this method will be treated as "points".
     const displayType = _displayType !== "bars" && _displayType !== "histogram" ? "points" : "bars"
-    if (this.displayType !== displayType) {
+    if (this.displayType !== displayType && this.points.length > 0) {
       this.displayTypeTransitionState.isActive = true
       this.forEachPoint(point => {
         this.pointTransitionStates.set(point, { hasTransitioned: false })


### PR DESCRIPTION
[#187751419] Bug fix: Restore of bar chart and histogram doesn't show bars

* The initial call to pixiPoints.matchPointsToData was bailing because the pointDisplayType was different than the default type ("points") and thus regarded as a transition. But there were not points to transition to rectangles and thus no points got constructed. Fixed by not bailing if there are not yet any points.