### PR TITLE
fix: case table update on exit from performance mode

### DIFF
--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -73,11 +73,12 @@ export const useRows = () => {
 
   const syncRowsToDom = useCallback(() => {
     prf.measure("Table.useRows[syncRowsToDom]", () => {
+      const collection = data?.getCollection(collectionId)
       const grid = document.querySelector(".rdg")
       const domRows = grid?.querySelectorAll(".rdg-row")
       domRows?.forEach(row => {
         const rowIndex = Number(row.getAttribute("aria-rowindex")) - 2
-        const caseId = data?.itemIDFromIndex(rowIndex)
+        const caseId = collection?.caseIds[rowIndex]
         const cells = row.querySelectorAll(".rdg-cell")
         cells.forEach(cell => {
           const colIndex = Number(cell.getAttribute("aria-colindex")) - 2
@@ -94,7 +95,7 @@ export const useRows = () => {
         })
       })
     })
-  }, [data, setCachedDomAttr])
+  }, [collectionId, data, setCachedDomAttr])
 
   const resetRowCacheAndSyncRows = useDebouncedCallback(() => {
     resetRowCache()


### PR DESCRIPTION
[[PT-188524711]](https://www.pivotaltracker.com/story/show/188524711)

The root cause of the bug was an itemId/caseId confusion. In performance mode we keep track of the cells that have been directly altered so that we can trigger a React refresh when exiting performance mode. The code was caching item ids and then querying the cache with case ids. Now we use case ids consistently.