### PR TITLE
fix flakey clicks

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -50,7 +50,11 @@ export const AxisOrLegendAttributeMenu = ({ place, target, portal,
   }
   const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions)
 
-  useOutsidePointerDown({ref: menuRef, handler: () => onCloseRef.current?.()})
+  useOutsidePointerDown({
+    ref: menuRef,
+    handler: () => onCloseRef.current?.(),
+    info: { name: "AxisOrLegendAttributeMenu", attrId, attrName: attribute?.name }
+  })
 
   return (
     <div className={`axis-legend-attribute-menu ${place}`} ref={menuRef}>

--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -63,7 +63,14 @@ export const AttributeHeader = observer(function AttributeHeader({
     prefix: instanceId, dataSet: data, attributeId
   }
   const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions)
-  useOutsidePointerDown({ ref: menuListRef, handler: () => onCloseMenuRef.current?.() })
+  // TODO: we really should only enable the outside pointer down listener when the menu is open.
+  // However there doesn't seem to be simple way to do that.
+  // `isMenuOpen` is a ref so we won't be re-rendered when that changes.
+  useOutsidePointerDown({
+    ref: menuListRef,
+    handler: () => onCloseMenuRef.current?.(),
+    info: {name: "AttributeHeader menuList", attributeId, attrName}
+   })
 
   const setHeaderContentRef = (elt: HTMLDivElement | null) => {
     contentRef.current = elt
@@ -102,12 +109,16 @@ export const AttributeHeader = observer(function AttributeHeader({
 
   // focus our content when the cell is focused
   useParentChildFocusRedirect(parentRef.current, menuButtonRef.current)
-  useOutsidePointerDown({ ref: inputRef, handler: () => {
-                                if (isFocused) {
-                                  handleClose(true)
-                                }
-                              }
-                        })
+  useOutsidePointerDown({
+    ref: inputRef,
+    handler: () => {
+      if (isFocused) {
+        handleClose(true)
+      }
+    },
+    enabled: isFocused,
+    info: {name: "AttributeHeader input", attributeId, attrName}
+  })
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const { key } = e

--- a/v3/src/components/case-tile-common/color-text-editor.tsx
+++ b/v3/src/components/case-tile-common/color-text-editor.tsx
@@ -59,8 +59,11 @@ export default function ColorTextEditor({attributeId, caseId, value, acceptValue
   const [placement, setPlacement ]= useState<"right" | "left">("right")
   const triggerButtonRef = useRef<HTMLButtonElement>(null)
   const colorEditorRef = useRef<HTMLDivElement>(null)
-  useOutsidePointerDown({ref: colorEditorRef as unknown as RefObject<HTMLElement>,
-                          handler: ()=> handleSubmit(inputValue as string)})
+  useOutsidePointerDown({
+    ref: colorEditorRef as unknown as RefObject<HTMLElement>,
+    handler: ()=> handleSubmit(inputValue as string),
+    info: { name: "ColorTextEditor", attributeId, attributeName: attribute?.name }
+  })
 
   const { isOpen: isPaletteOpen, onToggle: setOpenPopover, onClose } = useDisclosure()
 

--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -47,15 +47,20 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
       const draggedElement = document.getElementById(dragTileId)
       if (draggedElement) {
         // Capture pointer events for the dragged tile
-        draggedElement.addEventListener('pointermove', (event) => {
-          if (!draggedElement.hasPointerCapture(event.pointerId)) {
-            draggedElement.setPointerCapture(event.pointerId)
+        function pointerMove(event: any) {
+          if (!draggedElement?.hasPointerCapture(event.pointerId)) {
+            draggedElement?.setPointerCapture(event.pointerId)
           }
-        })
+        }
 
-        draggedElement.addEventListener('pointerup', (event) => {
-          draggedElement.releasePointerCapture(event.pointerId)
-        })
+        function pointerUp(event: any) {
+          draggedElement?.releasePointerCapture(event.pointerId)
+          draggedElement?.removeEventListener("pointermove", pointerMove)
+          draggedElement?.removeEventListener("pointerup", pointerUp)
+        }
+
+        draggedElement.addEventListener('pointermove', pointerMove)
+        draggedElement.addEventListener('pointerup', pointerUp)
       }
 
       if (isFreeTileRow(row)) {

--- a/v3/src/components/data-display/inspector/point-color-setting.tsx
+++ b/v3/src/components/data-display/inspector/point-color-setting.tsx
@@ -18,7 +18,11 @@ export const PointColorSetting = observer(function PointColorSetting({ onColorCh
   const initialColorRef = useRef(swatchBackgroundColor)
   const pointColorSettingButtonRef = useRef<HTMLButtonElement>(null)
 
-  useOutsidePointerDown({ ref: popoverContainerRef, handler: () => setOpenPopover?.(null) })
+  useOutsidePointerDown({
+    ref: popoverContainerRef,
+    handler: () => setOpenPopover?.(null),
+    info: { name: "PointColorSetting", propertyLabel }
+   })
 
   const closePopover = useCallback(() => {
     setOpenPopover(null)

--- a/v3/src/components/inspector-panel.tsx
+++ b/v3/src/components/inspector-panel.tsx
@@ -14,7 +14,12 @@ interface IProps {
 }
 
 export const InspectorPanel = forwardRef(({ component, show, setShowPalette, children }: IProps, ref) => {
-  useOutsidePointerDown({ref: ref as unknown as RefObject<HTMLElement>, handler: ()=> setShowPalette?.(undefined)})
+  useOutsidePointerDown({
+    ref: ref as unknown as RefObject<HTMLElement>,
+    handler: ()=> setShowPalette?.(undefined),
+    enabled: !!(show && ref && setShowPalette),
+    info: {name: "InspectorPanel", component}
+  })
   return (show
     ? <Box ref={ref} className={`inspector-panel ${component ?? "" }`} bg="tealDark" data-testid={"inspector-panel"}>
         {children}

--- a/v3/src/components/web-view/web-view-inspector.tsx
+++ b/v3/src/components/web-view/web-view-inspector.tsx
@@ -1,6 +1,6 @@
 import {useDisclosure} from "@chakra-ui/react"
 import {observer} from "mobx-react-lite"
-import React, {useRef} from "react"
+import React from "react"
 import MediaToolIcon from "../../assets/icons/icon-media-tool.svg"
 import { useDocumentContent } from "../../hooks/use-document-content"
 import { t } from "../../utilities/translation/translate"
@@ -15,7 +15,6 @@ import "./web-view-inspector.scss"
 export const WebViewInspector = observer(function WebViewInspector({tile, show}: ITileInspectorPanelProps) {
   const documentContent = useDocumentContent()
   const webViewModel = isWebViewModel(tile?.content) ? tile?.content : undefined
-  const panelRef = useRef<HTMLDivElement>()
   const webViewModal = useDisclosure()
 
   const handleSetWebViewUrlOpen = () => {
@@ -41,7 +40,7 @@ export const WebViewInspector = observer(function WebViewInspector({tile, show}:
 
   return (
     <>
-      <InspectorPanel ref={panelRef} component="web-view" show={show}>
+      <InspectorPanel component="web-view" show={show}>
         <InspectorButton
           onButtonClick={handleSetWebViewUrlOpen}
           showMoreOptions={false}

--- a/v3/src/hooks/use-callback-ref.ts
+++ b/v3/src/hooks/use-callback-ref.ts
@@ -1,16 +1,23 @@
-// local copy of @chakra-ui/react-use-callback-ref
-import { useCallback, useEffect, useRef } from "react"
+// local copy of @chakra-ui/react-use-callback-ref:
+// https://github.com/chakra-ui/chakra-ui/blob/main/packages/react/src/hooks/use-callback-ref.ts
+import { useCallback, useInsertionEffect, useRef } from "react"
 
-export function useCallbackRef<T extends (...args: any[]) => any>(
-  callback: T | undefined,
+/**
+ * This hook is user-land implementation of the experimental `useEffectEvent` hook.
+ * React docs: https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event
+ */
+export function useCallbackRef<Args extends unknown[], Return>(
+  callback: ((...args: Args) => Return) | undefined,
   deps: React.DependencyList = [],
 ) {
-  const callbackRef = useRef(callback)
+  const callbackRef = useRef<typeof callback>(() => {
+    throw new Error("Cannot call an event handler while rendering.")
+  })
 
-  useEffect(() => {
+  useInsertionEffect(() => {
     callbackRef.current = callback
   })
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useCallback(((...args) => callbackRef.current?.(...args)) as T, deps)
+  return useCallback(((...args: Args) => callbackRef.current?.(...args)), deps)
 }

--- a/v3/src/hooks/use-outside-pointer-down.ts
+++ b/v3/src/hooks/use-outside-pointer-down.ts
@@ -16,23 +16,32 @@ interface IProps {
    * Function invoked when a click is triggered outside the referenced element.
    */
   handler?: (e: Event) => void
+  /**
+   * The info gets attached to the pointerdown handler. This handler.info can
+   * be inspected by the chrome dev tools. In the "Elements" tab select the html
+   * element, go to the "Event Listeners" sub tab, make sure the "Ancestors" box is checked,
+   * expand the "pointerdown" and look at the entries for "use-outside-pointer-down.ts"
+   */
+  info?: any
 }
 
 /**
  * Example, used in components like Dialogs and Popovers, so they can close
  * when a user clicks outside them.
  */
-export function useOutsidePointerDown({ ref, handler, enabled = true }: IProps) {
-  const savedHandler = useCallbackRef(handler)
+export function useOutsidePointerDown({ ref, handler, enabled = true, info }: IProps) {
+  const onPointerDown = useCallbackRef((e: Event) => {
+    if (ref && isValidEvent(e, ref) && handler) {
+      handler(e)
+    }
+  })
+
+  if (onPointerDown) {
+    (onPointerDown as any).info = info
+  }
 
   useEffect(() => {
     if (!enabled) return
-
-    const onPointerDown: any = (e: PointerEvent) => {
-      if (ref && isValidEvent(e, ref)) {
-        savedHandler(e)
-      }
-    }
 
     // listen for pointerdown because D3 drag handlers intercept subsequent mouse events
     const doc = getOwnerDocument(ref?.current)
@@ -41,7 +50,7 @@ export function useOutsidePointerDown({ ref, handler, enabled = true }: IProps) 
     return () => {
       doc.removeEventListener("pointerdown", onPointerDown, true)
     }
-  }, [enabled, ref, savedHandler])
+  }, [enabled, ref, onPointerDown])
 }
 
 function isValidEvent(event: any, ref: React.RefObject<HTMLElement>) {
@@ -56,6 +65,9 @@ function isValidEvent(event: any, ref: React.RefObject<HTMLElement>) {
   // This is to prevent the inspector panel from closing when a user clicks on a color picker
   if (target.closest('.chakra-portal')) return false
 
+  // Note: If ref.current is undefined, isValidEvent will return true
+  // so useOutsidePointerDown will call the callback. The code using
+  // this hasn't been reviewed to see if this behavior is relied on.
   return !ref.current?.contains(target)
 }
 


### PR DESCRIPTION
This fixes the flakey clicks that were first found on the graph inspector panel, but can happen anywhere inside of a component that has been dragged to a new position.

Additionally it:
- reduces the number of pointerdown listeners by disabling the useOutsidePointerDown hook when possible
- adds info the useOutsidePointerDown to make it easier to see which components have active listeners
- updates the useCallbackRef with the latest code from chakra-ui