### PR TITLE
fix: selection of first argument after inserting function from list

### DIFF
--- a/v3/src/components/common/formula-editor-context.tsx
+++ b/v3/src/components/common/formula-editor-context.tsx
@@ -34,15 +34,17 @@ export class FormulaEditorApi {
     this.insertString(fnStr)
 
     // select the first argument (if any)
-    const execResult = /.+\(([^,)]+)[,)]/.exec(fnStr)
-    const fullMatch = execResult?.[0]
-    const firstArg = execResult?.[1]
-    if (fullMatch && firstArg) {
-      const from = initialSelectionFrom + fullMatch.indexOf(firstArg)
-      const to = from + firstArg.length
+    const execResult = /.+(\([^,)]+)[,)]/.exec(fnStr)
+    const parenAndFirstArg = execResult?.[1]
+    if (fnStr && parenAndFirstArg) {
+      const from = initialSelectionFrom + fnStr.indexOf(parenAndFirstArg) + 1
+      const to = from + parenAndFirstArg.length - 1
       if (from >= 0 && to >= 0 && from < to) {
-        this.editorView.dispatch({
-          selection: EditorSelection.single(from, to)
+        // setTimeout seems to be required on Safari
+        setTimeout(() => {
+          this.editorView.dispatch({
+            selection: EditorSelection.single(from, to)
+          })
         })
       }
     }


### PR DESCRIPTION
Fixes two separate issues in the code for inserting a function from the function list menu:
- Short argument names (e.g. `n`) could confuse the code for selecting the first argument on any browser. This is fixed by searching for `(${firstArg}` rather than just `${firstArg}`.
- Setting the selection immediately after changing the string could fail on Safari. This was fixed by adding a `setTimeout()` to delay setting the selection.