### PR TITLE
feat: case table enter key advances to next row [PT-187967544]

### DIFF
--- a/v3/src/components/case-table/case-table-types.ts
+++ b/v3/src/components/case-table/case-table-types.ts
@@ -1,6 +1,6 @@
 import {
-  CalculatedColumn, CellClickArgs, ColSpanArgs, Column, RenderCellProps, RenderEditCellProps, Renderers,
-  RenderHeaderCellProps, RenderRowProps, RowsChangeData
+  CalculatedColumn, CellClickArgs, CellKeyDownArgs, CellSelectArgs, ColSpanArgs, Column, RenderCellProps,
+  RenderEditCellProps, Renderers, RenderHeaderCellProps, RenderRowProps, RowsChangeData
 } from "react-data-grid"
 import { IGroupedCase, symFirstChild } from "../../models/data/data-set-types"
 
@@ -24,6 +24,8 @@ export interface TRenderCellProps extends RenderCellProps<TRow> {}
 export interface TRenderHeaderCellProps extends RenderHeaderCellProps<TRow> {}
 export interface TRenderRowProps extends RenderRowProps<TRow> {}
 export interface TCellClickArgs extends CellClickArgs<TRow> {}
+export interface TCellSelectArgs extends CellSelectArgs<TRow> {}
+export type TCellKeyDownArgs = CellKeyDownArgs<TRow>
 export type TColSpanArgs = ColSpanArgs<TRow, unknown>
 
 export interface IBaseTableScrollInfo {

--- a/v3/src/components/case-table/use-selected-cell.ts
+++ b/v3/src/components/case-table/use-selected-cell.ts
@@ -1,0 +1,35 @@
+import { useCallback, useRef } from "react"
+import { DataGridHandle } from "react-data-grid"
+import { TCellSelectArgs, TColumn } from "./case-table-types"
+import { useCollectionTableModel } from "./use-collection-table-model"
+
+interface ISelectedCell {
+  columnId: string
+  rowId: string
+  rowIdx: number
+}
+
+export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>, columns: TColumn[]) {
+  const collectionTableModel = useCollectionTableModel()
+  const selectedCell = useRef<Maybe<ISelectedCell>>()
+
+  const handleSelectedCellChange = useCallback((args: TCellSelectArgs) => {
+    const columnId = args.column?.key
+    const rowId = args.row?.__id__
+    selectedCell.current = columnId && rowId
+                            ? { columnId, rowId, rowIdx: args.rowIdx }
+                            : undefined
+  }, [])
+
+  const navigateToNextRow = useCallback(() => {
+    if (selectedCell.current?.columnId) {
+      const idx = columns.findIndex(column => column.key === selectedCell.current?.columnId)
+      const rowIdx = selectedCell.current.rowIdx + 1
+      const position = { idx, rowIdx }
+      gridRef.current?.selectCell(position, true)
+      collectionTableModel?.scrollRowIntoView(rowIdx)
+    }
+  }, [collectionTableModel, columns, gridRef])
+
+  return { selectedCell: selectedCell.current, handleSelectedCellChange, navigateToNextRow }
+}


### PR DESCRIPTION
[[PT-187967544]](https://www.pivotaltracker.com/story/show/187967544)

From the PT story:
>When editing a cell in the case table, if the user types the enter key it should accept the cell edits and advance to the next row like CODAP v2. By default, RDG enters/exits edit mode without changing the selected cell when the enter key is pressed.

RDG makes it reasonably straightforward to intervene in the key-handling to achieve the desired behavior.