### PR TITLE
fix: reset `caseIds` in `itemInfoMap` when appropriate

### DIFF
--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -473,6 +473,7 @@ export const DataSet = V2Model.named("DataSet").props({
   validateCases() {
     if (!self.isValidCases) {
       self.caseInfoMap.clear()
+      self.itemInfoMap.forEach(item => item.caseIds = [])
       self.collections.forEach((collection, index) => {
         // update the cases
         collection.updateCaseGroups()


### PR DESCRIPTION
While reviewing #1438, I noticed some redundant values in the `caseIds` field of the `itemInfoMap`. Turns out the `caseIds` were never being cleared, so the array just kept getting longer.