### PR TITLE
Captures pointer when dragging resize handle

### DIFF
--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -57,7 +57,9 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
   }, [rowTile])
 
   const handleResizePointerDown = useCallback((e: PointerEvent, tileLayout: IFreeTileLayout, direction: string) => {
-    e.currentTarget.setPointerCapture(e.pointerId)
+    if (e.pointerId !== undefined) {
+      e.currentTarget.setPointerCapture(e.pointerId)
+    }
     const startWidth = tileLayout.width
     const startHeight = tileLayout.height
     const startPosition = {x: e.pageX, y: e.pageY}

--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -57,6 +57,7 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
   }, [rowTile])
 
   const handleResizePointerDown = useCallback((e: PointerEvent, tileLayout: IFreeTileLayout, direction: string) => {
+    e.currentTarget.setPointerCapture(e.pointerId)
     const startWidth = tileLayout.width
     const startHeight = tileLayout.height
     const startPosition = {x: e.pageX, y: e.pageY}


### PR DESCRIPTION
From this [story](https://www.pivotaltracker.com/story/show/187774818):
When resizing webviews with the resize handle, sometimes the pointer loses the resize handle focus causing it to stop resizing.
This forces the resizers to capture the pointer focus.