### PR TITLE
chore: downgrade chakra-ui

### DIFF
--- a/v3/eslint.config.mjs
+++ b/v3/eslint.config.mjs
@@ -103,7 +103,7 @@ export default [{
     "curly": ["error", "multi-line", "consistent"],
     "dot-notation": "error",
     "eqeqeq": ["error", "smart"],
-    "import/no-cycle": "warn",
+    "import/no-cycle": ["warn", { ignoreExternal: true, disableScc: true }],
     "import/no-extraneous-dependencies": "warn",
     "import/no-useless-path-segments": "warn",
     "no-bitwise": "error",

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
-        "@chakra-ui/react": "~2.9.5",
+        "@chakra-ui/react": "~2.8.2",
         "@codemirror/autocomplete": "^6.18.2",
         "@codemirror/commands": "^6.7.1",
         "@codemirror/language": "^6.10.3",
@@ -2048,24 +2048,313 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@chakra-ui/anatomy": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.3.tgz",
-      "integrity": "sha512-Sy2VAG0WrzkQE40Y0fY406c6AlyqFxAc7j6fDz8Wwotz9veAvm+y5UgFUyhZ6FoYNAjDMPQ7JCcN7OGz74pNlA==",
-      "license": "MIT"
-    },
-    "node_modules/@chakra-ui/hooks": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.3.3.tgz",
-      "integrity": "sha512-nvqQfR+u0qAJ2/mdGF1XTrnfW9WahSsOc62E/xtRm5hPClfkxPCIXDuw0C17lZ2RYfg/hxsYKLJCGnQWZcC/7w==",
+    "node_modules/@chakra-ui/accordion": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.3.1.tgz",
+      "integrity": "sha512-FSXRm8iClFyU+gVaXisOSEw0/4Q+qZbFRiuhIAkVU6Boj0FxAMrlo9a8AV5TuF77rgaHytCdHk0Ng+cyUijrag==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/utils": "2.1.3",
-        "@zag-js/element-size": "0.31.1",
-        "copy-to-clipboard": "3.3.3",
-        "framesync": "6.1.2"
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
       },
       "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/alert": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.2.2.tgz",
+      "integrity": "sha512-jHg4LYMRNOJH830ViLuicjb3F+v6iriE/2G5T+Sd0Hna04nukNJ1MxUmBPE+vI22me2dIflfelu2v9wdB6Pojw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/anatomy": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.2.tgz",
+      "integrity": "sha512-MV6D4VLRIHr4PkW4zMyqfrNS1mPlCTiCXwvYGtDFQYr+xHFfonhAuf9WjsSc0nyp2m0OdkSLnzmVKkZFLo25Tg==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/avatar": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.3.0.tgz",
+      "integrity": "sha512-8gKSyLfygnaotbJbDMHDiJoF38OHXUYVme4gGxZ1fLnQEdPVEaIWfH+NndIjOM0z8S+YEFnT9KyGMUtvPrBk3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/breadcrumb": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.2.0.tgz",
+      "integrity": "sha512-4cWCG24flYBxjruRi4RJREWTGF74L/KzI2CognAW/d/zWR0CjiScuJhf37Am3LFbCySP6WSoyBOtTIoTA4yLEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/breakpoint-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breakpoint-utils/-/breakpoint-utils-2.0.8.tgz",
+      "integrity": "sha512-Pq32MlEX9fwb5j5xx8s18zJMARNHlQZH2VH1RZgfgRDpp7DcEgtRW5AInfN5CfqdHLO1dGxA7I3MqEuL5JnIsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "node_modules/@chakra-ui/button": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.1.0.tgz",
+      "integrity": "sha512-95CplwlRKmmUXkdEp/21VkEWgnwcx2TOBG6NfYlsuLBDHSLlo5FKIiE2oSi4zXc4TLcopGcWPNcm/NDaSC5pvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/card": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.2.0.tgz",
+      "integrity": "sha512-xUB/k5MURj4CtPAhdSoXZidUbm8j3hci9vnc+eZJVDqhDOShNlD6QeniQNRPRys4lWAQLCbFcrwL29C8naDi6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/checkbox": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.3.2.tgz",
+      "integrity": "sha512-85g38JIXMEv6M+AcyIGLh7igNtfpAN6KGQFYxY9tBj0eWvWk4NKQxvqqyVta0bSAyIl1rixNIIezNpNWk2iO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/visually-hidden": "2.2.0",
+        "@zag-js/focus-visible": "0.16.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/clickable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.1.0.tgz",
+      "integrity": "sha512-flRA/ClPUGPYabu+/GLREZVZr9j2uyyazCAUHAdrTUEdDYCr31SVGhgh7dgKdtq23bOvAQJpIJjw/0Bs0WvbXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/close-button": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.1.1.tgz",
+      "integrity": "sha512-gnpENKOanKexswSVpVz7ojZEALl2x5qjLYNqSQGbxz+aP9sOXPfUS56ebyBrre7T7exuWGiFeRwnM0oVeGPaiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/color-mode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.2.0.tgz",
+      "integrity": "sha512-niTEA8PALtMWRI9wJ4LL0CSBDo8NBfLNp4GD6/0hstcm3IlbBHTVKxN6HwSaoNYfphDQLxCjT4yG+0BJA5tFpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/control-box": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.1.0.tgz",
+      "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/counter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.1.0.tgz",
+      "integrity": "sha512-s6hZAEcWT5zzjNz2JIWUBzRubo9la/oof1W7EKZVVfPYHERnl5e16FmBC79Yfq8p09LQ+aqFKm/etYoJMMgghw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/css-reset": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.3.0.tgz",
+      "integrity": "sha512-cQwwBy5O0jzvl0K7PLTLgp8ijqLPKyuEMiDXwYzl95seD3AoeuoCLyzZcJtVqaUZ573PiBdAbY/IlZcwDOItWg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@emotion/react": ">=10.0.35",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/descendant": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.1.0.tgz",
+      "integrity": "sha512-VxCIAir08g5w27klLyi7PVo8BxhW4tgU/lxQyujkmi4zx7hT9ZdrcQLAted/dAa+aSIZ14S1oV0Q9lGjsAdxUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/dom-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.1.0.tgz",
+      "integrity": "sha512-ZmF2qRa1QZ0CMLU8M1zCfmw29DmPNtfjR9iTo74U5FPr3i1aoAh7fbJ4qAlZ197Xw9eAW28tvzQuoVWeL5C7fQ==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/editable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.1.0.tgz",
+      "integrity": "sha512-j2JLrUL9wgg4YA6jLlbU88370eCRyor7DZQD9lzpY95tSOXpTljeg3uF9eOmDnCs6fxp3zDWIfkgMm/ExhcGTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/event-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/event-utils/-/event-utils-2.0.8.tgz",
+      "integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/focus-lock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.1.0.tgz",
+      "integrity": "sha512-EmGx4PhWGjm4dpjRqM4Aa+rCWBxP+Rq8Uc/nAVnD4YVqkEhBkrPTpui2lnjsuxqNaZ24fIAZ10cF1hlpemte/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "react-focus-lock": "^2.9.4"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/form-control": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.2.0.tgz",
+      "integrity": "sha512-wehLC1t4fafCVJ2RvJQT2jyqsAwX7KymmiGqBu7nQoQz8ApTkGABWpo/QwDh3F/dBLrouHDoOvGmYTqft3Mirw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/hooks": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.2.1.tgz",
+      "integrity": "sha512-RQbTnzl6b1tBjbDPf9zGRo9rf/pQMholsOudTxjy4i9GfTfz6kgp5ValGjQm2z7ng6Z31N1cnjZ1AlSzQ//ZfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/utils": "2.0.15",
+        "compute-scroll-into-view": "3.0.3",
+        "copy-to-clipboard": "3.3.3"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icon": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.2.0.tgz",
+      "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
         "react": ">=18"
       }
     },
@@ -2078,81 +2367,941 @@
         "react": ">=18"
       }
     },
-    "node_modules/@chakra-ui/react": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.9.5.tgz",
-      "integrity": "sha512-g4CIow3I424Va6f/v5wIA+6nAbvsALARST/uqUmGMJJ4qDa95FpJx0XNJzlcFABBkuNDWplciCTUL0whKReL9w==",
+    "node_modules/@chakra-ui/image": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.1.0.tgz",
+      "integrity": "sha512-bskumBYKLiLMySIWDGcz0+D9Th0jPvmX6xnRMs4o92tT3Od/bW26lahmV2a2Op2ItXeCmRMY+XxJH5Gy1i46VA==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/hooks": "2.3.3",
-        "@chakra-ui/styled-system": "2.10.3",
-        "@chakra-ui/theme": "3.4.3",
-        "@chakra-ui/utils": "2.1.3",
-        "@popperjs/core": "^2.11.8",
-        "@zag-js/focus-visible": "^0.31.1",
-        "aria-hidden": "^1.2.3",
-        "react-fast-compare": "3.2.2",
-        "react-focus-lock": "^2.9.6",
-        "react-lorem-component": "^0.13.0",
-        "react-remove-scroll": "^2.5.7"
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
-        "@emotion/react": ">=11",
-        "@emotion/styled": ">=11",
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/input": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.1.2.tgz",
+      "integrity": "sha512-GiBbb3EqAA8Ph43yGa6Mc+kUPjh4Spmxp1Pkelr8qtudpc3p2PJOOebLpd90mcqw8UePPa+l6YhhPtp6o0irhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/layout": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.3.1.tgz",
+      "integrity": "sha512-nXuZ6WRbq0WdgnRgLw+QuxWAHuhDtVX8ElWqcTK+cSMFg/52eVP47czYBE5F35YhnoW2XBwfNoNgZ7+e8Z01Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/lazy-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/lazy-utils/-/lazy-utils-2.0.5.tgz",
+      "integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/live-region": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.1.0.tgz",
+      "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/media-query": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.3.0.tgz",
+      "integrity": "sha512-IsTGgFLoICVoPRp9ykOgqmdMotJG0CnPsKvGQeSFOB/dZfIujdVb14TYxDU4+MURXry1MhJ7LzZhv+Ml7cr8/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/menu": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.2.1.tgz",
+      "integrity": "sha512-lJS7XEObzJxsOwWQh7yfG4H8FzFPRP5hVPN/CL+JzytEINCSBvsCDHrYPQGp7jzpCi8vnTqQQGQe0f8dwnXd2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-outside-click": "2.2.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/modal": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.3.1.tgz",
+      "integrity": "sha512-TQv1ZaiJMZN+rR9DK0snx/OPwmtaGH1HbZtlYt4W4s6CzyK541fxLRTjIXfEzIGpvNW+b6VFuFjbcR78p4DEoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0",
+        "aria-hidden": "^1.2.3",
+        "react-remove-scroll": "^2.5.6"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
         "framer-motion": ">=4.0.0",
         "react": ">=18",
         "react-dom": ">=18"
       }
     },
-    "node_modules/@chakra-ui/styled-system": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.10.3.tgz",
-      "integrity": "sha512-rU4sG712pnp3Qrc8XT5AKcMhZjByXp1IrErLJ8wmiez2v8hAl/Dv8roK2BTqd4GfkJOrtkyfq2e2ZcDWjbd9Dw==",
+    "node_modules/@chakra-ui/number-input": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.1.2.tgz",
+      "integrity": "sha512-pfOdX02sqUN0qC2ysuvgVDiws7xZ20XDIlcNhva55Jgm095xjm8eVdIBfNm3SFbSUNxyXvLTW/YQanX74tKmuA==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/utils": "2.1.3",
-        "csstype": "^3.1.2"
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-interval": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/number-utils": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-utils/-/number-utils-2.0.7.tgz",
+      "integrity": "sha512-yOGxBjXNvLTBvQyhMDqGU0Oj26s91mbAlqKHiuw737AXHt0aPllOthVUqQMeaYLwLCjGMg0jtI7JReRzyi94Dg==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/object-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/object-utils/-/object-utils-2.1.0.tgz",
+      "integrity": "sha512-tgIZOgLHaoti5PYGPTwK3t/cqtcycW0owaiOXoZOcpwwX/vlVb+H1jFsQyWiiwQVPt9RkoSLtxzXamx+aHH+bQ==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/pin-input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.1.0.tgz",
+      "integrity": "sha512-x4vBqLStDxJFMt+jdAHHS8jbh294O53CPQJoL4g228P513rHylV/uPscYUHrVJXRxsHfRztQO9k45jjTYaPRMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/popover": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.2.1.tgz",
+      "integrity": "sha512-K+2ai2dD0ljvJnlrzesCDT9mNzLifE3noGKZ3QwLqd/K34Ym1W/0aL1ERSynrcG78NKoXS54SdEzkhCZ4Gn/Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/popper": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.1.0.tgz",
+      "integrity": "sha512-ciDdpdYbeFG7og6/6J8lkTFxsSvwTdMLFkpVylAF6VNC22jssiWfquj2eyD4rJnzkRFPvIWJq8hvbfhsm+AjSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@popperjs/core": "^2.9.3"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/portal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.1.0.tgz",
+      "integrity": "sha512-9q9KWf6SArEcIq1gGofNcFPSWEyl+MfJjEUg/un1SMlQjaROOh3zYr+6JAwvcORiX7tyHosnmWC3d3wI2aPSQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/progress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.2.0.tgz",
+      "integrity": "sha512-qUXuKbuhN60EzDD9mHR7B67D7p/ZqNS2Aze4Pbl1qGGZfulPW0PY8Rof32qDtttDQBkzQIzFGE8d9QpAemToIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/provider": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.4.2.tgz",
+      "integrity": "sha512-w0Tef5ZCJK1mlJorcSjItCSbyvVuqpvyWdxZiVQmE6fvSJR83wZof42ux0+sfWD+I7rHSfj+f9nzhNaEWClysw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/css-reset": "2.3.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/system": "2.6.2",
+        "@chakra-ui/utils": "2.0.15"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/radio": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.1.2.tgz",
+      "integrity": "sha512-n10M46wJrMGbonaghvSRnZ9ToTv/q76Szz284gv4QUWvyljQACcGrXIONUnQ3BIwbOfkRqSk7Xl/JgZtVfll+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@zag-js/focus-visible": "0.16.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.8.2.tgz",
+      "integrity": "sha512-Hn0moyxxyCDKuR9ywYpqgX8dvjqwu9ArwpIb9wHNYjnODETjLwazgNIliCVBRcJvysGRiV51U2/JtJVrpeCjUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/accordion": "2.3.1",
+        "@chakra-ui/alert": "2.2.2",
+        "@chakra-ui/avatar": "2.3.0",
+        "@chakra-ui/breadcrumb": "2.2.0",
+        "@chakra-ui/button": "2.1.0",
+        "@chakra-ui/card": "2.2.0",
+        "@chakra-ui/checkbox": "2.3.2",
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/control-box": "2.1.0",
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/css-reset": "2.3.0",
+        "@chakra-ui/editable": "3.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/hooks": "2.2.1",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/input": "2.1.2",
+        "@chakra-ui/layout": "2.3.1",
+        "@chakra-ui/live-region": "2.1.0",
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/menu": "2.2.1",
+        "@chakra-ui/modal": "2.3.1",
+        "@chakra-ui/number-input": "2.1.2",
+        "@chakra-ui/pin-input": "2.1.0",
+        "@chakra-ui/popover": "2.2.1",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/progress": "2.2.0",
+        "@chakra-ui/provider": "2.4.2",
+        "@chakra-ui/radio": "2.1.2",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/select": "2.1.2",
+        "@chakra-ui/skeleton": "2.1.0",
+        "@chakra-ui/skip-nav": "2.1.0",
+        "@chakra-ui/slider": "2.1.0",
+        "@chakra-ui/spinner": "2.1.0",
+        "@chakra-ui/stat": "2.1.1",
+        "@chakra-ui/stepper": "2.3.1",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/switch": "2.1.2",
+        "@chakra-ui/system": "2.6.2",
+        "@chakra-ui/table": "2.1.0",
+        "@chakra-ui/tabs": "3.0.0",
+        "@chakra-ui/tag": "3.1.1",
+        "@chakra-ui/textarea": "2.1.2",
+        "@chakra-ui/theme": "3.3.1",
+        "@chakra-ui/theme-utils": "2.0.21",
+        "@chakra-ui/toast": "7.0.2",
+        "@chakra-ui/tooltip": "2.3.1",
+        "@chakra-ui/transition": "2.1.0",
+        "@chakra-ui/utils": "2.0.15",
+        "@chakra-ui/visually-hidden": "2.2.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-children-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
+      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-context": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.1.0.tgz",
+      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-env": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.1.0.tgz",
+      "integrity": "sha512-Vr96GV2LNBth3+IKzr/rq1IcnkXv+MLmwjQH6C8BRtn3sNskgDFD5vLkVXcEhagzZMCh8FR3V/bzZPojBOyNhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
+      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-animation-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.1.0.tgz",
+      "integrity": "sha512-CFZkQU3gmDBwhqy0vC1ryf90BVHxVN8cTLpSyCpdmExUEtSEInSCGMydj2fvn7QXsz/za8JNdO2xxgJwxpLMtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-callback-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.1.0.tgz",
+      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-controllable-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.1.0.tgz",
+      "integrity": "sha512-QR/8fKNokxZUs4PfxjXuwl0fj/d71WPrmLJvEpCTkHjnzu7LnYvzoe2wB867IdooQJL0G1zBxl0Dq+6W1P3jpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-disclosure": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.1.0.tgz",
+      "integrity": "sha512-Ax4pmxA9LBGMyEZJhhUZobg9C0t3qFE4jVF1tGBsrLDcdBeLR9fwOogIPY9Hf0/wqSlAryAimICbr5hkpa5GSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-event-listener": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.1.0.tgz",
+      "integrity": "sha512-U5greryDLS8ISP69DKDsYcsXRtAdnTQT+jjIlRYZ49K/XhUR/AqVZCK5BkR1spTDmO9H8SPhgeNKI70ODuDU/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-focus-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.1.0.tgz",
+      "integrity": "sha512-xzVboNy7J64xveLcxTIJ3jv+lUJKDwRM7Szwn9tNzUIPD94O3qwjV7DDCUzN2490nSYDF4OBMt/wuDBtaR3kUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-focus-on-pointer-down": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.1.0.tgz",
+      "integrity": "sha512-2jzrUZ+aiCG/cfanrolsnSMDykCAbv9EK/4iUyZno6BYb3vziucmvgKuoXbMPAzWNtwUwtuMhkby8rc61Ue+Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-interval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.1.0.tgz",
+      "integrity": "sha512-8iWj+I/+A0J08pgEXP1J1flcvhLBHkk0ln7ZvGIyXiEyM6XagOTJpwNhiu+Bmk59t3HoV/VyvyJTa+44sEApuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-latest-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.1.0.tgz",
+      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-merge-refs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.1.0.tgz",
+      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-outside-click": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.2.0.tgz",
+      "integrity": "sha512-PNX+s/JEaMneijbgAM4iFL+f3m1ga9+6QK0E5Yh4s8KZJQ/bLwZzdhMz8J/+mL+XEXQ5J0N8ivZN28B82N1kNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-pan-event": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.1.0.tgz",
+      "integrity": "sha512-xmL2qOHiXqfcj0q7ZK5s9UjTh4Gz0/gL9jcWPA6GVf+A0Od5imEDa/Vz+533yQKWiNSm1QGrIj0eJAokc7O4fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/event-utils": "2.0.8",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "framesync": "6.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-previous": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.1.0.tgz",
+      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-safe-layout-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.1.0.tgz",
+      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-size": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.1.0.tgz",
+      "integrity": "sha512-tbLqrQhbnqOjzTaMlYytp7wY8BW1JpL78iG7Ru1DlV4EWGiAmXFGvtnEt9HftU0NJ0aJyjgymkxfVGI55/1Z4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/element-size": "0.10.5"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-timeout": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.1.0.tgz",
+      "integrity": "sha512-cFN0sobKMM9hXUhyCofx3/Mjlzah6ADaEl/AXl5Y+GawB5rgedgAcu2ErAgarEkwvsKdP6c68CKjQ9dmTQlJxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-update-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.1.0.tgz",
+      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-utils": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-2.0.12.tgz",
+      "integrity": "sha512-GbSfVb283+YA3kA8w8xWmzbjNWk14uhNpntnipHCftBibl0lxtQ9YqMFQLwuFOO0U2gYVocszqqDWX+XNKq9hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/utils": "2.0.15"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/select": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.1.2.tgz",
+      "integrity": "sha512-ZwCb7LqKCVLJhru3DXvKXpZ7Pbu1TDZ7N0PdQ0Zj1oyVLJyrpef1u9HR5u0amOpqcH++Ugt0f5JSmirjNlctjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/shared-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz",
+      "integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/skeleton": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.1.0.tgz",
+      "integrity": "sha512-JNRuMPpdZGd6zFVKjVQ0iusu3tXAdI29n4ZENYwAJEMf/fN0l12sVeirOxkJ7oEL0yOx2AgEYFSKdbcAgfUsAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/react-use-previous": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/skip-nav": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skip-nav/-/skip-nav-2.1.0.tgz",
+      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/slider": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.1.0.tgz",
+      "integrity": "sha512-lUOBcLMCnFZiA/s2NONXhELJh6sY5WtbRykPtclGfynqqOo47lwWJx+VP7xaeuhDOPcWSSecWc9Y1BfPOCz9cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-pan-event": "2.1.0",
+        "@chakra-ui/react-use-size": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/spinner": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.1.0.tgz",
+      "integrity": "sha512-hczbnoXt+MMv/d3gE+hjQhmkzLiKuoTo42YhUG7Bs9OSv2lg1fZHW1fGNRFP3wTi6OIbD044U1P9HK+AOgFH3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/stat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.1.1.tgz",
+      "integrity": "sha512-LDn0d/LXQNbAn2KaR3F1zivsZCewY4Jsy1qShmfBMKwn6rI8yVlbvu6SiA3OpHS0FhxbsZxQI6HefEoIgtqY6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/stepper": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.3.1.tgz",
+      "integrity": "sha512-ky77lZbW60zYkSXhYz7kbItUpAQfEdycT0Q4bkHLxfqbuiGMf8OmgZOQkOB9uM4v0zPwy2HXhe0vq4Dd0xa55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/styled-system": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
+      "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5",
+        "csstype": "^3.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/switch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.1.2.tgz",
+      "integrity": "sha512-pgmi/CC+E1v31FcnQhsSGjJnOE2OcND4cKPyTE+0F+bmGm48Q/b5UmKD9Y+CmZsrt/7V3h8KNczowupfuBfIHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/checkbox": "2.3.2",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/system": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.2.tgz",
+      "integrity": "sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/color-mode": "2.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme-utils": "2.0.21",
+        "@chakra-ui/utils": "2.0.15",
+        "react-fast-compare": "3.2.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.1.0.tgz",
+      "integrity": "sha512-o5OrjoHCh5uCLdiUb0Oc0vq9rIAeHSIRScc2ExTC9Qg/uVZl2ygLrjToCaKfaaKl1oQexIeAcZDKvPG8tVkHyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/tabs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-3.0.0.tgz",
+      "integrity": "sha512-6Mlclp8L9lqXmsGWF5q5gmemZXOiOYuh0SGT/7PgJVNPz3LXREXlXg2an4MBUD8W5oTkduCX+3KTMCwRrVrDYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/tag": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.1.1.tgz",
+      "integrity": "sha512-Bdel79Dv86Hnge2PKOU+t8H28nm/7Y3cKd4Kfk9k3lOpUh4+nkSGe58dhRzht59lEqa4N9waCgQiBdkydjvBXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/textarea": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.1.2.tgz",
+      "integrity": "sha512-ip7tvklVCZUb2fOHDb23qPy/Fr2mzDOGdkrpbNi50hDCiV4hFX02jdQJdi3ydHZUyVgZVBKPOJ+lT9i7sKA2wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/theme": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.3.tgz",
-      "integrity": "sha512-WxGk5wEMr8x/YmR99TfVcnt+qsHt9qy5FJycPgcKoL8blQiZ+v/rLhdWhXvu8K03DyfAoLkQDh2guVl+wKFfHA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.3.1.tgz",
+      "integrity": "sha512-Hft/VaT8GYnItGCBbgWd75ICrIrIFrR7lVOhV/dQnqtfGqsVDlrztbSErvMkoPKt0UgAkd9/o44jmZ6X4U2nZQ==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/anatomy": "2.3.3",
-        "@chakra-ui/theme-tools": "2.2.3",
-        "@chakra-ui/utils": "2.1.3"
+        "@chakra-ui/anatomy": "2.2.2",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/theme-tools": "2.1.2"
       },
       "peerDependencies": {
         "@chakra-ui/styled-system": ">=2.8.0"
       }
     },
     "node_modules/@chakra-ui/theme-tools": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.3.tgz",
-      "integrity": "sha512-9fbBh4YaF8k1puovMnvdZtoVxQd1IKlRvWQBmIzXoae3KSJi9p1znRLzEX+Qjvph15dFCa2Q4h1gynI+HOh8oQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.2.tgz",
+      "integrity": "sha512-Qdj8ajF9kxY4gLrq7gA+Azp8CtFHGO9tWMN2wfF9aQNgG9AuMhPrUzMq9AMQ0MXiYcgNq/FD3eegB43nHVmXVA==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/anatomy": "2.3.3",
-        "@chakra-ui/utils": "2.1.3",
+        "@chakra-ui/anatomy": "2.2.2",
+        "@chakra-ui/shared-utils": "2.0.5",
         "color2k": "^2.0.2"
       },
       "peerDependencies": {
         "@chakra-ui/styled-system": ">=2.0.0"
       }
     },
-    "node_modules/@chakra-ui/utils": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.1.3.tgz",
-      "integrity": "sha512-qIuyEg1ThVrUAnkV5nOngMDxUVCKavC04LfuraOCS1PHU4zhU4urJC2FURriALIQSgy6LpegASjvRzi7CIDDQQ==",
+    "node_modules/@chakra-ui/theme-utils": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.21.tgz",
+      "integrity": "sha512-FjH5LJbT794r0+VSCXB3lT4aubI24bLLRWB+CuRKHijRvsOg717bRdUN/N1fEmEpFnRVrbewttWh/OQs0EWpWw==",
       "license": "MIT",
       "dependencies": {
-        "@types/lodash.mergewith": "4.6.9",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme": "3.3.1",
         "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/toast": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-7.0.2.tgz",
+      "integrity": "sha512-yvRP8jFKRs/YnkuE41BVTq9nB2v/KDRmje9u6dgDmE5+1bFt3bwjdf9gVbif4u5Ve7F7BGk5E093ARRVtvLvXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/alert": "2.2.2",
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-timeout": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme": "3.3.1"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "@chakra-ui/system": "2.6.2",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/tooltip": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.3.1.tgz",
+      "integrity": "sha512-Rh39GBn/bL4kZpuEMPPRwYNnccRCL+w9OqamWHIB3Qboxs6h8cOyXfIdGxjo72lvhu1QI/a4KFqkM3St+WfC0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/transition": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.1.0.tgz",
+      "integrity": "sha512-orkT6T/Dt+/+kVwJNy7zwJ+U2xAZ3EU7M3XCs45RBvUnZDr/u9vdmaM/3D/rOpmQJWgQBwKPJleUXrYWUagEDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/utils": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+      "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash.mergewith": "4.6.7",
+        "css-box-model": "1.2.1",
+        "framesync": "6.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/visually-hidden": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.2.0.tgz",
+      "integrity": "sha512-KmKDg01SrQ7VbTD3+cPWf/UfpF5MSwm3v7MWi0n5t8HnnadT13MF0MJCDSXbBWnzLv1ZKJ6zlyAOeARWX+DpjQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -6156,9 +7305,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash.mergewith": {
-      "version": "4.6.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
-      "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+      "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
@@ -6931,24 +8080,24 @@
       "dev": true
     },
     "node_modules/@zag-js/dom-query": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.31.1.tgz",
-      "integrity": "sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.16.0.tgz",
+      "integrity": "sha512-Oqhd6+biWyKnhKwFFuZrrf6lxBz2tX2pRQe6grUnYwO6HJ8BcbqZomy2lpOdr+3itlaUqx+Ywj5E5ZZDr/LBfQ==",
       "license": "MIT"
     },
     "node_modules/@zag-js/element-size": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.31.1.tgz",
-      "integrity": "sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.10.5.tgz",
+      "integrity": "sha512-uQre5IidULANvVkNOBQ1tfgwTQcGl4hliPSe69Fct1VfYb2Fd0jdAcGzqQgPhfrXFpR62MxLPB7erxJ/ngtL8w==",
       "license": "MIT"
     },
     "node_modules/@zag-js/focus-visible": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.31.1.tgz",
-      "integrity": "sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.16.0.tgz",
+      "integrity": "sha512-a7U/HSopvQbrDU4GLerpqiMcHKEkQkNPeDZJWz38cw/6Upunh41GjHetq5TB84hxyCaDzJ6q2nEdNoBQfC0FKA==",
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "0.31.1"
+        "@zag-js/dom-query": "0.16.0"
       }
     },
     "node_modules/abab": {
@@ -8671,6 +9820,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.0.3.tgz",
+      "integrity": "sha512-nadqwNxghAGTamwIqQSG433W6OADZx2vCo3UXHNrzTRHK/htu+7+L0zhjEoaeaQVNAi3YgqWDv8+tzf0hRfR+A==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8905,6 +10060,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css-loader": {
@@ -11961,9 +13125,9 @@
       "license": "ISC"
     },
     "node_modules/focus-lock": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
-      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -13297,15 +14461,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -16945,18 +18100,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lorem-ipsum": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.6.tgz",
-      "integrity": "sha512-Rx4XH8X4KSDCKAVvWGYlhAfNqdUP5ZdT4rRyf0jjrvWgtViZimDIlopWNfn/y3lGM5K4uuiAoY28TaD+7YKFrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "~1.2.0"
-      },
-      "bin": {
-        "lorem-ipsum": "bin/lorem-ipsum.bin.js"
-      }
-    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -17294,6 +18437,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -19338,15 +20482,15 @@
       }
     },
     "node_modules/react-clientside-effect": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
-      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.7.tgz",
+      "integrity": "sha512-gce9m0Pk/xYYMEojRI9bgvqQAkl6hm7ozQvqWPyQx+kULiatdHgkNM1QG4DQRx5N9BAzWSCJmt9mMV8/KsdgVg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.13"
       },
       "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-colorful": {
@@ -19394,9 +20538,9 @@
       "license": "MIT"
     },
     "node_modules/react-focus-lock": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.2.tgz",
-      "integrity": "sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==",
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.5.tgz",
+      "integrity": "sha512-HjHuZFFk2+j6ZT3LDQpyqffue541HrxUG/OFchCEwis9nstgNg0rREVRAxHBcB1lHJ5Fsxtx1qya/5xFwxDb4g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -19407,8 +20551,8 @@
         "use-sidecar": "^1.1.2"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -19434,39 +20578,24 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/react-lorem-component": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/react-lorem-component/-/react-lorem-component-0.13.0.tgz",
-      "integrity": "sha512-4mWjxmcG/DJJwdxdKwXWyP2N9zohbJg/yYaC+7JffQNrKj3LYDpA/A4u/Dju1v1ZF6Jew2gbFKGb5Z6CL+UNTw==",
-      "license": "MIT",
-      "dependencies": {
-        "create-react-class": "^15.5.3",
-        "lorem-ipsum": "^1.0.3",
-        "object-assign": "^4.1.0",
-        "seedable-random": "0.0.1"
-      },
-      "peerDependencies": {
-        "react": "16.x"
-      }
-    },
     "node_modules/react-remove-scroll": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
-      "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
+      "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
       "license": "MIT",
       "dependencies": {
-        "react-remove-scroll-bar": "^2.3.6",
-        "react-style-singleton": "^2.2.1",
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
         "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -19475,20 +20604,20 @@
       }
     },
     "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
-      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "license": "MIT",
       "dependencies": {
-        "react-style-singleton": "^2.2.1",
+        "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -19529,21 +20658,20 @@
       }
     },
     "node_modules/react-style-singleton": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -20335,12 +21463,6 @@
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
       "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
-    },
-    "node_modules/seedable-random": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/seedable-random/-/seedable-random-0.0.1.tgz",
-      "integrity": "sha512-uZWbEfz3BQdBl4QlUPELPqhInGEO1Q6zjzqrTDkd3j7mHaWWJo7h4ydr2g24a2WtTLk3imTLc8mPbBdQqdsbGw==",
-      "license": "BSD"
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",
@@ -21671,6 +22793,12 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -22424,9 +23552,9 @@
       "dev": true
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
-      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -22435,8 +23563,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -22489,9 +23617,9 @@
       }
     },
     "node_modules/use-sidecar": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
-      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
       "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
@@ -22501,8 +23629,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -24875,20 +26003,222 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@chakra-ui/accordion": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.3.1.tgz",
+      "integrity": "sha512-FSXRm8iClFyU+gVaXisOSEw0/4Q+qZbFRiuhIAkVU6Boj0FxAMrlo9a8AV5TuF77rgaHytCdHk0Ng+cyUijrag==",
+      "requires": {
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
+      }
+    },
+    "@chakra-ui/alert": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.2.2.tgz",
+      "integrity": "sha512-jHg4LYMRNOJH830ViLuicjb3F+v6iriE/2G5T+Sd0Hna04nukNJ1MxUmBPE+vI22me2dIflfelu2v9wdB6Pojw==",
+      "requires": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      }
+    },
     "@chakra-ui/anatomy": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.3.tgz",
-      "integrity": "sha512-Sy2VAG0WrzkQE40Y0fY406c6AlyqFxAc7j6fDz8Wwotz9veAvm+y5UgFUyhZ6FoYNAjDMPQ7JCcN7OGz74pNlA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.2.tgz",
+      "integrity": "sha512-MV6D4VLRIHr4PkW4zMyqfrNS1mPlCTiCXwvYGtDFQYr+xHFfonhAuf9WjsSc0nyp2m0OdkSLnzmVKkZFLo25Tg=="
+    },
+    "@chakra-ui/avatar": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.3.0.tgz",
+      "integrity": "sha512-8gKSyLfygnaotbJbDMHDiJoF38OHXUYVme4gGxZ1fLnQEdPVEaIWfH+NndIjOM0z8S+YEFnT9KyGMUtvPrBk3g==",
+      "requires": {
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/breadcrumb": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.2.0.tgz",
+      "integrity": "sha512-4cWCG24flYBxjruRi4RJREWTGF74L/KzI2CognAW/d/zWR0CjiScuJhf37Am3LFbCySP6WSoyBOtTIoTA4yLEA==",
+      "requires": {
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/breakpoint-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breakpoint-utils/-/breakpoint-utils-2.0.8.tgz",
+      "integrity": "sha512-Pq32MlEX9fwb5j5xx8s18zJMARNHlQZH2VH1RZgfgRDpp7DcEgtRW5AInfN5CfqdHLO1dGxA7I3MqEuL5JnIsA==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/button": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.1.0.tgz",
+      "integrity": "sha512-95CplwlRKmmUXkdEp/21VkEWgnwcx2TOBG6NfYlsuLBDHSLlo5FKIiE2oSi4zXc4TLcopGcWPNcm/NDaSC5pvA==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      }
+    },
+    "@chakra-ui/card": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.2.0.tgz",
+      "integrity": "sha512-xUB/k5MURj4CtPAhdSoXZidUbm8j3hci9vnc+eZJVDqhDOShNlD6QeniQNRPRys4lWAQLCbFcrwL29C8naDi6g==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/checkbox": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.3.2.tgz",
+      "integrity": "sha512-85g38JIXMEv6M+AcyIGLh7igNtfpAN6KGQFYxY9tBj0eWvWk4NKQxvqqyVta0bSAyIl1rixNIIezNpNWk2iO4g==",
+      "requires": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/visually-hidden": "2.2.0",
+        "@zag-js/focus-visible": "0.16.0"
+      }
+    },
+    "@chakra-ui/clickable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.1.0.tgz",
+      "integrity": "sha512-flRA/ClPUGPYabu+/GLREZVZr9j2uyyazCAUHAdrTUEdDYCr31SVGhgh7dgKdtq23bOvAQJpIJjw/0Bs0WvbXw==",
+      "requires": {
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/close-button": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.1.1.tgz",
+      "integrity": "sha512-gnpENKOanKexswSVpVz7ojZEALl2x5qjLYNqSQGbxz+aP9sOXPfUS56ebyBrre7T7exuWGiFeRwnM0oVeGPaiw==",
+      "requires": {
+        "@chakra-ui/icon": "3.2.0"
+      }
+    },
+    "@chakra-ui/color-mode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.2.0.tgz",
+      "integrity": "sha512-niTEA8PALtMWRI9wJ4LL0CSBDo8NBfLNp4GD6/0hstcm3IlbBHTVKxN6HwSaoNYfphDQLxCjT4yG+0BJA5tFpg==",
+      "requires": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/control-box": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.1.0.tgz",
+      "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==",
+      "requires": {}
+    },
+    "@chakra-ui/counter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.1.0.tgz",
+      "integrity": "sha512-s6hZAEcWT5zzjNz2JIWUBzRubo9la/oof1W7EKZVVfPYHERnl5e16FmBC79Yfq8p09LQ+aqFKm/etYoJMMgghw==",
+      "requires": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/css-reset": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.3.0.tgz",
+      "integrity": "sha512-cQwwBy5O0jzvl0K7PLTLgp8ijqLPKyuEMiDXwYzl95seD3AoeuoCLyzZcJtVqaUZ573PiBdAbY/IlZcwDOItWg==",
+      "requires": {}
+    },
+    "@chakra-ui/descendant": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.1.0.tgz",
+      "integrity": "sha512-VxCIAir08g5w27klLyi7PVo8BxhW4tgU/lxQyujkmi4zx7hT9ZdrcQLAted/dAa+aSIZ14S1oV0Q9lGjsAdxUQ==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0"
+      }
+    },
+    "@chakra-ui/dom-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.1.0.tgz",
+      "integrity": "sha512-ZmF2qRa1QZ0CMLU8M1zCfmw29DmPNtfjR9iTo74U5FPr3i1aoAh7fbJ4qAlZ197Xw9eAW28tvzQuoVWeL5C7fQ=="
+    },
+    "@chakra-ui/editable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.1.0.tgz",
+      "integrity": "sha512-j2JLrUL9wgg4YA6jLlbU88370eCRyor7DZQD9lzpY95tSOXpTljeg3uF9eOmDnCs6fxp3zDWIfkgMm/ExhcGTg==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/event-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/event-utils/-/event-utils-2.0.8.tgz",
+      "integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw=="
+    },
+    "@chakra-ui/focus-lock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.1.0.tgz",
+      "integrity": "sha512-EmGx4PhWGjm4dpjRqM4Aa+rCWBxP+Rq8Uc/nAVnD4YVqkEhBkrPTpui2lnjsuxqNaZ24fIAZ10cF1hlpemte/w==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "react-focus-lock": "^2.9.4"
+      }
+    },
+    "@chakra-ui/form-control": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.2.0.tgz",
+      "integrity": "sha512-wehLC1t4fafCVJ2RvJQT2jyqsAwX7KymmiGqBu7nQoQz8ApTkGABWpo/QwDh3F/dBLrouHDoOvGmYTqft3Mirw==",
+      "requires": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
     },
     "@chakra-ui/hooks": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.3.3.tgz",
-      "integrity": "sha512-nvqQfR+u0qAJ2/mdGF1XTrnfW9WahSsOc62E/xtRm5hPClfkxPCIXDuw0C17lZ2RYfg/hxsYKLJCGnQWZcC/7w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.2.1.tgz",
+      "integrity": "sha512-RQbTnzl6b1tBjbDPf9zGRo9rf/pQMholsOudTxjy4i9GfTfz6kgp5ValGjQm2z7ng6Z31N1cnjZ1AlSzQ//ZfQ==",
       "requires": {
-        "@chakra-ui/utils": "2.1.3",
-        "@zag-js/element-size": "0.31.1",
-        "copy-to-clipboard": "3.3.3",
-        "framesync": "6.1.2"
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/utils": "2.0.15",
+        "compute-scroll-into-view": "3.0.3",
+        "copy-to-clipboard": "3.3.3"
+      }
+    },
+    "@chakra-ui/icon": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.2.0.tgz",
+      "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/icons": {
@@ -24897,61 +26227,673 @@
       "integrity": "sha512-l5QdBgwrAg3Sc2BRqtNkJpfuLw/pWRDwwT58J6c4PqQT6wzXxyNa8Q0PForu1ltB5qEiFb1kxr/F/HO1EwNa6g==",
       "requires": {}
     },
-    "@chakra-ui/react": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.9.5.tgz",
-      "integrity": "sha512-g4CIow3I424Va6f/v5wIA+6nAbvsALARST/uqUmGMJJ4qDa95FpJx0XNJzlcFABBkuNDWplciCTUL0whKReL9w==",
+    "@chakra-ui/image": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.1.0.tgz",
+      "integrity": "sha512-bskumBYKLiLMySIWDGcz0+D9Th0jPvmX6xnRMs4o92tT3Od/bW26lahmV2a2Op2ItXeCmRMY+XxJH5Gy1i46VA==",
       "requires": {
-        "@chakra-ui/hooks": "2.3.3",
-        "@chakra-ui/styled-system": "2.10.3",
-        "@chakra-ui/theme": "3.4.3",
-        "@chakra-ui/utils": "2.1.3",
-        "@popperjs/core": "^2.11.8",
-        "@zag-js/focus-visible": "^0.31.1",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/input": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.1.2.tgz",
+      "integrity": "sha512-GiBbb3EqAA8Ph43yGa6Mc+kUPjh4Spmxp1Pkelr8qtudpc3p2PJOOebLpd90mcqw8UePPa+l6YhhPtp6o0irhw==",
+      "requires": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/layout": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.3.1.tgz",
+      "integrity": "sha512-nXuZ6WRbq0WdgnRgLw+QuxWAHuhDtVX8ElWqcTK+cSMFg/52eVP47czYBE5F35YhnoW2XBwfNoNgZ7+e8Z01Rg==",
+      "requires": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/lazy-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/lazy-utils/-/lazy-utils-2.0.5.tgz",
+      "integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg=="
+    },
+    "@chakra-ui/live-region": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.1.0.tgz",
+      "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==",
+      "requires": {}
+    },
+    "@chakra-ui/media-query": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.3.0.tgz",
+      "integrity": "sha512-IsTGgFLoICVoPRp9ykOgqmdMotJG0CnPsKvGQeSFOB/dZfIujdVb14TYxDU4+MURXry1MhJ7LzZhv+Ml7cr8/g==",
+      "requires": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/menu": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.2.1.tgz",
+      "integrity": "sha512-lJS7XEObzJxsOwWQh7yfG4H8FzFPRP5hVPN/CL+JzytEINCSBvsCDHrYPQGp7jzpCi8vnTqQQGQe0f8dwnXd2g==",
+      "requires": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-outside-click": "2.2.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
+      }
+    },
+    "@chakra-ui/modal": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.3.1.tgz",
+      "integrity": "sha512-TQv1ZaiJMZN+rR9DK0snx/OPwmtaGH1HbZtlYt4W4s6CzyK541fxLRTjIXfEzIGpvNW+b6VFuFjbcR78p4DEoQ==",
+      "requires": {
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0",
         "aria-hidden": "^1.2.3",
-        "react-fast-compare": "3.2.2",
-        "react-focus-lock": "^2.9.6",
-        "react-lorem-component": "^0.13.0",
-        "react-remove-scroll": "^2.5.7"
+        "react-remove-scroll": "^2.5.6"
+      }
+    },
+    "@chakra-ui/number-input": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.1.2.tgz",
+      "integrity": "sha512-pfOdX02sqUN0qC2ysuvgVDiws7xZ20XDIlcNhva55Jgm095xjm8eVdIBfNm3SFbSUNxyXvLTW/YQanX74tKmuA==",
+      "requires": {
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-interval": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/number-utils": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-utils/-/number-utils-2.0.7.tgz",
+      "integrity": "sha512-yOGxBjXNvLTBvQyhMDqGU0Oj26s91mbAlqKHiuw737AXHt0aPllOthVUqQMeaYLwLCjGMg0jtI7JReRzyi94Dg=="
+    },
+    "@chakra-ui/object-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/object-utils/-/object-utils-2.1.0.tgz",
+      "integrity": "sha512-tgIZOgLHaoti5PYGPTwK3t/cqtcycW0owaiOXoZOcpwwX/vlVb+H1jFsQyWiiwQVPt9RkoSLtxzXamx+aHH+bQ=="
+    },
+    "@chakra-ui/pin-input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.1.0.tgz",
+      "integrity": "sha512-x4vBqLStDxJFMt+jdAHHS8jbh294O53CPQJoL4g228P513rHylV/uPscYUHrVJXRxsHfRztQO9k45jjTYaPRMw==",
+      "requires": {
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/popover": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.2.1.tgz",
+      "integrity": "sha512-K+2ai2dD0ljvJnlrzesCDT9mNzLifE3noGKZ3QwLqd/K34Ym1W/0aL1ERSynrcG78NKoXS54SdEzkhCZ4Gn/Zg==",
+      "requires": {
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/popper": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.1.0.tgz",
+      "integrity": "sha512-ciDdpdYbeFG7og6/6J8lkTFxsSvwTdMLFkpVylAF6VNC22jssiWfquj2eyD4rJnzkRFPvIWJq8hvbfhsm+AjSg==",
+      "requires": {
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@popperjs/core": "^2.9.3"
+      }
+    },
+    "@chakra-ui/portal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.1.0.tgz",
+      "integrity": "sha512-9q9KWf6SArEcIq1gGofNcFPSWEyl+MfJjEUg/un1SMlQjaROOh3zYr+6JAwvcORiX7tyHosnmWC3d3wI2aPSQg==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/progress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.2.0.tgz",
+      "integrity": "sha512-qUXuKbuhN60EzDD9mHR7B67D7p/ZqNS2Aze4Pbl1qGGZfulPW0PY8Rof32qDtttDQBkzQIzFGE8d9QpAemToIQ==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0"
+      }
+    },
+    "@chakra-ui/provider": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.4.2.tgz",
+      "integrity": "sha512-w0Tef5ZCJK1mlJorcSjItCSbyvVuqpvyWdxZiVQmE6fvSJR83wZof42ux0+sfWD+I7rHSfj+f9nzhNaEWClysw==",
+      "requires": {
+        "@chakra-ui/css-reset": "2.3.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/system": "2.6.2",
+        "@chakra-ui/utils": "2.0.15"
+      }
+    },
+    "@chakra-ui/radio": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.1.2.tgz",
+      "integrity": "sha512-n10M46wJrMGbonaghvSRnZ9ToTv/q76Szz284gv4QUWvyljQACcGrXIONUnQ3BIwbOfkRqSk7Xl/JgZtVfll+w==",
+      "requires": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@zag-js/focus-visible": "0.16.0"
+      }
+    },
+    "@chakra-ui/react": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.8.2.tgz",
+      "integrity": "sha512-Hn0moyxxyCDKuR9ywYpqgX8dvjqwu9ArwpIb9wHNYjnODETjLwazgNIliCVBRcJvysGRiV51U2/JtJVrpeCjUQ==",
+      "requires": {
+        "@chakra-ui/accordion": "2.3.1",
+        "@chakra-ui/alert": "2.2.2",
+        "@chakra-ui/avatar": "2.3.0",
+        "@chakra-ui/breadcrumb": "2.2.0",
+        "@chakra-ui/button": "2.1.0",
+        "@chakra-ui/card": "2.2.0",
+        "@chakra-ui/checkbox": "2.3.2",
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/control-box": "2.1.0",
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/css-reset": "2.3.0",
+        "@chakra-ui/editable": "3.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/hooks": "2.2.1",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/input": "2.1.2",
+        "@chakra-ui/layout": "2.3.1",
+        "@chakra-ui/live-region": "2.1.0",
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/menu": "2.2.1",
+        "@chakra-ui/modal": "2.3.1",
+        "@chakra-ui/number-input": "2.1.2",
+        "@chakra-ui/pin-input": "2.1.0",
+        "@chakra-ui/popover": "2.2.1",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/progress": "2.2.0",
+        "@chakra-ui/provider": "2.4.2",
+        "@chakra-ui/radio": "2.1.2",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/select": "2.1.2",
+        "@chakra-ui/skeleton": "2.1.0",
+        "@chakra-ui/skip-nav": "2.1.0",
+        "@chakra-ui/slider": "2.1.0",
+        "@chakra-ui/spinner": "2.1.0",
+        "@chakra-ui/stat": "2.1.1",
+        "@chakra-ui/stepper": "2.3.1",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/switch": "2.1.2",
+        "@chakra-ui/system": "2.6.2",
+        "@chakra-ui/table": "2.1.0",
+        "@chakra-ui/tabs": "3.0.0",
+        "@chakra-ui/tag": "3.1.1",
+        "@chakra-ui/textarea": "2.1.2",
+        "@chakra-ui/theme": "3.3.1",
+        "@chakra-ui/theme-utils": "2.0.21",
+        "@chakra-ui/toast": "7.0.2",
+        "@chakra-ui/tooltip": "2.3.1",
+        "@chakra-ui/transition": "2.1.0",
+        "@chakra-ui/utils": "2.0.15",
+        "@chakra-ui/visually-hidden": "2.2.0"
+      }
+    },
+    "@chakra-ui/react-children-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
+      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
+      "requires": {}
+    },
+    "@chakra-ui/react-context": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.1.0.tgz",
+      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==",
+      "requires": {}
+    },
+    "@chakra-ui/react-env": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.1.0.tgz",
+      "integrity": "sha512-Vr96GV2LNBth3+IKzr/rq1IcnkXv+MLmwjQH6C8BRtn3sNskgDFD5vLkVXcEhagzZMCh8FR3V/bzZPojBOyNhw==",
+      "requires": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
+      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-animation-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.1.0.tgz",
+      "integrity": "sha512-CFZkQU3gmDBwhqy0vC1ryf90BVHxVN8cTLpSyCpdmExUEtSEInSCGMydj2fvn7QXsz/za8JNdO2xxgJwxpLMtg==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-callback-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.1.0.tgz",
+      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-controllable-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.1.0.tgz",
+      "integrity": "sha512-QR/8fKNokxZUs4PfxjXuwl0fj/d71WPrmLJvEpCTkHjnzu7LnYvzoe2wB867IdooQJL0G1zBxl0Dq+6W1P3jpg==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-disclosure": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.1.0.tgz",
+      "integrity": "sha512-Ax4pmxA9LBGMyEZJhhUZobg9C0t3qFE4jVF1tGBsrLDcdBeLR9fwOogIPY9Hf0/wqSlAryAimICbr5hkpa5GSw==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-event-listener": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.1.0.tgz",
+      "integrity": "sha512-U5greryDLS8ISP69DKDsYcsXRtAdnTQT+jjIlRYZ49K/XhUR/AqVZCK5BkR1spTDmO9H8SPhgeNKI70ODuDU/Q==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-focus-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.1.0.tgz",
+      "integrity": "sha512-xzVboNy7J64xveLcxTIJ3jv+lUJKDwRM7Szwn9tNzUIPD94O3qwjV7DDCUzN2490nSYDF4OBMt/wuDBtaR3kUQ==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-focus-on-pointer-down": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.1.0.tgz",
+      "integrity": "sha512-2jzrUZ+aiCG/cfanrolsnSMDykCAbv9EK/4iUyZno6BYb3vziucmvgKuoXbMPAzWNtwUwtuMhkby8rc61Ue+Lg==",
+      "requires": {
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-interval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.1.0.tgz",
+      "integrity": "sha512-8iWj+I/+A0J08pgEXP1J1flcvhLBHkk0ln7ZvGIyXiEyM6XagOTJpwNhiu+Bmk59t3HoV/VyvyJTa+44sEApuw==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-latest-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.1.0.tgz",
+      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-merge-refs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.1.0.tgz",
+      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-outside-click": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.2.0.tgz",
+      "integrity": "sha512-PNX+s/JEaMneijbgAM4iFL+f3m1ga9+6QK0E5Yh4s8KZJQ/bLwZzdhMz8J/+mL+XEXQ5J0N8ivZN28B82N1kNw==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-pan-event": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.1.0.tgz",
+      "integrity": "sha512-xmL2qOHiXqfcj0q7ZK5s9UjTh4Gz0/gL9jcWPA6GVf+A0Od5imEDa/Vz+533yQKWiNSm1QGrIj0eJAokc7O4fg==",
+      "requires": {
+        "@chakra-ui/event-utils": "2.0.8",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "framesync": "6.1.2"
+      }
+    },
+    "@chakra-ui/react-use-previous": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.1.0.tgz",
+      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-safe-layout-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.1.0.tgz",
+      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-size": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.1.0.tgz",
+      "integrity": "sha512-tbLqrQhbnqOjzTaMlYytp7wY8BW1JpL78iG7Ru1DlV4EWGiAmXFGvtnEt9HftU0NJ0aJyjgymkxfVGI55/1Z4A==",
+      "requires": {
+        "@zag-js/element-size": "0.10.5"
+      }
+    },
+    "@chakra-ui/react-use-timeout": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.1.0.tgz",
+      "integrity": "sha512-cFN0sobKMM9hXUhyCofx3/Mjlzah6ADaEl/AXl5Y+GawB5rgedgAcu2ErAgarEkwvsKdP6c68CKjQ9dmTQlJxQ==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-update-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.1.0.tgz",
+      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==",
+      "requires": {}
+    },
+    "@chakra-ui/react-utils": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-2.0.12.tgz",
+      "integrity": "sha512-GbSfVb283+YA3kA8w8xWmzbjNWk14uhNpntnipHCftBibl0lxtQ9YqMFQLwuFOO0U2gYVocszqqDWX+XNKq9hw==",
+      "requires": {
+        "@chakra-ui/utils": "2.0.15"
+      }
+    },
+    "@chakra-ui/select": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.1.2.tgz",
+      "integrity": "sha512-ZwCb7LqKCVLJhru3DXvKXpZ7Pbu1TDZ7N0PdQ0Zj1oyVLJyrpef1u9HR5u0amOpqcH++Ugt0f5JSmirjNlctjA==",
+      "requires": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/shared-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz",
+      "integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q=="
+    },
+    "@chakra-ui/skeleton": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.1.0.tgz",
+      "integrity": "sha512-JNRuMPpdZGd6zFVKjVQ0iusu3tXAdI29n4ZENYwAJEMf/fN0l12sVeirOxkJ7oEL0yOx2AgEYFSKdbcAgfUsAQ==",
+      "requires": {
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/react-use-previous": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/skip-nav": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skip-nav/-/skip-nav-2.1.0.tgz",
+      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==",
+      "requires": {}
+    },
+    "@chakra-ui/slider": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.1.0.tgz",
+      "integrity": "sha512-lUOBcLMCnFZiA/s2NONXhELJh6sY5WtbRykPtclGfynqqOo47lwWJx+VP7xaeuhDOPcWSSecWc9Y1BfPOCz9cQ==",
+      "requires": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-pan-event": "2.1.0",
+        "@chakra-ui/react-use-size": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/spinner": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.1.0.tgz",
+      "integrity": "sha512-hczbnoXt+MMv/d3gE+hjQhmkzLiKuoTo42YhUG7Bs9OSv2lg1fZHW1fGNRFP3wTi6OIbD044U1P9HK+AOgFH3g==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/stat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.1.1.tgz",
+      "integrity": "sha512-LDn0d/LXQNbAn2KaR3F1zivsZCewY4Jsy1qShmfBMKwn6rI8yVlbvu6SiA3OpHS0FhxbsZxQI6HefEoIgtqY6Q==",
+      "requires": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/stepper": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.3.1.tgz",
+      "integrity": "sha512-ky77lZbW60zYkSXhYz7kbItUpAQfEdycT0Q4bkHLxfqbuiGMf8OmgZOQkOB9uM4v0zPwy2HXhe0vq4Dd0xa55Q==",
+      "requires": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/styled-system": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.10.3.tgz",
-      "integrity": "sha512-rU4sG712pnp3Qrc8XT5AKcMhZjByXp1IrErLJ8wmiez2v8hAl/Dv8roK2BTqd4GfkJOrtkyfq2e2ZcDWjbd9Dw==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
+      "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
       "requires": {
-        "@chakra-ui/utils": "2.1.3",
-        "csstype": "^3.1.2"
+        "@chakra-ui/shared-utils": "2.0.5",
+        "csstype": "^3.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "@chakra-ui/switch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.1.2.tgz",
+      "integrity": "sha512-pgmi/CC+E1v31FcnQhsSGjJnOE2OcND4cKPyTE+0F+bmGm48Q/b5UmKD9Y+CmZsrt/7V3h8KNczowupfuBfIHA==",
+      "requires": {
+        "@chakra-ui/checkbox": "2.3.2",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/system": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.2.tgz",
+      "integrity": "sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==",
+      "requires": {
+        "@chakra-ui/color-mode": "2.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme-utils": "2.0.21",
+        "@chakra-ui/utils": "2.0.15",
+        "react-fast-compare": "3.2.2"
+      }
+    },
+    "@chakra-ui/table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.1.0.tgz",
+      "integrity": "sha512-o5OrjoHCh5uCLdiUb0Oc0vq9rIAeHSIRScc2ExTC9Qg/uVZl2ygLrjToCaKfaaKl1oQexIeAcZDKvPG8tVkHyQ==",
+      "requires": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/tabs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-3.0.0.tgz",
+      "integrity": "sha512-6Mlclp8L9lqXmsGWF5q5gmemZXOiOYuh0SGT/7PgJVNPz3LXREXlXg2an4MBUD8W5oTkduCX+3KTMCwRrVrDYw==",
+      "requires": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/tag": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.1.1.tgz",
+      "integrity": "sha512-Bdel79Dv86Hnge2PKOU+t8H28nm/7Y3cKd4Kfk9k3lOpUh4+nkSGe58dhRzht59lEqa4N9waCgQiBdkydjvBXQ==",
+      "requires": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0"
+      }
+    },
+    "@chakra-ui/textarea": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.1.2.tgz",
+      "integrity": "sha512-ip7tvklVCZUb2fOHDb23qPy/Fr2mzDOGdkrpbNi50hDCiV4hFX02jdQJdi3ydHZUyVgZVBKPOJ+lT9i7sKA2wA==",
+      "requires": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/theme": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.3.tgz",
-      "integrity": "sha512-WxGk5wEMr8x/YmR99TfVcnt+qsHt9qy5FJycPgcKoL8blQiZ+v/rLhdWhXvu8K03DyfAoLkQDh2guVl+wKFfHA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.3.1.tgz",
+      "integrity": "sha512-Hft/VaT8GYnItGCBbgWd75ICrIrIFrR7lVOhV/dQnqtfGqsVDlrztbSErvMkoPKt0UgAkd9/o44jmZ6X4U2nZQ==",
       "requires": {
-        "@chakra-ui/anatomy": "2.3.3",
-        "@chakra-ui/theme-tools": "2.2.3",
-        "@chakra-ui/utils": "2.1.3"
+        "@chakra-ui/anatomy": "2.2.2",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/theme-tools": "2.1.2"
       }
     },
     "@chakra-ui/theme-tools": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.3.tgz",
-      "integrity": "sha512-9fbBh4YaF8k1puovMnvdZtoVxQd1IKlRvWQBmIzXoae3KSJi9p1znRLzEX+Qjvph15dFCa2Q4h1gynI+HOh8oQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.2.tgz",
+      "integrity": "sha512-Qdj8ajF9kxY4gLrq7gA+Azp8CtFHGO9tWMN2wfF9aQNgG9AuMhPrUzMq9AMQ0MXiYcgNq/FD3eegB43nHVmXVA==",
       "requires": {
-        "@chakra-ui/anatomy": "2.3.3",
-        "@chakra-ui/utils": "2.1.3",
+        "@chakra-ui/anatomy": "2.2.2",
+        "@chakra-ui/shared-utils": "2.0.5",
         "color2k": "^2.0.2"
       }
     },
-    "@chakra-ui/utils": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.1.3.tgz",
-      "integrity": "sha512-qIuyEg1ThVrUAnkV5nOngMDxUVCKavC04LfuraOCS1PHU4zhU4urJC2FURriALIQSgy6LpegASjvRzi7CIDDQQ==",
+    "@chakra-ui/theme-utils": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.21.tgz",
+      "integrity": "sha512-FjH5LJbT794r0+VSCXB3lT4aubI24bLLRWB+CuRKHijRvsOg717bRdUN/N1fEmEpFnRVrbewttWh/OQs0EWpWw==",
       "requires": {
-        "@types/lodash.mergewith": "4.6.9",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme": "3.3.1",
         "lodash.mergewith": "4.6.2"
       }
+    },
+    "@chakra-ui/toast": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-7.0.2.tgz",
+      "integrity": "sha512-yvRP8jFKRs/YnkuE41BVTq9nB2v/KDRmje9u6dgDmE5+1bFt3bwjdf9gVbif4u5Ve7F7BGk5E093ARRVtvLvXA==",
+      "requires": {
+        "@chakra-ui/alert": "2.2.2",
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-timeout": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme": "3.3.1"
+      }
+    },
+    "@chakra-ui/tooltip": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.3.1.tgz",
+      "integrity": "sha512-Rh39GBn/bL4kZpuEMPPRwYNnccRCL+w9OqamWHIB3Qboxs6h8cOyXfIdGxjo72lvhu1QI/a4KFqkM3St+WfC0A==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/transition": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.1.0.tgz",
+      "integrity": "sha512-orkT6T/Dt+/+kVwJNy7zwJ+U2xAZ3EU7M3XCs45RBvUnZDr/u9vdmaM/3D/rOpmQJWgQBwKPJleUXrYWUagEDQ==",
+      "requires": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/utils": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+      "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+      "requires": {
+        "@types/lodash.mergewith": "4.6.7",
+        "css-box-model": "1.2.1",
+        "framesync": "6.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "@chakra-ui/visually-hidden": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.2.0.tgz",
+      "integrity": "sha512-KmKDg01SrQ7VbTD3+cPWf/UfpF5MSwm3v7MWi0n5t8HnnadT13MF0MJCDSXbBWnzLv1ZKJ6zlyAOeARWX+DpjQ==",
+      "requires": {}
     },
     "@codemirror/autocomplete": {
       "version": "6.18.2",
@@ -27844,9 +29786,9 @@
       "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
     },
     "@types/lodash.mergewith": {
-      "version": "4.6.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
-      "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+      "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
       "requires": {
         "@types/lodash": "*"
       }
@@ -28440,21 +30382,21 @@
       "dev": true
     },
     "@zag-js/dom-query": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.31.1.tgz",
-      "integrity": "sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.16.0.tgz",
+      "integrity": "sha512-Oqhd6+biWyKnhKwFFuZrrf6lxBz2tX2pRQe6grUnYwO6HJ8BcbqZomy2lpOdr+3itlaUqx+Ywj5E5ZZDr/LBfQ=="
     },
     "@zag-js/element-size": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.31.1.tgz",
-      "integrity": "sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ=="
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.10.5.tgz",
+      "integrity": "sha512-uQre5IidULANvVkNOBQ1tfgwTQcGl4hliPSe69Fct1VfYb2Fd0jdAcGzqQgPhfrXFpR62MxLPB7erxJ/ngtL8w=="
     },
     "@zag-js/focus-visible": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.31.1.tgz",
-      "integrity": "sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.16.0.tgz",
+      "integrity": "sha512-a7U/HSopvQbrDU4GLerpqiMcHKEkQkNPeDZJWz38cw/6Upunh41GjHetq5TB84hxyCaDzJ6q2nEdNoBQfC0FKA==",
       "requires": {
-        "@zag-js/dom-query": "0.31.1"
+        "@zag-js/dom-query": "0.16.0"
       }
     },
     "abab": {
@@ -29706,6 +31648,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.0.3.tgz",
+      "integrity": "sha512-nadqwNxghAGTamwIqQSG433W6OADZx2vCo3UXHNrzTRHK/htu+7+L0zhjEoaeaQVNAi3YgqWDv8+tzf0hRfR+A=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -29889,6 +31836,14 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "css-loader": {
@@ -32129,9 +34084,9 @@
       "dev": true
     },
     "focus-lock": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
-      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -33046,14 +35001,6 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
       "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "ipaddr.js": {
       "version": "2.2.0",
@@ -35714,14 +37661,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lorem-ipsum": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.6.tgz",
-      "integrity": "sha512-Rx4XH8X4KSDCKAVvWGYlhAfNqdUP5ZdT4rRyf0jjrvWgtViZimDIlopWNfn/y3lGM5K4uuiAoY28TaD+7YKFrQ==",
-      "requires": {
-        "minimist": "~1.2.0"
-      }
-    },
     "lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -35972,7 +37911,8 @@
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
     },
     "minipass": {
       "version": "7.1.2",
@@ -37449,9 +39389,9 @@
       }
     },
     "react-clientside-effect": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
-      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.7.tgz",
+      "integrity": "sha512-gce9m0Pk/xYYMEojRI9bgvqQAkl6hm7ozQvqWPyQx+kULiatdHgkNM1QG4DQRx5N9BAzWSCJmt9mMV8/KsdgVg==",
       "requires": {
         "@babel/runtime": "^7.12.13"
       }
@@ -37490,9 +39430,9 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.2.tgz",
-      "integrity": "sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==",
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.5.tgz",
+      "integrity": "sha512-HjHuZFFk2+j6ZT3LDQpyqffue541HrxUG/OFchCEwis9nstgNg0rREVRAxHBcB1lHJ5Fsxtx1qya/5xFwxDb4g==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^1.3.5",
@@ -37515,35 +39455,24 @@
         "@react-leaflet/core": "^2.1.0"
       }
     },
-    "react-lorem-component": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/react-lorem-component/-/react-lorem-component-0.13.0.tgz",
-      "integrity": "sha512-4mWjxmcG/DJJwdxdKwXWyP2N9zohbJg/yYaC+7JffQNrKj3LYDpA/A4u/Dju1v1ZF6Jew2gbFKGb5Z6CL+UNTw==",
-      "requires": {
-        "create-react-class": "^15.5.3",
-        "lorem-ipsum": "^1.0.3",
-        "object-assign": "^4.1.0",
-        "seedable-random": "0.0.1"
-      }
-    },
     "react-remove-scroll": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
-      "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
+      "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
       "requires": {
-        "react-remove-scroll-bar": "^2.3.6",
-        "react-style-singleton": "^2.2.1",
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
         "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
       }
     },
     "react-remove-scroll-bar": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
-      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "requires": {
-        "react-style-singleton": "^2.2.1",
+        "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
       }
     },
@@ -37572,12 +39501,11 @@
       }
     },
     "react-style-singleton": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "requires": {
         "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
         "tslib": "^2.0.0"
       }
     },
@@ -38122,11 +40050,6 @@
           "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
         }
       }
-    },
-    "seedable-random": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/seedable-random/-/seedable-random-0.0.1.tgz",
-      "integrity": "sha512-uZWbEfz3BQdBl4QlUPELPqhInGEO1Q6zjzqrTDkd3j7mHaWWJo7h4ydr2g24a2WtTLk3imTLc8mPbBdQqdsbGw=="
     },
     "seedrandom": {
       "version": "3.0.5",
@@ -39155,6 +41078,11 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
+    "tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -39664,9 +41592,9 @@
       }
     },
     "use-callback-ref": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
-      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -39698,9 +41626,9 @@
       "requires": {}
     },
     "use-sidecar": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
-      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
       "requires": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"

--- a/v3/package.json
+++ b/v3/package.json
@@ -191,7 +191,7 @@
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",
-    "@chakra-ui/react": "~2.9.5",
+    "@chakra-ui/react": "~2.8.2",
     "@codemirror/autocomplete": "^6.18.2",
     "@codemirror/commands": "^6.7.1",
     "@codemirror/language": "^6.10.3",


### PR DESCRIPTION
- downgrade Chakra UI to address performance regression
- adjust `import/no-cycle` configuration to reduce lint times

Note: Chakra UI 2.10.5 (which was supposed to have a fix for the performance regression in 2.9.x) was tried in #1788 and found not to be as performant as 2.8.2, so we're sticking with this for the time being.