### PR TITLE
feat: support DEBUG_CFM_NO_AUTO_SAVE debug option to disable auto-save

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -132,6 +132,7 @@ Various developer features can be enabled by adding a `debug` local storage key 
 
 - `cfmEvents` console log all events received from the CFM
 - `cfmLocalStorage` enable the CFM local storage provider so documents can be saved and loaded from the browser's local storage
+- `cfmNoAutoSave` disable CFM auto-save for any document loaded by the CFM
 - `document` this will add the active document as `window.currentDocument`, you can use `currentDocument.toJSON()` to views the current documents content. You can also use `currentDocument.treeManagerAPI.document.toJSON()` to inspect the history of the document.
 - `formulas` print info about recalculating formulas
 - `history` this will: print some info to the console as the history system records changes, print the full history as JSON each time it is loaded from Firestore, and provide a `window.historyDocument` so you can inspect the document while navigating the history.

--- a/v3/src/lib/debug.ts
+++ b/v3/src/lib/debug.ts
@@ -24,6 +24,7 @@ const debugContains = (key: string) => debug.indexOf(key) !== -1
 export const DEBUG_CASE_IDS = debugContains("caseIds")
 export const DEBUG_CFM_EVENTS = debugContains("cfmEvents")
 export const DEBUG_CFM_LOCAL_STORAGE = debugContains("cfmLocalStorage")
+export const DEBUG_CFM_NO_AUTO_SAVE = debugContains("cfmNoAutoSave")
 export const DEBUG_DOCUMENT = debugContains("document")
 export const DEBUG_FORMULAS = debugContains("formulas")
 export const DEBUG_HISTORY = debugContains("history")

--- a/v3/src/lib/use-cloud-file-manager.ts
+++ b/v3/src/lib/use-cloud-file-manager.ts
@@ -9,7 +9,7 @@ import { gLocale } from "../utilities/translation/locale"
 import { t } from "../utilities/translation/translate"
 import { removeDevUrlParams, urlParams } from "../utilities/url-params"
 import { clientConnect, createCloudFileManager, renderRoot } from "./cfm-utils"
-import { DEBUG_CFM_LOCAL_STORAGE } from "./debug"
+import { DEBUG_CFM_LOCAL_STORAGE, DEBUG_CFM_NO_AUTO_SAVE } from "./debug"
 import { handleCFMEvent } from "./handle-cfm-event"
 
 const locales = [
@@ -147,8 +147,9 @@ export function useCloudFileManager(optionsArg: CFMAppOptions) {
 
   useEffect(function initCfm() {
 
+    const autoSaveInterval = DEBUG_CFM_NO_AUTO_SAVE ? undefined : 5
     const _options: CFMAppOptions = {
-      autoSaveInterval: 5,
+      autoSaveInterval,
       // When running in the Activity Player, hide the hamburger menu
       hideMenuBar: urlParams.interactiveApi !== undefined,
       ui: {


### PR DESCRIPTION
[[PT-188623447]](https://www.pivotaltracker.com/story/show/188623447)

When testing import/export code, it is useful to be able to open documents without worrying about them possibly being overwritten via auto-save. (I inadvertently overwrote a legacy document I was testing with, which led to this PR.)

Adding `cfmNoAutoSave` to the `debug` settings in the `Application` tab of the Chrome debugger will disable auto-save for any document loaded during that session.