### PR TITLE
188326911 Fix Title of Imported Datasets

### DIFF
--- a/v3/src/data-interactive/handlers/data-context-list-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-list-handler.ts
@@ -16,7 +16,7 @@ export const diDataContextListHandler: DIHandler = {
         return {
           name: dataSet.name,
           guid: id,
-          title: dataSet._title,
+          title: dataSet.title,
           id
         }
       })

--- a/v3/src/utilities/csv-import.ts
+++ b/v3/src/utilities/csv-import.ts
@@ -13,7 +13,10 @@ export function downloadCsvFile(dataUrl: string, onComplete: (results: CsvParseR
 }
 
 export function convertParsedCsvToDataSet(results: CsvParseResult, filename: string) {
-  const ds = DataSet.create({ name: filename })
+  // Remove extension
+  // From https://stackoverflow.com/questions/4250364/how-to-trim-a-file-extension-from-a-string-in-javascript
+  const name = filename.replace(/\.[^/.]+$/, "")
+  const ds = DataSet.create({ name })
   // add attributes (extracted from first case)
   for (const pName in results.data[0]) {
     ds.addAttribute({name: pName})


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188326911

This PR does two things:
- It removes the file extension from the name of datasets imported into Codap (making v3 align with v2).
- It includes the displayed title in response to `get dataContextList` requests, rather than the actual title. This change was needed to make StoryQ work properly in v3.