### PR TITLE
fix: default name of text tile

### DIFF
--- a/v3/src/components/text/text-registration.ts
+++ b/v3/src/components/text/text-registration.ts
@@ -25,6 +25,7 @@ registerTileContentInfo({
   prefix: kTextIdPrefix,
   modelClass: TextModel,
   defaultContent: () => ({ type: kTextTileType }),
+  defaultName: () => t("DG.DocumentController.textTitle"),
   getTitle: (tile: ITileLikeModel) => {
     return tile.title || t("DG.DocumentController.textTitle")
   }


### PR DESCRIPTION
[[PT-188616819]](https://www.pivotaltracker.com/story/show/188616819/comments/243450794)

Fixes default name issue logged in testing of v2 text tile export. Technically, it was a tile initialization bug that was revealed by v2 export rather than a bug in the export code, but the effect was the same.