### PR TITLE
Fix excessive categorical axis rerending

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -300,8 +300,11 @@ export const useSubAxis = ({
   const updateDomainAndRenderSubAxis = useCallback(() => {
     const role = axisPlaceToAttrRole[axisPlace]
     if (isCategoricalAxisModel(axisModel)) {
-      const categoryValues = dataConfig?.categoryArrayForAttrRole(role) ?? []
-      layout.getAxisMultiScale(axisPlace)?.setCategoricalDomain(categoryValues)
+      const categoryValues = dataConfig?.categoryArrayForAttrRole(role) ?? [],
+        multiScale = layout.getAxisMultiScale(axisPlace),
+        existingCategoryDomain = multiScale?.categoricalScale?.domain() ?? []
+      if (JSON.stringify(categoryValues) === JSON.stringify(existingCategoryDomain)) return
+      multiScale?.setCategoricalDomain(categoryValues)
       setupCategories()
     } else if (isBaseNumericAxisModel(axisModel)) {
       const numericValues = dataConfig?.numericValuesForAttrRole(role) ?? []


### PR DESCRIPTION
[#188227145] Bug fix: Excessive categorical axis repainting

* In `use-sub-axis.ts` `updateDomainAndRenderSubAxis` we detect that the existing displayed categories are the same as the data configuration's categorical values and, if so, bail without rendering