### PR TITLE
feat: v2 export of movable lines and points

### DIFF
--- a/v3/src/components/graph/adornments/adornment-models.ts
+++ b/v3/src/components/graph/adornments/adornment-models.ts
@@ -27,6 +27,7 @@ export const PointModel = types.model("Point", {
       }
     }
   }))
+export interface IPointModel extends Instance<typeof PointModel> {}
 export interface IPointModelSnapshot extends SnapshotIn<typeof PointModel> {}
 
 export const kInfinitePoint = {x:NaN, y:NaN}

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
@@ -49,6 +49,9 @@ export const MovableLineAdornmentModel = AdornmentModel
   lines: types.map(MovableLineInstance)
 })
 .views(self => ({
+  get firstLineInstance(): Maybe<IMovableLineInstance> {
+    return self.lines.values().next().value
+  },
   get lineDescriptions() {
     const lineDescriptions: ILineDescription[] = []
     self.lines.forEach((line, key) => {

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.tsx
@@ -1,12 +1,14 @@
 import React from "react"
-import { registerAdornmentComponentInfo } from "../adornment-component-info"
-import { registerAdornmentContentInfo } from "../adornment-content-info"
-import { MovableLineAdornmentModel } from "./movable-line-adornment-model"
-import { kMovableLineClass, kMovableLineLabelKey, kMovableLinePrefix, kMovableLineRedoAddKey,
-         kMovableLineRedoRemoveKey, kMovableLineType, kMovableLineUndoAddKey,
-         kMovableLineUndoRemoveKey } from "./movable-line-adornment-types"
-import { MovableLineAdornment } from "./movable-line-adornment-component"
+import { ICodapV2MovableLineAdornment } from "../../../../v2/codap-v2-types"
 import { AdornmentCheckbox } from "../adornment-checkbox"
+import { registerAdornmentComponentInfo } from "../adornment-component-info"
+import { exportAdornmentBase, registerAdornmentContentInfo } from "../adornment-content-info"
+import { MovableLineAdornment } from "./movable-line-adornment-component"
+import { isMovableLineAdornment, MovableLineAdornmentModel } from "./movable-line-adornment-model"
+import {
+  kMovableLineClass, kMovableLineLabelKey, kMovableLinePrefix, kMovableLineRedoAddKey,
+  kMovableLineRedoRemoveKey, kMovableLineType, kMovableLineUndoAddKey, kMovableLineUndoRemoveKey
+} from "./movable-line-adornment-types"
 
 const Controls = () => {
   return (
@@ -28,6 +30,26 @@ registerAdornmentContentInfo({
     redoAdd: kMovableLineRedoAddKey,
     undoRemove: kMovableLineUndoRemoveKey,
     redoRemove: kMovableLineRedoRemoveKey
+  },
+  exporter: (model, options) => {
+    const adornment = isMovableLineAdornment(model) ? model : undefined
+    if (!adornment) return undefined
+    const firstLineInstance = adornment.firstLineInstance
+    if (!firstLineInstance) return undefined
+    const isVertical = !isFinite(firstLineInstance.slope)
+    return {
+      // v2 never writes out more than one movable line instance
+      movableLineStorage: {
+        ...exportAdornmentBase(adornment, options),
+        isInterceptLocked: options.isInterceptLocked,
+        // TODO_V2_EXPORT export label/equation coordinates for adornments
+        equationCoords: null,
+        intercept: isVertical ? null : firstLineInstance.intercept,
+        slope: isVertical ? null : firstLineInstance.slope,
+        isVertical,
+        xIntercept: isVertical ? firstLineInstance.intercept : null
+      } as ICodapV2MovableLineAdornment
+    }
   }
 })
 

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-model.ts
@@ -1,6 +1,6 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { Point } from "../../../data-display/data-display-types"
-import { AdornmentModel, IAdornmentModel, IUpdateCategoriesOptions, PointModel } from "../adornment-models"
+import { AdornmentModel, IAdornmentModel, IPointModel, IUpdateCategoriesOptions, PointModel } from "../adornment-models"
 import { IAxisModel, isNumericAxisModel } from "../../../axis/models/axis-model"
 import { kMovablePointType } from "./movable-point-adornment-types"
 
@@ -12,6 +12,9 @@ export const MovablePointAdornmentModel = AdornmentModel
     points: types.map(PointModel)
   })
   .views(self => ({
+    get firstPoint(): Maybe<IPointModel> {
+      return self.points.values().next().value
+    },
     getInitialPosition(axis?: IAxisModel) {
       if (!isNumericAxisModel(axis)) return 0
       const [min, max] = axis.domain

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.tsx
@@ -1,12 +1,13 @@
 import React from "react"
 import { registerAdornmentComponentInfo } from "../adornment-component-info"
-import { registerAdornmentContentInfo } from "../adornment-content-info"
-import { MovablePointAdornmentModel } from "./movable-point-adornment-model"
-import { kMovablePointClass, kMovablePointLabelKey, kMovablePointPrefix, kMovablePointRedoAddKey,
-         kMovablePointRedoRemoveKey, kMovablePointType, kMovablePointUndoAddKey, 
-         kMovablePointUndoRemoveKey} from "./movable-point-adornment-types"
-import { MovablePointAdornment } from "./movable-point-adornment-component"
 import { AdornmentCheckbox } from "../adornment-checkbox"
+import { exportAdornmentBase, registerAdornmentContentInfo } from "../adornment-content-info"
+import { MovablePointAdornment } from "./movable-point-adornment-component"
+import { isMovablePointAdornment, MovablePointAdornmentModel } from "./movable-point-adornment-model"
+import {
+  kMovablePointClass, kMovablePointLabelKey, kMovablePointPrefix, kMovablePointRedoAddKey,
+  kMovablePointRedoRemoveKey, kMovablePointType, kMovablePointUndoAddKey, kMovablePointUndoRemoveKey
+} from "./movable-point-adornment-types"
 
 const Controls = () => {
   return (
@@ -28,6 +29,19 @@ registerAdornmentContentInfo({
     redoAdd: kMovablePointRedoAddKey,
     undoRemove: kMovablePointUndoRemoveKey,
     redoRemove: kMovablePointRedoRemoveKey
+  },
+  exporter: (model, options) => {
+    const adornment = isMovablePointAdornment(model) ? model : undefined
+    if (!adornment) return undefined
+    const firstPoint = adornment.firstPoint
+    if (!firstPoint) return undefined
+    return {
+      // v2 never writes out more than one movable point instance
+      movablePointStorage: {
+        ...exportAdornmentBase(adornment, options),
+        coordinates: { x: firstPoint.x, y: firstPoint.y }
+      }
+    }
   }
 })
 

--- a/v3/src/components/graph/adornments/v2-adornment-importer.ts
+++ b/v3/src/components/graph/adornments/v2-adornment-importer.ts
@@ -242,15 +242,15 @@ export const v2AdornmentImporter = ({data, plotModels, attributeDescriptions, yA
   // MOVABLE LINE
   const movableLineAdornment = plotModelStorage.movableLineStorage
   if (movableLineAdornment) {
-    const equationCoords = movableLineAdornment.equationCoords
+    const { equationCoords, intercept, slope, isVertical, xIntercept } = movableLineAdornment
     const lines: Record<string, IMovableLineInstanceSnapshot> = {}
     instanceKeys?.forEach((key: string) => {
       const lineInstance = {
         // TODO_V2_IMPORT: [Story: **#188695677**] equationCoords are not handled correctly, the model stores x and y
         // but the loaded equationCoords have proportionCenterX and proportionCenterY
         equationCoords: equationCoords ?? undefined, // The V2 default is null, but we want undefined
-        intercept: movableLineAdornment.intercept,
-        slope: movableLineAdornment.slope
+        intercept: isVertical ? xIntercept : intercept,
+        slope: isVertical ? Infinity : slope
       }
       lines[key] = lineInstance
     })

--- a/v3/src/components/graph/v2-graph-exporter.test.ts
+++ b/v3/src/components/graph/v2-graph-exporter.test.ts
@@ -5,13 +5,20 @@ import { SharedModelDocumentManager } from "../../models/document/shared-model-d
 import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
 import { safeJsonParse } from "../../utilities/js-utils"
 import { CodapV2Document } from "../../v2/codap-v2-document"
-import { ICodapV2DocumentJson } from "../../v2/codap-v2-types"
+import { ICodapV2DocumentJson, ICodapV2GraphComponent } from "../../v2/codap-v2-types"
 import { v2GraphExporter } from "./v2-graph-exporter"
 import { v2GraphImporter } from "./v2-graph-importer"
 import "./graph-registration"
 
 const fs = require("fs")
 const path = require("path")
+
+// When working on these tests, it's critical to know what graph instance is failing.
+// Passing true logs the graph title and the last title logged is the failing graph.
+// Passing tests should be silent, however, so false is passed by default.
+function logGraphTitleMaybe(log: boolean, v2GraphTile: ICodapV2GraphComponent) {
+  log && console.log("v2GraphTile:", v2GraphTile.componentStorage.title || v2GraphTile.componentStorage.name)
+}
 
 function removePropertiesRecursive(obj: any, keysToRemove: string[]): any {
   if (Array.isArray(obj)) {
@@ -89,7 +96,7 @@ describe("V2GraphImporter", () => {
     const { v2Document } = loadCodapDocument("mammals-all-graphs.codap")
     const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
     v2GraphTiles.forEach(v2GraphTile => {
-      // console.log("v2GraphTile", v2GraphTile.componentStorage.title || v2GraphTile.componentStorage.name)
+      logGraphTitleMaybe(false, v2GraphTile)
       const v3GraphTile = v2GraphImporter({
         v2Component: v2GraphTile,
         v2Document,
@@ -99,7 +106,6 @@ describe("V2GraphImporter", () => {
       const v2GraphTileOut = v2GraphExporter({ tile: v3GraphTile! })
       const v2GraphTileStorage = removePropertiesRecursive(v2GraphTile.componentStorage, kIgnoreProps)
       const v2GraphTileOutStorage = removePropertiesRecursive(v2GraphTileOut?.componentStorage, kIgnoreProps)
-      // console.log("v2GraphTileOutStorage", JSON.stringify(v2GraphTileOutStorage, null, 2))
       expect(v2GraphTileOutStorage).toEqual(v2GraphTileStorage)
     })
   })
@@ -108,7 +114,7 @@ describe("V2GraphImporter", () => {
     const { v2Document } = loadCodapDocument("mammals-all-diet-legends.codap")
     const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
     v2GraphTiles.forEach(v2GraphTile => {
-      // console.log("v2GraphTile", v2GraphTile.componentStorage.title || v2GraphTile.componentStorage.name)
+      logGraphTitleMaybe(false, v2GraphTile)
       const v3GraphTile = v2GraphImporter({
         v2Component: v2GraphTile,
         v2Document,
@@ -126,7 +132,7 @@ describe("V2GraphImporter", () => {
     const { v2Document } = loadCodapDocument("mammals-all-diet-legends.codap")
     const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
     v2GraphTiles.forEach(v2GraphTile => {
-      // console.log("v2GraphTile", v2GraphTile.componentStorage.title || v2GraphTile.componentStorage.name)
+      logGraphTitleMaybe(false, v2GraphTile)
       const v3GraphTile = v2GraphImporter({
         v2Component: v2GraphTile,
         v2Document,
@@ -144,7 +150,7 @@ describe("V2GraphImporter", () => {
     const { v2Document } = loadCodapDocument("mammals-simple-adornments.codap")
     const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
     v2GraphTiles.forEach(v2GraphTile => {
-      // console.log("v2GraphTile", v2GraphTile.componentStorage.title || v2GraphTile.componentStorage.name)
+      logGraphTitleMaybe(false, v2GraphTile)
       const v3GraphTile = v2GraphImporter({
         v2Component: v2GraphTile,
         v2Document,
@@ -162,7 +168,7 @@ describe("V2GraphImporter", () => {
     const { v2Document } = loadCodapDocument("mammals-lsrl-adornment.codap")
     const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
     v2GraphTiles.forEach(v2GraphTile => {
-      // console.log("v2GraphTile", v2GraphTile.componentStorage.title || v2GraphTile.componentStorage.name)
+      logGraphTitleMaybe(false, v2GraphTile)
       const v3GraphTile = v2GraphImporter({
         v2Component: v2GraphTile,
         v2Document,
@@ -180,7 +186,7 @@ describe("V2GraphImporter", () => {
     const { v2Document } = loadCodapDocument("mammals-movable-line-point-adornments.codap")
     const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
     v2GraphTiles.forEach(v2GraphTile => {
-      // console.log("v2GraphTile", v2GraphTile.componentStorage.title || v2GraphTile.componentStorage.name)
+      logGraphTitleMaybe(false, v2GraphTile)
       const v3GraphTile = v2GraphImporter({
         v2Component: v2GraphTile,
         v2Document,

--- a/v3/src/components/graph/v2-graph-exporter.test.ts
+++ b/v3/src/components/graph/v2-graph-exporter.test.ts
@@ -175,4 +175,22 @@ describe("V2GraphImporter", () => {
       expect(v2GraphTileOutStorage).toEqual(v2GraphTileStorage)
     })
   })
+
+  it("exports graph components with movable line and point adornments", () => {
+    const { v2Document } = loadCodapDocument("mammals-movable-line-point-adornments.codap")
+    const v2GraphTiles = v2Document.components.filter(c => c.type === "DG.GraphView")
+    v2GraphTiles.forEach(v2GraphTile => {
+      // console.log("v2GraphTile", v2GraphTile.componentStorage.title || v2GraphTile.componentStorage.name)
+      const v3GraphTile = v2GraphImporter({
+        v2Component: v2GraphTile,
+        v2Document,
+        insertTile: mockInsertTile
+      })
+      // tests round-trip import/export of every graph component
+      const v2GraphTileOut = v2GraphExporter({ tile: v3GraphTile! })
+      const v2GraphTileStorage = removePropertiesRecursive(v2GraphTile.componentStorage, kIgnoreProps)
+      const v2GraphTileOutStorage = removePropertiesRecursive(v2GraphTileOut?.componentStorage, kIgnoreProps)
+      expect(v2GraphTileOutStorage).toEqual(v2GraphTileStorage)
+    })
+  })
 })

--- a/v3/src/components/graph/v2-graph-exporter.ts
+++ b/v3/src/components/graph/v2-graph-exporter.ts
@@ -190,7 +190,9 @@ function getPlotModels(graph: IGraphContentModel): Partial<ICodapV2GraphStorage>
     plotModels: [{
       plotClass: v2PlotClass[graph.plotType],
       plotModelStorage: {
+        // in v2, every plot model has the exact same nested adornments
         adornments: nestedAdornments,
+        // in v2 only the first plot model has the top-level adornments
         ...Object.assign({}, ...topAdornments),
         ...areSquaresVisible,
         verticalAxisIsY2: false
@@ -202,7 +204,9 @@ function getPlotModels(graph: IGraphContentModel): Partial<ICodapV2GraphStorage>
     storage.plotModels.push({
       plotClass: v2PlotClass.scatterPlot,
       plotModelStorage: {
+        // in v2, every plot model has the exact same nested adornments
         adornments: nestedAdornments,
+        // in v2 only the first plot model has the top-level adornments
         verticalAxisIsY2: false
       }
     })
@@ -212,7 +216,9 @@ function getPlotModels(graph: IGraphContentModel): Partial<ICodapV2GraphStorage>
     storage.plotModels.push({
       plotClass: v2PlotClass.scatterPlot,
       plotModelStorage: {
+        // in v2, every plot model has the exact same nested adornments
         adornments: nestedAdornments,
+        // in v2 only the first plot model has the top-level adornments
         verticalAxisIsY2: true
       }
     })

--- a/v3/src/test/v2/mammals-movable-line-point-adornments.codap
+++ b/v3/src/test/v2/mammals-movable-line-point-adornments.codap
@@ -183,8 +183,8 @@
                                 "enableMeasuresForSelection": false,
                                 "isInterceptLocked": false,
                                 "equationCoords": null,
-                                "intercept": 4,
-                                "slope": 2.8,
+                                "intercept": -16.453907550077027,
+                                "slope": 3.2545312788906005,
                                 "isVertical": false,
                                 "xIntercept": null
                             }
@@ -199,7 +199,7 @@
             "layout": {
                 "width": 240,
                 "height": 230,
-                "zIndex": 242,
+                "zIndex": 345,
                 "left": 210,
                 "top": 5,
                 "isVisible": true,
@@ -399,8 +399,8 @@
                                 "enableMeasuresForSelection": false,
                                 "isInterceptLocked": false,
                                 "equationCoords": null,
-                                "intercept": 4,
-                                "slope": 2.8,
+                                "intercept": -49.56753194230166,
+                                "slope": 3.990389598717815,
                                 "isVertical": false,
                                 "xIntercept": null
                             }
@@ -430,7 +430,7 @@
             "layout": {
                 "width": 245,
                 "height": 230,
-                "zIndex": 240,
+                "zIndex": 347,
                 "left": 700,
                 "top": 5,
                 "isVisible": true,
@@ -655,8 +655,8 @@
                                 "enableMeasuresForSelection": false,
                                 "isInterceptLocked": false,
                                 "equationCoords": null,
-                                "intercept": 4,
-                                "slope": 2.8,
+                                "intercept": -49.24696435867603,
+                                "slope": 3.983265874637245,
                                 "isVertical": false,
                                 "xIntercept": null
                             }
@@ -686,7 +686,7 @@
             "layout": {
                 "width": 240,
                 "height": 225,
-                "zIndex": 248,
+                "zIndex": 349,
                 "left": 210,
                 "top": 240,
                 "isVisible": true,
@@ -785,8 +785,8 @@
                                 "isVisible": true,
                                 "enableMeasuresForSelection": false,
                                 "coordinates": {
-                                    "x": 61.666666666666664,
-                                    "y": 83.33333333333334
+                                    "x": 69.84276729559748,
+                                    "y": 85.33742331288343
                                 }
                             }
                         },
@@ -815,7 +815,7 @@
             "layout": {
                 "width": 240,
                 "height": 225,
-                "zIndex": 271,
+                "zIndex": 397,
                 "left": 455,
                 "top": 240,
                 "isVisible": true,
@@ -913,8 +913,8 @@
                                 "enableMeasuresForSelection": false,
                                 "isInterceptLocked": false,
                                 "equationCoords": null,
-                                "intercept": 4,
-                                "slope": 2.8,
+                                "intercept": -128.8543688118812,
+                                "slope": 5.752319306930693,
                                 "isVertical": false,
                                 "xIntercept": null
                             }
@@ -929,7 +929,7 @@
             "layout": {
                 "width": 245,
                 "height": 225,
-                "zIndex": 252,
+                "zIndex": 355,
                 "left": 700,
                 "top": 240,
                 "isVisible": true,
@@ -1026,8 +1026,8 @@
                                 "isVisible": true,
                                 "enableMeasuresForSelection": false,
                                 "coordinates": {
-                                    "x": 61.666666666666664,
-                                    "y": 83.33333333333334
+                                    "x": 50.882352941176464,
+                                    "y": 77.5
                                 }
                             }
                         },
@@ -1041,7 +1041,7 @@
             "layout": {
                 "width": 245,
                 "height": 225,
-                "zIndex": 312,
+                "zIndex": 403,
                 "left": 950,
                 "top": 240,
                 "isVisible": true,
@@ -1139,8 +1139,8 @@
                                 "enableMeasuresForSelection": false,
                                 "isInterceptLocked": false,
                                 "equationCoords": null,
-                                "intercept": 4,
-                                "slope": 2.8,
+                                "intercept": -27.083546548816656,
+                                "slope": 3.4907454788625922,
                                 "isVertical": false,
                                 "xIntercept": null
                             }
@@ -1155,7 +1155,7 @@
             "layout": {
                 "width": 240,
                 "height": 220,
-                "zIndex": 269,
+                "zIndex": 357,
                 "left": 210,
                 "top": 470,
                 "isVisible": true,
@@ -1252,8 +1252,8 @@
                                 "isVisible": true,
                                 "enableMeasuresForSelection": false,
                                 "coordinates": {
-                                    "x": 61.666666666666664,
-                                    "y": 83.33333333333334
+                                    "x": 56.92893401015228,
+                                    "y": 75
                                 }
                             }
                         },
@@ -1267,7 +1267,7 @@
             "layout": {
                 "width": 240,
                 "height": 220,
-                "zIndex": 287,
+                "zIndex": 405,
                 "left": 455,
                 "top": 470,
                 "isVisible": true,
@@ -1358,7 +1358,7 @@
                                 "isInterceptLocked": true,
                                 "equationCoords": null,
                                 "intercept": 0,
-                                "slope": 1.3333333333333333,
+                                "slope": 1.6343173813713758,
                                 "isVertical": false,
                                 "xIntercept": null
                             },
@@ -1374,7 +1374,7 @@
             "layout": {
                 "width": 245,
                 "height": 220,
-                "zIndex": 260,
+                "zIndex": 361,
                 "left": 700,
                 "top": 470,
                 "isVisible": true,
@@ -1471,7 +1471,7 @@
                                 "isInterceptLocked": true,
                                 "equationCoords": null,
                                 "intercept": 0,
-                                "slope": 1.3333333333333333,
+                                "slope": 1.6477024966190192,
                                 "isVertical": false,
                                 "xIntercept": null
                             },
@@ -1502,7 +1502,7 @@
             "layout": {
                 "width": 245,
                 "height": 220,
-                "zIndex": 262,
+                "zIndex": 365,
                 "left": 950,
                 "top": 470,
                 "isVisible": true,
@@ -1603,7 +1603,7 @@
                                 "isInterceptLocked": true,
                                 "equationCoords": null,
                                 "intercept": 0,
-                                "slope": 1.3333333333333333,
+                                "slope": 1.6364087587409697,
                                 "isVertical": false,
                                 "xIntercept": null
                             },
@@ -1634,7 +1634,7 @@
             "layout": {
                 "width": 240,
                 "height": 210,
-                "zIndex": 285,
+                "zIndex": 367,
                 "left": 210,
                 "top": 695,
                 "isVisible": true,
@@ -1732,8 +1732,8 @@
                                 "enableMeasuresForSelection": false,
                                 "isInterceptLocked": true,
                                 "equationCoords": null,
-                                "intercept": 0,
-                                "slope": 1.3333333333333333,
+                                "intercept": -1.4210854715202004e-14,
+                                "slope": 2.0886973446406225,
                                 "isVertical": false,
                                 "xIntercept": null
                             },
@@ -1749,7 +1749,7 @@
             "layout": {
                 "width": 240,
                 "height": 210,
-                "zIndex": 299,
+                "zIndex": 373,
                 "left": 455,
                 "top": 695,
                 "isVisible": true,
@@ -1848,7 +1848,7 @@
                                 "isInterceptLocked": true,
                                 "equationCoords": null,
                                 "intercept": 0,
-                                "slope": 1.3333333333333333,
+                                "slope": 1.6049750704192869,
                                 "isVertical": false,
                                 "xIntercept": null
                             },
@@ -1864,7 +1864,7 @@
             "layout": {
                 "width": 245,
                 "height": 210,
-                "zIndex": 310,
+                "zIndex": 375,
                 "left": 700,
                 "top": 695,
                 "isVisible": true,
@@ -1970,8 +1970,8 @@
                                 "enableMeasuresForSelection": false,
                                 "isInterceptLocked": false,
                                 "equationCoords": null,
-                                "intercept": 4,
-                                "slope": 2.8,
+                                "intercept": -4.98204697516867,
+                                "slope": 1.5939380196523056,
                                 "isVertical": false,
                                 "xIntercept": null
                             }
@@ -1986,7 +1986,7 @@
             "layout": {
                 "width": 245,
                 "height": 210,
-                "zIndex": 316,
+                "zIndex": 414,
                 "left": 950,
                 "top": 695,
                 "isVisible": true,
@@ -2204,6 +2204,126 @@
                 "top": 910,
                 "isVisible": true,
                 "right": 695,
+                "bottom": 1130
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 63,
+            "id": 63,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "rightColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "rightAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 2,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movablePointStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "coordinates": {
+                                    "x": 50.68862275449102,
+                                    "y": 70.23391812865496
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 220,
+                "zIndex": 443,
+                "left": 950,
+                "top": 910,
+                "isVisible": true,
+                "right": 1195,
                 "bottom": 1130
             },
             "savedHeight": null
@@ -3030,6 +3150,6 @@
     "appVersion": "2.0",
     "appBuildNum": "0733",
     "lang": "en",
-    "idCount": 62,
+    "idCount": 63,
     "metadata": {}
 }

--- a/v3/src/test/v2/mammals-movable-line-point-adornments.codap
+++ b/v3/src/test/v2/mammals-movable-line-point-adornments.codap
@@ -1,0 +1,3035 @@
+{
+    "name": "Mammals",
+    "guid": 1,
+    "id": 1,
+    "components": [
+        {
+            "type": "DG.TableView",
+            "guid": 40,
+            "id": 40,
+            "componentStorage": {
+                "isActive": false,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "attributeWidths": [
+                    {
+                        "_links_": {
+                            "attr": {
+                                "type": "DG.Attribute",
+                                "id": 12
+                            }
+                        },
+                        "width": 45
+                    }
+                ],
+                "rowHeights": [],
+                "title": "Mammals",
+                "name": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 583,
+                "height": 237,
+                "left": 5,
+                "top": 5,
+                "isVisible": false,
+                "zIndex": 101,
+                "right": 588,
+                "bottom": 242
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GuideView",
+            "guid": 41,
+            "id": 41,
+            "componentStorage": {
+                "title": "Mammals Sample Guide",
+                "items": [
+                    {
+                        "itemTitle": "Get Started",
+                        "url": "../../../../extn/example-documents/guides/Mammals/mammals_getstarted.html"
+                    }
+                ],
+                "currentItemIndex": 0,
+                "isVisible": false,
+                "name": "Mammals Sample Guide",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "left": 665,
+                "top": 10,
+                "width": 416,
+                "height": 510,
+                "isVisible": false,
+                "zIndex": 15,
+                "right": 1081,
+                "bottom": 520
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.CaseCard",
+            "guid": 42,
+            "id": 42,
+            "componentStorage": {
+                "isActive": true,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "title": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "top": 5,
+                "left": 5,
+                "width": 200,
+                "height": 399,
+                "zIndex": 102,
+                "isVisible": true,
+                "right": 205,
+                "bottom": 404
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 43,
+            "id": 43,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": false,
+                                "equationCoords": null,
+                                "intercept": 4,
+                                "slope": 2.8,
+                                "isVertical": false,
+                                "xIntercept": null
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "Simple-MovLine",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 230,
+                "zIndex": 242,
+                "left": 210,
+                "top": 5,
+                "isVisible": true,
+                "right": 450,
+                "bottom": 235
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 44,
+            "id": 44,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movablePointStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "coordinates": {
+                                    "x": 61.666666666666664,
+                                    "y": 83.33333333333334
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "Simple-MovPoint",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 230,
+                "zIndex": 244,
+                "left": 455,
+                "top": 5,
+                "isVisible": true,
+                "right": 695,
+                "bottom": 235
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 46,
+            "id": 46,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": [
+                        {
+                            "type": "DG.Attribute",
+                            "id": 10
+                        },
+                        {
+                            "type": "DG.Attribute",
+                            "id": 9
+                        }
+                    ]
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": false,
+                                "equationCoords": null,
+                                "intercept": 4,
+                                "slope": 2.8,
+                                "isVertical": false,
+                                "xIntercept": null
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "MultY-MovLine",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 230,
+                "zIndex": 240,
+                "left": 700,
+                "top": 5,
+                "isVisible": true,
+                "right": 945,
+                "bottom": 235
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 47,
+            "id": 47,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": [
+                        {
+                            "type": "DG.Attribute",
+                            "id": 10
+                        },
+                        {
+                            "type": "DG.Attribute",
+                            "id": 9
+                        }
+                    ]
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movablePointStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "coordinates": {
+                                    "x": 61.666666666666664,
+                                    "y": 83.33333333333334
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "MultY-MovPoint",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 230,
+                "zIndex": 246,
+                "left": 950,
+                "top": 5,
+                "isVisible": true,
+                "right": 1195,
+                "bottom": 235
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 48,
+            "id": 48,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "y2Coll": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "y2Attr": {
+                        "type": "DG.Attribute",
+                        "id": 9
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 1,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.CellLinearAxisModel",
+                "y2LowerBound": -1,
+                "y2UpperBound": 23,
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": false,
+                                "equationCoords": null,
+                                "intercept": 4,
+                                "slope": 2.8,
+                                "isVertical": false,
+                                "xIntercept": null
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": true,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "RightY-MovLine",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 225,
+                "zIndex": 248,
+                "left": 210,
+                "top": 240,
+                "isVisible": true,
+                "right": 450,
+                "bottom": 465
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 49,
+            "id": 49,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "y2Coll": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "y2Attr": {
+                        "type": "DG.Attribute",
+                        "id": 9
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 1,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.CellLinearAxisModel",
+                "y2LowerBound": -1,
+                "y2UpperBound": 23,
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movablePointStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "coordinates": {
+                                    "x": 61.666666666666664,
+                                    "y": 83.33333333333334
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": true,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "RightY-MovPoint",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 225,
+                "zIndex": 271,
+                "left": 455,
+                "top": 240,
+                "isVisible": true,
+                "right": 695,
+                "bottom": 465
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 50,
+            "id": 50,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": false,
+                                "equationCoords": null,
+                                "intercept": 4,
+                                "slope": 2.8,
+                                "isVertical": false,
+                                "xIntercept": null
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "TopSplit-MovLine",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 225,
+                "zIndex": 252,
+                "left": 700,
+                "top": 240,
+                "isVisible": true,
+                "right": 945,
+                "bottom": 465
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 51,
+            "id": 51,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movablePointStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "coordinates": {
+                                    "x": 61.666666666666664,
+                                    "y": 83.33333333333334
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "TopSplit-MovPoint",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 225,
+                "zIndex": 312,
+                "left": 950,
+                "top": 240,
+                "isVisible": true,
+                "right": 1195,
+                "bottom": 465
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 52,
+            "id": 52,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "lightgrey",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": false,
+                                "equationCoords": null,
+                                "intercept": 4,
+                                "slope": 2.8,
+                                "isVertical": false,
+                                "xIntercept": null
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "Simple-Legend-MovLine",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 220,
+                "zIndex": 269,
+                "left": 210,
+                "top": 470,
+                "isVisible": true,
+                "right": 450,
+                "bottom": 690
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 53,
+            "id": 53,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "lightgrey",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movablePointStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "coordinates": {
+                                    "x": 61.666666666666664,
+                                    "y": 83.33333333333334
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "Simple-Legend-MovPoint",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 220,
+                "zIndex": 287,
+                "left": 455,
+                "top": 470,
+                "isVisible": true,
+                "right": 695,
+                "bottom": 690
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 54,
+            "id": 54,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": true,
+                                "equationCoords": null,
+                                "intercept": 0,
+                                "slope": 1.3333333333333333,
+                                "isVertical": false,
+                                "xIntercept": null
+                            },
+                            "areSquaresVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "Simple-MovLine-LockSquares",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 220,
+                "zIndex": 260,
+                "left": 700,
+                "top": 470,
+                "isVisible": true,
+                "right": 945,
+                "bottom": 690
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 55,
+            "id": 55,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": [
+                        {
+                            "type": "DG.Attribute",
+                            "id": 10
+                        },
+                        {
+                            "type": "DG.Attribute",
+                            "id": 9
+                        }
+                    ]
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": true,
+                                "equationCoords": null,
+                                "intercept": 0,
+                                "slope": 1.3333333333333333,
+                                "isVertical": false,
+                                "xIntercept": null
+                            },
+                            "areSquaresVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "MultY-MovLine-LockSquares",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 220,
+                "zIndex": 262,
+                "left": 950,
+                "top": 470,
+                "isVisible": true,
+                "right": 1195,
+                "bottom": 690
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 56,
+            "id": 56,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "y2Coll": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "y2Attr": {
+                        "type": "DG.Attribute",
+                        "id": 9
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 1,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.CellLinearAxisModel",
+                "y2LowerBound": -1,
+                "y2UpperBound": 23,
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": true,
+                                "equationCoords": null,
+                                "intercept": 0,
+                                "slope": 1.3333333333333333,
+                                "isVertical": false,
+                                "xIntercept": null
+                            },
+                            "areSquaresVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    },
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": true,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "RightY-MovLine-LockSquares",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 210,
+                "zIndex": 285,
+                "left": 210,
+                "top": 695,
+                "isVisible": true,
+                "right": 450,
+                "bottom": 905
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 57,
+            "id": 57,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": true,
+                                "equationCoords": null,
+                                "intercept": 0,
+                                "slope": 1.3333333333333333,
+                                "isVertical": false,
+                                "xIntercept": null
+                            },
+                            "areSquaresVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "TopSplit-MovLine-LockSquares",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 210,
+                "zIndex": 299,
+                "left": 455,
+                "top": 695,
+                "isVisible": true,
+                "right": 695,
+                "bottom": 905
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 58,
+            "id": 58,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "lightgrey",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": true,
+                                "equationCoords": null,
+                                "intercept": 0,
+                                "slope": 1.3333333333333333,
+                                "isVertical": false,
+                                "xIntercept": null
+                            },
+                            "areSquaresVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "Simple-Legend-MovLine-LockSquares",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 210,
+                "zIndex": 310,
+                "left": 700,
+                "top": 695,
+                "isVisible": true,
+                "right": 945,
+                "bottom": 905
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 59,
+            "id": 59,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "rightColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "rightAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 2,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": false,
+                                "equationCoords": null,
+                                "intercept": 4,
+                                "slope": 2.8,
+                                "isVertical": false,
+                                "xIntercept": null
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "TopRightSplit-MovLine",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 245,
+                "height": 210,
+                "zIndex": 316,
+                "left": 950,
+                "top": 695,
+                "isVisible": true,
+                "right": 1195,
+                "bottom": 905
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 60,
+            "id": 60,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": false,
+                                "equationCoords": null,
+                                "intercept": null,
+                                "slope": null,
+                                "isVertical": true,
+                                "xIntercept": 45
+                            }
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "Simple-MovLine-Vertical",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 220,
+                "zIndex": 343,
+                "left": 210,
+                "top": 908.5,
+                "isVisible": true,
+                "right": 450,
+                "bottom": 1128.5
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 61,
+            "id": 61,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "movableLineStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "isInterceptLocked": false,
+                                "equationCoords": null,
+                                "intercept": null,
+                                "slope": null,
+                                "isVertical": true,
+                                "xIntercept": 45
+                            },
+                            "areSquaresVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "Simple-MovLine-Vertical-Squares",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 220,
+                "zIndex": 338,
+                "left": 455,
+                "top": 910,
+                "isVisible": true,
+                "right": 695,
+                "bottom": 1130
+            },
+            "savedHeight": null
+        }
+    ],
+    "contexts": [
+        {
+            "type": "DG.DataContext",
+            "document": 1,
+            "guid": 2,
+            "id": 2,
+            "flexibleGroupingChangeFlag": false,
+            "name": "Mammals",
+            "title": "Mammals",
+            "collections": [
+                {
+                    "areParentChildLinksConfigured": false,
+                    "attrs": [
+                        {
+                            "name": "Mammal",
+                            "type": "none",
+                            "title": "Mammal",
+                            "cid": "id:ieEwC74uQH5H7j2A",
+                            "description": "The species of the mammal",
+                            "_categoryMap": {
+                                "__order": [
+                                    "African Elephant",
+                                    "Asian Elephant",
+                                    "Big Brown Bat",
+                                    "Bottlenose Dolphin",
+                                    "Cheetah",
+                                    "Chimpanzee",
+                                    "Domestic Cat",
+                                    "Donkey",
+                                    "Giraffe",
+                                    "Gray Wolf",
+                                    "Grey Seal",
+                                    "Ground Squirrel",
+                                    "Horse",
+                                    "House Mouse",
+                                    "Human",
+                                    "Jaguar",
+                                    "Killer Whale",
+                                    "Lion",
+                                    "N. American Opossum",
+                                    "Nine-Banded Armadillo",
+                                    "Owl Monkey",
+                                    "Patas Monkey",
+                                    "Pig",
+                                    "Pronghorn Antelope",
+                                    "Rabbit",
+                                    "Red Fox",
+                                    "Spotted Hyena"
+                                ],
+                                "African Elephant": "#FFB300",
+                                "Asian Elephant": "#803E75",
+                                "Big Brown Bat": "#FF6800",
+                                "Bottlenose Dolphin": "#A6BDD7",
+                                "Cheetah": "#C10020",
+                                "Chimpanzee": "#CEA262",
+                                "Domestic Cat": "#817066",
+                                "Donkey": "#007D34",
+                                "Giraffe": "#00538A",
+                                "Gray Wolf": "#F13A13",
+                                "Grey Seal": "#53377A",
+                                "Ground Squirrel": "#FF8E00",
+                                "Horse": "#B32851",
+                                "House Mouse": "#F4C800",
+                                "Human": "#7F180D",
+                                "Jaguar": "#93AA00",
+                                "Killer Whale": "#593315",
+                                "Lion": "#232C16",
+                                "N. American Opossum": "#FF7A5C",
+                                "Nine-Banded Armadillo": "#F6768E",
+                                "Owl Monkey": "#FFB300",
+                                "Patas Monkey": "#803E75",
+                                "Pig": "#FF6800",
+                                "Pronghorn Antelope": "#A6BDD7",
+                                "Rabbit": "#C10020",
+                                "Red Fox": "#CEA262",
+                                "Spotted Hyena": "#817066"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 4,
+                            "id": 4,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Order",
+                            "type": "none",
+                            "title": "Order",
+                            "cid": "id:GGomtqcqSG2E8Pyf",
+                            "description": "The order of the mammal",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 5,
+                            "id": 5,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "LifeSpan",
+                            "type": "numeric",
+                            "title": "LifeSpan",
+                            "cid": "id:B2eRuCrzCB2OM0L6",
+                            "description": "",
+                            "_categoryMap": {
+                                "3": "#00538A",
+                                "5": "#F4C800",
+                                "7": "#593315",
+                                "9": "#007D34",
+                                "10": "#7F180D",
+                                "12": "#93AA00",
+                                "14": "#A6BDD7",
+                                "15": "#B32851",
+                                "16": "#CEA262",
+                                "19": "#803E75",
+                                "20": "#53377A",
+                                "25": "#FF6800",
+                                "30": "#817066",
+                                "40": "#C10020",
+                                "50": "#FF8E00",
+                                "70": "#FFB300",
+                                "80": "#F13A13",
+                                "__order": [
+                                    "10",
+                                    "12",
+                                    "14",
+                                    "15",
+                                    "16",
+                                    "19",
+                                    "20",
+                                    "25",
+                                    "3",
+                                    "30",
+                                    "40",
+                                    "5",
+                                    "50",
+                                    "7",
+                                    "70",
+                                    "80",
+                                    "9"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 6,
+                            "id": 6,
+                            "precision": 2,
+                            "unit": "years"
+                        },
+                        {
+                            "name": "Height",
+                            "type": "none",
+                            "title": "Height",
+                            "cid": "id:Ji01-XBgJ-gqAhZk",
+                            "description": "The average height of the mammal.",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 7,
+                            "id": 7,
+                            "precision": 2,
+                            "unit": "meters"
+                        },
+                        {
+                            "name": "Mass",
+                            "type": "numeric",
+                            "title": "Mass",
+                            "cid": "id:kvRxFNIrd83ypuRO",
+                            "description": "The mass of the mammal",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 8,
+                            "id": 8,
+                            "precision": 2,
+                            "unit": "kg"
+                        },
+                        {
+                            "name": "Sleep",
+                            "type": "numeric",
+                            "title": "Sleep",
+                            "cid": "id:OYULbihxf8r-mpyh",
+                            "description": "The number of hours the animal sleeps in a 24 hour period",
+                            "_categoryMap": {
+                                "2": "#817066",
+                                "3": "#FF6800",
+                                "4": "#803E75",
+                                "5": "#FFB300",
+                                "6": "#00538A",
+                                "8": "#53377A",
+                                "10": "#CEA262",
+                                "11": "#FF8E00",
+                                "12": "#C10020",
+                                "13": "#007D34",
+                                "15": "#F13A13",
+                                "17": "#F4C800",
+                                "18": "#7F180D",
+                                "19": "#B32851",
+                                "20": "#A6BDD7",
+                                "__order": [
+                                    "2",
+                                    "3",
+                                    "4",
+                                    "5",
+                                    "6",
+                                    "8",
+                                    "10",
+                                    "11",
+                                    "12",
+                                    "13",
+                                    "15",
+                                    "17",
+                                    "18",
+                                    "19",
+                                    "20"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 9,
+                            "id": 9,
+                            "precision": 2,
+                            "unit": "hours"
+                        },
+                        {
+                            "name": "Speed",
+                            "type": "none",
+                            "title": "Speed",
+                            "cid": "id:GIDIufH8qY2Cha0Y",
+                            "description": "The average speed of the mammal.",
+                            "_categoryMap": {
+                                "1": "#B32851",
+                                "13": "#007D34",
+                                "18": "#7F180D",
+                                "19": "#CEA262",
+                                "37": "#803E75",
+                                "40": "#FF6800",
+                                "45": "#00538A",
+                                "48": "#53377A",
+                                "50": "#FFB300",
+                                "55": "#F4C800",
+                                "56": "#593315",
+                                "60": "#F13A13",
+                                "64": "#C10020",
+                                "69": "#817066",
+                                "80": "#FF8E00",
+                                "98": "#93AA00",
+                                "110": "#A6BDD7",
+                                "__order": [
+                                    "1",
+                                    "13",
+                                    "18",
+                                    "19",
+                                    "37",
+                                    "40",
+                                    "45",
+                                    "48",
+                                    "50",
+                                    "55",
+                                    "56",
+                                    "60",
+                                    "64",
+                                    "69",
+                                    "80",
+                                    "98",
+                                    "110"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 10,
+                            "id": 10,
+                            "precision": 2,
+                            "unit": "km/h"
+                        },
+                        {
+                            "name": "Habitat",
+                            "type": null,
+                            "title": "Habitat",
+                            "cid": "id:CYauqVJgJxdWAyc2",
+                            "description": "",
+                            "_categoryMap": {
+                                "land": {
+                                    "h": 0.4444444444444444,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(85,255,198)"
+                                },
+                                "water": {
+                                    "h": 0.711111111111111,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(130,85,255)"
+                                },
+                                "both": {
+                                    "h": 0.9777777777777777,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(255,85,108)"
+                                },
+                                "__order": [
+                                    "land",
+                                    "water",
+                                    "both"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 11,
+                            "id": 11,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Diet",
+                            "type": null,
+                            "title": "Diet",
+                            "cid": "id:JpkBNmsi1a2mPgER",
+                            "description": "",
+                            "_categoryMap": {
+                                "__order": [
+                                    "both",
+                                    "meat",
+                                    "plants"
+                                ],
+                                "plants": "#FFB300",
+                                "meat": "#803E75",
+                                "both": "#FF6800"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 12,
+                            "id": 12,
+                            "precision": 2,
+                            "unit": null
+                        }
+                    ],
+                    "cases": [
+                        {
+                            "guid": 13,
+                            "id": 13,
+                            "itemID": "id:otvFJcjL2Ge1lYaO",
+                            "values": {
+                                "Mammal": "African Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 4,
+                                "Mass": 6400,
+                                "Sleep": 3,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 14,
+                            "id": 14,
+                            "itemID": "id:SMowkUy8WEsJqgBt",
+                            "values": {
+                                "Mammal": "Asian Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 3,
+                                "Mass": 5000,
+                                "Sleep": 4,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 15,
+                            "id": 15,
+                            "itemID": "id:sVUr1pyFn28n-sXE",
+                            "values": {
+                                "Mammal": "Big Brown Bat",
+                                "Order": "Chiroptera",
+                                "LifeSpan": 19,
+                                "Height": 0.1,
+                                "Mass": 0.02,
+                                "Sleep": 20,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 16,
+                            "id": 16,
+                            "itemID": "id:Xe10MHytD0uBobKn",
+                            "values": {
+                                "Mammal": "Bottlenose Dolphin",
+                                "Order": "Cetacea",
+                                "LifeSpan": 25,
+                                "Height": 3.5,
+                                "Mass": 635,
+                                "Sleep": 5,
+                                "Speed": 37,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 17,
+                            "id": 17,
+                            "itemID": "id:DabKtXzwIDWbXL8Y",
+                            "values": {
+                                "Mammal": "Cheetah",
+                                "Order": "Carnivora",
+                                "LifeSpan": 14,
+                                "Height": 1.5,
+                                "Mass": 50,
+                                "Sleep": 12,
+                                "Speed": 110,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 18,
+                            "id": 18,
+                            "itemID": "id:4dOKy8iQ6_6KEF-O",
+                            "values": {
+                                "Mammal": "Chimpanzee",
+                                "Order": "Primate",
+                                "LifeSpan": 40,
+                                "Height": 1.5,
+                                "Mass": 68,
+                                "Sleep": 10,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 19,
+                            "id": 19,
+                            "itemID": "id:4C-JhUdwch7BOIab",
+                            "values": {
+                                "Mammal": "Domestic Cat",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 0.8,
+                                "Mass": 4.5,
+                                "Sleep": 12,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 20,
+                            "id": 20,
+                            "itemID": "id:FgVp_msehBkXmKaZ",
+                            "values": {
+                                "Mammal": "Donkey",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 40,
+                                "Height": 1.2,
+                                "Mass": 187,
+                                "Sleep": 3,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 21,
+                            "id": 21,
+                            "itemID": "id:Y5O-iIWtA3YGzpiU",
+                            "values": {
+                                "Mammal": "Giraffe",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 25,
+                                "Height": 5,
+                                "Mass": 1100,
+                                "Sleep": 2,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 22,
+                            "id": 22,
+                            "itemID": "id:akHHu_FfD9Zma6FO",
+                            "values": {
+                                "Mammal": "Gray Wolf",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 1.6,
+                                "Mass": 80,
+                                "Sleep": 13,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 23,
+                            "id": 23,
+                            "itemID": "id:wiVhp0p5rVEsxB-u",
+                            "values": {
+                                "Mammal": "Grey Seal",
+                                "Order": "Pinnipedia",
+                                "LifeSpan": 30,
+                                "Height": 2.1,
+                                "Mass": 275,
+                                "Sleep": 6,
+                                "Speed": 19,
+                                "Habitat": "both",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 24,
+                            "id": 24,
+                            "itemID": "id:b8n-yO0Z9xPLmsTC",
+                            "values": {
+                                "Mammal": "Ground Squirrel",
+                                "Order": "Rodentia",
+                                "LifeSpan": 9,
+                                "Height": 0.3,
+                                "Mass": 0.1,
+                                "Sleep": 15,
+                                "Speed": 19,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 25,
+                            "id": 25,
+                            "itemID": "id:HZluaX5NCLQD_mD6",
+                            "values": {
+                                "Mammal": "Horse",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 25,
+                                "Height": 1.5,
+                                "Mass": 521,
+                                "Sleep": 3,
+                                "Speed": 69,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 26,
+                            "id": 26,
+                            "itemID": "id:xw-d1DbBfP8RuYAt",
+                            "values": {
+                                "Mammal": "House Mouse",
+                                "Order": "Rodentia",
+                                "LifeSpan": 3,
+                                "Height": 0.1,
+                                "Mass": 0.03,
+                                "Sleep": 12,
+                                "Speed": 13,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 27,
+                            "id": 27,
+                            "itemID": "id:iHJLtgDjPakPuhww",
+                            "values": {
+                                "Mammal": "Human",
+                                "Order": "Primate",
+                                "LifeSpan": 80,
+                                "Height": 1.9,
+                                "Mass": 80,
+                                "Sleep": 8,
+                                "Speed": 45,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 28,
+                            "id": 28,
+                            "itemID": "id:oXpY4YcBawlPCVm9",
+                            "values": {
+                                "Mammal": "Jaguar",
+                                "Order": "Carnivora",
+                                "LifeSpan": 20,
+                                "Height": 1.8,
+                                "Mass": 115,
+                                "Sleep": 11,
+                                "Speed": 60,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 29,
+                            "id": 29,
+                            "itemID": "id:Afw9Y7567pT19-ui",
+                            "values": {
+                                "Mammal": "Killer Whale",
+                                "Order": "Cetacea",
+                                "LifeSpan": 50,
+                                "Height": 6.5,
+                                "Mass": 4000,
+                                "Sleep": "",
+                                "Speed": 48,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 30,
+                            "id": 30,
+                            "itemID": "id:NR81z3H58yHpTHDQ",
+                            "values": {
+                                "Mammal": "Lion",
+                                "Order": "Carnivora",
+                                "LifeSpan": 15,
+                                "Height": 2.5,
+                                "Mass": 250,
+                                "Sleep": 20,
+                                "Speed": 80,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 31,
+                            "id": 31,
+                            "itemID": "id:Upj78ktLdDZNg1Cy",
+                            "values": {
+                                "Mammal": "N. American Opossum",
+                                "Order": "Didelphimorphia",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 5,
+                                "Sleep": 19,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 32,
+                            "id": 32,
+                            "itemID": "id:URIU2cyiA5vr3pTF",
+                            "values": {
+                                "Mammal": "Nine-Banded Armadillo",
+                                "Order": "Xenarthra",
+                                "LifeSpan": 10,
+                                "Height": 0.6,
+                                "Mass": 7,
+                                "Sleep": 17,
+                                "Speed": 1,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 33,
+                            "id": 33,
+                            "itemID": "id:jvuPvlc-Kdg1-TA6",
+                            "values": {
+                                "Mammal": "Owl Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 12,
+                                "Height": 0.4,
+                                "Mass": 1,
+                                "Sleep": 17,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 34,
+                            "id": 34,
+                            "itemID": "id:sEkeGQRhXdWC5hKU",
+                            "values": {
+                                "Mammal": "Patas Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 20,
+                                "Height": 0.9,
+                                "Mass": 13,
+                                "Sleep": "",
+                                "Speed": 55,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 35,
+                            "id": 35,
+                            "itemID": "id:ToKmU6iyTWvA0hIg",
+                            "values": {
+                                "Mammal": "Pig",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 1,
+                                "Mass": 192,
+                                "Sleep": 8,
+                                "Speed": 18,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 36,
+                            "id": 36,
+                            "itemID": "id:s8GPPAnOOfI7KmnG",
+                            "values": {
+                                "Mammal": "Pronghorn Antelope",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": "",
+                                "Speed": 98,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 37,
+                            "id": 37,
+                            "itemID": "id:h82O5HhJwMy7jwav",
+                            "values": {
+                                "Mammal": "Rabbit",
+                                "Order": "Lagomorpha",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 3,
+                                "Sleep": 11,
+                                "Speed": 56,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 38,
+                            "id": 38,
+                            "itemID": "id:1s-aDt7BV_qgS1Ut",
+                            "values": {
+                                "Mammal": "Red Fox",
+                                "Order": "Carnivora",
+                                "LifeSpan": 7,
+                                "Height": 0.8,
+                                "Mass": 5,
+                                "Sleep": 10,
+                                "Speed": 48,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 39,
+                            "id": 39,
+                            "itemID": "id:7fecF42sXsVTC0ar",
+                            "values": {
+                                "Mammal": "Spotted Hyena",
+                                "Order": "Carnivora",
+                                "LifeSpan": 25,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": 18,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        }
+                    ],
+                    "caseName": null,
+                    "childAttrName": null,
+                    "collapseChildren": null,
+                    "guid": 3,
+                    "id": 3,
+                    "name": "Mammals",
+                    "title": "Mammals",
+                    "type": "DG.Collection"
+                }
+            ],
+            "description": "",
+            "metadata": null,
+            "preventReorg": false,
+            "setAsideItems": [],
+            "contextStorage": {
+                "_links_": {
+                    "selectedCases": []
+                }
+            }
+        }
+    ],
+    "globalValues": [],
+    "appName": "DG",
+    "appVersion": "2.0",
+    "appBuildNum": "0733",
+    "lang": "en",
+    "idCount": 62,
+    "metadata": {}
+}

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -318,18 +318,30 @@ interface ICodapV2ProportionCenterEquationCoords {
   proportionCenterY: number
 }
 
-interface ICodapV2MovableLineAdornment extends ICodapV2Adornment {
+interface ICodapV2MovableLineAdornmentBase extends ICodapV2Adornment {
   isInterceptLocked: boolean
   // TODO_V2_IMPORT: equationCoords are not handled correctly, the import code assumes they have
   // an x and y instead of proportionCenterX and proportionCenterY
   // There are 2,000 instances of this in cfm-shared
   // example: cfm-shared/02RllCJzS0Nt4wX3c6XL/file.json
   equationCoords?: ICodapV2ProportionCenterEquationCoords | null
+}
+
+interface ICodapV2NormalMovableLineAdornment extends ICodapV2MovableLineAdornmentBase {
   intercept: number
   slope: number
-  isVertical: boolean
-  xIntercept: number | null
+  isVertical: false
+  xIntercept: null
 }
+
+interface ICodapV2VerticalMovableLineAdornment extends ICodapV2MovableLineAdornmentBase {
+  intercept: null
+  slope: null
+  isVertical: true
+  xIntercept: number
+}
+
+export type ICodapV2MovableLineAdornment = ICodapV2NormalMovableLineAdornment | ICodapV2VerticalMovableLineAdornment
 
 interface ICodapV2LSRLInstance extends ICodapV2Adornment {
   // this is a graph-wide property that is redundantly stored with each instance


### PR DESCRIPTION
Supports v2 export of movable line and movable point adornments by round-tripping a document with numerous examples created by v2, imported to v3 and then re-exported to v2 format.
See enclosed document `mammals-movable-line-point-adornments.codap` to see what graph configurations are successfully round-tripped.

Note that v2 sometimes renders multiple movable lines or movable points in a single graph, but it never serializes more than a single line or point. v3 handles more of these multiple lines/points situations appropriately, and so there will be a loss of information in these cases when round-tripping a v3-created document through the v2 export/import process. We'll need to extend the v2 format (hybrid format?) to handle that case.

This PR is based on #1774, which should be merged first (with merge commit).

Also fixes import of vertical movable lines from v2 documents.

Last major adornment-related feature to address is label/equation coordinates.