### PR TITLE
Fix spurious circular reference error

### DIFF
--- a/v3/src/models/formula/utils/formula-dependency-utils.ts
+++ b/v3/src/models/formula/utils/formula-dependency-utils.ts
@@ -46,7 +46,10 @@ export const getFormulaDependencies = (formulaCanonical: string, formulaAttribut
       const isSelfReference = ifSelfReference(dependency, formulaAttributeId)
       // Note that when self reference is allowed, we should NOT add the attribute to the dependency list.
       // This would create cycle in observers and trigger an error even earlier, when we check for this scenario.
-      if (dependency && (!isSelfReference || !isSelfReferenceAllowed)) {
+      // Todo: Fix this TS error
+      // @ts-expect-error does-not-exist
+      const isPresent = result.some((dep) => dep.attrId === dependency?.attrId)
+      if (dependency && (!isSelfReference || !isSelfReferenceAllowed) && !isPresent) {
         result.push(dependency)
       }
     }


### PR DESCRIPTION
[#CODAP-53] Bug fix: Circular ref error

* The problem is that `getFormulaDependencies` in formula-dependency-utils.ts was not protecting against adding the same attribute more than once to the result when a formula has two occurrences of a given attribute. Because of this `isDependencyCyclePresent` was returning true when there actually was no cycle.