### PR TITLE
feat: allow plugins to get information about specific adornments (CODAP-68)

### DIFF
--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -68,6 +68,7 @@ export interface DIDataDisplay {
 }
 
 export interface DIResources {
+  adornment?: IAdornmentModel
   adornmentList?: IAdornmentModel[]
   attribute?: IAttribute
   attributeList?: IAttribute[]

--- a/v3/src/data-interactive/handlers/adornment-handler.test.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.test.ts
@@ -1,0 +1,32 @@
+import { CountAdornmentModel } from "../../components/graph/adornments/count/count-adornment-model"
+import { diAdornmentHandler } from "./adornment-handler"
+
+describe("DataInteractive AdornmentHandler", () => {
+  const handler = diAdornmentHandler
+  const countAdornment = CountAdornmentModel.create({
+    id: "ADRN123",
+    isVisible: false,
+    percentType: "row",
+    showCount: false,
+    showPercent: false,
+    type: "Count"
+  })
+
+  it("get works as expected when provided with an adornment", () => {  
+    const result = handler.get?.({ adornment: countAdornment })
+    const { success, values } = result || {}
+    const getValue = (key: string) => {
+      return (values && typeof values === "object" && key in values) ? (values as Record<string, any>)[key] : undefined
+    }
+    expect(success).toBe(true)
+    expect(getValue("id")).toBe(countAdornment.id)
+    expect(getValue("type")).toBe(countAdornment.type)
+    expect(getValue("isVisible")).toBe(countAdornment.isVisible)
+  })
+
+  it("get returns an error when no adornment provided", () => {
+    const result = handler.get?.({})
+    expect(result?.success).toBe(false)
+  })
+
+})

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -1,0 +1,33 @@
+import { getSnapshot } from "@concord-consortium/mobx-state-tree"
+import { registerDIHandler } from "../data-interactive-handler"
+import { DIHandler, DIResources } from "../data-interactive-types"
+import { adornmentNotFoundResult } from "./di-results"
+import { t } from "../../utilities/translation/translate"
+
+
+export const diAdornmentHandler: DIHandler = {
+  get(resources: DIResources) {
+    const { adornment } = resources
+    if (!adornment) return adornmentNotFoundResult
+
+    const adornmentSnapshot = getSnapshot(adornment)
+
+    // Translate `labelTitle` if it exists.
+    if ("labelTitle" in adornmentSnapshot && typeof adornmentSnapshot.labelTitle === "string") {
+      return {
+        success: true,
+        values: {
+          ...adornmentSnapshot,
+          labelTitle: t(adornmentSnapshot.labelTitle)
+        }
+      }
+    }
+
+    return {
+      success: true,
+      values: adornmentSnapshot
+    } 
+  }
+}
+
+registerDIHandler("adornment", diAdornmentHandler)

--- a/v3/src/data-interactive/handlers/adornment-list-handler.test.ts
+++ b/v3/src/data-interactive/handlers/adornment-list-handler.test.ts
@@ -28,5 +28,4 @@ describe("DataInteractive AdornmentListHandler", () => {
     const result = handler.get?.({})
     expect(result?.success).toBe(false)
   })
-
 })

--- a/v3/src/data-interactive/handlers/adornment-list-handler.test.ts
+++ b/v3/src/data-interactive/handlers/adornment-list-handler.test.ts
@@ -29,13 +29,4 @@ describe("DataInteractive AdornmentListHandler", () => {
     expect(result?.success).toBe(false)
   })
 
-  it("filters by type when provided with a type", () => {
-    const result = handler.get?.({ adornmentList }, { type: "Median" })
-    expect(result?.success).toBe(true)
-    const values = result?.values as any[]
-    expect(values.length).toBe(1)
-    expect(values[0].id).toBe(adornment2.id)
-    expect(values[0].type).toBe(adornment2.type)
-    expect(values[0].isVisible).toBe(adornment2.isVisible)
-  })
 })

--- a/v3/src/data-interactive/handlers/adornment-list-handler.test.ts
+++ b/v3/src/data-interactive/handlers/adornment-list-handler.test.ts
@@ -28,4 +28,14 @@ describe("DataInteractive AdornmentListHandler", () => {
     const result = handler.get?.({})
     expect(result?.success).toBe(false)
   })
+
+  it("filters by type when provided with a type", () => {
+    const result = handler.get?.({ adornmentList }, { type: "Median" })
+    expect(result?.success).toBe(true)
+    const values = result?.values as any[]
+    expect(values.length).toBe(1)
+    expect(values[0].id).toBe(adornment2.id)
+    expect(values[0].type).toBe(adornment2.type)
+    expect(values[0].isVisible).toBe(adornment2.isVisible)
+  })
 })

--- a/v3/src/data-interactive/handlers/adornment-list-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-list-handler.ts
@@ -2,7 +2,6 @@ import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DIResources } from "../data-interactive-types"
 import { adornmentListNotFoundResult } from "./di-results"
 
-
 export const diAdornmentListHandler: DIHandler = {
   get(resources: DIResources) {
     const { adornmentList } = resources

--- a/v3/src/data-interactive/handlers/di-results.ts
+++ b/v3/src/data-interactive/handlers/di-results.ts
@@ -1,6 +1,7 @@
 import { t } from "../../utilities/translation/translate"
 
 export const errorResult = (error: string) => ({ success: false as const, values: { error } })
+export const adornmentNotFoundResult = errorResult(t("V3.DI.Error.adornmentNotFound"))
 export const adornmentListNotFoundResult = errorResult(t("V3.DI.Error.adornmentListNotFound"))
 export const attributeNotFoundResult = errorResult(t("V3.DI.Error.attributeNotFound"))
 export const caseNotFoundResult = errorResult(t("V3.DI.Error.caseNotFound"))

--- a/v3/src/data-interactive/register-handlers.ts
+++ b/v3/src/data-interactive/register-handlers.ts
@@ -1,3 +1,4 @@
+import "./handlers/adornment-handler"
 import "./handlers/adornment-list-handler"
 import "./handlers/all-cases-handler"
 import "./handlers/attribute-handler"

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -149,10 +149,10 @@ export function resolveResources(
   }
 
   if ("adornment" in resourceSelector && isGraphContentModel(result.component?.content)) {
-    const adornmentNameOrId = resourceSelector.adornment
+    const adornmentTypeOrId = resourceSelector.adornment
     const adornments = result.component.content.adornmentsStore.adornments
     result.adornment = adornments.find((adornment) => {
-      return adornment.id === adornmentNameOrId || adornment.type === adornmentNameOrId
+      return adornment.id === adornmentTypeOrId || adornment.type === adornmentTypeOrId
     })
   }
 

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -148,6 +148,14 @@ export function resolveResources(
     result.attributeList = attributeList
   }
 
+  if ("adornment" in resourceSelector && isGraphContentModel(result.component?.content)) {
+    const adornmentNameOrId = resourceSelector.adornment
+    const adornments = result.component.content.adornmentsStore.adornments
+    result.adornment = adornments.find((adornment) => {
+      return adornment.id === adornmentNameOrId || adornment.type === adornmentNameOrId
+    })
+  }
+
   if ("adornmentList" in resourceSelector && isGraphContentModel(result.component?.content)) {
     result.adornmentList = result.component.content.adornmentsStore.adornments ?? []
   }

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -141,6 +141,7 @@
     "V3.DI.Error.invalidEvaluationRecord": "Invalid record for evaluation",
     "V3.DI.Error.couldNotParseQuery": "Unable to parse query.",
     "V3.DI.Error.unknownRequest": "unknown request: %@",
+    "V3.DI.Error.adornmentNotFound": "Adornment not found",
     "V3.DI.Error.adornmentListNotFound": "Adornment list not found",
 
     // CFM/File menu


### PR DESCRIPTION
[CODAP-68](https://concord-consortium.atlassian.net/browse/CODAP-68)

Allows plugins to get information about a specific adornment on a specific graph. The request can specify the adornment by type or by ID.

**Examples**

Get Adornment of type Count:
```
  "action": "get",
  "resource": "component[LifeSpan].adornment[Count]"
```

Get Adornment with ID ADRN123:
```
  "action": "get",
  "resource": "component[LifeSpan].adornment[ADRN123]"
```

[CODAP-68]: https://concord-consortium.atlassian.net/browse/CODAP-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ