### PR TITLE
fix: Slate error on closing text component

### DIFF
--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -29,14 +29,21 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
   }, [initialValue])
 
   useEffect(() => {
-    return tile && mstReaction(
+    let animationFrame: number
+    const disposer = tile && mstReaction(
       () => isTileSelected() && tile?.transitionComplete,
       isSelected => {
         // RAF to delay focus request until after model processing completes
-        isSelected && requestAnimationFrame(() => ReactEditor.focus(editor))
+        if (isSelected) {
+          animationFrame = requestAnimationFrame(() => ReactEditor.focus(editor))
+        }
       },
       { name: "FocusEditorOnTileSelect" }, tile
     )
+    return () => {
+      if (animationFrame) cancelAnimationFrame(animationFrame)
+      disposer?.()
+    }
   }, [editor, isTileSelected, tile])
 
   const textTileRef = useRef<HTMLDivElement | null>(null)


### PR DESCRIPTION
[[PT-188319487]](https://www.pivotaltracker.com/story/show/188319487)

We were properly disposing of the MobX reaction when the text tile was closed, but not canceling any in-flight `requestAnimationFrame` callback.