### PR TITLE
Fix parent visibility toggles

### DIFF
--- a/v3/src/components/axis/helper-models/axis-helper.test.ts
+++ b/v3/src/components/axis/helper-models/axis-helper.test.ts
@@ -80,7 +80,6 @@ describe("AxisHelper", () => {
   it("should render axis line correctly", () => {
     axisHelper.renderAxisLine()
     expect(select).toHaveBeenCalledWith(props.subAxisElt)
-    expect(select(props.subAxisElt).selectAll).toHaveBeenCalledWith('*')
     expect(select(props.subAxisElt).attr).toHaveBeenCalledWith("transform", "translate(100, 0)")
     expect(select(props.subAxisElt).append).toHaveBeenCalledWith('line')
     expect(select(props.subAxisElt).style).toHaveBeenCalledWith("stroke", "darkgray")

--- a/v3/src/components/axis/helper-models/axis-helper.ts
+++ b/v3/src/components/axis/helper-models/axis-helper.ts
@@ -72,10 +72,11 @@ export class AxisHelper {
   }
 
   renderAxisLine() {
-    select(this.subAxisElt).selectAll('*').remove()
+    select(this.subAxisElt).selectAll('.axis-line').remove()
     select(this.subAxisElt)
       .attr("transform", this.initialTransform)
       .append('line')
+      .attr("class", "axis-line")
       .attr('x1', 0)
       .attr('x2', this.isVertical ? 0 : this.subAxisLength)
       .attr('y1', 0)

--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -44,7 +44,6 @@ export class NumericAxisHelper extends AxisHelper {
       : undefined
     if (!isNumericAxisModel(this.axisModel) || !numericScale) return
 
-    select(this.subAxisElt).selectAll('*').remove()
     this.renderAxisLine()
 
     const axisScale = this.axis(numericScale).tickSizeOuter(0).tickFormat(format('.9'))

--- a/v3/src/components/graph/components/parent-toggles.tsx
+++ b/v3/src/components/graph/components/parent-toggles.tsx
@@ -82,7 +82,7 @@ export const ParentToggles = observer(function ParentToggles() {
   const collectionIndexForPrimaryAttribute = dataset?.getCollectionIndexForAttribute(primaryAttribute) ?? 0
   const isCollectionSet = !!(dataset && dataset.collections?.length > 0)
   const hiddenCases = dataConfig?.hiddenCases ?? []
-  const itemIDs = dataset?.items.map((c) => c.__id__) ?? []
+  const itemIDs = dataset?.itemIds ?? []
   const caseButtons = createCaseButtons(
     { itemIDs, dataset, collectionIndexForPrimaryAttribute, isCollectionSet, hiddenCases })
   const caseButtonsListWidth = caseButtons.reduce((acc, button) => acc + button.width + TEXT_OFFSET, 0)

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -383,7 +383,7 @@ export const DataSet = V2Model.named("DataSet").props({
   }
 
   function getCollectionIndexForAttribute(attributeId: string): number | undefined {
-    const id = (self.collections.find(coll => coll.getAttribute(attributeId)))?.id
+    const id = getCollectionForAttribute(attributeId)?.id
     return id ? getCollectionIndex(id) : undefined
   }
 

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -382,6 +382,11 @@ export const DataSet = V2Model.named("DataSet").props({
     return self.collections.find(coll => coll.getAttribute(attributeId))
   }
 
+  function getCollectionIndexForAttribute(attributeId: string): number | undefined {
+    const id = (self.collections.find(coll => coll.getAttribute(attributeId)))?.id
+    return id ? getCollectionIndex(id) : undefined
+  }
+
   function getUniqueCollectionName(name: string) {
     let suffix = 1
     let collectionName = name
@@ -400,6 +405,7 @@ export const DataSet = V2Model.named("DataSet").props({
       // get collection from attribute
       // undefined => attribute not present in dataset
       getCollectionForAttribute,
+      getCollectionIndexForAttribute,
       getUniqueCollectionName
     },
     actions: {


### PR DESCRIPTION
[#188234714] Bug fix: Parent visibility toggles not working

* There are several things going on here, the first of which has to do with the fact that what was being stored in each toggle button was the *item* ids of the cases associated with that button rather than the *case* id.
* The second of which is that when we render a numeric axis we're unnecessarily removing the current instance of it and rerendering from scratch. We fix that by not removing the axis.
* The third of which is that we rerendering even if the numeric axis domain is not changing. So we detect that condition and don't rerender.
* The fourth of which is that in one place we were incorrectly calling `setNumericDomain` with the complete array of numeric values instead of an array with just the min and max.