### PR TITLE
Speed up build

### DIFF
--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -59,12 +59,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: v3/node_modules/.cache/webpack/
-          key: ${{ github.head_ref || github.ref_name }}-webpack-dev-build
-          restore-keys: |
-            main-webpack-dev-build
       - uses: cypress-io/github-action@v6
         with:
           working-directory: v3

--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -6,6 +6,8 @@ on:
     paths:      # only run this workflow if it contains v3 files
       - 'v3/**' # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-including-paths
       - '.github/workflows/v3-regression.yml'
+      - '.github/workflows/v3.yml'
+      - '.github/workflows/run-regression-label.yml'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -60,9 +62,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: v3/node_modules/.cache/webpack/
-          key: ${{ github.head_ref || github.ref_name }}-webpack-build
+          key: ${{ github.head_ref || github.ref_name }}-webpack-dev-build
           restore-keys: |
-            main-webpack-build
+            main-webpack-dev-build
       - uses: cypress-io/github-action@v6
         with:
           working-directory: v3

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/jest_rt
-          key: ${{ hashFiles('v3/package-lock.json') }}
+          key: jest-${{ hashFiles('v3/package-lock.json') }}
       - name: Get number of CPU cores
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@v2

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -92,15 +92,6 @@ jobs:
       - uses: snow-actions/sparse-checkout@v1.2.0
         with:
           patterns: v3
-      - name: Webpack Cache
-        uses: actions/cache@v4
-        with:
-          path: v3/node_modules/.cache/webpack/
-          key: ${{ github.head_ref || github.ref_name }}-webpack-dev-build
-          restore-keys: |
-            main-webpack-dev-build
-      - name: Print Webpack Cache
-        run: ls -R v3/node_modules/.cache/webpack/
       - uses: cypress-io/github-action@v6
         with:
           working-directory: v3

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -7,8 +7,8 @@ on:
       - '.github/workflows/v3.yml'
 
 jobs:
-  build_test:
-    name: Build and Run Jest Tests
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: snow-actions/sparse-checkout@v1.2.0
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: 'npm'
+          cache-dependency-path: v3/package-lock.json
       - name: Install Dependencies
         working-directory: v3
         run: npm ci
@@ -26,12 +28,52 @@ jobs:
           key: ${{ github.head_ref || github.ref_name }}-webpack-build
           restore-keys: |
             main-webpack-build
+      - uses: concord-consortium/s3-deploy-action/deploy-path@v1
+        id: s3-deploy-path
+      - name: Configure Environment
+        working-directory: v3
+        run: |
+          cat <<EOF > .env
+          GOOGLE_DRIVE_CLIENT_ID="${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}"
+          GOOGLE_DRIVE_API_KEY="${{ secrets.GOOGLE_DRIVE_API_KEY }}"
+          GOOGLE_DRIVE_APP_ID="${{ secrets.GOOGLE_DRIVE_APP_ID }}"
+          EOF
       - name: Build
         working-directory: v3
         run: npm run build
+        env:
+          DEPLOY_PATH: ${{ steps.s3-deploy-path.outputs.deployPath }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: v3/dist/
+      
+  jest:
+    name: Run Jest Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: snow-actions/sparse-checkout@v1.2.0
+        with:
+          patterns: v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: v3/package-lock.json
+      - name: Install Dependencies
+        working-directory: v3
+        run: npm ci
+      - name: Cache Jest cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/jest_rt
+          key: ${{ hashFiles('v3/package-lock.json') }}
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@v2
       - name: Run Tests
         working-directory: v3
-        run: npm run test:coverage -- --maxWorkers=2
+        run: npm run test:coverage -- --maxWorkers=${{ steps.cpu-cores.outputs.count }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -46,8 +88,9 @@ jobs:
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: snow-actions/sparse-checkout@v1.2.0
+        with:
+          patterns: v3
       - uses: actions/cache@v4
         with:
           path: v3/node_modules/.cache/webpack/
@@ -89,37 +132,21 @@ jobs:
   s3-deploy:
     name: S3 Deploy
     needs:
-      - build_test
+      - build
+      - jest
       - cypress
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_type == 'branch' && 'branches' || 'versions' }}
+      url: https://codap3.concord.org/${{ steps.s3-deploy.outputs.deployPath }}/
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/download-artifact@v4
         with:
-          node-version: 18
-      - name: Install Dependencies
-        working-directory: v3
-        run: npm ci
-        env:
-          # skip installing cypress since it isn't needed for just building
-          # This decreases the deploy time quite a bit
-          CYPRESS_INSTALL_BINARY: 0
-      - uses: actions/cache@v4
-        with:
-          path: v3/node_modules/.cache/webpack/
-          key: ${{ github.head_ref || github.ref_name }}-webpack-build
-          restore-keys: |
-            main-webpack-build
-      - name: Configure Environment
-        working-directory: v3
-        run: |
-          cat <<EOF > .env
-          GOOGLE_DRIVE_CLIENT_ID="${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}"
-          GOOGLE_DRIVE_API_KEY="${{ secrets.GOOGLE_DRIVE_API_KEY }}"
-          GOOGLE_DRIVE_APP_ID="${{ secrets.GOOGLE_DRIVE_APP_ID }}"
-          EOF
+          name: build
+          path: v3/dist
       - uses: concord-consortium/s3-deploy-action@v1
         with:
+          build: echo no build
           bucket: models-resources
           prefix: codap3
           workingDirectory: v3

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install Dependencies
         working-directory: v3
         run: npm ci
-      - uses: actions/cache@v4
+      - name: Webpack Cache
+        uses: actions/cache@v4
         with:
           path: v3/node_modules/.cache/webpack/
           key: ${{ github.head_ref || github.ref_name }}-webpack-build
@@ -63,7 +64,7 @@ jobs:
       - name: Install Dependencies
         working-directory: v3
         run: npm ci
-      - name: Cache Jest cache
+      - name: Jest Cache
         uses: actions/cache@v4
         with:
           path: /tmp/jest_rt
@@ -91,12 +92,13 @@ jobs:
       - uses: snow-actions/sparse-checkout@v1.2.0
         with:
           patterns: v3
-      - uses: actions/cache@v4
+      - name: Webpack Cache
+        uses: actions/cache@v4
         with:
           path: v3/node_modules/.cache/webpack/
-          key: ${{ github.head_ref || github.ref_name }}-webpack-build
+          key: ${{ github.head_ref || github.ref_name }}-webpack-dev-build
           restore-keys: |
-            main-webpack-build
+            main-webpack-dev-build
       - uses: cypress-io/github-action@v6
         with:
           working-directory: v3

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -145,6 +145,7 @@ jobs:
           name: build
           path: v3/dist
       - uses: concord-consortium/s3-deploy-action@v1
+        id: s3-deploy
         with:
           build: echo no build
           bucket: models-resources

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -99,6 +99,8 @@ jobs:
           key: ${{ github.head_ref || github.ref_name }}-webpack-dev-build
           restore-keys: |
             main-webpack-dev-build
+      - name: Print Webpack Cache
+        run: ls -R v3/node_modules/.cache/webpack/
       - uses: cypress-io/github-action@v6
         with:
           working-directory: v3

--- a/v3/webpack.config.js
+++ b/v3/webpack.config.js
@@ -73,10 +73,12 @@ module.exports = (env, argv) => {
       path: path.resolve(__dirname, 'dist'),
       filename: 'assets/index.[contenthash].js',
     },
+    infrastructureLogging: { debug: true },
     cache: {
       buildDependencies: {
         config: [__filename],
       },
+      profile: true,
       type: 'filesystem',
     },
     performance: { hints: false },

--- a/v3/webpack.config.js
+++ b/v3/webpack.config.js
@@ -73,12 +73,10 @@ module.exports = (env, argv) => {
       path: path.resolve(__dirname, 'dist'),
       filename: 'assets/index.[contenthash].js',
     },
-    infrastructureLogging: { debug: true },
     cache: {
       buildDependencies: {
         config: [__filename],
       },
-      profile: true,
       type: 'filesystem',
     },
     performance: { hints: false },


### PR DESCRIPTION
Bring over GitHub Actions improvements from CLUE

## Speed ups
- split the build and jest tasks into 2 jobs
- upload the build result from the build job and download it in the deploy job. This eliminates the need for the deploy job to checkout code, install dependencies and build yet again.
- setup the jest cache which might speed up the jest tests further
- setup npm cache on setup-node step
- get the cores of the machine dynamically, we might be able to bump up the cores on the Jest job to get faster build times.

## GitHub Deployments
This also adds GitHub "deployment" support. This adds a section to the bottom of the PR that includes a link to where the code was deployed. In this case that location is: https://codap3.concord.org/branch/speed-up-build/