### PR TITLE
fix: auto-complete of function doesn't add redundant parentheses

### DIFF
--- a/v3/src/components/common/formula-editor.tsx
+++ b/v3/src/components/common/formula-editor.tsx
@@ -124,15 +124,19 @@ function cmCodapCompletions(context: CompletionContext): CompletionResult | null
     label: `${fnName}()`,
     // provide a custom apply function so we can place the caret between the parentheses
     apply: (view: EditorView, completion: Completion, from: number, to: number) => {
+      const hasParens = view.state.sliceDoc(to, to + 1) === "("
+      const replaceStr =  hasParens ? fnName : `${fnName}()`
       // apply the completion
       view.dispatch({
-        ...insertCompletionText(view.state, completion.label, from, to),
+        ...insertCompletionText(view.state, replaceStr, from, to),
         annotations: pickedCompletion.of(completion)
       })
-      // put the caret between the parentheses of the function
-      const selectionStart = view.state.selection.main.from
-      const transaction = view.state.update({ selection: { anchor: selectionStart - 1 } })
-      view.dispatch(transaction)
+      if (!hasParens) {
+        // put the caret between the parentheses of the function
+        const selectionStart = view.state.selection.main.from
+        const transaction = view.state.update({ selection: { anchor: selectionStart - 1 } })
+        view.dispatch(transaction)
+      }
     }
   })) : []
   const completions: Completion[] = [...attributes, ...constants, ...specials, ...globals, ...functions]


### PR DESCRIPTION
[[PT-188484892]](https://www.pivotaltracker.com/story/show/188484892)

When auto-completing a function, only insert trailing parentheses if there don't appear to be parentheses already there. This occurs most commonly when replacing one function name with another via auto-complete.

Note: There is one difference from the v2 behavior -- In the case in which only the function name is being replaced, the caret is placed immediately after the function name, which is consistent with what occurs when replacing an attribute name. This seems more intuitive to me than putting the caret between the preexisting parentheses (the v2 behavior).