### PR TITLE
Fixes deselection when clicking in whitespace in new table

### DIFF
--- a/v3/src/components/case-table/use-white-space-click.ts
+++ b/v3/src/components/case-table/use-white-space-click.ts
@@ -17,8 +17,8 @@ export function useWhiteSpaceClick({ gridRef }: IProps) {
   // then the table should be focused and the selection should not be cleared.
   // So we track if the table is in focus and if it was in focus before.
   const { isTileSelected } = useTileModelContext()
-  const isFocusedTileRef = useRef(false)
-  const wasFocusedTileRef = useRef(false)
+  const isFocusedTileRef = useRef(isTileSelected())
+  const wasFocusedTileRef = useRef(isTileSelected())
   const isFocusedTile = isTileSelected()
 
   // Store the previous focus state


### PR DESCRIPTION
There was a problem with the whitespace deselection click with new tables.
The whitespace click only deselects when table is already in focus. When we created new tables, it didn't know that the table tile was already in focus on open. So you would have to click twice to deselect.
This should fix that.
