### PR TITLE
187178550 v3 DI Delete Improvements

### DIFF
--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="cypress" />
 import { CfmElements as cfm } from "../support/elements/cfm"
 import { ComponentElements as c } from "../support/elements/component-elements"
 import { SliderTileElements as slider } from "../support/elements/slider-tile"

--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -1,3 +1,4 @@
+/// <reference types="cypress" />
 import { CfmElements as cfm } from "../support/elements/cfm"
 import { ComponentElements as c } from "../support/elements/component-elements"
 import { SliderTileElements as slider } from "../support/elements/slider-tile"
@@ -253,6 +254,12 @@ context("codap plugins", () => {
     table.getGridCell(2, 2).dblclick()
     table.getGridCell(2, 2).find("input").type("test{enter}")
     webView.confirmAPITesterResponseContains(/"operation":\s"updateCases/)
+    webView.clearAPITesterResponses()
+
+    cy.log("Broadcast deleteCases notifications")
+    table.openIndexMenuForRow(2)
+    table.deleteCase()
+    webView.confirmAPITesterResponseContains(/"operation":\s"deleteCases/)
     webView.clearAPITesterResponses()
 
     cy.log("Broadcast updateCollection notifications")

--- a/v3/src/components/case-table/index-menu-list.tsx
+++ b/v3/src/components/case-table/index-menu-list.tsx
@@ -4,6 +4,7 @@ import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { removeCasesWithCustomUndoRedo } from "../../models/data/data-set-undo"
 import { t } from "../../utilities/translation/translate"
 import { InsertCasesModal } from "./insert-cases-modal"
+import { isItemEditable } from "../../utilities/plugin-utils"
 
 interface IProps {
   caseId: string
@@ -14,7 +15,11 @@ export const IndexMenuList = ({caseId, index}: IProps) => {
   const toast = useToast()
   const data = useDataSetContext()
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const deleteCasesItemText = data?.selection.size === 1
+  const deletableSelectedItems = data?.selection
+    ? Array.from(data.selection).filter(itemId => isItemEditable(data, itemId))
+    : []
+  const disableDeleteCases = deletableSelectedItems.length < 1
+  const deleteCasesItemText = deletableSelectedItems.length === 1
                                 ? t("DG.CaseTable.indexMenu.deleteCase")
                                 : t("DG.CaseTable.indexMenu.deleteCases")
 
@@ -38,7 +43,7 @@ export const IndexMenuList = ({caseId, index}: IProps) => {
 
   const handleDeleteCases = () => {
     if (data?.selection.size) {
-      removeCasesWithCustomUndoRedo(data, Array.from(data.selection))
+      removeCasesWithCustomUndoRedo(data, deletableSelectedItems)
     }
   }
 
@@ -50,7 +55,7 @@ export const IndexMenuList = ({caseId, index}: IProps) => {
         </MenuItem>
         <MenuItem onClick={handleInsertCase}>{t("DG.CaseTable.indexMenu.insertCase")}</MenuItem>
         <MenuItem onClick={handleInsertCases}>{t("DG.CaseTable.indexMenu.insertCases")}</MenuItem>
-        <MenuItem onClick={handleDeleteCases}>{deleteCasesItemText}</MenuItem>
+        <MenuItem isDisabled={disableDeleteCases} onClick={handleDeleteCases}>{deleteCasesItemText}</MenuItem>
       </MenuList>
       <InsertCasesModal caseId={caseId} isOpen={isOpen} onClose={onClose}/>
     </>

--- a/v3/src/components/case-table/index-menu-list.tsx
+++ b/v3/src/components/case-table/index-menu-list.tsx
@@ -18,7 +18,7 @@ export const IndexMenuList = ({caseId, index}: IProps) => {
   const deletableSelectedItems = data?.selection
     ? Array.from(data.selection).filter(itemId => isItemEditable(data, itemId))
     : []
-  const disableDeleteCases = deletableSelectedItems.length < 1
+  const disableEdits = deletableSelectedItems.length < 1
   const deleteCasesItemText = deletableSelectedItems.length === 1
                                 ? t("DG.CaseTable.indexMenu.deleteCase")
                                 : t("DG.CaseTable.indexMenu.deleteCases")
@@ -53,9 +53,15 @@ export const IndexMenuList = ({caseId, index}: IProps) => {
         <MenuItem onClick={()=>handleMenuItemClick("Move Data Entry Row")}>
           {t("DG.CaseTable.indexMenu.moveEntryRow")}
         </MenuItem>
-        <MenuItem onClick={handleInsertCase}>{t("DG.CaseTable.indexMenu.insertCase")}</MenuItem>
-        <MenuItem onClick={handleInsertCases}>{t("DG.CaseTable.indexMenu.insertCases")}</MenuItem>
-        <MenuItem isDisabled={disableDeleteCases} onClick={handleDeleteCases}>{deleteCasesItemText}</MenuItem>
+        <MenuItem isDisabled={disableEdits} onClick={handleInsertCase}>
+          {t("DG.CaseTable.indexMenu.insertCase")}
+        </MenuItem>
+        <MenuItem isDisabled={disableEdits} onClick={handleInsertCases}>
+          {t("DG.CaseTable.indexMenu.insertCases")}
+        </MenuItem>
+        <MenuItem isDisabled={disableEdits} onClick={handleDeleteCases}>
+          {deleteCasesItemText}
+        </MenuItem>
       </MenuList>
       <InsertCasesModal caseId={caseId} isOpen={isOpen} onClose={onClose}/>
     </>

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -80,6 +80,7 @@ export interface DIGetCaseResult {
 export interface DIInteractiveFrame {
   allowEmptyAttributeDeletion?: boolean
   cannotClose?: boolean
+  codapVersion?: string
   dimensions?: {
     height?: number
     width?: number

--- a/v3/src/data-interactive/handlers/handler-functions.ts
+++ b/v3/src/data-interactive/handlers/handler-functions.ts
@@ -23,16 +23,17 @@ export function deleteCaseBy(resources: DIResources, aCase?: ICase) {
   return { success: true as const, values: [toV2Id(aCase.__id__)] }
 }
 
-export function deleteItem(resources: DIResources, item?: ICase) {
+export function deleteItem(resources: DIResources, item?: ICase | string[]) {
   const { dataContext } = resources
   if (!dataContext) return dataContextNotFoundResult
   if (!item) return itemNotFoundResult
 
+  const itemIds = Array.isArray(item) ? item : [item.__id__]
   dataContext.applyModelChange(() => {
-    dataContext.removeCases([item.__id__])
+    dataContext.removeCases(itemIds)
   })
 
-  return { success: true as const, values: [toV2Id(item.__id__)] }
+  return { success: true as const, values: itemIds.map(itemId => toV2Id(itemId)) }
 }
 
 export function getCaseBy(resources: DIResources, aCase?: ICase) {

--- a/v3/src/data-interactive/handlers/interactive-frame-handler.ts
+++ b/v3/src/data-interactive/handlers/interactive-frame-handler.ts
@@ -20,7 +20,7 @@ export const diInteractiveFrameHandler: DIHandler = {
     } = webViewContent ?? {}
     const values: DIInteractiveFrame = {
       allowEmptyAttributeDeletion,
-      codapVersion: "v3", // TODO Correct version
+      codapVersion: appState.getVersion(),
       dimensions,
       externalUndoAvailable: true, // TODO Fix hard coded value
       id: toV2Id(interactiveFrame.id),

--- a/v3/src/data-interactive/handlers/interactive-frame-handler.ts
+++ b/v3/src/data-interactive/handlers/interactive-frame-handler.ts
@@ -20,6 +20,7 @@ export const diInteractiveFrameHandler: DIHandler = {
     } = webViewContent ?? {}
     const values: DIInteractiveFrame = {
       allowEmptyAttributeDeletion,
+      codapVersion: "v3", // TODO Correct version
       dimensions,
       externalUndoAvailable: true, // TODO Fix hard coded value
       id: toV2Id(interactiveFrame.id),

--- a/v3/src/data-interactive/handlers/item-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-handler.test.ts
@@ -55,6 +55,13 @@ describe("DataInteractive ItemHandler", () => {
     const values = result.values as number[]
     expect(values[0]).toBe(toV2Id(itemId))
     expect(dataContext.getItem(itemId)).toBeUndefined()
+
+    const item2Id = dataContext.getItemAtIndex(2)!.__id__
+    const item3Id = dataContext.getItemAtIndex(3)!.__id__
+    const resultMultiple = handler.delete!({ dataContext }, [{ id: toV2Id(item2Id) }, { id: toV2Id(item3Id) }])
+    expect(resultMultiple?.success).toBe(true)
+    expect(dataContext.getItem(item2Id)).toBeUndefined()
+    expect(dataContext.getItem(item3Id)).toBeUndefined()
   })
 
   it("get works", () => {

--- a/v3/src/data-interactive/handlers/item-handler.ts
+++ b/v3/src/data-interactive/handlers/item-handler.ts
@@ -1,7 +1,7 @@
 import { createCasesNotification } from "../../models/data/data-set-notifications"
 import { toV2Id, toV3ItemId } from "../../utilities/codap-utils"
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIHandler, DIItem, DIItemValues, DIResources, DIValues } from "../data-interactive-types"
+import { DIHandler, DIItem, DIItemValues, DINewCase, DIResources, DIValues } from "../data-interactive-types"
 import { deleteItem, getItem, updateCaseBy, updateCasesBy } from "./handler-functions"
 import { dataContextNotFoundResult, valuesRequiredResult } from "./di-results"
 
@@ -76,10 +76,16 @@ export const diItemHandler: DIHandler = {
     }
   },
 
-  delete(resources: DIResources) {
+  delete(resources: DIResources, values?: DIValues) {
     const { item } = resources
 
-    return deleteItem(resources, item)
+    let itemIds: string[] | undefined
+    if (!item && values && Array.isArray(values)) {
+      itemIds = (values as DINewCase[]).map(aCase => aCase.id != null && toV3ItemId(aCase.id))
+        .filter(id => !!id) as string[]
+    }
+
+    return deleteItem(resources, item ?? itemIds)
   },
 
   get(resources: DIResources) {

--- a/v3/src/lib/handle-cfm-event.ts
+++ b/v3/src/lib/handle-cfm-event.ts
@@ -21,6 +21,7 @@ export function handleCFMEvent(cfmClient: CloudFileManagerClient, event: CloudFi
         appBuildNum: build.buildNumber
       })
       wrapCfmCallback(() => cfmClient._ui.setMenuBarInfo(`v${pkg.version} (${build.buildNumber})`))
+      appState.setVersion(pkg.version)
       break
     // case "requiresUserInteraction":
     //   break

--- a/v3/src/models/app-state.ts
+++ b/v3/src/models/app-state.ts
@@ -30,6 +30,8 @@ class AppState {
   @observable
   private isPerformanceEnabled = true
 
+  private version = ""
+
   constructor() {
     this.currentDocument = createCodapDocument()
 
@@ -99,6 +101,14 @@ class AppState {
   @action
   disablePerformance() {
     this.isPerformanceEnabled = false
+  }
+
+  setVersion(version: string) {
+    this.version = version
+  }
+
+  getVersion() {
+    return this.version
   }
 
   @computed

--- a/v3/src/models/data/data-set-notifications.ts
+++ b/v3/src/models/data/data-set-notifications.ts
@@ -123,6 +123,14 @@ export function updateCasesNotification(data: IDataSet, cases?: ICase[]) {
   return notification("updateCases", result, data)
 }
 
+export function deleteCasesNotification(data: IDataSet, cases?: ICase[]) {
+  const result = {
+    success: true,
+    cases: cases?.map(c => convertCaseToV2FullCase(c, data))
+  }
+  return notification("deleteCases", result, data)
+}
+
 // selectCasesNotification returns a function that will later be called to determine if the selection
 // actually changed and a notification is necessary to broadcast
 export function selectCasesNotification(dataset: IDataSet, extend?: boolean) {

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -149,6 +149,8 @@ export const DataSet = V2Model.named("DataSet").props({
   selectionChanges: 0,
   // map from case ID to the CaseGroup it represents
   caseInfoMap: new Map<string, CaseInfo>(),
+  // map from item ID to the child case containing it
+  itemIdChildCaseMap: new Map<string, CaseInfo>(),
   transactionCount: 0,
   // the id of the interactive frame handling this dataset
   // used by the Collaborative plugin
@@ -474,6 +476,10 @@ export const DataSet = V2Model.named("DataSet").props({
         collection.completeCaseGroups(parentCaseGroups)
         // update the caseGroupMap
         collection.caseGroups.forEach(group => self.caseInfoMap.set(group.groupedCase.__id__, group))
+      })
+      self.itemIdChildCaseMap.clear()
+      self.childCollection.caseGroups.forEach(caseGroup => {
+        self.itemIdChildCaseMap.set(caseGroup.childItemIds[0], caseGroup)
       })
       self.setValidCases()
     }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187178550

This PR makes several improvements related to deleting items.
- Deleting items now broadcasts a notification like it does in v2. The lack of notifications was causing a bug in the Collaborative plugin.
  - In order to include the deleted cases in the notification, a new volatile property has been added, `DataSet.itemIdChildCaseMap`. This links each item to the child case that contains it, and is computed in `validateCases`.
- It's now possible to batch items in a `delete item` API request. This is much more efficient than sending a separate API request for each item to be deleted. An API request that deletes multiple items looks like this:
```
{
  "action": "delete",
  "resource": "dataContext[Mammals].item",
  "values": [
    { "id": 1 },
    { "id": 2 },
    ...
  ]
}
```
- The delete case(s) option is now disabled in the case menu (comes up when you click on the index cell) when the plugin prevents the case from being edited. Now this menu item is consistent with the delete all/selected/unselected cases menu items in the trash menu, and protects other users' data in shared tables.
  - I also disabled the insert case(s) options here at the request of Dan.