### PR TITLE
chore: track hidden cases in grouping code

### DIFF
--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -35,7 +35,7 @@ describe("CollectionModel", () => {
     expect(withNameAndTitle.title).toBe("newTitle")
     expect(isCollectionModel(withNameAndTitle)).toBe(true)
 
-    defaultItemData.addItemInfo("foo", 0, "bar")
+    defaultItemData.addItemInfo("foo", "bar")
     defaultItemData.invalidate()
   })
 
@@ -103,7 +103,7 @@ describe("CollectionModel", () => {
     expect(defaultItemData.itemIds()).toEqual([])
     expect(defaultItemData.isHidden("foo")).toEqual(false)
     expect(defaultItemData.getValue("foo", "bar")).toBe("")
-    expect(defaultItemData.addItemInfo("foo", 0, "bar")).toBeNull()
+    expect(defaultItemData.addItemInfo("foo", "bar")).toBeNull()
 
     jestSpyConsole("warn", spy => {
       c1.addChildCase("foo", "bar")
@@ -275,7 +275,7 @@ describe("CollectionModel", () => {
                     ? "parent"
                     : "child"
       },
-      addItemInfo: (itemId, index, caseId) => {
+      addItemInfo: (itemId, caseId) => {
         const entry = itemIdToCaseIdsMap.get(itemId)
         if (entry) {
           entry.push(caseId)
@@ -405,5 +405,19 @@ describe("CollectionModel", () => {
     expect(getCaseIdInfo(c2)).toEqual(origChildCollectionInfo)
     expect(c1.groupKeyCaseIds.get(bGroupKey)).toBeUndefined()
     validateItemCaseIds()
+
+    // hiding items works as expected
+    itemData.isHidden = itemId => ["i0", "i2"].includes(itemId)
+    validateCases()
+
+    // when i0 & i2 are hidden, first parent case is odds, second is evens (except i0, i2)
+    expect(c1.caseIds.length).toBe(2)
+    expect(c1.cases.length).toBe(2)
+    expect(c2.caseIds).toEqual(caseIdsForItems(["i1", "i3", "i5", "i4"], 1))
+    expect(c2.findParentCaseGroup("foo")).toBeUndefined()
+    expect(c1.caseGroups[0].childCaseIds).toEqual(caseIdsForItems(["i1", "i3", "i5"], 1))
+    expect(c1.caseGroups[0].childItemIds).toEqual(["i1", "i3", "i5"])
+    expect(c1.caseGroups[1].childCaseIds).toEqual(caseIdsForItems(["i4"], 1))
+    expect(c1.caseGroups[1].childItemIds).toEqual(["i4"])
   })
 })

--- a/v3/src/models/data/data-set-types.ts
+++ b/v3/src/models/data/data-set-types.ts
@@ -106,14 +106,18 @@ export interface CaseInfo {
   groupedCase: IGroupedCase
   // ids of child cases in the group (if any)
   childCaseIds?: string[]
-  // ids of leaf child cases (items) in the group
+  // ids of leaf child items in the group
   childItemIds: string[]
+  // ids of hidden leaf child items in the group
+  hiddenChildItemIds: string[]
   // stringified version of grouped case values for easy comparison/categorization
   groupKey: string
+  isHidden: boolean
 }
 
 export interface ItemInfo {
   index: number
   // ids of cases associated with this item from parent-most collection (0) to child-most (n-1)
   caseIds: string[]
+  isHidden: boolean
 }

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -582,30 +582,52 @@ test("DataSet case hiding/showing (set aside)", () => {
     { __id__: "item4", [parentAttr.id]: "even", [childAttr.id]: 4 },
     { __id__: "item5", [parentAttr.id]: "odd", [childAttr.id]: 5 },
   ])
+  data.validateCases()
+  expect(data._itemIds.length).toBe(6)
   expect(data.items.length).toBe(6)
+  expect(data.itemInfoMap.size).toBe(6)
+  expect(data.caseInfoMap.size).toBe(8)
   // hide/show cases
   const evenCase = data.getCasesForCollection(parentCollection.id)[0]
   data.hideCasesOrItems([evenCase.__id__])
+  data.validateCases()
   expect(data._itemIds.length).toBe(6)
   expect(data.items.length).toBe(3)
+  expect(data.itemInfoMap.size).toBe(6)
+  expect(data.caseInfoMap.size).toBe(8)
   data.showHiddenCasesAndItems([evenCase.__id__])
+  data.validateCases()
   expect(data._itemIds.length).toBe(6)
   expect(data.items.length).toBe(6)
+  expect(data.itemInfoMap.size).toBe(6)
+  expect(data.caseInfoMap.size).toBe(8)
   // hide/show items
   const [firstItem, secondItem] = data.itemIds
   data.hideCasesOrItems([firstItem, secondItem])
+  data.validateCases()
   expect(data._itemIds.length).toBe(6)
   expect(data.items.length).toBe(4)
+  expect(data.itemInfoMap.size).toBe(6)
+  expect(data.caseInfoMap.size).toBe(8)
   data.showHiddenCasesAndItems([firstItem, secondItem])
+  data.validateCases()
   expect(data._itemIds.length).toBe(6)
   expect(data.items.length).toBe(6)
+  expect(data.itemInfoMap.size).toBe(6)
+  expect(data.caseInfoMap.size).toBe(8)
   // hide cases/items and show all
   data.hideCasesOrItems([evenCase.__id__, firstItem, secondItem])
+  data.validateCases()
   expect(data._itemIds.length).toBe(6)
   expect(data.items.length).toBe(2)
+  expect(data.itemInfoMap.size).toBe(6)
+  expect(data.caseInfoMap.size).toBe(8)
   data.showHiddenCasesAndItems()
+  data.validateCases()
   expect(data._itemIds.length).toBe(6)
   expect(data.items.length).toBe(6)
+  expect(data.itemInfoMap.size).toBe(6)
+  expect(data.caseInfoMap.size).toBe(8)
 
   // unrelated but convenient to test with a configured data set
   expect(data.hasCase(evenCase.__id__)).toBe(true)

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -377,14 +377,13 @@ export const DataSet = V2Model.named("DataSet").props({
                       ? self.items[index + 1] : undefined
     return nextItem?.__id__
   },
-  addItemInfo(itemId: string, index: number, caseId: string) {
+  addItemInfo(itemId: string, caseId: string) {
     const itemInfo = self.itemInfoMap.get(itemId)
     if (itemInfo) {
-      itemInfo.index = index
       itemInfo.caseIds.push(caseId)
     }
     else {
-      self.itemInfoMap.set(itemId, { index, caseIds: [caseId] })
+      console.warn("DataSet.addItemInfo called for missing item:", itemId)
     }
   }
 }))
@@ -536,7 +535,7 @@ export const DataSet = V2Model.named("DataSet").props({
       const itemsToValidate = new Set<string>(self.itemInfoMap.keys())
       self.itemInfoMap.clear()
       self._itemIds.forEach((itemId, index) => {
-        self.itemInfoMap.set(itemId, { index, caseIds: [] })
+        self.itemInfoMap.set(itemId, { index, caseIds: [], isHidden: self.isCaseOrItemHidden(itemId) })
         itemsToValidate.delete(itemId)
       })
       self.collections.forEach((collection, index) => {
@@ -548,7 +547,7 @@ export const DataSet = V2Model.named("DataSet").props({
         const parentCaseGroups = index > 0 ? self.collections[index - 1].caseGroups : undefined
         collection.completeCaseGroups(parentCaseGroups)
         // update the caseGroupMap
-        collection.caseGroups.forEach(group => self.caseInfoMap.set(group.groupedCase.__id__, group))
+        collection.caseGroupMap.forEach(group => self.caseInfoMap.set(group.groupedCase.__id__, group))
       })
       self.itemIdChildCaseMap.clear()
       self.childCollection.caseGroups.forEach(caseGroup => {
@@ -604,7 +603,7 @@ export const DataSet = V2Model.named("DataSet").props({
       caseOrItemIds.forEach(id => {
         const caseInfo = self.caseInfoMap.get(id)
         if (caseInfo) {
-          caseInfo.childItemIds.forEach(itemId => {
+          caseInfo.hiddenChildItemIds.forEach(itemId => {
             const foundIndex = self.setAsideItemIds.findIndex(hiddenItemId => hiddenItemId === itemId)
             if (foundIndex >= 0) self.setAsideItemIds.splice(foundIndex, 1)
           })
@@ -1026,7 +1025,7 @@ export const DataSet = V2Model.named("DataSet").props({
         }
         // add the itemInfo for the appended cases
         ids.forEach((caseId, index) => {
-          self.itemInfoMap.set(caseId, { index: insertPosition + index, caseIds: [] })
+          self.itemInfoMap.set(caseId, { index: insertPosition + index, caseIds: [], isHidden: false })
         })
 
         // copy any values provided
@@ -1216,7 +1215,7 @@ export const DataSet = V2Model.named("DataSet").props({
 
     // build itemIDMap
     self._itemIds.forEach((itemId, index) => {
-      self.itemInfoMap.set(itemId, { index, caseIds: [] })
+      self.itemInfoMap.set(itemId, { index, caseIds: [], isHidden: self.isCaseOrItemHidden(itemId) })
     })
 
     // make sure attributes have appropriate length, including attributes with formulas
@@ -1256,7 +1255,7 @@ export const DataSet = V2Model.named("DataSet").props({
             itemIds: () => self._itemIds,
             isHidden: (itemId) => self.isCaseOrItemHidden(itemId),
             getValue: (itemId, attrId) => self.getStrValue(itemId, attrId) ?? "",
-            addItemInfo: (itemId, index, caseId) => self.addItemInfo(itemId, index, caseId),
+            addItemInfo: (itemId, caseId) => self.addItemInfo(itemId, caseId),
             invalidate: () => self.invalidateCases()
           }
           syncCollectionLinks(self.collections, itemData)


### PR DESCRIPTION
In #1566, @tealefristoe pointed out that working with set-aside cases is problematic because hidden (set-aside or filtered) cases are not fully instantiated. This is because when set-aside was implemented, a simplifying assumption was made that hidden items/cases could be ignored internally in addition to being hidden from the standpoint of external clients. With this PR, hidden items/cases are processed and instantiated like visible items/cases, but are tracked as hidden internally where appropriate. It remains the case that `DataSet.itemIds`, `DataSet.items`, `Collection.cases`, and `Collection.caseGroups` only return visible items/cases to clients. Several internal data structures, e.g. `DataSet.caseInfoMap` and `Collection.caseGroupMap` now contain information about hidden and visible cases, however. Jest tests have been updated to validate this behavior.