### PR TITLE
Date-time values not showing on date-time slider

### DIFF
--- a/v3/src/components/axis/helper-models/date-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/date-axis-helper.ts
@@ -463,7 +463,7 @@ export class DateAxisHelper extends AxisHelper {
       {rangeMin, rangeMax} = this
 
     sAS.selectAll('*').remove()
-    sAS.attr("class", "date-axis")
+    sAS.attr("class", "date-axis axis")
 
     this.renderAxisLine()
     drawTicks()


### PR DESCRIPTION
[#CODAP-300] Bug fix: Date values not showing on date-time slider

* This bug appeared a couple months ago with changes made to `DateAxisHelper` but insufficient attention to effects on the slider date-time axis.
* The fix is simple. Reinstate the `axis` class for the sub axis. This brings along with it a value of "black" for the `fill`.