### PR TITLE
188323297 Allow Domains to Shrink When Rescaling

### DIFF
--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -569,6 +569,7 @@ export const GraphContentModel = DataDisplayContentModel
             role = axisPlaceToAttrRole[axisPlace]
           if (isBaseNumericAxisModel(axis)) {
             const numericValues = dataConfiguration.numericValuesForAttrRole(role)
+            axis.setAllowRangeToShrink(true)
             setNiceDomain(numericValues, axis, self.axisDomainOptions)
           }
         })


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188323297

This PR allows domain axes to shrink when calling `GraphContentModel.rescale()`. This function is called when the user clicks the rescale button in the graph menu, or Show All Cases and Display Only Selected Cases from the graph eye menu.