### PR TITLE
Add case table dates support

### DIFF
--- a/v3/src/components/case-table/use-columns.tsx
+++ b/v3/src/components/case-table/use-columns.tsx
@@ -15,6 +15,8 @@ import { kDefaultColumnWidth, symDom, TColumn, TRenderCellProps } from "./case-t
 import CellTextEditor from "./cell-text-editor"
 import ColorCellTextEditor from "./color-cell-text-editor"
 import { ColumnHeader } from "./column-header"
+import { parseDate } from "../../utilities/date-parser"
+import { DatePrecision, formatDate } from "../../utilities/date-utils"
 
 // cache d3 number formatters so we don't have to generate them on every render
 type TNumberFormatter = (n: number) => string
@@ -50,6 +52,24 @@ export function renderValue(str = "", num = NaN, attr?: IAttribute, key?: number
     const formatStr = attr?.format ?? kDefaultFormatStr
     const formatter = getNumFormatter(formatStr)
     if (formatter) str = formatter(num)
+  }
+
+  // dates
+  // Note that CODAP v2 formats dates in the case table ONLY if the user explicitly specified type as "date".
+  // Dates are not interpreted as dates and formatted by default.
+  if (userType === "date" && str !== "") {
+    const date = parseDate(str, true)
+    if (date) {
+      // TODO: add precision support for date formatting
+      const formattedDate = formatDate(date, DatePrecision.None)
+      return {
+        value: str,
+        content: <span className="cell-span" key={key}>{formattedDate || str}</span>
+      }
+    } else {
+      // If the date is not valid, wrap it in quotes (CODAP V2 behavior).
+      str = `"${str}"`
+    }
   }
 
   return {

--- a/v3/src/utilities/data-utils.ts
+++ b/v3/src/utilities/data-utils.ts
@@ -42,3 +42,7 @@ export const numericSortComparator = function ({a, b, order}: ICompareProps): nu
   if (aIsNaN) return order === "asc" ? -1 : 1
   return order === "asc" ? a - b : b - a
 }
+
+export const isNumeric = function (value: any): value is number {
+  return value != null && value !== "" && !isNaN(value)
+}

--- a/v3/src/utilities/date-parser.test.ts
+++ b/v3/src/utilities/date-parser.test.ts
@@ -1,0 +1,80 @@
+import { isDateString, parseDate } from './date-parser'
+
+describe('Date Parser tests - V2 compatibility', () => {
+  // These tests are ported from V2 and should always pass unchanged as long as we want to maintain compatibility.
+  test('local date format', () => {
+    expect(parseDate('11/9/2016', true)?.toISOString()).toBe(new Date(2016, 10, 9).toISOString())
+    expect(parseDate('11/09/2016', true)?.toISOString()).toBe(new Date(2016, 10, 9).toISOString())
+    expect(parseDate('4/1/1928', true)?.toISOString()).toBe(new Date(1928, 3, 1).toISOString())
+    expect(parseDate('11/9/16', true)?.toISOString()).toBe(new Date(2016, 10, 9).toISOString())
+    expect(parseDate('11/09/16', true)?.toISOString()).toBe(new Date(2016, 10, 9).toISOString())
+    expect(parseDate('04/1/28', true)?.toISOString()).toBe(new Date(2028, 3, 1).toISOString())
+  })
+test('ISO dates', () => {
+    expect(parseDate('2016-01', true)?.toISOString()).toBe(new Date(2016, 0, 1).toISOString())
+    expect(parseDate('2016-02-02', true)?.toISOString()).toBe(new Date(2016, 1, 2).toISOString())
+  })
+test('day, month name, year dates', () => {
+    expect(parseDate('03 Mar 2016', true)?.toISOString()).toBe(new Date(2016, 2, 3).toISOString())
+  })
+test('traditional US dates', () => {
+    expect(parseDate('April 4, 2016', true)?.toISOString()).toBe(new Date(2016, 3, 4).toISOString())
+    expect(parseDate('Apr 5, 2016', true)?.toISOString()).toBe(new Date(2016, 3, 5).toISOString())
+    expect(parseDate('Monday, May 5, 2016', true)?.toISOString()).toBe(new Date(2016, 4, 5).toISOString())
+  })
+test('year.month.day dates', () => {
+    expect(parseDate('2016.6.6', true)?.toISOString()).toBe(new Date(2016, 5, 6).toISOString())
+  })
+test('unix dates', () => {
+    expect(parseDate('Thu Jul 11 09:12:47 PDT 2019', true)?.toISOString()).toBe(new Date(2019, 6, 11, 9, 12, 47).toISOString())
+  })
+test('UTC dates', () => {
+    expect(parseDate('Thu, 11 Jul 2019 16:17:01 GMT', true)?.toISOString()).toBe(new Date(2019, 6, 11, 16, 17, 1).toISOString())
+  })
+test('ISO Date/time', () => {
+    expect(parseDate('2019-07-11T16:20:38.575Z', true)?.toISOString()).toBe(new Date(2019, 6, 11, 16, 20, 38, 575).toISOString())
+  })
+test('dates with times', () => {
+    expect(parseDate('11/9/2016 7:18', true)?.toISOString()).toBe(new Date(2016, 10, 9, 7, 18).toISOString())
+    expect(parseDate('11/9/2016 7:18am', true)?.toISOString()).toBe(new Date(2016, 10, 9, 7, 18).toISOString())
+    expect(parseDate('11/9/2016 7:18 am', true)?.toISOString()).toBe(new Date(2016, 10, 9, 7, 18).toISOString())
+    expect(parseDate('11/9/2016 7:18AM', true)?.toISOString()).toBe(new Date(2016, 10, 9, 7, 18).toISOString())
+    expect(parseDate('11/9/2016 7:18:02', true)?.toISOString()).toBe(new Date(2016, 10, 9, 7, 18, 2).toISOString())
+    expect(parseDate('11/9/2016 7:18:02 AM', true)?.toISOString()).toBe(new Date(2016, 10, 9, 7, 18, 2).toISOString())
+    expect(parseDate('11/9/2016 7:18:02PM', true)?.toISOString()).toBe(new Date(2016, 10, 9, 19, 18, 2).toISOString())
+    expect(parseDate('11/9/2016 7:18:02.123', true)?.toISOString()).toBe(new Date(2016, 10, 9, 7, 18, 2, 123).toISOString())
+    expect(parseDate('11/9/2016 7:18:02.234 pm', true)?.toISOString()).toBe(new Date(2016, 10, 9, 19, 18, 2, 234).toISOString())
+    expect(parseDate('11/9/2016 7:18:02.234am', true)?.toISOString()).toBe(new Date(2016, 10, 9, 7, 18, 2, 234).toISOString())
+    expect(parseDate('11/9/2016 17:18:02', true)?.toISOString()).toBe(new Date(2016, 10, 9, 17, 18, 2).toISOString())
+    expect(parseDate('11/9/2016 17:18:02.123', true)?.toISOString()).toBe(new Date(2016, 10, 9, 17, 18, 2, 123).toISOString())
+  })
+test('ISO 8601', () => {
+    expect(isDateString('2016-11-10')).toBe(true)
+    expect(isDateString('2016-11-09T07:18:02')).toBe(true)
+    expect(isDateString('2016-11-09T07:18:02-07:00')).toBe(true)
+    expect(isDateString('2016-11-09T07:18:02+0700')).toBe(true)
+    expect(isDateString('2016-11-10T21:27:42Z')).toBe(true)
+    expect(isDateString('2016-11-09T07:18:02.123')).toBe(true)
+    expect(isDateString('2016-11-09T07:18:02.123+07:00')).toBe(true)
+    expect(isDateString('2016-11-09T07:18:02.123-0700')).toBe(true)
+    expect(isDateString('2016-11-10T21:27:42.123Z')).toBe(true)
+    expect(isDateString('September 1, 2016')).toBe(true)
+    expect(isDateString('2016-11-10T21:27:42.12Z')).toBe(true)
+  })
+test('invalid strings', () => {
+    expect(isDateString('')).toBe(false)
+    expect(isDateString('a')).toBe(false)
+    expect(isDateString('123')).toBe(false)
+    expect(isDateString('123%')).toBe(false)
+    expect(isDateString('//')).toBe(false)
+    expect(isDateString(':')).toBe(false)
+    expect(isDateString('::')).toBe(false)
+    // Likely meant to be dates, but not recognized, yet.
+    expect(isDateString('11/ 9/2016')).toBe(false)
+    expect(isDateString('12/31')).toBe(false)
+    expect(isDateString('1/2')).toBe(false)
+    expect(isDateString('2016-1-10T21:27:42.123Z')).toBe(false)
+    expect(isDateString('2016-1-10T21:7:42.123Z')).toBe(false)
+    expect(isDateString('2016-1-10T1:07:42.123Z')).toBe(false)
+  })
+})

--- a/v3/src/utilities/date-parser.ts
+++ b/v3/src/utilities/date-parser.ts
@@ -1,0 +1,286 @@
+import { t } from "./translation/translate"
+
+/**
+ * parseDate - Parses dates in a uniform manner across browser
+ *
+ * Has two modes: strict (default) and loose
+ *
+ * In strict mode recognizes year, month or year, month, day iso calendar date
+ * or date/time strings (not just year) and local dates and date/time strings.
+ * In loose mode recognizes all iso calendar dates and iso date-time strings and
+ * a constiety of date and date/time formats.
+ *
+ * Recognized in strict mode or loose mode, en/US locale:
+ *   * 2019-05
+ *   * 2019-05-25
+ *   * 2019-05-25 10:04Z
+ *   * 2019-05-25T10:04Z
+ *   * 2019-05-25T10:04:03+01:00
+ *   * 2019-05-25T10:04:03.123+01:00
+ *   * 5/25/2019
+ *   * 5/25/2019 10:04
+ *   * 5/25/2019 10:04am
+ *   * 5/25/2019 10:04:32.123 AM
+ *
+ * Recognized in loose mode
+ *   * 2019
+ *   * 2019.05.25
+ *   * 25 Oct 2019
+ *   * Oct 25, 2019
+ *   * Oct. 25, 2019
+ *   * October 25, 2019
+ * Not recognized as dates
+ *   * relative dates (e.g. today, tomorrow, next week)
+ *   * anniversary dates (e.g. June 5)
+ *   * out of range dates (e.g. June 32, 2019)
+ */
+
+type GroupMap = Record<string, number>
+
+type DateSpec = {
+  year: number
+  month: number
+  day: number
+  hour: number
+  min: number
+  sec: number
+  subsec: number
+}
+
+const timePart = '(\\d\\d?)(?::(\\d\\d?)(?::(\\d\\d)(?:\\.(\\d+))?)?)?'
+
+const monthsFull = [
+  'DG.Formula.DateLongMonthJanuary',
+  'DG.Formula.DateLongMonthFebruary',
+  'DG.Formula.DateLongMonthMarch',
+  'DG.Formula.DateLongMonthApril',
+  'DG.Formula.DateLongMonthMay',
+  'DG.Formula.DateLongMonthJune',
+  'DG.Formula.DateLongMonthJuly',
+  'DG.Formula.DateLongMonthAugust',
+  'DG.Formula.DateLongMonthSeptember',
+  'DG.Formula.DateLongMonthOctober',
+  'DG.Formula.DateLongMonthNovember',
+  'DG.Formula.DateLongMonthDecember'
+].map(function (m) { return t(m).toLowerCase() })
+
+const monthsAbbr = [
+  'DG.Formula.DateShortMonthJanuary',
+  'DG.Formula.DateShortMonthFebruary',
+  'DG.Formula.DateShortMonthMarch',
+  'DG.Formula.DateShortMonthApril',
+  'DG.Formula.DateShortMonthMay',
+  'DG.Formula.DateShortMonthJune',
+  'DG.Formula.DateShortMonthJuly',
+  'DG.Formula.DateShortMonthAugust',
+  'DG.Formula.DateShortMonthSeptember',
+  'DG.Formula.DateShortMonthOctober',
+  'DG.Formula.DateShortMonthNovember',
+  'DG.Formula.DateShortMonthDecember'
+].map(function (m) { return t(m).toLowerCase() })
+
+const daysOfWeek = [
+  "DG.Formula.DateLongDaySunday",
+  "DG.Formula.DateLongDayMonday",
+  "DG.Formula.DateLongDayTuesday",
+  "DG.Formula.DateLongDayWednesday",
+  "DG.Formula.DateLongDayThursday",
+  "DG.Formula.DateLongDayFriday",
+  "DG.Formula.DateLongDaySaturday",
+].map(function (dow) { return t(dow).toLowerCase() })
+
+const daysOfWeekAbbr = [
+  "DG.Formula.DateShortDaySunday",
+  "DG.Formula.DateShortDayMonday",
+  "DG.Formula.DateShortDayTuesday",
+  "DG.Formula.DateShortDayWednesday",
+  "DG.Formula.DateShortDayThursday",
+  "DG.Formula.DateShortDayFriday",
+  "DG.Formula.DateShortDaySaturday",
+].map(function (dow) { return t(dow).toLowerCase() })
+
+const monthsProperAbbrRE = monthsAbbr.map(function (str) { return `${str  }\\.` })
+const monthsProperAbbr = monthsAbbr.map(function (str) { return `${str  }.` })
+// const ordinals='0th,1st,2nd,3rd,4th,5th,6th,7th,8th,9th'
+const monthsArray = monthsAbbr.concat(monthsProperAbbr, monthsFull)
+const monthsArrayRE = monthsAbbr.concat(monthsProperAbbrRE, monthsFull)
+const daysOfWeekArray = daysOfWeek.concat(daysOfWeekAbbr)
+
+// yyyy-MM-dd hh:mm:ss.SSSZ
+const isoDateTimeRE =
+  // eslint-disable-next-line max-len
+  /^(\d{4})-([01]\d)(?:-([0-3]\d)(?:[T ]([0-2]\d)(?::([0-5]\d)(?::([0-5]\d)(?:[.,](\d+))?)?)?(Z|(?:[+-]\d\d:?\d\d?)| ?[a-zA-Z]{1,4}T)?)?)?$/
+const isoDateTimeGroupMap = { year: 1, month: 2, day: 3, hour: 4, min: 5, sec: 6, subsec: 7, timezone: 8 }
+
+// MM/dd/yyyy hh:mm:ss.SSS PM
+// eslint-disable-next-line max-len
+const localDateTimeRE = /^([01]?\d)\/([0-3]?\d)\/(\d{4}|\d{2})(?:,? (\d\d?)(?::(\d\d?)(?::(\d\d)(?:\.(\d+))?)?)?(?: ?(am|pm|AM|PM))?)?$/
+const localDateTimeGroupMap = { year: 3, month: 1, day: 2, hour: 4, min: 5, sec: 6, subsec: 7, ampm: 8, timezone: 9 }
+
+// dd MMM, yyyy or MMM, yyyy
+// eslint-disable-next-line max-len
+const dateVar1 = new RegExp(`^(\\d\\d?) (${  monthsArrayRE.join('|')  }),? (\\d{4})(?: ${  timePart  }(?: (am|pm))?)?$`, 'i')
+const dateVar1GroupMap = { year: 3, month: 2, day: 1, hour: 4, min: 5, sec: 6, subsec: 7, ampm: 8 }
+
+// yyyy-mm-dd, yyyy.mm.dd, yyyy/mm/dd
+// Require all three parts
+const dateVar2 = new RegExp(`^(\\d{4})[./-](\\d\\d?)[./-](\\d\\d?)(?: ${  timePart  }(?: (am|pm|AM|PM))?)?$`)
+const dateVar2GroupMap = { year: 1, month: 2, day: 3, hour: 4, min: 5, sec: 6, subsec: 7, ampm: 8 }
+
+// MMM dd, yyyy or MMM yyyy
+// eslint-disable-next-line max-len
+const dateVar3 = new RegExp(`^(?:(?:${  daysOfWeekArray.join('|')  }),? )?(${  monthsArrayRE.join('|')  })(?: (\\d\\d?),)? (\\d{4})(?: ${  timePart  }(?: (am|pm))?)?$`, 'i')
+const dateVar3GroupMap = { year: 3, month: 1, day: 2, hour: 4, min: 5, sec: 6, subsec: 7, ampm: 8 }
+
+// 'hh:mm:ss AM/PM on dd/MM/yyyy'
+const dateVar4 = /(\d\d?):(\d\d)(?::(\d\d))? (AM|PM) on (\d\d?)\/(\d\d?)\/(\d{4})/
+const dateVar4GroupMap = { year: 5, month: 6, day: 7, hour: 1, min: 2, sec: 3, ampm: 4 }
+
+// unix dates: Tue Jul  9 18:16:04 PDT 2019
+// eslint-disable-next-line max-len
+const unixDate = new RegExp(`^(?:(?:${  daysOfWeekAbbr.join('|')  }) )?(${  monthsAbbr.join('|')  }) ([ \\d]\\d) ([ \\d]\\d):(\\d\\d):(\\d\\d) ([A-Z]{3}) (\\d{4})$`, 'i')
+const unixDateGroupMap = { year: 7, month: 1, day: 2, hour: 3, min: 4, sec: 5, timezone: 6 }
+
+// new Date().toString(), most browsers
+// eslint-disable-next-line max-len
+const browserDate = new RegExp(`^(?:${  daysOfWeekAbbr.join('|')  }) (${  monthsAbbr.join('|')  }) (\\d\\d?),? (\\d{4})(?: ${  timePart  } (GMT(?:[+-]\\d{4})?(?: \\([\\w ]+\\))?))`, 'i')
+const browserDateGroupMap = { year: 3, month: 1, day: 2, hour: 4, min: 5, sec: 6, subsec: 7, timezone: 8 }
+
+// eslint-disable-next-line max-len
+const utcDate = new RegExp(`^(?:${  daysOfWeekAbbr.join('|')  }),? (\\d\\d?) (${  monthsAbbr.join('|')  }) (\\d{4}) ${  timePart  } GMT$`, 'i')
+const utcDateGroupMap = { year: 3, month: 2, day: 1, hour: 4, min: 5, sec: 6, subsec: 7, timezone: 8 }
+
+// yyyy
+const dateVarYearOnly = /^\d{4}$/
+const dateVarYearOnlyGroupMap = { year: 0 }
+
+// MMMM dd, yyyy hh:mm:ss.SSS PM
+
+const formatSpecs = [
+  { strict: true, regex: localDateTimeRE, groupMap: localDateTimeGroupMap },
+  { strict: true, regex: isoDateTimeRE, groupMap: isoDateTimeGroupMap },
+  { strict: true, regex: unixDate, groupMap: unixDateGroupMap },
+  { strict: true, regex: browserDate, groupMap: browserDateGroupMap },
+  { strict: true, regex: utcDate, groupMap: utcDateGroupMap },
+  { strict: false, regex: dateVar2, groupMap: dateVar2GroupMap },
+  { strict: true, regex: dateVar1, groupMap: dateVar1GroupMap },
+  { strict: true, regex: dateVar3, groupMap: dateVar3GroupMap },
+  { strict: false, regex: dateVarYearOnly, groupMap: dateVarYearOnlyGroupMap },
+  { strict: false, regex: dateVar4, groupMap: dateVar4GroupMap }
+]
+
+function extractDateProps(match: string[], map: GroupMap): DateSpec {
+  function fixHour(hr: string, amPm?: string) {
+    if (isNaN(Number(hr))) {
+      return NaN
+    }
+    let newHr = Number(hr)
+    if (amPm != null && (0 < newHr && newHr <= 12)) {
+      newHr = newHr % 12
+      if (amPm && amPm.toLowerCase() === 'pm') {
+        newHr += 12
+      }
+    }
+    return newHr
+  }
+
+  function fixMonth(m: string) {
+    if (!isNaN(Number(m))) {
+      return Number(m)
+    }
+    const lcMonth = m.toLowerCase()
+    const monthIx = monthsArray.findIndex(function (monthName) { return monthName === lcMonth })
+    return (monthIx % 12) + 1
+  }
+
+  function fixYear(y: string) {
+    if (y.length === 2) {
+      const yNumber = Number(y)
+      if (yNumber < 49) {
+        return 2000 + yNumber
+      } else {
+        return 1900 + yNumber
+      }
+    }
+    else {
+      return y
+    }
+  }
+
+  return {
+    year: Number(fixYear(match[map.year])),
+    month: fixMonth(match[map.month] || '1'),
+    day: Number(match[map.day] || '1'),
+    hour: fixHour(match[map.hour] || '0', match[map.ampm]),
+    min: Number(match[map.min] || '0'),
+    sec: Number(match[map.sec] || '0'),
+    subsec: Number(match[map.subsec] || '0'),
+  }
+}
+
+function isValidDateSpec(dateSpec: DateSpec) {
+  const isValid =
+    !isNaN(dateSpec.year) &&
+    (!isNaN(dateSpec.month) && (1 <= dateSpec.month && dateSpec.month <= 12)) &&
+    (!isNaN(dateSpec.day) && (1 <= dateSpec.day && dateSpec.day <= 31)) &&
+    (!isNaN(dateSpec.hour) && (0 <= dateSpec.hour && dateSpec.hour <= 23)) &&
+    (!isNaN(dateSpec.min) && (0 <= dateSpec.min && dateSpec.min <= 59)) &&
+    (!isNaN(dateSpec.sec) && (0 <= dateSpec.sec && dateSpec.sec <= 59)) &&
+    !isNaN(dateSpec.subsec)
+  if (isValid) { return dateSpec }
+}
+
+
+export function parseDate(iValue: any, iLoose?: boolean) {
+  if (iValue == null) {
+    return null
+  }
+  if (iValue instanceof Date) {
+    return iValue
+  }
+  iValue = String(iValue)
+  let match
+  let dateSpec
+  let groupMap: GroupMap | null = null
+  let date
+  const spec = formatSpecs.some(function (_spec) {
+    let m
+    let parsed = false
+    if (_spec.strict || iLoose) {
+      m = iValue.match(_spec.regex)
+      if (m) {
+        match = m
+        groupMap = _spec.groupMap
+        parsed = true
+      }
+    }
+    return parsed
+  })
+
+  if (spec && match && groupMap) {
+    dateSpec = isValidDateSpec(extractDateProps(match, groupMap))
+    if (dateSpec) {
+      date = new Date(dateSpec.year, (-1 + dateSpec.month), dateSpec.day,
+        dateSpec.hour, dateSpec.min, dateSpec.sec, dateSpec.subsec)
+      if (date) date.valueOf = function () { return Date.prototype.valueOf.apply(this) / 1000 }
+      return date
+    }
+  }
+  return null
+}
+
+/**
+ * Returns true if the specified value is a string that can be converted to a
+ * valid date.
+ * If iLoose is true, applies a looser definition of date. For example, a four
+ * digit number is interpreted as a year.
+ */
+export function isDateString(iValue: any, iLoose?: boolean) {
+  return (typeof iValue === 'string') && !!formatSpecs.find(function (spec) {
+    if (!(spec.strict || iLoose)) {
+      return false
+    }
+    return spec.regex.test(iValue)
+  })
+}
+

--- a/v3/src/utilities/date-utils.ts
+++ b/v3/src/utilities/date-utils.ts
@@ -1,27 +1,36 @@
-/* eslint-disable max-len */
+import { isNumeric } from "./data-utils"
+import { isDateString } from "./date-parser"
 import { goodTickValue } from "./math-utils"
+import { getDefaultLanguage } from "./translation/translate"
 
-/**
- @namespace Date value utility functions
- */
-  // DateTime levels
-export const EDateTimeLevel = {
-    eSecond: 0,
-    eMinute: 1,
-    eHour: 2,
-    eDay: 3,
-    eMonth: 4,
-    eYear: 5
-  }
+export enum EDateTimeLevel {
+  eSecond = 0,
+  eMinute = 1,
+  eHour = 2,
+  eDay = 3,
+  eMonth = 4,
+  eYear = 5
+}
 
-  export const secondsConverter = {
-kSecond: 1000,
-kMinute: 1000 * 60,
-kHour: ((1000) * 60) * 60,
-kDay: (((1000) * 60) * 60) * 24,
-kMonth: ((((1000) * 60) * 60) * 24) * 30,
-kYear: ((((1000) * 60) * 60) * 24) * 365
-    }
+export enum DatePrecision {
+  None = '',
+  Millisecond = 'millisecond',
+  Second = 'second',
+  Minute = 'minute',
+  Hour = 'hour',
+  Day = 'day',
+  Month = 'month',
+  Year = 'year'
+}
+
+export const secondsConverter = {
+  kSecond: 1000,
+  kMinute: 1000 * 60,
+  kHour: ((1000) * 60) * 60,
+  kDay: (((1000) * 60) * 60) * 24,
+  kMonth: ((((1000) * 60) * 60) * 24) * 30,
+  kYear: ((((1000) * 60) * 60) * 24) * 365
+}
 
 /**
  * 1. Compute the outermost date-time level that changes from the
@@ -34,10 +43,11 @@ kYear: ((((1000) * 60) * 60) * 24) * 365
  * @param iMaxDate { Number } milliseconds
  * @return {{outerLevel: EDateTimeLevel, innerLevel: EDateTimeLevel, increment: {Number}}}
  */
-export const determineLevels = (iMinDate: number, iMaxDate: number) => {
+export function determineLevels(iMinDate: number, iMaxDate: number) {
   const tDateDiff = iMaxDate - iMinDate
-  let tIncrement = 1, // Will only be something else if inner level is year
-    tOuterLevel, tInnerLevel
+  let tIncrement = 1 // Will only be something else if inner level is year
+  let tOuterLevel
+  let tInnerLevel
 
   if (tDateDiff < 3 * secondsConverter.kMinute) {
     tOuterLevel = EDateTimeLevel.eDay
@@ -66,32 +76,73 @@ export const determineLevels = (iMinDate: number, iMaxDate: number) => {
   }
 }
 
-/*
-DateUtilities.mapLevelToPrecision = function( iLevel) {
-  var tPrecision = Attribute.DATE_PRECISION_NONE
+export function mapLevelToPrecision(iLevel: EDateTimeLevel) {
+  let tPrecision = DatePrecision.None
   switch (iLevel) {
-    case this.EDateTimeLevel.eSecond:
-      tPrecision = Attribute.DATE_PRECISION_SECOND
+    case EDateTimeLevel.eSecond:
+      tPrecision = DatePrecision.Second
       break
-    case this.EDateTimeLevel.eMinute:
-      tPrecision = Attribute.DATE_PRECISION_MINUTE
+    case EDateTimeLevel.eMinute:
+      tPrecision = DatePrecision.Minute
       break
-    case this.EDateTimeLevel.eHour:
-      tPrecision = Attribute.DATE_PRECISION_HOUR
+    case EDateTimeLevel.eHour:
+      tPrecision = DatePrecision.Hour
       break
-    case this.EDateTimeLevel.eDay:
-      tPrecision = Attribute.DATE_PRECISION_DAY
+    case EDateTimeLevel.eDay:
+      tPrecision = DatePrecision.Day
       break
-    case this.EDateTimeLevel.eMonth:
-      tPrecision = Attribute.DATE_PRECISION_MONTH
+    case EDateTimeLevel.eMonth:
+      tPrecision = DatePrecision.Month
       break
-    case this.EDateTimeLevel.eYear:
-      tPrecision = Attribute.DATE_PRECISION_YEAR
+    case EDateTimeLevel.eYear:
+      tPrecision = DatePrecision.Year
       break
   }
   return tPrecision
 }
-*/
+
+/**
+  Returns true if the specified value is a DG date object.
+ */
+export function isDate(iValue: any): iValue is Date {
+  return iValue instanceof Date
+}
+
+/**
+ * Default formatting for Date objects.
+ * @param date {Date | number | string }
+ * @param precision {number}
+ * @return {string}
+ */
+export function formatDate(x: Date | number | string, precision: DatePrecision) {
+  const formatPrecisions: Record<DatePrecision, any> = {
+    [DatePrecision.None]: null,
+    [DatePrecision.Year]: { year: 'numeric' },
+    [DatePrecision.Month]: { year: 'numeric', month: 'numeric' },
+    [DatePrecision.Day]: { year: 'numeric', month: 'numeric', day: 'numeric' },
+    [DatePrecision.Hour]: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric' },
+    [DatePrecision.Minute]: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' },
+    [DatePrecision.Second]: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric',
+      second: 'numeric' },
+    [DatePrecision.Millisecond]: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric',
+      minute: 'numeric', second: 'numeric', fractionalSecondDigits: 3 }
+  }
+
+  const precisionFormat = formatPrecisions[precision] || formatPrecisions.minute
+
+  if (!(x && (isDate(x) || isDateString(x) || isNumeric(x)))) {
+    return null
+  }
+
+  if (isNumeric(x)) {
+    x = new Date(x * 1000)
+  } else if (isDateString(x)) {
+    x = new Date(x)
+  }
+
+  const locale = getDefaultLanguage()
+  return new Intl.DateTimeFormat(locale, precisionFormat).format(x as Date)
+}
 
 /**
  Returns true if the specified value should be treated as epoch
@@ -99,11 +150,9 @@ DateUtilities.mapLevelToPrecision = function( iLevel) {
  false if the value should be treated as a year.
  date(2000) should be treated as a year, but date(12345) should not.
  */
-/*
-DateUtilities.defaultToEpochSecs = function(iValue) {
+ export function defaultToEpochSecs(iValue: number) {
   return Math.abs(iValue) >= 5000
 }
-*/
 
 /**
  Returns a DG date object constructed from its arguments.
@@ -145,59 +194,6 @@ DateUtilities.createDate = function(/!* iArgs *!/) {
 createDate = DateUtilities.createDate
 */
 
-// _isDateRegex = null
-
-/**
- * Returns true if the specified value is a string that can be converted to a
- * valid date.
- * If iLoose is true, applies a looser definition of date. For example, a four
- * digit number is interpreted as a year.
- */
-/*
-DateUtilities.isDateString = function(iValue, iLoose) {
-  return DateUtilities.dateParser.isDateString(iValue, iLoose)
-}
-isDateString = DateUtilities.isDateString
-*/
-
-/**
- * Default formatting for Date objects.
- * @param date {Date | number }
- * @param precision {number}
- * @param useShortFormat {boolean} default is false
- * @return {string}
- */
-
-/*
-DateUtilities.formatDate = function(x, precision, useShortFormat) {
-  var formatPrecisions = {
-    'year': {year: 'numeric'},
-    'month': {year: 'numeric', month: 'numeric'},
-    'day': {year: 'numeric', month: 'numeric', day: 'numeric'},
-    'hour': {year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric'},
-    'minute': {year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric'},
-    'second': {year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric',
-      second: 'numeric'},
-    'millisecond': {year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric',
-      second: 'numeric', fractionalSecondDigits: 3}
-  }
-
-  var precisionFormat = formatPrecisions[precision] || formatPrecisions.minute
-
-  if (!(x && (isDate(x) || isDateString(x) || MathUtilities.isNumeric(x)))) return
-
-  if ( MathUtilities.isNumeric(x)) {
-    x = new Date(x*1000)
-  } else if (isDateString(x)) {
-    x = new Date(x)
-  }
-
-  var locale = get('currentLanguage')
-  return new Intl.DateTimeFormat(locale, precisionFormat).format(x)
-}
-formatDate = DateUtilities.formatDate
-*/
-
 /**
  Default formatting for Date objects.
  Uses toLocaleDateString() for default date formatting.
@@ -230,277 +226,3 @@ DateUtilities.monthName = function(x) {
 }
 monthName = DateUtilities.monthName
 */
-
-/**
- * parseDate - Parses dates in a uniform manner across browser
- *
- * Has two modes: strict (default) and loose
- *
- * In strict mode recognizes year, month or year, month, day iso calendar date
- * or date/time strings (not just year) and local dates and date/time strings.
- * In loose mode recognizes all iso calendar dates and iso date-time strings and
- * a variety of date and date/time formats.
- *
- * Recognized in strict mode or loose mode, en/US locale:
- *   * 2019-05
- *   * 2019-05-25
- *   * 2019-05-25 10:04Z
- *   * 2019-05-25T10:04Z
- *   * 2019-05-25T10:04:03+01:00
- *   * 2019-05-25T10:04:03.123+01:00
- *   * 5/25/2019
- *   * 5/25/2019 10:04
- *   * 5/25/2019 10:04am
- *   * 5/25/2019 10:04:32.123 AM
- *
- * Recognized in loose mode
- *   * 2019
- *   * 2019.05.25
- *   * 25 Oct 2019
- *   * Oct 25, 2019
- *   * Oct. 25, 2019
- *   * October 25, 2019
- * Not recognized as dates
- *   * relative dates (e.g. today, tomorrow, next week)
- *   * anniversary dates (e.g. June 5)
- *   * out of range dates (e.g. June 32, 2019)
- */
-/*
-DateUtilities.dateParser = (function () {
-  var timePart = '(\\d\\d?)(?::(\\d\\d?)(?::(\\d\\d)(?:\\.(\\d+))?)?)?'
-  var monthsFull = [
-    'Formula.DateLongMonthJanuary',
-    'Formula.DateLongMonthFebruary',
-    'Formula.DateLongMonthMarch',
-    'Formula.DateLongMonthApril',
-    'Formula.DateLongMonthMay',
-    'Formula.DateLongMonthJune',
-    'Formula.DateLongMonthJuly',
-    'Formula.DateLongMonthAugust',
-    'Formula.DateLongMonthSeptember',
-    'Formula.DateLongMonthOctober',
-    'Formula.DateLongMonthNovember',
-    'Formula.DateLongMonthDecember'
-  ].map(function (m) {return m.loc().toLowerCase() })
-
-  var monthsAbbr = [
-    'Formula.DateShortMonthJanuary',
-    'Formula.DateShortMonthFebruary',
-    'Formula.DateShortMonthMarch',
-    'Formula.DateShortMonthApril',
-    'Formula.DateShortMonthMay',
-    'Formula.DateShortMonthJune',
-    'Formula.DateShortMonthJuly',
-    'Formula.DateShortMonthAugust',
-    'Formula.DateShortMonthSeptember',
-    'Formula.DateShortMonthOctober',
-    'Formula.DateShortMonthNovember',
-    'Formula.DateShortMonthDecember'
-  ].map(function(m) {return m.loc().toLowerCase()})
-
-  var daysOfWeek = [
-    "Formula.DateLongDaySunday",
-    "Formula.DateLongDayMonday",
-    "Formula.DateLongDayTuesday",
-    "Formula.DateLongDayWednesday",
-    "Formula.DateLongDayThursday",
-    "Formula.DateLongDayFriday",
-    "Formula.DateLongDaySaturday",
-  ].map( function (dow) {return dow.loc().toLowerCase()})
-
-  var daysOfWeekAbbr = [
-    "Formula.DateShortDaySunday",
-    "Formula.DateShortDayMonday",
-    "Formula.DateShortDayTuesday",
-    "Formula.DateShortDayWednesday",
-    "Formula.DateShortDayThursday",
-    "Formula.DateShortDayFriday",
-    "Formula.DateShortDaySaturday",
-  ].map( function (dow) {return dow.loc().toLowerCase()})
-
-  var monthsProperAbbrRE = monthsAbbr.map(function (str) {return str + '\\.'})
-  var monthsProperAbbr = monthsAbbr.map(function (str) {return str + '.'})
-  // var ordinals='0th,1st,2nd,3rd,4th,5th,6th,7th,8th,9th'
-  var monthsArray = monthsAbbr.concat(monthsProperAbbr, monthsFull)
-  var monthsArrayRE = monthsAbbr.concat(monthsProperAbbrRE, monthsFull)
-  var daysOfWeekArray = daysOfWeek.concat(daysOfWeekAbbr)
-
-  // yyyy-MM-dd hh:mm:ss.SSSZ
-  var isoDateTimeRE =
-  // eslint-disable-next-line max-len
-  /^(\d{4})-([01]\d)(?:-([0-3]\d)(?:[T ]([0-2]\d)(?::([0-5]\d)(?::([0-5]\d)(?:[.,](\d+))?)?)?(Z|(?:[+-]\d\d:?\d\d?)| ?[a-zA-Z]{1,4}T)?)?)?$/
-  var isoDateTimeGroupMap = {year:1, month:2, day:3, hour:4, min:5, sec: 6, subsec: 7, timezone: 8}
-
-  // MM/dd/yyyy hh:mm:ss.SSS PM
-  // eslint-disable-next-line max-len
-  var localDateTimeRE = /^([01]?\d)\/([0-3]?\d)\/(\d{4}|\d{2})(?:,? (\d\d?)(?::(\d\d?)(?::(\d\d)(?:\.(\d+))?)?)?(?: ?(am|pm|AM|PM))?)?$/
-  var localDateTimeGroupMap = {year:3, month:1, day:2, hour:4, min:5, sec: 6, subsec: 7, ampm: 8, timezone: 9}
-
-  // dd MMM, yyyy or MMM, yyyy
-  // eslint-disable-next-line max-len
-  var  dateVar1 = new RegExp('^(\\d\\d?) (' + monthsArrayRE.join('|') + '),? (\\d{4})(?: ' + timePart + '(?: (am|pm))?)?$', 'i')
-  var dateVar1GroupMap = {year:3, month:2, day:1, hour:4, min:5, sec: 6, subsec: 7, ampm: 8}
-
-  // yyyy-mm-dd, yyyy.mm.dd, yyyy/mm/dd
-  // Require all three parts
-  var dateVar2 = new RegExp('^(\\d{4})[./-](\\d\\d?)[./-](\\d\\d?)(?: ' + timePart + '(?: (am|pm|AM|PM))?)?$')
-  var dateVar2GroupMap = {year:1, month:2, day:3, hour:4, min:5, sec: 6, subsec: 7, ampm: 8}
-
-  // MMM dd, yyyy or MMM yyyy
-  // eslint-disable-next-line max-len
-  var dateVar3 = new RegExp('^(?:(?:' + daysOfWeekArray.join('|') + '),? )?(' + monthsArrayRE.join('|') + ')(?: (\\d\\d?),)? (\\d{4})(?: ' + timePart + '(?: (am|pm))?)?$', 'i')
-  var dateVar3GroupMap = {year:3, month:1, day:2, hour:4, min:5, sec: 6, subsec: 7, ampm: 8}
-
-  // 'hh:mm:ss AM/PM on dd/MM/yyyy'
-  var dateVar4 = /(\d\d?):(\d\d)(?::(\d\d))? (AM|PM) on (\d\d?)\/(\d\d?)\/(\d{4})/
-  var dateVar4GroupMap = {year:5, month: 6, day: 7, hour: 1, min: 2, sec: 3, ampm: 4}
-
-  // unix dates: Tue Jul  9 18:16:04 PDT 2019
-  // eslint-disable-next-line max-len
-  var unixDate = new RegExp('^(?:(?:' + daysOfWeekAbbr.join('|') + ') )?(' + monthsAbbr.join('|') + ') ([ \\d]\\d) ([ \\d]\\d):(\\d\\d):(\\d\\d) ([A-Z]{3}) (\\d{4})$', 'i')
-  var unixDateGroupMap = {year: 7, month: 1, day: 2, hour: 3, min: 4, sec:5, timezone: 6}
-
-  // new Date().toString(), most browsers
-  // eslint-disable-next-line max-len
-  var browserDate = new RegExp('^(?:' + daysOfWeekAbbr.join('|') + ') (' + monthsAbbr.join('|') + ') (\\d\\d?),? (\\d{4})(?: ' + timePart + ' (GMT(?:[+-]\\d{4})?(?: \\([\\w ]+\\))?))', 'i')
-  var browserDateGroupMap = {year:3, month:1, day:2, hour:4, min:5, sec: 6, subsec: 7, timezone: 8}
-
-  // eslint-disable-next-line max-len
-  var utcDate = new RegExp('^(?:' + daysOfWeekAbbr.join('|') + '),? (\\d\\d?) (' + monthsAbbr.join('|') + ') (\\d{4}) ' + timePart + ' GMT$', 'i')
-  var utcDateGroupMap = {year:3, month:2, day:1, hour:4, min:5, sec: 6, subsec: 7, timezone: 8}
-
-  // yyyy
-  var dateVarYearOnly = /^\d{4}$/
-  var dateVarYearOnlyGroupMap = {year:0}
-
-
-
-// MMMM dd, yyyy hh:mm:ss.SSS PM
-
-  var formatSpecs = [
-    { strict: true, regex: localDateTimeRE, groupMap: localDateTimeGroupMap },
-    { strict: true, regex: isoDateTimeRE, groupMap: isoDateTimeGroupMap },
-    { strict: true, regex: unixDate, groupMap: unixDateGroupMap },
-    { strict: true, regex: browserDate, groupMap: browserDateGroupMap},
-    { strict: true, regex: utcDate, groupMap: utcDateGroupMap},
-    { strict: false, regex: dateVar2, groupMap: dateVar2GroupMap },
-    { strict: true, regex: dateVar1, groupMap: dateVar1GroupMap },
-    { strict: true, regex: dateVar3, groupMap: dateVar3GroupMap },
-    { strict: false, regex: dateVarYearOnly, groupMap: dateVarYearOnlyGroupMap },
-    { strict: false, regex: dateVar4, groupMap: dateVar4GroupMap }
-  ]
-
-  function extractDateProps(match, map) {
-    function fixHour(hr, amPm) {
-      if (isNaN(hr)) {
-        return null
-      }
-      var newHr = Number(hr)
-      if (amPm != null && (0<newHr<=12)) {
-        newHr = newHr % 12
-        if (amPm && amPm.toLowerCase() === 'pm') {
-          newHr += 12
-        }
-      }
-      return newHr
-    }
-    function fixMonth(m) {
-      if (!isNaN(m)) {
-        return Number(m)
-      }
-      var lcMonth = m.toLowerCase()
-      var monthIx = monthsArray.findIndex(function (monthName) { return monthName === lcMonth })
-      return (monthIx % 12) + 1
-    }
-    function fixYear(y) {
-      if (y.length === 2) {
-        y = Number(y)
-        if (y<49) {
-          return 2000 + y
-        } else {
-          return 1900 + y
-        }
-      }
-      else {
-        return y
-      }
-    }
-    return {
-      year: Number(fixYear(match[map.year])),
-      month: fixMonth(match[map.month] || 1),
-      day: Number(match[map.day] || 1),
-      hour: fixHour(match[map.hour] || 0,match[map.ampm]) ,
-      min: Number(match[map.min] || 0) ,
-      sec: Number(match[map.sec] || 0),
-      subsec: Number(match[map.subsec] || 0),
-    }
-  }
-  function isValidDateSpec(dateSpec) {
-    var isValid =
-      !isNaN(dateSpec.year) &&
-      (!isNaN(dateSpec.month) && (1<=dateSpec.month<=12)) &&
-      (!isNaN(dateSpec.day) && (1<=dateSpec.day<=31)) &&
-      (!isNaN(dateSpec.hour) && (0<=dateSpec.hour<=23)) &&
-      (!isNaN(dateSpec.min) && (0<=dateSpec.min<=59)) &&
-      (!isNaN(dateSpec.sec) && (0<=dateSpec.sec<=59)) &&
-      !isNaN(dateSpec.subsec)
-    if (isValid) { return dateSpec }
-  }
-
-
-  function parseDate(iValue, iLoose) {
-    if (iValue == null) {
-      return iValue
-    }
-    if (iValue instanceof Date) {
-      return iValue
-    }
-    iValue = String(iValue)
-    var match
-    var dateSpec
-    var groupMap
-    var date
-    var spec = formatSpecs.some(function (spec) {
-      var m
-      var parsed = false
-      if (spec.strict || iLoose) {
-        m = iValue.match(spec.regex)
-        if (m) {
-          match = m
-          groupMap = spec.groupMap
-          parsed = true
-        }
-      }
-      return parsed
-    })
-
-    if (spec && match) {
-      dateSpec = isValidDateSpec(extractDateProps(match, groupMap))
-      if (dateSpec) {
-        date = new Date(dateSpec.year, (-1 + dateSpec.month), dateSpec.day,
-          dateSpec.hour, dateSpec.min, dateSpec.sec, dateSpec.subsec)
-        if (date) date.valueOf = function() { return Date.prototype.valueOf.apply(this) / 1000 }
-        return date
-      }
-    }
-  }
-  function isDateString(iValue, iLoose) {
-    return (typeof iValue === 'string') && !!formatSpecs.find(function (spec) {
-      if (!(spec.strict || iLoose)) {
-        return false
-      }
-      return spec.regex.test(iValue)
-    })
-  }
-
-  return {
-    parseDate: parseDate,
-    isDateString: isDateString
-  }
-
-}())
-
-parseDate = DateUtilities.dateParser.parseDate
-*/
-/* eslint-enable max-len */
-

--- a/v3/src/utilities/translation/translate.ts
+++ b/v3/src/utilities/translation/translate.ts
@@ -72,6 +72,10 @@ for (const lang of candidates) {
   }
 }
 
+export function getDefaultLanguage () {
+  return defaultLang
+}
+
 type VarValue = string | number | undefined
 interface ITranslateOptions {
   lang?: string


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187965959

This PR adds basic date support to the case table. It also lays the foundation for further date-related work, as various utilities were ported from V2.

I split date-utils and date-parser, as the parser has quite a bit of code. I've also ported existing V2 tests to modern Jest and ensured they all pass, which should ensure backward compatibility.

If we want to improve date support in the future, I'd suggest leaving this code and adding a second pass to the `isDateString` and `parseDate` functions. This second pass would attempt to interpret the date using an external library that likely supports more formats.

I also had to add a small helper to the translation file.

Regarding case table logic, I based my implementation on my tests of the V2 behavior. It seems formatting happens only when the "date" type is explicitly selected (so `userType = "date"` is requried, it's not enough if the inferred `type` is equal to `"date"`). This is more strict than the graph, which assumes dates even if the type is inferred. I described all the rules in the PT story, but I'm pasting them here too:

> 1. Strings resembling dates are NOT formatted in any way unless the user explicitly selects the "Date" type in the Attribute Properties dialog (this is the CODAP v2 behavior).
> 2. When the "Date" type is selected by the user, CODAP tries to interpret strings and numbers as dates and formats them accordingly.
> 3. Output formatting should depend on the selected language (add `?lang=es` parameter in V3 or change it in V2 using the menu in the top-right corner).
> 4. Language does NOT affect how the string is interpreted (e.g., 2/1/2020 is always interpreted as February 1st, both in en-US and in Spanish).
> 5. Strings and numbers that are not recognized as dates are rendered in quotes (e.g., "ABC").
> 6. Formatting in V2 and V3 for various strings should be identical. Some test cases:
>  - 11/9/2016
>  - 2016-02-02
>  - April 4, 2016
>  - Thu Jul 11 09:12:47 PDT 2019
>  - 11/9/2016 7:18:02.234am


