### PR TITLE
Trim attribute names on csv import

### DIFF
--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -266,7 +266,7 @@ export const Attribute = V2Model.named("Attribute").props({
 }))
 .actions(self => ({
   setName(newName: string) {
-    self.name = newName
+    self.name = newName.trim()
   },
   setUnits(units?: string) {
     self.units = units

--- a/v3/src/utilities/csv-import.ts
+++ b/v3/src/utilities/csv-import.ts
@@ -22,7 +22,7 @@ export function convertParsedCsvToDataSet(results: CsvParseResult, filename: str
   const ds = DataSet.create({ name })
   // add attributes (extracted from first case)
   for (const pName in results.data[0]) {
-    ds.addAttribute({name: pName})
+    ds.addAttribute({name: pName.trim()})
   }
   // add cases
   ds.addCases(results.data, { canonicalize: true })


### PR DESCRIPTION
[#188801759] Bug fix: Attribute name needs to be trimmed

* When attributes are being created during csv import, their names were not being trimmed. We fix by trimming the name when creating the attribute snapshot in convertParsedCsvToDataSet
* For good measure, we trim any string passed to Attribute:setName