### PR TITLE
make TileContentModel more independent

### DIFF
--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -11,8 +11,7 @@ import {applyModelChange} from "../../../models/history/apply-model-change"
 import {
   getDataSetFromId, getSharedCaseMetadataFromDataset, getTileCaseMetadata, getTileDataSet
 } from "../../../models/shared/shared-data-utils"
-import {ISharedModel} from "../../../models/shared/shared-model"
-import {SharedModelChangeType} from "../../../models/shared/shared-model-manager"
+import {ISharedModel, SharedModelChangeType} from "../../../models/shared/shared-model"
 import {ITileContentModel} from "../../../models/tiles/tile-content"
 import { getFormulaManager } from "../../../models/tiles/tile-environment"
 import {typedId} from "../../../utilities/js-utils"

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -1,11 +1,9 @@
-import iframePhone from "iframe-phone"
 import { Instance, SnapshotIn } from "mobx-state-tree"
 import { BaseDocumentContentModel } from "./base-document-content"
 import { urlParams } from "../../utilities/url-params"
 import { isFreeTileLayout, isFreeTileRow } from "./free-tile-row"
 import { kTitleBarHeight } from "../../components/constants"
 import { kCaseTableTileType } from "../../components/case-table/case-table-defs"
-import { DIMessage } from "../../data-interactive/iframe-phone-types"
 import { getTileComponentInfo } from "../tiles/tile-component-info"
 import { getFormulaManager, getSharedModelManager, getTileEnvironment } from "../tiles/tile-environment"
 import { getTileContentInfo } from "../tiles/tile-content-info"
@@ -19,6 +17,7 @@ import { applyModelChange } from "../history/apply-model-change"
 import { SharedCaseMetadata } from "../shared/shared-case-metadata"
 import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
 import { getSharedDataSets, linkTileToDataSet } from "../shared/shared-data-utils"
+import { TileBroadcastCallback, TileBroadcastMessage } from "../tiles/tile-content"
 
 /**
  * The DocumentContentModel is the combination of 2 parts:
@@ -78,7 +77,7 @@ export const DocumentContentModel = BaseDocumentContentModel
       // complete serialization for each row
       self.rowMap.forEach(row => row.completeSnapshot())
     },
-    broadcastMessage(message: DIMessage, callback: iframePhone.ListenerCallback, targetTileId?: string) {
+    broadcastMessage(message: TileBroadcastMessage, callback: TileBroadcastCallback, targetTileId?: string) {
       const tileIds = self.tileMap.keys()
       if (tileIds) {
         Array.from(tileIds).forEach(tileId => {

--- a/v3/src/models/shared/shared-model-manager.ts
+++ b/v3/src/models/shared/shared-model-manager.ts
@@ -44,8 +44,6 @@ export const UnknownSharedModel = types.snapshotProcessor(_UnknownSharedModel, {
   }
 })
 
-export type SharedModelChangeType = "link" | "change" | "unlink"
-
 /**
  * An instance of this interface should be provided to tiles so they can interact
  * with shared models.

--- a/v3/src/models/shared/shared-model.ts
+++ b/v3/src/models/shared/shared-model.ts
@@ -2,6 +2,7 @@ import { Instance, types } from "mobx-state-tree"
 import { typedId } from "../../utilities/js-utils"
 
 export const kUnknownSharedModel = "unknownSharedModel"
+export type SharedModelChangeType = "link" | "change" | "unlink"
 
 // Generic "super class" of all shared models
 export const SharedModel = types.model("SharedModel", {

--- a/v3/src/models/tiles/tile-content.ts
+++ b/v3/src/models/tiles/tile-content.ts
@@ -1,13 +1,13 @@
-import iframePhone from "iframe-phone"
 import { getSnapshot, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { SetRequired } from "type-fest"
-import { DIMessage } from "../../data-interactive/iframe-phone-types"
 import { applyModelChange } from "../history/apply-model-change"
-import { ISharedModel } from "../shared/shared-model"
-import { SharedModelChangeType } from "../shared/shared-model-manager"
+import { ISharedModel, SharedModelChangeType } from "../shared/shared-model"
 import { getTileEnvironment, ITileEnvironment } from "./tile-environment"
 import { tileModelHooks } from "./tile-model-hooks"
 import { kUnknownTileType } from "./unknown-types"
+
+export type TileBroadcastMessage = any
+export type TileBroadcastCallback = (value: any) => void
 
 // Generic "super class" of all tile content models
 export const TileContentModel = types.model("TileContentModel", {
@@ -76,7 +76,7 @@ export const TileContentModel = types.model("TileContentModel", {
     updateAfterSharedModelChanges(sharedModel: ISharedModel | undefined, type: SharedModelChangeType) {
       console.warn("updateAfterSharedModelChanges not implemented for:", self.type)
     },
-    broadcastMessage(message: DIMessage, callback: iframePhone.ListenerCallback) {
+    broadcastMessage(message: TileBroadcastMessage, callback: TileBroadcastCallback) {
       // Override in derived models as appropriate
     }
   }))


### PR DESCRIPTION
This removes the dependency on iframe-phone and shared-model-manager.

The tile-environment still brings in more dependencies, but that should be taken care of in a future PR.