### PR TITLE
fix: import of hierarchical v2 documents

### DIFF
--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -545,13 +545,13 @@ export const DataSet = V2Model.named("DataSet").props({
         self.itemIdChildCaseMap.set(caseGroup.childItemIds[0], caseGroup)
       })
       // delete removed items
-      for (const [itemId, itemInfo] of self.itemInfoMap.entries()) {
-        if (itemInfo.caseIds.length === 0) {
-          self.itemInfoMap.delete(itemId)
-          // update selection
-          self.selection.delete(itemId)
-        }
-      }
+      const itemsToValidate = new Set<string>(self.itemInfoMap.keys())
+      self._itemIds.forEach(itemId => itemsToValidate.delete(itemId))
+      itemsToValidate.forEach(itemId => {
+        self.itemInfoMap.delete(itemId)
+        // update selection
+        self.selection.delete(itemId)
+      })
       self.setValidCases()
     }
   }


### PR DESCRIPTION
[[PT-188382390]](https://www.pivotaltracker.com/story/show/188382390)

This was broken recently in #1533. The code to prune stale items was over-aggressive and was inadvertently triggered during the v2 import process. This replaces the stale items test with a more conservative/reliable one.