### PR TITLE
split out v2 dataset conversion

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -12,6 +12,8 @@ import { addDefaultComponents } from "../models/codap/add-default-content"
 import {gDataBroker} from "../models/data/data-broker"
 import {IDataSet} from "../models/data/data-set"
 import { dataContextCountChangedNotification } from "../models/data/data-set-notifications"
+import { setDataSetNotificationAdapter } from "../models/data/data-set-notification-adapter"
+import { V2DataSetNotificationAdapter } from "../models/data/data-set-notification-adapter-v2"
 import { IImportDataSetOptions } from "../models/document/document-content"
 import { AttributeFormulaAdapter } from "../models/formula/attribute-formula-adapter"
 import { FilterFormulaAdapter } from "../models/formula/filter-formula-adapter"
@@ -35,6 +37,9 @@ import "./app.scss"
 
 AttributeFormulaAdapter.register()
 FilterFormulaAdapter.register()
+
+// CODAP uses v2 cases and attributes in the notifications it sends to plugins
+setDataSetNotificationAdapter(V2DataSetNotificationAdapter)
 
 registerTileTypes([])
 

--- a/v3/src/models/data/data-set-notification-adapter-v2.ts
+++ b/v3/src/models/data/data-set-notification-adapter-v2.ts
@@ -1,0 +1,11 @@
+import { convertAttributeToV2, convertCaseToV2FullCase } from "../../data-interactive/data-interactive-type-utils"
+import { IDataSetNotificationAdapter } from "./data-set-notification-adapter"
+
+export const V2DataSetNotificationAdapter: IDataSetNotificationAdapter = {
+  convertAttribute(attr, dataset) {
+    return convertAttributeToV2(attr, dataset)
+  },
+  convertCase(_case, dataset) {
+    return convertCaseToV2FullCase(_case, dataset)
+  }
+}

--- a/v3/src/models/data/data-set-notification-adapter.ts
+++ b/v3/src/models/data/data-set-notification-adapter.ts
@@ -1,0 +1,21 @@
+import { IAttribute } from "./attribute"
+import { IDataSet } from "./data-set"
+import { ICase } from "./data-set-types"
+
+export interface IDataSetNotificationAdapter {
+  convertAttribute: (attr: IAttribute, dataset?: IDataSet) => any;
+  convertCase: (_case: ICase, dataset: IDataSet) => any
+}
+
+let gDataSetNotificationAdapter: IDataSetNotificationAdapter = {
+  convertAttribute(attr, dataset) { return attr },
+  convertCase(_case, dataset) { return _case }
+}
+
+export function setDataSetNotificationAdapter(adapter: IDataSetNotificationAdapter) {
+  gDataSetNotificationAdapter = adapter
+}
+
+export function getDataSetNotificationAdapter() {
+  return gDataSetNotificationAdapter
+}


### PR DESCRIPTION
DataSet notifications in CODAP convert cases and attributes to v2 form.
This conversion brings in several files and probably is unnecessary in a library.

This PR adds an adapter which can convert the attributes and cases.
A default adapter is configured which does no conversion.

Hopefully this won't cause too much confusion if someone is tracing through the code and trying to figure out why what they see in the plugin messages doesn't match what they expect.

This also probably resulted in reduced code coverage by the Jest tests. However the actual coverage only dropped a little, probably because the Cypress tests covered it. Perhaps some Jest tests should install the V2Adapter.