### PR TITLE
fix: undo hierarchy change in Roller Coasters [PT-187967231]

### DIFF
--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -13,6 +13,7 @@ import { createCasesNotification, updateCasesNotification } from "../../models/d
 import {
   IAddCasesOptions, ICase, ICaseCreation, IGroupedCase, symFirstChild, symIndex, symParent
 } from "../../models/data/data-set-types"
+import { setCaseValuesWithCustomUndoRedo } from "../../models/data/data-set-undo"
 import { isSetIsCollapsedAction } from "../../models/shared/shared-case-metadata"
 import { onAnyAction } from "../../utilities/mst-utils"
 import { prf } from "../../utilities/profiler"
@@ -277,7 +278,7 @@ export const useRows = () => {
       () => {
         // Update existing cases
         if (casesToUpdate.length > 0) {
-          data.setCaseValues(casesToUpdate)
+          setCaseValuesWithCustomUndoRedo(data, casesToUpdate)
           if (collection?.id === data.childCollection.id) {
             // The child collection's case ids are persistent, so we can just use the casesToUpdate to
             // determine which case ids to use in the updateCasesNotification

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -191,13 +191,14 @@ describe("DataConfigurationModel", () => {
       { name: "GraphDataConfigurationTest.caseDataArray reaction" })
     expect(trigger).not.toHaveBeenCalled()
     tree.data.setCaseValues([{ __id__: "c2", "yId": "" }])
-    expect(trigger).toHaveBeenCalledTimes(1)
+    expect(trigger).toHaveBeenCalled()
     expect(config.caseDataArray).toEqual([
       {plotNum: 0, caseID: "c1"},
       {plotNum: 0, caseID: "c3"}
     ])
+    trigger.mockClear()
     tree.data.setCaseValues([{ __id__: "c2", "yId": "2" }])
-    expect(trigger).toHaveBeenCalledTimes(2)
+    expect(trigger).toHaveBeenCalled()
     expect(config.caseDataArray).toEqual([
       {plotNum: 0, caseID: "c1"},
       {plotNum: 0, caseID: "c2"},

--- a/v3/src/models/data/data-set-undo.test.ts
+++ b/v3/src/models/data/data-set-undo.test.ts
@@ -4,7 +4,7 @@ import { createCodapDocument } from "../codap/create-codap-document"
 import { TreeManager } from "../history/tree-manager"
 import { getSharedModelManager } from "../tiles/tile-environment"
 import { SharedDataSet } from "../shared/shared-data-set"
-import { removeCasesWithCustomUndoRedo } from "./data-set-undo"
+import { removeCasesWithCustomUndoRedo, setCaseValuesWithCustomUndoRedo } from "./data-set-undo"
 
 describe("DataSet undo/redo", () => {
 
@@ -67,7 +67,7 @@ describe("DataSet undo/redo", () => {
     const { data, whenTreeManagerIsReady, undoManager } = setupDocument()
 
     data.applyModelChange(
-      () => data.setCaseValues([{ __id__: "case0", aId: 2, bId: 3 }]),
+      () => setCaseValuesWithCustomUndoRedo(data, [{ __id__: "case0", aId: 2, bId: 3 }]),
       { undoStringKey: "Undo edit value", redoStringKey: "Redo edit value" })
     expect(data.getItem("case0")).toEqual({ __id__: "case0", aId: 2, bId: 3 })
 

--- a/v3/src/models/data/data-set-undo.ts
+++ b/v3/src/models/data/data-set-undo.ts
@@ -34,21 +34,14 @@ const setCaseValuesCustomUndoRedoPatcher: ICustomUndoRedoPatcher = {
 }
 
 export function setCaseValuesWithCustomUndoRedo(data: IDataSet, cases: ICase[], affectedAttributes?: string[]) {
-  const items: IItem[] = []
-  cases.forEach(aCase => {
-    // convert each parent case change to a change to each underlying item
-    const caseGroup = data.caseGroupMap.get(aCase.__id__)
-    if (caseGroup?.childCaseIds?.length) {
-      items.push(...caseGroup.childItemIds.map(id => ({ ...aCase, __id__: id })))
-    }
-  })
-  const _cases = items.length > 0 ? items : cases
-  const before = data.getItems(_cases.map(({ __id__ }) => __id__))
+  const items = data.getItemsForCases(cases)
+  const itemIds = items.map(({ __id__ }) => __id__)
+  const before = data.getItems(itemIds)
 
   data.setCaseValues(cases, affectedAttributes)
 
   // custom undo/redo since values aren't observed all the way down
-  const after = data.getItems(_cases.map(({ __id__ }) => __id__))
+  const after = data.getItems(itemIds)
   withCustomUndoRedo<ISetCaseValuesCustomPatch>({
     type: "DataSet.setCaseValues",
     data: { dataId: data.id, before, after }

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -55,12 +55,9 @@ import {
   CaseGroup, IAddAttributeOptions, IAddCasesOptions, IAddCollectionOptions, IAttributeChangeResult, ICase,
   ICaseCreation, IDerivationSpec, IGetCaseOptions, IGetCasesOptions, IItem, IMoveAttributeCollectionOptions
 } from "./data-set-types"
-/* eslint-disable import/no-cycle */
+// eslint-disable-next-line import/no-cycle
 import { isLegacyDataSetSnap, isOriginalDataSetSnap, isTempDataSetSnap } from "./data-set-conversion"
-import { ISetCaseValuesCustomPatch, setCaseValuesCustomUndoRedo } from "./data-set-undo"
-/* eslint-enable import/no-cycle */
 import { applyModelChange } from "../history/apply-model-change"
-import { withCustomUndoRedo } from "../history/with-custom-undo-redo"
 import { withoutUndo } from "../history/without-undo"
 import { kAttrIdPrefix, kItemIdPrefix, typeV3Id, v3Id } from "../../utilities/codap-utils"
 import { t } from "../../utilities/translation/translate"
@@ -793,7 +790,7 @@ export const DataSet = V2Model.named("DataSet").props({
           // If after is an item id, return one index after that item
           const afterItemId = self.itemIDMap.get(after)
           if (afterItemId) return afterItemId + 1
-          
+
           // If after is a case id, find its last item and return one index after that
           const afterCase = self.caseGroupMap.get(after)
           if (!afterCase?.childItemIds.length) return
@@ -870,7 +867,7 @@ export const DataSet = V2Model.named("DataSet").props({
           }
         })
         const _cases = items.length > 0 ? items : cases
-        const before = getItems(_cases.map(({ __id__ }) => __id__))
+
         if (self.isCaching()) {
           // update the cases in the cache
           _cases.forEach(aCase => {
@@ -888,12 +885,6 @@ export const DataSet = V2Model.named("DataSet").props({
             setCaseValues(caseValues)
           })
         }
-        // custom undo/redo since values aren't observed all the way down
-        const after = getItems(_cases.map(({ __id__ }) => __id__))
-        withCustomUndoRedo<ISetCaseValuesCustomPatch>({
-          type: "DataSet.setCaseValues",
-          data: { dataId: self.id, before, after }
-        }, setCaseValuesCustomUndoRedo)
 
         // only changes to parent collection attributes invalidate grouping
         items.length && self.invalidateCaseGroups()

--- a/v3/src/utilities/v2/dg-data-context-utilities.v2.js
+++ b/v3/src/utilities/v2/dg-data-context-utilities.v2.js
@@ -4,6 +4,7 @@ import { SC } from "../../v2/sc-compat"
 import {
   createAttributesNotification, hideAttributeNotification, removeAttributesNotification, deleteCollectionNotification
 } from "../../models/data/data-set-notifications"
+import { setCaseValuesWithCustomUndoRedo } from "../../models/data/data-set-undo"
 import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
 
 DG.DataContextUtilities = {
@@ -665,7 +666,7 @@ DG.UndoHistory.execute(DG.Command.create({
         // caseIndex = collection.getCaseIndexByID(iCase.get('id'))
 
     iContext.data.applyModelChange(() => {
-      iContext.data.setCaseValues([{ __id__: iCase.get('id'), [tAttrID]: newValue }])
+      setCaseValuesWithCustomUndoRedo(iContext.data, [{ __id__: iCase.get('id'), [tAttrID]: newValue }])
     }, {
       undoStringKey: "DG.Undo.caseTable.editCellValue",
       redoStringKey: "DG.Redo.caseTable.editCellValue",


### PR DESCRIPTION
[[PT-187967231]](https://www.pivotaltracker.com/story/show/187967231)

From the PT story:
>Roller Coasters fails in this case because of the hidden `Boundary` attribute. Moving the `State` attribute causes the `Boundary` attribute formula to fail, which results in a call to `setCaseValues()` to set the error message. `setCaseValues()` has a custom undo/redo implementation which interferes with the overall undo/redo of the attribute move.

The key realization here is that `setCaseValues()` calls from the formula engine need not be undoable at all. The same is true for `setCaseValues()` calls from the graph in response to dragging points. Therefore, we take this opportunity to eliminate undo/redo considerations from the `DataSet` itself and add a new `setCaseValuesWithCustomUndoRedo()` utility function for handling undo/redo. Clients for whom undo/redo support is important should then call the new utility function. Clients that call `DataSet.setCaseValues()` directly are on their own.

A consequence of this change is that the `DataSet` is no longer involved in undo/redo considerations, which allowed me to eliminate a dependency cycle between `data-set.ts` and `data-set-undo.ts`.