### PR TITLE
188150453 DI Fix Get dataContextList

### DIFF
--- a/v3/src/data-interactive/handlers/data-context-list-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-list-handler.test.ts
@@ -1,0 +1,26 @@
+import { DIDataContext } from "../data-interactive-types"
+import { diDataContextListHandler } from "./data-context-list-handler"
+import { setupTestDataset } from "./handler-test-utils"
+import { toV2Id } from "../../utilities/codap-utils"
+
+describe("DataInteractive DataContextHandler", () => {
+  const handler = diDataContextListHandler
+
+  it("get works as expected", () => {
+    const { dataset } = setupTestDataset()
+    const title = "dataset title"
+    dataset.setTitle(title)
+
+    expect(handler.get?.({}).success).toBe(false)
+
+    const result = handler.get?.({ dataContextList: [dataset] })!
+    expect(result.success).toBe(true)
+    const values = result.values as DIDataContext[]
+    expect(values.length).toBe(1)
+    const diDataContext = values[0]
+    expect(diDataContext.name).toBe(dataset.name)
+    expect(diDataContext.title).toBe(dataset._title)
+    expect(diDataContext.guid).toBe(toV2Id(dataset.id))
+    expect(diDataContext.id).toBe(toV2Id(dataset.id))
+  })
+})

--- a/v3/src/data-interactive/handlers/data-context-list-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-list-handler.test.ts
@@ -13,7 +13,7 @@ describe("DataInteractive DataContextHandler", () => {
 
     expect(handler.get?.({}).success).toBe(false)
 
-    const result = handler.get?.({ dataContextList: [dataset] })!
+    const result = handler.get!({ dataContextList: [dataset] })
     expect(result.success).toBe(true)
     const values = result.values as DIDataContext[]
     expect(values.length).toBe(1)

--- a/v3/src/data-interactive/handlers/data-context-list-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-list-handler.ts
@@ -16,7 +16,7 @@ export const diDataContextListHandler: DIHandler = {
         return {
           name: dataSet.name,
           guid: id,
-          title: dataSet.name, // TODO: DataSets don't have titles in v3
+          title: dataSet._title,
           id
         }
       })


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188150453

This PR fixes the outdated `get dataContextList` handler, which was written at a time before datasets had titles.