### PR TITLE
Adds language menu UI to CFM bar

### DIFF
--- a/v3/cypress/e2e/cfm.spec.ts
+++ b/v3/cypress/e2e/cfm.spec.ts
@@ -92,7 +92,7 @@ context("CloudFileManager", () => {
     // Verify document was closed (Map data table doesn't exist)
     c.checkComponentDoesNotExist("table")
   })
-  it("verify langugae menu is present", () => {
+  it("verify language menu is present", () => {
     cfm.getLanguageMenuButton().should("exist")
     cfm.getLanguageMenu().should("not.exist")
     cfm.getLanguageMenuButton().click()

--- a/v3/cypress/e2e/cfm.spec.ts
+++ b/v3/cypress/e2e/cfm.spec.ts
@@ -92,4 +92,12 @@ context("CloudFileManager", () => {
     // Verify document was closed (Map data table doesn't exist)
     c.checkComponentDoesNotExist("table")
   })
+  it("verify langugae menu is present", () => {
+    cfm.getLanguageMenuButton().should("exist")
+    cfm.getLanguageMenu().should("not.exist")
+    cfm.getLanguageMenuButton().click()
+    cfm.getLanguageMenu().should("exist")
+    cfm.getLanguageMenuButton().click()
+    cfm.getLanguageMenu().should("not.exist")
+  })
 })

--- a/v3/cypress/support/elements/cfm.ts
+++ b/v3/cypress/support/elements/cfm.ts
@@ -10,9 +10,15 @@ export const CfmElements = {
     return cy.get('#codap-menu-bar-id')
   },
   getHamburgerMenuButton() {
-    return cy.get('#codap-menu-bar-id .cfm-menu.menu-anchor')
+    return cy.get('#codap-menu-bar-id .menu-bar-left .cfm-menu.menu-anchor')
   },
   getHamburgerMenu() {
+    return cy.get('#codap-menu-bar-id .cfm-menu.menu-showing')
+  },
+  getLanguageMenuButton() {
+    return cy.get('#codap-menu-bar-id .menu-bar-right .cfm-menu.menu-anchor')
+  },
+  getLanguageMenu() {
     return cy.get('#codap-menu-bar-id .cfm-menu.menu-showing')
   },
   getModalDialog() {

--- a/v3/src/components/menu-bar/menu-bar.scss
+++ b/v3/src/components/menu-bar/menu-bar.scss
@@ -29,6 +29,25 @@
         font-size: 12px
       }
     }
+
+    .cfm-menu > .lang-menu {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      &.with-border {
+        margin-top: -5px;
+      }
+      .lang-label {
+        background-position: 4px 5px;
+        margin-top: 0;
+      }
+    }
+
+    .menu.lang-menu {
+      .cfm-menu.menu-showing {
+        top: 24px;
+      }
+    }
   }
 
 }

--- a/v3/src/lib/use-cloud-file-manager.ts
+++ b/v3/src/lib/use-cloud-file-manager.ts
@@ -7,7 +7,7 @@ import { clientConnect, createCloudFileManager, renderRoot } from "./cfm-utils"
 import { handleCFMEvent } from "./handle-cfm-event"
 import { appState } from "../models/app-state"
 import { createCodapDocument, isCodapDocument } from "../models/codap/create-codap-document"
-import { t } from "../utilities/translation/translate"
+import { getDefaultLanguage, t } from "../utilities/translation/translate"
 import { removeDevUrlParams } from "../utilities/url-params"
 
 const locales = [
@@ -121,13 +121,14 @@ export function useCloudFileManager(optionsArg: CFMAppOptions) {
         menuBar: {
           info: "Language menu",
           languageMenu: {
-            currentLang: "EN-us",
-            options: locales.map(function (locale) {
-              return {
-                label: locale.langName,
-                langCode: locale.langDigraph,
-              }
-            }),
+            currentLang: "en",
+            options: locales.filter(locale => locale.langDigraph !== getDefaultLanguage())
+                            .map(function (locale) {
+                              return {
+                                label: locale.langName,
+                                langCode: locale.langDigraph,
+                              }
+                            }),
           },
           // onLangChanged: (langCode: string) => {
           //   Logger.log(`Changed language: ${langCode}`)

--- a/v3/src/lib/use-cloud-file-manager.ts
+++ b/v3/src/lib/use-cloud-file-manager.ts
@@ -112,20 +112,24 @@ const locales = [
 function makeNewLocaleUrl(digraph: string, locationHref: string) {
   const location = new URL(locationHref)
   const locMatch = location.pathname.match(/(^.*\/static\/dg\/)[^/]+(\/cert\/.*$)/)
-  let baseURL = `https://codapV3.concord.org`
-  let queryParams
+  let baseURL = "https://codap3.concord.org/branch/main/"
+  let queryParams = ""
+
   if (locMatch) {
-    baseURL = location.protocol + location.host + locMatch[1] + digraph + locMatch[2]
+    baseURL = `${location.protocol}//${location.host}${locMatch[1]}${digraph}${locMatch[2]}`
   }
   let hash = location.hash
-
   if (hash.startsWith('#file=examples:')) {
-    hash = ''
+    hash = ""
   }
+
   if (location.search) {
-    queryParams = `?${location.search}&lang=${digraph}`
+    queryParams = `${location.search}&lang=${digraph}`
+  } else {
+    queryParams = `?lang=${digraph}`
   }
-  return baseURL + queryParams + hash
+
+  return `${baseURL}${queryParams}${hash}`
 }
 
 export function useCloudFileManager(optionsArg: CFMAppOptions) {

--- a/v3/src/lib/use-cloud-file-manager.ts
+++ b/v3/src/lib/use-cloud-file-manager.ts
@@ -9,6 +9,123 @@ import { appState } from "../models/app-state"
 import { createCodapDocument, isCodapDocument } from "../models/codap/create-codap-document"
 import { t } from "../utilities/translation/translate"
 import { removeDevUrlParams } from "../utilities/url-params"
+import { Logger } from "./logger"
+
+const locales = [
+  {
+    langName: 'Deutsch',
+    langDigraph: 'de',
+    countryDigraph: 'DE',
+    icon: 'flag flag-de'
+  },
+  {
+    langName: 'English',
+    langDigraph: 'en',
+    countryDigraph: 'US',
+    icon: 'flag flag-us'
+  },
+  {
+    langName: 'Español',
+    langDigraph: 'es',
+    countryDigraph: 'ES',
+    icon: 'flag flag-es'
+  },
+  {
+    langName: 'فارسی',
+    langDigraph: 'fa',
+    countryDigraph: 'IR',
+    icon: 'flag flag-ir'
+  },
+  {
+    langName: 'Ελληνικά',
+    langDigraph: 'el',
+    countryDigraph: 'GR',
+    icon: 'flag flag-gr'
+  },
+  {
+    langName: 'עברית',
+    langDigraph: 'he',
+    countryDigraph: 'IL',
+    icon: 'flag flag-il'
+  },
+  {
+    langName: '日本語',
+    langDigraph: 'ja',
+    countryDigraph: 'JP',
+    icon: 'flag flag-jp'
+  },
+  {
+    langName: '한국어',
+    langDigraph: 'ko',
+    countryDigraph: 'KO',
+    icon: 'flag flag-kr'
+  },
+  {
+    langName: 'Bokmål',
+    langDigraph: 'nb',
+    countryDigraph: 'NO',
+    icon: 'flag flag-no'
+  },
+  {
+    langName: 'Nynorsk',
+    langDigraph: 'nn',
+    countryDigraph: 'NO',
+    icon: 'flag flag-no'
+  },
+  {
+    langName: 'Polski',
+    langDigraph: 'pl',
+    countryDigraph: 'PL',
+    icon: 'flag flag-pl'
+  },
+  {
+    langName: 'Português do Brasil',
+    langDigraph: 'pt-BR',
+    countryDigraph: 'BR',
+    icon: 'flag flag-br'
+  },
+  {
+    langName: 'ไทย',
+    langDigraph: 'th',
+    countryDigraph: 'TH',
+    icon: 'flag flag-th'
+  },
+  {
+    langName: 'Türkçe',
+    langDigraph: 'tr',
+    countryDigraph: 'TR',
+    icon: 'flag flag-tr'
+  },
+  {
+    langName: '繁体中文',
+    langDigraph: 'zh-TW',
+    countryDigraph: 'TW',
+    icon: 'flag flag-tw'
+  },
+  {
+    langName: '简体中文',
+    langDigraph: 'zh-Hans',
+    countryDigraph: 'Hans',
+    icon: 'flag flag-cn'
+  }
+]
+
+function makeNewLocaleUrl(digraph: string, locationHref: string) {
+  const location = new URL(locationHref)
+  const locMatch = location.pathname.match(/(^.*\/static\/dg\/)[^/]+(\/cert\/.*$)/)
+  let baseURL = `https://codap.concord.org/releases/latest/static/dg/${digraph}/cert/`
+  if (locMatch) {
+    baseURL = location.protocol + location.host + locMatch[1] + digraph + locMatch[2]
+  }
+  let hash = location.hash
+  if (location.pathname.indexOf('static/dg')>0) {
+    baseURL = `../../${digraph}/cert`
+  }
+  if (hash.startsWith('#file=examples:')) {
+    hash = ''
+  }
+  return baseURL + location.search+hash
+}
 
 export function useCloudFileManager(optionsArg: CFMAppOptions) {
   const options = useRef(optionsArg)
@@ -19,22 +136,22 @@ export function useCloudFileManager(optionsArg: CFMAppOptions) {
 
     const _options: CFMAppOptions = {
       ui: {
-        // menuBar: {
-        //   info: "Language menu",
-        //   languageMenu: {
-        //     currentLang: "EN-us",
-        //     options: DG.locales.map(function (locale) {
-        //       return {
-        //         label: locale.langName,
-        //         langCode: locale.langDigraph,
-        //       };
-        //     }),
-        //     onLangChanged: function (langCode) {
-        //       DG.log('Changed language: ' + langCode);
-        //       window.location = makeNewLocaleUrl(langCode, window.location);
-        //     }
-        //   }
-        // },
+        menuBar: {
+          info: "Language menu",
+          languageMenu: {
+            currentLang: "EN-us",
+            options: locales.map(function (locale) {
+              return {
+                label: locale.langName,
+                langCode: locale.langDigraph,
+              }
+            }),
+          },
+          onLangChanged: (langCode: string) => {
+            Logger.log(`Changed language: ${langCode}`)
+            window.location.href = makeNewLocaleUrl(langCode, window.location.href)
+          }
+        },
         menu: [
           { name: t('DG.fileMenu.menuItem.newDocument'), action: 'newFileDialog' },
           { name: t('DG.fileMenu.menuItem.openDocument'), action: 'openFileDialog' },

--- a/v3/src/lib/use-cloud-file-manager.ts
+++ b/v3/src/lib/use-cloud-file-manager.ts
@@ -109,22 +109,23 @@ const locales = [
     icon: 'flag flag-cn'
   }
 ]
-
 function makeNewLocaleUrl(digraph: string, locationHref: string) {
   const location = new URL(locationHref)
   const locMatch = location.pathname.match(/(^.*\/static\/dg\/)[^/]+(\/cert\/.*$)/)
-  let baseURL = `https://codap.concord.org/releases/latest/static/dg/${digraph}/cert/`
+  let baseURL = `https://codapV3.concord.org`
+  let queryParams
   if (locMatch) {
     baseURL = location.protocol + location.host + locMatch[1] + digraph + locMatch[2]
   }
   let hash = location.hash
-  if (location.pathname.indexOf('static/dg')>0) {
-    baseURL = `../../${digraph}/cert`
-  }
+
   if (hash.startsWith('#file=examples:')) {
     hash = ''
   }
-  return baseURL + location.search+hash
+  if (location.search) {
+    queryParams = `?${location.search}&lang=${digraph}`
+  }
+  return baseURL + queryParams + hash
 }
 
 export function useCloudFileManager(optionsArg: CFMAppOptions) {
@@ -152,6 +153,7 @@ export function useCloudFileManager(optionsArg: CFMAppOptions) {
             window.location.href = makeNewLocaleUrl(langCode, window.location.href)
           }
         },
+
         menu: [
           { name: t('DG.fileMenu.menuItem.newDocument'), action: 'newFileDialog' },
           { name: t('DG.fileMenu.menuItem.openDocument'), action: 'openFileDialog' },

--- a/v3/src/lib/use-cloud-file-manager.ts
+++ b/v3/src/lib/use-cloud-file-manager.ts
@@ -9,7 +9,6 @@ import { appState } from "../models/app-state"
 import { createCodapDocument, isCodapDocument } from "../models/codap/create-codap-document"
 import { t } from "../utilities/translation/translate"
 import { removeDevUrlParams } from "../utilities/url-params"
-import { Logger } from "./logger"
 
 const locales = [
   {
@@ -109,28 +108,6 @@ const locales = [
     icon: 'flag flag-cn'
   }
 ]
-function makeNewLocaleUrl(digraph: string, locationHref: string) {
-  const location = new URL(locationHref)
-  const locMatch = location.pathname.match(/(^.*\/static\/dg\/)[^/]+(\/cert\/.*$)/)
-  let baseURL = "https://codap3.concord.org/branch/main/"
-  let queryParams = ""
-
-  if (locMatch) {
-    baseURL = `${location.protocol}//${location.host}${locMatch[1]}${digraph}${locMatch[2]}`
-  }
-  let hash = location.hash
-  if (hash.startsWith('#file=examples:')) {
-    hash = ""
-  }
-
-  if (location.search) {
-    queryParams = `${location.search}&lang=${digraph}`
-  } else {
-    queryParams = `?lang=${digraph}`
-  }
-
-  return `${baseURL}${queryParams}${hash}`
-}
 
 export function useCloudFileManager(optionsArg: CFMAppOptions) {
   const options = useRef(optionsArg)
@@ -152,10 +129,9 @@ export function useCloudFileManager(optionsArg: CFMAppOptions) {
               }
             }),
           },
-          onLangChanged: (langCode: string) => {
-            Logger.log(`Changed language: ${langCode}`)
-            window.location.href = makeNewLocaleUrl(langCode, window.location.href)
-          }
+          // onLangChanged: (langCode: string) => {
+          //   Logger.log(`Changed language: ${langCode}`)
+          // }
         },
 
         menu: [

--- a/v3/src/utilities/translation/translate.ts
+++ b/v3/src/utilities/translation/translate.ts
@@ -60,7 +60,7 @@ const varRegExp = /%({\s*([^}\s]*)\s*}|@(\d*))/g
 
 const urlLanguage = urlParams.lang as string | null || urlParams["lang-override"] as string | null || ""
 const candidates = [urlLanguage, ...window.navigator.languages]
-let defaultLang = "en"
+let defaultLang = "en-US"
 for (const lang of candidates) {
   if (lang && translations[lang]) {
     defaultLang = lang


### PR DESCRIPTION
This adds the UI for language menu to the CFM bar. The UI is currently non-functional.

Note that in testing this, if I run the `makeNewLocaleUrl` function manually, CODAP does reload with the new language correctly. But when I select a language from the dropdown, nothing happens.