### PR TITLE
Fix for map failure to zoom on open bug

### DIFF
--- a/v3/src/components/map/models/map-content-model.ts
+++ b/v3/src/components/map/models/map-content-model.ts
@@ -199,13 +199,9 @@ export const MapContentModel = DataDisplayContentModel
 
       // Rescale when the layers are changed
       addDisposer(self, reaction(
-        () => {
-          const {layers} = self
-          return {layers}
-        },
-        () => {
-          self.rescale()
-        }, {name: "MapContentModel.reaction rescale when layers change", equals: comparer.structural}
+        () => self.layers.map(layer => layer.id),
+        () => self.rescale(),
+        {name: "MapContentModel.reaction rescale when layers change", equals: comparer.structural}
       ))
     },
     afterAttachToDocument() {

--- a/v3/src/components/map/models/map-content-model.ts
+++ b/v3/src/components/map/models/map-content-model.ts
@@ -196,6 +196,17 @@ export const MapContentModel = DataDisplayContentModel
           }
         }, {name: "MapContentModel.reaction [sync mapModel => leaflet map]", equals: comparer.structural}
       ))
+
+      // Rescale when the layers are changed
+      addDisposer(self, reaction(
+        () => {
+          const {layers} = self
+          return {layers}
+        },
+        () => {
+          self.rescale()
+        }, {name: "MapContentModel.reaction rescale when layers change", equals: comparer.structural}
+      ))
     },
     afterAttachToDocument() {
       // Monitor coming and going of shared datasets
@@ -216,7 +227,6 @@ export const MapContentModel = DataDisplayContentModel
           // We make a copy of the layers array and remove any layers that are still in the shared model
           // If there are any layers left in the copy, they are no longer in any shared dataset and should be removed
           const layersToCheck = Array.from(self.layers)
-          let layersHaveChanged = false
           sharedDataSets.forEach(sharedDataSet => {
             if (datasetHasLatLongData(sharedDataSet.dataSet)) {
               const foundIndex = layersToCheck.findIndex(aLayer => aLayer.data === sharedDataSet.dataSet)
@@ -229,7 +239,6 @@ export const MapContentModel = DataDisplayContentModel
               } else {
                 // Add a new layer for this dataset
                 this.addPointLayer(sharedDataSet.dataSet)
-                layersHaveChanged = true
               }
             }
             // Todo: We should allow both points and polygons from the same dataset
@@ -241,18 +250,13 @@ export const MapContentModel = DataDisplayContentModel
               } else {
                 // Add a new layer for this dataset
                 this.addPolygonLayer(sharedDataSet.dataSet)
-                layersHaveChanged = true
               }
             }
           })
           // Remove any remaining layers in layersToCheck since they are no longer in any shared dataset
           layersToCheck.forEach(layer => {
             self.layers.splice(self.layers.indexOf(layer), 1)
-            layersHaveChanged = true
           })
-          if (layersHaveChanged) {
-            self.rescale()
-          }
           self.isSharedDataInitialized = true
         },
         {name: "MapContentModel.respondToSharedDatasetsChanges", fireImmediately: true}))


### PR DESCRIPTION
[#188514843] Bug fix: Maps do not open at correct zoom level

* This was essentially a timing issue whereby the data configuration had not been given time to compute its filtered cases before being asked to cough up the lat/long bounds. We fix by wrapping the `MapContentModel`'s call to `rescale` in a setTimeout.
* Apparently as a side effect of this change, the inspector's rescale button now works, whereas it didn't work before this change.