### PR TITLE
fix: deselect on click on PIXI point

### DIFF
--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -14,7 +14,7 @@ import {
   pointRadiusSelectionAddend, Rect, rTreeRect
 } from "./data-display-types"
 import {IDataConfigurationModel } from "./models/data-configuration-model"
-import {IPixiPointStyle, PixiPoints} from "./pixi/pixi-points"
+import {getPixiPointsDispatcher, IPixiPointStyle, PixiPoints} from "./pixi/pixi-points"
 import {CaseDataWithSubPlot} from "./d3-types"
 
 export const maxWidthOfStringsD3 = (strings: Iterable<string>) => {
@@ -51,6 +51,9 @@ export const computePointRadius = (numPoints: number, pointSizeMultiplier: numbe
 }
 
 export function handleClickOnCase(event: PointerEvent, caseID: string, dataset?: IDataSet) {
+  // click occurred on a point, so don't deselect
+  getPixiPointsDispatcher(event)?.cancelAnimationFrame("deselectAll")
+
   const extendSelection = event.shiftKey,
     caseIsSelected = dataset?.isCaseSelected(caseID)
 

--- a/v3/src/components/data-display/hooks/use-pixi-pointer-down-deselect.ts
+++ b/v3/src/components/data-display/hooks/use-pixi-pointer-down-deselect.ts
@@ -4,10 +4,12 @@ import { PixiPoints } from "../pixi/pixi-points"
 import { usePixiPointerDown } from "./use-pixi-pointer-down"
 
 export function usePixiPointerDownDeselect(pixiPointsArray: PixiPoints[], model?: IDataDisplayContentModel) {
-  usePixiPointerDown(pixiPointsArray, event => {
+  usePixiPointerDown(pixiPointsArray, (event, pixiPoints: PixiPoints) => {
     if (!event.shiftKey && !event.metaKey && !event.ctrlKey) {
-      const datasetsArray = model?.datasetsArray ?? []
-      datasetsArray.forEach(data => selectAllCases(data, false))
+      pixiPoints.requestAnimationFrame("deselectAll", () => {
+        const datasetsArray = model?.datasetsArray ?? []
+        datasetsArray.forEach(data => selectAllCases(data, false))
+      })
     }
   })
 }

--- a/v3/src/components/data-display/hooks/use-pixi-pointer-down.ts
+++ b/v3/src/components/data-display/hooks/use-pixi-pointer-down.ts
@@ -2,18 +2,19 @@ import { useEffect } from "react"
 import { useTileModelContext } from "../../../hooks/use-tile-model-context"
 import { PixiPoints } from "../pixi/pixi-points"
 
-export function usePixiPointerDown(pixiPointsArray: PixiPoints[], onPointerDown: (event: PointerEvent) => void) {
+type OnPointerDownCallback = (event: PointerEvent, pixiPoints: PixiPoints) => void
+
+export function usePixiPointerDown(pixiPointsArray: PixiPoints[], onPointerDown: OnPointerDownCallback) {
   const { isTileSelected } = useTileModelContext()
 
   useEffect(() => {
     const handlePointerDownCapture = (event: PointerEvent) => {
       // Browser events are dispatched directly to the PIXI canvas.
       // Re-dispatched events are dispatched to elements behind the PIXI canvas.
-      const canvases: Array<EventTarget | null> = pixiPointsArray.map(pixiPoints => pixiPoints.canvas)
-      const isBrowserEventOnPixiCanvas = canvases.includes(event.target)
+      const pixiPointsIndex = pixiPointsArray.findIndex(pixiPoints => event.target === pixiPoints.canvas)
       // first click selects tile; deselection only occurs once the tile is already selected
-      if (isBrowserEventOnPixiCanvas && isTileSelected()) {
-        onPointerDown(event)
+      if (pixiPointsIndex >= 0 && isTileSelected()) {
+        onPointerDown(event, pixiPointsArray[pixiPointsIndex])
       }
     }
     window.addEventListener("pointerdown", handlePointerDownCapture, { capture: true })


### PR DESCRIPTION
[[PT-188524747]](https://www.pivotaltracker.com/story/show/188524747) Clicking on selected points deselects other points preventing multiple point drag

This bug was introduced in #1563, the purpose of which was to handle clicks in white space of the graph to first select the tile and _then_ to deselect all selected cases on the second click (i.e. when the tile is already selected). The fix there was to add a capturing pointer-down handler on the window that would trigger on clicks in the graph. The problem is that we don't want to deselect on _all_ clicks on the graph, only on those on the background/white space of the graph. Unfortunately, we don't have a good way of determining in a capturing pointer-down handler on the window whether a given event is going to result in a click on a point or other graph element or not.

To solve this problem, we use an approach I first encountered in the `react-data-grid` library used in the case table. In `react-data-grid` it's used to handle clicks outside an editable input element to complete the edit. Instead of deselecting all cases directly in the window's capturing pointer-down handler, we schedule the deselection for later using `requestAnimationFrame()`. This guarantees that the deselection won't occur until after the processing of the current event is complete. Then in the standard event handler(s) for the graph (e.g. `DataDisplayUtils.handleClickOnCase()`) we cancel the scheduled deselection. In other words, rather than trying to affirmatively decide whether a click is on the background or not in the window's capturing handler, we always schedule the deselection and then cancel it in the existing handlers for elements that should _not_ trigger deselection.

For this to work, however, the code that's canceling the deselection must have a means of retrieving the frame id of the request to cancel. The `PixiPoints` object is at the center of all of this, so there are new `requestAnimationFrame()` and `cancelAnimationFrame()` methods on the `PixiPoints` class. I could have made the API specific to deselection, e.g. `requestDeselectAll()`/`cancelDeselectAll()`, but it seems likely that other issues will arise with this Pixi event-dispatching system, so I made it take a request id, `deselectAll` in this case, and maintain a map so that other requests can be handled similarly in the future.

One wrinkle remains, however, which is that clients like `DataDisplayUtils.handleClickOnCase()` don't have access to the relevant `PixiPoints` instance as things stand. The obvious thing to do is to add a `PixiPoints` argument to the necessary functions and require callers to pass it in. But that requires changing a bunch of clients and not all of them have ready access to the `PixiPoints` instance, so there's some additional prop-drilling required beyond that. 🤮 Instead, we take advantage of the fact that all of the relevant code here is in event handlers that we control. Therefore, we can use a `WeakMap` to associate a `PixiPoints` instance with events being handled/dispatched and provide a `getPixiPointsDispatcher()` function for retrieving the relevant `PixiPoints` instance.

Once all the infrastructure is in place, the relevant part of `usePixiPointerDownSelect()` becomes:
```typescript
      pixiPoints.requestAnimationFrame("deselectAll", () => {
        const datasetsArray = model?.datasetsArray ?? []
        datasetsArray.forEach(data => selectAllCases(data, false))
      })
```
and a single line gets added to `DataDisplayUtils.handleClickOnCase()` (or other such handlers):
```typescript
  // click occurred on a point, so don't deselect
  getPixiPointsDispatcher(event)?.cancelAnimationFrame("deselectAll")
```
