### PR TITLE
Fix bar chart all hidden bug

### DIFF
--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -112,8 +112,8 @@ export const BaseNumericAxisModel = AxisModel
       } else if ((min < 0) && (Math.abs(max) < Math.abs(min / snapFactor))) {
         max = 0
       }
-      self.min = min
-      self.max = max
+      if (isFinite(min)) self.min = min
+      if (isFinite(max)) self.max = max
       self.dynamicMin = undefined
       self.dynamicMax = undefined
     },


### PR DESCRIPTION
[#188200067] Bug fix: **Bar Chart** Compresses to Top When Hiding Unselected Cases in Mammals Dataset

* The problem was that when all cases were hidden, the Count axis min and max got set to NaN. We fix by not allowing this to happen. On encountering NaN, we leave the min or max alone.
* With an intact Count axis, the bar chart is able to correctly compute the placement of the bars when the hidden cases are shown.