### PR TITLE
No rescale on hide points in graph

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -315,9 +315,14 @@ export const useSubAxis = ({
       setupCategories()
     } else if (isBaseNumericAxisModel(axisModel)) {
       const currentAxisDomain = axisModel.domain
+      const allowToShrink = axisModel.allowRangeToShrink
       const numericValues = dataConfig?.numericValuesForAttrRole(role) ?? []
       const [minValue, maxValue] = extent(numericValues, d => d) as [number, number]
       const niceBounds = computeNiceNumericBounds(minValue, maxValue)
+      if (!allowToShrink) {
+        niceBounds.min = Math.min(niceBounds.min, currentAxisDomain[0])
+        niceBounds.max = Math.max(niceBounds.max, currentAxisDomain[1])
+      }
       if (niceBounds.min === currentAxisDomain[0] && niceBounds.max === currentAxisDomain[1]) return
       layout.getAxisMultiScale(axisPlace)?.setNumericDomain([niceBounds.min, niceBounds.max])
       isBaseNumericAxisModel(axisModel) && setNiceDomain(numericValues, axisModel)

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -84,7 +84,8 @@ export const BaseNumericAxisModel = AxisModel
   })
   .volatile(_self => ({
     dynamicMin: undefined as number | undefined,
-    dynamicMax: undefined as number | undefined
+    dynamicMax: undefined as number | undefined,
+    allowRangeToShrink: false
   }))
   .views(self => ({
     get domain() {
@@ -112,6 +113,14 @@ export const BaseNumericAxisModel = AxisModel
       } else if ((min < 0) && (Math.abs(max) < Math.abs(min / snapFactor))) {
         max = 0
       }
+      if (!self.allowRangeToShrink) {
+        const currentMin = self.dynamicMin ?? self.min,
+          currentMax = self.dynamicMax ?? self.max
+        min = Math.min(min, currentMin)
+        max = Math.max(max, currentMax)
+      } else {
+        self.allowRangeToShrink = false
+      }
       if (isFinite(min)) self.min = min
       if (isFinite(max)) self.max = max
       self.dynamicMin = undefined
@@ -119,6 +128,9 @@ export const BaseNumericAxisModel = AxisModel
     },
     setLockZero(lockZero: boolean) {
       self.lockZero = lockZero
+    },
+    setAllowRangeToShrink(allowRangeToShrink: boolean) {
+      self.allowRangeToShrink = allowRangeToShrink
     }
   }))
 

--- a/v3/src/components/graph/components/parent-toggles.tsx
+++ b/v3/src/components/graph/components/parent-toggles.tsx
@@ -156,8 +156,8 @@ export const ParentToggles = observer(function ParentToggles() {
           dataConfig.clearHiddenCases()
         },
         {
-          undoStringKey: "DG.mainPage.mainPane.undoButton.toolTip",
-          redoStringKey: "DG.mainPage.mainPane.redoButton.toolTip",
+          undoStringKey: "V3.Undo.graph.showAllCases",
+          redoStringKey: "V3.Redo.graph.showAllCases",
           log: {message: "Show all cases from parent toggles", args: {}, category: "data"}
         }
       )
@@ -165,8 +165,8 @@ export const ParentToggles = observer(function ParentToggles() {
       dataConfig?.applyModelChange(
         () => dataConfig.setHiddenCases(Array.from(dataConfig.allCaseIDs)),
         {
-          undoStringKey: "DG.mainPage.mainPane.undoButton.toolTip",
-          redoStringKey: "DG.mainPage.mainPane.redoButton.toolTip",
+          undoStringKey: "V3.Undo.graph.hideAllCases",
+          redoStringKey: "V3.Redo.graph.hideAllCases",
           log: {message: "Hide all cases from parent toggles", args: {}, category: "data"}
         }
       )
@@ -174,6 +174,10 @@ export const ParentToggles = observer(function ParentToggles() {
   }
 
   const handleToggleLast = () => {
+    const undoString = isOnlyLastShown
+      ? "V3.Undo.graph.uncheckLastParentOnly" : "V3.Undo.graph.showLastParentOnly"
+    const redoString = isOnlyLastShown
+      ? "V3.Redo.graph.uncheckLastParentOnly" : "V3.Redo.graph.showLastParentOnly"
     dataConfig?.applyModelChange(
       () => {
         graphModel?.setShowOnlyLastCase(!isOnlyLastShown)
@@ -185,8 +189,8 @@ export const ParentToggles = observer(function ParentToggles() {
         }
       },
       {
-        undoStringKey: "DG.mainPage.mainPane.undoButton.toolTip",
-        redoStringKey: "DG.mainPage.mainPane.redoButton.toolTip",
+        undoStringKey: undoString,
+        redoStringKey: redoString,
         log: isOnlyLastShown ? "Disable only showing last parent toggle" : "Enable only showing last parent toggle"
       }
     )
@@ -207,9 +211,9 @@ export const ParentToggles = observer(function ParentToggles() {
         dataConfig.setHiddenCases(Array.from(currentHiddenCases))
       },
       {
-        undoStringKey: "DG.mainPage.mainPane.undoButton.toolTip",
-        redoStringKey: "DG.mainPage.mainPane.redoButton.toolTip",
-        log: "Toggle parent toggle"
+        undoStringKey: "V3.Undo.graph.toggleParentVisibility",
+        redoStringKey: "V3.Redo.graph.toggleParentVisibility",
+        log: "Toggle parent group visibility"
       }
     )
   }

--- a/v3/src/components/graph/models/graph-model-utils.ts
+++ b/v3/src/components/graph/models/graph-model-utils.ts
@@ -56,11 +56,13 @@ function setupAxes(graphModel: IGraphContentModel, layout: GraphLayout) {
       case 'numeric': {
         if (!currAxisModel || !isNumericAxisModel(currAxisModel)) {
           const newAxisModel = NumericAxisModel.create({place, min: 0, max: 1})
+          newAxisModel.setAllowRangeToShrink(true)
           graphModel?.setAxis(place, newAxisModel)
           dataConfig?.setAttributeType(attrRole, 'numeric')
           layout.setAxisScaleType(place, 'linear')
           setNiceDomain(attr?.numValues || [], newAxisModel, graphModel?.axisDomainOptions)
         } else {
+          currAxisModel.setAllowRangeToShrink(true)
           setNiceDomain(attr?.numValues || [], currAxisModel, graphModel?.axisDomainOptions)
         }
       }

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -60,6 +60,7 @@ export function setNiceDomain(values: number[], axisModel: IAxisModel, options?:
     // When clamping, the domain should start at 0 unless there are negative values.
     if (options?.clampPosMinAtZero && minValue >= 0) {
       niceMin = 0
+      axisModel.setAllowRangeToShrink(true)
     }
     axisModel.setDomain(niceMin, niceMax)
   }

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -8,6 +8,17 @@
     "V3.general.yes": "Yes",
     "V3.general.no": "No",
 
+    "V3.Undo.graph.toggleParentVisibility": "Undo toggling visibility",
+    "V3.Redo.graph.toggleParentVisibility": "Redo toggling visibility",
+    "V3.Undo.graph.hideAllCases": "Undo hiding all cases",
+    "V3.Redo.graph.hideAllCases": "Redo hiding all cases",
+    "V3.Undo.graph.showAllCases": "Undo showing all cases",
+    "V3.Redo.graph.showAllCases": "Redo showing all cases",
+    "V3.Undo.graph.showLastParentOnly": "Undo showing only last parent case",
+    "V3.Redo.graph.showLastParentOnly": "Redo showing only last parent case",
+    "V3.Undo.graph.uncheckLastParentOnly": "Undo unchecking \"Last\" checkbox",
+    "V3.Redo.graph.uncheckLastParentOnly": "Redo unchecking \"Last\" checkbox",
+
     "V3.map.inspector.base": "Base",
     "V3.map.inspector.oceans": "Oceans",
     "V3.map.inspector.topo": "Topo",


### PR DESCRIPTION
[#188293477] Bug fix: When hiding cases, numeric axes should not rescale

Actually, in **most** situations a user action should not zoom in; i.e. shrink the scale. But there are some where we do. So it's a bit finicky.

* Add `allowRangeToShrink` to `BaseNumericAxisModel` as a flag that clients can set. Then use the flag in `setDomain` to adjust the requested domain.
* Took the opportunity to add undo/redo strings for various parent visibility toggle actions