### PR TITLE
Graph filter formula

### DIFF
--- a/v3/cypress/e2e/adornments.spec.ts
+++ b/v3/cypress/e2e/adornments.spec.ts
@@ -24,12 +24,10 @@ context("Graph adornments", () => {
     // add undo/redo to this test
     toolbar.getUndoTool().click()
     ae.getAxisLabel("left").should("have.length", 0)
-    cy.wait(250)
     toolbar.getRedoTool().click()
     ae.getAxisLabel("left").should("have.length", 1)
-    cy.wait(250)
 
-
+    // show the count adornment
     graph.getDisplayValuesButton().click()
     graph.getInspectorPalette().should("be.visible")
     graph.getInspectorPalette().find("[data-testid=adornment-checkbox-count-count]").should("be.visible").click()
@@ -39,27 +37,51 @@ context("Graph adornments", () => {
     cy.get("[data-testid=adornment-wrapper]").should("have.length", 1)
     cy.get("[data-testid=adornment-wrapper]").should("have.class", "visible")
     cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("exist")
-    // this test is still flaky, sometimes returning 21 and sometimes returning 24
-    // cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("have.text", "21")
-    cy.wait(250)
+    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("have.text", "21")
+
+    // add a filter formula
+    graph.getHideShowButton().click()
+    cy.get("[data-testid=hide-show-menu-list]").should("be.visible")
+    cy.get("[data-testid=hide-show-menu-list]").find("[data-testid=edit-filter-formula]").should("be.visible").click()
+    cy.get(".codap-modal-content [data-testid=attr-formula-input]").type(`Diet="meat"`)
+    cy.get(".codap-modal-content [data-testid=Apply-button]").should("be.visible").click()
+    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("exist")
+    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("have.text", "10")
+
+    // change the filter formula
+    graph.getHideShowButton().click()
+    cy.get("[data-testid=hide-show-menu-list]").should("be.visible")
+    cy.get("[data-testid=hide-show-menu-list]").find("[data-testid=edit-filter-formula]").should("be.visible").click()
+    cy.get(".codap-modal-content [data-testid=attr-formula-input]").type(`{selectAll}{del}Diet="plants"`)
+    cy.get(".codap-modal-content [data-testid=Apply-button]").should("be.visible").click()
+    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("exist")
+    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("have.text", "11")
+
+    // delete the filter formula
+    graph.getHideShowButton().click()
+    cy.get("[data-testid=hide-show-menu-list]").should("be.visible")
+    cy.get("[data-testid=hide-show-menu-list]").find("[data-testid=edit-filter-formula]").should("be.visible").click()
+    cy.get(".codap-modal-content [data-testid=attr-formula-input]").type(`{selectAll}{del}`)
+    cy.get(".codap-modal-content [data-testid=Apply-button]").should("be.visible").click()
+    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("exist")
+    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("have.text", "21")
+
+    // hide the count adornment
+    graph.getDisplayValuesButton().click()
+    graph.getInspectorPalette().should("be.visible")
     graph.getInspectorPalette().find("[data-testid=adornment-checkbox-count-count]").click()
     cy.get("[data-testid=adornment-wrapper]").should("have.class", "hidden")
 
-    // Add a test undo/redo for the count checkbox
-
+    // Undo hiding the adornment
     toolbar.getUndoTool().click()
-    cy.wait(250)
     cy.get("[data-testid=adornment-wrapper]").should("have.length", 1)
     cy.get("[data-testid=adornment-wrapper]").should("have.class", "visible")
     cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("exist")
-    // this test is flaky, sometimes returning 21 and sometimes returning 24
-    // cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("have.text", "21")
+    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("have.text", "21")
 
+    // Redo hiding the adornment
     toolbar.getRedoTool().click()
-    cy.wait(250)
-
     cy.get("[data-testid=adornment-wrapper]").should("have.class", "hidden")
-
   })
   // TODO: Reinstate this skipped test. Even though it passes locally, it fails in CI with an error saying
   // the element with data-testid of `graph-adornments-grid__cell` cannot be found.

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -343,9 +343,9 @@ export const useSubAxis = ({
   useEffect(function respondToHiddenCasesChange() {
     if (dataConfig) {
       return mstReaction(
-        () => [dataConfig.dataset?.itemIds.length, dataConfig.hiddenCases.length],
+        () => dataConfig.caseDataHash,
         () => updateDomainAndRenderSubAxis(),
-        {name: "useSubAxis.respondToHiddenCasesChange", equals: comparer.structural}, dataConfig
+        {name: "useSubAxis.respondToHiddenCasesChange"}, dataConfig
       )
     }
   }, [dataConfig, updateDomainAndRenderSubAxis])

--- a/v3/src/components/case-tile-common/edit-filter-formula-modal.tsx
+++ b/v3/src/components/case-tile-common/edit-filter-formula-modal.tsx
@@ -4,30 +4,36 @@ import {
 } from "@chakra-ui/react"
 import React, { useEffect, useState } from "react"
 import { observer } from "mobx-react-lite"
-import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { t } from "../../utilities/translation/translate"
 import { CodapModal } from "../codap-modal"
+import { IFormula } from "../../models/formula/formula"
 
+interface IFormulaSource {
+  filterFormula?: IFormula
+  filterFormulaError: string
+  setFilterFormula: (formula: string) => void
+  applyModelChange: (change: () => void, options: { undoStringKey: string, redoStringKey: string }) => void
+}
 interface IProps {
+  formulaSource: IFormulaSource
   isOpen: boolean
   onClose: () => void
 }
 
-export const EditFilterFormulaModal = observer(function EditFormulaModal({ isOpen, onClose }: IProps) {
-  const data = useDataSetContext()
+export const EditFilterFormulaModal = observer(function EditFormulaModal({ formulaSource, isOpen, onClose }: IProps) {
   const [formula, setFormula] = useState("")
 
   useEffect(() => {
-    setFormula(data?.filterFormula?.display || "")
-  }, [data?.filterFormula?.display])
+    setFormula(formulaSource.filterFormula?.display || "")
+  }, [formulaSource.filterFormula?.display])
 
   const closeModal = () => {
     onClose()
   }
 
   function applyFilterFormula() {
-    data?.applyModelChange(() => {
-      data.setFilterFormula(formula)
+    formulaSource.applyModelChange(() => {
+      formulaSource.setFilterFormula(formula)
     }, {
       undoStringKey: "V3.Undo.hideShowMenu.changeFilterFormula",
       redoStringKey: "V3.Redo.hideShowMenu.changeFilterFormula"
@@ -61,9 +67,9 @@ export const EditFilterFormulaModal = observer(function EditFormulaModal({ isOpe
       </ModalHeader>
       <ModalBody>
         {
-          data?.filterFormulaError &&
+          formulaSource.filterFormulaError &&
           <div className="formula-error" style={{ background: "rgb(254, 224, 228)", fontSize: "0.8em" }}>
-            {data.filterFormulaError}
+            {formulaSource.filterFormulaError}
           </div>
         }
         <FormControl display="flex" flexDirection="column" className="formula-form-control">

--- a/v3/src/components/case-tile-common/hide-show-menu-list.tsx
+++ b/v3/src/components/case-tile-common/hide-show-menu-list.tsx
@@ -125,7 +125,10 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
   return (
     <>
       <StdMenuList data-testid="hide-show-menu-list" menuItems={menuItems} />
-      <EditFilterFormulaModal isOpen={formulaModal.isOpen} onClose={handleEditFormulaClose} />
+      {
+        data &&
+        <EditFilterFormulaModal formulaSource={data} isOpen={formulaModal.isOpen} onClose={handleEditFormulaClose} />
+      }
     </>
   )
 })

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -1,4 +1,4 @@
-import { MenuItem, MenuList } from "@chakra-ui/react"
+import { MenuItem, MenuList, useDisclosure } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import { isAlive } from "mobx-state-tree"
 import React from "react"
@@ -6,6 +6,7 @@ import { ITileModel } from "../../../../models/tiles/tile-model"
 import { isGraphContentModel } from "../../models/graph-content-model"
 import { t } from "../../../../utilities/translation/translate"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
+import { EditFilterFormulaModal } from "../../../case-tile-common/edit-filter-formula-modal"
 
 interface IProps {
   tile?: ITileModel
@@ -14,6 +15,7 @@ interface IProps {
 export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProps) {
   const graphModel = tile && isAlive(tile) && isGraphContentModel(tile?.content) ? tile?.content : undefined
   const dataConfig = graphModel?.dataConfiguration
+  const formulaModal = useDisclosure()
 
   const hideSelectedCases = () => {
     dataConfig?.applyModelChange(
@@ -73,6 +75,14 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
     )
   }
 
+  const handleEditFormulaOpen = () => {
+    formulaModal.onOpen()
+  }
+
+  const handleEditFormulaClose = () => {
+    formulaModal.onClose()
+  }
+
   const handleParentTogglesChange = () => {
     const [undoStringKey, redoStringKey] = graphModel?.showParentToggles
       ? ["DG.Undo.disableNumberToggle", "DG.Redo.disableNumberToggle"]
@@ -116,26 +126,40 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
     displayOnlySelectedIsDisabled = dataConfig?.displayOnlySelectedCases
 
   return (
-    <MenuList data-testid="hide-show-menu-list">
-      <MenuItem onClick={hideSelectedCases} isDisabled={hideSelectedIsDisabled} data-testid="hide-selected-cases">
-        {hideSelectedString}
-      </MenuItem>
-      <MenuItem onClick={hideUnselectedCases} isDisabled={hideUnselectedIsDisabled} data-testid="hide-unselected-cases">
-        {hideUnselectedString}
-      </MenuItem>
-      <MenuItem onClick={showAllCases} isDisabled={showAllIsDisabled} data-testid="show-all-cases">
-        {t("DG.DataDisplayMenu.showAll")}
-      </MenuItem>
-      <MenuItem onClick={displayOnlySelectedCases} isDisabled={displayOnlySelectedIsDisabled}
-       data-testid="display-selected-cases">
-        {t("DG.DataDisplayMenu.displayOnlySelected")}
-      </MenuItem>
-      <MenuItem onClick={handleParentTogglesChange} data-testid="show-parent-toggles">
-        {parentToggleString}
-      </MenuItem>
-      <MenuItem onClick={handleMeasuresForSelectionChange} data-testid="show-selection-measures">
-        {measuresForSelectionString}
-      </MenuItem>
-    </MenuList>
+    <>
+      <MenuList data-testid="hide-show-menu-list">
+        <MenuItem onClick={hideSelectedCases} isDisabled={hideSelectedIsDisabled} data-testid="hide-selected-cases">
+          {hideSelectedString}
+        </MenuItem>
+        <MenuItem onClick={hideUnselectedCases} isDisabled={hideUnselectedIsDisabled}
+          data-testid="hide-unselected-cases">
+          {hideUnselectedString}
+        </MenuItem>
+        <MenuItem onClick={showAllCases} isDisabled={showAllIsDisabled} data-testid="show-all-cases">
+          {t("DG.DataDisplayMenu.showAll")}
+        </MenuItem>
+        <MenuItem onClick={handleEditFormulaOpen} data-testid="edit-filter-formula">
+          {t("V3.hideShowMenu.editFilterFormula")}
+        </MenuItem>
+        <MenuItem onClick={displayOnlySelectedCases} isDisabled={displayOnlySelectedIsDisabled}
+        data-testid="display-selected-cases">
+          {t("DG.DataDisplayMenu.displayOnlySelected")}
+        </MenuItem>
+        <MenuItem onClick={handleParentTogglesChange} data-testid="show-parent-toggles">
+          {parentToggleString}
+        </MenuItem>
+        <MenuItem onClick={handleMeasuresForSelectionChange} data-testid="show-selection-measures">
+          {measuresForSelectionString}
+        </MenuItem>
+      </MenuList>
+      {
+        dataConfig &&
+        <EditFilterFormulaModal
+          formulaSource={dataConfig}
+          isOpen={formulaModal.isOpen}
+          onClose={handleEditFormulaClose}
+        />
+      }
+    </>
   )
 })

--- a/v3/src/components/graph/components/parent-toggles.tsx
+++ b/v3/src/components/graph/components/parent-toggles.tsx
@@ -163,7 +163,7 @@ export const ParentToggles = observer(function ParentToggles() {
       )
     } else {
       dataConfig?.applyModelChange(
-        () => dataConfig.setHiddenCases(Array.from(dataConfig.allCaseIDs)),
+        () => dataConfig.setHiddenCases(Array.from(dataConfig.visibleCaseIds)),
         {
           undoStringKey: "V3.Undo.graph.hideAllCases",
           redoStringKey: "V3.Redo.graph.hideAllCases",

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -1,5 +1,5 @@
 import {useEffect} from "react"
-import {comparer, reaction} from "mobx"
+import {reaction} from "mobx"
 import {isAlive} from "mobx-state-tree"
 import {onAnyAction} from "../../../utilities/mst-utils"
 import {mstAutorun} from "../../../utilities/mst-autorun"
@@ -137,7 +137,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
 
   useEffect(function respondToHiddenCasesChange() {
     const disposer = mstReaction(
-      () => [dataConfiguration?.dataset?.itemIds.length, dataConfiguration?.hiddenCases.length],
+      () => dataConfiguration?.caseDataHash,
       () => {
         if (!pixiPoints) {
           return
@@ -152,7 +152,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           startAnimation, instanceId
         })
         callRefreshPointPositions(false)
-      }, {name: "respondToHiddenCasesChange", equals: comparer.structural}, dataConfiguration
+      }, {name: "respondToHiddenCasesChange"}, dataConfiguration
     )
     return () => disposer()
   }, [callRefreshPointPositions, dataConfiguration, graphModel, instanceId, pixiPoints, startAnimation])

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -36,6 +36,7 @@ import {
 import {AdornmentsStore} from "../adornments/adornments-store"
 import {getPlottedValueFormulaAdapter} from "../../../models/formula/plotted-value-formula-adapter"
 import {getPlottedFunctionFormulaAdapter} from "../../../models/formula/plotted-function-formula-adapter"
+import {getGraphFilterFormulaAdapter} from "../../../models/formula/graph-filter-formula-adapter"
 import { ICase } from "../../../models/data/data-set-types"
 import { isFiniteNumber } from "../../../utilities/math-utils"
 import { t } from "../../../utilities/translation/translate"
@@ -43,7 +44,8 @@ import { CaseData } from "../../data-display/d3-types"
 
 const getFormulaAdapters = (node?: IAnyStateTreeNode) => [
   getPlottedValueFormulaAdapter(node),
-  getPlottedFunctionFormulaAdapter(node)
+  getPlottedFunctionFormulaAdapter(node),
+  getGraphFilterFormulaAdapter(node),
 ]
 
 export interface GraphProperties {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -160,7 +160,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
      */
     filterCase(data: IDataSet, caseID: string, caseArrayNumber?: number) {
       // If the case is hidden we don't plot it
-      if (self.hiddenCasesSet.has(caseID)) return false
+      if (self.hiddenCasesSet.has(caseID) || self.filterFormulaResults.get(caseID) === false) return false
       if (caseArrayNumber === 0 || caseArrayNumber === undefined) {
         return self._filterCase(data, caseID)
       }

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -62,6 +62,7 @@ import { Formula, IFormula } from "../formula/formula"
 import { applyModelChange } from "../history/apply-model-change"
 import { withoutUndo } from "../history/without-undo"
 import { kAttrIdPrefix, kItemIdPrefix, typeV3Id, v3Id } from "../../utilities/codap-utils"
+import { hashStringSet } from "../../utilities/js-utils"
 import { t } from "../../utilities/translation/translate"
 import { V2Model } from "./v2-model"
 
@@ -315,6 +316,10 @@ export const DataSet = V2Model.named("DataSet").props({
       })
     })
     return attrs
+  },
+  get itemIdsHash() {
+    // observable hash of visible (not set aside, not filtered out) item ids
+    return hashStringSet(self.itemIds)
   },
   get items(): readonly IItem[] {
     return self.itemIds.map(id => ({ __id__: id }))

--- a/v3/src/models/data/filtered-cases.ts
+++ b/v3/src/models/data/filtered-cases.ts
@@ -55,6 +55,14 @@ export class FilteredCases {
   }
 
   @computed
+  get rawCaseIds() {
+    const rawCases = this.collectionID
+                      ? this.source?.getCasesForCollection(this.collectionID) ?? []
+                      : this.source?.items ?? []
+    return rawCases.map(aCase => aCase.__id__)
+  }
+
+  @computed
   get caseIds(): string[] {
     // MobX will cache the resulting array until either the source's `cases` array changes or the
     // filter function changes, at which point it will run the filter function over all the cases.
@@ -62,12 +70,8 @@ export class FilteredCases {
     // cases when cases are inserted, but that would be more code to write/maintain and running
     // the filter function over an array of cases should be quick so rather than succumb to the
     // temptation of premature optimization, let's wait to see whether it becomes a bottleneck.
-    const rawCases = this.collectionID
-                      ? this.source?.getCasesForCollection(this.collectionID) ?? []
-                      : this.source?.items ?? []
-    return rawCases
-            .map(aCase => aCase.__id__)
-            .filter(id => !this.filter || (this.source && this.filter(this.source, id, this.casesArrayNumber)))
+    return this.rawCaseIds
+          .filter(id => !this.filter || (this.source && this.filter(this.source, id, this.casesArrayNumber)))
   }
 
   @computed

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -12,6 +12,7 @@ import { AttributeFormulaAdapter } from "../formula/attribute-formula-adapter"
 import { FilterFormulaAdapter } from "../formula/filter-formula-adapter"
 import { PlottedValueFormulaAdapter } from "../formula/plotted-value-formula-adapter"
 import { PlottedFunctionFormulaAdapter } from "../formula/plotted-function-formula-adapter"
+import { GraphFilterFormulaAdapter } from "../formula/graph-filter-formula-adapter"
 import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
 
 /**
@@ -37,7 +38,8 @@ export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
       new AttributeFormulaAdapter(adapterApi),
       new FilterFormulaAdapter(adapterApi),
       new PlottedValueFormulaAdapter(adapterApi),
-      new PlottedFunctionFormulaAdapter(adapterApi)
+      new PlottedFunctionFormulaAdapter(adapterApi),
+      new GraphFilterFormulaAdapter(adapterApi)
     ])
 
     addDisposer(document, onAction(document, (call) => {

--- a/v3/src/models/formula/formula-observers.ts
+++ b/v3/src/models/formula/formula-observers.ts
@@ -32,7 +32,7 @@ export const observeLocalAttributes = (formulaDependencies: IFormulaDependency[]
   // If we needed to optimize the non-aggregate case, we could cache the items and then determine which ones
   // were added/removed ourselves, but it's not clear that it will be worth it.
   const disposeDatasetItemsObserver = mstReaction(
-    () => localDataSet.itemIds.length,
+    () => localDataSet.itemIdsHash,
     () => recalculateCallback("ALL_CASES"),
     { name: "FormulaObservers.itemsReaction" }, localDataSet
   )

--- a/v3/src/models/formula/graph-filter-formula-adapter.ts
+++ b/v3/src/models/formula/graph-filter-formula-adapter.ts
@@ -1,0 +1,161 @@
+import { action, makeObservable, observable } from "mobx"
+import { math } from "./functions/math"
+import { FormulaMathJsScope } from "./formula-mathjs-scope"
+import { formulaError } from "./utils/misc"
+import { ICase } from "../data/data-set-types"
+import { IFormula } from "./formula"
+import type {
+  IFormulaAdapterApi, IFormulaContext, IFormulaExtraMetadata, IFormulaManagerAdapter
+} from "./formula-manager"
+import { DEBUG_FORMULAS, debugLog } from "../../lib/debug"
+import { isFilterFormulaDataConfiguration } from "../../components/data-display/models/data-configuration-model"
+import { IAnyStateTreeNode } from "@concord-consortium/mobx-state-tree"
+import { getFormulaManager } from "../tiles/tile-environment"
+import type { IGraphContentModel } from "../../components/graph/models/graph-content-model"
+
+const GRAPH_FILTER_FORMULA_ADAPTER = "GraphFilterFormulaAdapter"
+
+export const getGraphFilterFormulaAdapter = (node?: IAnyStateTreeNode): GraphFilterFormulaAdapter | undefined =>
+  getFormulaManager(node)?.adapters.find(a =>
+    a.type === GRAPH_FILTER_FORMULA_ADAPTER
+  ) as GraphFilterFormulaAdapter
+
+export interface IGraphFilterFormulaExtraMetadata extends IFormulaExtraMetadata {
+  graphContentModelId: string
+}
+
+export class GraphFilterFormulaAdapter implements IFormulaManagerAdapter {
+  type = GRAPH_FILTER_FORMULA_ADAPTER
+  api: IFormulaAdapterApi
+  @observable.shallow graphContentModels = new Map<string, IGraphContentModel>()
+
+  constructor(api: IFormulaAdapterApi) {
+    makeObservable(this)
+    this.api = api
+  }
+
+  @action
+  addGraphContentModel(graphContentModel: IGraphContentModel) {
+    this.graphContentModels.set(graphContentModel.id, graphContentModel)
+  }
+
+  @action
+  removeGraphContentModel(graphContentModelId: string) {
+    this.graphContentModels.delete(graphContentModelId)
+  }
+
+  getGraphContentModel(extraMetadata: IGraphFilterFormulaExtraMetadata) {
+    const { graphContentModelId } = extraMetadata
+    const graphContentModel = this.graphContentModels.get(graphContentModelId)
+    if (!graphContentModel) {
+      throw new Error(`GraphContentModel with id "${graphContentModelId}" not found`)
+    }
+    return graphContentModel
+  }
+
+  getDataConfiguration(extraMetadata: IGraphFilterFormulaExtraMetadata) {
+    return this.getGraphContentModel(extraMetadata).dataConfiguration
+  }
+
+  getActiveFormulas(): ({ formula: IFormula, extraMetadata: IGraphFilterFormulaExtraMetadata })[] {
+    const result: ({ formula: IFormula, extraMetadata: IGraphFilterFormulaExtraMetadata })[] = []
+    this.graphContentModels.forEach(graphContentModel => {
+      const dataConfig = graphContentModel.dataConfiguration
+      const dataSet = graphContentModel.dataset
+      if (dataSet && isFilterFormulaDataConfiguration(dataConfig)) {
+        result.push({
+          formula: dataConfig.filterFormula,
+          extraMetadata: {
+            dataSetId: dataSet.id,
+            graphContentModelId: graphContentModel.id
+          }
+        })
+      }
+    })
+    return result
+  }
+
+  recalculateFormula(formulaContext: IFormulaContext, extraMetadata: IGraphFilterFormulaExtraMetadata,
+    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
+    if (formulaContext.formula.empty) {
+      return
+    }
+
+    // Clear any previous error first.
+    this.setFormulaError(formulaContext, extraMetadata, "")
+
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+    if (!dataConfig) {
+      throw new Error(`GraphContentModel with id "${extraMetadata.graphContentModelId}" not found`)
+    }
+    const results = this.computeFormula(formulaContext, extraMetadata, casesToRecalculateDesc)
+    if (results && results.length > 0) {
+      dataConfig.updateFilterFormulaResults(results, { replaceAll: casesToRecalculateDesc === "ALL_CASES" })
+    }
+  }
+
+  computeFormula(formulaContext: IFormulaContext, extraMetadata: IGraphFilterFormulaExtraMetadata,
+    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
+    const { formula, dataSet } = formulaContext
+    const { attributeId } = extraMetadata
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+
+    // Use unhiddenCaseIDs to exclude hidden cases so they're not included in calculations,
+    // such as aggregate functions like mean.
+    const childMostCollectionCaseIds = [...dataConfig.unhiddenCaseIDs]
+
+    let casesToRecalculate: string[] = []
+    if (casesToRecalculateDesc === "ALL_CASES") {
+      // If casesToRecalculate is not provided, recalculate all cases.
+      casesToRecalculate = childMostCollectionCaseIds
+    } else {
+      casesToRecalculate = casesToRecalculateDesc.map(c => c.__id__)
+    }
+
+    if (!casesToRecalculate || casesToRecalculate.length === 0) {
+      return
+    }
+
+    debugLog(
+      DEBUG_FORMULAS,
+      `[graph filter formula] recalculate "${formula.canonical}" for ${casesToRecalculate.length} cases`
+    )
+
+    const formulaScope = new FormulaMathJsScope({
+      localDataSet: dataSet,
+      dataSets: this.api.getDatasets(),
+      globalValueManager: this.api.getGlobalValueManager(),
+      formulaAttrId: attributeId,
+      caseIds: casesToRecalculate,
+      childMostCollectionCaseIds
+    })
+
+    try {
+      const compiledFormula = math.compile(formula.canonical)
+      return casesToRecalculate.map((c, idx) => {
+        formulaScope.setCasePointer(idx)
+        const formulaValue = compiledFormula.evaluate(formulaScope)
+        // This is necessary for functions like `prev` that need to know the previous result when they reference
+        // its own attribute.
+        formulaScope.savePreviousResult(formulaValue)
+        return {
+          itemId: c,
+          result: !!formulaValue // only boolean values are supported
+        }
+      })
+    } catch (e: any) {
+      return this.setFormulaError(formulaContext, extraMetadata, formulaError(e.message))
+    }
+  }
+
+  // Error message is set as formula output, similarly as in CODAP V2.
+  setFormulaError(formulaContext: IFormulaContext, extraMetadata: IGraphFilterFormulaExtraMetadata, errorMsg: string) {
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+    dataConfig.setFilterFormulaError(errorMsg)
+  }
+
+  getFormulaError(formulaContext: IFormulaContext, extraMetadata: IGraphFilterFormulaExtraMetadata) {
+    // No custom errors yet.
+    return undefined
+  }
+}

--- a/v3/src/models/formula/graph-filter-formula-adapter.ts
+++ b/v3/src/models/formula/graph-filter-formula-adapter.ts
@@ -100,9 +100,9 @@ export class GraphFilterFormulaAdapter implements IFormulaManagerAdapter {
     const { attributeId } = extraMetadata
     const dataConfig = this.getDataConfiguration(extraMetadata)
 
-    // Use unhiddenCaseIDs to exclude hidden cases so they're not included in calculations,
+    // Use visibleCaseIds to exclude hidden cases so they're not included in calculations,
     // such as aggregate functions like mean.
-    const childMostCollectionCaseIds = [...dataConfig.unhiddenCaseIDs]
+    const childMostCollectionCaseIds = [...dataConfig.visibleCaseIds]
 
     let casesToRecalculate: string[] = []
     if (casesToRecalculateDesc === "ALL_CASES") {

--- a/v3/src/utilities/js-utils.test.ts
+++ b/v3/src/utilities/js-utils.test.ts
@@ -1,4 +1,6 @@
-import { hasOwnProperty, isEquivalentArray, isEquivalentSet } from "./js-utils"
+import {
+  hashString, hashStringSet, hashStringSets, hasOwnProperty, isEquivalentArray, isEquivalentSet
+} from "./js-utils"
 
 describe("JavaScript Utilities", () => {
 
@@ -30,4 +32,31 @@ describe("JavaScript Utilities", () => {
     expect(isEquivalentSet(new Set(["a", "a", "b"]), new Set(["a", "b", "b"]))).toBe(true)
   })
 
+  test("hashString", () => {
+    expect(hashString("")).toBe(hashString(""))
+    expect(hashString("")).not.toBe(hashString("a"))
+    expect(hashString("a")).toBe(hashString("a"))
+    expect(hashString("a")).not.toBe(hashString("A"))
+    expect(hashString("a")).not.toBe(hashString("b"))
+    expect(hashString("abcdef")).toBe(hashString("abcdef"))
+    expect(hashString("abcdef")).not.toBe(hashString("abCdef"))
+  })
+
+  test("hashStringSet", () => {
+    expect(hashStringSet([])).toBe(hashStringSet([]))
+    expect(hashStringSet(["a", "b", "c"])).toBe(hashStringSet(["a", "b", "c"]))
+    expect(hashStringSet(["a", "b", "c"])).toBe(hashStringSet(["a", "b", "c"]))
+    expect(hashStringSet(["a", "b", "c"])).toBe(hashStringSet(["c", "b", "a"]))
+    expect(hashStringSet(["a", "b", "c"])).not.toBe(hashStringSet(["a", "b"]))
+    expect(hashStringSet(["a", "b", "c"])).not.toBe(hashStringSet(["a", "b", ""]))
+    expect(hashStringSet(["a", "b", "c"])).not.toBe(hashStringSet(["a", "b", "C"]))
+  })
+
+  test("hashStringSets", () => {
+    expect(hashStringSets([])).toBe(hashStringSets([]))
+    expect(hashStringSets([["a"], ["b"]])).toBe(hashStringSets([["a"], ["b"]]))
+    expect(hashStringSets([["a"]])).not.toBe(hashStringSets([["a"], ["a"]]))
+    expect(hashStringSets([["a"], ["b"]])).not.toBe(hashStringSets([["a"], ["a"]]))
+    expect(hashStringSets([["a"], ["b"]])).not.toBe(hashStringSets([["a"], ["b"], ["c"]]))
+  })
 })

--- a/v3/src/utilities/js-utils.ts
+++ b/v3/src/utilities/js-utils.ts
@@ -94,7 +94,7 @@ export function uniqueName(base: string, isValid: (name: string) => boolean) {
 }
 
 /*
- * generateValidId()
+ * safeDomIdentifier()
  *
  * returns a value that can safely be used for an HTML ID or class name from a given value
  */
@@ -129,4 +129,47 @@ export function isEquivalentSet<T = any>(set1: Set<T>, set2: Set<T>) {
     if (!set2.has(elem)) return false
   }
   return true
+}
+
+/*
+ * hashString()
+ *
+ * Returns a 32-bit hash value for a string.
+ * Provided by ChatGPT, but apparently originally developed by Daniel J. Bernstein.
+ */
+export function hashString(str: string) {
+  // Simple hash function for a single string (e.g., DJB2)
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    // eslint-disable-next-line no-bitwise
+    hash = (hash * 33) ^ str.charCodeAt(i)
+  }
+  // eslint-disable-next-line no-bitwise
+  return hash >>> 0 // Convert to unsigned 32-bit integer
+}
+
+/*
+ * hashStringSet()
+ *
+ * returns an order-invariant hash value for a set of strings (e.g. ids).
+ * developed with the help of ChatGPT.
+ */
+export function hashStringSet(strings: string[]) {
+  return strings
+    .map(hashString)
+    // eslint-disable-next-line no-bitwise
+    .reduce((acc, hash) => acc ^ hash, 0) // XOR all individual hashes
+}
+
+/*
+ * hashStringSets()
+ *
+ * returns an order-invariant hash value for a set of string arrays (e.g. ids).
+ * developed with the help of ChatGPT.
+ */
+export function hashStringSets(stringSets: Array<string[]>) {
+  return stringSets
+    .map(hashStringSet)
+    // eslint-disable-next-line no-bitwise
+    .reduce((acc, hash) => acc ^ hash, 0) // XOR all individual hashes
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187799311

This PR (partially) implements the graph filter formula. However, there's a missing piece - hopefully small, but very important - the graph view is not updating correctly after the filter formula results are applied. That's why I'm opening this as a draft PR.

The new adapter has some elements similar to the more basic `FilterFormulaAdapter` and some elements similar to the `PlottedValue` or `PlottedFunction` adapters. It sits somewhere in between.

I did struggle a bit with the concept of `CaseID` vs `ItemID` and working with the `DataConfiguration`. My (limited) understanding is that `ItemID` represents a leaf, while `CaseID` can encompass multiple `ItemIDs`. However, when we set aside cases/items in the Dataset/Case table, we work with `ItemIDs`, while graphs work with `CaseIDs`. 

I tried calling `self._invalidateCases()` (similar to what I did in the DataSet), but it doesn't seem to update the graph view. However, if you check the `DataConfigurationModel#allCaseIDs` console logs, they appear to be updated correctly. So, I assume it's just a matter of finding a better way to notify the graph, maybe another method? I've added more TODOs in spots that may require additional work or verification. E.g.  `unhiddenCaseIDs` can likely be implemented better - or perhaps should be. I hope this will be an easier task for you.

The second commit is semi-related, as it fixes a bug in the case table filter formula. For example, when I set the filter formula to "Sleep < 5" and then manually modify a single case in the case table to "Sleep = 10", it wasn't disappearing (due to CaseID vs ItemID conflict). Now, it does.

I'm pretty sad that I couldn't wrap up my last CC PR 🤧, but I hope this is still useful.