### PR TITLE
Fixes bug where user can drag a component under the toolshelf

### DIFF
--- a/v3/src/hooks/use-drag-drop.ts
+++ b/v3/src/hooks/use-drag-drop.ts
@@ -140,7 +140,7 @@ export const containerSnapToGridModifier: Modifier = ({transform, active}) => {
 }
 
 export const restrictDragToArea: Modifier = ({transform, activeNodeRect, containerNodeRect}) =>{
-  // Prevent dragging upwards beyond the main container but llow dragging freely in other directions
+  // Prevent dragging upwards beyond the main container but allow dragging freely in other directions
   if (activeNodeRect && containerNodeRect) {
     if (activeNodeRect.top + transform.y < containerNodeRect.top) {
       transform.y = containerNodeRect.top - activeNodeRect.top

--- a/v3/src/hooks/use-drag-drop.ts
+++ b/v3/src/hooks/use-drag-drop.ts
@@ -138,3 +138,13 @@ export const containerSnapToGridModifier: Modifier = ({transform, active}) => {
     y: Math.ceil(transform.y / gridSize) * gridSize,
   }
 }
+
+export const restrictDragToArea: Modifier = ({transform, activeNodeRect, containerNodeRect}) =>{
+  // Prevent dragging upwards beyond the main container but llow dragging freely in other directions
+  if (activeNodeRect && containerNodeRect) {
+    if (activeNodeRect.top + transform.y < containerNodeRect.top) {
+      transform.y = containerNodeRect.top - activeNodeRect.top
+    }
+  }
+  return transform
+}

--- a/v3/src/lib/dnd-kit/codap-dnd-context.tsx
+++ b/v3/src/lib/dnd-kit/codap-dnd-context.tsx
@@ -3,7 +3,7 @@ import {
   MouseSensor, PointerSensor, TraversalOrder, useSensor, useSensors
 } from "@dnd-kit/core"
 import React, { ReactNode } from "react"
-import { containerSnapToGridModifier } from "../../hooks/use-drag-drop"
+import { containerSnapToGridModifier, restrictDragToArea } from "../../hooks/use-drag-drop"
 import { urlParams } from "../../utilities/url-params"
 import { canAutoScroll } from "./dnd-can-auto-scroll"
 import { dndDetectCollision } from "./dnd-detect-collision"
@@ -37,7 +37,7 @@ export const CodapDndContext = ({ children }: IProps) => {
     <DndContext
       autoScroll={autoScrollOptions}
       collisionDetection={dndDetectCollision}
-      modifiers={[containerSnapToGridModifier]}
+      modifiers={[containerSnapToGridModifier, restrictDragToArea]}
       sensors={sensors} >
       {children}
     </DndContext>


### PR DESCRIPTION
Previously, you can drag a component beyond the `codap-container` and can end up with the component header under the toolshelf. Once there, user can't drag the component back down.
This restricts dragging of component to below the toolshelf. User can still drag left, right and below viewable area.