### PR TITLE
Fix Flaky Cypress Test for Slider Component

### DIFF
--- a/v3/cypress/support/elements/slider-tile.ts
+++ b/v3/cypress/support/elements/slider-tile.ts
@@ -2,7 +2,7 @@ import { ComponentElements as c } from "./component-elements"
 
 export const SliderTileElements = {
   getSliderTile(index = 0) {
-    return c.getComponentTile("slider", index)
+    return cy.get(`[data-testid="codap-slider"]`).eq(index)
   },
   getVariableName(index = 0) {
     return this.getSliderTile(index).find("[data-testid=slider-variable-name-text]")


### PR DESCRIPTION
### Pull Request: Fix Flaky Cypress Test for Slider Component
[PT-188031351](https://www.pivotaltracker.com/story/show/188031351)

**Description:**
This PR addresses a flaky Cypress test related to the slider component. The test intermittently failed due to assertion errors caused by the slider component's shadow rendering with an effective width of 0. Changes include:

1. **Check Existence Before Visibility:** Ensuring the component exists in the DOM before checking visibility.
2. **Check Internal Elements:** Verifying visibility of internal elements within the slider component.

Please review and provide feedback. Thank you!