### PR TITLE
187178550 v3 Improve Item Sort

### DIFF
--- a/v3/src/data-interactive/handlers/item-search-handler.ts
+++ b/v3/src/data-interactive/handlers/item-search-handler.ts
@@ -55,12 +55,7 @@ export const diItemSearchHandler: DIHandler = {
         })
       } else {
         // Otherwise, move all the items to the beginning or end
-        const items = itemIds.map(id => dataContext.getItem(id)) as ICase[]
-        dataContext.removeCases(itemIds)
-        const options = itemOrder === "first" && dataContext.itemIds.length > 0
-          ? { before: dataContext.itemIds[0] }
-          : undefined
-        dataContext.addCases(items, options)
+        dataContext.moveItems(itemIds, itemOrder)
       }
       dataContext.validateCases()
     })

--- a/v3/src/data-interactive/handlers/item-search-handler.ts
+++ b/v3/src/data-interactive/handlers/item-search-handler.ts
@@ -55,7 +55,11 @@ export const diItemSearchHandler: DIHandler = {
         })
       } else {
         // Otherwise, move all the items to the beginning or end
-        dataContext.moveItems(itemIds, itemOrder)
+        const movingItemIds = new Set(itemIds)
+        const before = itemOrder === "first"
+          ? dataContext.itemIds.find(id => !movingItemIds.has(id))
+          : undefined
+        dataContext.moveItems(itemIds, { before })
       }
       dataContext.validateCases()
     })

--- a/v3/src/models/data/data-set-types.ts
+++ b/v3/src/models/data/data-set-types.ts
@@ -42,6 +42,13 @@ export interface IAddCasesOptions {
   canonicalize?: boolean;
 }
 
+export interface IMoveItemsOptions {
+  // id of item before/after which to move items
+  // if not specified, items are moved to end
+  before?: string;
+  after?: string;
+}
+
 export interface IAddAttributeOptions {
   // id of attribute before which to insert new cases
   // if not specified, new attribute is appended

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -941,7 +941,6 @@ export const DataSet = V2Model.named("DataSet").props({
         }
       },
 
-      // If order is "first", items will be moved to the front. Otherwise, they are moved to the end.
       moveItems(itemIds: string[], options?: IMoveItemsOptions) {
         const indices = itemIds.map(itemId => self.getItemIndex(itemId)).filter(index => index != null)
           .sort((a: number, b: number) => b - a) // Reverse order

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -923,7 +923,7 @@ export const DataSet = V2Model.named("DataSet").props({
         const items = caseIDs.map(id => ({ id, index: self.getItemIndex(id) }))
           .filter(info => info.index != null) as { id: string, index: number }[]
         items.sort((a, b) => b.index - a.index)
-        const firstIndex = items[items.length - 1].index
+        const firstIndex = items[items.length - 1]?.index ?? -1
         items.forEach(({ id: caseID, index }) => {
           if (index != null) {
             self.itemIds.splice(index, 1)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187178550

This PR improves the efficiency of the `notify itemSearch itemOrder` API request by adding a new `dataset.moveItems` action that rearranges the order of items without removing them and then re-adding them.

As a step towards this solution, I also improved the efficiency of `dataset.removeCases`, changing it from O(n^2) to O(n*log(n)). Even though the API request no longer uses this action, it still seemed worth keeping the improvement for other cases where it's used.

I tested all three variants with tables shared between three users with approximately 5000 items. Here are the results:
- Original (less efficient `removeCases`) - 1200-1500 ms
- More efficient `removeCases` - 850-1000 ms
- `moveItems` - 650-800 ms