### PR TITLE
Bring back flaky graph axis test in smoke test spec

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -16,6 +16,8 @@
 - **PT-188524694:** Dragging dot plot point fails to cause other points to adjust their positions
 - **PT-188470760:** “TAB” Button Does Not Trigger Autocomplete in **Formula Editor**
 - **PT-187614572:** Dot chart and bar chart respond dynamically to change in category order (*Delivered*)
+- **PT-188476241:** **[MultiData]** Hidden attributes are visible in MultiData Nested Table plugin (Delivered)
+
 
 ### 🛠️ Under the Hood:
 - **PT-187223531:** The plugin api supports the ability to specify set aside cases

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -7,6 +7,7 @@ import { SliderTileElements as slider } from "../../support/elements/slider-tile
 import { CalculatorTileElements as calculator } from "../../support/elements/calculator-tile"
 import { WebViewTileElements as webView } from "../../support/elements/web-view-tile"
 import { CfmElements as cfm } from "../../support/elements/cfm"
+import { AxisHelper as ah } from "../../support/helpers/axis-helper"
 
 
 context("codap single smoke test", () => {
@@ -119,21 +120,21 @@ context("codap single smoke test", () => {
     cy.get('button[data-testid="codap-attribute-button date"]').should('exist')
     table.getGridCell(2, 3, 2).should('be.visible').and("contain", "5/23/2005")
 
-    // This test has become flaky, commenting out for now
+    cy.log("Test date display in bottom axis of graph")
+    ah.verifyDefaultAxisLabel("bottom")
+    ah.openAxisAttributeMenu("bottom")
+    ah.selectMenuAttribute("date", "bottom") // Date => x-axis
+    cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "date")
+    // Check that the date axis contains the year '2005'
+    cy.get('[data-testid="axis-bottom"]')
+      .find('text')
+      .contains('2005')
+      .should('exist')
 
-    // cy.log("Test date display in bottom axis of graph")
-    // cy.dragAttributeToTarget("table", "date", "bottom")
-    // cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "date")
-    // // Check that the date axis contains the year '2005'
-    // cy.get('[data-testid="axis-bottom"]')
-    //   .find('text')
-    //   .contains('2005')
-    //   .should('exist')
-
-    // // Check the number of tick marks on axis (e.g., ensuring there are 9 months: May to Jan)
-    // cy.get('[data-testid="axis-bottom"]')
-    //   .find('text')
-    //   .should('have.length', 10) // Adjust this if the expected number changes (currently 9 + ghost div=10)
+    // Check the number of tick marks on axis (e.g., ensuring there are 9 months: May to Jan)
+    cy.get('[data-testid="axis-bottom"]')
+      .find('text')
+      .should('have.length', 10) // Adjust this if the expected number changes (currently 9 + ghost div=10)
 
     cy.log("checks map component")
     c.getComponentTitle("map").should("have.text", "Measurements")

--- a/v3/cypress/support/helpers/axis-helper.ts
+++ b/v3/cypress/support/helpers/axis-helper.ts
@@ -89,6 +89,12 @@ export const AxisHelper = {
     ae.getAttributeFromAttributeMenu(axis).contains(name).click()
     cy.wait(2000)
   },
+  selectMenuAttribute(attributeName: string, axis: string) {
+    ae.getAttributeFromAttributeMenu(axis)
+      .contains("button", attributeName) // This finds the button with the text
+      .click()
+    cy.wait(2000)
+  },
   removeAttributeFromAxis(name: string, axis: string) {
     ae.getAttributeFromAttributeMenu(axis).contains(`Remove`).click()
   },


### PR DESCRIPTION
[PT-#188534232](https://www.pivotaltracker.com/story/show/188534232)

### Description:
This PR introduces a new helper function, `selectAttributeButton`, to streamline the selection of attribute buttons in the axis menu. The function enables more reliable targeting by using button text.

### Changes:
- **New Function:** Added `selectAttributeButton(attributeName, axis)` to select and click attribute buttons by name.
- **Cypress Test Update:** Replaced `addAttributeToAxis` calls with `selectAttributeButton` for better reliability in dynamic menus.

### Why:
The previous approach relied on `dragAttributeToTarget`, which led to occasional test instability. This new function uses button text, which will hopefully be less prone to errors than the dragging misbehavior. The dragging behavior is still covered in the Mammals portion of the smoke test.

### Checklist:

- [x] Function added
- [x] Updated release notes from yesterday (one PR slipped its way in)
- [x] Cypress test updated to use selectAttributeButton
- [x] Smoke test and all tests passing with `run_regression` label