### PR TITLE
Bug fix for restore bar chart with hidden cases

### DIFF
--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -74,7 +74,7 @@ export class GraphController {
             axisMultiScale.setScaleType('ordinal')
           }
           if (isCategoricalAxisModel(axisModel)) {
-            axisMultiScale.setCategorySet(dataConfig.categorySetForAttrRole(attrRole))
+            axisMultiScale.setCategoricalDomain(dataConfig.categoryArrayForAttrRole(attrRole))
           }
           if (isNumericAxisModel(axisModel)) {
             axisMultiScale.setNumericDomain(axisModel.domain)


### PR DESCRIPTION
[#188254368] Bug fix: Dot chart not restoring properly with hidden cases

* The bug was caused in graph-controller.ts `syncAxisScalesWithModel` where a misguided attempt to set the categorical axis' domain was done using a category set obtained from the data configuration with `categorySetForAttrRole`. But this category set is obtained from the metadata with no regard for hidden cases. So the fix is to request the categoryArrayForAttrRole from the data configuration since this array is computed taking into hidden cases into account.