### PR TITLE
Trimming imported and manually entered values

### DIFF
--- a/v3/src/models/data/attribute-types.ts
+++ b/v3/src/models/data/attribute-types.ts
@@ -13,7 +13,7 @@ export function importValueToString(value: IValueType): string {
     return ""
   }
   if (typeof value === "string") {
-    return value
+    return value.trim()
   }
   if (value instanceof Date) {
     return formatStdISODateString(value)


### PR DESCRIPTION
[#188801759] Bug fix: Values and attribute names in an imported CSV should be trimmed
[#188804884] Bug fix: Values entered in case table/card are not being trimmed.

* Added trimming to importValueToString. This applies to both bug situations.