### PR TITLE
fix: table row selection and child table scrolling

### DIFF
--- a/v3/src/components/case-table/case-table-types.ts
+++ b/v3/src/components/case-table/case-table-types.ts
@@ -28,6 +28,13 @@ export interface TCellSelectArgs extends CellSelectArgs<TRow> {}
 export type TCellKeyDownArgs = CellKeyDownArgs<TRow>
 export type TColSpanArgs = ColSpanArgs<TRow, unknown>
 
+export interface IScrollOptions {
+  // "auto" moves immediately; "smooth" animates
+  scrollBehavior?: "auto" | "smooth"
+  // disable parent/child scroll sync for the target table
+  disableScrollSync?: boolean
+}
+
 export interface IBaseTableScrollInfo {
   element: HTMLDivElement
   scrollRowIntoView: (rowIndex: number) => void
@@ -43,6 +50,7 @@ export type SetScrollInfoFn = (scrollInfo: ISetTableScrollInfo) => void
 export type TableScrollEvent = React.UIEvent<HTMLDivElement, UIEvent>
 export type OnTableScrollFn = (event: TableScrollEvent, collectionId: string, element: HTMLDivElement) => void
 export type OnScrollClosestRowIntoViewFn = (collectionId: string, rowIndices: number[]) => void
+export type OnScrollRowRangeIntoViewFn = (collectionId: string, rowIndices: number[], options?: IScrollOptions) => void
 
 export const kInputRowKey = "__input__"
 

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -17,6 +17,7 @@ import { t } from "../../utilities/translation/translate"
 import { excludeDragOverlayRegEx } from "../case-tile-common/case-tile-types"
 import { AttributeHeaderDividerContext } from "../case-tile-common/use-attribute-header-divider-context"
 import { AttributeDragOverlay } from "../drag-drop/attribute-drag-overlay"
+import { IScrollOptions } from "./case-table-types"
 import { CollectionTable } from "./collection-table"
 import { useCaseTableModel } from "./use-case-table-model"
 import { useSyncScrolling } from "./use-sync-scrolling"
@@ -74,6 +75,19 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
     }
   }, [syncTableScroll, tableModel])
 
+  const handleScrollRowRangeIntoView = useCallback(
+    function(collectionId: string, rowIndices: number[], options?: IScrollOptions) {
+      const collectionTableModel = tableModel?.getCollectionTableModel(collectionId)
+      if (collectionTableModel) {
+        const [firstIndex, lastIndex] = rowIndices.reduce((prev, index) => {
+          const [minIndex, maxIndex] = prev
+          return [Math.min(minIndex, index), Math.max(maxIndex, index)] as const
+        }, [Infinity, -Infinity] as const)
+        collectionTableModel.scrollRangeIntoView(firstIndex, lastIndex, options)
+        syncTableScroll(collectionId)
+      }
+    }, [syncTableScroll, tableModel])
+
   const handleCollectionTableMount = useCallback((collectionId: string) => {
     if (collectionId === lastNewCollectionDrop.current?.newCollectionId) {
       syncTableScroll(lastNewCollectionDrop.current.beforeCollectionId)
@@ -130,7 +144,8 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
                   <CollectionContext.Provider value={collection.id}>
                     <CollectionTable onMount={handleCollectionTableMount}
                       onNewCollectionDrop={handleNewCollectionDrop} onTableScroll={handleTableScroll}
-                      onScrollClosestRowIntoView={handleScrollClosestRowIntoView} />
+                      onScrollClosestRowIntoView={handleScrollClosestRowIntoView}
+                      onScrollRowRangeIntoView={handleScrollRowRangeIntoView} />
                   </CollectionContext.Provider>
                 </ParentCollectionContext.Provider>
               )

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -4,7 +4,8 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import DataGrid, { CellKeyboardEvent, DataGridHandle } from "react-data-grid"
 import { kCollectionTableBodyDropZoneBaseId } from "./case-table-drag-drop"
 import {
-  kInputRowKey, OnScrollClosestRowIntoViewFn, OnTableScrollFn, TCellKeyDownArgs, TRenderers, TRow
+  kInputRowKey, OnScrollClosestRowIntoViewFn, OnScrollRowRangeIntoViewFn, OnTableScrollFn,
+  TCellKeyDownArgs, TRenderers, TRow
 } from "./case-table-types"
 import { CollectionTableSpacer } from "./collection-table-spacer"
 import { CollectionTitle } from "../case-tile-common/collection-title"
@@ -51,9 +52,12 @@ interface IProps {
   onNewCollectionDrop: OnNewCollectionDropFn
   onTableScroll: OnTableScrollFn
   onScrollClosestRowIntoView: OnScrollClosestRowIntoViewFn
+  onScrollRowRangeIntoView: OnScrollRowRangeIntoViewFn
 }
 export const CollectionTable = observer(function CollectionTable(props: IProps) {
-  const { onMount, onNewCollectionDrop, onTableScroll, onScrollClosestRowIntoView } = props
+  const {
+    onMount, onNewCollectionDrop, onScrollClosestRowIntoView, onScrollRowRangeIntoView, onTableScroll
+  } = props
   const data = useDataSetContext()
   const collectionId = useCollectionContext()
   const caseTableModel = useCaseTableModel()
@@ -63,7 +67,8 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
                               getComputedStyle(gridRef.current.element)
                                 .getPropertyValue("--rdg-row-selected-background-color") || undefined
   const visibleAttributes = useVisibleAttributes(collectionId)
-  const { selectedRows, setSelectedRows, handleCellClick } = useSelectedRows({ gridRef, onScrollClosestRowIntoView })
+  const { selectedRows, setSelectedRows, handleCellClick } =
+    useSelectedRows({ gridRef, onScrollClosestRowIntoView, onScrollRowRangeIntoView })
   const { handleWhiteSpaceClick } = useWhiteSpaceClick({ gridRef })
   const { isTileSelected } = useTileModelContext()
   const [isSelecting, setIsSelecting] = useState(false)

--- a/v3/src/components/case-table/use-selected-rows.ts
+++ b/v3/src/components/case-table/use-selected-rows.ts
@@ -138,18 +138,31 @@ export const useSelectedRows = (props: UseSelectedRows) => {
     // In this case, we match the v2 behavior in that clicking on a single row when multiple rows
     // are selected deselects other rows.
     else {
-      setSelectedCases([caseId], data)
+      let caseIds = [caseId]
+      setSelectedCases(caseIds, data)
       anchorCase.current = caseId
 
-      const caseInfo = data?.caseInfoMap.get(caseId)
-      const collection = data?.getCollection(caseInfo?.collectionId)
-      // scroll to newly selected child cases (if any)
-      const childCollection = collection?.child
-      if (childCollection && caseInfo?.childCaseIds?.length) {
-        const childIndices = caseInfo?.childCaseIds.map(id => {
-          return collectionCaseIndexFromId(id, data, childCollection.id)
-        }).filter(index => index != null)
-        onScrollRowRangeIntoView(childCollection.id, childIndices, { disableScrollSync: true })
+      // loop through collections and scroll newly selected child cases into view
+      const collection = data?.getCollection(collectionId)
+      for (let childCollection = collection?.child; childCollection; childCollection = childCollection?.child) {
+        const childCaseIds: string[] = []
+        const childIndices: number[] = []
+        caseIds.forEach(id => {
+          const caseInfo = data?.caseInfoMap.get(id)
+          caseInfo?.childCaseIds?.forEach(childCaseId => {
+            childCaseIds.push(childCaseId)
+            const caseIndex = collectionCaseIndexFromId(childCaseId, data, childCollection.id)
+            if (caseIndex != null) {
+              childIndices.push(caseIndex)
+            }
+          })
+        })
+        // scroll to newly selected child cases (if any)
+        if (childIndices.length) {
+          onScrollRowRangeIntoView(childCollection.id, childIndices, { disableScrollSync: true })
+        }
+        // advance to child cases in next collection
+        caseIds = childCaseIds
       }
     }
   }, [collectionId, data, onScrollRowRangeIntoView])

--- a/v3/src/components/case-table/use-sync-scrolling.ts
+++ b/v3/src/components/case-table/use-sync-scrolling.ts
@@ -13,13 +13,7 @@ export function useSyncScrolling() {
    * a visible case should also be visible. We have gotten here from a
    * notification from a scroll event from RDG and any scrolling
    * of dependent tables will also produce scroll events, so we need to
-   * avoid getting into feedback loops. We do this by keeping a global scrollCount
-   * count and, in each case table, a scroll event count. We increment the
-   * global scrollCount and the event count for any case table that wasn't
-   * scrolled from propagation. When a new notification arrives if its
-   * table has a count less than the propagation count then it was a scroll
-   * event from propagation and bypasses further propagation. If it has an event
-   * count higher, it is a new event, so propagation should occur.
+   * avoid getting into feedback loops.
    */
   const syncTableScroll = useCallback((collectionId: string) => {
     const collectionTableModel = tableModel?.getCollectionTableModel(collectionId)


### PR DESCRIPTION
[[PT-188036951]](https://www.pivotaltracker.com/story/show/188036951)

Two issues were requested/addressed:
1. Clicking on a single selected case among a set of selected cases should deselect all other cases.
    - This differs from the way most applications behave when clicking on a selected object, but it's what v2 did so we match the behavior here. This was easy to fix.
2. Clicking on a parent case should not only select the given parent, but also scroll the children into view.
    - The code to scroll the children into view is also straightforward to write, but dealing with the resulting scroll synchronization responses took much longer than expected. I ended up adding a mechanism for disabling sync scroll responses that relies on a one-second timer and triggering it from the call to select the child cases. It's not particularly elegant, but it works better than the myriad other things I tried along the way. ¯\\_(ツ)_/¯