### PR TITLE
async api handlers

### DIFF
--- a/v3/src/components/web-view/request-queue.ts
+++ b/v3/src/components/web-view/request-queue.ts
@@ -14,17 +14,38 @@ export class RequestQueue {
     return this.requestQueue.length
   }
 
-  get nextItem() {
-    return this.requestQueue[0]
-  }
-
   @action
   push(pair: RequestPair) {
     this.requestQueue.push(pair)
   }
 
+
   @action
-  shift() {
-    return this.requestQueue.shift()
+  clear() {
+    this.requestQueue.splice(0)
   }
+
+  /**
+   * Process all of the current items in the array. A copy of the current items
+   * is made and the current items are cleared.
+   *
+   * processItems does not wait for async processor functions. It will call the processor
+   * function for every item even if one of them is waiting for something to finish.
+   *
+   * The approach copying the array and then clearing it means the array is only
+   * updated one time. So if this function is observed, it will only trigger a single update.
+   *
+   * @param processor
+   */
+  processItems(processor: (item: RequestPair) => void) {
+    // copy the items
+    const items = this.requestQueue.slice(0)
+    // clear the items to prepare for the next one to be added
+    this.clear()
+    // Call the processor for each item
+    for (const item of items) {
+      processor(item)
+    }
+  }
+
 }

--- a/v3/src/components/web-view/request-queue.ts
+++ b/v3/src/components/web-view/request-queue.ts
@@ -33,7 +33,8 @@ export class RequestQueue {
    * function for every item even if one of them is waiting for something to finish.
    *
    * The approach copying the array and then clearing it means the array is only
-   * updated one time. So if this function is observed, it will only trigger a single update.
+   * updated one time. So if this function is observed, it will only trigger a single
+   * update.
    *
    * @param processor
    */

--- a/v3/src/components/web-view/use-data-interactive-controller.ts
+++ b/v3/src/components/web-view/use-data-interactive-controller.ts
@@ -13,6 +13,7 @@ import { uiState } from "../../models/ui-state"
 import { t } from "../../utilities/translation/translate"
 import { RequestQueue } from "./request-queue"
 import { isWebViewModel } from "./web-view-model"
+import { errorResult } from "../../data-interactive/handlers/di-results"
 
 function extractOrigin(url?: string) {
   if (!url) return
@@ -71,7 +72,6 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
           debugLog(DEBUG_PLUGINS, `Processing data-interactive: ${JSON.stringify(request)}`)
           let result: DIRequestResponse = { success: false }
 
-          const errorResult = (error: string) => ({ success: false, values: { error }} as const)
           const processAction = async (action: DIAction) => {
             if (!action) return errorResult(t("V3.DI.Error.noAction"))
             if (!tile) return errorResult(t("V3.DI.Error.noTile"))

--- a/v3/src/components/web-view/use-data-interactive-controller.ts
+++ b/v3/src/components/web-view/use-data-interactive-controller.ts
@@ -1,5 +1,5 @@
 import iframePhone from "iframe-phone"
-import { autorun } from "mobx"
+import { reaction } from "mobx"
 import React, { useEffect } from "react"
 import { getDIHandler } from "../../data-interactive/data-interactive-handler"
 import {
@@ -52,53 +52,65 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
       webViewModel?.setDataInteractiveController(rpcEndpoint)
       webViewModel?.applyModelChange(() => {}, {log: {message: "Plugin initialized", args:{}, category: "plugin"}})
 
-      const disposer = autorun(() => {
-        const canProcessRequest = !uiState.isEditingBlockingCell
-        if (canProcessRequest && requestQueue.length > 0) {
-          uiState.captureEditingStateBeforeInterruption()
-          let tableModified = false
-          while (requestQueue.length > 0) {
-            const { request, callback } = requestQueue.nextItem
-            debugLog(DEBUG_PLUGINS, `Processing data-interactive: ${JSON.stringify(request)}`)
-            let result: DIRequestResponse = { success: false }
-
-            const errorResult = (error: string) => ({ success: false, values: { error }} as const)
-            const processAction = (action: DIAction) => {
-              if (!action) return errorResult(t("V3.DI.Error.noAction"))
-              if (!tile) return errorResult(t("V3.DI.Error.noTile"))
-
-              const resourceSelector = parseResourceSelector(action.resource)
-              const resources = resolveResources(resourceSelector, action.action, tile)
-              const type = resourceSelector.type ?? ""
-              const a = action.action
-              const func = getDIHandler(type)?.[a as keyof DIHandler]
-              if (!func) return errorResult(t("V3.DI.Error.unsupportedAction", {vars: [a, type]}))
-
-              const actionResult = func?.(resources, action.values)
-              if (actionResult &&
-                ["create", "delete", "notify"].includes(a) &&
-                !["component", "global", "interactiveFrame"].includes(type)
-              ) {
-                // Increment request batches processed if a table may have been modified
-                tableModified = true
-              }
-              return actionResult ?? errorResult(t("V3.DI.Error.undefinedResponse"))
-            }
-            if (Array.isArray(request)) {
-              result = request.map(action => processAction(action))
-            } else {
-              result = processAction(request)
-            }
-
-            debugLog(DEBUG_PLUGINS, `Responding with`, result)
-            callback(result)
-            requestQueue.shift()
-          }
-          // TODO Only increment if a table may have changed
-          // - many actions and resources could be ignored
-          // - could specify which dataContext has been updated
-          if (tableModified) uiState.incrementInterruptionCount()
+      // A reaction is used here instead of an autorun so properties accessed by each handler are not
+      // observed. We only want to run the loop when a new request comes in, not when something changes
+      // that a handler accessed.
+      const disposer = reaction(() => {
+        return {
+          canProcessRequest: !uiState.isEditingBlockingCell,
+          queueLength: requestQueue.length
         }
+      },
+      ({ canProcessRequest, queueLength }) => {
+        if (!canProcessRequest || queueLength === 0) return
+
+        uiState.captureEditingStateBeforeInterruption()
+        let tableModified = false
+
+        requestQueue.processItems(async ({ request, callback }) => {
+          debugLog(DEBUG_PLUGINS, `Processing data-interactive: ${JSON.stringify(request)}`)
+          let result: DIRequestResponse = { success: false }
+
+          const errorResult = (error: string) => ({ success: false, values: { error }} as const)
+          const processAction = async (action: DIAction) => {
+            if (!action) return errorResult(t("V3.DI.Error.noAction"))
+            if (!tile) return errorResult(t("V3.DI.Error.noTile"))
+
+            const resourceSelector = parseResourceSelector(action.resource)
+            const resources = resolveResources(resourceSelector, action.action, tile)
+            const type = resourceSelector.type ?? ""
+            const a = action.action
+            const func = getDIHandler(type)?.[a as keyof DIHandler]
+            if (!func) return errorResult(t("V3.DI.Error.unsupportedAction", {vars: [a, type]}))
+
+            const actionResult = await func?.(resources, action.values)
+            if (actionResult &&
+              ["create", "delete", "notify"].includes(a) &&
+              !["component", "global", "interactiveFrame"].includes(type)
+            ) {
+              // Increment request batches processed if a table may have been modified
+              tableModified = true
+            }
+            return actionResult ?? errorResult(t("V3.DI.Error.undefinedResponse"))
+          }
+          if (Array.isArray(request)) {
+            result = []
+            for (const action of request) {
+              result.push(await processAction(action))
+            }
+          } else {
+            result = await processAction(request)
+          }
+
+          debugLog(DEBUG_PLUGINS, `Responding with`, result)
+          callback(result)
+        })
+
+        // TODO Only increment if a table may have changed
+        // - many actions and resources could be ignored
+        // - could specify which dataContext has been updated
+        if (tableModified) uiState.incrementInterruptionCount()
+
       }, { name: "DataInteractiveController request processor autorun" })
 
       return () => {

--- a/v3/src/data-interactive/data-interactive-handler.ts
+++ b/v3/src/data-interactive/data-interactive-handler.ts
@@ -1,8 +1,8 @@
-import { DIHandler } from "./data-interactive-types"
+import { DIAsyncHandler, DIHandler } from "./data-interactive-types"
 
-const diHandlers: Map<string, DIHandler> = new Map()
+const diHandlers: Map<string, DIHandler | DIAsyncHandler> = new Map()
 
-export function registerDIHandler(resource: string, handler: DIHandler) {
+export function registerDIHandler(resource: string, handler: DIHandler | DIAsyncHandler) {
   diHandlers.set(resource, handler)
 }
 

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -223,10 +223,14 @@ export function isErrorResult(result: unknown): result is DIErrorResult {
 }
 
 export type DIHandlerFn = (resources: DIResources, values?: DIValues, metadata?: DIMetadata) => DIHandlerFnResult
+export type DIHandlerAsyncFn = (...args: Parameters<DIHandlerFn>) => DIHandlerFnResult | Promise<DIHandlerFnResult>
 
 export const diNotImplementedYetResult = {success: false, values: {error: "not implemented (yet)"}} as const
 export const diNotImplementedYet: DIHandlerFn = () => diNotImplementedYetResult
 
+// This approach of defining both a synchronous and asynchronous handler makes it easier
+// for simple synchronous handlers to write tests. They don't need to await every call
+// when we know the calls are synchronous.
 interface DIBaseHandler {
   get?: DIHandlerFn
   create?: DIHandlerFn
@@ -239,6 +243,17 @@ interface DIBaseHandler {
 
 export type ActionName = keyof DIBaseHandler
 export type DIHandler = RequireAtLeastOne<DIBaseHandler, ActionName>
+
+interface DIBaseAsyncHandler {
+  get?: DIHandlerAsyncFn
+  create?: DIHandlerAsyncFn
+  update?: DIHandlerAsyncFn
+  delete?: DIHandlerAsyncFn
+  notify?: DIHandlerAsyncFn
+  register?: DIHandlerAsyncFn
+  unregister?: DIHandlerAsyncFn
+}
+export type DIAsyncHandler = RequireAtLeastOne<DIBaseAsyncHandler, ActionName>
 
 export interface DIResourceSelector {
   attribute?: string


### PR DESCRIPTION
Refactor the handling of api requests from interactives.
The handlers can now be asynchronous. If an array of api requests is sent by the interactive they will be run one after the other with each waiting for the previous one to finish.
Individual api requests will be run when they come in even if there is another api request or array of request waiting to finish.

The api request loop is changed from an autorun based observer to a reaction observer. This way properties accessed by each handler are not observed. We only want to run the loop when a new request comes in, not when a property changes that a handler accessed.

The cell editing state handling will be broken when an async handler is used. While the async handler is still running `incrementInterruptionCount` will called. This is because `processItems` doesn't wait. Simply making `processItems` wait would not fix the problem because additional requests might come and finish in while one is waiting. 

It seems OK to punt this problem since it should only be a problem when the shared data table is mixed with a plugin which uses async apis, and that plugin calls an async api in the middle of someone editing. When @kswenson comes back, if he thinks it is isn't OK to punt this problem, I can put a little more time into it. I think I could add some better waiting that would prevent this problem. The additional waiting would mean that a slow async handler could hold up a whole chain of handlers, but given our limited number of async handlers this might be a safer approach.