### PR TITLE
Restore dynamic update of mean adornment

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -651,6 +651,7 @@ export const DataConfigurationModel = types
         const idSet = new Set(cases.changed)
         const changedCases = affectedCases.filter(aCase => idSet.has(aCase.__id__))
         self.handlers.forEach(handler => handler({name: "setCaseValues", args: [changedCases]}))
+        ++self.casesChangeCount
       }
       // Changes to case values require that existing cached categorySets be wiped.
       // But if we know the ids of the attributes involved, we can determine whether


### PR DESCRIPTION
[#188640918] Bug fix: When points in dot plot are dragged, mean isn't updating

* This bug first appeared in build 1949, in October, 2024. Some update machinery in data-configuration-model.ts was removed around then so `GraphContentModel:updateAdornments` was no longer being called when case values are changed. The only thing that needed to be fixed was to increment the `DataConfigurationModel`'s `casesChangeCount` in `handleSetCaseValues`. Doing so restored the previous behavior with no apparent added cost.