### PR TITLE
Bar chart & histogram bar behavior fixes

### DIFF
--- a/v3/src/components/data-display/components/data-tip.tsx
+++ b/v3/src/components/data-display/components/data-tip.tsx
@@ -1,11 +1,12 @@
 import React, { Fragment, useCallback, useEffect, useRef, useState } from "react"
 import * as PIXI from "pixi.js"
 import { computePosition, offset, useFloating } from "@floating-ui/react"
+import { useDataDisplayModelContext } from "../hooks/use-data-display-model"
 import { IDataSet } from "../../../models/data/data-set"
 import {IPixiPointMetadata, PixiPoints} from "../pixi/pixi-points"
 import { urlParams } from "../../../utilities/url-params"
 import { IDataConfigurationModel } from "../models/data-configuration-model"
-import { IGetTipTextProps } from "../data-tip-types"
+import { IGetTipTextProps, IShowDataTipProps } from "../data-tip-types"
 
 import "./data-tip.scss"
 
@@ -18,7 +19,8 @@ interface IDataTipBaseProps {
 
 interface IDataTipHelperProps extends IDataTipBaseProps {
   legendAttrID?: string
-  metadata: IPixiPointMetadata
+  caseID: string
+  plotNum: number
 }
 
 export interface IDataTipProps extends IDataTipBaseProps {
@@ -44,15 +46,15 @@ const createVirtualElement = (event: PointerEvent) => {
 }
 
 const tipText = (props: IDataTipHelperProps) => {
-  const {dataConfiguration, dataset, getTipAttrs, legendAttrID, metadata, getTipText} = props
-  const caseID = metadata.caseID
-  const attributeIDs = getTipAttrs(metadata.plotNum)
+  const {dataConfiguration, dataset, getTipAttrs, legendAttrID, caseID, plotNum, getTipText} = props
+  const attributeIDs = getTipAttrs(plotNum)
   const caseTipText = getTipText({caseID, attributeIDs, legendAttrID, dataset, dataConfig: dataConfiguration})
   return caseTipText
 }
 
 export const DataTip = (props: IDataTipProps) => {
   const { dataConfiguration, dataset, getTipAttrs, pixiPoints, getTipText } = props
+  const dataDisplayModel = useDataDisplayModelContext()
   const legendAttrID = dataConfiguration?.attributeID("legend")
   const tipTextLines = useRef<string[]>([])
   const [isTipOpen, setIsTipOpen] = useState(false)
@@ -71,16 +73,21 @@ export const DataTip = (props: IDataTipProps) => {
     }
   }, [refs.floating, refs.reference])
 
-  const showDataTip = (event: PointerEvent, sprite: PIXI.Sprite, metadata: IPixiPointMetadata) => {
+  const showDataTip = (showDataTipProps: IShowDataTipProps) => {
+    const {event, caseID, plotNum} = showDataTipProps
     event.stopPropagation()
     // Get the text to display in the data tip
-    const tipTextString = tipText({dataset, metadata, getTipAttrs, legendAttrID, dataConfiguration, getTipText})
+    const tipTextString = tipText({dataset, caseID, plotNum, getTipAttrs, legendAttrID, dataConfiguration, getTipText})
     tipTextLines.current = tipTextString.split("<br>")
     // Create the virtual element to use as a reference for positioning the data tip
     const virtualElement = createVirtualElement(event)
     refs.setPositionReference(virtualElement)
     // Open the data tip
     context.onOpenChange(true)
+  }
+
+  const showPixiDataTip = (event: PointerEvent, sprite: PIXI.Sprite, metadata: IPixiPointMetadata) => {
+    showDataTip({event, caseID: metadata.caseID, plotNum: metadata.plotNum})
   }
 
   const hideDataTip = (event: MouseEvent) => {
@@ -93,9 +100,11 @@ export const DataTip = (props: IDataTipProps) => {
   }, [isTipOpen, positionDataTip])
 
   // support disabling data tips via url parameter for jest tests
-  if (urlParams.noDataTips === undefined && pixiPoints) {
-    pixiPoints.onPointOver = showDataTip
+  if (urlParams.noDataTips === undefined && pixiPoints && dataDisplayModel) {
+    pixiPoints.onPointOver = showPixiDataTip
     pixiPoints.onPointLeave = hideDataTip
+    dataDisplayModel.setShowDataTip(showDataTip)
+    dataDisplayModel.setHideDataTip(hideDataTip)
   }
 
   return (

--- a/v3/src/components/data-display/data-tip-types.ts
+++ b/v3/src/components/data-display/data-tip-types.ts
@@ -8,3 +8,9 @@ export interface IGetTipTextProps {
   dataset?: IDataSet
   legendAttrID?: string
 }
+
+export interface IShowDataTipProps {
+  event: PointerEvent
+  caseID:string
+  plotNum:number
+}

--- a/v3/src/components/data-display/data-tip-types.ts
+++ b/v3/src/components/data-display/data-tip-types.ts
@@ -11,6 +11,6 @@ export interface IGetTipTextProps {
 
 export interface IShowDataTipProps {
   event: PointerEvent
-  caseID:string
-  plotNum:number
+  caseID: string
+  plotNum: number
 }

--- a/v3/src/components/data-display/models/data-display-content-model.ts
+++ b/v3/src/components/data-display/models/data-display-content-model.ts
@@ -19,7 +19,7 @@ import { IAxisTicks, TickFormatter } from "../../axis/axis-types"
 import {GraphPlace} from "../../axis-graph-shared"
 import { IAxisModel, isBaseNumericAxisModel } from "../../axis/models/axis-model"
 import { MarqueeMode } from "../data-display-types"
-import { IGetTipTextProps } from "../data-tip-types"
+import { IGetTipTextProps, IShowDataTipProps } from "../data-tip-types"
 import { IDataConfigurationModel } from "./data-configuration-model"
 import {DataDisplayLayerModelUnion} from "./data-display-layer-union"
 import {DisplayItemDescriptionModel} from "./display-item-description-model"
@@ -41,6 +41,8 @@ export const DataDisplayContentModel = TileContentModel
     animationTimerId: 0,
     marqueeMode: 'unclicked' as MarqueeMode,
     renderState: undefined as DataDisplayRenderState | undefined,
+    showDataTip: (props: IShowDataTipProps) => {},
+    hideDataTip: (event: MouseEvent) => {}
   }))
   .views(self => ({
     placeCanAcceptAttributeIDDrop(place: GraphPlace,
@@ -152,6 +154,12 @@ export const DataDisplayContentModel = TileContentModel
     },
     setRenderState(renderState: DataDisplayRenderState) {
       self.renderState = renderState
+    },
+    setShowDataTip: (showDataTip: (props: IShowDataTipProps) => void) => {
+      self.showDataTip = showDataTip
+    },
+    setHideDataTip: (hideDataTip: (event: MouseEvent) => void) => {
+      self.hideDataTip = hideDataTip
     }
   }))
 export interface IDataDisplayContentModel extends Instance<typeof DataDisplayContentModel> {}

--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -96,6 +96,11 @@ export class PixiPoints {
   tickerStopTimeoutId: number | undefined
   // For bar charts and histograms, we need events to be passed to the "cover" rectangles that
   // overlay the pixi sprites. This happens seamlessly in Chrome and Firefox, but not in Safari.
+  // TODO: Rather than using browser-detection, a better approach would be to runtime-detect the
+  // problematic behavior and use that to determine whether to use the workaround. For instance,
+  // if the problem is really that the bar cover SVGs never receive pointer events, then the
+  // handler for those pointer events could be used to disable the Safari-specific event dispatch.
+  // This would allow the code to continue to work once Safari fixes the underlying issue.
   isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
   // To dispatch to Safari for 'mouseout' we need the element we are leaving, computable from the event's x,y coords.
   mostRecentSvgElement: SVGElement | null = null
@@ -647,7 +652,7 @@ export class PixiPoints {
    * Dispatches events to the SVG elements lying on top of the PixiJS canvas. This is necessary for Safari,
    * as it does not pass events through the canvas to the elements above it.
    */
-  dispatchForSafari(event: PIXI.FederatedPointerEvent, eventType:string) {
+  dispatchForSafari(event: PIXI.FederatedPointerEvent, eventType: string) {
     const x = event.clientX
     const y = event.clientY
     const canvas = this.renderer?.view.canvas

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
@@ -64,12 +64,13 @@ export const BarChartModel = DotChartModel
       const secondCount = legendAttrId ? casesInSubPlot.length : totalCases
       const percent = float1(100 * firstCount / secondCount)
       // <n> of <m> <category> (<p>%) are <legend category>
-      const attrArray = [ firstCount, secondCount, caseCategoryString, percent, caseLegendCategoryString ]
-        .filter((a) => a !== "")
+      const vars = [ firstCount, secondCount, percent, caseLegendCategoryString ]
+      // data tips have an additional variable when there's a legend
+      caseCategoryString && vars.splice(2, 0, caseCategoryString)
       const translationKey = legendAttrId
         ? firstCount === 1 ? "DG.BarChartModel.cellTipSingular" : "DG.BarChartModel.cellTipPlural"
         : firstCount === 1 ? "DG.BarChartModel.cellTipNoLegendSingular" : "DG.BarChartModel.cellTipNoLegendPlural"
-      return t(translationKey, {vars: attrArray})
+      return t(translationKey, {vars})
     }
   }))
 export interface IBarChartModel extends Instance<typeof BarChartModel> {}

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
@@ -64,7 +64,8 @@ export const BarChartModel = DotChartModel
       const secondCount = legendAttrId ? casesInSubPlot.length : totalCases
       const percent = float1(100 * firstCount / secondCount)
       // <n> of <m> <category> (<p>%) are <legend category>
-      const attrArray = [ firstCount, secondCount, caseCategoryString, percent, caseLegendCategoryString ].filter((a) => a !== "")
+      const attrArray = [ firstCount, secondCount, caseCategoryString, percent, caseLegendCategoryString ]
+        .filter((a) => a !== "")
       const translationKey = legendAttrId
         ? firstCount === 1 ? "DG.BarChartModel.cellTipSingular" : "DG.BarChartModel.cellTipPlural"
         : firstCount === 1 ? "DG.BarChartModel.cellTipNoLegendSingular" : "DG.BarChartModel.cellTipNoLegendPlural"

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
@@ -64,7 +64,7 @@ export const BarChartModel = DotChartModel
       const secondCount = legendAttrId ? casesInSubPlot.length : totalCases
       const percent = float1(100 * firstCount / secondCount)
       // <n> of <m> <category> (<p>%) are <legend category>
-      const attrArray = [ firstCount, secondCount, caseCategoryString, percent, caseLegendCategoryString ]
+      const attrArray = [ firstCount, secondCount, caseCategoryString, percent, caseLegendCategoryString ].filter((a) => a !== "")
       const translationKey = legendAttrId
         ? firstCount === 1 ? "DG.BarChartModel.cellTipSingular" : "DG.BarChartModel.cellTipPlural"
         : firstCount === 1 ? "DG.BarChartModel.cellTipNoLegendSingular" : "DG.BarChartModel.cellTipNoLegendPlural"

--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -126,7 +126,7 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, pixiPo
           })
         })
       })
-      renderBarCovers({ barCovers, barCoversRef, dataConfig, primaryAttrRole })
+      renderBarCovers({ barCovers, barCoversRef, graphModel, primaryAttrRole })
     }
 
     setPointCoordinates({

--- a/v3/src/components/graph/plots/bar-utils.ts
+++ b/v3/src/components/graph/plots/bar-utils.ts
@@ -1,14 +1,14 @@
 import { select } from "d3"
 import { handleClickOnBar } from "../../data-display/data-display-utils"
-import { IDataConfigurationModel } from "../../data-display/models/data-configuration-model"
 import { CellType, IBarCover } from "../graphing-types"
 import { GraphLayout } from "../models/graph-layout"
 import { SubPlotCells } from "../models/sub-plot-cells"
+import { IGraphContentModel } from "../models/graph-content-model"
 
 interface IRenderBarCoverProps {
   barCovers: IBarCover[]
   barCoversRef: React.RefObject<SVGGElement>
-  dataConfig: IDataConfigurationModel
+  graphModel: IGraphContentModel
   primaryAttrRole: "x" | "y"
 }
 
@@ -55,7 +55,9 @@ export const barCoverDimensions = (props: IBarCoverDimensionsProps) => {
 }
 
 export const renderBarCovers = (props: IRenderBarCoverProps) => {
-  const { barCovers, barCoversRef, dataConfig } = props
+  const { barCovers, barCoversRef, graphModel } = props
+  const dataConfig = graphModel.dataConfiguration
+  const { showDataTip, hideDataTip } = graphModel
   select(barCoversRef.current).selectAll("rect").remove()
   select(barCoversRef.current).selectAll("rect")
     .data(barCovers)
@@ -66,8 +68,14 @@ export const renderBarCovers = (props: IRenderBarCoverProps) => {
       .attr("y", (d) => d.y)
       .attr("width", (d) => d.width)
       .attr("height", (d) => d.height)
-      .on("mouseover", function() { select(this).classed("active", true) })
-      .on("mouseout", function() { select(this).classed("active", false) })
+      .on("mouseover", function(event, d) {
+        select(this).classed("active", true)
+        showDataTip({event, caseID: d.caseIDs[0], plotNum: 0})
+      })
+      .on("mouseout", function(event) {
+        select(this).classed("active", false)
+        hideDataTip(event)
+      })
       .on("click", function(event, d) {
         dataConfig && handleClickOnBar({event, dataConfig, barCover: d})
       })

--- a/v3/src/components/graph/plots/bar-utils.ts
+++ b/v3/src/components/graph/plots/bar-utils.ts
@@ -56,8 +56,7 @@ export const barCoverDimensions = (props: IBarCoverDimensionsProps) => {
 
 export const renderBarCovers = (props: IRenderBarCoverProps) => {
   const { barCovers, barCoversRef, graphModel } = props
-  const dataConfig = graphModel.dataConfiguration
-  const { showDataTip, hideDataTip } = graphModel
+  const { dataConfiguration: dataConfig, showDataTip, hideDataTip } = graphModel
   select(barCoversRef.current).selectAll("rect").remove()
   select(barCoversRef.current).selectAll("rect")
     .data(barCovers)

--- a/v3/src/components/graph/plots/histogram/histogram.tsx
+++ b/v3/src/components/graph/plots/histogram/histogram.tsx
@@ -98,7 +98,7 @@ export const Histogram = observer(function Histogram({ abovePointsGroupRef, pixi
         })
       })
       const barCovers: IBarCover[] = Array.from(uniqueBarCovers.entries()).map(([_, cover]) => cover)
-      renderBarCovers({ barCovers, barCoversRef, dataConfig, primaryAttrRole })
+      renderBarCovers({ barCovers, barCoversRef, graphModel, primaryAttrRole })
     }
 
     setPointCoordinates({


### PR DESCRIPTION
[#CODAP-123] Bug fix: Bar chart selection misbehaves in Safari

* Working on this bug flushed out a number of problems in bar charts:
  * As the mouse moves over a bar, the data tip flashes, once for each portion of the bar corresponding to a case
  * In Safari, the hover tip was not showing and click did not select cases
  * The data tip of a bar chart for no legend was incorrect
* There were similar problems for histogram bars
--
## Fixes
* DataDisplayContentModel how has volatile properties `showDataTip` and `hideDateTip` so that these can be accessed when rendering bar cover rectangles for bar charts and histograms. The DataTip component, of which there is only one, sets these properties.
* If the browser is Safari, PisiPoints treats events specially for fused bars so that the different way Safari handles events in the presence of WebGl can be dealt with.