### PR TITLE
188050066 v3 Collaborative Premade Tables

### DIFF
--- a/v3/src/data-interactive/data-interactive-type-utils.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.ts
@@ -106,13 +106,13 @@ export function getCaseRequestResultValues(c: ICase, dataContext: IDataSet): DIG
 
 export function convertAttributeToV2(attribute: IAttribute, dataContext?: IDataSet): ICodapV2AttributeV3 {
   const metadata = dataContext && getSharedCaseMetadataFromDataset(dataContext)
-  const { name, type, title, description, deleteable, editable, id, precision } = attribute
+  const { cid, name, type, title, description, deleteable, editable, id, precision } = attribute
   const v2Id = toV2Id(id)
   return {
     name,
     type,
     title,
-    cid: id,
+    cid,
     // colorMap
     // defaultMin: self.defaultMin, // TODO Where should this come from?
     // defaultMax: self.defaultMax, // TODO Where should this come from?

--- a/v3/src/data-interactive/handlers/attribute-handler.test.ts
+++ b/v3/src/data-interactive/handlers/attribute-handler.test.ts
@@ -54,6 +54,7 @@ describe("DataInteractive AttributeHandler", () => {
 
   it("update works as expected", () => {
     const attribute = Attribute.create({ name: "test" })
+    const cid = "new cid"
     const name = "new name"
     const title = "new title"
     const description = "new description"
@@ -63,18 +64,28 @@ describe("DataInteractive AttributeHandler", () => {
     const type = "qualitative"
     const precision = 10
     const result = handler.update?.({ attribute },
-      { name, title, description, unit, formula, editable, type, precision })
+      { cid, name, title, description, unit, formula, editable, type, precision })
     expect(result?.success).toBe(true)
     const values = result?.values as DIResultAttributes
     const resultAttr = values.attrs?.[0]
+    expect(resultAttr?.cid).toBe(cid)
+    expect(attribute.cid).toBe(cid)
     expect(resultAttr?.name).toBe(name)
+    expect(attribute.name).toBe(name)
     expect(resultAttr?.title).toBe(title)
+    expect(attribute.title).toBe(title)
     expect(resultAttr?.description).toBe(description)
+    expect(attribute.description).toBe(description)
     expect(resultAttr?.unit).toBe(unit)
+    expect(attribute.units).toBe(unit)
     expect(resultAttr?.formula).toBe(formula)
+    expect(attribute.formula?.display).toBe(formula)
     expect(resultAttr?.editable).toBe(editable)
+    expect(attribute.editable).toBe(editable)
     expect(resultAttr?.type).toBe(type)
+    expect(attribute.type).toBe(type)
     expect(resultAttr?.precision).toBe(precision)
+    expect(attribute.precision).toBe(precision)
 
     const result2 = handler.update?.({ attribute }, { type: "fake type" })
     const values2 = result2?.values as DIResultAttributes

--- a/v3/src/data-interactive/handlers/di-handler-utils.ts
+++ b/v3/src/data-interactive/handlers/di-handler-utils.ts
@@ -36,6 +36,7 @@ export function createCollection(v2collection: DICollection, dataContext: IDataS
 }
 
 export function updateAttribute(attribute: IAttribute, value: DIAttribute, dataContext?: IDataSet) {
+  if (value?.cid != null) attribute.setCid(value.cid)
   if (value?.description != null) attribute.setDescription(value.description)
   if (value?.editable != null) attribute.setEditable(!!value.editable)
   if (value?.formula != null) attribute.setDisplayExpression(value.formula)

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -72,6 +72,7 @@ export function isAttributeType(type?: string | null): type is AttributeType {
 
 export const Attribute = V2Model.named("Attribute").props({
   id: typeV3Id(kAttrIdPrefix),
+  _cid: types.maybe(types.string), // cid was a v2 property that is used by some plugins (Collaborative)
   clientKey: "",
   sourceID: types.maybe(types.string),
   description: types.maybe(types.string),
@@ -157,6 +158,9 @@ export const Attribute = V2Model.named("Attribute").props({
   },
   get shouldSerializeValues() {
     return !this.hasFormula
+  },
+  get cid() {
+    return self._cid ?? self.id
   }
 }))
 .actions(self => ({
@@ -165,6 +169,9 @@ export const Attribute = V2Model.named("Attribute").props({
     self.getEmptyCount.invalidate()
     self.getNumericCount.invalidate()
     self.getStrictColorCount.invalidate()
+  },
+  setCid(cid?: string) {
+    self._cid = cid
   }
 }))
 .actions(self => ({

--- a/v3/src/models/data/v2-model.test.ts
+++ b/v3/src/models/data/v2-model.test.ts
@@ -65,12 +65,6 @@ describe("V2Model", () => {
       title: "title"
     }
     expect(isV2ModelSnapshot(m)).toBe(true)
-    m = {
-      id: 1,
-      name: "name",
-      title: "title"
-    } as V2ModelStorage
-    expect(isV2ModelSnapshot(m)).toBe(true)
   })
 
   it("can convert v2 name/title to v3 title", () => {

--- a/v3/src/models/data/v2-model.test.ts
+++ b/v3/src/models/data/v2-model.test.ts
@@ -67,7 +67,6 @@ describe("V2Model", () => {
     expect(isV2ModelSnapshot(m)).toBe(true)
     m = {
       id: 1,
-      cid: "cid",
       name: "name",
       title: "title"
     } as V2ModelStorage
@@ -92,7 +91,6 @@ describe("V2Model", () => {
     v2m = {
       id: 1,
       guid: 1,
-      cid: "cid",
       name: "name",
       title: "title"
     }

--- a/v3/src/models/data/v2-model.ts
+++ b/v3/src/models/data/v2-model.ts
@@ -35,13 +35,12 @@ export interface IV2ModelSnapshot extends SnapshotIn<typeof V2Model> {}
 export interface V2ModelStorage {
   id: number
   guid: number
-  cid?: string | null
   name: string
   title?: string | null
 }
 
 export function isV2ModelSnapshot(snap?: any): snap is IV2ModelSnapshot {
-  return snap?.guid != null || snap?.cid != null
+  return snap?.guid != null
 }
 
 export function v2NameTitleToV3Title(name: string, v2Title?: string | null) {

--- a/v3/src/test/v2/mammals.codap
+++ b/v3/src/test/v2/mammals.codap
@@ -239,6 +239,7 @@
               "colormap": {},
               "editable": false,
               "guid": 4,
+              "cid": "MammalCID",
               "precision": 2,
               "unit": null
             },

--- a/v3/src/v2/codap-v2-document.ts
+++ b/v3/src/v2/codap-v2-document.ts
@@ -137,7 +137,7 @@ export class CodapV2Document {
   registerAttributes(data: IDataSet, caseMetadata: ISharedCaseMetadata, attributes: ICodapV2Attribute[]) {
     attributes.forEach(v2Attr => {
       const {
-        guid, description: v2Description, name = "", title: v2Title, type: v2Type, formula: v2Formula,
+        cid: _cid, guid, description: v2Description, name = "", title: v2Title, type: v2Type, formula: v2Formula,
         editable: v2Editable, unit: v2Unit, precision: v2Precision
       } = v2Attr
       const _title = v2NameTitleToV3Title(name, v2Title)
@@ -149,7 +149,7 @@ export class CodapV2Document {
       const units = v2Unit ?? undefined
       this.guidMap.set(guid, { type: "DG.Attribute", object: v2Attr })
       const attribute = data.addAttribute({
-        id: toV3AttrId(guid), name, description, formula, _title, userType, editable, units, precision
+        id: toV3AttrId(guid), _cid, name, description, formula, _title, userType, editable, units, precision
       })
       if (attribute) {
         this.v3AttrMap.set(guid, attribute)

--- a/v3/src/v2/codap-v2-import.test.ts
+++ b/v3/src/v2/codap-v2-import.test.ts
@@ -76,6 +76,7 @@ describe(`V2 "mammals.codap"`, () => {
     expect(data.collections[0].id).toBe(`COLL${collection.guid}`)
     expect(data.attributes.length).toBe(9)
     expect(data.attributes[0].id).toBe(`ATTR${collection.attrs[0].guid}`)
+    expect(data.attributes[0].cid).toBe(collection.attrs[0].cid)
     expect(data.items.length).toBe(27)
     expect(data.items[0].__id__).toBe(`CASE${collection.cases[0].guid}`)
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188050066

This PR fixes a bug where sharing premade tables using the Collaborative plugin would result in tables losing all data. This was the result of the `cid` property of attributes not being implemented in v3. Collaborative relies on matching `cids`to connect attributes between different users, setting the `cid` of attributes with matching `names` when first connecting. V3 was not updating the `cid` of these attributes properly, so the attributes were later not being matched, and Collaborative was ruthlessly deleting them as a result.

The fix is to better support attribute `cids` in v3. The id is still used as the `cid` in most cases, unless:
- A plugin requests that a `cid` be set.
- A `cid` is set in a v2 document that is imported.