### PR TITLE
Fix rendering of numeric axis

### DIFF
--- a/v3/src/components/axis/helper-models/axis-helper.ts
+++ b/v3/src/components/axis/helper-models/axis-helper.ts
@@ -94,6 +94,7 @@ export class AxisHelper {
 export class EmptyAxisHelper extends AxisHelper {
 
   render() {
+    select(this.subAxisElt).selectAll('*').remove()
     this.renderAxisLine()
   }
 }

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -269,8 +269,9 @@ export const useSubAxis = ({
           multiScale?.setScaleType('linear')  // Make sure it's linear
           if (JSON.stringify(domain) !== JSON.stringify(multiScale?.numericScale?.domain())) {
             multiScale?.setNumericDomain(domain)
-            renderSubAxis()
           }
+          // Render regardless because we can get here during undo/redo with the domains identical
+          renderSubAxis()
         }
       } else if (_axisModel) {
         console.warn("useSubAxis.installDomainSync skipping sync of defunct axis model")


### PR DESCRIPTION
[#188300061] Bug fix: Undo of add numeric attribute to axis is broken

This bug occurred as a result of PR that reduced the rerendering of numeric axes, but a little too much so that it broke some things that showed up in cypress tests

* When rendering an empty axis, we first remove whatever is already present
* In `use-sub-axis` the `installDomainSync` was doing an mstAutorun and assuming that if the axis domain and multi-sync domain were the same there was no need to rerender. But this is false since undo/redo can bring about this condition but we still need to rerender.