### PR TITLE
legend type based on the data configuration

### DIFF
--- a/v3/src/components/data-display/components/legend/legend.tsx
+++ b/v3/src/components/data-display/components/legend/legend.tsx
@@ -7,6 +7,7 @@ import {CategoricalLegend} from "./categorical-legend"
 import { ColorLegend } from "./color-legend"
 import { IBaseLegendProps } from "./legend-common"
 import {NumericLegend} from "./numeric-legend"
+import { observer } from "mobx-react-lite"
 
 const legendComponentMap: Partial<Record<string, React.ComponentType<IBaseLegendProps>>> = {
   categorical: CategoricalLegend,
@@ -21,16 +22,15 @@ interface ILegendProps {
   onDropAttribute: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
 }
 
-export const Legend = function Legend({
+export const Legend = observer(function Legend({
                                         layerIndex, setDesiredExtent, onDropAttribute
                                       }: ILegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
-    legendAttrID = dataConfiguration?.attributeID('legend'),
-    attrType = dataConfiguration?.dataset?.attrFromID(legendAttrID ?? '')?.type,
+    attrType = dataConfiguration?.attributeType('legend'),
     LegendComponent = attrType && legendComponentMap[attrType],
     legendRef = useRef() as React.RefObject<SVGSVGElement>
 
-  return legendAttrID ? (
+  return attrType ? (
     <>
       <svg ref={legendRef} className='legend-component' data-testid='legend-component'>
         <LegendAttributeLabel
@@ -40,5 +40,4 @@ export const Legend = function Legend({
       </svg>
     </>
   ) : null
-}
-Legend.displayName = "Legend"
+})

--- a/v3/src/components/data-display/components/legend/legend.tsx
+++ b/v3/src/components/data-display/components/legend/legend.tsx
@@ -1,13 +1,13 @@
-import React, {useRef} from "react"
-import {IDataSet} from "../../../../models/data/data-set"
-import {GraphPlace} from "../../../axis-graph-shared"
-import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
-import {LegendAttributeLabel} from "./legend-attribute-label"
-import {CategoricalLegend} from "./categorical-legend"
+import React, { useRef } from "react"
+import { observer } from "mobx-react-lite"
+import { IDataSet } from "../../../../models/data/data-set"
+import { GraphPlace } from "../../../axis-graph-shared"
+import { useDataConfigurationContext } from "../../hooks/use-data-configuration-context"
+import { LegendAttributeLabel } from "./legend-attribute-label"
+import { CategoricalLegend } from "./categorical-legend"
 import { ColorLegend } from "./color-legend"
 import { IBaseLegendProps } from "./legend-common"
-import {NumericLegend} from "./numeric-legend"
-import { observer } from "mobx-react-lite"
+import { NumericLegend } from "./numeric-legend"
 
 const legendComponentMap: Partial<Record<string, React.ComponentType<IBaseLegendProps>>> = {
   categorical: CategoricalLegend,


### PR DESCRIPTION
The user can set an attribute type in the data configuration of the graph or map. The legend was ignoring this and just showing the type from the table.

Additionally the component wasn't observing the attribute type. So if the user changed the type in the table and they hadn't overridden it with a setting in the graph or map it wouldn't update.