### PR TITLE
Bar chart hide all/show all bug

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -298,7 +298,11 @@ export const useSubAxis = ({
   }, [axisModel, renderSubAxis, layout, isCategorical, setupCategories])
 
   const updateDomainAndRenderSubAxis = useCallback(() => {
-    const role = axisPlaceToAttrRole[axisPlace]
+    const role = axisPlaceToAttrRole[axisPlace],
+      attrID = dataConfig?.attributeID(role)
+    if (!attrID) {
+      return // We don't have an attribute. We're a count axis, so we rely on other methods for domain updates
+    }
     if (isCategoricalAxisModel(axisModel)) {
       const categoryValues = dataConfig?.categoryArrayForAttrRole(role) ?? [],
         multiScale = layout.getAxisMultiScale(axisPlace),


### PR DESCRIPTION
[#188200067] Bug fix: **Bar Chart** Compresses to Top When Hiding Unselected Cases in Mammals Dataset

* This is a second try at this bug. It turned out that in the presence of a legend attribute the previous fix was not sufficient. Now, in `updateDomainAndRenderSubAxis` if we determine that there is no attribute associated with `axisPlace`; i.e. we have a Count axis, we bail because there won't be any values to use for the domain.