### PR TITLE
fix: parsing of inequality operators in formulas

### DIFF
--- a/v3/src/models/formula/utils/canonicalization-utils.test.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.test.ts
@@ -77,10 +77,23 @@ describe("customizeDisplayFormula", () => {
     expect(customizeDisplayFormula("a = b")).toEqual("a == b")
     expect(customizeDisplayFormula("a = b = c")).toEqual("a == b == c")
   })
-  it("doesn't replace unequality operator", () => {
+  it("doesn't replace double equality operator", () => {
+    expect(customizeDisplayFormula("a == 1")).toEqual("a == 1")
+    expect(customizeDisplayFormula("a == b")).toEqual("a == b")
+    expect(customizeDisplayFormula("a == b = c = d == e")).toEqual("a == b == c == d == e")
+  })
+  it("doesn't replace inequality operators", () => {
     expect(customizeDisplayFormula("a != 1")).toEqual("a != 1")
     expect(customizeDisplayFormula("a != b")).toEqual("a != b")
     expect(customizeDisplayFormula("a != b = c = d != e")).toEqual("a != b == c == d != e")
+
+    expect(customizeDisplayFormula("a <= 1")).toEqual("a <= 1")
+    expect(customizeDisplayFormula("a <= b")).toEqual("a <= b")
+    expect(customizeDisplayFormula("a <= b = c = d <= e")).toEqual("a <= b == c == d <= e")
+
+    expect(customizeDisplayFormula("a >= 1")).toEqual("a >= 1")
+    expect(customizeDisplayFormula("a >= b")).toEqual("a >= b")
+    expect(customizeDisplayFormula("a >= b = c = d >= e")).toEqual("a >= b == c == d >= e")
   })
 })
 

--- a/v3/src/models/formula/utils/canonicalization-utils.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.ts
@@ -31,7 +31,9 @@ export const makeDisplayNamesSafe = (formula: string) => {
 export const customizeDisplayFormula = (formula: string) => {
   // Over time, this function might grow significantly and require more advanced parsing of the formula.
   // Replace all the assignment operators with equality operators, as CODAP v2 uses a single "=" for equality check.
-  return formula.replace(/(?<!!)=(?!=)/g, "==")
+  // Regular expression developed with the help of ChatGPT.
+  // Matches `=` when not preceded by '<', '>', '!', or '=` and not followed by `=`, preserving white space.
+  return formula.replace(/(?<!<|>|!|=)(\s*)=(\s*)(?!=)/g, "$1==$2")
 }
 
 export const preprocessDisplayFormula = (formula: string) => customizeDisplayFormula(makeDisplayNamesSafe(formula))


### PR DESCRIPTION
[[PT-188009575]](https://www.pivotaltracker.com/story/show/188009575)

We preprocess expressions to convert `=` to `==`, but the regular expression used to do so needed to be more restrictive.