### PR TITLE
feat: table does not become selected on attribute drag

### DIFF
--- a/v3/src/components/case-table/case-table-component.test.tsx
+++ b/v3/src/components/case-table/case-table-component.test.tsx
@@ -25,29 +25,44 @@ const UseKeyStatesWrapper = () => {
 describe("Case Table", () => {
   let broker: DataBroker
   let tile: ITileModel
+
+  const tileSelection: ITileSelection = {
+    isTileSelected() {
+      return false
+    },
+    selectTile() {
+    },
+    addFocusFilter() {
+      return () => null
+    }
+  }
+
   beforeEach(() => {
     broker = new DataBroker()
     tile = TileModel.create({ content: getSnapshot(CaseTableModel.create()) })
   })
 
   it("renders nothing with no broker", () => {
-    render(<DndContext><CaseTableComponent tile={tile}/></DndContext>)
+    render(
+      <DndContext>
+        <TileSelectionContext.Provider value={tileSelection}>
+          <CaseTableComponent tile={tile}/>
+        </TileSelectionContext.Provider>
+      </DndContext>)
     expect(screen.queryByTestId("case-table")).not.toBeInTheDocument()
   })
 
   it("renders nothing with empty broker", () => {
-    render(<DndContext><CaseTableComponent tile={tile}/></DndContext>)
+    render(
+      <DndContext>
+        <TileSelectionContext.Provider value={tileSelection}>
+          <CaseTableComponent tile={tile}/>
+        </TileSelectionContext.Provider>
+      </DndContext>)
     expect(screen.queryByTestId("case-table")).not.toBeInTheDocument()
   })
 
   it("renders table with data", () => {
-    const tileSelection: ITileSelection = {
-      isTileSelected() {
-        return false
-      },
-      selectTile() {
-      }
-    }
     const data = DataSet.create()
     data.addAttribute({ name: "a"})
     data.addAttribute({ name: "b" })

--- a/v3/src/components/case-table/case-table-component.test.tsx
+++ b/v3/src/components/case-table/case-table-component.test.tsx
@@ -32,7 +32,7 @@ describe("Case Table", () => {
     },
     selectTile() {
     },
-    addFocusFilter() {
+    addFocusIgnoreFn() {
       return () => null
     }
   }

--- a/v3/src/components/case-table/case-table-drag-drop.ts
+++ b/v3/src/components/case-table/case-table-drag-drop.ts
@@ -46,7 +46,6 @@ export const caseTableCollisionDetection: CollisionDetection = (args) => {
   // https://docs.dndkit.com/api-documentation/context-provider/collision-detection-algorithms#pointer-within
   // Therefore, we also provide fallback to rectangle intersection if pointer within doesn't fire.
 
-  // if the pointer is within the new collection drop zone, then we're done
   const withinCollisions = pointerWithin(args)
   const withinTableBody = findCollision(withinCollisions, kCollectionTableBodyDropZoneRegEx)
 
@@ -62,10 +61,11 @@ export const caseTableCollisionDetection: CollisionDetection = (args) => {
   }
   // attribute drag
   else {
-    // if the pointer is within the collection table body, find the nearest attribute divider drop zone
+    // if the pointer is within the new collection drop zone, then we're done
     const withinNewCollection = findCollision(withinCollisions, kNewCollectionDropZoneRegEx)
     if (withinNewCollection) return [withinNewCollection]
 
+    // if the pointer is within the collection table body, find the nearest attribute divider drop zone
     const droppableColumnDividers = filterContainers(args.droppableContainers, kAttributeDividerDropZoneRegEx)
     if (withinTableBody) {
       // use closestCenter among column dividers for moving attributes within table

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -43,7 +43,7 @@ export const CaseTable = observer(function CaseTable() {
   }, [])
 
   useEffect(() => {
-    return tileSelection.addFocusFilter(event => {
+    return tileSelection.addFocusIgnoreFn(event => {
       // disable table becoming selected on attribute drag
       return event.target instanceof HTMLElement && event.target.closest(".codap-attribute-button") != null
     })

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -1,3 +1,4 @@
+import { Portal } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React, { useCallback, useEffect, useRef } from "react"
 import { ICoreNotification } from "../../data-interactive/notification-core-types"
@@ -5,6 +6,7 @@ import { CollectionContext, ParentCollectionContext } from "../../hooks/use-coll
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useTileDropOverlay } from "../../hooks/use-drag-drop"
 import { useInstanceIdContext } from "../../hooks/use-instance-id-context"
+import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { registerCanAutoScrollCallback } from "../../lib/dnd-kit/dnd-can-auto-scroll"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { ICollectionModel } from "../../models/data/collection"
@@ -13,11 +15,11 @@ import { createCollectionNotification, deleteCollectionNotification } from "../.
 import { mstReaction } from "../../utilities/mst-reaction"
 import { prf } from "../../utilities/profiler"
 import { excludeDragOverlayRegEx } from "../case-tile-common/case-tile-types"
+import { FilterFormulaBar } from "../case-tile-common/filter-formula-bar"
 import { AttributeHeaderDividerContext } from "../case-tile-common/use-attribute-header-divider-context"
 import { AttributeDragOverlay } from "../drag-drop/attribute-drag-overlay"
 import { IScrollOptions } from "./case-table-types"
 import { CollectionTable } from "./collection-table"
-import { FilterFormulaBar } from "../case-tile-common/filter-formula-bar"
 import { useCaseTableModel } from "./use-case-table-model"
 import { useSyncScrolling } from "./use-sync-scrolling"
 
@@ -29,6 +31,7 @@ export const CaseTable = observer(function CaseTable() {
   const { setNodeRef } = useTileDropOverlay(instanceId)
   const data = useDataSetContext()
   const tableModel = useCaseTableModel()
+  const tileSelection = useTileSelectionContext()
   const contentRef = useRef<HTMLDivElement>(null)
   const lastNewCollectionDrop = useRef<{ newCollectionId: string, beforeCollectionId: string } | undefined>()
 
@@ -38,6 +41,13 @@ export const CaseTable = observer(function CaseTable() {
       return element !== contentRef.current || (direction && direction.y === 0)
     })
   }, [])
+
+  useEffect(() => {
+    return tileSelection.addFocusFilter(event => {
+      // disable table becoming selected on attribute drag
+      return event.target instanceof HTMLElement && event.target.closest(".codap-attribute-button") != null
+    })
+  }, [tileSelection])
 
   useEffect(() => {
     const updateScroll = (horizontalScrollOffset?: number) => {
@@ -149,7 +159,9 @@ export const CaseTable = observer(function CaseTable() {
               )
             })}
           </AttributeHeaderDividerContext.Provider>
-          <AttributeDragOverlay dragIdPrefix={instanceId} dragIdExcludeRegEx={excludeDragOverlayRegEx} />
+          <Portal>
+            <AttributeDragOverlay dragIdPrefix={instanceId} dragIdExcludeRegEx={excludeDragOverlayRegEx} />
+          </Portal>
         </div>
       </div>
     )

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -6,7 +6,7 @@ import ResizeHandle from "../assets/icons/icon-corner-resize-handle.svg"
 import { CodapComponentContext } from "../hooks/use-codap-component-context"
 import { TileModelContext } from "../hooks/use-tile-model-context"
 import {
-  FilterEventType, FocusFilterFn, ITileSelection, TileSelectionContext
+  FocusIgnoreEventType, FocusIgnoreFn, ITileSelection, TileSelectionContext
 } from "../hooks/use-tile-selection-context"
 import { getTileComponentInfo } from "../models/tiles/tile-component-info"
 import { ITileModel } from "../models/tiles/tile-model"
@@ -31,7 +31,7 @@ export interface IProps extends ITileBaseProps {
 
 class TileSelectionHandler implements ITileSelection {
   tile: ITileModel
-  focusFilterMap = new Map<string, FocusFilterFn>()
+  focusIgnoreMap = new Map<string, FocusIgnoreFn>()
 
   constructor(tile: ITileModel) {
     this.tile = tile
@@ -46,7 +46,7 @@ class TileSelectionHandler implements ITileSelection {
   }
 
   handleFocusEvent = (event: React.FocusEvent<HTMLDivElement> | React.PointerEvent<HTMLDivElement>) => {
-    if (!Array.from(this.focusFilterMap.values()).some(filter => filter(event))) {
+    if (!Array.from(this.focusIgnoreMap.values()).some(filter => filter(event))) {
       if (isAlive(this.tile)) {
         this.selectTile()
       }
@@ -56,10 +56,10 @@ class TileSelectionHandler implements ITileSelection {
     }
   }
 
-  addFocusFilter = (filter: FocusFilterFn) => {
+  addFocusIgnoreFn = (ignoreFn: FocusIgnoreFn) => {
     const id = uniqueId()
-    this.focusFilterMap.set(id, filter)
-    return () => this.focusFilterMap.delete(id)
+    this.focusIgnoreMap.set(id, ignoreFn)
+    return () => this.focusIgnoreMap.delete(id)
   }
 }
 
@@ -73,7 +73,7 @@ export const CodapComponent = observer(function CodapComponent({
   // useState for guaranteed lifetime
   const [tileSelection] = useState<TileSelectionHandler>(() => new TileSelectionHandler(tile))
 
-  const handleFocusEvent = (event: FilterEventType) => tileSelection.handleFocusEvent(event)
+  const handleFocusEvent = (event: FocusIgnoreEventType) => tileSelection.handleFocusEvent(event)
 
   if (!info) return null
 

--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -184,7 +184,8 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
 
   return (
     <ComponentWrapperContext.Provider value={componentRef}>
-      <div id={tileId} className={classes} style={style} key={tileId} ref={mergedComponentRef}>
+      <div id={tileId} className={classes} style={style} key={tileId} ref={mergedComponentRef}
+          data-tile-z-index={zIndex}>
         {tile && rowTile &&
           <CodapComponent tile={tile}
             isMinimized={rowTile.isMinimized}

--- a/v3/src/components/drag-drop/attribute-drag-overlay.scss
+++ b/v3/src/components/drag-drop/attribute-drag-overlay.scss
@@ -16,4 +16,5 @@
 .dnd-kit-drag-overlay {
   // This element was preventing WebViewDropOverlays from receiving pointerenter, pointermove, and pointerleave events.
   pointer-events: none;
+  z-index: 999999;
 }

--- a/v3/src/hooks/use-tile-selection-context.ts
+++ b/v3/src/hooks/use-tile-selection-context.ts
@@ -1,14 +1,14 @@
 import React, { createContext, useContext } from "react"
 
-export type FilterEventType = React.FocusEvent<HTMLDivElement> | React.PointerEvent<HTMLDivElement>
+export type FocusIgnoreEventType = React.FocusEvent<HTMLDivElement> | React.PointerEvent<HTMLDivElement>
 // return true to prevent tile focus
-export type FocusFilterFn = (event: FilterEventType) => Maybe<boolean>
+export type FocusIgnoreFn = (event: FocusIgnoreEventType) => Maybe<boolean>
 
 export interface ITileSelection {
   isTileSelected: () => boolean
   selectTile: () => void
   // returns disposer function for removing filter
-  addFocusFilter: (filter: FocusFilterFn) => () => void
+  addFocusIgnoreFn: (ignoreFn: FocusIgnoreFn) => () => void
 }
 
 export const TileSelectionContext = createContext<ITileSelection | undefined>(undefined)

--- a/v3/src/hooks/use-tile-selection-context.ts
+++ b/v3/src/hooks/use-tile-selection-context.ts
@@ -1,8 +1,14 @@
-import { createContext, useContext } from "react"
+import React, { createContext, useContext } from "react"
+
+export type FilterEventType = React.FocusEvent<HTMLDivElement> | React.PointerEvent<HTMLDivElement>
+// return true to prevent tile focus
+export type FocusFilterFn = (event: FilterEventType) => Maybe<boolean>
 
 export interface ITileSelection {
   isTileSelected: () => boolean
   selectTile: () => void
+  // returns disposer function for removing filter
+  addFocusFilter: (filter: FocusFilterFn) => () => void
 }
 
 export const TileSelectionContext = createContext<ITileSelection | undefined>(undefined)


### PR DESCRIPTION
[[PT-188514669]](https://www.pivotaltracker.com/story/show/188514669)

My first attempt at this was purely focused on not selecting the table when an attribute drag is initiated in the table. I maintain that this worked as I expected.

@scytacki correctly pointed out that when the table and graph are overlapping, there is an additional problem in that the table handles the _drop_ even when it's behind the graph, and the act of handling the drop results in the table becoming selected. This turns out to be a more fundamental problem with our collision-detection code. I have now added a commit which sorts the available drop targets by the z-index of their corresponding tile and finds the appropriate handler for the most salient collision, rather than finding the first matching collision for the earliest-registered handler.