### PR TITLE
Fix for hiding cases in graph with multiple y attributes

### DIFF
--- a/v3/src/utilities/js-utils.ts
+++ b/v3/src/utilities/js-utils.ts
@@ -171,7 +171,7 @@ export function hashStringSets(stringSets: Array<string[]>) {
   return stringSets
     .map(hashStringSet)
     // eslint-disable-next-line no-bitwise
-    .reduce((acc, hash) => acc ^ hash, 0) // XOR all individual hashes
+    .reduce((acc, hash, index) => acc ^ (hash * (index + 1)), 0x9e3779b9) // XOR all individual hashes with an index-based multiplier and a large initial value
 }
 
 /*


### PR DESCRIPTION
[#CODAP-17] Bug fix: Unable to hide selected cases in graphs with multiple y-axes

* This turned out to be a bug in the `hashStringSets` function which takes an array of string arrays and computes a hash value. It was working fine for a *single* array of strings (caseIDs) but would return zero for two identical arrays, which was the situation in this bug's scenario. With the help of co-pilot we modify the function to use the array index as part of the exponent of the accumulator, and we start with a better initial value than zero, namely 0x9e3779b9 which is the "golden ratio constant," known to help achieve a good distribution of hash values.
* With this change, reactions that are triggered by changes in a data configuration's caseDataHash respond to hiding cases even when there are multiple sets of cases being plotted.