### PR TITLE
beginning of history service

### DIFF
--- a/v3/src/components/axis/models/axis-model.test.ts
+++ b/v3/src/components/axis/models/axis-model.test.ts
@@ -1,8 +1,10 @@
+import {getSnapshot, types} from "mobx-state-tree"
 import {
   AxisModel, AxisModelUnion, CategoricalAxisModel, EmptyAxisModel, IAxisModelUnion,
   isCategoricalAxisModel, isEmptyAxisModel, isNumericAxisModel, NumericAxisModel
 } from "./axis-model"
-import {getSnapshot, types} from "mobx-state-tree"
+
+import "../../../models/history/register-app-history-service"
 
 describe("AxisModel", () => {
   it("should error if AxisModel is instantiated directly", () => {

--- a/v3/src/components/case-card/case-card.tsx
+++ b/v3/src/components/case-card/case-card.tsx
@@ -12,9 +12,9 @@ import { excludeDragOverlayRegEx } from "../case-tile-common/case-tile-types"
 import { AttributeDragOverlay } from "../drag-drop/attribute-drag-overlay"
 import { CardView } from "./card-view"
 import { useCaseCardModel } from "./use-case-card-model"
+import { ICoreNotification } from "../../data-interactive/notification-core-types"
 import { IDataSet } from "../../models/data/data-set"
 import { ICollectionModel } from "../../models/data/collection"
-import { INotification } from "../../models/history/apply-model-change"
 import { createCollectionNotification, deleteCollectionNotification } from "../../models/data/data-set-notifications"
 import { logMessageWithReplacement } from "../../lib/log-message"
 
@@ -55,7 +55,7 @@ export const CaseCard = observer(function CaseCard({ setNodeRef }: IProps) {
         removedOldCollection = !!(oldCollectionId && !dataSet.getCollection(oldCollectionId))
       }, {
         notify: () => {
-          const notifications: INotification[] = []
+          const notifications: ICoreNotification[] = []
           if (removedOldCollection) notifications.push(deleteCollectionNotification(dataSet))
           if (collection) notifications.push(createCollectionNotification(collection, dataSet))
           return notifications

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -1,6 +1,7 @@
 import { useDndContext } from "@dnd-kit/core"
 import { observer } from "mobx-react-lite"
 import React, { useCallback, useEffect, useRef } from "react"
+import { ICoreNotification } from "../../data-interactive/notification-core-types"
 import { CollectionContext, ParentCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { getOverlayDragId } from "../../hooks/use-drag-drop"
@@ -10,7 +11,6 @@ import { logMessageWithReplacement } from "../../lib/log-message"
 import { ICollectionModel } from "../../models/data/collection"
 import { IDataSet } from "../../models/data/data-set"
 import { createCollectionNotification, deleteCollectionNotification } from "../../models/data/data-set-notifications"
-import { INotification } from "../../models/history/apply-model-change"
 import { mstReaction } from "../../utilities/mst-reaction"
 import { prf } from "../../utilities/profiler"
 import { excludeDragOverlayRegEx } from "../case-tile-common/case-tile-types"
@@ -110,7 +110,7 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
         removedOldCollection = !!(oldCollectionId && !dataSet.getCollection(oldCollectionId))
       }, {
         notify: () => {
-          const notifications: INotification[] = []
+          const notifications: ICoreNotification[] = []
           if (removedOldCollection) notifications.push(deleteCollectionNotification(dataSet))
           if (collection) notifications.push(createCollectionNotification(collection, dataSet))
           return notifications

--- a/v3/src/components/slider/slider-model.test.ts
+++ b/v3/src/components/slider/slider-model.test.ts
@@ -3,6 +3,8 @@ import { GlobalValue, IGlobalValue } from "../../models/global/global-value"
 import { isSliderModel, SliderModel } from "./slider-model"
 import { kDefaultAnimationDirection, kDefaultAnimationMode, kDefaultAnimationRate } from "./slider-types"
 
+import "../../models/history/register-app-history-service"
+
 describe("SliderModel", () => {
   const mockSharedModelManagerWithoutGlobalValueManager = {
     isReady: true,

--- a/v3/src/components/web-view/web-view-drop-overlay.tsx
+++ b/v3/src/components/web-view/web-view-drop-overlay.tsx
@@ -6,7 +6,7 @@ import {
   dragEndNotification, dragNotification, dragStartNotification, dragWithPositionNotification
 } from "../../lib/dnd-kit/dnd-notifications"
 import { IDataSet } from "../../models/data/data-set"
-import { INotification } from "../../models/history/apply-model-change"
+import { IFullNotification } from "../../data-interactive/notification-full-types"
 
 import "./web-view-drop-overlay.scss"
 
@@ -23,14 +23,14 @@ export function WebViewDropOverlay() {
   const mouseX = useRef<number|undefined>()
   const mouseY = useRef<number|undefined>()
 
-  const sendNotification = (notification: INotification) => {
+  const sendNotification = (notification: IFullNotification) => {
     const { message, callback } = notification
     tile?.content.broadcastMessage(message, callback ?? (() => null))
   }
 
   // Broadcast dragstart and dragend notifications
   const handleDragStartEnd = (
-    notification: (dataSet: IDataSet, attributeId: string) => INotification, _active: Active
+    notification: (dataSet: IDataSet, attributeId: string) => IFullNotification, _active: Active
   ) => {
     const _info = getDragAttributeInfo(_active)
     if (_info?.dataSet && _info.attributeId) {

--- a/v3/src/data-interactive/handlers/all-cases-handler.test.ts
+++ b/v3/src/data-interactive/handlers/all-cases-handler.test.ts
@@ -2,6 +2,8 @@ import { DIAllCases } from "../data-interactive-types"
 import { diAllCasesHandler } from "./all-cases-handler"
 import { setupTestDataset, testCases } from "./handler-test-utils"
 
+import "../../models/history/register-app-history-service"
+
 describe("DataInteractive AllCasesHandler", () => {
   const handler = diAllCasesHandler
 

--- a/v3/src/data-interactive/handlers/attribute-location-handler.test.ts
+++ b/v3/src/data-interactive/handlers/attribute-location-handler.test.ts
@@ -2,6 +2,8 @@ import { ICollectionModel } from "../../models/data/collection"
 import { diAttributeLocationHandler } from "./attribute-location-handler"
 import { setupTestDataset } from "./handler-test-utils"
 
+import "../../models/history/register-app-history-service"
+
 describe("DataInteractive AttributeLocationHandler", () => {
   const handler = diAttributeLocationHandler
 

--- a/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-id-handler.test.ts
@@ -3,6 +3,8 @@ import { DIGetCaseResult } from "../data-interactive-types"
 import { diCaseByIDHandler } from "./case-by-id-handler"
 import { setupForCaseTest } from "./handler-test-utils"
 
+import "../../models/history/register-app-history-service"
+
 describe("DataInteractive CaseByIDHandler", () => {
   const handler = diCaseByIDHandler
 

--- a/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-by-index-handler.test.ts
@@ -3,6 +3,8 @@ import { DIGetCaseResult } from "../data-interactive-types"
 import { diCaseByIndexHandler } from "./case-by-index-handler"
 import { setupForCaseTest } from "./handler-test-utils"
 
+import "../../models/history/register-app-history-service"
+
 describe("DataInteractive CaseByIndexHandler", () => {
   const handler = diCaseByIndexHandler
 

--- a/v3/src/data-interactive/handlers/case-handler.test.ts
+++ b/v3/src/data-interactive/handlers/case-handler.test.ts
@@ -3,6 +3,8 @@ import { DINewCase, DISuccessResult, DIValues } from "../data-interactive-types"
 import { diCaseHandler } from "./case-handler"
 import { setupTestDataset } from "./handler-test-utils"
 
+import "../../models/history/register-app-history-service"
+
 describe("DataInteractive CaseHandler", () => {
   const handler = diCaseHandler
 

--- a/v3/src/data-interactive/handlers/item-by-case-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-by-case-id-handler.test.ts
@@ -3,6 +3,7 @@ import { DIFullCase, DIItem, DIUpdateItemResult } from "../data-interactive-type
 import { setupTestDataset } from "./handler-test-utils"
 import { diItemByCaseIDHandler } from "./item-by-case-id-handler"
 
+import "../../models/history/register-app-history-service"
 
 describe("DataInteractive ItemByCaseIDHandler", () => {
   const handler = diItemByCaseIDHandler

--- a/v3/src/data-interactive/handlers/item-by-id-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-by-id-handler.test.ts
@@ -3,6 +3,7 @@ import { DIFullCase, DIItem, DIUpdateItemResult } from "../data-interactive-type
 import { setupTestDataset } from "./handler-test-utils"
 import { diItemByIDHandler } from "./item-by-id-handler"
 
+import "../../models/history/register-app-history-service"
 
 describe("DataInteractive ItemByIDHandler", () => {
   const handler = diItemByIDHandler

--- a/v3/src/data-interactive/handlers/item-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-handler.test.ts
@@ -3,6 +3,8 @@ import { DIFullCase, DIItem, DISuccessResult, DIUpdateItemResult } from "../data
 import { setupTestDataset } from "./handler-test-utils"
 import { diItemHandler } from "./item-handler"
 
+import "../../models/history/register-app-history-service"
+
 
 describe("DataInteractive ItemHandler", () => {
   const handler = diItemHandler

--- a/v3/src/data-interactive/handlers/item-search-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-search-handler.test.ts
@@ -3,6 +3,7 @@ import { DIFullCase } from "../data-interactive-types"
 import { setupTestDataset } from "./handler-test-utils"
 import { diItemSearchHandler } from "./item-search-handler"
 
+import "../../models/history/register-app-history-service"
 
 describe("DataInteractive ItemSearchHandler", () => {
   const handler = diItemSearchHandler

--- a/v3/src/data-interactive/notification-core-types.ts
+++ b/v3/src/data-interactive/notification-core-types.ts
@@ -1,0 +1,21 @@
+export interface IBasicNotificationValue {
+  operation: string
+  result: any
+}
+
+export interface IGlobalNotificationValue {
+  globalValue: number
+}
+
+export type ICoreNotificationMessageValues = IBasicNotificationValue | IGlobalNotificationValue
+
+export interface INotification<ValuesType> {
+  message: {
+    action: string
+    resource: string
+    values: ValuesType
+  }
+  callback?: (value: any) => void
+}
+
+export type ICoreNotification = INotification<ICoreNotificationMessageValues>

--- a/v3/src/data-interactive/notification-full-types.ts
+++ b/v3/src/data-interactive/notification-full-types.ts
@@ -1,0 +1,26 @@
+import { ICoreNotificationMessageValues, INotification } from "./notification-core-types"
+
+export interface IDragNotificationValue {
+    operation: string
+    text?: string
+    attribute: {
+      id: number
+      name?: string
+      title?: string
+    },
+    collection?: {
+      id: number
+      name: string
+      title: string
+    }
+    context: {
+      id: number
+      name: string
+      title: string
+    }
+    [key: string]: any
+  }
+
+  export type IFullNotificationMessageValues = ICoreNotificationMessageValues | IDragNotificationValue
+
+  export type IFullNotification = INotification<IFullNotificationMessageValues>

--- a/v3/src/lib/dnd-kit/dnd-notifications.ts
+++ b/v3/src/lib/dnd-kit/dnd-notifications.ts
@@ -1,3 +1,4 @@
+import { IDragNotificationValue } from "../../data-interactive/notification-full-types"
 import { IDataSet } from "../../models/data/data-set"
 import { toV2Id } from "../../utilities/codap-utils"
 import { DEBUG_PLUGINS, debugLog } from "../debug"
@@ -32,7 +33,7 @@ export function dragNotification(
   }
 
   const resource = `dragDrop[attribute]`
-  const values = { operation, text, attribute, collection, context, ...extraValues }
+  const values: IDragNotificationValue = { operation, text, attribute, collection, context, ...extraValues }
   const callback = _callback ?? makeCallback(operation)
   return { message: { action, resource, values }, callback }
 }

--- a/v3/src/models/data/data-set-utils.test.ts
+++ b/v3/src/models/data/data-set-utils.test.ts
@@ -3,6 +3,8 @@ import { ICollectionModel } from "./collection"
 import { DataSet, IDataSet } from "./data-set"
 import { getCollectionAttrs, moveAttribute } from "./data-set-utils"
 
+import "../history/register-app-history-service"
+
 function names(attrs: IAttribute[]) {
   return attrs.map(({ name }) => name)
 }

--- a/v3/src/models/document/document.ts
+++ b/v3/src/models/document/document.ts
@@ -12,6 +12,8 @@ import { ISharedModelDocumentManager } from "./shared-model-document-manager"
 import { typedId } from "../../utilities/js-utils"
 import { t } from "../../utilities/translation/translate"
 
+import "../history/register-app-history-service"
+
 export const DocumentModel = Tree.named("Document")
   .props({
     key: types.optional(types.identifier, () => typedId("DOC_")),

--- a/v3/src/models/history/apply-model-change.ts
+++ b/v3/src/models/history/apply-model-change.ts
@@ -1,17 +1,12 @@
-import iframePhone from "iframe-phone"
 import { IAnyStateTreeNode } from "mobx-state-tree"
-import { DIMessage } from "../../data-interactive/iframe-phone-types"
+import { ICoreNotification } from "../../data-interactive/notification-core-types"
 import { ILogMessage } from "../../lib/log-message"
-import { getTileEnvironment } from "../tiles/tile-environment"
-import { withUndoRedoStrings } from "./codap-undo-types"
-import { withoutUndo } from "./without-undo"
+import { getHistoryService } from "./history-service"
 
-export interface INotification {
-  message: DIMessage
-  callback?: iframePhone.ListenerCallback
-}
 export type INotify =
-  INotification | (INotification | (() => Maybe<INotification>))[] | (() => Maybe<INotification | INotification[]>)
+  ICoreNotification |
+  (ICoreNotification | (() => Maybe<ICoreNotification>))[] |
+  (() => Maybe<ICoreNotification | ICoreNotification[]>)
 export interface IApplyModelChangeOptions {
   log?: string | ILogMessage | (() => Maybe<string | ILogMessage>)
   notify?: INotify
@@ -19,51 +14,16 @@ export interface IApplyModelChangeOptions {
   undoStringKey?: string
   redoStringKey?: string
 }
+
 // returns an object which defines the `applyModelChange` method on an MST model
 // designed to be passed to `.actions()`, i.e. `.actions(applyModelChange)`
 export function applyModelChange(self: IAnyStateTreeNode) {
   return ({
     // performs the specified action so that response actions are included and undo/redo strings assigned
     applyModelChange<TResult = unknown>(actionFn: () => TResult, options?: IApplyModelChangeOptions) {
-      const { log, notify, notifyTileId, undoStringKey, redoStringKey } = options || {}
       const result = actionFn()
 
-      // Add strings to undoable action or keep out of the undo stack
-      if (undoStringKey != null && redoStringKey != null) {
-        withUndoRedoStrings(undoStringKey, redoStringKey)
-      } else {
-        withoutUndo()
-      }
-
-      const tileEnv = getTileEnvironment(self)
-      if (tileEnv) {
-        // Send log message to logger
-        if (tileEnv.log) {
-          const logInfo = typeof log === "function" ? log() : log
-          const logMessage = typeof logInfo === "string" ? { message: logInfo } : logInfo
-          if (logMessage) {
-            tileEnv.log(logMessage)
-          }
-        }
-
-        // Broadcast notifications to plugins
-        if (notify && tileEnv.notify) {
-          // Convert notifications to INotification[]
-          const actualNotifications = notify instanceof Function ? notify() : notify
-          if (actualNotifications) {
-            const notificationArray = Array.isArray(actualNotifications) ? actualNotifications : [actualNotifications]
-
-            // Actually broadcast the notifications
-            notificationArray.forEach(_notification => {
-              const __notification = typeof _notification === "function" ? _notification() : _notification
-              if (__notification) {
-                const { message, callback } = __notification
-                tileEnv.notify?.(message, callback ?? (() => null), notifyTileId)
-              }
-            })
-          }
-        }
-      }
+      getHistoryService().handleApplyModelChange(self, options)
 
       return result
     }

--- a/v3/src/models/history/history-service.ts
+++ b/v3/src/models/history/history-service.ts
@@ -1,0 +1,33 @@
+import { IAnyStateTreeNode } from "mobx-state-tree"
+import { ICoreNotification } from "../../data-interactive/notification-core-types"
+import { ILogMessage } from "../../lib/log-message"
+
+export type INotify =
+  ICoreNotification |
+  (ICoreNotification | (() => Maybe<ICoreNotification>))[] |
+  (() => Maybe<ICoreNotification | ICoreNotification[]>)
+
+export interface IApplyModelChangeOptions {
+  log?: string | ILogMessage | (() => Maybe<string | ILogMessage>)
+  notify?: INotify
+  notifyTileId?: string
+  undoStringKey?: string
+  redoStringKey?: string
+}
+
+export interface IHistoryService {
+  handleApplyModelChange: (mstNode: IAnyStateTreeNode, options?: IApplyModelChangeOptions) => void
+}
+
+const gHistoryServiceRef: {ref?: IHistoryService} = {}
+
+export function getHistoryService() {
+  if (!gHistoryServiceRef.ref) {
+    throw new Error("History Service must be registered before it is used")
+  }
+  return gHistoryServiceRef.ref
+}
+
+export function registerHistoryService(service: IHistoryService) {
+  gHistoryServiceRef.ref = service
+}

--- a/v3/src/models/history/register-app-history-service.ts
+++ b/v3/src/models/history/register-app-history-service.ts
@@ -1,0 +1,47 @@
+import { getTileEnvironment } from "../tiles/tile-environment"
+import { withUndoRedoStrings } from "./codap-undo-types"
+import { registerHistoryService } from "./history-service"
+import { withoutUndo } from "./without-undo"
+
+registerHistoryService({
+  handleApplyModelChange(mstNode, options) {
+    const { log, notify, notifyTileId, undoStringKey, redoStringKey } = options || {}
+
+    // Add strings to undoable action or keep out of the undo stack
+    if (undoStringKey != null && redoStringKey != null) {
+      withUndoRedoStrings(undoStringKey, redoStringKey)
+    } else {
+      withoutUndo()
+    }
+
+    const tileEnv = getTileEnvironment(mstNode)
+    if (tileEnv) {
+      // Send log message to logger
+      if (tileEnv.log) {
+        const logInfo = typeof log === "function" ? log() : log
+        const logMessage = typeof logInfo === "string" ? { message: logInfo } : logInfo
+        if (logMessage) {
+          tileEnv.log(logMessage)
+        }
+      }
+
+      // Broadcast notifications to plugins
+      if (notify && tileEnv.notify) {
+        // Convert notifications to INotification[]
+        const actualNotifications = notify instanceof Function ? notify() : notify
+        if (actualNotifications) {
+          const notificationArray = Array.isArray(actualNotifications) ? actualNotifications : [actualNotifications]
+
+          // Actually broadcast the notifications
+          notificationArray.forEach(_notification => {
+            const __notification = typeof _notification === "function" ? _notification() : _notification
+            if (__notification) {
+              const { message, callback } = __notification
+              tileEnv.notify?.(message, callback ?? (() => null), notifyTileId)
+            }
+          })
+        }
+      }
+    }
+  }
+})


### PR DESCRIPTION
The idea is that within CODAP the "app" history service will handle the applyModelChange. When the code is used outside of CODAP a no-op history service can be used.

Part of this work is also to type the INotification better. Instead of just using the iframePhone generic types, now the notifications are type specific to how CODAP is using them. The core of CODAP will work with ICoreNotifications. And then things like drag and drop support for iframes extend ICoreNotifications.  The rational is that the notification system isn't necessary specific to iframePhone or iframes at all. It is just a generic notification system which is then exposed to plugins via the iframe API.

When the tests are made part of the CODAP "library", instead of importing `models/history/register-app-history-service` they'd import a no-op history service. Or if they are actually checking the history then a simplified history service could be used.

A variation of this PR could be to register a default no-op history service. This would remove the need for most of the tests to import `models/history/register-app-history-service`.  However this will make it less obvious how to fix a new test that is expecting the history to work. So my preference is to fail fast and require the more explicit import.