### PR TITLE
Prevent first map/graph click from clearing selection

### DIFF
--- a/v3/src/components/case-table/use-white-space-click.ts
+++ b/v3/src/components/case-table/use-white-space-click.ts
@@ -37,6 +37,8 @@ export function useWhiteSpaceClick({ gridRef }: IProps) {
   }, [componentRef, data])
 
   const handleWhiteSpaceClick = useCallback(() => {
+    console.log(`handleWhiteSpaceClick: wasFocusedTileRef.current: ${wasFocusedTileRef.current}; 
+    isFocusedTileRef.current: ${isFocusedTileRef.current}`)
     if (!wasFocusedTileRef.current && isFocusedTileRef.current) {
       // Focused the table, do nothing with the selection
       wasFocusedTileRef.current = true

--- a/v3/src/components/data-display/hooks/use-pointer-down-capture.ts
+++ b/v3/src/components/data-display/hooks/use-pointer-down-capture.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react"
+import { useTileModelContext } from "../../../hooks/use-tile-model-context"
+import { selectAllCases } from "../../../models/data/data-set-utils"
+import { IDataDisplayContentModel } from "../models/data-display-content-model"
+
+export function usePointerDownCapture(dataDisplayModel?: IDataDisplayContentModel) {
+  const { isTileSelected } = useTileModelContext()
+
+  useEffect(() => {
+    const handlePointerDownCapture = (event: PointerEvent) => {
+      const isWindowEvent = event.target instanceof HTMLCanvasElement
+      if (isWindowEvent && !event.shiftKey && isTileSelected()) {
+        const datasetsArray = dataDisplayModel?.datasetsArray ?? []
+        datasetsArray.forEach(data => selectAllCases(data, false))
+      }
+    }
+    window.addEventListener("pointerdown", handlePointerDownCapture, { capture: true })
+    return () => window.removeEventListener("pointerdown", handlePointerDownCapture, { capture: true })
+  }, [dataDisplayModel?.datasetsArray, isTileSelected])
+
+}

--- a/v3/src/components/map/components/map-component.tsx
+++ b/v3/src/components/map/components/map-component.tsx
@@ -4,10 +4,10 @@ import React, {useEffect, useRef} from "react"
 import {useResizeDetector} from "react-resize-detector"
 import { getOverlayDragId } from '../../../hooks/use-drag-drop'
 import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-id-context"
-import { selectAllCases } from '../../../models/data/data-set-utils'
-import {DataDisplayLayoutContext} from "../../data-display/hooks/use-data-display-layout"
-import {AttributeDragOverlay} from "../../drag-drop/attribute-drag-overlay"
 import {ITileBaseProps} from '../../tiles/tile-base-props'
+import {DataDisplayLayoutContext} from "../../data-display/hooks/use-data-display-layout"
+import { usePointerDownCapture } from "../../data-display/hooks/use-pointer-down-capture"
+import {AttributeDragOverlay} from "../../drag-drop/attribute-drag-overlay"
 import {isMapContentModel} from "../models/map-content-model"
 import {MapModelContext} from "../hooks/use-map-model-context"
 import {useInitMapLayout} from "../hooks/use-init-map-layout"
@@ -21,16 +21,7 @@ export const MapComponent = observer(function MapComponent({tile}: ITileBaseProp
   const mapRef = useRef<HTMLDivElement | null>(null)
   const {width, height} = useResizeDetector<HTMLDivElement>({targetRef: mapRef})
 
-  useEffect(() => {
-    if (mapModel) {
-      mapModel.leafletMapState.setOnClickCallback((event: MouseEvent) => {
-        if (!event.shiftKey && !event.metaKey && !mapModel._ignoreLeafletClicks) {
-          mapModel.layers.forEach(layer => selectAllCases(layer.data, false))
-        }
-      })
-      return () => mapModel.leafletMapState.setOnClickCallback()
-    }
-  }, [mapModel])
+  usePointerDownCapture(mapModel)
 
   useEffect(() => {
     (width != null) && (height != null) && layout.setTileExtent(width, height)

--- a/v3/src/hooks/use-tile-model-context.ts
+++ b/v3/src/hooks/use-tile-model-context.ts
@@ -9,7 +9,8 @@ export const useTileModelContext = () => {
   const transitionComplete = tile?.transitionComplete ?? false
 
   const isTileSelected = useCallback(function isTileSelected() {
-    return uiState.isFocusedTile(tile?.id)
+    const isFocused = uiState.isFocusedTile(tile?.id)
+    return isFocused
   }, [tile])
 
   const selectTile = useCallback(function selectTile() {


### PR DESCRIPTION
[#187953007] Bug Fix: First click in graph/map empty space does not change selection

The trick for both graph and map is to distinguish between a window event and a PointerDown event sent by PixiPoints. We create use-pointer-down-capture.ts to encapsulate the process and call usePointerDownCapture from background.tsx and map-component.tsx