### PR TITLE
188104291 Handle update attribute deleteable API requests.

### DIFF
--- a/v3/src/data-interactive/handlers/di-handler-utils.ts
+++ b/v3/src/data-interactive/handlers/di-handler-utils.ts
@@ -37,6 +37,7 @@ export function createCollection(v2collection: DICollection, dataContext: IDataS
 
 export function updateAttribute(attribute: IAttribute, value: DIAttribute, dataContext?: IDataSet) {
   if (value?.cid != null) attribute.setCid(value.cid)
+  if (value?.deleteable != null) attribute.setDeleteable(value.deleteable)
   if (value?.description != null) attribute.setDescription(value.description)
   if (value?.editable != null) attribute.setEditable(!!value.editable)
   if (value?.formula != null) attribute.setDisplayExpression(value.formula)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188104291

Previously, the `update attribute` handler would ignore any changes to `deleteable`. This PR fixes that, which is necessary to return unshared tables to full user control in Collaborative.