### PR TITLE
add check for point compression interaction with categorical plots

### DIFF
--- a/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
+++ b/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
@@ -357,8 +357,7 @@ context("Graph UI with Pixi interaction", () => {
         })
       })
     })
-    // this test will work when PT-#188601933 is delivered
-    it.skip("check for point compression interaction", () => {
+    it("check for point compression interaction", () => {
       // Open Four Seals
       cy.log("Open Four Seals from Hamburger menu")
       cfm.getHamburgerMenuButton().should("exist")


### PR DESCRIPTION
[PT-#188713862](https://www.pivotaltracker.com/story/show/188713862)

This is a simple PR that enables a Cypress check for checking regression with graph point compression. It was built as part of the PixiJS test suite and unblocked by PT-[188601933](https://www.pivotaltracker.com/story/show/188601933)