### PR TITLE
fix: first() and last() functions

### DIFF
--- a/v3/src/models/formula/functions/aggregate-functions.ts
+++ b/v3/src/models/formula/functions/aggregate-functions.ts
@@ -92,7 +92,6 @@ export const aggregateFnWithFilterFactory = (fn: ClientFn) => {
       filterValues = [ filterValues ]
     }
     expressionValues = expressionValues.filter((v: FValue, i: number) =>
-      // Numeric aggregate functions should ignore non-numeric values.
       isValueNonEmpty(v) && (filterValues ? isValueTruthy(filterValues[i]) : true)
     )
     return expressionValues.length > 0 ? fn(expressionValues, args, scope) : UNDEF_RESULT

--- a/v3/src/models/formula/functions/math.ts
+++ b/v3/src/models/formula/functions/math.ts
@@ -9,11 +9,11 @@ import { bivariateStatsFunctions } from "./bivariate-stats-functions"
 import { colorFunctions } from "./color-functions"
 import { dateFunctions } from "./date-functions"
 import { evaluateNode, getRootScope } from "./function-utils"
+import { localLookupFunctions } from "./local-lookup-functions"
 import { logicFunctions } from "./logic-functions"
 import { lookupFunctions } from "./lookup-functions"
 import { operators } from "./operators"
 import { otherFunctions } from "./other-functions"
-import { semiAggregateFunctions } from "./semi-aggregate-functions"
 import { stringFunctions } from "./string-functions"
 import { univariateStatsFunctions } from "./univariate-stats-functions"
 
@@ -81,6 +81,8 @@ export const fnRegistry = {
 
   ...stringFunctions,
 
+  ...localLookupFunctions,
+
   ...lookupFunctions,
 
   ...otherFunctions,
@@ -89,9 +91,7 @@ export const fnRegistry = {
 
   ...univariateStatsFunctions,
 
-  ...bivariateStatsFunctions,
-
-  ...semiAggregateFunctions
+  ...bivariateStatsFunctions
 }
 
 export const typedFnRegistry: CODAPMathjsFunctionRegistry = fnRegistry


### PR DESCRIPTION
In my initial implementation of `first()` and `last()` (#1806), I assumed that `first()` and `last()` were like their cousins `next()` and `prev()` in requiring a semi-aggregate implementation in which the looping and filtering of appropriate cases is handled within the function implementation. Upon further reflection, `first()` and `last()` are actually full aggregate functions, i.e. they're more like `mean()` and `median()` in returning the same value for every case in a group. 🤦 This means we can make use of aggregate function utilities like `cachedAggregateFnFactory` and `aggregateFnWithFilterFactory` which handle all of the looping and filtering for us and simplify the implementation dramatically. With this realization, I've also renamed the former `semi-aggregate-functions.ts` module to `local-lookup-functions.ts`, reflecting the fact that not all of the functions within it are semi-aggregate (and most people don't know what "semi-aggregate" means anyway 😉).