### PR TITLE
split data set linking from shared-data-utils

### DIFF
--- a/v3/src/models/document/data-set-linking.test.ts
+++ b/v3/src/models/document/data-set-linking.test.ts
@@ -1,0 +1,114 @@
+import { createCodapDocument } from "../codap/create-codap-document"
+import { SharedCaseMetadata } from "../shared/shared-case-metadata"
+import { SharedDataSet } from "../shared/shared-data-set"
+import { getDataSetFromId, getTileCaseMetadata, getTileDataSet, getTileSharedModels } from "../shared/shared-data-utils"
+import { isTileLinkedToDataSet, unlinkTileFromDataSets, linkTileToDataSet } from "./data-set-linking"
+import { TileContentModel } from "../tiles/tile-content"
+import { registerTileContentInfo } from "../tiles/tile-content-info"
+import { TileModel } from "../tiles/tile-model"
+import { IDocumentModel } from "./document"
+import { getSharedModelManager } from "../tiles/tile-environment"
+
+const TestTileContent = TileContentModel
+  .named("TestTile")
+  .props({
+    type: "Test"
+  })
+  .actions(self => ({
+    updateAfterSharedModelChanges() {
+      // NOP
+    }
+  }))
+
+registerTileContentInfo({
+  type: "Test",
+  prefix: "TEST",
+  modelClass: TestTileContent,
+  defaultContent(options) {
+    return TestTileContent.create()
+  },
+  getTitle() {
+    return "Test"
+  }
+})
+
+describe("DataSetLinking", () => {
+  let document: IDocumentModel = createCodapDocument(undefined, { noGlobals: true })
+  let tile = TileModel.create({ content: TestTileContent.create() })
+  let sharedDataSet = SharedDataSet.create()
+  let sharedMetadata = SharedCaseMetadata.create()
+
+  beforeEach(() => {
+    document = createCodapDocument(undefined, { noGlobals: true })
+    tile = TileModel.create({ content: TestTileContent.create() })
+    document.addTile(tile)
+    sharedDataSet = SharedDataSet.create()
+    document.content?.addSharedModel(sharedDataSet)
+    sharedMetadata = SharedCaseMetadata.create()
+    document.content?.addSharedModel(sharedMetadata)
+    sharedMetadata.setData(sharedDataSet.dataSet)
+  })
+
+  it("handles tiles not connected to the document", () => {
+    const orphan = TileModel.create({ content: TestTileContent.create() })
+    expect(getTileSharedModels(orphan.content)).toEqual([])
+    expect(getDataSetFromId(orphan.content, sharedDataSet.dataSet.id)).toBeUndefined()
+    linkTileToDataSet(orphan, sharedDataSet.dataSet)
+    expect(isTileLinkedToDataSet(orphan.content, sharedDataSet.dataSet)).toBe(false)
+    expect(getTileSharedModels(orphan.content)).toEqual([])
+    unlinkTileFromDataSets(orphan.content)
+    expect(isTileLinkedToDataSet(orphan.content, sharedDataSet.dataSet)).toBe(false)
+    expect(getTileSharedModels(orphan.content)).toEqual([])
+  })
+
+  it("works as expected when no tiles are linked", () => {
+    expect(getSharedModelManager(document)).toBeDefined()
+    expect(getSharedModelManager(tile)).toBeDefined()
+    expect(sharedMetadata.data).toBeDefined()
+    expect(document.content?.sharedModelMap.size).toBe(2)
+    expect(getDataSetFromId(document, "foo")).toBeUndefined()
+    expect(getDataSetFromId(document, sharedDataSet.dataSet.id)).toBe(sharedDataSet.dataSet)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
+    expect(getTileSharedModels(tile.content)).toEqual([])
+    expect(getTileDataSet(tile.content)).toBeUndefined()
+    expect(getTileCaseMetadata(tile.content)).toBeUndefined()
+  })
+
+  it("can link/unlink tiles to/from data sets and shared case metadata", () => {
+    linkTileToDataSet(tile, sharedDataSet.dataSet)
+    expect(document.content?.sharedModelMap.size).toBe(2)
+    expect(getTileSharedModels(tile.content).length).toEqual(2)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(true)
+    expect(getTileDataSet(tile.content)).toBe(sharedDataSet.dataSet)
+    expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata)
+
+    unlinkTileFromDataSets(tile.content)
+    expect(document.content?.sharedModelMap.size).toBe(2)
+    expect(getTileSharedModels(tile.content).length).toEqual(0)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
+    expect(getTileDataSet(tile.content)).not.toBeDefined()
+    expect(getTileCaseMetadata(tile.content)).not.toBeDefined()
+  })
+
+  it("auto-unlinks previously linked data sets when linking a new data set", () => {
+    const sharedDataSet2 = SharedDataSet.create()
+    document.content?.addSharedModel(sharedDataSet2)
+    const sharedMetadata2 = SharedCaseMetadata.create()
+    document.content?.addSharedModel(sharedMetadata2)
+    sharedMetadata2.setData(sharedDataSet2.dataSet)
+    expect(document.content?.sharedModelMap.size).toBe(4)
+
+    linkTileToDataSet(tile, sharedDataSet.dataSet)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(true)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(false)
+    expect(getTileDataSet(tile.content)).toBe(sharedDataSet.dataSet)
+    expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata)
+
+    linkTileToDataSet(tile, sharedDataSet2.dataSet)
+    expect(getTileSharedModels(tile.content).length).toEqual(2)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
+    expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(true)
+    expect(getTileDataSet(tile.content)).toBe(sharedDataSet2.dataSet)
+    expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata2)
+  })
+})

--- a/v3/src/models/document/data-set-linking.ts
+++ b/v3/src/models/document/data-set-linking.ts
@@ -1,0 +1,49 @@
+import { IDataSet } from "../data/data-set"
+import { SharedCaseMetadata, kSharedCaseMetadataType, ISharedCaseMetadata } from "../shared/shared-case-metadata"
+import { SharedDataSet, kSharedDataSetType, ISharedDataSet, isSharedDataSet } from "../shared/shared-data-set"
+import { getTileSharedModels } from "../shared/shared-data-utils"
+import { ITileContentModel } from "../tiles/tile-content"
+import { getSharedModelManager } from "../tiles/tile-environment"
+import { ITileModel } from "../tiles/tile-model"
+
+export function isTileLinkedToDataSet(tile: ITileContentModel, dataSet: IDataSet) {
+  const sharedModels = getTileSharedModels(tile)
+  return !!sharedModels.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id === dataSet.id)
+}
+
+export function isTileLinkedToOtherDataSet(tile: ITileContentModel, dataSet: IDataSet) {
+  const sharedModels = getTileSharedModels(tile)
+  return !!sharedModels.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id !== dataSet.id)
+}
+
+// adds references to the specified tile to the specified SharedDataSet and its SharedCaseMetadata
+export function linkTileToDataSet(tile: ITileModel, dataSet: IDataSet) {
+  const tileContent = tile.content
+  if (isTileLinkedToOtherDataSet(tileContent, dataSet)) {
+    unlinkTileFromDataSets(tileContent)
+  }
+
+  const sharedModelManager = getSharedModelManager(tile)
+  const sharedDataSets = sharedModelManager?.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
+  const sharedDataSet = sharedDataSets?.find(model => model.dataSet.id === dataSet.id) as ISharedDataSet | undefined
+  if (sharedModelManager && sharedDataSet) {
+    sharedModelManager.addTileSharedModel(tileContent, sharedDataSet)
+
+    const sharedMetadata = sharedModelManager.getSharedModelsByType<typeof SharedCaseMetadata>(kSharedCaseMetadataType)
+    const sharedCaseMetadata: ISharedCaseMetadata | undefined =
+      sharedMetadata.find(model => model.data?.id === dataSet.id)
+    sharedCaseMetadata && sharedModelManager.addTileSharedModel(tileContent, sharedCaseMetadata)
+    sharedCaseMetadata?.setCaseTableTileId(tile.id)
+  }
+}
+
+// removes references to the specified tile from SharedDataSet and SharedCaseMetadata tiles
+export function unlinkTileFromDataSets(tile: ITileContentModel) {
+  const sharedModelManager = getSharedModelManager(tile)
+  const sharedModels = sharedModelManager?.getTileSharedModels(tile) ?? []
+  sharedModelManager && sharedModels.forEach(sharedModel => {
+    if (sharedModel.type === kSharedDataSetType || sharedModel.type === kSharedCaseMetadataType) {
+      sharedModelManager.removeTileSharedModel(tile, sharedModel)
+    }
+  })
+}

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -16,7 +16,8 @@ import { gDataBroker } from "../data/data-broker"
 import { applyModelChange } from "../history/apply-model-change"
 import { SharedCaseMetadata } from "../shared/shared-case-metadata"
 import { ISharedDataSet, SharedDataSet, kSharedDataSetType } from "../shared/shared-data-set"
-import { getSharedDataSets, linkTileToDataSet } from "../shared/shared-data-utils"
+import { getSharedDataSets } from "../shared/shared-data-utils"
+import { linkTileToDataSet } from "./data-set-linking"
 import { TileBroadcastCallback, TileBroadcastMessage } from "../tiles/tile-content"
 
 /**

--- a/v3/src/models/shared/shared-data-utils.test.ts
+++ b/v3/src/models/shared/shared-data-utils.test.ts
@@ -1,41 +1,12 @@
+import { TestTileContent } from "../../test/test-tile-content"
 import { createCodapDocument } from "../codap/create-codap-document"
 import { IDocumentModel } from "../document/document"
-import { TileContentModel } from "../tiles/tile-content"
-import { registerTileContentInfo } from "../tiles/tile-content-info"
-import { getSharedModelManager } from "../tiles/tile-environment"
 import { TileModel } from "../tiles/tile-model"
 import { SharedCaseMetadata } from "./shared-case-metadata"
 import { SharedDataSet } from "./shared-data-set"
-import {
-  getDataSetFromId, getTileCaseMetadata, getTileDataSet, getTileSharedModels, isTileLinkedToDataSet,
-  linkTileToDataSet, unlinkTileFromDataSets
-} from "./shared-data-utils"
-import "./shared-data-set-registration"
-import "./shared-case-metadata-registration"
+import { getSharedDataSets } from "./shared-data-utils"
 
-const TestTileContent = TileContentModel
-  .named("TestTile")
-  .props({
-    type: "Test"
-  })
-  .actions(self => ({
-    updateAfterSharedModelChanges() {
-      // NOP
-    }
-  }))
-
-registerTileContentInfo({
-  type: "Test",
-  prefix: "TEST",
-  modelClass: TestTileContent,
-  defaultContent(options) {
-    return TestTileContent.create()
-  },
-  getTitle() {
-    return "Test"
-  }
-})
-
+// shared-data-utils is tested pretty well by data-set-linking.test.ts
 describe("SharedDataUtils", () => {
   let document: IDocumentModel = createCodapDocument(undefined, { noGlobals: true })
   let tile = TileModel.create({ content: TestTileContent.create() })
@@ -53,66 +24,8 @@ describe("SharedDataUtils", () => {
     sharedMetadata.setData(sharedDataSet.dataSet)
   })
 
-  it("handles tiles not connected to the document", () => {
-    const orphan = TileModel.create({ content: TestTileContent.create() })
-    expect(getTileSharedModels(orphan.content)).toEqual([])
-    expect(getDataSetFromId(orphan.content, sharedDataSet.dataSet.id)).toBeUndefined()
-    linkTileToDataSet(orphan, sharedDataSet.dataSet)
-    expect(isTileLinkedToDataSet(orphan.content, sharedDataSet.dataSet)).toBe(false)
-    expect(getTileSharedModels(orphan.content)).toEqual([])
-    unlinkTileFromDataSets(orphan.content)
-    expect(isTileLinkedToDataSet(orphan.content, sharedDataSet.dataSet)).toBe(false)
-    expect(getTileSharedModels(orphan.content)).toEqual([])
-  })
-
-  it("works as expected when no tiles are linked", () => {
-    expect(getSharedModelManager(document)).toBeDefined()
-    expect(getSharedModelManager(tile)).toBeDefined()
-    expect(sharedMetadata.data).toBeDefined()
-    expect(document.content?.sharedModelMap.size).toBe(2)
-    expect(getDataSetFromId(document, "foo")).toBeUndefined()
-    expect(getDataSetFromId(document, sharedDataSet.dataSet.id)).toBe(sharedDataSet.dataSet)
-    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
-    expect(getTileSharedModels(tile.content)).toEqual([])
-    expect(getTileDataSet(tile.content)).toBeUndefined()
-    expect(getTileCaseMetadata(tile.content)).toBeUndefined()
-  })
-
-  it("can link/unlink tiles to/from data sets and shared case metadata", () => {
-    linkTileToDataSet(tile, sharedDataSet.dataSet)
-    expect(document.content?.sharedModelMap.size).toBe(2)
-    expect(getTileSharedModels(tile.content).length).toEqual(2)
-    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(true)
-    expect(getTileDataSet(tile.content)).toBe(sharedDataSet.dataSet)
-    expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata)
-
-    unlinkTileFromDataSets(tile.content)
-    expect(document.content?.sharedModelMap.size).toBe(2)
-    expect(getTileSharedModels(tile.content).length).toEqual(0)
-    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
-    expect(getTileDataSet(tile.content)).not.toBeDefined()
-    expect(getTileCaseMetadata(tile.content)).not.toBeDefined()
-  })
-
-  it("auto-unlinks previously linked data sets when linking a new data set", () => {
-    const sharedDataSet2 = SharedDataSet.create()
-    document.content?.addSharedModel(sharedDataSet2)
-    const sharedMetadata2 = SharedCaseMetadata.create()
-    document.content?.addSharedModel(sharedMetadata2)
-    sharedMetadata2.setData(sharedDataSet2.dataSet)
-    expect(document.content?.sharedModelMap.size).toBe(4)
-
-    linkTileToDataSet(tile, sharedDataSet.dataSet)
-    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(true)
-    expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(false)
-    expect(getTileDataSet(tile.content)).toBe(sharedDataSet.dataSet)
-    expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata)
-
-    linkTileToDataSet(tile, sharedDataSet2.dataSet)
-    expect(getTileSharedModels(tile.content).length).toEqual(2)
-    expect(isTileLinkedToDataSet(tile.content, sharedDataSet.dataSet)).toBe(false)
-    expect(isTileLinkedToDataSet(tile.content, sharedDataSet2.dataSet)).toBe(true)
-    expect(getTileDataSet(tile.content)).toBe(sharedDataSet2.dataSet)
-    expect(getTileCaseMetadata(tile.content)).toBe(sharedMetadata2)
+  it("find shared datasets", () => {
+    const dataSets = getSharedDataSets(tile)
+    expect(dataSets.length).toBe(1)
   })
 })

--- a/v3/src/models/shared/shared-data-utils.ts
+++ b/v3/src/models/shared/shared-data-utils.ts
@@ -2,7 +2,6 @@ import { IAnyStateTreeNode } from "mobx-state-tree"
 import { toV2Id } from "../../utilities/codap-utils"
 import { IDataSet } from "../data/data-set"
 import { ITileContentModel } from "../tiles/tile-content"
-import { ITileModel } from "../tiles/tile-model"
 import { getSharedModelManager } from "../tiles/tile-environment"
 import {
   ISharedCaseMetadata, isSharedCaseMetadata, kSharedCaseMetadataType, SharedCaseMetadata
@@ -59,46 +58,4 @@ export function getTileCaseMetadata(tile: ITileContentModel) {
 
 export function getAllTileCaseMetadata(tile: ITileContentModel): ISharedCaseMetadata[] {
   return getTileSharedModels(tile).filter(m => isSharedCaseMetadata(m))
-}
-
-export function isTileLinkedToDataSet(tile: ITileContentModel, dataSet: IDataSet) {
-  const sharedModels = getTileSharedModels(tile)
-  return !!sharedModels.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id === dataSet.id)
-}
-
-export function isTileLinkedToOtherDataSet(tile: ITileContentModel, dataSet: IDataSet) {
-  const sharedModels = getTileSharedModels(tile)
-  return !!sharedModels.find(sharedModel => isSharedDataSet(sharedModel) && sharedModel.dataSet.id !== dataSet.id)
-}
-
-// removes references to the specified tile from SharedDataSet and SharedCaseMetadata tiles
-export function unlinkTileFromDataSets(tile: ITileContentModel) {
-  const sharedModelManager = getSharedModelManager(tile)
-  const sharedModels = sharedModelManager?.getTileSharedModels(tile) ?? []
-  sharedModelManager && sharedModels.forEach(sharedModel => {
-    if (sharedModel.type === kSharedDataSetType || sharedModel.type === kSharedCaseMetadataType) {
-      sharedModelManager.removeTileSharedModel(tile, sharedModel)
-    }
-  })
-}
-
-// adds references to the specified tile to the specified SharedDataSet and its SharedCaseMetadata
-export function linkTileToDataSet(tile: ITileModel, dataSet: IDataSet) {
-  const tileContent = tile.content
-  if (isTileLinkedToOtherDataSet(tileContent, dataSet)) {
-    unlinkTileFromDataSets(tileContent)
-  }
-
-  const sharedModelManager = getSharedModelManager(tile)
-  const sharedDataSets = sharedModelManager?.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
-  const sharedDataSet = sharedDataSets?.find(model => model.dataSet.id === dataSet.id) as ISharedDataSet | undefined
-  if (sharedModelManager && sharedDataSet) {
-    sharedModelManager.addTileSharedModel(tileContent, sharedDataSet)
-
-    const sharedMetadata = sharedModelManager.getSharedModelsByType<typeof SharedCaseMetadata>(kSharedCaseMetadataType)
-    const sharedCaseMetadata: ISharedCaseMetadata | undefined =
-            sharedMetadata.find(model => model.data?.id === dataSet.id)
-    sharedCaseMetadata && sharedModelManager.addTileSharedModel(tileContent, sharedCaseMetadata)
-    sharedCaseMetadata?.setCaseTableTileId(tile.id)
-  }
 }


### PR DESCRIPTION
The data set linking methods were only used by the document. They also required the ITileModel, so this split allows shared-data-utils to be used in the library without the ITileModel.