### PR TITLE
Fix numeric axis crash

### DIFF
--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -42,9 +42,18 @@ export class NumericAxisHelper extends AxisHelper {
     const numericScale = this.multiScale?.scaleType === "linear"
       ? this.multiScale.numericScale?.copy().range(this.newRange) as ScaleLinear<number, number>
       : undefined
-    if (!isNumericAxisModel(this.axisModel) || !numericScale) return
+    if (!isNumericAxisModel(this.axisModel) || !numericScale || !this.subAxisElt) return
 
+    const subAxisSelection = select(this.subAxisElt),
+      numericAxisSelection = subAxisSelection.selectAll('.numeric-axis-tag')
+    // If we don't already have a numeric axis, we have to remove whatever is there
+    if (numericAxisSelection.size() === 0) {
+      subAxisSelection.selectAll('*').remove()
+    }
     this.renderAxisLine()
+    // The axis line gets removed and rerendered each time.
+    // Tag it so the next time around we know we have a numeric axis.
+    subAxisSelection.select('.axis-line').classed('numeric-axis-tag', true)
 
     const axisScale = this.axis(numericScale).tickSizeOuter(0).tickFormat(format('.9'))
     const duration = this.isAnimating() ? transitionDuration : 0
@@ -64,7 +73,7 @@ export class NumericAxisHelper extends AxisHelper {
         return Number.isInteger(d) ? d.toString() : ""
       })
     }
-    this.subAxisElt && select(this.subAxisElt)
+    subAxisSelection
       .attr("transform", this.initialTransform)
       .transition().duration(duration)
       .call(axisScale).selectAll("line,path")


### PR DESCRIPTION
[#188305480] Bug fix: Crash on undo of drag attribute to graph

* Prior PR limited the amount of redrawing we do for numeric axes by not erasing what we find for the axis. But we went too far. If we don't already have a numeric axis, we *do* need to remove what is there or, otherwise, we crash. So this PR makes it possible in `NumericAxisHelper:render` to tell whether we rerendering as opposed to starting fresh. If the latter, remove what is already present.