### PR TITLE
fix: preserve case and item ids on import of v2 document

### DIFF
--- a/v3/src/components/case-table/use-index-column.tsx
+++ b/v3/src/components/case-table/use-index-column.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom"
 import { useCaseMetadata } from "../../hooks/use-case-metadata"
 import { useCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { DEBUG_CASE_IDS } from "../../lib/debug"
 import { ICollectionModel } from "../../models/data/collection"
 import { IDataSet } from "../../models/data/data-set"
 import { symIndex, symParent } from "../../models/data/data-set-types"
@@ -19,6 +20,8 @@ import { kInputRowKey, TColSpanArgs, TColumn, TRenderCellProps } from "./case-ta
 import { ColumnHeader } from "./column-header"
 
 import DragIndicator from "../../assets/icons/drag-indicator.svg"
+
+const kIndexColumnWidth = DEBUG_CASE_IDS ? 150 : 52
 
 interface IColSpanProps {
   data?: IDataSet
@@ -79,8 +82,8 @@ export const useIndexColumn = () => {
     indexColumn.current = {
       key: kIndexColumnKey,
       name: t("DG.CaseTable.indexColumnName"),
-      minWidth: 52,
-      width: 52,
+      minWidth: kIndexColumnWidth,
+      width: kIndexColumnWidth,
       headerCellClass: "codap-column-header index",
       renderHeaderCell: ColumnHeader,
       cellClass: "codap-index-cell",
@@ -150,9 +153,10 @@ export function IndexCell({ caseId, disableMenu, index, collapsedCases, onClick 
 
   // cell contents
   const casesStr = t(collapsedCases === 1 ? "DG.DataContext.singleCaseName" : "DG.DataContext.pluralCaseName")
+  const caseIdStr = DEBUG_CASE_IDS ? `: ${caseId}` : ""
   const cellContents = collapsedCases
-    ? `${collapsedCases} ${casesStr}`
-    : index != null ? `${index + 1}` : ""
+                        ? `${collapsedCases} ${casesStr}`
+                        : index != null ? `${index + 1}${caseIdStr}` : ""
   const handleClick = collapsedCases ? onClick : undefined
 
   // collapsed row or normal row with no menu

--- a/v3/src/components/graph/adornments/v2-adornment-importer.ts
+++ b/v3/src/components/graph/adornments/v2-adornment-importer.ts
@@ -1,9 +1,8 @@
-
+import { ICodapV2PlotStorage } from "../../../v2/codap-v2-types"
 import { IAttribute } from "../../../models/data/attribute"
 import { typedId } from "../../../utilities/js-utils"
 import { updateCellKey } from "./adornment-utils"
 import { kCountType } from "./count/count-adornment-types"
-import { ILSRLInstance } from "./lsrl/lsrl-adornment-model"
 import { kLSRLType } from "./lsrl/lsrl-adornment-types"
 import { kMovableLineType } from "./movable-line/movable-line-adornment-types"
 import { kMovablePointType } from "./movable-point/movable-point-adornment-types"
@@ -131,7 +130,7 @@ const instanceKeysForAdornments = (props: IInstanceKeysForAdornmentsProps) => {
 
 export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yAttributeDescriptions}: IProps) => {
   const instanceKeys = instanceKeysForAdornments({data, attributeDescriptions, yAttributeDescriptions})
-  const plotModelStorage = plotModels?.[0].plotModelStorage
+  const plotModelStorage = plotModels?.[0].plotModelStorage as ICodapV2PlotStorage
   const v2Adornments = plotModelStorage.adornments
   const showSquaresOfResiduals = plotModelStorage.areSquaresVisible
   const showMeasureLabels = plotModelStorage.showMeasureLabels
@@ -140,7 +139,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   let interceptLocked = false
 
   // COUNT/PERCENT
-  const countAdornment = v2Adornments.plottedCount
+  const countAdornment = v2Adornments?.plottedCount
   const percentTypeMap: Record<string, string> = { 1: "cell", 2: "column", 3: "row" }
   if (countAdornment) {
     const countAdornmentImport = {
@@ -155,7 +154,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // CONNECTING LINES
-  const connectingLinesAdornment = v2Adornments.connectingLine
+  const connectingLinesAdornment = v2Adornments?.connectingLine
   if (connectingLinesAdornment?.isVisible) {
     showConnectingLines = true
   }
@@ -209,7 +208,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
     const lines: Record<string, any> = {}
     instanceKeys?.forEach((key: string) => {
       const lsrlInstances: ILSRLImportInstance[] = []
-      lsrlAdornment.lsrls.forEach((lsrl: ILSRLInstance) => {
+      lsrlAdornment.lsrls.forEach(lsrl => {
         const lsrlInstance = {
           equationCoords: lsrl.equationCoords ?? undefined // The V2 default is null, but we want undefined
         }
@@ -229,7 +228,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // MEAN
-  const meanAdornment = v2Adornments.plottedMean
+  const meanAdornment = v2Adornments?.plottedMean
   if (meanAdornment) {
     const measures = univariateMeasureInstances(meanAdornment, instanceKeys)
     const meanAdornmentImport = {
@@ -242,7 +241,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // MEDIAN
-  const medianAdornment = v2Adornments.plottedMedian
+  const medianAdornment = v2Adornments?.plottedMedian
   if (medianAdornment) {
     const measures = univariateMeasureInstances(medianAdornment, instanceKeys)
     const medianAdornmentImport = {
@@ -255,7 +254,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // STANDARD DEVIATION
-  const stDevAdornment = v2Adornments.plottedStDev
+  const stDevAdornment = v2Adornments?.plottedStDev
   if (stDevAdornment) {
     const measures = univariateMeasureInstances(stDevAdornment, instanceKeys)
     const stDevAdornmentImport = {
@@ -268,7 +267,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // STANDARD ERROR
-  const stErrAdornment = v2Adornments.plottedStDev
+  const stErrAdornment = v2Adornments?.plottedStDev
   if (stErrAdornment) {
     const measures = univariateMeasureInstances(stErrAdornment, instanceKeys)
     const stErrAdornmentImport = {
@@ -282,7 +281,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // MEAN ABSOLUTE DEVIATION
-  const madAdornment = v2Adornments.plottedMad
+  const madAdornment = v2Adornments?.plottedMad
   if (madAdornment) {
     const measures = univariateMeasureInstances(madAdornment, instanceKeys)
     const madAdornmentImport = {
@@ -295,7 +294,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // BOX PLOT
-  const boxPlotAdornment = v2Adornments.plottedBoxPlot
+  const boxPlotAdornment = v2Adornments?.plottedBoxPlot
   if (boxPlotAdornment) {
     const measures = univariateMeasureInstances(boxPlotAdornment, instanceKeys)
     const boxPlotAdornmentImport = {
@@ -309,7 +308,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // NORMAL CURVE
-  const normalCurveAdornment = v2Adornments.plottedNormal
+  const normalCurveAdornment = v2Adornments?.plottedNormal
   if (normalCurveAdornment) {
     const measures = univariateMeasureInstances(normalCurveAdornment, instanceKeys)
     const normalCurveAdornmentImport = {
@@ -322,12 +321,13 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // MOVABLE VALUES
-  const movableValuesAdornment = v2Adornments.multipleMovableValues
+  const movableValuesAdornment = v2Adornments?.multipleMovableValues
   if (movableValuesAdornment) {
     const values: Record<string, any> = {}
     instanceKeys?.forEach((key: string) => {
       const plotValues: number[] = []
-      movableValuesAdornment.valueModels.forEach((valueModel: Record<string, any>) => {
+      const valueModels = movableValuesAdornment.valueModels ?? movableValuesAdornment.values
+      valueModels.forEach((valueModel: Record<string, any>) => {
         plotValues.push(valueModel.values._main)
       })
       values[key] = plotValues
@@ -342,7 +342,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // PLOTTED VALUES
-  const plottedValueAdornment = v2Adornments.plottedValue
+  const plottedValueAdornment = v2Adornments?.plottedValue
   if (plottedValueAdornment) {
     const formula = {
       id: typedId("FORM"),
@@ -359,7 +359,7 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   }
 
   // PLOTTED FUNCTION
-  const plottedFunctionAdornment = v2Adornments.plottedFunction
+  const plottedFunctionAdornment = v2Adornments?.plottedFunction
   if (plottedFunctionAdornment) {
     const formula = {
       id: typedId("FORM"),

--- a/v3/src/components/graph/adornments/v2-adornment-importer.ts
+++ b/v3/src/components/graph/adornments/v2-adornment-importer.ts
@@ -326,8 +326,8 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
     const values: Record<string, any> = {}
     instanceKeys?.forEach((key: string) => {
       const plotValues: number[] = []
-      const valueModels = movableValuesAdornment.valueModels ?? movableValuesAdornment.values
-      valueModels.forEach((valueModel: Record<string, any>) => {
+      // ignoring legacy `values` for now
+      movableValuesAdornment.valueModels?.forEach((valueModel: Record<string, any>) => {
         plotValues.push(valueModel.values._main)
       })
       values[key] = plotValues

--- a/v3/src/lib/debug.ts
+++ b/v3/src/lib/debug.ts
@@ -21,6 +21,7 @@ if (debug.length > 0) {
 
 const debugContains = (key: string) => debug.indexOf(key) !== -1
 
+export const DEBUG_CASE_IDS = debugContains("caseIds")
 export const DEBUG_CFM_EVENTS = debugContains("cfmEvents")
 export const DEBUG_CFM_LOCAL_STORAGE = debugContains("cfmLocalStorage")
 export const DEBUG_DOCUMENT = debugContains("document")

--- a/v3/src/v2/codap-v2-import.test.ts
+++ b/v3/src/v2/codap-v2-import.test.ts
@@ -72,13 +72,15 @@ describe(`V2 "mammals.codap"`, () => {
     const context = mammals.contexts[0]
     const collection = context.collections[0]
     const data = mammals.dataSets[0].dataSet
+    data.validateCases()
     expect(data.id).toBe(`DATA${context.guid}`)
     expect(data.collections[0].id).toBe(`COLL${collection.guid}`)
+    expect(data.collections[0].caseIds[0]).toBe(`CASE${collection.cases[0].guid}`)
     expect(data.attributes.length).toBe(9)
     expect(data.attributes[0].id).toBe(`ATTR${collection.attrs[0].guid}`)
     expect(data.attributes[0].cid).toBe(collection.attrs[0].cid)
     expect(data.items.length).toBe(27)
-    expect(data.items[0].__id__).toBe(`CASE${collection.cases[0].guid}`)
+    // note: mammals doesn't contain item ids
 
     // mammals has no parent cases
     const firstCase = collection.cases[0]
@@ -119,6 +121,7 @@ describe(`V2 "24cats.codap"`, () => {
     const context = cats.contexts[0]
     const [v2ParentCollection, v2ChildCollection] = context.collections
     const data = cats.dataSets[0].dataSet
+    data.validateCases()
     expect(data.collections.length).toBe(2)
     expect(data.collections[0].attributes.length).toBe(1)
     expect(data.attributes.length).toBe(9)
@@ -133,8 +136,11 @@ describe(`V2 "24cats.codap"`, () => {
     expect(dsSexAttr!.title).toBe(v2SexAttr.title)
 
     // should be able to look up parent cases for child cases
-    const firstCase = v2ChildCollection.cases[0]
-    expect(cats.getParentCase(firstCase)).toBeDefined()
+    const firstParentCase = v2ParentCollection.cases[0]
+    const firstChildCase = v2ChildCollection.cases[0]
+    expect(data.collections[0].caseIds[0]).toBe(`CASE${firstParentCase.guid}`)
+    expect(data.collections[1].caseIds[0]).toBe(`CASE${firstChildCase.guid}`)
+    expect(cats.getParentCase(firstChildCase)).toBeDefined()
 
     expect(cats.components.map(c => c.type))
       .toEqual(["DG.TableView", "DG.GraphView", "DG.TextView", "DG.TextView", "DG.GraphView"])

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -185,6 +185,11 @@ interface ICodapV2ProportionCoordinates {
   proportionY: number
 }
 
+interface ICodapV2LegacyValueModel {
+  isVisible: boolean
+  value: number
+}
+
 interface ICodapV2ValueModel {
   isVisible: boolean
   enableMeasuresForSelection: boolean
@@ -210,7 +215,7 @@ interface ICodapV2MovableValueAdornment {
   isShowingCount: boolean
   isShowingPercent: boolean
   // some (older?) documents have `values`, e.g. 24cats.codap
-  values?: ICodapV2ValueModel[]
+  values?: ICodapV2LegacyValueModel[]
   // more recent documents have `valueModels` ¯\_(ツ)_/¯
   valueModels?: ICodapV2ValueModel[]
 }

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -53,7 +53,7 @@ export function v3TypeFromV2TypeString(v2Type?: string | null): AttributeType | 
 export interface ICodapV2Case {
   id?: number
   guid: number
-  itemID?: number
+  itemID?: string
   parent?: number
   values: Record<string, number | string>
 }
@@ -209,7 +209,10 @@ interface ICodapV2MovableValueAdornment {
   enableMeasuresForSelection: boolean
   isShowingCount: boolean
   isShowingPercent: boolean
-  valueModels: ICodapV2ValueModel[]
+  // some (older?) documents have `values`, e.g. 24cats.codap
+  values?: ICodapV2ValueModel[]
+  // more recent documents have `valueModels` ¯\_(ツ)_/¯
+  valueModels?: ICodapV2ValueModel[]
 }
 
 interface ICodapV2MeanAdornment {
@@ -269,6 +272,8 @@ type ICodapV2Adornment = ICodapV2CountAdornment | ICodapV2ConnectingLinesAdornme
                          ICodapV2MeanAdornment | ICodapV2MedianAdornment | ICodapV2StDevAdornment |
                          ICodapV2StErrAdornment | ICodapV2MadAdornment | ICodapV2PlottedFunctionAdornment |
                          ICodapV2PlottedValueAdornment | ICodapV2BoxPlotAdornment
+// TODO: fix adornments typing
+type CodapV2AdornmentMap = Record<string, ICodapV2Adornment | any>
 
 interface ICodapV2MovablePointStorage {
   isVisible: boolean
@@ -306,13 +311,13 @@ interface ICodapV2MultipleLSRLsStorage {
 
 export interface ICodapV2PlotStorage {
   verticalAxisIsY2: boolean
-  adornments: ICodapV2Adornment
-  areSquaresVisible: boolean
-  isLSRLVisible: boolean
-  movableLineStorage: ICodapV2MovableLineStorage
-  movablePointStorage: ICodapV2MovablePointStorage
-  multipleLSRLsStorage: ICodapV2MultipleLSRLsStorage
-  showMeasureLabels: boolean
+  adornments?: CodapV2AdornmentMap
+  areSquaresVisible?: boolean
+  isLSRLVisible?: boolean
+  movableLineStorage?: ICodapV2MovableLineStorage
+  movablePointStorage?: ICodapV2MovablePointStorage
+  multipleLSRLsStorage?: ICodapV2MultipleLSRLsStorage
+  showMeasureLabels?: boolean
 }
 
 export interface ICodapV2PlotModel {


### PR DESCRIPTION
[[PT-188383228]](https://www.pivotaltracker.com/story/show/188383228)

- adds a DEBUG_CASE_IDS options which displays case ids in the index column of the case table
- some older documents don't save item ids, so case ids are preserved but not item ids for those documents
- in testing, I tried loading the `24cats.codap` sample document, which led to some unrelated adornments-related typing changes just to make the file importable. There's more work to be done here, for which there is already a separate story: [[PT-188618233]](https://www.pivotaltracker.com/story/show/188618233).