### PR TITLE
fix: graph response to collection hierarchy change

### DIFF
--- a/v3/cypress/e2e/hierarchical-table.spec.ts
+++ b/v3/cypress/e2e/hierarchical-table.spec.ts
@@ -9,7 +9,7 @@ context("hierarchical collections", () => {
     const queryParams = "?sample=mammals&dashboard&mouseSensor"
     const url = `${Cypress.config("index")}${queryParams}`
     cy.visit(url)
-    cy.wait(2500)
+    cy.wait(1000)
   })
   hierarchical.tests.forEach((h: HierarchicalTest) => {
     // FIXME: enable skipped tests
@@ -23,13 +23,11 @@ context("hierarchical collections", () => {
           table.moveAttributeToParent(attribute.name, attribute.move)
           table.getColumnHeaders(collection.index+1).should("not.contain", attribute.name)
           table.getAttribute(attribute.name, collection.index).should("have.text", attribute.name)
-          cy.wait(2000)
         })
         table.getCollectionTitle(collection.index).should("have.text", collection.name)
         table.getColumnHeaders(collection.index).should("have.length", collection.attributes.length+1)
         table.getNumOfRows().should("contain", collection.cases+2) // +1 for the header row, +1 for input row
         table.verifyAttributeValues(collection.attributes, values, collection.index)
-        cy.wait(2000)
 
         cy.log("Testing expanding/collapsing...")
         table.verifyCollapseAllGroupsButton(collection.index+1)

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -281,7 +281,6 @@ export const TableTileElements = {
     attributes.forEach(a => {
       const attribute = a.name
       for (let rowIndex = 0; rowIndex < values[attribute].length; rowIndex++) {
-        cy.wait(1000)
         this.getAttributeValue(attribute, rowIndex+2, collectionIndex).then(cell => {
           expect(values[attribute]).to.include(cell.text())
         })

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -85,10 +85,10 @@ export const CaseDots = function CaseDots(props: {
       xLength = layout.getAxisMultiScale('bottom')?.length ?? 0,
       yLength = layout.getAxisMultiScale('left')?.length ?? 0,
       getScreenX = (anID: string) => {
-        return pointRadius + randomPointsRef.current[anID].x * (xLength - 2 * pointRadius)
+        return pointRadius + randomPointsRef.current[anID]?.x * (xLength - 2 * pointRadius)
       },
       getScreenY = (anID: string) => {
-        return yLength - (pointRadius + randomPointsRef.current[anID].y * (yLength - 2 * pointRadius))
+        return yLength - (pointRadius + randomPointsRef.current[anID]?.y * (yLength - 2 * pointRadius))
       },
       getLegendColor = dataConfiguration?.attributeID('legend')
         ? dataConfiguration?.getLegendColorForCase : undefined

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -123,6 +123,18 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
       {name: "Graph.handleAttributeConfigurationChange"}, graphModel)
   }, [graphController, graphModel])
 
+  // Respond to collection addition/removal. Note that this can fire in addition to the collection
+  // map changes reaction below, but that fires too early, so this gives the graph another chance.
+  useEffect(() => {
+    return dataset && mstReaction(
+      () => dataset.syncCollectionLinksCount,
+      () => {
+        graphModel.dataConfiguration._updateFilteredCasesCollectionID()
+        graphModel.dataConfiguration._invalidateCases()
+        graphController.callMatchCirclesToData()
+      }, { name: "Graph.mstReaction [syncCollectionLinksCount]" }, dataset)
+  }, [dataset, graphController, graphModel.dataConfiguration])
+
   useEffect(function handleAttributeCollectionMapChange() {
 
     const constructAttrCollections = () => {

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -151,6 +151,8 @@ export const DataSet = V2Model.named("DataSet").props({
   caseInfoMap: new Map<string, CaseInfo>(),
   // map from item ID to the child case containing it
   itemIdChildCaseMap: new Map<string, CaseInfo>(),
+  // incremented when collection parent/child links are updated
+  syncCollectionLinksCount: 0,
   transactionCount: 0,
   // the id of the interactive frame handling this dataset
   // used by the Collaborative plugin
@@ -330,6 +332,11 @@ export const DataSet = V2Model.named("DataSet").props({
     else {
       self.itemInfoMap.set(itemId, { index, caseIds: [caseId] })
     }
+  }
+}))
+.actions(self => ({
+  incSyncCollectionLinksCount() {
+    ++self.syncCollectionLinksCount
   }
 }))
 .extend(self => {
@@ -1101,6 +1108,7 @@ export const DataSet = V2Model.named("DataSet").props({
             invalidate: () => self.invalidateCases()
           }
           syncCollectionLinks(self.collections, itemData)
+          self.incSyncCollectionLinksCount()
           self.invalidateCases()
         },
         { name: "DataSet.collections", equals: comparer.structural, fireImmediately: true }


### PR DESCRIPTION
[[PT-188117637]](https://www.pivotaltracker.com/story/show/188117637) Undo of graph response to moving attribute from child to parent collection not working

A couple of issues:
- collection parent/child links weren't being cleared in some cases when hierarchy changes occurred
- collection cleared its case id map cache unnecessarily in some cases
- graph was responding too early to hierarchy change, before `DataSet` had completed its response

Here we fix the collection issues and add a mechanism for clients to listen for `DataSet` response to hierarchy changes.