### PR TITLE
188411147 rename click away

### DIFF
--- a/v3/cypress/support/commands.ts
+++ b/v3/cypress/support/commands.ts
@@ -21,7 +21,7 @@ Cypress.Commands.add("clickWhenClickable", (selector: string, shouldCondition = 
         ensuring the action only happens once the assertion is fully satisfied.
   */
   cy.get(selector).should(shouldCondition).then($el => {
-    cy.wrap($el).click()
+    cy.wrap($el).click({force:true})
   })
 })
 

--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -61,6 +61,7 @@ export const AttributeHeader = observer(function AttributeHeader({
     prefix: instanceId, dataSet: data, attributeId
   }
   const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions)
+  useOutsidePointerDown({ ref: inputRef, handler: () => onCloseMenuRef.current?.() })
 
   const setHeaderContentRef = (elt: HTMLDivElement | null) => {
     contentRef.current = elt

--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -43,6 +43,7 @@ export const AttributeHeader = observer(function AttributeHeader({
   const menuButtonRef = useRef<HTMLButtonElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
+  const menuListRef = useRef<HTMLDivElement | null>(null)
   const isMenuOpen = useRef(false)
   const [editingAttrId, setEditingAttrId] = useState("")
   const [editingAttrName, setEditingAttrName] = useState("")
@@ -61,7 +62,7 @@ export const AttributeHeader = observer(function AttributeHeader({
     prefix: instanceId, dataSet: data, attributeId
   }
   const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions)
-  useOutsidePointerDown({ ref: inputRef, handler: () => onCloseMenuRef.current?.() })
+  useOutsidePointerDown({ ref: menuListRef, handler: () => onCloseMenuRef.current?.() })
 
   const setHeaderContentRef = (elt: HTMLDivElement | null) => {
     contentRef.current = elt
@@ -241,7 +242,7 @@ export const AttributeHeader = observer(function AttributeHeader({
               }
               {attributeId !== kIndexColumnKey &&
                 <CaseTilePortal>
-                  <AttributeMenuList attributeId={attributeId} onRenameAttribute={handleRenameAttribute}
+                  <AttributeMenuList ref={menuListRef} attributeId={attributeId} onRenameAttribute={handleRenameAttribute}
                     onModalOpen={handleModalOpen}
                   />
                 </CaseTilePortal>

--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -15,6 +15,7 @@ import { CaseTilePortal } from "./case-tile-portal"
 import { GetDividerBoundsFn, IDividerProps, kIndexColumnKey } from "./case-tile-types"
 import { useParentChildFocusRedirect } from "./use-parent-child-focus-redirect"
 import { useAdjustHeaderForOverflow } from "../../hooks/use-adjust-header-overflow"
+import { useOutsidePointerDown } from "../../hooks/use-outside-pointer-down"
 
 interface IProps {
   attributeId: string
@@ -98,6 +99,7 @@ export const AttributeHeader = observer(function AttributeHeader({
 
   // focus our content when the cell is focused
   useParentChildFocusRedirect(parentRef.current, menuButtonRef.current)
+  useOutsidePointerDown({ ref: inputRef, handler: () => handleClose(true) })
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const { key } = e


### PR DESCRIPTION
Currently, the input status of the attribute header is left in limbo status when user clicks outside the input area. This accepts input changes to attribute header when user clicks outside the input.

Currently, attribute menu only closes on user mouse up outside the attribute menu. This closes attribute menu on user mousedown.