### PR TITLE
Map grid display bug fix

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -119,7 +119,7 @@ export const DataConfigurationModel = types
       const defaultCaptionAttributeID = () => {
         // We find the childmost collection and return the first attribute in that collection. If there is no
         // childmost collection, we return the first attribute in the dataset.
-        const attrIDs = (['x', 'y', 'rightNumeric', 'topSplit', 'rightSplit', 'legend'] as const)
+        const attrIDs = (['x', 'y', 'rightNumeric', 'topSplit', 'rightSplit', 'legend', 'lat', 'long'] as const)
             .map(aRole => this.attributeID(aRole))
             .filter(id => !!id),
           childmostCollectionID = idOfChildmostCollectionForAttributes(attrIDs, self.dataset)
@@ -266,9 +266,7 @@ export const DataConfigurationModel = types
      */
     get selection() {
       if (!self.dataset || !self.filteredCases[0]) return []
-      const selection = Array.from(self.dataset.selection),
-        allGraphCaseIds = this.visibleCaseIds
-      return selection.filter((caseId: string) => allGraphCaseIds.has(caseId))
+      return Array.from(this.visibleCaseIds).filter(caseId => self.dataset?.isCaseSelected(caseId))
     },
     /**
      * Note that in order to eliminate a selected case from the graph's selection, we have to check that it is not

--- a/v3/src/components/map/components/map-point-grid.tsx
+++ b/v3/src/components/map/components/map-point-grid.tsx
@@ -2,11 +2,9 @@ import React, {useCallback, useEffect, useRef} from "react"
 import {DomEvent, LeafletMouseEvent, point, popup, Rectangle, rectangle} from "leaflet"
 import {useMap} from "react-leaflet"
 import {useMemo} from "use-memo-one"
-import {isSelectionAction, isSetCaseValuesAction} from "../../../models/data/data-set-actions"
 import { setOrExtendSelection } from "../../../models/data/data-set-utils"
 import {mstAutorun} from "../../../utilities/mst-autorun"
 import {mstReaction} from "../../../utilities/mst-reaction"
-import {onAnyAction} from "../../../utilities/mst-utils"
 import {IMapPointLayerModel} from "../models/map-point-layer-model"
 import {getCaseCountString, getCategoryBreakdownHtml} from "../utilities/map-utils"
 
@@ -107,20 +105,19 @@ export const MapPointGrid = function MapPointGrid(props: IMapPointGridProps) {
       }, {name: 'MapPointGrid respondToHiddenCasesChange'}, mapLayerModel)
   }, [mapLayerModel, refreshLeafletRects])
 
-  // Actions in the dataset can trigger need for grid updates
-  useEffect(function setupResponsesToDatasetActions() {
-    const dataset = mapLayerModel.dataConfiguration?.dataset
-    if (dataset) {
-      const disposer = onAnyAction(dataset, action => {
-        if (isSelectionAction(action)) {
-          refreshGridSelection()
-        } else if (isSetCaseValuesAction(action) || ["addCases", "removeCases"].includes(action.name)) {
-          refreshLeafletRects()
-        }
-      })
-      return () => disposer()
-    }
-  }, [mapLayerModel.dataConfiguration?.dataset, refreshGridSelection, refreshLeafletRects])
+  useEffect(() => {
+    return mstReaction(
+      () => mapGridModel.changeCount,
+      () => {
+        refreshLeafletRects()
+        refreshGridSelection()
+      }, {name: 'MapPointGrid respondToGridChange'}, mapGridModel
+    )
+  }, [mapGridModel, refreshGridSelection, refreshLeafletRects])
+
+  useEffect(() => {
+    refreshLeafletRects()
+  }, [refreshLeafletRects])
 
   return (
     <></>

--- a/v3/src/components/map/models/map-grid-model.ts
+++ b/v3/src/components/map/models/map-grid-model.ts
@@ -1,5 +1,5 @@
 import {reaction} from "mobx"
-import {addDisposer, types} from "mobx-state-tree"
+import { addDisposer, Instance, types } from "mobx-state-tree"
 import {applyModelChange} from "../../../models/history/apply-model-change"
 import {IDataConfigurationModel} from "../../data-display/models/data-configuration-model"
 import {LatLngGrid} from "../utilities/lat-lng-grid"
@@ -11,11 +11,20 @@ export const MapGridModel = types.model("MapGridModel", {
 })
   .volatile(() => ({
     dataConfiguration: undefined as IDataConfigurationModel | undefined,
-    latLngGrid: new LatLngGrid(),
+    _latLngGrid: new LatLngGrid(),
     _gridSize: 0,  // degrees
-    _dynamicGridMultiplier: undefined as number | undefined  // Used during slider drag
+    _dynamicGridMultiplier: undefined as number | undefined,  // Used during slider drag
+    changeCount: 0
+  }))
+  .views(self => ({
+    get gridSize() {
+      return self._gridSize
+    }
   }))
   .actions(self => ({
+    incrementChangeCount() {
+      self.changeCount++
+    },
     setIsVisible(isVisible: boolean) {
       self.isVisible = isVisible
     },
@@ -32,6 +41,78 @@ export const MapGridModel = types.model("MapGridModel", {
       self._gridMultiplier = multiplier
       self._dynamicGridMultiplier = undefined
     }
+  }))
+  .extend((self) => {
+    let startingCorners: { startWest: number, startSouth: number } | undefined
+    const setupLatLngGrid = () => {
+      startingCorners = self._latLngGrid.setupGridFromBounds(
+        self.dataConfiguration ? getLatLongBounds(self.dataConfiguration) : undefined,
+        self.setGridSize, () => self.gridSize)
+    }
+
+    const computeCounts = () => {
+      if (self.dataConfiguration) {
+        const {
+            dataConfiguration: {dataset, caseDataArray},
+            _latLngGrid, gridSize
+          } = self,
+          dataConfiguration = self.dataConfiguration
+
+        _latLngGrid.zeroCounts()
+        caseDataArray.forEach(({caseID}: { plotNum: number, caseID: string }) => {
+          const long = dataset?.getNumeric(caseID, dataConfiguration.attributeID('long')),
+            lat = dataset?.getNumeric(caseID, dataConfiguration.attributeID('lat'))
+          if (long !== undefined && lat !== undefined) {
+            const longIndex = Math.floor((long - (startingCorners?.startWest ?? 0)) / gridSize),
+              latIndex = Math.floor((lat - (startingCorners?.startSouth ?? 0)) / gridSize)
+            _latLngGrid.addCaseToGridCell(longIndex, latIndex, caseID)
+          }
+        })
+      }
+    }
+    const _updateSelection = () => {
+      self._latLngGrid.forEachGridCell((gridCell) => {
+        gridCell.selected = gridCell.cases.every((aCase) => self.dataConfiguration?.dataset?.isCaseSelected(aCase))
+      })
+    }
+    const _initializeGrid = () => {
+      if (!self.isVisible) return
+      const cases = self.dataConfiguration?.caseDataArray,
+        bounds = self.dataConfiguration ? getLatLongBounds(self.dataConfiguration) : undefined
+      if (cases?.length && bounds?.isValid()) {
+        setupLatLngGrid()
+        computeCounts()
+        self._latLngGrid.deleteGridCellsWithZeroCount()
+      }
+      _updateSelection()
+      self._latLngGrid.initialized = true
+    }
+    return {
+      views: {
+        get latLngGrid() {
+          if (!self._latLngGrid.initialized) {
+            _initializeGrid()
+          }
+          return self._latLngGrid
+        },
+      },
+      actions: {
+        updateSelection() {
+          if (!self._latLngGrid.initialized) {
+            _initializeGrid()
+          }
+          _updateSelection()
+        },
+        initializeGrid() {
+          _initializeGrid()
+        }
+      }
+    }
+  })
+  .actions(self => ({
+    clear() {
+      self.latLngGrid.clear()
+    },
   }))
   .views(self => ({
     get gridMultiplier() {
@@ -52,73 +133,30 @@ export const MapGridModel = types.model("MapGridModel", {
       })
     }
   }))
-  .extend((self) => {
-    let startingCorners: { startWest: number, startSouth: number } | undefined
-    const setupLatLngGrid = () => {
-      startingCorners = self.latLngGrid.setupGridFromBounds(
-        self.dataConfiguration ? getLatLongBounds(self.dataConfiguration) : undefined,
-        self.setGridSize, () => self.gridSize)
-    }
-
-    const computeCounts = () => {
-      if (self.dataConfiguration) {
-        const {
-            dataConfiguration: {dataset, caseDataArray},
-            latLngGrid, gridSize
-          } = self,
-          dataConfiguration = self.dataConfiguration
-
-        self.latLngGrid.zeroCounts()
-        caseDataArray.forEach(({caseID}: { plotNum: number, caseID: string }) => {
-          const long = dataset?.getNumeric(caseID, dataConfiguration.attributeID('long')),
-            lat = dataset?.getNumeric(caseID, dataConfiguration.attributeID('lat'))
-          if (long !== undefined && lat !== undefined) {
-            const longIndex = Math.floor((long - (startingCorners?.startWest ?? 0)) / gridSize),
-              latIndex = Math.floor((lat - (startingCorners?.startSouth ?? 0)) / gridSize)
-            latLngGrid.addCaseToGridCell(longIndex, latIndex, caseID)
-          }
-        })
-      }
-    }
-
-    return {
-      actions: {
-        initializeGrid() {
-          const cases = self.dataConfiguration?.caseDataArray,
-            bounds = self.dataConfiguration ? getLatLongBounds(self.dataConfiguration) : undefined
-          if (cases?.length && bounds?.isValid()) {
-            setupLatLngGrid()
-            computeCounts()
-            self.latLngGrid.deleteGridCellsWithZeroCount()
-          }
-        },
-        clear() {
-          self.latLngGrid.clear()
-        },
-        updateSelection() {
-          self.latLngGrid.forEachGridCell((gridCell) => {
-            gridCell.selected = gridCell.cases.every((aCase) => self.dataConfiguration?.dataset?.isCaseSelected(aCase))
-          })
-        }
-      }
-    }
-  })
   .actions(self => ({
     afterCreate() {
       addDisposer(self, reaction(
-        () => [self.dataConfiguration,
+        () => [self.dataConfiguration, self.dataConfiguration?.caseDataHash,
           self.dataConfiguration?.hiddenCases.length, self.gridMultiplier, self._gridSize],
         () => {
           self.initializeGrid()
           self.updateSelection()
+          self.incrementChangeCount()
         },
         {name: "MapGridModel.afterCreate.reaction [dataConfiguration]", fireImmediately: true}
       ))
       addDisposer(self, reaction(
         () => [self.dataConfiguration?.selection?.length],
-        () => self.updateSelection(),
+        () => {
+          self.updateSelection()
+          self.incrementChangeCount()
+        },
         {name: "MapGridModel.afterCreate.reaction [selection]"}
       ))
     },
   }))
   .actions(applyModelChange)
+
+export interface IMapGridModel extends Instance<typeof MapGridModel> {
+
+}

--- a/v3/src/components/map/utilities/lat-lng-grid.ts
+++ b/v3/src/components/map/utilities/lat-lng-grid.ts
@@ -17,10 +17,12 @@ export class LatLngGridCell {
 }
 
 export class LatLngGrid {
+  initialized: boolean
   maxCount: number
   gridCells: (LatLngGridCell | undefined)[][]
 
   constructor() {
+    this.initialized = false
     this.maxCount = 0
     this.gridCells = []
   }


### PR DESCRIPTION
[#188104342] Bug Fix: Grid does not display in Four Seals

* The bug occurs only for restored codap3 documents and is brought about by the way a MapGridModel initializes its latlngGrid property at a moment when the map's data configuration has not yet computed the cases and thus the grid has zero rectangles. We fix this by adding the data configuration's caseDataHash to the things it observes so that it can initialize things properly when the has changes. We also only attempt the initialization if the grid is visible.
* I discovered that the display of grid selection was not synchronized with selection of cases because of an order of operations issue. This is fixed by having the map grid model increment a change count that can be observed by the MapPointGrid component which was previously checking for dataset selection actions.
* Hover over map points was not displaying a caption and this was because 'lat' and 'long' were not included among the attributes to check in the data configuration model's `defaultCaptionAttributeID` method. So we add those.