### PR TITLE
fix: PixiPoints cell masking

### DIFF
--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -115,7 +115,10 @@ export const Graph = observer(function Graph({graphController, setGraphRef, pixi
         .attr("width", `${Math.max(0, layout.plotWidth)}px`)
         .attr("height", `${Math.max(0, layout.plotHeight)}px`)
 
-      pixiPoints?.resize(layout.plotWidth, layout.plotHeight, layout.numColumns, layout.numRows)
+      const { xCats, yCats, topCats, rightCats } = graphModel.dataConfiguration.getCategoriesOptions()
+      const xCellCount = xCats.length * topCats.length
+      const yCellCount = yCats.length * rightCats.length
+      pixiPoints?.resize(layout.plotWidth, layout.plotHeight, xCellCount, yCellCount)
       pixiPoints?.setPointsMask(graphModel.dataConfiguration.caseDataWithSubPlot)
     }
   }, [dataset, graphModel.dataConfiguration, layout, layout.plotHeight, layout.plotWidth, pixiPoints, xScale])


### PR DESCRIPTION
[[CODAP-129](https://concord-consortium.atlassian.net/browse/CODAP-129)]

The PixiPoints rendering uses masks to clip rendered points to their appropriate subplot cell in the graph. This computation was incorrect in the case of a categorical on both the bottom and top (or left and right) axis places, resulting in the points in some cells being clipped out completely.


[CODAP-129]: https://concord-consortium.atlassian.net/browse/CODAP-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ