### PR TITLE
188651787 card attribute rename

### DIFF
--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -150,6 +150,7 @@ export const AttributeHeader = observer(function AttributeHeader({
     }
     setEditingAttrId("")
     setEditingAttrName("")
+    setIsFocused(false)
     uiState.setAttrIdToEdit?.()
   }
   const handleRenameAttribute = () => {

--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -101,7 +101,12 @@ export const AttributeHeader = observer(function AttributeHeader({
 
   // focus our content when the cell is focused
   useParentChildFocusRedirect(parentRef.current, menuButtonRef.current)
-  useOutsidePointerDown({ ref: inputRef, handler: () => handleClose(true) })
+  useOutsidePointerDown({ ref: inputRef, handler: () => {
+                                if (isFocused) {
+                                  handleClose(true)
+                                }
+                              }
+                        })
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const { key } = e


### PR DESCRIPTION
We were calling handleClose even though the Input element wasn't focused which made the editingAttrId state to be emptied prematurely when attribute headers are re-rendered, so the applyModelChange wasn't being called.
Adding the focus check for the useOnOutsidePointerDown prevents the extra handleClose calls.