### PR TITLE
feat: support `url` url parameter

### DIFF
--- a/v3/cypress/e2e/cfm.spec.ts
+++ b/v3/cypress/e2e/cfm.spec.ts
@@ -7,7 +7,11 @@ context("CloudFileManager", () => {
     const queryParams = "?mouseSensor"
     const url = `${Cypress.config("index")}${queryParams}`
     cy.visit(url)
-    cy.wait(2500)
+  })
+  it("Opens Mammals example document via url parameter", () => {
+    const mammalsUrl = "https://codap-resources.s3.amazonaws.com/example-documents/documents/mammals.codap"
+    cy.visit(`${Cypress.config("index")}?url=${mammalsUrl}`)
+    cy.get(".codap-component.codap-case-table").contains(".title-bar", "Mammals").should("exist")
   })
   it("Opens Mammals example document via CFM Open dialog", () => {
     // hamburger menu is hidden initially

--- a/v3/src/lib/handle-cfm-event.ts
+++ b/v3/src/lib/handle-cfm-event.ts
@@ -1,6 +1,6 @@
 import { CloudFileManagerClient, CloudFileManagerClientEvent } from "@concord-consortium/cloud-file-manager"
 import { appState } from "../models/app-state"
-import { removeDevUrlParams } from "../utilities/url-params"
+import { removeDevUrlParams, urlParams } from "../utilities/url-params"
 import { isCodapV2Document } from "../v2/codap-v2-types"
 import { CodapV2Document } from "../v2/codap-v2-document"
 import { importV2Document } from "../v2/import-v2-document"
@@ -20,8 +20,14 @@ export function handleCFMEvent(cfmClient: CloudFileManagerClient, event: CloudFi
         appVersion: pkg.version,
         appBuildNum: build.buildNumber
       })
+      // pass the version number for display in the CFM menu bar
       wrapCfmCallback(() => cfmClient._ui.setMenuBarInfo(`v${pkg.version} (${build.buildNumber})`))
       appState.setVersion(pkg.version)
+
+      // load initial document specified via `url` parameter (if any)
+      if (urlParams.url) {
+        cfmClient.openUrlFile(urlParams.url)
+      }
       break
     // case "requiresUserInteraction":
     //   break

--- a/v3/src/utilities/url-params.ts
+++ b/v3/src/utilities/url-params.ts
@@ -20,11 +20,96 @@ export function removeSearchParams(paramsToRemove: string[]) {
   window.history.pushState({path: newUrl}, "", newUrl)
 }
 
-export let urlParams = queryString.parse(getSearchParams())
+export interface UrlParams {
+  /*
+   * For testing -- when present brings up a default set of tiles (table, graph, calculator, slider, text).
+   * value: ignored
+   */
+  dashboard?: string | null
+  /*
+   * [v2] Loads the specified url as a data interactive/plugin tile.
+   * value: url string
+   */
+  di?: string | null
+  /*
+   * [v2] When present enables the gaussian fit feature of the normal curve adornment.
+   * value: ignored
+   */
+  gaussianFit?: string | null
+  /*
+   * [v2] When present enables the informal confidence interval on the box plot adornment.
+   * value: ignored
+   */
+  ICI?: string | null
+  /*
+   * [v2] Specifies the default locale, overriding the browser default.
+   * value: locale string, e.g. `en-US` or `es`
+   */
+  lang?: string | null
+  /*
+   * [v2] Alternate means to specify default locale.
+   * v2 comment: "Allow override of lang query param"(?)
+   * value: locale string, e.g. `en-US` or `es`
+   */
+  "lang-override"?: string | null
+  /*
+   * Specifies the type of tile container. Defaults to "free", which is the standard free layout used by CODAP.
+   * Limited/provisional support for "mosaic" layout, in which tiles are connected and cannot overlap.
+   * Experimental flag for possible future development direction.
+   * value: "free" (default) | "mosaic"
+   */
+  layout?: string | null
+  /*
+   * [v3] Specifies a url that can be used to add additional items to the Plugins menu.
+   * See useRemotePluginsConfig() hook for more details, including format of remote document.
+   * value: url string
+   */
+  morePlugins?: string | null
+  /*
+   * For testing -- when present adds the DnDKit MouseSensor in addition to the PointerSensor for drag/drop.
+   * The MouseSensor has proven more amenable for testing drag/drop in cypress tests.
+   * value: ignored
+   */
+  mouseSensor?: string | null
+  /*
+   * For testing -- when present disables animation, which can be useful in automated tests.
+   * value: ignored
+   */
+  noComponentAnimation?: string | null
+  /*
+   * For testing -- when present disables data tips, which can be useful in automated tests.
+   * value: ignored
+   */
+  noDataTips?: string | null
+  /*
+   * For testing -- specifies a built-in sample document to be loaded on startup.
+   * Useful for automated tests; often combined with `dashboard`.
+   * value: "abalone" | "cats" | "coasters" | "colors" | "four" | "mammals"
+   */
+  sample?: string | null
+  /*
+   * Primarily for testing -- specifies whether scrolling should be "smooth" (default) or not.
+   * Disable smooth scrolling by setting it to "auto", which can be useful in automated tests.
+   * value: "auto" | "smooth" (default)
+   */
+  scrollBehavior?: string | null
+  /*
+   * For testing -- when present along with `dashboard`, only a single table will be created by default.
+   * value: ignored
+   */
+  tableOnly?: string | null
+  /*
+   * [v2] Specifies the url of a document to load on application launch.
+   * value: url string
+   */
+  url?: string | null
+}
+
+export let urlParams: UrlParams = queryString.parse(getSearchParams())
 
 export const setUrlParams = (search: string) => urlParams = queryString.parse(search)
 
 // remove developer-convenience url params
 export function removeDevUrlParams() {
-  removeSearchParams(["sample", "dashboard"])
+  removeSearchParams(["dashboard", "sample", "tableOnly"])
 }


### PR DESCRIPTION
[[PT-188188119]](https://www.pivotaltracker.com/story/show/188188119)

- adds type-safety to `urlParams` usage
- documents existing url parameters
- implements new `url` parameter for specifying document to load on launch