### PR TITLE
use autorun in numeric legend

### DIFF
--- a/v3/cypress/e2e/graph-legend.spec.ts
+++ b/v3/cypress/e2e/graph-legend.spec.ts
@@ -533,7 +533,7 @@ context("Test selecting and selecting categories in legend", () => {
     cy.visit(url)
     cy.wait(2500)
   })
-  it.skip("will select and unselect categories in categorical legend with categorical x axis", () => {
+  it("will select and unselect categories in categorical legend with categorical x axis", () => {
     cy.dragAttributeToTarget("table", arrayOfAttributes[8], "bottom") // Diet => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[7]) // Habitat => plot area
     glh.selectCategoryNameForCategoricalLegend(arrayOfValues[7].values[0])
@@ -549,14 +549,16 @@ context("Test selecting and selecting categories in legend", () => {
     glh.selectCategoryColorForCategoricalLegend(arrayOfValues[7].values[2])
     glh.verifyCategoricalLegendKeySelected(arrayOfValues[7].values[2])
 
-    glh.unselectLegendCategory()
-    glh.verifyNoLegendCategorySelectedForCategoricalLegend()
-    glh.openLegendMenu()
-    glh.removeAttributeFromLegend(arrayOfAttributes[7])
-    ah.openAxisAttributeMenu("bottom")
-    ah.removeAttributeFromAxis(arrayOfAttributes[8], "bottom")
+    // For some reason clicking on the background to unselect the legend
+    // is not working
+    // glh.unselectLegendCategory()
+    // glh.verifyNoLegendCategorySelectedForCategoricalLegend()
+    // glh.openLegendMenu()
+    // glh.removeAttributeFromLegend(arrayOfAttributes[7])
+    // ah.openAxisAttributeMenu("bottom")
+    // ah.removeAttributeFromAxis(arrayOfAttributes[8], "bottom")
   })
-  it.skip("will select and unselect keys in numeric legend with categorical x axis", () => {
+  it("will select and unselect keys in numeric legend with categorical x axis", () => {
     cy.dragAttributeToTarget("table", arrayOfAttributes[8], "bottom") // Diet => x-axis
     glh.dragAttributeToPlot(arrayOfAttributes[3]) // Height => plot area
     glh.selectNumericLegendCategory(0)
@@ -564,13 +566,15 @@ context("Test selecting and selecting categories in legend", () => {
     glh.selectNumericLegendCategory(1)
     glh.verifyNumericLegendKeySelected()
 
-    glh.unselectLegendCategory()
-    glh.verifyNoLegendCategorySelectedForNumericLegend()
+    // For some reason clicking on the background to unselect the legend
+    // is not working
+    // glh.unselectLegendCategory()
+    // glh.verifyNoLegendCategorySelectedForNumericLegend()
 
-    glh.openLegendMenu()
-    glh.removeAttributeFromLegend(arrayOfAttributes[3])
-    ah.openAxisAttributeMenu("bottom")
-    ah.removeAttributeFromAxis(arrayOfAttributes[8], "bottom")
+    // glh.openLegendMenu()
+    // glh.removeAttributeFromLegend(arrayOfAttributes[3])
+    // ah.openAxisAttributeMenu("bottom")
+    // ah.removeAttributeFromAxis(arrayOfAttributes[8], "bottom")
   })
 })
 context("Test changing legend colors", () => {

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -1,15 +1,13 @@
-import {ScaleQuantile, scaleQuantile, schemeBlues} from "d3"
-import {comparer, reaction} from "mobx"
-import {observer} from "mobx-react-lite"
-import React, {useCallback, useEffect, useRef, useState} from "react"
-import { mstReaction } from "../../../../utilities/mst-reaction"
+import { observer } from "mobx-react-lite"
+import React, { useCallback, useEffect, useState } from "react"
 import { setOrExtendSelection } from "../../../../models/data/data-set-utils"
-import {axisGap} from "../../../axis/axis-types"
-import {getStringBounds} from "../../../axis/axis-utils"
-import {kChoroplethHeight} from "../../data-display-types"
-import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
-import {useDataDisplayLayout} from "../../hooks/use-data-display-layout"
-import {choroplethLegend} from "./choropleth-legend/choropleth-legend"
+import { mstAutorun } from "../../../../utilities/mst-autorun"
+import { axisGap } from "../../../axis/axis-types"
+import { getStringBounds } from "../../../axis/axis-utils"
+import { kChoroplethHeight } from "../../data-display-types"
+import { useDataConfigurationContext } from "../../hooks/use-data-configuration-context"
+import { useDataDisplayLayout } from "../../hooks/use-data-display-layout"
+import { choroplethLegend } from "./choropleth-legend/choropleth-legend"
 import { IBaseLegendProps } from "./legend-common"
 
 import vars from "../../../vars.scss"
@@ -18,18 +16,16 @@ export const NumericLegend =
   observer(function NumericLegend({layerIndex, setDesiredExtent}: IBaseLegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
     tileWidth = useDataDisplayLayout().tileWidth,
-    quantileScale = useRef<ScaleQuantile<string>>(scaleQuantile()),
     [choroplethElt, setChoroplethElt] = useState<SVGGElement | null>(null),
-    valuesRef = useRef<number[]>([]),
-    metadata = dataConfiguration?.metadata,
     legendAttrID = dataConfiguration?.attributeID("legend") ?? "",
 
     getLabelHeight = useCallback(() => {
       const labelFont = vars.labelFont
       return getStringBounds(dataConfiguration?.dataset?.attrFromID(legendAttrID)?.name ?? '', labelFont).height
-    }, [dataConfiguration, legendAttrID]),
+    }, [dataConfiguration, legendAttrID])
 
-    refreshScale = useCallback(() => {
+  useEffect(() => mstAutorun(
+    () => {
       const numberHeight = getStringBounds('0').height
       const labelHeight = getLabelHeight()
       const computeDesiredExtent = () => {
@@ -39,98 +35,42 @@ export const NumericLegend =
         return labelHeight + kChoroplethHeight + numberHeight + 2 * axisGap
       }
 
-      if (choroplethElt) {
-        /**
-         *  Adjust the value range displayed by the legend based on the data configuration model's properties:
-         *  1. If all cases are hidden, the legend displays no range.
-         *  2. If `displayOnlySelectedCases` is true and not all cases are visible, the legend displays the range of all
-         *     cases, both hidden and visible.
-         *  3. Otherwise, the legend displays the range of only the visible cases.
-         *
-         *  TODO: When `displayOnlySelectedCases` is true and all visible cases have the exact same value for the legend
-         *  attribute, the legend should only reflect the values of the case(s) shown.
-         */
-        const allCasesCount = dataConfiguration?.dataset?.items.length ?? 0
-        const hiddenCasesCount = dataConfiguration?.hiddenCases.length ?? 0
-        const allCasesHidden = hiddenCasesCount === allCasesCount
-        if (allCasesHidden) {
-          valuesRef.current = []
-        } else if (dataConfiguration?.displayOnlySelectedCases && hiddenCasesCount > 0) {
-          const attribute = dataConfiguration?.dataset?.attrFromID(dataConfiguration?.attributeID("legend"))
-          valuesRef.current = attribute?.numValues ?? []
-        } else {
-          valuesRef.current = dataConfiguration?.numericValuesForAttrRole("legend") ?? []
-        }
+      if (!choroplethElt || !dataConfiguration) return
 
-        setDesiredExtent(layerIndex, computeDesiredExtent())
-        quantileScale.current.domain(valuesRef.current).range(dataConfiguration?.quantileScaleColors ?? schemeBlues[5])
-        choroplethLegend(quantileScale.current, choroplethElt,
-          {
-            isDate: dataConfiguration?.attributeType('legend') === 'date',
-            width: tileWidth,
-            marginLeft: 6, marginTop: labelHeight, marginRight: 6, ticks: 5,
-            clickHandler: (quantile: number, extend: boolean) => {
-              const dataset = dataConfiguration?.dataset
-              const quantileCases = dataConfiguration?.getCasesForLegendQuantile(quantile)
-              if (quantileCases) {
-                setOrExtendSelection(quantileCases, dataset, extend)
-              }
-            },
-            casesInQuantileSelectedHandler: (quantile: number) => {
-              return !!dataConfiguration?.casesInQuantileAreSelected(quantile)
+      setDesiredExtent(layerIndex, computeDesiredExtent())
+      choroplethLegend(dataConfiguration.legendQuantileScale, choroplethElt,
+        {
+          isDate: dataConfiguration.attributeType('legend') === 'date',
+          width: tileWidth,
+          marginLeft: 6, marginTop: labelHeight, marginRight: 6, ticks: 5,
+          clickHandler: (quantile: number, extend: boolean) => {
+            const dataset = dataConfiguration.dataset
+            const quantileCases = dataConfiguration.getCasesForLegendQuantile(quantile)
+            if (quantileCases) {
+              setOrExtendSelection(quantileCases, dataset, extend)
             }
-          })
-      }
-    }, [choroplethElt, dataConfiguration, getLabelHeight, setDesiredExtent, tileWidth, layerIndex])
+          },
+          casesInQuantileSelectedHandler: (quantile: number) => {
+            return !!dataConfiguration?.casesInQuantileAreSelected(quantile)
+          }
+        })
+    },
+    {
+      name: "NumericLegend render"
+    },
+    [dataConfiguration]
+  ),
+  [choroplethElt, dataConfiguration, getLabelHeight, setDesiredExtent, tileWidth, layerIndex])
 
-  useEffect(function refresh() {
-    refreshScale()
-  }, [refreshScale])
-
-  useEffect(function respondToLayoutChange() {
-    const disposer = reaction(
-      () => {
-        const legendID = dataConfiguration?.attributeID('legend')
-        return {legendID}
-      },
-      () => {
-        refreshScale()
-      }, {fireImmediately: true}
-    )
-    return () => disposer()
-  }, [dataConfiguration, refreshScale])
-
-    useEffect(function respondToSelectionChange() {
-      return mstReaction(
-        () => dataConfiguration?.selection,
-        () => {
-          refreshScale()
-        }, {name: 'NumericLegend respondToSelectionChange'}, dataConfiguration)
-    }, [refreshScale, dataConfiguration])
-
-  useEffect(function respondToHiddenCaseChange() {
-  return mstReaction(
-    () => dataConfiguration?.hiddenCases.length,
-    () => refreshScale(),
-    {name: "NumericLegend respondToHiddenCaseChange"}, dataConfiguration)
-  }, [dataConfiguration, refreshScale])
-
-  useEffect(function respondToColorChange() {
-    return mstReaction(
-      () => metadata?.getAttributeColorRange(legendAttrID),
-      refreshScale, { name: "NumericLegend respondToColorChange", equals: comparer.structural }, metadata
-    )
-  }, [legendAttrID, metadata, refreshScale])
-
-  // todo: This reaction is not being triggered when a legend attribute value is changed.
-  // It should be.
-  useEffect(function respondToNumericValuesChange() {
-    return reaction(
-      () => dataConfiguration?.numericValuesForAttrRole('legend'),
-      () => {
-        refreshScale()
-      })
-  }, [dataConfiguration, refreshScale])
+  // Reactions to check
+  // - changing attribute by menu
+  // - changing attribute by dragging
+  // - selecting points in table
+  // - selecting points in graph
+  // - clicking on legend to select points
+  // - hide cases?
+  // - change attribute color range
+  // - update values in the attribute
 
   useEffect(function cleanup () {
     return () => {

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -1,5 +1,5 @@
 import {scaleQuantile} from "d3"
-import {comparer, observable, reaction, trace} from "mobx"
+import {comparer, observable, reaction} from "mobx"
 import {
   addDisposer, getEnv, getSnapshot, hasEnv, IAnyStateTreeNode, Instance, ISerializedActionCall,
   resolveIdentifier, SnapshotIn, types

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -283,7 +283,7 @@ export const DataConfigurationModel = types
      * - cases filtered by the filter formula in the dataset should be excluded
      * - cases hidden in the visualization should be excluded
      * - cases filtered by the filter formula in the visualization should be excluded
-     * - cases that do not have valid values for the configured role attribute descriptions. And example is
+     * - cases that do not have valid values for the configured role attribute descriptions. An example is
      *   when a case has a non-numeric value for a numeric axis. If the case can be shown multiple times,
      *   all instances have to be invalid for it to be excluded.
      */

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -277,6 +277,16 @@ export const DataConfigurationModel = types
       // The first attribute is always assigned as 'caption'. So it's really no attributes assigned except for that
       return this.attributes.length <= 1
     },
+    /**
+     * Return all cases that are plotted at least once:
+     * - set aside cases in the dataset should be excluded
+     * - cases filtered by the filter formula in the dataset should be excluded
+     * - cases hidden in the visualization should be excluded
+     * - cases filtered by the filter formula in the visualization should be excluded
+     * - cases that do not have valid values for the configured role attribute descriptions. And example is
+     *   when a case has a non-numeric value for a numeric axis. If the case can be shown multiple times,
+     *   all instances have to be invalid for it to be excluded.
+     */
     get visibleCaseIds() {
       const allCaseIds = new Set<string>()
       self.filteredCases.forEach(aFilteredCases => {
@@ -294,6 +304,10 @@ export const DataConfigurationModel = types
       if (!self.dataset) return []
       return Array.from(this.visibleCaseIds).filter(caseId => self.dataset?.isCaseSelected(caseId))
     },
+    /**
+     * This returns an array of the visible cases that are unselected.
+     * If displayOnlySelectedCases is enabled, this will return an empty set.
+     */
     get unselectedCases() {
       if (!self.dataset) return []
       return Array.from(this.visibleCaseIds).filter(caseId => !self.dataset?.isCaseSelected(caseId))
@@ -314,6 +328,11 @@ export const DataConfigurationModel = types
     })
   }))
   .views(self => ({
+    /**
+     * This returns just values which can be converted to numbers for the
+     * attribute of this role. It does not include all cases, see `visibleCaseIds`.
+     * TODO: it seems better if this included unselected cases when displayOnlySelectedCases is enabled
+     */
     numericValuesForAttrRole: cachedFnWithArgsFactory({
       key: (role: AttrRole) => role,
       calculate: (role: AttrRole) => {
@@ -452,28 +471,31 @@ export const DataConfigurationModel = types
   }))
   .views(self => ({
     get legendQuantileScale() {
-      /**
-       *  Adjust the value range displayed by the legend based on the data configuration model's properties:
-       *  1. If all cases are hidden, the legend displays no range.
-       *  2. If `displayOnlySelectedCases` is true and not all cases are visible, the legend displays the range of all
-       *     cases, both hidden and visible.
-       *  3. Otherwise, the legend displays the range of only the visible cases.
-       *
-       *  TODO: When `displayOnlySelectedCases` is true and all visible cases have the exact same value for the legend
-       *  attribute, the legend should only reflect the values of the case(s) shown.
-       */
-      const allCasesCount = self.dataset?.items.length ?? 0
-      const hiddenCasesCount = self.hiddenCases.length ?? 0
-      const allCasesHidden = hiddenCasesCount === allCasesCount
-      let values: number[]
-      if (allCasesHidden) {
-        values = []
-      } else if (self.displayOnlySelectedCases && hiddenCasesCount > 0) {
-        const attribute = self.dataset?.attrFromID(self.attributeID("legend"))
-        values = attribute?.numValues ?? []
-      } else {
-        values = self.numericValuesForAttrRole("legend") ?? []
-      }
+      // TODO: Handle the displayOnlySelectedCases better. What we would like to do is
+      // to basically ignore displayOnlySelectedCases when computing the legend bins.
+      // This way the legend will not jump around when the user is selecting different
+      // cases when in displayOnlySelectedCases mode.
+      // There are several criteria besides displayOnlySelectedCases which impact which
+      // cases are shown on the visualization:
+      // - set aside cases in the dataset should be excluded
+      // - cases filtered by the filter formula in the dataset should be excluded
+      // - cases hidden in the visualization should be excluded
+      // - cases filtered by the filter formula in the visualization should be excluded
+      // - cases that are not plottable on at least one of the plots of the visualization
+      //   should be excluded
+      // All of these criteria are handled by numericValuesForAttrRole("legend") but it also
+      // excludes unselected cases if displayOnlySelectedCases is enabled.
+      // It would make sense for numericValuesForAttrRole to ignore the
+      // displayOnlySelectedCases criteria. It is used here and also to compute the axis extents.
+      // The axes should also not jump around when using displayOnlySelectedCases.
+      // Implementing this is hard because of the last bullet. Handling the "not plottable"
+      // cases is done by the FilteredCases system which is overridden by the
+      // GraphDataConfigurationModel in order to handle graphs with multiple y axes. This
+      // FilterCases system is also what implements displayOnlySelectedCases.
+      // The best solution might be to separate the displayOnlySelectedCases from FilterCases,
+      // perhaps by renaming it PlottableCases and then apply the displayOnlySelectedCases
+      // criteria further up chain of filters.
+      const values = self.numericValuesForAttrRole("legend") ?? []
       return scaleQuantile(values, self.quantileScaleColors)
     },
   }))

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -492,7 +492,8 @@ export const GraphDataConfigurationModel = DataConfigurationModel
           }
         })
         return targetCases
-      }
+      },
+      name: "subPlotCases"
     }),
     cellCases: cachedFnWithArgsFactory({
       key: (cellKey: Record<string, string>) => JSON.stringify(cellKey),
@@ -512,7 +513,8 @@ export const GraphDataConfigurationModel = DataConfigurationModel
 
           return isRightMatch && isTopMatch
         })
-      }
+      },
+      name: "cellCases"
     }),
     rowCases: cachedFnWithArgsFactory({
       key: (cellKey: Record<string, string>) => JSON.stringify(cellKey),
@@ -536,7 +538,8 @@ export const GraphDataConfigurationModel = DataConfigurationModel
 
           return isLeftMatch && isRightMatch && isTopMatch
         })
-      }
+      },
+      name: "rowCases"
     }),
     columnCases: cachedFnWithArgsFactory({
       key: (cellKey: Record<string, string>) => JSON.stringify(cellKey),
@@ -560,7 +563,8 @@ export const GraphDataConfigurationModel = DataConfigurationModel
 
           return isBottomMatch && isTopMatch && isRightMatch
         })
-      }
+      },
+      name: "columnCases"
     }),
     filterCasesForDisplay(caseIds: string[] = []) {
       return self.showMeasuresForSelection ? caseIds.filter(caseId => self.dataset?.isCaseSelected(caseId)) : caseIds

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -306,7 +306,11 @@ export const DataSet = V2Model.named("DataSet").props({
   get itemsNotSetAside() {
     return self._itemIds.filter(itemId => !self.isItemSetAside(itemId))
   },
-  // ids of items that have not been hidden (set aside) or filtered by user
+  /**
+   * ids of items that have not been hidden (set aside) or filtered by user
+   * Note: this will not take into account any filtering applied at the visualization
+   * level: visualization hidden cases, visualization filter formula, or displayOnlySelectedCases
+   */
   get itemIds() {
     return self._itemIds.filter(itemId => !self.isItemHidden(itemId))
   }

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -308,8 +308,6 @@ export const DataSet = V2Model.named("DataSet").props({
   },
   /**
    * ids of items that have not been hidden (set aside) or filtered by user
-   * Note: this will not take into account any filtering applied at the visualization
-   * level: visualization hidden cases, visualization filter formula, or displayOnlySelectedCases
    */
   get itemIds() {
     return self._itemIds.filter(itemId => !self.isItemHidden(itemId))

--- a/v3/src/utilities/mst-utils.test.ts
+++ b/v3/src/utilities/mst-utils.test.ts
@@ -28,7 +28,7 @@ describe("cachedFnWithArgsFactory", () => {
   it("should return a function that lazily caches the value", () => {
     const calculate = jest.fn((a: number, b: number) => a + b)
     const key = jest.fn((a: number, b: number) => `${a}+${b}`)
-    const cachedFn = cachedFnWithArgsFactory({ key, calculate })
+    const cachedFn = cachedFnWithArgsFactory({ key, calculate, name: "testFn" })
     expect(key).not.toHaveBeenCalled()
     expect(calculate).not.toHaveBeenCalled()
     expect(cachedFn(1, 2)).toEqual(3)
@@ -46,7 +46,7 @@ describe("cachedFnWithArgsFactory", () => {
   it("should return a function that caches the value until invalidate() is called", () => {
     const calculate = jest.fn((a: number, b: number) => a + b)
     const key = jest.fn((a: number, b: number) => `${a}+${b}`)
-    const cachedFn = cachedFnWithArgsFactory({ key, calculate })
+    const cachedFn = cachedFnWithArgsFactory({ key, calculate, name: "testFn" })
     expect(cachedFn(1, 2)).toEqual(3)
     calculate.mockImplementation((a: number, b: number) => a * b)
     expect(cachedFn(1, 2)).toEqual(3)

--- a/v3/src/utilities/mst-utils.ts
+++ b/v3/src/utilities/mst-utils.ts
@@ -116,19 +116,21 @@ export function cachedFnFactory<T>(calculate: () => T): (() => T) & { invalidate
  */
 export function cachedFnWithArgsFactory<FunDef extends (...args: any[]) => any>(options: {
   key: (...args: Parameters<FunDef>) => string,
-  calculate: FunDef
+  calculate: FunDef,
+  name: string
 }): ((...args: Parameters<FunDef>) => ReturnType<FunDef>)
   & { invalidate: (...args: Parameters<FunDef>) => void, invalidateAll: () => void } {
   // TypeScript generics are a bit complicated here. However, they ensure that invalidate() function is called
   // with the same arguments as the calculate() function. It will work even if the client code completely skips
   // explicit type definition between < and >.
-  const { key, calculate } = options
+  const { key, calculate, name } = options
 
   // The map is observable so any observers will be triggered when the cache is updated
   // The values within the map are not automatically made observable since
   // cachedFnWithArgsFactory is usually used in cases where the values are large objects
   // and usually a whole new value object is created by on each calculate call
-  const cacheMap = observable.map<string, ReturnType<FunDef>>({}, {deep: false})
+  const cacheMap = observable.map<string, ReturnType<FunDef>>({},
+    {name: name || "cachedFnWithArgs", deep: false})
 
   const getter = (...args: Parameters<FunDef>) => {
     const cacheKey = key(...args)


### PR DESCRIPTION
- use autorun in the numeric legend
- share the same d3 quantile scale between the points and the legend
- add name field to help trace MobX recalculations caused by cachedFnWithArgs

The autorun fixes a couple of things:
- the extra reactions in the numeric legend are no longer needed
- the extra evaluations of legendQuantileScale go away. This one is nuanced. If a MobX computed value is not accessed from a reaction its value will not be cached and it will be recomputed on every call. This legendQuantileScale is used by the point rendering which is not in a reaction. And it was also used indirectly by some parts of the numeric legend which were also outside of a reaction. So it was never used by a reaction and never cached. Now with the numeric legend being inside of a reaction the value of legendQuantileScale is cached. More details are here: https://mobx.js.org/computeds.html#computed-suspend