### PR TITLE
fix: handling of hidden/minimized tiles

### DIFF
--- a/v3/src/v2/import-v2-document.ts
+++ b/v3/src/v2/import-v2-document.ts
@@ -43,14 +43,18 @@ export function importV2Document(v2Document: CodapV2Document) {
           const {
             layout: { left = 0, top = 0, width, height: v2Height, isVisible, zIndex }, savedHeight
           } = v2Component
-          const isMinimized = (!!savedHeight && savedHeight >= v2Height && !isVisible) || undefined
-          const height = savedHeight && isMinimized ? savedHeight : v2Height
+          const isHidden = isVisible === false
+          const v2Minimized = (!!savedHeight && savedHeight >= v2Height) || undefined
+          const isMinimized = v2Minimized && !isHidden
+          const height = savedHeight && v2Minimized ? savedHeight : v2Height
           // only apply imported width and height to resizable tiles
           const _width = !info.isFixedWidth ? { width } : {}
           const _height = !info?.isFixedHeight ? { height } : {}
           const _zIndex = zIndex != null ? { zIndex } : {}
           if (zIndex != null && zIndex > maxZIndex) maxZIndex = zIndex
-          const layout: IFreeTileInRowOptions = { x: left, y: top, ..._width, ..._height, ..._zIndex, isMinimized }
+          const layout: IFreeTileInRowOptions = {
+            x: left, y: top, ..._width, ..._height, ..._zIndex, isHidden, isMinimized
+          }
           newTile = content?.insertTileSnapshotInRow(tile, row, layout)
         }
       }


### PR DESCRIPTION
[[PT-188570070]](https://www.pivotaltracker.com/story/show/188570070)

#1622 addressed the case of minimized tiles, but did not properly capture the relationship between hidden and minimized tiles. The document in the PT story has a case table that has been minimized and hidden. In v2, when such a tile is shown/unhidden it is also unminimized. In other words, when a hidden tile is shown, its prior minimized/unminimized state is ignored, which is equivalent to saying that a tile cannot be both hidden and minimized. Therefore, we implement this rule at the model level, so that we don't have to find all clients that show hidden tiles (Calculator button in tool shelf, close button of certain tiles, table menu items, etc.).