### PR TITLE
fix: movable line undo/redo issues

### DIFF
--- a/v3/src/components/graph/adornments/adornment-models.ts
+++ b/v3/src/components/graph/adornments/adornment-models.ts
@@ -2,6 +2,7 @@
   Adornment models are strictly MST. They keep track of the user modifications of the defaults.
  */
 import {Instance, SnapshotIn, types} from "mobx-state-tree"
+import { applyModelChange } from "../../../models/history/apply-model-change"
 import {safeDomIdentifier, typedId} from "../../../utilities/js-utils"
 import { ScaleNumericBaseType } from "../../axis/axis-types"
 import { IAxisLayout } from "../../axis/models/axis-layout-context"
@@ -65,6 +66,7 @@ export const AdornmentModel = types.model("AdornmentModel", {
       // derived models should override to update their models when categories change
     }
   }))
+  .actions(applyModelChange)
 export interface IAdornmentModel extends Instance<typeof AdornmentModel> {}
 export interface IAdornmentModelSnapshot extends SnapshotIn<typeof AdornmentModel> {}
 

--- a/v3/src/components/graph/adornments/store/adornments-store.test.ts
+++ b/v3/src/components/graph/adornments/store/adornments-store.test.ts
@@ -24,7 +24,8 @@ const mockAdornment = {
   setVisibility: () => true,
   updateCategories: () => ({}),
   type: kCountType,
-  labelLines: 0
+  labelLines: 0,
+  applyModelChange: (fn: () => any) => fn()
 }
 const mockMovableValueAdornment = {
   cellCount: () => ({x: 1, y: 1}),
@@ -39,7 +40,8 @@ const mockMovableValueAdornment = {
   updateCategories: () => ({}),
   values: { "{}": [10] },
   type: kMovableValueType,
-  labelLines: 1
+  labelLines: 1,
+  applyModelChange: (fn: () => any) => fn()
 }
 const mockUpdateCategoriesOptions = {
   rightCats: [],

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -14,6 +14,8 @@
     "V3.Redo.graph.hideAllCases": "Redo hiding all cases",
     "V3.Undo.graph.showAllCases": "Undo showing all cases",
     "V3.Redo.graph.showAllCases": "Redo showing all cases",
+    "V3.Undo.graph.adjustMovableLine": "Undo adjusting movable line",
+    "V3.Redo.graph.adjustMovableLine": "Redo adjusting movable line",
     "V3.Undo.graph.showLastParentOnly": "Undo showing only last parent case",
     "V3.Redo.graph.showLastParentOnly": "Redo showing only last parent case",
     "V3.Undo.graph.uncheckLastParentOnly": "Undo unchecking \"Last\" checkbox",


### PR DESCRIPTION
[[PT-188872789]](https://www.pivotaltracker.com/story/show/188872789)

The MST warnings were fixed by using `mstAutorun` instead of `autorun`. The undo/redo strings were just a matter of using `applyModelChange()` and providing undo/redo strings. Curiously, adjusting the movable line is not undoable in v2, so I had to add a new pair of localizable undo/redo strings.