### PR TITLE
fix: sorting of hierarchical data sets

### DIFF
--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -643,7 +643,7 @@ test("DataSet case hiding/showing (set aside)", () => {
   expect(data.itemIds).toEqual(["item3", "item4", "item5", "item0", "item1", "item2"])
 })
 
-test("sortItems", () => {
+test("sortByAttribute with a flat DataSet", () => {
   const data = DataSet.create({ name: "data" })
   const a = data.addAttribute({ id: "AttrA", name: "A" })
   const b = data.addAttribute({ id: "AttrB", name: "B" })
@@ -656,18 +656,50 @@ test("sortItems", () => {
   ])
   expect(data.itemIds).toEqual(["ITEM0", "ITEM1", "ITEM2", "ITEM3", "ITEM4"])
   // sort by a
-  data.sortItems(a.id)
+  data.sortByAttribute(a.id)
   expect(data.itemIds).toEqual(["ITEM4", "ITEM0", "ITEM2", "ITEM3", "ITEM1"])
   data.prepareSnapshot()
   expect(a.values).toEqual(["A1", "A2", "A3", "-1", "1"])
   expect(b.values).toEqual(["3", "0", "5", "B0", "B1"])
   data.completeSnapshot()
   // sort by b descending
-  data.sortItems(b.id, "descending")
+  data.sortByAttribute(b.id, "descending")
   expect(data.itemIds).toEqual(["ITEM2", "ITEM4", "ITEM0", "ITEM1", "ITEM3"])
   data.prepareSnapshot()
   expect(a.values).toEqual(["A3", "A1", "A2", "1", "-1"])
   expect(b.values).toEqual(["5", "3", "0", "B1", "B0"])
+  data.completeSnapshot()
+})
+
+test("sortByAttribute with a hierarchical DataSet", () => {
+  const data = DataSet.create({
+    name: "data",
+    collections: [{ id: "Parent", name: "Parents" }, { id: "Child", name: "Children" }]
+  })
+  const p = data.addAttribute({ id: "ParentAttr", name: "parentAttr" }, { collection: "Parents" })
+  const c = data.addAttribute({ id: "ChildAttr", name: "childAttr" }, { collection: "Children" })
+
+  data.addCases([
+    { __id__: "ITEM0", [p.id]: "A", [c.id]: "5" },
+    { __id__: "ITEM1", [p.id]: "B", [c.id]: "2" },
+    { __id__: "ITEM2", [p.id]: "A", [c.id]: "3" },
+    { __id__: "ITEM3", [p.id]: "B", [c.id]: "4" },
+    { __id__: "ITEM4", [p.id]: "A", [c.id]: "1" }
+  ])
+  expect(data.itemIds).toEqual(["ITEM0", "ITEM1", "ITEM2", "ITEM3", "ITEM4"])
+  // sort by child attribute
+  data.sortByAttribute(c.id)
+  expect(data.itemIds).toEqual(["ITEM4", "ITEM1", "ITEM2", "ITEM3", "ITEM0"])
+  data.prepareSnapshot()
+  expect(p.values).toEqual(["A", "B", "A", "B", "A"])
+  expect(c.values).toEqual(["1", "2", "3", "4", "5"])
+  data.completeSnapshot()
+  // sort by child attribute descending
+  data.sortByAttribute(c.id, "descending")
+  expect(data.itemIds).toEqual(["ITEM0", "ITEM3", "ITEM2", "ITEM1", "ITEM4"])
+  data.prepareSnapshot()
+  expect(p.values).toEqual(["A", "B", "A", "B", "A"])
+  expect(c.values).toEqual(["5", "4", "3", "2", "1"])
   data.completeSnapshot()
 })
 

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -61,10 +61,10 @@ import { isLegacyDataSetSnap, isOriginalDataSetSnap, isTempDataSetSnap } from ".
 import { Formula, IFormula } from "../formula/formula"
 import { applyModelChange } from "../history/apply-model-change"
 import { withoutUndo } from "../history/without-undo"
-import { getCurrentLocale } from "../tiles/tile-environment"
 import { kAttrIdPrefix, kItemIdPrefix, typeV3Id, v3Id } from "../../utilities/codap-utils"
 import { compareValues } from "../../utilities/data-utils"
 import { hashStringSet } from "../../utilities/js-utils"
+import { gLocale } from "../../utilities/translation/locale"
 import { t } from "../../utilities/translation/translate"
 import { V2Model } from "./v2-model"
 
@@ -1319,28 +1319,64 @@ export const DataSet = V2Model.named("DataSet").props({
     })
     self.removeCollection(collection)
   },
-  sortItems(attributeId: string, direction: "ascending" | "descending" = "ascending") {
+  sortByAttribute(attributeId: string, direction: "ascending" | "descending" = "ascending") {
     self.validateCases()
-    // sort by the specified attribute to determine mapping from original to sorted indices
-    const itemIdsWithIndices = self._itemIds.map((itemId, origIndex) => ({ itemId, origIndex }))
-    // cf. https://stackoverflow.com/a/25775469 for performance issues with localeCompare
-    const collator = new Intl.Collator(getCurrentLocale(self), { sensitivity: 'base' })
-    itemIdsWithIndices.sort((a, b) => {
-      const aValue = self.getValue(a.itemId, attributeId)
-      const bValue = self.getValue(b.itemId, attributeId)
-      const compareResult = compareValues(aValue, bValue, collator.compare)
-      return direction === "descending" ? -compareResult : compareResult
-    })
-    // if no changes then nothing to do
-    if (itemIdsWithIndices.every(({ origIndex }, index) => index === origIndex)) return
-    // apply the index mapping to each attribute's value arrays
-    const origIndices = itemIdsWithIndices.map(({ origIndex }) => origIndex)
-    self.attributes.forEach(attr => attr.orderValues(origIndices))
-    // update the _itemIds array
-    const itemIds = itemIdsWithIndices.map(({ itemId }) => itemId)
-    self._itemIds.replace(itemIds)
 
-    return itemIdsWithIndices
+    const compareFn = (aItemId: string, bItemId: string) => {
+      const aValue = self.getValue(aItemId, attributeId)
+      const bValue = self.getValue(bItemId, attributeId)
+      const compareResult = compareValues(aValue, bValue, gLocale.compareStrings)
+      return direction === "descending" ? -compareResult : compareResult
+    }
+
+    const finalItemIds = Array.from(self._itemIds)
+    const itemIdToIndexMap: Record<string, { beforeIndex: number, afterIndex: number }> = {}
+    self._itemIds.forEach((itemId, beforeIndex) => itemIdToIndexMap[itemId] = { beforeIndex, afterIndex: -1 })
+
+    const collection = self.getCollectionForAttribute(attributeId)
+    const parentCollection = collection?.parent
+
+    // if there's a parent collection, items are sorted within their parent cases
+    if (parentCollection) {
+      parentCollection.caseGroups.forEach(group => {
+        // combine all the child item ids for this parent case
+        const origGroupItemIds = [...group.childItemIds, ...group.hiddenChildItemIds]
+        // sort them into their original order
+        origGroupItemIds.sort((aItemId, bItemId) => {
+          return itemIdToIndexMap[aItemId].beforeIndex - itemIdToIndexMap[bItemId].beforeIndex
+        })
+        // sort them into their sorted order
+        const sortedGroupItemIds = origGroupItemIds.slice()
+        sortedGroupItemIds.sort(compareFn)
+        // map indices from original to sorted
+        sortedGroupItemIds.forEach((itemId, index) => {
+          const origItemIdAtIndex = origGroupItemIds[index]
+          itemIdToIndexMap[itemId].afterIndex = itemIdToIndexMap[origItemIdAtIndex].beforeIndex
+        })
+        // sort the items into their appropriate sorted locations
+        finalItemIds.sort((aItemId, bItemId) => {
+          return itemIdToIndexMap[aItemId].afterIndex - itemIdToIndexMap[bItemId].afterIndex
+        })
+      })
+    }
+
+    // if no parent collection, items can be sorted globally
+    else {
+      finalItemIds.sort(compareFn)
+      finalItemIds.forEach((itemId, index) => itemIdToIndexMap[itemId].afterIndex = index)
+    }
+
+    // if no changes then nothing to do
+    if (finalItemIds.every((itemId, index) => itemId === self._itemIds[index])) return
+
+    // apply the index mapping to each attribute's value arrays
+    const origIndices = finalItemIds.map(itemId => itemIdToIndexMap[itemId].beforeIndex)
+    self.attributes.forEach(attr => attr.orderValues(origIndices))
+
+    // update the _itemIds array
+    self._itemIds.replace(finalItemIds)
+
+    return itemIdToIndexMap
   }
 }))
 // performs the specified action so that response actions are included and undo/redo strings assigned

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -3,7 +3,6 @@ import { addDisposer, onAction } from "mobx-state-tree"
 import { DIMessage } from "../../data-interactive/iframe-phone-types"
 import { ILogMessage } from "../../lib/log-message"
 import { Logger } from "../../lib/logger"
-import { gLocale } from "../../utilities/translation/locale"
 import { createFormulaAdapters } from "../formula/formula-adapter-registry"
 import { FormulaManager } from "../formula/formula-manager"
 import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
@@ -48,9 +47,6 @@ export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
     }
     sharedModelManager.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
       .forEach((model: ISharedDataSet) => formulaManager.addDataSet(model.dataSet))
-
-    // configure locale
-    fullEnvironment.getLocale = () => gLocale.current
 
     // configure logging
     fullEnvironment.log = function({ message, args, category }: ILogMessage) {

--- a/v3/src/models/tiles/tile-environment.ts
+++ b/v3/src/models/tiles/tile-environment.ts
@@ -11,17 +11,12 @@ import { IGlobalValueManager, kGlobalValueManagerType } from "../global/global-v
 export interface ITileEnvironment {
   sharedModelManager?: ISharedModelManager
   formulaManager?: FormulaManager
-  getLocale?: () => string
   log?: (message: ILogMessage) => void
   notify?: (message: DIMessage, callback: iframePhone.ListenerCallback, targetTileId?: string) => void
 }
 
 export function getTileEnvironment(node?: IAnyStateTreeNode) {
   return node && hasEnv(node) ? getEnv<ITileEnvironment | undefined>(node) : undefined
-}
-
-export function getCurrentLocale(node?: IAnyStateTreeNode) {
-  return getTileEnvironment(node)?.getLocale?.() ?? "en-US"
 }
 
 export function getSharedModelManager(node?: IAnyStateTreeNode) {

--- a/v3/src/utilities/translation/locale.ts
+++ b/v3/src/utilities/translation/locale.ts
@@ -41,17 +41,17 @@ export class Locale {
 
   @action
   setCurrent(_current: string) {
-    this.collator = new Intl.Collator(this.current, { sensitivity: "base" })
+    this.collator = new Intl.Collator(_current, { sensitivity: "base" })
     this.dateTimeFormats.clear()
     this.numberFormats.clear()
     this.current = _current
   }
 
-  compareStrings(str1: string, str2: string) {
-    return this.collator?.compare(str1, str2)
+  compareStrings = (str1: string, str2: string) => {
+    return this.collator?.compare(str1, str2) ?? 0
   }
 
-  formatDate(date?: Date | number, options: Intl.DateTimeFormatOptions = {}) {
+  formatDate = (date?: Date | number, options: Intl.DateTimeFormatOptions = {}) => {
     const optionsStr = JSON.stringify(options)
     let formatter = this.dateTimeFormats.get(optionsStr)
     if (!formatter) {
@@ -61,7 +61,7 @@ export class Locale {
     return formatter?.format(date)
   }
 
-  formatNumber(value: number, options: Intl.NumberFormatOptions = {}) {
+  formatNumber = (value: number, options: Intl.NumberFormatOptions = {}) => {
     const optionsStr = JSON.stringify(options)
     let formatter = this.numberFormats.get(optionsStr)
     if (!formatter) {


### PR DESCRIPTION
[[PT-188509712]](https://www.pivotaltracker.com/story/show/188509712)

The previous sort implementation worked for sorting attributes in the top-most collection, but the desired behavior when sorting child attributes is that the order of the parents not change, so sorting must be restricted to sorting within parent cases.

Also eliminated `getLocale()` from the `TileEnvironment`. Adding it seemed like a good idea when I did it but it never quite panned out.