### PR TITLE
fix: `di` url param loads plugin alongside any initial document

### DIFF
--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -114,6 +114,9 @@ export const App = observer(function App() {
 
       const { di } = urlParams
       if (typeof di === "string") {
+        // wait for CFM to complete its initialization
+        await cfmReadyPromise
+
         const webviewTiles = appState.document.content?.getTilesOfType(kWebViewTileType)
         if (webviewTiles) {
           const webviews = webviewTiles.map(wV => wV.content) as IWebViewModel[]
@@ -126,9 +129,7 @@ export const App = observer(function App() {
         }
         // setTimeout ensures that other components have been rendered,
         // which is necessary to properly position the plugin.
-        setTimeout(async () => {
-          // wait for CFM to complete its initialization
-          await cfmReadyPromise
+        setTimeout(() => {
           appState.document.content?.applyModelChange(() => {
             const plugin = appState.document.content?.createTile?.(kWebViewTileType)
             if (isWebViewModel(plugin?.content)) plugin.content.setUrl(di)

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -46,7 +46,7 @@ registerTileTypes([])
 export const App = observer(function App() {
   useKeyStates()
 
-  const cfm = useCloudFileManager({
+  const { cfm, cfmReadyPromise } = useCloudFileManager({
     appOrMenuElemId: kMenuBarElementId
   })
 
@@ -126,7 +126,9 @@ export const App = observer(function App() {
         }
         // setTimeout ensures that other components have been rendered,
         // which is necessary to properly position the plugin.
-        setTimeout(() => {
+        setTimeout(async () => {
+          // wait for CFM to complete its initialization
+          await cfmReadyPromise
           appState.document.content?.applyModelChange(() => {
             const plugin = appState.document.content?.createTile?.(kWebViewTileType)
             if (isWebViewModel(plugin?.content)) plugin.content.setUrl(di)
@@ -139,7 +141,7 @@ export const App = observer(function App() {
     }
 
     initialize()
-  }, [])
+  }, [cfmReadyPromise])
 
   return (
     <CodapDndContext>

--- a/v3/src/lib/use-cloud-file-manager.test.tsx
+++ b/v3/src/lib/use-cloud-file-manager.test.tsx
@@ -49,7 +49,8 @@ describe("useCloudFileManager", () => {
 
     let cfm: CloudFileManager | undefined
     renderHook(() => {
-      cfm = useCloudFileManager({ appOrMenuElemId: "container-div" })
+      const { cfm: _cfm } = useCloudFileManager({ appOrMenuElemId: "container-div" })
+      cfm = _cfm
     })
     expect(cfm).toBeDefined()
     await waitFor(() => {


### PR DESCRIPTION
[[CODAP-31](https://concord-consortium.atlassian.net/browse/CODAP-31)]

- adds a promise so that clients can detect when the CFM has completed its initialization, including the loading of any initial documents.
- waits to process the `di` url parameter until after the CFM has completed its initialization

[CODAP-31]: https://concord-consortium.atlassian.net/browse/CODAP-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ