### PR TITLE
feat: import/export regression line labels from/to v2

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -347,10 +347,9 @@ export const DataConfigurationModel = types
       calculate: (role: AttrRole, emptyCategoryArray = [kMain]) => {
         const valuesSet = new Set(self.valuesForAttrRole(role)),
           categoryLimitForRole = self.numberOfCategoriesLimitByRole.get(role)
+        if (valuesSet.size === 0) return emptyCategoryArray
+
         let resultArray: string[] = []
-        if (valuesSet.size === 0) {
-          resultArray.push(kMain)
-        }
         // category set maintains the canonical order of categories
         const allCategorySet = self.categorySetForAttrRole(role)
         // if we don't have a category set just return the values

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -1,3 +1,4 @@
+import { kMain } from "../../../data-display/data-display-types"
 import { LSRLAdornmentModel, LSRLInstance } from "./lsrl-adornment-model"
 
 const mockLSRLInstanceProps1 = {
@@ -67,10 +68,9 @@ describe("LSRLAdornmentModel", () => {
   })
   it("can have a line added to its lines property", () => {
     const lSRL = LSRLAdornmentModel.create()
-    lSRL.updateLines(mockLSRLInstanceProps1, "", 0)
+    lSRL.updateLines(mockLSRLInstanceProps1, "{}")
     expect(lSRL.lines.size).toEqual(1)
-    const modelLines = lSRL.lines.get("")
-    const modelLine = modelLines?.[0]
+    const modelLine = lSRL.lines.get("{}")?.get(kMain)
     expect(modelLine?.intercept).toEqual(mockLSRLInstanceProps1.intercept)
     expect(modelLine?.rSquared).toEqual(mockLSRLInstanceProps1.rSquared)
     expect(modelLine?.sdResiduals).toEqual(mockLSRLInstanceProps1.sdResiduals)
@@ -80,13 +80,11 @@ describe("LSRLAdornmentModel", () => {
     const line1 = mockLSRLInstanceProps1
     const line2 = mockLSRLInstanceProps2
     const lSRL = LSRLAdornmentModel.create()
-    lSRL.updateLines(line1, "cellkey1", 0)
-    lSRL.updateLines(line2, "cellkey2", 0)
+    lSRL.updateLines(line1, "cellkey1")
+    lSRL.updateLines(line2, "cellkey2")
     expect(lSRL.lines.size).toEqual(2)
-    const modelLines1 = lSRL.lines.get("cellkey1")
-    const modelLines2 = lSRL.lines.get("cellkey2")
-    const modelLine1 = modelLines1?.[0]
-    const modelLine2 = modelLines2?.[0]
+    const modelLine1 = lSRL.lines.get("cellkey1")?.get(kMain)
+    const modelLine2 = lSRL.lines.get("cellkey2")?.get(kMain)
     expect(modelLine1?.intercept).toEqual(line1.intercept)
     expect(modelLine1?.rSquared).toEqual(line1.rSquared)
     expect(modelLine1?.sdResiduals).toEqual(line1.sdResiduals)
@@ -100,12 +98,12 @@ describe("LSRLAdornmentModel", () => {
     const line1 = mockLSRLInstanceProps1
     const line2 = mockLSRLInstanceProps2
     const lSRL = LSRLAdornmentModel.create()
-    lSRL.updateLines(line1, "sameKey", 0)
-    lSRL.updateLines(line2, "sameKey", 1)
+    lSRL.updateLines(line1, "sameKey", "foo")
+    lSRL.updateLines(line2, "sameKey", "bar")
     expect(lSRL.lines.size).toEqual(1)
     const modelLines = lSRL.lines.get("sameKey")
-    const modelLine1 = modelLines?.[0]
-    const modelLine2 = modelLines?.[1]
+    const modelLine1 = modelLines?.get("foo")
+    const modelLine2 = modelLines?.get("bar")
     expect(modelLine1?.intercept).toEqual(line1.intercept)
     expect(modelLine1?.rSquared).toEqual(line1.rSquared)
     expect(modelLine1?.sdResiduals).toEqual(line1.sdResiduals)
@@ -123,7 +121,7 @@ describe("LSRLAdornmentModel", () => {
   })
   it("can get both the intercept and slope values of a line via the line's slopeAndIntercept view", () => {
     const lSRL = LSRLAdornmentModel.create()
-    lSRL.updateLines(mockLSRLInstanceProps1, "", 0)
-    expect(lSRL.lines.get("")?.[0]?.slopeAndIntercept).toEqual({intercept: 1, slope: 1})
+    lSRL.updateLines(mockLSRLInstanceProps1, "{}")
+    expect(lSRL.lines.get("{}")?.get(kMain)?.slopeAndIntercept).toEqual({intercept: 1, slope: 1})
   })
 })

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
@@ -1,6 +1,6 @@
 import { FormControl, Checkbox } from "@chakra-ui/react"
-import React from "react"
 import { observer } from "mobx-react-lite"
+import React from "react"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import { t } from "../../../../utilities/translation/translate"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
@@ -109,13 +109,16 @@ registerAdornmentContentInfo({
         isInterceptLocked: options.isInterceptLocked,
         showSumSquares: options.showSumSquares,
         showConfidenceBands: adornment.showConfidenceBands,
-        lsrls: options.legendCategories.map(cat => ({
-          ...exportAdornmentBase(adornment, options),
-          // TODO_V2_EXPORT export label/equation coordinates for adornments
-          equationCoords: null,
-          isInterceptLocked: options.isInterceptLocked,
-          showConfidenceBands: adornment.showConfidenceBands
-        }))
+        // v2 ignores top and right splits
+        lsrls: options.legendCategories.map(cat => {
+          const lineInstance = adornment.firstLineInstance(cat)
+          return {
+            ...exportAdornmentBase(adornment, options),
+            equationCoords: lineInstance?.v2ExportCoords ?? null,
+            isInterceptLocked: options.isInterceptLocked,
+            showConfidenceBands: adornment.showConfidenceBands
+          }
+        })
       }
     }
   }

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -24,16 +24,17 @@ describe("equationString", () => {
 describe("lsrlEquationString", () => {
   const layout = new GraphLayout()
   const attrNames = {x: "Lifespan", y: "Speed"}
+  const units = {}
   it("should return a valid equation for a given slope and intercept", () => {
-    expect(lsrlEquationString({caseValues: [], slope: 1, intercept: 0, attrNames, layout}))
+    expect(lsrlEquationString({caseValues: [], slope: 1, intercept: 0, attrNames, units, layout}))
       .toBe('<span><em>Speed</em> = 1 (<em>Lifespan</em>)</span>')
   })
   it("should return an equation containing only the y attribute when the slope is 0", () => {
-    expect(lsrlEquationString({caseValues: [], slope: 0, intercept: 1, attrNames, layout}))
+    expect(lsrlEquationString({caseValues: [], slope: 0, intercept: 1, attrNames, units, layout}))
       .toBe('<span><em>Speed</em> = 1</span>')
   })
   it("should return an equation containing only the x attribute when the slope is Infinity", () => {
-    expect(lsrlEquationString({caseValues: [], slope: Infinity, intercept: 1, attrNames, layout}))
+    expect(lsrlEquationString({caseValues: [], slope: Infinity, intercept: 1, attrNames, units, layout}))
       .toBe('<span><em>Lifespan</em> = 1</span>')
   })
 })

--- a/v3/src/test/v2/mammals-adornment-labels.codap
+++ b/v3/src/test/v2/mammals-adornment-labels.codap
@@ -1,1 +1,2530 @@
-{"name":"Mammals","guid":1,"id":1,"components":[{"type":"DG.TableView","guid":40,"id":40,"componentStorage":{"isActive":false,"_links_":{"context":{"type":"DG.DataContextRecord","id":2}},"attributeWidths":[{"_links_":{"attr":{"type":"DG.Attribute","id":12}},"width":45}],"rowHeights":[],"title":"Mammals","name":"Mammals","userSetTitle":false,"cannotClose":false},"layout":{"width":583,"height":237,"left":5,"top":5,"isVisible":false,"zIndex":106,"right":588,"bottom":242},"savedHeight":null},{"type":"DG.GuideView","guid":41,"id":41,"componentStorage":{"title":"Mammals Sample Guide","items":[{"itemTitle":"Get Started","url":"../../../../extn/example-documents/guides/Mammals/mammals_getstarted.html"}],"currentItemIndex":0,"isVisible":false,"name":"Mammals Sample Guide","userSetTitle":false,"cannotClose":false},"layout":{"left":665,"top":10,"width":416,"height":510,"isVisible":false,"zIndex":15,"right":1081,"bottom":520},"savedHeight":null},{"type":"DG.GraphView","guid":42,"id":42,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":0,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":0,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.AxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedMean":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":-0.00227272727272726,"proportionY":0}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"Mean-Label-Top-Left","userSetTitle":true,"cannotClose":false},"layout":{"width":205,"height":240,"zIndex":166,"left":210,"top":5,"isVisible":true,"right":415,"bottom":245},"savedHeight":null},{"type":"DG.CaseCard","guid":43,"id":43,"componentStorage":{"isActive":true,"_links_":{"context":{"type":"DG.DataContextRecord","id":2}},"title":"Mammals","userSetTitle":false,"cannotClose":false},"layout":{"top":5,"left":5,"width":200,"height":399,"zIndex":107,"isVisible":true,"right":205,"bottom":404},"savedHeight":null},{"type":"DG.GraphView","guid":44,"id":44,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":0,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":0,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.AxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedMean":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":0.4169212690951822,"proportionY":0}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"Mean-Label-Top-Right","userSetTitle":true,"cannotClose":false},"layout":{"width":205,"height":240,"zIndex":146,"left":420,"top":5,"isVisible":true,"right":625,"bottom":245},"savedHeight":null},{"type":"DG.GraphView","guid":45,"id":45,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":0,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":0,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.AxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedMean":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":-0.004444444444444473,"proportionY":0.8764044943820225}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"Mean-Label-Bottom-Left","userSetTitle":true,"cannotClose":false},"layout":{"width":205,"height":240,"zIndex":150,"left":630,"top":5,"isVisible":true,"right":835,"bottom":245},"savedHeight":null},{"type":"DG.GraphView","guid":46,"id":46,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":0,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":0,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.AxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedMean":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":0.5045454545454546,"proportionY":0.8707865168539326}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"Mean-Label-Bottom-Right","userSetTitle":true,"cannotClose":false},"layout":{"width":240,"height":240,"zIndex":159,"left":840,"top":5,"isVisible":true,"right":1080,"bottom":245},"savedHeight":null},{"type":"DG.GraphView","guid":47,"id":47,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":0,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":0,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.AxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedMean":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":0.2285714285714286,"proportionY":0.4157303370786517}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"Mean-Label-Center","userSetTitle":true,"cannotClose":false},"layout":{"width":230,"height":240,"zIndex":162,"left":1085,"top":5,"isVisible":true,"right":1315,"bottom":245},"savedHeight":null},{"type":"DG.GraphView","guid":48,"id":48,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6},"yColl":{"type":"DG.Collection","id":3},"yAttr":{"type":"DG.Attribute","id":12}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":2,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":0,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.CellAxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedMean":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":0.33333333333333337,"proportionY":0.8607594936708861},{"proportionX":0.19135802469135804,"proportionY":0.4240506329113924},{"proportionX":-0.012345679012345678,"proportionY":-0.006329113924050633}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"Mean-Labels-SplitY","userSetTitle":true,"cannotClose":false},"layout":{"width":205,"height":220,"zIndex":195,"left":210,"top":250,"isVisible":true,"right":415,"bottom":470},"savedHeight":null},{"type":"DG.GraphView","guid":49,"id":49,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6},"topColl":{"type":"DG.Collection","id":3},"topAttr":{"type":"DG.Attribute","id":12}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":0,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":2,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.AxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedMean":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":-0.49193548387096775,"proportionY":0.7844827586206896}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"Mean-Labels-SplitTop","userSetTitle":true,"cannotClose":false},"layout":{"width":205,"height":220,"zIndex":183,"left":420,"top":250,"isVisible":true,"right":625,"bottom":470},"savedHeight":null},{"type":"DG.GraphView","guid":50,"id":50,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6},"yColl":{"type":"DG.Collection","id":3},"yAttr":{"type":"DG.Attribute","id":12},"topColl":{"type":"DG.Collection","id":3},"topAttr":{"type":"DG.Attribute","id":11}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":2,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":2,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.CellAxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedMean":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":0.4636363636363636,"proportionY":0.6724137931034483},{"proportionX":0.34545454545454546,"proportionY":0.33620689655172414},{"proportionX":0,"proportionY":0}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"Mean-Labels-SplitLeftTop","userSetTitle":true,"cannotClose":false},"layout":{"width":205,"height":220,"zIndex":193,"left":630,"top":250,"isVisible":true,"right":835,"bottom":470},"savedHeight":null},{"type":"DG.GraphView","guid":51,"id":51,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6},"yColl":{"type":"DG.Collection","id":3},"yAttr":{"type":"DG.Attribute","id":12}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":2,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":0,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.CellAxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedNormal":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":0.45567602040816324,"proportionY":0.7547770700636943},{"proportionX":0.2263233418367347,"proportionY":0.37536617485017065},{"proportionX":-0.0078125,"proportionY":0}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"Normal-Labels-SplitY","userSetTitle":true,"cannotClose":false},"layout":{"width":240,"height":220,"zIndex":206,"left":840,"top":250,"isVisible":true,"right":1080,"bottom":470},"savedHeight":null},{"type":"DG.GraphView","guid":52,"id":52,"componentStorage":{"_links_":{"context":{"type":"DG.DataContextRecord","id":2},"hiddenCases":[],"xColl":{"type":"DG.Collection","id":3},"xAttr":{"type":"DG.Attribute","id":6},"yColl":{"type":"DG.Collection","id":3},"yAttr":{"type":"DG.Attribute","id":11}},"displayOnlySelected":false,"legendRole":0,"legendAttributeType":0,"numberOfLegendQuantiles":5,"legendQuantilesAreLocked":false,"pointColor":"#e6805b","strokeColor":"white","pointSizeMultiplier":1,"transparency":0.85,"strokeTransparency":0.4,"strokeSameAsFill":false,"isTransparent":false,"plotBackgroundColor":null,"plotBackgroundOpacity":1,"plotBackgroundImage":null,"plotBackgroundImageLockInfo":null,"xRole":1,"xAttributeType":1,"yRole":4,"yAttributeType":2,"y2Role":0,"y2AttributeType":0,"topRole":0,"topAttributeType":0,"rightRole":0,"rightAttributeType":0,"xAxisClass":"DG.CellLinearAxisModel","xLowerBound":-5,"xUpperBound":95,"yAxisClass":"DG.CellAxisModel","y2AxisClass":"DG.AxisModel","topAxisClass":"DG.CellAxisModel","rightAxisClass":"DG.CellAxisModel","plotModels":[{"plotModelStorage":{"verticalAxisIsY2":false,"adornments":{"plottedCount":{"isVisible":false,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"percentKind":1},"multipleMovableValues":{"isVisible":true,"enableMeasuresForSelection":false,"isShowingCount":false,"isShowingPercent":false,"valueModels":[]},"plottedStErr":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":0.40912212072660675,"proportionY":0.8354430379746836},{"proportionX":0.38675378180985887,"proportionY":0.4306456759919159}],"numberOfStdErrs":1},"plottedMean":{"isVisible":true,"enableMeasuresForSelection":false,"equationCoordsArray":[{"proportionX":-0.0053475935828877,"proportionY":0.8590575470694609},{"proportionX":0,"proportionY":0.4537815126050421},{"proportionX":0,"proportionY":0}]}},"showMeasureLabels":true},"plotClass":"DG.DotPlotModel"}],"title":"MeanStdErr-Labels-SplitY","userSetTitle":true,"cannotClose":false},"layout":{"width":230,"height":220,"zIndex":215,"left":1085,"top":250,"isVisible":true,"right":1315,"bottom":470},"savedHeight":null}],"contexts":[{"type":"DG.DataContext","document":1,"guid":2,"id":2,"flexibleGroupingChangeFlag":false,"name":"Mammals","title":"Mammals","collections":[{"areParentChildLinksConfigured":false,"attrs":[{"name":"Mammal","type":"none","title":"Mammal","cid":"id:WnIqDMHPdZeQ8o8e","description":"The species of the mammal","_categoryMap":{"__order":["African Elephant","Asian Elephant","Big Brown Bat","Bottlenose Dolphin","Cheetah","Chimpanzee","Domestic Cat","Donkey","Giraffe","Gray Wolf","Grey Seal","Ground Squirrel","Horse","House Mouse","Human","Jaguar","Killer Whale","Lion","N. American Opossum","Nine-Banded Armadillo","Owl Monkey","Patas Monkey","Pig","Pronghorn Antelope","Rabbit","Red Fox","Spotted Hyena"],"African Elephant":"#FFB300","Asian Elephant":"#803E75","Big Brown Bat":"#FF6800","Bottlenose Dolphin":"#A6BDD7","Cheetah":"#C10020","Chimpanzee":"#CEA262","Domestic Cat":"#817066","Donkey":"#007D34","Giraffe":"#00538A","Gray Wolf":"#F13A13","Grey Seal":"#53377A","Ground Squirrel":"#FF8E00","Horse":"#B32851","House Mouse":"#F4C800","Human":"#7F180D","Jaguar":"#93AA00","Killer Whale":"#593315","Lion":"#232C16","N. American Opossum":"#FF7A5C","Nine-Banded Armadillo":"#F6768E","Owl Monkey":"#FFB300","Patas Monkey":"#803E75","Pig":"#FF6800","Pronghorn Antelope":"#A6BDD7","Rabbit":"#C10020","Red Fox":"#CEA262","Spotted Hyena":"#817066"},"blockDisplayOfEmptyCategories":true,"editable":true,"hidden":false,"renameable":true,"deleteable":true,"guid":4,"id":4,"precision":2,"unit":null},{"name":"Order","type":"none","title":"Order","cid":"id:b199PwdCYoYUWotE","description":"The order of the mammal","blockDisplayOfEmptyCategories":true,"editable":true,"hidden":false,"renameable":true,"deleteable":true,"guid":5,"id":5,"precision":2,"unit":null},{"name":"LifeSpan","type":"numeric","title":"LifeSpan","cid":"id:pDLcgGkz1mo9gmQp","description":"","_categoryMap":{"3":"#00538A","5":"#F4C800","7":"#593315","9":"#007D34","10":"#7F180D","12":"#93AA00","14":"#A6BDD7","15":"#B32851","16":"#CEA262","19":"#803E75","20":"#53377A","25":"#FF6800","30":"#817066","40":"#C10020","50":"#FF8E00","70":"#FFB300","80":"#F13A13","__order":["10","12","14","15","16","19","20","25","3","30","40","5","50","7","70","80","9"]},"blockDisplayOfEmptyCategories":true,"editable":true,"hidden":false,"renameable":true,"deleteable":true,"guid":6,"id":6,"precision":2,"unit":"years"},{"name":"Height","type":"none","title":"Height","cid":"id:lzLJOzAcO6Ner-VN","description":"The average height of the mammal.","blockDisplayOfEmptyCategories":true,"editable":true,"hidden":false,"renameable":true,"deleteable":true,"guid":7,"id":7,"precision":2,"unit":"meters"},{"name":"Mass","type":"numeric","title":"Mass","cid":"id:BR6LZDwZgYCuhjPs","description":"The mass of the mammal","blockDisplayOfEmptyCategories":true,"editable":true,"hidden":false,"renameable":true,"deleteable":true,"guid":8,"id":8,"precision":2,"unit":"kg"},{"name":"Sleep","type":"numeric","title":"Sleep","cid":"id:2NO7QbQ-FwBakWhC","description":"The number of hours the animal sleeps in a 24 hour period","blockDisplayOfEmptyCategories":true,"editable":true,"hidden":false,"renameable":true,"deleteable":true,"guid":9,"id":9,"precision":2,"unit":"hours"},{"name":"Speed","type":"none","title":"Speed","cid":"id:HR3FcppJ9w9VKzyO","description":"The average speed of the mammal.","blockDisplayOfEmptyCategories":true,"editable":true,"hidden":false,"renameable":true,"deleteable":true,"guid":10,"id":10,"precision":2,"unit":"km/h"},{"name":"Habitat","type":null,"title":"Habitat","cid":"id:7WY17cbx_s_2ULni","description":"","_categoryMap":{"land":{"h":0.4444444444444444,"s":0.6666666666666666,"b":1,"colorString":"rgb(85,255,198)"},"water":{"h":0.711111111111111,"s":0.6666666666666666,"b":1,"colorString":"rgb(130,85,255)"},"both":{"h":0.9777777777777777,"s":0.6666666666666666,"b":1,"colorString":"rgb(255,85,108)"},"__order":["land","water","both"]},"blockDisplayOfEmptyCategories":true,"editable":true,"hidden":false,"renameable":true,"deleteable":true,"guid":11,"id":11,"precision":2,"unit":null},{"name":"Diet","type":null,"title":"Diet","cid":"id:WZLuWyRlDnAZsA20","description":"","_categoryMap":{"__order":["both","meat","plants"],"plants":"#FFB300","meat":"#803E75","both":"#FF6800"},"blockDisplayOfEmptyCategories":true,"editable":true,"hidden":false,"renameable":true,"deleteable":true,"guid":12,"id":12,"precision":2,"unit":null}],"cases":[{"guid":13,"id":13,"itemID":"id:4DiTjn4qPrzc9cer","values":{"Mammal":"African Elephant","Order":"Proboscidae","LifeSpan":70,"Height":4,"Mass":6400,"Sleep":3,"Speed":40,"Habitat":"land","Diet":"plants"}},{"guid":14,"id":14,"itemID":"id:MUfUW6xPY1FSSULf","values":{"Mammal":"Asian Elephant","Order":"Proboscidae","LifeSpan":70,"Height":3,"Mass":5000,"Sleep":4,"Speed":40,"Habitat":"land","Diet":"plants"}},{"guid":15,"id":15,"itemID":"id:nY2QnpmqOW68u58F","values":{"Mammal":"Big Brown Bat","Order":"Chiroptera","LifeSpan":19,"Height":0.1,"Mass":0.02,"Sleep":20,"Speed":40,"Habitat":"land","Diet":"meat"}},{"guid":16,"id":16,"itemID":"id:qlB0IRf35QNqzwdV","values":{"Mammal":"Bottlenose Dolphin","Order":"Cetacea","LifeSpan":25,"Height":3.5,"Mass":635,"Sleep":5,"Speed":37,"Habitat":"water","Diet":"meat"}},{"guid":17,"id":17,"itemID":"id:RI2V_fbx29-foXcz","values":{"Mammal":"Cheetah","Order":"Carnivora","LifeSpan":14,"Height":1.5,"Mass":50,"Sleep":12,"Speed":110,"Habitat":"land","Diet":"meat"}},{"guid":18,"id":18,"itemID":"id:sl1g9jzNu517QAX3","values":{"Mammal":"Chimpanzee","Order":"Primate","LifeSpan":40,"Height":1.5,"Mass":68,"Sleep":10,"Speed":"","Habitat":"land","Diet":"both"}},{"guid":19,"id":19,"itemID":"id:llBXjzGpj2v0O6Bu","values":{"Mammal":"Domestic Cat","Order":"Carnivora","LifeSpan":16,"Height":0.8,"Mass":4.5,"Sleep":12,"Speed":50,"Habitat":"land","Diet":"meat"}},{"guid":20,"id":20,"itemID":"id:IEhUCUROiVxsQ8XA","values":{"Mammal":"Donkey","Order":"Perissodactyla","LifeSpan":40,"Height":1.2,"Mass":187,"Sleep":3,"Speed":50,"Habitat":"land","Diet":"plants"}},{"guid":21,"id":21,"itemID":"id:yILdJW1Y0gA4KRJu","values":{"Mammal":"Giraffe","Order":"Artiodactyla","LifeSpan":25,"Height":5,"Mass":1100,"Sleep":2,"Speed":50,"Habitat":"land","Diet":"plants"}},{"guid":22,"id":22,"itemID":"id:ws3gDpYZWt6sNa4M","values":{"Mammal":"Gray Wolf","Order":"Carnivora","LifeSpan":16,"Height":1.6,"Mass":80,"Sleep":13,"Speed":64,"Habitat":"land","Diet":"meat"}},{"guid":23,"id":23,"itemID":"id:FDGJb2qq4tuHPMjU","values":{"Mammal":"Grey Seal","Order":"Pinnipedia","LifeSpan":30,"Height":2.1,"Mass":275,"Sleep":6,"Speed":19,"Habitat":"both","Diet":"meat"}},{"guid":24,"id":24,"itemID":"id:vfHjTg4Crsi4qt3-","values":{"Mammal":"Ground Squirrel","Order":"Rodentia","LifeSpan":9,"Height":0.3,"Mass":0.1,"Sleep":15,"Speed":19,"Habitat":"land","Diet":"both"}},{"guid":25,"id":25,"itemID":"id:85bNrURsW8l0p2m2","values":{"Mammal":"Horse","Order":"Perissodactyla","LifeSpan":25,"Height":1.5,"Mass":521,"Sleep":3,"Speed":69,"Habitat":"land","Diet":"plants"}},{"guid":26,"id":26,"itemID":"id:PXsjncrZbS_HBU9k","values":{"Mammal":"House Mouse","Order":"Rodentia","LifeSpan":3,"Height":0.1,"Mass":0.03,"Sleep":12,"Speed":13,"Habitat":"land","Diet":"both"}},{"guid":27,"id":27,"itemID":"id:vf9pOFOdFW6MqJ7T","values":{"Mammal":"Human","Order":"Primate","LifeSpan":80,"Height":1.9,"Mass":80,"Sleep":8,"Speed":45,"Habitat":"land","Diet":"both"}},{"guid":28,"id":28,"itemID":"id:S6moKAA_AWW1nzry","values":{"Mammal":"Jaguar","Order":"Carnivora","LifeSpan":20,"Height":1.8,"Mass":115,"Sleep":11,"Speed":60,"Habitat":"land","Diet":"meat"}},{"guid":29,"id":29,"itemID":"id:3KN2htqgg6fnUHyT","values":{"Mammal":"Killer Whale","Order":"Cetacea","LifeSpan":50,"Height":6.5,"Mass":4000,"Sleep":"","Speed":48,"Habitat":"water","Diet":"meat"}},{"guid":30,"id":30,"itemID":"id:cgmzq6wnYqJR7sNR","values":{"Mammal":"Lion","Order":"Carnivora","LifeSpan":15,"Height":2.5,"Mass":250,"Sleep":20,"Speed":80,"Habitat":"land","Diet":"meat"}},{"guid":31,"id":31,"itemID":"id:6y0LzR2abM2KCBDs","values":{"Mammal":"N. American Opossum","Order":"Didelphimorphia","LifeSpan":5,"Height":0.5,"Mass":5,"Sleep":19,"Speed":"","Habitat":"land","Diet":"both"}},{"guid":32,"id":32,"itemID":"id:dB0nNA9CY1TuUiRA","values":{"Mammal":"Nine-Banded Armadillo","Order":"Xenarthra","LifeSpan":10,"Height":0.6,"Mass":7,"Sleep":17,"Speed":1,"Habitat":"land","Diet":"meat"}},{"guid":33,"id":33,"itemID":"id:vdE0Bk-Mdir9-kGF","values":{"Mammal":"Owl Monkey","Order":"Primate","LifeSpan":12,"Height":0.4,"Mass":1,"Sleep":17,"Speed":"","Habitat":"land","Diet":"both"}},{"guid":34,"id":34,"itemID":"id:NZOcUw2vglQpGX8K","values":{"Mammal":"Patas Monkey","Order":"Primate","LifeSpan":20,"Height":0.9,"Mass":13,"Sleep":"","Speed":55,"Habitat":"land","Diet":"both"}},{"guid":35,"id":35,"itemID":"id:fxVFC289ARimyYm2","values":{"Mammal":"Pig","Order":"Artiodactyla","LifeSpan":10,"Height":1,"Mass":192,"Sleep":8,"Speed":18,"Habitat":"land","Diet":"both"}},{"guid":36,"id":36,"itemID":"id:Q7J42jBWQP8PCIXW","values":{"Mammal":"Pronghorn Antelope","Order":"Artiodactyla","LifeSpan":10,"Height":0.9,"Mass":70,"Sleep":"","Speed":98,"Habitat":"land","Diet":"plants"}},{"guid":37,"id":37,"itemID":"id:9eQgA4eqxmZgCh-f","values":{"Mammal":"Rabbit","Order":"Lagomorpha","LifeSpan":5,"Height":0.5,"Mass":3,"Sleep":11,"Speed":56,"Habitat":"land","Diet":"plants"}},{"guid":38,"id":38,"itemID":"id:KNjgPF4csEJEoZMU","values":{"Mammal":"Red Fox","Order":"Carnivora","LifeSpan":7,"Height":0.8,"Mass":5,"Sleep":10,"Speed":48,"Habitat":"land","Diet":"both"}},{"guid":39,"id":39,"itemID":"id:6Ssbg8pNQ2b3jDiL","values":{"Mammal":"Spotted Hyena","Order":"Carnivora","LifeSpan":25,"Height":0.9,"Mass":70,"Sleep":18,"Speed":64,"Habitat":"land","Diet":"meat"}}],"caseName":null,"childAttrName":null,"collapseChildren":null,"guid":3,"id":3,"name":"Mammals","title":"Mammals","type":"DG.Collection"}],"description":"","metadata":null,"preventReorg":false,"setAsideItems":[],"contextStorage":{"_links_":{"selectedCases":[]}}}],"globalValues":[],"appName":"DG","appVersion":"2.0","appBuildNum":"0733","lang":"en","idCount":52,"metadata":{}}
+{
+    "name": "Mammals",
+    "guid": 1,
+    "id": 1,
+    "components": [
+        {
+            "type": "DG.TableView",
+            "guid": 40,
+            "id": 40,
+            "componentStorage": {
+                "isActive": false,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "attributeWidths": [
+                    {
+                        "_links_": {
+                            "attr": {
+                                "type": "DG.Attribute",
+                                "id": 12
+                            }
+                        },
+                        "width": 45
+                    }
+                ],
+                "rowHeights": [],
+                "title": "Mammals",
+                "name": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 583,
+                "height": 237,
+                "left": 5,
+                "top": 5,
+                "isVisible": false,
+                "zIndex": 106,
+                "right": 588,
+                "bottom": 242
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GuideView",
+            "guid": 41,
+            "id": 41,
+            "componentStorage": {
+                "title": "Mammals Sample Guide",
+                "items": [
+                    {
+                        "itemTitle": "Get Started",
+                        "url": "../../../../extn/example-documents/guides/Mammals/mammals_getstarted.html"
+                    }
+                ],
+                "currentItemIndex": 0,
+                "isVisible": false,
+                "name": "Mammals Sample Guide",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "left": 665,
+                "top": 10,
+                "width": 416,
+                "height": 510,
+                "isVisible": false,
+                "zIndex": 15,
+                "right": 1081,
+                "bottom": 520
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 42,
+            "id": 42,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedMean": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": -0.00227272727272726,
+                                            "proportionY": 0
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Mean-Label-TopLeft",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 205,
+                "height": 240,
+                "zIndex": 248,
+                "left": 210,
+                "top": 5,
+                "isVisible": true,
+                "right": 415,
+                "bottom": 245
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.CaseCard",
+            "guid": 43,
+            "id": 43,
+            "componentStorage": {
+                "isActive": true,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    }
+                },
+                "title": "Mammals",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "top": 5,
+                "left": 5,
+                "width": 200,
+                "height": 399,
+                "zIndex": 107,
+                "isVisible": true,
+                "right": 205,
+                "bottom": 404
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 44,
+            "id": 44,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedMean": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": 0.4169212690951822,
+                                            "proportionY": 0
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Mean-Label-TopRight",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 205,
+                "height": 240,
+                "zIndex": 250,
+                "left": 420,
+                "top": 5,
+                "isVisible": true,
+                "right": 625,
+                "bottom": 245
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 45,
+            "id": 45,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedMean": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": -0.004444444444444473,
+                                            "proportionY": 0.8764044943820225
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Mean-Label-BottomLeft",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 205,
+                "height": 240,
+                "zIndex": 252,
+                "left": 630,
+                "top": 5,
+                "isVisible": true,
+                "right": 835,
+                "bottom": 245
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 46,
+            "id": 46,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedMean": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": 0.5045454545454546,
+                                            "proportionY": 0.8707865168539326
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Mean-Label-BottomRight",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 240,
+                "zIndex": 254,
+                "left": 840,
+                "top": 5,
+                "isVisible": true,
+                "right": 1080,
+                "bottom": 245
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 47,
+            "id": 47,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedMean": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": 0.2285714285714286,
+                                            "proportionY": 0.4157303370786517
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Mean-Label-Center",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 230,
+                "height": 240,
+                "zIndex": 226,
+                "left": 1085,
+                "top": 5,
+                "isVisible": true,
+                "right": 1315,
+                "bottom": 245
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 48,
+            "id": 48,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedMean": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": 0.33333333333333337,
+                                            "proportionY": 0.8607594936708861
+                                        },
+                                        {
+                                            "proportionX": 0.19135802469135804,
+                                            "proportionY": 0.4240506329113924
+                                        },
+                                        {
+                                            "proportionX": -0.012345679012345678,
+                                            "proportionY": -0.006329113924050633
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Mean-Labels-SplitY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 205,
+                "height": 220,
+                "zIndex": 224,
+                "left": 210,
+                "top": 250,
+                "isVisible": true,
+                "right": 415,
+                "bottom": 470
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 49,
+            "id": 49,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 0,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.AxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedMean": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": -0.49193548387096775,
+                                            "proportionY": 0.7844827586206896
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Mean-Labels-SplitTop",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 205,
+                "height": 220,
+                "zIndex": 183,
+                "left": 420,
+                "top": 250,
+                "isVisible": true,
+                "right": 625,
+                "bottom": 470
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 50,
+            "id": 50,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedMean": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": 0.4636363636363636,
+                                            "proportionY": 0.6724137931034483
+                                        },
+                                        {
+                                            "proportionX": 0.34545454545454546,
+                                            "proportionY": 0.33620689655172414
+                                        },
+                                        {
+                                            "proportionX": 0,
+                                            "proportionY": 0
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Mean-Labels-SplitLeftTop",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 205,
+                "height": 220,
+                "zIndex": 193,
+                "left": 630,
+                "top": 250,
+                "isVisible": true,
+                "right": 835,
+                "bottom": 470
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 51,
+            "id": 51,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedNormal": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": 0.45567602040816324,
+                                            "proportionY": 0.7547770700636943
+                                        },
+                                        {
+                                            "proportionX": 0.2263233418367347,
+                                            "proportionY": 0.37536617485017065
+                                        },
+                                        {
+                                            "proportionX": -0.0078125,
+                                            "proportionY": 0
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "Normal-Labels-SplitY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 220,
+                "zIndex": 266,
+                "left": 840,
+                "top": 250,
+                "isVisible": true,
+                "right": 1080,
+                "bottom": 470
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 52,
+            "id": 52,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 11
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 2,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellAxisModel",
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                },
+                                "multipleMovableValues": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "valueModels": []
+                                },
+                                "plottedStErr": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": 0.40912212072660675,
+                                            "proportionY": 0.8354430379746836
+                                        },
+                                        {
+                                            "proportionX": 0.38675378180985887,
+                                            "proportionY": 0.4306456759919159
+                                        }
+                                    ],
+                                    "numberOfStdErrs": 1
+                                },
+                                "plottedMean": {
+                                    "isVisible": true,
+                                    "enableMeasuresForSelection": false,
+                                    "equationCoordsArray": [
+                                        {
+                                            "proportionX": -0.0053475935828877,
+                                            "proportionY": 0.8590575470694609
+                                        },
+                                        {
+                                            "proportionX": 0,
+                                            "proportionY": 0.4537815126050421
+                                        },
+                                        {
+                                            "proportionX": 0,
+                                            "proportionY": 0
+                                        }
+                                    ]
+                                }
+                            },
+                            "showMeasureLabels": true
+                        },
+                        "plotClass": "DG.DotPlotModel"
+                    }
+                ],
+                "title": "MeanStdErr-Labels-SplitY",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 230,
+                "height": 220,
+                "zIndex": 215,
+                "left": 1085,
+                "top": 250,
+                "isVisible": true,
+                "right": 1315,
+                "bottom": 470
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 54,
+            "id": 54,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "multipleLSRLsStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "showSumSquares": false,
+                                "isInterceptLocked": false,
+                                "showConfidenceBands": false,
+                                "lsrls": [
+                                    {
+                                        "isVisible": true,
+                                        "enableMeasuresForSelection": false,
+                                        "isInterceptLocked": false,
+                                        "equationCoords": {
+                                            "proportionCenterX": 0.7009295287505405,
+                                            "proportionCenterY": 0.49053292202957127
+                                        },
+                                        "showConfidenceBands": false
+                                    }
+                                ]
+                            },
+                            "isLSRLVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LSRL-Label-TopRight",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 205,
+                "height": 220,
+                "zIndex": 264,
+                "left": 210,
+                "top": 475,
+                "isVisible": true,
+                "right": 415,
+                "bottom": 695
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 56,
+            "id": 56,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "multipleLSRLsStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "showSumSquares": false,
+                                "isInterceptLocked": false,
+                                "showConfidenceBands": false,
+                                "lsrls": [
+                                    {
+                                        "isVisible": true,
+                                        "enableMeasuresForSelection": false,
+                                        "isInterceptLocked": false,
+                                        "equationCoords": {
+                                            "proportionCenterX": 0.5061728395061729,
+                                            "proportionCenterY": 0.7689873417721519
+                                        },
+                                        "showConfidenceBands": false
+                                    }
+                                ]
+                            },
+                            "isLSRLVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LSRL-Label-BottomLeft",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 205,
+                "height": 220,
+                "zIndex": 276,
+                "left": 420,
+                "top": 475,
+                "isVisible": true,
+                "right": 625,
+                "bottom": 695
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 57,
+            "id": 57,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "legendColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "legendAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 2,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "lightgrey",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 0,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "multipleLSRLsStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "showSumSquares": false,
+                                "isInterceptLocked": false,
+                                "showConfidenceBands": false,
+                                "lsrls": [
+                                    {
+                                        "isVisible": true,
+                                        "enableMeasuresForSelection": false,
+                                        "isInterceptLocked": false,
+                                        "equationCoords": {
+                                            "proportionCenterX": 0.7857142857142857,
+                                            "proportionCenterY": 0.7857142857142857
+                                        },
+                                        "showConfidenceBands": false
+                                    },
+                                    {
+                                        "isVisible": true,
+                                        "enableMeasuresForSelection": false,
+                                        "isInterceptLocked": false,
+                                        "equationCoords": {
+                                            "proportionCenterX": 0.5,
+                                            "proportionCenterY": 0.6607142857142857
+                                        },
+                                        "showConfidenceBands": false
+                                    },
+                                    {
+                                        "isVisible": true,
+                                        "enableMeasuresForSelection": false,
+                                        "isInterceptLocked": false,
+                                        "equationCoords": {
+                                            "proportionCenterX": 0.49725274725274726,
+                                            "proportionCenterY": 0.4955357142857143
+                                        },
+                                        "showConfidenceBands": false
+                                    }
+                                ]
+                            },
+                            "isLSRLVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LSRL-Labels-Legend",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 205,
+                "height": 220,
+                "zIndex": 280,
+                "left": 630,
+                "top": 475,
+                "isVisible": true,
+                "right": 835,
+                "bottom": 695
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GraphView",
+            "guid": 58,
+            "id": 58,
+            "componentStorage": {
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 2
+                    },
+                    "hiddenCases": [],
+                    "xColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "xAttr": {
+                        "type": "DG.Attribute",
+                        "id": 6
+                    },
+                    "yColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "yAttr": {
+                        "type": "DG.Attribute",
+                        "id": 10
+                    },
+                    "topColl": {
+                        "type": "DG.Collection",
+                        "id": 3
+                    },
+                    "topAttr": {
+                        "type": "DG.Attribute",
+                        "id": 12
+                    }
+                },
+                "displayOnlySelected": false,
+                "legendRole": 0,
+                "legendAttributeType": 0,
+                "numberOfLegendQuantiles": 5,
+                "legendQuantilesAreLocked": false,
+                "pointColor": "#e6805b",
+                "strokeColor": "white",
+                "pointSizeMultiplier": 1,
+                "transparency": 0.85,
+                "strokeTransparency": 0.4,
+                "strokeSameAsFill": false,
+                "isTransparent": false,
+                "plotBackgroundColor": null,
+                "plotBackgroundOpacity": 1,
+                "plotBackgroundImage": null,
+                "plotBackgroundImageLockInfo": null,
+                "xRole": 1,
+                "xAttributeType": 1,
+                "yRole": 4,
+                "yAttributeType": 1,
+                "y2Role": 0,
+                "y2AttributeType": 0,
+                "topRole": 0,
+                "topAttributeType": 2,
+                "rightRole": 0,
+                "rightAttributeType": 0,
+                "xAxisClass": "DG.CellLinearAxisModel",
+                "xLowerBound": -5,
+                "xUpperBound": 95,
+                "yAxisClass": "DG.CellLinearAxisModel",
+                "yLowerBound": -10,
+                "yUpperBound": 130,
+                "y2AxisClass": "DG.AxisModel",
+                "topAxisClass": "DG.CellAxisModel",
+                "rightAxisClass": "DG.CellAxisModel",
+                "plotModels": [
+                    {
+                        "plotModelStorage": {
+                            "verticalAxisIsY2": false,
+                            "adornments": {
+                                "plottedCount": {
+                                    "isVisible": false,
+                                    "enableMeasuresForSelection": false,
+                                    "isShowingCount": false,
+                                    "isShowingPercent": false,
+                                    "percentKind": 1
+                                }
+                            },
+                            "multipleLSRLsStorage": {
+                                "isVisible": true,
+                                "enableMeasuresForSelection": false,
+                                "showSumSquares": false,
+                                "isInterceptLocked": false,
+                                "showConfidenceBands": false,
+                                "lsrls": [
+                                    {
+                                        "isVisible": true,
+                                        "enableMeasuresForSelection": false,
+                                        "isInterceptLocked": false,
+                                        "equationCoords": {
+                                            "proportionCenterX": 0.5232558139534884,
+                                            "proportionCenterY": 0.49489795918367346
+                                        },
+                                        "showConfidenceBands": false
+                                    }
+                                ]
+                            },
+                            "isLSRLVisible": true
+                        },
+                        "plotClass": "DG.ScatterPlotModel"
+                    }
+                ],
+                "title": "LSRL-Labels-SplitTop",
+                "userSetTitle": true,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 240,
+                "height": 220,
+                "zIndex": 286,
+                "left": 840,
+                "top": 475,
+                "isVisible": true,
+                "right": 1080,
+                "bottom": 695
+            },
+            "savedHeight": null
+        }
+    ],
+    "contexts": [
+        {
+            "type": "DG.DataContext",
+            "document": 1,
+            "guid": 2,
+            "id": 2,
+            "flexibleGroupingChangeFlag": false,
+            "name": "Mammals",
+            "title": "Mammals",
+            "collections": [
+                {
+                    "areParentChildLinksConfigured": false,
+                    "attrs": [
+                        {
+                            "name": "Mammal",
+                            "type": "none",
+                            "title": "Mammal",
+                            "cid": "id:WnIqDMHPdZeQ8o8e",
+                            "description": "The species of the mammal",
+                            "_categoryMap": {
+                                "__order": [
+                                    "African Elephant",
+                                    "Asian Elephant",
+                                    "Big Brown Bat",
+                                    "Bottlenose Dolphin",
+                                    "Cheetah",
+                                    "Chimpanzee",
+                                    "Domestic Cat",
+                                    "Donkey",
+                                    "Giraffe",
+                                    "Gray Wolf",
+                                    "Grey Seal",
+                                    "Ground Squirrel",
+                                    "Horse",
+                                    "House Mouse",
+                                    "Human",
+                                    "Jaguar",
+                                    "Killer Whale",
+                                    "Lion",
+                                    "N. American Opossum",
+                                    "Nine-Banded Armadillo",
+                                    "Owl Monkey",
+                                    "Patas Monkey",
+                                    "Pig",
+                                    "Pronghorn Antelope",
+                                    "Rabbit",
+                                    "Red Fox",
+                                    "Spotted Hyena"
+                                ],
+                                "African Elephant": "#FFB300",
+                                "Asian Elephant": "#803E75",
+                                "Big Brown Bat": "#FF6800",
+                                "Bottlenose Dolphin": "#A6BDD7",
+                                "Cheetah": "#C10020",
+                                "Chimpanzee": "#CEA262",
+                                "Domestic Cat": "#817066",
+                                "Donkey": "#007D34",
+                                "Giraffe": "#00538A",
+                                "Gray Wolf": "#F13A13",
+                                "Grey Seal": "#53377A",
+                                "Ground Squirrel": "#FF8E00",
+                                "Horse": "#B32851",
+                                "House Mouse": "#F4C800",
+                                "Human": "#7F180D",
+                                "Jaguar": "#93AA00",
+                                "Killer Whale": "#593315",
+                                "Lion": "#232C16",
+                                "N. American Opossum": "#FF7A5C",
+                                "Nine-Banded Armadillo": "#F6768E",
+                                "Owl Monkey": "#FFB300",
+                                "Patas Monkey": "#803E75",
+                                "Pig": "#FF6800",
+                                "Pronghorn Antelope": "#A6BDD7",
+                                "Rabbit": "#C10020",
+                                "Red Fox": "#CEA262",
+                                "Spotted Hyena": "#817066"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 4,
+                            "id": 4,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Order",
+                            "type": "none",
+                            "title": "Order",
+                            "cid": "id:b199PwdCYoYUWotE",
+                            "description": "The order of the mammal",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 5,
+                            "id": 5,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "LifeSpan",
+                            "type": "numeric",
+                            "title": "LifeSpan",
+                            "cid": "id:pDLcgGkz1mo9gmQp",
+                            "description": "",
+                            "_categoryMap": {
+                                "3": "#00538A",
+                                "5": "#F4C800",
+                                "7": "#593315",
+                                "9": "#007D34",
+                                "10": "#7F180D",
+                                "12": "#93AA00",
+                                "14": "#A6BDD7",
+                                "15": "#B32851",
+                                "16": "#CEA262",
+                                "19": "#803E75",
+                                "20": "#53377A",
+                                "25": "#FF6800",
+                                "30": "#817066",
+                                "40": "#C10020",
+                                "50": "#FF8E00",
+                                "70": "#FFB300",
+                                "80": "#F13A13",
+                                "__order": [
+                                    "10",
+                                    "12",
+                                    "14",
+                                    "15",
+                                    "16",
+                                    "19",
+                                    "20",
+                                    "25",
+                                    "3",
+                                    "30",
+                                    "40",
+                                    "5",
+                                    "50",
+                                    "7",
+                                    "70",
+                                    "80",
+                                    "9"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 6,
+                            "id": 6,
+                            "precision": 2,
+                            "unit": "years"
+                        },
+                        {
+                            "name": "Height",
+                            "type": "none",
+                            "title": "Height",
+                            "cid": "id:lzLJOzAcO6Ner-VN",
+                            "description": "The average height of the mammal.",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 7,
+                            "id": 7,
+                            "precision": 2,
+                            "unit": "meters"
+                        },
+                        {
+                            "name": "Mass",
+                            "type": "numeric",
+                            "title": "Mass",
+                            "cid": "id:BR6LZDwZgYCuhjPs",
+                            "description": "The mass of the mammal",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 8,
+                            "id": 8,
+                            "precision": 2,
+                            "unit": "kg"
+                        },
+                        {
+                            "name": "Sleep",
+                            "type": "numeric",
+                            "title": "Sleep",
+                            "cid": "id:2NO7QbQ-FwBakWhC",
+                            "description": "The number of hours the animal sleeps in a 24 hour period",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 9,
+                            "id": 9,
+                            "precision": 2,
+                            "unit": "hours"
+                        },
+                        {
+                            "name": "Speed",
+                            "type": "none",
+                            "title": "Speed",
+                            "cid": "id:HR3FcppJ9w9VKzyO",
+                            "description": "The average speed of the mammal.",
+                            "_categoryMap": {
+                                "1": "#B32851",
+                                "13": "#007D34",
+                                "18": "#7F180D",
+                                "19": "#CEA262",
+                                "37": "#803E75",
+                                "40": "#FF6800",
+                                "45": "#00538A",
+                                "48": "#53377A",
+                                "50": "#FFB300",
+                                "55": "#F4C800",
+                                "56": "#593315",
+                                "60": "#F13A13",
+                                "64": "#C10020",
+                                "69": "#817066",
+                                "80": "#FF8E00",
+                                "98": "#93AA00",
+                                "110": "#A6BDD7",
+                                "__order": [
+                                    "1",
+                                    "13",
+                                    "18",
+                                    "19",
+                                    "37",
+                                    "40",
+                                    "45",
+                                    "48",
+                                    "50",
+                                    "55",
+                                    "56",
+                                    "60",
+                                    "64",
+                                    "69",
+                                    "80",
+                                    "98",
+                                    "110"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 10,
+                            "id": 10,
+                            "precision": 2,
+                            "unit": "km/h"
+                        },
+                        {
+                            "name": "Habitat",
+                            "type": null,
+                            "title": "Habitat",
+                            "cid": "id:7WY17cbx_s_2ULni",
+                            "description": "",
+                            "_categoryMap": {
+                                "land": {
+                                    "h": 0.4444444444444444,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(85,255,198)"
+                                },
+                                "water": {
+                                    "h": 0.711111111111111,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(130,85,255)"
+                                },
+                                "both": {
+                                    "h": 0.9777777777777777,
+                                    "s": 0.6666666666666666,
+                                    "b": 1,
+                                    "colorString": "rgb(255,85,108)"
+                                },
+                                "__order": [
+                                    "land",
+                                    "water",
+                                    "both"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 11,
+                            "id": 11,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "Diet",
+                            "type": null,
+                            "title": "Diet",
+                            "cid": "id:WZLuWyRlDnAZsA20",
+                            "description": "",
+                            "_categoryMap": {
+                                "__order": [
+                                    "both",
+                                    "meat",
+                                    "plants"
+                                ],
+                                "plants": "#FFB300",
+                                "meat": "#803E75",
+                                "both": "#FF6800"
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": true,
+                            "hidden": false,
+                            "renameable": true,
+                            "deleteable": true,
+                            "guid": 12,
+                            "id": 12,
+                            "precision": 2,
+                            "unit": null
+                        }
+                    ],
+                    "cases": [
+                        {
+                            "guid": 13,
+                            "id": 13,
+                            "itemID": "id:4DiTjn4qPrzc9cer",
+                            "values": {
+                                "Mammal": "African Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 4,
+                                "Mass": 6400,
+                                "Sleep": 3,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 14,
+                            "id": 14,
+                            "itemID": "id:MUfUW6xPY1FSSULf",
+                            "values": {
+                                "Mammal": "Asian Elephant",
+                                "Order": "Proboscidae",
+                                "LifeSpan": 70,
+                                "Height": 3,
+                                "Mass": 5000,
+                                "Sleep": 4,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 15,
+                            "id": 15,
+                            "itemID": "id:nY2QnpmqOW68u58F",
+                            "values": {
+                                "Mammal": "Big Brown Bat",
+                                "Order": "Chiroptera",
+                                "LifeSpan": 19,
+                                "Height": 0.1,
+                                "Mass": 0.02,
+                                "Sleep": 20,
+                                "Speed": 40,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 16,
+                            "id": 16,
+                            "itemID": "id:qlB0IRf35QNqzwdV",
+                            "values": {
+                                "Mammal": "Bottlenose Dolphin",
+                                "Order": "Cetacea",
+                                "LifeSpan": 25,
+                                "Height": 3.5,
+                                "Mass": 635,
+                                "Sleep": 5,
+                                "Speed": 37,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 17,
+                            "id": 17,
+                            "itemID": "id:RI2V_fbx29-foXcz",
+                            "values": {
+                                "Mammal": "Cheetah",
+                                "Order": "Carnivora",
+                                "LifeSpan": 14,
+                                "Height": 1.5,
+                                "Mass": 50,
+                                "Sleep": 12,
+                                "Speed": 110,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 18,
+                            "id": 18,
+                            "itemID": "id:sl1g9jzNu517QAX3",
+                            "values": {
+                                "Mammal": "Chimpanzee",
+                                "Order": "Primate",
+                                "LifeSpan": 40,
+                                "Height": 1.5,
+                                "Mass": 68,
+                                "Sleep": 10,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 19,
+                            "id": 19,
+                            "itemID": "id:llBXjzGpj2v0O6Bu",
+                            "values": {
+                                "Mammal": "Domestic Cat",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 0.8,
+                                "Mass": 4.5,
+                                "Sleep": 12,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 20,
+                            "id": 20,
+                            "itemID": "id:IEhUCUROiVxsQ8XA",
+                            "values": {
+                                "Mammal": "Donkey",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 40,
+                                "Height": 1.2,
+                                "Mass": 187,
+                                "Sleep": 3,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 21,
+                            "id": 21,
+                            "itemID": "id:yILdJW1Y0gA4KRJu",
+                            "values": {
+                                "Mammal": "Giraffe",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 25,
+                                "Height": 5,
+                                "Mass": 1100,
+                                "Sleep": 2,
+                                "Speed": 50,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 22,
+                            "id": 22,
+                            "itemID": "id:ws3gDpYZWt6sNa4M",
+                            "values": {
+                                "Mammal": "Gray Wolf",
+                                "Order": "Carnivora",
+                                "LifeSpan": 16,
+                                "Height": 1.6,
+                                "Mass": 80,
+                                "Sleep": 13,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 23,
+                            "id": 23,
+                            "itemID": "id:FDGJb2qq4tuHPMjU",
+                            "values": {
+                                "Mammal": "Grey Seal",
+                                "Order": "Pinnipedia",
+                                "LifeSpan": 30,
+                                "Height": 2.1,
+                                "Mass": 275,
+                                "Sleep": 6,
+                                "Speed": 19,
+                                "Habitat": "both",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 24,
+                            "id": 24,
+                            "itemID": "id:vfHjTg4Crsi4qt3-",
+                            "values": {
+                                "Mammal": "Ground Squirrel",
+                                "Order": "Rodentia",
+                                "LifeSpan": 9,
+                                "Height": 0.3,
+                                "Mass": 0.1,
+                                "Sleep": 15,
+                                "Speed": 19,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 25,
+                            "id": 25,
+                            "itemID": "id:85bNrURsW8l0p2m2",
+                            "values": {
+                                "Mammal": "Horse",
+                                "Order": "Perissodactyla",
+                                "LifeSpan": 25,
+                                "Height": 1.5,
+                                "Mass": 521,
+                                "Sleep": 3,
+                                "Speed": 69,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 26,
+                            "id": 26,
+                            "itemID": "id:PXsjncrZbS_HBU9k",
+                            "values": {
+                                "Mammal": "House Mouse",
+                                "Order": "Rodentia",
+                                "LifeSpan": 3,
+                                "Height": 0.1,
+                                "Mass": 0.03,
+                                "Sleep": 12,
+                                "Speed": 13,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 27,
+                            "id": 27,
+                            "itemID": "id:vf9pOFOdFW6MqJ7T",
+                            "values": {
+                                "Mammal": "Human",
+                                "Order": "Primate",
+                                "LifeSpan": 80,
+                                "Height": 1.9,
+                                "Mass": 80,
+                                "Sleep": 8,
+                                "Speed": 45,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 28,
+                            "id": 28,
+                            "itemID": "id:S6moKAA_AWW1nzry",
+                            "values": {
+                                "Mammal": "Jaguar",
+                                "Order": "Carnivora",
+                                "LifeSpan": 20,
+                                "Height": 1.8,
+                                "Mass": 115,
+                                "Sleep": 11,
+                                "Speed": 60,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 29,
+                            "id": 29,
+                            "itemID": "id:3KN2htqgg6fnUHyT",
+                            "values": {
+                                "Mammal": "Killer Whale",
+                                "Order": "Cetacea",
+                                "LifeSpan": 50,
+                                "Height": 6.5,
+                                "Mass": 4000,
+                                "Sleep": "",
+                                "Speed": 48,
+                                "Habitat": "water",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 30,
+                            "id": 30,
+                            "itemID": "id:cgmzq6wnYqJR7sNR",
+                            "values": {
+                                "Mammal": "Lion",
+                                "Order": "Carnivora",
+                                "LifeSpan": 15,
+                                "Height": 2.5,
+                                "Mass": 250,
+                                "Sleep": 20,
+                                "Speed": 80,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 31,
+                            "id": 31,
+                            "itemID": "id:6y0LzR2abM2KCBDs",
+                            "values": {
+                                "Mammal": "N. American Opossum",
+                                "Order": "Didelphimorphia",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 5,
+                                "Sleep": 19,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 32,
+                            "id": 32,
+                            "itemID": "id:dB0nNA9CY1TuUiRA",
+                            "values": {
+                                "Mammal": "Nine-Banded Armadillo",
+                                "Order": "Xenarthra",
+                                "LifeSpan": 10,
+                                "Height": 0.6,
+                                "Mass": 7,
+                                "Sleep": 17,
+                                "Speed": 1,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        },
+                        {
+                            "guid": 33,
+                            "id": 33,
+                            "itemID": "id:vdE0Bk-Mdir9-kGF",
+                            "values": {
+                                "Mammal": "Owl Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 12,
+                                "Height": 0.4,
+                                "Mass": 1,
+                                "Sleep": 17,
+                                "Speed": "",
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 34,
+                            "id": 34,
+                            "itemID": "id:NZOcUw2vglQpGX8K",
+                            "values": {
+                                "Mammal": "Patas Monkey",
+                                "Order": "Primate",
+                                "LifeSpan": 20,
+                                "Height": 0.9,
+                                "Mass": 13,
+                                "Sleep": "",
+                                "Speed": 55,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 35,
+                            "id": 35,
+                            "itemID": "id:fxVFC289ARimyYm2",
+                            "values": {
+                                "Mammal": "Pig",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 1,
+                                "Mass": 192,
+                                "Sleep": 8,
+                                "Speed": 18,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 36,
+                            "id": 36,
+                            "itemID": "id:Q7J42jBWQP8PCIXW",
+                            "values": {
+                                "Mammal": "Pronghorn Antelope",
+                                "Order": "Artiodactyla",
+                                "LifeSpan": 10,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": "",
+                                "Speed": 98,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 37,
+                            "id": 37,
+                            "itemID": "id:9eQgA4eqxmZgCh-f",
+                            "values": {
+                                "Mammal": "Rabbit",
+                                "Order": "Lagomorpha",
+                                "LifeSpan": 5,
+                                "Height": 0.5,
+                                "Mass": 3,
+                                "Sleep": 11,
+                                "Speed": 56,
+                                "Habitat": "land",
+                                "Diet": "plants"
+                            }
+                        },
+                        {
+                            "guid": 38,
+                            "id": 38,
+                            "itemID": "id:KNjgPF4csEJEoZMU",
+                            "values": {
+                                "Mammal": "Red Fox",
+                                "Order": "Carnivora",
+                                "LifeSpan": 7,
+                                "Height": 0.8,
+                                "Mass": 5,
+                                "Sleep": 10,
+                                "Speed": 48,
+                                "Habitat": "land",
+                                "Diet": "both"
+                            }
+                        },
+                        {
+                            "guid": 39,
+                            "id": 39,
+                            "itemID": "id:6Ssbg8pNQ2b3jDiL",
+                            "values": {
+                                "Mammal": "Spotted Hyena",
+                                "Order": "Carnivora",
+                                "LifeSpan": 25,
+                                "Height": 0.9,
+                                "Mass": 70,
+                                "Sleep": 18,
+                                "Speed": 64,
+                                "Habitat": "land",
+                                "Diet": "meat"
+                            }
+                        }
+                    ],
+                    "caseName": null,
+                    "childAttrName": null,
+                    "collapseChildren": null,
+                    "guid": 3,
+                    "id": 3,
+                    "name": "Mammals",
+                    "title": "Mammals",
+                    "type": "DG.Collection"
+                }
+            ],
+            "description": "",
+            "metadata": null,
+            "preventReorg": false,
+            "setAsideItems": [],
+            "contextStorage": {
+                "_links_": {
+                    "selectedCases": []
+                }
+            }
+        }
+    ],
+    "globalValues": [],
+    "appName": "DG",
+    "appVersion": "2.0",
+    "appBuildNum": "0733",
+    "lang": "en",
+    "idCount": 58,
+    "metadata": {}
+}

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -343,13 +343,9 @@ interface ICodapV2VerticalMovableLineAdornment extends ICodapV2MovableLineAdornm
 
 export type ICodapV2MovableLineAdornment = ICodapV2NormalMovableLineAdornment | ICodapV2VerticalMovableLineAdornment
 
-interface ICodapV2LSRLInstance extends ICodapV2Adornment {
+export interface ICodapV2LSRLInstance extends ICodapV2Adornment {
   // this is a graph-wide property that is redundantly stored with each instance
   isInterceptLocked: boolean
-  // TODO_V2_IMPORT: equationCoords are not handled correctly, the import code assumes they have
-  // an x and y instead of proportionCenterX and proportionCenterY
-  // There are 4,000 instances of this in cfm-shared
-  // example: cfm-shared/00JG6PytJ4Zfhk3Yw4Xf/file.json
   equationCoords?: ICodapV2ProportionCenterEquationCoords | null,
   // this is an adornment-wide property that is redundantly stored with each instance
   showConfidenceBands?: boolean
@@ -358,6 +354,7 @@ interface ICodapV2LSRLInstance extends ICodapV2Adornment {
 export interface ICodapV2MultipleLSRLAdornments extends ICodapV2Adornment {
   // seems to be redundant with the `areSquaresVisible` property stored in plotModelStorage
   showSumSquares?: boolean
+  // this is a graph-wide property that is redundantly stored with each adornment and instance
   isInterceptLocked: boolean
   showConfidenceBands?: boolean
   lsrls?: ICodapV2LSRLInstance[]


### PR DESCRIPTION
This turned into more of an odyssey than expected. The existing LSRL code treated label positions as absolute coordinates rather than proportions, similar to the measure labels handled earlier. Unlike measure labels, however, LSRL labels split on legend categories. The existing LSRL code handled this with arrays, which embedded a problematic dependency on category order. The existing LSRL code also failed to include units in its regression equations. In addition, v2 made things more complicated by 1) storing label positions as relative position of the center of the label (rather than top-left as was true for measures), which embeds a dependency on label size, which means you have to have a rendering engine to determine the placement; and 2) having a bug in which the wrong height is used when performing the aforementioned label placement computations.

The result is that this PR:
- fixes import of LSRL label positions
- tracks LSRL label positions imported from v2 for adjustment
- changes internal representation of LSRL label instances to be a map keyed by category
- changes rendering of LSRL label positions to be proportional
- includes units in LSRL equation strings when available
- exports LSRL label positions correctly
- reverses (approximately) the v2 height computation bug
- factors out some redundancy in the v2 adornment importer's `instanceKeysForAdornments()` function
- restores the behavior of the `DataConfigurationModel.categoryArrayForAttrRole()` method that it returns the client-provided empty array value when there are no categories (lost in #1707)