### PR TITLE
fix: adding items/cases with set-asides [PT-188263826]

### DIFF
--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -702,10 +702,10 @@ export const DataSet = V2Model.named("DataSet").props({
       },
       getValueAtItemIndex(index: number, attributeID: string) {
         if (self.isCaching()) {
-          const caseID = self.items[index]?.__id__
-          const cachedCase = self.itemCache.get(caseID)
-          if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
-            return cachedCase[attributeID]
+          const itemId = self.items[index]?.__id__
+          const cachedItem = self.itemCache.get(itemId)
+          if (cachedItem && Object.prototype.hasOwnProperty.call(cachedItem, attributeID)) {
+            return cachedItem[attributeID]
           }
         }
         const attr = self.getAttribute(attributeID)
@@ -717,10 +717,10 @@ export const DataSet = V2Model.named("DataSet").props({
       },
       getStrValueAtItemIndex(itemIndex: number, attributeID: string) {
         if (self.isCaching()) {
-          const caseID = self.items[itemIndex]?.__id__
-          const cachedCase = self.itemCache.get(caseID)
-          if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
-            return cachedCase[attributeID]?.toString()
+          const itemId = self.items[itemIndex]?.__id__
+          const cachedItem = self.itemCache.get(itemId)
+          if (cachedItem && Object.prototype.hasOwnProperty.call(cachedItem, attributeID)) {
+            return cachedItem[attributeID]?.toString()
           }
         }
         const attr = self.getAttribute(attributeID)
@@ -732,10 +732,10 @@ export const DataSet = V2Model.named("DataSet").props({
       },
       getNumericAtItemIndex(index: number, attributeID: string) {
         if (self.isCaching()) {
-          const caseID = self.items[index]?.__id__
-          const cachedCase = self.itemCache.get(caseID)
-          if (cachedCase && Object.prototype.hasOwnProperty.call(cachedCase, attributeID)) {
-            return Number(cachedCase[attributeID])
+          const itemId = self.items[index]?.__id__
+          const cachedItem = self.itemCache.get(itemId)
+          if (cachedItem && Object.prototype.hasOwnProperty.call(cachedItem, attributeID)) {
+            return Number(cachedItem[attributeID])
           }
         }
         const attr = self.getAttribute(attributeID)
@@ -908,12 +908,12 @@ export const DataSet = V2Model.named("DataSet").props({
           if (afterCaseItemIndex) return afterCaseItemIndex + 1
         }
         const afterPosition = getAfterPosition()
-        const insertPosition = beforePosition ?? afterPosition ?? self.items.length
+        const insertPosition = beforePosition ?? afterPosition ?? self._itemIds.length
 
         // insert/append cases and empty values
         const ids = cases.map(({ __id__ = v3Id(kItemIdPrefix) }) => __id__)
         const _values = new Array(cases.length)
-        if (insertPosition < self.items.length) {
+        if (insertPosition < self._itemIds.length) {
           self._itemIds.splice(insertPosition, 0, ...ids)
           // update the indices of cases after the insert
           self.itemInfoMap.forEach((itemInfo, caseId) => {
@@ -930,7 +930,7 @@ export const DataSet = V2Model.named("DataSet").props({
           self._itemIds.push(...ids)
           // append values to each attribute
           self.attributesMap.forEach(attr => {
-            attr.setLength(self.items.length)
+            attr.setLength(self._itemIds.length)
           })
         }
         // add the itemInfo for the appended cases
@@ -1124,13 +1124,13 @@ export const DataSet = V2Model.named("DataSet").props({
     })
 
     // build itemIDMap
-    self.items.forEach((aCase, index) => {
-      self.itemInfoMap.set(aCase.__id__, { index, caseIds: [] })
+    self._itemIds.forEach((itemId, index) => {
+      self.itemInfoMap.set(itemId, { index, caseIds: [] })
     })
 
     // make sure attributes have appropriate length, including attributes with formulas
     self.attributesMap.forEach(attr => {
-      attr.setLength(self.items.length)
+      attr.setLength(self._itemIds.length)
     })
 
     // add initial collection if not already present


### PR DESCRIPTION
[[PT-188263826]](https://www.pivotaltracker.com/story/show/188263826)

There were a few places where `self.items.length` was being used synonymously with `self._itemIds.length`, which was a reasonable assumption to make before set-asides were implemented, but now one has to be careful about what you mean. `self.items.length` is the number of user-visible items, while `self._itemIds.length` is the total number of items before visibility is taken into account. When set-asides were implemented I searched for instances of `self.itemIds` and converted them to `self._itemIds` where appropriate, but I didn't specifically search for `self.items`. Now I have.

Also, did a little bit of `case` => `item` renaming in code I encountered while debugging.