### PR TITLE
notify the CODAPv3 slack channel of some failures

### DIFF
--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -102,3 +102,21 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: cypress
+  notify-slack:
+    if: ${{ failure() && github.ref_name == 'main' }}
+    needs: [cypress]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack the tests failed
+        id: slack
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          # This data can be any valid JSON from a previous step in the GitHub Action
+          payload: |
+            {
+              "ref_name": "${{ github.ref_name }}",
+              "workflow": "${{ github.workflow }}",
+              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This uses a Slack Workflow to provide a webhook that the github action can post to. The Workflow defines a template for the message, an icon and a channel. 
The process for setting it up is "technique 1" here:
https://github.com/slackapi/slack-github-action

The workflow is configured within the Slack app by going to the 3 dots on the left and choosing "Automations". If you want to setup something similiar you can duplicate either the the "CODAP Tests Failed" or "CLUE Tests Failed" workflows.

This is what the main workflow edit screen looks like:
<img width="701" alt="image" src="https://github.com/user-attachments/assets/534a0c5b-3de4-459e-918c-7ae1287b1631">

And here is the webhook edit screen:
<img width="530" alt="image" src="https://github.com/user-attachments/assets/b17fd62c-34ae-452a-a408-bf5f2a17d22c">

And the send a message edit screen:
<img width="525" alt="image" src="https://github.com/user-attachments/assets/4166195a-896e-4407-908a-3cd0d90a9d16">
