### PR TITLE
fix: case table enter key advances to next row [PT-187967544]

### DIFF
--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -84,7 +84,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
       args.onClose(true)
       // prevent RDG from handling the event
       event.preventGridDefault()
-      navigateToNextRow()
+      navigateToNextRow(event.shiftKey)
     }
   }
 

--- a/v3/src/components/case-table/use-selected-cell.ts
+++ b/v3/src/components/case-table/use-selected-cell.ts
@@ -21,13 +21,16 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
                             : undefined
   }, [])
 
-  const navigateToNextRow = useCallback(() => {
+  const navigateToNextRow = useCallback((back = false) => {
     if (selectedCell.current?.columnId) {
       const idx = columns.findIndex(column => column.key === selectedCell.current?.columnId)
-      const rowIdx = selectedCell.current.rowIdx + 1
+      const rowIdx = Math.max(0, selectedCell.current.rowIdx + (back ? -1 : 1))
       const position = { idx, rowIdx }
-      gridRef.current?.selectCell(position, true)
-      collectionTableModel?.scrollRowIntoView(rowIdx)
+      // setTimeout so it occurs after handling of current event completes
+      setTimeout(() => {
+        collectionTableModel?.scrollRowIntoView(rowIdx)
+        gridRef.current?.selectCell(position, true)
+      })
     }
   }, [collectionTableModel, columns, gridRef])
 


### PR DESCRIPTION
[[PT-187967544]](https://www.pivotaltracker.com/story/show/187967544)

The [previous fix](https://github.com/concord-consortium/codap/pull/1355) worked some of the time but other times the internal event handling of RDG would exit edit mode immediately after we'd requested to enter it. This version adds a `setTimeout` so that edit mode is entered after RDG has completely finished processing the current event and no longer has the opportunity to summarily cancel the edit mode we've requested. This version also add the ability to advance (retreat?) to the previous row if the shift key is pressed along with the enter key.