### PR TITLE
chore: reduce cypress waits

### DIFF
--- a/v3/cypress/support/commands.ts
+++ b/v3/cypress/support/commands.ts
@@ -130,7 +130,7 @@ Cypress.Commands.add("dragAttributeToTarget", (source, attribute, target, target
         })
       })
     })
-  cy.wait(4000)
+  cy.wait(2500)
 })
 
 Cypress.Commands.add("clickToUnselect", (subject, options?: { delay: number }) => {
@@ -275,5 +275,5 @@ Cypress.Commands.add("pointerMoveBy",
           cy.get(target_el).should("not.exist")
         }
       })
-    cy.wait(5000)
+    cy.wait(2500)
   })


### PR DESCRIPTION
The `dragAttributeToTarget` command is used repeatedly throughout our cypress tests and specifies that it must wait for five seconds after each drop before continuing with the test. CODAP animations generally have two second durations, so even if a test requires waiting for animation to complete, 2.5 seconds should be plenty of time. This PR tests that hypothesis.