### PR TITLE
Bar for each point not applicable to dates

### DIFF
--- a/v3/src/components/graph/components/inspector-panel/display-config-palette.tsx
+++ b/v3/src/components/graph/components/inspector-panel/display-config-palette.tsx
@@ -31,6 +31,8 @@ export const DisplayConfigPalette = observer(function DisplayConfigPanel(props: 
   const showFuseIntoBars = (plotType === "dotChart" && plotHasExactlyOneCategoricalAxis) ||
                            (plotType === "dotPlot" && pointDisplayType === "bins") ||
                            pointDisplayType === "histogram"
+  const showBarForEachPoint = plotType === "dotPlot" &&
+                            graphModel?.dataConfiguration.primaryAttributeType !== "date"
 
   const handleSelection = (configType: string) => {
     if (isPointDisplayType(configType)) {
@@ -125,14 +127,15 @@ export const DisplayConfigPalette = observer(function DisplayConfigPanel(props: 
             >
               {t("DG.Inspector.graphGroupIntoBins")}
             </Radio>
-            <Radio
-              size="md"
-              value="bars"
-              data-testid="bars-radio-button"
-              onChange={(e) => handleSelection(e.target.value)}
-            >
-              {t("DG.Inspector.graphBarForEachPoint")}
-            </Radio>
+            {showBarForEachPoint &&
+               <Radio
+                  size="md"
+                  value="bars"
+                  data-testid="bars-radio-button"
+                  onChange={(e) => handleSelection(e.target.value)}
+               >
+                 {t("DG.Inspector.graphBarForEachPoint")}
+               </Radio>}
           </Stack>
         </RadioGroup>
       )}

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -134,6 +134,9 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         }
       })
       return allGraphCaseIds
+    },
+    get primaryAttributeType(): AttributeType {
+      return self.primaryRole && self.attributeType(self.primaryRole) || "categorical"
     }
   }))
   .actions(self => ({


### PR DESCRIPTION
[#188219800] Bug fix: Bar for each point problem with dates

* The observed bug of black bars for points occurs because we are inappropriately allowed to request a bar for each point when the primary attribute is of type "date". The bar would go from a zero date to the date value, but we don't work with dates of value zero. So the solution is to prevent the option from showing.