### PR TITLE
Fix date axis restore bug

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -264,8 +264,10 @@ export const useSubAxis = ({
       const _axisModel = axisProvider?.getAxis?.(axisPlace)
       if (isAliveSafe(_axisModel)) {
         if (isBaseNumericAxisModel(_axisModel)) {
-          const {domain} = _axisModel || {}
-          layout.getAxisMultiScale(axisPlace)?.setNumericDomain(domain)
+          const {domain} = _axisModel || {},
+            multiScale = layout.getAxisMultiScale(axisPlace)
+          multiScale?.setScaleType('linear')  // Make sure it's linear
+          multiScale?.setNumericDomain(domain)
           renderSubAxis()
         }
       } else if (_axisModel) {


### PR DESCRIPTION
[#188188327] Bug fix: Date axis not restored properly

* In the restore process the date axis' multiscale is not getting 'linear' as its scaleType. We fix this in use-sub-axis.ts `installDomainSync` by guaranteeing that if we're dealing with BaseNumericAxisModel, the multiscale has the right scaleType.