### PR TITLE
Round date time slider input value based on multiples of

### DIFF
--- a/v3/src/components/axis/models/multi-scale.ts
+++ b/v3/src/components/axis/models/multi-scale.ts
@@ -1,11 +1,12 @@
-import { mstReaction } from "../../../utilities/mst-reaction"
 import { action, comparer, computed, makeObservable, observable } from "mobx"
 import {
   format, NumberValue, ScaleBand, scaleBand, scaleLinear, scaleLog, ScaleOrdinal, scaleOrdinal
 } from "d3"
-import { formatDate } from "../../../utilities/date-utils"
-import { AxisScaleType, IScaleType, ScaleNumericBaseType } from "../axis-types"
 import { ICategorySet } from "../../../models/data/category-set"
+import { DatePrecision, formatDate } from "../../../utilities/date-utils"
+import { mstReaction } from "../../../utilities/mst-reaction"
+import { kDefaultDateMultipleOfUnit } from "../../slider/slider-types"
+import { AxisScaleType, IScaleType, ScaleNumericBaseType } from "../axis-types"
 
 interface IDataCoordinate {
   cell: number
@@ -189,7 +190,7 @@ export class MultiScale {
    *   the value for one screen pixel from the value for the adjacent screen pixel.
    *   If isDate is true, the value is the number of seconds since the epoch.
    * **/
-  formatValueForScale(value: number, isDate = false): string {
+  formatValueForScale(value: number, isDate = false, dateMultipleOfUnit = kDefaultDateMultipleOfUnit): string {
     const formatNumber = (n: number): string => {
       const resolution = this.resolution ?? 1
       // Calculate the number of significant digits based on domain and range
@@ -205,8 +206,14 @@ export class MultiScale {
       // Use D3 format to generate a string with the appropriate number of decimal places
       return format('.9')(roundedNumber)
     }
+
+    const formatSliderInputDate = (n: number): string => {
+      if (isDate) {
+        return formatDate(n * 1000, dateMultipleOfUnit as DatePrecision) ?? ''
+      } else { return ''}
+    }
     return isDate
-             ? formatDate(value * 1000) ?? ''
+             ? formatSliderInputDate(value)
              : this.resolution ? formatNumber(value) : String(value)
   }
 }

--- a/v3/src/components/axis/models/multi-scale.ts
+++ b/v3/src/components/axis/models/multi-scale.ts
@@ -190,7 +190,8 @@ export class MultiScale {
    *   the value for one screen pixel from the value for the adjacent screen pixel.
    *   If isDate is true, the value is the number of seconds since the epoch.
    * **/
-  formatValueForScale(value: number, isDate = false, dateMultipleOfUnit = kDefaultDateMultipleOfUnit): string {
+  formatValueForScale(value: number, isDate = false,
+                      dateMultipleOfUnit: DatePrecision | string = kDefaultDateMultipleOfUnit): string {
     const formatNumber = (n: number): string => {
       const resolution = this.resolution ?? 1
       // Calculate the number of significant digits based on domain and range
@@ -207,11 +208,13 @@ export class MultiScale {
       return format('.9')(roundedNumber)
     }
 
+    const formatDatePrecisionArr = [DatePrecision.Year, DatePrecision.Month, DatePrecision.Day, DatePrecision.Hour]
     const formatSliderInputDate = (n: number): string => {
-      if (isDate) {
+      if (isDate && formatDatePrecisionArr.includes(dateMultipleOfUnit as DatePrecision)) {
         return formatDate(n * 1000, dateMultipleOfUnit as DatePrecision) ?? ''
-      } else { return ''}
+      } else { return formatDate(n * 1000, DatePrecision.Minute) ?? '' }
     }
+
     return isDate
              ? formatSliderInputDate(value)
              : this.resolution ? formatNumber(value) : String(value)

--- a/v3/src/components/axis/models/multi-scale.ts
+++ b/v3/src/components/axis/models/multi-scale.ts
@@ -5,7 +5,6 @@ import {
 import { ICategorySet } from "../../../models/data/category-set"
 import { DatePrecision, formatDate } from "../../../utilities/date-utils"
 import { mstReaction } from "../../../utilities/mst-reaction"
-import { kDefaultDateMultipleOfUnit } from "../../slider/slider-types"
 import { AxisScaleType, IScaleType, ScaleNumericBaseType } from "../axis-types"
 
 interface IDataCoordinate {
@@ -191,7 +190,7 @@ export class MultiScale {
    *   If isDate is true, the value is the number of seconds since the epoch.
    * **/
   formatValueForScale(value: number, isDate = false,
-                      dateMultipleOfUnit: DatePrecision | string = kDefaultDateMultipleOfUnit): string {
+                      dateMultipleOfUnit: DatePrecision | string = ""): string {
     const formatNumber = (n: number): string => {
       const resolution = this.resolution ?? 1
       // Calculate the number of significant digits based on domain and range

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -26,7 +26,7 @@ export const EditableSliderValue = observer(function EditableSliderValue({slider
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const domain = sliderModel.domain
       setCandidate(multiScale.formatValueForScale(sliderModel.value, sliderModel.scaleType === "date",
-                                                    sliderModel.dateMultipleOfUnit))
+                                    sliderModel.multipleOf !== undefined ? sliderModel.dateMultipleOfUnit : undefined))
     })
   }, [multiScale, sliderModel])
 

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -25,7 +25,8 @@ export const EditableSliderValue = observer(function EditableSliderValue({slider
       // trigger update on domain change
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const domain = sliderModel.domain
-      setCandidate(multiScale.formatValueForScale(sliderModel.value, sliderModel.scaleType === "date"))
+      setCandidate(multiScale.formatValueForScale(sliderModel.value, sliderModel.scaleType === "date",
+                                                    sliderModel.dateMultipleOfUnit))
     })
   }, [multiScale, sliderModel])
 


### PR DESCRIPTION
If user has specified that slider date precision in years, months, days, or hours, we format the input value to show those precision. All other precision defaults to minutes precision.

demo at https://codap3.concord.org/branch/round-date-time-slider-to-multiples-of/