### PR TITLE
Changes min width for auto rescale

### DIFF
--- a/v3/src/components/case-table/case-table-types.ts
+++ b/v3/src/components/case-table/case-table-types.ts
@@ -55,7 +55,7 @@ export type OnScrollRowRangeIntoViewFn = (collectionId: string, rowIndices: numb
 export const kInputRowKey = "__input__"
 
 export const kDefaultColumnWidth = 80
-export const kMinAutoColumnWidth = 40
+export const kMinAutoColumnWidth = 52
 export const kMaxAutoColumnWidth = 600
 
 export const kCaseTableFontFamily = "Montserrat, sans-serif"

--- a/v3/src/components/case-table/case-table-types.ts
+++ b/v3/src/components/case-table/case-table-types.ts
@@ -55,7 +55,7 @@ export type OnScrollRowRangeIntoViewFn = (collectionId: string, rowIndices: numb
 export const kInputRowKey = "__input__"
 
 export const kDefaultColumnWidth = 80
-export const kMinAutoColumnWidth = 60
+export const kMinAutoColumnWidth = 50
 export const kMaxAutoColumnWidth = 600
 export const kCellPadding = 11
 

--- a/v3/src/components/case-table/case-table-types.ts
+++ b/v3/src/components/case-table/case-table-types.ts
@@ -55,8 +55,9 @@ export type OnScrollRowRangeIntoViewFn = (collectionId: string, rowIndices: numb
 export const kInputRowKey = "__input__"
 
 export const kDefaultColumnWidth = 80
-export const kMinAutoColumnWidth = 52
+export const kMinAutoColumnWidth = 60
 export const kMaxAutoColumnWidth = 600
+export const kCellPadding = 11
 
 export const kCaseTableFontFamily = "Montserrat, sans-serif"
 export const kCaseTableFontSize = "8pt"

--- a/v3/src/components/case-tile-common/attribute-format-utils.tsx
+++ b/v3/src/components/case-tile-common/attribute-format-utils.tsx
@@ -97,8 +97,9 @@ export function renderAttributeValue(str = "", num = NaN, attr?: IAttribute, key
 }
 
 export const findLongestContentWidth = (attr: IAttribute) => {
-  // include attribute name in content width calculation
-  let longestWidth = Math.max(kMinAutoColumnWidth, measureText(attr.name, kCaseTableHeaderFont))
+  // We do not include attribute name in content width calculation because header text can be split over
+  // two lines and ellided
+  let longestWidth = kMinAutoColumnWidth
   for (let i = 0; i < attr.length; ++i) {
     // use the formatted attribute value in content width calculation
     const { value } = renderAttributeValue(attr.strValues[i], attr.numValues[i], attr)

--- a/v3/src/components/case-tile-common/attribute-format-utils.tsx
+++ b/v3/src/components/case-tile-common/attribute-format-utils.tsx
@@ -99,7 +99,8 @@ export function renderAttributeValue(str = "", num = NaN, attr?: IAttribute, key
 export const findLongestContentWidth = (attr: IAttribute) => {
   // We do not include attribute name in content width calculation because header text can be split over
   // two lines and ellided
-  let longestWidth = kMinAutoColumnWidth
+  const headerWidth = measureText(attr.name, kCaseTableHeaderFont)
+  let longestWidth = Math.max(kMinAutoColumnWidth, Math.ceil(3 + (headerWidth/2)))
   for (let i = 0; i < attr.length; ++i) {
     // use the formatted attribute value in content width calculation
     const { value } = renderAttributeValue(attr.strValues[i], attr.numValues[i], attr)

--- a/v3/src/components/case-tile-common/attribute-format-utils.tsx
+++ b/v3/src/components/case-tile-common/attribute-format-utils.tsx
@@ -97,9 +97,9 @@ export function renderAttributeValue(str = "", num = NaN, attr?: IAttribute, key
 }
 
 export const findLongestContentWidth = (attr: IAttribute) => {
-  // We do not include attribute name in content width calculation because header text can be split over
-  // two lines and ellided
-  const headerWidth = measureText(attr.name, kCaseTableHeaderFont)
+  // We take in to account that attribute names can appear over two lines and elided
+  // when calculating their widths
+  const headerWidth = measureText(`${attr.name}${attr.units ? `_(${attr.units})` : ''}`, kCaseTableHeaderFont)
   let longestWidth = Math.max(kMinAutoColumnWidth, Math.ceil(3 + (headerWidth/2)))
   for (let i = 0; i < attr.length; ++i) {
     // use the formatted attribute value in content width calculation

--- a/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
@@ -17,6 +17,7 @@ import { t } from "../../../utilities/translation/translate"
 import { EditAttributePropertiesModal } from "./edit-attribute-properties-modal"
 import { useCaseTableModel } from "../../case-table/use-case-table-model"
 import { findLongestContentWidth } from "../attribute-format-utils"
+import { kCellPadding } from "../../case-table/case-table-types"
 
 interface IProps {
   attributeId: string
@@ -78,7 +79,7 @@ const AttributeMenuListComp = forwardRef<HTMLDivElement, IProps>(
       handleClick: () => {
         data?.applyModelChange(() => {
           if (attribute) {
-            const longestContentWidth = findLongestContentWidth(attribute)
+            const longestContentWidth = findLongestContentWidth(attribute) + kCellPadding
             tableModel?.setColumnWidth(attributeId, longestContentWidth)
           }
         }, {

--- a/v3/src/components/case-tile-common/inspector-panel/case-tile-inspector.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/case-tile-inspector.tsx
@@ -17,6 +17,7 @@ import { DataSetContext } from "../../../hooks/use-data-set-context"
 import { CaseMetadataContext } from "../../../hooks/use-case-metadata"
 import { ICaseTableModel, isCaseTableModel } from "../../case-table/case-table-model"
 import { findLongestContentWidth } from "../attribute-format-utils"
+import { kCellPadding } from "../../case-table/case-table-types"
 
 import "./case-tile-inspector.scss"
 
@@ -41,7 +42,6 @@ export const CaseTileInspector = ({ tile, show, showResizeColumnsButton }: IProp
   }
 
   const resizeAllColumns = () => {
-    const kCellPadding = 10
     const newColumnWidths = new Map<string, number>()
     data?.collections.forEach((collection) => {
       collection.attributes.forEach((attr) => {


### PR DESCRIPTION
Removes attribute neame from longest content width calculation because attribute  names can be split over 2 lines and ellided.