### PR TITLE
feat: export text tile in v2 format

### DIFF
--- a/v3/src/components/text/text-defs.ts
+++ b/v3/src/components/text/text-defs.ts
@@ -1,3 +1,4 @@
 export const kTextTileType = "CodapText"
-export const kV2TextType = "text"
+export const kV2TextDGType = "DG.TextView"
+export const kV2TextDIType = "text"
 export const kTextTileClass = "codap-text"

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -5,7 +5,7 @@ import { kCaseTableTileType, kV2CaseTableType } from "../components/case-table/c
 import { kGraphTileType, kV2GraphType } from "../components/graph/graph-defs"
 import { kMapTileType, kV2MapType } from "../components/map/map-defs"
 import { kSliderTileType, kV2SliderType } from "../components/slider/slider-defs"
-import { kTextTileType, kV2TextType } from "../components/text/text-defs"
+import { kTextTileType, kV2TextDIType } from "../components/text/text-defs"
 import { kV2GameType, kV2WebViewType, kWebViewTileType } from "../components/web-view/web-view-defs"
 
 // export const kV2ImageType = "image"
@@ -20,7 +20,7 @@ export const kComponentTypeV3ToV2Map: Record<string, string> = {
   // kV2ImageType
   [kMapTileType]: kV2MapType,
   [kSliderTileType]: kV2SliderType,
-  [kTextTileType]: kV2TextType,
+  [kTextTileType]: kV2TextDIType,
   [kWebViewTileType]: kV2WebViewType
 }
 


### PR DESCRIPTION
[[PT-188616819]](https://www.pivotaltracker.com/story/show/188616819)

We also take this opportunity to change the way the slate value is stored in the model. Previously, we were storing the `JSON.stringify`ed value directly in the model. Now, we store it in the model as a `types.frozen<SlateExchangeValue>()` and just `JSON.stringify()`/`JSON.parse()` it on export/import. This should provide performance benefits (less `JSON.stringify`ing) as well as additional type-safety.