### PR TITLE
feat: sort case table items by attribute [PT-181890013]

### DIFF
--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -517,6 +517,28 @@ context("case table ui", () => {
         expect(value).not.to.eq(random2)
       })
     })
+    it("verify sorting", () => {
+      // sort by ascending Order
+      table.openAttributeMenu("Order")
+      table.selectMenuItemFromAttributeMenu("Sort Ascending")
+      table.getGridCell(2, 2).should("contain", "Giraffe")
+      // sort by descending Speed
+      table.openAttributeMenu("Speed")
+      table.selectMenuItemFromAttributeMenu("Sort Descending")
+      table.getGridCell(2, 2).should("contain", "Cheetah")
+      // undo Speed sort
+      toolbar.getUndoTool().click()
+      table.getGridCell(2, 2).should("contain", "Giraffe")
+      // undo Order sort
+      toolbar.getUndoTool().click()
+      table.getGridCell(2, 2).should("contain", "African Elephant")
+      // redo Order sort
+      toolbar.getRedoTool().click()
+      table.getGridCell(2, 2).should("contain", "Giraffe")
+      // redo Speed sort
+      toolbar.getRedoTool().click()
+      table.getGridCell(2, 2).should("contain", "Cheetah")
+    })
     it("verify hide and showAll attribute with undo and redo", () => {
 
       // Hide the attribute

--- a/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
@@ -8,6 +8,7 @@ import {
   deleteCollectionNotification, hideAttributeNotification, removeAttributesNotification
 } from "../../../models/data/data-set-notifications"
 import { IAttributeChangeResult } from "../../../models/data/data-set-types"
+import { sortItemsWithCustomUndoRedo } from "../../../models/data/data-set-undo"
 import {
   allowAttributeDeletion, preventCollectionReorg, preventTopLevelReorg
 } from "../../../utilities/plugin-utils"
@@ -55,12 +56,10 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
     onModalOpen(false)
   }
 
-  // const handleSortCases = (item: IMenuItem) => {
-  //   data?.applyModelChange(() => {}, {
-  //     log: logStringifiedObjectMessage("Sort cases by attribute: %@",
-  //            { attributeId: attribute?.id, attribute: attributeName })
-  //   })
-  // }
+  const handleSortCases = (item: IMenuItem) => {
+    const direction = item.itemKey.includes("Descending") ? "descending" : "ascending"
+    data && sortItemsWithCustomUndoRedo(data, attributeId, direction)
+  }
 
   const handleMenuKeyDown = (e: React.KeyboardEvent) => {
     e.stopPropagation()
@@ -123,11 +122,11 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
     },
     {
       itemKey: "DG.TableController.headerMenuItems.sortAscending",
-      // handleClick: handleSortCases
+      handleClick: handleSortCases
     },
     {
       itemKey: "DG.TableController.headerMenuItems.sortDescending",
-      // handleClick: handleSortCases
+      handleClick: handleSortCases
     },
     {
       itemKey: "DG.TableController.headerMenuItems.hideAttribute",

--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -24,13 +24,19 @@ describe("Attribute", () => {
     expect(isAttributeType("color")).toBe(true)
   })
 
-  test("matchNameOrId", () => {
+  test("matchNameOrId and cid", () => {
     const a = Attribute.create({ id: "ATTR1", name: "name", _title: "title" })
     expect(a.matchNameOrId("")).toBe(false)
     expect(a.matchNameOrId(1)).toBe(true)
     expect(a.matchNameOrId("ATTR1")).toBe(true)
     expect(a.matchNameOrId("name")).toBe(true)
     expect(a.matchNameOrId("title")).toBe(false)
+
+    expect(a._cid).toBeUndefined()
+    expect(a.cid).toBe(a.id)
+    a.setCid("cid")
+    expect(a._cid).toBe("cid")
+    expect(a.cid).toBe("cid")
   })
 
   test("Value conversions", () => {
@@ -417,6 +423,20 @@ describe("Attribute", () => {
     attr.setDisplayExpression("")
     expect(isFormulaAttr(attr)).toBe(false)
     expect(isValidFormulaAttr(attr)).toBe(false)
+  })
+
+  test("orderValues", () => {
+    const a = Attribute.create({ id: "aId", name: "a", values: ["a", "b", "c"] })
+    // no order change
+    a.orderValues([0, 1, 2])
+    a.prepareSnapshot()
+    expect(a.values).toEqual(["a", "b", "c"])
+    a.completeSnapshot()
+    // reverse order
+    a.orderValues([2, 1, 0])
+    a.prepareSnapshot()
+    expect(a.values).toEqual(["c", "b", "a"])
+    a.completeSnapshot()
   })
 
   test("Attribute derivation", () => {

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -373,6 +373,15 @@ export const Attribute = V2Model.named("Attribute").props({
       self.incChangeCount()
     }
   },
+  // order the values of the attribute according to the provided indices
+  orderValues(indices: number[]) {
+    const _strValues = self.strValues.slice()
+    const _numValues = self.numValues.slice()
+    for (let i = 0; i < _strValues.length; ++i) {
+      self.strValues[i] = _strValues[indices[i]]
+      self.numValues[i] = _numValues[indices[i]]
+    }
+  },
   clearValues() {
     for (let i = self.strValues.length - 1; i >= 0; --i) {
       self.strValues[i] = ""

--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -332,8 +332,15 @@ describe("CollectionModel", () => {
 
     validateItemCaseIds()
 
-    const originalParentCaseIds = [...c1.caseIds]
-    const originalChildCaseIds = [...c2.caseIds]
+    function getCaseIdInfo(collection: ICollectionModel) {
+      return {
+        caseIds: [...collection.caseIds],
+        caseIdsHash: collection.caseIdsHash,
+        caseIdsOrderedHash: collection.caseIdsOrderedHash
+      }
+    }
+    const origParentCollectionInfo = getCaseIdInfo(c1)
+    const origChildCollectionInfo = getCaseIdInfo(c2)
 
     // serializes group key => case id map appropriately
     c1.prepareSnapshot()
@@ -358,8 +365,8 @@ describe("CollectionModel", () => {
 
     // adding constant attribute to the child collection doesn't change case ids
     validateCases()
-    expect(c1.caseIds).toEqual(originalParentCaseIds)
-    expect(c2.caseIds).toEqual(originalChildCaseIds)
+    expect(getCaseIdInfo(c1)).toEqual(origParentCollectionInfo)
+    expect(getCaseIdInfo(c2)).toEqual(origChildCollectionInfo)
     validateItemCaseIds()
 
     // adding constant attribute to the parent collection does invalidate grouping
@@ -368,30 +375,34 @@ describe("CollectionModel", () => {
 
     // adding constant attribute to the parent collection doesn't change case ids
     validateCases()
-    expect(c1.caseIds).toEqual(originalParentCaseIds)
-    expect(c2.caseIds).toEqual(originalChildCaseIds)
+    expect(getCaseIdInfo(c1)).toEqual(origParentCollectionInfo)
+    expect(getCaseIdInfo(c2)).toEqual(origChildCollectionInfo)
     validateItemCaseIds()
 
     // removing attr1 from the parent collection invalidates grouping and changes parent case ids
     c1.removeAttribute(a1.id)
     expect(itemData.invalidate).toHaveBeenCalledTimes(2)
     validateCases()
-    expect(c1.caseIds).not.toEqual(originalParentCaseIds)
-    expect([...c2.caseIds].sort()).toEqual([...originalChildCaseIds].sort())
+    expect(c1.caseIds).not.toEqual(origParentCollectionInfo.caseIds)
+    expect(c1.caseIdsHash).not.toEqual(origParentCollectionInfo.caseIdsHash)
+    expect(c1.caseIdsOrderedHash).not.toEqual(origParentCollectionInfo.caseIdsOrderedHash)
+    expect([...c2.caseIds].sort()).toEqual([...origChildCollectionInfo.caseIds].sort())
+    expect(c2.caseIdsHash).toEqual(origChildCollectionInfo.caseIdsHash)
+    expect(c2.caseIdsOrderedHash).not.toEqual(origChildCollectionInfo.caseIdsOrderedHash)
 
     // adding attr1 back to parent collection invalidates grouping and restores original parent case ids
     c1.addAttribute(a1)
     expect(itemData.invalidate).toHaveBeenCalledTimes(3)
     validateCases()
-    expect(c1.caseIds).toEqual(originalParentCaseIds)
-    expect(c2.caseIds).toEqual(originalChildCaseIds)
+    expect(getCaseIdInfo(c1)).toEqual(origParentCollectionInfo)
+    expect(getCaseIdInfo(c2)).toEqual(origChildCollectionInfo)
     validateItemCaseIds()
 
     // changing all b's to c's doesn't change case ids
     attr1Values = ["a", "c"]
     validateCases()
-    expect(c1.caseIds).toEqual(originalParentCaseIds)
-    expect(c2.caseIds).toEqual(originalChildCaseIds)
+    expect(getCaseIdInfo(c1)).toEqual(origParentCollectionInfo)
+    expect(getCaseIdInfo(c2)).toEqual(origChildCollectionInfo)
     expect(c1.groupKeyCaseIds.get(bGroupKey)).toBeUndefined()
     validateItemCaseIds()
   })

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -621,6 +621,34 @@ test("DataSet case hiding/showing (set aside)", () => {
   expect(data.itemIds).toEqual(["item3", "item4", "item5", "item0", "item1", "item2"])
 })
 
+test("sortItems", () => {
+  const data = DataSet.create({ name: "data" })
+  const a = data.addAttribute({ id: "AttrA", name: "A" })
+  const b = data.addAttribute({ id: "AttrB", name: "B" })
+  data.addCases([
+    { __id__: "ITEM0", [a.id]: "A2", [b.id]:  "0" },
+    { __id__: "ITEM1", [a.id]:  "1", [b.id]: "B1" },
+    { __id__: "ITEM2", [a.id]: "A3", [b.id]:  "5" },
+    { __id__: "ITEM3", [a.id]: "-1", [b.id]: "B0" },
+    { __id__: "ITEM4", [a.id]: "A1", [b.id]:  "3" }
+  ])
+  expect(data.itemIds).toEqual(["ITEM0", "ITEM1", "ITEM2", "ITEM3", "ITEM4"])
+  // sort by a
+  data.sortItems(a.id)
+  expect(data.itemIds).toEqual(["ITEM4", "ITEM0", "ITEM2", "ITEM3", "ITEM1"])
+  data.prepareSnapshot()
+  expect(a.values).toEqual(["A1", "A2", "A3", "-1", "1"])
+  expect(b.values).toEqual(["3", "0", "5", "B0", "B1"])
+  data.completeSnapshot()
+  // sort by b descending
+  data.sortItems(b.id, "descending")
+  expect(data.itemIds).toEqual(["ITEM2", "ITEM4", "ITEM0", "ITEM1", "ITEM3"])
+  data.prepareSnapshot()
+  expect(a.values).toEqual(["A3", "A1", "A2", "1", "-1"])
+  expect(b.values).toEqual(["5", "3", "0", "B1", "B0"])
+  data.completeSnapshot()
+})
+
 test("Caching mode", () => {
   const ds = DataSet.create({ name: "data" })
 

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -3,6 +3,7 @@ import { addDisposer, onAction } from "mobx-state-tree"
 import { DIMessage } from "../../data-interactive/iframe-phone-types"
 import { ILogMessage } from "../../lib/log-message"
 import { Logger } from "../../lib/logger"
+import { getDefaultLanguage } from "../../utilities/translation/translate"
 import { createFormulaAdapters } from "../formula/formula-adapter-registry"
 import { FormulaManager } from "../formula/formula-manager"
 import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
@@ -47,6 +48,10 @@ export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
     }
     sharedModelManager.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
       .forEach((model: ISharedDataSet) => formulaManager.addDataSet(model.dataSet))
+
+    // configure locale
+    // TODO_LOCALE: provide access to current locale
+    fullEnvironment.getLocale = () => getDefaultLanguage()
 
     // configure logging
     fullEnvironment.log = function({ message, args, category }: ILogMessage) {

--- a/v3/src/models/shared/shared-case-metadata.test.ts
+++ b/v3/src/models/shared/shared-case-metadata.test.ts
@@ -7,6 +7,7 @@ import { onAnyAction } from "../../utilities/mst-utils"
 // eslint-disable-next-line no-var
 var mockNodeIdCount = 0
 jest.mock("../../utilities/js-utils", () => ({
+  ...jest.requireActual("../../utilities/js-utils"),
   typedId: () => `test-${++mockNodeIdCount}`,
   uniqueOrderedId: () => `order-${++mockNodeIdCount}`
 }))

--- a/v3/src/models/tiles/tile-environment.ts
+++ b/v3/src/models/tiles/tile-environment.ts
@@ -11,12 +11,17 @@ import { IGlobalValueManager, kGlobalValueManagerType } from "../global/global-v
 export interface ITileEnvironment {
   sharedModelManager?: ISharedModelManager
   formulaManager?: FormulaManager
+  getLocale?: () => string
   log?: (message: ILogMessage) => void
   notify?: (message: DIMessage, callback: iframePhone.ListenerCallback) => void
 }
 
 export function getTileEnvironment(node?: IAnyStateTreeNode) {
   return node && hasEnv(node) ? getEnv<ITileEnvironment | undefined>(node) : undefined
+}
+
+export function getCurrentLocale(node?: IAnyStateTreeNode) {
+  return getTileEnvironment(node)?.getLocale?.() ?? "en-US"
 }
 
 export function getSharedModelManager(node?: IAnyStateTreeNode) {

--- a/v3/src/utilities/data-utils.test.ts
+++ b/v3/src/utilities/data-utils.test.ts
@@ -1,0 +1,75 @@
+import {
+  compareValues, kTypeBoolean, kTypeDate, kTypeError, kTypeNaN, kTypeNull, kTypeNumber, kTypeString,
+  sortableValue, typeCode
+} from "./data-utils"
+import { parseDate } from "./date-parser"
+
+describe("Data utilities", () => {
+
+  it("typeCode", () => {
+    expect(typeCode(new Error("Error!"))).toBe(kTypeError)
+    expect(typeCode(NaN)).toBe(kTypeNaN)
+    expect(typeCode(undefined)).toBe(kTypeNull)
+    expect(typeCode(null)).toBe(kTypeNull)
+    expect(typeCode("")).toBe(kTypeString)
+    expect(typeCode("1")).toBe(kTypeString)
+    expect(typeCode("foo")).toBe(kTypeString)
+    expect(typeCode(true)).toBe(kTypeBoolean)
+    expect(typeCode(false)).toBe(kTypeBoolean)
+    expect(typeCode(0)).toBe(kTypeNumber)
+    expect(typeCode(new Date())).toBe(kTypeDate)
+    expect(typeCode("2024-10-09")).toBe(kTypeDate)
+  })
+
+  it("sortableValue", () => {
+    const error = new Error("Error!")
+    expect(sortableValue(error)).toEqual({ type: kTypeError, value: error })
+    expect(sortableValue(NaN)).toEqual({ type: kTypeNaN, value: NaN })
+    expect(sortableValue(undefined)).toEqual({ type: kTypeNull, value: undefined })
+    expect(sortableValue(null)).toEqual({ type: kTypeNull, value: null })
+    expect(sortableValue("")).toEqual({ type: kTypeString, value: "" })
+    expect(sortableValue("1")).toEqual({ type: kTypeNumber, value: 1 })
+    expect(sortableValue("foo")).toEqual({ type: kTypeString, value: "foo" })
+    expect(sortableValue(true)).toEqual({ type: kTypeString, value: true })
+    expect(sortableValue(false)).toEqual({ type: kTypeString, value: false })
+    expect(sortableValue(0)).toEqual({ type: kTypeNumber, value: 0 })
+    const nowDate = new Date()
+    expect(sortableValue(nowDate)).toEqual({ type: kTypeNumber, value: nowDate.getTime() / 1000 })
+    const strDate = "2024-10-09"
+    const parsedDate = parseDate(strDate)
+    expect(sortableValue(strDate)).toEqual({ type: kTypeNumber, value: (parsedDate?.getTime() ?? NaN) / 1000 })
+  })
+
+  it("compareValues", () => {
+    const error = new Error("Error!")
+    const nowDate = new Date()
+    const values = [error, NaN, undefined, null, "", "1", "foo", true, false, 0, nowDate, "2024-10-09"]
+    const results = [
+      ["=", "<", "<", "<", "<", "<", "<", "<", "<", "<", "<", "<"], // error
+      [">", "=", "<", "<", "<", "<", "<", "<", "<", "<", "<", "<"], // NaN
+      [">", ">", "=", "=", "<", "<", "<", "<", "<", "<", "<", "<"], // undefined
+      [">", ">", "=", "=", "<", "<", "<", "<", "<", "<", "<", "<"], // null
+      [">", ">", ">", ">", "=", "<", "<", "<", "<", "<", "<", "<"], // ""
+      [">", ">", ">", ">", ">", "=", ">", ">", ">", ">", "<", "<"], // "1"
+      [">", ">", ">", ">", ">", "<", "=", "<", ">", "<", "<", "<"], // "foo"
+      [">", ">", ">", ">", ">", "<", ">", "=", ">", "<", "<", "<"], // true
+      [">", ">", ">", ">", ">", "<", "<", "<", "=", "<", "<", "<"], // false
+      [">", ">", ">", ">", ">", "<", ">", ">", ">", "=", "<", "<"], // 0
+      [">", ">", ">", ">", ">", ">", ">", ">", ">", ">", "=", ">"], // new Date()
+      [">", ">", ">", ">", ">", ">", ">", ">", ">", ">", "<", "="]  // "2024-10-09"
+    ]
+    const collator = new Intl.Collator("en-US", { sensitivity: 'base' })
+    const compare = (v1: any, v2: any) => {
+      const result = compareValues(v1, v2, collator.compare)
+      if (result < 0) return "<"
+      if (result > 0) return ">"
+      return "="
+    }
+    for (let i1 = 0; i1 < values.length; ++i1) {
+      for (let i2 = 0; i2 < values.length; ++i2) {
+        expect(compare(values[i1], values[i2])).toBe(results[i1][i2])
+      }
+    }
+  })
+
+})

--- a/v3/src/utilities/data-utils.ts
+++ b/v3/src/utilities/data-utils.ts
@@ -1,4 +1,5 @@
-import { isDate } from "mathjs"
+import { isDateString, parseDate } from "./date-parser"
+import { isDate } from "./date-utils"
 
 export const valueToString = function (iValue: any): string {
   let valType: string = typeof iValue,
@@ -41,4 +42,68 @@ export const numericSortComparator = function ({a, b, order}: ICompareProps): nu
   if (bIsNaN) return order === "asc" ? 1 : -1
   if (aIsNaN) return order === "asc" ? -1 : 1
   return order === "asc" ? a - b : b - a
+}
+
+export const
+  kTypeError = 1,
+  kTypeNaN = 2,
+  kTypeNull = 3,
+  kTypeString = 4,
+  kTypeBoolean = 5,
+  kTypeNumber = 6,
+  kTypeDate = 7,
+  // kTypeSimpleMap = 8, // e.g. boundaries
+  kTypeUnknown = 9
+
+export function typeCode(value: any) {
+  if (value == null) return kTypeNull
+  if (value instanceof Error) return kTypeError
+  if (isDate(value) || isDateString(value)) return kTypeDate
+  // if (value instanceof DG.SimpleMap) return kTypeSimpleMap;
+  switch (typeof value) {
+    case 'number': return isNaN(value) ? kTypeNaN : kTypeNumber
+    case 'boolean': return kTypeBoolean
+    case 'string': return kTypeString
+    /* istanbul ignore next */
+    default: return kTypeUnknown
+  }
+}
+
+export function sortableValue(value: any) {
+  const type = typeCode(value)
+  let num = type === kTypeNumber ? value : NaN
+  // strings convertible to numbers are treated numerically
+  if (type === kTypeString && value.length) {
+    num = Number(value)
+    if (!isNaN(num)) return { type: kTypeNumber, value: num }
+  }
+  // booleans are treated as strings
+  else if (type === kTypeBoolean) {
+    return { type: kTypeString, value }
+  }
+  // dates are treated numerically
+  else if (type === kTypeDate) {
+    const date = isDate(value) ? value : parseDate(value)
+    if (!date) return { type: kTypeNull, value: null }
+    return { type: kTypeNumber, value: date.getTime() / 1000 }
+  }
+  // other values are treated according to their type
+  return { type, value }
+}
+
+// Ascending comparator; negate the result for descending
+export function compareValues(value1: any, value2: any, strCompare: (a: string, b: string) => number) {
+  const v1 = sortableValue(value1)
+  const v2 = sortableValue(value2)
+
+  // if types differ, then sort by type
+  if (v1.type !== v2.type) return v1.type - v2.type
+
+  // if types are the same, then sort by value
+  switch (v1.type) {
+    case kTypeNumber: return v1.value - v2.value
+    case kTypeString:
+    case kTypeError: return strCompare(String(v1.value), String(v2.value))
+    default: return 0 // other types are not ordered within type
+  }
 }

--- a/v3/src/utilities/js-utils.test.ts
+++ b/v3/src/utilities/js-utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  hashOrderedStringSet,
   hashString, hashStringSet, hashStringSets, hasOwnProperty, isEquivalentArray, isEquivalentSet
 } from "./js-utils"
 
@@ -45,7 +46,6 @@ describe("JavaScript Utilities", () => {
   test("hashStringSet", () => {
     expect(hashStringSet([])).toBe(hashStringSet([]))
     expect(hashStringSet(["a", "b", "c"])).toBe(hashStringSet(["a", "b", "c"]))
-    expect(hashStringSet(["a", "b", "c"])).toBe(hashStringSet(["a", "b", "c"]))
     expect(hashStringSet(["a", "b", "c"])).toBe(hashStringSet(["c", "b", "a"]))
     expect(hashStringSet(["a", "b", "c"])).not.toBe(hashStringSet(["a", "b"]))
     expect(hashStringSet(["a", "b", "c"])).not.toBe(hashStringSet(["a", "b", ""]))
@@ -58,5 +58,14 @@ describe("JavaScript Utilities", () => {
     expect(hashStringSets([["a"]])).not.toBe(hashStringSets([["a"], ["a"]]))
     expect(hashStringSets([["a"], ["b"]])).not.toBe(hashStringSets([["a"], ["a"]]))
     expect(hashStringSets([["a"], ["b"]])).not.toBe(hashStringSets([["a"], ["b"], ["c"]]))
+  })
+
+  test("hashOrderedStringSet", () => {
+    expect(hashOrderedStringSet([])).toBe(hashOrderedStringSet([]))
+    expect(hashOrderedStringSet(["a", "b", "c"])).toBe(hashOrderedStringSet(["a", "b", "c"]))
+    expect(hashOrderedStringSet(["a", "b", "c"])).not.toBe(hashOrderedStringSet(["c", "b", "a"]))
+    expect(hashOrderedStringSet(["a", "b", "c"])).not.toBe(hashOrderedStringSet(["a", "b"]))
+    expect(hashOrderedStringSet(["a", "b", "c"])).not.toBe(hashOrderedStringSet(["a", "b", ""]))
+    expect(hashOrderedStringSet(["a", "b", "c"])).not.toBe(hashOrderedStringSet(["a", "b", "C"]))
   })
 })

--- a/v3/src/utilities/js-utils.ts
+++ b/v3/src/utilities/js-utils.ts
@@ -173,3 +173,15 @@ export function hashStringSets(stringSets: Array<string[]>) {
     // eslint-disable-next-line no-bitwise
     .reduce((acc, hash) => acc ^ hash, 0) // XOR all individual hashes
 }
+
+/*
+ * hashOrderedStringSet()
+ *
+ * returns an order-dependent hash value for a set of strings (e.g. ids).
+ * developed with the help of ChatGPT.
+ */
+export function hashOrderedStringSet(strings: string[]) {
+  return strings
+    .map((str, index) => hashString(str) * (index + 1)) // Multiply hash by index + 1 to reflect position
+    .reduce((acc, hash) => acc + hash, 0) // sum all individual hashes
+}


### PR DESCRIPTION
[[PT-181890013]](https://www.pivotaltracker.com/story/show/181890013)

- Required some interesting details including a custom undo/redo implementation.
- Adds `caseIdsHash` and `caseIdsOrderedHash` to the `CollectionModel`.
- Adds `hashOrderedStringSet` function to `js-utils`.
- Code for comparing values largely ported from v2.