### PR TITLE
Fix transition from numeric to categorical axis

### DIFF
--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -70,7 +70,7 @@ export class NumericAxisHelper extends AxisHelper {
         return Number.isInteger(d) ? d.toString() : ""
       })
     }
-    subAxisSelection  //.append("g").attr("class", "numeric")
+    subAxisSelection
       .attr("class", "numeric-axis")
       .attr("transform", this.initialTransform)
       .transition().duration(duration)

--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -70,7 +70,8 @@ export class NumericAxisHelper extends AxisHelper {
         return Number.isInteger(d) ? d.toString() : ""
       })
     }
-    subAxisSelection
+    subAxisSelection  //.append("g").attr("class", "numeric")
+      .attr("class", "numeric-axis")
       .attr("transform", this.initialTransform)
       .transition().duration(duration)
       .call(axisScale).selectAll("line,path")

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -177,6 +177,10 @@ export const useSubAxis = ({
       if (!subAxisElt) return
       subAxisSelectionRef.current = select(subAxisElt)
       const sAS = subAxisSelectionRef.current
+      if (sAS.classed('numeric-axis')) {
+        sAS.selectAll('g').remove()
+        sAS.classed('numeric-axis', false)
+      }
 
       if (sAS.select('line').empty()) {
         sAS.append('line').attr('class', 'axis')


### PR DESCRIPTION
[#188819856] Bug fix: Graph axis is incorrect when switching from numerical to categorical plots

* The problem is that a previous PR assumed that it was unnecessary for the category-axis-helper to remove everything before rendering. But this left behind numeric axis stuff.
* The fix is to add a class "numeric-axis" when we're rendering a numeric axis that we can detect when rendering a categorical axis and, if present, remove the numeric axis elements