### PR TITLE
fix flaky Cypress test (text tile undo/redo)

### DIFF
--- a/v3/cypress/e2e/text.spec.ts
+++ b/v3/cypress/e2e/text.spec.ts
@@ -24,6 +24,9 @@ context("Text tile", () => {
 
     // Redo title change
     toolbar.getRedoTool().click()
+    cy.wait(300) // this test has become flaky.
+    // Added a small wait here to see if this fixes
+    // the disabled redo button issue
     c.getComponentTitle(kTextTileTestId).should("have.text", newTextTileName)
   })
   it("close text tile from close button with undo/redo", () => {

--- a/v3/cypress/e2e/text.spec.ts
+++ b/v3/cypress/e2e/text.spec.ts
@@ -23,10 +23,10 @@ context("Text tile", () => {
     c.getComponentTitle(kTextTileTestId).should("have.text", textDefaultTitle)
 
     // Redo title change
-    toolbar.getRedoTool().click()
     cy.wait(300) // this test has become flaky.
     // Added a small wait here to see if this fixes
     // the disabled redo button issue
+    toolbar.getRedoTool().click()
     c.getComponentTitle(kTextTileTestId).should("have.text", newTextTileName)
   })
   it("close text tile from close button with undo/redo", () => {

--- a/v3/cypress/e2e/text.spec.ts
+++ b/v3/cypress/e2e/text.spec.ts
@@ -23,9 +23,7 @@ context("Text tile", () => {
     c.getComponentTitle(kTextTileTestId).should("have.text", textDefaultTitle)
 
     // Redo title change
-    cy.wait(300) // this test has become flaky.
-    // Added a small wait here to see if this fixes
-    // the disabled redo button issue
+    toolbar.getRedoTool().should("be.enabled")
     toolbar.getRedoTool().click()
     c.getComponentTitle(kTextTileTestId).should("have.text", newTextTileName)
   })


### PR DESCRIPTION
### Fixes Medium Flakiness in "updates text title with undo/redo" Test

This PR addresses a small issue in the "updates text title with undo/redo" test, which has recently become "medium" flaky (see [Flaky Test Analytics](https://cloud.cypress.io/projects/msrfxa/analytics/flaky-tests)).

**Issue**: During the test run, it seems that the Redo button is momentarily disabled right as Cypress attempts to press it, leading to test failures.

**Solution**: I've added a small wait before Cypress presses the Redo button as a minor tweak to address this issue. I'm hopeful this will resolve the flakiness, but I’ll keep an eye on the test over the next few runs to confirm.

Please review and feel free to merge if it looks good. I’ll update if any further adjustments are needed.