### PR TITLE
Fix bar charts

### DIFF
--- a/v3/src/components/graph/components/dot-chart-bars.tsx
+++ b/v3/src/components/graph/components/dot-chart-bars.tsx
@@ -146,20 +146,6 @@ export const DotChartBars = observer(function DotChartBars({ abovePointsGroupRef
     }
   }, [pixiPoints, graphModel.pointsFusedIntoBars])
 
-  // when points are fused into bars, we need to set the secondary axis scale type to linear
-  useEffect(function handleFuseIntoBars() {
-    return mstAutorun(
-      () => {
-        if (graphModel.pointsFusedIntoBars) {
-          const secondaryRole = graphModel.dataConfiguration.primaryRole === "x" ? "y" : "x"
-          const secondaryPlace = secondaryRole === "y" ? "left" : "bottom"
-          layout.setAxisScaleType(secondaryPlace, "linear")
-        }
-      },
-      {name: "useAxis [handleFuseIntoBars]"}, graphModel
-    )
-  }, [graphModel, layout])
-
   return (
     <>
       {abovePointsGroupRef?.current && createPortal(

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -28,7 +28,7 @@ import {GraphDataConfigurationContext} from "../hooks/use-graph-data-configurati
 import {useGraphLayoutContext} from "../hooks/use-graph-layout-context"
 import {useGraphModel} from "../hooks/use-graph-model"
 import {setNiceDomain} from "../utilities/graph-utils"
-import {IAxisModel} from "../../axis/models/axis-model"
+import { EmptyAxisModel, IAxisModel, isNumericAxisModel, NumericAxisModel } from "../../axis/models/axis-model"
 import {GraphPlace} from "../../axis-graph-shared"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 import {MarqueeState} from "../../data-display/models/marquee-state"
@@ -221,6 +221,29 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
     })
     return () => disposer?.()
   }, [graphController, layout, graphModel, startAnimation])
+
+  useEffect(function handlePointsFusedIntoBars() {
+    return mstReaction(
+      () => graphModel.pointsFusedIntoBars,
+      (pointsFusedIntoBars) => {
+        const dataConfiguration = graphModel.dataConfiguration
+        const { secondaryRole } = dataConfiguration
+        const secondaryPlace = secondaryRole === "y" ? "left" : "bottom"
+        if (pointsFusedIntoBars) {
+          graphModel.setPointConfig(graphModel.plotType !== "dotPlot" ? "bars" : "histogram")
+          layout.setAxisScaleType(secondaryPlace, "linear")
+          graphModel.setBarCountAxis()
+        }
+        else {
+          graphModel.setPointConfig(graphModel.pointsAreBinned ? "bins" : "points")
+          if (isNumericAxisModel(graphModel.getAxis(secondaryPlace))) {
+            graphModel.setAxis(secondaryPlace, EmptyAxisModel.create({ place: secondaryPlace }))
+          }
+        }
+      },
+      {name: "Graph.handlePointsFusedIntoBars"}, graphModel
+    )
+  }, [graphController, graphModel])
 
   const renderPlotComponent = () => {
     const props = {xAttrID, yAttrID, pixiPoints, abovePointsGroupRef},

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -31,8 +31,7 @@ import {setNiceDomain} from "../utilities/graph-utils"
 import {GraphPointLayerModel, IGraphPointLayerModel, kGraphPointLayerType} from "./graph-point-layer-model"
 import {IAdornmentModel, IUpdateCategoriesOptions} from "../adornments/adornment-models"
 import {
-  AxisModelUnion, EmptyAxisModel, IAxisModelUnion, isBaseNumericAxisModel, isNumericAxisModel,
-  NumericAxisModel
+  AxisModelUnion, EmptyAxisModel, IAxisModelUnion, isBaseNumericAxisModel, NumericAxisModel
 } from "../../axis/models/axis-model"
 import {AdornmentsStore} from "../adornments/adornments-store"
 import {getPlottedValueFormulaAdapter} from "../../../models/formula/plotted-value-formula-adapter"
@@ -601,7 +600,9 @@ export const GraphContentModel = DataDisplayContentModel
         self.setBinAlignment(binAlignment)
         self.pointsAreBinned = true
       } else if (configType !== "histogram") {
-        self.pointsFusedIntoBars = false
+        if (configType !== "bars") {
+          self.pointsFusedIntoBars = false
+        }
         self.pointsAreBinned = false
       }
     },
@@ -641,26 +642,9 @@ export const GraphContentModel = DataDisplayContentModel
       setNiceDomain([0, maxCellCaseCount], countAxis, {clampPosMinAtZero: true})
       self.setAxis(secondaryPlace, countAxis)
     },
-    unsetBarCountAxis() {
-      const { secondaryRole } = self.dataConfiguration
-      const secondaryPlace = secondaryRole === "y" ? "left" : "bottom"
-      if (isNumericAxisModel(self.getAxis(secondaryPlace))) {
-        self.setAxis(secondaryPlace, EmptyAxisModel.create({ place: secondaryPlace }))
-      }
-    }
   }))
   .actions(self => ({
     setPointsFusedIntoBars(fuseIntoBars: boolean) {
-      if (fuseIntoBars === self.pointsFusedIntoBars) return
-
-      if (fuseIntoBars) {
-        self.setPointConfig(self.plotType !== "dotPlot" ? "bars" : "histogram")
-        self.setBarCountAxis()
-      } else {
-        self.setPointConfig(self.pointsAreBinned ? "bins" : "points")
-        self.unsetBarCountAxis()
-      }
-
       self.pointsFusedIntoBars = fuseIntoBars
     },
   }))


### PR DESCRIPTION
[#188144634] Bug fix: Bar charts are broken

* Centralize the response to the change in `graphModel.pointsFusedIntoBars` as an mstReaction in graph.tsx so that the response doesn't rely on order of operations.