### PR TITLE
run cypress in docker

### DIFF
--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         # run multiple copies of the current job in parallel [1, ..., n]
-        containers: [1, 2, 3, 4, 5]
+        containers: [1, 2, 3, 4, 5, 6, 7]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -47,6 +47,10 @@ jobs:
     # only run the regression tests if the PR is labeled.
     if: fromJSON(needs.prepare.outputs.run_regression)
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.2849.52-1
+      # This is needed so the commit info can be recorded by cypress
+      options: --user 1001
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -121,6 +121,10 @@ jobs:
           flags: jest
   cypress:
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.2849.52-1
+      # This is needed so the commit info can be recorded by cypress
+      options: --user 1001
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes


### PR DESCRIPTION
This change tells GitHub to run the Cypress job in a docker container. This should prevent issues where the version of Chrome is updated by GitHub actions.

Unfortunately it adds about 25s to each worker while it is downloading the docker image. However I did bump up the number of workers from 5 to 7 so the overall time should go down slightly.

I'm not entirely sure this is worth it.