### PR TITLE
Graph responds to change in attribute's collection

### DIFF
--- a/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-table/attribute-menu/attribute-menu-list.tsx
@@ -178,7 +178,6 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
             undoStringKey: "DG.Undo.caseTable.deleteAttribute",
             redoStringKey: "DG.Redo.caseTable.deleteAttribute"
           })
-          attribute.completeSnapshot()
         }
       }
     }

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -1,6 +1,6 @@
 import {comparer} from "mobx"
 import {observer} from "mobx-react-lite"
-import {addDisposer, isAlive} from "mobx-state-tree"
+import {isAlive} from "mobx-state-tree"
 import React, {MutableRefObject, useCallback, useEffect, useMemo, useRef} from "react"
 import {select} from "d3"
 import {clsx} from "clsx"
@@ -35,7 +35,6 @@ import {DataTip} from "../../data-display/components/data-tip"
 import {MultiLegend} from "../../data-display/components/legend/multi-legend"
 import {AttributeType} from "../../../models/data/attribute"
 import {IDataSet} from "../../../models/data/data-set"
-import {isRemoveAttributeAction} from "../../../models/data/data-set-actions"
 import {isUndoingOrRedoing} from "../../../models/history/tree-types"
 import {useDataDisplayAnimation} from "../../data-display/hooks/use-data-display-animation"
 import {Adornments} from "../adornments/adornments"
@@ -65,6 +64,7 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
     abovePointsGroupRef = useRef<SVGGElement>(null),
     backgroundSvgRef = useRef<SVGGElement>(null),
     pixiContainerRef = useRef<SVGForeignObjectElement>(null),
+    prevAttrCollectionsMapRef = useRef<Record<string, string>>({}),
     xAttrID = graphModel.getAttributeID('x'),
     yAttrID = graphModel.getAttributeID('y')
 
@@ -122,20 +122,46 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
       {name: "Graph.handleAttributeConfigurationChange"}, graphModel)
   }, [graphController, graphModel])
 
-  useEffect(function handleDeleteAttribute() {
-    return dataset && addDisposer(dataset, onAnyAction(dataset, action => {
-      if (isRemoveAttributeAction(action)) {
-        const [attrId] = action.args
-        graphModel.dataConfiguration.rolesForAttribute(attrId).forEach(role => {
-          if (role === "yPlus") {
-            graphModel.dataConfiguration.removeYAttributeWithID(attrId)
-          } else {
-            graphModel.setAttributeID(role as GraphAttrRole, "", "")
+  useEffect(function handleAttributeCollectionMapChange() {
+
+    const constructAttrCollections = () => {
+      const graphAttrs = graphModel.dataConfiguration.attributes
+      const attrCollections: Record<string, string> = {}
+      graphAttrs.forEach(attrId => {
+        const collection = dataset?.getCollectionForAttribute(attrId)?.id
+        collection && (attrCollections[attrId] = collection)
+      })
+      return attrCollections
+    }
+
+    prevAttrCollectionsMapRef.current = constructAttrCollections()
+
+    return dataset && mstReaction(
+      () => {
+        return constructAttrCollections()
+      },
+      attrCollections => {
+        Object.entries(prevAttrCollectionsMapRef.current).forEach(([attrId, collectionId]) => {
+          if (!attrCollections[attrId]) { // attribute was removed
+            graphModel.dataConfiguration.rolesForAttribute(attrId).forEach(role => {
+              if (role === "yPlus") {
+                graphModel.dataConfiguration.removeYAttributeWithID(attrId)
+              } else {
+                graphModel.setAttributeID(role as GraphAttrRole, "", "")
+              }
+            })
+          }
+          else if (attrCollections[attrId] !== collectionId) { // attribute was moved to a different collection
+            // todo: Make sure this works once PT Story https://www.pivotaltracker.com/story/show/188117637 is fixed
+            graphModel.dataConfiguration._updateFilteredCasesCollectionID()
+            graphModel.dataConfiguration._invalidateCases()
+            graphController.callMatchCirclesToData()
           }
         })
-      }
-    }))
-  }, [dataset, graphModel])
+        prevAttrCollectionsMapRef.current = attrCollections
+      }, {name: "handleAttrConfigurationChange", equals: comparer.structural}, dataset
+    )
+  }, [dataset, graphController, graphModel])
 
   const handleChangeAttribute = useCallback((place: GraphPlace, dataSet: IDataSet, attrId: string) => {
     const computedPlace = place === 'plot' && graphModel.dataConfiguration.noAttributesAssigned ? 'bottom' : place

--- a/v3/src/models/data/data-set-actions.ts
+++ b/v3/src/models/data/data-set-actions.ts
@@ -24,13 +24,6 @@ export interface SetAttributeNameAction extends ISerializedActionCall {
 export const isSetAttributeNameAction = (action: ISerializedActionCall): action is SetAttributeNameAction =>
               action.name === "setAttributeName"
 
-export interface RemoveAttributeAction extends ISerializedActionCall {
-  name: "removeAttribute"
-  args: [attrID: string]
-}
-export const isRemoveAttributeAction = (action: ISerializedActionCall): action is SetAttributeNameAction =>
-              action.name === "removeAttribute"
-
 export interface RemoveCasesAction extends ISerializedActionCall {
   name: "removeCases"
   args: [string[]]


### PR DESCRIPTION
[#187798725] Bug fix: Graph turns into scatterplot when creating new collections in Mammals dataset

This fixes the graph bugs related to move an attribute within a dataset. But a bug occurs when the attribute is moved to a parent collection and then the user presses Undo. See #188117637.

* Remove `attribute.completeSnapshot` from `attribute-menu-list.ts handleClick` so that MST won't complain.
* `RemoveAttributeAction` in `data-set-actions` removed because no longer called.
* Changed the `onAnyAction` in `handleDeleteAttribute` to an mstReaction in what is now `handleAttributeCollectionMapChange`. This detects both deletion and moving of attributes to different collections.