### PR TITLE
Support unicode operators

### DIFF
--- a/v3/src/models/formula/utils/canonicalization-utils.test.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.test.ts
@@ -73,6 +73,30 @@ describe("customizeDisplayFormula", () => {
     expect(customizeDisplayFormula("a >= b")).toEqual("a >= b")
     expect(customizeDisplayFormula("a >= b = c = d >= e")).toEqual("a >= b == c == d >= e")
   })
+  it("replaces unicode characters with MathJS supported characters", () => {
+    expect(customizeDisplayFormula("a ≠ 1")).toEqual("a != 1")
+    expect(customizeDisplayFormula("a ≠ b")).toEqual("a != b")
+    expect(customizeDisplayFormula("a ≠ b = c = d ≠ e")).toEqual("a != b == c == d != e")
+
+    expect(customizeDisplayFormula("a ≥ 1")).toEqual("a >= 1")
+    expect(customizeDisplayFormula("a ≥ b")).toEqual("a >= b")
+    expect(customizeDisplayFormula("a ≥ b = c = d ≥ e")).toEqual("a >= b == c == d >= e")
+
+    expect(customizeDisplayFormula("a ≤ 1")).toEqual("a <= 1")
+    expect(customizeDisplayFormula("a ≤ b")).toEqual("a <= b")
+    expect(customizeDisplayFormula("a ≤ b = c = d ≤ e")).toEqual("a <= b == c == d <= e")
+
+    expect(customizeDisplayFormula("a × 1")).toEqual("a * 1")
+    expect(customizeDisplayFormula("a × b")).toEqual("a * b")
+    expect(customizeDisplayFormula("a × b = c = d × e")).toEqual("a * b == c == d * e")
+
+    expect(customizeDisplayFormula("a ÷ 1")).toEqual("a / 1")
+    expect(customizeDisplayFormula("a ÷ b")).toEqual("a / b")
+    expect(customizeDisplayFormula("a ÷ b = c = d ÷ e")).toEqual("a / b == c == d / e")
+
+    expect(customizeDisplayFormula("π")).toEqual("pi")
+    expect(customizeDisplayFormula("∞")).toEqual("Infinity")
+  })
 })
 
 describe("formulaIndexOf", () => {

--- a/v3/src/models/formula/utils/canonicalization-utils.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.ts
@@ -21,10 +21,19 @@ export const makeDisplayNamesSafe = (formula: string) => {
 
 export const customizeDisplayFormula = (formula: string) => {
   // Over time, this function might grow significantly and require more advanced parsing of the formula.
-  // Replace all the assignment operators with equality operators, as CODAP v2 uses a single "=" for equality check.
-  // Regular expression developed with the help of ChatGPT.
-  // Matches `=` when not preceded by '<', '>', '!', or '=` and not followed by `=`, preserving white space.
-  return formula.replace(/(?<!<|>|!|=)(\s*)=(\s*)(?!=)/g, "$1==$2")
+  return formula
+    // Replace all the assignment operators with equality operators, as CODAP v2 uses a single "=" for equality check.
+    // Regular expression developed with the help of ChatGPT.
+    // Matches `=` when not preceded by '<', '>', '!', or '=` and not followed by `=`, preserving white space.
+    .replace(/(?<!<|>|!|=)(\s*)=(\s*)(?!=)/g, "$1==$2")
+    // Replace unicode characters with the MathJS supported characters.
+    .replace(/≠/g, "!=")
+    .replace(/≥/g, ">=")
+    .replace(/≤/g, "<=")
+    .replace(/×/g, "*")
+    .replace(/÷/g, "/")
+    .replace(/π/g, "pi")
+    .replace(/∞/g, "Infinity")
 }
 
 export const preprocessDisplayFormula = (formula: string) => customizeDisplayFormula(makeDisplayNamesSafe(formula))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/188274494

MathJS doesn't support Unicode operators by default, and it doesn't appear possible to modify it to do so without changing the parser. Since we are dealing with single Unicode characters, this approach seems good enough.