### PR TITLE
Fix date axis scaling bug

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -896,6 +896,7 @@ export const DataConfigurationModel = types
     setAttribute(role: AttrRole, desc?: IAttributeDescriptionSnapshot) {
       self._setAttributeDescription(role, desc)
       self.setPointsNeedUpdating(true)
+      self.numericValuesForAttrRole.invalidate(role)  // No harm in invalidating even if not numeric
     },
     setAttributeType(role: AttrRole, type: AttributeType, plotNumber = 0) {
       self._attributeDescriptions.get(role)?.setType(type)

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -665,7 +665,6 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       }
     },
     setAttribute(role: GraphAttrRole, desc?: IAttributeDescriptionSnapshot) {
-
       // For 'x' and 'y' roles, if the given attribute is already present on the other axis, then
       // move whatever attribute is assigned to the given role to that axis.
       if (['x', 'y'].includes(role)) {
@@ -686,6 +685,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       } else {
         self._setAttributeDescription(role, desc)
       }
+      self.numericValuesForAttrRole.invalidate(role)  // No harm in invalidating even if not numeric
     },
     addYAttribute(desc: IAttributeDescriptionSnapshot, index?: number) {
       if (index != null && index >= 0) {

--- a/v3/src/components/graph/models/graph-model-utils.ts
+++ b/v3/src/components/graph/models/graph-model-utils.ts
@@ -92,6 +92,7 @@ function setupAxes(graphModel: IGraphContentModel, layout: GraphLayout) {
           setNiceDomain(valuesInSeconds, newAxisModel, graphModel?.axisDomainOptions)
         }
         else {
+          currAxisModel.setAllowRangeToShrink(true)
           const valuesInSeconds = stringValuesToDateSeconds(attr?.strValues || [])
           setNiceDomain(valuesInSeconds, currAxisModel, graphModel?.axisDomainOptions)
         }


### PR DESCRIPTION
[#188819773] Feature: Graph axes and scaling are incorrect when switching from a date attribute to another date attribute

* The immediate problem is fixed by calling setAllowRangeToShrink for the date axis.
* But another problem is that attempting to rescale the date axis with the new date attribute wasn't working because the numericValuesForAttrRole factory method wasn't being invalidated and therefore the rescale was happening with the previous values.