### PR TITLE
Fix split date axis bug

### DIFF
--- a/v3/src/components/axis/components/axis.tsx
+++ b/v3/src/components/axis/components/axis.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { observer } from "mobx-react-lite"
 import {range} from "d3"
 import {AxisPlace} from "../axis-types"
 import {useAxis} from "../hooks/use-axis"
@@ -13,10 +14,10 @@ interface IProps {
   centerCategoryLabels?: boolean
 }
 
-export const Axis = ({
+export const Axis = observer(function Axis ({
                        axisPlace, showScatterPlotGridLines = false,
                        centerCategoryLabels = true,
-                     }: IProps) => {
+                     }: IProps) {
   const
     layout = useAxisLayoutContext()
 
@@ -44,4 +45,4 @@ export const Axis = ({
       </g>
     </>
   )
-}
+})

--- a/v3/src/components/axis/helper-models/date-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/date-axis-helper.ts
@@ -379,11 +379,10 @@ export class DateAxisHelper extends AxisHelper {
 
         const drawTickAndLabel = (iDateLabel: ILabelDateAndString, drawLabel: boolean) => {
           const refPoint = {x: 0, y: 0}
-          let rotation = 0,
-            pixel = dataToCoordinate(iDateLabel.labelDate.valueOf() / 1000)
+          let rotation = 0
+          const pixel = dataToCoordinate(iDateLabel.labelDate.valueOf() / 1000)
           if (!isVertical) {
             refPoint.y = kAxisTickLength + kAxisGap + kDefaultFontHeight              // y-value
-            pixel += rangeMin
             refPoint.x = pixel
             sAS.append('line')
               .attr('style', 'stroke: black')

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -1,5 +1,5 @@
 import { BaseType, drag, select, Selection } from "d3"
-import { reaction } from "mobx"
+import { comparer, reaction } from "mobx"
 import { mstAutorun } from "../../../utilities/mst-autorun"
 import { mstReaction } from "../../../utilities/mst-reaction"
 import { useCallback, useEffect, useMemo, useRef } from "react"
@@ -340,7 +340,7 @@ export const useSubAxis = ({
       },
       () => {
         renderSubAxis()
-      }, {name: "useSubAxis [axisLength]"}
+      }, {name: "useSubAxis [axisLength]", equals: comparer.structural}
     )
     return () => disposer()
   }, [axisPlace, layout, renderSubAxis])

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -331,11 +331,12 @@ export const useSubAxis = ({
     }
   }, [dataConfig, updateDomainAndRenderSubAxis])
 
-  // update d3 scale and axis when layout/range changes
+  // Render when axis length or number of sub-axes changes
   useEffect(() => {
     const disposer = reaction(
       () => {
-        return layout.getAxisLength(axisPlace)
+        return [layout.getAxisLength(axisPlace),
+          layout.getAxisMultiScale(axisPlace)?.repetitions]
       },
       () => {
         renderSubAxis()


### PR DESCRIPTION
[#188109429] Bug fix: Horizontal date axis partly empty when split on top

* Mostly fixed by making Axis an observer.
* But we also have to rerender sub-axes when the number of repetitions changes; e.g. by introducing a new category in an attribute appearing on the top or right.