### PR TITLE
fix: bivariate semi-aggregates (linRegrPredicted, linRegrResidual) respect filter argument

### DIFF
--- a/v3/src/models/formula/functions/bivariate-stats-functions.ts
+++ b/v3/src/models/formula/functions/bivariate-stats-functions.ts
@@ -134,7 +134,8 @@ function evaluateRawLinearRegressionSemiAggregate(fn: (lsr: ValidLSRResult, x: n
     scope.withLocalContext(() => {
       const [xIsValid, x] = checkNumber(evaluateNode(xArg, scope))
       const [yIsValid, y] = checkNumber(evaluateNode(yArg, scope))
-      if (xIsValid && yIsValid) {
+      const filterValue = filterArg ? evaluateNode(filterArg, scope) : true
+      if (xIsValid && yIsValid && isValueTruthy(filterValue)) {
         result = fn(lsrResult, x, y)
       }
     })


### PR DESCRIPTION
[[PT-188459268]](https://www.pivotaltracker.com/story/show/188459268)
