### PR TITLE
feat: highlight grouping lines in case table based on selection

### DIFF
--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -17,9 +17,10 @@ import { CurvedSpline } from "./curved-spline"
 import { useCollectionTableModel } from "./use-collection-table-model"
 
 interface IProps {
+  selectedFillColor?: string
   onDrop?: (dataSet: IDataSet, attrId: string) => void
 }
-export const CollectionTableSpacer = observer(function CollectionTableSpacer({ onDrop }: IProps) {
+export const CollectionTableSpacer = observer(function CollectionTableSpacer({ selectedFillColor, onDrop }: IProps) {
   const data = useDataSetContext()
   const caseMetadata = useCaseMetadata()
   const parentCollectionId = useParentCollectionContext()
@@ -136,12 +137,14 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({ o
           <div className="spacer-mid">
             <svg className="spacer-mid-layer lower-layer">
               {indexRanges?.map(({ id: parentCaseId, firstChildIndex, lastChildIndex }, index) => {
+                const fillColor = data.isCaseSelected(parentCaseId) ? selectedFillColor : undefined
                 return <CurvedSpline key={`${parentCaseId}-${index}`}
                                       prevY1={parentTableModel.getTopOfRowModuloScroll(index)}
                                       y1={parentTableModel.getBottomOfRowModuloScroll(index)}
                                       prevY2={childTableModel.getTopOfRowModuloScroll(firstChildIndex)}
                                       y2={childTableModel.getBottomOfRowModuloScroll(lastChildIndex)}
                                       even={(index + 1) % 2 === 0}
+                                      fillColor={fillColor}
                         />
               })}
             </svg>

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -52,6 +52,9 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   const caseTableModel = useCaseTableModel()
   const collectionTableModel = useCollectionTableModel()
   const gridRef = useRef<DataGridHandle>(null)
+  const selectedFillColor = gridRef.current?.element &&
+                              getComputedStyle(gridRef.current.element)
+                                .getPropertyValue("--rdg-row-selected-background-color") || undefined
   const visibleAttributes = useVisibleAttributes(collectionId)
   const { selectedRows, setSelectedRows, handleCellClick } = useSelectedRows({ gridRef, onScrollClosestRowIntoView })
   const forceUpdate = useForceUpdate()
@@ -197,7 +200,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
 
   return (
     <div className={`collection-table collection-${collectionId}`}>
-      <CollectionTableSpacer onDrop={handleNewCollectionDrop} />
+      <CollectionTableSpacer selectedFillColor={selectedFillColor} onDrop={handleNewCollectionDrop} />
       <div className="collection-table-and-title" ref={setNodeRef}>
         <CollectionTitle onAddNewAttribute={handleAddNewAttribute}/>
         <DataGrid ref={gridRef} className="rdg-light" data-testid="collection-table-grid" renderers={renderers}

--- a/v3/src/components/case-table/curved-spline.tsx
+++ b/v3/src/components/case-table/curved-spline.tsx
@@ -1,3 +1,4 @@
+import { Colord } from "colord"
 import React from "react"
 
 interface IProps {
@@ -6,8 +7,9 @@ interface IProps {
   even: boolean
   prevY1: number
   prevY2: number
+  fillColor?: string
 }
-export function CurvedSpline({ y1, y2, even, prevY1, prevY2 }: IProps) {
+export function CurvedSpline({ y1, y2, even, prevY1, prevY2, fillColor }: IProps) {
   const kDividerWidth = 48,
         kRelationParentMargin = 12,
         kRelationChildMargin = 4,
@@ -91,10 +93,13 @@ export function CurvedSpline({ y1, y2, even, prevY1, prevY2 }: IProps) {
 
   const pathData = buildPathStr(y1, y2)
   const fillData = buildFillPathStr(prevY1, prevY2, y1, y2)
+  const finalFillColor = fillColor
+                          ? even ? new Colord(fillColor).darken(0.05).toHex() : fillColor
+                          : even ? kRelationFillColor : undefined
   return (
-    even
+    finalFillColor
       ? <>
-          <path d={fillData} fill={kRelationFillColor} stroke ="none" />
+          <path d={fillData} fill={finalFillColor} stroke="none" />
           <path d={pathData} fill="none" stroke={kRelationStrokeColor} />
         </>
       : <path d={pathData} fill="none" stroke={kRelationStrokeColor} />


### PR DESCRIPTION
While working on #1447 I found myself annoyed that the grouping/relationship lines in the case table did not indicate selection. It was straightforward to color the area as selected or not depending on whether the parent case (and hence all the child cases) were selected. I subsequently found [this PT story](https://www.pivotaltracker.com/story/show/185226959) which describes a more elaborate version of this feature in which the area between the grouping/relationship lines would be colored proportionally to the percentage of child cases selected. That PT story, however, also states that

>The first pass of implementation should be quick and dirty to determine whether the effect is actually helpful.

so this can be viewed as the initial quick and dirty implementation.

<img width="728" alt="CaseTableSelectedGroupingLines" src="https://github.com/user-attachments/assets/90470027-889d-4120-90ce-f0b03d64fd8d">
