### PR TITLE
iPad drag and resize components fix

### DIFF
--- a/v3/src/components/codap-component.scss
+++ b/v3/src/components/codap-component.scss
@@ -27,6 +27,7 @@ $corner-drag-size: calc($border-drag-width * 2);
   margin: 0;
   user-select: none;
   z-index: 11;
+  touch-action: none;
   &.right {
     bottom: $corner-drag-size;
     right: 0;
@@ -57,6 +58,7 @@ $corner-drag-size: calc($border-drag-width * 2);
   margin: 0;
   user-select: none;
   z-index: 11;
+  touch-action: none;
   &.bottom-left {
     bottom: 0;
     left: 0;

--- a/v3/src/components/component-title-bar.scss
+++ b/v3/src/components/component-title-bar.scss
@@ -94,6 +94,7 @@
 .title-bar {
   width: 100%;
   cursor: grab !important;
+  touch-action: none;
 }
 .title-text {
   display: flex !important;

--- a/v3/webpack.config.js
+++ b/v3/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = (env, argv) => {
   return {
     context: __dirname, // to automatically find tsconfig.json
     devServer: {
+      allowedHosts: 'all',
       static: 'dist',
       hot: true,
       server: {


### PR DESCRIPTION
[#CODAP-89] Bug fix: Component reposition and resize in iPadOS

* With some help from co-pilot we learn that adding `touch-action: none;` to component css governing the title bar, borders and corners serves to prevent touch actions from propagating to the browser, thus limiting their effect to the desired drag and resize behavior in CODAP.
* In order to be able to test using an iPad connected to one's development computer, we add `allowedHosts: 'all'` the webpack configuration `devserver:`

Note that it is also possible to test using xCode's **Simulator** running locally, and, for that, the `allowedHosts` change is not necessary.