### PR TITLE
feat: initial v2 graph export

### DIFF
--- a/v3/src/components/graph/graph-registration.ts
+++ b/v3/src/components/graph/graph-registration.ts
@@ -8,6 +8,7 @@ import { registerTileComponentInfo } from "../../models/tiles/tile-component-inf
 import { ITileLikeModel, registerTileContentInfo } from "../../models/tiles/tile-content-info"
 import { SharedDataSet } from "../../models/shared/shared-data-set"
 import { getSharedCaseMetadataFromDataset } from "../../models/shared/shared-data-utils"
+import { registerV2TileExporter } from "../../v2/codap-v2-tile-exporters"
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { ComponentTitleBar } from "../component-title-bar"
 import { PlottedFunctionFormulaAdapter } from "./adornments/plotted-function/plotted-function-formula-adapter"
@@ -23,6 +24,7 @@ import { GraphContentModel, IGraphContentModelSnapshot, isGraphContentModel } fr
 import { kGraphDataConfigurationType } from "./models/graph-data-configuration-model"
 import { GraphFilterFormulaAdapter } from "./models/graph-filter-formula-adapter"
 import { kGraphPointLayerType } from "./models/graph-point-layer-model"
+import { v2GraphExporter } from "./v2-graph-exporter"
 import { v2GraphImporter } from "./v2-graph-importer"
 
 GraphFilterFormulaAdapter.register()
@@ -85,6 +87,7 @@ registerTileComponentInfo({
   defaultHeight: 300
 })
 
+registerV2TileExporter(kGraphTileType, v2GraphExporter)
 registerV2TileImporter("DG.GraphView", v2GraphImporter)
 
 registerComponentHandler(kV2GraphType, graphComponentHandler)

--- a/v3/src/components/graph/v2-graph-exporter.test.ts
+++ b/v3/src/components/graph/v2-graph-exporter.test.ts
@@ -1,0 +1,139 @@
+import { isObject, transform } from "lodash"
+import { DocumentContentModel } from "../../models/document/document-content"
+import { FreeTileRow } from "../../models/document/free-tile-row"
+import { SharedModelDocumentManager } from "../../models/document/shared-model-document-manager"
+import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
+import { safeJsonParse } from "../../utilities/js-utils"
+import { CodapV2Document } from "../../v2/codap-v2-document"
+import { ICodapV2DocumentJson } from "../../v2/codap-v2-types"
+import { v2GraphExporter } from "./v2-graph-exporter"
+import { v2GraphImporter } from "./v2-graph-importer"
+import "./graph-registration"
+
+const fs = require("fs")
+const path = require("path")
+
+function removePropertiesRecursive(obj: any, keysToRemove: string[]): any {
+  if (Array.isArray(obj)) {
+    return obj.map(item => removePropertiesRecursive(item, keysToRemove))
+  }
+  if (isObject(obj)) {
+    return transform<any, any>(obj, (result, value, key) => {
+      if (!keysToRemove.includes(key)) {
+        result[key] = removePropertiesRecursive(value, keysToRemove)
+      }
+    })
+  }
+  return obj
+};
+
+const mockInsertTile = jest.fn()
+
+function loadCodapDocument(fileName: string) {
+  const file = path.join(__dirname, "../../test/v2", fileName)
+  const json = fs.readFileSync(file, "utf8")
+  const parsed = safeJsonParse<ICodapV2DocumentJson>(json)!
+  const v2Document = new CodapV2Document(parsed)
+
+  const sharedModelManager = new SharedModelDocumentManager()
+  const docContent = DocumentContentModel.create({}, { sharedModelManager })
+  docContent.setRowCreator(() => FreeTileRow.create())
+  sharedModelManager.setDocument(docContent)
+
+  mockInsertTile.mockImplementation((tileSnap: ITileModelSnapshotIn) => {
+    const tile = docContent.insertTileSnapshotInDefaultRow(tileSnap)
+    return tile
+  })
+
+  // load shared models into sharedModelManager
+  v2Document.dataContexts.forEach(({ guid }) => {
+    const { data, metadata } = v2Document.getDataAndMetadata(guid)
+    data && sharedModelManager.addSharedModel(data)
+    metadata?.setData(data?.dataSet)
+    metadata && sharedModelManager.addSharedModel(metadata)
+  })
+
+  return { v2Document }
+}
+
+describe("V2GraphImporter", () => {
+
+  // to be implemented in future PRs
+  const kNotImplementedProps = [
+    "numberOfLegendQuantiles",
+    "legendQuantilesAreLocked",
+    "pointColor",
+    "pointSizeMultiplier",
+    "plotBackgroundColor",
+    "plotBackgroundImage",
+    "plotBackgroundImageLockInfo",
+    "plotBackgroundOpacity",
+    "strokeColor",
+    "strokeSameAsFill",
+    "isTransparent",
+    "transparency",
+    "strokeTransparency",
+    "adornments",
+    "showMeasureLabels"
+  ]
+  const kIgnoreProps = [
+    // standard properties handled externally
+    "cannotClose", "name", "title", "userSetTitle",
+    ...kNotImplementedProps
+  ]
+
+  beforeEach(() => {
+    mockInsertTile.mockRestore()
+  })
+
+  it("exports graph components without legends", () => {
+    const { v2Document } = loadCodapDocument("mammals-all-graphs.codap")
+    const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
+    v2GraphTiles.forEach(v2GraphTile => {
+      const v3GraphTile = v2GraphImporter({
+        v2Component: v2GraphTile,
+        v2Document,
+        insertTile: mockInsertTile
+      })
+      // tests round-trip import/export of every graph component
+      const v2GraphTileOut = v2GraphExporter({ tile: v3GraphTile! })
+      const v2GraphTileStorage = removePropertiesRecursive(v2GraphTile.componentStorage, kIgnoreProps)
+      const v2GraphTileOutStorage = removePropertiesRecursive(v2GraphTileOut?.componentStorage, kIgnoreProps)
+      expect(v2GraphTileOutStorage).toEqual(v2GraphTileStorage)
+    })
+  })
+
+  it("exports graph components with categorical legends", () => {
+    const { v2Document } = loadCodapDocument("mammals-all-diet-legends.codap")
+    const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
+    v2GraphTiles.forEach(v2GraphTile => {
+      const v3GraphTile = v2GraphImporter({
+        v2Component: v2GraphTile,
+        v2Document,
+        insertTile: mockInsertTile
+      })
+      // tests round-trip import/export of every graph component
+      const v2GraphTileOut = v2GraphExporter({ tile: v3GraphTile! })
+      const v2GraphTileStorage = removePropertiesRecursive(v2GraphTile.componentStorage, kIgnoreProps)
+      const v2GraphTileOutStorage = removePropertiesRecursive(v2GraphTileOut?.componentStorage, kIgnoreProps)
+      expect(v2GraphTileOutStorage).toEqual(v2GraphTileStorage)
+    })
+  })
+
+  it("exports graph components with numeric legends", () => {
+    const { v2Document } = loadCodapDocument("mammals-all-diet-legends.codap")
+    const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
+    v2GraphTiles.forEach(v2GraphTile => {
+      const v3GraphTile = v2GraphImporter({
+        v2Component: v2GraphTile,
+        v2Document,
+        insertTile: mockInsertTile
+      })
+      // tests round-trip import/export of every graph component
+      const v2GraphTileOut = v2GraphExporter({ tile: v3GraphTile! })
+      const v2GraphTileStorage = removePropertiesRecursive(v2GraphTile.componentStorage, kIgnoreProps)
+      const v2GraphTileOutStorage = removePropertiesRecursive(v2GraphTileOut?.componentStorage, kIgnoreProps)
+      expect(v2GraphTileOutStorage).toEqual(v2GraphTileStorage)
+    })
+  })
+})

--- a/v3/src/components/graph/v2-graph-exporter.ts
+++ b/v3/src/components/graph/v2-graph-exporter.ts
@@ -1,0 +1,205 @@
+import { SetRequired } from "type-fest"
+import { AttributeType } from "../../models/data/attribute-types"
+import { toV2Id } from "../../utilities/codap-utils"
+import { V2TileExportFn } from "../../v2/codap-v2-tile-exporters"
+import { guidLink, ICodapV2GraphStorage, IGuidLink } from "../../v2/codap-v2-types"
+import { IAxisModel, isNumericAxisModel } from "../axis/models/axis-model"
+import { GraphAttrRole } from "../data-display/data-display-types"
+import { PlotType } from "./graphing-types"
+import { IGraphContentModel, isGraphContentModel } from "./models/graph-content-model"
+
+type V2GraphDimension = "x" | "y" | "y2" | "top" | "right" | "legend"
+
+// map from v3 attribute type to v2 numeric attribute type
+const v2TypesMap: Partial<Record<AttributeType, number>> = {
+  numeric: 1,
+  categorical: 2,
+  date: 3,
+  boundary: 4,
+  color: 5
+}
+
+// v2 role constants
+const v2Roles: Record<string, number> = {
+  eInvalid: -1,
+  eNone: 0,
+  ePrimaryNumeric: 1,
+  eSecondaryNumeric: 2,
+  ePrimaryCategorical: 3,
+  eSecondaryCategorical: 4,
+  // eLegendNumeric: 5,
+  // eLegendCategorical: 6,
+  // eVerticalSplit: 7,      // for attribute in place DG.GraphTypes.EPlace.eTopSplit
+  // eHorizontalSplit: 8     // for attribute in place DG.GraphTypes.EPlace.eRightSplit
+}
+
+const v2PlotClass: Record<PlotType, string> = {
+  casePlot: "DG.CasePlotModel",
+  dotPlot: "DG.DotPlotModel",
+  dotChart: "DG.DotChartModel",
+  scatterPlot: "DG.ScatterPlotModel"
+}
+
+type AttributeRoleAndType = Partial<ICodapV2GraphStorage>
+
+function getAttrRoleAndType(
+  graph: IGraphContentModel, role: GraphAttrRole, dim: V2GraphDimension
+): Maybe<AttributeRoleAndType> {
+  const { dataset } = graph
+  if (dataset) {
+    let v2Role = 0
+    const type = graph.dataConfiguration.attributeType(role)
+    const isPrimary = role === graph.dataConfiguration.primaryRole
+    const v2Type = (type && v2TypesMap[type]) ?? v2Roles.eNone
+    switch (role) {
+      case "x":
+      case "y":
+        // special case for empty graph
+        if (!graph.dataConfiguration.attributeType("x") && !graph.dataConfiguration.attributeType("y")) {
+          v2Role = v2Roles.eNone
+        }
+        else {
+          // note: v2 writes out all secondary axis roles as eSecondaryCategorical, even with no attribute
+          v2Role = type === "numeric"
+                    ? isPrimary ? v2Roles.ePrimaryNumeric : v2Roles.eSecondaryCategorical
+                    : isPrimary ? v2Roles.ePrimaryCategorical : v2Roles.eSecondaryCategorical
+        }
+        break
+      case "rightNumeric":
+      case "legend":
+      case "rightSplit":
+      case "topSplit":
+        // v2 always writes out 0 for these roles
+        v2Role = v2Roles.eNone
+        break
+    }
+    return {
+      [`${dim}Role`]: v2Role,
+      [`${dim}AttributeType`]: v2Type
+    }
+  }
+}
+
+type V2GraphLinks = ICodapV2GraphStorage["_links_"]
+
+function getAttrLinksForRole(graph: IGraphContentModel, role: GraphAttrRole, prefix: string): V2GraphLinks {
+  const { dataset } = graph
+  if (dataset) {
+    const collectionKey = `${prefix}Coll`
+    const attributeKey = `${prefix}Attr`
+    const attrId = graph.dataConfiguration.attributeID(role)
+    const collection = dataset.getCollectionForAttribute(attrId)
+    if (attrId && collection) {
+      let attributeLinks: IGuidLink<"DG.Attribute"> | Array<IGuidLink<"DG.Attribute">>
+      if (role === "y" && graph.dataConfiguration.yAttributeDescriptionsExcludingY2.length > 1) {
+        attributeLinks = graph.dataConfiguration.yAttributeDescriptionsExcludingY2
+                          .map(({ attributeID }) => guidLink("DG.Attribute", toV2Id(attributeID)))
+      }
+      else {
+        attributeLinks = guidLink("DG.Attribute", toV2Id(attrId))
+      }
+      return {
+        [collectionKey]: guidLink("DG.Collection", toV2Id(collection.id)),
+        [attributeKey]: attributeLinks
+      }
+    }
+  }
+  return {}
+}
+
+function getLinks(graph: IGraphContentModel): ICodapV2GraphStorage["_links_"] {
+  const { dataset } = graph
+  if (dataset) {
+    return {
+      context: guidLink("DG.DataContextRecord", toV2Id(dataset.id)),
+      // TODO: hiddenCases
+      hiddenCases: [],
+      ...getAttrLinksForRole(graph, "x", "x"),
+      ...getAttrLinksForRole(graph, "y", "y"),
+      ...getAttrLinksForRole(graph, "rightNumeric", "y2"),
+      ...getAttrLinksForRole(graph, "rightSplit", "right"),
+      ...getAttrLinksForRole(graph, "topSplit", "top"),
+      ...getAttrLinksForRole(graph, "legend", "legend")
+    }
+  }
+  return {}
+}
+
+type AxisClassAndBounds = Partial<ICodapV2GraphStorage>
+
+function getAxisClassAndBounds(
+  graph: IGraphContentModel, dim: V2GraphDimension, axis?: IAxisModel
+): AxisClassAndBounds {
+  const axisClass = axis?.isNumeric
+                      ? "DG.CellLinearAxisModel"
+                      : axis?.isCategorical || ["top", "right"].includes(dim)
+                        ? "DG.CellAxisModel"
+                        : "DG.AxisModel"
+  const axisBounds = isNumericAxisModel(axis)
+                      ? {
+                        [`${dim}LowerBound`]: axis.min,
+                        [`${dim}UpperBound`]: axis.max
+                      }
+                      : {}
+  return {
+    [`${dim}AxisClass`]: axisClass,
+    ...axisBounds
+  }
+}
+
+function getPlotModels(graph: IGraphContentModel): Partial<ICodapV2GraphStorage> {
+  const storage: SetRequired<Partial<ICodapV2GraphStorage>, "plotModels"> = {
+    plotModels: [{
+      plotClass: v2PlotClass[graph.plotType],
+      plotModelStorage: {
+        verticalAxisIsY2: false
+      }
+    }]
+  }
+  // in v2, additional Y attributes are represented as additional plot models
+  for (let y = 1; y < graph.dataConfiguration.yAttributeDescriptionsExcludingY2.length; y++) {
+    storage.plotModels.push({
+      plotClass: v2PlotClass.scatterPlot,
+      plotModelStorage: {
+        verticalAxisIsY2: false
+      }
+    })
+  }
+  // in v2, a rightNumeric attribute is represented as an additional plot model
+  if (graph.getAttributeID("rightNumeric")) {
+    storage.plotModels.push({
+      plotClass: v2PlotClass.scatterPlot,
+      plotModelStorage: {
+        verticalAxisIsY2: true
+      }
+    })
+  }
+  return storage
+}
+
+export const v2GraphExporter: V2TileExportFn = ({ tile }) => {
+  const graph = isGraphContentModel(tile.content) ? tile.content : undefined
+  if (!graph) return
+
+  const componentStorage: Partial<ICodapV2GraphStorage> = {
+    _links_: getLinks(graph),
+    displayOnlySelected: !!graph.dataConfiguration.displayOnlySelectedCases,
+    // attribute roles and types
+    ...getAttrRoleAndType(graph, "x", "x"),
+    ...getAttrRoleAndType(graph, "y", "y"),
+    ...getAttrRoleAndType(graph, "rightNumeric", "y2"),
+    ...getAttrRoleAndType(graph, "rightSplit", "right"),
+    ...getAttrRoleAndType(graph, "topSplit", "top"),
+    ...getAttrRoleAndType(graph, "legend", "legend"),
+    // axis classes and bounds
+    ...getAxisClassAndBounds(graph, "x", graph.axes.get("bottom")),
+    ...getAxisClassAndBounds(graph, "y", graph.axes.get("left")),
+    ...getAxisClassAndBounds(graph, "y2", graph.axes.get("rightNumeric")),
+    ...getAxisClassAndBounds(graph, "top", graph.axes.get("topSplit")),
+    ...getAxisClassAndBounds(graph, "right", graph.axes.get("rightSplit")),
+    // plot models
+    ...getPlotModels(graph)
+  }
+
+  return { type: "DG.GraphView", componentStorage }
+}

--- a/v3/src/components/graph/v2-graph-importer.test.ts
+++ b/v3/src/components/graph/v2-graph-importer.test.ts
@@ -1,6 +1,4 @@
 import { getType } from "mobx-state-tree"
-import { CodapV2Document } from "../../v2/codap-v2-document"
-import { ICodapV2DocumentJson } from "../../v2/codap-v2-types"
 import { DataSet } from "../../models/data/data-set"
 import { DocumentContentModel, IDocumentContentModel } from "../../models/document/document-content"
 import { FreeTileRow } from "../../models/document/free-tile-row"
@@ -8,6 +6,9 @@ import { SharedCaseMetadata } from "../../models/shared/shared-case-metadata"
 import { getSharedDataSetFromDataSetId } from "../../models/shared/shared-data-utils"
 import { SharedModelDocumentManager } from "../../models/document/shared-model-document-manager"
 import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
+import { safeJsonParse } from "../../utilities/js-utils"
+import { CodapV2Document } from "../../v2/codap-v2-document"
+import { ICodapV2DocumentJson } from "../../v2/codap-v2-types"
 import {isGraphContentModel} from "./models/graph-content-model"
 import { IGraphPointLayerModel } from "./models/graph-point-layer-model"
 import { v2GraphImporter } from "./v2-graph-importer"
@@ -27,7 +28,7 @@ function graphComponentWithTitle(v2Document: CodapV2Document, title: string) {
 describe("V2GraphImporter", () => {
   const mammalsFile = path.join(__dirname, "../../test/v2", "mammals-graphs.codap")
   const mammalsJson = fs.readFileSync(mammalsFile, "utf8")
-  const mammalsDoc = JSON.parse(mammalsJson) as ICodapV2DocumentJson
+  const mammalsDoc = safeJsonParse<ICodapV2DocumentJson>(mammalsJson)!
 
   let v2Document: CodapV2Document
   let docContent: IDocumentContentModel | undefined

--- a/v3/src/test/v2/mammals-all-diet-legends.codap
+++ b/v3/src/test/v2/mammals-all-diet-legends.codap
@@ -1,0 +1,2418 @@
+{
+    "name": "mammals-all-graphs",
+    "guid": 1,
+    "id": 1,
+    "components": [
+        {
+            "type": "DG.TableView",
+            "guid": 40,
+            "id": 40,
+            "componentStorage": {
+                "isActive": false,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "attributeWidths": [
+                    {
+                        "_links_": {
+                            "attr": {
+                                "type": "DG.Attribute",
+                                "id": 12
+                            }
+                        },
+                        "width": 45
+                    }
+                ],
+                "rowHeights": [],
+                "title": "Mammals",
+                "name": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 583,
+                "height": 237,
+                "left": 5,
+                "top": 5,
+                "isVisible": false,
+                "zIndex": 107,
+                "right": 588,
+                "bottom": 242
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GuideView",
+            "guid": 41,
+            "id": 41,
+            "componentStorage": {
+                "title": "Mammals Sample Guide",
+                "items": [
+                    {
+                        "itemTitle": "Get Started",
+                        "url": "../../../../extn/example-documents/guides/Mammals/mammals_getstarted.html"
+                    }
+                ],
+                "currentItemIndex": 0,
+                "isVisible": false,
+                "name": "Mammals Sample Guide",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "left": 665,
+                "top": 10,
+                "width": 416,
+                "height": 510,
+                "isVisible": false,
+                "zIndex": 15,
+                "right": 1081,
+                "bottom": 520
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.CaseCard",
+            "guid": 42,
+            "id": 42,
+            "componentStorage": {
+                "isActive": true,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "title": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "top": 5,
+                "left": 5,
+                "width": 220,
+                "height": 235,
+                "zIndex": 109,
+                "isVisible": true,
+                "right": 225,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 43,
+            "id": 43,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 9
+                    },
+                    "y2Coll": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "y2Attr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 1,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -1,
+                "yUpperBound": 23,
+                "y2AxisClass": "DG.CellLinearAxisModel",
+                "y2LowerBound": -10,
+                "y2UpperBound": 130,
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": true,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-SleepY-SpeedY2",
+                "name": "Lifespan",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 220,
+                "height": 235,
+                "left": 5,
+                "top": 490,
+                "isVisible": true,
+                "zIndex": 224,
+                "right": 590,
+                "bottom": 585
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 44,
+            "id": 44,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "Empty",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 250,
+                "height": 235,
+                "zIndex": 215,
+                "left": 230,
+                "top": 5,
+                "isVisible": true,
+                "right": 480,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 45,
+            "id": 45,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 235,
+                "zIndex": 216,
+                "left": 485,
+                "top": 5,
+                "isVisible": true,
+                "right": 730,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 46,
+            "id": 46,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 8
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 4,
+                "xAttributeType": 0,
+                "yRole": 1,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.AxisModel",
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -500,
+                "yUpperBound": 7500,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "MassY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 255,
+                "height": 235,
+                "zIndex": 217,
+                "left": 735,
+                "top": 5,
+                "isVisible": true,
+                "right": 990,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 47,
+            "id": 47,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 8
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -500,
+                "yUpperBound": 7500,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-MassY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 265,
+                "height": 235,
+                "zIndex": 218,
+                "left": 995,
+                "top": 5,
+                "isVisible": true,
+                "right": 1260,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 48,
+            "id": 48,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": [
+                        {
+                            "type": "DG.Attribute",
+                            "id": 9
+                        },
+                        {
+                            "type": "DG.Attribute",
+                            "id": 10
+                        }
+                    ]
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-SleepSpeedY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 220,
+                "height": 240,
+                "zIndex": 219,
+                "left": 5,
+                "top": 245,
+                "isVisible": true,
+                "right": 225,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 49,
+            "id": 49,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-DietY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 240,
+                "zIndex": 220,
+                "left": 230,
+                "top": 245,
+                "isVisible": true,
+                "right": 475,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 50,
+            "id": 50,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-DietTop",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 250,
+                "height": 240,
+                "zIndex": 221,
+                "left": 480,
+                "top": 245,
+                "isVisible": true,
+                "right": 730,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 51,
+            "id": 51,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "rightColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "rightAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 2,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-DietRight",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 255,
+                "height": 240,
+                "zIndex": 222,
+                "left": 735,
+                "top": 245,
+                "isVisible": true,
+                "right": 990,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 52,
+            "id": 52,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    },
+                    "rightColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "rightAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 2,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-HabitatTop-DietRight",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 265,
+                "height": 240,
+                "zIndex": 223,
+                "left": 995,
+                "top": 245,
+                "isVisible": true,
+                "right": 1260,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 53,
+            "id": 53,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "DietX",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 235,
+                "zIndex": 225,
+                "left": 230,
+                "top": 490,
+                "isVisible": true,
+                "right": 475,
+                "bottom": 725
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 54,
+            "id": 54,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 4,
+                "xAttributeType": 0,
+                "yRole": 3,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.AxisModel",
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "DietY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 250,
+                "height": 235,
+                "zIndex": 226,
+                "left": 480,
+                "top": 490,
+                "isVisible": true,
+                "right": 730,
+                "bottom": 725
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 55,
+            "id": 55,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "DietX-HabitatY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 255,
+                "height": 235,
+                "zIndex": 227,
+                "left": 735,
+                "top": 490,
+                "isVisible": true,
+                "right": 990,
+                "bottom": 725
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 56,
+            "id": 56,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "HabitatY-DietX (bug?)",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 265,
+                "height": 235,
+                "zIndex": 228,
+                "left": 995,
+                "top": 490,
+                "isVisible": true,
+                "right": 1260,
+                "bottom": 725
+            },
+            "savedHeight": null
+        }
+    ],
+    "contexts": [
+        {
+            "type": "DG.DataContext",
+            "document": 1,
+            "guid": 2,
+            "id": 2,
+            "flexibleGroupingChangeFlag": false,
+            "name": "Mammals",
+            "title": "Mammals",
+            "collections": [
+                {
+                    "areParentChildLinksConfigured": false,
+                    "attrs": [
+                        {
+                            "name": "Mammal",
+                            "type": "none",
+                            "title": "Mammal",
+                            "cid": "id:OeZG-mrujTgO3Rol",
+                            "description": "The species of the mammal",
+                            "_categoryMap": {
+                                "__order": [
+                                    "African Elephant",
+                                    "Asian Elephant",
+                                    "Big Brown Bat",
+                                    "Bottlenose Dolphin",
+                                    "Cheetah",
+                                    "Chimpanzee",
+                                    "Domestic Cat",
+                                    "Donkey",
+                                    "Giraffe",
+                                    "Gray Wolf",
+                                    "Grey Seal",
+                                    "Ground Squirrel",
+                                    "Horse",
+                                    "House Mouse",
+                                    "Human",
+                                    "Jaguar",
+                                    "Killer Whale",
+                                    "Lion",
+                                    "N. American Opossum",
+                                    "Nine-Banded Armadillo",
+                                    "Owl Monkey",
+                                    "Patas Monkey",
+                                    "Pig",
+                                    "Pronghorn Antelope",
+                                    "Rabbit",
+                                    "Red Fox",
+                                    "Spotted Hyena"
+                                ],
+                                "African Elephant": "#FFB300",
+                                "Asian Elephant": "#803E75",
+                                "Big Brown Bat": "#FF6800",
+                                "Bottlenose Dolphin": "#A6BDD7",
+                                "Cheetah": "#C10020",
+                                "Chimpanzee": "#CEA262",
+                                "Domestic Cat": "#817066",
+                                "Donkey": "#007D34",
+                                "Giraffe": "#00538A",
+                                "Gray Wolf": "#F13A13",
+                                "Grey Seal": "#53377A",
+                                "Ground Squirrel": "#FF8E00",
+                                "Horse": "#B32851",
+                                "House Mouse": "#F4C800",
+                                "Human": "#7F180D",
+                                "Jaguar": "#93AA00",
+                                "Killer Whale": "#593315",
+                                "Lion": "#232C16",
+                                "N. American Opossum": "#FF7A5C",
+                                "Nine-Banded Armadillo": "#F6768E",
+                                "Owl Monkey": "#FFB300",
+                                "Patas Monkey": "#803E75",
+                                "Pig": "#FF6800",
+                                "Pronghorn Antelope": "#A6BDD7",
+                                "Rabbit": "#C10020",
+                                "Red Fox": "#CEA262",
+                                "Spotted Hyena": "#817066"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 4,
+                            "id": 4,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Order",
+                            "type": "none",
+                            "title": "Order",
+                            "cid": "id:v0tgEH-ZeDT_1YK0",
+                            "description": "The order of the mammal",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 5,
+                            "id": 5,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "LifeSpan",
+                            "type": "numeric",
+                            "title": "LifeSpan",
+                            "cid": "id:wph23fQdzlKDwrVD",
+                            "description": "",
+                            "_categoryMap": {
+                                "3": "#00538A",
+                                "5": "#F4C800",
+                                "7": "#593315",
+                                "9": "#007D34",
+                                "10": "#7F180D",
+                                "12": "#93AA00",
+                                "14": "#A6BDD7",
+                                "15": "#B32851",
+                                "16": "#CEA262",
+                                "19": "#803E75",
+                                "20": "#53377A",
+                                "25": "#FF6800",
+                                "30": "#817066",
+                                "40": "#C10020",
+                                "50": "#FF8E00",
+                                "70": "#FFB300",
+                                "80": "#F13A13",
+                                "__order": [
+                                    "10",
+                                    "12",
+                                    "14",
+                                    "15",
+                                    "16",
+                                    "19",
+                                    "20",
+                                    "25",
+                                    "3",
+                                    "30",
+                                    "40",
+                                    "5",
+                                    "50",
+                                    "7",
+                                    "70",
+                                    "80",
+                                    "9"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 6,
+                            "id": 6,
+                            "precision": 2,
+                            "unit": "years"
+                        },
+                        {
+                            "name": "Height",
+                            "type": "none",
+                            "title": "Height",
+                            "cid": "id:SF7w_Lk9WiFQuskE",
+                            "description": "The average height of the mammal.",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 7,
+                            "id": 7,
+                            "precision": 2,
+                            "unit": "meters"
+                        },
+                        {
+                            "name": "Mass",
+                            "type": "numeric",
+                            "title": "Mass",
+                            "cid": "id:Itl15QYV6VIJgiRl",
+                            "description": "The mass of the mammal",
+                            "_categoryMap": {
+                                "1": "#F6768E",
+                                "3": "#FFB300",
+                                "5": "#232C16",
+                                "7": "#FF7A5C",
+                                "13": "#FF6800",
+                                "50": "#C10020",
+                                "68": "#CEA262",
+                                "70": "#A6BDD7",
+                                "80": "#F13A13",
+                                "115": "#7F180D",
+                                "187": "#007D34",
+                                "192": "#803E75",
+                                "250": "#593315",
+                                "275": "#53377A",
+                                "521": "#B32851",
+                                "635": "#FFB300",
+                                "1100": "#00538A",
+                                "4000": "#93AA00",
+                                "5000": "#803E75",
+                                "6400": "#FF6800",
+                                "__order": [
+                                    "0.02",
+                                    "0.03",
+                                    "0.1",
+                                    "1",
+                                    "3",
+                                    "4.5",
+                                    "5",
+                                    "7",
+                                    "13",
+                                    "50",
+                                    "68",
+                                    "70",
+                                    "80",
+                                    "115",
+                                    "187",
+                                    "192",
+                                    "250",
+                                    "275",
+                                    "521",
+                                    "635",
+                                    "1100",
+                                    "4000",
+                                    "5000",
+                                    "6400"
+                                ],
+                                "0.02": "#A6BDD7",
+                                "4.5": "#817066",
+                                "0.1": "#FF8E00",
+                                "0.03": "#F4C800"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 8,
+                            "id": 8,
+                            "precision": 2,
+                            "unit": "kg"
+                        },
+                        {
+                            "name": "Sleep",
+                            "type": "numeric",
+                            "title": "Sleep",
+                            "cid": "id:_QDNGutX5kDgYaS9",
+                            "description": "The number of hours the animal sleeps in a 24 hour period",
+                            "_categoryMap": {
+                                "2": "#817066",
+                                "3": "#FF6800",
+                                "4": "#803E75",
+                                "5": "#FFB300",
+                                "6": "#00538A",
+                                "8": "#53377A",
+                                "10": "#CEA262",
+                                "11": "#FF8E00",
+                                "12": "#C10020",
+                                "13": "#007D34",
+                                "15": "#F13A13",
+                                "17": "#F4C800",
+                                "18": "#7F180D",
+                                "19": "#B32851",
+                                "20": "#A6BDD7",
+                                "__order": [
+                                    "2",
+                                    "3",
+                                    "4",
+                                    "5",
+                                    "6",
+                                    "8",
+                                    "10",
+                                    "11",
+                                    "12",
+                                    "13",
+                                    "15",
+                                    "17",
+                                    "18",
+                                    "19",
+                                    "20"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 9,
+                            "id": 9,
+                            "precision": 2,
+                            "unit": "hours"
+                        },
+                        {
+                            "name": "Speed",
+                            "type": "none",
+                            "title": "Speed",
+                            "cid": "id:_kfDY4c5ig4m9n1Y",
+                            "description": "The average speed of the mammal.",
+                            "_categoryMap": {
+                                "1": "#B32851",
+                                "13": "#007D34",
+                                "18": "#7F180D",
+                                "19": "#CEA262",
+                                "37": "#803E75",
+                                "40": "#FF6800",
+                                "45": "#00538A",
+                                "48": "#53377A",
+                                "50": "#FFB300",
+                                "55": "#F4C800",
+                                "56": "#593315",
+                                "60": "#F13A13",
+                                "64": "#C10020",
+                                "69": "#817066",
+                                "80": "#FF8E00",
+                                "98": "#93AA00",
+                                "110": "#A6BDD7",
+                                "__order": [
+                                    "1",
+                                    "110",
+                                    "13",
+                                    "18",
+                                    "19",
+                                    "37",
+                                    "40",
+                                    "45",
+                                    "48",
+                                    "50",
+                                    "55",
+                                    "56",
+                                    "60",
+                                    "64",
+                                    "69",
+                                    "80",
+                                    "98"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 10,
+                            "id": 10,
+                            "precision": 2,
+                            "unit": "km/h"
+                        },
+                        {
+                            "name": "Habitat",
+                            "type": null,
+                            "title": "Habitat",
+                            "cid": "id:-w-cjn2pxub0lnv8",
+                            "description": "",
+                            "_categoryMap": {
+                                "land": {
+                                    "h": 0.4444444444444444,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(85,255,198)"
+                                },
+                                "water": {
+                                    "h": 0.711111111111111,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(130,85,255)"
+                                },
+                                "both": {
+                                    "h": 0.9777777777777777,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(255,85,108)"
+                                },
+                                "__order": [
+                                    "land",
+                                    "water",
+                                    "both"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 11,
+                            "id": 11,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Diet",
+                            "type": null,
+                            "title": "Diet",
+                            "cid": "id:VDyeIN49ME78Q16K",
+                            "description": "",
+                            "_categoryMap": {
+                                "__order": [
+                                    "both",
+                                    "meat",
+                                    "plants"
+                                ],
+                                "plants": "#FFB300",
+                                "meat": "#803E75",
+                                "both": "#FF6800"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 12,
+                            "id": 12,
+                            "precision": 2,
+                            "unit": null
+                        }
+                    ],
+                    "cases": [
+                        {
+                            "guid": 13,
+                            "id": 13,
+                            "itemID": "id:ig3c_O--wnASfPea",
+                            "values": {
+                                "Mammal": "African Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 4,
+                                "Mass": 6400,
+                                "Sleep": 3,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 14,
+                            "id": 14,
+                            "itemID": "id:5fvOQGKlqlALHZyV",
+                            "values": {
+                                "Mammal": "Asian Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 3,
+                                "Mass": 5000,
+                                "Sleep": 4,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 15,
+                            "id": 15,
+                            "itemID": "id:OqVDRqn4FEuLr0vi",
+                            "values": {
+                                "Mammal": "Big Brown Bat",
+                                "Order": "Chiroptera",
+                                "LifeSpan": 19,
+                                "Height": 0.1,
+                                "Mass": 0.02,
+                                "Sleep": 20,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 16,
+                            "id": 16,
+                            "itemID": "id:pBGVGFsx1XtZeeJK",
+                            "values": {
+                                "Mammal": "Bottlenose Dolphin",
+                                "Order": "Cetacea",
+                                "LifeSpan": 25,
+                                "Height": 3.5,
+                                "Mass": 635,
+                                "Sleep": 5,
+                                "Speed": 37,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 17,
+                            "id": 17,
+                            "itemID": "id:u6szUXjRUPYQbf0z",
+                            "values": {
+                                "Mammal": "Cheetah",
+                                "Order": "Carnivora",
+                                "LifeSpan": 14,
+                                "Height": 1.5,
+                                "Mass": 50,
+                                "Sleep": 12,
+                                "Speed": 110,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 18,
+                            "id": 18,
+                            "itemID": "id:ELJjhBucV_ChIjXv",
+                            "values": {
+                                "Mammal": "Chimpanzee",
+                                "Order": "Primate",
+                                "LifeSpan": 40,
+                                "Height": 1.5,
+                                "Mass": 68,
+                                "Sleep": 10,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 19,
+                            "id": 19,
+                            "itemID": "id:Vu01ZRbuOUJfoHHW",
+                            "values": {
+                                "Mammal": "Domestic Cat",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 0.8,
+                                "Mass": 4.5,
+                                "Sleep": 12,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 20,
+                            "id": 20,
+                            "itemID": "id:2_-jpOCPFO7AJ781",
+                            "values": {
+                                "Mammal": "Donkey",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 40,
+                                "Height": 1.2,
+                                "Mass": 187,
+                                "Sleep": 3,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 21,
+                            "id": 21,
+                            "itemID": "id:9NrrFj8163K6fz1K",
+                            "values": {
+                                "Mammal": "Giraffe",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 25,
+                                "Height": 5,
+                                "Mass": 1100,
+                                "Sleep": 2,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 22,
+                            "id": 22,
+                            "itemID": "id:w7zBDPnBs7LZwpE6",
+                            "values": {
+                                "Mammal": "Gray Wolf",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 1.6,
+                                "Mass": 80,
+                                "Sleep": 13,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 23,
+                            "id": 23,
+                            "itemID": "id:e2fqzGUZEflqLdU3",
+                            "values": {
+                                "Mammal": "Grey Seal",
+                                "Order": "Pinnipedia",
+                                "LifeSpan": 30,
+                                "Height": 2.1,
+                                "Mass": 275,
+                                "Sleep": 6,
+                                "Speed": 19,
+                                "Habitat": "both",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 24,
+                            "id": 24,
+                            "itemID": "id:iShVYcjqv99srjkr",
+                            "values": {
+                                "Mammal": "Ground Squirrel",
+                                "Order": "Rodentia",
+                                "LifeSpan": 9,
+                                "Height": 0.3,
+                                "Mass": 0.1,
+                                "Sleep": 15,
+                                "Speed": 19,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 25,
+                            "id": 25,
+                            "itemID": "id:N67oxJchChueDtC_",
+                            "values": {
+                                "Mammal": "Horse",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 25,
+                                "Height": 1.5,
+                                "Mass": 521,
+                                "Sleep": 3,
+                                "Speed": 69,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 26,
+                            "id": 26,
+                            "itemID": "id:CoI3MWb1ui0gsAx9",
+                            "values": {
+                                "Mammal": "House Mouse",
+                                "Order": "Rodentia",
+                                "LifeSpan": 3,
+                                "Height": 0.1,
+                                "Mass": 0.03,
+                                "Sleep": 12,
+                                "Speed": 13,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 27,
+                            "id": 27,
+                            "itemID": "id:uWtZO9JXZ2SCTI6G",
+                            "values": {
+                                "Mammal": "Human",
+                                "Order": "Primate",
+                                "LifeSpan": 80,
+                                "Height": 1.9,
+                                "Mass": 80,
+                                "Sleep": 8,
+                                "Speed": 45,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 28,
+                            "id": 28,
+                            "itemID": "id:kowlipxggopX4Q3d",
+                            "values": {
+                                "Mammal": "Jaguar",
+                                "Order": "Carnivora",
+                                "LifeSpan": 20,
+                                "Height": 1.8,
+                                "Mass": 115,
+                                "Sleep": 11,
+                                "Speed": 60,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 29,
+                            "id": 29,
+                            "itemID": "id:BFiiPyTHN2LFU-O4",
+                            "values": {
+                                "Mammal": "Killer Whale",
+                                "Order": "Cetacea",
+                                "LifeSpan": 50,
+                                "Height": 6.5,
+                                "Mass": 4000,
+                                "Sleep": "",
+                                "Speed": 48,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 30,
+                            "id": 30,
+                            "itemID": "id:Clgel839okaHYawd",
+                            "values": {
+                                "Mammal": "Lion",
+                                "Order": "Carnivora",
+                                "LifeSpan": 15,
+                                "Height": 2.5,
+                                "Mass": 250,
+                                "Sleep": 20,
+                                "Speed": 80,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 31,
+                            "id": 31,
+                            "itemID": "id:w3Val7QA5meMBEEB",
+                            "values": {
+                                "Mammal": "N. American Opossum",
+                                "Order": "Didelphimorphia",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 5,
+                                "Sleep": 19,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 32,
+                            "id": 32,
+                            "itemID": "id:aLk9ZmNgx7E9E7NV",
+                            "values": {
+                                "Mammal": "Nine-Banded Armadillo",
+                                "Order": "Xenarthra",
+                                "LifeSpan": 10,
+                                "Height": 0.6,
+                                "Mass": 7,
+                                "Sleep": 17,
+                                "Speed": 1,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 33,
+                            "id": 33,
+                            "itemID": "id:p7NElX9Qhx3FCh5q",
+                            "values": {
+                                "Mammal": "Owl Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 12,
+                                "Height": 0.4,
+                                "Mass": 1,
+                                "Sleep": 17,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 34,
+                            "id": 34,
+                            "itemID": "id:Z5QypAvePMG2HM3Z",
+                            "values": {
+                                "Mammal": "Patas Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 20,
+                                "Height": 0.9,
+                                "Mass": 13,
+                                "Sleep": "",
+                                "Speed": 55,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 35,
+                            "id": 35,
+                            "itemID": "id:P5wH0mvnPn05JFmS",
+                            "values": {
+                                "Mammal": "Pig",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 1,
+                                "Mass": 192,
+                                "Sleep": 8,
+                                "Speed": 18,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 36,
+                            "id": 36,
+                            "itemID": "id:GPB4K3B9DOzhdb3L",
+                            "values": {
+                                "Mammal": "Pronghorn Antelope",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": "",
+                                "Speed": 98,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 37,
+                            "id": 37,
+                            "itemID": "id:At9JgEpDfH7_IGVQ",
+                            "values": {
+                                "Mammal": "Rabbit",
+                                "Order": "Lagomorpha",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 3,
+                                "Sleep": 11,
+                                "Speed": 56,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 38,
+                            "id": 38,
+                            "itemID": "id:RDK7bWCmb2C6TPcA",
+                            "values": {
+                                "Mammal": "Red Fox",
+                                "Order": "Carnivora",
+                                "LifeSpan": 7,
+                                "Height": 0.8,
+                                "Mass": 5,
+                                "Sleep": 10,
+                                "Speed": 48,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 39,
+                            "id": 39,
+                            "itemID": "id:ZftMZdiC1Eyle4kE",
+                            "values": {
+                                "Mammal": "Spotted Hyena",
+                                "Order": "Carnivora",
+                                "LifeSpan": 25,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": 18,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        }
+                    ],
+                    "caseName": null,
+                    "childAttrName": null,
+                    "collapseChildren": null,
+                    "guid": 3,
+                    "id": 3,
+                    "name": "Mammals",
+                    "title": "Mammals",
+                    "type": "DG.Collection"
+                }
+            ],
+            "description": "",
+            "metadata": null,
+            "preventReorg": false,
+            "setAsideItems": [],
+            "contextStorage": {
+                "_links_": {
+                    "selectedCases": []
+                }
+            }
+        }
+    ],
+    "globalValues": [],
+    "appName": "DG",
+    "appVersion": "2.0",
+    "appBuildNum": "0730",
+    "lang": "en",
+    "idCount": 56,
+    "metadata": {}
+}

--- a/v3/src/test/v2/mammals-all-graphs.codap
+++ b/v3/src/test/v2/mammals-all-graphs.codap
@@ -1,0 +1,2306 @@
+{
+    "name": "Mammals",
+    "guid": 1,
+    "id": 1,
+    "components": [
+        {
+            "type": "DG.TableView",
+            "guid": 40,
+            "id": 40,
+            "componentStorage": {
+                "isActive": false,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "attributeWidths": [
+                    {
+                        "_links_": {
+                            "attr": {
+                                "type": "DG.Attribute",
+                                "id": 12
+                            }
+                        },
+                        "width": 45
+                    }
+                ],
+                "rowHeights": [],
+                "title": "Mammals",
+                "name": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 583,
+                "height": 237,
+                "left": 5,
+                "top": 5,
+                "isVisible": false,
+                "zIndex": 107,
+                "right": 588,
+                "bottom": 242
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GuideView",
+            "guid": 41,
+            "id": 41,
+            "componentStorage": {
+                "title": "Mammals Sample Guide",
+                "items": [
+                    {
+                        "itemTitle": "Get Started",
+                        "url": "../../../../extn/example-documents/guides/Mammals/mammals_getstarted.html"
+                    }
+                ],
+                "currentItemIndex": 0,
+                "isVisible": false,
+                "name": "Mammals Sample Guide",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "left": 665,
+                "top": 10,
+                "width": 416,
+                "height": 510,
+                "isVisible": false,
+                "zIndex": 15,
+                "right": 1081,
+                "bottom": 520
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.CaseCard",
+            "guid": 42,
+            "id": 42,
+            "componentStorage": {
+                "isActive": true,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "title": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "top": 5,
+                "left": 5,
+                "width": 220,
+                "height": 235,
+                "zIndex": 109,
+                "isVisible": true,
+                "right": 225,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 43,
+            "id": 43,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 9
+                    },
+                    "y2Coll": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "y2Attr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 1,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -1,
+                "yUpperBound": 23,
+                "y2AxisClass": "DG.CellLinearAxisModel",
+                "y2LowerBound": -10,
+                "y2UpperBound": 130,
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": true,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-SleepY-SpeedY2",
+                "name": "Lifespan",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 220,
+                "height": 235,
+                "left": 5,
+                "top": 490,
+                "isVisible": true,
+                "zIndex": 182,
+                "right": 590,
+                "bottom": 585
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 44,
+            "id": 44,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": []
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 0,
+                "xAttributeType": 0,
+                "yRole": 0,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.AxisModel",
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.CasePlotModel"
+                    }
+                ],
+                "title": "Empty",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 250,
+                "height": 235,
+                "zIndex": 116,
+                "left": 230,
+                "top": 5,
+                "isVisible": true,
+                "right": 480,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 45,
+            "id": 45,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 235,
+                "zIndex": 122,
+                "left": 485,
+                "top": 5,
+                "isVisible": true,
+                "right": 730,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 46,
+            "id": 46,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 8
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 4,
+                "xAttributeType": 0,
+                "yRole": 1,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.AxisModel",
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -500,
+                "yUpperBound": 7500,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "MassY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 255,
+                "height": 235,
+                "zIndex": 128,
+                "left": 735,
+                "top": 5,
+                "isVisible": true,
+                "right": 990,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 47,
+            "id": 47,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 8
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -500,
+                "yUpperBound": 7500,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-MassY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 265,
+                "height": 235,
+                "zIndex": 136,
+                "left": 995,
+                "top": 5,
+                "isVisible": true,
+                "right": 1260,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 48,
+            "id": 48,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": [
+                        {
+                            "type": "DG.Attribute",
+                            "id": 9
+                        },
+                        {
+                            "type": "DG.Attribute",
+                            "id": 10
+                        }
+                    ]
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-SleepSpeedY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 220,
+                "height": 240,
+                "zIndex": 145,
+                "left": 5,
+                "top": 245,
+                "isVisible": true,
+                "right": 225,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 49,
+            "id": 49,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-DietY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 240,
+                "zIndex": 152,
+                "left": 230,
+                "top": 245,
+                "isVisible": true,
+                "right": 475,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 50,
+            "id": 50,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-DietTop",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 250,
+                "height": 240,
+                "zIndex": 159,
+                "left": 480,
+                "top": 245,
+                "isVisible": true,
+                "right": 730,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 51,
+            "id": 51,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "rightColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "rightAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 2,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-DietRight",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 255,
+                "height": 240,
+                "zIndex": 167,
+                "left": 735,
+                "top": 245,
+                "isVisible": true,
+                "right": 990,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 52,
+            "id": 52,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    },
+                    "rightColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "rightAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 2,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-HabitatTop-DietRight",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 265,
+                "height": 240,
+                "zIndex": 176,
+                "left": 995,
+                "top": 245,
+                "isVisible": true,
+                "right": 1260,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 53,
+            "id": 53,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "DietX",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 235,
+                "zIndex": 190,
+                "left": 230,
+                "top": 490,
+                "isVisible": true,
+                "right": 475,
+                "bottom": 725
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 54,
+            "id": 54,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 4,
+                "xAttributeType": 0,
+                "yRole": 3,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.AxisModel",
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "DietY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 250,
+                "height": 235,
+                "zIndex": 197,
+                "left": 480,
+                "top": 490,
+                "isVisible": true,
+                "right": 730,
+                "bottom": 725
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 55,
+            "id": 55,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "DietX-HabitatY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 255,
+                "height": 235,
+                "zIndex": 205,
+                "left": 735,
+                "top": 490,
+                "isVisible": true,
+                "right": 990,
+                "bottom": 725
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 56,
+            "id": 56,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "HabitatY-DietX (bug?)",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 265,
+                "height": 235,
+                "zIndex": 214,
+                "left": 995,
+                "top": 490,
+                "isVisible": true,
+                "right": 1260,
+                "bottom": 725
+            },
+            "savedHeight": null
+        }
+    ],
+    "contexts": [
+        {
+            "type": "DG.DataContext",
+            "document": 1,
+            "guid": 2,
+            "id": 2,
+            "flexibleGroupingChangeFlag": false,
+            "name": "Mammals",
+            "title": "Mammals",
+            "collections": [
+                {
+                    "areParentChildLinksConfigured": false,
+                    "attrs": [
+                        {
+                            "name": "Mammal",
+                            "type": "none",
+                            "title": "Mammal",
+                            "cid": "id:OeZG-mrujTgO3Rol",
+                            "description": "The species of the mammal",
+                            "_categoryMap": {
+                                "__order": [
+                                    "African Elephant",
+                                    "Asian Elephant",
+                                    "Big Brown Bat",
+                                    "Bottlenose Dolphin",
+                                    "Cheetah",
+                                    "Chimpanzee",
+                                    "Domestic Cat",
+                                    "Donkey",
+                                    "Giraffe",
+                                    "Gray Wolf",
+                                    "Grey Seal",
+                                    "Ground Squirrel",
+                                    "Horse",
+                                    "House Mouse",
+                                    "Human",
+                                    "Jaguar",
+                                    "Killer Whale",
+                                    "Lion",
+                                    "N. American Opossum",
+                                    "Nine-Banded Armadillo",
+                                    "Owl Monkey",
+                                    "Patas Monkey",
+                                    "Pig",
+                                    "Pronghorn Antelope",
+                                    "Rabbit",
+                                    "Red Fox",
+                                    "Spotted Hyena"
+                                ],
+                                "African Elephant": "#FFB300",
+                                "Asian Elephant": "#803E75",
+                                "Big Brown Bat": "#FF6800",
+                                "Bottlenose Dolphin": "#A6BDD7",
+                                "Cheetah": "#C10020",
+                                "Chimpanzee": "#CEA262",
+                                "Domestic Cat": "#817066",
+                                "Donkey": "#007D34",
+                                "Giraffe": "#00538A",
+                                "Gray Wolf": "#F13A13",
+                                "Grey Seal": "#53377A",
+                                "Ground Squirrel": "#FF8E00",
+                                "Horse": "#B32851",
+                                "House Mouse": "#F4C800",
+                                "Human": "#7F180D",
+                                "Jaguar": "#93AA00",
+                                "Killer Whale": "#593315",
+                                "Lion": "#232C16",
+                                "N. American Opossum": "#FF7A5C",
+                                "Nine-Banded Armadillo": "#F6768E",
+                                "Owl Monkey": "#FFB300",
+                                "Patas Monkey": "#803E75",
+                                "Pig": "#FF6800",
+                                "Pronghorn Antelope": "#A6BDD7",
+                                "Rabbit": "#C10020",
+                                "Red Fox": "#CEA262",
+                                "Spotted Hyena": "#817066"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 4,
+                            "id": 4,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Order",
+                            "type": "none",
+                            "title": "Order",
+                            "cid": "id:v0tgEH-ZeDT_1YK0",
+                            "description": "The order of the mammal",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 5,
+                            "id": 5,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "LifeSpan",
+                            "type": "numeric",
+                            "title": "LifeSpan",
+                            "cid": "id:wph23fQdzlKDwrVD",
+                            "description": "",
+                            "_categoryMap": {
+                                "3": "#00538A",
+                                "5": "#F4C800",
+                                "7": "#593315",
+                                "9": "#007D34",
+                                "10": "#7F180D",
+                                "12": "#93AA00",
+                                "14": "#A6BDD7",
+                                "15": "#B32851",
+                                "16": "#CEA262",
+                                "19": "#803E75",
+                                "20": "#53377A",
+                                "25": "#FF6800",
+                                "30": "#817066",
+                                "40": "#C10020",
+                                "50": "#FF8E00",
+                                "70": "#FFB300",
+                                "80": "#F13A13",
+                                "__order": [
+                                    "10",
+                                    "12",
+                                    "14",
+                                    "15",
+                                    "16",
+                                    "19",
+                                    "20",
+                                    "25",
+                                    "3",
+                                    "30",
+                                    "40",
+                                    "5",
+                                    "50",
+                                    "7",
+                                    "70",
+                                    "80",
+                                    "9"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 6,
+                            "id": 6,
+                            "precision": 2,
+                            "unit": "years"
+                        },
+                        {
+                            "name": "Height",
+                            "type": "none",
+                            "title": "Height",
+                            "cid": "id:SF7w_Lk9WiFQuskE",
+                            "description": "The average height of the mammal.",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 7,
+                            "id": 7,
+                            "precision": 2,
+                            "unit": "meters"
+                        },
+                        {
+                            "name": "Mass",
+                            "type": "numeric",
+                            "title": "Mass",
+                            "cid": "id:Itl15QYV6VIJgiRl",
+                            "description": "The mass of the mammal",
+                            "_categoryMap": {
+                                "1": "#F6768E",
+                                "3": "#FFB300",
+                                "5": "#232C16",
+                                "7": "#FF7A5C",
+                                "13": "#FF6800",
+                                "50": "#C10020",
+                                "68": "#CEA262",
+                                "70": "#A6BDD7",
+                                "80": "#F13A13",
+                                "115": "#7F180D",
+                                "187": "#007D34",
+                                "192": "#803E75",
+                                "250": "#593315",
+                                "275": "#53377A",
+                                "521": "#B32851",
+                                "635": "#FFB300",
+                                "1100": "#00538A",
+                                "4000": "#93AA00",
+                                "5000": "#803E75",
+                                "6400": "#FF6800",
+                                "__order": [
+                                    "0.02",
+                                    "0.03",
+                                    "0.1",
+                                    "1",
+                                    "3",
+                                    "4.5",
+                                    "5",
+                                    "7",
+                                    "13",
+                                    "50",
+                                    "68",
+                                    "70",
+                                    "80",
+                                    "115",
+                                    "187",
+                                    "192",
+                                    "250",
+                                    "275",
+                                    "521",
+                                    "635",
+                                    "1100",
+                                    "4000",
+                                    "5000",
+                                    "6400"
+                                ],
+                                "0.02": "#A6BDD7",
+                                "4.5": "#817066",
+                                "0.1": "#FF8E00",
+                                "0.03": "#F4C800"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 8,
+                            "id": 8,
+                            "precision": 2,
+                            "unit": "kg"
+                        },
+                        {
+                            "name": "Sleep",
+                            "type": "numeric",
+                            "title": "Sleep",
+                            "cid": "id:_QDNGutX5kDgYaS9",
+                            "description": "The number of hours the animal sleeps in a 24 hour period",
+                            "_categoryMap": {
+                                "2": "#817066",
+                                "3": "#FF6800",
+                                "4": "#803E75",
+                                "5": "#FFB300",
+                                "6": "#00538A",
+                                "8": "#53377A",
+                                "10": "#CEA262",
+                                "11": "#FF8E00",
+                                "12": "#C10020",
+                                "13": "#007D34",
+                                "15": "#F13A13",
+                                "17": "#F4C800",
+                                "18": "#7F180D",
+                                "19": "#B32851",
+                                "20": "#A6BDD7",
+                                "__order": [
+                                    "2",
+                                    "3",
+                                    "4",
+                                    "5",
+                                    "6",
+                                    "8",
+                                    "10",
+                                    "11",
+                                    "12",
+                                    "13",
+                                    "15",
+                                    "17",
+                                    "18",
+                                    "19",
+                                    "20"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 9,
+                            "id": 9,
+                            "precision": 2,
+                            "unit": "hours"
+                        },
+                        {
+                            "name": "Speed",
+                            "type": "none",
+                            "title": "Speed",
+                            "cid": "id:_kfDY4c5ig4m9n1Y",
+                            "description": "The average speed of the mammal.",
+                            "_categoryMap": {
+                                "1": "#B32851",
+                                "13": "#007D34",
+                                "18": "#7F180D",
+                                "19": "#CEA262",
+                                "37": "#803E75",
+                                "40": "#FF6800",
+                                "45": "#00538A",
+                                "48": "#53377A",
+                                "50": "#FFB300",
+                                "55": "#F4C800",
+                                "56": "#593315",
+                                "60": "#F13A13",
+                                "64": "#C10020",
+                                "69": "#817066",
+                                "80": "#FF8E00",
+                                "98": "#93AA00",
+                                "110": "#A6BDD7",
+                                "__order": [
+                                    "1",
+                                    "110",
+                                    "13",
+                                    "18",
+                                    "19",
+                                    "37",
+                                    "40",
+                                    "45",
+                                    "48",
+                                    "50",
+                                    "55",
+                                    "56",
+                                    "60",
+                                    "64",
+                                    "69",
+                                    "80",
+                                    "98"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 10,
+                            "id": 10,
+                            "precision": 2,
+                            "unit": "km/h"
+                        },
+                        {
+                            "name": "Habitat",
+                            "type": null,
+                            "title": "Habitat",
+                            "cid": "id:-w-cjn2pxub0lnv8",
+                            "description": "",
+                            "_categoryMap": {
+                                "land": {
+                                    "h": 0.4444444444444444,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(85,255,198)"
+                                },
+                                "water": {
+                                    "h": 0.711111111111111,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(130,85,255)"
+                                },
+                                "both": {
+                                    "h": 0.9777777777777777,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(255,85,108)"
+                                },
+                                "__order": [
+                                    "land",
+                                    "water",
+                                    "both"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 11,
+                            "id": 11,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Diet",
+                            "type": null,
+                            "title": "Diet",
+                            "cid": "id:VDyeIN49ME78Q16K",
+                            "description": "",
+                            "_categoryMap": {
+                                "__order": [
+                                    "both",
+                                    "meat",
+                                    "plants"
+                                ],
+                                "plants": "#FFB300",
+                                "meat": "#803E75",
+                                "both": "#FF6800"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 12,
+                            "id": 12,
+                            "precision": 2,
+                            "unit": null
+                        }
+                    ],
+                    "cases": [
+                        {
+                            "guid": 13,
+                            "id": 13,
+                            "itemID": "id:ig3c_O--wnASfPea",
+                            "values": {
+                                "Mammal": "African Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 4,
+                                "Mass": 6400,
+                                "Sleep": 3,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 14,
+                            "id": 14,
+                            "itemID": "id:5fvOQGKlqlALHZyV",
+                            "values": {
+                                "Mammal": "Asian Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 3,
+                                "Mass": 5000,
+                                "Sleep": 4,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 15,
+                            "id": 15,
+                            "itemID": "id:OqVDRqn4FEuLr0vi",
+                            "values": {
+                                "Mammal": "Big Brown Bat",
+                                "Order": "Chiroptera",
+                                "LifeSpan": 19,
+                                "Height": 0.1,
+                                "Mass": 0.02,
+                                "Sleep": 20,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 16,
+                            "id": 16,
+                            "itemID": "id:pBGVGFsx1XtZeeJK",
+                            "values": {
+                                "Mammal": "Bottlenose Dolphin",
+                                "Order": "Cetacea",
+                                "LifeSpan": 25,
+                                "Height": 3.5,
+                                "Mass": 635,
+                                "Sleep": 5,
+                                "Speed": 37,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 17,
+                            "id": 17,
+                            "itemID": "id:u6szUXjRUPYQbf0z",
+                            "values": {
+                                "Mammal": "Cheetah",
+                                "Order": "Carnivora",
+                                "LifeSpan": 14,
+                                "Height": 1.5,
+                                "Mass": 50,
+                                "Sleep": 12,
+                                "Speed": 110,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 18,
+                            "id": 18,
+                            "itemID": "id:ELJjhBucV_ChIjXv",
+                            "values": {
+                                "Mammal": "Chimpanzee",
+                                "Order": "Primate",
+                                "LifeSpan": 40,
+                                "Height": 1.5,
+                                "Mass": 68,
+                                "Sleep": 10,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 19,
+                            "id": 19,
+                            "itemID": "id:Vu01ZRbuOUJfoHHW",
+                            "values": {
+                                "Mammal": "Domestic Cat",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 0.8,
+                                "Mass": 4.5,
+                                "Sleep": 12,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 20,
+                            "id": 20,
+                            "itemID": "id:2_-jpOCPFO7AJ781",
+                            "values": {
+                                "Mammal": "Donkey",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 40,
+                                "Height": 1.2,
+                                "Mass": 187,
+                                "Sleep": 3,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 21,
+                            "id": 21,
+                            "itemID": "id:9NrrFj8163K6fz1K",
+                            "values": {
+                                "Mammal": "Giraffe",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 25,
+                                "Height": 5,
+                                "Mass": 1100,
+                                "Sleep": 2,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 22,
+                            "id": 22,
+                            "itemID": "id:w7zBDPnBs7LZwpE6",
+                            "values": {
+                                "Mammal": "Gray Wolf",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 1.6,
+                                "Mass": 80,
+                                "Sleep": 13,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 23,
+                            "id": 23,
+                            "itemID": "id:e2fqzGUZEflqLdU3",
+                            "values": {
+                                "Mammal": "Grey Seal",
+                                "Order": "Pinnipedia",
+                                "LifeSpan": 30,
+                                "Height": 2.1,
+                                "Mass": 275,
+                                "Sleep": 6,
+                                "Speed": 19,
+                                "Habitat": "both",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 24,
+                            "id": 24,
+                            "itemID": "id:iShVYcjqv99srjkr",
+                            "values": {
+                                "Mammal": "Ground Squirrel",
+                                "Order": "Rodentia",
+                                "LifeSpan": 9,
+                                "Height": 0.3,
+                                "Mass": 0.1,
+                                "Sleep": 15,
+                                "Speed": 19,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 25,
+                            "id": 25,
+                            "itemID": "id:N67oxJchChueDtC_",
+                            "values": {
+                                "Mammal": "Horse",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 25,
+                                "Height": 1.5,
+                                "Mass": 521,
+                                "Sleep": 3,
+                                "Speed": 69,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 26,
+                            "id": 26,
+                            "itemID": "id:CoI3MWb1ui0gsAx9",
+                            "values": {
+                                "Mammal": "House Mouse",
+                                "Order": "Rodentia",
+                                "LifeSpan": 3,
+                                "Height": 0.1,
+                                "Mass": 0.03,
+                                "Sleep": 12,
+                                "Speed": 13,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 27,
+                            "id": 27,
+                            "itemID": "id:uWtZO9JXZ2SCTI6G",
+                            "values": {
+                                "Mammal": "Human",
+                                "Order": "Primate",
+                                "LifeSpan": 80,
+                                "Height": 1.9,
+                                "Mass": 80,
+                                "Sleep": 8,
+                                "Speed": 45,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 28,
+                            "id": 28,
+                            "itemID": "id:kowlipxggopX4Q3d",
+                            "values": {
+                                "Mammal": "Jaguar",
+                                "Order": "Carnivora",
+                                "LifeSpan": 20,
+                                "Height": 1.8,
+                                "Mass": 115,
+                                "Sleep": 11,
+                                "Speed": 60,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 29,
+                            "id": 29,
+                            "itemID": "id:BFiiPyTHN2LFU-O4",
+                            "values": {
+                                "Mammal": "Killer Whale",
+                                "Order": "Cetacea",
+                                "LifeSpan": 50,
+                                "Height": 6.5,
+                                "Mass": 4000,
+                                "Sleep": "",
+                                "Speed": 48,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 30,
+                            "id": 30,
+                            "itemID": "id:Clgel839okaHYawd",
+                            "values": {
+                                "Mammal": "Lion",
+                                "Order": "Carnivora",
+                                "LifeSpan": 15,
+                                "Height": 2.5,
+                                "Mass": 250,
+                                "Sleep": 20,
+                                "Speed": 80,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 31,
+                            "id": 31,
+                            "itemID": "id:w3Val7QA5meMBEEB",
+                            "values": {
+                                "Mammal": "N. American Opossum",
+                                "Order": "Didelphimorphia",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 5,
+                                "Sleep": 19,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 32,
+                            "id": 32,
+                            "itemID": "id:aLk9ZmNgx7E9E7NV",
+                            "values": {
+                                "Mammal": "Nine-Banded Armadillo",
+                                "Order": "Xenarthra",
+                                "LifeSpan": 10,
+                                "Height": 0.6,
+                                "Mass": 7,
+                                "Sleep": 17,
+                                "Speed": 1,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 33,
+                            "id": 33,
+                            "itemID": "id:p7NElX9Qhx3FCh5q",
+                            "values": {
+                                "Mammal": "Owl Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 12,
+                                "Height": 0.4,
+                                "Mass": 1,
+                                "Sleep": 17,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 34,
+                            "id": 34,
+                            "itemID": "id:Z5QypAvePMG2HM3Z",
+                            "values": {
+                                "Mammal": "Patas Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 20,
+                                "Height": 0.9,
+                                "Mass": 13,
+                                "Sleep": "",
+                                "Speed": 55,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 35,
+                            "id": 35,
+                            "itemID": "id:P5wH0mvnPn05JFmS",
+                            "values": {
+                                "Mammal": "Pig",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 1,
+                                "Mass": 192,
+                                "Sleep": 8,
+                                "Speed": 18,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 36,
+                            "id": 36,
+                            "itemID": "id:GPB4K3B9DOzhdb3L",
+                            "values": {
+                                "Mammal": "Pronghorn Antelope",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": "",
+                                "Speed": 98,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 37,
+                            "id": 37,
+                            "itemID": "id:At9JgEpDfH7_IGVQ",
+                            "values": {
+                                "Mammal": "Rabbit",
+                                "Order": "Lagomorpha",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 3,
+                                "Sleep": 11,
+                                "Speed": 56,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 38,
+                            "id": 38,
+                            "itemID": "id:RDK7bWCmb2C6TPcA",
+                            "values": {
+                                "Mammal": "Red Fox",
+                                "Order": "Carnivora",
+                                "LifeSpan": 7,
+                                "Height": 0.8,
+                                "Mass": 5,
+                                "Sleep": 10,
+                                "Speed": 48,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 39,
+                            "id": 39,
+                            "itemID": "id:ZftMZdiC1Eyle4kE",
+                            "values": {
+                                "Mammal": "Spotted Hyena",
+                                "Order": "Carnivora",
+                                "LifeSpan": 25,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": 18,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        }
+                    ],
+                    "caseName": null,
+                    "childAttrName": null,
+                    "collapseChildren": null,
+                    "guid": 3,
+                    "id": 3,
+                    "name": "Mammals",
+                    "title": "Mammals",
+                    "type": "DG.Collection"
+                }
+            ],
+            "description": "",
+            "metadata": null,
+            "preventReorg": false,
+            "setAsideItems": [],
+            "contextStorage": {
+                "_links_": {
+                    "selectedCases": []
+                }
+            }
+        }
+    ],
+    "globalValues": [],
+    "appName": "DG",
+    "appVersion": "2.0",
+    "appBuildNum": "0730",
+    "lang": "en",
+    "idCount": 56,
+    "metadata": {}
+}

--- a/v3/src/test/v2/mammals-all-speed-legends.codap
+++ b/v3/src/test/v2/mammals-all-speed-legends.codap
@@ -1,0 +1,2421 @@
+{
+    "name": "mammals-all-graphs",
+    "guid": 1,
+    "id": 1,
+    "components": [
+        {
+            "type": "DG.TableView",
+            "guid": 40,
+            "id": 40,
+            "componentStorage": {
+                "isActive": false,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "attributeWidths": [
+                    {
+                        "_links_": {
+                            "attr": {
+                                "type": "DG.Attribute",
+                                "id": 12
+                            }
+                        },
+                        "width": 45
+                    }
+                ],
+                "rowHeights": [],
+                "title": "Mammals",
+                "name": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 583,
+                "height": 237,
+                "left": 5,
+                "top": 5,
+                "isVisible": false,
+                "zIndex": 107,
+                "right": 588,
+                "bottom": 242
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GuideView",
+            "guid": 41,
+            "id": 41,
+            "componentStorage": {
+                "title": "Mammals Sample Guide",
+                "items": [
+                    {
+                        "itemTitle": "Get Started",
+                        "url": "../../../../extn/example-documents/guides/Mammals/mammals_getstarted.html"
+                    }
+                ],
+                "currentItemIndex": 0,
+                "isVisible": false,
+                "name": "Mammals Sample Guide",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "left": 665,
+                "top": 10,
+                "width": 416,
+                "height": 510,
+                "isVisible": false,
+                "zIndex": 15,
+                "right": 1081,
+                "bottom": 520
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.CaseCard",
+            "guid": 42,
+            "id": 42,
+            "componentStorage": {
+                "isActive": true,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "title": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "top": 5,
+                "left": 5,
+                "width": 220,
+                "height": 235,
+                "zIndex": 109,
+                "isVisible": true,
+                "right": 225,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 43,
+            "id": 43,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 9
+                    },
+                    "y2Coll": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "y2Attr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 1,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -1,
+                "yUpperBound": 23,
+                "y2AxisClass": "DG.CellLinearAxisModel",
+                "y2LowerBound": -10,
+                "y2UpperBound": 130,
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": true,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-SleepY-SpeedY2",
+                "name": "Lifespan",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 220,
+                "height": 235,
+                "left": 5,
+                "top": 490,
+                "isVisible": true,
+                "zIndex": 224,
+                "right": 590,
+                "bottom": 585
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 44,
+            "id": 44,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -10,
+                "xUpperBound": 130,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Empty",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 250,
+                "height": 235,
+                "zIndex": 215,
+                "left": 230,
+                "top": 5,
+                "isVisible": true,
+                "right": 480,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 45,
+            "id": 45,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 235,
+                "zIndex": 216,
+                "left": 485,
+                "top": 5,
+                "isVisible": true,
+                "right": 730,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 46,
+            "id": 46,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 8
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 4,
+                "xAttributeType": 0,
+                "yRole": 1,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.AxisModel",
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -500,
+                "yUpperBound": 7500,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "MassY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 255,
+                "height": 235,
+                "zIndex": 217,
+                "left": 735,
+                "top": 5,
+                "isVisible": true,
+                "right": 990,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 47,
+            "id": 47,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 8
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -500,
+                "yUpperBound": 7500,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-MassY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 265,
+                "height": 235,
+                "zIndex": 218,
+                "left": 995,
+                "top": 5,
+                "isVisible": true,
+                "right": 1260,
+                "bottom": 240
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 48,
+            "id": 48,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": [
+                        {
+                            "type": "DG.Attribute",
+                            "id": 9
+                        },
+                        {
+                            "type": "DG.Attribute",
+                            "id": 10
+                        }
+                    ]
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-SleepSpeedY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 220,
+                "height": 240,
+                "zIndex": 219,
+                "left": 5,
+                "top": 245,
+                "isVisible": true,
+                "right": 225,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 49,
+            "id": 49,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-DietY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 240,
+                "zIndex": 220,
+                "left": 230,
+                "top": 245,
+                "isVisible": true,
+                "right": 475,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 50,
+            "id": 50,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-DietTop",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 250,
+                "height": 240,
+                "zIndex": 221,
+                "left": 480,
+                "top": 245,
+                "isVisible": true,
+                "right": 730,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 51,
+            "id": 51,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "rightColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "rightAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 2,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-DietRight",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 255,
+                "height": 240,
+                "zIndex": 222,
+                "left": 735,
+                "top": 245,
+                "isVisible": true,
+                "right": 990,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 52,
+            "id": 52,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    },
+                    "rightColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "rightAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 2,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "showMeasureLabels": false
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "LifeSpanX-HabitatTop-DietRight",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 265,
+                "height": 240,
+                "zIndex": 223,
+                "left": 995,
+                "top": 245,
+                "isVisible": true,
+                "right": 1260,
+                "bottom": 485
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 53,
+            "id": 53,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "DietX",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 235,
+                "zIndex": 225,
+                "left": 230,
+                "top": 490,
+                "isVisible": true,
+                "right": 475,
+                "bottom": 725
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 54,
+            "id": 54,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 4,
+                "xAttributeType": 0,
+                "yRole": 3,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.AxisModel",
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "DietY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 250,
+                "height": 235,
+                "zIndex": 226,
+                "left": 480,
+                "top": 490,
+                "isVisible": true,
+                "right": 730,
+                "bottom": 725
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 55,
+            "id": 55,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "DietX-HabitatY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 255,
+                "height": 235,
+                "zIndex": 227,
+                "left": 735,
+                "top": 490,
+                "isVisible": true,
+                "right": 990,
+                "bottom": 725
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 56,
+            "id": 56,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 1,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 3,
+                "xAttributeType": 2,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellAxisModel",
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.DotChartModel"
+                    }
+                ],
+                "title": "HabitatY-DietX (bug?)",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 265,
+                "height": 235,
+                "zIndex": 228,
+                "left": 995,
+                "top": 490,
+                "isVisible": true,
+                "right": 1260,
+                "bottom": 725
+            },
+            "savedHeight": null
+        }
+    ],
+    "contexts": [
+        {
+            "type": "DG.DataContext",
+            "document": 1,
+            "guid": 2,
+            "id": 2,
+            "flexibleGroupingChangeFlag": false,
+            "name": "Mammals",
+            "title": "Mammals",
+            "collections": [
+                {
+                    "areParentChildLinksConfigured": false,
+                    "attrs": [
+                        {
+                            "name": "Mammal",
+                            "type": "none",
+                            "title": "Mammal",
+                            "cid": "id:OeZG-mrujTgO3Rol",
+                            "description": "The species of the mammal",
+                            "_categoryMap": {
+                                "__order": [
+                                    "African Elephant",
+                                    "Asian Elephant",
+                                    "Big Brown Bat",
+                                    "Bottlenose Dolphin",
+                                    "Cheetah",
+                                    "Chimpanzee",
+                                    "Domestic Cat",
+                                    "Donkey",
+                                    "Giraffe",
+                                    "Gray Wolf",
+                                    "Grey Seal",
+                                    "Ground Squirrel",
+                                    "Horse",
+                                    "House Mouse",
+                                    "Human",
+                                    "Jaguar",
+                                    "Killer Whale",
+                                    "Lion",
+                                    "N. American Opossum",
+                                    "Nine-Banded Armadillo",
+                                    "Owl Monkey",
+                                    "Patas Monkey",
+                                    "Pig",
+                                    "Pronghorn Antelope",
+                                    "Rabbit",
+                                    "Red Fox",
+                                    "Spotted Hyena"
+                                ],
+                                "African Elephant": "#FFB300",
+                                "Asian Elephant": "#803E75",
+                                "Big Brown Bat": "#FF6800",
+                                "Bottlenose Dolphin": "#A6BDD7",
+                                "Cheetah": "#C10020",
+                                "Chimpanzee": "#CEA262",
+                                "Domestic Cat": "#817066",
+                                "Donkey": "#007D34",
+                                "Giraffe": "#00538A",
+                                "Gray Wolf": "#F13A13",
+                                "Grey Seal": "#53377A",
+                                "Ground Squirrel": "#FF8E00",
+                                "Horse": "#B32851",
+                                "House Mouse": "#F4C800",
+                                "Human": "#7F180D",
+                                "Jaguar": "#93AA00",
+                                "Killer Whale": "#593315",
+                                "Lion": "#232C16",
+                                "N. American Opossum": "#FF7A5C",
+                                "Nine-Banded Armadillo": "#F6768E",
+                                "Owl Monkey": "#FFB300",
+                                "Patas Monkey": "#803E75",
+                                "Pig": "#FF6800",
+                                "Pronghorn Antelope": "#A6BDD7",
+                                "Rabbit": "#C10020",
+                                "Red Fox": "#CEA262",
+                                "Spotted Hyena": "#817066"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 4,
+                            "id": 4,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Order",
+                            "type": "none",
+                            "title": "Order",
+                            "cid": "id:v0tgEH-ZeDT_1YK0",
+                            "description": "The order of the mammal",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 5,
+                            "id": 5,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "LifeSpan",
+                            "type": "numeric",
+                            "title": "LifeSpan",
+                            "cid": "id:wph23fQdzlKDwrVD",
+                            "description": "",
+                            "_categoryMap": {
+                                "3": "#00538A",
+                                "5": "#F4C800",
+                                "7": "#593315",
+                                "9": "#007D34",
+                                "10": "#7F180D",
+                                "12": "#93AA00",
+                                "14": "#A6BDD7",
+                                "15": "#B32851",
+                                "16": "#CEA262",
+                                "19": "#803E75",
+                                "20": "#53377A",
+                                "25": "#FF6800",
+                                "30": "#817066",
+                                "40": "#C10020",
+                                "50": "#FF8E00",
+                                "70": "#FFB300",
+                                "80": "#F13A13",
+                                "__order": [
+                                    "10",
+                                    "12",
+                                    "14",
+                                    "15",
+                                    "16",
+                                    "19",
+                                    "20",
+                                    "25",
+                                    "3",
+                                    "30",
+                                    "40",
+                                    "5",
+                                    "50",
+                                    "7",
+                                    "70",
+                                    "80",
+                                    "9"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 6,
+                            "id": 6,
+                            "precision": 2,
+                            "unit": "years"
+                        },
+                        {
+                            "name": "Height",
+                            "type": "none",
+                            "title": "Height",
+                            "cid": "id:SF7w_Lk9WiFQuskE",
+                            "description": "The average height of the mammal.",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 7,
+                            "id": 7,
+                            "precision": 2,
+                            "unit": "meters"
+                        },
+                        {
+                            "name": "Mass",
+                            "type": "numeric",
+                            "title": "Mass",
+                            "cid": "id:Itl15QYV6VIJgiRl",
+                            "description": "The mass of the mammal",
+                            "_categoryMap": {
+                                "1": "#F6768E",
+                                "3": "#FFB300",
+                                "5": "#232C16",
+                                "7": "#FF7A5C",
+                                "13": "#FF6800",
+                                "50": "#C10020",
+                                "68": "#CEA262",
+                                "70": "#A6BDD7",
+                                "80": "#F13A13",
+                                "115": "#7F180D",
+                                "187": "#007D34",
+                                "192": "#803E75",
+                                "250": "#593315",
+                                "275": "#53377A",
+                                "521": "#B32851",
+                                "635": "#FFB300",
+                                "1100": "#00538A",
+                                "4000": "#93AA00",
+                                "5000": "#803E75",
+                                "6400": "#FF6800",
+                                "__order": [
+                                    "0.02",
+                                    "0.03",
+                                    "0.1",
+                                    "1",
+                                    "3",
+                                    "4.5",
+                                    "5",
+                                    "7",
+                                    "13",
+                                    "50",
+                                    "68",
+                                    "70",
+                                    "80",
+                                    "115",
+                                    "187",
+                                    "192",
+                                    "250",
+                                    "275",
+                                    "521",
+                                    "635",
+                                    "1100",
+                                    "4000",
+                                    "5000",
+                                    "6400"
+                                ],
+                                "0.02": "#A6BDD7",
+                                "4.5": "#817066",
+                                "0.1": "#FF8E00",
+                                "0.03": "#F4C800"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 8,
+                            "id": 8,
+                            "precision": 2,
+                            "unit": "kg"
+                        },
+                        {
+                            "name": "Sleep",
+                            "type": "numeric",
+                            "title": "Sleep",
+                            "cid": "id:_QDNGutX5kDgYaS9",
+                            "description": "The number of hours the animal sleeps in a 24 hour period",
+                            "_categoryMap": {
+                                "2": "#817066",
+                                "3": "#FF6800",
+                                "4": "#803E75",
+                                "5": "#FFB300",
+                                "6": "#00538A",
+                                "8": "#53377A",
+                                "10": "#CEA262",
+                                "11": "#FF8E00",
+                                "12": "#C10020",
+                                "13": "#007D34",
+                                "15": "#F13A13",
+                                "17": "#F4C800",
+                                "18": "#7F180D",
+                                "19": "#B32851",
+                                "20": "#A6BDD7",
+                                "__order": [
+                                    "2",
+                                    "3",
+                                    "4",
+                                    "5",
+                                    "6",
+                                    "8",
+                                    "10",
+                                    "11",
+                                    "12",
+                                    "13",
+                                    "15",
+                                    "17",
+                                    "18",
+                                    "19",
+                                    "20"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 9,
+                            "id": 9,
+                            "precision": 2,
+                            "unit": "hours"
+                        },
+                        {
+                            "name": "Speed",
+                            "type": "none",
+                            "title": "Speed",
+                            "cid": "id:_kfDY4c5ig4m9n1Y",
+                            "description": "The average speed of the mammal.",
+                            "_categoryMap": {
+                                "1": "#B32851",
+                                "13": "#007D34",
+                                "18": "#7F180D",
+                                "19": "#CEA262",
+                                "37": "#803E75",
+                                "40": "#FF6800",
+                                "45": "#00538A",
+                                "48": "#53377A",
+                                "50": "#FFB300",
+                                "55": "#F4C800",
+                                "56": "#593315",
+                                "60": "#F13A13",
+                                "64": "#C10020",
+                                "69": "#817066",
+                                "80": "#FF8E00",
+                                "98": "#93AA00",
+                                "110": "#A6BDD7",
+                                "__order": [
+                                    "1",
+                                    "110",
+                                    "13",
+                                    "18",
+                                    "19",
+                                    "37",
+                                    "40",
+                                    "45",
+                                    "48",
+                                    "50",
+                                    "55",
+                                    "56",
+                                    "60",
+                                    "64",
+                                    "69",
+                                    "80",
+                                    "98"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 10,
+                            "id": 10,
+                            "precision": 2,
+                            "unit": "km/h"
+                        },
+                        {
+                            "name": "Habitat",
+                            "type": null,
+                            "title": "Habitat",
+                            "cid": "id:-w-cjn2pxub0lnv8",
+                            "description": "",
+                            "_categoryMap": {
+                                "land": {
+                                    "h": 0.4444444444444444,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(85,255,198)"
+                                },
+                                "water": {
+                                    "h": 0.711111111111111,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(130,85,255)"
+                                },
+                                "both": {
+                                    "h": 0.9777777777777777,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(255,85,108)"
+                                },
+                                "__order": [
+                                    "land",
+                                    "water",
+                                    "both"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 11,
+                            "id": 11,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Diet",
+                            "type": null,
+                            "title": "Diet",
+                            "cid": "id:VDyeIN49ME78Q16K",
+                            "description": "",
+                            "_categoryMap": {
+                                "__order": [
+                                    "both",
+                                    "meat",
+                                    "plants"
+                                ],
+                                "plants": "#FFB300",
+                                "meat": "#803E75",
+                                "both": "#FF6800"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 12,
+                            "id": 12,
+                            "precision": 2,
+                            "unit": null
+                        }
+                    ],
+                    "cases": [
+                        {
+                            "guid": 13,
+                            "id": 13,
+                            "itemID": "id:ig3c_O--wnASfPea",
+                            "values": {
+                                "Mammal": "African Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 4,
+                                "Mass": 6400,
+                                "Sleep": 3,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 14,
+                            "id": 14,
+                            "itemID": "id:5fvOQGKlqlALHZyV",
+                            "values": {
+                                "Mammal": "Asian Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 3,
+                                "Mass": 5000,
+                                "Sleep": 4,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 15,
+                            "id": 15,
+                            "itemID": "id:OqVDRqn4FEuLr0vi",
+                            "values": {
+                                "Mammal": "Big Brown Bat",
+                                "Order": "Chiroptera",
+                                "LifeSpan": 19,
+                                "Height": 0.1,
+                                "Mass": 0.02,
+                                "Sleep": 20,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 16,
+                            "id": 16,
+                            "itemID": "id:pBGVGFsx1XtZeeJK",
+                            "values": {
+                                "Mammal": "Bottlenose Dolphin",
+                                "Order": "Cetacea",
+                                "LifeSpan": 25,
+                                "Height": 3.5,
+                                "Mass": 635,
+                                "Sleep": 5,
+                                "Speed": 37,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 17,
+                            "id": 17,
+                            "itemID": "id:u6szUXjRUPYQbf0z",
+                            "values": {
+                                "Mammal": "Cheetah",
+                                "Order": "Carnivora",
+                                "LifeSpan": 14,
+                                "Height": 1.5,
+                                "Mass": 50,
+                                "Sleep": 12,
+                                "Speed": 110,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 18,
+                            "id": 18,
+                            "itemID": "id:ELJjhBucV_ChIjXv",
+                            "values": {
+                                "Mammal": "Chimpanzee",
+                                "Order": "Primate",
+                                "LifeSpan": 40,
+                                "Height": 1.5,
+                                "Mass": 68,
+                                "Sleep": 10,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 19,
+                            "id": 19,
+                            "itemID": "id:Vu01ZRbuOUJfoHHW",
+                            "values": {
+                                "Mammal": "Domestic Cat",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 0.8,
+                                "Mass": 4.5,
+                                "Sleep": 12,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 20,
+                            "id": 20,
+                            "itemID": "id:2_-jpOCPFO7AJ781",
+                            "values": {
+                                "Mammal": "Donkey",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 40,
+                                "Height": 1.2,
+                                "Mass": 187,
+                                "Sleep": 3,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 21,
+                            "id": 21,
+                            "itemID": "id:9NrrFj8163K6fz1K",
+                            "values": {
+                                "Mammal": "Giraffe",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 25,
+                                "Height": 5,
+                                "Mass": 1100,
+                                "Sleep": 2,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 22,
+                            "id": 22,
+                            "itemID": "id:w7zBDPnBs7LZwpE6",
+                            "values": {
+                                "Mammal": "Gray Wolf",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 1.6,
+                                "Mass": 80,
+                                "Sleep": 13,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 23,
+                            "id": 23,
+                            "itemID": "id:e2fqzGUZEflqLdU3",
+                            "values": {
+                                "Mammal": "Grey Seal",
+                                "Order": "Pinnipedia",
+                                "LifeSpan": 30,
+                                "Height": 2.1,
+                                "Mass": 275,
+                                "Sleep": 6,
+                                "Speed": 19,
+                                "Habitat": "both",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 24,
+                            "id": 24,
+                            "itemID": "id:iShVYcjqv99srjkr",
+                            "values": {
+                                "Mammal": "Ground Squirrel",
+                                "Order": "Rodentia",
+                                "LifeSpan": 9,
+                                "Height": 0.3,
+                                "Mass": 0.1,
+                                "Sleep": 15,
+                                "Speed": 19,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 25,
+                            "id": 25,
+                            "itemID": "id:N67oxJchChueDtC_",
+                            "values": {
+                                "Mammal": "Horse",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 25,
+                                "Height": 1.5,
+                                "Mass": 521,
+                                "Sleep": 3,
+                                "Speed": 69,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 26,
+                            "id": 26,
+                            "itemID": "id:CoI3MWb1ui0gsAx9",
+                            "values": {
+                                "Mammal": "House Mouse",
+                                "Order": "Rodentia",
+                                "LifeSpan": 3,
+                                "Height": 0.1,
+                                "Mass": 0.03,
+                                "Sleep": 12,
+                                "Speed": 13,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 27,
+                            "id": 27,
+                            "itemID": "id:uWtZO9JXZ2SCTI6G",
+                            "values": {
+                                "Mammal": "Human",
+                                "Order": "Primate",
+                                "LifeSpan": 80,
+                                "Height": 1.9,
+                                "Mass": 80,
+                                "Sleep": 8,
+                                "Speed": 45,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 28,
+                            "id": 28,
+                            "itemID": "id:kowlipxggopX4Q3d",
+                            "values": {
+                                "Mammal": "Jaguar",
+                                "Order": "Carnivora",
+                                "LifeSpan": 20,
+                                "Height": 1.8,
+                                "Mass": 115,
+                                "Sleep": 11,
+                                "Speed": 60,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 29,
+                            "id": 29,
+                            "itemID": "id:BFiiPyTHN2LFU-O4",
+                            "values": {
+                                "Mammal": "Killer Whale",
+                                "Order": "Cetacea",
+                                "LifeSpan": 50,
+                                "Height": 6.5,
+                                "Mass": 4000,
+                                "Sleep": "",
+                                "Speed": 48,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 30,
+                            "id": 30,
+                            "itemID": "id:Clgel839okaHYawd",
+                            "values": {
+                                "Mammal": "Lion",
+                                "Order": "Carnivora",
+                                "LifeSpan": 15,
+                                "Height": 2.5,
+                                "Mass": 250,
+                                "Sleep": 20,
+                                "Speed": 80,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 31,
+                            "id": 31,
+                            "itemID": "id:w3Val7QA5meMBEEB",
+                            "values": {
+                                "Mammal": "N. American Opossum",
+                                "Order": "Didelphimorphia",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 5,
+                                "Sleep": 19,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 32,
+                            "id": 32,
+                            "itemID": "id:aLk9ZmNgx7E9E7NV",
+                            "values": {
+                                "Mammal": "Nine-Banded Armadillo",
+                                "Order": "Xenarthra",
+                                "LifeSpan": 10,
+                                "Height": 0.6,
+                                "Mass": 7,
+                                "Sleep": 17,
+                                "Speed": 1,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 33,
+                            "id": 33,
+                            "itemID": "id:p7NElX9Qhx3FCh5q",
+                            "values": {
+                                "Mammal": "Owl Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 12,
+                                "Height": 0.4,
+                                "Mass": 1,
+                                "Sleep": 17,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 34,
+                            "id": 34,
+                            "itemID": "id:Z5QypAvePMG2HM3Z",
+                            "values": {
+                                "Mammal": "Patas Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 20,
+                                "Height": 0.9,
+                                "Mass": 13,
+                                "Sleep": "",
+                                "Speed": 55,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 35,
+                            "id": 35,
+                            "itemID": "id:P5wH0mvnPn05JFmS",
+                            "values": {
+                                "Mammal": "Pig",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 1,
+                                "Mass": 192,
+                                "Sleep": 8,
+                                "Speed": 18,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 36,
+                            "id": 36,
+                            "itemID": "id:GPB4K3B9DOzhdb3L",
+                            "values": {
+                                "Mammal": "Pronghorn Antelope",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": "",
+                                "Speed": 98,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 37,
+                            "id": 37,
+                            "itemID": "id:At9JgEpDfH7_IGVQ",
+                            "values": {
+                                "Mammal": "Rabbit",
+                                "Order": "Lagomorpha",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 3,
+                                "Sleep": 11,
+                                "Speed": 56,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 38,
+                            "id": 38,
+                            "itemID": "id:RDK7bWCmb2C6TPcA",
+                            "values": {
+                                "Mammal": "Red Fox",
+                                "Order": "Carnivora",
+                                "LifeSpan": 7,
+                                "Height": 0.8,
+                                "Mass": 5,
+                                "Sleep": 10,
+                                "Speed": 48,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 39,
+                            "id": 39,
+                            "itemID": "id:ZftMZdiC1Eyle4kE",
+                            "values": {
+                                "Mammal": "Spotted Hyena",
+                                "Order": "Carnivora",
+                                "LifeSpan": 25,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": 18,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        }
+                    ],
+                    "caseName": null,
+                    "childAttrName": null,
+                    "collapseChildren": null,
+                    "guid": 3,
+                    "id": 3,
+                    "name": "Mammals",
+                    "title": "Mammals",
+                    "type": "DG.Collection"
+                }
+            ],
+            "description": "",
+            "metadata": null,
+            "preventReorg": false,
+            "setAsideItems": [],
+            "contextStorage": {
+                "_links_": {
+                    "selectedCases": []
+                }
+            }
+        }
+    ],
+    "globalValues": [],
+    "appName": "DG",
+    "appVersion": "2.0",
+    "appBuildNum": "0730",
+    "lang": "en",
+    "idCount": 56,
+    "metadata": {}
+}

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -571,7 +571,7 @@ export interface ICodapV2PlotStorage {
   // TODO_V2_IMPORT totalNumberOfBins is not imported
   // it occurs 8,299 times in cfm-shared
   totalNumberOfBins?: number
-  // expresssion at this level existed in a single file of 6,000 checked
+  // expression at this level existed in a single file of 6,000 checked
   // in cfm-shared. It is unknown how many times it occurs in all of
   // of cfm-shared
   expression?: string


### PR DESCRIPTION
Implements v2 export of the basic graph configuration of attributes, types, roles, and axes. Includes jest test of full round-trip fidelity of opening a v2 document via the v2 importer, exporting it as a v2 document via the v2 exporter, and then comparing the exported graph to the original for each graph in the document, modulo an explicit list of unimplemented properties. Tests this round-trip fidelity against three documents with many different graph configurations. Moving forward, as new properties are supported in the export (e.g. `adornments`), they can be removed from the list of unsupported properties. When the list is empty, the basic work is complete.