### PR TITLE
fix: text selection in formula editor; disable dragging editor window from inside editor pane

### DIFF
--- a/v3/src/components/codap-modal.tsx
+++ b/v3/src/components/codap-modal.tsx
@@ -71,7 +71,11 @@ const DraggableModalContent = ({children, modalWidth, modalHeight, onClick, fRef
     const handleMouseDown = (e: MouseEvent) => {
       // Prevent dragging if the target is an interactive element (like Select, button, input, etc.)
       const interactiveTags = ["INPUT", "TEXTAREA", "SELECT", "OPTION", "BUTTON"]
-      if (interactiveTags.includes((e.target as HTMLElement).tagName)) {
+      const targetElt = e.target as HTMLElement
+      if (interactiveTags.includes(targetElt.tagName) ||
+          targetElt.getAttribute("contenteditable") === "true" ||
+          // client can add .input-element to indicate that an element should be treated like an input
+          targetElt.closest(".input-element") != null) {
         return
       }
 

--- a/v3/src/components/common/formula-editor.tsx
+++ b/v3/src/components/common/formula-editor.tsx
@@ -256,7 +256,10 @@ export function FormulaEditor({ formula, setFormula, options: _options }: IProps
 
   const handleFormulaChange = (value: string, viewUpdate: ViewUpdate) => setFormula(value)
 
-  return <CodeMirror ref={cmRef} value={formula} data-testid="formula-editor-input" height="70px"
+  // .input-element indicates to CodapModal not to drag the modal from within the element
+  const classes = "formula-editor-input input-element"
+  return <CodeMirror ref={cmRef} className={classes} data-testid="formula-editor-input" height="70px"
                      basicSetup={false} extensions={cmExtensionsSetup()}
-                     onCreateEditor={handleCreateEditor} onChange={handleFormulaChange} />
+                     onCreateEditor={handleCreateEditor}
+                     value={formula} onChange={handleFormulaChange} />
 }


### PR DESCRIPTION
- disable dragging editor modal from within the editing area
- fix text selection within the editor (which was being blocked by the modal-dragging code)
