### PR TITLE
fix: parent cases maintain persistent ids when possible

### DIFF
--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -357,6 +357,20 @@ describe("CollectionModel", () => {
     expect(c1.caseIds).toEqual(originalParentCaseIds)
     expect(c2.caseIds).toEqual(originalChildCaseIds)
 
+    // removing attr1 from the parent collection invalidates grouping and changes parent case ids
+    c1.removeAttribute(a1.id)
+    expect(itemData.invalidate).toHaveBeenCalledTimes(2)
+    validateCases()
+    expect(c1.caseIds).not.toEqual(originalParentCaseIds)
+    expect([...c2.caseIds].sort()).toEqual([...originalChildCaseIds].sort())
+
+    // adding attr1 back to parent collection invalidates grouping and restores original parent case ids
+    c1.addAttribute(a1)
+    expect(itemData.invalidate).toHaveBeenCalledTimes(3)
+    validateCases()
+    expect(c1.caseIds).toEqual(originalParentCaseIds)
+    expect(c2.caseIds).toEqual(originalChildCaseIds)
+
     // changing all b's to c's doesn't change case ids
     attr1Values = ["a", "c"]
     validateCases()

--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -34,6 +34,9 @@ describe("CollectionModel", () => {
     withNameAndTitle.setTitle("newTitle")
     expect(withNameAndTitle.title).toBe("newTitle")
     expect(isCollectionModel(withNameAndTitle)).toBe(true)
+
+    defaultItemData.addItemInfo("foo", 0, "bar")
+    defaultItemData.invalidate()
   })
 
   it("labels work as expected", () => {
@@ -80,6 +83,9 @@ describe("CollectionModel", () => {
   it("empty collections work as expected", () => {
     const c1 = CollectionModel.create({ name: "c1" })
     c1.updateCaseGroups()
+    expect(c1.parent).toBeUndefined()
+    expect(c1.child).toBeUndefined()
+    expect(c1.isTopLevel).toBe(true)
     expect(c1.caseIds).toEqual([])
     expect(c1.caseIdToIndexMap.size).toBe(0)
     expect(c1.caseIdToGroupKeyMap.size).toBe(0)
@@ -202,10 +208,13 @@ describe("CollectionModel", () => {
     const [c1, c2, c3] = root.collections
     expect(c1.parent).toBeUndefined()
     expect(c1.child).toBe(c2)
+    expect(c1.isTopLevel).toBe(true)
     expect(c2.parent).toBe(c1)
     expect(c2.child).toBe(c3)
+    expect(c2.isTopLevel).toBe(false)
     expect(c3.parent).toBe(c2)
     expect(c3.child).toBeUndefined()
+    expect(c3.isTopLevel).toBe(false)
 
     c1.addAttribute(a1)
     c2.addAttribute(a2)
@@ -233,56 +242,85 @@ describe("CollectionModel", () => {
     c1.addAttribute(a1)
     c2.addAttribute(a2)
 
-    const itemIdToCaseIdMap = new Map<string, string>()
+    const itemIdToCaseIdsMap = new Map<string, string[]>()
 
-    function caseIdsForItems(itemIds: string[]) {
-      return itemIds.map(itemId => itemIdToCaseIdMap.get(itemId))
+    function caseIdsForItems(itemIds: string[], index: number) {
+      return itemIds.reduce<string[]>((allCaseIds, itemId) => {
+        const caseIdsForItem = itemIdToCaseIdsMap.get(itemId) ?? []
+        allCaseIds.push(caseIdsForItem[index])
+        return allCaseIds
+      }, [])
     }
 
+    let attr1Values: [string, string] = ["a", "b"]
     const itemData: IItemData = {
       itemIds: () => ["0", "1", "2", "3", "4", "5"].map(id => `i${id}`),
       getValue: (itemId: string, attrId: string) => {
         const baseId = itemId.substring(1)
         const index = +baseId
         return attrId === "a1"
-                ? ["a", "b"][index % 2]
-                : baseId
+                ? attr1Values[index % 2]
+                : attrId === "a2"
+                  ? baseId
+                  : attrId === "a3"
+                    ? "parent"
+                    : "child"
       },
-      addItemInfo: (itemId, index, caseId) => itemIdToCaseIdMap.set(itemId, caseId),
+      addItemInfo: (itemId, index, caseId) => {
+        const entry = itemIdToCaseIdsMap.get(itemId)
+        if (entry) {
+          entry.push(caseId)
+        }
+        else {
+          itemIdToCaseIdsMap.set(itemId, [caseId])
+        }
+      },
       invalidate: jest.fn()
     }
     syncCollectionLinks(root.collections, itemData)
 
-    root.collections.forEach((collection, index) => {
-      // update the cases
-      collection.updateCaseGroups()
+    function validateCases() {
+      itemIdToCaseIdsMap.clear()
 
-      expect(collection.findParentCaseGroup("foo")).toBeUndefined()
-    })
+      root.collections.forEach((collection, index) => {
+        // update the cases
+        collection.updateCaseGroups()
 
-    root.collections.forEach((collection, index) => {
-      // sort child collection cases into groups
-      const parentCaseGroups = index > 0 ? root.collections[index - 1].caseGroups : undefined
-      collection.completeCaseGroups(parentCaseGroups)
-    })
+        expect(collection.findParentCaseGroup("foo")).toBeUndefined()
+      })
+
+      root.collections.forEach((collection, index) => {
+        // sort child collection cases into groups
+        const parentCaseGroups = index > 0 ? root.collections[index - 1].caseGroups : undefined
+        collection.completeCaseGroups(parentCaseGroups)
+      })
+    }
+    validateCases()
 
     expect(c1.caseIds.length).toBe(2)
     expect(c1.cases.length).toBe(2)
-    expect(c2.caseIds).toEqual(caseIdsForItems(["i0", "i2", "i4", "i1", "i3", "i5"]))
+    expect(c2.caseIds).toEqual(caseIdsForItems(["i0", "i2", "i4", "i1", "i3", "i5"], 1))
     expect(c2.findParentCaseGroup("foo")).toBeUndefined()
-    expect(c1.caseGroups[0].childCaseIds).toEqual(caseIdsForItems(["i0", "i2", "i4"]))
+    expect(c1.caseGroups[0].childCaseIds).toEqual(caseIdsForItems(["i0", "i2", "i4"], 1))
     expect(c1.caseGroups[0].childItemIds).toEqual(["i0", "i2", "i4"])
-    expect(c1.caseGroups[1].childCaseIds).toEqual(caseIdsForItems(["i1", "i3", "i5"]))
+    expect(c1.caseGroups[1].childCaseIds).toEqual(caseIdsForItems(["i1", "i3", "i5"], 1))
     expect(c1.caseGroups[1].childItemIds).toEqual(["i1", "i3", "i5"])
 
     itemData.itemIds().forEach((itemId, index) => {
       const itemBaseId = itemId.substring(1)
-      const caseId = itemIdToCaseIdMap.get(itemId)!
-      expect(c2.hasCase(caseId)).toBe(true)
-      expect(c2.getCaseIndex(caseId)).toBe(index)
-      expect(c2.getCaseGroup(caseId)!.childItemIds).toEqual([itemId])
-      expect(c1.findParentCaseGroup(caseId)).toBe(c1.caseGroups[+itemBaseId % 2])
+      const [parentCaseId, childCaseId] = itemIdToCaseIdsMap.get(itemId)!
+      const childItemIds = index % 2 ? ["i1", "i3", "i5"] : ["i0", "i2", "i4"]
+      expect(c1.hasCase(parentCaseId)).toBe(true)
+      expect(c1.getCaseIndex(parentCaseId)).toBe(index % 2)
+      expect(c1.getCaseGroup(parentCaseId)!.childItemIds).toEqual(childItemIds)
+      expect(c2.hasCase(childCaseId)).toBe(true)
+      expect(c2.getCaseIndex(childCaseId)).toBe(index)
+      expect(c2.getCaseGroup(childCaseId)!.childItemIds).toEqual([itemId])
+      expect(c1.findParentCaseGroup(childCaseId)).toBe(c1.caseGroups[+itemBaseId % 2])
     })
+
+    const originalParentCaseIds = [...c1.caseIds]
+    const originalChildCaseIds = [...c2.caseIds]
 
     // serializes group key => case id map appropriately
     c1.prepareSnapshot()
@@ -301,12 +339,28 @@ describe("CollectionModel", () => {
     c2.prepareSnapshot()
     expect(c2._groupKeyCaseIds!.length).toEqual(itemData.itemIds().length)
 
-    // adding an attribute to the child collection doesn't invalidate grouping
+    // adding constant attribute to the child collection doesn't invalidate grouping
     c2.addAttribute(a4)
     expect(itemData.invalidate).not.toHaveBeenCalled()
 
-    // adding an attribute to the parent collection does invalidate grouping
+    // adding constant attribute to the child collection doesn't change case ids
+    validateCases()
+    expect(c1.caseIds).toEqual(originalParentCaseIds)
+    expect(c2.caseIds).toEqual(originalChildCaseIds)
+
+    // adding constant attribute to the parent collection does invalidate grouping
     c1.addAttribute(a3)
     expect(itemData.invalidate).toHaveBeenCalledTimes(1)
+
+    // adding constant attribute to the parent collection doesn't change case ids
+    validateCases()
+    expect(c1.caseIds).toEqual(originalParentCaseIds)
+    expect(c2.caseIds).toEqual(originalChildCaseIds)
+
+    // changing all b's to c's doesn't change case ids
+    attr1Values = ["a", "c"]
+    validateCases()
+    expect(c1.caseIds).toEqual(originalParentCaseIds)
+    expect(c2.caseIds).toEqual(originalChildCaseIds)
   })
 })

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -56,7 +56,15 @@ export const CollectionModel = V2Model
   // map from case id to group key (stringified attribute values)
   caseIdToGroupKeyMap: new Map<string, string>(),
   // map from group key (stringified attribute values) to CaseGroup
-  caseGroupMap: new Map<string, CaseInfo>()
+  caseGroupMap: new Map<string, CaseInfo>(),
+  // case ids in case table/render order
+  prevCaseIds: undefined as Maybe<string[]>,
+  // map from case id to case index
+  prevCaseIdToIndexMap: undefined as Maybe<Map<string, number>>,
+  // map from case id to group key (stringified attribute values)
+  prevCaseIdToGroupKeyMap: undefined as Maybe<Map<string, string>>,
+  // map from group key (stringified attribute values) to CaseGroup
+  prevCaseGroupMap: undefined as Maybe<Map<string, CaseInfo>>
 }))
 .actions(self => ({
   setParent(parent?: ICollectionModel) {
@@ -152,20 +160,98 @@ export const CollectionModel = V2Model
     return caseId
   }
 }))
+.views(self => ({
+  getChildItemsToken(caseId: string) {
+    const groupKey = self.caseIdToGroupKeyMap.get(caseId)
+    const caseGroup = groupKey ? self.caseGroupMap.get(groupKey) : undefined
+    const childItemIds = caseGroup?.childItemIds.length ? caseGroup.childItemIds : undefined
+    return childItemIds?.sort().join()
+  },
+  getPrevChildItemsToken(caseId: string) {
+    const groupKey = self.prevCaseIdToGroupKeyMap?.get(caseId)
+    const caseGroup = groupKey ? self.prevCaseGroupMap?.get(groupKey) : undefined
+    const childItemIds = caseGroup?.childItemIds.length ? caseGroup.childItemIds : undefined
+    return childItemIds?.sort().join()
+  }
+}))
 .actions(self => ({
   clearCases() {
+    if (!self.prevCaseIds) self.prevCaseIds = self.caseIds
     self.caseIds = []
-    self.caseIdToIndexMap.clear()
-    self.caseIdToGroupKeyMap.clear()
-    self.caseGroupMap.clear()
+
+    if (!self.prevCaseIdToIndexMap) self.prevCaseIdToIndexMap = self.caseIdToIndexMap
+    self.caseIdToIndexMap = new Map<string, number>()
+
+    if (!self.prevCaseIdToGroupKeyMap) self.prevCaseIdToGroupKeyMap = self.caseIdToGroupKeyMap
+    self.caseIdToGroupKeyMap = new Map<string, string>()
+
+    if (!self.prevCaseGroupMap) self.prevCaseGroupMap = self.caseGroupMap
+    self.caseGroupMap = new Map<string, CaseInfo>()
+  },
+  clearPrevCases() {
+    self.prevCaseIds = undefined
+    self.prevCaseIdToIndexMap = undefined
+    self.prevCaseIdToGroupKeyMap = undefined
+    self.prevCaseGroupMap = undefined
+  }
+}))
+.views(self => ({
+  // returns a map from newly assigned case id to previously used case id
+  getRemappedCaseIds(newCaseIds: string[]) {
+    // See if any case ids should be remapped. This occurs when the grouping values of a parent
+    // case change in unison, in which case we preserve the original case id rather than assigning
+    // a new one. Because the grouping values are used to generate the groupKey, and groupKeys are
+    // mapped to case ids, normally changing grouping values results in generation of a new id.
+    // To detect this, we identify case ids that were in use the last time we grouped cases as
+    // well as newly generated case ids corresponding to new groupKeys. If there are any recently
+    // unused case ids that correspond to the same set of items as any of the newly generated case
+    // ids, then we replace the new case id with the original case id in our internal structures.
+    // We have to do this in a second pass because we don't know the full set of child item ids
+    // associated with a particular case id or groupKey until the completion of the first pass.
+    // This assumes that from one grouping pass to the next, either items were added/removed
+    // (in which case sets of child item ids may have changed but case ids should be persistent)
+    // OR item values were changed (in which case case ids may have changed but sets of child item
+    // ids will not have changed). If both sets of changes occur in one pass then the remapping
+    // algorithm won't recognize the new cases as appropriate to inherit the previous case ids.
+    const remappedCaseIds = new Map<string, string>() // new case id => original case id
+    if (self.prevCaseIds) {
+      // identify recently released case ids no longer in use
+      const unusedCaseIds = self.prevCaseIds.filter(caseId => !self.caseIdToGroupKeyMap.get(caseId))
+      if (unusedCaseIds.length && newCaseIds.length) {
+        // determine the set of child item ids corresponding to each unused case id
+        const unusedChildItemTokens = new Map<string, string>()
+        unusedCaseIds.forEach(caseId => {
+          const childItemToken = self.getPrevChildItemsToken(caseId)
+          if (childItemToken) {
+            unusedChildItemTokens.set(childItemToken, caseId)
+          }
+        })
+        // see if any newly assigned case ids correspond to sets of items previously
+        // associated with one of the recently released case ids no longer in use
+        newCaseIds.forEach(newCaseId => {
+          const childItemToken = self.getChildItemsToken(newCaseId)
+          const unusedCaseIdForToken = childItemToken && unusedChildItemTokens.get(childItemToken)
+          if (unusedCaseIdForToken) {
+            // found an unused case id corresponding to the same child items as a new case id
+            remappedCaseIds.set(newCaseId, unusedCaseIdForToken)
+          }
+        })
+      }
+    }
+    return remappedCaseIds
   }
 }))
 .views(self => ({
   updateCaseGroups() {
     self.clearCases()
+
+    const newCaseIds: string[] = []
+    const parentChildIdPairs: Array<[string, string]> = []
     self.itemData.itemIds().forEach((itemId, itemIndex) => {
       const groupKey = self.groupKey(itemId)
+      const hadCaseIdForGroupKey = !!self.groupKeyCaseIds.get(groupKey)
       const caseId = self.groupKeyCaseId(groupKey)
+      if (caseId && !hadCaseIdForGroupKey) newCaseIds.push(caseId)
       if (groupKey && caseId) {
         let caseGroup = self.caseGroupMap.get(groupKey)
         if (!caseGroup) {
@@ -177,7 +263,8 @@ export const CollectionModel = V2Model
           const parentGroupKey = self.parentGroupKey(itemId)
           const parentCaseId = self.parent?.groupKeyCaseId(parentGroupKey)
           const parent = parentCaseId ? { [symParent]: parentCaseId } : {}
-          parentCaseId && self.parent?.addChildCase(parentCaseId, caseId)
+          // stash parent/child pairs so they can be remapped if necessary
+          parentGroupKey && parentCaseId && parentChildIdPairs.push([parentCaseId, caseId])
 
           caseGroup = {
             collectionId: self.id,
@@ -194,9 +281,54 @@ export const CollectionModel = V2Model
         else {
           caseGroup.childItemIds.push(itemId)
         }
+
         self.itemData.addItemInfo(itemId, itemIndex, caseId)
       }
     })
+
+    // Identify any new case ids that should be replaced with a prior case id
+    const remappedCaseIds = self.getRemappedCaseIds(newCaseIds)
+
+    // add child case ids to parent cases, remapping child case ids where appropriate
+    parentChildIdPairs.forEach(([parentCaseId, _childCaseId]) => {
+      const childCaseId = remappedCaseIds.get(_childCaseId) ?? _childCaseId
+      self.parent?.addChildCase(parentCaseId, childCaseId)
+    })
+
+    // remap case ids in our internal structures
+    if (remappedCaseIds.size) {
+      self.caseIds.forEach((caseId, i) => {
+        const remappedCaseId = remappedCaseIds.get(caseId)
+        if (remappedCaseId) {
+          self.caseIds[i] = remappedCaseId
+        }
+      })
+    }
+    Array.from(remappedCaseIds.entries()).forEach(([newCaseId, origCaseId]) => {
+      // update index map
+      const caseIndex = self.caseIdToIndexMap.get(newCaseId)
+      if (caseIndex != null) {
+        self.caseIdToIndexMap.delete(newCaseId)
+        self.caseIdToIndexMap.set(origCaseId, caseIndex)
+      }
+      // update group key-case id relationships
+      const groupKey = self.caseIdToGroupKeyMap.get(newCaseId)
+      if (groupKey != null) {
+        // update group key to case id map
+        self.groupKeyCaseIds.set(groupKey, origCaseId)
+
+        // update case id to group key map
+        self.caseIdToGroupKeyMap.delete(newCaseId)
+        self.caseIdToGroupKeyMap.set(origCaseId, groupKey)
+
+        // update case group map entry
+        const caseGroup = self.caseGroupMap.get(groupKey)
+        if (caseGroup) {
+          caseGroup.groupedCase.__id__ = origCaseId
+        }
+      }
+    })
+    self.clearPrevCases()
   }
 }))
 .views(self => ({

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -460,7 +460,6 @@ export const CollectionModel = V2Model
       () => self.sortedDataAttributes.map(attr => attr.id),
       () => {
         if (self.child) {
-          self.groupKeyCaseIds.clear()
           self.itemData.invalidate()
         }
       }, { name: "CollectionModel.sortedDataAttributes reaction", equals: comparer.structural }


### PR DESCRIPTION
[[PT-188003195]](https://www.pivotaltracker.com/story/show/188003195)

Parent collections group items into cases based on the attribute values in those collections (and their parents). For tracking purposes, the case id generated for each case is associated with the specific set of values that defines that case. By default, therefore, changing the values of a parent case or adding new attributes to a parent collection necessarily results in new case ids being generated, because the set of values being used as a key has changed. We would prefer, however, that changes that _don't materially affect the case/item groups_ should _not_ change the case ids. Therefore, this PR adds a post-processing step to the case/item grouping algorithm which detects when new case ids were generated for a case whose constituent items didn't change and instead persists the prior case id. It has to be done as a post-processing step because we don't know whether the resulting case/item groups have changed until after we've completed the first pass.