### PR TITLE
Graph hierarchy with legend bug

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -108,7 +108,7 @@ export const DataConfigurationModel = types
         .map(aRole => this.attributeID(aRole))
         .filter(id => !!id)
     },
-    get childmostCollectionIDForPlottedAttributes() {
+    get childmostCollectionIDForAxisAttributes() {
         return idOfChildmostCollectionForAttributes(this.axisAttributeIDs, self.dataset)
     },
     get isEmpty() {

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -102,14 +102,14 @@ export const DataConfigurationModel = types
     filterFormulaError: ""
   }))
   .views(self => ({
-    get plottedAttributeIDs() {
+    get axisAttributeIDs() {
       // Note that 'caption' is not a role we include here
-      return (['x', 'y', 'rightNumeric', 'topSplit', 'rightSplit', 'legend', 'lat', 'long', 'polygon'] as const)
+      return (['x', 'y', 'rightNumeric', 'topSplit', 'rightSplit', 'lat', 'long', 'polygon'] as const)
         .map(aRole => this.attributeID(aRole))
         .filter(id => !!id)
     },
     get childmostCollectionIDForPlottedAttributes() {
-        return idOfChildmostCollectionForAttributes(this.plottedAttributeIDs, self.dataset)
+        return idOfChildmostCollectionForAttributes(this.axisAttributeIDs, self.dataset)
     },
     get isEmpty() {
       return self._attributeDescriptions.size === 0
@@ -625,7 +625,7 @@ export const DataConfigurationModel = types
       }
     },
     _updateFilteredCasesCollectionID() {
-      const childmostCollectionID = idOfChildmostCollectionForAttributes(self.attributes, self.dataset)
+      const childmostCollectionID = idOfChildmostCollectionForAttributes(self.axisAttributeIDs, self.dataset)
       self.filteredCases.forEach((aFilteredCases) => {
         aFilteredCases.setCollectionID(childmostCollectionID)
       })


### PR DESCRIPTION
[#188502341] Feature: Dot chart not responding correctly to change in hierarchy if it has a legend.

* We were including the legend attribute, if any, in the set of attributes used to determine the childmost collection. But, in fact, it should not participate in that. With this change, a legend attribute that comes from a child collection when the points being plotted are from a parent collection, should not change the number of cases, and the points should be colored gray, the missing color.