### PR TITLE
Remainder of adornments and show measures for selection

### DIFF
--- a/v3/src/components/graph/adornments/adornments.tsx
+++ b/v3/src/components/graph/adornments/adornments.tsx
@@ -36,7 +36,7 @@ export const Adornments = observer(function Adornments() {
       layout.setDesiredExtent("banners", bannersHeight)
       }, { name: "Graph.handleAdornmentBannerCountChange" }, graphModel
     )
-  }, [dataConfig?.showMeasuresForSelection, graphModel, layout])
+  }, [dataConfig, graphModel, layout])
 
   if (!adornments?.length && !dataConfig?.showMeasuresForSelection) return null
 

--- a/v3/src/components/graph/adornments/adornments.tsx
+++ b/v3/src/components/graph/adornments/adornments.tsx
@@ -36,7 +36,7 @@ export const Adornments = observer(function Adornments() {
       layout.setDesiredExtent("banners", bannersHeight)
       }, { name: "Graph.handleAdornmentBannerCountChange" }, graphModel
     )
-  }, [dataConfig, graphModel, layout])
+  }, [dataConfig?.showMeasuresForSelection, graphModel, layout])
 
   if (!adornments?.length && !dataConfig?.showMeasuresForSelection) return null
 

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -29,7 +29,7 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
   const primaryAttrRole = dataConfig?.primaryRole ?? "x"
   const scale = primaryAttrRole === "x" ? xScale : yScale
   const casesInPlot =
-    dataConfig?.filteredForShowMeasuresForSelection(dataConfig?.subPlotCases(cellKey) ?? []).length ?? 0
+    dataConfig?.filterCasesForDisplay(dataConfig?.subPlotCases(cellKey) ?? []).length ?? 0
   const percent = model.percentValue(casesInPlot, cellKey, dataConfig)
   const displayPercent = model.showCount ? ` (${percentString(percent)})` : percentString(percent)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -28,7 +28,8 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
   const adornmentsStore = graphModel?.adornmentsStore
   const primaryAttrRole = dataConfig?.primaryRole ?? "x"
   const scale = primaryAttrRole === "x" ? xScale : yScale
-  const casesInPlot = dataConfig?.subPlotCases(cellKey)?.length ?? 0
+  const casesInPlot =
+    dataConfig?.filteredForShowMeasuresForSelection(dataConfig?.subPlotCases(cellKey) ?? []).length ?? 0
   const percent = model.percentValue(casesInPlot, cellKey, dataConfig)
   const displayPercent = model.showCount ? ` (${percentString(percent)})` : percentString(percent)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -37,11 +37,14 @@ export const CountAdornmentModel = AdornmentModel
       // the divisor)
       const categoricalAttrCount = dataConfig?.categoricalAttrCount ?? 0
       const hasPercentTypeOptions = categoricalAttrCount > 1
+      const rowCases = dataConfig?.filteredForShowMeasuresForSelection(dataConfig?.rowCases(cellKey) ?? []) ?? []
+      const columnCases = dataConfig?.filteredForShowMeasuresForSelection(dataConfig?.columnCases(cellKey) ?? []) ?? []
+      const cellCases = dataConfig?.filteredForShowMeasuresForSelection(dataConfig?.cellCases(cellKey) ?? []) ?? []
       const divisor = hasPercentTypeOptions && self.percentType === "row"
-        ? dataConfig?.rowCases(cellKey).length ?? 0
+        ? rowCases.length ?? 0
         : hasPercentTypeOptions && self.percentType === "column"
-          ? dataConfig?.columnCases(cellKey).length ?? 0
-          : dataConfig?.cellCases(cellKey).length ?? 0
+          ? columnCases.length ?? 0
+          : cellCases.length ?? 0
       const percentValue = casesInPlot / divisor
       return isFinite(percentValue) ? percentValue : 0
     },

--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -37,14 +37,11 @@ export const CountAdornmentModel = AdornmentModel
       // the divisor)
       const categoricalAttrCount = dataConfig?.categoricalAttrCount ?? 0
       const hasPercentTypeOptions = categoricalAttrCount > 1
-      const rowCases = dataConfig?.filteredForShowMeasuresForSelection(dataConfig?.rowCases(cellKey) ?? []) ?? []
-      const columnCases = dataConfig?.filteredForShowMeasuresForSelection(dataConfig?.columnCases(cellKey) ?? []) ?? []
-      const cellCases = dataConfig?.filteredForShowMeasuresForSelection(dataConfig?.cellCases(cellKey) ?? []) ?? []
-      const divisor = hasPercentTypeOptions && self.percentType === "row"
-        ? rowCases.length ?? 0
-        : hasPercentTypeOptions && self.percentType === "column"
-          ? columnCases.length ?? 0
-          : cellCases.length ?? 0
+      const rowCases = dataConfig?.filterCasesForDisplay(dataConfig?.rowCases(cellKey) ?? []) ?? []
+      const columnCases = dataConfig?.filterCasesForDisplay(dataConfig?.columnCases(cellKey) ?? []) ?? []
+      const cellCases = dataConfig?.filterCasesForDisplay(dataConfig?.cellCases(cellKey) ?? []) ?? []
+      const divisor = hasPercentTypeOptions && self.percentType === "row" ? rowCases.length
+        : hasPercentTypeOptions && self.percentType === "column" ? columnCases.length : cellCases.length
       const percentValue = casesInPlot / divisor
       return isFinite(percentValue) ? percentValue : 0
     },

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
@@ -64,7 +64,8 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
   const fixEndPoints = useCallback((iLine: Selection<SVGLineElement, unknown, null, undefined>) => {
     if (
       !Number.isFinite(pointsOnAxes.current.pt1.x) || !Number.isFinite(pointsOnAxes.current.pt2.x) ||
-      !Number.isFinite(pointsOnAxes.current.pt1.y) || !Number.isFinite(pointsOnAxes.current.pt2.y)
+      !Number.isFinite(pointsOnAxes.current.pt1.y) || !Number.isFinite(pointsOnAxes.current.pt2.y) ||
+      xScale.range().length === 0 || yScale.range().length === 0
     ) return
 
     iLine

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -78,7 +78,7 @@ export const LSRLAdornmentModel = AdornmentModel
     if (!dataConfig) return []
     const dataset = dataConfig?.dataset
     const legendAttrId = dataConfig?.attributeID("legend")
-    const casesInPlot = dataConfig.subPlotCases(cellKey)
+    const casesInPlot = dataConfig?.filteredForShowMeasuresForSelection(dataConfig.subPlotCases(cellKey))
     const caseValues: Point[] = []
     casesInPlot.forEach(caseId => {
       const caseValueX = dataDisplayGetNumericValue(dataset, caseId, xAttrId)

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -78,7 +78,7 @@ export const LSRLAdornmentModel = AdornmentModel
     if (!dataConfig) return []
     const dataset = dataConfig?.dataset
     const legendAttrId = dataConfig?.attributeID("legend")
-    const casesInPlot = dataConfig?.filteredForShowMeasuresForSelection(dataConfig.subPlotCases(cellKey))
+    const casesInPlot = dataConfig?.filterCasesForDisplay(dataConfig.subPlotCases(cellKey))
     const caseValues: Point[] = []
     casesInPlot.forEach(caseId => {
       const caseValueX = dataDisplayGetNumericValue(dataset, caseId, xAttrId)

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -41,7 +41,7 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
   .views(self => ({
     getCaseValues(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
       const dataset = dataConfig?.dataset
-      const casesInPlot = dataConfig.filteredForShowMeasuresForSelection(dataConfig.subPlotCases(cellKey))
+      const casesInPlot = dataConfig.filterCasesForDisplay(dataConfig.subPlotCases(cellKey))
       const caseValues: number[] = []
       casesInPlot.forEach(caseId => {
         const caseValue = dataDisplayGetNumericValue(dataset, caseId, attrId)

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -1,10 +1,10 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { Point } from "../../../data-display/data-display-types"
-import { AdornmentModel, IAdornmentModel, IUpdateCategoriesOptions, PointModel } from "../adornment-models"
 import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
 import {IGraphDataConfigurationModel} from "../../models/graph-data-configuration-model"
 import { isFiniteNumber } from "../../../../utilities/math-utils"
 import { dataDisplayGetNumericValue } from "../../../data-display/data-display-value-utils"
+import { AdornmentModel, IAdornmentModel, IUpdateCategoriesOptions, PointModel } from "../adornment-models"
 
 export const MeasureInstance = types.model("MeasureInstance", {
   labelCoords: types.maybe(PointModel)
@@ -41,13 +41,9 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
   .views(self => ({
     getCaseValues(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
       const dataset = dataConfig?.dataset
-      const casesInPlot = dataConfig.subPlotCases(cellKey)
-      const onlyIncludeIfSelected = dataConfig.showMeasuresForSelection
+      const casesInPlot = dataConfig.filteredForShowMeasuresForSelection(dataConfig.subPlotCases(cellKey))
       const caseValues: number[] = []
       casesInPlot.forEach(caseId => {
-        if (onlyIncludeIfSelected && !dataset?.isCaseSelected(caseId)) {
-          return
-        }
         const caseValue = dataDisplayGetNumericValue(dataset, caseId, attrId)
         if (isFiniteNumber(caseValue)) {
           caseValues.push(caseValue)

--- a/v3/src/components/graph/components/scatter-plot-utils.ts
+++ b/v3/src/components/graph/components/scatter-plot-utils.ts
@@ -104,7 +104,7 @@ export function scatterPlotFuncs(layout: GraphLayout, dataConfiguration?: IGraph
     lineDescriptions.forEach((lineDescription: ILineDescription) => {
       const { category, cellKey, intercept, slope } = lineDescription
       const casesInPlot =
-        dataConfiguration?.filteredForShowMeasuresForSelection(dataConfiguration.subPlotCases(cellKey)) || []
+        dataConfiguration?.filterCasesForDisplay(dataConfiguration.subPlotCases(cellKey)) || []
       casesInPlot.forEach(caseID => {
         addSquare(caseID, category, (id: string) => residualSquare(slope, intercept, id), squares)
       })
@@ -134,7 +134,7 @@ export function scatterPlotFuncs(layout: GraphLayout, dataConfiguration?: IGraph
       const func = plottedFunctionModel.plottedFunctions.get(instanceKey)?.formulaFunction
       if (func) {
         const casesInPlot =
-          dataConfiguration?.filteredForShowMeasuresForSelection(dataConfiguration.subPlotCases(cellKey)) || []
+          dataConfiguration?.filterCasesForDisplay(dataConfiguration.subPlotCases(cellKey)) || []
         casesInPlot.forEach(caseID => {
           addSquare(caseID, category, (id: string) => residualSquareForFunction(func, id), squares)
         })

--- a/v3/src/components/graph/components/scatter-plot-utils.ts
+++ b/v3/src/components/graph/components/scatter-plot-utils.ts
@@ -1,5 +1,4 @@
 import { ScaleBand, ScaleLinear } from "d3"
-import { IItem } from "../../../models/data/data-set-types"
 import { IGraphDataConfigurationModel } from "../models/graph-data-configuration-model"
 import { GraphLayout } from "../models/graph-layout"
 import { ILineDescription, ISquareOfResidual } from "../adornments/shared-adornment-types"
@@ -86,31 +85,28 @@ export function scatterPlotFuncs(layout: GraphLayout, dataConfiguration?: IGraph
     return { caseID, color, side, x, y }
   }
 
-  function addSquare(caseData: IItem, category: string | undefined, cellKey: Record<string, string>,
+  function addSquare(caseID: string, category: string | undefined,
                      squareFunc: (caseID: string)=>ISquareOfResidual, squares: ISquareOfResidual[]) {
     const dataset = dataConfiguration?.dataset
     const legendID = dataConfiguration?.attributeID("legend")
     const legendType = dataConfiguration?.attributeType("legend")
-    const legendValue = caseData.__id__ && legendID ? dataset?.getStrValue(caseData.__id__, legendID) : null
+    const legendValue = caseID && legendID ? dataset?.getStrValue(caseID, legendID) : null
     // If the line has a category, and it does not match the categorical legend value,
     // do not render squares.
     if (category && legendValue !== category && legendType === "categorical") return
-    const fullCaseData = dataset?.getItem(caseData.__id__, { numeric: false })
-    if (fullCaseData && dataConfiguration?.isCaseInSubPlot(cellKey, fullCaseData)) {
-      const square = squareFunc(caseData.__id__)
-      if (!isFinite(square.x) || !isFinite(square.y)) return
-      squares.push(square)
-    }
+    const square = squareFunc(caseID)
+    if (!isFinite(square.x) || !isFinite(square.y)) return
+    squares.push(square)
   }
 
   function residualSquaresForLines(lineDescriptions: ILineDescription[]) {
     const squares: ISquareOfResidual[] = []
-    const dataset = dataConfiguration?.dataset
     lineDescriptions.forEach((lineDescription: ILineDescription) => {
       const { category, cellKey, intercept, slope } = lineDescription
-      dataset?.items.forEach(caseData => {
-        addSquare(caseData, category, cellKey,
-          (caseID: string) => residualSquare(slope, intercept, caseID), squares)
+      const casesInPlot =
+        dataConfiguration?.filteredForShowMeasuresForSelection(dataConfiguration.subPlotCases(cellKey)) || []
+      casesInPlot.forEach(caseID => {
+        addSquare(caseID, category, (id: string) => residualSquare(slope, intercept, id), squares)
       })
     })
     return squares
@@ -132,15 +128,15 @@ export function scatterPlotFuncs(layout: GraphLayout, dataConfiguration?: IGraph
   function residualSquaresForFunction(plottedFunctionModel: IPlottedFunctionAdornmentModel,
                                       caseSubsetDescriptions: ICaseSubsetDescription[]) {
     const squares: ISquareOfResidual[] = []
-    const dataset = dataConfiguration?.dataset
     caseSubsetDescriptions.forEach((caseSubsetDescription: ICaseSubsetDescription) => {
       const { cellKey, category } = caseSubsetDescription
       const instanceKey = plottedFunctionModel.instanceKey(cellKey)
       const func = plottedFunctionModel.plottedFunctions.get(instanceKey)?.formulaFunction
       if (func) {
-        dataset?.items.forEach(caseData => {
-          addSquare(caseData, category, cellKey,
-            (caseID: string) => residualSquareForFunction(func, caseID), squares)
+        const casesInPlot =
+          dataConfiguration?.filteredForShowMeasuresForSelection(dataConfiguration.subPlotCases(cellKey)) || []
+        casesInPlot.forEach(caseID => {
+          addSquare(caseID, category, (id: string) => residualSquareForFunction(func, id), squares)
         })
       }
     })

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -559,7 +559,10 @@ export const GraphDataConfigurationModel = DataConfigurationModel
           return isBottomMatch && isTopMatch && isRightMatch
         })
       }
-    })
+    }),
+    filteredForShowMeasuresForSelection(caseIds: string[]) {
+      return self.showMeasuresForSelection ? caseIds.filter(caseId => self.dataset?.isCaseSelected(caseId)) : caseIds
+    }
   }))
   .actions(self => {
     const baseSetNumberOfCategoriesLimitForRole = self.setNumberOfCategoriesLimitForRole

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -560,7 +560,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         })
       }
     }),
-    filteredForShowMeasuresForSelection(caseIds: string[]) {
+    filterCasesForDisplay(caseIds: string[] = []) {
       return self.showMeasuresForSelection ? caseIds.filter(caseId => self.dataset?.isCaseSelected(caseId)) : caseIds
     }
   }))


### PR DESCRIPTION
[#187711050] Feature: Adornments respond to Show Measures for Selection option

* The previous PR for this feature only dealt with univariate adornments but didn't cover the count adornment, lsrl adornment and  show squares. We cover them in this PR.