### PR TITLE
Scatterplot grid lines with date axis

### DIFF
--- a/v3/src/components/axis/helper-models/date-axis-helper.test.ts
+++ b/v3/src/components/axis/helper-models/date-axis-helper.test.ts
@@ -47,6 +47,7 @@ describe("DateAxisHelper", () => {
         getAxisLength: jest.fn().mockReturnValue(100)
       } as unknown as IAxisLayout,
       isAnimating: jest.fn().mockReturnValue(false),
+      showScatterPlotGridLines: false,
       subAxisSelectionRef
     }
     dateAxisHelper = new DateAxisHelper(props)

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -229,7 +229,7 @@ export const useSubAxis = ({
           break
         case 'date':
           subAxisSelectionRef.current = subAxisElt ? select(subAxisElt) : undefined
-          helper = new DateAxisHelper({ ...helperProps, subAxisSelectionRef })
+          helper = new DateAxisHelper({ ...helperProps, showScatterPlotGridLines, subAxisSelectionRef })
       }
     }
     if (helper) setAxisHelper(axisModel, subAxisIndex, helper)


### PR DESCRIPTION
[#188109499] Bug fix: Date axis grid lines missing for scatterplot

* We pass showScatterPlotGridLines into DateAxisHelper just as we do for NumericAxisHelper so we can know when to draw grid lines.
* We refactor a bit to get access to what we need to be able to routines we need to visit each location for a grid line.