### PR TITLE
fix: caseIds in itemInfo when remapping case ids

### DIFF
--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -309,18 +309,22 @@ describe("CollectionModel", () => {
     expect(c1.caseGroups[1].childCaseIds).toEqual(caseIdsForItems(["i1", "i3", "i5"], 1))
     expect(c1.caseGroups[1].childItemIds).toEqual(["i1", "i3", "i5"])
 
-    itemData.itemIds().forEach((itemId, index) => {
-      const itemBaseId = itemId.substring(1)
-      const [parentCaseId, childCaseId] = itemIdToCaseIdsMap.get(itemId)!
-      const childItemIds = index % 2 ? ["i1", "i3", "i5"] : ["i0", "i2", "i4"]
-      expect(c1.hasCase(parentCaseId)).toBe(true)
-      expect(c1.getCaseIndex(parentCaseId)).toBe(index % 2)
-      expect(c1.getCaseGroup(parentCaseId)!.childItemIds).toEqual(childItemIds)
-      expect(c2.hasCase(childCaseId)).toBe(true)
-      expect(c2.getCaseIndex(childCaseId)).toBe(index)
-      expect(c2.getCaseGroup(childCaseId)!.childItemIds).toEqual([itemId])
-      expect(c1.findParentCaseGroup(childCaseId)).toBe(c1.caseGroups[+itemBaseId % 2])
-    })
+    function validateItemCaseIds() {
+      itemData.itemIds().forEach((itemId, index) => {
+        const itemBaseId = itemId.substring(1)
+        const [parentCaseId, childCaseId] = itemIdToCaseIdsMap.get(itemId)!
+        const childItemIds = index % 2 ? ["i1", "i3", "i5"] : ["i0", "i2", "i4"]
+        expect(c1.hasCase(parentCaseId)).toBe(true)
+        expect(c1.getCaseIndex(parentCaseId)).toBe(index % 2)
+        expect(c1.getCaseGroup(parentCaseId)!.childItemIds).toEqual(childItemIds)
+        expect(c2.hasCase(childCaseId)).toBe(true)
+        expect(c2.getCaseIndex(childCaseId)).toBe(index)
+        expect(c2.getCaseGroup(childCaseId)!.childItemIds).toEqual([itemId])
+        expect(c1.findParentCaseGroup(childCaseId)).toBe(c1.caseGroups[+itemBaseId % 2])
+      })
+    }
+
+    validateItemCaseIds()
 
     const originalParentCaseIds = [...c1.caseIds]
     const originalChildCaseIds = [...c2.caseIds]
@@ -350,6 +354,7 @@ describe("CollectionModel", () => {
     validateCases()
     expect(c1.caseIds).toEqual(originalParentCaseIds)
     expect(c2.caseIds).toEqual(originalChildCaseIds)
+    validateItemCaseIds()
 
     // adding constant attribute to the parent collection does invalidate grouping
     c1.addAttribute(a3)
@@ -359,6 +364,7 @@ describe("CollectionModel", () => {
     validateCases()
     expect(c1.caseIds).toEqual(originalParentCaseIds)
     expect(c2.caseIds).toEqual(originalChildCaseIds)
+    validateItemCaseIds()
 
     // removing attr1 from the parent collection invalidates grouping and changes parent case ids
     c1.removeAttribute(a1.id)
@@ -373,11 +379,13 @@ describe("CollectionModel", () => {
     validateCases()
     expect(c1.caseIds).toEqual(originalParentCaseIds)
     expect(c2.caseIds).toEqual(originalChildCaseIds)
+    validateItemCaseIds()
 
     // changing all b's to c's doesn't change case ids
     attr1Values = ["a", "c"]
     validateCases()
     expect(c1.caseIds).toEqual(originalParentCaseIds)
     expect(c2.caseIds).toEqual(originalChildCaseIds)
+    validateItemCaseIds()
   })
 })

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -248,7 +248,9 @@ export const CollectionModel = V2Model
     self.clearCases()
 
     const newCaseIds: string[] = []
+    // [parentCaseId, childCaseId] tuples
     const parentChildIdPairs: Array<[string, string]> = []
+    const itemInfo: Array<{itemId: string, itemIndex: number, caseId: string}> = []
     self.itemData.itemIds().forEach((itemId, itemIndex) => {
       if (self.itemData.isHidden(itemId)) return
       const groupKey = self.groupKey(itemId)
@@ -285,12 +287,18 @@ export const CollectionModel = V2Model
           caseGroup.childItemIds.push(itemId)
         }
 
-        self.itemData.addItemInfo(itemId, itemIndex, caseId)
+        itemInfo.push({ itemId, itemIndex, caseId })
       }
     })
 
     // Identify any new case ids that should be replaced with a prior case id
     const remappedCaseIds = self.getRemappedCaseIds(newCaseIds)
+
+    // add item info, remapping case ids where appropriate
+    itemInfo.forEach(({ itemId, itemIndex, caseId }) => {
+      const _caseId = remappedCaseIds.get(caseId) ?? caseId
+      self.itemData.addItemInfo(itemId, itemIndex, _caseId)
+    })
 
     // add child case ids to parent cases, remapping child case ids where appropriate
     parentChildIdPairs.forEach(([parentCaseId, _childCaseId]) => {


### PR DESCRIPTION
While working on #1453, @emcelroy and @lublagg encountered a bug in the persistent id code that failed to properly map the `childIds` associated with an item in the `itemInfoMap`. This PR fixes the bug and extends the jest tests so that they fail without the fix in place.