### PR TITLE
Fix for legend response to selection bug

### DIFF
--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -4,10 +4,7 @@ import {comparer, reaction} from "mobx"
 import {drag, range, select} from "d3"
 import React, {useCallback, useEffect, useMemo, useRef} from "react"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
-// import { setOrExtendSelection } from "../../../../models/data/data-set-utils"
-import {isSelectionAction} from "../../../../models/data/data-set-actions"
 import {missingColor} from "../../../../utilities/color-utils"
-import {onAnyAction} from "../../../../utilities/mst-utils"
 import {measureText} from "../../../../hooks/use-measure-text"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {useDataDisplayLayout} from "../../hooks/use-data-display-layout"
@@ -63,7 +60,6 @@ const coordinatesToCatIndex = (lod: Layout, numCategories: number, localPoint: {
 export const CategoricalLegend = observer(
   function CategoricalLegend({layerIndex, setDesiredExtent}: IBaseLegendProps) {
     const dataConfiguration = useDataConfigurationContext(),
-      dataset = dataConfiguration?.dataset,
       tileWidth = useDataDisplayLayout().tileWidth,
       categoriesRef = useRef<string[] | undefined>(),
       categoryData = useRef<Key[]>([]),
@@ -290,12 +286,12 @@ export const CategoricalLegend = observer(
     }, [dataConfiguration, dragBehavior])
 
     useEffect(function respondToSelectionChange() {
-      return onAnyAction(dataset, action => {
-        if (isSelectionAction(action)) {
+      return mstReaction(
+        () => dataConfiguration?.selection,
+        () => {
           refreshKeys()
-        }
-      })
-    }, [refreshKeys, dataset, computeDesiredExtent])
+        }, {name: 'CategoricalLegend respondToSelectionChange'}, dataConfiguration)
+    }, [refreshKeys, dataConfiguration])
 
     useEffect(function respondToChangeCount() {
       return mstReaction(

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -3,7 +3,6 @@ import {comparer, reaction} from "mobx"
 import {observer} from "mobx-react-lite"
 import React, {useCallback, useEffect, useRef, useState} from "react"
 import { mstReaction } from "../../../../utilities/mst-reaction"
-import {isSelectionAction} from "../../../../models/data/data-set-actions"
 import { setOrExtendSelection } from "../../../../models/data/data-set-utils"
 import {axisGap} from "../../../axis/axis-types"
 import {getStringBounds} from "../../../axis/axis-utils"
@@ -101,13 +100,13 @@ export const NumericLegend =
     return () => disposer()
   }, [dataConfiguration, refreshScale])
 
-  useEffect(function respondToSelectionChange() {
-    return dataConfiguration?.onAction(action => {
-      if (isSelectionAction(action)) {
-        refreshScale()
-      }
-    })
-  }, [refreshScale, dataConfiguration])
+    useEffect(function respondToSelectionChange() {
+      return mstReaction(
+        () => dataConfiguration?.selection,
+        () => {
+          refreshScale()
+        }, {name: 'NumericLegend respondToSelectionChange'}, dataConfiguration)
+    }, [refreshScale, dataConfiguration])
 
   useEffect(function respondToHiddenCaseChange() {
   return mstReaction(


### PR DESCRIPTION
[#188492167] Bug fix: Selection of numeric legend key is not showing that the range is selected

* There were actually problems with selection in the categorical legend also. Both are fixed by using an `mstReaction` instead of an `onAnyAction` in the relevant useEffects.