### PR TITLE
feat: `levelColors` url parameter changes order of collection color assignments

### DIFF
--- a/v3/src/components/case-card/case-view.tsx
+++ b/v3/src/components/case-card/case-view.tsx
@@ -31,6 +31,7 @@ export const CaseView = observer(function CaseView(props: ICaseViewProps) {
   const {cases, level, onSelectCases, onNewCollectionDrop, displayedCaseLineage = []} = props
   const cardModel = useCaseCardModel()
   const data = cardModel?.data
+  const collectionCount = data?.collections.length ?? 1
   const collectionId = useCollectionContext()
   const collection = data?.getCollection(collectionId)
   const initialSelectedCase = collection?.cases.find(c => c.__id__ === displayedCaseLineage[level])
@@ -80,7 +81,7 @@ export const CaseView = observer(function CaseView(props: ICaseViewProps) {
 
   return (
     <>
-    <div className={`case-card-view fadeIn ${colorCycleClass(level)}`} data-testid="case-card-view">
+    <div className={`case-card-view fadeIn ${colorCycleClass(level, collectionCount)}`} data-testid="case-card-view">
       {level === 0 && <CaseCardCollectionSpacer onDrop={handleNewCollectionDrop} collectionId={collectionId}/>}
       <CaseCardHeader cases={cases} level={level}/>
       <div className="case-card-attributes">

--- a/v3/src/components/case-tile-common/case-tile-utils.ts
+++ b/v3/src/components/case-tile-common/case-tile-utils.ts
@@ -18,6 +18,7 @@ import { getTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { ITileContentModel } from "../../models/tiles/tile-content"
 import { getSharedModelManager, getTileEnvironment } from "../../models/tiles/tile-environment"
 import { uiState } from "../../models/ui-state"
+import { urlParams } from "../../utilities/url-params"
 import { getPositionOfNewComponent } from "../../utilities/view-utils"
 import { kTitleBarHeight } from "../constants"
 import { kCaseTableTileType } from "../case-table/case-table-defs"
@@ -174,8 +175,11 @@ export function applyCaseValueChanges(data: IDataSet, cases: ICase[], log?: ILog
   })
 }
 
-export const colorCycleClass = (level: number) => {
+export const colorCycleClass = (level: number, levelCount: number) => {
   const colorCycleCount = 5
+  const levelIndex = urlParams.levelColors === "child-parent"
+                      ? (levelCount - 1) - level
+                      : level
   // e.g. `color-cycle-1`, `color-cycle-2`, etc.
-  return `color-cycle-${level % colorCycleCount + 1}`
+  return `color-cycle-${levelIndex % colorCycleCount + 1}`
 }

--- a/v3/src/components/case-tile-common/collection-title.tsx
+++ b/v3/src/components/case-tile-common/collection-title.tsx
@@ -24,6 +24,7 @@ interface IProps {
 export const CollectionTitle =
                 observer(function CollectionTitle({onAddNewAttribute, showCount, collectionIndex}: IProps) {
   const data = useDataSetContext()
+  const collectionCount = data?.collections.length ?? 1
   const collectionId = useCollectionContext()
   const collection = data?.getCollection(collectionId)
   const collectionName = collection?.name || t("DG.AppController.createDataSet.collectionName")
@@ -112,7 +113,7 @@ export const CollectionTitle =
   const addIconClass = clsx("add-icon", { focused: isTileInFocus })
 
   return (
-    <div className={`collection-title-wrapper ${colorCycleClass(collectionIndex)}`} ref={titleRef}>
+    <div className={`collection-title-wrapper ${colorCycleClass(collectionIndex, collectionCount)}`} ref={titleRef}>
       <div className="collection-title" style={titleStyle}>
         <Editable value={isEditing ? editingName : displayName}
             onEdit={() => setIsEditing(true)} onSubmit={handleSubmit} onCancel={handleCancel}

--- a/v3/src/utilities/url-params.ts
+++ b/v3/src/utilities/url-params.ts
@@ -42,7 +42,7 @@ export interface UrlParams {
    */
   ICI?: string | null
   /*
-   * Indicates CODAP is running in the Activity Player. Used by the CFM and to configure 
+   * Indicates CODAP is running in the Activity Player. Used by the CFM and to configure
    * the CFM.
    * value: ignored
    */
@@ -65,6 +65,12 @@ export interface UrlParams {
    * value: "free" (default) | "mosaic"
    */
   layout?: string | null
+  /*
+   * [v3] Specifies whether collection header colors should be assigned from parent-to-child
+   * (default) or child-to-parent.
+   * value: "parent-child" (default) | "child-parent"
+   */
+  levelColors?: string | null
   /*
    * [v3] Specifies a url that can be used to add additional items to the Plugins menu.
    * See useRemotePluginsConfig() hook for more details, including format of remote document.


### PR DESCRIPTION
[[CODAP-13](https://concord-consortium.atlassian.net/browse/CODAP-13?atlOrigin=eyJpIjoiZjA0OGQ4MDBlMTU3NGU2NTlmMWNkNTE4MWZjZGVlODYiLCJwIjoiaiJ9)]

Slack discussion from [here](https://concord-consortium.slack.com/archives/C041A45FY1X/p1740437405578759) to [here](https://concord-consortium.slack.com/archives/C041A45FY1X/p1740501019988839).

Default (parent-to-child) color assignments testable at:
https://codap3.concord.org/branch/CODAP-13-level-colors-url-param/

Proposed (child-to-parent) color assignments testable at:
https://codap3.concord.org/branch/CODAP-13-level-colors-url-param/?levelColors=child-parent

[CODAP-13]: https://concord-consortium.atlassian.net/browse/CODAP-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ