### PR TITLE
188839221 Fix Legend Select

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -546,7 +546,7 @@ export const DataConfigurationModel = types
           const dataset = self.dataset
           const legendID = self.attributeID('legend')
           const selection = (legendID && self.getCaseDataArray(0).filter((aCaseData: CaseData) =>
-            dataset?.getValue(aCaseData.caseID, legendID) === cat
+            dataset?.getStrValue(aCaseData.caseID, legendID) === cat
           ).map((aCaseData: CaseData) => aCaseData.caseID)) ?? []
           return selection.length > 0 && (selection as Array<string>).every(anID => dataset?.isCaseSelected(anID))
         }

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -528,13 +528,13 @@ export const DataConfigurationModel = types
         if (collectionGroup) {
           const parentCases = dataset?.getCasesForCollection(collectionGroup.id)
           parentCases?.forEach((aCase: ICase) => {
-            if (dataset?.getValue(aCase.__id__, legendID || '') === aValue) {
+            if (dataset?.getStrValue(aCase.__id__, legendID || '') === aValue) {
               caseIDs?.push(aCase.__id__)
             }
           })
         } else {
           caseIDs = legendID ? self.getCaseDataArray(0).filter((aCaseData: CaseData) => {
-              return dataset?.getValue(aCaseData.caseID, legendID) === aValue
+              return dataset?.getStrValue(aCaseData.caseID, legendID) === aValue
             }).map((aCaseData: CaseData) => aCaseData.caseID)
             : []
         }


### PR DESCRIPTION
PT Stories:
https://www.pivotaltracker.com/story/show/188839221
https://www.pivotaltracker.com/story/show/188820212

This PR fixes a bug where legends with both strings and numbers would not select the cases with numbers ([here's a better description](https://www.pivotaltracker.com/story/show/188820212)). It fixes the problem by always comparing string values rather than raw values.

It also fixes another bug where number entries would not highlight in a categorical legend, even when all of the relevant cases were selected. This was a result of the same problem, comparing a string with `getValue` instead of `getStrValue`.