### PR TITLE
fix: graph filter function in restored documents

### DIFF
--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -23,6 +23,9 @@ export class FormulaManager {
 
   adapters: IFormulaManagerAdapter[] = []
 
+  @observable
+  areAdaptersInitialized = false
+
   constructor() {
     makeObservable(this)
   }
@@ -36,9 +39,10 @@ export class FormulaManager {
     }
   }
 
-  addAdapters(adapters: IFormulaManagerAdapter[]) {
+  @action addAdapters(adapters: IFormulaManagerAdapter[]) {
     this.adapters.push(...adapters)
     this.registerActiveFormulas()
+    this.areAdaptersInitialized = true
   }
 
   @action addDataSet(dataSet: IDataSet) {


### PR DESCRIPTION
Fix order-of-initialization issue which prevented filter functions from working in graphs restored from documents.