### PR TITLE
fix: redundant calls to handleRowsChange

### DIFF
--- a/v3/src/components/case-table/color-cell-text-editor.tsx
+++ b/v3/src/components/case-table/color-cell-text-editor.tsx
@@ -91,11 +91,6 @@ export default function ColorCellTextEditor({ row, column, onRowChange, onClose 
     updateValue(event.target.value)
   }
 
-  function handleInputKeyDown(event: React.KeyboardEvent) {
-    if (event.key === "Enter") acceptValue()
-    if (event.key === "Escape") rejectValue()
-  }
-
   function handleInputBlur() {
     !isPaletteOpen && acceptValue()
   }
@@ -103,7 +98,6 @@ export default function ColorCellTextEditor({ row, column, onRowChange, onClose 
   const swatchStyle: React.CSSProperties | undefined = showColorSwatch.current ? { background: color } : undefined
   const inputElt = <InputElt
                     value={inputValue}
-                    onKeyDown={handleInputKeyDown}
                     onChange={handleInputColorChange}
                     onBlur={handleInputBlur}
                   />


### PR DESCRIPTION
The `ColorCellTextEditor` component (which is used in situations in which no attribute type has been assigned, since the user _could_ theoretically enter a color at any time) was handling key events like `enter`/`escape`, but RDG handles key events internally as well, resulting in redundant calls.