### PR TITLE
187849648 v3 DI Create Attribute with Duplicate Names

### DIFF
--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -27,7 +27,7 @@ context("codap plugins", () => {
     cy.log("Handle get attribute request")
     const cmd1 = `{
       "action": "get",
-      "resource": "dataContext[Mammals].collection[Mammals].attribute[Order]"
+      "resource": "dataContext[Mammals].collection[Cases].attribute[Order]"
     }`
     webView.sendAPITesterCommand(cmd1)
     webView.confirmAPITesterResponseContains(/"success":\s*true/)
@@ -36,7 +36,7 @@ context("codap plugins", () => {
     cy.log("Properly handles illegal actions")
     const cmd2 = `{
       "action": "fake",
-      "resource": "dataContext[Mammals].collection[Mammals].attribute[Order]"
+      "resource": "dataContext[Mammals].collection[Cases].attribute[Order]"
     }`
     webView.sendAPITesterCommand(cmd2, cmd1)
     webView.confirmAPITesterResponseContains(/"Unsupported action: fake\/attribute"/)
@@ -45,7 +45,7 @@ context("codap plugins", () => {
     cy.log("Handle update attribute hidden")
     const cmd3 = `{
       "action": "update",
-      "resource": "dataContext[Mammals].collection[Mammals].attribute[Order]",
+      "resource": "dataContext[Mammals].collection[Cases].attribute[Order]",
       "values": {
         "hidden": true
       }
@@ -58,7 +58,7 @@ context("codap plugins", () => {
     cy.log("Handle create attribute")
     const cmd4 =`{
       "action": "create",
-      "resource": "dataContext[Mammals].collection[Mammals].attribute",
+      "resource": "dataContext[Mammals].collection[Cases].attribute",
       "values": [
         {
           "name": "Heartrate"
@@ -73,7 +73,7 @@ context("codap plugins", () => {
     cy.log("handle delete attribute")
     const cmd5 = `{
       "action": "delete",
-      "resource": "dataContext[Mammals].collection[Mammals].attribute[Heartrate]"
+      "resource": "dataContext[Mammals].collection[Cases].attribute[Heartrate]"
     }`
     table.getAttributeHeader().contains("Heartrate").should("exist")
     webView.sendAPITesterCommand(cmd5, cmd4)
@@ -83,7 +83,7 @@ context("codap plugins", () => {
     cy.log("Finds the default dataset when no dataset is included")
     const cmd6 = `{
       "action": "get",
-      "resource": "collection[Mammals].attribute[Order]"
+      "resource": "collection[Cases].attribute[Order]"
     }`
     webView.sendAPITesterCommand(cmd6, cmd5)
     webView.confirmAPITesterResponseContains(/"success":\s*true/)

--- a/v3/src/data-interactive/handlers/attribute-handler.test.ts
+++ b/v3/src/data-interactive/handlers/attribute-handler.test.ts
@@ -17,29 +17,39 @@ describe("DataInteractive AttributeHandler", () => {
   })
 
   it("create works as expected", () => {
-    const dataContext = DataSet.create({})
-    const resources = { dataContext }
-    expect(handler.create?.(resources).success).toEqual(false)
-    expect(dataContext.attributes.length).toBe(0)
-    const name1 = "test"
-    expect(handler.create?.(resources, { name: name1 }).success).toEqual(true)
-    expect(dataContext.attributes.length).toBe(1)
-    expect(dataContext.attributes[0].name).toBe(name1)
-    const name2 = "test2"
-    expect(handler.create?.(resources, [{ name: name2 }, {}]).success).toEqual(false)
-    expect(dataContext.attributes.length).toBe(1)
-    const name3 = "test3"
-    const results = handler.create?.(resources, [{ name: name2 }, { name: name3 }])
-    expect(results?.success).toEqual(true)
-    expect((results?.values as DIResultAttributes)?.attrs?.length).toBe(2)
-    expect(dataContext.attributes.length).toBe(3)
-    expect(dataContext.attributes[1].name).toBe(name2)
-    expect(dataContext.attributes[2].name).toBe(name3)
+    const { dataset: dataContext, c1 } = setupTestDataset()
+    const resources = { dataContext, collection: c1 }
+    const create = handler.create!
 
-    const { dataset, c1 } = setupTestDataset()
+    expect(create(resources).success).toEqual(false)
+    expect(create({ dataContext }, { name: "noCollection" }).success).toEqual(false)
+
+    expect(dataContext.attributes.length).toBe(3)
     expect(c1.attributes.length).toBe(1)
-    expect(handler.create?.({ dataContext: dataset, collection: c1 }, [{ name: name1 }]).success).toBe(true)
+    const name1 = "test"
+    expect(create(resources, { name: name1 }).success).toEqual(true)
+    expect(dataContext.attributes.length).toBe(4)
     expect(c1.attributes.length).toBe(2)
+    const testAttr = c1.attributes[1]!
+    expect(testAttr.name).toBe(name1)
+
+    expect(testAttr.description).toBeUndefined()
+    const description = "Test Description"
+    expect(create(resources, { name: name1, description }).success).toBe(true)
+    expect(c1.attributes.length).toBe(2)
+    expect(testAttr.description).toBe(description)
+
+    const name2 = "test2"
+    expect(create(resources, [{ name: name2 }, {}]).success).toEqual(false)
+    expect(dataContext.attributes.length).toBe(4)
+
+    const name3 = "test3"
+    const results = create(resources, [{ name: name2 }, { name: name3 }])
+    expect(results.success).toEqual(true)
+    expect((results.values as DIResultAttributes).attrs.length).toBe(2)
+    expect(dataContext.attributes.length).toBe(6)
+    expect(c1.attributes[2]!.name).toBe(name2)
+    expect(c1.attributes[3]!.name).toBe(name3)
   })
 
   it("update works as expected", () => {

--- a/v3/src/data-interactive/handlers/di-handler-utils.ts
+++ b/v3/src/data-interactive/handlers/di-handler-utils.ts
@@ -1,8 +1,11 @@
+import { IAttribute, isAttributeType } from "../../models/data/attribute"
 import { ICollectionModel } from "../../models/data/collection"
 import { IDataSet } from "../../models/data/data-set"
 import { IAddCollectionOptions } from "../../models/data/data-set-types"
 import { v2NameTitleToV3Title } from "../../models/data/v2-model"
 import { ISharedCaseMetadata } from "../../models/shared/shared-case-metadata"
+import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
+import { hasOwnProperty } from "../../utilities/js-utils"
 import { DIAttribute, DICollection } from "../data-interactive-types"
 import { convertValuesToAttributeSnapshot } from "../data-interactive-type-utils"
 
@@ -31,4 +34,23 @@ export function createCollection(v2collection: DICollection, dataContext: IDataS
   })
 
   return collection
+}
+
+export function updateAttribute(attribute: IAttribute, value: DIAttribute, dataContext?: IDataSet) {
+  if (value?.description != null) attribute.setDescription(value.description)
+  if (value?.editable != null) attribute.setEditable(!!value.editable)
+  if (value?.formula != null) attribute.setDisplayExpression(value.formula)
+  if (value?.name != null) attribute.setName(value.name)
+  if (hasOwnProperty(value, "precision")) {
+    attribute.setPrecision(value.precision == null || value.precision === "" ? undefined : +value.precision)
+  }
+  if (value?.title != null) attribute.setTitle(value.title)
+  if (isAttributeType(value?.type)) attribute.setUserType(value.type)
+  if (value?.unit != null) attribute.setUnits(value.unit)
+  if (value?.hidden != null) {
+    if (dataContext) {
+      const metadata = getSharedCaseMetadataFromDataset(dataContext)
+      metadata?.setIsHidden(attribute.id, value.hidden)
+    }
+  }
 }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187849648

This PR fixes an issue with the Sensor Interactive plugin. The symptom was that Sensor Interactive was creating new attributes with every run.

The underlying problem was that Sensor Interactive was making the same `create attribute` requests with every run. In v2, requesting to create an attribute with a name that already exists in the specified collection resulted in the existing attribute getting updated, but in v3 it was just creating new attributes every time.

This led me to discover some other issues, like `create attribute` requiring a collection in v2, but not in v3. So I tried to get v3 more in line with v2. I also added tests for the changes.

I do have one remaining question. v2 will not allow an attribute with a duplicate name to be created within a collection, but it doesn't check between collections. So it's possible to create two attributes with the same name in the same dataset, as long as they're in different collections. I've mimicked the v2 behavior in v3, but this feels like a bug to me, so please let me know if I should change how this is handled in v3.