### PR TITLE
Change attribute type to categorical with a date on opposite axis plot bug fix

### DIFF
--- a/v3/src/components/graph/models/graph-model-utils.ts
+++ b/v3/src/components/graph/models/graph-model-utils.ts
@@ -27,10 +27,11 @@ function setPrimaryRoleAndPlotType(graphModel: IGraphContentModel) {
   // Numeric attributes get priority for primaryRole when present. First one that is already present
   // and then the newly assigned one. If there is an already assigned categorical then its place is
   // the primaryRole, or, lastly, the newly assigned place
-  primaryRole = attributeType === 'numeric' ? oldPrimaryRole
-    : otherAttributeType === 'numeric' ? otherAttrRole
-      : otherAttributeType === 'date' ? otherAttrRole
-        : attributeType !== 'empty' ? oldPrimaryRole : otherAttrRole
+  primaryRole = ['numeric', 'date'].includes(attributeType)
+                    ? oldPrimaryRole
+                    : ['numeric', 'date'].includes(otherAttributeType)
+                          ? otherAttrRole
+                          : attributeType !== 'empty' ? oldPrimaryRole : otherAttrRole
   dataConfig?.setPrimaryRole(primaryRole)
   // TODO COLOR: treat color like categorical for now
   const typeOverrides: Record<string, string> = { color: 'categorical', date: 'numeric' },

--- a/v3/src/components/graph/models/graph-model-utils.ts
+++ b/v3/src/components/graph/models/graph-model-utils.ts
@@ -29,7 +29,8 @@ function setPrimaryRoleAndPlotType(graphModel: IGraphContentModel) {
   // the primaryRole, or, lastly, the newly assigned place
   primaryRole = attributeType === 'numeric' ? oldPrimaryRole
     : otherAttributeType === 'numeric' ? otherAttrRole
-      : attributeType !== 'empty' ? oldPrimaryRole : otherAttrRole
+      : otherAttributeType === 'date' ? otherAttrRole
+        : attributeType !== 'empty' ? oldPrimaryRole : otherAttrRole
   dataConfig?.setPrimaryRole(primaryRole)
   // TODO COLOR: treat color like categorical for now
   const typeOverrides: Record<string, string> = { color: 'categorical', date: 'numeric' },


### PR DESCRIPTION
Adds check for date type and makes that primaryRole in the abscence of a numeric type in either if the axis