### PR TITLE
Fix for LSRL's not properly split by categorical legend

### DIFF
--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -67,7 +67,7 @@ describe("LSRLAdornmentModel", () => {
   })
   it("can have a line added to its lines property", () => {
     const lSRL = LSRLAdornmentModel.create()
-    lSRL.updateLines(mockLSRLInstanceProps1)
+    lSRL.updateLines(mockLSRLInstanceProps1,"", 0)
     expect(lSRL.lines.size).toEqual(1)
     const modelLines = lSRL.lines.get("")
     const modelLine = modelLines?.[0]
@@ -80,8 +80,8 @@ describe("LSRLAdornmentModel", () => {
     const line1 = mockLSRLInstanceProps1
     const line2 = mockLSRLInstanceProps2
     const lSRL = LSRLAdornmentModel.create()
-    lSRL.updateLines(line1, "cellkey1")
-    lSRL.updateLines(line2, "cellkey2")
+    lSRL.updateLines(line1, "cellkey1", 0)
+    lSRL.updateLines(line2, "cellkey2", 0)
     expect(lSRL.lines.size).toEqual(2)
     const modelLines1 = lSRL.lines.get("cellkey1")
     const modelLines2 = lSRL.lines.get("cellkey2")
@@ -100,8 +100,8 @@ describe("LSRLAdornmentModel", () => {
     const line1 = mockLSRLInstanceProps1
     const line2 = mockLSRLInstanceProps2
     const lSRL = LSRLAdornmentModel.create()
-    lSRL.updateLines(line1, "sameKey")
-    lSRL.updateLines(line2, "sameKey")
+    lSRL.updateLines(line1, "sameKey", 0)
+    lSRL.updateLines(line2, "sameKey", 1)
     expect(lSRL.lines.size).toEqual(1)
     const modelLines = lSRL.lines.get("sameKey")
     const modelLine1 = modelLines?.[0]
@@ -123,7 +123,7 @@ describe("LSRLAdornmentModel", () => {
   })
   it("can get both the intercept and slope values of a line via the line's slopeAndIntercept view", () => {
     const lSRL = LSRLAdornmentModel.create()
-    lSRL.updateLines(mockLSRLInstanceProps1)
+    lSRL.updateLines(mockLSRLInstanceProps1, "", 0)
     expect(lSRL.lines.get("")?.[0]?.slopeAndIntercept).toEqual({intercept: 1, slope: 1})
   })
 })

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -140,7 +140,7 @@ export const LSRLAdornmentModel = AdornmentModel
   }
 }))
 .actions(self => ({
-  updateLines(line: ILSRLine, key="", index: number) {
+  updateLines(line: ILSRLine, key:string, index: number) {
     const { category, equationCoords, intercept, rSquared, sdResiduals, slope } = line
     const existingLines = self.lines.get(key)
     const newLines = existingLines ? [...existingLines] : []

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -140,12 +140,12 @@ export const LSRLAdornmentModel = AdornmentModel
   }
 }))
 .actions(self => ({
-  updateLines(line: ILSRLine, key="", index?: number) {
+  updateLines(line: ILSRLine, key="", index: number) {
     const { category, equationCoords, intercept, rSquared, sdResiduals, slope } = line
     const existingLines = self.lines.get(key)
     const newLines = existingLines ? [...existingLines] : []
     // Remove any pre-existing line in newLines at specified index, otherwise we can end up with duplicates.
-    ;(index != null) && newLines.splice(index, 1)
+    newLines.splice(index, 1)
     const newLine = LSRLInstance.create(line)
     newLine.setCategory(category)
     newLine.setIntercept(intercept)
@@ -153,7 +153,7 @@ export const LSRLAdornmentModel = AdornmentModel
     newLine.setSlope(slope)
     newLine.setSdResiduals(sdResiduals)
     equationCoords && newLine.setEquationCoords(equationCoords)
-    newLines.push(newLine)
+    newLines[index] = newLine
     self.lines.set(key, newLines)
   },
   setShowConfidenceBands(showConfidenceBands: boolean) {

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
@@ -311,7 +311,7 @@ export const NormalCurveAdornmentComponent = observer(
 
       const gaussianFitTitle = useGaussianFit
         ? showLabel
-          ? `<p style="text-decoration-line:underline;color:${kNormalCurveStrokeColor}"> ${t(kGaussianFitLabelKey)} </p>`
+          ? `<p style="text-decoration-line:underline;color:${kNormalCurveStrokeColor}"> ${t(kGaussianFitLabelKey)}</p>`
           : `${t(kGaussianFitLabelKey)}: `
         : ""
 


### PR DESCRIPTION
[#187879648] Bug fix: Least squares line is not properly split by categorical legend

* In `LSRLAdornmentModel.updateLines` there were some wrong assumptions being made about the array of lines for a given cell. In particular, a new line was being pushed into the array on the assumption that they are added sequentially (I guess) even though the desired index was given.
* The jest test for this model was *not* passing the desired index, so we fixed that