### PR TITLE
Dragging dot plot point bug

### DIFF
--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -206,7 +206,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
       const disposer = onAnyAction(dataset, action => {
         if (isSetCaseValuesAction(action)) {
           // assumes that if we're caching then only selected cases are being updated
-          callRefreshPointPositions(dataset.isCaching())
+          callRefreshPointPositions(dataset.isCaching() && graphModel.plotType !== "dotPlot")
           // TODO: handling of add/remove cases was added specifically for the case plot.
           // Bill has expressed a desire to refactor the case plot to behave more like the
           // other plots, which already handle removal of cases (and perhaps addition of cases?)
@@ -217,7 +217,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
       })
       return () => disposer()
     }
-  }, [dataset, callRefreshPointPositions])
+  }, [dataset, callRefreshPointPositions, graphModel.plotType])
 
   // respond to added or removed cases or change in attribute type or change in collection groups
   useEffect(function handleDataConfigurationActions() {

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -205,7 +205,8 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     if (dataset) {
       const disposer = onAnyAction(dataset, action => {
         if (isSetCaseValuesAction(action)) {
-          // assumes that if we're caching then only selected cases are being updated
+          // If we're caching then only selected cases need to be updated in scatterplots. But for dotplots
+          // we need to update all points because the unselecte points positions change.
           callRefreshPointPositions(dataset.isCaching() && graphModel.plotType !== "dotPlot")
           // TODO: handling of add/remove cases was added specifically for the case plot.
           // Bill has expressed a desire to refactor the case plot to behave more like the


### PR DESCRIPTION
[#188524694] Bug fix: Dragging dot plot point fails to cause other points to adjust their positions

* When dragging dot plot points, points other than those being dragged were not adjusting their positions. This was because refreshPointPositions was being called limited only to selected points. We change this so that for dot plots the refresh happens for all points.