### PR TITLE
fix: flaky cypress test

### DIFF
--- a/v3/cypress/e2e/hierarchical-table.spec.ts
+++ b/v3/cypress/e2e/hierarchical-table.spec.ts
@@ -7,7 +7,7 @@ const values = hierarchical.attributes
 
 context("hierarchical collections", () => {
   beforeEach(function () {
-    const queryParams = "?sample=mammals&mouseSensor"
+    const queryParams = "?sample=mammals&mouseSensor&scrollBehavior=auto"
     const url = `${Cypress.config("index")}${queryParams}`
     cy.visit(url)
     cy.wait(1000)


### PR DESCRIPTION
Add `scrollBehavior=auto` in `hierarchical-table.spec.ts` to fix flakiness.