### PR TITLE
fix: restore of graph adornments

### DIFF
--- a/v3/src/components/axis/models/multi-scale.ts
+++ b/v3/src/components/axis/models/multi-scale.ts
@@ -37,10 +37,10 @@ export const scaleTypeToD3Scale = (iScaleType: IScaleType) => {
 export type AxisExtent = [number, number]
 
 /**
- * This class is used to by plots to compute screen coordinates from data coordinates. It can also invert
+ * This class is used by plots to compute screen coordinates from data coordinates. It can also invert
  * the process, computing data coordinates from screen coordinates.
  * One instance is assigned to each axis place. Only 'left', 'bottom' and 'rightNumeric' places ever have
- * more than one repetition, and these only when a 'rightCat' or 'top' axis is present.
+ * more than one repetition, and these only when a 'rightCat' or 'top' attribute is present.
  */
 export class MultiScale {
   @observable scaleType: IScaleType

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -31,8 +31,6 @@ export class UnivariateMeasureAdornmentHelper {
   layout: GraphLayout
   measureSlug = ""
   model: IUnivariateMeasureAdornmentModel
-  xScale: ScaleNumericBaseType
-  yScale: ScaleNumericBaseType
 
   constructor (
     cellKey: Record<string, string>,
@@ -47,8 +45,21 @@ export class UnivariateMeasureAdornmentHelper {
     this.layout = layout
     this.measureSlug = model.type.toLowerCase().replace(/ /g, "-")
     this.model = model
-    this.xScale = layout.getAxisScale("bottom") as ScaleNumericBaseType
-    this.yScale = layout.getAxisScale("left") as ScaleNumericBaseType
+  }
+
+  // There is a convenient fiction in the types of these scales in that one of them is _actually_
+  // numeric, but the other will generally _not_ be numeric. The logic below (e.g. `isVertical`)
+  // is designed to guarantee that only the numeric scale will be asked to perform numeric
+  // calculations, but that functions like `range()` can be called for either scale.
+  // This could probably be rewritten in terms of `primaryScale()` and `secondaryScale()`
+  // which would make the code clearer and could be correctly typed.
+
+  get xScale() {
+    return this.layout.getAxisScale("bottom") as ScaleNumericBaseType
+  }
+
+  get yScale() {
+    return this.layout.getAxisScale("left") as ScaleNumericBaseType
   }
 
   generateIdString = (elementType: string) => {


### PR DESCRIPTION
The bug was that on restore the `UnivariateMeasureAdornmentHelper` was caching `xScale` and `yScale` properties passed to it on construction, but these were preliminary scales that were later configured/replaced. The fix is simply to look them up when needed rather than caching them, guaranteeing that the current/correct scales are always used.