### PR TITLE
187881303-informal-confidence-interval-v3

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
@@ -49,7 +49,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
   const secondaryAxisY = plotHeight / cellCounts.y / 2 - boxPlotOffset
   const valueRef = useRef<SVGGElement>(null)
   const labelRef = useRef<HTMLDivElement>(null)
-  const fullHeightLinesRef = useRef<Selection<SVGPathElement, unknown, null, undefined>>(null)
+  const fullHeightLinesRef = useRef<Selection<SVGPathElement, unknown, null, undefined> | null>(null)
 
   const toggleBoxPlotLabels = useCallback((labelId: string, visible: boolean, event: MouseEvent) => {
     const label = select(`#${labelId}`)
@@ -243,10 +243,8 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     valueObj.iciCover = helper.newLine(valueRef.current, iciCoverSpecs)
     if (spannerRef) {
       fullHeightLinesRef.current?.remove()
-      select(spannerRef.current).attr("class", "measure-container")  // So the classes applied to the lines
-                                                                                  // will be scoped to the spanner
-      // todo: Figure out why we seem to need this
-      // @ts-expect-error cannot assign to 'current' because it is read-only
+      select(spannerRef.current).attr("class", "measure-container") // So the classes applied to the lines
+                                                                    // will be scoped to the spanner
       fullHeightLinesRef.current = spannerRef.current && select(spannerRef.current).append("path")
         .attr("class", "full-height-lines ici")
         .attr("id", `${helper.generateIdString("path")}`)
@@ -420,7 +418,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     if (model.showICI) {
       const iciRange = model.computeICIRange(attrId, cellKey, dataConfig)
       addICI(valueObj)
-      textContent += `\n${t('ICI: [%@, %@]', 
+      textContent += `\n${t('ICI: [%@, %@]',
         { vars: [helper.formatValueForScale(isVertical.current, iciRange.min),
             helper.formatValueForScale(isVertical.current, iciRange.max)] })}`
     }

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { FormControl, Checkbox } from "@chakra-ui/react"
 import { t } from "../../../../../utilities/translation/translate"
+import { getDocumentContentPropertyFromNode } from "../../../../../utilities/mst-utils"
 import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { getAdornmentContentInfo, registerAdornmentContentInfo } from "../../adornment-content-info"
 import { BoxPlotAdornmentModel, IBoxPlotAdornmentModel } from "./box-plot-adornment-model"
@@ -14,6 +15,7 @@ const Controls = observer(function Controls() {
   const graphModel = useGraphContentModelContext()
   const adornmentsStore = graphModel.adornmentsStore
   const existingAdornment = adornmentsStore.findAdornmentOfType<IBoxPlotAdornmentModel>(kBoxPlotType)
+  const showICIOption = getDocumentContentPropertyFromNode(graphModel, "iciEnabled") || existingAdornment?.showICI
 
   const handleBoxPlotSetting = (checked: boolean) => {
     const existingBoxPlotAdornment = adornmentsStore.findAdornmentOfType<IBoxPlotAdornmentModel>(kBoxPlotType)
@@ -49,6 +51,40 @@ const Controls = observer(function Controls() {
     existingAdornment?.setShowOutliers(checked)
   }
 
+  const handleShowIciSetting = (checked: boolean) => {
+    existingAdornment?.setShowICI(checked)
+  }
+
+  const renderShowOutliers = () => {
+    return (
+      <FormControl isDisabled={!existingAdornment?.isVisible}>
+        <Checkbox
+          data-testid={`adornment-checkbox-${kBoxPlotClass}-show-outliers`}
+          defaultChecked={existingAdornment?.showOutliers}
+          onChange={e => handleShowOutliersSetting(e.target.checked)}
+        >
+          {t("DG.Inspector.graphBoxPlotShowOutliers")}
+        </Checkbox>
+      </FormControl>
+    )
+  }
+
+  const renderShowICI = () => {
+    if (showICIOption) {
+      return (
+        <FormControl isDisabled={!existingAdornment?.isVisible}>
+          <Checkbox
+            data-testid={`adornment-checkbox-${kBoxPlotClass}-show-outliers`}
+            defaultChecked={existingAdornment?.showICI}
+            onChange={e => handleShowIciSetting(e.target.checked)}
+          >
+            {t("DG.Inspector.graphBoxPlotShowICI")}
+          </Checkbox>
+        </FormControl>
+      )
+    }
+  }
+
   return (
     <>
       <FormControl>
@@ -64,15 +100,8 @@ const Controls = observer(function Controls() {
         className="sub-options show-outliers"
         data-testid="adornment-show-outliers-options"
       >
-        <FormControl isDisabled={!existingAdornment?.isVisible}>
-          <Checkbox
-            data-testid={`adornment-checkbox-${kBoxPlotClass}-show-outliers`}
-            defaultChecked={existingAdornment?.showOutliers}
-            onChange={e => handleShowOutliersSetting(e.target.checked)}
-          >
-            {t("DG.Inspector.graphBoxPlotShowOutliers")}
-          </Checkbox>
-        </FormControl>
+        {renderShowOutliers()}
+        {renderShowICI()}
       </div>
     </>
   )

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.scss
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.scss
@@ -146,7 +146,6 @@
 
   .measure-range {
     fill-opacity: .5;
-    //pointer-events: none;
     stroke: none;
     stroke-width: 0;
 

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.scss
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.scss
@@ -58,12 +58,21 @@
     }
   }
 
+  .box-plot-ici {
+    stroke: #3300ff !important;
+    stroke-width: 2px !important;
+  }
+
   .full-height-lines {
     stroke: #f6768e;
     opacity: 0;
 
     &.highlighted {
       opacity: 1;
+    }
+
+    &.ici {
+      stroke: #3300ff;
     }
   }
 
@@ -137,7 +146,7 @@
 
   .measure-range {
     fill-opacity: .5;
-    pointer-events: none;
+    //pointer-events: none;
     stroke: none;
     stroke-width: 0;
 

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -72,6 +72,13 @@ export class UnivariateMeasureAdornmentHelper {
       : ""
   }
 
+  // Calculate the coordinates for the line endpoints
+  // index = 1 for the left/bottom endpoint, 2 for the right/top endpoint
+  // isVertical = true for vertical lines, false for horizontal lines
+  // cellCounts = {x: number of columns, y: number of rows}
+  // secondaryAxisX = x-coordinate of the secondary axis
+  // secondaryAxisY = y-coordinate of the secondary axis
+  // Returns an object with x and y coordinates
   calculateLineCoords = (
     value: number, index: number, isVertical: boolean, cellCounts: Record<string, number>,
     secondaryAxisX=0, secondaryAxisY=0
@@ -137,7 +144,17 @@ export class UnivariateMeasureAdornmentHelper {
       .attr("transform", `translate(${leftOffset}, ${topOffset})`)
   }
 
-  addRange = (valueElement: SVGGElement | null, valueObj: IValue, rangeSpecs: IRangeSpecs) => {
+ /**
+ * This function adds a range to the given value element. It creates a new rectangle and lines for the range.
+ * It calculates the coordinates for the range based on the given parameters and appends the new elements to
+ * the value element.
+ *
+ * @param valueElement - The SVG element to which the range is to be added.
+ * @param valueObj - The object representing the value for which the range is being added.
+ * @param rangeSpecs - The specifications for the range, including cell counts, coordinates, classes, offsets,
+ * and secondary axis positions.
+ */
+ addRange = (valueElement: SVGGElement | null, valueObj: IValue, rangeSpecs: IRangeSpecs) => {
     if (!valueElement) return
     const { cellCounts, coords, coverClass, extentForSecondaryAxis="100%", isVertical, lineClass,
             lineOffset=0, rangeMin, rangeMax, rectOffset=0, secondaryAxisX=0, secondaryAxisY=0 } = rangeSpecs

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -5,8 +5,8 @@ import { IUnivariateMeasureAdornmentModel } from "./univariate-measure-adornment
 import { ILineCoords, ILineSpecs, IRange, IRangeSpecs, IRectSpecs, IValue } from "./univariate-measure-adornment-types"
 import { clsx } from "clsx"
 import { ScaleNumericBaseType } from "../../../axis/axis-types"
+import { GraphLayout } from "../../models/graph-layout"
 import { isBoxPlotAdornment } from "./box-plot/box-plot-adornment-model"
-import { IAxisLayout } from "../../../axis/models/axis-layout-context"
 import { valueLabelString } from "../../utilities/graph-utils"
 import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
 import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
@@ -28,7 +28,7 @@ export class UnivariateMeasureAdornmentHelper {
   classFromKey = ""
   containerId = ""
   instanceKey = ""
-  layout: IAxisLayout
+  layout: GraphLayout
   measureSlug = ""
   model: IUnivariateMeasureAdornmentModel
   plotHeight = 0
@@ -38,7 +38,7 @@ export class UnivariateMeasureAdornmentHelper {
 
   constructor (
     cellKey: Record<string, string>,
-    layout: IAxisLayout,
+    layout: GraphLayout,
     model: IUnivariateMeasureAdornmentModel,
     plotHeight: number,
     plotWidth: number,

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -143,6 +143,9 @@ export const DocumentContentModel = BaseDocumentContentModel
     },
     get gaussianFitEnabled() {
       return self._gaussianFitEnabled || urlParams.gaussianFit !== undefined
+    },
+    get iciEnabled() {
+      return urlParams.ICI !== undefined
     }
   }))
   .actions(self => ({

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -165,6 +165,33 @@ export function normal(x: number, amp: number, mu: number, sigma: number) {
   return amp * Math.exp(exponent)
 }
 
+/**
+ * Get the quantile
+ * sortedArray is an array of finite numeric values (no non-numeric or missing values allowed)
+ * quantile [0.0-1.0] to calculate, e.g. first quartile = 0.25
+ * return quantile value or undefined if ioArray has no elements
+ */
+export function quantileOfSortedArray (sortedArray:number[], quantile:number) {
+  const lastIndex = sortedArray.length - 1,
+    i = lastIndex * quantile, // quantile's numeric-real index in 0-(n-1) array
+    i1 = Math.floor(i),
+    i2 = Math.ceil(i),
+    fraction = i - i1
+  if (i < 0) {
+    return undefined // length === 0, or quantile < 0.0
+  } else if (i >= lastIndex) {
+    return sortedArray[lastIndex] // quantile >= 1.0
+  } else if (i === i1) {
+    return sortedArray[i1] // quantile falls on data value exactly
+  } else {
+    // quantile between two data values
+    // note that quantile algorithms vary on method used to get value here, there is no fixed standard.
+    return (sortedArray[i2] * fraction + sortedArray[i1] * (1.0 - fraction))
+  }
+}
+
+
+
 type XYToNumberFunction = (x: number, y: number) => number
 
 /**


### PR DESCRIPTION
[#187881303] Feature: An ICI url parameter allows the user to display an "informal confidence interval" on a box plot.

* Added accessor for IciEnabled in document-content.ts
* Added ici svg elements to BoxPlotAdornmentComponent
* Added computeICIRange box-plot-adornment-model.ts
* Added checkbox for "Show Informal CI"
* Added hover tips for Q1 and Q3
* Added quantileOfSortedArray function to math-utils.ts
* Added some comments to univariate-measure-adornment-helper.ts
* Hovering over ICI shows perpendicular lines the full height or width of the graph