### PR TITLE
fix: undo/redo of component creation [PT-187949749][PT-187948687]

### DIFF
--- a/v3/src/components/case-table-card-common/case-table-card-utils.ts
+++ b/v3/src/components/case-table-card-common/case-table-card-utils.ts
@@ -12,7 +12,6 @@ import { getSharedDataSetFromDataSetId, getTileCaseMetadata } from "../../models
 import { getTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { getSharedModelManager, getTileEnvironment } from "../../models/tiles/tile-environment"
 import { uiState } from "../../models/ui-state"
-import { ComponentRect } from "../../utilities/animation-utils"
 import { getPositionOfNewComponent } from "../../utilities/view-utils"
 import { kTitleBarHeight } from "../constants"
 import { kCaseTableTileType } from "../case-table/case-table-defs"
@@ -53,20 +52,9 @@ export function createTableOrCardForDataset (
   let {x, y} = getPositionOfNewComponent({width, height})
   if (options?.x != null) x = options.x
   if (options?.y != null) y = options.y
-  const from: ComponentRect = { x: 0, y: 0, width: 0, height: kTitleBarHeight },
-    to: ComponentRect = { x, y, width, height: height + kTitleBarHeight}
-  content?.insertTileInRow(tile, row, from)
+  const tileOptions = { x, y, width, height: height + kTitleBarHeight, animateCreation: options?.animateCreation }
+  content?.insertTileInRow(tile, row, tileOptions)
   uiState.setFocusedTile(tile.id)
-  const tileLayout = content.getTileLayoutById(tile.id)
-  if (!isFreeTileLayout(tileLayout)) return
-  // use setTimeout to push the change into a subsequent action
-  setTimeout(() => {
-    // use applyModelChange to wrap into a single non-undoable action without undo string
-    content.applyModelChange(() => {
-      tileLayout.setPosition(to.x, to.y)
-      tileLayout.setSize(to.width, to.height)
-    })
-  })
 
   return tile
 }

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -4,6 +4,7 @@ import { Button, Menu, MenuButton, MenuItem, MenuList, ModalBody, ModalFooter,
 import { observer } from "mobx-react-lite"
 import { appState } from "../../models/app-state"
 import { createDefaultTileOfType } from "../../models/codap/add-default-content"
+import { INewTileOptions } from "../../models/codap/create-tile"
 import { gDataBroker } from "../../models/data/data-broker"
 import { DataSet, toCanonical } from "../../models/data/data-set"
 import {
@@ -36,18 +37,19 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
 
   if (!content) return null
 
-  const handleCreateNewDataSet = () => {
+  const handleCreateNewCaseTable = () => {
     document.applyModelChange(() => {
       const newData = [{ AttributeName: "" }]
       const ds = DataSet.create({ name: t("DG.AppController.createDataSet.name")})
       ds.addAttribute({ name: t("DG.AppController.createDataSet.initialAttribute") })
       ds.addCases(toCanonical(ds, newData))
-      const tile = createDefaultTileOfType(kCaseTableTileType)
+      const options: INewTileOptions = { animateCreation: true }
+      const tile = createDefaultTileOfType(kCaseTableTileType, options)
       if (!tile) return
       const { sharedData, caseMetadata } = gDataBroker.addDataSet(ds, tile.id)
       // Add dataset to the formula manager
       getFormulaManager(document)?.addDataSet(ds)
-      createTableOrCardForDataset(sharedData, caseMetadata)
+      createTableOrCardForDataset(sharedData, caseMetadata, kCaseTableTileType, options)
     }, {
       notifications: dataContextCountChangedNotification,
       undoStringKey: "V3.Undo.caseTable.create",
@@ -78,7 +80,7 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
         <MenuItem data-testid="tool-shelf-table-new-clipboard">
           {t("DG.AppController.caseTableMenu.clipboardDataset")}
         </MenuItem>
-        <MenuItem onClick={handleCreateNewDataSet} data-testid="tool-shelf-table-new">
+        <MenuItem onClick={handleCreateNewCaseTable} data-testid="tool-shelf-table-new">
           {t("DG.AppController.caseTableMenu.newDataSet")}
         </MenuItem>
       </MenuList>

--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -11,22 +11,31 @@ import { kTitleBarHeight } from "../constants"
 import { urlParams } from "../../utilities/url-params"
 
 interface IProps {
-  row: IFreeTileRow;
-  tile: ITileModel;
-  onCloseTile: (tileId: string) => void;
+  row: IFreeTileRow
+  tile: ITileModel
+  onCloseTile: (tileId: string) => void
 }
 
 export const FreeTileComponent = observer(function FreeTileComponent({ row, tile, onCloseTile}: IProps) {
+  const { active } = useDndContext()
+  const { id: tileId, content: { type: tileType } } = tile
+  const [useDefaultCreationStyle, setUseDefaultCreationStyle] = useState(row.animateCreationTiles.has(tileId))
   const [resizingTileStyle, setResizingTileStyle] =
     useState<{left: number, top: number, width?: number, height?: number, zIndex?: number, transition: string}>()
   const [resizingTileId, setResizingTileId] = useState("")
-  const tileId = tile.id
-  const tileType = tile.content.type
   const rowTile = row.tiles.get(tileId)
   const { x: left, y: top, width, height, zIndex } = rowTile || {}
-  const { active } = useDndContext()
-  const tileStyle: React.CSSProperties = { left, top, width, height, zIndex }
+  // when animating creation, use the default creation style on the first render
+  const tileStyle: React.CSSProperties = useDefaultCreationStyle
+          ? { left: 0, top: 0, width: 0, height: kTitleBarHeight, zIndex }
+          : { left, top, width, height, zIndex }
   const draggableOptions: IUseDraggableTile = { prefix: tileType || "tile", tileId }
+
+  useEffect(() => {
+    // after the first render, render the actual style; CSS transitions will handle the animation
+    setUseDefaultCreationStyle(false)
+  }, [])
+
   const {setNodeRef, transform} = useDraggableTile(draggableOptions,
     activeDrag => {
     const dragTileId = getDragTileId(activeDrag)

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -118,7 +118,7 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
     }
     const [undoStringKey = "", redoStringKey = ""] = undoRedoStringKeysMap[tileType] || []
     document?.content?.applyModelChange(() => {
-      document?.content?.createOrShowTile?.(tileType)
+      document?.content?.createOrShowTile?.(tileType, { animateCreation: true })
     }, { undoStringKey, redoStringKey })
   }
 

--- a/v3/src/models/codap/create-tile.ts
+++ b/v3/src/models/codap/create-tile.ts
@@ -6,6 +6,7 @@ import { ITileEnvironment } from "../tiles/tile-environment"
 import { TileModel } from "../tiles/tile-model"
 
 export interface INewTileOptions {
+  animateCreation?: boolean
   cannotClose?: boolean
   content?: ITileContentSnapshotWithType
   title?: string

--- a/v3/src/models/document/free-tile-row.ts
+++ b/v3/src/models/document/free-tile-row.ts
@@ -66,6 +66,7 @@ export interface IFreeTileInRowOptions extends ITileInRowOptions {
   width?: number
   height?: number
   zIndex?: number
+  animateCreation?: boolean
 }
 export const isFreeTileInRowOptions = (options?: ITileInRowOptions): options is IFreeTileInRowOptions =>
               !!options && ("x" in options && options.x != null) && ("y" in options && options.y != null)
@@ -81,6 +82,10 @@ export const FreeTileRow = TileRowModel
     tiles: types.map(FreeTileLayout), // tile id => layout
     maxZIndex: 0
   })
+  .volatile(self => ({
+    // tile ids of tiles created by user whose creation should be animated
+    animateCreationTiles: new Set<string>()
+  }))
   .views(self => ({
     get acceptDefaultInsert() {
       return true
@@ -131,9 +136,11 @@ export const FreeTileRow = TileRowModel
       self.maxZIndex = zIndex
     },
     insertTile(tileId: string, options?: ITileInRowOptions) {
-      const { x = 50, y = 50, width = undefined, height = undefined, zIndex = this.nextZIndex() } =
-        isFreeTileInRowOptions(options) ? options : {}
+      const {
+        x = 50, y = 50, width = undefined, height = undefined, zIndex = this.nextZIndex(), animateCreation = false
+      } = isFreeTileInRowOptions(options) ? options : {}
       self.tiles.set(tileId, { tileId, x, y, width, height, zIndex })
+      animateCreation && self.animateCreationTiles.add(tileId)
     },
     removeTile(tileId: string) {
       self.tiles.delete(tileId)

--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -1,5 +1,5 @@
 import { comparer, makeObservable, observable, reaction, action } from "mobx"
-import { isAlive } from "mobx-state-tree"
+import { addDisposer, isAlive } from "mobx-state-tree"
 import { ICase } from "../data/data-set-types"
 import { CaseList } from "./formula-types"
 import { IDataSet } from "../data/data-set"
@@ -83,6 +83,8 @@ export class FormulaManager {
 
   @action addDataSet(dataSet: IDataSet) {
     this.dataSets.set(dataSet.id, dataSet)
+    // remove the DataSet if it is destroyed
+    addDisposer(dataSet, () => this.removeDataSet(dataSet.id))
   }
 
   @action removeDataSet(dataSetId: string) {

--- a/v3/src/utilities/animation-utils.ts
+++ b/v3/src/utilities/animation-utils.ts
@@ -1,11 +1,4 @@
 export const kDefaultAnimationDuration = 500
-export interface ComponentRect {
-  x: number
-  y: number
-  width: number
-  height: number
-  [key: string]: number
-}
 
 export const interpolateEaseInOut = <T extends Record<string, number>>(duration: number, from: T, to: T) => {
   return (time: number) => {


### PR DESCRIPTION
[[PT-187949749]](https://www.pivotaltracker.com/story/show/187949749) -- Redo of component creation results in invisible components
[[PT-187948687]](https://www.pivotaltracker.com/story/show/187948687) -- MST warning on undo create case table

The MST warning was due to the `FormulaManager`'s use of a MobX `reaction` which accessed the `DataSet`. Undoing the creation of the case table destroys the underlying `DataSet`, and so the `DataSet` must be removed from the `FormulaManager` when it is destroyed.

The bug in redoing component creation occurs because of the way component animation was implemented. When the component is created, its pre-animation dimensions are stored in the model, i.e. `{ x: 0, y: 0, width: 0, height: 25 }`. Then in a separate step, the tile's dimensions are updated to their desired position and extent (without undo), which triggers the animation due to a CSS transition. The redo bug arises because the undo history captures the pre-animation dimensions, so redo instantiates a zero-width tile.

After considering several model-related approaches to solving the problem (`onPatch`?, MST middleware?), it occurred to me that the problem arises because the model is being manipulated to achieve a display-only result (animation). A better approach is to store the correct tile dimensions in the model from the start, and then handle animating to those dimensions in the React component when desired. This simplified the implementation substantially.

The solution involves several pieces:
- a new `animateCreation` option is added to `INewTileOptions`
- this option is used when creating tiles from the tool shelf (not when restoring documents, for instance)
- when the `animateCreation` option is specified, the id of the tile is stored in volatile state in the `FreeTileRow`
- when a `FreeTileComponent` is first rendered, if `animateCreation` was specified, then it is initially rendered in pre-animation dimensions (`{ x: 0, y: 0, width: 0, height: 25 }`) on the first render, and then a second render is triggered, after which the final dimensions of the tile are used.
- the preexisting CSS transition triggers the animation

As a result, the model always stores the correct dimensions for all tiles, undo/redo works as desired, and animation is handled entirely in volatile MST state and React state. The moral of the story is that it's better to keep model changes simple and handle complexities like animations in the React components.