### PR TITLE
fix: crash on delete DataSet

### DIFF
--- a/v3/src/components/case-tile-common/hide-show-menu-list.tsx
+++ b/v3/src/components/case-tile-common/hide-show-menu-list.tsx
@@ -1,5 +1,6 @@
 import { useDisclosure } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
+import { isAlive } from "mobx-state-tree"
 import React from "react"
 import { useCaseMetadata } from "../../hooks/use-case-metadata"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
@@ -12,6 +13,8 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
   const data = useDataSetContext()
   const caseMetadata = useCaseMetadata()
   const formulaModal = useDisclosure()
+
+  if (data && !isAlive(data)) return null
 
   const handleSetAsideCases = (itemIds: string[], deselect: boolean) => {
     if (data && itemIds.length) {

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -146,7 +146,7 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
         getAxisDomains(xAxis, yAxis)
         subPlotRegionBoundariesRef.current = subPlotRegionBoundaries()
         plotCaseCounts()
-      }, { name: "Count.refreshBoundariesAndCaseCounts" }, model)
+      }, { name: "Count.refreshBoundariesAndCaseCounts" }, [model, xAxis, yAxis])
   }, [model, plotCaseCounts, subPlotRegionBoundaries, xAxis, yAxis])
 
   useEffect(function refreshOnSubPlotRegionChange() {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -695,7 +695,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
               self.filteredCases.pop()?.destroy()
             }
             // add any required filteredCases
-            while (self.filteredCases.length < filteredCasesRequired) {
+            while (self.dataset && self.filteredCases.length < filteredCasesRequired) {
               self._addNewFilteredCases()
             }
           }, { name: "GraphDataConfigurationModel yAttrDescriptions reaction", equals: comparer.structural }

--- a/v3/src/utilities/mst-autorun.ts
+++ b/v3/src/utilities/mst-autorun.ts
@@ -9,8 +9,9 @@ import { SetRequired } from "type-fest"
   MobX `autorun` API, except that passing a name is required.
  */
 type IAutorunOptionsWithName = SetRequired<IAutorunOptions, "name">
+type IAnyModels = IAnyStateTreeNode | IAnyStateTreeNode[]
 
-export function mstAutorun(fn: () => void, options: IAutorunOptionsWithName, model: IAnyStateTreeNode) {
+export function mstAutorun(fn: () => void, options: IAutorunOptionsWithName, models: IAnyModels) {
   // install autorun
   let _disposer: IReactionDisposer | undefined = autorun(fn, options)
   // returned disposer prevents MobX disposer from being called multiple times
@@ -18,7 +19,8 @@ export function mstAutorun(fn: () => void, options: IAutorunOptionsWithName, mod
     _disposer?.()
     _disposer = undefined
   }
-  // dispose of autorun if the model it depends on is destroyed
-  addDisposer(model, disposer)
+  // dispose of autorun if the model(s) it depends on is/are destroyed
+  const _models = Array.isArray(models) ? models : [models]
+  _models.forEach(model => model && addDisposer(model, disposer))
   return disposer
 }

--- a/v3/src/utilities/mst-reaction.ts
+++ b/v3/src/utilities/mst-reaction.ts
@@ -13,7 +13,7 @@ type IReactionOptionsWithName<T, fireImmediately extends boolean> =
 
 export function mstReaction<T, fireImmediately extends boolean>(
   accessor: () => T, effect: (args: T) => void,
-  options: IReactionOptionsWithName<T, fireImmediately>, model: IAnyStateTreeNode) {
+  options: IReactionOptionsWithName<T, fireImmediately>, models: IAnyStateTreeNode | IAnyStateTreeNode[]) {
   // install reaction
   let _disposer: IReactionDisposer | undefined = reaction(accessor, effect, options)
   // returned disposer prevents MobX disposer from being called multiple times
@@ -21,7 +21,8 @@ export function mstReaction<T, fireImmediately extends boolean>(
     _disposer?.()
     _disposer = undefined
   }
-  // dispose of the reaction if the model it depends on is destroyed
-  addDisposer(model, disposer)
+  // dispose of the reaction if the model(s) it depends on is/are destroyed
+  const _models = Array.isArray(models) ? models : [models]
+  _models.forEach(model => model && addDisposer(model, disposer))
   return disposer
 }


### PR DESCRIPTION
There were several things going on here:
- The primary cause of the hang/crash was an infinite loop in the `GraphDataConfigurationModel`'s attempt to synchronize its `filteredCases` array after its `DataSet` was destroyed.

Once that was fixed, there were still several clients that were attempting to access the defunct `DataSet` triggering warnings. These have also been fixed:
- The `FilteredCases` class now responds to disposal of its `DataSet`, thus preventing further access.
- The `CaseTile`'s `HideShowMenuList` checks whether its `DataSet` is alive before accessing it. (We conventionally avoid `isAlive` in models, but in components there often isn't a better way.)
- The `CountAdornmentComponent` was properly using `mstAutorun`, but the model it was attached to was the `CountAdornmentModel`, not the axis models that were _also_ accessed within the `autorun`.
- Therefore, `mstAutorun` and `mstReaction` have been extended to support an array of model dependencies _or_ a single model and so now the `CountAdornmentComponent` can specify all of its model dependencies. (I have wondered for some time whether we would ever encounter a situation in which a single model dependency was insufficient for these utilities and now we have.)