### PR TITLE
[#188862999] - Back ticks to attributes names with non-characters added via Insert Value button

### DIFF
--- a/v3/src/components/common/formula-insert-values-menu.tsx
+++ b/v3/src/components/common/formula-insert-values-menu.tsx
@@ -39,6 +39,8 @@ export const InsertValuesMenu = ({setShowValuesMenu}: IProps) => {
   const maxItemLength = useRef(0)
 
   const insertValueToFormula = (value: string) => {
+    // if the attribute name has any non-alphanumeric chars, wrap it in backticks
+    if (/[^\w]/.test(value)) value = `\`${value}\``
     editorApi?.insertVariableString(value)
     setShowValuesMenu(false)
   }


### PR DESCRIPTION
Adds back ticks to attribute names when attributes are added via Insert Value button