### PR TITLE
Fix bar chart (line chart) rendering on restore

### DIFF
--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -390,6 +390,7 @@ export class PixiPoints {
     if (this.displayTypeTransitionState.isActive) {
       this.transitionPointDisplayType({ point, style, x, y })
     } else {
+      this.setPointAnchor(point, this.anchor.x, this.anchor.y)
       this.setPointPosition(point, x, y)
     }
   }


### PR DESCRIPTION
[#188848789] Bug fix: Bar chart is not rendering correctly in shared documents

* When a graph is restored the positioning of the points or bars goes through a different path than when the graph is manipulated by user action. In particular the PixiPoints.displayTypeTransitionState.isActive property is set to false. This meant that `setPointAnchor` was not being called. For points this didn't make any difference, but for bars it does. So we add a call to this in the `false` path.
* Note that though the title refers to shared documents, the bug has only to do with restoring.