### PR TITLE
Propagate null value in arithmetic

### DIFF
--- a/v3/src/models/formula/functions/operators.test.ts
+++ b/v3/src/models/formula/functions/operators.test.ts
@@ -255,6 +255,15 @@ describe("- operator", () => {
     expect(fn.evaluate()).toEqual(new Date(2020, 0, 1))
   })
 
+  it("returns an empty string when either argument is an empty string", () => {
+    const fn1 = math.compile("10 - ''")
+    expect(fn1.evaluate()).toEqual("")
+    const fn2 = math.compile("'' - 10")
+    expect(fn2.evaluate()).toEqual("")
+    const fn3 = math.compile("'' - ''")
+    expect(fn3.evaluate()).toEqual("")
+  })
+
   it("throws an error when subtracting a date from a number", () => {
     const fn = math.compile("86400 - '1/2/2020'") // 1 day
     expect(() => fn.evaluate()).toThrow()
@@ -264,4 +273,84 @@ describe("- operator", () => {
     const fn = math.compile("'foo' - 'bar'")
     expect(() => fn.evaluate()).toThrow("Invalid arguments for subtract operator: foo, bar")
   })
+})
+
+describe("* operator", () => {
+  it("multiplies two numbers", () => {
+    const fn = math.compile("2 * 10")
+    expect(fn.evaluate()).toEqual(20)
+  })
+
+  it("multiplies two numeric strings", () => {
+    const fn = math.compile("'2' * '10'")
+    expect(fn.evaluate()).toEqual(20)
+  })
+
+  it("multiplies a number and a numeric string", () => {
+    const fn = math.compile("2 * '10'")
+    expect(fn.evaluate()).toEqual(20)
+  })
+
+  it("returns an empty string when either argument is an empty string", () => {
+    const fn1 = math.compile("10 * ''")
+    expect(fn1.evaluate()).toEqual("")
+    const fn2 = math.compile("'' * 10")
+    expect(fn2.evaluate()).toEqual("")
+    const fn3 = math.compile("'' * ''")
+    expect(fn3.evaluate()).toEqual("")
+  })
+
+  it("throws an error when multiplying a date by a number", () => {
+    const fn = math.compile("86400 * '1/2/2020'")
+    expect(() => fn.evaluate()).toThrow()
+  })
+
+  it("throws an error when multiplying strings", () => {
+    const fn = math.compile("'foo' * 'bar'")
+    expect(() => fn.evaluate()).toThrow("Invalid arguments for multiply operator: foo, bar")
+  })
+})
+
+describe("/ operator", () => {
+  it("divides two numbers", () => {
+    const fn = math.compile("2 / 10")
+    expect(fn.evaluate()).toEqual(0.2)
+  })
+
+  it("divides two numeric strings", () => {
+    const fn = math.compile("'2' / '10'")
+    expect(fn.evaluate()).toEqual(0.2)
+  })
+
+  it("divides a number and a numeric string", () => {
+    const fn = math.compile("2 / '10'")
+    expect(fn.evaluate()).toEqual(0.2)
+  })
+
+  it("returns an empty string when either argument is an empty string", () => {
+    const fn1 = math.compile("10 / ''")
+    expect(fn1.evaluate()).toEqual("")
+    const fn2 = math.compile("'' / 10")
+    expect(fn2.evaluate()).toEqual("")
+    const fn3 = math.compile("'' / ''")
+    expect(fn3.evaluate()).toEqual("")
+  })
+
+  it("throws an error when dividing a date by a number", () => {
+    const fn = math.compile("86400 / '1/2/2020'")
+    expect(() => fn.evaluate()).toThrow()
+  })
+
+  it("throws an error when dividing strings", () => {
+    const fn = math.compile("'foo' / 'bar'")
+    expect(() => fn.evaluate()).toThrow("Invalid arguments for divide operator: foo, bar")
+  })
+})
+
+describe("% operator", () => {
+  it("computes modulus of two numbers", () => {
+    const fn = math.compile("15 % 7")
+    expect(fn.evaluate()).toEqual(1)
+  })
+  // Trying to compute the modulus with strings is difficult so we punt on that for now
 })

--- a/v3/src/models/formula/functions/operators.ts
+++ b/v3/src/models/formula/functions/operators.ts
@@ -140,6 +140,11 @@ export const operators = {
       const [isANumber, aNumber] = checkNumber(a)
       const [isBNumber, bNumber] = checkNumber(b)
 
+      // Empty strings
+      if (a === "" || b === "") {
+        return ""
+      }
+
       // Date objects
       if (isADate || isBDate) {
         // both are dates
@@ -160,6 +165,72 @@ export const operators = {
       }
 
       throw subtractError
+    }
+  },
+
+  multiply: {
+    isOperator: true,
+    numOfRequiredArguments: 2,
+    evaluateOperator: (a: any, b: any) => {
+      const multiplyError = new Error(`Invalid arguments for multiply operator: ${a}, ${b}`)
+
+      const [isANumber, aNumber] = checkNumber(a)
+      const [isBNumber, bNumber] = checkNumber(b)
+
+      // Empty strings
+      if (a === "" || b === "") {
+        return ""
+      }
+
+      if (!isANumber || !isBNumber) {
+        throw multiplyError
+      }
+
+      return aNumber * bNumber
+    }
+  },
+
+  divide: {
+    isOperator: true,
+    numOfRequiredArguments: 2,
+    evaluateOperator: (a: any, b: any) => {
+      const divideError = new Error(`Invalid arguments for multiply operator: ${a}, ${b}`)
+
+      const [isANumber, aNumber] = checkNumber(a)
+      const [isBNumber, bNumber] = checkNumber(b)
+
+      // Empty strings
+      if (a === "" || b === "") {
+        return ""
+      }
+
+      if (!isANumber || !isBNumber) {
+        throw divideError
+      }
+
+      return aNumber / bNumber
+    }
+  },
+
+  mod: {
+    isOperator: true,
+    numOfRequiredArguments: 2,
+    evaluateOperator: (a: any, b: any) => {
+      const modError = new Error(`Invalid arguments for multiply operator: ${a}, ${b}`)
+
+      const [isANumber, aNumber] = checkNumber(a)
+      const [isBNumber, bNumber] = checkNumber(b)
+
+      // Empty strings
+      if (a === "" || b === "") {
+        return ""
+      }
+
+      if (!isANumber || !isBNumber) {
+        throw modError
+      }
+
+      return aNumber % bNumber
     }
   }
 }

--- a/v3/src/models/formula/functions/operators.ts
+++ b/v3/src/models/formula/functions/operators.ts
@@ -194,7 +194,7 @@ export const operators = {
     isOperator: true,
     numOfRequiredArguments: 2,
     evaluateOperator: (a: any, b: any) => {
-      const divideError = new Error(`Invalid arguments for multiply operator: ${a}, ${b}`)
+      const divideError = new Error(`Invalid arguments for divide operator: ${a}, ${b}`)
 
       const [isANumber, aNumber] = checkNumber(a)
       const [isBNumber, bNumber] = checkNumber(b)

--- a/v3/src/models/formula/functions/operators.ts
+++ b/v3/src/models/formula/functions/operators.ts
@@ -135,15 +135,15 @@ export const operators = {
     evaluateOperator: (a: any, b: any) => {
       const subtractError = new Error(`Invalid arguments for subtract operator: ${a}, ${b}`)
 
-      const [isADate, aDate] = checkDate(a)
-      const [isBDate, bDate] = checkDate(b)
-      const [isANumber, aNumber] = checkNumber(a)
-      const [isBNumber, bNumber] = checkNumber(b)
-
       // Empty strings
       if (a === "" || b === "") {
         return ""
       }
+
+      const [isADate, aDate] = checkDate(a)
+      const [isBDate, bDate] = checkDate(b)
+      const [isANumber, aNumber] = checkNumber(a)
+      const [isBNumber, bNumber] = checkNumber(b)
 
       // Date objects
       if (isADate || isBDate) {
@@ -174,13 +174,13 @@ export const operators = {
     evaluateOperator: (a: any, b: any) => {
       const multiplyError = new Error(`Invalid arguments for multiply operator: ${a}, ${b}`)
 
-      const [isANumber, aNumber] = checkNumber(a)
-      const [isBNumber, bNumber] = checkNumber(b)
-
       // Empty strings
       if (a === "" || b === "") {
         return ""
       }
+
+      const [isANumber, aNumber] = checkNumber(a)
+      const [isBNumber, bNumber] = checkNumber(b)
 
       if (!isANumber || !isBNumber) {
         throw multiplyError
@@ -216,15 +216,15 @@ export const operators = {
     isOperator: true,
     numOfRequiredArguments: 2,
     evaluateOperator: (a: any, b: any) => {
-      const modError = new Error(`Invalid arguments for multiply operator: ${a}, ${b}`)
-
-      const [isANumber, aNumber] = checkNumber(a)
-      const [isBNumber, bNumber] = checkNumber(b)
+      const modError = new Error(`Invalid arguments for mod operator: ${a}, ${b}`)
 
       // Empty strings
       if (a === "" || b === "") {
         return ""
       }
+
+      const [isANumber, aNumber] = checkNumber(a)
+      const [isBNumber, bNumber] = checkNumber(b)
 
       if (!isANumber || !isBNumber) {
         throw modError


### PR DESCRIPTION
[#188590675] Bug fix: **Formula Editor** prev() and next () function produces invalid argument error in first cell

[#188517456] Feature: You can use the "modulo" operator ('%') in formulas

* The problem is that the formula engine was not propagating null values ("").
* We modify `subtract` and add `multiply` and `divide` in operators.ts to return "" if either of the operators are the empty string.
* As a bonus, we add `mod` so that V3 can evaluate the `%` operator.