### PR TITLE
Remove the defocus when we are already in input mode

### DIFF
--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -169,7 +169,6 @@ export const AttributeHeader = observer(function AttributeHeader({
   }
 
   const handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
-    setIsFocused(false)
     const input = inputRef.current
     if (input) {
       const { selectionStart, selectionEnd } = input


### PR DESCRIPTION
We were telling the component state that a click inside the Input component should set the focus to false even though it should still be in edit mode.
Removed the setFocus so we keep the focus in the input until we click away.