### PR TITLE
separate tile selection context

### DIFF
--- a/v3/src/components/case-table/case-table-component.test.tsx
+++ b/v3/src/components/case-table/case-table-component.test.tsx
@@ -11,6 +11,7 @@ import { DataBroker } from "../../models/data/data-broker"
 import { DataSet, toCanonical } from "../../models/data/data-set"
 import { ITileModel, TileModel } from "../../models/tiles/tile-model"
 import "./case-table-registration"
+import { ITileSelection, TileSelectionContext } from "../../hooks/use-tile-selection-context"
 
 jest.mock("./case-table-shared.scss", () => ({
   headerRowHeight: "30"
@@ -40,17 +41,26 @@ describe("Case Table", () => {
   })
 
   it("renders table with data", () => {
+    const tileSelection: ITileSelection = {
+      isTileSelected() {
+        return false
+      },
+      selectTile() {
+      }
+    }
     const data = DataSet.create()
     data.addAttribute({ name: "a"})
     data.addAttribute({ name: "b" })
     data.addCases(toCanonical(data, [{ a: 1, b: 2 }, { a: 3, b: 4 }]))
     broker.addDataSet(data)
     render(
-      <DndContext>
-        <DataSetContext.Provider value={data}>
-          <CaseTableComponent tile={tile}/>
-        </DataSetContext.Provider>
-      </DndContext>)
+      <TileSelectionContext.Provider value={tileSelection}>
+        <DndContext>
+          <DataSetContext.Provider value={data}>
+            <CaseTableComponent tile={tile}/>
+          </DataSetContext.Provider>
+        </DndContext>
+      </TileSelectionContext.Provider>)
     expect(screen.getByTestId("case-table")).toBeInTheDocument()
   })
 

--- a/v3/src/components/case-table/case-table-component.test.tsx
+++ b/v3/src/components/case-table/case-table-component.test.tsx
@@ -6,12 +6,12 @@ import React from "react"
 import { CaseTableComponent } from "./case-table-component"
 import { CaseTableModel } from "./case-table-model"
 import { DataSetContext } from "../../hooks/use-data-set-context"
+import { ITileSelection, TileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { useKeyStates } from "../../hooks/use-key-states"
 import { DataBroker } from "../../models/data/data-broker"
 import { DataSet, toCanonical } from "../../models/data/data-set"
 import { ITileModel, TileModel } from "../../models/tiles/tile-model"
 import "./case-table-registration"
-import { ITileSelection, TileSelectionContext } from "../../hooks/use-tile-selection-context"
 
 jest.mock("./case-table-shared.scss", () => ({
   headerRowHeight: "30"

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -18,7 +18,7 @@ import { useSelectedRows } from "./use-selected-rows"
 import { useCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useTileDroppable } from "../../hooks/use-drag-drop"
-import { useTileModelContext } from "../../hooks/use-tile-model-context"
+import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { useVisibleAttributes } from "../../hooks/use-visible-attributes"
 import { registerCanAutoScrollCallback } from "../../lib/dnd-kit/dnd-can-auto-scroll"
 import { logStringifiedObjectMessage } from "../../lib/log-message"
@@ -89,7 +89,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   const { selectedRows, setSelectedRows, handleCellClick } =
     useSelectedRows({ gridRef, onScrollClosestRowIntoView, onScrollRowRangeIntoView })
   const { handleWhiteSpaceClick } = useWhiteSpaceClick({ gridRef })
-  const { isTileSelected } = useTileModelContext()
+  const { isTileSelected } = useTileSelectionContext()
   const [isSelecting, setIsSelecting] = useState(false)
   const [selectionStartRowIdx, setSelectionStartRowIdx] = useState<number | null>(null)
   const initialPointerDownPosition = useRef({ x: 0, y: 0 })

--- a/v3/src/components/case-table/use-white-space-click.ts
+++ b/v3/src/components/case-table/use-white-space-click.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react"
 import { DataGridHandle } from "react-data-grid"
-import { useTileModelContext } from "../../hooks/use-tile-model-context"
+import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { selectAllCases } from "../../models/data/data-set-utils"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useCodapComponentContext } from "../../hooks/use-codap-component-context"
@@ -16,7 +16,7 @@ export function useWhiteSpaceClick({ gridRef }: IProps) {
   // If user clicks on the whitespace of the table and the table is not focused,
   // then the table should be focused and the selection should not be cleared.
   // So we track if the table is in focus and if it was in focus before.
-  const { isTileSelected } = useTileModelContext()
+  const { isTileSelected } = useTileSelectionContext()
   const isFocusedTileRef = useRef(isTileSelected())
   const wasFocusedTileRef = useRef(isTileSelected())
   const isFocusedTile = isTileSelected()

--- a/v3/src/components/case-tile-common/collection-title.tsx
+++ b/v3/src/components/case-tile-common/collection-title.tsx
@@ -8,7 +8,7 @@ import { clsx } from "clsx"
 import AddIcon from "../../assets/icons/icon-add-circle.svg"
 import { useCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { useTileModelContext } from "../../hooks/use-tile-model-context"
+import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { logModelChangeFn } from "../../lib/log-message"
 import { updateCollectionNotification } from "../../models/data/data-set-notifications"
 import { preventCollectionReorg } from "../../utilities/plugin-utils"
@@ -24,7 +24,7 @@ export const CollectionTitle = observer(function CollectionTitle({onAddNewAttrib
   const collectionId = useCollectionContext()
   const collection = data?.getCollection(collectionId)
   const collectionName = collection?.name || t("DG.AppController.createDataSet.collectionName")
-  const { isTileSelected } = useTileModelContext()
+  const { isTileSelected } = useTileSelectionContext()
   const caseCount = data?.getCasesForCollection(collection?.id).length ?? 0
   const tileRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -4,6 +4,7 @@ import { isAlive } from "mobx-state-tree"
 import React, { useMemo, useRef } from "react"
 import { CodapComponentContext } from "../hooks/use-codap-component-context"
 import { TileModelContext } from "../hooks/use-tile-model-context"
+import { ITileSelection, TileSelectionContext } from "../hooks/use-tile-selection-context"
 import { InspectorPanelWrapper } from "./inspector-panel-wrapper"
 import { ITileBaseProps } from "./tiles/tile-base-props"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
@@ -12,7 +13,6 @@ import { uiState } from "../models/ui-state"
 import ResizeHandle from "../assets/icons/icon-corner-resize-handle.svg"
 
 import "./codap-component.scss"
-import { ITileSelection, TileSelectionContext } from "../hooks/use-tile-selection-context"
 
 export interface IProps extends ITileBaseProps {
   tile: ITileModel

--- a/v3/src/components/data-display/hooks/use-pixi-pointer-down.ts
+++ b/v3/src/components/data-display/hooks/use-pixi-pointer-down.ts
@@ -1,11 +1,11 @@
 import { useEffect } from "react"
-import { useTileModelContext } from "../../../hooks/use-tile-model-context"
+import { useTileSelectionContext } from "../../../hooks/use-tile-selection-context"
 import { PixiPoints, PixiPointsArray } from "../pixi/pixi-points"
 
 type OnPointerDownCallback = (event: PointerEvent, pixiPoints: PixiPoints) => void
 
 export function usePixiPointerDown(pixiPointsArray: PixiPointsArray, onPointerDown: OnPointerDownCallback) {
-  const { isTileSelected } = useTileModelContext()
+  const { isTileSelected } = useTileSelectionContext()
 
   useEffect(() => {
     const handlePointerDownCapture = (event: PointerEvent) => {

--- a/v3/src/components/graph/adornments/adornments.tsx
+++ b/v3/src/components/graph/adornments/adornments.tsx
@@ -7,7 +7,7 @@ import { Adornment } from "./adornment"
 import { getAdornmentContentInfo } from "./adornment-content-info"
 import { IAdornmentModel } from "./adornment-models"
 import { useInstanceIdContext } from "../../../hooks/use-instance-id-context"
-import { useTileModelContext } from "../../../hooks/use-tile-model-context"
+import { useTileSelectionContext } from "../../../hooks/use-tile-selection-context"
 import { useGraphContentModelContext } from "../hooks/use-graph-content-model-context"
 import { useGraphDataConfigurationContext } from "../hooks/use-graph-data-configuration-context"
 import { useGraphLayoutContext } from "../hooks/use-graph-layout-context"
@@ -23,7 +23,7 @@ export const Adornments = observer(function Adornments() {
   const dataConfig = useGraphDataConfigurationContext()
   const instanceId = useInstanceIdContext()
   const layout = useGraphLayoutContext()
-  const { isTileSelected } = useTileModelContext()
+  const { isTileSelected } = useTileSelectionContext()
   const adornments = graphModel.adornmentsStore.adornments
   const { left, top, width, height } = layout.computedBounds.plot
   const spannerRef = useRef<SVGSVGElement>(null)

--- a/v3/src/components/graph/components/graph-attribute-label.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label.tsx
@@ -9,7 +9,7 @@ import { IDataSet } from "../../../models/data/data-set"
 import { GraphPlace, isVertical } from "../../axis-graph-shared"
 import { AttributeLabel } from "../../data-display/components/attribute-label"
 import { graphPlaceToAttrRole } from "../../data-display/data-display-types"
-import { useTileModelContext } from "../../../hooks/use-tile-model-context"
+import { useTileSelectionContext } from "../../../hooks/use-tile-selection-context"
 import { getStringBounds } from "../../axis/axis-utils"
 
 import vars from "../../vars.scss"
@@ -29,7 +29,7 @@ export const GraphAttributeLabel =
     const graphModel = useGraphContentModelContext(),
       dataConfiguration = useGraphDataConfigurationContext(),
       layout = useGraphLayoutContext(),
-      {isTileSelected} = useTileModelContext(),
+      {isTileSelected} = useTileSelectionContext(),
       dataset = dataConfiguration?.dataset,
       labelRef = useRef<SVGGElement>(null)
 

--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react-lite"
 import { addDisposer, onPatch } from "mobx-state-tree"
 import React, { useEffect, useRef, useState } from "react"
 import { useMemo } from "use-memo-one"
-import { useTileModelContext } from "../../hooks/use-tile-model-context"
+import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { ITileBaseProps } from "../tiles/tile-base-props"
 import { mstReaction } from "../../utilities/mst-reaction"
 import { isTextModel, modelValueToEditorValue } from "./text-model"
@@ -14,7 +14,7 @@ import "./text-tile.scss"
 
 export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
   const textModel = isTextModel(tile?.content) ? tile.content : undefined
-  const { isTileSelected } = useTileModelContext()
+  const { isTileSelected } = useTileSelectionContext()
   const textOnFocus = useRef("")
 
   const [initialValue, setInitialValue] = useState(() => modelValueToEditorValue(textModel?.value))

--- a/v3/src/components/text/text-toolbar.tsx
+++ b/v3/src/components/text/text-toolbar.tsx
@@ -1,7 +1,7 @@
 import { IButtonSpec, SlateToolbar, ToolbarTransform } from "@concord-consortium/slate-editor"
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { useTileModelContext } from "../../hooks/use-tile-model-context"
+import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { useDocumentContainerContext } from "../../hooks/use-document-container-context"
 
 const buttonOrder = [
@@ -41,7 +41,7 @@ export const transformToolbarButtons: ToolbarTransform = (buttons) => {
 
 export const TextToolbar = observer(function TextToolbar() {
   const documentContainerRef = useDocumentContainerContext()
-  const { isTileSelected } = useTileModelContext()
+  const { isTileSelected } = useTileSelectionContext()
 
   return (
     <div className="codap-toolbar-wrapper">

--- a/v3/src/hooks/use-drag-drop.ts
+++ b/v3/src/hooks/use-drag-drop.ts
@@ -5,7 +5,7 @@ import {
 import { kDragContainerClass } from "../components/container/container-constants"
 import { IDataSet } from "../models/data/data-set"
 import { useInstanceIdContext } from "./use-instance-id-context"
-import { useTileModelContext } from "./use-tile-model-context"
+import { useTileSelectionContext } from "./use-tile-selection-context"
 
 // list of draggable types
 export const DragTypes = ["attribute", "row", "tile"] as const
@@ -72,7 +72,7 @@ export const useTileDroppable = (
 }
 
 export const useDropHandler = (dropId: string, onDrop?: (active: Active) => void) => {
-  const { selectTile } = useTileModelContext()
+  const { selectTile } = useTileSelectionContext()
   useDndMonitor({ onDragEnd: ({ active, over }) => {
     // only call onDrop for the handler that registered it
     if (over?.id === dropId) {

--- a/v3/src/hooks/use-tile-model-context.ts
+++ b/v3/src/hooks/use-tile-model-context.ts
@@ -1,6 +1,5 @@
-import { createContext, useCallback, useContext } from "react"
+import { createContext, useContext } from "react"
 import { ITileModel } from "../models/tiles/tile-model"
-import { uiState } from "../models/ui-state"
 
 export const TileModelContext = createContext<ITileModel | undefined>(undefined)
 
@@ -8,13 +7,5 @@ export const useTileModelContext = () => {
   const tile = useContext(TileModelContext)
   const transitionComplete = tile?.transitionComplete ?? false
 
-  const isTileSelected = useCallback(function isTileSelected() {
-    return uiState.isFocusedTile(tile?.id)
-  }, [tile])
-
-  const selectTile = useCallback(function selectTile() {
-    uiState.setFocusedTile(tile?.id)
-  }, [tile])
-
-  return { tile, tileId: tile?.id, isTileSelected, selectTile, transitionComplete }
+  return { tile, tileId: tile?.id, transitionComplete }
 }

--- a/v3/src/hooks/use-tile-selection-context.ts
+++ b/v3/src/hooks/use-tile-selection-context.ts
@@ -8,7 +8,7 @@ export interface ITileSelection {
 export const TileSelectionContext = createContext<ITileSelection | undefined>(undefined)
 
 /**
- * The methods of ITileSelection apply to the tile the current component
+ * The methods of ITileSelection apply to the component in which the hook is used
  *
  * @returns ITileSelection
  */

--- a/v3/src/hooks/use-tile-selection-context.ts
+++ b/v3/src/hooks/use-tile-selection-context.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react"
+
+export interface ITileSelection {
+  isTileSelected: () => boolean
+  selectTile: () => void
+}
+
+export const TileSelectionContext = createContext<ITileSelection | undefined>(undefined)
+
+/**
+ * The methods of ITileSelection apply to the tile the current component
+ *
+ * @returns ITileSelection
+ */
+export const useTileSelectionContext = () => {
+  const tileSelection = useContext(TileSelectionContext)
+  if (!tileSelection) {
+    throw new Error("useTileSelection must be used within a TileSelectionContext Provider")
+  }
+  return tileSelection
+}


### PR DESCRIPTION
The selection methods were moved out of  useTileModelContext.
This change allows the legend and other tiles to work without depending on ITileModel directly.

This is the final step to have a group of separate CODAP files. You can see the group here:
https://github.com/concord-consortium/dst-codap-plugin/pull/9