### PR TITLE
Make Date a valid IValueType, refactor how dates are handled in formulas and case table

### DIFF
--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -8,7 +8,7 @@ import { ITileModel } from "../models/tiles/tile-model"
 import { ICollectionLabels, ICollectionModel } from "../models/data/collection"
 import { V2SpecificComponent } from "./data-interactive-component-types"
 
-export type DICaseValue = string | number | boolean | undefined
+export type DICaseValue = string | number | boolean | Date | undefined
 export type DICaseValues = Record<string, DICaseValue>
 export interface DIFullCase {
   children?: number[]

--- a/v3/src/data-interactive/handlers/item-handler.ts
+++ b/v3/src/data-interactive/handlers/item-handler.ts
@@ -18,7 +18,7 @@ export const diItemHandler: DIHandler = {
     _items.forEach(item => {
       let newItem: DIItem
       if (typeof item.values === "object") {
-        newItem = item.values
+        newItem = item.values as DIItem
       } else {
         newItem = item as DIItem
       }

--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -42,6 +42,7 @@ describe("Attribute", () => {
     expect(importValueToString(1e-6)).toBe("0.000001")
     expect(importValueToString(true)).toBe("true")
     expect(importValueToString(false)).toBe("false")
+    expect(importValueToString(new Date("2020-06-14T10:13:34.123Z"))).toBe("2020-06-14T10:13:34.123Z")
 
     const attr = Attribute.create({ name: "a" })
     expect(attr.toNumeric(null as any)).toBeNaN()

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -40,7 +40,7 @@ export const kDefaultFormatStr = ".3~f"
 const isDevelopment = () => process.env.NODE_ENV !== "production"
 const isProduction = () => process.env.NODE_ENV === "production"
 
-export type IValueType = string | number | boolean | undefined | Date
+export type IValueType = string | number | boolean | Date | undefined
 
 export interface ISetValueOptions {
   noInvalidate?: boolean

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -55,7 +55,7 @@ export function importValueToString(value: IValueType): string {
   }
   if (value instanceof Date) {
     // Convert Date to ISO string format. It's a consistent format that can be parsed back into a Date object
-    // without loosing any information. Also, it's relatively compact and it can be easily recognized as a date string,
+    // without losing any information. Also, it's relatively compact and it can be easily recognized as a date string,
     // in contrast to storing the date as a number (e.g. milliseconds since epoch).
     return value.toISOString()
   }

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -40,14 +40,26 @@ export const kDefaultFormatStr = ".3~f"
 const isDevelopment = () => process.env.NODE_ENV !== "production"
 const isProduction = () => process.env.NODE_ENV === "production"
 
-export type IValueType = string | number | boolean | undefined
+export type IValueType = string | number | boolean | undefined | Date
 
 export interface ISetValueOptions {
   noInvalidate?: boolean
 }
 
-export function importValueToString(value: IValueType) {
-  return value == null ? "" : typeof value === "string" ? value : value.toString()
+export function importValueToString(value: IValueType): string {
+  if (value == null) {
+    return ""
+  }
+  if (typeof value === "string") {
+    return value
+  }
+  if (value instanceof Date) {
+    // Convert Date to ISO string format. It's a consistent format that can be parsed back into a Date object
+    // without loosing any information. Also, it's relatively compact and it can be easily recognized as a date string,
+    // in contrast to storing the date as a number (e.g. milliseconds since epoch).
+    return value.toISOString()
+  }
+  return value.toString()
 }
 
 export const attributeTypes = [

--- a/v3/src/models/formula/formula-types.ts
+++ b/v3/src/models/formula/formula-types.ts
@@ -33,7 +33,7 @@ export interface ILookupDependency {
 
 export type IFormulaDependency = ILocalAttributeDependency | IGlobalValueDependency | ILookupDependency
 
-export type FValue = string | number | boolean
+export type FValue = string | number | boolean | Date
 
 export type FValueOrArray = FValue | FValue[]
 

--- a/v3/src/models/formula/functions/date-functions.test.ts
+++ b/v3/src/models/formula/functions/date-functions.test.ts
@@ -1,59 +1,58 @@
-import { formatDate } from "../../../utilities/date-utils"
 import { UNDEF_RESULT } from "./function-utils"
 import { math } from "./math"
 
 describe("date", () => {
   it("returns current date if no arguments are provided", () => {
     const fn = math.compile("date()")
-    expect(fn.evaluate()).toEqual(formatDate(new Date()))
+    expect(fn.evaluate().valueOf()).toBeCloseTo(Date.now(), -3)
   })
 
   it("interprets [0, 50) as 20xx year", () => {
     const fn = math.compile("date(x)")
-    expect(fn.evaluate({ x: 1 })).toEqual(formatDate(new Date(2001, 0, 1)))
-    expect(fn.evaluate({ x: 10 })).toEqual(formatDate(new Date(2010, 0, 1)))
-    expect(fn.evaluate({ x: 20 })).toEqual(formatDate(new Date(2020, 0, 1)))
-    expect(fn.evaluate({ x: 30 })).toEqual(formatDate(new Date(2030, 0, 1)))
-    expect(fn.evaluate({ x: 49 })).toEqual(formatDate(new Date(2049, 0, 1)))
+    expect(fn.evaluate({ x: 1 })).toEqual(new Date(2001, 0, 1))
+    expect(fn.evaluate({ x: 10 })).toEqual(new Date(2010, 0, 1))
+    expect(fn.evaluate({ x: 20 })).toEqual(new Date(2020, 0, 1))
+    expect(fn.evaluate({ x: 30 })).toEqual(new Date(2030, 0, 1))
+    expect(fn.evaluate({ x: 49 })).toEqual(new Date(2049, 0, 1))
   })
 
   it("interprets [50, 99] as 19xx year", () => {
     const fn = math.compile("date(x)")
-    expect(fn.evaluate({ x: 50 })).toEqual(formatDate(new Date(1950, 0, 1)))
-    expect(fn.evaluate({ x: 60 })).toEqual(formatDate(new Date(1960, 0, 1)))
-    expect(fn.evaluate({ x: 70 })).toEqual(formatDate(new Date(1970, 0, 1)))
-    expect(fn.evaluate({ x: 99 })).toEqual(formatDate(new Date(1999, 0, 1)))
+    expect(fn.evaluate({ x: 50 })).toEqual(new Date(1950, 0, 1))
+    expect(fn.evaluate({ x: 60 })).toEqual(new Date(1960, 0, 1))
+    expect(fn.evaluate({ x: 70 })).toEqual(new Date(1970, 0, 1))
+    expect(fn.evaluate({ x: 99 })).toEqual(new Date(1999, 0, 1))
   })
 
   it("interprets number as year if it's bigger than 100 but smaller than 5000", () => {
     const fn = math.compile("date(x)")
-    expect(fn.evaluate({ x: 100 })).toEqual(formatDate(new Date(100, 0, 1)))
-    expect(fn.evaluate({ x: 1000 })).toEqual(formatDate(new Date(1000, 0, 1)))
-    expect(fn.evaluate({ x: 2000 })).toEqual(formatDate(new Date(2000, 0, 1)))
-    expect(fn.evaluate({ x: 4999 })).toEqual(formatDate(new Date(4999, 0, 1)))
+    expect(fn.evaluate({ x: 100 })).toEqual(new Date(100, 0, 1))
+    expect(fn.evaluate({ x: 1000 })).toEqual(new Date(1000, 0, 1))
+    expect(fn.evaluate({ x: 2000 })).toEqual(new Date(2000, 0, 1))
+    expect(fn.evaluate({ x: 4999 })).toEqual(new Date(4999, 0, 1))
   })
 
   it("interprets number as epoch seconds if it's bigger than 5000", () => {
     const fn = math.compile("date(x)")
-    expect(fn.evaluate({ x: 5000 })).toEqual(formatDate(new Date(5000 * 1000)))
-    expect(fn.evaluate({ x: 10000 })).toEqual(formatDate(new Date(10000 * 1000)))
-    expect(fn.evaluate({ x: 12345 })).toEqual(formatDate(new Date(12345 * 1000)))
+    expect(fn.evaluate({ x: 5000 })).toEqual(new Date(5000 * 1000))
+    expect(fn.evaluate({ x: 10000 })).toEqual(new Date(10000 * 1000))
+    expect(fn.evaluate({ x: 12345 })).toEqual(new Date(12345 * 1000))
   })
 
   it("supports month, day, hours, minutes, seconds, and milliseconds arguments", () => {
     const fn = math.compile("date(2020, 2, 3, 4, 5, 6, 7)")
-    expect(fn.evaluate()).toEqual(formatDate(new Date(2020, 1, 3, 4, 5, 6, 7)))
+    expect(fn.evaluate()).toEqual(new Date(2020, 1, 3, 4, 5, 6, 7))
     const fn2 = math.compile("date(2020, 2, 3)")
-    expect(fn2.evaluate()).toEqual(formatDate(new Date(2020, 1, 3)))
+    expect(fn2.evaluate()).toEqual(new Date(2020, 1, 3))
     const fn3 = math.compile("date(2020, 2)")
-    expect(fn3.evaluate()).toEqual(formatDate(new Date(2020, 1, 1)))
+    expect(fn3.evaluate()).toEqual(new Date(2020, 1, 1))
   })
 
   it("assumes month is in range 1-12, but 0 is interpreted as January", () => {
     const fn = math.compile("date(2020, 0, 1)")
-    expect(fn.evaluate()).toEqual(formatDate(new Date(2020, 0, 1)))
+    expect(fn.evaluate()).toEqual(new Date(2020, 0, 1))
     const fn2 = math.compile("date(2020, 5, 1)")
-    expect(fn2.evaluate()).toEqual(formatDate(new Date(2020, 4, 1)))
+    expect(fn2.evaluate()).toEqual(new Date(2020, 4, 1))
   })
 })
 
@@ -193,10 +192,27 @@ describe("minutes", () => {
   })
 })
 
+describe("seconds", () => {
+  it("returns the seconds of the provided date object", () => {
+    const fn = math.compile("seconds(date(2020, 2, 3, 4, 5, 6, 7))")
+    expect(fn.evaluate()).toEqual(6)
+  })
+
+  it("returns the seconds of the provided date string", () => {
+    const fn = math.compile("seconds('2020-02-03T04:05:06.007Z')")
+    expect(fn.evaluate()).toEqual(6)
+  })
+
+  it("returns undefined if the date is incorrect", () => {
+    const fn = math.compile("seconds(null)")
+    expect(fn.evaluate()).toEqual(UNDEF_RESULT)
+  })
+})
+
 describe("now", () => {
   it("returns the current date", () => {
     const fn = math.compile("now()")
-    expect(fn.evaluate()).toEqual(formatDate(new Date()))
+    expect(fn.evaluate().valueOf()).toBeCloseTo(Date.now(), -3)
   })
 })
 
@@ -204,6 +220,6 @@ describe("today", () => {
   it("returns the current date without time", () => {
     const fn = math.compile("today()")
     const now = new Date()
-    expect(fn.evaluate()).toEqual(formatDate(new Date(now.getFullYear(), now.getMonth(), now.getDate())))
+    expect(fn.evaluate()).toEqual(new Date(now.getFullYear(), now.getMonth(), now.getDate()))
   })
 })

--- a/v3/src/models/formula/functions/date-functions.ts
+++ b/v3/src/models/formula/functions/date-functions.ts
@@ -1,16 +1,12 @@
 import { FValue } from "../formula-types"
 import { UNDEF_RESULT } from "./function-utils"
-import { convertToDate, createDate, formatDate } from "../../../utilities/date-utils"
+import { convertToDate, createDate } from "../../../utilities/date-utils"
 import { t } from "../../../utilities/translation/translate"
-
-function formatDateWithUndefFallback(date: Date | null) {
-  return formatDate(date) ?? UNDEF_RESULT
-}
 
 export const dateFunctions = {
   date: {
     numOfRequiredArguments: 1,
-    evaluate: (...args: FValue[]) => formatDateWithUndefFallback(createDate(...args as (string | number)[]))
+    evaluate: (...args: FValue[]) => createDate(...args as (string | number)[]) ?? UNDEF_RESULT
   },
 
   year: {
@@ -93,24 +89,24 @@ export const dateFunctions = {
     evaluate: (date: FValue) => convertToDate(date)?.getMinutes() ?? UNDEF_RESULT
   },
 
-  // TODO: this revealed an issue in the new implementation (date is converted to string too early), fix it
-  // when the formatting / storage of dates is refactored.
-  // seconds: {
-  //   numOfRequiredArguments: 1,
-  //   evaluate: (date: FValue) => convertToDate(date)?.getSeconds() ?? UNDEF_RESULT
-  // },
+  seconds: {
+    numOfRequiredArguments: 1,
+    evaluate: (date: FValue) => {
+      return convertToDate(date)?.getSeconds() ?? UNDEF_RESULT
+    }
+  },
 
   today: {
     numOfRequiredArguments: 0,
     evaluate: () => {
       const now = new Date()
       // eliminate time within the day
-      return formatDateWithUndefFallback(new Date(now.getFullYear(), now.getMonth(), now.getDate()))
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate())
     }
   },
 
   now: {
     numOfRequiredArguments: 0,
-    evaluate: () => formatDateWithUndefFallback(createDate())
+    evaluate: () => new Date()
   }
 }

--- a/v3/src/utilities/date-parser.test.ts
+++ b/v3/src/utilities/date-parser.test.ts
@@ -1,4 +1,4 @@
-import { fixYear, isDateString, isValidDateSpec, parseDate } from './date-parser'
+import { fixYear, isBrowserISOString, isDateString, isValidDateSpec, parseDate } from './date-parser'
 
 describe('Date Parser tests - V2 compatibility', () => {
   // These tests are ported from V2 and should always pass unchanged as long as we want to maintain compatibility.
@@ -221,5 +221,20 @@ describe('fixYear', () => {
   test('returns 19xx year when year is 2 digits and greater than or equal to 50', () => {
     expect(fixYear(50)).toEqual(1950)
     expect(fixYear(99)).toEqual(1999)
+  })
+})
+
+describe('isBrowserISOString', () => {
+  test('returns true for strings that were produced by native Date.toISOString() method', () => {
+    expect(isBrowserISOString(new Date().toISOString())).toBe(true)
+    expect(isBrowserISOString(new Date(2023, 7, 17, 15, 30, 45, 123).toISOString())).toBe(true)
+    expect(isBrowserISOString('2023-08-17T15:30:45.123Z')).toBe(true)
+  })
+  test('returns false for strings that were not produced by native Date.toISOString() method', () => {
+    // Still valid ISO date strings, but not produced by native Date.toISOString() method
+    expect(isBrowserISOString('2023-08-17T15:30:45.123')).toBe(false)
+    expect(isBrowserISOString('2023-08-17T15:30:45.123Z+07:00')).toBe(false)
+    expect(isBrowserISOString('2023-08-17T15:30:45.123+07:00')).toBe(false)
+    expect(isBrowserISOString('2023-08-17T15:30:45.123-07:00')).toBe(false)
   })
 })

--- a/v3/src/utilities/date-parser.test.ts
+++ b/v3/src/utilities/date-parser.test.ts
@@ -228,7 +228,9 @@ describe('isBrowserISOString', () => {
   test('returns true for strings that were produced by native Date.toISOString() method', () => {
     expect(isBrowserISOString(new Date().toISOString())).toBe(true)
     expect(isBrowserISOString(new Date(2023, 7, 17, 15, 30, 45, 123).toISOString())).toBe(true)
+    expect(isBrowserISOString(new Date(-2023, 7, 17, 15, 30, 45, 123).toISOString())).toBe(true)
     expect(isBrowserISOString('2023-08-17T15:30:45.123Z')).toBe(true)
+    expect(isBrowserISOString('-002023-08-17T15:30:45.123Z')).toBe(true)
   })
   test('returns false for strings that were not produced by native Date.toISOString() method', () => {
     // Still valid ISO date strings, but not produced by native Date.toISOString() method
@@ -236,5 +238,6 @@ describe('isBrowserISOString', () => {
     expect(isBrowserISOString('2023-08-17T15:30:45.123Z+07:00')).toBe(false)
     expect(isBrowserISOString('2023-08-17T15:30:45.123+07:00')).toBe(false)
     expect(isBrowserISOString('2023-08-17T15:30:45.123-07:00')).toBe(false)
+    expect(isBrowserISOString('002023-08-17T15:30:45.123Z')).toBe(false)
   })
 })

--- a/v3/src/utilities/date-parser.ts
+++ b/v3/src/utilities/date-parser.ts
@@ -306,7 +306,7 @@ export function isDateString(iValue: any, iLoose?: boolean) {
 // Regular expression to match ISO 8601 date strings as produced by Date.toISOString.
 // Note that this regular expression is more strict than the one used in parseDate (isoDateTimeRE) which supports
 // additional formats.
-const browserIsoDatePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/
+const browserIsoDatePattern = /^([+-]\d{6}|\d{4})-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/
 
 export function isBrowserISOString(value: string): boolean {
   return browserIsoDatePattern.test(value)

--- a/v3/src/utilities/date-parser.ts
+++ b/v3/src/utilities/date-parser.ts
@@ -302,3 +302,12 @@ export function isDateString(iValue: any, iLoose?: boolean) {
     return spec.regex.test(iValue)
   }) || (!!iLoose && parseDateV3(iValue) != null)
 }
+
+// Regular expression to match ISO 8601 date strings as produced by Date.toISOString.
+// Note that this regular expression is more strict than the one used in parseDate (isoDateTimeRE) which supports
+// additional formats.
+const browserIsoDatePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/
+
+export function isBrowserISOString(value: string): boolean {
+  return browserIsoDatePattern.test(value)
+}


### PR DESCRIPTION
This PR aims to fix some design issues that were causing the following problem:

`seconds(date(2020, 5, 14, 5, 4, 3))` or `seconds(AnotherAttrWithFormattedDate)` was returning 0 because I used the `formatDate` utility function, which formats the date to a locale string often without seconds, too early in the whole processing chain. The problem was that Date was not a first-class citizen type and was always stringified, and some data was lost.

Here’s what I did to fix it:
- I made Date a valid type that can be passed directly in formulas. This fixed `seconds(date(2020, 5, 14, 5, 4, 3))` because now `seconds` receives a Date instance.
- I also made Date a valid IValueType so it can be passed around in data-set/attribute functions. I updated `importValueToString` to serialize Date to an explicit string format (I chose ISO string, as it's complete, can be easily parsed, and is relatively compact) because Date cannot be stored in any attribute storage (string values or numeric values). This also fixes `seconds(AnotherAttrWithFormattedDate)` because each attribute now stores complete date information (ISO strings are a complete representation of a date). This is better than a number representing epoch milliseconds, as ISO strings can be easily interpreted as dates, unlike milliseconds which can be mistaken for regular numbers.
- Finally, I updated `use-columns` to recognize this ISO string and treat it as if it were an instance of Date. I believe the comments in this file explain that clearly.

@kswenson, does this make sense to you? Another approach might be to have a "real" Date storage in the attribute, similar to strings and numbers. However, I'm not sure where and when even these numeric values are used, as often various helpers work with string values only (e.g. useColumns). And I'm concerned this would be quite a significant change. Also, you might have a better sense of how to implement this approach than I do. This is always an option for the future, as the current implementation does not lock us into it in any way.

Also, I did not update `attribute.toNumeric` to convert date strings to epoch seconds/milliseconds because I don't see a use case for it yet, and it would cause some performance overhead if we had to parse each string passed there, hoping it's a date.