### PR TITLE
Fix date-to-categorical axis bug

### DIFF
--- a/v3/src/components/axis/helper-models/date-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/date-axis-helper.ts
@@ -463,6 +463,7 @@ export class DateAxisHelper extends AxisHelper {
       {rangeMin, rangeMax} = this
 
     sAS.selectAll('*').remove()
+    sAS.attr("class", "date-axis")
 
     this.renderAxisLine()
     drawTicks()

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -179,9 +179,10 @@ export const useSubAxis = ({
       if (!subAxisElt) return
       subAxisSelectionRef.current = select(subAxisElt)
       const sAS = subAxisSelectionRef.current
-      if (sAS.classed('numeric-axis')) {
-        sAS.selectAll('g').remove()
+      if (sAS.classed('numeric-axis') || sAS.classed('date-axis')) {
+        sAS.selectAll('*').remove()
         sAS.classed('numeric-axis', false)
+        sAS.classed('date-axis', false)
       }
 
       if (sAS.select('line').empty()) {


### PR DESCRIPTION
[#188919673] Bug fix: Replacing date axis with categorical attribute doesn't work properly

* In the transition from *numeric* axis to categorical we were properly detecting the presence of the numeric axis elements and removing them. Do the same for date axis elements.