### PR TITLE
HistoryService take 2

### DIFF
--- a/v3/src/components/axis/models/axis-model.test.ts
+++ b/v3/src/components/axis/models/axis-model.test.ts
@@ -1,8 +1,9 @@
+import {getSnapshot, types} from "mobx-state-tree"
 import {
   AxisModel, AxisModelUnion, CategoricalAxisModel, EmptyAxisModel, IAxisModelUnion,
   isCategoricalAxisModel, isEmptyAxisModel, isNumericAxisModel, NumericAxisModel
 } from "./axis-model"
-import {getSnapshot, types} from "mobx-state-tree"
+import { AppHistoryService } from "../../../models/history/app-history-service"
 
 describe("AxisModel", () => {
   it("should error if AxisModel is instantiated directly", () => {
@@ -53,7 +54,8 @@ describe("NumericAxisModel", () => {
     expect(NumericAxisModel.create({ place: "left", min: 0, max: 10 }).orientation).toBe("vertical")
   })
   it("should set domain without undo and with undo", () => {
-    const aModel = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
+    const aModel = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 },
+      {historyService: new AppHistoryService()})
     aModel.setDynamicDomain(10, 20)
     expect(aModel.isUpdatingDynamically).toBe(true)
     expect(aModel.domain).toEqual([10, 20])

--- a/v3/src/components/case-card/case-card.tsx
+++ b/v3/src/components/case-card/case-card.tsx
@@ -13,9 +13,9 @@ import { AttributeDragOverlay } from "../drag-drop/attribute-drag-overlay"
 import { CardView } from "./card-view"
 import { FilterFormulaBar } from "../case-tile-common/filter-formula-bar"
 import { useCaseCardModel } from "./use-case-card-model"
+import { ICoreNotification } from "../../data-interactive/notification-core-types"
 import { IDataSet } from "../../models/data/data-set"
 import { ICollectionModel } from "../../models/data/collection"
-import { INotification } from "../../models/history/apply-model-change"
 import { createCollectionNotification, deleteCollectionNotification } from "../../models/data/data-set-notifications"
 import { logMessageWithReplacement } from "../../lib/log-message"
 
@@ -56,7 +56,7 @@ export const CaseCard = observer(function CaseCard({ setNodeRef }: IProps) {
         removedOldCollection = !!(oldCollectionId && !dataSet.getCollection(oldCollectionId))
       }, {
         notify: () => {
-          const notifications: INotification[] = []
+          const notifications: ICoreNotification[] = []
           if (removedOldCollection) notifications.push(deleteCollectionNotification(dataSet))
           if (collection) notifications.push(createCollectionNotification(collection, dataSet))
           return notifications

--- a/v3/src/components/case-card/case-card.v2.test.tsx
+++ b/v3/src/components/case-card/case-card.v2.test.tsx
@@ -8,6 +8,7 @@ import { DGDataContext } from "../../models/v2/dg-data-context"
 import { t } from "../../utilities/translation/translate"
 import "./case-card.v2"
 import { SharedCaseMetadata } from "../../models/shared/shared-case-metadata"
+import { AppHistoryService } from "../../models/history/app-history-service"
 const { CaseCard } = DG.React as any
 
 describe("CaseCard component", () => {
@@ -25,7 +26,7 @@ describe("CaseCard component", () => {
   it("renders a flat data set", async () => {
     const data = createDataSet({
       attributes: [{ id: "AttrId", name: "AttrName" }]
-    })
+    }, {historyService: new AppHistoryService()})
     data.addCases([{ __id__: "Case1", AttrId: "foo" }, { __id__: "Case2", AttrId: "bar" }])
     const context = new DGDataContext(data)
     const metadata = SharedCaseMetadata.create()
@@ -168,7 +169,7 @@ describe("CaseCard component", () => {
         { id: "Attr1Id", name: "Attr1Name" },
         { id: "Attr2Id", name: "Attr2Name" }
       ]
-    })
+    }, {historyService: new AppHistoryService()})
     const metadata = SharedCaseMetadata.create()
     data.addCases([
       { __id__: "Case1", Attr1Id: "foo", Attr2Id: 1 },

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -1,6 +1,7 @@
 import { useDndContext } from "@dnd-kit/core"
 import { observer } from "mobx-react-lite"
 import React, { useCallback, useEffect, useRef } from "react"
+import { ICoreNotification } from "../../data-interactive/notification-core-types"
 import { CollectionContext, ParentCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { getOverlayDragId } from "../../hooks/use-drag-drop"
@@ -10,7 +11,6 @@ import { logMessageWithReplacement } from "../../lib/log-message"
 import { ICollectionModel } from "../../models/data/collection"
 import { IDataSet } from "../../models/data/data-set"
 import { createCollectionNotification, deleteCollectionNotification } from "../../models/data/data-set-notifications"
-import { INotification } from "../../models/history/apply-model-change"
 import { mstReaction } from "../../utilities/mst-reaction"
 import { prf } from "../../utilities/profiler"
 import { excludeDragOverlayRegEx } from "../case-tile-common/case-tile-types"
@@ -111,7 +111,7 @@ export const CaseTable = observer(function CaseTable({ setNodeRef }: IProps) {
         removedOldCollection = !!(oldCollectionId && !dataSet.getCollection(oldCollectionId))
       }, {
         notify: () => {
-          const notifications: INotification[] = []
+          const notifications: ICoreNotification[] = []
           if (removedOldCollection) notifications.push(deleteCollectionNotification(dataSet))
           if (collection) notifications.push(createCollectionNotification(collection, dataSet))
           return notifications

--- a/v3/src/components/case-table/cell-text-editor.test.tsx
+++ b/v3/src/components/case-table/cell-text-editor.test.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { DataSet } from "../../models/data/data-set"
 import { TCalculatedColumn } from "./case-table-types"
 import CellTextEditor from "./cell-text-editor"
+import { AppHistoryService } from "../../models/history/app-history-service"
 const mockUseDataSetContext = jest.fn()
 jest.mock("../../hooks/use-data-set-context", () => ({
   useDataSetContext: () => mockUseDataSetContext()
@@ -31,7 +32,7 @@ describe("CellTextEditor", () => {
 
   it("should render with dataset", async () => {
     const user = userEvent.setup()
-    const data = DataSet.create({ name: "data" })
+    const data = DataSet.create({ name: "data" }, {historyService: new AppHistoryService()})
     data.addAttribute({ id: "columnKey", name: "columnName" })
     data.addCases([{ columnKey: "1" }])
     mockUseDataSetContext.mockImplementation(() => data)

--- a/v3/src/components/slider/slider-model.test.ts
+++ b/v3/src/components/slider/slider-model.test.ts
@@ -2,6 +2,7 @@ import { destroy, types } from "mobx-state-tree"
 import { GlobalValue, IGlobalValue } from "../../models/global/global-value"
 import { isSliderModel, SliderModel } from "./slider-model"
 import { kDefaultAnimationDirection, kDefaultAnimationMode, kDefaultAnimationRate } from "./slider-types"
+import { AppHistoryService } from "../../models/history/app-history-service"
 
 describe("SliderModel", () => {
   const mockSharedModelManagerWithoutGlobalValueManager = {
@@ -91,7 +92,7 @@ describe("SliderModel", () => {
     const tree = Tree.create({
       globalValue: g1,
       sliderModel: { globalValue: g1.id }
-    })
+    }, {historyService: new AppHistoryService()})
     const slider = tree.sliderModel
     expect(slider.isUpdatingDynamically).toBe(false)
     const initialValue = slider.value

--- a/v3/src/components/web-view/web-view-drop-overlay.tsx
+++ b/v3/src/components/web-view/web-view-drop-overlay.tsx
@@ -6,7 +6,7 @@ import {
   dragEndNotification, dragNotification, dragStartNotification, dragWithPositionNotification
 } from "../../lib/dnd-kit/dnd-notifications"
 import { IDataSet } from "../../models/data/data-set"
-import { INotification } from "../../models/history/apply-model-change"
+import { IFullNotification } from "../../data-interactive/notification-full-types"
 
 import "./web-view-drop-overlay.scss"
 
@@ -23,14 +23,14 @@ export function WebViewDropOverlay() {
   const mouseX = useRef<number|undefined>()
   const mouseY = useRef<number|undefined>()
 
-  const sendNotification = (notification: INotification) => {
+  const sendNotification = (notification: IFullNotification) => {
     const { message, callback } = notification
     tile?.content.broadcastMessage(message, callback ?? (() => null))
   }
 
   // Broadcast dragstart and dragend notifications
   const handleDragStartEnd = (
-    notification: (dataSet: IDataSet, attributeId: string) => INotification, _active: Active
+    notification: (dataSet: IDataSet, attributeId: string) => IFullNotification, _active: Active
   ) => {
     const _info = getDragAttributeInfo(_active)
     if (_info?.dataSet && _info.attributeId) {

--- a/v3/src/data-interactive/handlers/attribute-handler.test.ts
+++ b/v3/src/data-interactive/handlers/attribute-handler.test.ts
@@ -3,6 +3,7 @@ import { diAttributeHandler } from "./attribute-handler"
 import { DIResultAttributes } from "../data-interactive-types"
 import { DataSet } from "../../models/data/data-set"
 import { setupTestDataset } from "./handler-test-utils"
+import { AppHistoryService } from "../../models/history/app-history-service"
 
 describe("DataInteractive AttributeHandler", () => {
   const handler = diAttributeHandler
@@ -95,7 +96,7 @@ describe("DataInteractive AttributeHandler", () => {
 
   it("delete works as expected", () => {
     const attribute = Attribute.create({ name: "name" })
-    const dataContext = DataSet.create({})
+    const dataContext = DataSet.create({}, {historyService: new AppHistoryService()})
     dataContext.addAttribute(attribute)
     expect(dataContext.attributes.length).toBe(1)
     expect(handler.delete?.({ dataContext }).success).toEqual(false)

--- a/v3/src/data-interactive/handlers/handler-test-utils.ts
+++ b/v3/src/data-interactive/handlers/handler-test-utils.ts
@@ -1,4 +1,5 @@
 import { DataSet } from "../../models/data/data-set"
+import { AppHistoryService } from "../../models/history/app-history-service"
 
 export const testCases = [
   { a1: "a", a2: "x", a3: 1, a4: -1 },
@@ -19,7 +20,7 @@ export const setupTestDataset = (options?: ITestDatasetOptions) => {
       { name: "collection2" },
       { name: "collection3" }
     ]
-  })
+  }, {historyService: new AppHistoryService()})
   const [c1, c2] = dataset.collections
   const a1 = dataset.addAttribute({ name: "a1" }, { collection: c1.id })
   const a2 = dataset.addAttribute({ name: "a2" }, { collection: c2.id })

--- a/v3/src/data-interactive/handlers/selection-list-handler.test.ts
+++ b/v3/src/data-interactive/handlers/selection-list-handler.test.ts
@@ -1,4 +1,5 @@
 import { DataSet, IDataSet } from "../../models/data/data-set"
+import { AppHistoryService } from "../../models/history/app-history-service"
 import { toV2Id } from "../../utilities/codap-utils"
 import { DICase, DIValues } from "../data-interactive-types"
 import { diSelectionListHandler } from "./selection-list-handler"
@@ -11,7 +12,7 @@ describe("DataInteractive SelectionListHandler", () => {
   const caseId2 = "case2"
   const caseIdUnused = "unused"
   beforeEach(function() {
-    dataset = DataSet.create({ name: "data" })
+    dataset = DataSet.create({ name: "data" }, {historyService: new AppHistoryService()})
     dataset.addCases([{ __id__: caseId1 }, { __id__: caseId2 }])
     dataset.validateCases()
   })

--- a/v3/src/data-interactive/notification-core-types.ts
+++ b/v3/src/data-interactive/notification-core-types.ts
@@ -1,0 +1,31 @@
+export interface IBasicNotificationValue {
+  operation: string
+  result: any
+}
+
+export interface IGlobalNotificationValue {
+  globalValue: number
+}
+
+export type ICoreNotificationMessageValues = IBasicNotificationValue | IGlobalNotificationValue
+
+type NotificationCallback = (value: any) => void
+
+export interface INotification<ValuesType> {
+  message: {
+    action: string
+    resource: string
+    values: ValuesType
+  }
+  callback?: NotificationCallback
+}
+
+export type ICoreNotification = INotification<ICoreNotificationMessageValues>
+
+export interface ICoreNotifyFunctionEnv {
+  notify: (
+    message: ICoreNotification["message"],
+    callback: NotificationCallback,
+    notifyTileId?: string
+  ) => void
+}

--- a/v3/src/data-interactive/notification-full-types.ts
+++ b/v3/src/data-interactive/notification-full-types.ts
@@ -1,0 +1,26 @@
+import { ICoreNotificationMessageValues, INotification } from "./notification-core-types"
+
+export interface IDragNotificationValue {
+    operation: string
+    text?: string
+    attribute: {
+      id: number
+      name?: string
+      title?: string
+    },
+    collection?: {
+      id: number
+      name: string
+      title: string
+    }
+    context: {
+      id: number
+      name: string
+      title: string
+    }
+    [key: string]: any
+  }
+
+  export type IFullNotificationMessageValues = ICoreNotificationMessageValues | IDragNotificationValue
+
+  export type IFullNotification = INotification<IFullNotificationMessageValues>

--- a/v3/src/lib/dnd-kit/dnd-notifications.ts
+++ b/v3/src/lib/dnd-kit/dnd-notifications.ts
@@ -1,3 +1,4 @@
+import { IDragNotificationValue } from "../../data-interactive/notification-full-types"
 import { IDataSet } from "../../models/data/data-set"
 import { toV2Id } from "../../utilities/codap-utils"
 import { DEBUG_PLUGINS, debugLog } from "../debug"
@@ -32,7 +33,7 @@ export function dragNotification(
   }
 
   const resource = `dragDrop[attribute]`
-  const values = { operation, text, attribute, collection, context, ...extraValues }
+  const values: IDragNotificationValue = { operation, text, attribute, collection, context, ...extraValues }
   const callback = _callback ?? makeCallback(operation)
   return { message: { action, resource, values }, callback }
 }

--- a/v3/src/lib/log-message.ts
+++ b/v3/src/lib/log-message.ts
@@ -10,6 +10,10 @@ export interface ILogMessage {
   category?: AnalyticsCategory;
 }
 
+export interface ILogFunctionEnv {
+  log: (message: ILogMessage) => void
+}
+
 export type LogMessageFn = () => ILogMessage
 
 // e.g. logMessageWithReplacement("Moved category %@ into position of %@", { movedCat: string, targetCat: string })

--- a/v3/src/models/data/data-set-utils.test.ts
+++ b/v3/src/models/data/data-set-utils.test.ts
@@ -1,3 +1,4 @@
+import { AppHistoryService } from "../history/app-history-service"
 import { IAttribute } from "./attribute"
 import { ICollectionModel } from "./collection"
 import { DataSet, IDataSet } from "./data-set"
@@ -33,7 +34,7 @@ describe("DataSetUtils", () => {
   })
 
   it("moveAttribute works as expected", () => {
-    const data = DataSet.create()
+    const data = DataSet.create(undefined, {historyService: new AppHistoryService()})
     const parentCollection = data.addCollection({ id: "parentColl" })
     data.addAttribute({ id: "aAttr", name: "a" })
     data.addAttribute({ id: "bAttr", name: "b" })

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -1,7 +1,7 @@
 import { isAlive } from "mobx-state-tree"
 import { logMessageWithReplacement } from "../../lib/log-message"
-import { INotify } from "../history/apply-model-change"
 import { getSharedCaseMetadataFromDataset } from "../shared/shared-data-utils"
+import { INotify } from "../history/history-service"
 import { IAttribute } from "./attribute"
 import { ICollectionModel } from "./collection"
 import { IDataSet } from "./data-set"

--- a/v3/src/models/history/app-history-service.ts
+++ b/v3/src/models/history/app-history-service.ts
@@ -1,0 +1,56 @@
+import { IAnyStateTreeNode } from "mobx-state-tree"
+import { withUndoRedoStrings } from "./codap-undo-types"
+import { IApplyModelChangeOptions, IHistoryService } from "./history-service"
+import { withoutUndo } from "./without-undo"
+import { ILogFunctionEnv } from "../../lib/log-message"
+import { ICoreNotifyFunctionEnv } from "../../data-interactive/notification-core-types"
+
+interface IDependencies extends
+  Partial<ILogFunctionEnv>, Partial<ICoreNotifyFunctionEnv>
+{}
+
+export class AppHistoryService implements IHistoryService {
+  tileEnv?: IDependencies
+
+  setDependencies(dependencies: IDependencies) {
+    this.tileEnv = dependencies
+  }
+
+  handleApplyModelChange(mstNode: IAnyStateTreeNode, options?: IApplyModelChangeOptions) {
+    const { log, notify, notifyTileId, undoStringKey, redoStringKey } = options || {}
+
+    // Add strings to undoable action or keep out of the undo stack
+    if (undoStringKey != null && redoStringKey != null) {
+      withUndoRedoStrings(undoStringKey, redoStringKey)
+    } else {
+      withoutUndo()
+    }
+
+    // Send log message to logger
+    if (this.tileEnv?.log) {
+      const logInfo = typeof log === "function" ? log() : log
+      const logMessage = typeof logInfo === "string" ? { message: logInfo } : logInfo
+      if (logMessage) {
+        this.tileEnv.log(logMessage)
+      }
+    }
+
+    // Broadcast notifications to plugins
+    if (notify && this.tileEnv?.notify) {
+      // Convert notifications to INotification[]
+      const actualNotifications = notify instanceof Function ? notify() : notify
+      if (actualNotifications) {
+        const notificationArray = Array.isArray(actualNotifications) ? actualNotifications : [actualNotifications]
+
+        // Actually broadcast the notifications
+        for (const _notification of notificationArray) {
+          const __notification = typeof _notification === "function" ? _notification() : _notification
+          if (__notification) {
+            const { message, callback } = __notification
+            this.tileEnv.notify(message, callback ?? (() => null), notifyTileId)
+          }
+        }
+      }
+    }
+  }
+}

--- a/v3/src/models/history/apply-model-change.ts
+++ b/v3/src/models/history/apply-model-change.ts
@@ -1,17 +1,7 @@
-import iframePhone from "iframe-phone"
 import { IAnyStateTreeNode } from "mobx-state-tree"
-import { DIMessage } from "../../data-interactive/iframe-phone-types"
 import { ILogMessage } from "../../lib/log-message"
-import { getTileEnvironment } from "../tiles/tile-environment"
-import { withUndoRedoStrings } from "./codap-undo-types"
-import { withoutUndo } from "./without-undo"
+import { getHistoryService, INotify } from "./history-service"
 
-export interface INotification {
-  message: DIMessage
-  callback?: iframePhone.ListenerCallback
-}
-export type INotify =
-  INotification | (INotification | (() => Maybe<INotification>))[] | (() => Maybe<INotification | INotification[]>)
 export interface IApplyModelChangeOptions {
   log?: string | ILogMessage | (() => Maybe<string | ILogMessage>)
   notify?: INotify
@@ -19,51 +9,16 @@ export interface IApplyModelChangeOptions {
   undoStringKey?: string
   redoStringKey?: string
 }
+
 // returns an object which defines the `applyModelChange` method on an MST model
 // designed to be passed to `.actions()`, i.e. `.actions(applyModelChange)`
 export function applyModelChange(self: IAnyStateTreeNode) {
   return ({
     // performs the specified action so that response actions are included and undo/redo strings assigned
     applyModelChange<TResult = unknown>(actionFn: () => TResult, options?: IApplyModelChangeOptions) {
-      const { log, notify, notifyTileId, undoStringKey, redoStringKey } = options || {}
       const result = actionFn()
 
-      // Add strings to undoable action or keep out of the undo stack
-      if (undoStringKey != null && redoStringKey != null) {
-        withUndoRedoStrings(undoStringKey, redoStringKey)
-      } else {
-        withoutUndo()
-      }
-
-      const tileEnv = getTileEnvironment(self)
-      if (tileEnv) {
-        // Send log message to logger
-        if (tileEnv.log) {
-          const logInfo = typeof log === "function" ? log() : log
-          const logMessage = typeof logInfo === "string" ? { message: logInfo } : logInfo
-          if (logMessage) {
-            tileEnv.log(logMessage)
-          }
-        }
-
-        // Broadcast notifications to plugins
-        if (notify && tileEnv.notify) {
-          // Convert notifications to INotification[]
-          const actualNotifications = notify instanceof Function ? notify() : notify
-          if (actualNotifications) {
-            const notificationArray = Array.isArray(actualNotifications) ? actualNotifications : [actualNotifications]
-
-            // Actually broadcast the notifications
-            notificationArray.forEach(_notification => {
-              const __notification = typeof _notification === "function" ? _notification() : _notification
-              if (__notification) {
-                const { message, callback } = __notification
-                tileEnv.notify?.(message, callback ?? (() => null), notifyTileId)
-              }
-            })
-          }
-        }
-      }
+      getHistoryService(self).handleApplyModelChange(self, options)
 
       return result
     }

--- a/v3/src/models/history/history-service.ts
+++ b/v3/src/models/history/history-service.ts
@@ -1,0 +1,34 @@
+import { getEnv, hasEnv, IAnyStateTreeNode } from "mobx-state-tree"
+import { ICoreNotification } from "../../data-interactive/notification-core-types"
+import { ILogMessage } from "../../lib/log-message"
+
+export type INotify =
+  ICoreNotification |
+  (ICoreNotification | (() => Maybe<ICoreNotification>))[] |
+  (() => Maybe<ICoreNotification | ICoreNotification[]>)
+
+export interface IApplyModelChangeOptions {
+  log?: string | ILogMessage | (() => Maybe<string | ILogMessage>)
+  notify?: INotify
+  notifyTileId?: string
+  undoStringKey?: string
+  redoStringKey?: string
+}
+
+export interface IHistoryService {
+  handleApplyModelChange: (mstNode: IAnyStateTreeNode, options?: IApplyModelChangeOptions) => void
+}
+
+// This should be used when adding the history service to the MST Env
+export interface IHistoryServiceEnv {
+  historyService: IHistoryService
+}
+
+export function getHistoryService(node: IAnyStateTreeNode) {
+  const env = node && hasEnv(node) ? getEnv<Partial<IHistoryServiceEnv>>(node) : undefined
+  const historyService = env?.historyService
+  if (!historyService) {
+    throw new Error("History Service not found in MST environment")
+  }
+  return historyService
+}

--- a/v3/src/models/tiles/tile-environment.ts
+++ b/v3/src/models/tiles/tile-environment.ts
@@ -1,18 +1,17 @@
-import iframePhone from "iframe-phone"
 import { getEnv, hasEnv, IAnyStateTreeNode } from "mobx-state-tree"
-import { DIMessage } from "../../data-interactive/iframe-phone-types"
-import { ILogMessage } from "../../lib/log-message"
+import { ILogFunctionEnv } from "../../lib/log-message"
 // There's nothing wrong in explicit ISharedModelManager interface, but probably dependency cycle could have been also
 // avoided using `import type { SharedModelManager } from ...`.
 import { ISharedModelManager } from "../shared/shared-model-manager"
 import type { IFormulaManager } from "../formula/formula-manager-types"
 import { IGlobalValueManager, kGlobalValueManagerType } from "../global/global-value-manager"
+import { ICoreNotifyFunctionEnv } from "../../data-interactive/notification-core-types"
 
-export interface ITileEnvironment {
+export interface ITileEnvironment extends
+  Partial<ILogFunctionEnv>, Partial<ICoreNotifyFunctionEnv>
+{
   sharedModelManager?: ISharedModelManager
   formulaManager?: IFormulaManager
-  log?: (message: ILogMessage) => void
-  notify?: (message: DIMessage, callback: iframePhone.ListenerCallback, targetTileId?: string) => void
 }
 
 export function getTileEnvironment(node?: IAnyStateTreeNode) {


### PR DESCRIPTION
The idea is that within CODAP the AppHistoryService will handle the applyModelChange. When the code is used outside of CODAP a no-op history service can be used.

Part of this work is also to type the INotification better. Instead of just using the iframePhone generic types, now the notifications are typed specific to how CODAP is using them. The core of CODAP will work with ICoreNotifications. And then things like drag and drop support for iframes extend ICoreNotifications. The rational is that the notification system isn't necessary specific to iframePhone or iframes at all. It is just a generic notification system which is then exposed to plugins via the iframe API.

Additionally this takes a new approach for the ITileEnvironment. It is now created by intersecting several individual environment interfaces. This makes it possible for services like the history service to depend on them in a way where the "key" of the service in the environment is typed in a single place while not making the history service dependent on the full ITileEnvironment.

When the tests are made part of the CODAP "library", instead of importing using AppHistoryService they'd use a no-op history service. Or if they are actually checking the history then a simplified history service could be used.

A variation of this PR could be have applyModelChange handle the case of not finding the history service. This would remove the need for most of the tests to setup MST environments with a historyService. However this will make it less obvious how to fix a new test that is expecting the history to work. So my preference is to fail fast and require the more explicit configuration.