### PR TITLE
188476241 API Get Collection Hidden Attributes

### DIFF
--- a/v3/src/data-interactive/handlers/collection-handler.ts
+++ b/v3/src/data-interactive/handlers/collection-handler.ts
@@ -109,7 +109,7 @@ export const diCollectionHandler: DIHandler = {
     if (!dataContext) return dataContextNotFoundResult
     if (!collection) return collectionNotFoundResult
 
-    const v2Collection = convertCollectionToV2(collection)
+    const v2Collection = convertCollectionToV2(collection, dataContext)
     return {
       success: true,
       values: v2Collection


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188476241

This PR fixes the `hidden` value for `attributes` included in `get collection` requests. A small oversight (not including the `dataset` when converting the collection to API output format) was preventing this from working previously.

The PR also adds a test for this change, which is the vast majority of line changes.

*Note*: I'm not applying the `run regression` label since this change doesn't impact any cypress tests.