### PR TITLE
fix: line plot issues after plot model refactor

### DIFF
--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -93,7 +93,7 @@ export const GraphContentModel = DataDisplayContentModel
       return self.plot.type
     },
     get pointsFusedIntoBars() {
-      return self.plot.displayType === "bars"
+      return self.plot.hasPointsFusedIntoBars
     },
     get graphPointLayerModel(): IGraphPointLayerModel {
       return self.layers[0] as IGraphPointLayerModel

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
@@ -23,6 +23,9 @@ export const BarChartModel = DotChartModel
     get displayType(): PointDisplayType {
       return "bars"
     },
+    get hasPointsFusedIntoBars(): boolean {
+      return true
+    },
     get hasCountAxis(): boolean {
       return true
     },
@@ -36,7 +39,7 @@ export const BarChartModel = DotChartModel
       return self.getValidCountAxis(place, attrType, axisModel)
     },
     get showZeroLine() {
-      return false
+      return true
     },
     barTipText(props: IBarTipTextProps) {
       const { dataset } = self.dataConfiguration ?? {}

--- a/v3/src/components/graph/plots/histogram/histogram-model.ts
+++ b/v3/src/components/graph/plots/histogram/histogram-model.ts
@@ -18,6 +18,9 @@ export const HistogramModel = BinnedDotPlotModel
     get displayType(): PointDisplayType {
       return "bars"
     },
+    get hasPointsFusedIntoBars(): boolean {
+      return true
+    },
     get hasCountAxis(): boolean {
       return true
     },

--- a/v3/src/components/graph/plots/line-plot/line-plot-model.ts
+++ b/v3/src/components/graph/plots/line-plot/line-plot-model.ts
@@ -11,5 +11,8 @@ export const LinePlotModel = DotPlotModel
   .views(() => ({
     get displayType(): PointDisplayType {
       return "bars"
+    },
+    get showZeroLine() {
+      return true
     }
   }))

--- a/v3/src/components/graph/plots/plot-model.ts
+++ b/v3/src/components/graph/plots/plot-model.ts
@@ -50,6 +50,9 @@ export const PlotModel = types
     get displayType(): PointDisplayType {
       return "points"
     },
+    get hasPointsFusedIntoBars(): boolean {
+      return false
+    },
     get hasCountAxis(): boolean {
       return false
     },


### PR DESCRIPTION
[[CODAP-122](https://concord-consortium.atlassian.net/browse/CODAP-122)]

- zero line not displayed
  - copy-paste configuration error
- data tip not displayed
  - added `hasPointsFusedIntoBars()` plot model method to distinguish line plots (which have bars but not points fused into bars) from other plots that display bars.

[CODAP-122]: https://concord-consortium.atlassian.net/browse/CODAP-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ