### PR TITLE
188565497 map filter formula

### DIFF
--- a/v3/src/components/data-display/models/data-display-content-model.ts
+++ b/v3/src/components/data-display/models/data-display-content-model.ts
@@ -5,25 +5,29 @@
 import {comparer, reaction} from "mobx"
 import {addDisposer, Instance, types} from "mobx-state-tree"
 import { format } from "d3"
-import {TileContentModel} from "../../../models/tiles/tile-content"
 import {IDataSet} from "../../../models/data/data-set"
 import {ISharedCaseMetadata} from "../../../models/shared/shared-case-metadata"
 import {ISharedDataSet} from "../../../models/shared/shared-data-set"
 import {
   getAllTileCaseMetadata, getAllTileDataSets, getSharedDataSetFromDataSetId
 } from "../../../models/shared/shared-data-utils"
-import {DataDisplayLayerModelUnion} from "./data-display-layer-union"
-import {DisplayItemDescriptionModel} from "./display-item-description-model"
-import {GraphPlace} from "../../axis-graph-shared"
-import { IDataConfigurationModel } from "./data-configuration-model"
+import {TileContentModel} from "../../../models/tiles/tile-content"
+import { getTileContentInfo } from "../../../models/tiles/tile-content-info"
 import {defaultBackgroundColor} from "../../../utilities/color-utils"
+import { typedId } from "../../../utilities/js-utils"
+import {GraphPlace} from "../../axis-graph-shared"
+import { IAxisModel, isBaseNumericAxisModel } from "../../axis/models/axis-model"
 import { MarqueeMode, PointDisplayTypes } from "../data-display-types"
 import { IGetTipTextProps } from "../data-tip-types"
-import { IAxisModel, isBaseNumericAxisModel } from "../../axis/models/axis-model"
+import { IDataConfigurationModel } from "./data-configuration-model"
+import {DataDisplayLayerModelUnion} from "./data-display-layer-union"
+import {DisplayItemDescriptionModel} from "./display-item-description-model"
 
 export const DataDisplayContentModel = TileContentModel
   .named("DataDisplayContentModel")
   .props({
+    // expected to be overridden by derived models
+    id: types.optional(types.string, () => typedId("DDCM")),
     layers: types.array(DataDisplayLayerModelUnion),
     pointDescription: types.optional(DisplayItemDescriptionModel, () => DisplayItemDescriptionModel.create()),
     pointDisplayType: types.optional(types.enumeration([...PointDisplayTypes]), "points"),
@@ -54,6 +58,9 @@ export const DataDisplayContentModel = TileContentModel
     get datasetsArray(): IDataSet[] {
       // derived models should override
       return []
+    },
+    get formulaAdapters() {
+      return getTileContentInfo(self.type)?.getFormulaAdapters?.(self) ?? []
     },
     caseTipText(attributeIDs: string[], caseID: string, dataset?: IDataSet) {
       const float = format('.3~f')

--- a/v3/src/components/data-display/models/data-display-filter-formula-adapter.ts
+++ b/v3/src/components/data-display/models/data-display-filter-formula-adapter.ts
@@ -63,11 +63,6 @@ export class DataDisplayFilterFormulaAdapter extends FormulaManagerAdapter imple
     return contentModel
   }
 
- createExtraMetadata(contentModel: IDataDisplayContentModel,
-                      dataSet: any) {
-  // subclasses should override
-  return {} as IDataDisplayFilterFormulaExtraMetadata
-}
 
   recalculateFormula(formulaContext: IFormulaContext, extraMetadata: IDataDisplayFilterFormulaExtraMetadata,
     casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {

--- a/v3/src/components/data-display/models/data-display-filter-formula-adapter.ts
+++ b/v3/src/components/data-display/models/data-display-filter-formula-adapter.ts
@@ -1,0 +1,187 @@
+import { action, makeObservable, observable } from "mobx"
+import { IAnyStateTreeNode } from "mobx-state-tree"
+import { DEBUG_FORMULAS, debugLog } from "../../../lib/debug"
+import { ICase } from "../../../models/data/data-set-types"
+import { IFormula } from "../../../models/formula/formula"
+import { registerFormulaAdapter } from "../../../models/formula/formula-adapter-registry"
+import {
+  FormulaManagerAdapter, IFormulaAdapterApi, IFormulaContext, IFormulaExtraMetadata, IFormulaManagerAdapter
+} from "../../../models/formula/formula-manager-types"
+import { FormulaMathJsScope } from "../../../models/formula/formula-mathjs-scope"
+import { math } from "../../../models/formula/functions/math"
+import { formulaError } from "../../../models/formula/utils/misc"
+import { getFormulaManager } from "../../../models/tiles/tile-environment"
+import { mstReaction } from "../../../utilities/mst-reaction"
+import { isFilterFormulaDataConfiguration } from "./data-configuration-model"
+import type { IDataDisplayContentModel } from "./data-display-content-model"
+
+
+export interface IDataDisplayFilterFormulaExtraMetadata extends IFormulaExtraMetadata {
+  contentModelId: string
+}
+
+export class DataDisplayFilterFormulaAdapter extends FormulaManagerAdapter implements IFormulaManagerAdapter {
+
+  // static register() {
+  //   registerFormulaAdapter(api => new GraphFilterFormulaAdapter(api))
+  // }
+
+  // static get(node?: IAnyStateTreeNode) {
+  //   return getFormulaManager(node)?.adapters.find(({ type }) =>
+  //     type === GRAPH_FILTER_FORMULA_ADAPTER
+  //   ) as Maybe<GraphFilterFormulaAdapter>
+  // }
+
+  @observable.shallow contentModels = new Map<string, IDataDisplayContentModel>()
+
+  // constructor(api: IFormulaAdapterApi) {
+  //   super(GRAPH_FILTER_FORMULA_ADAPTER, api)
+  //   makeObservable(this)
+  // }
+
+  // @action
+  // addContentModel(contentModel: IDataDisplayContentModel) {
+  //   if (contentModel.dataConfiguration) {
+  //     this.contentModels.set(contentModel.id, contentModel)
+  //   }
+  // }
+
+  // @action
+  // removeContentModel(contentModelId: string) {
+  //   this.contentModels.delete(contentModelId)
+  // }
+
+  getContentModel(extraMetadata: IDataDisplayFilterFormulaExtraMetadata) {
+    const { contentModelId } = extraMetadata
+    const contentModel = this.contentModels.get(contentModelId)
+    if (!contentModel) {
+      throw new Error(`GraphContentModel with id "${contentModelId}" not found`)
+    }
+    return contentModel
+  }
+
+  getDataConfiguration(extraMetadata: IDataDisplayFilterFormulaExtraMetadata) {
+    return this.getContentModel(extraMetadata).dataConfiguration
+  }
+
+  getActiveFormulas(): ({ formula: IFormula, extraMetadata: IDataDisplayFilterFormulaExtraMetadata })[] {
+    const result: ({ formula: IFormula, extraMetadata: IDataDisplayFilterFormulaExtraMetadata })[] = []
+    this.contentModels.forEach(contentModel => {
+      const dataConfig = contentModel.dataConfiguration
+      const dataSet = dataConfig?.dataset
+      if (dataSet && isFilterFormulaDataConfiguration(dataConfig)) {
+        result.push({
+          formula: dataConfig.filterFormula,
+          extraMetadata: {
+            dataSetId: dataSet.id,
+            contentModelId: dataConfig.id
+          }
+        })
+      }
+    })
+    return result
+  }
+
+  recalculateFormula(formulaContext: IFormulaContext, extraMetadata: IDataDisplayFilterFormulaExtraMetadata,
+    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+
+    if (formulaContext.formula.empty) {
+      // if there is no filter formula, clear any filter results
+      dataConfig?.updateFilterFormulaResults([], { replaceAll: true })
+      return
+    }
+
+    // Clear any previous error first.
+    this.setFormulaError(formulaContext, extraMetadata, "")
+
+    if (!dataConfig) {
+      throw new Error(`GraphContentModel with id "${extraMetadata.contentModelId}" not found`)
+    }
+    const results = this.computeFormula(formulaContext, extraMetadata, casesToRecalculateDesc)
+    if (results && results.length > 0) {
+      dataConfig.updateFilterFormulaResults(results, { replaceAll: casesToRecalculateDesc === "ALL_CASES" })
+    }
+  }
+
+  computeFormula(formulaContext: IFormulaContext, extraMetadata: IDataDisplayFilterFormulaExtraMetadata,
+    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
+    const { formula, dataSet } = formulaContext
+    const { attributeId } = extraMetadata
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+    if (!dataConfig) {
+      console.error(`ContentModel with id "${extraMetadata.contentModelId}" not found`)
+      return
+    }
+    // Use visibleCaseIds to exclude hidden cases so they're not included in calculations,
+    // such as aggregate functions like mean.
+    const childMostCollectionCaseIds = [...dataConfig.visibleCaseIds]
+
+    let casesToRecalculate: string[] = []
+    if (casesToRecalculateDesc === "ALL_CASES") {
+      // If casesToRecalculate is not provided, recalculate all cases.
+      casesToRecalculate = childMostCollectionCaseIds
+    } else {
+      casesToRecalculate = casesToRecalculateDesc.map(c => c.__id__)
+    }
+
+    if (!casesToRecalculate || casesToRecalculate.length === 0) {
+      return
+    }
+
+    debugLog(
+      DEBUG_FORMULAS,
+      `[filter formula] recalculate "${formula.canonical}" for ${casesToRecalculate.length} cases`
+    )
+
+    const formulaScope = new FormulaMathJsScope({
+      localDataSet: dataSet,
+      dataSets: this.api.getDatasets(),
+      globalValueManager: this.api.getGlobalValueManager(),
+      formulaAttrId: attributeId,
+      caseIds: casesToRecalculate,
+      childMostCollectionCaseIds
+    })
+
+    try {
+      const compiledFormula = math.compile(formula.canonical)
+      return casesToRecalculate.map((c, idx) => {
+        formulaScope.setCasePointer(idx)
+        const formulaValue = compiledFormula.evaluate(formulaScope)
+        // This is necessary for functions like `prev` that need to know the previous result when they reference
+        // its own attribute.
+        formulaScope.savePreviousResult(formulaValue)
+        return {
+          itemId: c,
+          result: !!formulaValue // only boolean values are supported
+        }
+      })
+    } catch (e: any) {
+      return this.setFormulaError(formulaContext, extraMetadata, formulaError(e.message))
+    }
+  }
+
+  // Error message is set as formula output, similarly as in CODAP V2.
+  setFormulaError(formulaContext: IFormulaContext, extraMetadata: IDataDisplayFilterFormulaExtraMetadata, errorMsg: string) {
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+    dataConfig?.setFilterFormulaError(errorMsg)
+  }
+
+  getFormulaError(formulaContext: IFormulaContext, extraMetadata: IDataDisplayFilterFormulaExtraMetadata) {
+    // No custom errors yet.
+    return undefined
+  }
+
+  setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IDataDisplayFilterFormulaExtraMetadata) {
+    const contentModel = this.contentModels.get(extraMetadata.contentModelId)
+    const disposer = contentModel && mstReaction(
+                      () => contentModel?.dataConfiguration?.filterFormula?.display,
+                      () => this.recalculateFormula(formulaContext, extraMetadata, "ALL_CASES"),
+                      { name: "FilterFormulaAdapter.reaction" }, contentModel)
+    return () => {
+      // if there is no filter formula, clear any filter results
+      contentModel?.dataConfiguration?.updateFilterFormulaResults([], { replaceAll: true })
+      disposer?.()
+    }
+  }
+}

--- a/v3/src/components/graph/adornments/base-graph-formula-adapter.ts
+++ b/v3/src/components/graph/adornments/base-graph-formula-adapter.ts
@@ -48,12 +48,12 @@ export class BaseGraphFormulaAdapter extends FormulaManagerAdapter implements IF
   }
 
   @action
-  addGraphContentModel(graphContentModel: IGraphContentModel) {
+  addContentModel(graphContentModel: IGraphContentModel) {
     this.graphContentModels.set(graphContentModel.id, graphContentModel)
   }
 
   @action
-  removeGraphContentModel(graphContentModelId: string) {
+  removeContentModel(graphContentModelId: string) {
     this.graphContentModels.delete(graphContentModelId)
   }
 

--- a/v3/src/components/graph/adornments/base-graph-formula-adapter.ts
+++ b/v3/src/components/graph/adornments/base-graph-formula-adapter.ts
@@ -7,7 +7,8 @@ import {
 } from "../../../models/formula/formula-manager-types"
 import { FormulaMathJsScope } from "../../../models/formula/formula-mathjs-scope"
 import { localAttrIdToCanonical } from "../../../models/formula/utils/name-mapping-utils"
-import type { IGraphContentModel } from "../models/graph-content-model"
+import { ITileContentModel } from "../../../models/tiles/tile-content"
+import { isGraphContentModel, type IGraphContentModel } from "../models/graph-content-model"
 import { IAdornmentModel } from "./adornment-models"
 
 type GraphCellKey = Record<string, string>
@@ -48,8 +49,10 @@ export class BaseGraphFormulaAdapter extends FormulaManagerAdapter implements IF
   }
 
   @action
-  addContentModel(graphContentModel: IGraphContentModel) {
-    this.graphContentModels.set(graphContentModel.id, graphContentModel)
+  addContentModel(contentModel: ITileContentModel) {
+    if (isGraphContentModel(contentModel)) {
+      this.graphContentModels.set(contentModel.id, contentModel)
+    }
   }
 
   @action

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-formula-adapter.test.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-formula-adapter.test.ts
@@ -64,7 +64,7 @@ const getTestEnv = () => {
     getFormulaContext: jest.fn(() => context),
   }
   const adapter = new PlottedFunctionFormulaAdapter(api)
-  adapter.addGraphContentModel(graphContentModel as any)
+  adapter.addContentModel(graphContentModel as any)
   return { adapter, adornment, graphContentModel, api, dataSet, attribute, formula, context, extraMetadata }
 }
 

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-formula-adapter.test.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-formula-adapter.test.ts
@@ -1,6 +1,7 @@
 import { IDataSet } from "../../../../models/data/data-set"
 import { createDataSet } from "../../../../models/data/data-set-conversion"
 import { localAttrIdToCanonical } from "../../../../models/formula/utils/name-mapping-utils"
+import { IGraphContentModel } from "../../models/graph-content-model"
 import { GraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
 import { PlottedFunctionAdornmentModel } from "./plotted-function-adornment-model"
 import { PlottedFunctionFormulaAdapter } from "./plotted-function-formula-adapter"
@@ -34,8 +35,9 @@ const getTestEnv = () => {
   dataConfig.attributeType = (role: string) => mockData.type[role]
   ;(dataConfig as any).categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
 
-  const graphContentModel = {
+  const graphContentModel: Partial<IGraphContentModel> = {
     id: "fake-graph-content-model-id",
+    type: "Graph",
     adornments: [adornment],
     dataset: dataSet,
     dataConfiguration: dataConfig,

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-formula-adapter.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-formula-adapter.test.ts
@@ -63,7 +63,7 @@ const getTestEnv = () => {
     getFormulaContext: jest.fn(() => context),
   }
   const adapter = new PlottedValueFormulaAdapter(api)
-  adapter.addGraphContentModel(graphContentModel as any)
+  adapter.addContentModel(graphContentModel as any)
   return { adapter, adornment, graphContentModel, api, dataSet, attribute, formula, context, extraMetadata }
 }
 

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-formula-adapter.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-formula-adapter.test.ts
@@ -1,6 +1,7 @@
 import { IDataSet } from "../../../../../models/data/data-set"
 import { createDataSet } from "../../../../../models/data/data-set-conversion"
 import { localAttrIdToCanonical } from "../../../../../models/formula/utils/name-mapping-utils"
+import { IGraphContentModel } from "../../../models/graph-content-model"
 import { GraphDataConfigurationModel } from "../../../models/graph-data-configuration-model"
 import { PlottedValueAdornmentModel } from "./plotted-value-adornment-model"
 import { PlottedValueFormulaAdapter } from "./plotted-value-formula-adapter"
@@ -33,14 +34,15 @@ const getTestEnv = () => {
   dataConfig.attributeID = (role: string) => mockData.id[role]
   dataConfig.attributeType = (role: string) => mockData.type[role]
   ;(dataConfig as any).categoryArrayForAttrRole = (role: string) => mockData.categoryArrayForAttrRole[role]
-  const graphContentModel = {
+  const graphContentModel: Partial<IGraphContentModel> = {
     id: "fake-graph-content-model-id",
+    type: "Graph",
     adornments: [adornment],
     dataset: dataSet,
     dataConfiguration: dataConfig,
     getUpdateCategoriesOptions: () => ({
       dataConfig
-    }),
+    })
   }
   const formula = adornment.formula
   const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])

--- a/v3/src/components/graph/graph-registration.ts
+++ b/v3/src/components/graph/graph-registration.ts
@@ -1,20 +1,25 @@
+import { IAnyStateTreeNode } from "mobx-state-tree"
 import { SetRequired } from "type-fest"
+import GraphIcon from "../../assets/icons/icon-graph.svg"
 import { registerComponentHandler } from "../../data-interactive/handlers/component-handler"
 import { registerTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { ITileLikeModel, registerTileContentInfo } from "../../models/tiles/tile-content-info"
-import { graphComponentHandler } from "./graph-component-handler"
-import { kGraphIdPrefix, kGraphTileClass, kGraphTileType, kV2GraphType } from "./graph-defs"
 import { SharedDataSet } from "../../models/shared/shared-data-set"
 import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
+import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { ComponentTitleBar } from "../component-title-bar"
+import { PlottedFunctionFormulaAdapter } from "./adornments/plotted-function/plotted-function-formula-adapter"
+import {
+  PlottedValueFormulaAdapter
+} from "./adornments/univariate-measures/plotted-value/plotted-value-formula-adapter"
+import { GraphComponent } from "./components/graph-component"
+import { GraphInspector } from "./components/graph-inspector"
+import { graphComponentHandler } from "./graph-component-handler"
+import { kGraphIdPrefix, kGraphTileClass, kGraphTileType, kV2GraphType } from "./graph-defs"
 import { GraphContentModel, IGraphContentModelSnapshot, isGraphContentModel } from "./models/graph-content-model"
 import { kGraphDataConfigurationType } from "./models/graph-data-configuration-model"
 import { GraphFilterFormulaAdapter } from "./models/graph-filter-formula-adapter"
 import { kGraphPointLayerType } from "./models/graph-point-layer-model"
-import { GraphComponent } from "./components/graph-component"
-import { GraphInspector } from "./components/graph-inspector"
-import GraphIcon from '../../assets/icons/icon-graph.svg'
-import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { v2GraphImporter } from "./v2-graph-importer"
 
 GraphFilterFormulaAdapter.register()
@@ -45,7 +50,12 @@ registerTileContentInfo({
   getTitle: (tile: ITileLikeModel) => {
     const data = isGraphContentModel(tile?.content) ? tile.content.dataset : undefined
     return tile.title || data?.title || ""
-  }
+  },
+  getFormulaAdapters: (node: IAnyStateTreeNode) => [
+    GraphFilterFormulaAdapter.get(node),
+    PlottedFunctionFormulaAdapter.get(node),
+    PlottedValueFormulaAdapter.get(node)
+  ]
 })
 
 registerTileComponentInfo({

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -4,7 +4,7 @@
  */
 import {cloneDeep} from "lodash"
 import {when} from "mobx"
-import {addDisposer, IAnyStateTreeNode, Instance, SnapshotIn, types} from "mobx-state-tree"
+import {addDisposer, Instance, SnapshotIn, types} from "mobx-state-tree"
 import { format } from "d3"
 import {IDataSet} from "../../../models/data/data-set"
 import {applyModelChange} from "../../../models/history/apply-model-change"
@@ -32,10 +32,6 @@ import {setNiceDomain} from "../utilities/graph-utils"
 import {GraphPointLayerModel, IGraphPointLayerModel, kGraphPointLayerType} from "./graph-point-layer-model"
 import {IAdornmentModel, IUpdateCategoriesOptions} from "../adornments/adornment-models"
 import {AdornmentsStore} from "../adornments/adornments-store"
-import { PlottedFunctionFormulaAdapter } from "../adornments/plotted-function/plotted-function-formula-adapter"
-import {
-  PlottedValueFormulaAdapter
-} from "../adornments/univariate-measures/plotted-value/plotted-value-formula-adapter"
 import {
   AxisModelUnion, EmptyAxisModel, IAxisModelUnion, isBaseNumericAxisModel, NumericAxisModel
 } from "../../axis/models/axis-model"
@@ -43,13 +39,6 @@ import { ICase } from "../../../models/data/data-set-types"
 import { isFiniteNumber } from "../../../utilities/math-utils"
 import { t } from "../../../utilities/translation/translate"
 import { CaseData } from "../../data-display/d3-types"
-import { GRAPH_FILTER_FORMULA_ADAPTER, GraphFilterFormulaAdapter } from "./graph-filter-formula-adapter"
-
-const getFormulaAdapters = (node?: IAnyStateTreeNode) => [
-  GraphFilterFormulaAdapter.get(GRAPH_FILTER_FORMULA_ADAPTER, node),
-  PlottedFunctionFormulaAdapter.get(node),
-  PlottedValueFormulaAdapter.get(node)
-]
 
 export interface GraphProperties {
   axes: Record<string, IAxisModelUnion>
@@ -70,7 +59,7 @@ export const NumberToggleModel = types
 export const GraphContentModel = DataDisplayContentModel
   .named("GraphContentModel")
   .props({
-    id: types.optional(types.identifier, () => typedId("GRCM")),
+    id: types.optional(types.string, () => typedId("GRCM")),
     type: types.optional(types.literal(kGraphTileType), kGraphTileType),
     adornmentsStore: types.optional(AdornmentsStore, () => AdornmentsStore.create()),
     // keys are AxisPlaces
@@ -268,8 +257,8 @@ export const GraphContentModel = DataDisplayContentModel
       when(
         () => getFormulaManager(self)?.areAdaptersInitialized ?? false,
         () => {
-          getFormulaAdapters(self).forEach(adapter => {
-            adapter?.addContentModel(self as IGraphContentModel)
+          self.formulaAdapters.forEach(adapter => {
+            adapter?.addContentModel(self)
           })
         }
       )
@@ -284,7 +273,7 @@ export const GraphContentModel = DataDisplayContentModel
       }, {name: "GraphContentModel.afterAttachToDocument.updateAdornments"}, self.dataConfiguration))
     },
     beforeDestroy() {
-      getFormulaAdapters(self).forEach(adapter => {
+      self.formulaAdapters.forEach(adapter => {
         adapter?.removeContentModel(self.id)
       })
     }

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -43,10 +43,10 @@ import { ICase } from "../../../models/data/data-set-types"
 import { isFiniteNumber } from "../../../utilities/math-utils"
 import { t } from "../../../utilities/translation/translate"
 import { CaseData } from "../../data-display/d3-types"
-import { GraphFilterFormulaAdapter } from "./graph-filter-formula-adapter"
+import { GRAPH_FILTER_FORMULA_ADAPTER, GraphFilterFormulaAdapter } from "./graph-filter-formula-adapter"
 
 const getFormulaAdapters = (node?: IAnyStateTreeNode) => [
-  GraphFilterFormulaAdapter.get(node),
+  GraphFilterFormulaAdapter.get(GRAPH_FILTER_FORMULA_ADAPTER, node),
   PlottedFunctionFormulaAdapter.get(node),
   PlottedValueFormulaAdapter.get(node)
 ]
@@ -269,7 +269,7 @@ export const GraphContentModel = DataDisplayContentModel
         () => getFormulaManager(self)?.areAdaptersInitialized ?? false,
         () => {
           getFormulaAdapters(self).forEach(adapter => {
-            adapter?.addGraphContentModel(self as IGraphContentModel)
+            adapter?.addContentModel(self as IGraphContentModel)
           })
         }
       )
@@ -285,7 +285,7 @@ export const GraphContentModel = DataDisplayContentModel
     },
     beforeDestroy() {
       getFormulaAdapters(self).forEach(adapter => {
-        adapter?.removeGraphContentModel(self.id)
+        adapter?.removeContentModel(self.id)
       })
     }
   }))

--- a/v3/src/components/graph/models/graph-filter-formula-adapter.ts
+++ b/v3/src/components/graph/models/graph-filter-formula-adapter.ts
@@ -1,60 +1,51 @@
-import { action, makeObservable, observable } from "mobx"
-import { IAnyStateTreeNode } from "mobx-state-tree"
-import { DEBUG_FORMULAS, debugLog } from "../../../lib/debug"
-import { ICase } from "../../../models/data/data-set-types"
+import { makeObservable } from "mobx"
 import { IFormula } from "../../../models/formula/formula"
 import { registerFormulaAdapter } from "../../../models/formula/formula-adapter-registry"
 import {
-  FormulaManagerAdapter, IFormulaAdapterApi, IFormulaContext, IFormulaExtraMetadata, IFormulaManagerAdapter
+  IFormulaAdapterApi, IFormulaContext, IFormulaManagerAdapter
 } from "../../../models/formula/formula-manager-types"
-import { FormulaMathJsScope } from "../../../models/formula/formula-mathjs-scope"
-import { math } from "../../../models/formula/functions/math"
-import { formulaError } from "../../../models/formula/utils/misc"
-import { getFormulaManager } from "../../../models/tiles/tile-environment"
 import { mstReaction } from "../../../utilities/mst-reaction"
 import { isFilterFormulaDataConfiguration } from "../../data-display/models/data-configuration-model"
 import type { IGraphContentModel } from "./graph-content-model"
+import { DataDisplayFilterFormulaAdapter, IDataDisplayFilterFormulaExtraMetadata }
+    from "../../data-display/models/data-display-filter-formula-adapter"
+import { kGraphTileType } from "../graph-defs"
 
-const GRAPH_FILTER_FORMULA_ADAPTER = "GraphFilterFormulaAdapter"
+export const GRAPH_FILTER_FORMULA_ADAPTER = "GraphFilterFormulaAdapter"
 
-export interface IGraphFilterFormulaExtraMetadata extends IFormulaExtraMetadata {
-  graphContentModelId: string
+export interface IGraphFilterFormulaExtraMetadata extends IDataDisplayFilterFormulaExtraMetadata {
 }
 
-export class GraphFilterFormulaAdapter extends FormulaManagerAdapter implements IFormulaManagerAdapter {
+export class GraphFilterFormulaAdapter extends DataDisplayFilterFormulaAdapter implements IFormulaManagerAdapter {
 
   static register() {
     registerFormulaAdapter(api => new GraphFilterFormulaAdapter(api))
   }
 
-  static get(node?: IAnyStateTreeNode) {
-    return getFormulaManager(node)?.adapters.find(({ type }) =>
-      type === GRAPH_FILTER_FORMULA_ADAPTER
-    ) as Maybe<GraphFilterFormulaAdapter>
-  }
 
-  @observable.shallow graphContentModels = new Map<string, IGraphContentModel>()
 
   constructor(api: IFormulaAdapterApi) {
     super(GRAPH_FILTER_FORMULA_ADAPTER, api)
     makeObservable(this)
   }
 
-  @action
-  addGraphContentModel(graphContentModel: IGraphContentModel) {
-    this.graphContentModels.set(graphContentModel.id, graphContentModel)
-  }
-
-  @action
-  removeGraphContentModel(graphContentModelId: string) {
-    this.graphContentModels.delete(graphContentModelId)
+  get graphContentModels() {
+    const graphContentModels: IGraphContentModel[] = []
+    // find all the map content models from the contentModels
+    this.contentModels.forEach(contentModel => {
+      if (contentModel.type === kGraphTileType) {
+        graphContentModels.push(contentModel as IGraphContentModel)
+      }
+    }
+    )
+    return graphContentModels
   }
 
   getGraphContentModel(extraMetadata: IGraphFilterFormulaExtraMetadata) {
-    const { graphContentModelId } = extraMetadata
-    const graphContentModel = this.graphContentModels.get(graphContentModelId)
+    const { contentModelId } = extraMetadata
+    const graphContentModel = this.getContentModel(extraMetadata)
     if (!graphContentModel) {
-      throw new Error(`GraphContentModel with id "${graphContentModelId}" not found`)
+      throw new Error(`GraphContentModel with id "${contentModelId}" not found`)
     }
     return graphContentModel
   }
@@ -73,7 +64,7 @@ export class GraphFilterFormulaAdapter extends FormulaManagerAdapter implements 
           formula: dataConfig.filterFormula,
           extraMetadata: {
             dataSetId: dataSet.id,
-            graphContentModelId: graphContentModel.id
+            contentModelId: graphContentModel.id
           }
         })
       }
@@ -81,102 +72,20 @@ export class GraphFilterFormulaAdapter extends FormulaManagerAdapter implements 
     return result
   }
 
-  recalculateFormula(formulaContext: IFormulaContext, extraMetadata: IGraphFilterFormulaExtraMetadata,
-    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
-    const dataConfig = this.getDataConfiguration(extraMetadata)
-
-    if (formulaContext.formula.empty) {
-      // if there is no filter formula, clear any filter results
-      dataConfig?.updateFilterFormulaResults([], { replaceAll: true })
-      return
-    }
-
-    // Clear any previous error first.
-    this.setFormulaError(formulaContext, extraMetadata, "")
-
-    if (!dataConfig) {
-      throw new Error(`GraphContentModel with id "${extraMetadata.graphContentModelId}" not found`)
-    }
-    const results = this.computeFormula(formulaContext, extraMetadata, casesToRecalculateDesc)
-    if (results && results.length > 0) {
-      dataConfig.updateFilterFormulaResults(results, { replaceAll: casesToRecalculateDesc === "ALL_CASES" })
-    }
-  }
-
-  computeFormula(formulaContext: IFormulaContext, extraMetadata: IGraphFilterFormulaExtraMetadata,
-    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
-    const { formula, dataSet } = formulaContext
-    const { attributeId } = extraMetadata
-    const dataConfig = this.getDataConfiguration(extraMetadata)
-
-    // Use visibleCaseIds to exclude hidden cases so they're not included in calculations,
-    // such as aggregate functions like mean.
-    const childMostCollectionCaseIds = [...dataConfig.visibleCaseIds]
-
-    let casesToRecalculate: string[] = []
-    if (casesToRecalculateDesc === "ALL_CASES") {
-      // If casesToRecalculate is not provided, recalculate all cases.
-      casesToRecalculate = childMostCollectionCaseIds
-    } else {
-      casesToRecalculate = casesToRecalculateDesc.map(c => c.__id__)
-    }
-
-    if (!casesToRecalculate || casesToRecalculate.length === 0) {
-      return
-    }
-
-    debugLog(
-      DEBUG_FORMULAS,
-      `[graph filter formula] recalculate "${formula.canonical}" for ${casesToRecalculate.length} cases`
-    )
-
-    const formulaScope = new FormulaMathJsScope({
-      localDataSet: dataSet,
-      dataSets: this.api.getDatasets(),
-      globalValueManager: this.api.getGlobalValueManager(),
-      formulaAttrId: attributeId,
-      caseIds: casesToRecalculate,
-      childMostCollectionCaseIds
-    })
-
-    try {
-      const compiledFormula = math.compile(formula.canonical)
-      return casesToRecalculate.map((c, idx) => {
-        formulaScope.setCasePointer(idx)
-        const formulaValue = compiledFormula.evaluate(formulaScope)
-        // This is necessary for functions like `prev` that need to know the previous result when they reference
-        // its own attribute.
-        formulaScope.savePreviousResult(formulaValue)
-        return {
-          itemId: c,
-          result: !!formulaValue // only boolean values are supported
-        }
-      })
-    } catch (e: any) {
-      return this.setFormulaError(formulaContext, extraMetadata, formulaError(e.message))
-    }
-  }
 
   // Error message is set as formula output, similarly as in CODAP V2.
-  setFormulaError(formulaContext: IFormulaContext, extraMetadata: IGraphFilterFormulaExtraMetadata, errorMsg: string) {
-    const dataConfig = this.getDataConfiguration(extraMetadata)
-    dataConfig.setFilterFormulaError(errorMsg)
-  }
 
-  getFormulaError(formulaContext: IFormulaContext, extraMetadata: IGraphFilterFormulaExtraMetadata) {
-    // No custom errors yet.
-    return undefined
-  }
 
   setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IGraphFilterFormulaExtraMetadata) {
-    const graphContent = this.graphContentModels.get(extraMetadata.graphContentModelId)
+    const graphContent = this.contentModels.get(extraMetadata.contentModelId)
+    const dataConfig = this.getDataConfiguration(extraMetadata)
     const disposer = graphContent && mstReaction(
-                      () => graphContent?.dataConfiguration.filterFormula?.display,
+                      () => dataConfig?.filterFormula?.display,
                       () => this.recalculateFormula(formulaContext, extraMetadata, "ALL_CASES"),
                       { name: "GraphFilterFormulaAdapter.reaction" }, graphContent)
     return () => {
       // if there is no filter formula, clear any filter results
-      graphContent?.dataConfiguration.updateFilterFormulaResults([], { replaceAll: true })
+      dataConfig?.updateFilterFormulaResults([], { replaceAll: true })
       disposer?.()
     }
   }

--- a/v3/src/components/map/map-registration.ts
+++ b/v3/src/components/map/map-registration.ts
@@ -1,11 +1,12 @@
 import { SetRequired } from "type-fest"
-import { registerComponentHandler } from "../../data-interactive/handlers/component-handler"
+import MapIcon from "../../assets/icons/icon-map.svg"
 import { V2Map } from "../../data-interactive/data-interactive-component-types"
+import { registerComponentHandler } from "../../data-interactive/handlers/component-handler"
+import { appState } from "../../models/app-state"
 import {
   getDataSetByNameOrId, getSharedCaseMetadataFromDataset, getSharedDataSets
 } from "../../models/shared/shared-data-utils"
 import { registerTileComponentInfo } from "../../models/tiles/tile-component-info"
-import { appState } from "../../models/app-state"
 import { ITileLikeModel, registerTileContentInfo } from "../../models/tiles/tile-content-info"
 import { t } from "../../utilities/translation/translate"
 import {registerV2TileImporter} from "../../v2/codap-v2-tile-importers"
@@ -13,22 +14,21 @@ import { ComponentTitleBar } from "../component-title-bar"
 import {
   AttributeDescriptionsMapSnapshot, kDataConfigurationType
 } from "../data-display/models/data-configuration-model"
+import { MapComponent } from "./components/map-component"
+import { MapInspector } from "./components/map-inspector"
 import {kMapIdPrefix, kMapTileClass, kMapTileType, kV2MapType} from "./map-defs"
 import {kDefaultMapHeight, kDefaultMapWidth, kMapPointLayerType, kMapPolygonLayerType} from "./map-types"
-import MapIcon from "../../assets/icons/icon-map.svg"
 import { IMapBaseLayerModelSnapshot } from "./models/map-base-layer-model"
 import { IMapPointLayerModelSnapshot } from "./models/map-point-layer-model"
 import { IMapPolygonLayerModelSnapshot } from "./models/map-polygon-layer-model"
 import {
   createMapContentModel, IMapModelContentSnapshot, isMapContentModel, MapContentModel
 } from "./models/map-content-model"
-import {MapComponent} from "./components/map-component"
-import {MapInspector} from "./components/map-inspector"
+import { MapFilterFormulaAdapter } from "./models/map-filter-formula-adapter"
 import {
   boundaryAttributeFromDataSet, datasetHasBoundaryData, datasetHasLatLongData, latLongAttributesFromDataSet
 } from "./utilities/map-utils"
 import {v2MapImporter} from "./v2-map-importer"
-import { MapFilterFormulaAdapter } from "./models/map-filter-formula-adapter"
 
 MapFilterFormulaAdapter.register()
 
@@ -40,7 +40,8 @@ registerTileContentInfo({
   defaultName: () => t("DG.DocumentController.mapTitle"),
   getTitle: (tile: ITileLikeModel) => {
     return tile.title || t("DG.DocumentController.mapTitle")
-  }
+  },
+  getFormulaAdapters: (node) => [MapFilterFormulaAdapter.get(node)]
 })
 
 registerTileComponentInfo({

--- a/v3/src/components/map/map-registration.ts
+++ b/v3/src/components/map/map-registration.ts
@@ -28,6 +28,9 @@ import {
   boundaryAttributeFromDataSet, datasetHasBoundaryData, datasetHasLatLongData, latLongAttributesFromDataSet
 } from "./utilities/map-utils"
 import {v2MapImporter} from "./v2-map-importer"
+import { MapFilterFormulaAdapter } from "./models/map-filter-formula-adapter"
+
+MapFilterFormulaAdapter.register()
 
 registerTileContentInfo({
   type: kMapTileType,

--- a/v3/src/components/map/models/map-content-model.ts
+++ b/v3/src/components/map/models/map-content-model.ts
@@ -20,12 +20,13 @@ import {isMapPointLayerModel, MapPointLayerModel} from "./map-point-layer-model"
 import {ILatLngSnapshot, LatLngModel} from '../map-model-types'
 import {LeafletMapState} from './leaflet-map-state'
 import {isMapLayerModel} from "./map-layer-model"
-import { MapFilterFormulaAdapter } from './map-filter-formula-adapter'
-import { typedId } from '../../../utilities/js-utils'
-import { IDataConfigurationModel } from '../../data-display/models/data-configuration-model'
+import {MAP_FILTER_FORMULA_ADAPTER} from './map-filter-formula-adapter'
+import {typedId} from '../../../utilities/js-utils'
+import {IDataConfigurationModel} from '../../data-display/models/data-configuration-model'
+import {DataDisplayFilterFormulaAdapter} from '../../data-display/models/data-display-filter-formula-adapter'
 
 const getFormulaAdapters = (node?: IAnyStateTreeNode) => [
-  MapFilterFormulaAdapter.get(node)
+  DataDisplayFilterFormulaAdapter.get(MAP_FILTER_FORMULA_ADAPTER, node)
 ]
 
 export const MapContentModel = DataDisplayContentModel
@@ -229,7 +230,7 @@ export const MapContentModel = DataDisplayContentModel
         () => getFormulaManager(self)?.areAdaptersInitialized ?? false,
         () => {
           getFormulaAdapters(self).forEach(adapter => {
-            adapter?.addMapContentModel(self as IMapContentModel)
+            adapter?.addContentModel(self as IMapContentModel)
           })
         }
       )
@@ -296,7 +297,7 @@ export const MapContentModel = DataDisplayContentModel
     },
     beforeDestroy() {
       getFormulaAdapters(self).forEach(adapter => {
-        adapter?.removeMapContentModel(self.id)
+        adapter?.removeContentModel(self.id)
       })
     }
   }))

--- a/v3/src/components/map/models/map-filter-formula-adapter.ts
+++ b/v3/src/components/map/models/map-filter-formula-adapter.ts
@@ -1,69 +1,75 @@
-import { action, makeObservable, observable } from "mobx"
-import { IAnyStateTreeNode } from "mobx-state-tree"
-import { DEBUG_FORMULAS, debugLog } from "../../../lib/debug"
-import { ICase } from "../../../models/data/data-set-types"
+import { makeObservable } from "mobx"
 import { IFormula } from "../../../models/formula/formula"
 import { registerFormulaAdapter } from "../../../models/formula/formula-adapter-registry"
 import {
-  FormulaManagerAdapter, IFormulaAdapterApi, IFormulaContext, IFormulaExtraMetadata, IFormulaManagerAdapter
+  IFormulaAdapterApi, IFormulaContext, IFormulaManagerAdapter
 } from "../../../models/formula/formula-manager-types"
-import { FormulaMathJsScope } from "../../../models/formula/formula-mathjs-scope"
-import { math } from "../../../models/formula/functions/math"
-import { formulaError } from "../../../models/formula/utils/misc"
-import { getFormulaManager } from "../../../models/tiles/tile-environment"
 import { mstReaction } from "../../../utilities/mst-reaction"
 import { isFilterFormulaDataConfiguration } from "../../data-display/models/data-configuration-model"
 import type { IMapContentModel } from "./map-content-model"
+import { DataDisplayFilterFormulaAdapter, IDataDisplayFilterFormulaExtraMetadata }
+    from "../../data-display/models/data-display-filter-formula-adapter"
+import { kMapTileType } from "../map-defs"
 
-const MAP_FILTER_FORMULA_ADAPTER = "MapFilterFormulaAdapter"
+export const MAP_FILTER_FORMULA_ADAPTER = "MapFilterFormulaAdapter"
 
-export interface IMapFilterFormulaExtraMetadata extends IFormulaExtraMetadata {
-  mapContentModelId: string
+export interface IMapFilterFormulaExtraMetadata extends IDataDisplayFilterFormulaExtraMetadata {
   mapLayerId: string
 }
 
-export class MapFilterFormulaAdapter extends FormulaManagerAdapter implements IFormulaManagerAdapter {
+export class MapFilterFormulaAdapter extends DataDisplayFilterFormulaAdapter implements IFormulaManagerAdapter {
 
   static register() {
     registerFormulaAdapter(api => new MapFilterFormulaAdapter(api))
   }
-
-  static get(node?: IAnyStateTreeNode) {
-    return getFormulaManager(node)?.adapters.find(({ type }) =>
-      type === MAP_FILTER_FORMULA_ADAPTER
-    ) as Maybe<MapFilterFormulaAdapter>
-  }
-
-  @observable.shallow mapContentModels = new Map<string, IMapContentModel>()
 
   constructor(api: IFormulaAdapterApi) {
     super(MAP_FILTER_FORMULA_ADAPTER, api)
     makeObservable(this)
   }
 
-  @action
-  addMapContentModel(mapContentModel: IMapContentModel) {
-    this.mapContentModels.set(mapContentModel.id, mapContentModel)
-  }
-
-  @action
-  removeMapContentModel(mapContentModelId: string) {
-    this.mapContentModels.delete(mapContentModelId)
-  }
-
-  getMapContentModel(extraMetadata: IMapFilterFormulaExtraMetadata) {
-    const { mapContentModelId } = extraMetadata
-    const mapContentModel = this.mapContentModels.get(mapContentModelId)
-    if (!mapContentModel) {
-      throw new Error(`MapContentModel with id "${mapContentModelId}" not found`)
+  get mapContentModels() {
+    const mapContentModels: IMapContentModel[] = []
+    // find all the map content models from the contentModels
+    this.contentModels.forEach(contentModel => {
+      if (contentModel.type === kMapTileType) {
+        mapContentModels.push(contentModel as IMapContentModel)
+      }
     }
-    return mapContentModel
+    )
+    return mapContentModels
+  }
+
+  getMapLayer(extraMetadata: IMapFilterFormulaExtraMetadata) {
+    const { mapLayerId } = extraMetadata
+    const mapContentModel = this.getContentModel(extraMetadata)
+    const mapLayer = mapContentModel.layers.find(l => l.id === mapLayerId)
+    if (!mapLayer) {
+      throw new Error(`MapLayer with id "${mapLayerId}" not found`)
+    }
+    return mapLayer
   }
 
   getDataConfiguration(extraMetadata: IMapFilterFormulaExtraMetadata) {
-    const contentModel = this.getMapContentModel(extraMetadata)
-    const mapLayer = contentModel.layers.find(l => l.id === extraMetadata.mapLayerId)
+    const mapLayer = this.getMapLayer(extraMetadata)
     return mapLayer?.dataConfiguration
+  }
+
+  createExtraMetadata(contentModel: IMapContentModel, dataSet: any) {
+    return {
+      dataSetId: dataSet.id,
+      contentModelId: contentModel.id,
+      mapLayerId: contentModel.layers[0].id, //TODO: currently only returns the first layer id
+    }
+  }
+
+  getMapContentModel(extraMetadata: IMapFilterFormulaExtraMetadata) {
+    const { contentModelId } = extraMetadata
+    const mapContentModel = this.contentModels.get(contentModelId)
+    if (!mapContentModel) {
+      throw new Error(`MapContentModel with id "${contentModelId}" not found`)
+    }
+    return mapContentModel
   }
 
   getActiveFormulas(): ({ formula: IFormula, extraMetadata: IMapFilterFormulaExtraMetadata })[] {
@@ -77,7 +83,7 @@ export class MapFilterFormulaAdapter extends FormulaManagerAdapter implements IF
             formula: dataConfig.filterFormula,
             extraMetadata: {
               dataSetId: dataSet.id,
-              mapContentModelId: mapContentModel.id,
+              contentModelId: mapContentModel.id,
               mapLayerId: layer.id
             }
           })
@@ -88,93 +94,8 @@ export class MapFilterFormulaAdapter extends FormulaManagerAdapter implements IF
     return result
   }
 
-  recalculateFormula(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata,
-    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
-    const dataConfig = this.getDataConfiguration(extraMetadata)
-    if (formulaContext.formula.empty) {
-      // if there is no filter formula, clear any filter results
-      dataConfig?.updateFilterFormulaResults([], { replaceAll: true })
-      return
-    }
-
-    // Clear any previous error first.
-    this.setFormulaError(formulaContext, extraMetadata, "")
-
-    if (!dataConfig) {
-      throw new Error(`MapContentModel with id "${extraMetadata.mapContentModelId}" not found`)
-    }
-    const results = this.computeFormula(formulaContext, extraMetadata, casesToRecalculateDesc)
-    if (results && results.length > 0) {
-      dataConfig.updateFilterFormulaResults(results, { replaceAll: casesToRecalculateDesc === "ALL_CASES" })
-    }
-  }
-
-  computeFormula(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata,
-    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
-    const { formula, dataSet } = formulaContext
-    const { attributeId } = extraMetadata
-    const dataConfig = this.getDataConfiguration(extraMetadata)
-    // Use visibleCaseIds to exclude hidden cases so they're not included in calculations,
-    // such as aggregate functions like mean.
-    const childMostCollectionCaseIds = dataConfig ? [...dataConfig.visibleCaseIds] : []
-
-    let casesToRecalculate: string[] = []
-    if (casesToRecalculateDesc === "ALL_CASES") {
-      // If casesToRecalculate is not provided, recalculate all cases.
-      casesToRecalculate = childMostCollectionCaseIds
-    } else {
-      casesToRecalculate = casesToRecalculateDesc.map(c => c.__id__)
-    }
-
-    if (!casesToRecalculate || casesToRecalculate.length === 0) {
-      return
-    }
-
-    debugLog(
-      DEBUG_FORMULAS,
-      `[map filter formula] recalculate "${formula.canonical}" for ${casesToRecalculate.length} cases`
-    )
-
-    const formulaScope = new FormulaMathJsScope({
-      localDataSet: dataSet,
-      dataSets: this.api.getDatasets(),
-      globalValueManager: this.api.getGlobalValueManager(),
-      formulaAttrId: attributeId,
-      caseIds: casesToRecalculate,
-      childMostCollectionCaseIds
-    })
-
-    try {
-      const compiledFormula = math.compile(formula.canonical)
-      return casesToRecalculate.map((c, idx) => {
-        formulaScope.setCasePointer(idx)
-        const formulaValue = compiledFormula.evaluate(formulaScope)
-        // This is necessary for functions like `prev` that need to know the previous result when they reference
-        // its own attribute.
-        formulaScope.savePreviousResult(formulaValue)
-        return {
-          itemId: c,
-          result: !!formulaValue // only boolean values are supported
-        }
-      })
-    } catch (e: any) {
-      return this.setFormulaError(formulaContext, extraMetadata, formulaError(e.message))
-    }
-  }
-
-  // Error message is set as formula output, similarly as in CODAP V2.
-  setFormulaError(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata, errorMsg: string) {
-    const dataConfig = this.getDataConfiguration(extraMetadata)
-    dataConfig?.setFilterFormulaError(errorMsg)
-  }
-
-  getFormulaError(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata) {
-    // No custom errors yet.
-    return undefined
-  }
-
   setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata) {
-    const mapContent = this.mapContentModels.get(extraMetadata.mapContentModelId)
+    const mapContent = this.contentModels.get(extraMetadata.contentModelId)
     const dataConfig = this.getDataConfiguration(extraMetadata)
     const disposer = mapContent && mstReaction(
                       () => dataConfig?.filterFormula?.display,

--- a/v3/src/components/map/models/map-filter-formula-adapter.ts
+++ b/v3/src/components/map/models/map-filter-formula-adapter.ts
@@ -1,0 +1,191 @@
+import { action, makeObservable, observable } from "mobx"
+import { IAnyStateTreeNode } from "mobx-state-tree"
+import { DEBUG_FORMULAS, debugLog } from "../../../lib/debug"
+import { ICase } from "../../../models/data/data-set-types"
+import { IFormula } from "../../../models/formula/formula"
+import { registerFormulaAdapter } from "../../../models/formula/formula-adapter-registry"
+import {
+  FormulaManagerAdapter, IFormulaAdapterApi, IFormulaContext, IFormulaExtraMetadata, IFormulaManagerAdapter
+} from "../../../models/formula/formula-manager-types"
+import { FormulaMathJsScope } from "../../../models/formula/formula-mathjs-scope"
+import { math } from "../../../models/formula/functions/math"
+import { formulaError } from "../../../models/formula/utils/misc"
+import { getFormulaManager } from "../../../models/tiles/tile-environment"
+import { mstReaction } from "../../../utilities/mst-reaction"
+import { isFilterFormulaDataConfiguration } from "../../data-display/models/data-configuration-model"
+import type { IMapContentModel } from "./map-content-model"
+
+const MAP_FILTER_FORMULA_ADAPTER = "MapFilterFormulaAdapter"
+
+export interface IMapFilterFormulaExtraMetadata extends IFormulaExtraMetadata {
+  mapContentModelId: string
+}
+
+export class MapFilterFormulaAdapter extends FormulaManagerAdapter implements IFormulaManagerAdapter {
+
+  static register() {
+    registerFormulaAdapter(api => new MapFilterFormulaAdapter(api))
+  }
+
+  static get(node?: IAnyStateTreeNode) {
+    return getFormulaManager(node)?.adapters.find(({ type }) =>
+      type === MAP_FILTER_FORMULA_ADAPTER
+    ) as Maybe<MapFilterFormulaAdapter>
+  }
+
+  @observable.shallow mapContentModels = new Map<string, IMapContentModel>()
+
+  constructor(api: IFormulaAdapterApi) {
+    super(MAP_FILTER_FORMULA_ADAPTER, api)
+    makeObservable(this)
+  }
+
+  @action
+  addMapContentModel(mapContentModel: IMapContentModel) {
+    console.log(" map addMapContentModel", mapContentModel)
+    this.mapContentModels.set(mapContentModel.layers[0].id, mapContentModel)
+  }
+
+  @action
+  removeMapContentModel(mapContentModelId: string) {
+    this.mapContentModels.delete(mapContentModelId)
+  }
+
+  getMapContentModel(extraMetadata: IMapFilterFormulaExtraMetadata) {
+    const { mapContentModelId } = extraMetadata
+    const mapContentModel = this.mapContentModels.get(mapContentModelId)
+    console.log("getMapContentModel", mapContentModel)
+    if (!mapContentModel) {
+      throw new Error(`MapContentModel with id "${mapContentModelId}" not found`)
+    }
+    return mapContentModel
+  }
+
+  getDataConfiguration(extraMetadata: IMapFilterFormulaExtraMetadata) {
+    console.log("getDataConfiguration", this.getMapContentModel(extraMetadata).layers[0].dataConfiguration)
+    return this.getMapContentModel(extraMetadata).layers[0].dataConfiguration
+  }
+
+  getActiveFormulas(): ({ formula: IFormula, extraMetadata: IMapFilterFormulaExtraMetadata })[] {
+    console.log("map getActiveFormulas")
+    const result: ({ formula: IFormula, extraMetadata: IMapFilterFormulaExtraMetadata })[] = []
+    this.mapContentModels.forEach(mapContentModel => {
+      const dataConfig = mapContentModel.layers[0].dataConfiguration
+      console.log("map getActiveFormulas dataConfig", dataConfig)
+      const dataSet = dataConfig?.dataset
+      if (dataSet && isFilterFormulaDataConfiguration(dataConfig)) {
+        result.push({
+          formula: dataConfig.filterFormula,
+          extraMetadata: {
+            dataSetId: dataSet.id,
+            mapContentModelId: mapContentModel.layers[0].id
+          }
+        })
+      }
+    })
+    console.log("map getActiveFormulas", result)
+
+    return result
+  }
+
+  recalculateFormula(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata,
+    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+      console.log("recalculateFormula", formulaContext, extraMetadata, casesToRecalculateDesc)
+    if (formulaContext.formula.empty) {
+      // if there is no filter formula, clear any filter results
+      dataConfig?.updateFilterFormulaResults([], { replaceAll: true })
+      return
+    }
+
+    // Clear any previous error first.
+    this.setFormulaError(formulaContext, extraMetadata, "")
+
+    if (!dataConfig) {
+      throw new Error(`MapContentModel with id "${extraMetadata.mapContentModelId}" not found`)
+    }
+    const results = this.computeFormula(formulaContext, extraMetadata, casesToRecalculateDesc)
+    if (results && results.length > 0) {
+      dataConfig.updateFilterFormulaResults(results, { replaceAll: casesToRecalculateDesc === "ALL_CASES" })
+    }
+  }
+
+  computeFormula(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata,
+    casesToRecalculateDesc: ICase[] | "ALL_CASES" = "ALL_CASES") {
+    const { formula, dataSet } = formulaContext
+    const { attributeId } = extraMetadata
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+console.log("computeFormula", formula, dataSet, attributeId, dataConfig)
+    // Use visibleCaseIds to exclude hidden cases so they're not included in calculations,
+    // such as aggregate functions like mean.
+    const childMostCollectionCaseIds = dataConfig ? [...dataConfig.visibleCaseIds] : []
+
+    let casesToRecalculate: string[] = []
+    if (casesToRecalculateDesc === "ALL_CASES") {
+      // If casesToRecalculate is not provided, recalculate all cases.
+      casesToRecalculate = childMostCollectionCaseIds
+    } else {
+      casesToRecalculate = casesToRecalculateDesc.map(c => c.__id__)
+    }
+
+    if (!casesToRecalculate || casesToRecalculate.length === 0) {
+      return
+    }
+
+    debugLog(
+      DEBUG_FORMULAS,
+      `[map filter formula] recalculate "${formula.canonical}" for ${casesToRecalculate.length} cases`
+    )
+
+    const formulaScope = new FormulaMathJsScope({
+      localDataSet: dataSet,
+      dataSets: this.api.getDatasets(),
+      globalValueManager: this.api.getGlobalValueManager(),
+      formulaAttrId: attributeId,
+      caseIds: casesToRecalculate,
+      childMostCollectionCaseIds
+    })
+
+    try {
+      const compiledFormula = math.compile(formula.canonical)
+      return casesToRecalculate.map((c, idx) => {
+        formulaScope.setCasePointer(idx)
+        const formulaValue = compiledFormula.evaluate(formulaScope)
+        // This is necessary for functions like `prev` that need to know the previous result when they reference
+        // its own attribute.
+        formulaScope.savePreviousResult(formulaValue)
+        return {
+          itemId: c,
+          result: !!formulaValue // only boolean values are supported
+        }
+      })
+    } catch (e: any) {
+      return this.setFormulaError(formulaContext, extraMetadata, formulaError(e.message))
+    }
+  }
+
+  // Error message is set as formula output, similarly as in CODAP V2.
+  setFormulaError(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata, errorMsg: string) {
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+    dataConfig?.setFilterFormulaError(errorMsg)
+  }
+
+  getFormulaError(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata) {
+    // No custom errors yet.
+    return undefined
+  }
+
+  setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IMapFilterFormulaExtraMetadata) {
+    const mapContent = this.mapContentModels.get(extraMetadata.mapContentModelId)
+    const dataConfig = this.getDataConfiguration(extraMetadata)
+    const disposer = mapContent && mstReaction(
+                      () => dataConfig?.filterFormula?.display,
+                      () => this.recalculateFormula(formulaContext, extraMetadata, "ALL_CASES"),
+                      { name: "MapFilterFormulaAdapter.reaction" }, mapContent)
+    return () => {
+      // if there is no filter formula, clear any filter results
+      dataConfig?.updateFilterFormulaResults([], { replaceAll: true })
+      disposer?.()
+    }
+  }
+}

--- a/v3/src/components/map/models/map-filter-formula-adapter.ts
+++ b/v3/src/components/map/models/map-filter-formula-adapter.ts
@@ -55,13 +55,6 @@ export class MapFilterFormulaAdapter extends DataDisplayFilterFormulaAdapter imp
     return mapLayer?.dataConfiguration
   }
 
-  createExtraMetadata(contentModel: IMapContentModel, dataSet: any) {
-    return {
-      dataSetId: dataSet.id,
-      contentModelId: contentModel.id,
-      mapLayerId: contentModel.layers[0].id, //TODO: currently only returns the first layer id
-    }
-  }
 
   getMapContentModel(extraMetadata: IMapFilterFormulaExtraMetadata) {
     const { contentModelId } = extraMetadata

--- a/v3/src/models/formula/formula-manager-types.ts
+++ b/v3/src/models/formula/formula-manager-types.ts
@@ -1,6 +1,7 @@
 import { BoundaryManager } from "../boundaries/boundary-manager"
 import { IDataSet } from "../data/data-set"
 import { IGlobalValueManager } from "../global/global-value-manager"
+import { ITileContentModel } from "../tiles/tile-content"
 import { IFormula } from "./formula"
 import { CaseList } from "./formula-types"
 
@@ -43,6 +44,14 @@ export class FormulaManagerAdapter implements IFormulaManagerAdapter {
     this.api = api
   }
 
+  addContentModel(tileContent: ITileContentModel) {
+    // subclasses should override if they deal with content models
+  }
+
+  removeContentModel(IMapContentModelId: string) {
+    // subclasses should override if they deal with content models
+  }
+
   getActiveFormulas() {
     // subclasses should override
     return [] as Array<{ formula: IFormula, extraMetadata: any }>
@@ -72,6 +81,8 @@ export interface IFormulaManagerAdapter {
   // This method returns all the formulas supported by this adapter. It should exclusively return formulas that need
   // active tracking and recalculation whenever any of their dependencies change. The adapter might opt not to return
   // formulas that currently shouldn't be recalculated, such as when the formula's adornment is hidden.
+  addContentModel: (contentModel: ITileContentModel) => void
+  removeContentModel: (IMapContentModelId: string) => void
   getActiveFormulas: () => ({ formula: IFormula, extraMetadata: any })[]
   recalculateFormula: (formulaContext: IFormulaContext, extraMetadata: any, casesToRecalculateDesc?: CaseList) => void
   getFormulaError: (formulaContext: IFormulaContext, extraMetadata: any) => Maybe<string>

--- a/v3/src/models/formula/formula-manager.test.ts
+++ b/v3/src/models/formula/formula-manager.test.ts
@@ -12,6 +12,8 @@ const getFakeAdapter = (formula: IFormula, dataSet: IDataSet) => {
   const activeFormulas = observable.box([formula])
   return {
     type: "fakeAdapter",
+    addContentModel: jest.fn(),
+    removeContentModel: jest.fn(),
     getActiveFormulas: jest.fn(() => {
       return activeFormulas.get().map(f => ({ formula: f, extraMetadata: { dataSetId: dataSet.id } }))
     }),

--- a/v3/src/models/tiles/tile-content-info.ts
+++ b/v3/src/models/tiles/tile-content-info.ts
@@ -1,7 +1,9 @@
-import { ITileMetadataModel, TileMetadataModel } from "./tile-metadata"
-import { TileContentModel, ITileContentSnapshotWithType, ITileContentModel } from "./tile-content"
+import { IAnyStateTreeNode } from "mobx-state-tree"
+import { FormulaManagerAdapter } from "../formula/formula-manager-types"
 import { AppConfigModelType } from "../stores/app-config-model"
+import { TileContentModel, ITileContentSnapshotWithType, ITileContentModel } from "./tile-content"
 import { ITileEnvironment } from "./tile-environment"
+import { ITileMetadataModel, TileMetadataModel } from "./tile-metadata"
 
 // avoids circular dependency on ITileModel
 export interface ITileLikeModel {
@@ -36,13 +38,14 @@ export interface ITileContentInfo {
   getTitle: (tile: ITileLikeModel) => string | undefined;
   getV2Type?: (content: ITileContentModel) => string;
   metadataClass?: typeof TileMetadataModel;
-  isSingleton?: boolean; // Only one instance of a tile is open per document (calculator and guide)
+  isSingleton?: boolean; // Only one instance of a tile is open per document (e.g. calculator and guide)
   hideOnClose?: boolean;
   addSidecarNotes?: boolean;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;
   tileSnapshotPreProcessor?: TileModelSnapshotPreProcessor;
   contentSnapshotPostProcessor?: TileContentSnapshotPostProcessor;
+  getFormulaAdapters?: (node: IAnyStateTreeNode) => Array<Maybe<FormulaManagerAdapter>>;
 }
 
 const gTileContentInfoMap: Record<string, ITileContentInfo> = {}


### PR DESCRIPTION
Adds a DataDisplayFilterFormulaAdapter as a base class for the new MapFilterFormulaAdapter and the refactored GraphFilterFormulaAdapter.
Adds a MapFilterFormulaAdapter to make the filter formula editor in the map functional. 
Note that the current implementation of the map filter formula editor only works for the first layer of the first dataset attached to the map.

Demo at https://codap3.concord.org/branch/map-filter-formula/#file=examples:Four%20Seals