### PR TITLE
categorical legend refactor

### DIFF
--- a/v3/src/components/data-display/components/legend/categorical-legend-model.ts
+++ b/v3/src/components/data-display/components/legend/categorical-legend-model.ts
@@ -1,0 +1,254 @@
+import { makeAutoObservable } from "mobx"
+import { measureText } from "../../../../hooks/use-measure-text"
+import { logMessageWithReplacement } from "../../../../lib/log-message"
+import { missingColor } from "../../../../utilities/color-utils"
+import { axisGap } from "../../../axis/axis-types"
+import { getStringBounds } from "../../../axis/axis-utils"
+import vars from "../../../vars.scss"
+import { kMain, kDataDisplayFont } from "../../data-display-types"
+import { IDataConfigurationModel } from "../../models/data-configuration-model"
+import { DataDisplayLayout } from "../../models/data-display-layout"
+
+export interface Key {
+  category: string;
+  color: string;
+  index: number;
+  column: number;
+  row: number;
+}
+interface Layout {
+  maxWidth: number;
+  fullWidth: number;
+  numColumns: number;
+  numRows: number;
+  columnWidth: number;
+}
+
+export const keySize = 15
+export const padding = 5
+export const labelHeight = getStringBounds('Wy', vars.labelFont).height + axisGap
+
+export class CategoricalLegendModel {
+  dragInfo = {
+    category: "",
+    initialOffset: { x: 0, y: 0 },
+    currentDragPosition: { x: 0, y: 0 },
+    initialIndex: -1,
+    currentIndex: -1
+  }
+
+  dataDisplayLayout: DataDisplayLayout
+  dataConfiguration: IDataConfigurationModel | undefined
+
+  categoriesAtDragStart: string[] = []
+  colorsAtDragStart: Record<string, string> = {}
+
+  constructor(dataConfiguration: IDataConfigurationModel | undefined, dataDisplayLayout: DataDisplayLayout) {
+    this.dataDisplayLayout = dataDisplayLayout
+    this.dataConfiguration = dataConfiguration
+    makeAutoObservable(this)
+  }
+
+  setDataConfiguration(dataConfiguration: IDataConfigurationModel | undefined) {
+    this.dataConfiguration = dataConfiguration
+  }
+
+  setDataDisplayLayout(dataDisplayLayout: DataDisplayLayout) {
+    this.dataDisplayLayout = dataDisplayLayout
+  }
+
+  get categoriesFromDoc() {
+    const categories = this.dataConfiguration?.categoryArrayForAttrRole('legend') || []
+    return categories.filter(cat => cat !== kMain)
+  }
+
+  getColorForCategoryFromDoc(cat: string, defaultColor = missingColor) {
+    return this.dataConfiguration?.getLegendColorForCategory(cat) ?? defaultColor
+  }
+
+  get numCategories() {
+    return this.categoriesFromDoc.length
+  }
+
+  get categoryTextMaxWidth() {
+    let maxWidth = 0
+    this.categoriesFromDoc.forEach(cat => {
+      maxWidth = Math.max(maxWidth, measureText(cat, kDataDisplayFont))
+    })
+    return maxWidth
+  }
+
+  get layoutData() {
+    const fullWidth = this.dataDisplayLayout.tileWidth
+    const maxWidth = this.categoryTextMaxWidth + keySize + padding
+    const numColumns = Math.max(Math.floor(fullWidth / maxWidth), 1)
+    const columnWidth = fullWidth / numColumns
+    const numRows = Math.ceil((this.numCategories ?? 0) / numColumns)
+
+    const lod: Layout = {
+      fullWidth,
+      maxWidth,
+      numColumns,
+      columnWidth,
+      numRows
+    }
+
+    return lod
+  }
+
+  coordinatesToCatIndex(localPoint: { x: number; y: number; }) {
+    const lod = this.layoutData
+    const { x, y } = localPoint
+    const col = Math.floor(x / lod.columnWidth)
+    const row = Math.floor(y / (keySize + padding))
+    const catIndex = row * lod.numColumns + col
+
+    return catIndex >= 0 && catIndex < this.numCategories ? catIndex : -1
+  }
+
+  catLocation(categoryKey: Key) {
+    return {
+      x: axisGap + categoryKey.column * this.layoutData.columnWidth,
+      y: /*labelHeight + */ categoryKey.row * (keySize + padding)
+    }
+  }
+
+  get isDragging() {
+    return !!this.dragInfo.category
+  }
+
+  getColorForCategory(cat: string, defaultColor = missingColor) {
+    if (this.isDragging) {
+      return this.colorsAtDragStart[cat] || defaultColor
+    } else {
+      return this.getColorForCategoryFromDoc(cat, defaultColor)
+    }
+  }
+
+  get categoryData() {
+    const categories = this.isDragging ? this.getCategoriesDuringDrag() : this.categoriesFromDoc
+
+    return categories.map((cat: string, index) => ({
+      category: cat,
+      color: this.getColorForCategory(cat, "white"),
+      column: index % this.layoutData.numColumns,
+      index,
+      row: Math.floor(index / this.layoutData.numColumns)
+    }))
+  }
+
+  onDragStart(event: { x: number; y: number; }, d: Key) {
+    const localPt = {
+      x: event.x,
+      y: event.y - labelHeight
+    }
+    const keyLocation = this.catLocation(d)
+
+    this.categoriesAtDragStart = this.categoriesFromDoc
+    // TODO: saving the colors is probably not necessary
+    // They shouldn't be changing while we are dragging since the dragging doesn't
+    // change the document
+    this.categoriesAtDragStart.forEach(cat => {
+      this.colorsAtDragStart[cat] = this.getColorForCategoryFromDoc(cat)
+    })
+
+    const dI = this.dragInfo
+    // We save the information but we don't save the dragging category to indicate we are
+    // dragging. This prevents extra re-renders on single clicks
+    dI.initialOffset = { x: localPt.x - keyLocation.x, y: localPt.y - keyLocation.y }
+    dI.currentDragPosition = localPt
+    dI.initialIndex = d.index
+    dI.currentIndex = d.index
+  }
+
+  onDrag(event: { dx: number; dy: number; }, d: Key) {
+    if (event.dx !== 0 || event.dy !== 0) {
+      const dI = this.dragInfo
+
+      // Indicate that we are now dragging
+      dI.category = d.category
+
+      const newDragPosition = {
+        x: dI.currentDragPosition.x + event.dx,
+        y: dI.currentDragPosition.y + event.dy
+      }
+
+      dI.currentIndex = this.coordinatesToCatIndex(newDragPosition)
+      dI.currentDragPosition = newDragPosition
+    }
+  }
+
+  onDragEnd(
+    dataConfiguration: IDataConfigurationModel | undefined, d: Key
+  ) {
+    const categories = dataConfiguration?.categoryArrayForAttrRole('legend') || []
+    const dI = this.dragInfo
+
+    const targetCategory = categories[dI.currentIndex]
+
+    if (dI.currentIndex === dI.initialIndex) {
+      // Nothing changed so stop the drag and do nothing else.
+      dI.category = ""
+    } else {
+      // TODO: This is calling a MST action inside of a MobX action, it might be why undo and redo
+      // Isn't always working properly. If that is true, we can annotate it so onDragEnd itself isn't a
+      // MobX action
+      dataConfiguration?.applyModelChange(() => {
+        dataConfiguration?.storeAllCurrentColorsForAttrRole('legend')
+        let beforeCategory: string | undefined = ""
+        if (dI.currentIndex > dI.initialIndex) {
+          // The gap is on the left of where we want the dragged category to go so we want to
+          // go before the category to the right of our target position. If we are at the end then we use
+          // a special undefined value to indicate we want go to the last position
+          beforeCategory = dI.currentIndex < categories.length - 1 ? categories[dI.currentIndex + 1] : undefined
+        } else {
+          // The gap is on the right of where we want the dragged category to go so we want to
+          // go before the category at our target position. This will push all of the categories right.
+          beforeCategory = categories[dI.currentIndex]
+        }
+        const categorySet = dataConfiguration?.categorySetForAttrRole("legend")
+        categorySet?.move(dI.category, beforeCategory)
+        dI.category = ""
+      }, {
+        undoStringKey: 'DG.Undo.graph.swapCategories',
+        redoStringKey: 'DG.Redo.graph.swapCategories',
+        log: logMessageWithReplacement(
+          "Moved category %@ into position of %@",
+          {
+            movedCategory: d.category,
+            targetCategory
+          })
+      })
+    }
+  }
+
+  getCategoriesDuringDrag() {
+    const { dragInfo } = this
+    if (dragInfo.currentIndex === dragInfo.initialIndex) return this.categoriesAtDragStart
+
+    const updatedCategories: string[] = []
+    this.categoriesAtDragStart.forEach((cat, index) => {
+      // Ignore the old location
+      if (cat === dragInfo.category) return
+
+      if (index !== dragInfo.currentIndex) {
+        // If we aren't at the location of the dragged category just
+        // add the original category
+        updatedCategories.push(cat)
+      } else {
+        if (dragInfo.currentIndex < dragInfo.initialIndex) {
+          // If the "gap" is after our location add the dragged category first
+          // then add the category that was in this spot previously
+          updatedCategories.push(dragInfo.category)
+          updatedCategories.push(cat)
+        } else {
+          // If the "gap" is before our location add the original category first
+          // and then our draged category second
+          updatedCategories.push(cat)
+          updatedCategories.push(dragInfo.category)
+        }
+      }
+    })
+    return updatedCategories
+  }
+}

--- a/v3/src/components/data-display/components/legend/categorical-legend-model.ts
+++ b/v3/src/components/data-display/components/legend/categorical-legend-model.ts
@@ -4,10 +4,11 @@ import { logMessageWithReplacement } from "../../../../lib/log-message"
 import { missingColor } from "../../../../utilities/color-utils"
 import { axisGap } from "../../../axis/axis-types"
 import { getStringBounds } from "../../../axis/axis-utils"
-import vars from "../../../vars.scss"
 import { kMain, kDataDisplayFont } from "../../data-display-types"
 import { IDataConfigurationModel } from "../../models/data-configuration-model"
 import { DataDisplayLayout } from "../../models/data-display-layout"
+
+import vars from "../../../vars.scss"
 
 export interface Key {
   category: string;
@@ -97,11 +98,10 @@ export class CategoricalLegendModel {
   }
 
   coordinatesToCatIndex(localPoint: { x: number; y: number; }) {
-    const lod = this.layoutData
     const { x, y } = localPoint
-    const col = Math.floor(x / lod.columnWidth)
+    const col = Math.floor(x / this.layoutData.columnWidth)
     const row = Math.floor(y / (keySize + padding))
-    const catIndex = row * lod.numColumns + col
+    const catIndex = row * this.layoutData.numColumns + col
 
     return catIndex >= 0 && catIndex < this.numCategories ? catIndex : -1
   }
@@ -109,7 +109,7 @@ export class CategoricalLegendModel {
   catLocation(categoryKey: Key) {
     return {
       x: axisGap + categoryKey.column * this.layoutData.columnWidth,
-      y: /*labelHeight + */ categoryKey.row * (keySize + padding)
+      y: categoryKey.row * (keySize + padding)
     }
   }
 

--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -1,130 +1,64 @@
 import {observer} from "mobx-react-lite"
+import {drag, select} from "d3"
+import React, {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {mstReaction} from "../../../../utilities/mst-reaction"
-import {comparer, reaction} from "mobx"
-import {drag, range, select} from "d3"
-import React, {useCallback, useEffect, useMemo, useRef} from "react"
-import { logMessageWithReplacement } from "../../../../lib/log-message"
-import {missingColor} from "../../../../utilities/color-utils"
-import {measureText} from "../../../../hooks/use-measure-text"
+import { mstAutorun } from "../../../../utilities/mst-autorun"
+import {axisGap} from "../../../axis/axis-types"
+import { transitionDuration } from "../../data-display-types"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {useDataDisplayLayout} from "../../hooks/use-data-display-layout"
-import {getStringBounds} from "../../../axis/axis-utils"
-import { kDataDisplayFont, kMain, transitionDuration } from "../../data-display-types"
-import {axisGap} from "../../../axis/axis-types"
 import { IBaseLegendProps } from "./legend-common"
+import { CategoricalLegendModel, keySize, padding, labelHeight, Key } from "./categorical-legend-model"
 
 import './legend.scss'
-import vars from "../../../vars.scss"
 
-interface Key {
-  category: string
-  color: string
-  index: number
-  column: number,
-  row: number
-}
-
-interface Layout {
-  maxWidth: number
-  fullWidth: number
-  numColumns: number
-  numRows: number
-  columnWidth: number
-}
-
-interface DragInfo {
-  indexOfCategory: number
-  initialOffset: { x: number, y: number }
-  currentDragPosition: { x: number, y: number }
-}
-
-const keySize = 15,
-  padding = 5
-
-const labelHeight = getStringBounds('Wy', vars.labelFont).height + axisGap
-
-const coordinatesToCatIndex = (lod: Layout, numCategories: number, localPoint: { x: number, y: number }) => {
-    const {x, y} = localPoint,
-      col = Math.floor(x / lod.columnWidth),
-      row = Math.floor(y / (keySize + padding)),
-      catIndex = row * lod.numColumns + col
-    return catIndex >= 0 && catIndex < numCategories ? catIndex : -1
-  },
-  catLocation = (lod: Layout, catData: Key[], index: number) => {
-    return {
-      x: axisGap + catData[index].column * lod.columnWidth,
-      y: /*labelHeight + */catData[index].row * (keySize + padding)
-    }
-  }
-
-export const CategoricalLegend = observer(
+export const CategoricalLegend =
   function CategoricalLegend({layerIndex, setDesiredExtent}: IBaseLegendProps) {
-    const dataConfiguration = useDataConfigurationContext(),
-      tileWidth = useDataDisplayLayout().tileWidth,
-      categoriesRef = useRef<string[] | undefined>(),
-      categoryData = useRef<Key[]>([]),
-      layoutData = useRef<Layout>({
-          maxWidth: 0,
-          fullWidth: 0,
-          numColumns: 0,
-          numRows: 0,
-          columnWidth: 0
-        }
-      ),
-      dragInfo = useRef<DragInfo>({
-        indexOfCategory: -1,
-        initialOffset: {x: 0, y: 0},
-        currentDragPosition: {x: 0, y: 0}
-      }),
-      duration = useRef(0)
-    const prevCategoryIndex = useRef(0)
-    const
-      keysElt = useRef(null)
 
-    const setCategoryData = useCallback(() => {
-      if (categoriesRef.current) {
-        const newCategoryData = categoriesRef.current.map((cat: string, index) => {
-          return (
-          {
-            category: cat,
-            color: dataConfiguration?.getLegendColorForCategory(cat) || missingColor,
-            column: index % layoutData.current.numColumns,
-            index,
-            row: Math.floor(index / layoutData.current.numColumns)
-          })
-        })
-        categoryData.current = newCategoryData
+    const dataConfiguration = useDataConfigurationContext()
+    const dataDisplayLayout = useDataDisplayLayout()
+    const duration = useRef(0)
+    const keysElt = useRef(null)
+
+    const [legendModel] = useState(
+      () => new CategoricalLegendModel(dataConfiguration, dataDisplayLayout)
+    )
+
+    // This is outside of the main autorun because it only needs to run when
+    // number of categories changes or the maxWidth of a category changes
+    // Also the setDesiredExtent might cause extra re-renders so it only
+    // runs when the desiredExtent actually changes
+    useEffect(function updateDesiredExtent() {
+      return mstReaction(
+        () => {
+          if (dataConfiguration?.placeCanHaveZeroExtent('legend')) {
+            return 0
+          }
+          const lod = legendModel.layoutData
+          return lod.numRows * (keySize + padding) + labelHeight + axisGap
+        },
+        (desiredExtent) => {
+          setDesiredExtent(layerIndex, desiredExtent)
+        },
+        {name: 'CategoricalLegend updateDesiredExtent', fireImmediately: true},
+        dataConfiguration
+      )
+    }, [dataConfiguration, setDesiredExtent, layerIndex, legendModel])
+
+    // These variables should not change, but theoretically it is possible
+    useEffect(function updateContextVariables() {
+      legendModel.setDataConfiguration(dataConfiguration)
+      legendModel.setDataDisplayLayout(dataDisplayLayout)
+    }, [dataConfiguration, dataDisplayLayout, legendModel])
+
+    useEffect(() => {
+      return function cleanup() {
+        setDesiredExtent(layerIndex, 0)
       }
-    }, [dataConfiguration])
+    }, [layerIndex, setDesiredExtent])
 
-    const computeLayout = useCallback(() => {
-      categoriesRef.current = dataConfiguration?.categoryArrayForAttrRole('legend')
-      const numCategories = categoriesRef.current?.length,
-        lod: Layout = layoutData.current
-      lod.fullWidth = tileWidth
-      lod.maxWidth = 0
-      categoriesRef.current?.forEach(cat => {
-        lod.maxWidth = Math.max(lod.maxWidth, measureText(cat, kDataDisplayFont))
-      })
-      lod.maxWidth += keySize + padding
-      lod.numColumns = Math.max(Math.floor(lod.fullWidth / lod.maxWidth), 1)
-      lod.columnWidth = lod.fullWidth / lod.numColumns
-      lod.numRows = Math.ceil((numCategories ?? 0) / lod.numColumns)
-      setCategoryData()
-      layoutData.current = lod
-    }, [dataConfiguration, setCategoryData, tileWidth])
-
-    const computeDesiredExtent = useCallback(() => {
-      if (dataConfiguration?.placeCanHaveZeroExtent('legend')) {
-        return 0
-      }
-      computeLayout()
-      const lod = layoutData.current
-      return lod.numRows * (keySize + padding) + labelHeight + axisGap
-    }, [computeLayout, dataConfiguration])
-
-    const handleLegendKeyClick = useCallback((event: any, i: number) => {
-      const caseIds = dataConfiguration?.getCasesForLegendValue(categoryData.current[i].category)
+    const handleLegendKeyClick = useCallback((event: any, d: Key) => {
+      const caseIds = dataConfiguration?.getCasesForLegendValue(d.category)
       if (caseIds) {
         // This is breaking the graph-legend cypress test
         // setOrExtendSelection(caseIds, dataConfiguration?.dataset, event.shiftKey)
@@ -133,29 +67,34 @@ export const CategoricalLegend = observer(
       }
     }, [dataConfiguration])
 
-    // An empty dragBehavior is created first, so refreshKeys can add this to all new elements
-    // and then the drag event handlers can be defined after refreshKeys and still call refreshKeys
-    const dragBehavior = useMemo(() => drag<SVGGElement, number>(), [])
-
-    const refreshKeys = useCallback(() => {
-      categoriesRef.current = dataConfiguration?.categoryArrayForAttrRole('legend')
-      const numCategories = categoriesRef.current?.length
-      const hasCategories = !(numCategories === 1 && categoriesRef.current?.[0] === kMain)
-      const catData = categoryData.current
-
-      if (!keysElt.current) return
-
-      if (!categoryData.current || !hasCategories) {
-        // This would be handled automatically if the data passed to the join was empty
-        select(keysElt.current)
-          .selectAll('g')
-          .remove()
-        return
+    // The dragBehavior is created first, so d3Render can add this to all new elements.
+    const dragBehavior = useMemo(() => {
+      const onDragStart = (event: { x: number; y: number }, d: Key) => {
+        legendModel.onDragStart(event, d)
+        duration.current = 0
       }
 
+      const onDrag = (event: { dx: number; dy: number }, d: Key) => {
+        legendModel.onDrag(event, d)
+      }
+
+      const onDragEnd = (event: any, d: Key) => {
+        duration.current = transitionDuration
+        legendModel.onDragEnd(dataConfiguration, d)
+      }
+
+      return drag<SVGGElement, Key>()
+        .on("start", onDragStart)
+        .on("drag", onDrag)
+        .on("end", onDragEnd)
+    }, [dataConfiguration, legendModel])
+
+    useEffect(() => { return mstAutorun(function d3Render() {
+      if (!keysElt.current) return
+
       const keysSelection = select(keysElt.current)
-        .selectAll<SVGGElement, number>('g')
-        .data(range(0, numCategories ?? 0))
+        .selectAll<SVGGElement, Key>('g')
+        .data(legendModel.categoryData, d => d.category)
         .join(
           enter => {
             const group = enter.append('g')
@@ -172,164 +111,49 @@ export const CategoricalLegend = observer(
           }
         )
 
+      const dI = legendModel.dragInfo
+
       keysSelection.select('rect')
-        .classed('legend-rect-selected',
-          (index) => {
-            return dataConfiguration?.allCasesForCategoryAreSelected(catData[index]?.category) ??
+        .classed('legend-rect-selected', (d) => {
+          return dataConfiguration?.allCasesForCategoryAreSelected(d.category) ??
               false
-          })
-        .style('fill', (index: number) =>
-                          dataConfiguration?.getLegendColorForCategory(catData[index]?.category) || 'white')
+        })
+        .style('fill', (d) => d.color)
         .transition().duration(duration.current)
         .on('end', () => {
           duration.current = 0
         })
-        .attr('x', (index: number) => {
-          return dragInfo.current.indexOfCategory === index
-            ? dragInfo.current.currentDragPosition.x - dragInfo.current.initialOffset.x
-            : axisGap + (catData[index]?.column || 0)* layoutData.current.columnWidth
+        .attr('x', (d) => {
+          return dI.category === d.category
+            ? dI.currentDragPosition.x - dI.initialOffset.x
+            : axisGap + (d.column || 0)* legendModel.layoutData.columnWidth
         })
-        .attr('y',
-          (index: number) => {
-            return labelHeight + (dragInfo.current.indexOfCategory === index
-              ? dragInfo.current.currentDragPosition.y - dragInfo.current.initialOffset.y
-              : (catData[index]?.row || 0) * (keySize + padding))
-          })
+        .attr('y', (d) => {
+          return labelHeight + (dI.category === d.category
+            ? dI.currentDragPosition.y - dI.initialOffset.y
+            : (d.row || 0) * (keySize + padding))
+        })
       keysSelection.select('text')
-        .text((index: number) => catData[index]?.category)
+        .text((d) => d.category)
         .transition().duration(duration.current)
         .on('end', () => {
           duration.current = 0
         })
-        .attr('x', (index: number) => {
-          return keySize + 3 + (dragInfo.current.indexOfCategory === index
-            ? dragInfo.current.currentDragPosition.x - dragInfo.current.initialOffset.x
-            : axisGap + (catData[index]?.column || 0)* layoutData.current.columnWidth)
+        .attr('x', (d) => {
+          return keySize + 3 + (dI.category === d.category
+            ? dI.currentDragPosition.x - dI.initialOffset.x
+            : axisGap + (d.column || 0)* legendModel.layoutData.columnWidth)
         })
-        .attr('y',
-          (index: number) => {
-            return labelHeight + 0.8 * keySize + (dragInfo.current.indexOfCategory === index
-              ? dragInfo.current.currentDragPosition.y - dragInfo.current.initialOffset.y
-              : (catData[index]?.row || 0)* (keySize + padding))
-          })
-    }, [dataConfiguration, dragBehavior, handleLegendKeyClick])
-
-    useEffect(() => {
-      const onDragStart = (event: { x: number; y: number }) => {
-        const dI = dragInfo.current,
-          lod = layoutData.current,
-          numCategories = categoriesRef.current?.length ?? 0,
-          localPt = {
-            x: event.x,
-            y: event.y - labelHeight
-          },
-          catIndex = coordinatesToCatIndex(lod, numCategories, localPt),
-          keyLocation = catLocation(lod, categoryData.current, catIndex)
-        dI.indexOfCategory = catIndex
-        dI.initialOffset = {x: localPt.x - keyLocation.x, y: localPt.y - keyLocation.y}
-        dI.currentDragPosition = localPt
-        duration.current = 0
-      }
-
-      const onDrag = (event: { dx: number; dy: number }) => {
-        if (event.dx !== 0 || event.dy !== 0) {
-          const dI = dragInfo.current,
-            lod = layoutData.current,
-            numCategories = categoriesRef.current?.length ?? 0,
-            newDragPosition = {
-              x: dI.currentDragPosition.x + event.dx,
-              y: dI.currentDragPosition.y + event.dy
-            },
-            newCatIndex = coordinatesToCatIndex(lod, numCategories, newDragPosition)
-          if (newCatIndex >= 0 && newCatIndex !== dI.indexOfCategory) {
-            // swap the two categories
-            dataConfiguration?.storeAllCurrentColorsForAttrRole('legend')
-            dataConfiguration?.swapCategoriesForAttrRole('legend', dI.indexOfCategory, newCatIndex)
-            categoriesRef.current = dataConfiguration?.categoryArrayForAttrRole('legend')
-            setCategoryData()
-            prevCategoryIndex.current = dI.indexOfCategory
-            dI.indexOfCategory = newCatIndex
-          } else {
-            refreshKeys()
-          }
-          dI.currentDragPosition = newDragPosition
-        }
-      }
-
-      const onDragEnd = () => {
-        duration.current = transitionDuration
-        dragInfo.current.indexOfCategory = -1
-        refreshKeys()
-
-        dataConfiguration?.applyModelChange(() => {}, {
-          undoStringKey: 'DG.Undo.graph.swapCategories',
-          redoStringKey: 'DG.Redo.graph.swapCategories',
-          log: logMessageWithReplacement(
-                "Moved category %@ into position of %@",
-                { movedCategory: categoriesRef.current?.[dragInfo.current.indexOfCategory],
-                  targetCategory: categoriesRef.current?.[prevCategoryIndex.current] })
+        .attr('y', (d) => {
+          return labelHeight + 0.8 * keySize + (dI.category === d.category
+            ? dI.currentDragPosition.y - dI.initialOffset.y
+            : (d.row || 0)* (keySize + padding))
         })
-      }
-
-      dragBehavior
-        .on("start", onDragStart)
-        .on("drag", onDrag)
-        .on("end", onDragEnd)
-    }, [dataConfiguration, dragBehavior, refreshKeys, setCategoryData])
-
-    useEffect(function respondToSelectionChange() {
-      return mstReaction(
-        () => dataConfiguration?.selection,
-        () => {
-          refreshKeys()
-        }, {name: 'CategoricalLegend respondToSelectionChange'}, dataConfiguration)
-    }, [refreshKeys, dataConfiguration])
-
-    useEffect(function respondToChangeCount() {
-      return mstReaction(
-        () => dataConfiguration?.casesChangeCount,
-        () => {
-          setDesiredExtent(layerIndex, computeDesiredExtent())
-          refreshKeys()
-        }, {name: 'CategoricalLegend respondToChangeCount',
-          equals: comparer.structural}, dataConfiguration)
-    }, [refreshKeys, dataConfiguration, computeDesiredExtent, setDesiredExtent, layerIndex])
-
-    useEffect(function respondToAttributeIDChange() {
-      const disposer = reaction(
-        () => {
-          return [dataConfiguration?.attributeID('legend')]
-        },
-        () => {
-          setDesiredExtent(layerIndex, computeDesiredExtent())
-          // todo: Figure out whether this is cause extra calls to setupKeys and refreshKeys
-          refreshKeys()
-        }, {fireImmediately: true}
-      )
-      return () => disposer()
-    }, [refreshKeys, computeDesiredExtent, dataConfiguration, setDesiredExtent, layerIndex])
-
-    useEffect(function respondToLegendColorChange() {
-      const disposer = reaction(
-        () => {
-          return dataConfiguration?.categorySetForAttrRole('legend')?.colorHash
-        },
-        () => {
-          refreshKeys()
-        }, {fireImmediately: true}
-      )
-      return () => disposer()
-    }, [dataConfiguration, refreshKeys])
-
-    useEffect(function setup() {
-      refreshKeys()
-      return function cleanup() {
-        setDesiredExtent(layerIndex, 0)
-      }
-    }, [layerIndex, refreshKeys, setDesiredExtent])
+    }, {name: "CategoricalLegend d3 render"}, dataConfiguration) },
+      [dataConfiguration, dragBehavior, handleLegendKeyClick, legendModel]
+    )
 
     return (
       <g className='legend-categories' ref={keysElt} data-testid='legend-categories'></g>
     )
-  })
-CategoricalLegend.displayName = "CategoricalLegend"
+  }

--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -1,4 +1,3 @@
-import {observer} from "mobx-react-lite"
 import {drag, select} from "d3"
 import React, {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {mstReaction} from "../../../../utilities/mst-reaction"
@@ -12,6 +11,8 @@ import { CategoricalLegendModel, keySize, padding, labelHeight, Key } from "./ca
 
 import './legend.scss'
 
+// This is not an observing component because all of its real rendering happens in
+// a mstAutorun.
 export const CategoricalLegend =
   function CategoricalLegend({layerIndex, setDesiredExtent}: IBaseLegendProps) {
 
@@ -20,13 +21,15 @@ export const CategoricalLegend =
     const duration = useRef(0)
     const keysElt = useRef(null)
 
+    // useState guarantees the model will only be created once
+    // useMemo doesn't have that guarantee
     const [legendModel] = useState(
       () => new CategoricalLegendModel(dataConfiguration, dataDisplayLayout)
     )
 
     // This is outside of the main autorun because it only needs to run when
-    // number of categories changes or the maxWidth of a category changes
-    // Also the setDesiredExtent might cause extra re-renders so it only
+    // the number of categories changes or the max width of a category changes.
+    // Also the setDesiredExtent might cause extra re-renders, so it only
     // runs when the desiredExtent actually changes
     useEffect(function updateDesiredExtent() {
       return mstReaction(

--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -37,8 +37,7 @@ export const CategoricalLegend =
           if (dataConfiguration?.placeCanHaveZeroExtent('legend')) {
             return 0
           }
-          const lod = legendModel.layoutData
-          return lod.numRows * (keySize + padding) + labelHeight + axisGap
+          return legendModel.layoutData.numRows * (keySize + padding) + labelHeight + axisGap
         },
         (desiredExtent) => {
           setDesiredExtent(layerIndex, desiredExtent)
@@ -129,7 +128,7 @@ export const CategoricalLegend =
         .attr('x', (d) => {
           return dI.category === d.category
             ? dI.currentDragPosition.x - dI.initialOffset.x
-            : axisGap + (d.column || 0)* legendModel.layoutData.columnWidth
+            : axisGap + (d.column || 0) * legendModel.layoutData.columnWidth
         })
         .attr('y', (d) => {
           return labelHeight + (dI.category === d.category
@@ -145,7 +144,7 @@ export const CategoricalLegend =
         .attr('x', (d) => {
           return keySize + 3 + (dI.category === d.category
             ? dI.currentDragPosition.x - dI.initialOffset.x
-            : axisGap + (d.column || 0)* legendModel.layoutData.columnWidth)
+            : axisGap + (d.column || 0) * legendModel.layoutData.columnWidth)
         })
         .attr('y', (d) => {
           return labelHeight + 0.8 * keySize + (dI.category === d.category

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -644,6 +644,9 @@ export const DataConfigurationModel = types
         categorySet.storeAllCurrentColors()
       }
     },
+    // This will only swap the categories if they are neighbors.
+    // If the categories are not next to each other the behavior is complex,
+    // so it is best to read the code to understand what will happen.
     swapCategoriesForAttrRole(role: AttrRole, catIndex1: number, catIndex2: number) {
       const categoryArray = self.categoryArrayForAttrRole(role),
         numCategories = categoryArray.length,


### PR DESCRIPTION
create categorical legend model

- use autorun to do the d3 rendering
- leverage MobX computed properties to do caching
- use a single d3 join instead of two, the double d3 join was the source of the error shown before
- don't modify the categorySet during dragging, only modify at the end. This makes undo/redo work better, but there is still a lingering issue with it. I've found a single legend key move is undone correctly, but when I do multiple legend moves undo doesn't work anymore.