### PR TITLE
Export game view

### DIFF
--- a/v3/src/components/web-view/component-handler-web-view.test.ts
+++ b/v3/src/components/web-view/component-handler-web-view.test.ts
@@ -75,8 +75,8 @@ describe("DataInteractive ComponentHandler WebView and Game", () => {
     expect(tileLayout?.width).toBe(newValue)
 
     // Create game with url
-    const multidataUrl = "https://codap.concord.org/multidata-plugin/"
-    const result3 = handler.create!({}, { type: "game", URL: multidataUrl })
+    const multiDataUrl = "https://codap.concord.org/multidata-plugin/"
+    const result3 = handler.create!({}, { type: "game", URL: multiDataUrl })
     expect(result3.success).toBe(true)
     expect(documentContent.tileMap.size).toBe(2)
     const result3Values = result3.values as DIComponentInfo
@@ -84,10 +84,10 @@ describe("DataInteractive ComponentHandler WebView and Game", () => {
     expect(tile3).toBeDefined()
     expect(isWebViewModel(tile3.content)).toBe(true)
     const gameModel = tile3.content as IWebViewModel
-    expect(gameModel.url).toBe(multidataUrl)
+    expect(gameModel.url).toBe(multiDataUrl)
 
     // Get game
-    gameModel.setIsPlugin(true) // This would normally be set automatically when the plugin connects to codap
+    gameModel.setSubType("plugin") // This would normally be set automatically when the plugin connects to codap
     testGetComponent(tile3, handler, (gameTile, values) => {
       const { URL } = values as V2Game
       expect(URL).toBe((gameTile.content as IWebViewModel).url)

--- a/v3/src/components/web-view/use-data-interactive-controller.ts
+++ b/v3/src/components/web-view/use-data-interactive-controller.ts
@@ -36,7 +36,7 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
       const originUrl = extractOrigin(url) ?? ""
       const phone = new iframePhone.ParentEndpoint(iframeRef.current, originUrl,
         () => {
-          webViewModel?.setIsPlugin(true)
+          webViewModel?.setSubType("plugin")
           debugLog(DEBUG_PLUGINS, "connection with iframe established")
         })
       const handler: iframePhone.IframePhoneRpcEndpointHandlerFn =

--- a/v3/src/components/web-view/web-view-defs.ts
+++ b/v3/src/components/web-view/web-view-defs.ts
@@ -4,3 +4,6 @@ export const kV2GuideViewType = "guideView"
 export const kV2WebViewType = "webView"
 export const kWebViewTileClass = "codap-web-view"
 export const kWebViewBodyClass = "codap-web-view-body"
+
+export const webViewSubTypes = ["guide", "plugin"] as const
+export type WebViewSubType = typeof webViewSubTypes[number]

--- a/v3/src/components/web-view/web-view-model.ts
+++ b/v3/src/components/web-view/web-view-model.ts
@@ -49,7 +49,7 @@ export const WebViewModel = TileContentModel
     setDataInteractiveController(controller?: iframePhone.IframePhoneRpcEndpoint) {
       self.dataInteractiveController = controller
     },
-    setSubType(subType: WebViewSubType) {
+    setSubType(subType?: WebViewSubType) {
       withoutUndo()
       self.subType = subType
     },

--- a/v3/src/components/web-view/web-view-model.ts
+++ b/v3/src/components/web-view/web-view-model.ts
@@ -3,7 +3,7 @@ import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { DIMessage } from "../../data-interactive/iframe-phone-types"
 import { ITileContentModel, TileContentModel } from "../../models/tiles/tile-content"
 import { withoutUndo } from "../../models/history/without-undo"
-import { kWebViewTileType } from "./web-view-defs"
+import { kWebViewTileType, WebViewSubType, webViewSubTypes } from "./web-view-defs"
 
 export const kDefaultAllowEmptyAttributeDeletion = true
 export const kDefaultBlockAPIRequestsWhileEditing = false
@@ -18,6 +18,7 @@ export const WebViewModel = TileContentModel
   .named("WebViewModel")
   .props({
     type: types.optional(types.literal(kWebViewTileType), kWebViewTileType),
+    subType: types.maybe(types.enumeration(webViewSubTypes)),
     url: "",
     state: types.frozen<unknown>(),
     // fields controlled by plugins (like Collaborative) via interactiveFrame requests
@@ -27,8 +28,7 @@ export const WebViewModel = TileContentModel
     preventBringToFront: kDefaultPreventBringToFront,
     preventDataContextReorg: kDefaultPreventDataContextReorg,
     preventTopLevelReorg: kDefaultPreventTopLevelReorg,
-    respectEditableItemAttribute: kDefaultRespectEditableItemAttribute,
-    isPlugin: false
+    respectEditableItemAttribute: kDefaultRespectEditableItemAttribute
   })
   .volatile(self => ({
     dataInteractiveController: undefined as iframePhone.IframePhoneRpcEndpoint | undefined,
@@ -37,15 +37,21 @@ export const WebViewModel = TileContentModel
   .views(self => ({
     get allowBringToFront() {
       return !self.preventBringToFront
+    },
+    get isGuide() {
+      return self.subType === "guide"
+    },
+    get isPlugin() {
+      return self.subType === "plugin"
     }
   }))
   .actions(self => ({
     setDataInteractiveController(controller?: iframePhone.IframePhoneRpcEndpoint) {
       self.dataInteractiveController = controller
     },
-    setIsPlugin(isPlugin: boolean) {
+    setSubType(subType: WebViewSubType) {
       withoutUndo()
-      self.isPlugin = isPlugin
+      self.subType = subType
     },
     setSavedState(state: unknown) {
       self.state = state

--- a/v3/src/components/web-view/web-view-model.ts
+++ b/v3/src/components/web-view/web-view-model.ts
@@ -2,6 +2,7 @@ import iframePhone from "iframe-phone"
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { DIMessage } from "../../data-interactive/iframe-phone-types"
 import { ITileContentModel, TileContentModel } from "../../models/tiles/tile-content"
+import { withoutUndo } from "../../models/history/without-undo"
 import { kWebViewTileType } from "./web-view-defs"
 
 export const kDefaultAllowEmptyAttributeDeletion = true
@@ -26,11 +27,11 @@ export const WebViewModel = TileContentModel
     preventBringToFront: kDefaultPreventBringToFront,
     preventDataContextReorg: kDefaultPreventDataContextReorg,
     preventTopLevelReorg: kDefaultPreventTopLevelReorg,
-    respectEditableItemAttribute: kDefaultRespectEditableItemAttribute
+    respectEditableItemAttribute: kDefaultRespectEditableItemAttribute,
+    isPlugin: false
   })
   .volatile(self => ({
     dataInteractiveController: undefined as iframePhone.IframePhoneRpcEndpoint | undefined,
-    isPlugin: false,
     version: kDefaultWebViewVersion
   }))
   .views(self => ({
@@ -43,6 +44,7 @@ export const WebViewModel = TileContentModel
       self.dataInteractiveController = controller
     },
     setIsPlugin(isPlugin: boolean) {
+      withoutUndo()
       self.isPlugin = isPlugin
     },
     setSavedState(state: unknown) {

--- a/v3/src/components/web-view/web-view-registration.test.ts
+++ b/v3/src/components/web-view/web-view-registration.test.ts
@@ -4,7 +4,7 @@ import { getTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { getTileContentInfo } from "../../models/tiles/tile-content-info"
 import { getSharedModelManager } from "../../models/tiles/tile-environment"
 import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
-import { safeJsonParse } from "../../utilities/js-utils"
+import { hasOwnProperty, safeJsonParse } from "../../utilities/js-utils"
 import { CodapV2Document } from "../../v2/codap-v2-document"
 import { exportV2Component } from "../../v2/codap-v2-tile-exporters"
 import { importV2Component } from "../../v2/codap-v2-tile-importers"
@@ -22,7 +22,7 @@ describe("WebView registration", () =>  {
     expect(contentInfo).toBeDefined()
     expect(getTileComponentInfo(kWebViewTileType)).toBeDefined()
     const defaultContent = contentInfo?.defaultContent()
-    expect(defaultContent).toBeDefined();
+    expect(defaultContent).toBeDefined()
   })
 
   it("imports/exports v2 web view components", () => {
@@ -102,7 +102,8 @@ describe("WebView registration", () =>  {
     const componentExport = exportV2Component({ tile, row, sharedModelManager })
     expect(componentExport?.type).toBe("DG.GameView")
     const contentStorage = componentExport?.componentStorage as ICodapV2GameViewStorage
-
+    // shouldn't write out `name` property for GameView components
+    expect(hasOwnProperty(contentStorage, "name")).toBe(false)
     expect(contentStorage.currentGameName).toBe("Microdata Portal")
     // Note: the value of the exported title can probably be anything here, but undefined seems
     // to be a safe value to make it clear to CODAPv2 that user hasn't set the title

--- a/v3/src/components/web-view/web-view-registration.test.ts
+++ b/v3/src/components/web-view/web-view-registration.test.ts
@@ -8,7 +8,7 @@ import { safeJsonParse } from "../../utilities/js-utils"
 import { CodapV2Document } from "../../v2/codap-v2-document"
 import { exportV2Component } from "../../v2/codap-v2-tile-exporters"
 import { importV2Component } from "../../v2/codap-v2-tile-importers"
-import { ICodapV2DocumentJson, ICodapV2WebViewStorage } from "../../v2/codap-v2-types"
+import { ICodapV2DocumentJson, ICodapV2GameViewStorage, ICodapV2WebViewStorage } from "../../v2/codap-v2-types"
 import { kWebViewTileType } from "./web-view-defs"
 import { isWebViewModel } from "./web-view-model"
 import "./web-view-registration"
@@ -50,13 +50,67 @@ describe("WebView registration", () =>  {
     expect(tile).toBeDefined()
     expect(mockInsertTile).toHaveBeenCalledTimes(1)
     const content = isWebViewModel(tile?.content) ? tile?.content : undefined
+    expect(tile.name).toBe("https://codap-resources.concord.org/images/walkingrates-50-percent.png")
+    expect(tile._title).toBe("Walking Rates")
     expect(getTileContentInfo(kWebViewTileType)!.getTitle(tile)).toBe("Walking Rates")
     expect(content?.url).toBe("https://codap-resources.concord.org/images/walkingrates-50-percent.png")
+    expect(content?.isPlugin).toBe(false)
 
     const row = docContent.getRowByIndex(0) as IFreeTileRow
     const componentExport = exportV2Component({ tile, row, sharedModelManager })
     expect(componentExport?.type).toBe("DG.WebView")
     const contentStorage = componentExport?.componentStorage as ICodapV2WebViewStorage
     expect(contentStorage.URL).toBe("https://codap-resources.concord.org/images/walkingrates-50-percent.png")
+    expect(contentStorage.name).toBe("https://codap-resources.concord.org/images/walkingrates-50-percent.png")
+    expect(contentStorage.title).toBe("Walking Rates")
+    expect(contentStorage.userSetTitle).toBe(true)
+  })
+
+  it("imports/exports v2 game view components", () => {
+    const file = path.join(__dirname, "../../test/v2", "game-view-microdata.codap")
+    const json = fs.readFileSync(file, "utf8")
+    const doc = safeJsonParse<ICodapV2DocumentJson>(json)!
+    const v2Document = new CodapV2Document(doc)
+
+    const codapDoc = createCodapDocument()
+    const docContent = codapDoc.content!
+    docContent.setRowCreator(() => FreeTileRow.create())
+    const sharedModelManager = getSharedModelManager(docContent)
+    const mockInsertTile = jest.fn((tileSnap: ITileModelSnapshotIn) => {
+      return docContent?.insertTileSnapshotInDefaultRow(tileSnap)
+    })
+
+    const tile = importV2Component({
+      v2Component: v2Document.components[0],
+      v2Document,
+      sharedModelManager,
+      insertTile: mockInsertTile
+    })!
+    expect(tile).toBeDefined()
+    expect(mockInsertTile).toHaveBeenCalledTimes(1)
+    const content = isWebViewModel(tile?.content) ? tile?.content : undefined
+    // Note: a component with a userSetTitle false (like in this case) does not import the
+    // title into _title. However the name is imported.
+    // When the _title is undefined the name is used as the title
+    expect(tile._title).toBeUndefined()
+    expect(tile.name).toBe("Microdata Portal")
+    expect(getTileContentInfo(kWebViewTileType)!.getTitle(tile)).toBe("Microdata Portal")
+    expect(content?.url).toBe("https://codap-resources.concord.org/plugins/sdlc/plugin/index.html")
+    expect(content?.isPlugin).toBe(true)
+
+    const row = docContent.getRowByIndex(0) as IFreeTileRow
+    const componentExport = exportV2Component({ tile, row, sharedModelManager })
+    expect(componentExport?.type).toBe("DG.GameView")
+    const contentStorage = componentExport?.componentStorage as ICodapV2GameViewStorage
+
+    expect(contentStorage.currentGameName).toBe("Microdata Portal")
+    // Note: the value of the exported title can probably be anything here, but undefined seems
+    // to be a safe value to make it clear to CODAPv2 that user hasn't set the title
+    expect(contentStorage.title).toBeUndefined()
+    expect(contentStorage.userSetTitle).toBe(false)
+
+    // Note: we do not convert the URL back to the relative one that is used by CODAPv2
+    // this seems OK to do.
+    expect(contentStorage.currentGameUrl).toBe("https://codap-resources.concord.org/plugins/sdlc/plugin/index.html")
   })
 })

--- a/v3/src/components/web-view/web-view-registration.ts
+++ b/v3/src/components/web-view/web-view-registration.ts
@@ -11,7 +11,7 @@ import { registerV2TileExporter, V2ExportedComponent, V2TileExportFn } from "../
 import {
   isV2WebViewComponent, isV2GameViewComponent, ICodapV2WebViewComponent, ICodapV2GameViewComponent
 } from "../../v2/codap-v2-types"
-import { kV2GameType, kV2WebViewType, kWebViewTileType } from "./web-view-defs"
+import { kV2GameType, kV2WebViewType, kWebViewTileType, WebViewSubType } from "./web-view-defs"
 import { isWebViewModel, IWebViewSnapshot, WebViewModel } from "./web-view-model"
 import { WebViewComponent } from "./web-view"
 import { WebViewInspector } from "./web-view-inspector"
@@ -80,12 +80,16 @@ function addWebViewSnapshot(args: V2TileImportArgs, name?: string, url?: string,
   const { v2Component, insertTile } = args
   const { guid } = v2Component
   const { title, userSetTitle } = v2Component.componentStorage || {}
+  const subTypeMap: Record<string, WebViewSubType> = {
+    "DG.GameView": "plugin",
+    "DG.GuideView": "guide"
+  }
 
   const content: IWebViewSnapshot = {
     type: kWebViewTileType,
+    subType: subTypeMap[v2Component.type],
     state,
-    url,
-    isPlugin: isV2GameViewComponent(v2Component)
+    url
   }
   const webViewTileSnap: ITileModelSnapshotIn = {
     id: toV3Id(kWebViewIdPrefix, guid),
@@ -132,6 +136,8 @@ function importGameView(args: V2TileImportArgs) {
   return addWebViewSnapshot(args, currentGameName, processPluginUrl(currentGameUrl), savedGameState)
 }
 registerV2TileImporter("DG.GameView", importGameView)
+
+// TODO add importer for DG.GuideView
 
 const webViewComponentHandler: DIComponentHandler = {
   create({ values }) {

--- a/v3/src/data-interactive/data-interactive-type-utils.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.ts
@@ -202,10 +202,11 @@ export function convertDataSetToV2(dataSet: IDataSet, exportCases = false): ICod
     description,
     // metadata,
     // preventReorg,
-    // TODO_V2_EXPORT
+    // TODO_V2_EXPORT setAsideItems
     setAsideItems: [],
-    // TODO_V2_IMPORT, TODO_V2_EXPORT
-    contextStorage: { _links_: { selectedCases: [] } }
+    // TODO_V2_EXPORT contextStorage
+    // providing an empty object makes it possible for CODAPv2 to load more exported documents
+    contextStorage: {}
   }
 }
 

--- a/v3/src/test/v2/game-view-microdata.codap
+++ b/v3/src/test/v2/game-view-microdata.codap
@@ -1,0 +1,61 @@
+{
+  "name": "Untitled Document",
+  "guid": 1,
+  "id": 1,
+  "components": [
+    {
+      "type": "DG.GameView",
+      "guid": 2,
+      "id": 2,
+      "componentStorage": {
+        "currentGameName": "Microdata Portal",
+        "currentGameUrl": "../../../../extn/plugins/sdlc/plugin/index.html",
+        "allowInitGameOverride": true,
+        "savedGameState": {
+          "sampleNumber": 1,
+          "sampleSize": 16,
+          "selectedYears": [
+            2020
+          ],
+          "selectedStates": [],
+          "selectedAttributes": [
+            "Sex",
+            "Age",
+            "Year",
+            "State",
+            "Boundaries"
+          ],
+          "keepExistingData": false,
+          "activityLog": [
+            {
+              "time": "12/17/2024, 9:08:16 AM",
+              "message": "Connection: /4g/false/50/10/"
+            }
+          ]
+        },
+        "title": "Microdata Portal",
+        "userSetTitle": false,
+        "cannotClose": false
+      },
+      "layout": {
+        "width": 380,
+        "height": 520,
+        "left": 5,
+        "top": 5,
+        "zIndex": 101,
+        "isVisible": true,
+        "right": 385,
+        "bottom": 525
+      },
+      "savedHeight": null
+    }
+  ],
+  "contexts": [],
+  "globalValues": [],
+  "appName": "DG",
+  "appVersion": "2.0",
+  "appBuildNum": "0730",
+  "lang": "en",
+  "idCount": 2,
+  "metadata": {}
+}

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -210,9 +210,8 @@ export interface ICodapV2GameContext extends Omit<ICodapV2DataContext, "type"> {
 }
 
 // when exporting a v3 data set to v2 data context
-type DCNotYetExported = "flexibleGroupingChangeFlag"
 export interface ICodapV2DataContextV3
-  extends SetOptional<Omit<ICodapV2DataContext, "collections">, DCNotYetExported> {
+  extends Omit<ICodapV2DataContext, "collections"> {
   collections: ICodapV2CollectionV3[]
 }
 
@@ -340,9 +339,6 @@ export interface ICodapV2WebViewStorage extends ICodapV2BaseComponentStorage {
 export interface ICodapV2GameViewStorage extends ICodapV2BaseComponentStorage {
   currentGameUrl: string
   savedGameState?: unknown
-  // TODO_V2_IMPORT currentGameName is not imported
-  // it occurs in 17,000 files in cfm-shared
-  // it might not be optional
   currentGameName?: string
   // TODO_V2_IMPORT allowInitGameOverride is not imported
   // it occurs in at least 12,500 files in cfm-shared


### PR DESCRIPTION
This makes `isPlugin` a serialized field in V3. That is necessary so we can keep track of which WebViews are v2 GameViews and which are v2 WebViews.
The `setIsPlugin` is marked as `withoutUndo` so when a plugin is added and it sets up the iframe phone this change of the document state doesn't add an action to the undo stack.

The `contextStorage` field is added to the DataSet conversion. This was necessary to get a document to load with a plugin that had created a data table. However this document is still broken because it data context collections seem to be reversed and disconnected.

Name handling in GameViews adds more complexity to the already complex name and title handling. GameViews store their name in componentStorage.currentGameName instead of componentStorage.name