### PR TITLE
Fix for bug in which splitting on top and right not working properly

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -319,8 +319,8 @@ export const DataConfigurationModel = types
         return self.metadata.getCategorySet(attributeID)
       }
     },
-    potentiallyCategoricalRoles(): AttrRole[] {
-      return ["legend"] as const
+    categoricalRoles(): AttrRole[] {
+      return self.attributeType("legend") === "categorical" ? ["legend"] : []
     }
   }))
   .views(self => ({
@@ -349,7 +349,7 @@ export const DataConfigurationModel = types
     }),
     get allCategoriesForRoles() {
       const categories: Map<AttrRole, string[]> = new Map()
-      const roles = self.potentiallyCategoricalRoles()
+      const roles = self.categoricalRoles()
       roles.forEach(role => {
         const categorySet = self.categorySetForAttrRole(role)
         if (categorySet) {

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -40,7 +40,6 @@ export class GraphController {
   handleAttributeAssignment() {
     const { graphModel, layout } = this
     if (graphModel) syncModelWithAttributeConfiguration(graphModel, layout)
-    this.callMatchCirclesToData()
   }
 
   callMatchCirclesToData() {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -226,8 +226,10 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       const attrTypes = self.attrTypes
       return Object.values(attrTypes).filter(a => a === "categorical").length
     },
-    potentiallyCategoricalRoles(): AttrRole[] {
-      return ["legend", "x", "y", "topSplit", "rightSplit"] as const
+    categoricalRoles(): AttrRole[] {
+      return (["legend", "x", "y", "topSplit", "rightSplit"] as const).filter((role) => {
+        return self.attributeType(role) === "categorical"
+      })
     },
     get hasExactlyOneCategoricalAxis() {
       const attrTypes = self.attrTypes


### PR DESCRIPTION
[#188589248] Bug fix: Plots not showing when split on top and/or right

* `matchCirclesToData` was being called too early (in GraphController:handleAttributeAssignment); i.e. before we had a chance to call `clearCasesCache` so that `categoryArrayForAttrRole` gets invalidated and can subsequently return the categories belonging to the 'topSplit' or 'rightSplit' attribute. But it turns out we didn't need to call it there since it gets called later.
* Also revised `potentiallyCategoricalRoles` (renamed to `categoricalRoles)` to only return roles that actually have a categorical attribute. Before we were including categories even for numeric attributes if they had a categorySet, which we don't want to do.