### PR TITLE
setup github actions for run regression label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - 'v3/**'   # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-excluding-paths
       - '.github/workflows/v3.yml'
       - '.github/workflows/build-num-increment.yml'
+      - '.github/workflows/run-regression-label.yml'
+      - '.github/workflows/v3-regression.yml'
+      - '.github/workflows/release-v3-production.yml'
+      - '.github/workflows/release-v3-staging.yml'
     tags-ignore:
       - '3.*'
     branches-ignore:

--- a/.github/workflows/run-regression-label.yml
+++ b/.github/workflows/run-regression-label.yml
@@ -1,0 +1,44 @@
+name: Regression Label
+
+on:
+  pull_request:
+    types: [ labeled ]
+jobs:
+  re_run:
+    # only conintue if a push or PR labeled with 'run regression'
+    if: github.event.label.name == 'run regression'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re Run last push
+        # get the last regression run triggered by a pull, and get this run's id
+        # then rerun the run
+        # if the run id can't be found the rerun command will fail which should
+        # fail the job
+        # When the run hasn't finished yet, we try to cancel the run
+        # and wait 30s for it to fnish canceling before trying to re-run it.
+        # If the run isn't complete the rerun command prints this message:
+        # returned: run 6410886572 cannot be rerun; its workflow file may be broken
+        run: |
+          run_id=$(gh run list -e push -b ${{github.head_ref}} -w 'CI v3 Regression' -L 1 --json databaseId -q '.[0].databaseId')
+          run_status=$(gh run view $run_id --json status -q '.status')
+          if [[ "$run_status" != "completed" ]]
+          then
+            echo "run $run_id is $run_status, trying to cancel"
+            gh run cancel $run_id
+            count=0
+            until [[ "$run_status" == "completed" || $count -gt 15 ]]
+            do
+              sleep 2
+              count=$((count+1))
+              run_status=$(gh run view $run_id --json status -q '.status')
+              echo "run: $run_id, status: $run_status, try: $count"
+            done
+          fi
+          echo "rerunning $run_id"
+          gh run rerun $run_id
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # set repository so we don't have to check out all of the code
+          GH_REPO: ${{github.repository}}

--- a/.github/workflows/run-regression-label.yml
+++ b/.github/workflows/run-regression-label.yml
@@ -5,7 +5,7 @@ on:
     types: [ labeled ]
 jobs:
   re_run:
-    # only conintue if a push or PR labeled with 'run regression'
+    # only continue if a push or PR labeled with 'run regression'
     if: github.event.label.name == 'run regression'
     runs-on: ubuntu-latest
     permissions:
@@ -17,7 +17,7 @@ jobs:
         # if the run id can't be found the rerun command will fail which should
         # fail the job
         # When the run hasn't finished yet, we try to cancel the run
-        # and wait 30s for it to fnish canceling before trying to re-run it.
+        # and wait 30s for it to finish canceling before trying to re-run it.
         # If the run isn't complete the rerun command prints this message:
         # returned: run 6410886572 cannot be rerun; its workflow file may be broken
         run: |

--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -1,0 +1,99 @@
+# If this name is changed we also need to change it in run-regression-label.yml
+name: CI v3 Regression
+
+on:
+  push:
+    paths:      # only run this workflow if it contains v3 files
+      - 'v3/**' # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-including-paths
+      - '.github/workflows/v3.yml'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_labels: ${{ steps.pr.outputs.labels }}
+      # If there is no label then steps.run_regression.outputs.value will be "false" which
+      # being a string is actually considered true, so fromJSON is needed to turn `"false"` into `false`.
+      # If we are on the 'main' branch then run the regression tests regardless of the PR label
+      run_regression: ${{ fromJSON(steps.run_regression.outputs.value) || github.ref_name == 'main' }}
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Get PR labels
+        id: pr
+        # the github.event.pull_request.labels is not available when a build
+        # is triggered by a push. So we use the `gh` CLI to get info about the PR for the
+        # current branch.
+        # - If the branch doesn't have a PR yet, then the `gh pr view` command fails with
+        # the message: no pull requests found for branch "pr-label-test"
+        # - If the same branch is part of multiple PRs, it isn't clear what will
+        # happen, but that should be very unusual.
+        run: echo "labels=$(gh pr view ${{ github.ref_name }} --json labels -q '.labels' || echo "[]")" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # set repository so we don't have to check out all of the code
+          GH_REPO: ${{github.repository}}
+      - name: Print PR labels
+        run: echo "PR labels ${{ steps.pr.outputs.labels }}"
+      - name: Get run_regression
+        id: run_regression
+        run: echo "value=${{ contains(fromJSON(steps.pr.outputs.labels).*.name, 'run regression') }}" >> $GITHUB_OUTPUT
+  cypress:
+    needs: ['prepare']
+    # only run the regression tests if the PR is labeled.
+    if: fromJSON(needs.prepare.outputs.run_regression)
+    runs-on: ubuntu-latest
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving the Dashboard hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # run multiple copies of the current job in parallel [1, ..., n]
+        containers: [1, 2, 3, 4, 5]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: v3/node_modules/.cache/webpack/
+          key: ${{ github.head_ref || github.ref_name }}-webpack-build
+          restore-keys: |
+            main-webpack-build
+      - uses: cypress-io/github-action@v6
+        with:
+          working-directory: v3
+          start: npm start
+          wait-on: 'http://localhost:8080'
+          # add timeout of 5 minutes to start
+          wait-on-timeout: 300
+          # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
+          record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
+          # only do parallel if we have a record key
+          parallel: ${{ !!secrets.CYPRESS_RECORD_KEY }}
+          browser: chrome
+          # TODO: this currently will re-run the smoke test, once we have a dedicated smoke
+          # test that should be excluded
+          # spec: cypress/e2e/**
+          group: 'Regression Tests'
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          # pass GitHub token to allow accurately detecting a build vs a re-run build
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # turn on code coverage when running npm start
+          # so far we've been using a webpack coverage-istanbul-loader for this
+          # but there has been work on using the code coverage support in the browser directly,
+          # which should be much faster
+          CODE_COVERAGE: true
+          # Also turn on the code coverage tasks in cypress itself, these are disabled
+          # by default.
+          CYPRESS_coverage: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: cypress

--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths:      # only run this workflow if it contains v3 files
       - 'v3/**' # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-including-paths
-      - '.github/workflows/v3.yml'
+      - '.github/workflows/v3-regression.yml'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -45,9 +45,6 @@ jobs:
       # leaving the Dashboard hanging ...
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
-      matrix:
-        # run multiple copies of the current job in parallel [1, ..., n]
-        containers: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,8 +63,6 @@ jobs:
           wait-on-timeout: 300
           # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
           record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
-          # only do parallel if we have a record key
-          parallel: ${{ !!secrets.CYPRESS_RECORD_KEY }}
           browser: chrome
           # only run a single test
           # TODO: setup a special test for this purpose

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -69,6 +69,10 @@ jobs:
           # only do parallel if we have a record key
           parallel: ${{ !!secrets.CYPRESS_RECORD_KEY }}
           browser: chrome
+          # only run a single test
+          # TODO: setup a special test for this purpose
+          spec: cypress/e2e/import-v2.spec.ts
+          group: 'Smoke Tests'
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
This adds two new github workflows:
- `run-regresssion-label.yml` (Regression Label) is triggered when a PR is labeled. If the label is `run regression`, then it looks for the last run of the "CI v3 Regression" workflow and re-runs it. If the "CI v3 Regression" is currently running we cancel it and then re-run it. 
- `v3-regression.yml` (CI v3 Regression) - this checks if the PR associated with the branch that was pushed has the `run regression` label and if it does then the workflow runs all of the Cypress tests in the project. These Cypress tests are organized in a "group" called "Regression Tests". This group shows up in the Cypress Cloud when looking at the test results.

It updates the original `v3.yml` so it only runs a single spec. Because it is running a single spec there is no need for the parallel running of the tests. Currently it is running the `import-v2.spec.ts` spec. We probably want to create a special smoke test spec and run that instead. This spec is organized in a Cypress group called "Smoke Tests".

Finally it updates `ci.yml` (the CODAP v2 file) to ignore the v3 files.