### PR TITLE
Fix Hide Unselected Cases for maps and graphs

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -274,18 +274,12 @@ export const DataConfigurationModel = types
      * present in any of the case sets, not just the 0th one.
      */
     get selection() {
-      if (!self.dataset || !self.filteredCases[0]) return []
+      if (!self.dataset) return []
       return Array.from(this.visibleCaseIds).filter(caseId => self.dataset?.isCaseSelected(caseId))
     },
-    /**
-     * Note that in order to eliminate a selected case from the graph's selection, we have to check that it is not
-     * present in any of the case sets, not just the 0th one.
-     */
     get unselectedCases() {
-      if (!self.dataset || !self.filteredCases[0]) return []
-      const selection = self.dataset.selection,
-        allGraphCaseIds = Array.from(this.visibleCaseIds)
-      return allGraphCaseIds.filter((caseId: string) => !selection.has(caseId))
+      if (!self.dataset) return []
+      return Array.from(this.visibleCaseIds).filter(caseId => !self.dataset?.isCaseSelected(caseId))
     }
   }))
   .views(self => ({


### PR DESCRIPTION
[#188351110] Bug Fix: Hide cases is broken in map

Actually, the bug is that **Hide Unselected Cases** is broken for both maps and graphs in that it hides *all* the cases, not just in the map. 

* The bug was in data-configuration-model.ts `get unselectedCases` which was wrongly assuming that `dataset.selection` is an array of case ids when, in fact it is an array of item ids. So, instead of using it, we call the much more transparent `dataset.isCaseSelected` to filter out the selected cases.
* We also clean up both `get selection` and `get unselectedCases` a bit.