### PR TITLE
Trim attribute names and values in imported csv

### DIFF
--- a/v3/src/utilities/csv-import.ts
+++ b/v3/src/utilities/csv-import.ts
@@ -19,7 +19,7 @@ export function convertParsedCsvToDataSet(results: CsvParseResult, filename: str
   // trim all values
   results.data.forEach(row => {
     for (const key in row) {
-      row[key] = row[key].trim()
+      row[key] = typeof row[key] === 'string' ? row[key].trim() : row[key]
     }
   })
 

--- a/v3/src/utilities/csv-import.ts
+++ b/v3/src/utilities/csv-import.ts
@@ -16,13 +16,20 @@ export function downloadCsvFile(dataUrl: string,
 }
 
 export function convertParsedCsvToDataSet(results: CsvParseResult, filename: string) {
+  // trim all values
+  results.data.forEach(row => {
+    for (const key in row) {
+      row[key] = row[key].trim()
+    }
+  })
+
   // Remove extension
   // From https://stackoverflow.com/questions/4250364/how-to-trim-a-file-extension-from-a-string-in-javascript
   const name = filename.replace(/\.[^/.]+$/, "")
   const ds = DataSet.create({ name })
   // add attributes (extracted from first case)
   for (const pName in results.data[0]) {
-    ds.addAttribute({name: pName})
+    ds.addAttribute({name: pName.trim()})
   }
   // add cases
   ds.addCases(results.data, { canonicalize: true })


### PR DESCRIPTION
[#188801759] Bug fix: Values and attribute names in an imported CSV should be trimmed

* Added trimming to convertParsedCsvToDataSet