### PR TITLE
chore: simplify ToolShelf by moving undo/redo strings into component registration

### DIFF
--- a/v3/src/components/calculator/calculator-registration.ts
+++ b/v3/src/components/calculator/calculator-registration.ts
@@ -35,7 +35,9 @@ registerTileComponentInfo({
   shelf: {
     position: 5,
     labelKey: "DG.ToolButtonData.calcButton.title",
-    hintKey: "DG.ToolButtonData.calcButton.toolTip"
+    hintKey: "DG.ToolButtonData.calcButton.toolTip",
+    undoStringKey: "DG.Undo.toggleComponent.add.calcView",
+    redoStringKey: "DG.Redo.toggleComponent.add.calcView"
   },
   isFixedWidth: true,
   isFixedHeight: true,

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -42,7 +42,9 @@ registerTileComponentInfo({
     ButtonComponent: CaseTableToolShelfButton,
     position: 1,
     labelKey: "DG.ToolButtonData.tableButton.title",
-    hintKey: "DG.ToolButtonData.tableButton.toolTip"
+    hintKey: "DG.ToolButtonData.tableButton.toolTip",
+    undoStringKey: "V3.Undo.caseTable.create",
+    redoStringKey: "V3.Redo.caseTable.create"
   },
   defaultWidth: 580,
   defaultHeight: 200

--- a/v3/src/components/graph/graph-registration.ts
+++ b/v3/src/components/graph/graph-registration.ts
@@ -55,7 +55,9 @@ registerTileComponentInfo({
   shelf: {
     position: 2,
     labelKey: "DG.ToolButtonData.graphButton.title",
-    hintKey: "DG.ToolButtonData.graphButton.toolTip"
+    hintKey: "DG.ToolButtonData.graphButton.toolTip",
+    undoStringKey: "DG.Undo.graphComponent.create",
+    redoStringKey: "DG.Redo.graphComponent.create"
   },
   defaultWidth: 300,
   defaultHeight: 300

--- a/v3/src/components/map/map-registration.ts
+++ b/v3/src/components/map/map-registration.ts
@@ -50,7 +50,9 @@ registerTileComponentInfo({
   shelf: {
     position: 3,
     labelKey: "DG.ToolButtonData.mapButton.title",
-    hintKey: "DG.ToolButtonData.mapButton.toolTip"
+    hintKey: "DG.ToolButtonData.mapButton.toolTip",
+    undoStringKey: "DG.Undo.map.create",
+    redoStringKey: "DG.Redo.map.create"
   },
   defaultWidth: kDefaultMapWidth,
   defaultHeight: kDefaultMapHeight

--- a/v3/src/components/slider/slider-registration.ts
+++ b/v3/src/components/slider/slider-registration.ts
@@ -57,7 +57,9 @@ registerTileComponentInfo({
   shelf: {
     position: 4,
     labelKey: "DG.ToolButtonData.sliderButton.title",
-    hintKey: "DG.ToolButtonData.sliderButton.toolTip"
+    hintKey: "DG.ToolButtonData.sliderButton.toolTip",
+    undoStringKey: "DG.Undo.sliderComponent.create",
+    redoStringKey: "DG.Redo.sliderComponent.create"
   },
   defaultWidth: 300,
   isFixedHeight: true,

--- a/v3/src/components/text/text-registration.ts
+++ b/v3/src/components/text/text-registration.ts
@@ -22,7 +22,9 @@ registerTileComponentInfo({
   shelf: {
     position: 6,
     labelKey: "DG.ToolButtonData.textButton.title",
-    hintKey: "DG.ToolButtonData.textButton.toolTip"
+    hintKey: "DG.ToolButtonData.textButton.toolTip",
+    undoStringKey: "DG.Undo.textComponent.create",
+    redoStringKey: "DG.Redo.textComponent.create"
   },
   defaultWidth: 300,
   defaultHeight: 300

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -24,6 +24,9 @@ import "./tool-shelf.scss"
 
 // Type for components known to have shelf properties
 type IShelfTileComponentInfo = SetRequired<ITileComponentInfo, "shelf">
+export function isShelfTileComponent(info?: ITileComponentInfo): info is IShelfTileComponentInfo {
+  return !!info && "shelf" in info && info.shelf != null
+}
 
 interface IRightButtonEntry {
   className?: string
@@ -107,18 +110,12 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
   }
 
   const keys = getTileComponentKeys()
-  const tileComponentInfo = keys.map(key => getTileComponentInfo(key))
-    .filter(info => info?.shelf != null) as IShelfTileComponentInfo[]
+  const tileComponentInfo = keys.map(key => getTileComponentInfo(key)).filter(info => isShelfTileComponent(info))
   tileComponentInfo.sort((a, b) => a.shelf.position - b.shelf.position)
 
   function handleTileButtonClick(tileType: string) {
-    const undoRedoStringKeysMap: Record<string, [string, string]> = {
-      Calculator: ["DG.Undo.toggleComponent.add.calcView", "DG.Redo.toggleComponent.add.calcView"],
-      CodapSlider: ["DG.Undo.sliderComponent.create", "DG.Redo.sliderComponent.create"],
-      Graph: ["DG.Undo.graphComponent.create", "DG.Redo.graphComponent.create"],
-      Map: ["DG.Undo.map.create", "DG.Redo.map.create"]
-    }
-    const [undoStringKey = "", redoStringKey = ""] = undoRedoStringKeysMap[tileType] || []
+    const tileInfo = getTileComponentInfo(tileType)
+    const { undoStringKey = "", redoStringKey = "" } = tileInfo?.shelf || {}
     document?.content?.applyModelChange(() => {
       document?.content?.createOrShowTile?.(tileType, { animateCreation: true })
     }, { undoStringKey, redoStringKey, log: `Create ${tileType} tile` })

--- a/v3/src/models/tiles/tile-component-info.ts
+++ b/v3/src/models/tiles/tile-component-info.ts
@@ -7,6 +7,8 @@ export interface IToolShelfOptions {
   ButtonComponent?: React.FC<IToolShelfTileButtonProps>
   labelKey: string
   hintKey: string
+  undoStringKey: string
+  redoStringKey: string
 }
 
 export interface ITileComponentInfo {


### PR DESCRIPTION
Moving the undo/redo strings into the component registration allows us to eliminate component-specific code in the `ToolShelf` component.

Note: This PR is rooted on #1389, which should be merged first.