### PR TITLE
Date Axis Model needs proper initialization

### DIFF
--- a/v3/src/components/graph/models/graph-model-utils.ts
+++ b/v3/src/components/graph/models/graph-model-utils.ts
@@ -82,6 +82,7 @@ function setupAxes(graphModel: IGraphContentModel, layout: GraphLayout) {
       case 'date': {
         if (!currAxisModel || !isDateAxisModel(currAxisModel)) {
           const newAxisModel = DateAxisModel.create({place, min: 0, max: 1})
+          newAxisModel.setAllowRangeToShrink(true)
           graphModel?.setAxis(place, newAxisModel)
           dataConfig?.setAttributeType(attrRole, 'date')
           layout.setAxisScaleType(place, 'linear')


### PR DESCRIPTION
[#188312576] Bug fix: Date axis not working properly

* Prior PR for not "shrinking" numeric axes unnecessarily cause date axis model to get spurious min and max. In `graph-model-utils.ts` `setAllowRangeToShrink(true)` was being called for a new numeric axis model, but not for a new date axis model. So, we fix that.