### PR TITLE
Fix crash on resize categorical

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -756,6 +756,9 @@ export const DataConfigurationModel = types
       categorySet?.setColorForCategory(cat, color)
     },
     setNumberOfCategoriesLimitForRole(role: AttrRole, limit: number | undefined) {
+      if (limit !== undefined && limit <= 0) {
+        limit = undefined
+      }
       self.numberOfCategoriesLimitByRole.set(role, limit)
       self.categoryArrayForAttrRole.invalidate(role)
     },


### PR DESCRIPTION
[#188794755] Bug fix: Crash on categorical/categorical plot graph resize

* The fix is to prevent the number of categories limit from going negative.