### PR TITLE
Fix dot chart point clipping bug

### DIFF
--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -577,8 +577,12 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     const baseSetNumberOfCategoriesLimitForRole = self.setNumberOfCategoriesLimitForRole
     return {
       setNumberOfCategoriesLimitForRole(role: AttrRole, limit: number) {
-        self.subPlotCases.invalidateAll()
-        baseSetNumberOfCategoriesLimitForRole.call(self, role, limit)
+        if (self.numberOfCategoriesLimitByRole.get(role) !== limit) {
+          self.subPlotCases.invalidateAll()
+          baseSetNumberOfCategoriesLimitForRole.call(self, role, limit)
+          self.categoryArrayForAttrRole.invalidate(role)
+          self.categoryArrayForAttrRole.invalidate(role, [])
+        }
       }
     }
   })


### PR DESCRIPTION
[#CODAP-89] Bug fix: Dot chart dots are getting clipped and/or hidden

* When we call `GraphDataConfigurationModel:setNumberOfCategoriesLimitForRole` we must invalidate `categoryArrayForAttrRole` and be sure to do it both for the argument `role` *and also* for the pair of arguments `role, []`.