### PR TITLE
Adds a zero axis line when graph is a dotPlot with points as bars

### DIFF
--- a/v3/src/components/axis/components/axis.tsx
+++ b/v3/src/components/axis/components/axis.tsx
@@ -11,11 +11,12 @@ import "./axis.scss"
 interface IProps {
   axisPlace: AxisPlace
   showScatterPlotGridLines?: boolean
+  showZeroAxisLine?: boolean
   centerCategoryLabels?: boolean
 }
 
 export const Axis = observer(function Axis ({
-                       axisPlace, showScatterPlotGridLines = false,
+                       axisPlace, showScatterPlotGridLines = false, showZeroAxisLine = false,
                        centerCategoryLabels = true,
                      }: IProps) {
   const
@@ -33,6 +34,7 @@ export const Axis = observer(function Axis ({
                       subAxisIndex={i}
                       axisPlace={axisPlace}
                       showScatterPlotGridLines={showScatterPlotGridLines}
+                      showZeroAxisLine={showZeroAxisLine}
                       centerCategoryLabels={centerCategoryLabels}
       />
     })

--- a/v3/src/components/axis/components/sub-axis.tsx
+++ b/v3/src/components/axis/components/sub-axis.tsx
@@ -13,11 +13,13 @@ interface ISubAxisProps {
   subAxisIndex: number
   axisPlace: AxisPlace
   showScatterPlotGridLines?: boolean
+  showZeroAxisLine?: boolean
   centerCategoryLabels?: boolean
 }
 
 export const SubAxis = observer(function SubAxis({
                                                numSubAxes, subAxisIndex, axisPlace, showScatterPlotGridLines = false,
+                                               showZeroAxisLine = false,
                                                centerCategoryLabels = true /*, getCategorySet*/
                                              }: ISubAxisProps) {
   const
@@ -29,7 +31,7 @@ export const SubAxis = observer(function SubAxis({
     subAxisEltRef = useRef<SVGGElement | null>(null)
 
   useSubAxis({
-    subAxisIndex, axisPlace, subAxisEltRef, showScatterPlotGridLines, centerCategoryLabels
+    subAxisIndex, axisPlace, subAxisEltRef, showScatterPlotGridLines, centerCategoryLabels, showZeroAxisLine
   })
 
   return (

--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -8,13 +8,16 @@ import { AxisHelper, IAxisHelperArgs } from "./axis-helper"
 
 export interface INumericAxisHelperArgs extends IAxisHelperArgs {
   showScatterPlotGridLines: boolean
+  showZeroAxisLine?: boolean
 }
 export class NumericAxisHelper extends AxisHelper {
   showScatterPlotGridLines: boolean
+  showZeroAxisLine?: boolean
 
   constructor(props: INumericAxisHelperArgs) {
     super(props)
     this.showScatterPlotGridLines = props.showScatterPlotGridLines
+    this.showZeroAxisLine = props.showZeroAxisLine
   }
 
   get newRange() {
@@ -30,6 +33,20 @@ export class NumericAxisHelper extends AxisHelper {
       .attr('class', 'grid')
       .call(this.axis(numericScale).tickSizeInner(-tickLength))
     select(this.subAxisElt).select('.grid').selectAll('text').remove()
+    if (between(0, numericScale.domain()[0], numericScale.domain()[1])) {
+      select(this.subAxisElt).append('g')
+        .attr('class', 'zero')
+        .call(this.axis(numericScale).tickSizeInner(-tickLength).tickValues([0]))
+      select(this.subAxisElt).select('.zero').selectAll('text').remove()
+    }
+  }
+
+  renderZeroAxisLine() {
+    const d3Scale: AxisScaleType = this.multiScale?.scale.copy().range(this.newRange) as AxisScaleType,
+      numericScale = d3Scale as unknown as ScaleLinear<number, number>
+    select(this.subAxisElt).selectAll('.zero, .grid').remove()
+    const tickLength = this.layout.getAxisLength(otherPlace(this.axisPlace)) ?? 0
+    console.log("in renderZeroAxisLine numericalScale: ", numericScale)
     if (between(0, numericScale.domain()[0], numericScale.domain()[1])) {
       select(this.subAxisElt).append('g')
         .attr('class', 'zero')
@@ -77,6 +94,7 @@ export class NumericAxisHelper extends AxisHelper {
       .style("stroke", "lightgrey")
       .style("stroke-opacity", "0.7")
 
-    this.showScatterPlotGridLines && this.renderScatterPlotGridLines()
+      this.showZeroAxisLine && this.renderZeroAxisLine()
+      this.showScatterPlotGridLines && this.renderScatterPlotGridLines()
   }
 }

--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -46,7 +46,6 @@ export class NumericAxisHelper extends AxisHelper {
       numericScale = d3Scale as unknown as ScaleLinear<number, number>
     select(this.subAxisElt).selectAll('.zero, .grid').remove()
     const tickLength = this.layout.getAxisLength(otherPlace(this.axisPlace)) ?? 0
-    console.log("in renderZeroAxisLine numericalScale: ", numericScale)
     if (between(0, numericScale.domain()[0], numericScale.domain()[1])) {
       select(this.subAxisElt).append('g')
         .attr('class', 'zero')

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -27,6 +27,7 @@ export interface IUseSubAxis {
   axisPlace: AxisPlace
   subAxisEltRef: MutableRefObject<SVGGElement | null>
   showScatterPlotGridLines: boolean
+  showZeroAxisLine: boolean
   centerCategoryLabels: boolean
 }
 
@@ -50,7 +51,8 @@ function setAxisHelper(axisModel: IAxisModel, subAxisIndex: number, axisHelper: 
 }
 
 export const useSubAxis = ({
-                             subAxisIndex, axisPlace, subAxisEltRef, showScatterPlotGridLines, centerCategoryLabels
+                             subAxisIndex, axisPlace, subAxisEltRef, showScatterPlotGridLines, centerCategoryLabels,
+                             showZeroAxisLine
                            }: IUseSubAxis) => {
   const layout = useAxisLayoutContext(),
     displayModel = useDataDisplayModelContextMaybe(),
@@ -240,7 +242,7 @@ export const useSubAxis = ({
           break
         case 'numeric':
           helper = new NumericAxisHelper(
-            { ...helperProps, showScatterPlotGridLines })
+            { ...helperProps, showScatterPlotGridLines, showZeroAxisLine })
           break
         case 'categorical':
           // It is necessary to call renderSubAxis in most cases, but doing so for a categorical axis causes
@@ -260,7 +262,7 @@ export const useSubAxis = ({
       }
     }
   }, [axisModel, axisProvider, centerCategoryLabels, displayModel, isAnimating, layout, renderSubAxis,
-            showScatterPlotGridLines, subAxisEltRef, subAxisIndex])
+            showScatterPlotGridLines, showZeroAxisLine, subAxisEltRef, subAxisIndex])
 
   // update d3 scale and axis when scale type changes
   useEffect(() => {

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -95,6 +95,7 @@ export const GraphAxis = observer(function GraphAxis(
       {axisModel &&
         <Axis axisPlace={place}
               showScatterPlotGridLines={graphModel.axisShouldShowGridLines(place)}
+              showZeroAxisLine={graphModel.axisShouldShowZeroLine(place)}
               centerCategoryLabels={graphModel.dataConfiguration.categoriesForAxisShouldBeCentered(place)}
         />}
       <GraphAttributeLabel

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -161,6 +161,12 @@ export const GraphContentModel = DataDisplayContentModel
       return (self.plotType === 'scatterPlot' && ['left', 'bottom'].includes(place)) ||
              (self.pointDisplayType === "histogram")
     },
+    axisShouldShowZeroLine(place: AxisPlace) {
+      const otherPlace = place === "left" ? "bottom" : "left"
+      const otherPlaceRole = axisPlaceToAttrRole[otherPlace]
+      const attributeID = self.dataConfiguration.attributeID(otherPlaceRole)
+      return (self.plotType === 'dotPlot' && ['left', 'bottom'].includes(place)) && !!attributeID
+    },
     placeCanAcceptAttributeIDDrop(place: GraphPlace,
                                   dataset: IDataSet | undefined,
                                   attributeID: string | undefined): boolean {

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -162,10 +162,7 @@ export const GraphContentModel = DataDisplayContentModel
              (self.pointDisplayType === "histogram")
     },
     axisShouldShowZeroLine(place: AxisPlace) {
-      const otherPlace = place === "left" ? "bottom" : "left"
-      const otherPlaceRole = axisPlaceToAttrRole[otherPlace]
-      const attributeID = self.dataConfiguration.attributeID(otherPlaceRole)
-      return (self.plotType === 'dotPlot' && ['left', 'bottom'].includes(place)) && !!attributeID
+      return (self.plotType === 'dotPlot' && ['left', 'bottom'].includes(place)) && self.pointDisplayType === "bars"
     },
     placeCanAcceptAttributeIDDrop(place: GraphPlace,
                                   dataset: IDataSet | undefined,


### PR DESCRIPTION
We were only showing the zero axis line for x and y when the graph is a scatterplot. 
This shows the zero axis line when the graph is a dotplot with points as bars.