### PR TITLE
188150453 v3 DI Handle Slate Objects in API Requests

### DIFF
--- a/v3/src/components/text/text-model.ts
+++ b/v3/src/components/text/text-model.ts
@@ -35,6 +35,7 @@ export const TextModel = TileContentModel
   }))
   .actions(self => ({
     setValue(value: EditorValue) {
+      console.log(`... value`, value)
       self.isSettingValue = true
       self.value = editorValueToModelValue(value)
       self.isSettingValue = false

--- a/v3/src/components/text/text-model.ts
+++ b/v3/src/components/text/text-model.ts
@@ -34,10 +34,15 @@ export const TextModel = TileContentModel
     }
   }))
   .actions(self => ({
-    setValue(value: EditorValue) {
-      console.log(`... value`, value)
-      self.isSettingValue = true
+    setValueAndUpdate(value: EditorValue) {
       self.value = editorValueToModelValue(value)
+    }
+  }))
+  .actions(self => ({
+    setValue(value: EditorValue) {
+      // The component will not update when isSettingValue is true
+      self.isSettingValue = true
+      self.setValueAndUpdate(value)
       self.isSettingValue = false
     }
   }))

--- a/v3/src/components/text/text-model.ts
+++ b/v3/src/components/text/text-model.ts
@@ -34,15 +34,15 @@ export const TextModel = TileContentModel
     }
   }))
   .actions(self => ({
-    setValueAndUpdate(value: EditorValue) {
+    setValue(value: EditorValue) {
       self.value = editorValueToModelValue(value)
     }
   }))
   .actions(self => ({
-    setValue(value: EditorValue) {
+    setValueFromEditor(value: EditorValue) {
       // The component will not update when isSettingValue is true
       self.isSettingValue = true
-      self.setValueAndUpdate(value)
+      self.setValue(value)
       self.isSettingValue = false
     }
   }))

--- a/v3/src/components/text/text-registration.test.ts
+++ b/v3/src/components/text/text-registration.test.ts
@@ -155,8 +155,7 @@ describe("text component handler", () => {
               text: "To be, or not to be"
             }]
           }]
-        },
-        objTypes: { paragraph: "block" }
+        }
       }
     })
     expect(emptyTextTileResult.success).toBe(true)
@@ -182,8 +181,7 @@ describe("text component handler", () => {
               text: "To be, or not to be, that is the question."
             }]
           }]
-        },
-        objTypes: { paragraph: "block" }
+        }
       }
     }
     testUpdateComponent(tile, diHandler, newValues, (textTile, values) => {

--- a/v3/src/components/text/text-registration.test.ts
+++ b/v3/src/components/text/text-registration.test.ts
@@ -140,4 +140,58 @@ describe("text component handler", () => {
     documentContent.deleteTile(tileId)
     expect(documentContent.tileMap.size).toBe(0)
   })
+
+  it("can create and then update a text tile with slate type text content and retrieve its contents", () => {
+    expect(documentContent.tileMap.size).toBe(0)
+    // creating empty text tile
+    const emptyTextTileResult = diHandler.create!({}, {
+      type: "text",
+      text: {
+        object: "value",
+        document: {
+          children: [{
+            type: "paragraph",
+            children: [{
+              text: "To be, or not to be"
+            }]
+          }]
+        },
+        objTypes: { paragraph: "block" }
+      }
+    })
+    expect(emptyTextTileResult.success).toBe(true)
+    expect(documentContent.tileMap.size).toBe(1)
+    const [tileId, tile] = Array.from(documentContent.tileMap.entries())[0]
+    expect(isTextModel(tile.content)).toBe(true)
+    expect((tile.content as ITextModel).textContent).toBe("To be, or not to be")
+
+    testGetComponent(tile, diHandler, (textTile, values) => {
+      const { text } = values as V2Text
+      expect(isTextModel(textTile.content)).toBe(true)
+      const textContent = textTile.content as ITextModel
+      expect(textContent.value).toBe(text)
+    })
+
+    const newValues: Partial<V2Text> = {
+      text: {
+        object: "value",
+        document: {
+          children: [{
+            type: "paragraph",
+            children: [{
+              text: "To be, or not to be, that is the question."
+            }]
+          }]
+        },
+        objTypes: { paragraph: "block" }
+      }
+    }
+    testUpdateComponent(tile, diHandler, newValues, (textTile, values) => {
+      expect(isTextModel(tile.content)).toBe(true)
+      expect((tile.content as ITextModel).textContent).toBe("To be, or not to be, that is the question.")
+    })
+
+    documentContent.deleteTile(tileId)
+    expect(documentContent.tileMap.size).toBe(0)
+  })
 })

--- a/v3/src/components/text/text-registration.ts
+++ b/v3/src/components/text/text-registration.ts
@@ -98,9 +98,9 @@ registerComponentHandler(kV2TextType, {
       if (text) {
         if (typeof text === "string") {
           const modelValue = importTextToModelValue(text)
-          content.setValue(modelValueToEditorValue(modelValue))
+          content.setValueAndUpdate(modelValueToEditorValue(modelValue))
         } else {
-          content.setValue(text.document.children)
+          content.setValueAndUpdate(text.document.children)
         }
       }
     }

--- a/v3/src/components/text/text-registration.ts
+++ b/v3/src/components/text/text-registration.ts
@@ -1,4 +1,4 @@
-import { textToSlate } from "@concord-consortium/slate-editor"
+import { SlateExchangeValue, textToSlate } from "@concord-consortium/slate-editor"
 import { SetRequired } from "type-fest"
 import { V2Text } from "../../data-interactive/data-interactive-component-types"
 import { registerComponentHandler } from "../../data-interactive/handlers/component-handler"
@@ -14,7 +14,6 @@ import { ComponentTitleBar } from "../component-title-bar"
 import { kTextTileClass, kTextTileType, kV2TextType } from "./text-defs"
 import { editorValueToModelValue, isTextModel, ITextSnapshot, modelValueToEditorValue, TextModel } from "./text-model"
 import { TextTile } from "./text-tile"
-import { SlateDocument } from "./text-types"
 import TextIcon from "../../assets/icons/icon-text.svg"
 
 export const kTextIdPrefix = "TEXT"
@@ -46,7 +45,7 @@ registerTileComponentInfo({
   defaultHeight: 100
 })
 
-function importTextToModelValue(text?: string | SlateDocument) {
+function importTextToModelValue(text?: string | SlateExchangeValue) {
   // According to a comment in the v2 code: "Prior to build 0535 this was simple text.
   // As of 0535 it is a JSON representation of the rich text content."
   // For v3, we make sure we're always dealing with rich-text JSON.
@@ -55,9 +54,8 @@ function importTextToModelValue(text?: string | SlateDocument) {
     return text != null && json != null && typeof json === "object"
             ? text
             : editorValueToModelValue(textToSlate(text))
-  } else if (text?.document?.children) {
-    return editorValueToModelValue(text.document.children)
   }
+  return editorValueToModelValue(text?.document?.children ?? [])
 }
 
 registerV2TileImporter("DG.TextView", ({ v2Component, insertTile }) => {
@@ -97,9 +95,9 @@ registerComponentHandler(kV2TextType, {
     if (isTextModel(content)) {
       const { text } = values as V2Text
       if (typeof text === "string") {
-        content.setValueAndUpdate(modelValueToEditorValue(importTextToModelValue(text)))
+        content.setValue(modelValueToEditorValue(importTextToModelValue(text)))
       } else if (text?.document?.children) {
-        content.setValueAndUpdate(text.document.children)
+        content.setValue(text.document.children)
       }
     }
 

--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -18,14 +18,15 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
   const textOnFocus = useRef("")
 
   const [initialValue, setInitialValue] = useState(() => modelValueToEditorValue(textModel?.value))
+  // changes to this value trigger a remount of the slate editor
+  const mountKey = useRef(0)
   const editor = useMemo(() => {
     // slate doesn't have a convenient API for replacing the value in an existing editor,
     // so we create a new editor instance when the value changes externally (e.g. undo/redo).
     initialValue  // eslint-disable-line no-unused-expressions
+    ++mountKey.current
     return createEditor()
   }, [initialValue])
-  // changes to this value trigger a remount of the slate editor
-  const mountKey = useRef(0)
 
   useEffect(() => {
     return tile && mstReaction(

--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -49,7 +49,6 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
           if (!textModel.isSettingValue) {
             // set the new value and remount the editor
             setInitialValue(modelValueToEditorValue(textModel?.value))
-            ++mountKey.current
           }
         }
       }))
@@ -68,7 +67,7 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
     if (textModel && !textModel.isEquivalent(editor.children)) {
       const textDidChange = textOnFocus.current !== textModel.textContent
       textModel?.applyModelChange(() => {
-        textModel.setValue(editor.children)
+        textModel.setValueFromEditor(editor.children)
       }, {
         // log only when the text actually changed, e.g. not on style changes
         // Note that logging of text changes was commented out in v2 in build 0601. ¯\_(ツ)_/¯

--- a/v3/src/components/text/text-types.ts
+++ b/v3/src/components/text/text-types.ts
@@ -1,0 +1,9 @@
+import { EditorValue } from "@concord-consortium/slate-editor"
+
+export interface SlateDocument {
+  document?: {
+    children?: EditorValue
+  }
+  object?: string // "value"
+  objTypes?: Record<string, string> // like { "paragraph": "block" }
+}

--- a/v3/src/components/text/text-types.ts
+++ b/v3/src/components/text/text-types.ts
@@ -1,9 +1,0 @@
-import { EditorValue } from "@concord-consortium/slate-editor"
-
-export interface SlateDocument {
-  document?: {
-    children?: EditorValue
-  }
-  object?: string // "value"
-  objTypes?: Record<string, string> // like { "paragraph": "block" }
-}

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -5,6 +5,7 @@ import { kGraphTileType, kV2GraphType } from "../components/graph/graph-defs"
 import { kMapTileType, kV2MapType } from "../components/map/map-defs"
 import { kSliderTileType, kV2SliderType } from "../components/slider/slider-defs"
 import { kTextTileType, kV2TextType } from "../components/text/text-defs"
+import { SlateDocument } from "../components/text/text-types"
 import { kV2GameType, kV2WebViewType, kWebViewTileType } from "../components/web-view/web-view-defs"
 
 // export const kV2ImageType = "image"
@@ -113,7 +114,7 @@ export interface V2GetSlider extends V2Slider {
   value?: number
 }
 export interface V2Text extends V2Component {
-  text?: string | any
+  text?: string | SlateDocument
   type: "text"
 }
 export interface V2WebView extends V2Component {

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -1,3 +1,4 @@
+import { SlateExchangeValue } from "@concord-consortium/slate-editor"
 import { kCalculatorTileType, kV2CalculatorType } from "../components/calculator/calculator-defs"
 import { kCaseCardTileType, kV2CaseCardType } from "../components/case-card/case-card-defs"
 import { kCaseTableTileType, kV2CaseTableType } from "../components/case-table/case-table-defs"
@@ -5,7 +6,6 @@ import { kGraphTileType, kV2GraphType } from "../components/graph/graph-defs"
 import { kMapTileType, kV2MapType } from "../components/map/map-defs"
 import { kSliderTileType, kV2SliderType } from "../components/slider/slider-defs"
 import { kTextTileType, kV2TextType } from "../components/text/text-defs"
-import { SlateDocument } from "../components/text/text-types"
 import { kV2GameType, kV2WebViewType, kWebViewTileType } from "../components/web-view/web-view-defs"
 
 // export const kV2ImageType = "image"
@@ -114,7 +114,7 @@ export interface V2GetSlider extends V2Slider {
   value?: number
 }
 export interface V2Text extends V2Component {
-  text?: string | SlateDocument
+  text?: string | SlateExchangeValue
   type: "text"
 }
 export interface V2WebView extends V2Component {

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -113,7 +113,7 @@ export interface V2GetSlider extends V2Slider {
   value?: number
 }
 export interface V2Text extends V2Component {
-  text?: string
+  text?: string | any
   type: "text"
 }
 export interface V2WebView extends V2Component {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188150453

This PR updates the text request handler.
- Previously, only strings were supported for the `text` field. Now, Slate style objects are handled as well.
- Text components now update when their contents are changed via API requests.