### PR TITLE
Count axis should only show only integers

### DIFF
--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -57,6 +57,14 @@ export class NumericAxisHelper extends AxisHelper {
       axisScale.tickValues(tickValues)
       axisScale.tickFormat((d, i) => tickLabels[i])
     }
+    if (this.axisModel.integersOnly) {
+      // Note: This has the desirable effect of removing the decimal point from the tick labels,
+      // but it doesn't prevent the tick marks from showing for fractional values or grid lines
+      // from being drawn at fractional values.
+      axisScale.tickFormat((d, i) => {
+        return Number.isInteger(d) ? d.toString() : ""
+      })
+    }
     this.subAxisElt && select(this.subAxisElt)
       .attr("transform", this.initialTransform)
       .transition().duration(duration)

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -133,7 +133,13 @@ export const NumericAxisModel = BaseNumericAxisModel
   .named("NumericAxisModel")
   .props({
     type: types.optional(types.literal("numeric"), "numeric"),
+    integersOnly: false
   })
+  .actions(self => ({
+    setIntegersOnly(integersOnly: boolean) {
+      self.integersOnly = integersOnly
+    }
+  }))
 
 export interface INumericAxisModel extends Instance<typeof NumericAxisModel> {}
 export interface INumericAxisModelSnapshot extends SnapshotIn<typeof NumericAxisModel> {}

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -637,7 +637,8 @@ export const GraphContentModel = DataDisplayContentModel
         place: secondaryPlace,
         min: 0,
         max: maxCellCaseCount,
-        lockZero: true
+        lockZero: true,
+        integersOnly: true
       })
       setNiceDomain([0, maxCellCaseCount], countAxis, {clampPosMinAtZero: true})
       self.setAxis(secondaryPlace, countAxis)


### PR DESCRIPTION
[#188221613] Bug fix: A Count axis should only show integer values

* We introduce the `integersOnly` property for `NumericAxisModel` and refer to it when rendering a numeric axis

D3 makes it difficult to control the tick marks so we end up with fractional tick marks and gridlines for histograms. But we regard this as an acceptable difference from V2.