### PR TITLE
Fix to categorical axis update bug

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -317,14 +317,14 @@ export const useSubAxis = ({
   // Refresh when category set, if any, changes
   useEffect(function installCategorySetSync() {
     if (isCategorical) {
-      const disposer = reaction(() => {
+      const disposer = mstReaction(() => {
         return (dataConfig?.categorySetForAttrRole(axisPlaceToAttrRole[axisPlace]))?.valuesArray
       }, () => {
         setupCategories()
         swapInProgress.current = true
         renderSubAxis()
         swapInProgress.current = false
-      }, {name: "useSubAxis [categories]", equals: comparer.structural})
+      }, {name: "useSubAxis [categories]", equals: comparer.structural}, dataConfig)
       return () => disposer()
     }
   }, [renderSubAxis, isCategorical, setupCategories, dataConfig, axisPlace])

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -63,7 +63,6 @@ export const useSubAxis = ({
     isNumeric = isNumericAxisModel(axisModel),
     isCategorical = isCategoricalAxisModel(axisModel),
     multiScaleChangeCount = layout.getAxisMultiScale(axisModel?.place ?? 'bottom')?.changeCount ?? 0,
-    savedCategorySetValuesRef = useRef<string[]>([]),
     dragInfo = useRef<DragInfo>({
       indexOfCategory: -1,
       catName: '',
@@ -319,22 +318,16 @@ export const useSubAxis = ({
   useEffect(function installCategorySetSync() {
     if (isCategorical) {
       const disposer = reaction(() => {
-        const multiScale = layout.getAxisMultiScale(axisModel.place),
-          categoryValues = multiScale?.categoryValues
-        return Array.from(categoryValues ?? [])
-      }, (values) => {
-        // todo: The above reaction is detecting changes to the set of values even when they haven't changed. Why?
-        if (JSON.stringify(values) !== JSON.stringify(savedCategorySetValuesRef.current)) {
-          setupCategories()
-          swapInProgress.current = true
-          renderSubAxis()
-          savedCategorySetValuesRef.current = values
-          swapInProgress.current = false
-        }
+        return (dataConfig?.categorySetForAttrRole(axisPlaceToAttrRole[axisPlace]))?.valuesArray
+      }, () => {
+        setupCategories()
+        swapInProgress.current = true
+        renderSubAxis()
+        swapInProgress.current = false
       }, {name: "useSubAxis [categories]", equals: comparer.structural})
       return () => disposer()
     }
-  }, [axisModel, renderSubAxis, layout, isCategorical, setupCategories])
+  }, [renderSubAxis, isCategorical, setupCategories, dataConfig, axisPlace])
 
   const updateDomainAndRenderSubAxis = useCallback(() => {
     const role = axisPlaceToAttrRole[axisPlace],


### PR DESCRIPTION
[#188914180] Bug fix: Graph axis doesn't update when initial checkbox value changes

* The bug does not have to do with checkboxes in particular, just a failure to detect changes in the category set determining the categorical axis. By paying attention to the appropriate category set rather than to the multiScale for the axis, we properly detect and react to changes.
* We also take a chance that this change will obviate the need for the comparison of current values with previously saved values of the categories.