### PR TITLE
Show squares of residuals for plotted functions

### DIFF
--- a/v3/src/components/data-display/data-display-types.ts
+++ b/v3/src/components/data-display/data-display-types.ts
@@ -33,6 +33,11 @@ export interface IConnectingLineDescription {
   plotNum?: number
 }
 
+export interface ICaseSubsetDescription {
+  category?: string
+  cellKey: Record<string, string>
+}
+
 export const
   transitionDuration = 1000,
   pointRadiusMax = 10,

--- a/v3/src/components/graph/adornments/adornments-store-utils.ts
+++ b/v3/src/components/graph/adornments/adornments-store-utils.ts
@@ -3,6 +3,7 @@ import { getAdornmentComponentInfo, IAdornmentComponentInfo } from "./adornment-
 import { IMeasure, measures, RulerStateKey } from "./adornment-ui-types"
 import { kMovableLineType } from "./movable-line/movable-line-adornment-types"
 import { kLSRLType } from "./lsrl/lsrl-adornment-types"
+import { kPlottedFunctionType } from "./plotted-function/plotted-function-adornment-types"
 import { kCountType } from "./count/count-adornment-types"
 import { IAdornmentsBaseStore } from "./adornments-base-store"
 import { PlotType } from "../graphing-types"
@@ -122,9 +123,10 @@ export function getAdornmentsMenuItemsFromTheStore(theStore: IAdornmentsBaseStor
   if (plotType === "scatterPlot") {
     const movableLineVisible = theStore.isShowingAdornment(kMovableLineType)
     const lsrlVisible = theStore.isShowingAdornment(kLSRLType)
+    const plottedFunctionVisible = theStore.isShowingAdornment(kPlottedFunctionType)
     addItemIfCondition(true, {
       checked: theStore.showSquaresOfResiduals,
-      disabled: !movableLineVisible && !lsrlVisible,
+      disabled: !movableLineVisible && !lsrlVisible && !plottedFunctionVisible,
       title: "DG.Inspector.graphSquares",
       type: "control",
       clickHandler: theStore.toggleShowSquaresOfResiduals

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
@@ -136,7 +136,7 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
       const { slope, intercept, rSquared } = lines[linesIndex]
       if (slope == null || intercept == null) return
       const sumOfSquares = dataConfig && showSumSquares
-        ? calculateSumOfSquares({ cellKey, dataConfig, intercept, slope })
+        ? calculateSumOfSquares({ cellKey, dataConfig, computeY: (x) => intercept + slope * x })
         : undefined
       const screenX = xScale((pointsOnAxes.current.pt1.x + pointsOnAxes.current.pt2.x) / 2) / xSubAxesCount
       const screenY = yScale((pointsOnAxes.current.pt1.y + pointsOnAxes.current.pt2.y) / 2) / ySubAxesCount

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
@@ -83,7 +83,7 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
     const screenY = yScaleRef.current((pointsOnAxes.current.pt1.y + pointsOnAxes.current.pt2.y) / 2) / ySubAxesCount
     const attrNames = {x: xAttrName, y: yAttrName}
     const sumOfSquares = dataConfig && showSumSquares
-      ? calculateSumOfSquares({ cellKey, dataConfig, intercept, slope })
+      ? calculateSumOfSquares({ cellKey, dataConfig, computeY: (x) => intercept + slope * x })
       : undefined
     const string = equationString({slope, intercept, attrNames, sumOfSquares, layout})
     const equation = select(equationContainerSelector).select("p")

--- a/v3/src/components/graph/adornments/shared-adornment-types.ts
+++ b/v3/src/components/graph/adornments/shared-adornment-types.ts
@@ -1,6 +1,6 @@
-export interface ILineDescription {
-  category?: string
-  cellKey: Record<string, string>
+import { ICaseSubsetDescription } from "../../data-display/data-display-types"
+
+export interface ILineDescription extends ICaseSubsetDescription {
   intercept: number
   slope: number
 }

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -8,7 +8,8 @@ import {AxisPlace} from "../../axis/axis-types"
 import {GraphPlace} from "../../axis-graph-shared"
 import {AttributeDescription, DataConfigurationModel, IAttributeDescriptionSnapshot, IDataConfigurationModel}
   from "../../data-display/models/data-configuration-model"
-import {AttrRole, GraphAttrRole, graphPlaceToAttrRole, PrimaryAttrRoles} from "../../data-display/data-display-types"
+import {AttrRole, GraphAttrRole, graphPlaceToAttrRole, ICaseSubsetDescription, PrimaryAttrRoles}
+  from "../../data-display/data-display-types"
 import {updateCellKey} from "../adornments/adornment-utils"
 import { isFiniteNumber } from "../../../utilities/math-utils"
 import { CaseData, CaseDataWithSubPlot } from "../../data-display/d3-types"
@@ -397,6 +398,17 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         cellKeys.push(this.cellKey(i))
       }
       return cellKeys
+    },
+    getAllCaseSubsetDescriptions() {
+      const cellKeys = this.getAllCellKeys()
+      const legendCategories = self.categoryArrayForAttrRole("legend") ?? [""]
+      const cellSubsetDescriptions: ICaseSubsetDescription[] = []
+      cellKeys.forEach(cellKey => {
+        legendCategories.forEach(category => {
+          cellSubsetDescriptions.push({category, cellKey})
+        })
+      })
+      return cellSubsetDescriptions
     },
     isCaseInSubPlot(cellKey: Record<string, string>, caseData: Record<string, any>) {
       const numOfKeys = Object.keys(cellKey).length

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -291,6 +291,13 @@ interface IEquationString {
   sumOfSquares?: number
 }
 
+export function residualsString(sumOfSquares:number, includeBreak = true) {
+  const squaresMaxDec = !sumOfSquares || sumOfSquares > 100 ? 0 : 3
+  const formattedSumOfSquares = formatEquationValue(sumOfSquares || 0, squaresMaxDec)
+  return isFiniteNumber(sumOfSquares)
+    ? `${includeBreak ? '<br />' : ''}${t("DG.ScatterPlotModel.sumSquares")} = ${formattedSumOfSquares}` : ""
+}
+
 export function equationString({ slope, intercept, attrNames, sumOfSquares, layout }: IEquationString) {
   const slopeIsFinite = isFinite(slope) && slope !== 0
   const neededFractionDigits = findNeededFractionDigits(slopeIsFinite ? slope : 0, intercept, layout)
@@ -622,12 +629,10 @@ export const leastSquaresLinearRegression = (iValues: Point[], iInterceptLocked:
 interface ISumOfSquares {
   cellKey: Record<string, string>
   dataConfig: IGraphDataConfigurationModel
-  intercept: number
-  slope: number
-  defaultVal?: number
+  computeY: (x: number) => number
 }
 
-export const calculateSumOfSquares = ({ cellKey, dataConfig, intercept, slope }: ISumOfSquares) => {
+export const calculateSumOfSquares = ({ cellKey, dataConfig, computeY }: ISumOfSquares) => {
   const dataset = dataConfig?.dataset
   const caseData = dataset?.items
   const xAttrID = dataConfig?.attributeID("x") ?? ""
@@ -638,9 +643,8 @@ export const calculateSumOfSquares = ({ cellKey, dataConfig, intercept, slope }:
     if (fullCaseData && dataConfig?.isCaseInSubPlot(cellKey, fullCaseData)) {
       const x = dataset?.getNumeric(datum.__id__, xAttrID) ?? NaN
       const y = dataset?.getNumeric(datum.__id__, yAttrID) ?? NaN
-      if (slope == null || intercept == null) return
-      const lineY = slope * x + intercept
-      const residual = y - lineY
+      const yValue = computeY(x)
+      const residual = y - yValue
       if (isFinite(residual)) {
         sumOfSquares += residual * residual
       }


### PR DESCRIPTION
[#188356056] Feature: The user can choose to display the squares of residuals from a plotted function

* Enable the Squares of Residuals checkbox when a plotted function exists on a scatterplot
* In scatterdots.tsx obtain the plotted function model (if any) for use in drawing residual squares
* In scatterdots.tsx we add an text element for the sum of squares of residuals to a plotted function. It shows if there is a plotted function and squares are showing