### PR TITLE
Adds plugin notification when user changes case focused in case card

### DIFF
--- a/v3/src/components/case-card/case-card-header.tsx
+++ b/v3/src/components/case-card/case-card-header.tsx
@@ -6,6 +6,7 @@ import { useCollectionContext } from "../../hooks/use-collection-context"
 import { createCasesNotification } from "../../models/data/data-set-notifications"
 import { t } from "../../utilities/translation/translate"
 import { IGroupedCase } from "../../models/data/data-set-types"
+import { setSelectedCases } from "../../models/data/data-set-utils"
 
 import Arrow from "../../assets/icons/arrow.svg"
 import AddIcon from "../../assets/icons/add-data-icon.svg"
@@ -68,7 +69,7 @@ export const CaseCardHeader = observer(function CaseView(props: ICaseHeaderProps
                                 : displayedCaseIndex + delta
     const newCase = cases[selectedCaseIndex]
     if (!newCase.__id__) return
-    data?.setSelectedCases([newCase.__id__])
+    setSelectedCases([newCase.__id__], data)
   }
 
   const handleAddNewCase = () => {


### PR DESCRIPTION
Case card navigation did not send notifications to plugins. This caused issues for the MultiData plugin, which needed notifications to show the correct selected case.
This makes it that case card navigation triggers the necessary notifications.