### PR TITLE
Fix date axis dynamic resize

### DIFF
--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -9,7 +9,7 @@ import { maxWidthOfStringsD3 } from "../../data-display/data-display-utils"
 import { useDataConfigurationContext } from "../../data-display/hooks/use-data-configuration-context"
 import { AxisPlace, AxisScaleType, axisGap } from "../axis-types"
 import { useAxisLayoutContext } from "../models/axis-layout-context"
-import { IAxisModel, isDateAxisModel, isNumericAxisModel } from "../models/axis-model"
+import { IAxisModel, isBaseNumericAxisModel, isDateAxisModel } from "../models/axis-model"
 import { collisionExists, getNumberOfLevelsForDateAxis, getStringBounds, isScaleLinear } from "../axis-utils"
 import { useAxisProviderContext } from "./use-axis-provider-context"
 import { useDataDisplayModelContext } from "../../data-display/hooks/use-data-display-model"
@@ -54,7 +54,7 @@ export const useAxis = ({axisPlace, axisTitle = "", centerCategoryLabels}: IUseA
     displayModel = useDataDisplayModelContext(),
     axisProvider = useAxisProviderContext(),
     axisModel = axisProvider.getAxis?.(axisPlace),
-    isNumeric = axisModel && isNumericAxisModel(axisModel),
+    isNumeric = axisModel && isBaseNumericAxisModel(axisModel),
     multiScale = layout.getAxisMultiScale(axisPlace),
     ordinalScale = isNumeric || axisModel?.type === 'empty' ? null : multiScale?.scale as ScaleBand<string>,
     // eslint-disable-next-line react-hooks/exhaustive-deps  --  see note below
@@ -111,7 +111,8 @@ export const useAxis = ({axisPlace, axisTitle = "", centerCategoryLabels}: IUseA
       }
       case 'date': {
         if (isDateAxisModel(axisModel)) {
-          desiredExtent += getNumberOfLevelsForDateAxis(axisModel.min, axisModel.max) * numbersHeight + axisGap
+          const [min, max] = axisModel.domain
+          desiredExtent += getNumberOfLevelsForDateAxis(min, max) * numbersHeight + axisGap
         }
         break
       }


### PR DESCRIPTION
[#188109309] Bug fix: Graph doesn't respond dynamically to change in extent of date axis

* Includes a couple of lint fixes

* In use-axis.ts we weren't doing a test for numeric axis that includes a date axis. And in computeDesiredExtent for the date axis we weren't getting the dynamic values.