### PR TITLE
Prevents selection of row when user clicks on checkbox

### DIFF
--- a/v3/src/components/case-tile-common/checkbox-cell.tsx
+++ b/v3/src/components/case-tile-common/checkbox-cell.tsx
@@ -46,7 +46,7 @@ export function CheckboxCell ({ caseId, attrId }: ICheckboxCellProps) {
   // When checkbox is in the indeterminate state, we want the tooltip to show "undefined"
   return (
     <span className="cell-checkbox">
-      <input type="checkbox" ref={checkRef}  onChange={handleChange}
+      <input type="checkbox" ref={checkRef}  onChange={handleChange} onClick={(e) => e.stopPropagation()}
               title={String(cellValue)}/>
     </span>
   )


### PR DESCRIPTION
Previously, when user clicked on checkbox, the row would get selected.
This only allows case selection if user clicks on the cell outside the checkbox. If checkbox is clicked, it only changes the state of the checkbox and not the state of case selection.