### PR TITLE
Fix drag-rearrange of categories bug

### DIFF
--- a/v3/src/components/axis/helper-models/categorical-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/categorical-axis-helper.ts
@@ -116,7 +116,7 @@ export class CategoricalAxisHelper extends AxisHelper {
             .attr('class', 'category-label')
             .attr('x', (d, i) => fns.getLabelX(i))
             .attr('y', (d, i) => fns.getLabelY(i))
-            .text((catObject: CatObject) => String(catObject.cat))
+            .text((d: CatObject, i) => String(categories[i]))
           return update
         }
       )

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -130,6 +130,7 @@ export const useSubAxis = ({
           dI.indexOfCategory = newCatIndex
           dI.categorySet?.move(dI.catName, catToMoveBefore)
           dI.currentDragPositionCatName = catToMoveBefore
+          categoriesRef.current = dI.categorySet?.valuesArray ?? []
         } else {
           renderSubAxis()
         }
@@ -324,7 +325,7 @@ export const useSubAxis = ({
           savedCategorySetValuesRef.current = values
           swapInProgress.current = false
         }
-      }, {name: "useSubAxis [categories]"})
+      }, {name: "useSubAxis [categories]", equals: comparer.structural})
       return () => disposer()
     }
   }, [axisModel, renderSubAxis, layout, isCategorical, setupCategories])

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -105,12 +105,12 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
   }, [callRefreshPointPositions, graphModel])
 
   useEffect(function respondToCategorySetChanges() {
-    return reaction(() => {
+    return mstReaction(() => {
       return dataConfiguration.allCategoriesForRoles
     }, () => {
       startAnimation()
       callRefreshPointPositions(false)
-    }, {name: "usePlot.respondToCategorySetChanges"})
+    }, {name: "usePlot.respondToCategorySetChanges", equals: comparer.structural}, dataConfiguration)
   }, [callRefreshPointPositions, dataConfiguration, startAnimation])
 
   // respond to attribute assignment changes


### PR DESCRIPTION
[#188815937] Bug fix: Cannot rearrange categories on a graph

This PR brings about the correct behavior when dragging categories. But it leaves undo/redo pretty much completely broken. See [this PT story](https://www.pivotaltracker.com/story/show/188820369).
* We improve categorical-axis-helper.ts by always displaying the actual categories rather than what has been stored in the reference to the d3 element.
* In use-plot.ts we improve things in `respondToCategorySetChanges` by using an mstReaction rather than a reaction.
* In the `onDrag` code of use-sub-axis.ts we do a better job of transferring the updated categories to the categoriesRef that the `CategoryAxisHelper` is going to use.