### PR TITLE
Dispose unused Pixi textures

### DIFF
--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -168,6 +168,7 @@ export class PixiPoints {
     } else {
       // The only reason for ticker to run is to handle ongoing transitions. If there are no transitions, we can stop.
       this.ticker.stop()
+      this.cleanupUnusedTextures()
     }
     this.renderer?.render(this.stage)
   }
@@ -500,7 +501,16 @@ export class PixiPoints {
   }
 
   cleanupUnusedTextures() {
-    // TODO PIXI
+    const texturesInUse: Set<PIXI.Texture> = new Set()
+    this.points.forEach(point => {
+      texturesInUse.add(point.texture)
+    })
+    for (const [key, texture] of this.textures) {
+      if (!texturesInUse.has(texture)) {
+        texture.destroy()
+        this.textures.delete(key)
+      }
+    }
   }
 
   setupBackgroundEventDistribution(options: IBackgroundEventDistributionOptions) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186784013

I think it's unlikely to cause serious problems, but I suppose if there are multiple graphs with large legend sets that change frequently, some cleanup wouldn’t hurt.