### PR TITLE
fix: restore set-asides after parent value change [PT-188254408]

### DIFF
--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -135,7 +135,7 @@ export const useRows = () => {
 
     const onPatchDisposer = data && onPatch(data, ({ op, path, value }) => {
       // reset on any changes to items or hidden items
-      if (/(_itemIds|hiddenItems)(\/\d+)?$/.test(path)) {
+      if (/(_itemIds|hiddenItemIds)(\/\d+)?$/.test(path)) {
         resetRowCacheAndSyncRows()
       }
     })

--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -392,6 +392,7 @@ describe("CollectionModel", () => {
     validateCases()
     expect(c1.caseIds).toEqual(originalParentCaseIds)
     expect(c2.caseIds).toEqual(originalChildCaseIds)
+    expect(c1.groupKeyCaseIds.get(bGroupKey)).toBeUndefined()
     validateItemCaseIds()
   })
 })

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -322,6 +322,8 @@ export const CollectionModel = V2Model
       const groupKey = self.caseIdToGroupKeyMap.get(newCaseId)
       if (groupKey != null) {
         // update group key to case id map
+        const origGroupKey = self.prevCaseIdToGroupKeyMap?.get(origCaseId)
+        origGroupKey && self.groupKeyCaseIds.delete(origGroupKey)
         self.groupKeyCaseIds.set(groupKey, origCaseId)
 
         // update case id to group key map


### PR DESCRIPTION
[[PT-188254408]](https://www.pivotaltracker.com/story/show/188254408)

fix: remove stale entries from group key to case id map

Note: `useRows` change turned out to be unrelated, but seemed worth fixing.