### PR TITLE
chore: conditionalize logging to server when debugging

### DIFF
--- a/v3/src/lib/logger.ts
+++ b/v3/src/lib/logger.ts
@@ -2,6 +2,10 @@ import { nanoid } from "nanoid"
 import { debugLog, DEBUG_LOGGER } from "./debug"
 import { IDocumentModel } from "../models/document/document"
 
+// Set to true (temporarily) to debug logging to server specifically.
+// Otherwise, we assume that console.logs are sufficient.
+const DEBUG_LOG_TO_SERVER = !DEBUG_LOGGER
+
 type LoggerEnvironment = "dev" | "production"
 
 const logManagerUrl: Record<LoggerEnvironment, string> = {
@@ -144,8 +148,10 @@ function sendToLoggingService(data: LogMessage) {
   // const isProduction = user.portal === productionPortal || data.parameters?.portal === productionPortal
   // const url = logManagerUrl[isProduction ? "production" : "dev"]
   const url = logManagerUrl.dev
+
+  if (!Logger.isLoggingEnabled || !DEBUG_LOG_TO_SERVER) return
+
   debugLog(DEBUG_LOGGER, "Logger#sendToLoggingService sending", data, "to", url)
-  if (!Logger.isLoggingEnabled) return
 
   const request = new XMLHttpRequest()
 


### PR DESCRIPTION
Adds a separate `DEBUG_LOG_TO_SERVER` flag to enable/disable logging to the log server. This flag defaults to `!DEBUG_LOGGER`, i.e. if you are debugging/observing logs in the browser the assumption is that logging to an actual server is not necessary. If a developer is actually debugging the server communication, of course, the flag can be enabled locally.