### PR TITLE
Add support for the filter function

### DIFF
--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -135,7 +135,7 @@ export const useRows = () => {
 
     const onPatchDisposer = data && onPatch(data, ({ op, path, value }) => {
       // reset on any changes to items or hidden items
-      if (/(_itemIds|hiddenItemIds)(\/\d+)?$/.test(path)) {
+      if (/(_itemIds|setAsideItemIds)(\/\d+)?$/.test(path)) {
         resetRowCacheAndSyncRows()
       }
     })

--- a/v3/src/components/case-tile-common/edit-filter-formula-modal.tsx
+++ b/v3/src/components/case-tile-common/edit-filter-formula-modal.tsx
@@ -1,0 +1,89 @@
+import {
+  Button, FormControl, FormLabel, ModalBody, ModalCloseButton, ModalFooter, ModalHeader,
+  Textarea, Tooltip
+} from "@chakra-ui/react"
+import React, { useEffect, useState } from "react"
+import { observer } from "mobx-react-lite"
+import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { t } from "../../utilities/translation/translate"
+import { CodapModal } from "../codap-modal"
+
+interface IProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export const EditFilterFormulaModal = observer(function EditFormulaModal({ isOpen, onClose }: IProps) {
+  const data = useDataSetContext()
+  const [formula, setFormula] = useState("")
+
+  useEffect(() => {
+    setFormula(data?.filterFormula?.display || "")
+  }, [data?.filterFormula?.display])
+
+  const closeModal = () => {
+    onClose()
+  }
+
+  function applyFilterFormula() {
+    data?.applyModelChange(() => {
+      data.setFilterFormula(formula)
+    }, {
+      undoStringKey: "V3.Undo.hideShowMenu.changeFilterFormula",
+      redoStringKey: "V3.Redo.hideShowMenu.changeFilterFormula"
+    })
+    closeModal()
+  }
+
+  const handleFormulaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => setFormula(e.target.value)
+
+  const buttons = [{
+    label: t("DG.AttrFormView.cancelBtnTitle"),
+    tooltip: t("DG.AttrFormView.cancelBtnTooltip"),
+    onClick: closeModal
+  }, {
+    label: t("DG.AttrFormView.applyBtnTitle"),
+    onClick: applyFilterFormula,
+    default: true
+  }]
+
+  return (
+    <CodapModal
+      isOpen={isOpen}
+      onClose={onClose}
+      modalWidth={"400px"}
+      modalHeight={"180px"}
+    >
+      <ModalHeader h="30" className="codap-modal-header" fontSize="md" data-testid="codap-modal-header">
+        <div className="codap-modal-icon-container" />
+        <div className="codap-header-title" />
+        <ModalCloseButton onClick={onClose} data-testid="modal-close-button" />
+      </ModalHeader>
+      <ModalBody>
+        <FormControl display="flex" flexDirection="column" className="formula-form-control">
+          <FormLabel>{t("DG.AttrFormView.formulaPrompt")}
+            <Textarea size="xs" value={formula} onChange={handleFormulaChange}
+              onKeyDown={(e) => e.stopPropagation()} data-testid="attr-formula-input" />
+          </FormLabel>
+        </FormControl>
+      </ModalBody>
+      <ModalFooter mt="-5">
+        {
+          buttons.map((b, idx) => {
+            const key = `${idx}-${b.label}`
+            return (
+              <Tooltip key={idx} label={b.tooltip} h="20px" fontSize="12px" color="white" openDelay={1000}
+                placement="bottom" bottom="15px" left="15px" data-testid="modal-tooltip"
+              >
+                <Button key={key} size="xs" variant={`${b.default ? "default" : ""}`} ml="5" onClick={b.onClick}
+                      _hover={{backgroundColor: "#72bfca", color: "white"}} data-testid={`${b.label}-button`}>
+                  {b.label}
+                </Button>
+              </Tooltip>
+            )
+          })
+        }
+      </ModalFooter>
+    </CodapModal>
+  )
+})

--- a/v3/src/components/case-tile-common/edit-filter-formula-modal.tsx
+++ b/v3/src/components/case-tile-common/edit-filter-formula-modal.tsx
@@ -58,7 +58,7 @@ export const EditFilterFormulaModal = observer(function EditFormulaModal({ isOpe
         <div className="codap-modal-icon-container" />
         <div className="codap-header-title" />
         <ModalCloseButton onClick={onClose} data-testid="modal-close-button" />
-      </ModalHeader>=
+      </ModalHeader>
       <ModalBody>
         {
           data?.filterFormulaError &&

--- a/v3/src/components/case-tile-common/edit-filter-formula-modal.tsx
+++ b/v3/src/components/case-tile-common/edit-filter-formula-modal.tsx
@@ -58,8 +58,14 @@ export const EditFilterFormulaModal = observer(function EditFormulaModal({ isOpe
         <div className="codap-modal-icon-container" />
         <div className="codap-header-title" />
         <ModalCloseButton onClick={onClose} data-testid="modal-close-button" />
-      </ModalHeader>
+      </ModalHeader>=
       <ModalBody>
+        {
+          data?.filterFormulaError &&
+          <div className="formula-error" style={{ background: "rgb(254, 224, 228)", fontSize: "0.8em" }}>
+            {data.filterFormulaError}
+          </div>
+        }
         <FormControl display="flex" flexDirection="column" className="formula-form-control">
           <FormLabel>{t("DG.AttrFormView.formulaPrompt")}
             <Textarea size="xs" value={formula} onChange={handleFormulaChange}

--- a/v3/src/components/case-tile-common/hide-show-menu-list.tsx
+++ b/v3/src/components/case-tile-common/hide-show-menu-list.tsx
@@ -35,7 +35,7 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
 
   const itemCount = data?.items.length ?? 0
   const selectionCount = data?.selection.size ?? 0
-  const setAsideCount = data?.hiddenItemIds.length ?? 0
+  const setAsideCount = data?.setAsideItemIds.length ?? 0
 
   const hiddenAttributes = data?.attributes.filter(attr => attr && caseMetadata?.isHidden(attr.id))
   const hiddenAttributeCount = hiddenAttributes?.length ?? 0
@@ -65,9 +65,9 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
       itemLabel: () => t("DG.Inspector.setaside.restoreSetAsideCases", { vars: [setAsideCount] }),
       isEnabled: () => setAsideCount > 0,
       handleClick: () => {
-        if (data?.hiddenItemIds.length) {
+        if (data?.setAsideItemIds.length) {
           data.applyModelChange(() => {
-            const hiddenItems = [...data.hiddenItemIds]
+            const hiddenItems = [...data.setAsideItemIds]
             data.showHiddenCasesAndItems()
             data.setSelectedCases(hiddenItems)
           }, {

--- a/v3/src/components/case-tile-common/hide-show-menu-list.tsx
+++ b/v3/src/components/case-tile-common/hide-show-menu-list.tsx
@@ -1,14 +1,17 @@
+import { useDisclosure } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useCaseMetadata } from "../../hooks/use-case-metadata"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { hideAttributeNotification } from "../../models/data/data-set-notifications"
 import { t } from "../../utilities/translation/translate"
+import { EditFilterFormulaModal } from "./edit-filter-formula-modal"
 import { IMenuItem, StdMenuList } from "./std-menu-list"
 
 export const HideShowMenuList = observer(function HideShowMenuList() {
   const data = useDataSetContext()
   const caseMetadata = useCaseMetadata()
+  const formulaModal = useDisclosure()
 
   const handleSetAsideCases = (itemIds: string[], deselect: boolean) => {
     if (data && itemIds.length) {
@@ -20,6 +23,14 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
         redoStringKey: "V3.Redo.hideShowMenu.setAsideCases"
       })
     }
+  }
+
+  const handleEditFormulaOpen = () => {
+    formulaModal.onOpen()
+  }
+
+  const handleEditFormulaClose = () => {
+    formulaModal.onClose()
   }
 
   const itemCount = data?.items.length ?? 0
@@ -68,6 +79,13 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
       }
     },
     {
+      itemKey: !data?.filterFormula?.empty
+                ? "V3.hideShowMenu.editFilterFormula"
+                : "V3.hideShowMenu.addFilterFormula",
+      isEnabled: () => !!data,
+      handleClick: handleEditFormulaOpen
+    },
+    {
       itemKey: "DG.Inspector.attributes.showAllHiddenAttributesPlural",
       isEnabled: () => hiddenAttributeCount > 0,
       itemLabel: () => {
@@ -98,6 +116,9 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
   ]
 
   return (
-    <StdMenuList data-testid="hide-show-menu-list" menuItems={menuItems} />
+    <>
+      <StdMenuList data-testid="hide-show-menu-list" menuItems={menuItems} />
+      <EditFilterFormulaModal isOpen={formulaModal.isOpen} onClose={handleEditFormulaClose} />
+    </>
   )
 })

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -89,7 +89,7 @@ describe("createCodapDocument", () => {
                 }
               },
               _itemIds: ["test-9", "test-10", "test-11"],
-              hiddenItemIds: [],
+              setAsideItemIds: [],
               collections: [{
                 id: "test-7",
                 name: "Cases",

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -307,11 +307,6 @@ export const Attribute = V2Model.named("Attribute").props({
       }
     }
     else {
-      // Note that this generates a warning that the formula is unregistered in an unexpected way.
-      // Originally, the formula manager was designed to handle only empty formulas. However,
-      // https://github.com/concord-consortium/codap/pull/1124 changed the behavior, and formula objects now get deleted
-      // from the parent model.
-      // TODO: handle it better, or remove the warning from the formula manager if it doesn't cause any issues
       this.clearFormula()
     }
   },

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -307,6 +307,11 @@ export const Attribute = V2Model.named("Attribute").props({
       }
     }
     else {
+      // Note that this generates a warning that the formula is unregistered in an unexpected way.
+      // Originally, the formula manager was designed to handle only empty formulas. However,
+      // https://github.com/concord-consortium/codap/pull/1124 changed the behavior, and formula objects now get deleted
+      // from the parent model.
+      // TODO: handle it better, or remove the warning from the formula manager if it doesn't cause any issues
       this.clearFormula()
     }
   },

--- a/v3/src/models/data/data-set-conversion.test.ts
+++ b/v3/src/models/data/data-set-conversion.test.ts
@@ -2,7 +2,7 @@ import { IAttributeSnapshot } from "./attribute"
 import { ICollectionModelSnapshot } from "./collection"
 import { DataSet } from "./data-set"
 import {
-  IInitialItemsDataSetSnap, IOriginalDataSetSnap, IPreItemsDataSetSnap, ITempDataSetSnap
+  IHiddenItemIdsDataSetSnap, IInitialItemsDataSetSnap, IOriginalDataSetSnap, IPreItemsDataSetSnap, ITempDataSetSnap
 } from "./data-set-conversion"
 
 const kUngroupedCollectionName = "Collection Formerly Known As Ungrouped"
@@ -108,5 +108,27 @@ describe("DataSet conversions", () => {
     expect(data.attributes.length).toBe(3)
     expect(data._itemIds.length).toBe(1)
     expect(data.itemIds.length).toBe(1)
+  })
+
+  test("DataSet hiddenItemIds flat snapshot conversion", () => {
+    const data = DataSet.create({
+      name: "Data",
+      collections: [{
+        name: "Cases",
+        attributes: ["a1Id", "a2Id", "a3Id"]
+      }],
+      attributesMap: {
+        a1Id: { id: "a1Id", name: "a1", values: ["a1-0"] },
+        a2Id: { id: "a2Id", name: "a2", values: ["a2-0"] },
+        a3Id: { id: "a3Id", name: "a3", values: ["a3-0"] }
+      },
+      _itemIds: ["ITEM0"],
+      hiddenItemIds: ["ITEM0"]
+    } as IHiddenItemIdsDataSetSnap)
+    expect(data.attributesMap.size).toBe(3)
+    expect(data.attributes.length).toBe(3)
+    expect(data._itemIds.length).toBe(1)
+    expect(data.itemIds.length).toBe(1)
+    expect(data.setAsideItemIds.length).toBe(1)
   })
 })

--- a/v3/src/models/data/data-set-conversion.ts
+++ b/v3/src/models/data/data-set-conversion.ts
@@ -47,11 +47,19 @@ export function isInitialItemsDataSetSnap(snap: IDataSetSnapshot): snap is IInit
   return !("attributes" in snap) && !("ungrouped" in snap) && !("cases" in snap) && ("itemIds" in snap)
 }
 
-export type ILegacyDataSetSnap = (IOriginalDataSetSnap | ITempDataSetSnap |
-            IPreItemsDataSetSnap | IInitialItemsDataSetSnap) & { itemIds?: string[] }
+// hiddenItemIds => setAsideItemIds
+export interface IHiddenItemIdsDataSetSnap extends Omit<IInitialItemsDataSetSnap, "itemIds"> {
+  hiddenItemIds?: string[]
+}
+export function isHiddenItemIdsDataSetSnap(snap: IDataSetSnapshot): snap is IHiddenItemIdsDataSetSnap {
+  return "hiddenItemIds" in snap
+}
+
+export type ILegacyDataSetSnap = (IOriginalDataSetSnap | ITempDataSetSnap | IPreItemsDataSetSnap |
+            IInitialItemsDataSetSnap | IHiddenItemIdsDataSetSnap) & { itemIds?: string[], hiddenItemIds?: string[] }
 export function isLegacyDataSetSnap(snap: IDataSetSnapshot): snap is ILegacyDataSetSnap {
-  return isOriginalDataSetSnap(snap) || isTempDataSetSnap(snap) ||
-          isPreItemDataSetSnap(snap) || isInitialItemsDataSetSnap(snap)
+  return isOriginalDataSetSnap(snap) || isTempDataSetSnap(snap) || isPreItemDataSetSnap(snap) ||
+          isInitialItemsDataSetSnap(snap) || isHiddenItemIdsDataSetSnap(snap)
 }
 
 export function createDataSet(snap: IDataSetSnapshot | ILegacyDataSetSnap): IDataSet {

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -9,10 +9,10 @@ import { IDocumentEnvironment } from "./document-environment"
 import { SharedModelDocumentManager } from "./shared-model-document-manager"
 import { FormulaManager } from "../formula/formula-manager"
 import { AttributeFormulaAdapter } from "../formula/attribute-formula-adapter"
+import { FilterFormulaAdapter } from "../formula/filter-formula-adapter"
 import { PlottedValueFormulaAdapter } from "../formula/plotted-value-formula-adapter"
 import { PlottedFunctionFormulaAdapter } from "../formula/plotted-function-formula-adapter"
 import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
-import { FilterFormulaAdapter } from "../formula/filter-formula-adapter"
 
 /**
  * Create a DocumentModel and add a new sharedModelManager into its environment
@@ -35,9 +35,9 @@ export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
     // initialize formula adapters after the document has been created
     formulaManager.addAdapters([
       new AttributeFormulaAdapter(adapterApi),
+      new FilterFormulaAdapter(adapterApi),
       new PlottedValueFormulaAdapter(adapterApi),
-      new PlottedFunctionFormulaAdapter(adapterApi),
-      new FilterFormulaAdapter(adapterApi)
+      new PlottedFunctionFormulaAdapter(adapterApi)
     ])
 
     addDisposer(document, onAction(document, (call) => {

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -12,6 +12,7 @@ import { AttributeFormulaAdapter } from "../formula/attribute-formula-adapter"
 import { PlottedValueFormulaAdapter } from "../formula/plotted-value-formula-adapter"
 import { PlottedFunctionFormulaAdapter } from "../formula/plotted-function-formula-adapter"
 import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
+import { FilterFormulaAdapter } from "../formula/filter-formula-adapter"
 
 /**
  * Create a DocumentModel and add a new sharedModelManager into its environment
@@ -35,7 +36,8 @@ export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
     formulaManager.addAdapters([
       new AttributeFormulaAdapter(adapterApi),
       new PlottedValueFormulaAdapter(adapterApi),
-      new PlottedFunctionFormulaAdapter(adapterApi)
+      new PlottedFunctionFormulaAdapter(adapterApi),
+      new FilterFormulaAdapter(adapterApi)
     ])
 
     addDisposer(document, onAction(document, (call) => {

--- a/v3/src/models/formula/filter-formula-adapter.test.ts
+++ b/v3/src/models/formula/filter-formula-adapter.test.ts
@@ -1,0 +1,127 @@
+import { IDataSet } from "../data/data-set"
+import { createDataSet } from "../data/data-set-conversion"
+import { FilterFormulaAdapter } from "./filter-formula-adapter"
+import { displayToCanonical } from "./utils/canonicalization-utils"
+import { getDisplayNameMap } from "./utils/name-mapping-utils"
+
+const AttrID = "AttrID"
+const AttrName = "foo"
+
+const getTestEnv = (filterFormula: string) => {
+  const dataSet = createDataSet({ name: "DataSet" })
+  dataSet.addAttribute({ id: AttrID, name: AttrName })
+  dataSet.addCases([{ __id__: "1", AttrID: 1 }, { __id__: "2", AttrID: 2 }, { __id__: "3", AttrID: 3 }])
+  dataSet.setFilterFormula(filterFormula)
+  const formula = dataSet.filterFormula!
+  const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
+  const context = { dataSet, formula }
+  const extraMetadata = { dataSetId: dataSet.id }
+  const api = {
+    getDatasets: jest.fn(() => dataSets),
+    getGlobalValueManager: jest.fn(),
+    getFormulaExtraMetadata: jest.fn(() => extraMetadata),
+    getFormulaContext: jest.fn(() => context),
+  }
+  const adapter = new FilterFormulaAdapter(api)
+
+  const displayNameMap = getDisplayNameMap({ localDataSet: dataSet, dataSets })
+  formula.setCanonicalExpression(displayToCanonical(formula.display, displayNameMap))
+
+  return { adapter, api, dataSet, formula, context, extraMetadata }
+}
+
+describe("AttributeFormulaAdapter", () => {
+  describe("getAllFormulas", () => {
+    it("should return attribute formulas and extra metadata", () => {
+      const { adapter, extraMetadata, formula } = getTestEnv("foo < 2")
+      const formulas = adapter.getActiveFormulas()
+      expect(formulas.length).toBe(1)
+      expect(formulas[0].formula).toBe(formula)
+      expect(formulas[0].formula.display).toBe("foo < 2")
+      expect(formulas[0].extraMetadata).toEqual(extraMetadata)
+    })
+  })
+
+  describe("computeFormula", () => {
+    it("should return results for each provided case", () => {
+      const { adapter, context, extraMetadata } = getTestEnv("foo < 2")
+      const results = adapter.computeFormula(context, extraMetadata, "ALL_CASES")
+      expect(results).toEqual([
+        { itemId: "1", result: true },
+        { itemId: "2", result: false },
+        { itemId: "3", result: false },
+      ])
+    })
+
+    it("should ignore cases that are set aside by the user", () => {
+      const { adapter, context, extraMetadata } = getTestEnv("foo < 2")
+      const dataSet = context.dataSet
+      dataSet.hideCasesOrItems(["3"])
+      const results = adapter.computeFormula(context, extraMetadata, "ALL_CASES")
+      expect(results).toEqual([
+        { itemId: "1", result: true },
+        { itemId: "2", result: false }
+      ])
+    })
+
+    it("should not include set-aside cases in the aggregate function calculations", () => {
+      const { adapter, context, dataSet, extraMetadata } = getTestEnv("foo < max(foo)")
+      const results = adapter.computeFormula(context, extraMetadata, "ALL_CASES")
+      // max(foo) = 3 when all the cases are included
+      expect(results).toEqual([
+        { itemId: "1", result: true },
+        { itemId: "2", result: true },
+        { itemId: "3", result: false },
+      ])
+
+      dataSet.hideCasesOrItems(["3"])
+
+      const results2 = adapter.computeFormula(context, extraMetadata, "ALL_CASES")
+      // max(foo) = 2 when case 3 is set aside
+      expect(results2).toEqual([
+        { itemId: "1", result: true },
+        { itemId: "2", result: false }
+      ])
+    })
+  })
+
+  describe("recalculateFormula", () => {
+    it("should store results in DataSet filterFormulaResult map", () => {
+      const { adapter, dataSet, context, extraMetadata } = getTestEnv("foo < 2")
+      adapter.recalculateFormula(context, extraMetadata, "ALL_CASES")
+      expect(dataSet.filterFormulaResults.toJSON()).toEqual([
+        ["1", true],
+        ["2", false],
+        ["3", false],
+      ])
+    })
+
+    it("should update just provided cases when casesToRecalculateDesc is an array", () => {
+      const { adapter, dataSet, context, extraMetadata } = getTestEnv("foo < 2")
+      dataSet.filterFormulaResults.set("1", false)
+      dataSet.filterFormulaResults.set("2", true)
+
+      adapter.recalculateFormula(context, extraMetadata, [{ __id__: "1" }])
+      expect(dataSet.filterFormulaResults.toJSON()).toEqual([
+        ["1", true],
+        // Old values should be preserved
+        ["2", true]
+      ])
+    })
+
+    it("should clear previous filter formula error", () => {
+      const { adapter, dataSet, context, extraMetadata } = getTestEnv("foo < 2")
+      adapter.setFormulaError(context, extraMetadata, "test error")
+      adapter.recalculateFormula(context, extraMetadata, "ALL_CASES")
+      expect(dataSet.filterFormulaError).toEqual("")
+    })
+  })
+
+  describe("setError", () => {
+    it("should store error in DataSet case values", () => {
+      const { adapter, dataSet, context, extraMetadata } = getTestEnv("foo < 2")
+      adapter.setFormulaError(context, extraMetadata, "test error")
+      expect(dataSet.filterFormulaError).toEqual("test error")
+    })
+  })
+})

--- a/v3/src/models/formula/filter-formula-adapter.ts
+++ b/v3/src/models/formula/filter-formula-adapter.ts
@@ -1,0 +1,115 @@
+import { math } from "./functions/math"
+import { FormulaMathJsScope } from "./formula-mathjs-scope"
+import { formulaError } from "./utils/misc"
+import { ICase } from "../data/data-set-types"
+import { IFormula } from "./formula"
+import type {
+  IFormulaAdapterApi, IFormulaContext, IFormulaExtraMetadata, IFormulaManagerAdapter
+} from "./formula-manager"
+import { DEBUG_FORMULAS, debugLog } from "../../lib/debug"
+import { isFilterFormulaDataSet } from "../data/data-set"
+
+const FILTER_FORMULA_ADAPTER = "FilterFormulaAdapter"
+
+export class FilterFormulaAdapter implements IFormulaManagerAdapter {
+  type = FILTER_FORMULA_ADAPTER
+  api: IFormulaAdapterApi
+
+  constructor(api: IFormulaAdapterApi) {
+    this.api = api
+  }
+
+  getActiveFormulas(): ({ formula: IFormula, extraMetadata: IFormulaExtraMetadata })[] {
+    const result: ({ formula: IFormula, extraMetadata: IFormulaExtraMetadata })[] = []
+    this.api.getDatasets().forEach(dataSet => {
+      if (isFilterFormulaDataSet(dataSet)) {
+        result.push({
+          formula: dataSet.filterFormula,
+          extraMetadata: {
+            dataSetId: dataSet.id
+          }
+        })
+      }
+    })
+    return result
+  }
+
+  recalculateFormula(formulaContext: IFormulaContext, extraMetadata: IFormulaExtraMetadata,
+    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
+    if (formulaContext.formula.empty) {
+      return
+    }
+
+    // Clear any previous error first.
+    this.setFormulaError(formulaContext, extraMetadata, "")
+
+    const dataSet = this.api.getDatasets().get(extraMetadata.dataSetId)
+    if (!dataSet) {
+      throw new Error(`Dataset with id "${extraMetadata.dataSetId}" not found`)
+    }
+    const results = this.computeFormula(formulaContext, extraMetadata, casesToRecalculateDesc)
+    if (results && results.length > 0) {
+      dataSet.updateFilterFormulaResults(results, { replaceAll: casesToRecalculateDesc === "ALL_CASES" })
+    }
+  }
+
+  computeFormula(formulaContext: IFormulaContext, extraMetadata: IFormulaExtraMetadata,
+    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
+    const { formula, dataSet } = formulaContext
+    const { attributeId } = extraMetadata
+
+    let casesToRecalculate: ICase[] = []
+    if (casesToRecalculateDesc === "ALL_CASES") {
+      // If casesToRecalculate is not provided, recalculate all cases.
+      // Use itemsNotSetAside to exclude set-aside cases so they're not included in calculations,
+      // such as aggregate functions like mean.
+      casesToRecalculate = dataSet.itemsNotSetAside.map(id => dataSet.getItem(id)).filter(c => c) as ICase[]
+    } else {
+      casesToRecalculate = casesToRecalculateDesc
+    }
+    if (!casesToRecalculate || casesToRecalculate.length === 0) {
+      return
+    }
+
+    const caseIds = casesToRecalculate.map(c => c.__id__)
+
+    debugLog(DEBUG_FORMULAS, `[attr formula] recalculate "${formula.canonical}" for ${casesToRecalculate.length} cases`)
+
+    const formulaScope = new FormulaMathJsScope({
+      localDataSet: dataSet,
+      dataSets: this.api.getDatasets(),
+      globalValueManager: this.api.getGlobalValueManager(),
+      formulaAttrId: attributeId,
+      caseIds,
+      childMostCollectionCaseIds: caseIds
+    })
+
+    try {
+      const compiledFormula = math.compile(formula.canonical)
+      return casesToRecalculate.map((c, idx) => {
+        formulaScope.setCasePointer(idx)
+        const formulaValue = compiledFormula.evaluate(formulaScope)
+        // This is necessary for functions like `prev` that need to know the previous result when they reference
+        // its own attribute.
+        formulaScope.savePreviousResult(formulaValue)
+        return {
+          itemId: c.__id__,
+          result: !!formulaValue // only boolean values are supported
+        }
+      })
+    } catch (e: any) {
+      return this.setFormulaError(formulaContext, extraMetadata, formulaError(e.message))
+    }
+  }
+
+  // Error message is set as formula output, similarly as in CODAP V2.
+  setFormulaError(formulaContext: IFormulaContext, extraMetadata: IFormulaExtraMetadata, errorMsg: string) {
+    const { dataSet } = formulaContext
+    dataSet.setFilterFormulaError(errorMsg)
+  }
+
+  getFormulaError(formulaContext: IFormulaContext, extraMetadata: IFormulaExtraMetadata) {
+    // No custom errors yet.
+    return undefined
+  }
+}

--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -1,5 +1,5 @@
 import { comparer, makeObservable, observable, reaction, action } from "mobx"
-import { addDisposer, isAlive } from "mobx-state-tree"
+import { addDisposer } from "mobx-state-tree"
 import { ICase } from "../data/data-set-types"
 import { CaseList } from "./formula-types"
 import { IDataSet } from "../data/data-set"
@@ -236,10 +236,6 @@ export class FormulaManager {
       if (!activeFormulas.has(formulaId)) {
         this.unregisterFormula(formulaId)
       }
-      if (!isAlive(metadata.formula)) {
-        console.warn(`Formula ${metadata.formula.display} unregistered in an unexpected way`)
-        this.unregisterFormula(formulaId)
-      }
     })
   }
 
@@ -307,6 +303,10 @@ export class FormulaManager {
     const { dataSet } = formulaContext
     const { formula, adapter } = formulaMetadata
     const { defaultArgument } = extraMetadata
+
+    // unregister formulas when they're destroyed
+    addDisposer(formula, () => this.unregisterFormula(formulaId))
+
     if (formula.empty) {
       return
     }

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -40,6 +40,10 @@
     "V3.Redo.hideShowMenu.setAsideCases": "Redo setting aside cases",
     "V3.Undo.hideShowMenu.restoreSetAsideCases": "Undo restoring set aside cases",
     "V3.Redo.hideShowMenu.restoreSetAsideCases": "Redo restoring set aside cases",
+    "V3.hideShowMenu.addFilterFormula": "Add Filter Formula...",
+    "V3.hideShowMenu.editFilterFormula": "Edit Filter Formula...",
+    "V3.Undo.hideShowMenu.changeFilterFormula": "Undo changing filter formula",
+    "V3.Redo.hideShowMenu.changeFilterFormula": "Redo changing filter formula",
 
     "V3.Inspector.rescale.noRescale.toolTip": "All the data are already visible",
     "V3.Inspector.rescale.casePlot.toolTip": "Move the points to new random positions",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187799307

This PR adds support for the dataset filter function. The UI and initial helpers in the dataset were added by Kirk in the first commit.

My next commit added a filter formula adapter, similar to other adapters but actually significantly simpler than the attribute formula adapter. The main reason for that is the fact that filter formulas don't need to care about the case table hierarchy/collections (so we also don't need to react to hierarchy changes). Also, we don't need to detect dependency cycles, as they are not possible there (a filter formula can't reference itself, nor can any other attribute reference it).

@kswenson, I slightly renamed helpers that you proposed in the first commit. I tried to be reasonably consistent about what "hidden" means and split that into two possible options:

- case can be set aside by user manually
- case can be filtered out by the filter formula

That's why I renamed the previous `isHidden<...>` helpers to `isSetAside<...>`, added `isFilteredOut<...>`, and reimplemented `isHidden<...>` to use these two helpers first. We could go one step further and probably rename `hiddenItemIds` and `hiddenItemIdsSet` to `setAsideItemIds`, but I didn't go that far, as I'm not sure if you like the concept in the first place, and it's pretty trivial to do later anyway.

Also, I renamed `_unhiddenItemIds` to `itemsNotSetAside` to follow the above convention, and to make it a more "public" property (since the filter formula adapter uses it).

I struggled a bit to make the case table (or graph) update on the filtered result update. It's not enough to modify the result of `get itemIds()`. The missing piece was to update `isCaseOrItemHidden` (at first, I didn't change this function, but I had a separate helper for filtered-out items) as it's used here:

```javascript
     addDisposer(self, reaction(
        () => self.collectionIds,
        () => {
          // update parent/child links and provide access to item data
          const itemData: IItemData = {
            itemIds: () => self._itemIds,
            isHidden: (itemId) => self.isCaseOrItemHidden(itemId), // <===
```

I tested filter formulas for various cases, and they work with aggregate functions as expected (there are specs for that). Also, I checked cases where the number of filtered items doesn't change - the case table still updates correctly (an easy test case for that is `caseIndex == 1`, then `caseIndex == 2`, etc.).

Also, I added a TODO item about the warning when the formula is deleted. I think it's better to handle that separately, as it's not currently a regression.
