### PR TITLE
handle vertical movable lines

### DIFF
--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.test.ts
@@ -1,4 +1,15 @@
-import { MovableLineAdornmentModel, MovableLineInstance } from "./movable-line-adornment-model"
+import { getSnapshot } from "mobx-state-tree"
+import { IMovableLineInstanceSnapshot, MovableLineAdornmentModel,
+  MovableLineInstance
+} from "./movable-line-adornment-model"
+
+function roundTripLine(initialSnapshot: IMovableLineInstanceSnapshot) {
+  const line = MovableLineInstance.create(initialSnapshot)
+  const savedSnapshot = getSnapshot(line)
+  const savedJson = JSON.stringify(savedSnapshot)
+  const loadedSnapshot = JSON.parse(savedJson)
+  return MovableLineInstance.create(loadedSnapshot)
+}
 
 describe("MovableLineInstance", () => {
   it("is created with intercept and slope properties", () => {
@@ -31,6 +42,37 @@ describe("MovableLineInstance", () => {
     expect(lineParams.dynamicSlope).toEqual(2)
     expect(lineParams.intercept).toEqual(1)
     expect(lineParams.slope).toEqual(1)
+  })
+  it("can serialize when vertical", () => {
+    const line1 = roundTripLine({intercept: 1, slope: Infinity})
+    expect(line1.slope).toBe(Infinity)
+
+    const line2 = roundTripLine({intercept: 1, slope: "Infinity"})
+    expect(line2.slope).toBe(Infinity)
+
+    const line3 = roundTripLine({intercept: 1, slope: -Infinity})
+    expect(line3.slope).toBe(-Infinity)
+
+    const line4 = roundTripLine({intercept: 1, slope: "-Infinity"})
+    expect(line4.slope).toBe(-Infinity)
+  })
+  it("saves finite slopes as numbers", () => {
+    const line = MovableLineInstance.create({intercept: 1, slope: 5})
+    const snapshot = getSnapshot(line)
+    expect(snapshot.slope).not.toBe("5")
+    expect(snapshot.slope).toBe(5)
+  })
+  it("can handle string slopes", () => {
+    // This isn't required but is nice incase a string number ends up in
+    // the JSON
+    const line = roundTripLine({intercept: 1, slope: "5" as unknown as number})
+    expect(line.slope).toBe(5)
+  })
+  it("can handle null slopes", () => {
+    // This isn't ideal but it is nice that old documents will not completely crash if loaded
+    // with a null slope
+    const line = roundTripLine({intercept: 1, slope: null as unknown as number})
+    expect(line.slope).toBe(NaN)
   })
 })
 

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
@@ -6,11 +6,12 @@ import { IAxisModel } from "../../../axis/models/axis-model"
 import { computeSlopeAndIntercept } from "../../utilities/graph-utils"
 import { kMovableLineType } from "./movable-line-adornment-types"
 import { ILineDescription } from "../shared-adornment-types"
+import { JsonNumber } from "../../../../utilities/json-number"
 
 export const MovableLineInstance = types.model("MovableLineInstance", {
   equationCoords: types.maybe(PointModel),
   intercept: types.number,
-  slope: types.number,
+  slope: JsonNumber,
 })
 .volatile(() => ({
   dynamicIntercept: undefined as number | undefined,

--- a/v3/src/utilities/json-number.test.ts
+++ b/v3/src/utilities/json-number.test.ts
@@ -1,0 +1,70 @@
+import { SnapshotIn, types, getSnapshot } from "mobx-state-tree";
+import { JsonNumber } from "./json-number";
+
+const TestObject = types.model("TestObject", {
+  numProp: JsonNumber
+})
+.actions(self => ({
+  setNumProp(value: string | number) {
+    // This is a weird feature of MST where a value can be set as either a
+    // snapshot or the actual value
+    self.numProp = value as number;
+  }
+}));
+interface TestObjectSnapshot extends SnapshotIn<typeof TestObject> {}
+
+function roundTripObject(initialSnapshot: TestObjectSnapshot) {
+  const line = TestObject.create(initialSnapshot);
+  const savedSnapshot = getSnapshot(line);
+  const savedJson = JSON.stringify(savedSnapshot);
+  const loadedSnapshot = JSON.parse(savedJson);
+  return TestObject.create(loadedSnapshot);
+}
+
+describe("JsonNumber", () => {
+  it("serializes NaN", () => {
+    const obj1 = roundTripObject({numProp: NaN});
+    expect(obj1.numProp).toBe(NaN);
+
+    const obj2 = roundTripObject({numProp: "NaN"});
+    expect(obj2.numProp).toBe(NaN);
+  });
+  it("serializes Infinity", () => {
+    const obj1 = roundTripObject({numProp: Infinity});
+    expect(obj1.numProp).toBe(Infinity);
+
+    const obj2 = roundTripObject({numProp: "Infinity"});
+    expect(obj2.numProp).toBe(Infinity);
+  });
+  it("serializes -Infinity", () => {
+    const obj1 = roundTripObject({numProp: -Infinity});
+    expect(obj1.numProp).toBe(-Infinity);
+
+    const obj2 = roundTripObject({numProp: "-Infinity"});
+    expect(obj2.numProp).toBe(-Infinity);
+  });
+  it("serializes finite numbers as numbers", () => {
+    const obj = TestObject.create({numProp: 5});
+    const snapshot = getSnapshot(obj);
+    expect(snapshot.numProp).not.toBe("5");
+    expect(snapshot.numProp).toBe(5);
+  });
+  it("loads string numbers", () => {
+    // This isn't required but is nice in case a string number ends up in
+    // the JSON
+    const obj = roundTripObject({numProp: "5" as unknown as number});
+    expect(obj.numProp).toBe(5);
+  });
+  it("loads null values", () => {
+    // This isn't required but it is nice that old documents will not completely crash if loaded
+    // with a null value
+    const obj = roundTripObject({numProp: null as unknown as number});
+    expect(obj.numProp).toBe(NaN);
+  });
+  it("converts value on assignment", () => {
+    const obj = TestObject.create({numProp: 1});
+    expect(obj.numProp).toBe(1);
+    obj.setNumProp("NaN");
+    expect(obj.numProp).toBe(NaN);
+  });
+});

--- a/v3/src/utilities/json-number.ts
+++ b/v3/src/utilities/json-number.ts
@@ -1,0 +1,44 @@
+import { types } from "mobx-state-tree";
+
+type SpecialNumbers = "NaN" | "Infinity" | "-Infinity";
+
+/**
+ * This custom MST type handles NaN, Infinity, and -Infinity better than the built in
+ * `type.number`
+ * When NaN, Infinity, or -Infinity are stored in a `types.number` field,
+ * JSON.stringify(getSnapshot(obj)) will turn these values into `null`.
+ * This custom type turns those values into strings so they can be stored JSON.
+ *
+ * The typescript typing will only allow you to pass a number or "NaN", "Infinity", or "-Infinity"
+ * as a value in a snapshot. However at runtime stringified numbers will be handled too.
+ * Additionally if the value is null at runtime this will be turned in NaN.
+ */
+export const JsonNumber = types.custom<SpecialNumbers | number, number>({
+  name: "StringifiedNumber",
+  fromSnapshot(snapshot: SpecialNumbers | number, env?: any): number {
+    // Handle legacy values. In some cases a user might want to customize
+    // how null is handled. By default `Number(null)` returns 0
+    // If you want null to be invalid, change getValidationMessage
+    if (snapshot === null) {
+      return NaN;
+    }
+    return Number(snapshot);
+  },
+  toSnapshot(value: number): SpecialNumbers | number {
+    if (!isFinite(value)) {
+      return value.toString() as SpecialNumbers;
+    }
+    return value;
+  },
+  isTargetType(value: string | number): boolean {
+    return typeof value === "number";
+  },
+  getValidationMessage(snapshot: number | string): string {
+    const parsed = Number(snapshot);
+    if (isNaN(parsed) && snapshot !== "NaN") {
+      return `'${snapshot}' can't be parsed as a number`;
+    } else {
+      return "";
+    }
+  }
+});


### PR DESCRIPTION
This adds a JsonNumber type which serializes NaN, Infinity, and -Infinity as strings.
This makes the javascript number type safe to serialize with MST.

It fixes a bug where vertical lines with Infinity slope were not round tripping.