### PR TITLE
simplify plugin drop support

### DIFF
--- a/v3/src/components/web-view/web-view-drop-overlay.tsx
+++ b/v3/src/components/web-view/web-view-drop-overlay.tsx
@@ -23,16 +23,20 @@ export function WebViewDropOverlay() {
   const mouseX = useRef<number|undefined>()
   const mouseY = useRef<number|undefined>()
 
+  const sendNotification = (notification: INotification) => {
+    const { message, callback } = notification
+    tile?.content.broadcastMessage(message, callback ?? (() => null))
+  }
+
   // Broadcast dragstart and dragend notifications
   const handleDragStartEnd = (
     notification: (dataSet: IDataSet, attributeId: string) => INotification, _active: Active
   ) => {
     const _info = getDragAttributeInfo(_active)
     if (_info?.dataSet && _info.attributeId) {
-      tile?.applyModelChange(() => {}, {
-        notify: notification(_info.dataSet, _info.attributeId),
-        notifyTileId: tileId
-      })
+      sendNotification(
+        notification(_info.dataSet, _info.attributeId)
+      )
     }
   }
 
@@ -45,10 +49,9 @@ export function WebViewDropOverlay() {
   useDropHandler(dropId, (_active: Active) => {
     const { dataSet: dropDataSet, attributeId: dropAttributeId } = getDragAttributeInfo(_active) || {}
     if (dropDataSet && dropAttributeId && mouseX.current != null && mouseY.current != null) {
-      tile?.applyModelChange(() => {}, {
-        notify: dragWithPositionNotification("drop", dropDataSet, dropAttributeId, mouseX.current, mouseY.current),
-        notifyTileId: tileId
-      })
+      sendNotification(
+        dragWithPositionNotification("drop", dropDataSet, dropAttributeId, mouseX.current, mouseY.current)
+      )
     }
   })
 
@@ -62,10 +65,9 @@ export function WebViewDropOverlay() {
     const y = event.clientY - top
 
     if (mouseX.current !== x || mouseY.current !== y) {
-      tile?.applyModelChange(() => {}, {
-        notify: dragWithPositionNotification("drag", dataSet, attributeId, x, y),
-        notifyTileId: tileId
-      })
+      sendNotification(
+        dragWithPositionNotification("drag", dataSet, attributeId, x, y)
+      )
       mouseX.current = x
       mouseY.current = y
     }
@@ -73,10 +75,9 @@ export function WebViewDropOverlay() {
 
   // Broadcast dragenter and dragleave notifications
   const handlePointerEnterLeave = (operation: string) => {
-    tile?.applyModelChange(() => {}, {
-      notify: dragNotification(operation, dataSet, attributeId),
-      notifyTileId: tileId
-    })
+    sendNotification(
+      dragNotification(operation, dataSet, attributeId)
+    )
   }
 
   const setRef = (ref: HTMLDivElement) => {


### PR DESCRIPTION
This replaces the use of applyModelChange and just calls broadcastMessage directly on the tile.

The reason for tackling this is that I'm trying to type the `INotification`s better. Without the drag notification this type is pretty simple and consistent. So by having the drag notifications not use applyModelChange, it is now possible for applyModelChange to take a more restrictive and simple set of arguments.

With that change it is easier for a simple version of applyModelChange to be included in the CODAP "library" I'm trying to create. The basic idea is that this library would support a notification system which it uses internally. The system isn't specific to sending messages to data interactives, but that is the way it will be used when the components of the library are used within the main CODAP app.  

A further step could be removing the `notifyTileId` from the applyModelChange arguments. A tileId will not really have a meaning when the CODAP library is used outside of CODAP, but it is just a string so won't cause problems to leave it in.

This is the first in a series of PRs:
- https://github.com/concord-consortium/codap/pull/1724
- https://github.com/concord-consortium/codap/pull/1728