### PR TITLE
add dataContextFromURL api

### DIFF
--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -162,6 +162,10 @@ export interface DILogMessage {
   replaceArgs?: LoggableValue | LoggableValue[]
 }
 
+export interface DIUrl {
+  URL: string
+}
+
 export interface DIResources {
   attribute?: IAttribute
   attributeList?: IAttribute[]
@@ -189,7 +193,7 @@ export interface DIResources {
 // types for values accepted as inputs by the API
 export type DISingleValues = DIAttribute | DINotifyAttribute | DIAttributeLocationValues | DICase | DIDataContext |
   DINotifyDataContext | DIGlobal | DIInteractiveFrame | DIItemValues | DICreateCollection | DINewCase | DIUpdateCase |
-  DINotification | DIItemSearchNotify | DILogMessage | V2SpecificComponent
+  DINotification | DIItemSearchNotify | DILogMessage | DIUrl | V2SpecificComponent
 export type DIValues = DISingleValues | DISingleValues[] | number | string[]
 
 // types returned as outputs by the API

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
@@ -1,0 +1,108 @@
+import { DIDataContext } from "../data-interactive-types"
+import { setupTestDataset } from "./handler-test-utils"
+import { toV2Id } from "../../utilities/codap-utils"
+import { diDataContextFromURLHandler, getFilenameFromUrl } from "./data-context-from-url-handler"
+import { CsvParseResult, downloadCsvFile } from "../../utilities/csv-import"
+import { appState } from "../../models/app-state"
+import { gDataBroker } from "../../models/data/data-broker"
+import { getSharedModelManager } from "../../models/tiles/tile-environment"
+
+jest.mock("../../utilities/csv-import", () => {
+  const originalModule = jest.requireActual("../../utilities/csv-import")
+  return {
+    __esModule: true,
+    ...originalModule,
+    downloadCsvFile: jest.fn()
+  }
+})
+const mockedDownloadCsvFile = downloadCsvFile as jest.MockedFunction<typeof downloadCsvFile>
+
+
+describe("DataInteractive DataContextHandler", () => {
+  const handler = diDataContextFromURLHandler
+
+  const alertSpy = jest.spyOn(appState, "alert")
+  alertSpy.mockReturnValue(undefined)
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("create" , () => {
+    it("handles invalid values", () => {
+      expect(handler.create?.({}).success).toBe(false)
+      expect(handler.create?.({}, 1).success).toBe(false)
+      expect(handler.create?.({}, ["hi"]).success).toBe(false)
+      expect(handler.create?.({}, {fake: "value"}).success).toBe(false)
+    })
+
+    it("returns success true", () => {
+      const result = handler.create!({}, {URL: "https://example.com"})
+      expect(mockedDownloadCsvFile).toHaveBeenCalled()
+      expect(result.success).toBe(true)
+    })
+
+    it("handles onError from downloadCsvFile", () => {
+      mockedDownloadCsvFile.mockImplementation((url, onComplete, onError) => {
+        onError({
+            name: "",
+            message: ""
+        }, "")
+      })
+
+      const result = handler.create!({}, {URL: "https://example.com"})
+      expect(mockedDownloadCsvFile).toHaveBeenCalled()
+      expect(alertSpy).toHaveBeenCalled()
+      expect(result.success).toBe(true)
+    })
+
+    it("creates a dataset", () => {
+      gDataBroker.setSharedModelManager(getSharedModelManager(appState.document)!)
+
+      mockedDownloadCsvFile.mockImplementation((url, onComplete, onError) => {
+        const parseResult: CsvParseResult = {
+            data: [{col1: "value1"}],
+            errors: [],
+            meta: {
+                delimiter: "",
+                linebreak: "",
+                aborted: false,
+                truncated: false,
+                cursor: 0
+            }
+        }
+        onComplete(parseResult, "")
+      })
+
+      expect(gDataBroker.length).toBe(0)
+      const result = handler.create!({}, {URL: "https://example.com"})
+      expect(gDataBroker.length).toBe(1)
+      expect(mockedDownloadCsvFile).toHaveBeenCalled()
+      expect(alertSpy).not.toHaveBeenCalled()
+      expect(result.success).toBe(true)
+    })
+  })
+})
+
+describe("getFilenameFromUrl", () => {
+  it("handles regular urls", () => {
+    expect(getFilenameFromUrl("https://example.com/myfile.txt")).toBe("myfile.txt")
+    expect(getFilenameFromUrl("https://example.com/folder/myfile.txt")).toBe("myfile.txt")
+  })
+
+  it("handles files without extensions", () => {
+    expect(getFilenameFromUrl("https://example.com/myfile")).toBe("myfile")
+  })
+
+  it("handles bare domains", () => {
+    expect(getFilenameFromUrl("https://example.com")).toBe("")
+  })
+
+  it("handles folders", () => {
+    expect(getFilenameFromUrl("https://example.com/myfolder/")).toBe("")
+  })
+
+  it("handles relative urls", () => {
+    expect(getFilenameFromUrl("myfile.txt")).toBe("myfile.txt")
+  })
+})

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
@@ -1,11 +1,8 @@
-import { DIDataContext } from "../data-interactive-types"
-import { setupTestDataset } from "./handler-test-utils"
-import { toV2Id } from "../../utilities/codap-utils"
-import { diDataContextFromURLHandler, getFilenameFromUrl } from "./data-context-from-url-handler"
-import { CsvParseResult, downloadCsvFile } from "../../utilities/csv-import"
 import { appState } from "../../models/app-state"
 import { gDataBroker } from "../../models/data/data-broker"
 import { getSharedModelManager } from "../../models/tiles/tile-environment"
+import { CsvParseResult, downloadCsvFile } from "../../utilities/csv-import"
+import { diDataContextFromURLHandler, getFilenameFromUrl } from "./data-context-from-url-handler"
 
 jest.mock("../../utilities/csv-import", () => {
   const originalModule = jest.requireActual("../../utilities/csv-import")

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
@@ -1,8 +1,62 @@
+import { appState } from "../../models/app-state"
+import { convertParsedCsvToDataSet, CsvParseResult, downloadCsvFile } from "../../utilities/csv-import"
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIHandler, diNotImplementedYet } from "../data-interactive-types"
+import { DIErrorResult, DIHandler, diNotImplementedYet, DIResources, DIUrl, DIValues } from "../data-interactive-types"
+
+const kInvalidValuesError: DIErrorResult = {
+  success: false,
+  values: {
+    error: "dataContextFromURL requires a { URL: [url] } value"
+  }
+}
+
+function getFilenameFromUrl(url: string) {
+  return new URL(url, window.location.href).pathname.split("/").pop()
+}
 
 export const diDataContextFromURLHandler: DIHandler = {
-  create: diNotImplementedYet
+
+  // The API tester has a template for this under the dataContext section.
+  // Because the download is async we won't know if this succeeded or failed until it
+  // has been downloaded. As a first pass we always say it succeeds. And then when if
+  // it fails we show an alert.
+  create(resources: DIResources, _values?: DIValues) {
+    const values = _values as DIUrl | undefined
+    if (!values || !(typeof values === "object") || !values.URL) return kInvalidValuesError
+
+    const url = values.URL
+
+    const failureAlert = () => {
+      // Because the handlers don't support async calls we just show a dialog when it fails
+      appState.alert(`A plugin tried to import the URL ${url} and failed.`, "Import dataset failed")
+    }
+
+    try {
+      downloadCsvFile(url,
+        (results: CsvParseResult) => {
+          const filename = getFilenameFromUrl(url)
+          // TODO: look at v2 to figure out if it has a default name perhaps that is translated
+          const ds = convertParsedCsvToDataSet(results, filename || "Imported Data")
+          if (ds) {
+            appState.document.content?.importDataSet(ds, { createDefaultTile: true })
+          }
+          else {
+            // Because the handlers don't support async calls we just show a dialog when it fails
+            failureAlert()
+          }
+        },
+        (error) => {
+          // It seems the error object returned by papaparse does not include useful information for
+          // the user.
+          failureAlert()
+        }
+      )
+
+      return { success: true }
+    } catch (e) {
+      return { success: false, values: { error: "Failed to download CSV file"}}
+    }
+  }
 }
-  
+
 registerDIHandler("dataContextFromURL", diDataContextFromURLHandler)

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
@@ -1,28 +1,24 @@
 import { appState } from "../../models/app-state"
 import { convertParsedCsvToDataSet, CsvParseResult, downloadCsvFile } from "../../utilities/csv-import"
+import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIErrorResult, DIHandler, diNotImplementedYet, DIResources, DIUrl, DIValues } from "../data-interactive-types"
-
-const kInvalidValuesError: DIErrorResult = {
-  success: false,
-  values: {
-    error: "dataContextFromURL requires a { URL: [url] } value"
-  }
-}
+import { DIHandler, DIResources, DIUrl, DIValues } from "../data-interactive-types"
+import { errorResult, fieldRequiredResult } from "./di-results"
 
 export function getFilenameFromUrl(url: string) {
   return new URL(url, window.location.href).pathname.split("/").pop()
 }
 
 export const diDataContextFromURLHandler: DIHandler = {
-
   // The API tester has a template for this under the dataContext section.
   // Because the download is async we won't know if this succeeded or failed until it
   // has been downloaded. As a first pass we always say it succeeds. And then when if
   // it fails we show an alert.
-  create(resources: DIResources, _values?: DIValues) {
+  create(_resources: DIResources, _values?: DIValues) {
     const values = _values as DIUrl | undefined
-    if (!values || !(typeof values === "object") || !values.URL) return kInvalidValuesError
+    if (!values || !(typeof values === "object") || !values.URL) {
+      return fieldRequiredResult("create", "dataContextFromURL", "URL")
+    }
 
     const url = values.URL
 
@@ -54,7 +50,7 @@ export const diDataContextFromURLHandler: DIHandler = {
 
       return { success: true }
     } catch (e) {
-      return { success: false, values: { error: "Failed to download CSV file"}}
+      return errorResult(t("V3.DI.Error.downloadCSV"))
     }
   }
 }

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
@@ -10,7 +10,7 @@ const kInvalidValuesError: DIErrorResult = {
   }
 }
 
-function getFilenameFromUrl(url: string) {
+export function getFilenameFromUrl(url: string) {
   return new URL(url, window.location.href).pathname.split("/").pop()
 }
 

--- a/v3/src/models/app-state.ts
+++ b/v3/src/models/app-state.ts
@@ -71,6 +71,10 @@ class AppState {
     return this.document.treeManagerAPI as TreeManagerType | undefined
   }
 
+  alert(message: string, title: string | undefined, callback?: () => void) {
+    this.cfm?.client.alert(message, title, callback)
+  }
+
   /**
    * Check if this revisionId is the same as the current document's revisionId
    *

--- a/v3/src/sample-data/index.ts
+++ b/v3/src/sample-data/index.ts
@@ -22,14 +22,19 @@ const sampleMap: Record<SampleType, string> = {
 export function importSample(sample: SampleType): Promise<IDataSet> {
   const dataUrl = sampleMap[sample]
   return new Promise((resolve, reject) => {
-    downloadCsvFile(dataUrl, (results: CsvParseResult) => {
-      const ds = convertParsedCsvToDataSet(results, sample)
-      if (ds) {
-        resolve(ds)
+    downloadCsvFile(dataUrl,
+      (results: CsvParseResult) => {
+        const ds = convertParsedCsvToDataSet(results, sample)
+        if (ds) {
+          resolve(ds)
+        }
+        else {
+          reject()
+        }
+      },
+      (error) => {
+        reject(error)
       }
-      else {
-        reject()
-      }
-    })
+    )
   })
 }

--- a/v3/src/utilities/csv-import.ts
+++ b/v3/src/utilities/csv-import.ts
@@ -8,8 +8,11 @@ export function importCsvFile(file: File | null, onComplete: (results: CsvParseR
   parse(file, { comments: "#", header: true, complete: onComplete })
 }
 
-export function downloadCsvFile(dataUrl: string, onComplete: (results: CsvParseResult, aFile: any) => void) {
-  parse(dataUrl, { download: true, comments: "#", header: true, complete: onComplete })
+export function downloadCsvFile(dataUrl: string,
+  onComplete: (results: CsvParseResult, aFile: any) => void,
+  onError: (error: Error, file: string) => void
+) {
+  parse(dataUrl, { download: true, comments: "#", header: true, complete: onComplete, error: onError })
 }
 
 export function convertParsedCsvToDataSet(results: CsvParseResult, filename: string) {

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -117,6 +117,7 @@
     "V3.DI.Error.caseNotFound": "Case not found",
     "V3.DI.Error.collectionNotFound": "Collection not found",
     "V3.DI.Error.componentNotCreated": "Could not create component",
+    "V3.DI.Error.downloadCSV": "Failed to download CSV file",
     "V3.DI.Error.illegalAttributeAssignment": "Cannot assign %@1 to %@2",
     "V3.DI.Error.componentNotFound": "Component not found",
     "V3.DI.Error.unsupportedComponent": "Unsupported component type %@",


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/187738928

This PR implements a synchronous version of the `create dataContextFromURL` API request. It works similarly to v2, where the result is success if there's enough information to attempt to download the data context, even if the actual download fails. In this case, an alert is displayed so the user knows the download failed, but the plugin will not be informed.

A separate PR implements an asynchronous version of this API request, which will return a fail response if the download does not succeed: https://github.com/concord-consortium/codap/pull/1699.