### PR TITLE
187738926 Broadcast Sort Attribute Notifications

### DIFF
--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -259,6 +259,12 @@ context("codap plugins", () => {
     webView.confirmAPITesterResponseContains(/"operation":\s"updateCases/)
     webView.clearAPITesterResponses()
 
+    cy.log("Broadcast moveCases notifications")
+    table.openAttributeMenu("Mammal")
+    table.selectMenuItemFromAttributeMenu("Sort Ascending (A→Z, 0→9)")
+    webView.confirmAPITesterResponseContains(/"operation":\s"moveCases/)
+    webView.clearAPITesterResponses()
+
     cy.log("Broadcast deleteCases notifications")
     table.openIndexMenuForRow(2)
     table.deleteCase()

--- a/v3/src/models/data/data-set-notifications.ts
+++ b/v3/src/models/data/data-set-notifications.ts
@@ -113,6 +113,14 @@ export function createCasesNotification(caseIDs: string[], data?: IDataSet) {
   return notification("createCases", result, data)
 }
 
+export function moveCasesNotification(data: IDataSet, cases: ICase[] = []) {
+  const result = {
+    success: true,
+    caseIDs: cases.map(aCase => toV2Id(aCase.__id__))
+  }
+  return notification("moveCases", result, data)
+}
+
 export function updateCasesNotification(data: IDataSet, cases?: ICase[]) {
   const caseIDs = cases?.map(c => toV2Id(c.__id__))
   const result = {

--- a/v3/src/models/data/data-set-undo.ts
+++ b/v3/src/models/data/data-set-undo.ts
@@ -8,7 +8,7 @@ import { withCustomUndoRedo } from "../history/with-custom-undo-redo"
 import { ICollectionModel } from "./collection"
 import { CaseInfo, IAddCasesOptions, ICase, ICaseCreation, IItem } from "./data-set-types"
 import { DataSet, IDataSet } from "./data-set"
-import { deleteCasesNotification, } from "./data-set-notifications"
+import { deleteCasesNotification, moveCasesNotification, } from "./data-set-notifications"
 
 /*
  * setCaseValues custom undo/redo
@@ -328,6 +328,7 @@ export function sortItemsWithCustomUndoRedo(data: IDataSet, attrId: string, dire
   }, {
     log: logStringifiedObjectMessage("Sort cases by attribute: %@",
             { attributeId: attrId, attribute: data?.getAttribute(attrId)?.name }),
+    notify: moveCasesNotification(data),
     undoStringKey: "DG.Undo.caseTable.sortCases",
     redoStringKey: "DG.Redo.caseTable.sortCases"
   })


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187738926

This PR fixes a bug in the Multidata plugin, where the plugin was not updating properly when an attribute was sorted. This is because notifications were never being broadcast when an attribute was sorted.

Note that in v2 this notification has an empty array for `caseIDs`. I kept this in v3, since doing anything more would require more work. Like with many notifications, plugins seem to just care that a notification was broadcast, not any of the specific information in the notification, relying on subsequent API requests to get details about the state of Codap after the change.