### PR TITLE
chore: disable slow graph cypress test

### DIFF
--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -11,7 +11,10 @@ const collectionName = "Mammals"
 const newCollectionName = "Animals"
 const plots = graphRules.plots
 
-context("Test graph plot transitions", () => {
+// Skipping because with these enabled the graph tests take 23+ minutes to run.
+// For them to be useful, they would have to be much quicker, possibly by reloading
+// the page less often and/or by waiting less. As written, each test takes ~75 sec.
+context.skip("Test graph plot transitions", () => {
   beforeEach(function () {
     const queryParams = "?mouseSensor"
     const url = `${Cypress.config("index")}${queryParams}`


### PR DESCRIPTION
This test was reenabled in #1637, but with it enabled the time to run the cypress tests remotely on GitHub goes from ~7 min to ~23 min, so the benefit is not worth the cost.