### PR TITLE
Add Targeted Cypress Smoke Test for Developer Pushes Without Run Regression Label

### DIFF
--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -151,7 +151,7 @@ jobs:
           browser: chrome
           # only run a single test
           # TODO: setup a special test for this purpose
-          spec: cypress/e2e/import-v2.spec.ts
+          spec: cypress/e2e/smoke/single-codap-smoke.ts
           group: 'Smoke Tests'
         env:
           # pass the Dashboard record key as an environment variable

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -8,6 +8,7 @@ import { CalculatorTileElements as calculator } from "../support/elements/calcul
 import { WebViewTileElements as webView } from "../support/elements/web-view-tile"
 
 const helpURL = 'https://codap.concord.org/help'
+const helpURL_ja = 'https://codap.concord.org/resources/latest/help-documents/CODAP解説書.pdf'
 const helpForumURL = 'https://codap.concord.org/forums/forum/test/'
 const projectWebSiteURL = 'https://codap.concord.org'
 const privacyURL = 'https://codap.concord.org/privacy'

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -62,9 +62,9 @@ context("codap single smoke test", () => {
         cy.log("verify selecting cases in the table")
           table.getGridCell(2, 2).should("contain", "African Elephant").click()
           table.getGridCell(2, 2).should('have.attr', 'aria-selected', 'true')
-        // TODO: Add more thorough checks to make sure graph points and table rows actually change color when selected,
-        // once Cypress is configured to interact with the PixiJS canvas. For now, we just check that the buttons in table
-        // are enabled upon selection.
+        // TODO: Add more thorough checks to make sure graph points and table rows actually
+        // change color when selected, once Cypress is configured to interact with the PixiJS canvas.
+        // For now, we just check that the buttons in table are enabled upon selection.
 
         cy.log("test graph axis functionalities in Mammals sample doc")
         // it is possible to create a graph

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -17,177 +17,175 @@ context("codap single smoke test", () => {
 
   it("verify Mammals opens from Hamburger menu and tests graph and table functionality", () => {
     cy.log("Open Mammals from Hamburger menu")
-      // hamburger menu is hidden initially
-      cfm.getHamburgerMenuButton().should("exist")
-      cfm.getHamburgerMenu().should("not.exist")
-      // hamburger menu is shows when button is clicked
-      cfm.getHamburgerMenuButton().click()
-      cfm.getHamburgerMenu().should("exist")
-      // clicking Open... item closes menu and shows Open dialog
-      cfm.getHamburgerMenu().contains("li", "Open...").click()
-      cfm.getHamburgerMenu().should("not.exist")
-      cfm.getModalDialog().contains(".modal-dialog-title", "Open")
-      // Example Documents should be selected by default
-      cfm.getModalDialog().contains(".tab-selected", "Example Documents")
-      cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
-      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
-      // Selecting Mammals document should load the mammals example document
-      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").click()
-      cfm.getModalDialog().contains(".buttons button", "Open").click()
-      cy.wait(1000)
-      // once loaded, Open dialog should be hidden and document content should be shown
-      cfm.getModalDialog().should("not.exist")
-      cy.get(".codap-component.codap-case-table").contains(".title-bar", "Mammals").should("exist")
+    // hamburger menu is hidden initially
+    cfm.getHamburgerMenuButton().should("exist")
+    cfm.getHamburgerMenu().should("not.exist")
+    // hamburger menu is shows when button is clicked
+    cfm.getHamburgerMenuButton().click()
+    cfm.getHamburgerMenu().should("exist")
+    // clicking Open... item closes menu and shows Open dialog
+    cfm.getHamburgerMenu().contains("li", "Open...").click()
+    cfm.getHamburgerMenu().should("not.exist")
+    cfm.getModalDialog().contains(".modal-dialog-title", "Open")
+    // Example Documents should be selected by default
+    cfm.getModalDialog().contains(".tab-selected", "Example Documents")
+    cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
+    cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
+    // Selecting Mammals document should load the mammals example document
+    cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").click()
+    cfm.getModalDialog().contains(".buttons button", "Open").click()
+    cy.wait(1000)
+    // once loaded, Open dialog should be hidden and document content should be shown
+    cfm.getModalDialog().should("not.exist")
+    cy.get(".codap-component.codap-case-table").contains(".title-bar", "Mammals").should("exist")
 
     cy.log("Test table functionalities in Mammals sample doc")
-      cy.log("verify columns exist")
-          // css width specification caused grid virtualization to only have 9 attributes in the DOM
-          table.getColumnHeaders().should("have.length.be.within", 9, 10)
-          table.getColumnHeader(0).invoke("text").then(columnName => {
-            // const columnNameArr = columnName.split()
-            table.getColumnHeader(0).rightclick({ force: true })
-            // table.getColumnHeaderTooltip().should("contain", columnNameArr[0])
-          })
-        table.getColumnHeader(1).invoke("text").then(columnName => {
-          table.getColumnHeader(1).rightclick({ force: true })
-          })
-        table.getAttribute("Order").should('be.visible').and("have.text", "Order")
-        table.getAttribute("LifeSpan").should('be.visible').and('have.text', 'LifeSpan(years)')
+    cy.log("verify columns exist")
+    // css width specification caused grid virtualization to only have 9 attributes in the DOM
+    table.getColumnHeaders().should("have.length.be.within", 9, 10)
+    table.getColumnHeader(0).invoke("text").then(columnName => {
+      // const columnNameArr = columnName.split()
+      table.getColumnHeader(0).rightclick({ force: true })
+      // table.getColumnHeaderTooltip().should("contain", columnNameArr[0])
+    })
+    table.getColumnHeader(1).invoke("text").then(columnName => {
+      table.getColumnHeader(1).rightclick({ force: true })
+      })
+    table.getAttribute("Order").should('be.visible').and("have.text", "Order")
+    table.getAttribute("LifeSpan").should('be.visible').and('have.text', 'LifeSpan(years)')
 
-        cy.log("verify grid cells exist")
-          table.getGridCell(2, 2).should('be.visible').and("contain", "African Elephant")
-          table.getGridCell(4, 4).should('be.visible').and("contain", "19")
-          table.getNumOfRows().should('eq', '29') // 27 cases, plus the empty row and top row
+    cy.log("verify grid cells exist")
+    table.getGridCell(2, 2).should('be.visible').and("contain", "African Elephant")
+    table.getGridCell(4, 4).should('be.visible').and("contain", "19")
+    table.getNumOfRows().should('eq', '29') // 27 cases, plus the empty row and top row
 
-        cy.log("verify selecting cases in the table")
-          table.getGridCell(2, 2).should("contain", "African Elephant").click()
-          table.getGridCell(2, 2).should('have.attr', 'aria-selected', 'true')
-        // TODO: Add more thorough checks to make sure graph points and table rows actually
-        // change color when selected, once Cypress is configured to interact with the PixiJS canvas.
-        // For now, we just check that the buttons in table are enabled upon selection.
+    cy.log("verify selecting cases in the table")
+    table.getGridCell(2, 2).should("contain", "African Elephant").click()
+    table.getGridCell(2, 2).should('have.attr', 'aria-selected', 'true')
+    // TODO: Add more thorough checks to make sure graph points and table rows actually
+    // change color when selected, once Cypress is configured to interact with the PixiJS canvas.
+    // For now, we just check that the buttons in table are enabled upon selection.
 
-        cy.log("test graph axis functionalities in Mammals sample doc")
-        // it is possible to create a graph
-          cy.dragAttributeToTarget("table", "Speed", "left")
-          //cy.wait(500)
-          cy.get('[data-testid="axis-legend-attribute-button-left"]').eq(0).should("have.text", "Speed")
-          cy.get("[data-testid=graph]").find("[data-testid=axis-left]").find(".tick").should("have.length", 25)
-          cy.dragAttributeToTarget("table", "Mammal", "bottom")
-          //cy.wait(500)
-          cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "Mammal")
-          cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".tick").should("have.length", 27)
+    cy.log("test graph axis functionalities in Mammals sample doc")
+    // it is possible to create a graph
+    cy.dragAttributeToTarget("table", "Speed", "left")
+    //cy.wait(500)
+    cy.get('[data-testid="axis-legend-attribute-button-left"]').eq(0).should("have.text", "Speed")
+    cy.get("[data-testid=graph]").find("[data-testid=axis-left]").find(".tick").should("have.length", 25)
+    cy.dragAttributeToTarget("table", "Mammal", "bottom")
+    //cy.wait(500)
+    cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "Mammal")
+    cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".tick").should("have.length", 27)
 
-        cy.log("test creating parent collections")
-        // NOTE: the graph compresses to a single point in Cypress here.
-        // This is a known issue and seems tied to just the Mammals sample dataset (PT-#188415914)
-          table.moveAttributeToParent("Habitat", "newCollection")
-          table.getNumOfRows(1).should("contain", 5) // five rows: top, land, water, both, bottom
-          table.moveAttributeToParent("Diet", "newCollection")
-          table.getNumOfRows(1).should("contain", 5) // five rows: top, plants, meat, both, bottom
+    cy.log("test creating parent collections")
+    // NOTE: the graph compresses to a single point in Cypress here.
+    // This is a known issue and seems tied to just the Mammals sample dataset (PT-#188415914)
+    table.moveAttributeToParent("Habitat", "newCollection")
+    table.getNumOfRows(1).should("contain", 5) // five rows: top, land, water, both, bottom
+    table.moveAttributeToParent("Diet", "newCollection")
+    table.getNumOfRows(1).should("contain", 5) // five rows: top, plants, meat, both, bottom
 
-      cy.log("Delete all cases from the hierarchical table and verify the cases delete.")
-        c.selectTile("table", 0)
-        table.getDeleteCasesButton().click()
-        table.getDeleteMenuItem("Delete All Cases").click()
-        table.getNumOfRows(1).should("contain", 2) // two rows: top, empty
-        cy.get('[data-testid="no-cases-message"]').should('exist').and('contain.text', 'no cases')
+    cy.log("Delete all cases from the hierarchical table and verify the cases delete.")
+    c.selectTile("table", 0)
+    table.getDeleteCasesButton().click()
+    table.getDeleteMenuItem("Delete All Cases").click()
+    table.getNumOfRows(1).should("contain", 2) // two rows: top, empty
+    cy.get('[data-testid="no-cases-message"]').should('exist').and('contain.text', 'no cases')
   })
   it("verify Four Seals opens from Hamburger menu and tests graph date and table functionality", () => {
     // Open Four Seals
     cy.log("Open Four Seals from Hamburger menu")
-      // hamburger menu is hidden initially
-      cfm.getHamburgerMenuButton().should("exist")
-      cfm.getHamburgerMenu().should("not.exist")
-      // hamburger menu is shows when button is clicked
-      cfm.getHamburgerMenuButton().click()
-      cfm.getHamburgerMenu().should("exist")
-      // clicking Open... item closes menu and shows Open dialog
-      cfm.getHamburgerMenu().contains("li", "Open...").click()
-      cfm.getHamburgerMenu().should("not.exist")
-      cfm.getModalDialog().contains(".modal-dialog-title", "Open")
-      // Example Documents should be selected by default
-      cfm.getModalDialog().contains(".tab-selected", "Example Documents")
-      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
-      cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
-      // Selecting Mammals document should load the mammals example document
-      cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").click()
-      cfm.getModalDialog().contains(".buttons button", "Open").click()
-      cy.wait(1000)
-      // once loaded, Open dialog should be hidden and document content should be shown
-      cfm.getModalDialog().should("not.exist")
-      cy.get(".codap-component.codap-case-table").contains(".title-bar", "Tracks/Measurements").should("exist")
+    // hamburger menu is hidden initially
+    cfm.getHamburgerMenuButton().should("exist")
+    cfm.getHamburgerMenu().should("not.exist")
+    // hamburger menu is shows when button is clicked
+    cfm.getHamburgerMenuButton().click()
+    cfm.getHamburgerMenu().should("exist")
+    // clicking Open... item closes menu and shows Open dialog
+    cfm.getHamburgerMenu().contains("li", "Open...").click()
+    cfm.getHamburgerMenu().should("not.exist")
+    cfm.getModalDialog().contains(".modal-dialog-title", "Open")
+    // Example Documents should be selected by default
+    cfm.getModalDialog().contains(".tab-selected", "Example Documents")
+    cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
+    cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
+    // Selecting Mammals document should load the mammals example document
+    cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").click()
+    cfm.getModalDialog().contains(".buttons button", "Open").click()
+    cy.wait(1000)
+    // once loaded, Open dialog should be hidden and document content should be shown
+    cfm.getModalDialog().should("not.exist")
+    cy.get(".codap-component.codap-case-table").contains(".title-bar", "Tracks/Measurements").should("exist")
 
     cy.log("Test date display exists in table")
-      cy.get('button[data-testid="codap-attribute-button date"]').should('exist')
-      table.getGridCell(2, 3, 2).should('be.visible').and("contain", "5/23/2005")
+    cy.get('button[data-testid="codap-attribute-button date"]').should('exist')
+    table.getGridCell(2, 3, 2).should('be.visible').and("contain", "5/23/2005")
 
     cy.log("Test date display in bottom axis of graph")
-      cy.dragAttributeToTarget("table", "date", "bottom")
-      cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "date")
-      // Check that the date axis contains the year '2005'
-      cy.get('[data-testid="axis-bottom"]')
-      .find('text')
-      .contains('2005')
-      .should('exist')
+    cy.dragAttributeToTarget("table", "date", "bottom")
+    cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "date")
+    // Check that the date axis contains the year '2005'
+    cy.get('[data-testid="axis-bottom"]')
+    .find('text')
+    .contains('2005')
+    .should('exist')
 
-      // Check the number of tick marks on axis (e.g., ensuring there are 9 months: May to Jan)
-      cy.get('[data-testid="axis-bottom"]')
-      .find('text')
-      .should('have.length', 10) // Adjust this if the expected number changes (currently 9 + ghost div=10)
+    // Check the number of tick marks on axis (e.g., ensuring there are 9 months: May to Jan)
+    cy.get('[data-testid="axis-bottom"]')
+    .find('text')
+    .should('have.length', 10) // Adjust this if the expected number changes (currently 9 + ghost div=10)
 
     cy.log("checks map component")
-      c.getComponentTitle("map").should("have.text", "Measurements")
-      // Some day add a check for map with points, see PT #187534790
-      // Also some day add a legend to the map.
+    c.getComponentTitle("map").should("have.text", "Measurements")
+    // Some day add a check for map with points, see PT #187534790
+    // Also some day add a legend to the map.
 
   })
-  // NOTE: This test was drafted on 10/16/2024 but will be skipped since we decided we don't need to
-  // smoke test empty CODAP documents
-  it.skip("verify an empty CODAP document appears", () => {
+  it("verify an empty CODAP document appears", () => {
     cy.log("verifies that toolshelf items open")
     cy.log("will open a new table")
-      c.clickIconFromToolShelf("table")
-      toolbar.getNewCaseTable().click()
-      table.getCollection().should("be.visible")
-      c.getComponentTitle("table").should("have.text", "New Dataset")
-      c.getIconFromToolShelf("table").click()
-      toolbar.getDatasetListedInToolShelf("New Dataset").should("be.visible")
-      c.closeComponent("table")
+    c.clickIconFromToolShelf("table")
+    toolbar.getNewCaseTable().click()
+    table.getCollection().should("be.visible")
+    c.getComponentTitle("table").should("have.text", "New Dataset")
+    c.getIconFromToolShelf("table").click()
+    toolbar.getDatasetListedInToolShelf("New Dataset").should("be.visible")
+    c.closeComponent("table")
 
     cy.log("will open a graph")
-      c.clickIconFromToolShelf("graph")
-      graph.getGraphTile().should("be.visible")
-      // graphs with no associated data set should not have a title but show a blank space when hovered
-      c.getComponentTitle("graph").should("have.text", "New Dataset")
-      // This is the expected behavior, but there's a bug. PT-#188439366
-      //c.getComponentTitleBar("graph").trigger("mouseover")
-      //c.getComponentTitle("graph").should("have.text", "_____")
-      c.closeComponent("graph")
+    c.clickIconFromToolShelf("graph")
+    graph.getGraphTile().should("be.visible")
+    // graphs with no associated data set should not have a title but show a blank space when hovered
+    c.getComponentTitle("graph").should("have.text", "New Dataset")
+    // This is the expected behavior, but there's a bug. PT-#188439366
+    //c.getComponentTitleBar("graph").trigger("mouseover")
+    //c.getComponentTitle("graph").should("have.text", "_____")
+    c.closeComponent("graph")
 
     cy.log("will open a map")
-      c.clickIconFromToolShelf("map")
-      map.getMapTile().should("be.visible")
-      c.getComponentTitle("map").should("have.text", "Map")
-      c.closeComponent("map")
+    c.clickIconFromToolShelf("map")
+    map.getMapTile().should("be.visible")
+    c.getComponentTitle("map").should("have.text", "Map")
+    c.closeComponent("map")
 
     cy.log("will open a slider")
-      c.clickIconFromToolShelf("slider")
-      slider.getSliderTile().should("be.visible")
-      c.getComponentTitle("slider").should("have.text", "v1")
-      c.closeComponent("slider")
+    c.clickIconFromToolShelf("slider")
+    slider.getSliderTile().should("be.visible")
+    c.getComponentTitle("slider").should("have.text", "v1")
+    c.closeComponent("slider")
 
     cy.log("will open a calculator")
-      c.clickIconFromToolShelf("calc")
-      calculator.getCalculatorTile().should("be.visible")
-      c.getComponentTitle("calculator").should("have.text", "Calculator")
-      c.closeComponent("calculator")
+    c.clickIconFromToolShelf("calc")
+    calculator.getCalculatorTile().should("be.visible")
+    c.getComponentTitle("calculator").should("have.text", "Calculator")
+    c.closeComponent("calculator")
 
     cy.log("plugin menu works")
-      c.getIconFromToolShelf("plugins").should("exist").click()
-      toolbar.getPluginSelection().should("have.length", 9)
-      webView.getTitle().should("not.exist")
-      toolbar.getPluginSelection().eq(0).click()
-      webView.getTitle().should("have.text", "Sampler")
-      toolbar.getPluginSelection().should("not.exist")
+    c.getIconFromToolShelf("plugins").should("exist").click()
+    toolbar.getPluginSelection().should("have.length", 9)
+    webView.getTitle().should("not.exist")
+    toolbar.getPluginSelection().eq(0).click()
+    webView.getTitle().should("have.text", "Sampler")
+    toolbar.getPluginSelection().should("not.exist")
   })
 })

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -41,7 +41,7 @@ context("codap single smoke test", () => {
 
     cy.log("Test table functionalities in Mammals sample doc")
       // Test linking of selected cases
-    cy.log("verify columns and tooltips")
+    cy.log("verify columns exist")
         // css width specification caused grid virtualization to only have 9 attributes in the DOM
         table.getColumnHeaders().should("have.length.be.within", 9, 10)
         table.getColumnHeader(0).invoke("text").then(columnName => {
@@ -52,17 +52,41 @@ context("codap single smoke test", () => {
       table.getColumnHeader(1).invoke("text").then(columnName => {
         table.getColumnHeader(1).rightclick({ force: true })
         })
-      table.getAttribute("Order").should("have.text", "Order")
-      table.getAttribute("LifeSpan").should('have.text', 'LifeSpan(years)')
+      table.getAttribute("Order").should('be.visible').and("have.text", "Order")
+      table.getAttribute("LifeSpan").should('be.visible').and('have.text', 'LifeSpan(years)')
+
+      cy.log("verify grid cells exist")
+      table.getGridCell(2, 2).should('be.visible').and("contain", "African Elephant")
+      table.getGridCell(4, 4).should('be.visible').and("contain", "19")
+      table.getNumOfRows().should('eq', '29') // 27 cases, plus the empty row and top row
+
+      cy.log("test table functionalities")
+      // test lined selection
+      table.getGridCell(2, 2).should("contain", "African Elephant").click()
+      // TODO: Add more thorough checks to make sure graph points and table rows actually change color when selected,
+      // once Cypress is configured to interact with the PixiJS canvas. For now, we just check that the buttons
+      // are disabled and enabled as expected.
+
+      // test selecting cases
+      table.getGridCell(2, 2).should('have.attr', 'aria-selected', 'true')
+
+      cy.log("test creating parent collections")
+        //table.moveAttributeToParent("Habitat", "parent", 1)
+
+        table.moveAttributeToParent("Habitat", "newCollection")
+        table.getNumOfRows(1).should("contain", 5) // five rows: top, land, water, both, bottom
+
+       table.moveAttributeToParent("Diet", "newCollection")
+       table.getNumOfRows(1).should("contain", 5) // five rows: top, plants, meat, both, bottom
+
 
     // Test table functionalities: (use cy.log())
-      // // Test linking?
-      // // Test selecting cases?
-      // // Test creating parent collections
-      // // Test Expand / collaspe button (?)
+      // // Test linking? (x)
+      // // Test creating parent collections (x)
+      // // ~~Test Expand / collaspe button (?)~~
 
       // Test graph functionalities: (use cy.log()) (all with undo/redo if possible)
-      // // Click on a data point in graph and verify highlighting (if possible)
+      // // ~~Click on a data point in graph and verify highlighting (if possible)~~
       // // Use click and drag to create a graph with x and y attributes and verify the graph axes are made
       // // Change the x and y attributes using the attribute menu and verify new graph axes are made
 

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -1,23 +1,118 @@
-import { ComponentElements as c } from "../support/elements/component-elements"
-import { ToolbarElements as toolbar } from "../support/elements/toolbar-elements"
-import { TableTileElements as table } from "../support/elements/table-tile"
-import { GraphTileElements as graph } from "../support/elements/graph-tile"
-import { MapTileElements as map } from "../support/elements/map-tile"
-import { SliderTileElements as slider } from "../support/elements/slider-tile"
-import { CalculatorTileElements as calculator } from "../support/elements/calculator-tile"
-import { WebViewTileElements as webView } from "../support/elements/web-view-tile"
+import { ComponentElements as c } from "../../support/elements/component-elements"
+import { ToolbarElements as toolbar } from "../../support/elements/toolbar-elements"
+import { TableTileElements as table } from "../../support/elements/table-tile"
+import { GraphTileElements as graph } from "../../support/elements/graph-tile"
+import { MapTileElements as map } from "../../support/elements/map-tile"
+import { SliderTileElements as slider } from "../../support/elements/slider-tile"
+import { CalculatorTileElements as calculator } from "../../support/elements/calculator-tile"
+import { WebViewTileElements as webView } from "../../support/elements/web-view-tile"
+import { CfmElements as cfm } from "../../support/elements/cfm"
 
-const helpURL = 'https://codap.concord.org/help'
-const helpURL_ja = 'https://codap.concord.org/resources/latest/help-documents/CODAP解説書.pdf'
-const helpForumURL = 'https://codap.concord.org/forums/forum/test/'
-const projectWebSiteURL = 'https://codap.concord.org'
-const privacyURL = 'https://codap.concord.org/privacy'
 
-context("codap toolbar", () => {
+context("codap single smoke test", () => {
   beforeEach(function () {
     const url = `${Cypress.config("index")}?mouseSensor`
     cy.visit(url)
   })
+
+  it.only("verify an empty CODAP document appears", () => {
+    cy.log("verifies that toolshelf items open")
+    cy.log("will open a new table")
+      c.clickIconFromToolShelf("table")
+      toolbar.getNewCaseTable().click()
+      table.getCollection().should("be.visible")
+      c.getComponentTitle("table").should("have.text", "New Dataset")
+      c.getIconFromToolShelf("table").click()
+      toolbar.getDatasetListedInToolShelf("New Dataset").should("be.visible")
+      c.closeComponent("table")
+
+    cy.log("will open a graph")
+      c.clickIconFromToolShelf("graph")
+      graph.getGraphTile().should("be.visible")
+      // graphs with no associated data set should not have a title but show a blank space when hovered
+      c.getComponentTitle("graph").should("have.text", "New Dataset")
+      // This is the expected behavior, but there's a bug. PT-#188439366
+      //c.getComponentTitleBar("graph").trigger("mouseover")
+      //c.getComponentTitle("graph").should("have.text", "_____")
+      c.closeComponent("graph")
+
+    cy.log("will open a map")
+      c.clickIconFromToolShelf("map")
+      map.getMapTile().should("be.visible")
+      c.getComponentTitle("map").should("have.text", "Map")
+      c.closeComponent("map")
+
+    cy.log("will open a slider")
+      c.clickIconFromToolShelf("slider")
+      slider.getSliderTile().should("be.visible")
+      c.getComponentTitle("slider").should("have.text", "v1")
+      c.closeComponent("slider")
+
+    cy.log("will open a calculator")
+      c.clickIconFromToolShelf("calc")
+      calculator.getCalculatorTile().should("be.visible")
+      c.getComponentTitle("calculator").should("have.text", "Calculator")
+      c.closeComponent("calculator")
+
+    cy.log("plugin menu works")
+      c.getIconFromToolShelf("plugins").should("exist").click()
+      toolbar.getPluginSelection().should("have.length", 9)
+      webView.getTitle().should("not.exist")
+      toolbar.getPluginSelection().eq(0).click()
+      webView.getTitle().should("have.text", "Sampler")
+      toolbar.getPluginSelection().should("not.exist")
+  })
+
+  it.only("verify Mammals opens and tests graph and table functionality", () => {
+    cy.log("Open Mammals from Hamburger menu")
+      // hamburger menu is hidden initially
+      cfm.getHamburgerMenuButton().should("exist")
+      cfm.getHamburgerMenu().should("not.exist")
+      // hamburger menu is shows when button is clicked
+      cfm.getHamburgerMenuButton().click()
+      cfm.getHamburgerMenu().should("exist")
+      // clicking Open... item closes menu and shows Open dialog
+      cfm.getHamburgerMenu().contains("li", "Open...").click()
+      cfm.getHamburgerMenu().should("not.exist")
+      cfm.getModalDialog().contains(".modal-dialog-title", "Open")
+      // Example Documents should be selected by default
+      cfm.getModalDialog().contains(".tab-selected", "Example Documents")
+      cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
+      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
+      // Selecting Mammals document should load the mammals example document
+      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").click()
+      cfm.getModalDialog().contains(".buttons button", "Open").click()
+      cy.wait(1000)
+      // once loaded, Open dialog should be hidden and document content should be shown
+      cfm.getModalDialog().should("not.exist")
+      cy.get(".codap-component.codap-case-table").contains(".title-bar", "Mammals").should("exist")
+
+    cy.log("Test table functionalities in Mammals sample doc")
+      // Test linking of selected cases
+
+    // Test table functionalities: (use cy.log())
+      // // Test linking?
+      // // Test selecting cases?
+      // // Test creating parent collections
+      // // Test Expand / collaspe button (?)
+
+      // Test graph functionalities: (use cy.log()) (all with undo/redo if possible)
+      // // Click on a data point in graph and verify highlighting (if possible)
+      // // Use click and drag to create a graph with x and y attributes and verify the graph axes are made
+      // // Change the x and y attributes using the attribute menu and verify new graph axes are made
+
+      // Delete all cases from a table and verify it deletes.
+
+  })
+
+
+
+  // (some day) open Roller Coasters
+  // use the Hamburger menu to do so
+
+  // (some day) Test the Map component: (use cy.log())
+  // // Click on the Map button to open a Map
+  // // Add a legend to the map.
   it("will open a new table", () => {
     c.clickIconFromToolShelf("table")
     toolbar.getNewCaseTable().click()

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -15,7 +15,73 @@ context("codap single smoke test", () => {
     cy.visit(url)
   })
 
-  it.only("verify an empty CODAP document appears", () => {
+  it.only("verify Mammals opens from Hamburger menu and tests graph and table functionality", () => {
+    cy.log("Open Mammals from Hamburger menu")
+      // hamburger menu is hidden initially
+      cfm.getHamburgerMenuButton().should("exist")
+      cfm.getHamburgerMenu().should("not.exist")
+      // hamburger menu is shows when button is clicked
+      cfm.getHamburgerMenuButton().click()
+      cfm.getHamburgerMenu().should("exist")
+      // clicking Open... item closes menu and shows Open dialog
+      cfm.getHamburgerMenu().contains("li", "Open...").click()
+      cfm.getHamburgerMenu().should("not.exist")
+      cfm.getModalDialog().contains(".modal-dialog-title", "Open")
+      // Example Documents should be selected by default
+      cfm.getModalDialog().contains(".tab-selected", "Example Documents")
+      cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
+      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
+      // Selecting Mammals document should load the mammals example document
+      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").click()
+      cfm.getModalDialog().contains(".buttons button", "Open").click()
+      cy.wait(1000)
+      // once loaded, Open dialog should be hidden and document content should be shown
+      cfm.getModalDialog().should("not.exist")
+      cy.get(".codap-component.codap-case-table").contains(".title-bar", "Mammals").should("exist")
+
+    cy.log("Test table functionalities in Mammals sample doc")
+      // Test linking of selected cases
+    cy.log("verify columns and tooltips")
+        // css width specification caused grid virtualization to only have 9 attributes in the DOM
+        table.getColumnHeaders().should("have.length.be.within", 9, 10)
+        table.getColumnHeader(0).invoke("text").then(columnName => {
+          // const columnNameArr = columnName.split()
+          table.getColumnHeader(0).rightclick({ force: true })
+          // table.getColumnHeaderTooltip().should("contain", columnNameArr[0])
+        })
+      table.getColumnHeader(1).invoke("text").then(columnName => {
+        table.getColumnHeader(1).rightclick({ force: true })
+        })
+      table.getAttribute("Order").should("have.text", "Order")
+      table.getAttribute("LifeSpan").should('have.text', 'LifeSpan(years)')
+
+    // Test table functionalities: (use cy.log())
+      // // Test linking?
+      // // Test selecting cases?
+      // // Test creating parent collections
+      // // Test Expand / collaspe button (?)
+
+      // Test graph functionalities: (use cy.log()) (all with undo/redo if possible)
+      // // Click on a data point in graph and verify highlighting (if possible)
+      // // Use click and drag to create a graph with x and y attributes and verify the graph axes are made
+      // // Change the x and y attributes using the attribute menu and verify new graph axes are made
+
+      // Delete all cases from a table and verify it deletes.
+
+  })
+
+  // Open Roller Coasters
+  // use the Hamburger menu to do so
+  // Test date display in table
+  // Test date display in graph
+
+  // (some day) Test the Map component: (use cy.log())
+  // // Click on the Map button to open a Map
+  // // Add a legend to the map.
+
+  // this test was drafted on 10/16 but will be skipped since we decided we don't need to
+  // test empty CODAP documents
+  it.skip("verify an empty CODAP document appears", () => {
     cy.log("verifies that toolshelf items open")
     cy.log("will open a new table")
       c.clickIconFromToolShelf("table")
@@ -62,192 +128,4 @@ context("codap single smoke test", () => {
       webView.getTitle().should("have.text", "Sampler")
       toolbar.getPluginSelection().should("not.exist")
   })
-
-  it.only("verify Mammals opens and tests graph and table functionality", () => {
-    cy.log("Open Mammals from Hamburger menu")
-      // hamburger menu is hidden initially
-      cfm.getHamburgerMenuButton().should("exist")
-      cfm.getHamburgerMenu().should("not.exist")
-      // hamburger menu is shows when button is clicked
-      cfm.getHamburgerMenuButton().click()
-      cfm.getHamburgerMenu().should("exist")
-      // clicking Open... item closes menu and shows Open dialog
-      cfm.getHamburgerMenu().contains("li", "Open...").click()
-      cfm.getHamburgerMenu().should("not.exist")
-      cfm.getModalDialog().contains(".modal-dialog-title", "Open")
-      // Example Documents should be selected by default
-      cfm.getModalDialog().contains(".tab-selected", "Example Documents")
-      cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
-      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
-      // Selecting Mammals document should load the mammals example document
-      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").click()
-      cfm.getModalDialog().contains(".buttons button", "Open").click()
-      cy.wait(1000)
-      // once loaded, Open dialog should be hidden and document content should be shown
-      cfm.getModalDialog().should("not.exist")
-      cy.get(".codap-component.codap-case-table").contains(".title-bar", "Mammals").should("exist")
-
-    cy.log("Test table functionalities in Mammals sample doc")
-      // Test linking of selected cases
-
-    // Test table functionalities: (use cy.log())
-      // // Test linking?
-      // // Test selecting cases?
-      // // Test creating parent collections
-      // // Test Expand / collaspe button (?)
-
-      // Test graph functionalities: (use cy.log()) (all with undo/redo if possible)
-      // // Click on a data point in graph and verify highlighting (if possible)
-      // // Use click and drag to create a graph with x and y attributes and verify the graph axes are made
-      // // Change the x and y attributes using the attribute menu and verify new graph axes are made
-
-      // Delete all cases from a table and verify it deletes.
-
-  })
-
-
-
-  // (some day) open Roller Coasters
-  // use the Hamburger menu to do so
-
-  // (some day) Test the Map component: (use cy.log())
-  // // Click on the Map button to open a Map
-  // // Add a legend to the map.
-  it("will open a new table", () => {
-    c.clickIconFromToolShelf("table")
-    toolbar.getNewCaseTable().click()
-    table.getCollection().should("be.visible")
-    c.getComponentTitle("table").should("have.text", "New Dataset")
-    c.getIconFromToolShelf("table").click()
-    toolbar.getDatasetListedInToolShelf("New Dataset").should("be.visible")
-  })
-  it("will open a graph", () => {
-    c.clickIconFromToolShelf("graph")
-    graph.getGraphTile().should("be.visible")
-    // graphs with no associated data set should not have a title but show a blank space when hovered
-    c.getComponentTitle("graph").should("not.be.visible")
-    c.getComponentTitleBar("graph").trigger("mouseover")
-    c.getComponentTitle("graph").should("have.text", "_____")
-  })
-  it("will open a map", () => {
-    c.clickIconFromToolShelf("map")
-    map.getMapTile().should("be.visible")
-    c.getComponentTitle("map").should("have.text", "Map")
-  })
-  it("will open a slider", () => {
-    c.clickIconFromToolShelf("slider")
-    slider.getSliderTile().should("be.visible")
-    c.getComponentTitle("slider").should("have.text", "v1")
-  })
-  it("will open a calculator", () => {
-    c.clickIconFromToolShelf("calc")
-    calculator.getCalculatorTile().should("be.visible")
-    c.getComponentTitle("calculator").should("have.text", "Calculator")
-  })
-  it("plugin menu works", () => {
-    c.getIconFromToolShelf("plugins").should("exist").click()
-    toolbar.getPluginSelection().should("have.length", 9)
-    webView.getTitle().should("not.exist")
-    toolbar.getPluginSelection().eq(0).click()
-    webView.getTitle().should("have.text", "Sampler")
-    toolbar.getPluginSelection().should("not.exist")
-  })
-  it('will display a webpage', ()=>{
-      const url='https://www.wikipedia.org'
-      const url2='https://en.wikipedia.org/wiki/Concord_Consortium'
-      toolbar.getOptionsButton().click()
-      toolbar.getWebViewButton().click()
-      webView.getUrlModal().should("exist")
-      webView.enterUrl(url)
-      cy.wait(1500)
-      webView.getUrlModal().should("not.exist")
-      webView.getIFrame().find(`.central-textlogo`).should("be.visible")
-      webView.getEditUrlButton().click()
-      webView.getUrlModal().should("exist")
-      webView.enterUrl(url2)
-      cy.wait(1500)
-      webView.getIFrame().find(`.mw-page-title-main`).should("contain.text", "Concord Consortium")
-  })
-  it('will show a list of open tiles when there is no data context', ()=>{
-    // Don't open a table as this automatically creates a data context
-    c.getIconFromToolShelf("graph").click()
-    c.getIconFromToolShelf("map").click()
-    c.getIconFromToolShelf("slider").click()
-    c.getIconFromToolShelf("calc").click()
-    c.getIconFromToolShelf("plugins").click()
-    toolbar.getPluginSelection().eq(0).click()
-    //TODO need to add check for Text component
-    toolbar.getTilesButton().click()
-    toolbar.getTilesListMenu().should("be.visible")
-    toolbar.getTilesListMenuItem().should("have.length", 5)
-
-    toolbar.getTilesListMenuItem().eq(0).should("have.text", "")
-    toolbar.getTilesListMenuIcon().eq(0).should("have.class", "Graph")
-    toolbar.getTilesListMenuItem().eq(1).should("have.text", "Map")
-    toolbar.getTilesListMenuIcon().eq(1).should("have.class", "Map")
-    toolbar.getTilesListMenuItem().eq(2).should("have.text", "v1")
-    toolbar.getTilesListMenuIcon().eq(2).should("have.class", "CodapSlider")
-    toolbar.getTilesListMenuItem().eq(3).should("have.text", "Calculator")
-    toolbar.getTilesListMenuIcon().eq(3).should("have.class", "Calculator")
-    toolbar.getTilesListMenuItem().eq(4).should("have.text", "Sampler")
-    toolbar.getTilesListMenuIcon().eq(4).should("have.class", "WebView")
-  })
-  it('will show correct title for a new table', ()=>{
-    c.getIconFromToolShelf("table").click()
-    toolbar.getNewCaseTable().click()
-    toolbar.getTilesButton().click()
-    toolbar.getTilesListMenu().should("be.visible")
-    toolbar.getTilesListMenuItem().should("have.length", 1)
-    toolbar.getTilesListMenuItem().eq(0).should("have.text", "New Dataset")
-    toolbar.getTilesListMenuIcon().eq(0).should("have.class", "CaseTable")
-  })
-  it('will show a list of open tiles when there is a data context', ()=>{
-    cy.visit("#file=examples:Four%20Seals")
-    toolbar.getTilesButton().click()
-    toolbar.getTilesListMenu().should("be.visible")
-    toolbar.getTilesListMenuItem().should("have.length", 4)
-    toolbar.getTilesListMenuItem().eq(0).should("have.text", "Tracks/Measurements")
-    toolbar.getTilesListMenuItem().eq(1).should("have.text", "Measurements")
-    toolbar.getTilesListMenuItem().eq(2).should("have.text", "Measurements")
-    toolbar.getTilesListMenuItem().eq(3).should("have.text", "Getting Started")
-  })
-  it('will show the help pages list', ()=>{
-    cy.visit("#file=examples:Four%20Seals")
-    c.getIconFromToolShelf("help").click()
-    toolbar.getHelpMenu().should("be.visible")
-    toolbar.getHelpMenuItem("help").should("contains.text", "Help Pages and Videos")
-    toolbar.getHelpMenuItem("forum").should("contains.text", "Help Forum")
-    toolbar.getHelpMenuItem("project").should("contains.text", "The CODAP Project")
-    toolbar.getHelpMenuItem("privacy").should("contains.text", "Privacy Page")
-  })
-})
-
-context("Help Pages", () => {
-  beforeEach(() => {
-    cy.visit("#file=examples:Four%20Seals")
-    cy.window().then((win) => {
-      cy.stub(win, "open").as("windowOpen")
-    })
-  })
-  it('will open the help page', ()=>{
-    c.getIconFromToolShelf("help").click()
-    toolbar.getHelpMenuItem("help").click()
-    cy.get('@windowOpen').should('have.been.calledWith', helpURL)
-  })
-  it('will open the forum page', ()=>{
-    c.getIconFromToolShelf("help").click()
-    toolbar.getHelpMenuItem("forum").click()
-    cy.get('@windowOpen').should('have.been.calledWith', helpForumURL)
-  })
-  it('will open the project website', ()=>{
-    c.getIconFromToolShelf("help").click()
-    toolbar.getHelpMenuItem("project").click()
-    cy.get('@windowOpen').should('have.been.calledWith', projectWebSiteURL)
-  })
-  it('will open the privacy policy page', ()=>{
-    c.getIconFromToolShelf("help").click()
-    toolbar.getHelpMenuItem("privacy").click()
-    cy.get('@windowOpen').should('have.been.calledWith', privacyURL)
-  })
-  //TODO need to add test for the translated help page
 })

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -31,7 +31,7 @@ context("codap single smoke test", () => {
     cfm.getModalDialog().contains(".tab-selected", "Example Documents")
     cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
     cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
-    // Selecting Mammals document should load the mammals example document
+    // Selecting Mammals document should load the Mammals example document
     cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").click()
     cfm.getModalDialog().contains(".buttons button", "Open").click()
     cy.wait(1000)
@@ -50,7 +50,7 @@ context("codap single smoke test", () => {
     })
     table.getColumnHeader(1).invoke("text").then(columnName => {
       table.getColumnHeader(1).rightclick({ force: true })
-      })
+    })
     table.getAttribute("Order").should('be.visible').and("have.text", "Order")
     table.getAttribute("LifeSpan").should('be.visible').and('have.text', 'LifeSpan(years)')
 
@@ -69,17 +69,15 @@ context("codap single smoke test", () => {
     cy.log("test graph axis functionalities in Mammals sample doc")
     // it is possible to create a graph
     cy.dragAttributeToTarget("table", "Speed", "left")
-    //cy.wait(500)
     cy.get('[data-testid="axis-legend-attribute-button-left"]').eq(0).should("have.text", "Speed")
     cy.get("[data-testid=graph]").find("[data-testid=axis-left]").find(".tick").should("have.length", 25)
     cy.dragAttributeToTarget("table", "Mammal", "bottom")
-    //cy.wait(500)
     cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "Mammal")
     cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".tick").should("have.length", 27)
 
     cy.log("test creating parent collections")
     // NOTE: the graph compresses to a single point in Cypress here.
-    // This is a known issue and seems tied to just the Mammals sample dataset (PT-#188415914)
+    // This is a known issue and seems tied to just the Mammals example dataset (PT-#188415914)
     table.moveAttributeToParent("Habitat", "newCollection")
     table.getNumOfRows(1).should("contain", 5) // five rows: top, land, water, both, bottom
     table.moveAttributeToParent("Diet", "newCollection")
@@ -109,7 +107,7 @@ context("codap single smoke test", () => {
     cfm.getModalDialog().contains(".tab-selected", "Example Documents")
     cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
     cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
-    // Selecting Mammals document should load the mammals example document
+    // Selecting Four Seals document should load the Four Seals example document
     cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").click()
     cfm.getModalDialog().contains(".buttons button", "Open").click()
     cy.wait(1000)
@@ -126,22 +124,22 @@ context("codap single smoke test", () => {
     cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "date")
     // Check that the date axis contains the year '2005'
     cy.get('[data-testid="axis-bottom"]')
-    .find('text')
-    .contains('2005')
-    .should('exist')
+      .find('text')
+      .contains('2005')
+      .should('exist')
 
     // Check the number of tick marks on axis (e.g., ensuring there are 9 months: May to Jan)
     cy.get('[data-testid="axis-bottom"]')
-    .find('text')
-    .should('have.length', 10) // Adjust this if the expected number changes (currently 9 + ghost div=10)
+      .find('text')
+      .should('have.length', 10) // Adjust this if the expected number changes (currently 9 + ghost div=10)
 
     cy.log("checks map component")
     c.getComponentTitle("map").should("have.text", "Measurements")
+    cy.get('.leaflet-container').should('exist') // Ensure the map container is ready
     // Some day add a check for map with points, see PT #187534790
     // Also some day add a legend to the map.
-
   })
-  it("verify an empty CODAP document appears", () => {
+  it("verify an empty CODAP document appears and components open", () => {
     cy.log("verifies that toolshelf items open")
     cy.log("will open a new table")
     c.clickIconFromToolShelf("table")
@@ -166,6 +164,7 @@ context("codap single smoke test", () => {
     c.clickIconFromToolShelf("map")
     map.getMapTile().should("be.visible")
     c.getComponentTitle("map").should("have.text", "Map")
+    cy.get('.leaflet-container').should('exist') // Ensure the map container is ready
     c.closeComponent("map")
 
     cy.log("will open a slider")

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -15,7 +15,7 @@ context("codap single smoke test", () => {
     cy.visit(url)
   })
 
-  it.only("verify Mammals opens from Hamburger menu and tests graph and table functionality", () => {
+  it("verify Mammals opens from Hamburger menu and tests graph and table functionality", () => {
     cy.log("Open Mammals from Hamburger menu")
       // hamburger menu is hidden initially
       cfm.getHamburgerMenuButton().should("exist")
@@ -40,71 +40,109 @@ context("codap single smoke test", () => {
       cy.get(".codap-component.codap-case-table").contains(".title-bar", "Mammals").should("exist")
 
     cy.log("Test table functionalities in Mammals sample doc")
-      // Test linking of selected cases
-    cy.log("verify columns exist")
-        // css width specification caused grid virtualization to only have 9 attributes in the DOM
-        table.getColumnHeaders().should("have.length.be.within", 9, 10)
-        table.getColumnHeader(0).invoke("text").then(columnName => {
-          // const columnNameArr = columnName.split()
-          table.getColumnHeader(0).rightclick({ force: true })
-          // table.getColumnHeaderTooltip().should("contain", columnNameArr[0])
-        })
-      table.getColumnHeader(1).invoke("text").then(columnName => {
-        table.getColumnHeader(1).rightclick({ force: true })
-        })
-      table.getAttribute("Order").should('be.visible').and("have.text", "Order")
-      table.getAttribute("LifeSpan").should('be.visible').and('have.text', 'LifeSpan(years)')
+      cy.log("verify columns exist")
+          // css width specification caused grid virtualization to only have 9 attributes in the DOM
+          table.getColumnHeaders().should("have.length.be.within", 9, 10)
+          table.getColumnHeader(0).invoke("text").then(columnName => {
+            // const columnNameArr = columnName.split()
+            table.getColumnHeader(0).rightclick({ force: true })
+            // table.getColumnHeaderTooltip().should("contain", columnNameArr[0])
+          })
+        table.getColumnHeader(1).invoke("text").then(columnName => {
+          table.getColumnHeader(1).rightclick({ force: true })
+          })
+        table.getAttribute("Order").should('be.visible').and("have.text", "Order")
+        table.getAttribute("LifeSpan").should('be.visible').and('have.text', 'LifeSpan(years)')
 
-      cy.log("verify grid cells exist")
-      table.getGridCell(2, 2).should('be.visible').and("contain", "African Elephant")
-      table.getGridCell(4, 4).should('be.visible').and("contain", "19")
-      table.getNumOfRows().should('eq', '29') // 27 cases, plus the empty row and top row
+        cy.log("verify grid cells exist")
+          table.getGridCell(2, 2).should('be.visible').and("contain", "African Elephant")
+          table.getGridCell(4, 4).should('be.visible').and("contain", "19")
+          table.getNumOfRows().should('eq', '29') // 27 cases, plus the empty row and top row
 
-      cy.log("test table functionalities")
-      // test lined selection
-      table.getGridCell(2, 2).should("contain", "African Elephant").click()
-      // TODO: Add more thorough checks to make sure graph points and table rows actually change color when selected,
-      // once Cypress is configured to interact with the PixiJS canvas. For now, we just check that the buttons
-      // are disabled and enabled as expected.
+        cy.log("verify selecting cases in the table")
+          table.getGridCell(2, 2).should("contain", "African Elephant").click()
+          table.getGridCell(2, 2).should('have.attr', 'aria-selected', 'true')
+        // TODO: Add more thorough checks to make sure graph points and table rows actually change color when selected,
+        // once Cypress is configured to interact with the PixiJS canvas. For now, we just check that the buttons in table
+        // are enabled upon selection.
 
-      // test selecting cases
-      table.getGridCell(2, 2).should('have.attr', 'aria-selected', 'true')
+        cy.log("test graph axis functionalities in Mammals sample doc")
+        // it is possible to create a graph
+          cy.dragAttributeToTarget("table", "Speed", "left")
+          //cy.wait(500)
+          cy.get('[data-testid="axis-legend-attribute-button-left"]').eq(0).should("have.text", "Speed")
+          cy.get("[data-testid=graph]").find("[data-testid=axis-left]").find(".tick").should("have.length", 25)
+          cy.dragAttributeToTarget("table", "Mammal", "bottom")
+          //cy.wait(500)
+          cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "Mammal")
+          cy.get("[data-testid=graph]").find("[data-testid=axis-bottom]").find(".tick").should("have.length", 27)
 
-      cy.log("test creating parent collections")
-        //table.moveAttributeToParent("Habitat", "parent", 1)
+        cy.log("test creating parent collections")
+        // NOTE: the graph compresses to a single point in Cypress here.
+        // This is a known issue and seems tied to just the Mammals sample dataset (PT-#188415914)
+          table.moveAttributeToParent("Habitat", "newCollection")
+          table.getNumOfRows(1).should("contain", 5) // five rows: top, land, water, both, bottom
+          table.moveAttributeToParent("Diet", "newCollection")
+          table.getNumOfRows(1).should("contain", 5) // five rows: top, plants, meat, both, bottom
 
-        table.moveAttributeToParent("Habitat", "newCollection")
-        table.getNumOfRows(1).should("contain", 5) // five rows: top, land, water, both, bottom
+      cy.log("Delete all cases from the hierarchical table and verify the cases delete.")
+        c.selectTile("table", 0)
+        table.getDeleteCasesButton().click()
+        table.getDeleteMenuItem("Delete All Cases").click()
+        table.getNumOfRows(1).should("contain", 2) // two rows: top, empty
+        cy.get('[data-testid="no-cases-message"]').should('exist').and('contain.text', 'no cases')
+  })
+  it("verify Four Seals opens from Hamburger menu and tests graph date and table functionality", () => {
+    // Open Four Seals
+    cy.log("Open Four Seals from Hamburger menu")
+      // hamburger menu is hidden initially
+      cfm.getHamburgerMenuButton().should("exist")
+      cfm.getHamburgerMenu().should("not.exist")
+      // hamburger menu is shows when button is clicked
+      cfm.getHamburgerMenuButton().click()
+      cfm.getHamburgerMenu().should("exist")
+      // clicking Open... item closes menu and shows Open dialog
+      cfm.getHamburgerMenu().contains("li", "Open...").click()
+      cfm.getHamburgerMenu().should("not.exist")
+      cfm.getModalDialog().contains(".modal-dialog-title", "Open")
+      // Example Documents should be selected by default
+      cfm.getModalDialog().contains(".tab-selected", "Example Documents")
+      cfm.getModalDialog().contains(".filelist div.selectable", "Mammals").should("exist")
+      cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").should("exist")
+      // Selecting Mammals document should load the mammals example document
+      cfm.getModalDialog().contains(".filelist div.selectable", "Four Seals").click()
+      cfm.getModalDialog().contains(".buttons button", "Open").click()
+      cy.wait(1000)
+      // once loaded, Open dialog should be hidden and document content should be shown
+      cfm.getModalDialog().should("not.exist")
+      cy.get(".codap-component.codap-case-table").contains(".title-bar", "Tracks/Measurements").should("exist")
 
-       table.moveAttributeToParent("Diet", "newCollection")
-       table.getNumOfRows(1).should("contain", 5) // five rows: top, plants, meat, both, bottom
+    cy.log("Test date display exists in table")
+      cy.get('button[data-testid="codap-attribute-button date"]').should('exist')
+      table.getGridCell(2, 3, 2).should('be.visible').and("contain", "5/23/2005")
 
+    cy.log("Test date display in bottom axis of graph")
+      cy.dragAttributeToTarget("table", "date", "bottom")
+      cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "date")
+      // Check that the date axis contains the year '2005'
+      cy.get('[data-testid="axis-bottom"]')
+      .find('text')
+      .contains('2005')
+      .should('exist')
 
-    // Test table functionalities: (use cy.log())
-      // // Test linking? (x)
-      // // Test creating parent collections (x)
-      // // ~~Test Expand / collaspe button (?)~~
+      // Check the number of tick marks on axis (e.g., ensuring there are 9 months: May to Jan)
+      cy.get('[data-testid="axis-bottom"]')
+      .find('text')
+      .should('have.length', 10) // Adjust this if the expected number changes (currently 9 + ghost div=10)
 
-      // Test graph functionalities: (use cy.log()) (all with undo/redo if possible)
-      // // ~~Click on a data point in graph and verify highlighting (if possible)~~
-      // // Use click and drag to create a graph with x and y attributes and verify the graph axes are made
-      // // Change the x and y attributes using the attribute menu and verify new graph axes are made
-
-      // Delete all cases from a table and verify it deletes.
+    cy.log("checks map component")
+      c.getComponentTitle("map").should("have.text", "Measurements")
+      // Some day add a check for map with points, see PT #187534790
+      // Also some day add a legend to the map.
 
   })
-
-  // Open Roller Coasters
-  // use the Hamburger menu to do so
-  // Test date display in table
-  // Test date display in graph
-
-  // (some day) Test the Map component: (use cy.log())
-  // // Click on the Map button to open a Map
-  // // Add a legend to the map.
-
-  // this test was drafted on 10/16 but will be skipped since we decided we don't need to
-  // test empty CODAP documents
+  // NOTE: This test was drafted on 10/16/2024 but will be skipped since we decided we don't need to
+  // smoke test empty CODAP documents
   it.skip("verify an empty CODAP document appears", () => {
     cy.log("verifies that toolshelf items open")
     cy.log("will open a new table")

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -99,7 +99,8 @@ export const TableTileElements = {
     return cy.get("[data-testid^=codap-attribute-button]")
   },
   getAttribute(name: string, collectionIndex = 1) {
-    return this.getCollection(collectionIndex).find(`[data-testid^="codap-attribute-button ${name}"]`)
+    const sanitizedName = name.trim()
+    return this.getCollection(collectionIndex).find(`[data-testid="codap-attribute-button ${sanitizedName}"]`)
   },
   getAttributeInput(collectionIndex = 1) {
     return this.getCollection(collectionIndex).find("[data-testid=column-name-input]")

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -151,6 +151,6 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
 const NoCasesMessage = observer(function NoCasesMessage() {
   const data = useDataSetContext()
   return !data?.items.length
-          ? <div className="no-cases-message">{t("V3.caseTable.noCases")}</div>
+          ? <div className="no-cases-message" data-testid="no-cases-message">{t("V3.caseTable.noCases")}</div>
           : null
 })


### PR DESCRIPTION
[PT-#188412560](https://www.pivotaltracker.com/story/show/188412560)

### Description:
This PR introduces a new targeted Cypress smoke test that checks for essential functionality when developers push code without including the `run regression` label. Below are the key details of the changes included:

### Changes Made:
- **New Folder Structure:**
	•	Added a /smoke/ folder under Cypress to keep the smoke tests organized. This mirrors the structure used in the CLUE project and will help with future scalability if more smoke tests are needed.
- **New Smoke Tests:**
	1.	**Mammals Dataset Test:**
	•	Verifies the Mammals dataset opens and contains data.
	•	Checks the ability to create a hierarchy within the table.
	•	Includes a test to create a graph with both x and y axes.
	2.	**Four Seals Dataset Test:**
	•	Verifies the dataset opens and checks a table and graph with date attributes.
	•	Confirms that the Map component opens successfully.
	3.	**Empty Document Test (Skipped):**
	•	This test checks for an empty document but is skipped for now since document opening is already covered in a Jest test.
	•	Logged a related issue while working on this: [#188439366](https://www.pivotaltracker.com/story/show/188439366).

### Questions/Requests:

**Cypress Setup for Pushes:**
I’m unsure how to configure Cypress to automatically run these smoke tests on every push without the `run regression` label. This might need to be addressed in a separate story—perhaps Scott or Kirk could assist with that setup?
	•	I’d also love to learn how this process works, so please mark me as a reviewer on the PR when it gets set up!

### Testing Notes:
- I added comments in the code to document any minor issues I encountered during testing.
- The smoke tests are passing locally and took my machine 17 seconds to run through, and I believe the implementation is ready for review.

### Next Steps:

- If additional configuration is needed to run these smoke tests automatically, we can create a follow-up story.
- There's a lint error I see, `/Users/nstclair/ConcordConsortium/codap/v3/src/components/case-table/use-columns.tsx
  15:8  warning  Using exported name 'clsx' as identifier for default export  import/no-named-as-default`, which I believe may be tied to the datatest-id I was hoping to add in the code. Feedback on this issue is welcome!
- Feedback on the structure or test coverage is welcome!

Let me know if there are any questions or if further changes are needed. Thanks very much!