### PR TITLE
fix: v2 text export

### DIFF
--- a/v3/src/components/text/text-registration.test.ts
+++ b/v3/src/components/text/text-registration.test.ts
@@ -11,7 +11,7 @@ import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
 import { CodapV2Document } from "../../v2/codap-v2-document"
 import { exportV2Component } from "../../v2/codap-v2-tile-exporters"
 import { importV2Component } from "../../v2/codap-v2-tile-importers"
-import { ICodapV2DocumentJson, isV2TextComponent } from "../../v2/codap-v2-types"
+import { ICodapV2DocumentJson, isV2TextComponent, V2SlateExchangeValue } from "../../v2/codap-v2-types"
 import { kTextTileType, kV2TextDGType } from "./text-defs"
 import { editorValueToModelValue, isTextModel, ITextModel } from "./text-model"
 import "./text-registration"
@@ -105,7 +105,9 @@ describe("Text registration", () => {
     const output = exportV2Component({ tile, row: freeTileRow })
     expect(output?.type).toBe(kV2TextDGType)
     const textTileOutput = isV2TextComponent(output!) ? output : undefined
-    const expectedTextOutput = JSON.stringify(editorValueToModelValue(textToSlate("")))
+    const expectedModelValue = editorValueToModelValue(textToSlate("")) as V2SlateExchangeValue
+    expectedModelValue.document.objTypes = { paragraph: "block" }
+    const expectedTextOutput = JSON.stringify(expectedModelValue)
     expect(textTileOutput?.componentStorage?.text).toBe(expectedTextOutput)
   })
 })

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -1,3 +1,4 @@
+import { Descendant, SlateExchangeValue } from "@concord-consortium/slate-editor"
 import { SetOptional } from "type-fest"
 import { AttributeType } from "../models/data/attribute-types"
 
@@ -820,6 +821,16 @@ export interface ICodapV2GuideStorage extends ICodapV2BaseComponentStorage {
   currentURL?: string
   // This appears 997 times in cfm-shared
   currentItemTitle?: string | null
+}
+
+export type V2TextObjTypesMap = Record<string, "block" | "inline">
+
+export interface V2SlateExchangeValue extends Omit<SlateExchangeValue, "document"> {
+  document: {
+    children: Descendant[]
+    // legacy v2 documents require an objTypes map property
+    objTypes: V2TextObjTypesMap
+  }
 }
 
 export interface ICodapV2TextStorage extends ICodapV2BaseComponentStorage {


### PR DESCRIPTION
[[PT-188616819]](https://www.pivotaltracker.com/story/show/188616819)

CODAP v2 is using an older version of the slate editor library that requires additional metadata to be exported.