### PR TITLE
188214433 Fix Update Attribute Name Requests

### DIFF
--- a/v3/src/data-interactive/handlers/attribute-handler.test.ts
+++ b/v3/src/data-interactive/handlers/attribute-handler.test.ts
@@ -53,7 +53,7 @@ describe("DataInteractive AttributeHandler", () => {
   })
 
   it("update works as expected", () => {
-    const attribute = Attribute.create({ name: "test" })
+    const { dataset: dataContext, a1 } = setupTestDataset()
     const cid = "new cid"
     const name = "new name"
     const title = "new title"
@@ -63,31 +63,31 @@ describe("DataInteractive AttributeHandler", () => {
     const editable = false
     const type = "qualitative"
     const precision = 10
-    const result = handler.update?.({ attribute },
+    const result = handler.update?.({ attribute: a1, dataContext },
       { cid, name, title, description, unit, formula, editable, type, precision })
     expect(result?.success).toBe(true)
     const values = result?.values as DIResultAttributes
     const resultAttr = values.attrs?.[0]
     expect(resultAttr?.cid).toBe(cid)
-    expect(attribute.cid).toBe(cid)
+    expect(a1.cid).toBe(cid)
     expect(resultAttr?.name).toBe(name)
-    expect(attribute.name).toBe(name)
+    expect(a1.name).toBe(name)
     expect(resultAttr?.title).toBe(title)
-    expect(attribute.title).toBe(title)
+    expect(a1.title).toBe(title)
     expect(resultAttr?.description).toBe(description)
-    expect(attribute.description).toBe(description)
+    expect(a1.description).toBe(description)
     expect(resultAttr?.unit).toBe(unit)
-    expect(attribute.units).toBe(unit)
+    expect(a1.units).toBe(unit)
     expect(resultAttr?.formula).toBe(formula)
-    expect(attribute.formula?.display).toBe(formula)
+    expect(a1.formula?.display).toBe(formula)
     expect(resultAttr?.editable).toBe(editable)
-    expect(attribute.editable).toBe(editable)
+    expect(a1.editable).toBe(editable)
     expect(resultAttr?.type).toBe(type)
-    expect(attribute.type).toBe(type)
+    expect(a1.type).toBe(type)
     expect(resultAttr?.precision).toBe(precision)
-    expect(attribute.precision).toBe(precision)
+    expect(a1.precision).toBe(precision)
 
-    const result2 = handler.update?.({ attribute }, { type: "fake type" })
+    const result2 = handler.update?.({ attribute: a1, dataContext }, { type: "fake type" })
     const values2 = result2?.values as DIResultAttributes
     const resultAttr2 = values2.attrs?.[0]
     expect(resultAttr2?.type).toBe(type)

--- a/v3/src/data-interactive/handlers/di-handler-utils.ts
+++ b/v3/src/data-interactive/handlers/di-handler-utils.ts
@@ -40,13 +40,7 @@ export function updateAttribute(attribute: IAttribute, value: DIAttribute, dataC
   if (value?.description != null) attribute.setDescription(value.description)
   if (value?.editable != null) attribute.setEditable(!!value.editable)
   if (value?.formula != null) attribute.setDisplayExpression(value.formula)
-  if (value?.name != null) {
-    if (dataContext) {
-      dataContext.setAttributeName(attribute.id, value.name)
-    } else {
-      attribute.setName(value.name)
-    }
-  }
+  if (value?.name != null) dataContext?.setAttributeName(attribute.id, value.name)
   if (hasOwnProperty(value, "precision")) {
     attribute.setPrecision(value.precision == null || value.precision === "" ? undefined : +value.precision)
   }

--- a/v3/src/data-interactive/handlers/di-handler-utils.ts
+++ b/v3/src/data-interactive/handlers/di-handler-utils.ts
@@ -40,7 +40,13 @@ export function updateAttribute(attribute: IAttribute, value: DIAttribute, dataC
   if (value?.description != null) attribute.setDescription(value.description)
   if (value?.editable != null) attribute.setEditable(!!value.editable)
   if (value?.formula != null) attribute.setDisplayExpression(value.formula)
-  if (value?.name != null) attribute.setName(value.name)
+  if (value?.name != null) {
+    if (dataContext) {
+      dataContext.setAttributeName(attribute.id, value.name)
+    } else {
+      attribute.setName(value.name)
+    }
+  }
   if (hasOwnProperty(value, "precision")) {
     attribute.setPrecision(value.precision == null || value.precision === "" ? undefined : +value.precision)
   }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188214433

There was a bug in the Collaborative plugin where changing an attribute's name in a shared table was resulting in other users losing data. It turns out this is because `update attribute name` requests were not calling `dataset.setAttributeName`, which is necessary to keep the dataset's `attrNameMap` up to date.