### PR TITLE
Support dates in formulas with +/- operators, add date() implementation, tests

### DIFF
--- a/v3/src/models/formula/functions/date-functions.test.ts
+++ b/v3/src/models/formula/functions/date-functions.test.ts
@@ -1,0 +1,56 @@
+import { formatDate } from "../../../utilities/date-utils"
+import { math } from "./math"
+
+describe("date", () => {
+  it("returns current date if no arguments are provided", () => {
+    const fn = math.compile("date()")
+    expect(fn.evaluate()).toEqual(formatDate(new Date()))
+  })
+
+  it("interprets a small number as 20xx year if it's smaller than current year + 10", () => {
+    const fn = math.compile("date(x)")
+    expect(fn.evaluate({ x: 1 })).toEqual(formatDate(new Date(2001, 0, 1)))
+    expect(fn.evaluate({ x: 10 })).toEqual(formatDate(new Date(2010, 0, 1)))
+    expect(fn.evaluate({ x: 20 })).toEqual(formatDate(new Date(2020, 0, 1)))
+    expect(fn.evaluate({ x: 30 })).toEqual(formatDate(new Date(2030, 0, 1)))
+  })
+
+  it("interprets a small number as 19xx year if it's bigger than current year + 10, but smaller than 100", () => {
+    const fn = math.compile("date(x)")
+    expect(fn.evaluate({ x: 50 })).toEqual(formatDate(new Date(1950, 0, 1)))
+    expect(fn.evaluate({ x: 60 })).toEqual(formatDate(new Date(1960, 0, 1)))
+    expect(fn.evaluate({ x: 70 })).toEqual(formatDate(new Date(1970, 0, 1)))
+    expect(fn.evaluate({ x: 99 })).toEqual(formatDate(new Date(1999, 0, 1)))
+  })
+
+  it("interprets number as year if it's bigger than 100 but smaller than 5000", () => {
+    const fn = math.compile("date(x)")
+    expect(fn.evaluate({ x: 100 })).toEqual(formatDate(new Date(100, 0, 1)))
+    expect(fn.evaluate({ x: 1000 })).toEqual(formatDate(new Date(1000, 0, 1)))
+    expect(fn.evaluate({ x: 2000 })).toEqual(formatDate(new Date(2000, 0, 1)))
+    expect(fn.evaluate({ x: 4999 })).toEqual(formatDate(new Date(4999, 0, 1)))
+  })
+
+  it("interprets number as epoch seconds if it's bigger than 5000", () => {
+    const fn = math.compile("date(x)")
+    expect(fn.evaluate({ x: 5000 })).toEqual(formatDate(new Date(5000 * 1000)))
+    expect(fn.evaluate({ x: 10000 })).toEqual(formatDate(new Date(10000 * 1000)))
+    expect(fn.evaluate({ x: 12345 })).toEqual(formatDate(new Date(12345 * 1000)))
+  })
+
+  it("supports month, day, hours, minutes, seconds, and milliseconds arguments", () => {
+    const fn = math.compile("date(2020, 2, 3, 4, 5, 6, 7)")
+    expect(fn.evaluate()).toEqual(formatDate(new Date(2020, 1, 3, 4, 5, 6, 7)))
+    const fn2 = math.compile("date(2020, 2, 3)")
+    expect(fn2.evaluate()).toEqual(formatDate(new Date(2020, 1, 3)))
+    const fn3 = math.compile("date(2020, 2)")
+    expect(fn3.evaluate()).toEqual(formatDate(new Date(2020, 1, 1)))
+  })
+
+  it("assumes month is in range 1-12, but 0 is interpreted as January", () => {
+    const fn = math.compile("date(2020, 0, 1)")
+    expect(fn.evaluate()).toEqual(formatDate(new Date(2020, 0, 1)))
+    const fn2 = math.compile("date(2020, 5, 1)")
+    expect(fn2.evaluate()).toEqual(formatDate(new Date(2020, 4, 1)))
+  })
+})

--- a/v3/src/models/formula/functions/date-functions.test.ts
+++ b/v3/src/models/formula/functions/date-functions.test.ts
@@ -7,15 +7,16 @@ describe("date", () => {
     expect(fn.evaluate()).toEqual(formatDate(new Date()))
   })
 
-  it("interprets a small number as 20xx year if it's smaller than current year + 10", () => {
+  it("interprets [0, 50) as 20xx year", () => {
     const fn = math.compile("date(x)")
     expect(fn.evaluate({ x: 1 })).toEqual(formatDate(new Date(2001, 0, 1)))
     expect(fn.evaluate({ x: 10 })).toEqual(formatDate(new Date(2010, 0, 1)))
     expect(fn.evaluate({ x: 20 })).toEqual(formatDate(new Date(2020, 0, 1)))
     expect(fn.evaluate({ x: 30 })).toEqual(formatDate(new Date(2030, 0, 1)))
+    expect(fn.evaluate({ x: 49 })).toEqual(formatDate(new Date(2049, 0, 1)))
   })
 
-  it("interprets a small number as 19xx year if it's bigger than current year + 10, but smaller than 100", () => {
+  it("interprets [50, 99] as 19xx year", () => {
     const fn = math.compile("date(x)")
     expect(fn.evaluate({ x: 50 })).toEqual(formatDate(new Date(1950, 0, 1)))
     expect(fn.evaluate({ x: 60 })).toEqual(formatDate(new Date(1960, 0, 1)))

--- a/v3/src/models/formula/functions/date-functions.ts
+++ b/v3/src/models/formula/functions/date-functions.ts
@@ -25,7 +25,7 @@ export const dateFunctions = {
         return formatDateWithUndefFallback(new Date())
       }
 
-      let yearOrSeconds = args[0] != null ? Number(args[0]) : null
+      const yearOrSeconds = args[0] != null ? Number(args[0]) : null
 
       if (args.length === 1 && yearOrSeconds != null && defaultToEpochSecs(yearOrSeconds)) {
         // Only one argument and it's a number that should be treated as epoch seconds.

--- a/v3/src/models/formula/functions/date-functions.ts
+++ b/v3/src/models/formula/functions/date-functions.ts
@@ -1,7 +1,9 @@
-
 import { FValue } from "../formula-types"
 import { UNDEF_RESULT } from "./function-utils"
 import { formatDate } from "../../../utilities/date-utils"
+
+// dividing line between 20xx and 19xx years: [0, 50) -> 20xx, [50, 99] -> 19xx
+const CUTOFF_YEAR = 50
 
 /**
  Returns true if the specified value should be treated as epoch
@@ -40,14 +42,12 @@ export const dateFunctions = {
       const milliseconds = args[6] != null ? Number(args[6]) : 0
 
       const currentYear = new Date().getFullYear()
-      // dividing line for two-digit years is 10 yrs from now
-      const cutoffYear = (currentYear + 10) % 100
 
       // Logic ported from V2 for backwards compatibility
       if (yearOrSeconds == null) {
         yearOrSeconds = currentYear
       }
-      else if (yearOrSeconds < cutoffYear) {
+      else if (yearOrSeconds < CUTOFF_YEAR) {
         yearOrSeconds += 2000
       }
       else if (yearOrSeconds < 100) {

--- a/v3/src/models/formula/functions/date-functions.ts
+++ b/v3/src/models/formula/functions/date-functions.ts
@@ -1,0 +1,61 @@
+
+import { FValue } from "../formula-types"
+import { UNDEF_RESULT } from "./function-utils"
+import { formatDate } from "../../../utilities/date-utils"
+
+/**
+ Returns true if the specified value should be treated as epoch
+ seconds when provided as the only argument to the date() function,
+ false if the value should be treated as a year.
+ date(2000) should be treated as a year, but date(12345) should not.
+ */
+export function defaultToEpochSecs(iValue: number) {
+  return Math.abs(iValue) >= 5000
+}
+
+function formatDateWithUndefFallback(date: Date) {
+  return formatDate(date) || UNDEF_RESULT
+}
+
+export const dateFunctions = {
+  date: {
+    numOfRequiredArguments: 1,
+    evaluate: (...args: FValue[]) => {
+      if (args.length === 0) {
+        return formatDateWithUndefFallback(new Date())
+      }
+
+      let yearOrSeconds = args[0] != null ? Number(args[0]) : null
+
+      if (args.length === 1 && yearOrSeconds != null && defaultToEpochSecs(yearOrSeconds)) {
+        // convert from seconds to milliseconds
+        return formatDateWithUndefFallback(new Date(yearOrSeconds * 1000))
+      }
+
+      const monthIndex = args[1] != null ? Math.max(0, Number(args[1]) - 1) : 0
+      const day = args[2] != null ? Number(args[2]) : 1
+      const hours = args[3] != null ? Number(args[3]) : 0
+      const minutes = args[4] != null ? Number(args[4]) : 0
+      const seconds = args[5] != null ? Number(args[5]) : 0
+      const milliseconds = args[6] != null ? Number(args[6]) : 0
+
+      const currentYear = new Date().getFullYear()
+      // dividing line for two-digit years is 10 yrs from now
+      const cutoffYear = (currentYear + 10) % 100
+
+      // Logic ported from V2 for backwards compatibility
+      if (yearOrSeconds == null) {
+        yearOrSeconds = currentYear
+      }
+      else if (yearOrSeconds < cutoffYear) {
+        yearOrSeconds += 2000
+      }
+      else if (yearOrSeconds < 100) {
+        yearOrSeconds += 1900
+      }
+
+      const date = new Date(yearOrSeconds, monthIndex, day, hours, minutes, seconds, milliseconds)
+      return isNaN(date.valueOf()) ? UNDEF_RESULT : formatDateWithUndefFallback(date)
+    }
+  }
+}

--- a/v3/src/models/formula/functions/math.ts
+++ b/v3/src/models/formula/functions/math.ts
@@ -4,13 +4,15 @@ import {
   CODAPMathjsFunctionRegistry, EvaluateFunc, EvaluateFuncWithAggregateContextSupport, EvaluateRawFunc, FValue,
   FValueOrArray
 } from '../formula-types'
-import { equal, evaluateNode } from './function-utils'
+import { evaluateNode } from './function-utils'
 import { arithmeticFunctions } from './arithmetic-functions'
+import { dateFunctions } from './date-functions'
 import { stringFunctions } from './string-functions'
 import { lookupFunctions } from './lookup-functions'
 import { otherFunctions } from './other-functions'
 import { aggregateFunctions } from './aggregate-functions'
 import { semiAggregateFunctions } from './semi-aggregate-functions'
+import { operators } from './operators'
 
 export const math = create(all)
 
@@ -61,22 +63,11 @@ export const evaluateWithAggregateContextSupport = (fn: EvaluateFunc): EvaluateF
 }
 
 export const fnRegistry = {
-  // equal(a, b) or a == b
-  // Note that we need to override default MathJs implementation so we can compare strings like "ABC" == "CDE".
-  // MathJs doesn't allow that by default, as it assumes that equal operator can be used only with numbers.
-  equal: {
-    isOperator: true,
-    numOfRequiredArguments: 2,
-    evaluateOperator: equal
-  },
-
-  unequal: {
-    isOperator: true,
-    numOfRequiredArguments: 2,
-    evaluateOperator: (a: any, b: any) => !equal(a, b)
-  },
+  ...operators,
 
   ...arithmeticFunctions,
+
+  ...dateFunctions,
 
   ...stringFunctions,
 

--- a/v3/src/models/formula/functions/operators.test.ts
+++ b/v3/src/models/formula/functions/operators.test.ts
@@ -1,0 +1,72 @@
+import { formatDate } from "../../../utilities/date-utils"
+import { math } from "./math"
+
+describe("+ operator", () => {
+  it("adds two numbers", () => {
+    const fn = math.compile("1 + 2")
+    expect(fn.evaluate()).toEqual(3)
+  })
+
+  it("adds two numeric strings", () => {
+    const fn = math.compile("'1' + '2'")
+    expect(fn.evaluate()).toEqual(3)
+  })
+
+  it("adds a number and a numeric string", () => {
+    const fn = math.compile("1 + '2'")
+    expect(fn.evaluate()).toEqual(3)
+  })
+
+  it("adds dates", () => {
+    const fn = math.compile("'1/1/2020' + '1/1/2020'")
+    const val1 = new Date(2020, 0, 1).valueOf()
+    const val2 = new Date(2020, 0, 1).valueOf()
+    expect(fn.evaluate()).toEqual(formatDate(new Date(val1 + val2)))
+  })
+
+  it("adds seconds to dates", () => {
+    const fn = math.compile("'1/1/2020' + 60 * 60") // + 1 hour
+    expect(fn.evaluate()).toEqual(formatDate(new Date(2020, 0, 1, 1)))
+    const fn2 = math.compile("'1/1/2020' + 60 * 60 * 24") // + 1 day
+    expect(fn2.evaluate()).toEqual(formatDate(new Date(2020, 0, 2)))
+
+    const fn3 = math.compile("60 * 60 + '1/1/2020'") // + 1 hour
+    expect(fn3.evaluate()).toEqual(formatDate(new Date(2020, 0, 1, 1)))
+    const fn4 = math.compile("60 * 60 * 24 + '1/1/2020'") // + 1 day
+    expect(fn4.evaluate()).toEqual(formatDate(new Date(2020, 0, 2)))
+  })
+
+  it("concatenates strings", () => {
+    const fn = math.compile("'foo' + 'bar'")
+    expect(fn.evaluate()).toEqual("foobar")
+  })
+})
+
+describe("- operator", () => {
+  it("subtracts two numbers", () => {
+    const fn = math.compile("2 - 1")
+    expect(fn.evaluate()).toEqual(1)
+  })
+
+  it("subtracts two numeric strings", () => {
+    const fn = math.compile("'2' - '1'")
+    expect(fn.evaluate()).toEqual(1)
+  })
+
+  it("subtracts a number and a numeric string", () => {
+    const fn = math.compile("2 - '1'")
+    expect(fn.evaluate()).toEqual(1)
+  })
+
+  it("subtracts dates", () => {
+    const fn = math.compile("'1/2/2020' - '1/1/2020'") // 1 day
+    const val1 = new Date(2020, 0, 2).valueOf()
+    const val2 = new Date(2020, 0, 1).valueOf()
+    expect(fn.evaluate()).toEqual(formatDate(new Date(val1 - val2)))
+  })
+
+  it("throws an error when subtracting strings", () => {
+    const fn = math.compile("'foo' - 'bar'")
+    expect(() => fn.evaluate()).toThrow("Invalid arguments for subtract operator: foo, bar")
+  })
+})

--- a/v3/src/models/formula/functions/operators.ts
+++ b/v3/src/models/formula/functions/operators.ts
@@ -1,0 +1,84 @@
+import { equal, isNumber, UNDEF_RESULT } from './function-utils'
+import { parseDate } from '../../../utilities/date-parser'
+import { formatDate } from '../../../utilities/date-utils'
+
+export const operators = {
+  // equal(a, b) or a == b
+  // Note that we need to override default MathJs implementation so we can compare strings like "ABC" == "CDE".
+  // MathJs doesn't allow that by default, as it assumes that equal operator can be used only with numbers.
+  equal: {
+    isOperator: true,
+    numOfRequiredArguments: 2,
+    evaluateOperator: equal
+  },
+
+  unequal: {
+    isOperator: true,
+    numOfRequiredArguments: 2,
+    evaluateOperator: (a: any, b: any) => !equal(a, b)
+  },
+
+  add: {
+    isOperator: true,
+    numOfRequiredArguments: 2,
+    evaluateOperator: (a: any, b: any) => {
+      // Two numbers or numeric strings
+      const isANumber = isNumber(a)
+      const isBNumber = isNumber(b)
+      if (isANumber && isBNumber) {
+        return Number(a) + Number(b)
+      }
+
+      // Dates and numbers
+      const aDate = isANumber ? null : parseDate(a, true)
+      const bDate = isBNumber ? null : parseDate(b, true)
+      if (aDate != null && bDate != null) {
+        return formatDate(new Date(aDate.valueOf() + bDate.valueOf())) || UNDEF_RESULT
+      }
+      // When one of the arguments is a date and the other is a number, we assume that the number is in seconds.
+      if (aDate != null && isBNumber) {
+        return formatDate(new Date(aDate.valueOf() + Number(b) * 1000)) || UNDEF_RESULT
+      }
+      if (isANumber && bDate != null) {
+        return formatDate(new Date(Number(a) * 1000 + bDate.valueOf())) || UNDEF_RESULT
+      }
+
+      // Strings
+      if (typeof a === 'string' || typeof b === 'string') {
+        // Two non-date and non-numeric strings, so concatenate them.
+        return a + b
+      }
+
+      throw new Error(`Invalid arguments for add operator: ${a}, ${b}`)
+    }
+  },
+
+  subtract: {
+    isOperator: true,
+    numOfRequiredArguments: 2,
+    evaluateOperator: (a: any, b: any) => {
+      // Two numbers or numeric strings
+      const isANumber = isNumber(a)
+      const isBNumber = isNumber(b)
+      if (isANumber && isBNumber) {
+        return Number(a) - Number(b)
+      }
+
+      // Dates and numbers
+      const aDate = isANumber ? null : parseDate(a, true)
+      const bDate = isBNumber ? null : parseDate(b, true)
+      if (aDate != null && bDate != null) {
+        return formatDate(new Date(aDate.valueOf() - bDate.valueOf())) || UNDEF_RESULT
+      }
+      // When one of the arguments is a date and the other is a number, we assume that the number is in seconds.
+      if (aDate != null && isBNumber) {
+        return formatDate(new Date(aDate.valueOf() - Number(b) * 1000)) || UNDEF_RESULT
+      }
+      if (isANumber && bDate != null) {
+        return formatDate(new Date(Number(a) * 1000 - bDate.valueOf())) || UNDEF_RESULT
+      }
+
+      throw new Error(`Invalid arguments for subtract operator: ${a}, ${b}`)
+    }
+  }
+}

--- a/v3/src/utilities/date-parser.test.ts
+++ b/v3/src/utilities/date-parser.test.ts
@@ -1,4 +1,4 @@
-import { isDateString, isValidDateSpec, parseDate } from './date-parser'
+import { fixYear, isDateString, isValidDateSpec, parseDate } from './date-parser'
 
 describe('Date Parser tests - V2 compatibility', () => {
   // These tests are ported from V2 and should always pass unchanged as long as we want to maintain compatibility.
@@ -183,5 +183,23 @@ test('returns null when subsecond is NaN', () => {
       subsec: NaN
     }
     expect(isValidDateSpec(invalidDateSpec)).toBeFalsy()
+  })
+})
+
+describe('fixYear', () => {
+  test('returns year when year is 4 digits', () => {
+    expect(fixYear(2023)).toEqual(2023)
+  })
+  test('returns year when year is 3 digits', () => {
+    expect(fixYear(100)).toEqual(100)
+    expect(fixYear(123)).toEqual(123)
+  })
+  test('returns 20xx year when year is 2 digits and less than 50', () => {
+    expect(fixYear(10)).toEqual(2010)
+    expect(fixYear(49)).toEqual(2049)
+  })
+  test('returns 19xx year when year is 2 digits and greater than or equal to 50', () => {
+    expect(fixYear(50)).toEqual(1950)
+    expect(fixYear(99)).toEqual(1999)
   })
 })

--- a/v3/src/utilities/date-parser.ts
+++ b/v3/src/utilities/date-parser.ts
@@ -196,7 +196,7 @@ function extractDateProps(match: string[], map: GroupMap): DateSpec {
   function fixYear(y: string) {
     if (y.length === 2) {
       const yNumber = Number(y)
-      if (yNumber < 49) {
+      if (yNumber < 50) {
         return 2000 + yNumber
       } else {
         return 1900 + yNumber

--- a/v3/src/utilities/date-parser.ts
+++ b/v3/src/utilities/date-parser.ts
@@ -169,44 +169,43 @@ const formatSpecs = [
   { strict: false, regex: dateVar4, groupMap: dateVar4GroupMap }
 ]
 
-function extractDateProps(match: string[], map: GroupMap): DateSpec {
-  function fixHour(hr: string, amPm?: string) {
-    if (isNaN(Number(hr))) {
-      return NaN
-    }
-    let newHr = Number(hr)
-    if (amPm != null && (0 < newHr && newHr <= 12)) {
-      newHr = newHr % 12
-      if (amPm && amPm.toLowerCase() === 'pm') {
-        newHr += 12
-      }
-    }
-    return newHr
-  }
+// dividing line between 20xx and 19xx years: [0, 50) -> 20xx, [50, 99] -> 19xx
+const CUTOFF_YEAR = 50
 
-  function fixMonth(m: string) {
-    if (!isNaN(Number(m))) {
-      return Number(m)
-    }
-    const lcMonth = m.toLowerCase()
-    const monthIx = monthsArray.findIndex(function (monthName) { return monthName === lcMonth })
-    return (monthIx % 12) + 1
+export function fixYear(y: string | number) {
+  const yNumber = typeof y === 'string' ? Number(y) : y
+  if (yNumber < CUTOFF_YEAR) {
+    return 2000 + yNumber
+  } else if (yNumber < 100) {
+    return 1900 + yNumber
   }
+  return yNumber
+}
 
-  function fixYear(y: string) {
-    if (y.length === 2) {
-      const yNumber = Number(y)
-      if (yNumber < 50) {
-        return 2000 + yNumber
-      } else {
-        return 1900 + yNumber
-      }
-    }
-    else {
-      return y
+export function fixHour(hr: string, amPm?: string) {
+  if (isNaN(Number(hr))) {
+    return NaN
+  }
+  let newHr = Number(hr)
+  if (amPm != null && (0 < newHr && newHr <= 12)) {
+    newHr = newHr % 12
+    if (amPm && amPm.toLowerCase() === 'pm') {
+      newHr += 12
     }
   }
+  return newHr
+}
 
+export function fixMonth(m: string) {
+  if (!isNaN(Number(m))) {
+    return Number(m)
+  }
+  const lcMonth = m.toLowerCase()
+  const monthIx = monthsArray.findIndex(function (monthName) { return monthName === lcMonth })
+  return (monthIx % 12) + 1
+}
+
+export function extractDateProps(match: string[], map: GroupMap): DateSpec {
   return {
     year: Number(fixYear(match[map.year])),
     month: fixMonth(match[map.month] || '1'),
@@ -282,4 +281,3 @@ export function isDateString(iValue: any, iLoose?: boolean) {
     return spec.regex.test(iValue)
   })
 }
-

--- a/v3/src/utilities/date-parser.ts
+++ b/v3/src/utilities/date-parser.ts
@@ -262,7 +262,6 @@ export function parseDate(iValue: any, iLoose?: boolean) {
     if (dateSpec) {
       date = new Date(dateSpec.year, (-1 + dateSpec.month), dateSpec.day,
         dateSpec.hour, dateSpec.min, dateSpec.sec, dateSpec.subsec)
-      if (date) date.valueOf = function () { return Date.prototype.valueOf.apply(this) / 1000 }
       return date
     }
   }

--- a/v3/src/utilities/date-utils.ts
+++ b/v3/src/utilities/date-utils.ts
@@ -113,7 +113,7 @@ export function isDate(iValue: any): iValue is Date {
  * @param precision {number}
  * @return {string}
  */
-export function formatDate(x: Date | number | string, precision: DatePrecision) {
+export function formatDate(x: Date | number | string, precision: DatePrecision = DatePrecision.None): string | null {
   const formatPrecisions: Record<DatePrecision, any> = {
     [DatePrecision.None]: null,
     [DatePrecision.Year]: { year: 'numeric' },
@@ -138,7 +138,7 @@ export function formatDate(x: Date | number | string, precision: DatePrecision) 
     // differently from DG.MathUtilities.isNumeric in V2. The original isNumeric function in V2 returns true for
     // Date objects, which was probably not planned (as `isNaN(new Date())` actually returns `false`), but is necessary
     // here. Since isFiniteNumber() is more strict, we need an explicit check for Date objects here.
-    x = new Date(x.valueOf() * 1000)
+    x = new Date(x.valueOf())
   } else if (isDateString(x)) {
     x = new Date(x)
   }
@@ -146,56 +146,6 @@ export function formatDate(x: Date | number | string, precision: DatePrecision) 
   const locale = getDefaultLanguage()
   return new Intl.DateTimeFormat(locale, precisionFormat).format(x as Date)
 }
-
-/**
- Returns true if the specified value should be treated as epoch
- seconds when provided as the only argument to the date() function,
- false if the value should be treated as a year.
- date(2000) should be treated as a year, but date(12345) should not.
- */
- export function defaultToEpochSecs(iValue: number) {
-  return Math.abs(iValue) >= 5000
-}
-
-/**
- Returns a DG date object constructed from its arguments.
- Currently this is a JavaScript Date object, but could be
- replaced with another (e.g. moment.js) object at some point.
- */
-/*
-DateUtilities.createDate = function(/!* iArgs *!/) {
-  var args = [Date].concat(Array.prototype.slice.call(arguments)),
-    date
-
-  if (args.length === 2 && typeof args[1] === 'string' && isNaN(args[1])) {
-    return DateUtilities.dateParser.parseDate(args[1], true)
-  }
-
-  if ((args.length === 2)) {  // We have either seconds since 1970 or a year
-    if (DateUtilities.defaultToEpochSecs(args[1]))
-      args[1] = Number(args[1]) * 1000// convert from seconds to milliseconds
-    else {  // We have a value < 5000.
-      args[2] = 0  // This will force the constructor to treat args[1] as a year
-    }
-  }
-  // Call Date constructor with specified arguments
-  // cf. http://stackoverflow.com/a/8843181
-  /!* jshint -W058 *!/
-  date = new (Function.bind.apply(Date, args))()
-
-  if (isNaN(date)) {
-    date = null
-  }
-
-  // replace default numeric conversion (milliseconds) with our own (seconds)
-  if (date) {
-    date.valueOf = function() { return Date.prototype.valueOf.apply(this) / 1000 }
-  }
-
-  return date
-}
-createDate = DateUtilities.createDate
-*/
 
 /**
  Default formatting for Date objects.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187799270

This PR adds support for dates in the formula context. I've tried to replicate V2 behavior, but hopefully, it's also improved in some cases:
- We always produce date output instead of epoch values.
- The `-` (subtract) operator is supported.
- The `date()` formula works better when referencing other attributes.



Also, V2 had essentially 3 ways of interpreting input as a date: `parseDate` helper, `createDate` helper, `date()` formula.
They're slightly overlapping, but not too much and they might produce different results. E.g. they'd all return different result for "25" input. So, I'm trying to cleanup that in V3 a bit, and just have two options:
- `parseDate`
- `date()` formula with all its quirks and implicit treatment of the year argument

So, I'm intentionally not bringing in `createDate` (I removed it from V3 helpers). Hopefully places where `createDate` used to be called can be replaced with parseDate or regular new Date().

So far I'm doing well without custom/modified Date class that has `.valueOf()` modified to return seconds instead of milliseconds. I don't think we need that, but let me know if you see a reason for that. The only place where that matters is the + and - operators, as that's probably the only place where a Date object might be mixed with a number that has to be interpreted as ms or seconds. But handling that doesn't require using a custom Date class and modifying the numeric value internally.

Another side effect of this PR is that users might now concatenate strings in formulas using the `+` operator.
