### PR TITLE
187849622 v3 DI Better Tracking of Datasets in Multidata

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -28,6 +28,7 @@ import "../models/shared/shared-case-metadata-registration"
 import "../models/shared/shared-data-set-registration"
 
 import "./app.scss"
+import { dataContextCountChangedNotification } from "../models/data/data-set-notifications"
 
 registerTileTypes([])
 
@@ -44,6 +45,7 @@ export const App = observer(function App() {
       appState.document.content?.applyModelChange(() => {
         sharedData = appState.document.content?.importDataSet(data, options)
       }, {
+        notifications: dataContextCountChangedNotification,
         undoStringKey: "V3.Undo.import.data",
         redoStringKey: "V3.Redo.import.data"
       })

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -11,6 +11,7 @@ import { appState } from "../models/app-state"
 import { addDefaultComponents } from "../models/codap/add-default-content"
 import {gDataBroker} from "../models/data/data-broker"
 import {IDataSet} from "../models/data/data-set"
+import { dataContextCountChangedNotification } from "../models/data/data-set-notifications"
 import { IDocumentModelSnapshot } from "../models/document/document"
 import { IImportDataSetOptions } from "../models/document/document-content"
 import { ISharedDataSet } from "../models/shared/shared-data-set"
@@ -28,7 +29,6 @@ import "../models/shared/shared-case-metadata-registration"
 import "../models/shared/shared-data-set-registration"
 
 import "./app.scss"
-import { dataContextCountChangedNotification } from "../models/data/data-set-notifications"
 
 registerTileTypes([])
 

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -122,12 +122,12 @@ export const DeleteDataSetModal = ({dataSetId, isOpen, onClose, setModalOpen}: I
   const handleDeleteDataSet = () => {
     setModalOpen(false)
     onClose()
-    if (dataSetId) {
+    if (data) {
       document.applyModelChange(() => {
         manager?.removeSharedModel(dataSetId)
         getFormulaManager(document)?.removeDataSet(dataSetId)
       }, {
-        notifications: data ? dataContextDeletedNotification(data) : undefined,
+        notifications: [dataContextCountChangedNotification, dataContextDeletedNotification(data)],
         undoStringKey: "V3.Undo.caseTable.delete",
         redoStringKey: "V3.Redo.caseTable.delete"
       })

--- a/v3/src/data-interactive/handlers/data-context-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.ts
@@ -1,6 +1,7 @@
 import { appState } from "../../models/app-state"
 import { gDataBroker } from "../../models/data/data-broker"
 import { DataSet } from "../../models/data/data-set"
+import { dataContextCountChangedNotification, dataContextDeletedNotification } from "../../models/data/data-set-notifications"
 import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
 import { hasOwnProperty } from "../../utilities/js-utils"
 import { registerDIHandler } from "../data-interactive-handler"
@@ -42,6 +43,8 @@ export const diDataContextHandler: DIHandler = {
         success: true,
         values: basicDataSetInfo(dataSet)
       }
+    }, {
+      notifications: dataContextCountChangedNotification
     })
   },
 
@@ -49,8 +52,10 @@ export const diDataContextHandler: DIHandler = {
     const { dataContext } = resources
     if (!dataContext) return dataContextNotFoundResult
 
-    dataContext.applyModelChange(() => {
+    appState.document.applyModelChange(() => {
       gDataBroker.removeDataSet(dataContext.id)
+    }, {
+      notifications: [dataContextCountChangedNotification, dataContextDeletedNotification(dataContext)]
     })
 
     return { success: true }

--- a/v3/src/data-interactive/handlers/data-context-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.ts
@@ -1,7 +1,9 @@
 import { appState } from "../../models/app-state"
 import { gDataBroker } from "../../models/data/data-broker"
 import { DataSet } from "../../models/data/data-set"
-import { dataContextCountChangedNotification, dataContextDeletedNotification } from "../../models/data/data-set-notifications"
+import {
+  dataContextCountChangedNotification, dataContextDeletedNotification
+} from "../../models/data/data-set-notifications"
 import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
 import { hasOwnProperty } from "../../utilities/js-utils"
 import { registerDIHandler } from "../data-interactive-handler"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187849622

A recent addition of `dataContextCountChanged` and `dataContextDeleted` notifications missed a few places:
- `dataContextCountChanged` notifications need to be broadcast when deleting datasets, in addition to the `dataContextDeleted` notifications that were already being broadcast.
- `dataContextCountChanged` and `dataContextDeleted` notifications need to be broadcast when datasets are created or deleted via the plugin API.
- `dataContextCountChanged` notifications need to be broadcast when importing datasets.