### PR TITLE
fix: case table refresh issues [PT-187931119] [PT-187931309] [PT-187931070]

### DIFF
--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -67,7 +67,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({ o
   //   }
   // }
 
-  function handleTopClick() {
+  function handleExpandCollapseAllClick() {
     caseMetadata?.applyModelChange(() => {
       parentCases?.forEach((value) => caseMetadata?.setIsCollapsed(value.__id__, !everyCaseIsCollapsed))
     }, {
@@ -94,7 +94,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({ o
       {parentCollectionId && parentTableModel && childTableModel && visibleParentAttributes.length > 0 &&
         <>
           <div className="spacer-top">
-            {<ExpandCollapseButton isCollapsed={everyCaseIsCollapsed || false} onClick={handleTopClick}
+            {<ExpandCollapseButton isCollapsed={everyCaseIsCollapsed || false} onClick={handleExpandCollapseAllClick}
               title={topButtonTooltip} />}
           </div>
           <div className="spacer-mid">

--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -12,7 +12,6 @@ import { isAddCasesAction, isRemoveCasesAction, isSetCaseValuesAction } from "..
 import { updateCasesNotification } from "../../models/data/data-set-notifications"
 import { ICase, IGroupedCase, symFirstChild, symIndex, symParent } from "../../models/data/data-set-types"
 import { isSetIsCollapsedAction } from "../../models/shared/shared-case-metadata"
-import { mstReaction } from "../../utilities/mst-reaction"
 import { onAnyAction } from "../../utilities/mst-utils"
 import { prf } from "../../utilities/profiler"
 
@@ -21,30 +20,20 @@ export const useRows = () => {
   const data = useDataSetContext()
   const collectionId = useCollectionContext()
   const collectionTableModel = useCollectionTableModel()
-  const casesRef = useRef<readonly ICase[]>([])
-
-  useEffect(() => {
-    return mstReaction(
-      () => data?.getCasesForCollection(collectionId) ?? [],
-      cases => {
-        casesRef.current = cases
-        resetRowCache()
-      },
-      { name: "useRows.cases reaction", fireImmediately: true }, data)
-  })
 
   // reload the cache, e.g. on change of DataSet
   const resetRowCache = useCallback(() => {
     if (!collectionTableModel) return
     const { rowCache } = collectionTableModel
     rowCache.clear()
+    const cases = data?.getCasesForCollection(collectionId) ?? []
     let prevParent: string | undefined
-    casesRef.current.forEach(({ __id__, [symIndex]: i, [symParent]: parent }: IGroupedCase) => {
+    cases.forEach(({ __id__, [symIndex]: i, [symParent]: parent }: IGroupedCase) => {
       const firstChild = parent && (parent !== prevParent) ? { [symFirstChild]: true } : undefined
       rowCache.set(__id__, { __id__, [symIndex]: i, [symParent]: parent, ...firstChild })
       prevParent = parent
     })
-  }, [collectionTableModel])
+  }, [collectionId, collectionTableModel, data])
 
   const setCachedDomAttr = useCallback((caseId: string, attrId: string) => {
     if (!collectionTableModel) return
@@ -60,7 +49,8 @@ export const useRows = () => {
     prf.measure("Table.useRows[syncRowsToRdg]", () => {
       // RDG memoizes the grid, so we need to pass a new rows array to trigger a render.
       const newRows = prf.measure("Table.useRows[syncRowsToRdg-copy]", () => {
-        return casesRef.current.map(({ __id__ }) => {
+        const cases = data?.getCasesForCollection(collectionId) ?? []
+        return cases.map(({ __id__ }) => {
           const row = rowCache.get(__id__)
           const parentId = row?.[symParent]
           const isCollapsed = parentId && caseMetadata?.isCollapsed(parentId)
@@ -71,7 +61,7 @@ export const useRows = () => {
         collectionTableModel.resetRows(newRows || [])
       })
     })
-  }, [caseMetadata, collectionTableModel])
+  }, [caseMetadata, collectionId, collectionTableModel, data])
 
   const syncRowsToDom = useCallback(() => {
     prf.measure("Table.useRows[syncRowsToDom]", () => {
@@ -117,9 +107,9 @@ export const useRows = () => {
 
     // rebuild the entire cache after grouping changes
     const reactionDisposer = reaction(
-      () => data?.isValidCaseGroups,
-      isValid => {
-        if (isValid) {
+      () => data?.isValidCaseGroups && data?.validationCount,
+      validation => {
+        if (typeof validation === "number") {
           resetRowCache()
           if (appState.appMode === "performance") {
             syncRowsToDom()
@@ -228,7 +218,7 @@ export const useRows = () => {
       afterAnyActionDisposer?.()
       metadataDisposer?.()
     }
-  }, [caseMetadata, collectionTableModel, data, resetRowCache, syncRowsToDom, syncRowsToRdg])
+  }, [caseMetadata, collectionId, collectionTableModel, data, resetRowCache, syncRowsToDom, syncRowsToRdg])
 
   const handleRowsChange = useCallback((_rows: TRow[], changes: TRowsChangeData) => {
     // when rows change, e.g. after cell edits, update the dataset

--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -218,7 +218,7 @@ export const useRows = () => {
       afterAnyActionDisposer?.()
       metadataDisposer?.()
     }
-  }, [caseMetadata, collectionId, collectionTableModel, data, resetRowCache, syncRowsToDom, syncRowsToRdg])
+  }, [caseMetadata, collectionTableModel, data, resetRowCache, syncRowsToDom, syncRowsToRdg])
 
   const handleRowsChange = useCallback((_rows: TRow[], changes: TRowsChangeData) => {
     // when rows change, e.g. after cell edits, update the dataset

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -67,7 +67,7 @@ describe("LSRLAdornmentModel", () => {
   })
   it("can have a line added to its lines property", () => {
     const lSRL = LSRLAdornmentModel.create()
-    lSRL.updateLines(mockLSRLInstanceProps1,"", 0)
+    lSRL.updateLines(mockLSRLInstanceProps1, "", 0)
     expect(lSRL.lines.size).toEqual(1)
     const modelLines = lSRL.lines.get("")
     const modelLine = modelLines?.[0]

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -157,9 +157,13 @@ export const DataSet = V2Model.named("DataSet").props({
   managingControllerId: ""
 }))
 .extend(self => {
+  const _validationCount = observable.box<number>(0)
   const _isValidCaseGroups = observable.box<boolean>(false)
   return {
     views: {
+      get validationCount() {
+        return _validationCount.get()
+      },
       get isValidCaseGroups() {
         return _isValidCaseGroups.get()
       },
@@ -167,7 +171,12 @@ export const DataSet = V2Model.named("DataSet").props({
         runInAction(() => _isValidCaseGroups.set(false))
       },
       setValidCaseGroups() {
-        runInAction(() => _isValidCaseGroups.set(true))
+        if (!_isValidCaseGroups.get()) {
+          runInAction(() => {
+            _validationCount.set(_validationCount.get() + 1)
+            _isValidCaseGroups.set(true)
+          })
+        }
       }
     }
   }

--- a/v3/src/utilities/v2/dg-data-context-utilities.v2.js
+++ b/v3/src/utilities/v2/dg-data-context-utilities.v2.js
@@ -329,7 +329,7 @@ DG.DataContextUtilities = {
    */
   deleteAttributeFormula (iDataContext, iAttrID, iUpdateFunc) {
     // show an alert that this has not been implemented yet
-    console.log("This feature has not been implemented yet.")
+    console.warn("This feature has not been implemented yet.")
     alert("This feature has not been implemented yet.")
 
     // var tRef = iDataContext?.getAttrRefByID(iAttrID),


### PR DESCRIPTION
[[PT-187931119]](https://www.pivotaltracker.com/story/show/187931119)
[[PT-187931309]](https://www.pivotaltracker.com/story/show/187931309)
[[PT-187931070]](https://www.pivotaltracker.com/story/show/187931070)

There are two basic fixes here:
1. Eliminate the local cases cache in the `useRows` hook. It merely served as an opportunity to get out of sync.
2. Add a case grouping `validationCount` to the `DataSet`. There was a `reaction` in the `useRows` hooks that was listening to `isValidCaseGroups` that never fired because `isValidCaseGroups` would be set to false and then back to true before the reaction ran, so no change was detected. Adding the `validationCount` means that the reaction fires any time the grouping has been re-validated.

There are a few changes unrelated to the refresh bugs that were made along the way:
1. Rename `handleTopClick` function to `handleExpandCollapseAllClick`
2. A couple of unrelated lint warnings were fixed