### PR TITLE
Adornments respond to changes in selection if only showing measures for selection

### DIFF
--- a/v3/src/components/graph/adornments/adornments.tsx
+++ b/v3/src/components/graph/adornments/adornments.tsx
@@ -30,7 +30,7 @@ export const Adornments = observer(function Adornments() {
 
   useEffect(function handleAdornmentBannerCountChange() {
     return mstAutorun(() => {
-      let bannerCount = graphModel.showMeasuresForSelection ? 1 : 0
+      let bannerCount = dataConfig?.showMeasuresForSelection ? 1 : 0
       bannerCount += graphModel.adornmentsStore.activeBannerCount
       const bannersHeight = bannerCount * kGraphAdornmentsBannerHeight
       layout.setDesiredExtent("banners", bannersHeight)
@@ -38,7 +38,7 @@ export const Adornments = observer(function Adornments() {
     )
   }, [graphModel, layout])
 
-  if (!adornments?.length && !graphModel.showMeasuresForSelection) return null
+  if (!adornments?.length && !dataConfig?.showMeasuresForSelection) return null
 
   const adornmentBanners = adornments.map((adornment: IAdornmentModel) => {
     const componentContentInfo = getAdornmentContentInfo(adornment.type)
@@ -154,9 +154,9 @@ export const Adornments = observer(function Adornments() {
   )
   return (
     <>
-      {(adornmentBanners.length > 0 || graphModel.showMeasuresForSelection) &&
+      {(adornmentBanners.length > 0 || dataConfig?.showMeasuresForSelection) &&
         <div className="graph-adornments-banners" data-testid="graph-adornments-banners">
-          {graphModel.showMeasuresForSelection && <MeasuresForSelectionBanner />}
+          {dataConfig?.showMeasuresForSelection && <MeasuresForSelectionBanner />}
           {adornmentBanners}
         </div>
       }

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -42,8 +42,12 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
     getCaseValues(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
       const dataset = dataConfig?.dataset
       const casesInPlot = dataConfig.subPlotCases(cellKey)
+      const onlyIncludeIfSelected = dataConfig.showMeasuresForSelection
       const caseValues: number[] = []
       casesInPlot.forEach(caseId => {
+        if (onlyIncludeIfSelected && !dataset?.isCaseSelected(caseId)) {
+          return
+        }
         const caseValue = dataDisplayGetNumericValue(dataset, caseId, attrId)
         if (isFiniteNumber(caseValue)) {
           caseValues.push(caseValue)

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -101,13 +101,13 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
   }
 
   const handleMeasuresForSelectionChange = () => {
-    const [undoStringKey, redoStringKey] = graphModel?.showMeasuresForSelection
+    const [undoStringKey, redoStringKey] = dataConfig?.showMeasuresForSelection
       ? ["DG.Undo.disableMeasuresForSelection", "DG.Redo.disableMeasuresForSelection"]
       : ["DG.Undo.enableMeasuresForSelection", "DG.Redo.enableMeasuresForSelection"]
     dataConfig?.applyModelChange(
-      () => graphModel?.setShowMeasuresForSelection(!graphModel?.showMeasuresForSelection),
+      () => dataConfig?.setShowMeasuresForSelection(!dataConfig?.showMeasuresForSelection),
       { undoStringKey, redoStringKey,
-        log: graphModel?.showMeasuresForSelection ? "Disable Measures For Selection" : "Enable Measures For Selection"
+        log: dataConfig?.showMeasuresForSelection ? "Disable Measures For Selection" : "Enable Measures For Selection"
       }
     )
   }
@@ -124,7 +124,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
     parentToggleString = graphModel?.showParentToggles
       ? t("DG.DataDisplayMenu.disableNumberToggle")
       : t("DG.DataDisplayMenu.enableNumberToggle"),
-    measuresForSelectionString = graphModel?.showMeasuresForSelection
+    measuresForSelectionString = dataConfig?.showMeasuresForSelection
       ? t("DG.DataDisplayMenu.disableMeasuresForSelection")
       : t("DG.DataDisplayMenu.enableMeasuresForSelection"),
     displayOnlySelectedIsDisabled = dataConfig?.displayOnlySelectedCases

--- a/v3/src/components/graph/graph-component-handler.test.ts
+++ b/v3/src/components/graph/graph-component-handler.test.ts
@@ -57,14 +57,13 @@ describe("DataInteractive ComponentHandler Graph", () => {
     const pointConfig = "bars"
     const pointsFusedIntoBars = true
     const pointSize = 2
-    const showMeasuresForSelection = true
     const strokeColor = "#FF0000"
     const transparent = true
     const yAttributeType = "numeric"
     const y2AttributeType = "categorical"
     const resultIds = create({}, {
       type: "graph", backgroundColor, cannotClose: true, dataContext: "data",
-      pointColor, pointConfig, pointsFusedIntoBars, pointSize, showMeasuresForSelection, strokeColor,
+      pointColor, pointConfig, pointsFusedIntoBars, pointSize, strokeColor,
       transparent, xAttributeID: toV2Id(a3.id), yAttributeID: toV2Id(a2.id), yAttributeType,
       legendAttributeID: toV2Id(a1.id), captionAttributeID: toV2Id(a2.id), y2AttributeID: toV2Id(a3.id),
       rightSplitAttributeID: toV2Id(a1.id), topSplitAttributeID: toV2Id(a2.id), topSplitAttributeName: "a3",
@@ -102,7 +101,6 @@ describe("DataInteractive ComponentHandler Graph", () => {
     expect(pointDescription.pointSizeMultiplier).toBe(pointSize)
     expect(pointDescription.pointStrokeColor).toBe(strokeColor)
     expect(tileContentIds.pointsFusedIntoBars).toBe(pointsFusedIntoBars)
-    expect(tileContentIds.showMeasuresForSelection).toBe(showMeasuresForSelection)
     expect(tileContentIds.isTransparent).toBe(transparent)
     // Delete the graph when we're finished
     handler.delete!({ component: tileIds })
@@ -292,7 +290,7 @@ describe("DataInteractive ComponentHandler Graph", () => {
     // Update many of a graph's options
     const updateResultOptions = update({ component: tile }, {
       backgroundColor, displayOnlySelectedCases, filterFormula, hiddenCases: _hiddenCases.map(id => toV2Id(id)),
-      pointColor, pointConfig, pointsFusedIntoBars, pointSize, showMeasuresForSelection, strokeColor,
+      pointColor, pointConfig, pointsFusedIntoBars, pointSize, strokeColor,
       transparent
     })
     expect(updateResultOptions.success).toBe(true)
@@ -307,7 +305,6 @@ describe("DataInteractive ComponentHandler Graph", () => {
     expect(tileContent.pointDisplayType).toBe(pointConfig)
     expect(tileContent.pointsFusedIntoBars).toBe(pointsFusedIntoBars)
     expect(pointDescription.pointSizeMultiplier).toBe(pointSize)
-    expect(tileContent.showMeasuresForSelection).toBe(showMeasuresForSelection)
     expect(tileContent.pointDescription.pointStrokeColor).toBe(strokeColor)
     expect(tileContent.isTransparent).toBe(transparent)
 
@@ -322,7 +319,7 @@ describe("DataInteractive ComponentHandler Graph", () => {
         enableNumberToggle, filterFormula: _filterFormula, hiddenCases: hc, numberToggleLastMode, captionAttributeID,
         captionAttributeName, legendAttributeID, legendAttributeName, pointColor: _pointColor,
         pointConfig: _pointConfig, pointsFusedIntoBars: _pointsFusedIntoBars, pointSize: _pointSize,
-        rightSplitAttributeID, rightSplitAttributeName, showMeasuresForSelection: _showMeasuresForSelection,
+        rightSplitAttributeID, rightSplitAttributeName,
         strokeColor: _strokeColor, strokeSameAsFill: _strokeSameAsFill, topSplitAttributeID, topSplitAttributeName,
         transparent: _transparent, xAttributeID, xAttributeName, xAttributeType: _xAttributeType, xLowerBound,
         xUpperBound, yAttributeID, yAttributeIDs, yAttributeName, yAttributeNames, yLowerBound, yUpperBound,
@@ -387,7 +384,6 @@ describe("DataInteractive ComponentHandler Graph", () => {
       expect(_pointConfig).toBe(pointConfig)
       expect(_pointsFusedIntoBars).toBe(pointsFusedIntoBars)
       expect(_pointSize).toBe(pointSize)
-      expect(_showMeasuresForSelection).toBe(showMeasuresForSelection)
       expect(_strokeColor).toBe(pointColor) // strokeSameAsFill overrides strokeColor
       expect(_strokeSameAsFill).toBe(strokeSameAsFill)
       expect(_transparent).toBe(transparent)

--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -166,7 +166,6 @@ export const graphComponentHandler: DIComponentHandler = {
       },
       pointDisplayType: pointConfig && isPointDisplayType(pointConfig) ? pointConfig : undefined,
       pointsFusedIntoBars,
-      showMeasuresForSelection,
       showOnlyLastCase,
       showParentToggles,
       type: kGraphTileType
@@ -183,6 +182,7 @@ export const graphComponentHandler: DIComponentHandler = {
     const finalLayers: Array<IGraphPointLayerModelSnapshot> = []
     for (let i = 0; i < layers.length; i++) {
       const dataConfiguration = graphModel.layers[i].dataConfiguration as IGraphDataConfigurationModel
+      dataConfiguration.setShowMeasuresForSelection(showMeasuresForSelection ?? false)
       const { dataset } = dataConfiguration
       if (dataset && dataset.name === _dataContext) {
         // Make sure all attributes can legally fulfill their specified roles
@@ -283,8 +283,8 @@ export const graphComponentHandler: DIComponentHandler = {
       const yAttributeNames = dataConfiguration._yAttributeDescriptions
         .map(description => dataset?.getAttribute(description.attributeID)?.name).filter(name => name != null)
 
-      const { pointDescription, pointsFusedIntoBars, showMeasuresForSelection } = content
-      const { displayOnlySelectedCases } = dataConfiguration
+      const { pointDescription, pointsFusedIntoBars } = content
+      const { displayOnlySelectedCases, showMeasuresForSelection } = dataConfiguration
       const filterFormula = dataConfiguration.filterFormula?.display
       const hiddenCases = dataConfiguration.hiddenCases.map(id => toV2Id(id))
       const pointConfig = content.pointDisplayType
@@ -436,7 +436,7 @@ export const graphComponentHandler: DIComponentHandler = {
     if (pointConfig != null && isPointDisplayType(pointConfig)) content.setPointConfig(pointConfig)
     if (pointsFusedIntoBars != null) content.setPointsFusedIntoBars(pointsFusedIntoBars)
     if (pointSize != null) pointDescription.setPointSizeMultiplier(pointSize)
-    if (showMeasuresForSelection != null) content.setShowMeasuresForSelection(showMeasuresForSelection)
+    if (showMeasuresForSelection != null) dataConfiguration.setShowMeasuresForSelection(showMeasuresForSelection)
     if (showParentToggles != null) content.setShowParentToggles(showParentToggles)
     if (showOnlyLastCase != null) content.setShowOnlyLastCase(showOnlyLastCase)
     if (strokeColor != null) pointDescription.setPointStrokeColor(strokeColor)

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -3,7 +3,7 @@
  * Its array of DataDisplayLayerModels has just one element, a GraphPointLayerModel.
  */
 import {cloneDeep} from "lodash"
-import {when} from "mobx"
+import { comparer, when } from "mobx"
 import { format } from "d3"
 import {addDisposer, Instance, SnapshotIn, types} from "mobx-state-tree"
 import { t } from "../../../utilities/translation/translate"
@@ -280,7 +280,8 @@ export const GraphContentModel = DataDisplayContentModel
             const updateCategoriesOptions = self.getUpdateCategoriesOptions()
             self.adornmentsStore.updateAdornments(updateCategoriesOptions)
           }
-      }, {name: "GraphContentModel.afterAttachToDocument.updateAdornments"}, self.dataConfiguration))
+      }, {name: "GraphContentModel.afterAttachToDocument.updateAdornments", equals: comparer.structural},
+        self.dataConfiguration))
     },
     beforeDestroy() {
       self.formulaAdapters.forEach(adapter => {

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -4,8 +4,10 @@
  */
 import {cloneDeep} from "lodash"
 import {when} from "mobx"
-import {addDisposer, Instance, SnapshotIn, types} from "mobx-state-tree"
 import { format } from "d3"
+import {addDisposer, Instance, SnapshotIn, types} from "mobx-state-tree"
+import { t } from "../../../utilities/translation/translate"
+import { mstReaction } from "../../../utilities/mst-reaction"
 import {IDataSet} from "../../../models/data/data-set"
 import {applyModelChange} from "../../../models/history/apply-model-change"
 import {
@@ -16,10 +18,16 @@ import {ITileContentModel} from "../../../models/tiles/tile-content"
 import { getFormulaManager } from "../../../models/tiles/tile-environment"
 import {typedId} from "../../../utilities/js-utils"
 import {mstAutorun} from "../../../utilities/mst-autorun"
+import { ICase } from "../../../models/data/data-set-types"
+import { isFiniteNumber } from "../../../utilities/math-utils"
+import { CaseData } from "../../data-display/d3-types"
 import { computePointRadius } from "../../data-display/data-display-utils"
 import { dataDisplayGetNumericValue } from "../../data-display/data-display-value-utils"
 import {IGraphDataConfigurationModel} from "./graph-data-configuration-model"
 import {DataDisplayContentModel} from "../../data-display/models/data-display-content-model"
+import {
+  AxisModelUnion, EmptyAxisModel, IAxisModelUnion, isBaseNumericAxisModel, NumericAxisModel
+} from "../../axis/models/axis-model"
 import {GraphPlace} from "../../axis-graph-shared"
 import { attrRoleToAxisPlace, axisPlaceToAttrRole, GraphAttrRole, kMain, kOther, PointDisplayType }
   from "../../data-display/data-display-types"
@@ -31,13 +39,6 @@ import {setNiceDomain} from "../utilities/graph-utils"
 import {GraphPointLayerModel, IGraphPointLayerModel, kGraphPointLayerType} from "./graph-point-layer-model"
 import {IAdornmentModel, IUpdateCategoriesOptions} from "../adornments/adornment-models"
 import {AdornmentsStore} from "../adornments/adornments-store"
-import {
-  AxisModelUnion, EmptyAxisModel, IAxisModelUnion, isBaseNumericAxisModel, NumericAxisModel
-} from "../../axis/models/axis-model"
-import { ICase } from "../../../models/data/data-set-types"
-import { isFiniteNumber } from "../../../utilities/math-utils"
-import { t } from "../../../utilities/translation/translate"
-import { CaseData } from "../../data-display/d3-types"
 
 export interface GraphProperties {
   axes: Record<string, IAxisModelUnion>
@@ -75,8 +76,7 @@ export const GraphContentModel = DataDisplayContentModel
     plotBackgroundLockInfo: types.maybe(types.frozen<BackgroundLockInfo>()),
     // numberToggleModel: types.optional(types.union(NumberToggleModel, null))
     showParentToggles: false,
-    showOnlyLastCase: types.maybe(types.boolean),
-    showMeasuresForSelection: false
+    showOnlyLastCase: types.maybe(types.boolean)
   })
   .volatile(() => ({
     changeCount: 0, // used to notify observers when something has changed that may require a re-computation/redraw
@@ -269,6 +269,17 @@ export const GraphContentModel = DataDisplayContentModel
         self.dataConfiguration.casesChangeCount // eslint-disable-line @typescript-eslint/no-unused-expressions
         const updateCategoriesOptions = self.getUpdateCategoriesOptions()
         self.adornmentsStore.updateAdornments(updateCategoriesOptions)
+      }, {name: "GraphContentModel.afterAttachToDocument.updateAdornments"}, self.dataConfiguration))
+
+      // When showMeasuresForSelection is true, update adornments when selection changes
+      addDisposer(self, mstReaction(() => {
+        return self.dataConfiguration.selection
+      },
+        () => {
+          if (self.dataConfiguration.showMeasuresForSelection) {
+            const updateCategoriesOptions = self.getUpdateCategoriesOptions()
+            self.adornmentsStore.updateAdornments(updateCategoriesOptions)
+          }
       }, {name: "GraphContentModel.afterAttachToDocument.updateAdornments"}, self.dataConfiguration))
     },
     beforeDestroy() {
@@ -628,9 +639,6 @@ export const GraphContentModel = DataDisplayContentModel
     setShowOnlyLastCase(show: boolean) {
       self.showOnlyLastCase = show
     },
-    setShowMeasuresForSelection(show: boolean) {
-      self.showMeasuresForSelection = show
-    }
   }))
   .actions(self => ({
     displayOnlySelectedCases() {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -40,6 +40,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     primaryRole: types.maybe(types.enumeration([...PrimaryAttrRoles])),
     // all attributes for (left) y role
     _yAttributeDescriptions: types.array(AttributeDescription),
+    showMeasuresForSelection: types.maybe(types.boolean),
   })
   .views(self => ({
     get secondaryRole() {
@@ -168,6 +169,9 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       while (self.dataset && self.filteredCases.length < filteredCasesRequired) {
         self._addNewFilteredCases()
       }
+    },
+    setShowMeasuresForSelection(showMeasuresForSelection: boolean) {
+      self.showMeasuresForSelection = showMeasuresForSelection
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/models/graph-model.test.ts
+++ b/v3/src/components/graph/models/graph-model.test.ts
@@ -20,7 +20,6 @@ describe('GraphContentModel', () => {
     expect(graphModel.plotBackgroundImage).toBeUndefined()
     expect(graphModel.plotBackgroundLockInfo).toBe(undefined)
     expect(graphModel.showParentToggles).toBe(false)
-    expect(graphModel.showMeasuresForSelection).toBe(false)
   })
   it('should show and hide adornments', () => {
     const graphModel = GraphContentModel.create()


### PR DESCRIPTION
[#187711050] Feature: Adornments respond to Show Measures for Selection option

* The property governing this feature was being stored as part of the `GraphContentModel` which made it inaccessible to the `UnivariateMeasureAdornmentModel` which needs to know the value in its `getCaseValues` method. Accordingly, we move `showMeasuresForSelection` into the `GraphDataConfigurationModel` where it is more accessible. This causes a ripple effect of changes through the files that were assuming it belonged to `GraphContentModel`. Among these were graph-component-handler.test.ts where I simply removed references to `showMeasuresForSelection`.
* graph-content-model.ts (where I reorganized the imports), add an mstReaction that responds to selection changes and updates the adornments if showMeasuresForSelection is true.