### PR TITLE
188883647 checkbox undo redo

### DIFF
--- a/v3/src/components/case-tile-common/checkbox-cell.tsx
+++ b/v3/src/components/case-tile-common/checkbox-cell.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { FValue } from "../../models/formula/formula-types"
-import { updateCasesNotificationFromIds } from "../../models/data/data-set-notifications"
+import { applyCaseValueChanges } from "./case-tile-utils"
 
 export const isBoolean = (value: FValue | undefined) => {
   let v = value
@@ -35,14 +35,8 @@ export function CheckboxCell ({ caseId, attrId }: ICheckboxCellProps) {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.checked
-    data?.applyModelChange(() => {
-      data.setCaseValues([{ __id__: caseId, [attrId]: newValue }])
-    }, {
-      notify: () => updateCasesNotificationFromIds(data, [caseId]),
-      undoStringKey: "DG.Undo.caseTable.editCellValue",
-      redoStringKey: "DG.Redo.caseTable.editCellValue",
-      log: `update checkbox case: ${caseId} state: ${attrId} to ${newValue ? "checked" : "unchecked"}`
-    })
+    const log = {message: `update checkbox case: ${caseId} state: ${attrId} to ${newValue ? "checked" : "unchecked"}`}
+    data && applyCaseValueChanges(data, [{ __id__: caseId, [attrId]: newValue }], log)
   }
   // title is used to show the value of the cell when hovering over the checkbox
   // When checkbox is in the indeterminate state, we want the tooltip to show "undefined"

--- a/v3/src/components/case-tile-common/checkbox-cell.tsx
+++ b/v3/src/components/case-tile-common/checkbox-cell.tsx
@@ -39,7 +39,9 @@ export function CheckboxCell ({ caseId, attrId }: ICheckboxCellProps) {
       data.setCaseValues([{ __id__: caseId, [attrId]: newValue }])
     }, {
       notify: () => updateCasesNotificationFromIds(data, [caseId]),
-      log: `update checkbox state: ${attrId} to ${newValue ? "checked" : "unchecked"}`
+      undoStringKey: "DG.Undo.caseTable.editCellValue",
+      redoStringKey: "DG.Redo.caseTable.editCellValue",
+      log: `update checkbox case: ${caseId} state: ${attrId} to ${newValue ? "checked" : "unchecked"}`
     })
   }
   // title is used to show the value of the cell when hovering over the checkbox


### PR DESCRIPTION
Changes checkbox component to use standard cell applyModelChange so undo/redo and plugin notification uses the same code path as all the other cells.