### PR TITLE
fix: positioning of dots/bars in dot/bar charts

### DIFF
--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useRef } from "react"
 import { createPortal } from "react-dom"
 import { numericSortComparator } from "../../../../utilities/data-utils"
 import { kMain } from "../../../data-display/data-display-types"
+import { circleAnchor } from "../../../data-display/pixi/pixi-points"
 import { IBarCover, IPlotProps } from "../../graphing-types"
 import { useChartDots } from "../../hooks/use-chart-dots"
 import { usePlotResponders } from "../../hooks/use-plot"
@@ -129,8 +130,9 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, pixiPo
       renderBarCovers({ barCovers, barCoversRef, dataConfig, primaryAttrRole })
     }
 
+    const anchor = circleAnchor
     setPointCoordinates({
-      dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),
+      anchor, dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),
       pixiPoints, selectedOnly, pointColor, pointStrokeColor, pointDisplayType,
       getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating, getWidth, getHeight,
       pointsFusedIntoBars: graphModel?.pointsFusedIntoBars

--- a/v3/src/components/graph/plots/dot-chart/dot-chart.tsx
+++ b/v3/src/components/graph/plots/dot-chart/dot-chart.tsx
@@ -3,7 +3,7 @@ import * as PIXI from "pixi.js"
 import React, { useCallback, useEffect } from "react"
 import { mstReaction } from "../../../../utilities/mst-reaction"
 import { handleClickOnCase } from "../../../data-display/data-display-utils"
-import { IPixiPointMetadata, PixiPointEventHandler } from "../../../data-display/pixi/pixi-points"
+import { circleAnchor, IPixiPointMetadata, PixiPointEventHandler } from "../../../data-display/pixi/pixi-points"
 import { IPlotProps } from "../../graphing-types"
 import { useChartDots } from "../../hooks/use-chart-dots"
 import { usePlotResponders } from "../../hooks/use-plot"
@@ -27,8 +27,9 @@ export const DotChart = observer(function DotChart({ pixiPoints }: IPlotProps) {
     const getScreenX = primaryIsBottom ? getPrimaryScreenCoord : getSecondaryScreenCoord
     const getScreenY = primaryIsBottom ? getSecondaryScreenCoord : getPrimaryScreenCoord
 
+    const anchor = circleAnchor
     setPointCoordinates({
-      dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'), pixiPoints, selectedOnly,
+      anchor, dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'), pixiPoints, selectedOnly,
       pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating
     })
   }, [dataset, graphModel, isAnimating, pixiPoints, primaryScreenCoord, secondaryScreenCoord, subPlotCells])


### PR DESCRIPTION
[[CODAP-132](https://concord-consortium.atlassian.net/browse/CODAP-132)]

In PixiPoints, there is a notion of an `anchorPoint` which determines offsets used when rendering points or bars. The correct anchor point to use is plot-dependent, but wasn't always being reset correctly after switching plots.

[CODAP-132]: https://concord-consortium.atlassian.net/browse/CODAP-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ