### PR TITLE
Fix the graph issue after Pixi v8 upgrade

### DIFF
--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -59,6 +59,15 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     refreshPointPositions(selectedOnly)
   })
 
+  // Refresh point positions when pixiPoints become available to fix this bug:
+  // https://www.pivotaltracker.com/story/show/188333898
+  // This might be a workaround for the fact that useDebouncedCallback may not be updated when pixiPoints
+  // (a dependency of refreshPointPositions) are updated. useDebouncedCallback doesn't seem to declare any
+  // dependencies and I'd imagine it returns a stable result (?).
+  useEffect(() => {
+    callRefreshPointPositions(false)
+  }, [callRefreshPointPositions, pixiPoints])
+
   // respond to numeric axis domain changes (e.g. axis dragging)
   useEffect(() => {
     return mstReaction(


### PR DESCRIPTION
This PR fixes (workarounds?) the issue I mention on Slack:
https://concord-consortium.slack.com/archives/C035J6RDAK0/p1727283844619599

Also, I created a PT bug for it:
https://www.pivotaltracker.com/story/show/188333898

I doubt this is the best or absolutely correct solution. But it seems to work. I can't say I full understand where the things fail, as it's very hard to track how the graph is updated and what's the (correct?) sequence of these updates. 

But I spent some (too long) time comparing pixi-v8 branch with older main, and trying to observe the differences. The main one was about what the refreshPointPosition was called. Sometimes it was called before pixiPoints were available / initialized.