### PR TITLE
fix: plugin API matches data context title as well as name; table inspector info shows title

### DIFF
--- a/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
@@ -15,7 +15,7 @@ interface IProps {
 
 export const DatasetInfoModal = ({showInfoModal, setShowInfoModal}: IProps) => {
   const data = useDataSetContext()
-  const [datasetName, setDataSetName] = useState(data?.name || "")
+  const [datasetName, setDataSetName] = useState(data?.title || "")
   const [sourceName, setSourceName] = useState(data?.sourceName || "")
   const [importDate, setImportDate] = useState(data?.importDate || "")
   const [description, setDescription] = useState(data?.description || "")

--- a/v3/src/data-interactive/resource-parser.test.ts
+++ b/v3/src/data-interactive/resource-parser.test.ts
@@ -28,6 +28,9 @@ describe("DataInteractive ResourceParser", () => {
     expect(resolve("dataContext[data]").dataContext?.id).toBe(dataset.id)
     expect(resolve(`dataContext[${toV2Id(dataset.id)}]`).dataContext?.id).toBe(dataset.id)
     expect(resolve("dataContext[unknown]").dataContext).toBeUndefined()
+    // finds dataContext by user-set title
+    dataset.setTitle("NewTitle")
+    expect(resolve("dataContext[NewTitle]").dataContext?.id).toBe(dataset.id)
   })
 
   it("finds components", () => {

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -73,7 +73,7 @@ export function resolveResources(
     if (selector === '#default') {
       return dataSets[0]
     }
-    return dataSets.find(dataSet => dataSet.matchNameOrId(selector))
+    return dataSets.find(dataSet => dataSet.matchTitleOrNameOrId(selector))
   }
 
   const result: DIResources = { interactiveFrame }

--- a/v3/src/models/data/v2-model.test.ts
+++ b/v3/src/models/data/v2-model.test.ts
@@ -10,6 +10,7 @@ describe("V2Model", () => {
     expect(m._title).toBeUndefined()
     expect(m.title).toBe("")
     expect(m.matchNameOrId("")).toBe(false)
+    expect(m.matchTitleOrNameOrId("")).toBe(false)
 
     m.setName("name")
     expect(m.id).toBeDefined()
@@ -18,6 +19,8 @@ describe("V2Model", () => {
     expect(m.title).toBe("name")
     expect(m.matchNameOrId("")).toBe(false)
     expect(m.matchNameOrId("name")).toBe(true)
+    expect(m.matchTitleOrNameOrId("")).toBe(false)
+    expect(m.matchTitleOrNameOrId("name")).toBe(true)
 
     m.setTitle("title")
     expect(m.id).toBeDefined()
@@ -27,6 +30,9 @@ describe("V2Model", () => {
     expect(m.matchNameOrId("")).toBe(false)
     expect(m.matchNameOrId("name")).toBe(true)
     expect(m.matchNameOrId("title")).toBe(false)
+    expect(m.matchTitleOrNameOrId("")).toBe(false)
+    expect(m.matchTitleOrNameOrId("name")).toBe(true)
+    expect(m.matchTitleOrNameOrId("title")).toBe(true)
   })
 
   it("can be constructed with v2Id and name", () => {

--- a/v3/src/models/data/v2-model.ts
+++ b/v3/src/models/data/v2-model.ts
@@ -20,6 +20,11 @@ export const V2Model = types.model("V2Model", {
     /* eslint-enable eqeqeq */
   }
 }))
+.views(self => ({
+  matchTitleOrNameOrId(titleOrNameOrId: string | number) {
+    return (self.title && self.title === titleOrNameOrId) || self.matchNameOrId(titleOrNameOrId)
+  }
+}))
 .actions(self => ({
   // some models allow changing name
   setName(name: string) {


### PR DESCRIPTION
For historical reasons CODAP objects (attributes, data sets, etc.) generally have an internal `name` property and an external `title` property. When created the `name` and `title` are the same, but the user has the ability to change the `title` (but generally not the `name`). This PR fixes two name/title issues:
1. The plugin API matches data sets (nee data contexts) by title as well as name. This is an improvement over v2 behavior.
2. The case table and case card data set information dialog display the title rather than the name (matching v2 behavior).