### PR TITLE
unify handling of v2 documents

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -4,7 +4,7 @@ import { CodapDndContext } from "../lib/dnd-kit/codap-dnd-context"
 import { Container } from "./container/container"
 import { ToolShelf } from "./tool-shelf/tool-shelf"
 import { kCodapAppElementId } from "./constants"
-import { importV2Document } from "../v2/import-v2-document"
+import { ICodapV2DocumentJson } from "../v2/codap-v2-types"
 import { MenuBar, kMenuBarElementId } from "./menu-bar/menu-bar"
 import { useCloudFileManager } from "../lib/use-cloud-file-manager"
 import { Logger } from "../lib/logger"
@@ -57,7 +57,7 @@ export const App = observer(function App() {
       sharedData?.dataSet.completeSnapshot()
     }, [])
 
-  const handleImportV3Document = useCallback((document: IDocumentModelSnapshot) => {
+  const handleImportDocument = useCallback((document: IDocumentModelSnapshot | ICodapV2DocumentJson) => {
     appState.setDocument(document)
   }, [])
 
@@ -69,8 +69,7 @@ export const App = observer(function App() {
   useDropHandler({
     selector: `#${kCodapAppElementId}`,
     onImportDataSet: handleImportDataSet,
-    onImportV2Document: importV2Document,
-    onImportV3Document: handleImportV3Document,
+    onImportDocument: handleImportDocument,
     onHandleUrlDrop: handleUrlDrop
   })
 

--- a/v3/src/lib/handle-cfm-event.test.ts
+++ b/v3/src/lib/handle-cfm-event.test.ts
@@ -21,7 +21,7 @@ describe("handleCFMEvent", () => {
     updateDocumentSpy.mockRestore()
   })
 
-  it("handles the `connected` message", () => {
+  it("handles the `connected` message", async () => {
     const mockCfmClient = {
       openUrlFile: jest.fn(),
       setProviderOptions: jest.fn(),
@@ -33,7 +33,7 @@ describe("handleCFMEvent", () => {
     const cfmEvent = {
       type: "connected"
     } as CloudFileManagerClientEvent
-    handleCFMEvent(mockCfmClientArg, cfmEvent)
+    await handleCFMEvent(mockCfmClientArg, cfmEvent)
     expect(mockCfmClient.openUrlFile).not.toHaveBeenCalled()
     expect(mockCfmClient.setProviderOptions).toHaveBeenCalledTimes(1)
     const [providerNameArg, providerOptionsArg] = mockCfmClient.setProviderOptions.mock.calls[0]
@@ -46,28 +46,26 @@ describe("handleCFMEvent", () => {
     expect(menuBarInfoArg).toBe(`v${providerOptionsArg.appVersion} (${providerOptionsArg.appBuildNum})`)
 
     urlParamsModule.urlParams.url = "https://concord.org/example.json"
-    handleCFMEvent(mockCfmClientArg, cfmEvent)
+    await handleCFMEvent(mockCfmClientArg, cfmEvent)
     expect(mockCfmClient.openUrlFile).toHaveBeenCalledTimes(1)
     expect(mockCfmClient.setProviderOptions).toHaveBeenCalledTimes(2)
     expect(mockCfmClient._ui.setMenuBarInfo).toHaveBeenCalledTimes(2)
   })
 
-  it("handles the `getContent` message", done => {
+  it("handles the `getContent` message", async () => {
     const mockCfmClient = {} as CloudFileManagerClient
     const mockCfmEvent = {
       type: "getContent",
       callback: jest.fn()
     }
     const mockCfmEventArg = mockCfmEvent as unknown as CloudFileManagerClientEvent
-    handleCFMEvent(mockCfmClient, mockCfmEventArg)
-    setTimeout(() => {
-      const contentArg = mockCfmEvent.callback.mock.calls[0][0]
-      expect(isCodapDocument(contentArg)).toBe(true)
-      done()
-    })
+    await handleCFMEvent(mockCfmClient, mockCfmEventArg)
+
+    const contentArg = mockCfmEvent.callback.mock.calls[0][0]
+    expect(isCodapDocument(contentArg)).toBe(true)
   })
 
-  it("handles the willOpenFile message", () => {
+  it("handles the willOpenFile message", async () => {
     const mockCfmClient = {} as CloudFileManagerClient
     const mockCfmEvent = {
       type: "willOpenFile",
@@ -75,12 +73,12 @@ describe("handleCFMEvent", () => {
     }
     const spy = jest.spyOn(urlParamsModule, "removeDevUrlParams")
     const mockCfmEventArg = mockCfmEvent as unknown as CloudFileManagerClientEvent
-    handleCFMEvent(mockCfmClient, mockCfmEventArg)
+    await handleCFMEvent(mockCfmClient, mockCfmEventArg)
     expect(spy).toHaveBeenCalledTimes(1)
     spy.mockRestore()
   })
 
-  it("handles the `openedFile` message with a v2 document", () => {
+  it("handles the `openedFile` message with a v2 document", async () => {
     const mockCfmClient = {} as CloudFileManagerClient
     const mockV2Document: ICodapV2DocumentJson = {
       appName: "DG",
@@ -94,12 +92,12 @@ describe("handleCFMEvent", () => {
       }
     } as CloudFileManagerClientEvent
     const spy = jest.spyOn(ImportV2Document, "importV2Document")
-    handleCFMEvent(mockCfmClient, cfmEvent)
+    await handleCFMEvent(mockCfmClient, cfmEvent)
     expect(ImportV2Document.importV2Document).toHaveBeenCalledTimes(1)
     spy.mockRestore()
   })
 
-  it("handles the `openedFile` message with a v3 document", () => {
+  it("handles the `openedFile` message with a v3 document", async () => {
     const mockCfmClient = {} as CloudFileManagerClient
     const v3Document = createCodapDocument()
     const cfmEvent = {
@@ -109,7 +107,7 @@ describe("handleCFMEvent", () => {
       }
     } as CloudFileManagerClientEvent
     const spy = jest.spyOn(appState, "setDocument")
-    handleCFMEvent(mockCfmClient, cfmEvent)
+    await handleCFMEvent(mockCfmClient, cfmEvent)
     expect(spy).toHaveBeenCalledTimes(1)
     spy.mockRestore()
   })

--- a/v3/src/lib/handle-cfm-event.ts
+++ b/v3/src/lib/handle-cfm-event.ts
@@ -1,9 +1,6 @@
 import { CloudFileManagerClient, CloudFileManagerClientEvent } from "@concord-consortium/cloud-file-manager"
 import { appState } from "../models/app-state"
 import { removeDevUrlParams, urlParams } from "../utilities/url-params"
-import { isCodapV2Document } from "../v2/codap-v2-types"
-import { CodapV2Document } from "../v2/codap-v2-document"
-import { importV2Document } from "../v2/import-v2-document"
 import { wrapCfmCallback } from "./cfm-utils"
 
 import build from "../../build_number.json"
@@ -36,10 +33,10 @@ export function handleCFMEvent(cfmClient: CloudFileManagerClient, event: CloudFi
     // case "closedFile":
     //   break
     case "getContent": {
-      appState.getDocumentSnapshot().then(content => {
+      // return the promise so tests can make sure it is complete
+      return appState.getDocumentSnapshot().then(content => {
         event.callback(content)
       })
-      break
     }
     case "willOpenFile":
       removeDevUrlParams()
@@ -49,14 +46,8 @@ export function handleCFMEvent(cfmClient: CloudFileManagerClient, event: CloudFi
     case "openedFile": {
       const content = event.data.content
       const metadata = event.data.metadata
-      if (isCodapV2Document(content)) {
-        const v2Document = new CodapV2Document(content, metadata)
-        importV2Document(v2Document)
-      }
-      else {
-        appState.setDocument(content, metadata)
-      }
-      break
+      // return the promise so tests can make sure it is complete
+      return appState.setDocument(content, metadata)
     }
     case "savedFile": {
       const { content } = event.data

--- a/v3/src/lib/use-cloud-file-manager.ts
+++ b/v3/src/lib/use-cloud-file-manager.ts
@@ -114,7 +114,7 @@ function getMenuConfig(cfm: CloudFileManager) {
       action() {
         cfm.client.closeFileDialog(function() {
           removeDevUrlParams()
-          appState.setDocument(getSnapshot(createCodapDocument()))
+          appState.setDocument({type: "CODAP"})
         })
       }
     },

--- a/v3/src/v2/import-v2-document.ts
+++ b/v3/src/v2/import-v2-document.ts
@@ -1,8 +1,5 @@
-import { getSnapshot } from "mobx-state-tree"
-import { appState } from "../models/app-state"
 import { createCodapDocument } from "../models/codap/create-codap-document"
 import { gDataBroker } from "../models/data/data-broker"
-import { serializeDocument } from "../models/document/serialize-document"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { getSharedModelManager } from "../models/tiles/tile-environment"
 import { ITileModel, ITileModelSnapshotIn } from "../models/tiles/tile-model"
@@ -10,7 +7,7 @@ import { CodapV2Document } from "./codap-v2-document"
 import { importV2Component } from "./codap-v2-tile-importers"
 import { IFreeTileInRowOptions, isFreeTileRow } from "../models/document/free-tile-row"
 
-export async function importV2Document(v2Document: CodapV2Document) {
+export function importV2Document(v2Document: CodapV2Document) {
   const v3Document = createCodapDocument(undefined, { layout: "free" })
   const sharedModelManager = getSharedModelManager(v3Document)
   sharedModelManager && gDataBroker.setSharedModelManager(sharedModelManager)
@@ -61,8 +58,5 @@ export async function importV2Document(v2Document: CodapV2Document) {
     row.setMaxZIndex(maxZIndex)
   }
 
-  // retrieve document snapshot
-  const docSnapshot = await serializeDocument(v3Document, doc => getSnapshot(doc))
-  // use document snapshot
-  appState.setDocument(docSnapshot)
+  return v3Document
 }


### PR DESCRIPTION
- the codap3 and codap file extensions are now treated the same by the drop code. It is the content of the file that matters
- remove unnecessary createCodapDocument call when a new document was created by the close option which was doing a lot of duplicate work
- importV2Document now just returns the v3 document instance, which allows it to run synchronously
- handleCFMEvent now returns a promise when it does asynchronous things to help with testing