### PR TITLE
chore: enable `no-constant-binary-expression` lint rule; fix offending code

### DIFF
--- a/v3/.eslintrc.cjs
+++ b/v3/.eslintrc.cjs
@@ -71,6 +71,7 @@ module.exports = {
     "keyword-spacing": ["warn"],
     "max-len": ["warn", { code: 120, ignoreUrls: true }],
     "no-bitwise": "error",
+    "no-constant-binary-expression": "error",
     "no-debugger": "off",
     "no-duplicate-imports": "error",
     "no-sequences": "error",

--- a/v3/src/components/case-table/attribute-menu/edit-attribute-properties-modal.tsx
+++ b/v3/src/components/case-table/attribute-menu/edit-attribute-properties-modal.tsx
@@ -53,13 +53,13 @@ export const EditAttributePropertiesModal = ({ attributeId, isOpen, onClose }: I
           )
           attribute.setName(newName)
         }
-        if (description !== attribute.description ?? "") {
+        if (description !== (attribute.description ?? "")) {
           attribute.setDescription(description || undefined)
         }
-        if (units !== attribute.units ?? "") {
+        if (units !== (attribute.units ?? "")) {
           attribute.setUnits(units || undefined)
         }
-        if (userType !== attribute.userType ?? "none") {
+        if (userType !== (attribute.userType ?? "none")) {
           attribute.setUserType(userType === "none" ? undefined : userType)
         }
         if (precision !== `${attribute?.precision ?? ""}`) {

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
@@ -116,7 +116,7 @@ export const NormalCurveAdornmentComponent = observer(
       const labelSelection = select(labelRef.current)
       const labelCoords = measure.labelCoords
       const lineHeight = 20
-      const topOffset = lineHeight * adornmentsStore?.getLabelLinesAboveAdornment(model) ?? 0
+      const topOffset = lineHeight * (adornmentsStore?.getLabelLinesAboveAdornment(model) ?? 0)
       const labelLeft = labelCoords
         ? labelCoords.x / cellCounts.x
         : isVertical.current

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-component.tsx
@@ -84,7 +84,7 @@ export const StandardErrorAdornmentComponent = observer(
       const labelSelection = select(labelRef.current)
       const labelCoords = measure.labelCoords
       const lineHeight = 20
-      const topOffset = lineHeight * adornmentsStore?.getLabelLinesAboveAdornment(model, isGaussianFit) ?? 0
+      const topOffset = lineHeight * (adornmentsStore?.getLabelLinesAboveAdornment(model, isGaussianFit) ?? 0)
       const labelLeft = labelCoords
         ? labelCoords.x / cellCounts.x
         : isVertical.current

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -64,7 +64,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       const lineHeight = 20
       // We have to pass isGaussianFit to getLabelLinesAboveAdornment because the Gaussian fit is a special case where
       // if there is a gaussianFit (not just a normal curve), we need to add an extra line for the adornment title.
-      const topOffset = lineHeight * adornmentsStore?.getLabelLinesAboveAdornment(model, isGaussianFit) ?? 0
+      const topOffset = lineHeight * (adornmentsStore?.getLabelLinesAboveAdornment(model, isGaussianFit) ?? 0)
       let labelLeft = labelCoords
         ? labelCoords.x / cellCounts.x
         : isVertical.current


### PR DESCRIPTION
The [TypeScript 5.6 beta release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6-beta/#disallowed-nullish-and-truthy-checks) describes an upcoming feature of TypeScript patterned after a [recently added ESLint](https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/) rule that catches a surprising number of bugs. This PR enables the new lint rule and fixes the code that was found by it. All instances in the v3 code related to confusion around precedence of the `??` operator, which requires additional parentheses to fix.