### PR TITLE
feat: focus style for attribute buttons (PT-181869693)

### DIFF
--- a/v3/src/components/case-card/case-attr-view.tsx
+++ b/v3/src/components/case-card/case-attr-view.tsx
@@ -57,11 +57,20 @@ export const CaseAttrView = observer(function CaseAttrView (props: ICaseAttrView
     setIsEditing(false)
   }
 
+  const customButtonStyle = {
+    _focusVisible: {
+      borderRadius: 0,
+      outline: "2px solid #66afe9",
+      outlineOffset: "5px"
+    }
+  }
+
   return (
     <tr className="case-card-attr" data-testid="case-card-attr">
       <td className="case-card-attr-name" data-testid="case-card-attr-name">
         <AttributeHeader
           attributeId={attrId}
+          customButtonStyle={customButtonStyle}
           getDividerBounds={getDividerBounds}
           HeaderDivider={AttributeHeaderDivider}
           onSetHeaderContentElt={onSetContentElt}

--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, Menu, MenuButton, Input, VisuallyHidden } from "@chakra-ui/react"
+import { Tooltip, Menu, MenuButton, Input, VisuallyHidden, SystemStyleObject } from "@chakra-ui/react"
 import { useDndContext } from "@dnd-kit/core"
 import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
@@ -17,6 +17,7 @@ import { useParentChildFocusRedirect } from "./use-parent-child-focus-redirect"
 interface IProps {
   attributeId: string
   beforeHeaderDivider?: boolean
+  customButtonStyle?: SystemStyleObject
   getDividerBounds?: GetDividerBoundsFn
   HeaderDivider?: React.ComponentType<IDividerProps>
   // returns the draggable parent element for use with DnDKit
@@ -27,7 +28,7 @@ interface IProps {
 }
 
 export const AttributeHeader = observer(function AttributeHeader({
-  attributeId, beforeHeaderDivider, getDividerBounds, HeaderDivider,
+  attributeId, beforeHeaderDivider, customButtonStyle, getDividerBounds, HeaderDivider,
   onSetHeaderContentElt, onBeginEdit, onEndEdit, onOpenMenu
 }: IProps) {
   const { active } = useDndContext()
@@ -197,6 +198,7 @@ export const AttributeHeader = observer(function AttributeHeader({
                   : <>
                       <MenuButton className="codap-attribute-button" ref={menuButtonRef}
                           disabled={attributeId === kIndexColumnKey}
+                          sx={customButtonStyle}
                           fontWeight="bold" onKeyDown={handleButtonKeyDown}
                           data-testid={`codap-attribute-button ${attrName}`}
                           aria-describedby={`sr-column-header-drag-instructions-${instanceId}`}>


### PR DESCRIPTION
[#181869693](https://www.pivotaltracker.com/story/show/181869693)

Ensures that the attribute header/name buttons in the case card get a focus style similar to the case table's headers.  