### PR TITLE
Categorical legend and axis respond to order changes

### DIFF
--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -301,18 +301,14 @@ export const CategoricalLegend = observer(
       })
     }, [refreshKeys, dataset, computeDesiredExtent])
 
-    useEffect(function respondToCategorySetsChange() {
+    useEffect(function respondToChangeCount() {
       return mstReaction(
-        () => {
-          const categories = dataConfiguration?.categoryArrayForAttrRole('legend')
-          const numHidden = dataConfiguration?.hiddenCases.length
-          return { categories, numHidden }
-        },
+        () => dataConfiguration?.casesChangeCount,
         () => {
           setDesiredExtent(layerIndex, computeDesiredExtent())
           setupKeys()
           refreshKeys()
-        }, {name: 'CategoricalLegend respondToCategorySetsChange',
+        }, {name: 'CategoricalLegend respondToChangeCount',
           equals: comparer.structural}, dataConfiguration)
     }, [setupKeys, refreshKeys, dataConfiguration, computeDesiredExtent, setDesiredExtent, layerIndex])
 

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -48,7 +48,7 @@ export const kDataConfigurationType = "dataConfigurationType"
 // A DataConfigurationModel (or a containing tile model) can be created with an environment containing
 // a provisional dataset and metadata. In this case, the provisional dataset or metadata will be retrieved
 // instead of the DataConfiguration's own. This allows the DI system to set up a graph tile snapshot,
-// referencing the dataset and metadata as necessary, outside of the main MST tree.
+// referencing the dataset and metadata as necessary, outside the main MST tree.
 interface IProvisionalEnvironment {
   provisionalDataSet?: IDataSet
   provisionalMetadata?: ISharedCaseMetadata
@@ -344,9 +344,10 @@ export const DataConfigurationModel = types
         return orderedCategories
       }
     }),
-    getAllCategoriesForRoles() {
+    get allCategoriesForRoles() {
       const categories: Map<AttrRole, string[]> = new Map()
-      self.potentiallyCategoricalRoles().forEach(role => {
+      const roles = self.potentiallyCategoricalRoles()
+      roles.forEach(role => {
         const categorySet = self.categorySetForAttrRole(role)
         if (categorySet) {
           categories.set(role, categorySet.valuesArray)
@@ -360,28 +361,34 @@ export const DataConfigurationModel = types
       return (self.filteredCases[caseArrayNumber]?.caseIds || []).map(id => {
         return {plotNum: caseArrayNumber, caseID: id}
       })
-    },
-    getCaseDataArray(caseArrayNumber: number) {
-      const caseDataArray = this.getUnsortedCaseDataArray(caseArrayNumber),
-        legendAttrID = self.attributeID('legend')
-      if (legendAttrID) {
-        if (self.attributeType("legend") === "numeric") {
-          caseDataArray.sort((cd1: CaseData, cd2: CaseData) => {
-            const cd1Value = self.dataset?.getNumeric(cd1.caseID, legendAttrID) ?? NaN,
-              cd2Value = self.dataset?.getNumeric(cd2.caseID, legendAttrID) ?? NaN
-            return numericSortComparator({a: cd1Value, b: cd2Value, order: "desc"})
-          })
-        } else {
-          const categories = Array.from(self.categoryArrayForAttrRole('legend'))
-          caseDataArray.sort((cd1: CaseData, cd2: CaseData) => {
-            const cd1Value = self.dataset?.getStrValue(cd1.caseID, legendAttrID) ?? '',
-              cd2Value = self.dataset?.getStrValue(cd2.caseID, legendAttrID) ?? ''
-            return categories.indexOf(cd1Value) - categories.indexOf(cd2Value)
-          })
+    }
+  }))
+  .views(self => ({
+    // Note that we have to go through each of the filteredCases in order to return all the values
+    getCaseDataArray: cachedFnWithArgsFactory({
+      key: (caseArrayNumber: number) => String(caseArrayNumber),
+      calculate: (caseArrayNumber: number) => {
+        const caseDataArray = self.getUnsortedCaseDataArray(caseArrayNumber),
+          legendAttrID = self.attributeID('legend')
+        if (legendAttrID) {
+          if (self.attributeType("legend") === "numeric") {
+            caseDataArray.sort((cd1: CaseData, cd2: CaseData) => {
+              const cd1Value = self.dataset?.getNumeric(cd1.caseID, legendAttrID) ?? NaN,
+                cd2Value = self.dataset?.getNumeric(cd2.caseID, legendAttrID) ?? NaN
+              return numericSortComparator({a: cd1Value, b: cd2Value, order: "desc"})
+            })
+          } else {
+            const categories = Array.from(self.categoryArrayForAttrRole('legend'))
+            caseDataArray.sort((cd1: CaseData, cd2: CaseData) => {
+              const cd1Value = self.dataset?.getStrValue(cd1.caseID, legendAttrID) ?? '',
+                cd2Value = self.dataset?.getStrValue(cd2.caseID, legendAttrID) ?? ''
+              return categories.indexOf(cd1Value) - categories.indexOf(cd2Value)
+            })
+          }
         }
+        return caseDataArray
       }
-      return caseDataArray
-    },
+    }),
     get joinedCaseDataArrays() {
       const joinedCaseData: CaseData[] = []
       self.filteredCases.forEach((aFilteredCases, index) => {
@@ -391,9 +398,6 @@ export const DataConfigurationModel = types
       )
       return joinedCaseData
     },
-    get caseDataArray() {
-      return this.getCaseDataArray(0)
-    }
   }))
   .views(self => ({
     // observable hash of rendered case ids
@@ -452,7 +456,7 @@ export const DataConfigurationModel = types
           extraSecondaryAttrID = self.attributeID(extraSecondaryAttrRole)
 
         return primaryAttrID
-          ? self.caseDataArray.filter((aCaseData: CaseData) => {
+          ? self.getCaseDataArray(0).filter((aCaseData: CaseData) => {
             return dataset?.getStrValue(aCaseData.caseID, primaryAttrID) === primaryValue &&
               (secondaryValue === "__main__" ||
                 dataset?.getStrValue(aCaseData.caseID, secondaryAttrID) === secondaryValue) &&
@@ -479,7 +483,7 @@ export const DataConfigurationModel = types
             }
           })
         } else {
-          caseIDs = legendID ? self.caseDataArray.filter((aCaseData: CaseData) => {
+          caseIDs = legendID ? self.getCaseDataArray(0).filter((aCaseData: CaseData) => {
               return dataset?.getValue(aCaseData.caseID, legendID) === aValue
             }).map((aCaseData: CaseData) => aCaseData.caseID)
             : []
@@ -491,7 +495,7 @@ export const DataConfigurationModel = types
         calculate: (cat: string) => {
           const dataset = self.dataset
           const legendID = self.attributeID('legend')
-          const selection = (legendID && self.caseDataArray.filter((aCaseData: CaseData) =>
+          const selection = (legendID && self.getCaseDataArray(0).filter((aCaseData: CaseData) =>
             dataset?.getValue(aCaseData.caseID, legendID) === cat
           ).map((aCaseData: CaseData) => aCaseData.caseID)) ?? []
           return selection.length > 0 && (selection as Array<string>).every(anID => dataset?.isCaseSelected(anID))
@@ -504,7 +508,7 @@ export const DataConfigurationModel = types
           min = quantile === 0 ? -Infinity : thresholds[quantile - 1],
           max = quantile === thresholds.length ? Infinity : thresholds[quantile]
         return legendID
-          ? self.caseDataArray.filter((aCaseData: CaseData) => {
+          ? self.getCaseDataArray(0).filter((aCaseData: CaseData) => {
             const value = dataDisplayGetNumericValue(dataset, aCaseData.caseID, legendID)
             return value !== undefined && value >= min && value < max
           }).map((aCaseData: CaseData) => aCaseData.caseID)
@@ -569,6 +573,7 @@ export const DataConfigurationModel = types
       self.numericValuesForAttrRole.invalidateAll()
       self.categoryArrayForAttrRole.invalidateAll()
       self.allCasesForCategoryAreSelected.invalidateAll()
+      self.getCaseDataArray.invalidateAll()
       // increment observable change count
       ++self.casesChangeCount
     }
@@ -755,10 +760,21 @@ export const DataConfigurationModel = types
         {name: "DataConfigurationModel.afterCreate.reaction [dataset]", fireImmediately: true }
       ))
       addDisposer(self, reaction(
-        () => self.getAllCategoriesForRoles(),
+        () => self.allCategoriesForRoles,
         () => self.clearCasesCache(),
         {
-          name: "DataConfigurationModel.afterCreate.reaction [getAllCategoriesForRoles]",
+          name: "DataConfigurationModel.afterCreate.reaction [allCategoriesForRoles]",
+          equals: comparer.structural
+        }
+      ))
+      addDisposer(self, reaction(
+        () => {
+          const legendCategorySet = self.categorySetForAttrRole("legend")
+          return legendCategorySet?.valuesArray
+        },
+        () => self.clearCasesCache(),
+        {
+          name: "DataConfigurationModel.afterCreate.reaction [allCategoriesForRoles]",
           equals: comparer.structural
         }
       ))

--- a/v3/src/components/graph/components/casedots.tsx
+++ b/v3/src/components/graph/components/casedots.tsx
@@ -100,10 +100,10 @@ export const CaseDots = function CaseDots(props: {
   }, [pixiPoints, graphModel, layout, dataConfiguration, dataset, isAnimating])
 
   useEffect(function initDistribution() {
-    randomlyDistributePoints(dataConfiguration?.caseDataArray)
+    randomlyDistributePoints(dataConfiguration?.getCaseDataArray(0))
     const disposer = dataConfiguration?.onAction(action => {
       if (['addCases', 'removeCases'].includes(action.name)) {
-        randomlyDistributePoints(dataConfiguration?.caseDataArray)
+        randomlyDistributePoints(dataConfiguration?.getCaseDataArray(0))
       }
     }) || (() => true)
     return () => disposer?.()
@@ -114,7 +114,7 @@ export const CaseDots = function CaseDots(props: {
       () => graphModel.changeCount,
       () => {
         randomPointsRef.current = {}
-        randomlyDistributePoints(dataConfiguration?.caseDataArray)
+        randomlyDistributePoints(dataConfiguration?.getCaseDataArray(0))
         startAnimation()
         refreshPointPositions(false)
       },

--- a/v3/src/components/graph/components/dot-chart-bars.tsx
+++ b/v3/src/components/graph/components/dot-chart-bars.tsx
@@ -60,7 +60,7 @@ export const DotChartBars = observer(function DotChartBars({ abovePointsGroupRef
                 // Create a map of cases grouped by legend value so we don't need to filter all cases per value when
                 // creating the bar covers.
                 const caseGroups = new Map()
-                dataConfig.caseDataArray.forEach(aCase => {
+                dataConfig.getCaseDataArray(0).forEach(aCase => {
                   const legendValue = dataset?.getStrValue(aCase.caseID, legendAttrID)
                   const primaryValue = dataset?.getStrValue(aCase.caseID, dataConfig.attributeID(primaryAttrRole))
                   const primarySplitValue =

--- a/v3/src/components/graph/components/graph-inspector.tsx
+++ b/v3/src/components/graph/components/graph-inspector.tsx
@@ -20,7 +20,7 @@ import { CameraMenuList } from "./camera-menu-list"
 
 export const GraphInspector = observer(function GraphInspector({tile, show}: ITileInspectorPanelProps) {
   const graphModel = isGraphContentModel(tile?.content) ? tile?.content : undefined
-  const caseDataArray = graphModel?.dataConfiguration?.caseDataArray ?? []
+  const caseDataArray = graphModel?.dataConfiguration?.getCaseDataArray(0) ?? []
   const [showPalette, setShowPalette] = useState<string | undefined>(undefined)
   const panelRef = useRef<HTMLDivElement>()
   const panelRect = panelRef.current?.getBoundingClientRect()

--- a/v3/src/components/graph/hooks/use-graph-model.ts
+++ b/v3/src/components/graph/hooks/use-graph-model.ts
@@ -22,7 +22,7 @@ export function useGraphModel(props: IProps) {
   useEffect(function installPlotTypeAction() {
     const disposer = onAnyAction(graphModel, action => {
       if (action.name === 'setPlotType') {
-        const { caseDataArray } = dataConfig || {}
+        const caseDataArray = dataConfig.getCaseDataArray(0) || {}
         const newPlotType = action.args?.[0]/*,
           attrIDs = newPlotType === 'dotPlot' ? [xAttrID] : [xAttrID, yAttrID]*/
         startAnimation()

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -92,12 +92,12 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
 
   useEffect(function respondToCategorySetChanges() {
     return reaction(() => {
-      return dataConfiguration.casesChangeCount
+      return dataConfiguration.allCategoriesForRoles
     }, () => {
       startAnimation()
       callRefreshPointPositions(false)
     }, {name: "usePlot.respondToCategorySetChanges"})
-  }, [callRefreshPointPositions, dataConfiguration.casesChangeCount, startAnimation])
+  }, [callRefreshPointPositions, dataConfiguration, startAnimation])
 
   // respond to attribute assignment changes
   useEffect(() => {

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -1,5 +1,5 @@
 import {useEffect} from "react"
-import {comparer, reaction} from "mobx"
+import { comparer,reaction } from "mobx"
 import {isAlive} from "mobx-state-tree"
 import {onAnyAction} from "../../../utilities/mst-utils"
 import {mstAutorun} from "../../../utilities/mst-autorun"
@@ -63,7 +63,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
   // https://www.pivotaltracker.com/story/show/188333898
   // This might be a workaround for the fact that useDebouncedCallback may not be updated when pixiPoints
   // (a dependency of refreshPointPositions) are updated. useDebouncedCallback doesn't seem to declare any
-  // dependencies and I'd imagine it returns a stable result (?).
+  // dependencies, and I'd imagine it returns a stable result (?).
   useEffect(() => {
     callRefreshPointPositions(false)
   }, [callRefreshPointPositions, pixiPoints])
@@ -92,14 +92,12 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
 
   useEffect(function respondToCategorySetChanges() {
     return reaction(() => {
-      return layout.categorySetArrays
-    }, (categorySetsArrays) => {
-      if (categorySetsArrays.length) {
-        startAnimation()
-        callRefreshPointPositions(false)
-      }
+      return dataConfiguration.casesChangeCount
+    }, () => {
+      startAnimation()
+      callRefreshPointPositions(false)
     }, {name: "usePlot.respondToCategorySetChanges"})
-  }, [callRefreshPointPositions, layout.categorySetArrays, startAnimation])
+  }, [callRefreshPointPositions, dataConfiguration.casesChangeCount, startAnimation])
 
   // respond to attribute assignment changes
   useEffect(() => {
@@ -115,7 +113,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           graphModel?.setPointsFusedIntoBars(false)
         }
         // If points are fused into bars and a secondary attribute is added or the primary attribute is removed,
-        // unfuse the points. Otherwise, if a primary attribute exists, make sure the bar graph's count axis gets
+        // un-fuse the points. Otherwise, if a primary attribute exists, make sure the bar graph's count axis gets
         // updated.
         const { primaryRole } = dataConfiguration
         const primaryAttrID = primaryRole && dataConfiguration.attributeID(primaryRole)
@@ -228,7 +226,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
       if (['addCases', 'removeCases', 'setAttributeType', 'invalidateCollectionGroups'].includes(action.name)) {
         // there  are no longer any cases in the dataset, or if plot is not univariate and the attribute type changes,
         // we need to set the pointConfig to points
-        const caseDataArray = dataConfiguration?.caseDataArray ?? []
+        const caseDataArray = dataConfiguration?.getCaseDataArray(0) ?? []
         if (caseDataArray.length === 0 || graphModel?.plotType !== "dotPlot") {
           graphModel?.setPointConfig("points")
         }

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -1,5 +1,5 @@
 import {useEffect} from "react"
-import { comparer,reaction } from "mobx"
+import { comparer, reaction } from "mobx"
 import {isAlive} from "mobx-state-tree"
 import {onAnyAction} from "../../../utilities/mst-utils"
 import {mstAutorun} from "../../../utilities/mst-autorun"

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -209,7 +209,8 @@ export const GraphContentModel = DataDisplayContentModel
     },
     binDetails(options?: { initialize?: boolean }) {
       const { initialize = false } = options ?? {}
-      const { caseDataArray, dataset, primaryAttributeID } = self.dataConfiguration
+      const { dataset, primaryAttributeID } = self.dataConfiguration
+      const caseDataArray = self.dataConfiguration.getCaseDataArray(0)
       const minValue = caseDataArray.reduce((min, aCaseData) => {
         return Math.min(min, dataDisplayGetNumericValue(dataset, aCaseData.caseID, primaryAttributeID) ?? min)
       }, Infinity)
@@ -327,7 +328,7 @@ export const GraphContentModel = DataDisplayContentModel
   }))
   .views(self => ({
     getPointRadius(use: 'normal' | 'hover-drag' | 'select' = 'normal') {
-      return computePointRadius(self.dataConfiguration.caseDataArray.length,
+      return computePointRadius(self.dataConfiguration.getCaseDataArray(0).length,
         self.pointDescription.pointSizeMultiplier, use)
     },
     nonDraggableAxisTicks(formatter: (value: number) => string): { tickValues: number[], tickLabels: string[] } {
@@ -534,7 +535,7 @@ export const GraphContentModel = DataDisplayContentModel
       const extraSecondaryAttrID = dataConfig?.attributeID(extraSecondaryAttrRole) ?? ''
       const extraPrimaryAttrID = dataConfig.attributeID(extraPrimaryAttrRole)
 
-      primaryAttrID && (dataConfig.caseDataArray || []).forEach((aCaseData: CaseData) => {
+      primaryAttrID && (dataConfig.getCaseDataArray(0) || []).forEach((aCaseData: CaseData) => {
         const anID = aCaseData.caseID,
           hCat = dataset?.getStrValue(anID, primaryAttrID),
           vCat = secondaryAttrID ? dataset?.getStrValue(anID, secondaryAttrID) : '__main__',

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -75,6 +75,7 @@ export class GraphController {
           }
           if (isCategoricalAxisModel(axisModel)) {
             axisMultiScale.setCategoricalDomain(dataConfig.categoryArrayForAttrRole(attrRole))
+            axisMultiScale.setCategorySet(dataConfig.categorySetForAttrRole(attrRole))
           }
           if (isNumericAxisModel(axisModel)) {
             axisMultiScale.setNumericDomain(axisModel.domain)

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -191,7 +191,7 @@ describe("DataConfigurationModel", () => {
     reaction(
       () => config.casesChangeCount,
       () => trigger(),
-      { name: "GraphDataConfigurationTest.getCaseDataArray(0) reaction" })
+      { name: "GraphDataConfigurationTest.casesChangeCount reaction" })
     expect(trigger).not.toHaveBeenCalled()
     tree.data.setCaseValues([{ __id__: "c2", "yId": "" }])
     expect(trigger).toHaveBeenCalled()

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -189,7 +189,7 @@ describe("DataConfigurationModel", () => {
     // triggers observers when values change
     const trigger = jest.fn()
     reaction(
-      () => config.getCaseDataArray(0),
+      () => config.casesChangeCount,
       () => trigger(),
       { name: "GraphDataConfigurationTest.getCaseDataArray(0) reaction" })
     expect(trigger).not.toHaveBeenCalled()

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -46,7 +46,7 @@ describe("DataConfigurationModel", () => {
     expect(config.uniqueAttributes).toEqual([])
     expect(config.tipAttributes).toEqual([])
     expect(config.uniqueTipAttributes).toEqual([])
-    expect(config.caseDataArray).toEqual([])
+    expect(config.getCaseDataArray(0)).toEqual([])
     expect(isGraphDataConfigurationModel(config)).toBe(true)
   })
 
@@ -64,7 +64,7 @@ describe("DataConfigurationModel", () => {
     expect(config.uniqueAttributes).toEqual(["nId"])
     expect(config.tipAttributes).toEqual([{attributeID: "nId", role: "caption"}])
     expect(config.uniqueTipAttributes).toEqual([{attributeID: "nId", role: "caption"}])
-    expect(config.caseDataArray).toEqual([
+    expect(config.getCaseDataArray(0)).toEqual([
       {plotNum: 0, caseID: caseIdFromItemId("c1")},
       {plotNum: 0, caseID: caseIdFromItemId("c2")},
       {plotNum: 0, caseID: caseIdFromItemId("c3")}
@@ -89,7 +89,7 @@ describe("DataConfigurationModel", () => {
     expect(config.tipAttributes).toEqual([{attributeID: "nId", role: "x"},
       {attributeID: "nId", role: "caption"}])
     expect(config.uniqueTipAttributes).toEqual([{attributeID: "nId", role: "caption"}])
-    expect(config.caseDataArray).toEqual([
+    expect(config.getCaseDataArray(0)).toEqual([
       {plotNum: 0, caseID: caseIdFromItemId("c1")},
       {plotNum: 0, caseID: caseIdFromItemId("c3")}
     ])
@@ -113,7 +113,7 @@ describe("DataConfigurationModel", () => {
       {attributeID: "nId", role: "caption"}])
     expect(config.uniqueTipAttributes).toEqual([{attributeID: "xId", role: "x"},
       {attributeID: "nId", role: "caption"}])
-    expect(config.caseDataArray).toEqual([
+    expect(config.getCaseDataArray(0)).toEqual([
       {plotNum: 0, caseID: caseIdFromItemId("c1")},
       {plotNum: 0, caseID: caseIdFromItemId("c2")}
     ])
@@ -141,7 +141,7 @@ describe("DataConfigurationModel", () => {
       {attributeID: "yId", role: "y"}, {attributeID: "nId", role: "caption"}])
     expect(config.uniqueTipAttributes).toEqual([{attributeID: "xId", role: "x"},
       {attributeID: "yId", role: "y"}, {attributeID: "nId", role: "caption"}])
-    expect(config.caseDataArray).toEqual([{plotNum: 0, caseID: caseIdFromItemId("c1")}])
+    expect(config.getCaseDataArray(0)).toEqual([{plotNum: 0, caseID: caseIdFromItemId("c1")}])
 
     // behaves as expected after adding "x" as an additional y attribute
     config.addYAttribute({ attributeID: "xId" })
@@ -173,14 +173,14 @@ describe("DataConfigurationModel", () => {
       {attributeID: "nId", role: "caption"}])
     expect(config.uniqueTipAttributes).toEqual([{attributeID: "yId", role: "y"},
       {attributeID: "nId", role: "caption"}])
-    expect(config.caseDataArray).toEqual([
+    expect(config.getCaseDataArray(0)).toEqual([
       {plotNum: 0, caseID: caseIdFromItemId("c1")},
       {plotNum: 0, caseID: caseIdFromItemId("c3")}
     ])
 
     // updates cases when values change
     tree.data.setCaseValues([{ __id__: "c2", "yId": 2 }])
-    expect(config.caseDataArray).toEqual([
+    expect(config.getCaseDataArray(0)).toEqual([
       {plotNum: 0, caseID: caseIdFromItemId("c1")},
       {plotNum: 0, caseID: caseIdFromItemId("c2")},
       {plotNum: 0, caseID: caseIdFromItemId("c3")}
@@ -189,20 +189,20 @@ describe("DataConfigurationModel", () => {
     // triggers observers when values change
     const trigger = jest.fn()
     reaction(
-      () => config.caseDataArray,
+      () => config.getCaseDataArray(0),
       () => trigger(),
-      { name: "GraphDataConfigurationTest.caseDataArray reaction" })
+      { name: "GraphDataConfigurationTest.getCaseDataArray(0) reaction" })
     expect(trigger).not.toHaveBeenCalled()
     tree.data.setCaseValues([{ __id__: "c2", "yId": "" }])
     expect(trigger).toHaveBeenCalled()
-    expect(config.caseDataArray).toEqual([
+    expect(config.getCaseDataArray(0)).toEqual([
       {plotNum: 0, caseID: caseIdFromItemId("c1")},
       {plotNum: 0, caseID: caseIdFromItemId("c3")}
     ])
     trigger.mockClear()
     tree.data.setCaseValues([{ __id__: "c2", "yId": "2" }])
     expect(trigger).toHaveBeenCalled()
-    expect(config.caseDataArray).toEqual([
+    expect(config.getCaseDataArray(0)).toEqual([
       {plotNum: 0, caseID: caseIdFromItemId("c1")},
       {plotNum: 0, caseID: caseIdFromItemId("c2")},
       {plotNum: 0, caseID: caseIdFromItemId("c3")}

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -265,7 +265,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         secAttrID = self.secondaryRole ? self.attributeID(self.secondaryRole) : "",
         extraPrimAttrID = self.attributeID(extraPrimaryAttrRole) ?? '',
         extraSecAttrID = self.attributeID(extraSecondaryAttrRole) ?? '',
-        valueQuads = (self.caseDataArray || []).map((aCaseData: CaseData) => {
+        valueQuads = (self.getCaseDataArray(0) || []).map((aCaseData: CaseData) => {
           return {
             primary: (primAttrID && self.dataset?.getValue(aCaseData.caseID, primAttrID)) ?? '',
             secondary: (secAttrID && self.dataset?.getValue(aCaseData.caseID, secAttrID)) ?? '__main__',

--- a/v3/src/components/graph/utilities/dot-plot-utils.ts
+++ b/v3/src/components/graph/utilities/dot-plot-utils.ts
@@ -152,7 +152,7 @@ export const computeBinPlacements = (props: IComputeBinPlacements) => {
   const binMap: Record<string, BinMap> = {}
 
   if (primaryAxisScale) {
-    dataConfig?.caseDataArray.forEach((aCaseData: CaseData) => {
+    dataConfig?.getCaseDataArray(0).forEach((aCaseData: CaseData) => {
       const anID = aCaseData.caseID
       const caseValue = dataDisplayGetNumericValue(dataset, anID, primaryAttrID) ?? -1
       const numerator = primaryAxisScale(caseValue) / numExtraPrimaryBands

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -220,9 +220,9 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, set
     if (layerIsVisible && pointsAreVisible && !pixiPoints.isVisible) {
       pixiPoints?.setVisibility(true)
     }
-    const pointRadius = computePointRadius(dataConfiguration.caseDataArray.length,
+    const pointRadius = computePointRadius(dataConfiguration.getCaseDataArray(0).length,
         pointDescription.pointSizeMultiplier)
-    const selectedPointRadius = computePointRadius(dataConfiguration.caseDataArray.length,
+    const selectedPointRadius = computePointRadius(dataConfiguration.getCaseDataArray(0).length,
         pointDescription.pointSizeMultiplier, 'select')
     const {pointColor, pointStrokeColor} = pointDescription
     const getLegendColor = dataConfiguration?.attributeID('legend')
@@ -303,7 +303,7 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, set
 
   useEffect(function setupResponseToChangeInNumberOfCases() {
     return mstReaction(
-      () => dataConfiguration?.caseDataArray.length,
+      () => dataConfiguration?.getCaseDataArray(0).length,
       () => {
         callMatchCirclesToData()
         refreshPoints(false)

--- a/v3/src/components/map/components/map-polygon-layer.tsx
+++ b/v3/src/components/map/components/map-polygon-layer.tsx
@@ -136,7 +136,7 @@ export const MapPolygonLayer = function MapPolygonLayer(props: {
       })
     // If this layer is not visible, skipping the following mapping will cause all the features to be removed
     // which is what we want
-    mapLayerModel.isVisible && dataConfiguration.caseDataArray.forEach((aCaseData, caseIndex) => {
+    mapLayerModel.isVisible && dataConfiguration.getCaseDataArray(0).forEach((aCaseData, caseIndex) => {
       const notAlreadyStashed = mapLayerModel.features.findIndex((feature) => {
         return (feature.options as PolygonLayerOptions).caseID === aCaseData.caseID
       }) === -1
@@ -208,7 +208,7 @@ export const MapPolygonLayer = function MapPolygonLayer(props: {
 
   useEffect(function setupResponseToChangeInNumberOfCases() {
     return mstReaction(
-      () => dataConfiguration?.caseDataArray.length,
+      () => dataConfiguration?.getCaseDataArray(0).length,
       () => {
         refreshPolygons(false)
       }, {name: "MapPolygonLayer.setupResponseToChangeInNumberOfCases"}, dataConfiguration

--- a/v3/src/components/map/models/map-grid-model.ts
+++ b/v3/src/components/map/models/map-grid-model.ts
@@ -53,10 +53,11 @@ export const MapGridModel = types.model("MapGridModel", {
     const computeCounts = () => {
       if (self.dataConfiguration) {
         const {
-            dataConfiguration: {dataset, caseDataArray},
+            dataConfiguration: {dataset},
             _latLngGrid, gridSize
           } = self,
-          dataConfiguration = self.dataConfiguration
+          dataConfiguration = self.dataConfiguration,
+          caseDataArray = dataConfiguration.getCaseDataArray(0)
 
         _latLngGrid.zeroCounts()
         caseDataArray.forEach(({caseID}: { plotNum: number, caseID: string }) => {
@@ -77,7 +78,7 @@ export const MapGridModel = types.model("MapGridModel", {
     }
     const _initializeGrid = () => {
       if (!self.isVisible) return
-      const cases = self.dataConfiguration?.caseDataArray,
+      const cases = self.dataConfiguration?.getCaseDataArray(0),
         bounds = self.dataConfiguration ? getLatLongBounds(self.dataConfiguration) : undefined
       if (cases?.length && bounds?.isValid()) {
         setupLatLngGrid()

--- a/v3/src/components/map/models/map-point-layer-model.ts
+++ b/v3/src/components/map/models/map-point-layer-model.ts
@@ -35,7 +35,7 @@ export const MapPointLayerModel = MapLayerModel
   }))
   .views(self => ({
     getPointRadius(use: 'normal' | 'hover-drag' | 'select' = 'normal') {
-      return computePointRadius(self.dataConfiguration.caseDataArray.length,
+      return computePointRadius(self.dataConfiguration.getCaseDataArray(0).length,
         self.displayItemDescription.pointSizeMultiplier, use)
     },
     get pointDescription() {


### PR DESCRIPTION
[#187614572] Bug fix: Dot chart and bar chart respond dynamically to change in category order

* One fix is, in `GraphController:syncAxisScalesWithModel` to set the axisMultiScale category set. With this fix, dragging the categories in restored bar chart succeeds in actually changing the category set order.
* An improvement in usePlotResponders:respondToCategorySetChanges we now respond to dataConfiguration.allCategoriesForRoles and do a structural comparison
* A major change is that in data-configuration-model.ts, `getCaseDataArray` is now a `cachedFnWithArgsFactory` and `get caseDataArray` is now gone because it was being cached and not updated when we needed it to be. (Note that this required replacing `.caseDataArray` with .getCaseDataArray(0) in a lot of files.)
* Another bug fixed here is that a categorical legend was not responding to changes in the order of its categories brought about by dragging in a different graph. This was fixed by reacing to `dataConfiguration?.casesChangeCount`