### PR TITLE
Adds ability to rename attribute in formula editor modal.

### DIFF
--- a/v3/src/components/common/edit-attribute-formula-modal.tsx
+++ b/v3/src/components/common/edit-attribute-formula-modal.tsx
@@ -15,10 +15,13 @@ export const EditAttributeFormulaModal = observer(function EditAttributeFormulaM
   const attribute = dataSet?.attrFromID(attributeId)
   const value = attribute?.formula?.display
 
-  const applyFormula = (formula: string) => {
+  const applyFormula = (formula: string, attrName?: string) => {
     if (attribute) {
       dataSet?.applyModelChange(() => {
         attribute.setDisplayExpression(formula)
+        if (attrName && attrName !== attribute.name) {
+          attribute.name = attrName
+        }
       }, {
         // TODO Should also broadcast notify component edit formula notification
         notify: [

--- a/v3/src/components/common/edit-attribute-formula-modal.tsx
+++ b/v3/src/components/common/edit-attribute-formula-modal.tsx
@@ -20,7 +20,7 @@ export const EditAttributeFormulaModal = observer(function EditAttributeFormulaM
       dataSet?.applyModelChange(() => {
         attribute.setDisplayExpression(formula)
         if (attrName && attrName !== attribute.name) {
-          attribute.name = attrName
+          dataSet.setAttributeName(attributeId, attrName)
         }
       }, {
         // TODO Should also broadcast notify component edit formula notification

--- a/v3/src/components/common/edit-formula-modal.scss
+++ b/v3/src/components/common/edit-formula-modal.scss
@@ -28,13 +28,20 @@ $edit-formula-modal-min-width-px: #{$edit-formula-modal-min-width}px;
       flex-grow: 1;
       align-items: flex-start;
 
-      .title-label {
-        width: 140px;
+      .attr-name-form-label {
+        &.disabled {
+          opacity: 0.35;
+        }
       }
-      input {
-        max-width: 270px;
+
+      .title-label {
+        width: 90px;
+      }
+      .attr-name-input {
+        width: 270px;
         margin-right: 3px;
-        margin-left: 0
+        margin-left: 0;
+        padding-left: 5px;
       }
       .formula-editor-container {
         display: flex;

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -1,7 +1,7 @@
 import {
   Box, Button, Flex, FormControl, FormLabel, Input, ModalBody, ModalFooter, Tooltip
 } from "@chakra-ui/react"
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { isCommandKeyDown } from "../../utilities/platform-utils"
@@ -16,7 +16,7 @@ import ResizeHandle from "../../assets/icons/icon-corner-resize-handle.svg"
 import styles from './edit-formula-modal.scss'
 
 interface IProps {
-  applyFormula: (formula: string) => void
+  applyFormula: (formula: string, attrName: string) => void
   formulaPrompt?: string
   isOpen: boolean
   onClose?: () => void
@@ -42,13 +42,14 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   const { formula, setFormula } = formulaEditorState
   const [dimensions, setDimensions] = useState({ width: minWidth, height: minHeight })
   const editorHeight = dimensions.height - headerHeight - footerHeight - insertButtonsHeight
+  const attrInputRef = useRef("")
 
   useEffect(() => {
     setFormula(value || "")
   }, [value, setFormula])
 
   const applyAndClose = () => {
-    applyFormula(formula)
+    applyFormula(formula, attrInputRef.current)
     closeModal()
   }
 
@@ -124,6 +125,11 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     document.body.addEventListener("pointerup", onPointerUp, { capture: true })
   }, [dimensions.height, dimensions.width, minHeight, minWidth])
 
+  const handleAttributeNameInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const trimmedValue = (e.target.value).trim()
+    attrInputRef.current = trimmedValue
+  }
+
   return (
     <FormulaEditorContext.Provider value={formulaEditorState}>
       <CodapModal
@@ -135,15 +141,14 @@ export const EditFormulaModal = observer(function EditFormulaModal({
       >
         <ModalBody className="formula-modal-body" onKeyDown={handleKeyDown}>
           <FormControl display="flex" flexDirection="column" className="formula-form-control">
-            <FormLabel display="flex" flexDirection="row">
+            <FormLabel display="flex" flexDirection="row"
+                      className={clsx("attr-name-form-label", {"disabled": !titleInput})}>
               <span className="title-label">{titleLabel}</span>
-              <Input
-                size="xs"
-                ml={5}
-                placeholder={titlePlaceholder ?? ""}
-                value={titleInput ?? ""}
+              <input
+                className="attr-name-input"
+                defaultValue={titleInput}
                 data-testid="attr-name-input"
-                disabled
+                onBlur={handleAttributeNameInputBlur}
               />
               <span>=</span>
             </FormLabel>

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -126,7 +126,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   }, [dimensions.height, dimensions.width, minHeight, minWidth])
 
   const handleAttributeNameInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    const trimmedValue = (e.target.value).trim()
+    const trimmedValue = e.target.value.trim()
     attrInputRef.current = trimmedValue
   }
 


### PR DESCRIPTION
If formula editor modal is a filter formula, then attribute name input is disabled because we don't have an attribute.

Attribute name input was changed from ChakraUI Input to an html input tag because the ChakraUI Input kept stealing the focus from the formula editor.