### PR TITLE
fix: handling of set-aside cases in imported/restored documents

### DIFF
--- a/v3/src/data-interactive/data-interactive-type-utils.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.ts
@@ -8,7 +8,7 @@ import { IGlobalValue } from "../models/global/global-value"
 import { getSharedCaseMetadataFromDataset } from "../models/shared/shared-data-utils"
 import { kAttrIdPrefix, maybeToV2Id, toV2Id, toV3AttrId } from "../utilities/codap-utils"
 import {
-  ICodapV2AttributeV3, ICodapV2CollectionV3, ICodapV2DataContextV3, v3TypeFromV2TypeString
+  ICodapV2Attribute, ICodapV2CollectionV3, ICodapV2DataContextV3, v3TypeFromV2TypeString
 } from "../v2/codap-v2-types"
 import { DIAttribute, DIGetCaseResult, DIResources, DISingleValues } from "./data-interactive-types"
 import { getCaseValues } from "./data-interactive-utils"
@@ -104,7 +104,7 @@ export function getCaseRequestResultValues(c: ICase, dataContext: IDataSet): DIG
   }
 }
 
-export function convertAttributeToV2(attribute: IAttribute, dataContext?: IDataSet): ICodapV2AttributeV3 {
+export function convertAttributeToV2(attribute: IAttribute, dataContext?: IDataSet): ICodapV2Attribute {
   const metadata = dataContext && getSharedCaseMetadataFromDataset(dataContext)
   const { cid, name, type, title, description, deleteable, editable, id, precision } = attribute
   const v2Id = toV2Id(id)
@@ -143,11 +143,9 @@ export function convertCollectionToV2(collection: ICollectionModel, dataContext?
   const { name, title, id, labels: _labels } = collection
   const v2Id = toV2Id(id)
   const labels = _labels ? getSnapshot(_labels) : undefined
-  const v2Attrs = collection.attributes.map(attribute => {
+  const attrs = collection.attributes.map(attribute => {
     if (attribute) return convertAttributeToV2(attribute, dataContext)
-  })
-  const attrs: ICodapV2AttributeV3[] = []
-  v2Attrs.forEach(attr => attr && attrs.push(attr))
+  }).filter(attr => !!attr)
   return {
     // areParentChildLinksConfigured,
     attrs,
@@ -184,7 +182,8 @@ export function convertDataSetToV2(dataSet: IDataSet, docId: number | string): I
     description,
     // metadata,
     // preventReorg,
-    // setAsideItems,
+    // TODO_V2_EXPORT
+    setAsideItems: []
     // contextStorage
   }
 }

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -1,6 +1,6 @@
 import { RequireAtLeastOne } from "type-fest"
 import { IAttribute } from "../models/data/attribute"
-import { ICodapV2Attribute, ICodapV2AttributeV3, ICodapV2Collection, ICodapV2DataContext } from "../v2/codap-v2-types"
+import { ICodapV2Attribute, ICodapV2Collection, ICodapV2DataContext } from "../v2/codap-v2-types"
 import { IDataSet } from "../models/data/data-set"
 import { ICase, ICaseID } from "../models/data/data-set-types"
 import { IGlobalValue } from "../models/global/global-value"
@@ -192,7 +192,7 @@ export type DISingleValues = DIAttribute | DINotifyAttribute | DIAttributeLocati
 export type DIValues = DISingleValues | DISingleValues[] | number | string[]
 
 // types returned as outputs by the API
-export type DIResultAttributes = { attrs: ICodapV2AttributeV3[] }
+export type DIResultAttributes = { attrs: ICodapV2Attribute[] }
 export type DIResultSingleValues = DICase | DIComponentInfo |  DIGetCaseResult | DIGlobal | DIInteractiveFrame
 export type DIResultValues = DIResultSingleValues | DIResultSingleValues[] |
   DIAllCases | DIDeleteCollectionResult | DIUpdateItemResult | DIResultAttributes | number | number[]

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -304,7 +304,7 @@ export const CollectionModel = V2Model
           }
         }
 
-        // item info is only stored for visible items
+        // item info is stored for all items
         itemInfo.push({ itemId, caseId })
       }
     })

--- a/v3/src/models/data/data-set-conversion.test.ts
+++ b/v3/src/models/data/data-set-conversion.test.ts
@@ -128,7 +128,7 @@ describe("DataSet conversions", () => {
     expect(data.attributesMap.size).toBe(3)
     expect(data.attributes.length).toBe(3)
     expect(data._itemIds.length).toBe(1)
-    expect(data.itemIds.length).toBe(1)
+    expect(data.itemIds.length).toBe(0)
     expect(data.setAsideItemIds.length).toBe(1)
   })
 })

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -1231,6 +1231,9 @@ export const DataSet = V2Model.named("DataSet").props({
       self.addCollection({ name: t("DG.AppController.createDataSet.collectionName") })
     }
 
+    // initialize setAsideItemIdsSet
+    self.setAsideItemIdsSet.replace(self.setAsideItemIds)
+
     if (!srcDataSet) {
       // set up middleware to add ids to inserted attributes and cases
       // adding the ids in middleware makes them available as action arguments

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -1,11 +1,6 @@
 import { SetOptional } from "type-fest"
 import {AttributeType} from "../models/data/attribute"
 
-export type AllowStringIds<T> = Omit<T, "guid" | "id"> & {
-  guid: number | string
-  id: number | string
-}
-
 export interface ICodapV2Attribute {
   guid: number
   id: number
@@ -31,8 +26,6 @@ export interface ICodapV2Attribute {
   precision?: number | string | null
   unit?: string | null
 }
-// when exporting a v3 attribute to v2
-export type ICodapV2AttributeV3 = AllowStringIds<ICodapV2Attribute>
 
 export function isCodapV2Attribute(o: any): o is ICodapV2Attribute {
   return o.type === "DG.Attribute"
@@ -86,8 +79,13 @@ export interface ICodapV2Collection {
 // when exporting a v3 collection to v2
 type CollectionNotYetExported = "cases" | "caseName" | "childAttrName" | "collapseChildren"
 export interface ICodapV2CollectionV3
-  extends SetOptional<Omit<AllowStringIds<ICodapV2Collection>, "attrs">, CollectionNotYetExported> {
-  attrs: ICodapV2AttributeV3[]
+  extends SetOptional<Omit<ICodapV2Collection, "attrs">, CollectionNotYetExported> {
+  attrs: ICodapV2Attribute[]
+}
+
+export interface ICodapV2SetAsideItem {
+  id: string  // item id
+  values: Record<string, number | string>
 }
 
 export interface ICodapV2DataContextMetadata {
@@ -103,15 +101,15 @@ export interface ICodapV2DataContext {
   title: string
   collections: ICodapV2Collection[]
   description?: string
-  metadata?: ICodapV2DataContextMetadata | null,
+  metadata?: ICodapV2DataContextMetadata | null
   // preventReorg: boolean
-  // setAsideItems: this.get('dataSet').archiveSetAsideItems(),
+  setAsideItems?: ICodapV2SetAsideItem[]
   // contextStorage: this.contextStorage
 }
 // when exporting a v3 data set to v2 data context
 type DCNotYetExported = "flexibleGroupingChangeFlag"
 export interface ICodapV2DataContextV3
-  extends SetOptional<Omit<AllowStringIds<ICodapV2DataContext>, "document" | "collections">, DCNotYetExported> {
+  extends SetOptional<Omit<ICodapV2DataContext, "document" | "collections">, DCNotYetExported> {
   document: number | string
   collections: ICodapV2CollectionV3[]
 }


### PR DESCRIPTION
[[PT-188652082]](https://www.pivotaltracker.com/story/show/188652082)

This started as part of the effort to improve the TypeScript types for v2 documents. As part of fixing the types for `setAsideItems`, I noticed that `setAsideItems` were not being imported at all. Therefore, this PR:
- adds correct types for `setAsideItems` in v2 documents
- fixes the importer so that `setAsideItems` are imported correctly from v2 documents
- fixes a model initialization bug that prevented saved/restored `setAsideItems` from being handled correctly in newly restored models (restored from either v2 or v3 documents)
- [unrelated] eliminates the `AllowStringIds` and `ICodapV2AttributeV3` types
  - I believe these are left over from early id-handling efforts in which we thought we could get away with passing string ids through the v2 API. It became apparently fairly quickly, however, that some plugins expected ids to be strictly numeric and so now we no longer attempt to pass strings through the v2 API, which means the above types are no longer necessary.