### PR TITLE
fix: display of lists in text component [PT-188103062]

### DIFF
--- a/v3/src/components/text/text-tile.scss
+++ b/v3/src/components/text/text-tile.scss
@@ -13,6 +13,10 @@ $text-toolbar-width: 52px;
     font-size: 12px;
     font-family: 'Helvetica', sans-serif;
     outline: transparent;
+
+    ol, ul {
+      padding-inline-start: 15px;
+    }
   }
 }
 


### PR DESCRIPTION
There was a style conflict between the slate-editor library and Chakra which resulted in list item markers being displayed outside the bounds of the element, i.e. they were not visible.