### PR TITLE
Fixes bug with modal drag after dropdown select in Safari

### DIFF
--- a/v3/src/components/case-tile-common/attribute-menu/edit-attribute-properties-modal.tsx
+++ b/v3/src/components/case-tile-common/attribute-menu/edit-attribute-properties-modal.tsx
@@ -131,9 +131,12 @@ export const EditAttributePropertiesModal = ({ attributeId, isOpen, onClose }: I
           </FormLabel>
           <FormLabel mr={5} className="edit-attribute-form-row">{t("DG.CaseTable.attributeEditor.type")}
             <Select size="xs" ml={5} value={userType} data-testid="attr-type-select"
-                onChange={(e) => setUserType(e.target.value as AttributeType)}>
+                onChange={(e) => setUserType(e.target.value as AttributeType)}
+                onMouseDown={(e) => e.stopPropagation()}>
               {selectableAttributeTypes.map(aType => {
-                return (<option key={aType} value={aType} data-testid="attr-type-option">
+                return (<option key={aType} value={aType} data-testid="attr-type-option"
+                          // onClick={(e) => e.stopPropagation()}
+                          onMouseDown={(e)=>e.stopPropagation()}>
                           {t(`DG.CaseTable.attribute.type.${aType}`)}
                         </option>)
               })}

--- a/v3/src/components/case-tile-common/attribute-menu/edit-attribute-properties-modal.tsx
+++ b/v3/src/components/case-tile-common/attribute-menu/edit-attribute-properties-modal.tsx
@@ -135,8 +135,7 @@ export const EditAttributePropertiesModal = ({ attributeId, isOpen, onClose }: I
                 onMouseDown={(e) => e.stopPropagation()}>
               {selectableAttributeTypes.map(aType => {
                 return (<option key={aType} value={aType} data-testid="attr-type-option"
-                          // onClick={(e) => e.stopPropagation()}
-                          onMouseDown={(e)=>e.stopPropagation()}>
+                                onMouseDown={(e)=>e.stopPropagation()}>
                           {t(`DG.CaseTable.attribute.type.${aType}`)}
                         </option>)
               })}

--- a/v3/src/components/codap-modal.tsx
+++ b/v3/src/components/codap-modal.tsx
@@ -69,6 +69,12 @@ const DraggableModalContent = ({children, modalWidth, modalHeight, onClick, fRef
     let initialY = 0
 
     const handleMouseDown = (e: MouseEvent) => {
+      // Prevent dragging if the target is an interactive element (like Select, button, input, etc.)
+      const interactiveTags = ["INPUT", "TEXTAREA", "SELECT", "OPTION", "BUTTON"]
+      if (interactiveTags.includes((e.target as HTMLElement).tagName)) {
+        return
+      }
+
       e.stopPropagation()
       isDragging = true
       startX = e.clientX


### PR DESCRIPTION
This fixes the bug when in Safari, and user selects an option in a dropdown, the modal gets "stuck" to the mouse.