### PR TITLE
fix: undo filter formula change

### DIFF
--- a/v3/cypress/e2e/adornments.spec.ts
+++ b/v3/cypress/e2e/adornments.spec.ts
@@ -55,7 +55,7 @@ context("Graph adornments", () => {
     cy.get(".codap-modal-content [data-testid=attr-formula-input]").type(`{selectAll}{del}Diet="plants"`)
     cy.get(".codap-modal-content [data-testid=Apply-button]").should("be.visible").click()
     cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("exist")
-    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("have.text", "11")
+    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("have.text", "6")
 
     // delete the filter formula
     graph.getHideShowButton().click()

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -337,6 +337,53 @@ context("case table ui", () => {
       })
     })
 
+    it("behaves as expected with a filter formula", () => {
+      let initialCaseCount = 0
+
+      const caseCount = (rowCount?: string) => rowCount ? +rowCount - 2 : 0
+
+      // Get initial row count
+      table.getNumOfRows().then(rowCount => {
+        initialCaseCount = caseCount(rowCount)
+      })
+
+      // add a filter formula
+      table.addFilterFormulaInModal(`Diet="meat"`)
+      table.getNumOfRows().then(rowCount => expect(caseCount(rowCount)).to.eq(11))
+
+      // change the filter formula
+      table.addFilterFormulaInModal(`Diet="plants"`)
+      table.getNumOfRows().then(rowCount => expect(caseCount(rowCount)).to.eq(7))
+
+      // remove the filter formula
+      table.addFilterFormulaInModal("")
+      table.getNumOfRows().then(rowCount => expect(caseCount(rowCount)).to.eq(initialCaseCount))
+
+      // undo the removal of the filter formula
+      toolbar.getUndoTool().click()
+      table.getNumOfRows().then(rowCount => expect(caseCount(rowCount)).to.eq(7))
+
+      // undo the filter formula change
+      toolbar.getUndoTool().click()
+      table.getNumOfRows().then(rowCount => expect(caseCount(rowCount)).to.eq(11))
+
+      // undo the addition of the filter formula
+      toolbar.getUndoTool().click()
+      table.getNumOfRows().then(rowCount => expect(caseCount(rowCount)).to.eq(initialCaseCount))
+
+      // redo the addition of the filter formula
+      toolbar.getRedoTool().click()
+      table.getNumOfRows().then(rowCount => expect(caseCount(rowCount)).to.eq(11))
+
+      // redo the change of the filter formula
+      toolbar.getRedoTool().click()
+      table.getNumOfRows().then(rowCount => expect(caseCount(rowCount)).to.eq(7))
+
+      // redo the removal of the filter formula
+      toolbar.getRedoTool().click()
+      table.getNumOfRows().then(rowCount => expect(caseCount(rowCount)).to.eq(initialCaseCount))
+    })
+
     it("check New Attribute from inspector menu with undo/redo", () => {
       c.selectTile("table", 0)
       table.getRulerButton().click()

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -411,7 +411,7 @@ export const TableTileElements = {
   },
   addFilterFormulaInModal(formula: string) {
     this.getHideShowButton().click()
-    this.getHideShowMenuItem("Edit Filter Formula...").click()
+    this.getHideShowMenuItem(/(Add|Edit) Filter Formula.../).click()
     cy.get(".codap-modal-content [data-testid=attr-formula-input]").type(`{selectAll}{del}${formula}`)
     cy.get(".codap-modal-content [data-testid=Apply-button]").should("be.visible").click()
     cy.get("[data-testid=Apply-button]").click()

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -375,27 +375,27 @@ export const TableTileElements = {
   addFormula(attributeName: string, formula: string, collectionIndex = 1) {
     this.openAttributeMenu(attributeName, collectionIndex)
     this.selectMenuItemFromAttributeMenu("Edit Formula...")
-    this.addFormulaInModal(attributeName, formula)
+    this.addAttrFormulaInModal(attributeName, formula)
   },
   editFormula(attributeName: string, formula: string, collectionIndex = 1) {
     this.openAttributeMenu(attributeName, collectionIndex)
     this.selectMenuItemFromAttributeMenu("Edit Formula...")
-    this.clearFormulaInModal(attributeName)
+    this.clearAttrFormulaInModal(attributeName)
     this.addFormula(attributeName, formula, collectionIndex)
   },
   checkFormulaExists(attributeName: string, formula: string, collectionIndex = 1) {
     this.openAttributeMenu(attributeName, collectionIndex)
     this.selectMenuItemFromAttributeMenu("Edit Formula...")
-    this.checkFormulaInModal(attributeName, formula)
+    this.checkAttrFormulaInModal(attributeName, formula)
   },
-  addFormulaInModal(attributeName: string, formula: string) {
+  addAttrFormulaInModal(attributeName: string, formula: string) {
     cy.get("[data-testid=attr-name-input]").invoke("attr", "value").should("eq", attributeName)
     cy.get("[data-testid=formula-editor-input] .cm-content").should("be.visible").and("have.focus")
     cy.get("[data-testid=formula-editor-input] .cm-content").realType(formula)
     cy.get("[data-testid=Apply-button]").click()
     cy.get("[data-testid=attr-name-input]").should("not.exist")
   },
-  clearFormulaInModal(attributeName: string) {
+  clearAttrFormulaInModal(attributeName: string) {
     cy.get("[data-testid=attr-name-input]").invoke("attr", "value").should("eq", attributeName)
     cy.get("[data-testid=formula-editor-input] .cm-content").should("be.visible").and("have.focus")
     cy.get("[data-testid=formula-editor-input] .cm-content").realPress([metaCtrlKey, "A"])
@@ -403,11 +403,18 @@ export const TableTileElements = {
     cy.get("[data-testid=Apply-button]").click()
     cy.get("[data-testid=attr-name-input]").should("not.exist")
   },
-  checkFormulaInModal(attributeName: string, formula: string) {
+  checkAttrFormulaInModal(attributeName: string, formula: string) {
     cy.get("[data-testid=attr-name-input]").invoke("attr", "value").should("eq", attributeName)
     cy.get("[data-testid=formula-editor-input] .cm-content").should("have.text", formula)
     cy.get("[data-testid=Cancel-button]").click()
     cy.get("[data-testid=attr-name-input]").should("not.exist")
+  },
+  addFilterFormulaInModal(formula: string) {
+    this.getHideShowButton().click()
+    this.getHideShowMenuItem("Edit Filter Formula...").click()
+    cy.get(".codap-modal-content [data-testid=attr-formula-input]").type(`{selectAll}{del}${formula}`)
+    cy.get(".codap-modal-content [data-testid=Apply-button]").should("be.visible").click()
+    cy.get("[data-testid=Apply-button]").click()
   },
   verifyFormulaValues(attribute: string, values: Array<any>, collectionIndex = 1) {
     for (let rowIndex = 0; rowIndex < values.length; rowIndex++) {

--- a/v3/src/components/case-tile-common/hide-show-menu-list.tsx
+++ b/v3/src/components/case-tile-common/hide-show-menu-list.tsx
@@ -6,7 +6,7 @@ import { useCaseMetadata } from "../../hooks/use-case-metadata"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { hideAttributeNotification } from "../../models/data/data-set-notifications"
 import { t } from "../../utilities/translation/translate"
-import { EditFilterFormulaModal } from "./edit-filter-formula-modal"
+import { EditFilterFormulaModal } from "../common/edit-filter-formula-modal"
 import { IMenuItem, StdMenuList } from "./std-menu-list"
 
 export const HideShowMenuList = observer(function HideShowMenuList() {

--- a/v3/src/components/case-tile-common/hide-show-menu-list.tsx
+++ b/v3/src/components/case-tile-common/hide-show-menu-list.tsx
@@ -85,7 +85,7 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
       }
     },
     {
-      itemKey: !data?.filterFormula?.empty
+      itemKey: data?.filterFormula && !data.filterFormula.empty
                 ? "V3.hideShowMenu.editFilterFormula"
                 : "V3.hideShowMenu.addFilterFormula",
       isEnabled: () => !!data,

--- a/v3/src/components/common/edit-filter-formula-modal.tsx
+++ b/v3/src/components/common/edit-filter-formula-modal.tsx
@@ -2,11 +2,11 @@ import {
   Button, FormControl, FormLabel, ModalBody, ModalCloseButton, ModalFooter, ModalHeader,
   Textarea, Tooltip
 } from "@chakra-ui/react"
-import React, { useEffect, useState } from "react"
 import { observer } from "mobx-react-lite"
+import React, { useEffect, useState } from "react"
+import { IFormula } from "../../models/formula/formula"
 import { t } from "../../utilities/translation/translate"
 import { CodapModal } from "../codap-modal"
-import { IFormula } from "../../models/formula/formula"
 
 interface IFormulaSource {
   filterFormula?: IFormula

--- a/v3/src/components/data-display/hooks/use-data-display-animation.ts
+++ b/v3/src/components/data-display/hooks/use-data-display-animation.ts
@@ -1,10 +1,13 @@
+import { isAlive, isStateTreeNode } from "mobx-state-tree"
 import { useCallback } from "react"
 import { useDataDisplayModelContext } from "./use-data-display-model"
 
 export const useDataDisplayAnimation = () => {
-  const model = useDataDisplayModelContext()
-  const isAnimating = useCallback(() => model.animationEnabled, [model])
-  const startAnimation = useCallback(() => model.startAnimation(), [model])
-  const stopAnimation = useCallback(() => model.stopAnimation(), [model])
+  const _model = useDataDisplayModelContext()
+  // context is initialized with a default value that isn't a real model
+  const model = isStateTreeNode(_model) && isAlive(_model) ? _model : undefined
+  const isAnimating = useCallback(() => !!model?.animationTimerId, [model])
+  const startAnimation = useCallback(() => model?.startAnimation(), [model])
+  const stopAnimation = useCallback(() => model?.stopAnimation(), [model])
   return { isAnimating, startAnimation, stopAnimation }
 }

--- a/v3/src/components/data-display/models/data-display-content-model.ts
+++ b/v3/src/components/data-display/models/data-display-content-model.ts
@@ -31,7 +31,7 @@ export const DataDisplayContentModel = TileContentModel
     isTransparent: false,
   })
   .volatile(() => ({
-    animationEnabled: false,
+    animationTimerId: 0,
     marqueeMode: 'unclicked' as MarqueeMode,
   }))
   .views(self => ({
@@ -77,12 +77,17 @@ export const DataDisplayContentModel = TileContentModel
     }
   }))
   .actions(self => ({
+    beforeDestroy() {
+      if (self.animationTimerId) {
+        clearTimeout(self.animationTimerId)
+      }
+    },
     startAnimation() {
-      self.animationEnabled = true
-      setTimeout(() => this.stopAnimation(), 2000)
+      if (self.animationTimerId) clearTimeout(self.animationTimerId)
+      self.animationTimerId = window.setTimeout(() => this.stopAnimation(), 2000)
     },
     stopAnimation() {
-      self.animationEnabled = false
+      self.animationTimerId = 0
     },
     installSharedModelManagerSync() {
       // synchronizes shared model references from layers' DataConfigurations to the sharedModelManager

--- a/v3/src/components/graph/adornments/base-graph-formula-adapter.ts
+++ b/v3/src/components/graph/adornments/base-graph-formula-adapter.ts
@@ -1,13 +1,14 @@
 import { action, makeObservable, observable } from "mobx"
-import { ICase } from "../data/data-set-types"
-import { IFormula } from "./formula"
-import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
-import type {
-  IFormulaAdapterApi, IFormulaContext, IFormulaExtraMetadata, IFormulaManagerAdapter
-} from "./formula-manager"
-import type { IGraphContentModel } from "../../components/graph/models/graph-content-model"
-import { FormulaMathJsScope } from "./formula-mathjs-scope"
-import { IAdornmentModel } from "../../components/graph/adornments/adornment-models"
+import { ICase } from "../../../models/data/data-set-types"
+import { IFormula } from "../../../models/formula/formula"
+import {
+  FormulaManagerAdapter,
+  type IFormulaAdapterApi, type IFormulaContext, type IFormulaExtraMetadata, type IFormulaManagerAdapter
+} from "../../../models/formula/formula-manager-types"
+import { FormulaMathJsScope } from "../../../models/formula/formula-mathjs-scope"
+import { localAttrIdToCanonical } from "../../../models/formula/utils/name-mapping-utils"
+import type { IGraphContentModel } from "../models/graph-content-model"
+import { IAdornmentModel } from "./adornment-models"
 
 type GraphCellKey = Record<string, string>
 
@@ -27,9 +28,8 @@ interface IFormulaSupportingAdornment extends IAdornmentModel {
   setError(errorMsg: string): void
 }
 
-export class BaseGraphFormulaAdapter implements IFormulaManagerAdapter {
+export class BaseGraphFormulaAdapter extends FormulaManagerAdapter implements IFormulaManagerAdapter {
   // --- METHODS AND PROPS TO OVERRIDE/IMPLEMENT ---
-  type = "OVERRIDE"
 
   getAdornment(graphContentModel: IGraphContentModel): IFormulaSupportingAdornment | undefined {
     throw new Error("Method not implemented.")
@@ -40,12 +40,11 @@ export class BaseGraphFormulaAdapter implements IFormulaManagerAdapter {
   }
   // --- END OF METHODS AND PROPS TO OVERRIDE/IMPLEMENT ---
 
-  api: IFormulaAdapterApi
   @observable.shallow graphContentModels = new Map<string, IGraphContentModel>()
 
-  constructor(api: IFormulaAdapterApi) {
+  constructor(type: string, api: IFormulaAdapterApi) {
+    super(type, api)
     makeObservable(this)
-    this.api = api
   }
 
   @action

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.tsx
@@ -8,6 +8,7 @@ import { kPlottedFunctionClass, kPlottedFunctionLabelKey, kPlottedFunctionPrefix
 import { AdornmentCheckbox } from "../adornment-checkbox"
 import { PlottedFunctionAdornmentBanner } from "./plotted-function-adornment-banner"
 import { PlottedFunctionAdornmentComponent } from "./plotted-function-adornment-component"
+import { PlottedFunctionFormulaAdapter } from "./plotted-function-formula-adapter"
 
 const Controls = () => {
   return (
@@ -18,6 +19,8 @@ const Controls = () => {
     />
   )
 }
+
+PlottedFunctionFormulaAdapter.register()
 
 registerAdornmentContentInfo({
   type: kPlottedFunctionType,

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-formula-adapter.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-formula-adapter.ts
@@ -1,20 +1,17 @@
-import { IAnyStateTreeNode } from "@concord-consortium/mobx-state-tree"
-import { ICase } from "../data/data-set-types"
-import { formulaError } from "./utils/misc"
-import { math } from "./functions/math"
-import {
-  isPlottedFunctionAdornment
-} from "../../components/graph/adornments/plotted-function/plotted-function-adornment-model"
-import { getFormulaManager } from "../tiles/tile-environment"
-import { DEBUG_FORMULAS, debugLog } from "../../lib/debug"
-import {
-  FormulaFn, kPlottedFunctionType
-} from "../../components/graph/adornments/plotted-function/plotted-function-adornment-types"
+import { IAnyStateTreeNode } from "mobx-state-tree"
+import { DEBUG_FORMULAS, debugLog } from "../../../../lib/debug"
+import { ICase } from "../../../../models/data/data-set-types"
+import { registerFormulaAdapter } from "../../../../models/formula/formula-adapter-registry"
+import type { IFormulaAdapterApi, IFormulaContext } from "../../../../models/formula/formula-manager-types"
+import { math } from "../../../../models/formula/functions/math"
+import { formulaError } from "../../../../models/formula/utils/misc"
+import { getFormulaManager } from "../../../../models/tiles/tile-environment"
+import type { IGraphContentModel } from "../../models/graph-content-model"
 import {
   BaseGraphFormulaAdapter, IBaseGraphFormulaExtraMetadata, getDefaultArgument
-} from "./base-graph-formula-adapter"
-import type { IFormulaContext } from "./formula-manager"
-import type { IGraphContentModel } from "../../components/graph/models/graph-content-model"
+} from "../base-graph-formula-adapter"
+import { isPlottedFunctionAdornment } from "./plotted-function-adornment-model"
+import { FormulaFn, kPlottedFunctionType } from "./plotted-function-adornment-types"
 
 const PLOTTED_FUNCTION_FORMULA_ADAPTER = "PlottedFunctionFormulaAdapter"
 
@@ -22,13 +19,21 @@ const X_ARG_SYMBOL = "x"
 
 export interface IPlottedFunctionFormulaExtraMetadata extends IBaseGraphFormulaExtraMetadata {}
 
-export const getPlottedFunctionFormulaAdapter = (node?: IAnyStateTreeNode): PlottedFunctionFormulaAdapter | undefined =>
-  getFormulaManager(node)?.adapters.find(a =>
-    a.type === PLOTTED_FUNCTION_FORMULA_ADAPTER
-  ) as PlottedFunctionFormulaAdapter
-
 export class PlottedFunctionFormulaAdapter extends BaseGraphFormulaAdapter {
-  type = PLOTTED_FUNCTION_FORMULA_ADAPTER
+
+  static register() {
+    registerFormulaAdapter(api => new PlottedFunctionFormulaAdapter(api))
+  }
+
+  static get(node?: IAnyStateTreeNode) {
+    return getFormulaManager(node)?.adapters.find(({ type }) =>
+      type === PLOTTED_FUNCTION_FORMULA_ADAPTER
+    ) as Maybe<PlottedFunctionFormulaAdapter>
+  }
+
+  constructor(api: IFormulaAdapterApi) {
+    super(PLOTTED_FUNCTION_FORMULA_ADAPTER, api)
+  }
 
   getAdornment(graphContentModel: IGraphContentModel) {
     const adornment = graphContentModel.adornments.find(a => a.type === kPlottedFunctionType)

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.tsx
@@ -8,6 +8,7 @@ import { kPlottedValueClass, kPlottedValueLabelKey, kPlottedValuePrefix, kPlotte
 import { AdornmentCheckbox } from "../../adornment-checkbox"
 import { PlottedValueAdornmentBanner } from "./plotted-value-adornment-banner"
 import { PlottedValueComponent } from "./plotted-value-adornment-component"
+import { PlottedValueFormulaAdapter } from "./plotted-value-formula-adapter"
 
 const Controls = () => {
   return (
@@ -18,6 +19,8 @@ const Controls = () => {
     />
   )
 }
+
+PlottedValueFormulaAdapter.register()
 
 registerAdornmentContentInfo({
   type: kPlottedValueType,

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-formula-adapter.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-formula-adapter.test.ts
@@ -1,17 +1,15 @@
-import { IDataSet } from "../data/data-set"
-import { createDataSet } from "../data/data-set-conversion"
-import { PlottedFunctionFormulaAdapter } from "./plotted-function-formula-adapter"
-import { localAttrIdToCanonical } from "./utils/name-mapping-utils"
-import { GraphDataConfigurationModel } from "../../components/graph/models/graph-data-configuration-model"
-import {
-  PlottedFunctionAdornmentModel
-} from "../../components/graph/adornments/plotted-function/plotted-function-adornment-model"
+import { IDataSet } from "../../../../../models/data/data-set"
+import { createDataSet } from "../../../../../models/data/data-set-conversion"
+import { localAttrIdToCanonical } from "../../../../../models/formula/utils/name-mapping-utils"
+import { GraphDataConfigurationModel } from "../../../models/graph-data-configuration-model"
+import { PlottedValueAdornmentModel } from "./plotted-value-adornment-model"
+import { PlottedValueFormulaAdapter } from "./plotted-value-formula-adapter"
 
 const getTestEnv = () => {
   const dataSet = createDataSet({ attributes: [{ name: "foo" }] })
   dataSet.addCases([{ __id__: "1" }])
   const attribute = dataSet.attributes[0]
-  const adornment = PlottedFunctionAdornmentModel.create({ formula: { display: "1 + 2 + x" }})
+  const adornment = PlottedValueAdornmentModel.create({ formula: { display: "1 + 2" }})
   adornment.formula.setCanonicalExpression(adornment.formula.display)
   const dataConfig = GraphDataConfigurationModel.create({ })
   const mockData: Record<string, Record<string, any>> = {
@@ -35,7 +33,6 @@ const getTestEnv = () => {
   dataConfig.attributeID = (role: string) => mockData.id[role]
   dataConfig.attributeType = (role: string) => mockData.type[role]
   ;(dataConfig as any).categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
-
   const graphContentModel = {
     id: "fake-graph-content-model-id",
     adornments: [adornment],
@@ -64,19 +61,19 @@ const getTestEnv = () => {
     getFormulaExtraMetadata: jest.fn(() => extraMetadata),
     getFormulaContext: jest.fn(() => context),
   }
-  const adapter = new PlottedFunctionFormulaAdapter(api)
+  const adapter = new PlottedValueFormulaAdapter(api)
   adapter.addGraphContentModel(graphContentModel as any)
   return { adapter, adornment, graphContentModel, api, dataSet, attribute, formula, context, extraMetadata }
 }
 
-describe("PlottedFunctionFormulaAdapter", () => {
+describe("PlottedValueFormulaAdapter", () => {
   describe("getAllFormulas", () => {
     it("should return attribute formulas and extra metadata", () => {
       const { adapter, formula, extraMetadata } = getTestEnv()
       const formulas = adapter.getActiveFormulas()
       expect(formulas.length).toBe(1)
       expect(formulas[0].formula).toBe(formula)
-      expect(formulas[0].formula.display).toBe("1 + 2 + x")
+      expect(formulas[0].formula.display).toBe("1 + 2")
       expect(formulas[0].extraMetadata).toEqual(extraMetadata)
     })
   })
@@ -87,7 +84,7 @@ describe("PlottedFunctionFormulaAdapter", () => {
       adapter.recalculateFormula(context, extraMetadata)
       extraMetadata.graphCellKeys.forEach(cellKey => {
         const instanceKey = adornment.instanceKey(cellKey)
-        expect(adornment.plottedFunctions.get(instanceKey)?.formulaFunction(3)).toBe(6) // = 1 + 2 + x=3
+        expect(adornment.measures.get(instanceKey)?.value).toBe(3) // = 1 + 2
       })
     })
   })

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-formula-adapter.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-formula-adapter.ts
@@ -1,29 +1,35 @@
-import { IAnyStateTreeNode } from "@concord-consortium/mobx-state-tree"
-import { ICase } from "../data/data-set-types"
-import { formulaError } from "./utils/misc"
-import { math } from "./functions/math"
-import type { IFormulaContext } from "./formula-manager"
-import type { IGraphContentModel } from "../../components/graph/models/graph-content-model"
-import {
-  isPlottedValueAdornment
-} from "../../components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-model"
-
-import { getFormulaManager } from "../tiles/tile-environment"
-import { DEBUG_FORMULAS, debugLog } from "../../lib/debug"
-import {
-  kPlottedValueType
-} from "../../components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-types"
-import { BaseGraphFormulaAdapter, IBaseGraphFormulaExtraMetadata } from "./base-graph-formula-adapter"
+import { IAnyStateTreeNode } from "mobx-state-tree"
+import { DEBUG_FORMULAS, debugLog } from "../../../../../lib/debug"
+import { ICase } from "../../../../../models/data/data-set-types"
+import { registerFormulaAdapter } from "../../../../../models/formula/formula-adapter-registry"
+import type { IFormulaAdapterApi, IFormulaContext } from "../../../../../models/formula/formula-manager-types"
+import { math } from "../../../../../models/formula/functions/math"
+import { formulaError } from "../../../../../models/formula/utils/misc"
+import { getFormulaManager } from "../../../../../models/tiles/tile-environment"
+import type { IGraphContentModel } from "../../../models/graph-content-model"
+import { BaseGraphFormulaAdapter, IBaseGraphFormulaExtraMetadata } from "../../base-graph-formula-adapter"
+import { isPlottedValueAdornment } from "./plotted-value-adornment-model"
+import { kPlottedValueType } from "./plotted-value-adornment-types"
 
 const PLOTTED_VALUE_FORMULA_ADAPTER = "PlottedValueFormulaAdapter"
 
 export interface IPlottedValueFormulaExtraMetadata extends IBaseGraphFormulaExtraMetadata {}
 
-export const getPlottedValueFormulaAdapter = (node?: IAnyStateTreeNode): PlottedValueFormulaAdapter | undefined =>
-  getFormulaManager(node)?.adapters.find(a => a.type === PLOTTED_VALUE_FORMULA_ADAPTER) as PlottedValueFormulaAdapter
-
 export class PlottedValueFormulaAdapter extends BaseGraphFormulaAdapter {
-  type = PLOTTED_VALUE_FORMULA_ADAPTER
+
+  static register() {
+    registerFormulaAdapter(api => new PlottedValueFormulaAdapter(api))
+  }
+
+  static get(node?: IAnyStateTreeNode) {
+    return getFormulaManager(node)?.adapters.find(({ type }) =>
+      type === PLOTTED_VALUE_FORMULA_ADAPTER
+    ) as Maybe<PlottedValueFormulaAdapter>
+  }
+
+  constructor(api: IFormulaAdapterApi) {
+    super(PLOTTED_VALUE_FORMULA_ADAPTER, api)
+  }
 
   getAdornment(graphContentModel: IGraphContentModel) {
     const adornment = graphContentModel.adornments.find(a => a.type === kPlottedValueType)

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -6,7 +6,7 @@ import { ITileModel } from "../../../../models/tiles/tile-model"
 import { isGraphContentModel } from "../../models/graph-content-model"
 import { t } from "../../../../utilities/translation/translate"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
-import { EditFilterFormulaModal } from "../../../case-tile-common/edit-filter-formula-modal"
+import { EditFilterFormulaModal } from "../../../common/edit-filter-formula-modal"
 
 interface IProps {
   tile?: ITileModel

--- a/v3/src/components/graph/graph-registration.ts
+++ b/v3/src/components/graph/graph-registration.ts
@@ -9,12 +9,15 @@ import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-dat
 import { ComponentTitleBar } from "../component-title-bar"
 import { GraphContentModel, IGraphContentModelSnapshot, isGraphContentModel } from "./models/graph-content-model"
 import { kGraphDataConfigurationType } from "./models/graph-data-configuration-model"
+import { GraphFilterFormulaAdapter } from "./models/graph-filter-formula-adapter"
 import { kGraphPointLayerType } from "./models/graph-point-layer-model"
 import { GraphComponent } from "./components/graph-component"
 import { GraphInspector } from "./components/graph-inspector"
 import GraphIcon from '../../assets/icons/icon-graph.svg'
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { v2GraphImporter } from "./v2-graph-importer"
+
+GraphFilterFormulaAdapter.register()
 
 registerTileContentInfo({
   type: kGraphTileType,

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -30,22 +30,24 @@ import { CatMapType, CellType, IDomainOptions, PlotType, PlotTypes } from "../gr
 import {setNiceDomain} from "../utilities/graph-utils"
 import {GraphPointLayerModel, IGraphPointLayerModel, kGraphPointLayerType} from "./graph-point-layer-model"
 import {IAdornmentModel, IUpdateCategoriesOptions} from "../adornments/adornment-models"
+import {AdornmentsStore} from "../adornments/adornments-store"
+import { PlottedFunctionFormulaAdapter } from "../adornments/plotted-function/plotted-function-formula-adapter"
+import {
+  PlottedValueFormulaAdapter
+} from "../adornments/univariate-measures/plotted-value/plotted-value-formula-adapter"
 import {
   AxisModelUnion, EmptyAxisModel, IAxisModelUnion, isBaseNumericAxisModel, NumericAxisModel
 } from "../../axis/models/axis-model"
-import {AdornmentsStore} from "../adornments/adornments-store"
-import {getPlottedValueFormulaAdapter} from "../../../models/formula/plotted-value-formula-adapter"
-import {getPlottedFunctionFormulaAdapter} from "../../../models/formula/plotted-function-formula-adapter"
-import {getGraphFilterFormulaAdapter} from "../../../models/formula/graph-filter-formula-adapter"
 import { ICase } from "../../../models/data/data-set-types"
 import { isFiniteNumber } from "../../../utilities/math-utils"
 import { t } from "../../../utilities/translation/translate"
 import { CaseData } from "../../data-display/d3-types"
+import { GraphFilterFormulaAdapter } from "./graph-filter-formula-adapter"
 
 const getFormulaAdapters = (node?: IAnyStateTreeNode) => [
-  getPlottedValueFormulaAdapter(node),
-  getPlottedFunctionFormulaAdapter(node),
-  getGraphFilterFormulaAdapter(node),
+  GraphFilterFormulaAdapter.get(node),
+  PlottedFunctionFormulaAdapter.get(node),
+  PlottedValueFormulaAdapter.get(node)
 ]
 
 export interface GraphProperties {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -160,7 +160,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
      */
     filterCase(data: IDataSet, caseID: string, caseArrayNumber?: number) {
       // If the case is hidden we don't plot it
-      if (self.hiddenCasesSet.has(caseID) || self.filterFormulaResults.get(caseID) === false) return false
+      if (self.hiddenCasesSet.has(caseID) || self.filteredOutCaseIds.has(caseID)) return false
       if (caseArrayNumber === 0 || caseArrayNumber === undefined) {
         return self._filterCase(data, caseID)
       }

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -1,6 +1,8 @@
 import { isAlive } from "mobx-state-tree"
 import { kIndexColumnKey } from "../../components/case-tile-common/case-tile-types"
 import { logMessageWithReplacement } from "../../lib/log-message"
+import { AttributeFormulaAdapter } from "../formula/attribute-formula-adapter"
+import { FilterFormulaAdapter } from "../formula/filter-formula-adapter"
 import { getSharedCaseMetadataFromDataset } from "../shared/shared-data-utils"
 import { IAttribute } from "./attribute"
 import { ICollectionModel } from "./collection"
@@ -9,6 +11,9 @@ import {
   deleteCollectionNotification, moveAttributeNotification, selectCasesNotification
 } from "./data-set-notifications"
 import { IAttributeChangeResult, IMoveAttributeOptions } from "./data-set-types"
+
+AttributeFormulaAdapter.register()
+FilterFormulaAdapter.register()
 
 export function getCollectionAttrs(collection: ICollectionModel, data?: IDataSet): IAttribute[] {
   if (collection && !isAlive(collection)) {

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -3,17 +3,13 @@ import { addDisposer, onAction } from "mobx-state-tree"
 import { DIMessage } from "../../data-interactive/iframe-phone-types"
 import { ILogMessage } from "../../lib/log-message"
 import { Logger } from "../../lib/logger"
+import { createFormulaAdapters } from "../formula/formula-adapter-registry"
+import { FormulaManager } from "../formula/formula-manager"
+import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
 import { ITileEnvironment } from "../tiles/tile-environment"
 import { DocumentModel, IDocumentModelSnapshot } from "./document"
 import { IDocumentEnvironment } from "./document-environment"
 import { SharedModelDocumentManager } from "./shared-model-document-manager"
-import { FormulaManager } from "../formula/formula-manager"
-import { AttributeFormulaAdapter } from "../formula/attribute-formula-adapter"
-import { FilterFormulaAdapter } from "../formula/filter-formula-adapter"
-import { PlottedValueFormulaAdapter } from "../formula/plotted-value-formula-adapter"
-import { PlottedFunctionFormulaAdapter } from "../formula/plotted-function-formula-adapter"
-import { GraphFilterFormulaAdapter } from "../formula/graph-filter-formula-adapter"
-import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
 
 /**
  * Create a DocumentModel and add a new sharedModelManager into its environment
@@ -34,13 +30,7 @@ export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
     const document = DocumentModel.create(snapshot, fullEnvironment)
 
     // initialize formula adapters after the document has been created
-    formulaManager.addAdapters([
-      new AttributeFormulaAdapter(adapterApi),
-      new FilterFormulaAdapter(adapterApi),
-      new PlottedValueFormulaAdapter(adapterApi),
-      new PlottedFunctionFormulaAdapter(adapterApi),
-      new GraphFilterFormulaAdapter(adapterApi)
-    ])
+    setTimeout(() => formulaManager.addAdapters(createFormulaAdapters(adapterApi)))
 
     addDisposer(document, onAction(document, (call) => {
       if (!document.content || !call.path?.match(/\/content\/tileMap\//)) {

--- a/v3/src/models/formula/filter-formula-adapter.test.ts
+++ b/v3/src/models/formula/filter-formula-adapter.test.ts
@@ -89,24 +89,15 @@ describe("AttributeFormulaAdapter", () => {
     it("should store results in DataSet filterFormulaResult map", () => {
       const { adapter, dataSet, context, extraMetadata } = getTestEnv("foo < 2")
       adapter.recalculateFormula(context, extraMetadata, "ALL_CASES")
-      expect(dataSet.filterFormulaResults.toJSON()).toEqual([
-        ["1", true],
-        ["2", false],
-        ["3", false],
-      ])
+      expect(dataSet.filteredOutItemIds.toJSON()).toEqual(["2", "3"])
     })
 
     it("should update just provided cases when casesToRecalculateDesc is an array", () => {
       const { adapter, dataSet, context, extraMetadata } = getTestEnv("foo < 2")
-      dataSet.filterFormulaResults.set("1", false)
-      dataSet.filterFormulaResults.set("2", true)
+      dataSet.filteredOutItemIds.add("1")
 
       adapter.recalculateFormula(context, extraMetadata, [{ __id__: "1" }])
-      expect(dataSet.filterFormulaResults.toJSON()).toEqual([
-        ["1", true],
-        // Old values should be preserved
-        ["2", true]
-      ])
+      expect(dataSet.filteredOutItemIds.toJSON()).toEqual([])
     })
 
     it("should clear previous filter formula error", () => {

--- a/v3/src/models/formula/formula-adapter-registry.ts
+++ b/v3/src/models/formula/formula-adapter-registry.ts
@@ -1,0 +1,13 @@
+import { IFormulaAdapterApi, IFormulaManagerAdapter } from "./formula-manager-types"
+
+export type FormulaAdapterCreateFn = (api: IFormulaAdapterApi) => IFormulaManagerAdapter
+
+const formulaAdapterCreators: FormulaAdapterCreateFn[] = []
+
+export function registerFormulaAdapter(adapterCreator: FormulaAdapterCreateFn) {
+  formulaAdapterCreators.push(adapterCreator)
+}
+
+export function createFormulaAdapters(api: IFormulaAdapterApi) {
+  return formulaAdapterCreators.map(creator => creator(api))
+}

--- a/v3/src/models/formula/formula-manager-types.ts
+++ b/v3/src/models/formula/formula-manager-types.ts
@@ -1,0 +1,78 @@
+import { IDataSet } from "../data/data-set"
+import { IGlobalValueManager } from "../global/global-value-manager"
+import { IFormula } from "./formula"
+import { CaseList } from "./formula-types"
+
+export interface IFormulaMetadata {
+  formula: IFormula
+  registeredDisplay: string
+  isInitialized: boolean
+  adapter: IFormulaManagerAdapter
+  dispose?: () => void
+}
+
+// Note that specific formula adapters might extend this interface and provide more information.
+// `dataSetId` is the required minimum, as each formula is always associated with a single data set that is considered
+// to be the "local one" (e.g. any formula's symbol is resolved to an attribute of this data set).
+export interface IFormulaExtraMetadata {
+  dataSetId: string
+  attributeId?: string
+  defaultArgument?: string
+}
+
+export interface IFormulaContext {
+  formula: IFormula
+  dataSet: IDataSet
+}
+
+export interface IFormulaAdapterApi {
+  getDatasets: () => Map<string, IDataSet>
+  getGlobalValueManager: () => Maybe<IGlobalValueManager>
+  getFormulaContext(formulaId: string): IFormulaContext
+  getFormulaExtraMetadata(formulaId: string): IFormulaExtraMetadata
+}
+
+export class FormulaManagerAdapter implements IFormulaManagerAdapter {
+  type: string
+  api: IFormulaAdapterApi
+
+  constructor(type: string, api: IFormulaAdapterApi) {
+    this.type = type
+    this.api = api
+  }
+
+  getActiveFormulas() {
+    // subclasses should override
+    return [] as Array<{ formula: IFormula, extraMetadata: any }>
+  }
+
+  recalculateFormula(formulaContext: IFormulaContext, extraMetadata: any, casesToRecalculateDesc?: CaseList) {
+    // subclasses should override
+  }
+
+  getFormulaError(formulaContext: IFormulaContext, extraMetadata: any): Maybe<string> {
+    // subclasses should override
+    return undefined
+  }
+
+  setFormulaError(formulaContext: IFormulaContext, extraMetadata: any, errorMsg: string) {
+    // subclasses should override
+  }
+
+  setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: any): () => void {
+    // subclasses should override
+    return () => undefined
+  }
+}
+
+export interface IFormulaManagerAdapter {
+  type: string
+  // This method returns all the formulas supported by this adapter. It should exclusively return formulas that need
+  // active tracking and recalculation whenever any of their dependencies change. The adapter might opt not to return
+  // formulas that currently shouldn't be recalculated, such as when the formula's adornment is hidden.
+  getActiveFormulas: () => ({ formula: IFormula, extraMetadata: any })[]
+  recalculateFormula: (formulaContext: IFormulaContext, extraMetadata: any, casesToRecalculateDesc?: CaseList) => void
+  getFormulaError: (formulaContext: IFormulaContext, extraMetadata: any) => Maybe<string>
+  setFormulaError: (formulaContext: IFormulaContext, extraMetadata: any, errorMsg: string) => void
+  setupFormulaObservers?: (formulaContext: IFormulaContext, extraMetadata: any) => () => void
+}

--- a/v3/src/models/shared/shared-data-utils.ts
+++ b/v3/src/models/shared/shared-data-utils.ts
@@ -1,4 +1,4 @@
-import { IAnyStateTreeNode } from "@concord-consortium/mobx-state-tree"
+import { IAnyStateTreeNode } from "mobx-state-tree"
 import { toV2Id } from "../../utilities/codap-utils"
 import { IDataSet } from "../data/data-set"
 import { ITileContentModel } from "../tiles/tile-content"


### PR DESCRIPTION
- fix: undo/redo filter formula change
- chore: refactor formula adapters to have a common base class
- move graph-specific formula adapters into graph component folder
- fix issue with animation timer in `DataDisplayContentModel` that could access the content model after its destruction
- add cypress tests