### PR TITLE
188605717 Add Buffer Space to Bar Charts

### DIFF
--- a/v3/src/components/graph/components/freedotplotdots.tsx
+++ b/v3/src/components/graph/components/freedotplotdots.tsx
@@ -83,10 +83,10 @@ export const FreeDotPlotDots = observer(function FreeDotPlotDots(props: PlotProp
 
       const getBarStaticDimension = () => {
         // This function determines how much space is available for each bar on the non-primary axis by dividing the
-        // length of the non-primary axis by the number of cases in the subplot containing the most cases. This keeps
-        // the bars a uniform size across subplots.
+        // length of the non-primary axis by one more than the number of cases in the subplot containing the most cases.
+        // This keeps the bars a uniform size across subplots.
         const largestSubplotCount = Math.max(...Array.from(subPlotDetails.values()).map(sp => sp.cases.length))
-        return largestSubplotCount ? secondaryBandwidth / largestSubplotCount : 0
+        return largestSubplotCount ? secondaryBandwidth / (largestSubplotCount + 1) : 0
       }
 
       const getBarValueDimension = (anID: string) => {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188605717

This PR adds buffer space to `FreeDotPlots` displaying bars. This makes v3 more closely resemble v2, and in particular makes graphs of a single value look much better.