### PR TITLE
fix: MST warning on date axis

### DIFF
--- a/v3/src/components/axis/helper-models/axis-helper.ts
+++ b/v3/src/components/axis/helper-models/axis-helper.ts
@@ -84,6 +84,10 @@ export class AxisHelper {
       .style("stroke-opacity", "0.7")
   }
 
+  render() {
+    /* istanbul ignore next */
+    throw new Error("Subclass should override")
+  }
 }
 
 export class EmptyAxisHelper extends AxisHelper {

--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -57,11 +57,9 @@ export class NumericAxisHelper extends AxisHelper {
       axisScale.tickValues(tickValues)
       axisScale.tickFormat((d, i) => tickLabels[i])
     }
-    select(this.subAxisElt)
+    this.subAxisElt && select(this.subAxisElt)
       .attr("transform", this.initialTransform)
       .transition().duration(duration)
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore types are incompatible
       .call(axisScale).selectAll("line,path")
       .style("stroke", "lightgrey")
       .style("stroke-opacity", "0.7")

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -3,6 +3,7 @@ import { reaction } from "mobx"
 import { isAlive } from "mobx-state-tree"
 import { useCallback, useEffect, useRef } from "react"
 import { mstAutorun } from "../../../utilities/mst-autorun"
+import { mstReaction } from "../../../utilities/mst-reaction"
 import { graphPlaceToAttrRole } from "../../data-display/data-display-types"
 import { maxWidthOfStringsD3 } from "../../data-display/data-display-utils"
 import { useDataConfigurationContext } from "../../data-display/hooks/use-data-configuration-context"
@@ -154,13 +155,13 @@ useEffect(function installDomainSync() {
 
 // update d3 scale and axis when layout/range changes
 useEffect(() => {
-  const disposer = reaction(
+  const disposer = mstReaction(
     () => {
       return layout.getAxisLength(axisPlace)
     },
     () => {
       layout.setDesiredExtent(axisPlace, computeDesiredExtent())
-    }, {name: "useAxis [axisRange]"}
+    }, {name: "useAxis [axisRange]"}, axisModel
   )
   return () => disposer()
 }, [axisModel, layout, axisPlace, computeDesiredExtent])


### PR DESCRIPTION
[[PT-188130687]](https://www.pivotaltracker.com/story/show/188130687)

The `useSubAxis` hook makes use of an `AxisHelper` instance, which was being created/stored in a local variable using `useMemo()`. When transitioning from an empty axis to a date axis, a MobX reaction within `useSubAxis` was being triggered before the `useSubAxis` hook was re-rendered to update the axis helper instance, which meant that a stale axis helper connected to a defunct axis model was being called.

Instead of storing the axis helper instance in a local variable we now store it in a [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) keyed by the `AxisModel`, and look it up when needed so that the axis helper used will always be the one associated with the correct axis model. Because it's a `WeakMap`, axis helpers associated with defunct axis models will automatically be garbage-collected, so we don't need to worry about cleanup.

Separately, there was another reaction in the `useAxis` hook which was turned into a `mstReaction` to avoid another MST warning on destruction of the axis model.