### PR TITLE
fix: create a copy of document with boundaries

### DIFF
--- a/v3/src/models/boundaries/boundary-manager.ts
+++ b/v3/src/models/boundaries/boundary-manager.ts
@@ -1,9 +1,13 @@
-import { computed, makeObservable, observable } from "mobx"
+import { computed, makeObservable, observable, runInAction } from "mobx"
 import { kBoundariesRootUrl, kBoundariesSpecUrl, BoundaryInfo, isBoundaryInfo } from "./boundary-types"
 
 export class BoundaryManager {
   @observable.shallow
   private boundaryMap = new Map<string, BoundaryInfo>()
+
+  // set to true when the initial boundary specs have been loaded
+  @observable
+  boundariesLoaded = false
 
   // separate observable for remote boundaries for observability
   @observable.shallow
@@ -31,6 +35,10 @@ export class BoundaryManager {
           if (isBoundaryInfo(boundariesSpec)) {
             this.boundaryMap.set(boundariesSpec.name, boundariesSpec)
           }
+        })
+
+        runInAction(() => {
+          this.boundariesLoaded = true
         })
       }
     } catch (error) {

--- a/v3/src/models/formula/attribute-formula-adapter.test.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.test.ts
@@ -14,7 +14,7 @@ const getTestEnv = () => {
   formula.setCanonicalExpression(formula.display)
   const dataSets = new Map<string, IDataSet>([[dataSet.id, dataSet]])
   const context = { dataSet, formula }
-  const extraMetadata = { dataSetId: dataSet.id, attributeId: attribute.id }
+  const extraMetadata = { dataSetId: dataSet.id, attributeId: attribute.id, boundariesLoaded: false }
   const api = {
     getDatasets: jest.fn(() => dataSets),
     getBoundaryManager: jest.fn(),

--- a/v3/src/models/formula/attribute-formula-adapter.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "mathjs"
 import { DEBUG_FORMULAS, debugLog } from "../../lib/debug"
+import { boundaryManager } from "../boundaries/boundary-manager"
 import { isFormulaAttr, isValidFormulaAttr } from "../data/attribute"
 import { CaseInfo, ICase, IGroupedCase, symParent } from "../data/data-set-types"
 import { IFormula } from "./formula"
@@ -20,6 +21,7 @@ const ATTRIBUTE_FORMULA_ADAPTER = "AttributeFormulaAdapter"
 
 interface IAttrFormulaExtraMetadata extends IFormulaExtraMetadata {
   attributeId: string
+  boundariesLoaded?: boolean
 }
 
 export class AttributeFormulaAdapter extends FormulaManagerAdapter {
@@ -41,7 +43,8 @@ export class AttributeFormulaAdapter extends FormulaManagerAdapter {
             formula: attr.formula,
             extraMetadata: {
               dataSetId: dataSet.id,
-              attributeId: attr.id
+              attributeId: attr.id,
+              boundariesLoaded: boundaryManager.boundariesLoaded
             }
           })
         }


### PR DESCRIPTION
[[PT-188781023]](https://www.pivotaltracker.com/story/show/188781023)

The problem was that in the copy, formulas were being compiled before the boundary data was loaded. With this PR, we add a `boundariesLoaded` property to the metadata that is used by the formula manager. This property is observed, so when the boundaries are loaded formulas are recompiled.