### PR TITLE
fix: ruler menu re-renders on undo collection change

### DIFF
--- a/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react-lite"
 import React from "react"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
 import { logStringifiedObjectMessage } from "../../../lib/log-message"
@@ -9,7 +10,7 @@ import { preventCollectionReorg } from "../../../utilities/plugin-utils"
 import { t } from "../../../utilities/translation/translate"
 import { IMenuItem, StdMenuList } from "../std-menu-list"
 
-export const RulerMenuList = () => {
+export const RulerMenuList = observer(function RulerMenuList() {
   const data = useDataSetContext()
 
   const handleAddNewAttribute = (collectionId: string) => {
@@ -70,4 +71,4 @@ export const RulerMenuList = () => {
   return (
     <StdMenuList data-testid="ruler-menu-list" menuItems={menuItems} />
   )
-}
+})


### PR DESCRIPTION
[[PT-188548516]](https://www.pivotaltracker.com/story/show/188548516)

The PT story mentions a React warning which is a duplicate of another PT story and an MST warning, which is addressed in this PR. The error occurred in the case table/card inspector's ruler menu, which was accessing a stale collection that no longer existed after the undo. The fix is to make the `RulerMenuList` an `observer`, so that it re-renders when the collections change, flushing any stale collection references.