### PR TITLE
Update Pixi to v8

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -32,7 +32,7 @@
         "mobx-react-lite": "^4.0.7",
         "nanoid": "^5.0.7",
         "papaparse": "^5.4.1",
-        "pixi.js": "~7.4.2",
+        "pixi.js": "~8.4.1",
         "pluralize": "^8.0.0",
         "prop-types": "^15.8.1",
         "query-string": "^9.1.0",
@@ -5160,348 +5160,11 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pixi/accessibility": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.2.tgz",
-      "integrity": "sha512-R6VEolm8uyy1FB1F2qaLKxVbzXAFTZCF2ka8fl9lsz7We6ZfO4QpXv9ur7DvzratjCQUQVCKo0/V7xL5q1EV/g==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/events": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/app": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.2.tgz",
-      "integrity": "sha512-ugkH3kOgjT8P1mTMY29yCOgEh+KuVMAn8uBxeY0aMqaUgIMysfpnFv+Aepp2CtvI9ygr22NC+OiKl+u+eEaQHw==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/assets": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.2.tgz",
-      "integrity": "sha512-anxho59H9egZwoaEdM5aLvYyxoz6NCy3CaQIvNHD1bbGg8L16Ih0e26QSBR5fu53jl8OjT6M7s+p6n7uu4+fGA==",
-      "dependencies": {
-        "@types/css-font-loading-module": "^0.0.12"
-      },
-      "peerDependencies": {
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/color": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.2.tgz",
-      "integrity": "sha512-av1LOvhHsiaW8+T4n/FgnOKHby55/w7VcA1HzPIHRBtEcsmxvSCDanT1HU2LslNhrxLPzyVx18nlmalOyt5OBg==",
-      "dependencies": {
-        "@pixi/colord": "^2.9.6"
-      }
-    },
     "node_modules/@pixi/colord": {
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
-      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
-    },
-    "node_modules/@pixi/compressed-textures": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.2.tgz",
-      "integrity": "sha512-VJrt7el6O4ZJSWkeOGXwrhJaiLg1UBhHB3fj42VR4YloYkAxpfd9K6s6IcbcVz7n9L48APKBMgHyaB2pX2Ck/A==",
-      "peerDependencies": {
-        "@pixi/assets": "7.4.2",
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/constants": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.2.tgz",
-      "integrity": "sha512-N9vn6Wpz5WIQg7ugUg2+SdqD2u2+NM0QthE8YzLJ4tLH2Iz+/TrnPKUJzeyIqbg3sxJG5ZpGGPiacqIBpy1KyA=="
-    },
-    "node_modules/@pixi/core": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.2.tgz",
-      "integrity": "sha512-UbMtgSEnyCOFPzbE6ThB9qopXxbZ5GCof2ArB4FXOC5Xi/83MOIIYg5kf5M8689C5HJMhg2SrJu3xLKppF+CMg==",
-      "dependencies": {
-        "@pixi/color": "7.4.2",
-        "@pixi/constants": "7.4.2",
-        "@pixi/extensions": "7.4.2",
-        "@pixi/math": "7.4.2",
-        "@pixi/runner": "7.4.2",
-        "@pixi/settings": "7.4.2",
-        "@pixi/ticker": "7.4.2",
-        "@pixi/utils": "7.4.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      }
-    },
-    "node_modules/@pixi/display": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.2.tgz",
-      "integrity": "sha512-DaD0J7gIlNlzO0Fdlby/0OH+tB5LtCY6rgFeCBKVDnzmn8wKW3zYZRenWBSFJ0Psx6vLqXYkSIM/rcokaKviIw==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/events": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.2.tgz",
-      "integrity": "sha512-Jw/w57heZjzZShIXL0bxOvKB+XgGIevyezhGtfF2ZSzQoSBWo+Fj1uE0QwKd0RIaXegZw/DhSmiMJSbNmcjifA==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/extensions": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.2.tgz",
-      "integrity": "sha512-Hmx2+O0yZ8XIvgomHM9GZEGcy9S9Dd8flmtOK5Aa3fXs/8v7xD08+ANQpN9ZqWU2Xs+C6UBlpqlt2BWALvKKKA=="
-    },
-    "node_modules/@pixi/extract": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.2.tgz",
-      "integrity": "sha512-JOX27TRWjVEjauGBbF8PU7/g6LYXnivehdgqS5QlVDv1CNHTOrz/j3MdKcVWOhyZPbH5c9sh7lxyRxvd9AIuTQ==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/filter-alpha": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.2.tgz",
-      "integrity": "sha512-9OsKJ+yvY2wIcQXwswj5HQBiwNGymwmqdxfp7mo+nZSBoDmxUqvMZzE9UNJ3eUlswuNvNRO8zNOsQvwdz7WFww==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/filter-blur": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.2.tgz",
-      "integrity": "sha512-gOXBbIUx6CRZP1fmsis2wLzzSsofrqmIHhbf1gIkZMIQaLsc9T7brj+PaLTTiOiyJgnvGN5j20RZnkERWWKV0Q==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/filter-color-matrix": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.2.tgz",
-      "integrity": "sha512-ykZiR59Gvj80UKs9qm7jeUTKvn+wWk6HBVJOmJbK9jFK5juakDWp7BbH26U78Q61EWj97kI1FdfcbMkuQ7rqkA==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/filter-displacement": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.2.tgz",
-      "integrity": "sha512-QS/eWp/ivsxef3xapNeGwpPX7vrqQQeo99Fux4k5zsvplnNEsf91t6QYJLG776AbZEu/qh8VYRBA5raIVY/REw==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/filter-fxaa": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.2.tgz",
-      "integrity": "sha512-U/ptJgDsfs/r8y2a6gCaiPfDu2IFAxpQ4wtfmBpz6vRhqeE4kI8yNIUx5dZbui57zlsJaW0BNacOQxHU0vLkyQ==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/filter-noise": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.2.tgz",
-      "integrity": "sha512-Vy9ViBFhZEGh6xKkd3kFWErolZTwv1Y5Qb1bV7qPIYbvBECYsqzlR4uCrrjBV6KKm0PufpG/+NKC5vICZaqKzg==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/graphics": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.2.tgz",
-      "integrity": "sha512-jH4/Tum2RqWzHGzvlwEr7HIVduoLO57Ze705N2zQPkUD57TInn5911aGUeoua7f/wK8cTLGzgB9BzSo2kTdcHw==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/sprite": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/math": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.2.tgz",
-      "integrity": "sha512-7jHmCQoYk6e0rfSKjdNFOPl0wCcdgoraxgteXJTTHv3r0bMNx2pHD9FJ0VvocEUG7XHfj55O3+u7yItOAx0JaQ=="
-    },
-    "node_modules/@pixi/mesh": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.2.tgz",
-      "integrity": "sha512-mEkKyQvvMrYXC3pahvH5WBIKtrtB63WixRr91ANFI7zXD+ESG6Ap6XtxMCJmXDQPwBDNk7SWVMiCflYuchG7kA==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/mesh-extras": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.2.tgz",
-      "integrity": "sha512-vNR/7wjxjs7sv9fGoKkHyU91ZAD+7EnMHBS5F3CVISlOIFxLi96NNZCB81oUIdky/90pHw40johd/4izR5zTyw==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/mesh": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.2.tgz",
-      "integrity": "sha512-6dgthi2ruUT/lervSrFDQ7vXkEsHo6CxdgV7W/wNdW1dqgQlKfDvO6FhjXzyIMRLSooUf5FoeluVtfsjkUIYrw==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/sprite": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.2.tgz",
-      "integrity": "sha512-0Cfw8JpQhsixprxiYph4Lj+B5n83Kk4ftNMXgM5xtZz+tVLz5s91qR0MqcdzwTGTJ7utVygiGmS4/3EfR/duRQ==",
-      "peerDependencies": {
-        "@pixi/display": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/mixin-get-global-position": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.2.tgz",
-      "integrity": "sha512-LcsahbVdX4DFS2IcGfNp4KaXuu7SjAwUp/flZSGIfstyKOKb5FWFgihtqcc9ZT4coyri3gs2JbILZub/zPZj1w==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/particle-container": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.2.tgz",
-      "integrity": "sha512-B78Qq86kt0lEa5WtB2YFIm3+PjhKfw9La9R++GBSgABl+g13s2UaZ6BIPxvY3JxWMdxPm4iPrQPFX1QWRN68mw==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/sprite": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/prepare": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.2.tgz",
-      "integrity": "sha512-PugyMzReCHXUzc3so9PPJj2OdHwibpUNWyqG4mWY2UUkb6c8NAGK1AnAPiscOvLilJcv/XQSFoNhX+N1jrvJEg==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/graphics": "7.4.2",
-        "@pixi/text": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/runner": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.2.tgz",
-      "integrity": "sha512-LPBpwym4vdyyDY5ucF4INQccaGyxztERyLTY1YN6aqJyyMmnc7iqXlIKt+a0euMBtNoLoxy6MWMvIuZj0JfFPA=="
-    },
-    "node_modules/@pixi/settings": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.2.tgz",
-      "integrity": "sha512-pMN+L6aWgvUbwhFIL/BTHKe2ShYGPZ8h9wlVBnFHMtUcJcFLMF1B3lzuvCayZRepOphs6RY0TqvnDvVb585JhQ==",
-      "dependencies": {
-        "@pixi/constants": "7.4.2",
-        "@types/css-font-loading-module": "^0.0.12",
-        "ismobilejs": "^1.1.0"
-      }
-    },
-    "node_modules/@pixi/sprite": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.2.tgz",
-      "integrity": "sha512-Ccf/OVQsB+HQV0Fyf5lwD+jk1jeU7uSIqEjbxenNNssmEdB7S5qlkTBV2EJTHT83+T6Z9OMOHsreJZerydpjeg==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/sprite-animated": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.2.tgz",
-      "integrity": "sha512-QPT6yxCUGOBN+98H3pyIZ1ZO6Y7BN1o0Q2IMZEsD1rNfZJrTYS3Q8VlCG5t2YlFlcB8j5iBo24bZb6FUxLOmsQ==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/sprite": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/sprite-tiling": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.2.tgz",
-      "integrity": "sha512-Z8PP6ewy3nuDYL+NeEdltHAhuucVgia33uzAitvH3OqqRSx6a6YRBFbNLUM9Sx+fBO2Lk3PpV1g6QZX+NE5LOg==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/sprite": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/spritesheet": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.2.tgz",
-      "integrity": "sha512-YIvHdpXW+AYp8vD0NkjJmrdnVHTZKidCnx6k8ATSuuvCT6O5Tuh2N/Ul2oDj4/QaePy0lVhyhAbZpJW00Jr7mQ==",
-      "peerDependencies": {
-        "@pixi/assets": "7.4.2",
-        "@pixi/core": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/text": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.2.tgz",
-      "integrity": "sha512-rZZWpJNsIQ8WoCWrcVg8Gi6L/PDakB941clo6dO3XjoII2ucoOUcnpe5HIkudxi2xPvS/8Bfq990gFEx50TP5A==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/sprite": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/text-bitmap": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.2.tgz",
-      "integrity": "sha512-lPBMJ83JnpFVL+6ckQ8KO8QmwdPm0z9Zs/M0NgFKH2F+BcjelRNnk80NI3O0qBDYSEDQIE+cFbKoZ213kf7zwA==",
-      "peerDependencies": {
-        "@pixi/assets": "7.4.2",
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/mesh": "7.4.2",
-        "@pixi/text": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/text-html": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.2.tgz",
-      "integrity": "sha512-duOu8oDYeDNuyPozj2DAsQ5VZBbRiwIXy78Gn7H2pCiEAefw/Uv5jJYwdgneKME0e1tOxz1eOUGKPcI6IJnZjw==",
-      "peerDependencies": {
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/sprite": "7.4.2",
-        "@pixi/text": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/ticker": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.2.tgz",
-      "integrity": "sha512-cAvxCh/KI6IW4m3tp2b+GQIf+DoSj9NNmPJmsOeEJ7LzvruG8Ps7SKI6CdjQob5WbceL1apBTDbqZ/f77hFDiQ==",
-      "dependencies": {
-        "@pixi/extensions": "7.4.2",
-        "@pixi/settings": "7.4.2",
-        "@pixi/utils": "7.4.2"
-      }
-    },
-    "node_modules/@pixi/utils": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.2.tgz",
-      "integrity": "sha512-aU/itcyMC4TxFbmdngmak6ey4kC5c16Y5ntIYob9QnjNAfD/7GTsYIBnP6FqEAyO1eq0MjkAALxdONuay1BG3g==",
-      "dependencies": {
-        "@pixi/color": "7.4.2",
-        "@pixi/constants": "7.4.2",
-        "@pixi/settings": "7.4.2",
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^4.0.0",
-        "url": "^0.11.0"
-      }
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -6536,7 +6199,8 @@
     "node_modules/@types/css-font-loading-module": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
-      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA=="
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
+      "license": "MIT"
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",
@@ -6794,7 +6458,8 @@
     "node_modules/@types/earcut": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
-      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ=="
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
@@ -8018,6 +7683,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.46.tgz",
+      "integrity": "sha512-2iogO6Zh0pTbKLGZuuGWEmJpF/fTABGs7G9wXxpn7s24XSJchSUIiMqIJHURi5zsMZRRTuXrV/3GLOkmOFjq5w==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@webpack-cli/configtest": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
@@ -8072,6 +7743,15 @@
       },
       "peerDependencies": {
         "react": "^18"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -11612,7 +11292,8 @@
     "node_modules/earcut": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -12985,7 +12666,8 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -15535,7 +15217,8 @@
     "node_modules/ismobilejs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -19563,6 +19246,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -19890,6 +19574,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.1.2",
@@ -20256,45 +19946,27 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.2.tgz",
-      "integrity": "sha512-TifqgHGNofO7UCEbdZJOpUu7dUnpu4YZ0o76kfCqxDa4RS8ITc9zjECCbtalmuNXkVhSEZmBKQvE7qhHMqw/xg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.4.1.tgz",
+      "integrity": "sha512-3ZbEIkLYYi602UB5wuN7kPz3VsGHoJa6nxD8ustvMLRySxHAR9Z8tCAYY8ISgNplpPbaDw03B0yTD4/k9f6cAQ==",
+      "license": "MIT",
       "dependencies": {
-        "@pixi/accessibility": "7.4.2",
-        "@pixi/app": "7.4.2",
-        "@pixi/assets": "7.4.2",
-        "@pixi/compressed-textures": "7.4.2",
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/events": "7.4.2",
-        "@pixi/extensions": "7.4.2",
-        "@pixi/extract": "7.4.2",
-        "@pixi/filter-alpha": "7.4.2",
-        "@pixi/filter-blur": "7.4.2",
-        "@pixi/filter-color-matrix": "7.4.2",
-        "@pixi/filter-displacement": "7.4.2",
-        "@pixi/filter-fxaa": "7.4.2",
-        "@pixi/filter-noise": "7.4.2",
-        "@pixi/graphics": "7.4.2",
-        "@pixi/mesh": "7.4.2",
-        "@pixi/mesh-extras": "7.4.2",
-        "@pixi/mixin-cache-as-bitmap": "7.4.2",
-        "@pixi/mixin-get-child-by-name": "7.4.2",
-        "@pixi/mixin-get-global-position": "7.4.2",
-        "@pixi/particle-container": "7.4.2",
-        "@pixi/prepare": "7.4.2",
-        "@pixi/sprite": "7.4.2",
-        "@pixi/sprite-animated": "7.4.2",
-        "@pixi/sprite-tiling": "7.4.2",
-        "@pixi/spritesheet": "7.4.2",
-        "@pixi/text": "7.4.2",
-        "@pixi/text-bitmap": "7.4.2",
-        "@pixi/text-html": "7.4.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
+        "@pixi/colord": "^2.9.6",
+        "@types/css-font-loading-module": "^0.0.12",
+        "@types/earcut": "^2.1.4",
+        "@webgpu/types": "^0.1.40",
+        "@xmldom/xmldom": "^0.8.10",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^5.0.1",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2"
       }
+    },
+    "node_modules/pixi.js/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -22081,6 +21753,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -23906,6 +23579,7 @@
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
       "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "dev": true,
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.11.2"
@@ -23924,12 +23598,14 @@
     "node_modules/url/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true
     },
     "node_modules/url/node_modules/qs": {
       "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.3.tgz",
       "integrity": "sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==",
+      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -28884,257 +28560,10 @@
         "fastq": "^1.6.0"
       }
     },
-    "@pixi/accessibility": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.2.tgz",
-      "integrity": "sha512-R6VEolm8uyy1FB1F2qaLKxVbzXAFTZCF2ka8fl9lsz7We6ZfO4QpXv9ur7DvzratjCQUQVCKo0/V7xL5q1EV/g==",
-      "requires": {}
-    },
-    "@pixi/app": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.2.tgz",
-      "integrity": "sha512-ugkH3kOgjT8P1mTMY29yCOgEh+KuVMAn8uBxeY0aMqaUgIMysfpnFv+Aepp2CtvI9ygr22NC+OiKl+u+eEaQHw==",
-      "requires": {}
-    },
-    "@pixi/assets": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.2.tgz",
-      "integrity": "sha512-anxho59H9egZwoaEdM5aLvYyxoz6NCy3CaQIvNHD1bbGg8L16Ih0e26QSBR5fu53jl8OjT6M7s+p6n7uu4+fGA==",
-      "requires": {
-        "@types/css-font-loading-module": "^0.0.12"
-      }
-    },
-    "@pixi/color": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.2.tgz",
-      "integrity": "sha512-av1LOvhHsiaW8+T4n/FgnOKHby55/w7VcA1HzPIHRBtEcsmxvSCDanT1HU2LslNhrxLPzyVx18nlmalOyt5OBg==",
-      "requires": {
-        "@pixi/colord": "^2.9.6"
-      }
-    },
     "@pixi/colord": {
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
-    },
-    "@pixi/compressed-textures": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.2.tgz",
-      "integrity": "sha512-VJrt7el6O4ZJSWkeOGXwrhJaiLg1UBhHB3fj42VR4YloYkAxpfd9K6s6IcbcVz7n9L48APKBMgHyaB2pX2Ck/A==",
-      "requires": {}
-    },
-    "@pixi/constants": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.2.tgz",
-      "integrity": "sha512-N9vn6Wpz5WIQg7ugUg2+SdqD2u2+NM0QthE8YzLJ4tLH2Iz+/TrnPKUJzeyIqbg3sxJG5ZpGGPiacqIBpy1KyA=="
-    },
-    "@pixi/core": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.2.tgz",
-      "integrity": "sha512-UbMtgSEnyCOFPzbE6ThB9qopXxbZ5GCof2ArB4FXOC5Xi/83MOIIYg5kf5M8689C5HJMhg2SrJu3xLKppF+CMg==",
-      "requires": {
-        "@pixi/color": "7.4.2",
-        "@pixi/constants": "7.4.2",
-        "@pixi/extensions": "7.4.2",
-        "@pixi/math": "7.4.2",
-        "@pixi/runner": "7.4.2",
-        "@pixi/settings": "7.4.2",
-        "@pixi/ticker": "7.4.2",
-        "@pixi/utils": "7.4.2"
-      }
-    },
-    "@pixi/display": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.2.tgz",
-      "integrity": "sha512-DaD0J7gIlNlzO0Fdlby/0OH+tB5LtCY6rgFeCBKVDnzmn8wKW3zYZRenWBSFJ0Psx6vLqXYkSIM/rcokaKviIw==",
-      "requires": {}
-    },
-    "@pixi/events": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.2.tgz",
-      "integrity": "sha512-Jw/w57heZjzZShIXL0bxOvKB+XgGIevyezhGtfF2ZSzQoSBWo+Fj1uE0QwKd0RIaXegZw/DhSmiMJSbNmcjifA==",
-      "requires": {}
-    },
-    "@pixi/extensions": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.2.tgz",
-      "integrity": "sha512-Hmx2+O0yZ8XIvgomHM9GZEGcy9S9Dd8flmtOK5Aa3fXs/8v7xD08+ANQpN9ZqWU2Xs+C6UBlpqlt2BWALvKKKA=="
-    },
-    "@pixi/extract": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.2.tgz",
-      "integrity": "sha512-JOX27TRWjVEjauGBbF8PU7/g6LYXnivehdgqS5QlVDv1CNHTOrz/j3MdKcVWOhyZPbH5c9sh7lxyRxvd9AIuTQ==",
-      "requires": {}
-    },
-    "@pixi/filter-alpha": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.2.tgz",
-      "integrity": "sha512-9OsKJ+yvY2wIcQXwswj5HQBiwNGymwmqdxfp7mo+nZSBoDmxUqvMZzE9UNJ3eUlswuNvNRO8zNOsQvwdz7WFww==",
-      "requires": {}
-    },
-    "@pixi/filter-blur": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.2.tgz",
-      "integrity": "sha512-gOXBbIUx6CRZP1fmsis2wLzzSsofrqmIHhbf1gIkZMIQaLsc9T7brj+PaLTTiOiyJgnvGN5j20RZnkERWWKV0Q==",
-      "requires": {}
-    },
-    "@pixi/filter-color-matrix": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.2.tgz",
-      "integrity": "sha512-ykZiR59Gvj80UKs9qm7jeUTKvn+wWk6HBVJOmJbK9jFK5juakDWp7BbH26U78Q61EWj97kI1FdfcbMkuQ7rqkA==",
-      "requires": {}
-    },
-    "@pixi/filter-displacement": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.2.tgz",
-      "integrity": "sha512-QS/eWp/ivsxef3xapNeGwpPX7vrqQQeo99Fux4k5zsvplnNEsf91t6QYJLG776AbZEu/qh8VYRBA5raIVY/REw==",
-      "requires": {}
-    },
-    "@pixi/filter-fxaa": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.2.tgz",
-      "integrity": "sha512-U/ptJgDsfs/r8y2a6gCaiPfDu2IFAxpQ4wtfmBpz6vRhqeE4kI8yNIUx5dZbui57zlsJaW0BNacOQxHU0vLkyQ==",
-      "requires": {}
-    },
-    "@pixi/filter-noise": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.2.tgz",
-      "integrity": "sha512-Vy9ViBFhZEGh6xKkd3kFWErolZTwv1Y5Qb1bV7qPIYbvBECYsqzlR4uCrrjBV6KKm0PufpG/+NKC5vICZaqKzg==",
-      "requires": {}
-    },
-    "@pixi/graphics": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.2.tgz",
-      "integrity": "sha512-jH4/Tum2RqWzHGzvlwEr7HIVduoLO57Ze705N2zQPkUD57TInn5911aGUeoua7f/wK8cTLGzgB9BzSo2kTdcHw==",
-      "requires": {}
-    },
-    "@pixi/math": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.2.tgz",
-      "integrity": "sha512-7jHmCQoYk6e0rfSKjdNFOPl0wCcdgoraxgteXJTTHv3r0bMNx2pHD9FJ0VvocEUG7XHfj55O3+u7yItOAx0JaQ=="
-    },
-    "@pixi/mesh": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.2.tgz",
-      "integrity": "sha512-mEkKyQvvMrYXC3pahvH5WBIKtrtB63WixRr91ANFI7zXD+ESG6Ap6XtxMCJmXDQPwBDNk7SWVMiCflYuchG7kA==",
-      "requires": {}
-    },
-    "@pixi/mesh-extras": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.2.tgz",
-      "integrity": "sha512-vNR/7wjxjs7sv9fGoKkHyU91ZAD+7EnMHBS5F3CVISlOIFxLi96NNZCB81oUIdky/90pHw40johd/4izR5zTyw==",
-      "requires": {}
-    },
-    "@pixi/mixin-cache-as-bitmap": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.2.tgz",
-      "integrity": "sha512-6dgthi2ruUT/lervSrFDQ7vXkEsHo6CxdgV7W/wNdW1dqgQlKfDvO6FhjXzyIMRLSooUf5FoeluVtfsjkUIYrw==",
-      "requires": {}
-    },
-    "@pixi/mixin-get-child-by-name": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.2.tgz",
-      "integrity": "sha512-0Cfw8JpQhsixprxiYph4Lj+B5n83Kk4ftNMXgM5xtZz+tVLz5s91qR0MqcdzwTGTJ7utVygiGmS4/3EfR/duRQ==",
-      "requires": {}
-    },
-    "@pixi/mixin-get-global-position": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.2.tgz",
-      "integrity": "sha512-LcsahbVdX4DFS2IcGfNp4KaXuu7SjAwUp/flZSGIfstyKOKb5FWFgihtqcc9ZT4coyri3gs2JbILZub/zPZj1w==",
-      "requires": {}
-    },
-    "@pixi/particle-container": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.2.tgz",
-      "integrity": "sha512-B78Qq86kt0lEa5WtB2YFIm3+PjhKfw9La9R++GBSgABl+g13s2UaZ6BIPxvY3JxWMdxPm4iPrQPFX1QWRN68mw==",
-      "requires": {}
-    },
-    "@pixi/prepare": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.2.tgz",
-      "integrity": "sha512-PugyMzReCHXUzc3so9PPJj2OdHwibpUNWyqG4mWY2UUkb6c8NAGK1AnAPiscOvLilJcv/XQSFoNhX+N1jrvJEg==",
-      "requires": {}
-    },
-    "@pixi/runner": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.2.tgz",
-      "integrity": "sha512-LPBpwym4vdyyDY5ucF4INQccaGyxztERyLTY1YN6aqJyyMmnc7iqXlIKt+a0euMBtNoLoxy6MWMvIuZj0JfFPA=="
-    },
-    "@pixi/settings": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.2.tgz",
-      "integrity": "sha512-pMN+L6aWgvUbwhFIL/BTHKe2ShYGPZ8h9wlVBnFHMtUcJcFLMF1B3lzuvCayZRepOphs6RY0TqvnDvVb585JhQ==",
-      "requires": {
-        "@pixi/constants": "7.4.2",
-        "@types/css-font-loading-module": "^0.0.12",
-        "ismobilejs": "^1.1.0"
-      }
-    },
-    "@pixi/sprite": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.2.tgz",
-      "integrity": "sha512-Ccf/OVQsB+HQV0Fyf5lwD+jk1jeU7uSIqEjbxenNNssmEdB7S5qlkTBV2EJTHT83+T6Z9OMOHsreJZerydpjeg==",
-      "requires": {}
-    },
-    "@pixi/sprite-animated": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.2.tgz",
-      "integrity": "sha512-QPT6yxCUGOBN+98H3pyIZ1ZO6Y7BN1o0Q2IMZEsD1rNfZJrTYS3Q8VlCG5t2YlFlcB8j5iBo24bZb6FUxLOmsQ==",
-      "requires": {}
-    },
-    "@pixi/sprite-tiling": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.2.tgz",
-      "integrity": "sha512-Z8PP6ewy3nuDYL+NeEdltHAhuucVgia33uzAitvH3OqqRSx6a6YRBFbNLUM9Sx+fBO2Lk3PpV1g6QZX+NE5LOg==",
-      "requires": {}
-    },
-    "@pixi/spritesheet": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.2.tgz",
-      "integrity": "sha512-YIvHdpXW+AYp8vD0NkjJmrdnVHTZKidCnx6k8ATSuuvCT6O5Tuh2N/Ul2oDj4/QaePy0lVhyhAbZpJW00Jr7mQ==",
-      "requires": {}
-    },
-    "@pixi/text": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.2.tgz",
-      "integrity": "sha512-rZZWpJNsIQ8WoCWrcVg8Gi6L/PDakB941clo6dO3XjoII2ucoOUcnpe5HIkudxi2xPvS/8Bfq990gFEx50TP5A==",
-      "requires": {}
-    },
-    "@pixi/text-bitmap": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.2.tgz",
-      "integrity": "sha512-lPBMJ83JnpFVL+6ckQ8KO8QmwdPm0z9Zs/M0NgFKH2F+BcjelRNnk80NI3O0qBDYSEDQIE+cFbKoZ213kf7zwA==",
-      "requires": {}
-    },
-    "@pixi/text-html": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.2.tgz",
-      "integrity": "sha512-duOu8oDYeDNuyPozj2DAsQ5VZBbRiwIXy78Gn7H2pCiEAefw/Uv5jJYwdgneKME0e1tOxz1eOUGKPcI6IJnZjw==",
-      "requires": {}
-    },
-    "@pixi/ticker": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.2.tgz",
-      "integrity": "sha512-cAvxCh/KI6IW4m3tp2b+GQIf+DoSj9NNmPJmsOeEJ7LzvruG8Ps7SKI6CdjQob5WbceL1apBTDbqZ/f77hFDiQ==",
-      "requires": {
-        "@pixi/extensions": "7.4.2",
-        "@pixi/settings": "7.4.2",
-        "@pixi/utils": "7.4.2"
-      }
-    },
-    "@pixi/utils": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.2.tgz",
-      "integrity": "sha512-aU/itcyMC4TxFbmdngmak6ey4kC5c16Y5ntIYob9QnjNAfD/7GTsYIBnP6FqEAyO1eq0MjkAALxdONuay1BG3g==",
-      "requires": {
-        "@pixi/color": "7.4.2",
-        "@pixi/constants": "7.4.2",
-        "@pixi/settings": "7.4.2",
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^4.0.0",
-        "url": "^0.11.0"
-      }
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -31025,6 +30454,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@webgpu/types": {
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.46.tgz",
+      "integrity": "sha512-2iogO6Zh0pTbKLGZuuGWEmJpF/fTABGs7G9wXxpn7s24XSJchSUIiMqIJHURi5zsMZRRTuXrV/3GLOkmOFjq5w=="
+    },
     "@webpack-cli/configtest": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
@@ -31054,6 +30488,11 @@
       "requires": {
         "lodash": "^4"
       }
+    },
+    "@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -34667,7 +34106,8 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
     },
     "events": {
       "version": "3.3.0",
@@ -39551,7 +38991,8 @@
     "object-inspect": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g=="
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -39789,6 +39230,11 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
     },
     "parse5": {
       "version": "7.1.2",
@@ -40062,40 +39508,26 @@
       "dev": true
     },
     "pixi.js": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.2.tgz",
-      "integrity": "sha512-TifqgHGNofO7UCEbdZJOpUu7dUnpu4YZ0o76kfCqxDa4RS8ITc9zjECCbtalmuNXkVhSEZmBKQvE7qhHMqw/xg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.4.1.tgz",
+      "integrity": "sha512-3ZbEIkLYYi602UB5wuN7kPz3VsGHoJa6nxD8ustvMLRySxHAR9Z8tCAYY8ISgNplpPbaDw03B0yTD4/k9f6cAQ==",
       "requires": {
-        "@pixi/accessibility": "7.4.2",
-        "@pixi/app": "7.4.2",
-        "@pixi/assets": "7.4.2",
-        "@pixi/compressed-textures": "7.4.2",
-        "@pixi/core": "7.4.2",
-        "@pixi/display": "7.4.2",
-        "@pixi/events": "7.4.2",
-        "@pixi/extensions": "7.4.2",
-        "@pixi/extract": "7.4.2",
-        "@pixi/filter-alpha": "7.4.2",
-        "@pixi/filter-blur": "7.4.2",
-        "@pixi/filter-color-matrix": "7.4.2",
-        "@pixi/filter-displacement": "7.4.2",
-        "@pixi/filter-fxaa": "7.4.2",
-        "@pixi/filter-noise": "7.4.2",
-        "@pixi/graphics": "7.4.2",
-        "@pixi/mesh": "7.4.2",
-        "@pixi/mesh-extras": "7.4.2",
-        "@pixi/mixin-cache-as-bitmap": "7.4.2",
-        "@pixi/mixin-get-child-by-name": "7.4.2",
-        "@pixi/mixin-get-global-position": "7.4.2",
-        "@pixi/particle-container": "7.4.2",
-        "@pixi/prepare": "7.4.2",
-        "@pixi/sprite": "7.4.2",
-        "@pixi/sprite-animated": "7.4.2",
-        "@pixi/sprite-tiling": "7.4.2",
-        "@pixi/spritesheet": "7.4.2",
-        "@pixi/text": "7.4.2",
-        "@pixi/text-bitmap": "7.4.2",
-        "@pixi/text-html": "7.4.2"
+        "@pixi/colord": "^2.9.6",
+        "@types/css-font-loading-module": "^0.0.12",
+        "@types/earcut": "^2.1.4",
+        "@webgpu/types": "^0.1.40",
+        "@xmldom/xmldom": "^0.8.10",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^5.0.1",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+        }
       }
     },
     "pkg-dir": {
@@ -41376,6 +40808,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -42708,6 +42141,7 @@
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
       "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "dev": true,
       "requires": {
         "punycode": "^1.4.1",
         "qs": "^6.11.2"
@@ -42716,12 +42150,14 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+          "dev": true
         },
         "qs": {
           "version": "6.12.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.3.tgz",
           "integrity": "sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==",
+          "dev": true,
           "requires": {
             "side-channel": "^1.0.6"
           }

--- a/v3/package.json
+++ b/v3/package.json
@@ -202,7 +202,7 @@
     "mobx-react-lite": "^4.0.7",
     "nanoid": "^5.0.7",
     "papaparse": "^5.4.1",
-    "pixi.js": "~7.4.2",
+    "pixi.js": "~8.4.1",
     "pluralize": "^8.0.0",
     "prop-types": "^15.8.1",
     "query-string": "^9.1.0",

--- a/v3/src/components/data-display/components/background.tsx
+++ b/v3/src/components/data-display/components/background.tsx
@@ -13,12 +13,11 @@ import {rectangleSubtract, rectNormalize} from "../data-display-utils"
 import {useDataDisplayLayout} from "../hooks/use-data-display-layout"
 import {useDataDisplayModelContext} from "../hooks/use-data-display-model"
 import {MarqueeState} from "../models/marquee-state"
-import {IPixiPointMetadata, IPixiPointsArrayRef, PixiBackgroundPassThroughEvent, PixiPoints}
-  from "../pixi/pixi-points"
+import {IPixiPointMetadata, IPixiPointsArray, PixiBackgroundPassThroughEvent, PixiPoints} from "../pixi/pixi-points"
 
 interface IProps {
   marqueeState: MarqueeState
-  pixiPointsArrayRef: IPixiPointsArrayRef
+  pixiPointsArray: IPixiPointsArray
 }
 
 type RTree = ReturnType<typeof RTreeLib>
@@ -64,7 +63,7 @@ const prepareTree = (pixiPointsArray: PixiPoints[]): RTree => {
   }
 
 export const Background = forwardRef<SVGGElement | HTMLDivElement, IProps>((props, ref) => {
-  const {marqueeState, pixiPointsArrayRef} = props,
+  const {marqueeState, pixiPointsArray} = props,
     dataDisplayModel = useDataDisplayModelContext(),
     datasetsArray = dataDisplayModel.datasetsArray,
     datasetsMap: SelectionMap = useMemo(() => {
@@ -92,7 +91,7 @@ export const Background = forwardRef<SVGGElement | HTMLDivElement, IProps>((prop
 
     onDragStart = useCallback((event: PointerEvent) => {
       appState.beginPerformance()
-      selectionTree.current = prepareTree(pixiPointsArrayRef.current)
+      selectionTree.current = prepareTree(pixiPointsArray)
       // Event coordinates are window coordinates. To convert them to SVG coordinates, we need to subtract the
       // bounding rect of the SVG element.
       const bgRect = (bgRef.current as SVGGElement).getBoundingClientRect()
@@ -108,7 +107,7 @@ export const Background = forwardRef<SVGGElement | HTMLDivElement, IProps>((prop
         })
       }
       marqueeState.setMarqueeRect({x: startX.current, y: startY.current, width: 0, height: 0})
-    }, [bgRef, datasetsArray, marqueeState, pixiPointsArrayRef]),
+    }, [bgRef, datasetsArray, marqueeState, pixiPointsArray]),
 
     onDrag = useCallback((event: { dx: number; dy: number }) => {
       if (event.dx !== 0 || event.dy !== 0 && datasetsArray.length) {

--- a/v3/src/components/data-display/hooks/use-pixi-points-array.ts
+++ b/v3/src/components/data-display/hooks/use-pixi-points-array.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { PixiPoints } from "../pixi/pixi-points"
 
 interface IProps {
@@ -7,18 +7,33 @@ interface IProps {
 
 export function usePixiPointsArray(props?: IProps) {
   const { addInitialPixiPoints = false } = props || {}
-  const pixiPointsRef = useRef<PixiPoints[]>([])
+  const [ pixiPointsArray, setPixiPointsArray ] = useState<PixiPoints[]>([])
 
   useEffect(() => {
-    const pixiPointsArray = pixiPointsRef.current
     const initialPixiPoints = addInitialPixiPoints ? new PixiPoints() : undefined
-    initialPixiPoints && pixiPointsArray.push(initialPixiPoints)
+
+    async function initPixiPoints() {
+      if (initialPixiPoints) {
+        await initialPixiPoints.init()
+        setPixiPointsArray([initialPixiPoints])
+      }
+    }
+    initPixiPoints()
+
     return () => {
       // if we created it, we destroy it
       initialPixiPoints?.dispose()
-      pixiPointsArray.length = 0
+      setPixiPointsArray([])
     }
   }, [addInitialPixiPoints])
 
-  return pixiPointsRef
+  const setPixiPointsLayer = useCallback((pixiPoints: PixiPoints, layerIndex: number) => {
+    setPixiPointsArray((prev) => {
+      const newPixiPointsArray = [...prev]
+      newPixiPointsArray[layerIndex] = pixiPoints
+      return newPixiPointsArray
+    })
+  }, [])
+
+  return {pixiPointsArray, setPixiPointsLayer}
 }

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -29,13 +29,13 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
   const layout = useInitGraphLayout(graphModel)
   const graphRef = useRef<HTMLDivElement | null>(null)
   const {width, height} = useResizeDetector<HTMLDivElement>({targetRef: graphRef})
-  const pixiPointsArrayRef = usePixiPointsArray({ addInitialPixiPoints: true })
+  const {pixiPointsArray} = usePixiPointsArray({ addInitialPixiPoints: true })
   const graphController = useMemo(
     () => new GraphController({layout, instanceId}),
     [layout, instanceId]
   )
 
-  useGraphController({graphController, graphModel, pixiPointsArrayRef})
+  useGraphController({graphController, graphModel, pixiPointsArray})
 
   useEffect(() => {
     (width != null) && width >= 0 && (height != null) &&
@@ -69,7 +69,7 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
                 <Graph
                   graphController={graphController}
                   graphRef={graphRef}
-                  pixiPointsArrayRef={pixiPointsArrayRef}
+                  pixiPointsArray={pixiPointsArray}
                 />
               </AxisProviderContext.Provider>
               <AttributeDragOverlay activeDragId={overlayDragId}/>

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -7,7 +7,7 @@ import {clsx} from "clsx"
 import { logStringifiedObjectMessage } from "../../../lib/log-message"
 import {mstReaction} from "../../../utilities/mst-reaction"
 import {onAnyAction} from "../../../utilities/mst-utils"
-import {IPixiPointsArrayRef} from "../../data-display/pixi/pixi-points"
+import {IPixiPointsArray} from "../../data-display/pixi/pixi-points"
 import {GraphAttrRole, graphPlaceToAttrRole, kPortalClass} from "../../data-display/data-display-types"
 import {AxisPlace, AxisPlaces} from "../../axis/axis-types"
 import {GraphAxis} from "./graph-axis"
@@ -47,13 +47,13 @@ import "./graph.scss"
 interface IProps {
   graphController: GraphController
   graphRef: MutableRefObject<HTMLDivElement | null>
-  pixiPointsArrayRef: IPixiPointsArrayRef
+  pixiPointsArray: IPixiPointsArray
 }
 
-export const Graph = observer(function Graph({graphController, graphRef, pixiPointsArrayRef}: IProps) {
+export const Graph = observer(function Graph({graphController, graphRef, pixiPointsArray}: IProps) {
   const graphModel = useGraphContentModelContext(),
     {plotType} = graphModel,
-    pixiPoints = pixiPointsArrayRef.current?.[0],
+    pixiPoints = pixiPointsArray[0],
     {startAnimation} = useDataDisplayAnimation(),
     instanceId = useInstanceIdContext(),
     marqueeState = useMemo<MarqueeState>(() => new MarqueeState(), []),
@@ -350,7 +350,7 @@ export const Graph = observer(function Graph({graphController, graphRef, pixiPoi
           <Background
             ref={backgroundSvgRef}
             marqueeState={marqueeState}
-            pixiPointsArrayRef={pixiPointsArrayRef}
+            pixiPointsArray={pixiPointsArray}
           />
 
           {renderGraphAxes()}

--- a/v3/src/components/graph/hooks/use-graph-controller.ts
+++ b/v3/src/components/graph/hooks/use-graph-controller.ts
@@ -1,16 +1,17 @@
 import {useEffect} from "react"
 import {GraphController} from "../models/graph-controller"
 import {IGraphContentModel} from "../models/graph-content-model"
-import {IPixiPointsArrayRef} from "../../data-display/pixi/pixi-points"
+import {IPixiPointsArray} from "../../data-display/pixi/pixi-points"
 
 export interface IUseGraphControllerProps {
   graphController: GraphController,
   graphModel?: IGraphContentModel,
-  pixiPointsArrayRef: IPixiPointsArrayRef
+  pixiPointsArray: IPixiPointsArray
 }
 
-export const useGraphController = ({graphController, graphModel, pixiPointsArrayRef}: IUseGraphControllerProps) => {
+export const useGraphController = ({graphController, graphModel, pixiPointsArray}: IUseGraphControllerProps) => {
   useEffect(() => {
-    graphModel && graphController.setProperties(graphModel, pixiPointsArrayRef.current?.[0])
-  }, [graphController, graphModel, pixiPointsArrayRef])
+    const pixiPoints = pixiPointsArray[0]
+    graphModel && pixiPoints && graphController.setProperties(graphModel, pixiPoints)
+  }, [graphController, graphModel, pixiPointsArray])
 }

--- a/v3/src/components/map/components/codap-map.tsx
+++ b/v3/src/components/map/components/codap-map.tsx
@@ -33,7 +33,7 @@ export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
     interiorDivRef = useRef<HTMLDivElement>(null),
     prevMapSize = useRef<{ width: number, height: number, legend: number }>({width: 0, height: 0, legend: 0}),
     forceUpdate = useForceUpdate(),
-    pixiPointsArrayRef = usePixiPointsArray()
+    {pixiPointsArray, setPixiPointsLayer} = usePixiPointsArray()
 
   // trigger an additional render once references have been fulfilled
   useEffect(() => forceUpdate(), [forceUpdate])
@@ -92,9 +92,9 @@ export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
               })
             }
           </>
-          <MapInterior pixiPointsArrayRef={pixiPointsArrayRef}/>
+          <MapInterior setPixiPointsLayer={setPixiPointsLayer}/>
         </MapContainer>
-        <MapBackground mapModel={mapModel} pixiPointsArrayRef={pixiPointsArrayRef}/>
+        <MapBackground mapModel={mapModel} pixiPointsArray={pixiPointsArray}/>
       </div>
       {renderSliderIfAppropriate()}
       <DroppableMapArea

--- a/v3/src/components/map/components/map-background.tsx
+++ b/v3/src/components/map/components/map-background.tsx
@@ -4,16 +4,16 @@ import { useMemo } from "use-memo-one"
 import { Background } from "../../data-display/components/background"
 import { Marquee } from "../../data-display/components/marquee"
 import { MarqueeState } from "../../data-display/models/marquee-state"
-import { IPixiPointsArrayRef } from "../../data-display/pixi/pixi-points"
+import { IPixiPointsArray } from "../../data-display/pixi/pixi-points"
 import { IMapContentModel } from "../models/map-content-model"
 import { mstReaction } from "../../../utilities/mst-reaction"
 
 interface IProps {
   mapModel: IMapContentModel
-  pixiPointsArrayRef: IPixiPointsArrayRef
+  pixiPointsArray: IPixiPointsArray
 }
 
-export const MapBackground = observer(function MapBackground({ mapModel, pixiPointsArrayRef }: IProps) {
+export const MapBackground = observer(function MapBackground({ mapModel, pixiPointsArray }: IProps) {
   const backgroundSvgRef = useRef<SVGGElement>(null)
   const marqueeState = useMemo<MarqueeState>(() => new MarqueeState(), [])
 
@@ -42,7 +42,7 @@ export const MapBackground = observer(function MapBackground({ mapModel, pixiPoi
         <Background
           ref={backgroundSvgRef}
           marqueeState={marqueeState}
-          pixiPointsArrayRef={pixiPointsArrayRef}
+          pixiPointsArray={pixiPointsArray}
         />
         <Marquee marqueeState={marqueeState}/>
       </svg>

--- a/v3/src/components/map/components/map-interior.tsx
+++ b/v3/src/components/map/components/map-interior.tsx
@@ -1,5 +1,5 @@
 import {observer} from "mobx-react-lite"
-import React, {useCallback, useEffect} from "react"
+import React, {useEffect} from "react"
 import {PixiPoints} from "../../data-display/pixi/pixi-points"
 import {useMapModelContext} from "../hooks/use-map-model-context"
 import {useMapModel} from "../hooks/use-map-model"
@@ -12,19 +12,14 @@ import { DataConfigurationContext } from "../../data-display/hooks/use-data-conf
 import { useTileModelContext } from "../../../hooks/use-tile-model-context"
 
 interface IProps {
-  pixiPointsArrayRef:  React.MutableRefObject<PixiPoints[]>
+  setPixiPointsLayer: (pixiPoints: PixiPoints, layerIndex: number) => void
 }
 
-export const MapInterior = observer(function MapInterior({pixiPointsArrayRef}: IProps) {
+export const MapInterior = observer(function MapInterior({setPixiPointsLayer}: IProps) {
   const mapModel = useMapModelContext()
   const { transitionComplete: tileTransitionComplete } = useTileModelContext()
 
   useMapModel()
-
-  const onSetPixiPointsForLayer = useCallback((pixiPoints: PixiPoints, layerIndex: number) => {
-    pixiPointsArrayRef.current[layerIndex] = pixiPoints
-  }, [pixiPointsArrayRef])
-
 
   // Ensure the map rescales when its tile's CSS transition is complete to compensate for any changes to the tile's
   // size that may have occurred after the map was initially rendered.
@@ -46,7 +41,7 @@ export const MapInterior = observer(function MapInterior({pixiPointsArrayRef}: I
                >
                  <MapPointLayer
                    mapLayerModel={layerModel}
-                   onSetPixiPointsForLayer={onSetPixiPointsForLayer}
+                   setPixiPointsLayer={setPixiPointsLayer}
                  />
                </DataConfigurationContext.Provider>
       }

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef} from "react"
+import React, {useCallback, useEffect, useRef, useState} from "react"
 import {comparer, reaction} from "mobx"
 import { observer } from "mobx-react-lite"
 import { isAlive } from "mobx-state-tree"
@@ -30,10 +30,10 @@ import { useConnectingLines } from "../../data-display/hooks/use-connecting-line
 
 interface IProps {
   mapLayerModel: IMapPointLayerModel
-  onSetPixiPointsForLayer: (pixiPoints: PixiPoints, layerIndex: number) => void
+  setPixiPointsLayer: (pixiPoints: PixiPoints, layerIndex: number) => void
 }
 
-export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onSetPixiPointsForLayer}: IProps) {
+export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, setPixiPointsLayer}: IProps) {
   const {dataConfiguration, pointDescription} = mapLayerModel,
     dataset = isAlive(dataConfiguration) ? dataConfiguration?.dataset : undefined,
     mapModel = useMapModelContext(),
@@ -42,7 +42,7 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
     layout = useDataDisplayLayout(),
     instanceId = useInstanceIdContext(),
     pixiContainerRef = useRef<HTMLDivElement>(null),
-    pixiPointsRef = useRef<PixiPoints>(),
+    [pixiPoints, setPixiPoints] = useState<PixiPoints>(),
     showConnectingLines = mapLayerModel.connectingLinesAreVisible,
     connectingLinesRef = useRef<SVGGElement>(null),
     connectingLinesActivatedRef = useRef(false)
@@ -95,32 +95,41 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
   }, [mapModel])
 
   const { renderConnectingLines } = useConnectingLines({
-    clientType: "map", pixiPoints: pixiPointsRef.current, connectingLinesSvg: connectingLinesRef.current,
+    clientType: "map", pixiPoints, connectingLinesSvg: connectingLinesRef.current,
     connectingLinesActivatedRef, onConnectingLinesClick: handleConnectingLinesClick
   })
 
   useEffect(function createPixiPoints() {
-    if (!pixiContainerRef.current) {
-      return
-    }
-    pixiPointsRef.current = new PixiPoints({
-      resizeTo: pixiContainerRef.current,
-      // PixiPoints background should redistribute events to the geoJSON polygons that lie underneath.
-      backgroundEventDistribution: {
-        // Element that needs to be "hidden" to obtain another element at the current cursor position.
-        elementToHide: pixiContainerRef.current
-      }
-    })
-    onSetPixiPointsForLayer(pixiPointsRef.current, mapLayerModel.layerIndex)
+    let _pixiPoints: PixiPoints
 
-    return () => pixiPointsRef.current?.dispose()
-  }, [mapLayerModel.layerIndex, onSetPixiPointsForLayer])
+    async function initPixiPoints() {
+      if (!pixiContainerRef.current) {
+        return
+      }
+      _pixiPoints = new PixiPoints()
+      await _pixiPoints.init({
+        resizeTo: pixiContainerRef.current,
+        // PixiPoints background should redistribute events to the geoJSON polygons that lie underneath.
+        backgroundEventDistribution: {
+          // Element that needs to be "hidden" to obtain another element at the current cursor position.
+          elementToHide: pixiContainerRef.current
+        }
+      })
+      setPixiPoints(_pixiPoints)
+      setPixiPointsLayer(_pixiPoints, mapLayerModel.layerIndex)
+    }
+    initPixiPoints()
+
+    return () => {
+      _pixiPoints?.dispose()
+    }
+  }, [mapLayerModel.layerIndex, setPixiPointsLayer])
 
   useEffect(() => {
-    if (!pixiPointsRef.current) {
+    if (!pixiPoints) {
       return
     }
-    pixiPointsRef.current.onPointClick = (event: PointerEvent, sprite: PIXI.Sprite, metadata: IPixiPointMetadata) => {
+    pixiPoints.onPointClick = (event: PointerEvent, sprite: PIXI.Sprite, metadata: IPixiPointMetadata) => {
       handleClickOnCase(event, metadata.caseID, dataConfiguration.dataset)
       // TODO PIXI: this doesn't seem to work in pixi. Note that this click will be propagated to the map container
       // and handled by its click handler (which will deselect the point). The current workaround is to disable
@@ -134,14 +143,14 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
         setTimeout(() => mapModel.ignoreLeafletClicks(false), 10)
       }
     }
-  }, [dataConfiguration.dataset, mapModel])
+  }, [dataConfiguration.dataset, mapModel, pixiPoints])
 
   useEffect(() => {
-    if (pixiPointsRef.current != null && pixiContainerRef.current && pixiContainerRef.current.children.length === 0) {
-      pixiContainerRef.current.appendChild(pixiPointsRef.current.canvas)
-      pixiPointsRef.current.resize(layout.contentWidth, layout.contentHeight)
+    if (pixiPoints != null && pixiContainerRef.current && pixiContainerRef.current.children.length === 0) {
+      pixiContainerRef.current.appendChild(pixiPoints.canvas)
+      pixiPoints.resize(layout.contentWidth, layout.contentHeight)
     }
-  }, [layout.contentWidth, layout.contentHeight])
+  }, [layout.contentWidth, layout.contentHeight, pixiPoints])
 
   const refreshConnectingLines = useCallback(() => {
     if (!showConnectingLines && !connectingLinesActivatedRef.current) return
@@ -157,10 +166,10 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
       renderConnectingLines, showConnectingLines])
 
   const callMatchCirclesToData = useCallback(() => {
-    if (mapLayerModel && dataConfiguration && layout && pixiPointsRef.current) {
+    if (mapLayerModel && dataConfiguration && layout && pixiPoints) {
       matchCirclesToData({
         dataConfiguration,
-        pixiPoints: pixiPointsRef.current,
+        pixiPoints,
         pointRadius: mapLayerModel.getPointRadius(),
         instanceId: dataConfiguration.id,
         pointColor: pointDescription?.pointColor,
@@ -169,16 +178,16 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
       })
     }
   }, [dataConfiguration, layout, mapLayerModel, mapModel.startAnimation,
-    pointDescription?.pointColor, pointDescription?.pointStrokeColor])
+    pointDescription?.pointColor, pointDescription?.pointStrokeColor, pixiPoints])
 
   const refreshPointSelection = useCallback(() => {
     const {pointColor, pointStrokeColor} = pointDescription,
       selectedPointRadius = mapLayerModel.getPointRadius('select')
     dataConfiguration && setPointSelection({
-      pixiPoints: pixiPointsRef.current, dataConfiguration, pointRadius: mapLayerModel.getPointRadius(),
+      pixiPoints, dataConfiguration, pointRadius: mapLayerModel.getPointRadius(),
       selectedPointRadius, pointColor, pointStrokeColor
     })
-  }, [pointDescription, mapLayerModel, dataConfiguration])
+  }, [pointDescription, mapLayerModel, dataConfiguration, pixiPoints])
 
   const refreshPoints = useDebouncedCallback(async (selectedOnly: boolean) => {
     const lookupLegendColor = (aCaseData: CaseData) => {
@@ -201,16 +210,15 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
       },
       layerIsVisible = mapLayerModel.isVisible,
       pointsAreVisible = mapLayerModel.pointsAreVisible
-    const pixiPoints = pixiPointsRef.current
     if (!pixiPoints || !dataset) {
       return
     }
-    if (!(layerIsVisible && pointsAreVisible && pixiPointsRef.current?.isVisible)) {
-      pixiPointsRef.current?.setVisibility(false)
+    if (!(layerIsVisible && pointsAreVisible && pixiPoints.isVisible)) {
+      pixiPoints?.setVisibility(false)
       return
     }
-    if (layerIsVisible && pointsAreVisible && !pixiPointsRef.current?.isVisible) {
-      pixiPointsRef.current?.setVisibility(true)
+    if (layerIsVisible && pointsAreVisible && !pixiPoints.isVisible) {
+      pixiPoints?.setVisibility(true)
     }
     const pointRadius = computePointRadius(dataConfiguration.caseDataArray.length,
         pointDescription.pointSizeMultiplier)
@@ -309,17 +317,17 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
         return { layerIsVisible: mapLayerModel.isVisible, pointsAreVisible: mapLayerModel.pointsAreVisible}
       },
       ({layerIsVisible, pointsAreVisible}) => {
-        if (layerIsVisible && pointsAreVisible && !pixiPointsRef.current?.isVisible) {
-          pixiPointsRef.current?.setVisibility(true)
+        if (layerIsVisible && pointsAreVisible && !pixiPoints?.isVisible) {
+          pixiPoints?.setVisibility(true)
           refreshPoints(false)
         }
-        else if (!(layerIsVisible && pointsAreVisible) && pixiPointsRef.current?.isVisible) {
-          pixiPointsRef.current?.setVisibility(false)
+        else if (!(layerIsVisible && pointsAreVisible) && pixiPoints?.isVisible) {
+          pixiPoints?.setVisibility(false)
         }
       },
       {name: "MapPointLayer.respondToLayerVisibilityChange"}, mapLayerModel
     )
-  }, [mapLayerModel, callMatchCirclesToData, layout.contentWidth, layout.contentHeight, refreshPoints])
+  }, [mapLayerModel, callMatchCirclesToData, layout.contentWidth, layout.contentHeight, refreshPoints, pixiPoints])
 
   // respond to point properties change
   useEffect(function respondToPointVisualChange() {
@@ -358,7 +366,7 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, onS
       <DataTip
         dataset={dataset}
         getTipAttrs={getTipAttrs}
-        pixiPoints={pixiPointsRef.current}
+        pixiPoints={pixiPoints}
         getTipText={mapModel.getTipText}
       />
     </>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187950454

This PR upgrades Pixi from v7 to v8.

The API hasn't changed significantly, in theory. Compile-time errors were relatively easy to identify. The biggest change is that Pixi is now initialized asynchronously (both the Pixi Application, which we don't use, and the renderer).

This required updates to many of our components that previously relied on PixiPoints being available immediately. I modified `usePixiPointsArray` to populate the array only after the async initialization completes, and it now uses the React state (instead of refs) to notify and re-render dependent components.

On a side note, I'm not sure if this hook is worth using for non-map components, but I didn’t look too deeply into that or tried to fully understand its purpose. My goal was just to make the minimal changes necessary to get v8 running without errors.

I also updated the renderer to use the auto-detect feature. Currently, it returns the WebGL Renderer for me, but the docs suggest it might switch to WebGPU shortly. This could offer better performance, but more importantly, we'll always be using the "preferred" version (hopefully more stable).