### PR TITLE
fix: allow plugins to get information about specific adornments (CODAP-68)

### DIFF
--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -210,11 +210,9 @@ context("codap plugins", () => {
       webView.getAPITesterResponse().then((value: any) => {
         const response = JSON.parse(value.eq(1).text())
         const countInfo = response.values
-        expect(countInfo.type).to.equal("Count")
-        expect(countInfo.isVisible).to.equal(true)
-        expect(countInfo.showCount).to.equal(true)
-        expect(countInfo.showPercent).to.equal(false)
-        expect(countInfo.percentType).to.equal("row")
+        expect(countInfo.id).to.be.a("string")
+        expect(countInfo.data[0]).to.haveOwnProperty("count")
+        expect(countInfo.data[0].count).to.be.a("number")
       })
       webView.clearAPITesterResponses()
 
@@ -229,10 +227,9 @@ context("codap plugins", () => {
         webView.getAPITesterResponse().then((value: any) => {
           const response = JSON.parse(value.eq(1).text())
           const meanInfo = response.values
-          expect(meanInfo.type).to.equal("Mean")
-          expect(meanInfo.isVisible).to.equal(true)
-          expect(meanInfo.measures).to.deep.equal({"{}": {}})
-          expect(meanInfo.labelTitle).to.equal("mean=")
+          expect(meanInfo.id).to.be.a("string")
+          expect(meanInfo.data[0]).to.haveOwnProperty("mean")
+          expect(meanInfo.data[0].mean).to.be.a("number")
         })
         webView.clearAPITesterResponses()
       })

--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -211,6 +211,8 @@ context("codap plugins", () => {
         const response = JSON.parse(value.eq(1).text())
         const countInfo = response.values
         expect(countInfo.id).to.be.a("string")
+        expect(countInfo.isVisible).to.be.a("boolean")
+        expect(countInfo.type).to.eq("Count")
         expect(countInfo.data[0]).to.haveOwnProperty("count")
         expect(countInfo.data[0].count).to.be.a("number")
       })

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -49,4 +49,16 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
     expect(mockDataConfig.subPlotCases).toHaveBeenCalled()
   })
+
+  it("get only returns a count when showCount is true and showPercent is false", () => {
+    mockCountAdornment.showPercent = false
+    const result = handler.get?.(mockCountAdornment, mockGraphContent)
+    expect(result?.data[0]).toMatchObject({ count: 2 })
+  })
+
+  it("get only returns a percent when showCount is false and showPercent is true", () => {
+    mockCountAdornment.showCount = false
+    const result = handler.get?.(mockCountAdornment, mockGraphContent)
+    expect(result?.data[0]).toMatchObject({ percent: "50%" })
+  })
 })

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -37,7 +37,7 @@ describe("DataInteractive CountAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kCountType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kCountType} adornment.`)
   })
 
   it("get returns the expected data when count adornment provided", () => {

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -1,0 +1,52 @@
+import { countAdornmentHandler } from "./count-adornment-handler"
+import { kCountType } from "./count-adornment-types"
+
+describe("DataInteractive CountAdornmentHandler", () => {
+  const handler = countAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockCountAdornment: any
+  let mockInvalidAdornment: any
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockCountAdornment = {
+      id: adornmentId,
+      isVisible: true,
+      percentValue: jest.fn(() => 0.5),
+      showCount: true,
+      showPercent: true,
+      type: kCountType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kCountType} adornment`)
+  })
+
+  it("get returns the expected data when count adornment provided", () => {
+    const result = handler.get?.(mockCountAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({ count: 2, percent: "50%" })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+    expect(mockDataConfig.subPlotCases).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kCountType } from "./count-adornment-types"
 
 describe("DataInteractive CountAdornmentHandler", () => {
   const handler = countAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -20,9 +19,10 @@ describe("DataInteractive CountAdornmentHandler", () => {
     }
     
     mockCountAdornment = {
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       percentValue: jest.fn(() => 0.5),
+      percentType: "cell",
       showCount: true,
       showPercent: true,
       type: kCountType
@@ -42,10 +42,12 @@ describe("DataInteractive CountAdornmentHandler", () => {
 
   it("get returns the expected data when count adornment provided", () => {
     const result = handler.get?.(mockCountAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ count: 2, percent: "50%" })
+    expect(result?.percentType).toBe("cell")
+    expect(result?.showCount).toBe(true)
+    expect(result?.showPercent).toBe(true)
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
     expect(mockDataConfig.subPlotCases).toHaveBeenCalled()
   })

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -10,15 +10,22 @@ export const countAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isCountAdornment(adornment)) return { success: false, values: { error: `Not a ${kCountType} adornment` } }
 
+    const { id, showCount, showPercent } = adornment
+
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const subPlotCases = dataConfig.subPlotCases(cellKey)
-      const dataItem: AdornmentData = {
-        count: subPlotCases.length,
-        percent: percentString(adornment.percentValue(subPlotCases.length, cellKey, dataConfig))
+      const dataItem: AdornmentData = {}
+      
+      if (showCount) {
+        dataItem.count = subPlotCases.length
+      }
+
+      if (showPercent) {
+        dataItem.percent = percentString(adornment.percentValue(subPlotCases.length, cellKey, dataConfig))
       }
     
       if (Object.keys(cellKey).length > 0) {
@@ -28,6 +35,6 @@ export const countAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { id, data }
   }
 }

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -3,12 +3,12 @@ import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isCountAdornment } from "./count-adornment-model"
 import { percentString } from "../../utilities/graph-utils"
-import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 import { kCountType } from "./count-adornment-types"
 
 export const countAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isCountAdornment(adornment)) return { success: false, values: { error: `Not a ${kCountType} adornment` } }
+    if (!isCountAdornment(adornment)) return adornmentMismatchResult(kCountType)
 
     const { percentType, showCount, showPercent } = adornment
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -1,0 +1,35 @@
+import { getSnapshot } from "@concord-consortium/mobx-state-tree"
+import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { IGraphContentModel } from "../../models/graph-content-model"
+import { IAdornmentModel } from "../adornment-models"
+import { isCountAdornment } from "./count-adornment-model"
+import { percentString } from "../../utilities/graph-utils"
+
+export const countAdornmentHandler: DIAdornmentHandler = {
+  get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
+    if (!isCountAdornment(adornment)) return { success: false, values: { error: "Not a count adornment" } }
+
+    const adornmentSnapshot = getSnapshot(adornment)
+    const dataConfig = graphContent.dataConfiguration
+    const cellKeys = dataConfig?.getAllCellKeys()
+    const caseCountMap: Record<string, number> = {}
+    const percentMap: Record<string, string> = {}
+
+    for (const cellKey of cellKeys) {
+      const subPlotCases = dataConfig.subPlotCases(cellKey)
+      const key = JSON.stringify(cellKey)
+      if (adornment.showCount) {
+        caseCountMap[key] = subPlotCases.length
+      }
+      if (adornment.showPercent) {
+        percentMap[key] = percentString(adornment.percentValue(subPlotCases.length, cellKey, dataConfig))
+      }
+    }
+
+    return {
+      ...adornmentSnapshot,
+      countValues: caseCountMap,
+      percentValues: percentMap
+    }
+  }
+}

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -10,8 +10,7 @@ export const countAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isCountAdornment(adornment)) return { success: false, values: { error: `Not a ${kCountType} adornment` } }
 
-    const { id, showCount, showPercent } = adornment
-
+    const { percentType, showCount, showPercent } = adornment
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData[] = []
@@ -35,6 +34,6 @@ export const countAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id, data }
+    return { data, percentType, showCount, showPercent }
   }
 }

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -1,35 +1,32 @@
-import { getSnapshot } from "@concord-consortium/mobx-state-tree"
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isCountAdornment } from "./count-adornment-model"
 import { percentString } from "../../utilities/graph-utils"
+import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 
 export const countAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isCountAdornment(adornment)) return { success: false, values: { error: "Not a count adornment" } }
 
-    const adornmentSnapshot = getSnapshot(adornment)
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const caseCountMap: Record<string, number> = {}
-    const percentMap: Record<string, string> = {}
+    const data: AdornmentData<any>[] = []
 
     for (const cellKey of cellKeys) {
       const subPlotCases = dataConfig.subPlotCases(cellKey)
-      const key = JSON.stringify(cellKey)
-      if (adornment.showCount) {
-        caseCountMap[key] = subPlotCases.length
+      const dataItem: AdornmentData<any> = {
+        count: subPlotCases.length,
+        percent: percentString(adornment.percentValue(subPlotCases.length, cellKey, dataConfig))
       }
-      if (adornment.showPercent) {
-        percentMap[key] = percentString(adornment.percentValue(subPlotCases.length, cellKey, dataConfig))
+    
+      if (Object.keys(cellKey).length > 0) {
+        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
       }
+    
+      data.push(dataItem)
     }
 
-    return {
-      ...adornmentSnapshot,
-      countValues: caseCountMap,
-      percentValues: percentMap
-    }
+    return { id: adornment.id, data }
   }
 }

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -12,11 +12,11 @@ export const countAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const subPlotCases = dataConfig.subPlotCases(cellKey)
-      const dataItem: AdornmentData<any> = {
+      const dataItem: AdornmentData = {
         count: subPlotCases.length,
         percent: percentString(adornment.percentValue(subPlotCases.length, cellKey, dataConfig))
       }

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -4,10 +4,11 @@ import { IAdornmentModel } from "../adornment-models"
 import { isCountAdornment } from "./count-adornment-model"
 import { percentString } from "../../utilities/graph-utils"
 import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { kCountType } from "./count-adornment-types"
 
 export const countAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isCountAdornment(adornment)) return { success: false, values: { error: "Not a count adornment" } }
+    if (!isCountAdornment(adornment)) return { success: false, values: { error: `Not a ${kCountType} adornment` } }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
@@ -12,6 +12,8 @@ import { IAdornmentModel } from "../adornment-models"
 import { CountAdornment } from "./count-adornment-component"
 import { CountAdornmentModel, ICountAdornmentModel, isCountAdornment } from "./count-adornment-model"
 import { kCountClass, kCountLabelKey, kCountPrefix, kCountType, kPercentLabelKey } from "./count-adornment-types"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { countAdornmentHandler } from "./count-adornment-handler"
 
 const Controls = () => {
   const graphModel = useGraphContentModelContext()
@@ -161,3 +163,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kCountType
 })
+
+registerAdornmentHandler(kCountType, countAdornmentHandler)

--- a/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { FormControl, Checkbox, RadioGroup, Radio } from "@chakra-ui/react"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import { t } from "../../../../utilities/translation/translate"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
@@ -10,10 +11,9 @@ import {
 } from "../adornment-content-info"
 import { IAdornmentModel } from "../adornment-models"
 import { CountAdornment } from "./count-adornment-component"
+import { countAdornmentHandler } from "./count-adornment-handler"
 import { CountAdornmentModel, ICountAdornmentModel, isCountAdornment } from "./count-adornment-model"
 import { kCountClass, kCountLabelKey, kCountPrefix, kCountType, kPercentLabelKey } from "./count-adornment-types"
-import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { countAdornmentHandler } from "./count-adornment-handler"
 
 const Controls = () => {
   const graphModel = useGraphContentModelContext()

--- a/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
@@ -164,4 +164,4 @@ registerAdornmentComponentInfo({
   type: kCountType
 })
 
-registerAdornmentHandler(kCountType, countAdornmentHandler)
+registerAdornmentHandler(kCountType, countAdornmentHandler, "Percent")

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kLSRLType } from "./lsrl-adornment-types"
 
 describe("DataInteractive lsrlAdornmentHandler", () => {
   const handler = lsrlAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -25,9 +24,10 @@ describe("DataInteractive lsrlAdornmentHandler", () => {
     }
     
     mockLSRLAdornment = {
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       lines: mockLinesMap,
+      showConfidenceBands: true,
       type: kLSRLType
     }
 
@@ -45,12 +45,12 @@ describe("DataInteractive lsrlAdornmentHandler", () => {
 
   it("get returns the expected data when LSRL adornment provided", () => {
     const result = handler.get?.(mockLSRLAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({
       category: "category", intercept: 1, rSquared: 0.5, sdResiduals: 0.5, slope: 0.5
     })
+    expect(result?.showConfidenceBands).toBe(true)
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
   })
 })

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
@@ -1,0 +1,56 @@
+import { lsrlAdornmentHandler } from "./lsrl-adornment-handler"
+import { kLSRLType } from "./lsrl-adornment-types"
+
+describe("DataInteractive lsrlAdornmentHandler", () => {
+  const handler = lsrlAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockLSRLAdornment: any
+  let mockInvalidAdornment: any
+  const mockLinesMap = new Map([
+    ["{}", new Map([
+      ["__main__", { category: "category", intercept: 1, rSquared: 0.5, sdResiduals: 0.5, slope: 0.5 }]
+    ])]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockLSRLAdornment = {
+      id: adornmentId,
+      isVisible: true,
+      lines: mockLinesMap,
+      type: kLSRLType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not an ${kLSRLType} adornment`)
+  })
+
+  it("get returns the expected data when LSRL adornment provided", () => {
+    const result = handler.get?.(mockLSRLAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({
+      category: "category", intercept: 1, rSquared: 0.5, sdResiduals: 0.5, slope: 0.5
+    })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
@@ -40,7 +40,7 @@ describe("DataInteractive lsrlAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not an ${kLSRLType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kLSRLType} adornment.`)
   })
 
   it("get returns the expected data when LSRL adornment provided", () => {

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
@@ -13,7 +13,7 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
@@ -24,7 +24,7 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
       if (!line) continue
     
       const { category, intercept, rSquared, sdResiduals, slope } = line
-      const dataItem: AdornmentData<any> = {
+      const dataItem: AdornmentData = {
         category,
         intercept,
         rSquared,

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
@@ -1,0 +1,42 @@
+import { getSnapshot } from "@concord-consortium/mobx-state-tree"
+import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { IAdornmentModel } from "../adornment-models"
+import { isLSRLAdornment } from "./lsrl-adornment-model"
+
+export const lsrlAdornmentHandler: DIAdornmentHandler = {
+  get(adornment: IAdornmentModel) {
+    if (!isLSRLAdornment(adornment)) {
+      return { success: false, values: { error: "Not a least squares line adornment" } }
+    }
+
+    const fullAdornmentSnapshot = {
+      ...getSnapshot(adornment),
+      // Extract volatile properties for each line
+      lines: Object.fromEntries(
+        Array.from(adornment.lines.entries()).map(([cellKey, linesMap]) => {
+          return [
+            cellKey,
+            Object.fromEntries(
+              Array.from(linesMap.entries()).map(([legendKey, line]) => {
+                return [
+                  legendKey,
+                  {
+                    ...getSnapshot(line),
+                    category: line.category,
+                    intercept: line.intercept,
+                    rSquared: line.rSquared,
+                    sdResiduals: line.sdResiduals,
+                    slope: line.slope
+                  }
+                ]
+              })
+            )
+          ]
+        })
+      )
+    }
+
+    return fullAdornmentSnapshot
+  }
+}
+

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
@@ -11,6 +11,7 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
       return { success: false, values: { error: `Not an ${kLSRLType} adornment` } }
     }
 
+    const { showConfidenceBands } = adornment
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData[] = []
@@ -39,7 +40,7 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data, showConfidenceBands }
   }
 }
 

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
@@ -3,11 +3,12 @@ import { IAdornmentModel } from "../adornment-models"
 import { isLSRLAdornment } from "./lsrl-adornment-model"
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { kLSRLType } from "./lsrl-adornment-types"
 
 export const lsrlAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isLSRLAdornment(adornment)) {
-      return { success: false, values: { error: "Not a least squares line adornment" } }
+      return { success: false, values: { error: `Not an ${kLSRLType} adornment` } }
     }
 
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
@@ -2,14 +2,12 @@ import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornm
 import { IAdornmentModel } from "../adornment-models"
 import { isLSRLAdornment } from "./lsrl-adornment-model"
 import { IGraphContentModel } from "../../models/graph-content-model"
-import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 import { kLSRLType } from "./lsrl-adornment-types"
 
 export const lsrlAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isLSRLAdornment(adornment)) {
-      return { success: false, values: { error: `Not an ${kLSRLType} adornment` } }
-    }
+    if (!isLSRLAdornment(adornment))  return adornmentMismatchResult(kLSRLType)
 
     const { showConfidenceBands } = adornment
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
@@ -1,19 +1,19 @@
 import { FormControl, Checkbox } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import { t } from "../../../../utilities/translation/translate"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import { registerAdornmentComponentInfo } from "../adornment-component-info"
 import { exportAdornmentBase, getAdornmentContentInfo, registerAdornmentContentInfo } from "../adornment-content-info"
 import { LSRLAdornment } from "./lsrl-adornment-component"
+import { lsrlAdornmentHandler } from "./lsrl-adornment-handler"
 import { ILSRLAdornmentModel, isLSRLAdornment, LSRLAdornmentModel } from "./lsrl-adornment-model"
 import {
   kLSRLClass, kLSRLLabelKey, kLSRLPrefix, kLSRLRedoAddKey, kLSRLRedoRemoveKey, kLSRLType,
   kLSRLUndoAddKey, kLSRLUndoRemoveKey
 } from "./lsrl-adornment-types"
-import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { lsrlAdornmentHandler } from "./lsrl-adornment-handler"
 
 function logLSRLToggle(action: "hide" | "show") {
   return logMessageWithReplacement("toggleLSRL %@", { action })

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
@@ -12,6 +12,8 @@ import {
   kLSRLClass, kLSRLLabelKey, kLSRLPrefix, kLSRLRedoAddKey, kLSRLRedoRemoveKey, kLSRLType,
   kLSRLUndoAddKey, kLSRLUndoRemoveKey
 } from "./lsrl-adornment-types"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { lsrlAdornmentHandler } from "./lsrl-adornment-handler"
 
 function logLSRLToggle(action: "hide" | "show") {
   return logMessageWithReplacement("toggleLSRL %@", { action })
@@ -132,3 +134,5 @@ registerAdornmentComponentInfo({
   order: 20,
   type: kLSRLType
 })
+
+registerAdornmentHandler(kLSRLType, lsrlAdornmentHandler)

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kMovableLineType } from "./movable-line-adornment-types"
 
 describe("DataInteractive movableLineAdornmentHandler", () => {
   const handler = movableLineAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -23,7 +22,7 @@ describe("DataInteractive movableLineAdornmentHandler", () => {
     }
     
     mockMovableLineAdornment = {
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       lines: mockLinesMap,
       type: kMovableLineType
@@ -43,7 +42,6 @@ describe("DataInteractive movableLineAdornmentHandler", () => {
 
   it("get returns the expected data when movable line adornment provided", () => {
     const result = handler.get?.(mockMovableLineAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ intercept: 1, slope: 0.5 })

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.test.ts
@@ -1,0 +1,52 @@
+import { movableLineAdornmentHandler } from "./movable-line-adornment-handler"
+import { kMovableLineType } from "./movable-line-adornment-types"
+
+describe("DataInteractive movableLineAdornmentHandler", () => {
+  const handler = movableLineAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockMovableLineAdornment: any
+  let mockInvalidAdornment: any
+  const mockLinesMap = new Map([
+    ["{}", { intercept: 1, slope: 0.5 }]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockMovableLineAdornment = {
+      id: adornmentId,
+      isVisible: true,
+      lines: mockLinesMap,
+      type: kMovableLineType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kMovableLineType} adornment`)
+  })
+
+  it("get returns the expected data when movable line adornment provided", () => {
+    const result = handler.get?.(mockMovableLineAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({ intercept: 1, slope: 0.5 })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.test.ts
@@ -37,7 +37,7 @@ describe("DataInteractive movableLineAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kMovableLineType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kMovableLineType} adornment.`)
   })
 
   it("get returns the expected data when movable line adornment provided", () => {

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
@@ -3,10 +3,13 @@ import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isMovableLineAdornment } from "./movable-line-adornment-model"
 import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { kMovableLineType } from "./movable-line-adornment-types"
 
 export const movableLineAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMovableLineAdornment(adornment)) return { success: false, values: { error: "Not a movable line adornment" } }
+    if (!isMovableLineAdornment(adornment)) {
+      return { success: false, values: { error: `Not a ${kMovableLineType} adornment` } }
+    }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
@@ -2,14 +2,12 @@ import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornm
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isMovableLineAdornment } from "./movable-line-adornment-model"
-import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 import { kMovableLineType } from "./movable-line-adornment-types"
 
 export const movableLineAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMovableLineAdornment(adornment)) {
-      return { success: false, values: { error: `Not a ${kMovableLineType} adornment` } }
-    }
+    if (!isMovableLineAdornment(adornment)) return adornmentMismatchResult(kMovableLineType)
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
@@ -1,14 +1,12 @@
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { IAdornmentModel } from "../adornment-models"
-import { isLSRLAdornment } from "./lsrl-adornment-model"
 import { IGraphContentModel } from "../../models/graph-content-model"
+import { IAdornmentModel } from "../adornment-models"
+import { isMovableLineAdornment } from "./movable-line-adornment-model"
 import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 
-export const lsrlAdornmentHandler: DIAdornmentHandler = {
+export const movableLineAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isLSRLAdornment(adornment)) {
-      return { success: false, values: { error: "Not a least squares line adornment" } }
-    }
+    if (!isMovableLineAdornment(adornment)) return { success: false, values: { error: "Not a movable line adornment" } }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
@@ -16,20 +14,11 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
-      const linesMap = adornment.lines.get(cellKeyString)
-      if (!linesMap) continue
-    
-      const line = linesMap.get("__main__")
+      const line = adornment.lines.get(cellKeyString)
       if (!line) continue
     
-      const { category, intercept, rSquared, sdResiduals, slope } = line
-      const dataItem: AdornmentData<any> = {
-        category,
-        intercept,
-        rSquared,
-        sdResiduals,
-        slope
-      }
+      const { intercept, slope } = line
+      const dataItem: AdornmentData<any> = { intercept, slope }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
@@ -41,4 +30,3 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
     return { id: adornment.id, data }
   }
 }
-

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
@@ -30,6 +30,6 @@ export const movableLineAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data }
   }
 }

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-handler.ts
@@ -13,7 +13,7 @@ export const movableLineAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
@@ -21,7 +21,7 @@ export const movableLineAdornmentHandler: DIAdornmentHandler = {
       if (!line) continue
     
       const { intercept, slope } = line
-      const dataItem: AdornmentData<any> = { intercept, slope }
+      const dataItem: AdornmentData = { intercept, slope }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.tsx
@@ -1,16 +1,16 @@
 import React from "react"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
 import { ICodapV2MovableLineAdornment } from "../../../../v2/codap-v2-types"
 import { registerAdornmentComponentInfo } from "../adornment-component-info"
 import { exportAdornmentBase, registerAdornmentContentInfo } from "../adornment-content-info"
 import { AdornmentCheckbox } from "../components/adornment-checkbox"
 import { MovableLineAdornment } from "./movable-line-adornment-component"
+import { movableLineAdornmentHandler } from "./movable-line-adornment-handler"
 import { isMovableLineAdornment, MovableLineAdornmentModel } from "./movable-line-adornment-model"
 import {
   kMovableLineClass, kMovableLineLabelKey, kMovableLinePrefix, kMovableLineRedoAddKey,
   kMovableLineRedoRemoveKey, kMovableLineType, kMovableLineUndoAddKey, kMovableLineUndoRemoveKey
 } from "./movable-line-adornment-types"
-import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { movableLineAdornmentHandler } from "./movable-line-adornment-handler"
 
 const Controls = () => {
   return (

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.tsx
@@ -9,6 +9,8 @@ import {
   kMovableLineClass, kMovableLineLabelKey, kMovableLinePrefix, kMovableLineRedoAddKey,
   kMovableLineRedoRemoveKey, kMovableLineType, kMovableLineUndoAddKey, kMovableLineUndoRemoveKey
 } from "./movable-line-adornment-types"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { movableLineAdornmentHandler } from "./movable-line-adornment-handler"
 
 const Controls = () => {
   return (
@@ -60,3 +62,5 @@ registerAdornmentComponentInfo({
   order: 20,
   type: kMovableLineType
 })
+
+registerAdornmentHandler(kMovableLineType, movableLineAdornmentHandler)

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.test.ts
@@ -15,7 +15,10 @@ describe("DataInteractive movablePointAdornmentHandler", () => {
   beforeEach(() => {
     mockDataConfig = {
       attributeID: jest.fn((axis) => axis === "x" ? "idX" : "idY"),
-      dataset: { attributes: [{ id: "idX", name: "lifeSpan" }, { id: "idY", name: "mass" }] },
+      dataset: {
+        attributes: [{ id: "idX", name: "lifeSpan" }, { id: "idY", name: "mass" }],
+        getAttribute: jest.fn((id) => ({ id, name: id === "idX" ? "lifeSpan" : "mass" }))
+      },
       getAllCellKeys: jest.fn(() => [{}]),
       getAttribute: jest.fn((axis) => axis === "x" ? "lifeSpan" : "mass"),
       subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kMovablePointType } from "./movable-point-adornment-types"
 
 describe("DataInteractive movablePointAdornmentHandler", () => {
   const handler = movablePointAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -26,7 +25,7 @@ describe("DataInteractive movablePointAdornmentHandler", () => {
     }
     
     mockMovablePointAdornment = {
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       points: mockPointsMap,
       type: kMovablePointType
@@ -46,7 +45,6 @@ describe("DataInteractive movablePointAdornmentHandler", () => {
 
   it("get returns the expected data when movable point adornment provided", () => {
     const result = handler.get?.(mockMovablePointAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ lifeSpan: 1, mass: 2 })

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.test.ts
@@ -40,7 +40,7 @@ describe("DataInteractive movablePointAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kMovablePointType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kMovablePointType} adornment.`)
   })
 
   it("get returns the expected data when movable point adornment provided", () => {

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.test.ts
@@ -1,0 +1,55 @@
+import { movablePointAdornmentHandler } from "./movable-point-adornment-handler"
+import { kMovablePointType } from "./movable-point-adornment-types"
+
+describe("DataInteractive movablePointAdornmentHandler", () => {
+  const handler = movablePointAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockMovablePointAdornment: any
+  let mockInvalidAdornment: any
+  const mockPointsMap = new Map([
+    ["{}", { x: 1, y: 2 }]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      attributeID: jest.fn((axis) => axis === "x" ? "idX" : "idY"),
+      dataset: { attributes: [{ id: "idX", name: "lifeSpan" }, { id: "idY", name: "mass" }] },
+      getAllCellKeys: jest.fn(() => [{}]),
+      getAttribute: jest.fn((axis) => axis === "x" ? "lifeSpan" : "mass"),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockMovablePointAdornment = {
+      id: adornmentId,
+      isVisible: true,
+      points: mockPointsMap,
+      type: kMovablePointType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kMovablePointType} adornment`)
+  })
+
+  it("get returns the expected data when movable point adornment provided", () => {
+    const result = handler.get?.(mockMovablePointAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({ lifeSpan: 1, mass: 2 })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
@@ -10,12 +10,11 @@ export const movablePointAdornmentHandler: DIAdornmentHandler = {
     if (!isMovablePointAdornment(adornment)) return adornmentMismatchResult(kMovablePointType)
 
     const dataConfig = graphContent.dataConfiguration
-    const cellKeys = dataConfig?.getAllCellKeys()
-    const allAttributes = dataConfig?.dataset?.attributes
-    const xAttrId = dataConfig?.attributeID("x") || ""
-    const yAttrId = dataConfig?.attributeID("y") || ""
-    const xAttr = allAttributes?.find(attr => attr.id === xAttrId)
-    const yAttr = allAttributes?.find(attr => attr.id === yAttrId)
+    const cellKeys = dataConfig.getAllCellKeys()
+    const xAttrId = dataConfig.attributeID("x") || ""
+    const yAttrId = dataConfig.attributeID("y") || ""
+    const xAttr = dataConfig.dataset?.getAttribute(xAttrId)
+    const yAttr = dataConfig.dataset?.getAttribute(yAttrId)
     const xAttrName = xAttr?.name ?? ""
     const yAttrName = yAttr?.name ?? ""
     const data: AdornmentData[] = []

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
@@ -1,0 +1,41 @@
+import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { IGraphContentModel } from "../../models/graph-content-model"
+import { IAdornmentModel } from "../adornment-models"
+import { isMovablePointAdornment } from "./movable-point-adornment-model"
+import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+
+export const movablePointAdornmentHandler: DIAdornmentHandler = {
+  get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
+    if (!isMovablePointAdornment(adornment)) {
+      return { success: false, values: { error: "Not a movable point adornment" } }
+    }
+
+    const dataConfig = graphContent.dataConfiguration
+    const cellKeys = dataConfig?.getAllCellKeys()
+    const allAttributes = dataConfig?.dataset?.attributes
+    const xAttrId = dataConfig?.attributeID("x") || ""
+    const yAttrId = dataConfig?.attributeID("y") || ""
+    const xAttr = allAttributes?.find(attr => attr.id === xAttrId)
+    const yAttr = allAttributes?.find(attr => attr.id === yAttrId)
+    const xAttrName = xAttr?.name ?? ""
+    const yAttrName = yAttr?.name ?? ""
+    const data: AdornmentData<any>[] = []
+
+    for (const cellKey of cellKeys) {
+      const cellKeyString = JSON.stringify(cellKey)
+      const point = adornment.points.get(cellKeyString)
+      if (!point) continue
+    
+      const { x, y } = point
+      const dataItem: AdornmentData<any> = { [xAttrName]: x, [yAttrName]: y }
+    
+      if (Object.keys(cellKey).length > 0) {
+        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+      }
+    
+      data.push(dataItem)
+    }
+
+    return { id: adornment.id, data }
+  }
+}

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
@@ -37,6 +37,6 @@ export const movablePointAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data }
   }
 }

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
@@ -3,11 +3,12 @@ import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isMovablePointAdornment } from "./movable-point-adornment-model"
 import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { kMovablePointType } from "./movable-point-adornment-types"
 
 export const movablePointAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isMovablePointAdornment(adornment)) {
-      return { success: false, values: { error: "Not a movable point adornment" } }
+      return { success: false, values: { error: `Not a ${kMovablePointType} adornment` } }
     }
 
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
@@ -2,14 +2,12 @@ import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornm
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isMovablePointAdornment } from "./movable-point-adornment-model"
-import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 import { kMovablePointType } from "./movable-point-adornment-types"
 
 export const movablePointAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMovablePointAdornment(adornment)) {
-      return { success: false, values: { error: `Not a ${kMovablePointType} adornment` } }
-    }
+    if (!isMovablePointAdornment(adornment)) return adornmentMismatchResult(kMovablePointType)
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-handler.ts
@@ -20,7 +20,7 @@ export const movablePointAdornmentHandler: DIAdornmentHandler = {
     const yAttr = allAttributes?.find(attr => attr.id === yAttrId)
     const xAttrName = xAttr?.name ?? ""
     const yAttrName = yAttr?.name ?? ""
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
@@ -28,7 +28,7 @@ export const movablePointAdornmentHandler: DIAdornmentHandler = {
       if (!point) continue
     
       const { x, y } = point
-      const dataItem: AdornmentData<any> = { [xAttrName]: x, [yAttrName]: y }
+      const dataItem: AdornmentData = { [xAttrName]: x, [yAttrName]: y }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.tsx
@@ -1,15 +1,15 @@
 import React from "react"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
 import { registerAdornmentComponentInfo } from "../adornment-component-info"
 import { exportAdornmentBase, registerAdornmentContentInfo } from "../adornment-content-info"
 import { AdornmentCheckbox } from "../components/adornment-checkbox"
 import { MovablePointAdornment } from "./movable-point-adornment-component"
+import { movablePointAdornmentHandler } from "./movable-point-adornment-handler"
 import { isMovablePointAdornment, MovablePointAdornmentModel } from "./movable-point-adornment-model"
 import {
   kMovablePointClass, kMovablePointLabelKey, kMovablePointPrefix, kMovablePointRedoAddKey,
   kMovablePointRedoRemoveKey, kMovablePointType, kMovablePointUndoAddKey, kMovablePointUndoRemoveKey
 } from "./movable-point-adornment-types"
-import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { movablePointAdornmentHandler } from "./movable-point-adornment-handler"
 
 const Controls = () => {
   return (

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.tsx
@@ -8,6 +8,8 @@ import {
   kMovablePointClass, kMovablePointLabelKey, kMovablePointPrefix, kMovablePointRedoAddKey,
   kMovablePointRedoRemoveKey, kMovablePointType, kMovablePointUndoAddKey, kMovablePointUndoRemoveKey
 } from "./movable-point-adornment-types"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { movablePointAdornmentHandler } from "./movable-point-adornment-handler"
 
 const Controls = () => {
   return (
@@ -53,3 +55,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kMovablePointType
 })
+
+registerAdornmentHandler(kMovablePointType, movablePointAdornmentHandler)

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
@@ -1,0 +1,52 @@
+import { movableValueAdornmentHandler } from "./movable-value-adornment-handler"
+import { kMovableValueType } from "./movable-value-adornment-types"
+
+describe("DataInteractive movableValueAdornmentHandler", () => {
+  const handler = movableValueAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockMovableValueAdornment: any
+  let mockInvalidAdornment: any
+  const mockValuesMap = new Map([
+    ["{}", [1, 3000000]]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockMovableValueAdornment = {
+      id: adornmentId,
+      isVisible: true,
+      type: kMovableValueType,
+      values: mockValuesMap
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kMovableValueType} adornment`)
+  })
+
+  it("get returns the expected data when movable value adornment provided", () => {
+    const result = handler.get?.(mockMovableValueAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({movableValues: [1, 3000000]})
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
@@ -37,7 +37,7 @@ describe("DataInteractive movableValueAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kMovableValueType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kMovableValueType} adornment.`)
   })
 
   it("get returns the expected data when movable value adornment provided", () => {

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kMovableValueType } from "./movable-value-adornment-types"
 
 describe("DataInteractive movableValueAdornmentHandler", () => {
   const handler = movableValueAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -23,7 +22,7 @@ describe("DataInteractive movableValueAdornmentHandler", () => {
     }
     
     mockMovableValueAdornment = {
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       type: kMovableValueType,
       values: mockValuesMap
@@ -43,7 +42,6 @@ describe("DataInteractive movableValueAdornmentHandler", () => {
 
   it("get returns the expected data when movable value adornment provided", () => {
     const result = handler.get?.(mockMovableValueAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({movableValues: [1, 3000000]})

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
@@ -18,7 +18,7 @@ export const movableValueAdornmentHandler: DIAdornmentHandler = {
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
       const movableValues = adornment.values.get(cellKeyString)
-      const values = movableValues ? Object.values(movableValues).map(value => value) : []
+      const values = movableValues ? Object.values(movableValues) : []
       const dataItem: AdornmentData = { movableValues: values }
     
       if (Object.keys(cellKey).length > 0) {
@@ -28,6 +28,6 @@ export const movableValueAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data }
   }
 }

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
@@ -2,14 +2,12 @@ import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornm
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isMovableValueAdornment } from "./movable-value-adornment-model"
-import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 import { kMovableValueType } from "./movable-value-adornment-types"
 
 export const movableValueAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMovableValueAdornment(adornment)) {
-      return { success: false, values: { error: `Not a ${kMovableValueType} adornment` } }
-    }
+    if (!isMovableValueAdornment(adornment)) return adornmentMismatchResult(kMovableValueType)
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
@@ -1,13 +1,13 @@
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { IAdornmentModel } from "../adornment-models"
-import { isLSRLAdornment } from "./lsrl-adornment-model"
 import { IGraphContentModel } from "../../models/graph-content-model"
+import { IAdornmentModel } from "../adornment-models"
+import { isMovableValueAdornment } from "./movable-value-adornment-model"
 import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 
-export const lsrlAdornmentHandler: DIAdornmentHandler = {
+export const movableValueAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isLSRLAdornment(adornment)) {
-      return { success: false, values: { error: "Not a least squares line adornment" } }
+    if (!isMovableValueAdornment(adornment)) {
+      return { success: false, values: { error: "Not a movable value adornment" } }
     }
 
     const dataConfig = graphContent.dataConfiguration
@@ -16,20 +16,9 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
-      const linesMap = adornment.lines.get(cellKeyString)
-      if (!linesMap) continue
-    
-      const line = linesMap.get("__main__")
-      if (!line) continue
-    
-      const { category, intercept, rSquared, sdResiduals, slope } = line
-      const dataItem: AdornmentData<any> = {
-        category,
-        intercept,
-        rSquared,
-        sdResiduals,
-        slope
-      }
+      const movableValues = adornment.values.get(cellKeyString)
+      const values = movableValues ? Object.values(movableValues).map(value => value) : []
+      const dataItem: AdornmentData<any> = { movableValues: values }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
@@ -41,4 +30,3 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
     return { id: adornment.id, data }
   }
 }
-

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
@@ -3,11 +3,12 @@ import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isMovableValueAdornment } from "./movable-value-adornment-model"
 import { AdornmentData, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { kMovableValueType } from "./movable-value-adornment-types"
 
 export const movableValueAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isMovableValueAdornment(adornment)) {
-      return { success: false, values: { error: "Not a movable value adornment" } }
+      return { success: false, values: { error: `Not a ${kMovableValueType} adornment` } }
     }
 
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
@@ -13,13 +13,13 @@ export const movableValueAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
       const movableValues = adornment.values.get(cellKeyString)
       const values = movableValues ? Object.values(movableValues).map(value => value) : []
-      const dataItem: AdornmentData<any> = { movableValues: values }
+      const dataItem: AdornmentData = { movableValues: values }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
@@ -16,6 +16,8 @@ import {
   kMovableValueClass, kMovableValueLabelKey, kMovableValuePrefix, kMovableValueRedoAddKey,
   kMovableValueRedoRemoveKey, kMovableValueType, kMovableValueUndoAddKey, kMovableValueUndoRemoveKey
 } from "./movable-value-adornment-types"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { movableValueAdornmentHandler } from "./movable-value-adornment-handler"
 
 const Controls = () => {
   const graphModel = useGraphContentModelContext()
@@ -127,3 +129,5 @@ registerAdornmentComponentInfo({
   order: 100,
   type: kMovableValueType
 })
+
+registerAdornmentHandler(kMovableValueType, movableValueAdornmentHandler)

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
@@ -1,5 +1,6 @@
 import { Button, Flex } from "@chakra-ui/react"
 import React from "react"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
 import { safeJsonParse } from "../../../../utilities/js-utils"
 import { isFiniteNumber } from "../../../../utilities/math-utils"
 import { t } from "../../../../utilities/translation/translate"
@@ -9,6 +10,7 @@ import { registerAdornmentComponentInfo } from "../adornment-component-info"
 import { exportAdornmentBase, getAdornmentContentInfo, registerAdornmentContentInfo } from "../adornment-content-info"
 import { IUpdateCategoriesOptions } from "../adornment-models"
 import { MovableValueAdornment } from "./movable-value-adornment-component"
+import { movableValueAdornmentHandler } from "./movable-value-adornment-handler"
 import {
   IMovableValueAdornmentModel, isMovableValueAdornment, MovableValueAdornmentModel
 } from "./movable-value-adornment-model"
@@ -16,8 +18,6 @@ import {
   kMovableValueClass, kMovableValueLabelKey, kMovableValuePrefix, kMovableValueRedoAddKey,
   kMovableValueRedoRemoveKey, kMovableValueType, kMovableValueUndoAddKey, kMovableValueUndoRemoveKey
 } from "./movable-value-adornment-types"
-import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { movableValueAdornmentHandler } from "./movable-value-adornment-handler"
 
 const Controls = () => {
   const graphModel = useGraphContentModelContext()

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.test.ts
@@ -1,0 +1,47 @@
+import { plottedFunctionAdornmentHandler } from "./plotted-function-adornment-handler"
+import { kPlottedFunctionType } from "./plotted-function-adornment-types"
+
+describe("DataInteractive plottedFunctionAdornmentHandler", () => {
+  const handler = plottedFunctionAdornmentHandler
+  const adornmentId = "ADRN123"
+  const formula = { canonical: "y = 2x" }
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockPlottedFunctionAdornment: any
+  let mockInvalidAdornment: any
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockPlottedFunctionAdornment = {
+      formula,
+      id: adornmentId,
+      isVisible: true,
+      type: kPlottedFunctionType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kPlottedFunctionType} adornment`)
+  })
+
+  it("get returns the expected data when plotted function adornment provided", () => {
+    const result = handler.get?.(mockPlottedFunctionAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(result?.formula).toBe(JSON.stringify(formula.canonical))
+  })
+})

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.test.ts
@@ -3,8 +3,7 @@ import { kPlottedFunctionType } from "./plotted-function-adornment-types"
 
 describe("DataInteractive plottedFunctionAdornmentHandler", () => {
   const handler = plottedFunctionAdornmentHandler
-  const adornmentId = "ADRN123"
-  const formula = { canonical: "y = 2x" }
+  const formula = { display: "y = 2x" }
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -21,8 +20,9 @@ describe("DataInteractive plottedFunctionAdornmentHandler", () => {
     }
     
     mockPlottedFunctionAdornment = {
+      adornmentId: "ADRN123",
+      error: "",
       formula,
-      id: adornmentId,
       isVisible: true,
       type: kPlottedFunctionType
     }
@@ -41,7 +41,7 @@ describe("DataInteractive plottedFunctionAdornmentHandler", () => {
 
   it("get returns the expected data when plotted function adornment provided", () => {
     const result = handler.get?.(mockPlottedFunctionAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
-    expect(result?.formula).toBe(JSON.stringify(formula.canonical))
+    expect(result?.error).toBe("")
+    expect(result?.formula).toBe(JSON.stringify(formula.display))
   })
 })

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.test.ts
@@ -36,7 +36,7 @@ describe("DataInteractive plottedFunctionAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kPlottedFunctionType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kPlottedFunctionType} adornment.`)
   })
 
   it("get returns the expected data when plotted function adornment provided", () => {

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.ts
@@ -1,14 +1,13 @@
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
+import { adornmentMismatchResult } from "../utilities/adornment-handler-utils"
 import { isPlottedFunctionAdornment } from "./plotted-function-adornment-model"
 import { kPlottedFunctionType } from "./plotted-function-adornment-types"
 
 export const plottedFunctionAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isPlottedFunctionAdornment(adornment)) {
-      return { success: false, values: { error: `Not a ${kPlottedFunctionType} adornment` } }
-    }
+    if (!isPlottedFunctionAdornment(adornment)) return adornmentMismatchResult(kPlottedFunctionType)
 
     const { error, formula: _formula } = adornment
     const formula = JSON.stringify(_formula.display)

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.ts
@@ -2,11 +2,12 @@ import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornm
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isPlottedFunctionAdornment } from "./plotted-function-adornment-model"
+import { kPlottedFunctionType } from "./plotted-function-adornment-types"
 
 export const plottedFunctionAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isPlottedFunctionAdornment(adornment)) {
-      return { success: false, values: { error: "Not a plotted function adornment" } }
+      return { success: false, values: { error: `Not a ${kPlottedFunctionType} adornment` } }
     }
 
     const { formula: _formula, id } = adornment

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.ts
@@ -1,0 +1,17 @@
+import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { IGraphContentModel } from "../../models/graph-content-model"
+import { IAdornmentModel } from "../adornment-models"
+import { isPlottedFunctionAdornment } from "./plotted-function-adornment-model"
+
+export const plottedFunctionAdornmentHandler: DIAdornmentHandler = {
+  get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
+    if (!isPlottedFunctionAdornment(adornment)) {
+      return { success: false, values: { error: "Not a plotted function adornment" } }
+    }
+
+    const { formula: _formula, id } = adornment
+    const formula = JSON.stringify(_formula.canonical)
+
+    return { formula, id }
+  }
+}

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-handler.ts
@@ -10,9 +10,9 @@ export const plottedFunctionAdornmentHandler: DIAdornmentHandler = {
       return { success: false, values: { error: `Not a ${kPlottedFunctionType} adornment` } }
     }
 
-    const { formula: _formula, id } = adornment
-    const formula = JSON.stringify(_formula.canonical)
+    const { error, formula: _formula } = adornment
+    const formula = JSON.stringify(_formula.display)
 
-    return { formula, id }
+    return { error, formula }
   }
 }

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.tsx
@@ -1,17 +1,17 @@
 import React from "react"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
 import { registerAdornmentComponentInfo } from "../adornment-component-info"
 import { exportAdornmentBase, registerAdornmentContentInfo } from "../adornment-content-info"
 import { AdornmentCheckbox } from "../components/adornment-checkbox"
 import { PlottedFunctionAdornmentBanner } from "./plotted-function-adornment-banner"
 import { PlottedFunctionAdornmentComponent } from "./plotted-function-adornment-component"
+import { plottedFunctionAdornmentHandler } from "./plotted-function-adornment-handler"
 import { isPlottedFunctionAdornment, PlottedFunctionAdornmentModel } from "./plotted-function-adornment-model"
 import {
   kPlottedFunctionClass, kPlottedFunctionLabelKey, kPlottedFunctionPrefix, kPlottedFunctionRedoAddKey,
   kPlottedFunctionRedoRemoveKey, kPlottedFunctionType, kPlottedFunctionUndoAddKey, kPlottedFunctionUndoRemoveKey
 } from "./plotted-function-adornment-types"
 import { PlottedFunctionFormulaAdapter } from "./plotted-function-formula-adapter"
-import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { plottedFunctionAdornmentHandler } from "./plotted-function-adornment-handler"
 
 const Controls = () => {
   return (

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.tsx
@@ -10,6 +10,8 @@ import {
   kPlottedFunctionRedoRemoveKey, kPlottedFunctionType, kPlottedFunctionUndoAddKey, kPlottedFunctionUndoRemoveKey
 } from "./plotted-function-adornment-types"
 import { PlottedFunctionFormulaAdapter } from "./plotted-function-formula-adapter"
+import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { plottedFunctionAdornmentHandler } from "./plotted-function-adornment-handler"
 
 const Controls = () => {
   return (
@@ -57,3 +59,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kPlottedFunctionType
 })
+
+registerAdornmentHandler(kPlottedFunctionType, plottedFunctionAdornmentHandler)

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.test.ts
@@ -44,7 +44,7 @@ describe("DataInteractive boxPlotAdornmentHandler", () => {
   it("get returns an error when a an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kBoxPlotType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kBoxPlotType} adornment.`)
   })
 
   it("get returns the expected data when box plot adornment provided", () => {

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.test.ts
@@ -1,10 +1,8 @@
-import { getCaseValues } from "../../../../../data-interactive/data-interactive-utils"
 import { boxPlotAdornmentHandler } from "./box-plot-adornment-handler"
 import { kBoxPlotType } from "./box-plot-adornment-types"
 
 describe("DataInteractive boxPlotAdornmentHandler", () => {
   const handler = boxPlotAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -24,13 +22,15 @@ describe("DataInteractive boxPlotAdornmentHandler", () => {
     }
     
     mockBoxPlotAdornment = {
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       getCaseValues: jest.fn(() => [1, 2, 3, 4, 5, 10, 15, 20]),
       lowerQuartile: jest.fn(() => 5),
       measures: mockMeasuresMap,
       minWhiskerValue: jest.fn(() => 0),
       maxWhiskerValue: jest.fn(() => 20),
+      showICI: false,
+      showOutliers: true,
       type: kBoxPlotType,
       upperQuartile: jest.fn(() => 15),
     }
@@ -49,7 +49,6 @@ describe("DataInteractive boxPlotAdornmentHandler", () => {
 
   it("get returns the expected data when box plot adornment provided", () => {
     const result = handler.get?.(mockBoxPlotAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({
@@ -60,6 +59,8 @@ describe("DataInteractive boxPlotAdornmentHandler", () => {
       upper: 20,
       upperQuartile: 15
     })
+    expect(result?.showICI).toBe(false)
+    expect(result?.showOutliers).toBe(true)
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
   })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.test.ts
@@ -1,0 +1,65 @@
+import { getCaseValues } from "../../../../../data-interactive/data-interactive-utils"
+import { boxPlotAdornmentHandler } from "./box-plot-adornment-handler"
+import { kBoxPlotType } from "./box-plot-adornment-types"
+
+describe("DataInteractive boxPlotAdornmentHandler", () => {
+  const handler = boxPlotAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockBoxPlotAdornment: any
+  let mockInvalidAdornment: any
+  const mockMeasuresMap = new Map([
+    ["{}", { value: 10 }]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockBoxPlotAdornment = {
+      id: adornmentId,
+      isVisible: true,
+      getCaseValues: jest.fn(() => [1, 2, 3, 4, 5, 10, 15, 20]),
+      lowerQuartile: jest.fn(() => 5),
+      measures: mockMeasuresMap,
+      minWhiskerValue: jest.fn(() => 0),
+      maxWhiskerValue: jest.fn(() => 20),
+      type: kBoxPlotType,
+      upperQuartile: jest.fn(() => 15),
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when a an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kBoxPlotType} adornment`)
+  })
+
+  it("get returns the expected data when box plot adornment provided", () => {
+    const result = handler.get?.(mockBoxPlotAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({
+      interquartileRange: 10,
+      lower: 0,
+      lowerQuartile: 5,
+      median: 10,
+      upper: 20,
+      upperQuartile: 15
+    })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
@@ -2,12 +2,12 @@ import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/ado
 import { IAdornmentModel } from "../../adornment-models"
 import { isBoxPlotAdornment } from "./box-plot-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { kBoxPlotType } from "./box-plot-adornment-types"
 
 export const boxPlotAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isBoxPlotAdornment(adornment)) return { success: false, values: { error: `Not a ${kBoxPlotType} adornment` } }
+    if (!isBoxPlotAdornment(adornment)) return adornmentMismatchResult(kBoxPlotType)
 
     const { showICI, showOutliers } = adornment
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
@@ -13,9 +13,9 @@ export const boxPlotAdornmentHandler: DIAdornmentHandler = {
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData[] = []
+    const primaryAttrId = dataConfig?.primaryAttributeID
 
     for (const cellKey of cellKeys) {
-      const primaryAttrId = dataConfig?.primaryAttributeID
       const cellKeyString = JSON.stringify(cellKey)
       const cellCaseValues = adornment.getCaseValues(primaryAttrId, cellKey, dataConfig)
       const median = adornment.measures.get(cellKeyString)?.value ?? NaN

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
@@ -9,6 +9,7 @@ export const boxPlotAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isBoxPlotAdornment(adornment)) return { success: false, values: { error: `Not a ${kBoxPlotType} adornment` } }
 
+    const { showICI, showOutliers } = adornment
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData[] = []
@@ -39,6 +40,6 @@ export const boxPlotAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data, showICI, showOutliers }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
@@ -1,0 +1,43 @@
+import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { IAdornmentModel } from "../../adornment-models"
+import { isBoxPlotAdornment } from "./box-plot-adornment-model"
+import { IGraphContentModel } from "../../../models/graph-content-model"
+import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+
+export const boxPlotAdornmentHandler: DIAdornmentHandler = {
+  get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
+    if (!isBoxPlotAdornment(adornment)) return { success: false, values: { error: "Not a box plot adornment" } }
+
+    const dataConfig = graphContent.dataConfiguration
+    const cellKeys = dataConfig?.getAllCellKeys()
+    const data: AdornmentData<any>[] = []
+
+    for (const cellKey of cellKeys) {
+      const primaryAttrId = dataConfig?.primaryAttributeID
+      const cellKeyString = JSON.stringify(cellKey)
+      const cellCaseValues = adornment.getCaseValues(primaryAttrId, cellKey, dataConfig)
+      const median = adornment.measures.get(cellKeyString)?.value ?? NaN
+      const lower = adornment.minWhiskerValue(primaryAttrId, cellKey, dataConfig)
+      const upper = adornment.maxWhiskerValue(primaryAttrId, cellKey, dataConfig)
+      const lowerQuartile = adornment.lowerQuartile(cellCaseValues)
+      const upperQuartile = adornment.upperQuartile(cellCaseValues)
+      const interquartileRange = upperQuartile - lowerQuartile
+      const dataItem: AdornmentData<any> = {
+        interquartileRange,
+        lower,
+        lowerQuartile,
+        median,
+        upper,
+        upperQuartile
+      }
+    
+      if (Object.keys(cellKey).length > 0) {
+        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+      }
+    
+      data.push(dataItem)
+    }
+
+    return { id: adornment.id, data }
+  }
+}

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
@@ -3,10 +3,11 @@ import { IAdornmentModel } from "../../adornment-models"
 import { isBoxPlotAdornment } from "./box-plot-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { kBoxPlotType } from "./box-plot-adornment-types"
 
 export const boxPlotAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isBoxPlotAdornment(adornment)) return { success: false, values: { error: "Not a box plot adornment" } }
+    if (!isBoxPlotAdornment(adornment)) return { success: false, values: { error: `Not a ${kBoxPlotType} adornment` } }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
@@ -11,7 +11,7 @@ export const boxPlotAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const primaryAttrId = dataConfig?.primaryAttributeID
@@ -23,7 +23,7 @@ export const boxPlotAdornmentHandler: DIAdornmentHandler = {
       const lowerQuartile = adornment.lowerQuartile(cellCaseValues)
       const upperQuartile = adornment.upperQuartile(cellCaseValues)
       const interquartileRange = upperQuartile - lowerQuartile
-      const dataItem: AdornmentData<any> = {
+      const dataItem: AdornmentData = {
         interquartileRange,
         lower,
         lowerQuartile,

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
@@ -14,6 +14,8 @@ import {
   kBoxPlotClass, kBoxPlotLabelKey, kBoxPlotPrefix, kBoxPlotRedoAddKey, kBoxPlotRedoRemoveKey,
   kBoxPlotType, kBoxPlotUndoAddKey, kBoxPlotUndoRemoveKey
 } from "./box-plot-adornment-types"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { boxPlotAdornmentHandler } from "./box-plot-adornment-handler"
 
 const Controls = observer(function Controls() {
   const graphModel = useGraphContentModelContext()
@@ -147,3 +149,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kBoxPlotType
 })
+
+registerAdornmentHandler(kBoxPlotType, boxPlotAdornmentHandler)

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
@@ -1,6 +1,7 @@
 import { FormControl, Checkbox } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { logMessageWithReplacement } from "../../../../../lib/log-message"
 import { getDocumentContentPropertyFromNode } from "../../../../../utilities/mst-utils"
 import { t } from "../../../../../utilities/translation/translate"
@@ -9,13 +10,12 @@ import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { getAdornmentContentInfo, registerAdornmentContentInfo } from "../../adornment-content-info"
 import { exportUnivariateMeasure } from "../univariate-measure-adornment-utils"
 import { BoxPlotAdornmentComponent } from "./box-plot-adornment-component"
+import { boxPlotAdornmentHandler } from "./box-plot-adornment-handler"
 import { BoxPlotAdornmentModel, IBoxPlotAdornmentModel, isBoxPlotAdornment } from "./box-plot-adornment-model"
 import {
   kBoxPlotClass, kBoxPlotLabelKey, kBoxPlotPrefix, kBoxPlotRedoAddKey, kBoxPlotRedoRemoveKey,
   kBoxPlotType, kBoxPlotUndoAddKey, kBoxPlotUndoRemoveKey
 } from "./box-plot-adornment-types"
-import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { boxPlotAdornmentHandler } from "./box-plot-adornment-handler"
 
 const Controls = observer(function Controls() {
   const graphModel = useGraphContentModelContext()

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.test.ts
@@ -38,7 +38,7 @@ describe("DataInteractive meanAbsoluteDeviationAdornmentHandler", () => {
   it("get returns an error when a an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kMeanAbsoluteDeviationType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kMeanAbsoluteDeviationType} adornment.`)
   })
 
   it("get returns the expected data when mean absolute deviation adornment provided", () => {

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kMeanAbsoluteDeviationType } from "./mean-absolute-deviation-adornment-
 
 describe("DataInteractive meanAbsoluteDeviationAdornmentHandler", () => {
   const handler = meanAbsoluteDeviationAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -24,7 +23,7 @@ describe("DataInteractive meanAbsoluteDeviationAdornmentHandler", () => {
     
     mockMeanAbsoluteDeviationAdornment = {
       computeMeasureRange: jest.fn(() => { return {min: 0, max: 20} }),
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       measures: mockMeasuresMap,
       type: kMeanAbsoluteDeviationType
@@ -44,7 +43,6 @@ describe("DataInteractive meanAbsoluteDeviationAdornmentHandler", () => {
 
   it("get returns the expected data when mean absolute deviation adornment provided", () => {
     const result = handler.get?.(mockMeanAbsoluteDeviationAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ mean: 10, min: 0, max: 20 })

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.test.ts
@@ -1,0 +1,53 @@
+import { meanAbsoluteDeviationAdornmentHandler } from "./mean-absolute-deviation-adornment-handler"
+import { kMeanAbsoluteDeviationType } from "./mean-absolute-deviation-adornment-types"
+
+describe("DataInteractive meanAbsoluteDeviationAdornmentHandler", () => {
+  const handler = meanAbsoluteDeviationAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockMeanAbsoluteDeviationAdornment: any
+  let mockInvalidAdornment: any
+  const mockMeasuresMap = new Map([
+    ["{}", { value: 10 }]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockMeanAbsoluteDeviationAdornment = {
+      computeMeasureRange: jest.fn(() => { return {min: 0, max: 20} }),
+      id: adornmentId,
+      isVisible: true,
+      measures: mockMeasuresMap,
+      type: kMeanAbsoluteDeviationType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when a an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kMeanAbsoluteDeviationType} adornment`)
+  })
+
+  it("get returns the expected data when mean absolute deviation adornment provided", () => {
+    const result = handler.get?.(mockMeanAbsoluteDeviationAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({ mean: 10, min: 0, max: 20 })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
@@ -3,11 +3,12 @@ import { IGraphContentModel } from "../../../models/graph-content-model"
 import { IAdornmentModel } from "../../adornment-models"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { isMeanAbsoluteDeviationAdornment } from "./mean-absolute-deviation-adornment-model"
+import { kMeanAbsoluteDeviationType } from "./mean-absolute-deviation-adornment-types"
 
 export const meanAbsoluteDeviationAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isMeanAbsoluteDeviationAdornment(adornment)) {
-      return { success: false, values: { error: "Not a mean absolute deviation adornment" } }
+      return { success: false, values: { error: `Not a ${kMeanAbsoluteDeviationType} adornment` } }
     }
 
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
@@ -13,14 +13,14 @@ export const meanAbsoluteDeviationAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const primaryAttrId = dataConfig?.primaryAttributeID
       const cellKeyString = JSON.stringify(cellKey)
       const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
       const { min, max } = adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)
-      const dataItem: AdornmentData<any> = { mean, min, max }
+      const dataItem: AdornmentData = { mean, min, max }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
@@ -1,15 +1,13 @@
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { IAdornmentModel } from "../../adornment-models"
-import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { isMeanAbsoluteDeviationAdornment } from "./mean-absolute-deviation-adornment-model"
 import { kMeanAbsoluteDeviationType } from "./mean-absolute-deviation-adornment-types"
 
 export const meanAbsoluteDeviationAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMeanAbsoluteDeviationAdornment(adornment)) {
-      return { success: false, values: { error: `Not a ${kMeanAbsoluteDeviationType} adornment` } }
-    }
+    if (!isMeanAbsoluteDeviationAdornment(adornment)) return adornmentMismatchResult(kMeanAbsoluteDeviationType)
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
@@ -12,9 +12,9 @@ export const meanAbsoluteDeviationAdornmentHandler: DIAdornmentHandler = {
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData[] = []
+    const primaryAttrId = dataConfig?.primaryAttributeID
 
     for (const cellKey of cellKeys) {
-      const primaryAttrId = dataConfig?.primaryAttributeID
       const cellKeyString = JSON.stringify(cellKey)
       const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
       const { min, max } = adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-handler.ts
@@ -1,21 +1,25 @@
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { IAdornmentModel } from "../../adornment-models"
-import { isMeanAdornment } from "./mean-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
+import { IAdornmentModel } from "../../adornment-models"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { isMeanAbsoluteDeviationAdornment } from "./mean-absolute-deviation-adornment-model"
 
-export const meanAdornmentHandler: DIAdornmentHandler = {
+export const meanAbsoluteDeviationAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMeanAdornment(adornment)) return { success: false, values: { error: "Not a mean adornment" } }
+    if (!isMeanAbsoluteDeviationAdornment(adornment)) {
+      return { success: false, values: { error: "Not a mean absolute deviation adornment" } }
+    }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData<any>[] = []
 
     for (const cellKey of cellKeys) {
+      const primaryAttrId = dataConfig?.primaryAttributeID
       const cellKeyString = JSON.stringify(cellKey)
       const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData<any> = { mean }
+      const { min, max } = adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)
+      const dataItem: AdornmentData<any> = { mean, min, max }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-registration.tsx
@@ -1,17 +1,17 @@
 import React from "react"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { registerAdornmentContentInfo } from "../../adornment-content-info"
 import { AdornmentCheckbox } from "../../components/adornment-checkbox"
 import { UnivariateMeasureAdornmentSimpleComponent } from "../univariate-measure-adornment-simple-component"
 import { exportUnivariateMeasure } from "../univariate-measure-adornment-utils"
+import { meanAbsoluteDeviationAdornmentHandler } from "./mean-absolute-deviation-adornment-handler"
 import {
   isMeanAbsoluteDeviationAdornment, MeanAbsoluteDeviationAdornmentModel
 } from "./mean-absolute-deviation-adornment-model"
 import {
   kMeanAbsoluteDeviationClass, kMeanAbsoluteDeviationLabelKey, kMeanAbsoluteDeviationPrefix, kMeanAbsoluteDeviationType
 } from "./mean-absolute-deviation-adornment-types"
-import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { meanAbsoluteDeviationAdornmentHandler } from "./mean-absolute-deviation-adornment-handler"
 
 const Controls = () => {
   return (

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-registration.tsx
@@ -10,6 +10,8 @@ import {
 import {
   kMeanAbsoluteDeviationClass, kMeanAbsoluteDeviationLabelKey, kMeanAbsoluteDeviationPrefix, kMeanAbsoluteDeviationType
 } from "./mean-absolute-deviation-adornment-types"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { meanAbsoluteDeviationAdornmentHandler } from "./mean-absolute-deviation-adornment-handler"
 
 const Controls = () => {
   return (
@@ -43,3 +45,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kMeanAbsoluteDeviationType
 })
+
+registerAdornmentHandler(kMeanAbsoluteDeviationType, meanAbsoluteDeviationAdornmentHandler)

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kMeanType } from "./mean-adornment-types"
 
 describe("DataInteractive meanAdornmentHandler", () => {
   const handler = meanAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -23,7 +22,7 @@ describe("DataInteractive meanAdornmentHandler", () => {
     }
     
     mockMeanAdornment = {
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       measures: mockMeasuresMap,
       type: kMeanType
@@ -43,7 +42,6 @@ describe("DataInteractive meanAdornmentHandler", () => {
 
   it("get returns the expected data when mean adornment provided", () => {
     const result = handler.get?.(mockMeanAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ mean: 10 })

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
@@ -37,7 +37,7 @@ describe("DataInteractive meanAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kMeanType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kMeanType} adornment.`)
   })
 
   it("get returns the expected data when mean adornment provided", () => {

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
@@ -1,0 +1,52 @@
+import { meanAdornmentHandler } from "./mean-adornment-handler"
+import { kMeanType } from "./mean-adornment-types"
+
+describe("DataInteractive meanAdornmentHandler", () => {
+  const handler = meanAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockMeanAdornment: any
+  let mockInvalidAdornment: any
+  const mockMeasuresMap = new Map([
+    ["{}", { value: 10 }]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockMeanAdornment = {
+      id: adornmentId,
+      isVisible: true,
+      measures: mockMeasuresMap,
+      type: kMeanType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kMeanType} adornment`)
+  })
+
+  it("get returns the expected data when mean adornment provided", () => {
+    const result = handler.get?.(mockMeanAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({ mean: 10 })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
@@ -11,12 +11,12 @@ export const meanAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
       const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData<any> = { mean }
+      const dataItem: AdornmentData = { mean }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
@@ -3,10 +3,11 @@ import { IAdornmentModel } from "../../adornment-models"
 import { isMeanAdornment } from "./mean-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { kMeanType } from "./mean-adornment-types"
 
 export const meanAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMeanAdornment(adornment)) return { success: false, values: { error: "Not a mean adornment" } }
+    if (!isMeanAdornment(adornment)) return { success: false, values: { error: `Not a ${kMeanType} adornment` } }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
@@ -1,0 +1,24 @@
+import { getSnapshot } from "@concord-consortium/mobx-state-tree"
+import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { IAdornmentModel } from "../../adornment-models"
+import { isMeanAdornment } from "./mean-adornment-model"
+import { t } from "../../../../../utilities/translation/translate"
+
+export const meanAdornmentHandler: DIAdornmentHandler = {
+  get(adornment: IAdornmentModel) {
+    if (!isMeanAdornment(adornment)) return { success: false, values: { error: "Not a mean adornment" } }
+
+    const fullAdornmentSnapshot = {
+      ...getSnapshot(adornment),
+      // Add volatile measure values to snapshot.
+      measures: Object.fromEntries(
+        Array.from(adornment.measures.entries()).map(([key, measure]) => 
+          [key, { ...getSnapshot(measure), value: measure.value }]
+        )
+      ),
+      labelTitle: t(adornment.labelTitle)
+    }
+
+    return fullAdornmentSnapshot
+  }
+}

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
@@ -2,12 +2,12 @@ import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/ado
 import { IAdornmentModel } from "../../adornment-models"
 import { isMeanAdornment } from "./mean-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { kMeanType } from "./mean-adornment-types"
 
 export const meanAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMeanAdornment(adornment)) return { success: false, values: { error: `Not a ${kMeanType} adornment` } }
+    if (!isMeanAdornment(adornment)) return adornmentMismatchResult(kMeanType)
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
@@ -25,6 +25,6 @@ export const meanAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-registration.tsx
@@ -9,6 +9,8 @@ import {
   kMeanClass, kMeanLabelKey, kMeanType, kMeanPrefix, kMeanUndoAddKey, kMeanRedoAddKey,
   kMeanUndoRemoveKey, kMeanRedoRemoveKey
 } from "./mean-adornment-types"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { meanAdornmentHandler } from "./mean-adornment-handler"
 
 const Controls = () => {
   return (
@@ -48,3 +50,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kMeanType
 })
+
+registerAdornmentHandler(kMeanType, meanAdornmentHandler)

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-registration.tsx
@@ -1,16 +1,16 @@
 import React from "react"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { registerAdornmentContentInfo } from "../../adornment-content-info"
 import { AdornmentCheckbox } from "../../components/adornment-checkbox"
 import { UnivariateMeasureAdornmentSimpleComponent } from "../univariate-measure-adornment-simple-component"
 import { exportUnivariateMeasure } from "../univariate-measure-adornment-utils"
+import { meanAdornmentHandler } from "./mean-adornment-handler"
 import { isMeanAdornment, MeanAdornmentModel } from "./mean-adornment-model"
 import {
   kMeanClass, kMeanLabelKey, kMeanType, kMeanPrefix, kMeanUndoAddKey, kMeanRedoAddKey,
   kMeanUndoRemoveKey, kMeanRedoRemoveKey
 } from "./mean-adornment-types"
-import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { meanAdornmentHandler } from "./mean-adornment-handler"
 
 const Controls = () => {
   return (

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
@@ -37,7 +37,7 @@ describe("DataInteractive medianAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kMedianType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kMedianType} adornment.`)
   })
 
   it("get returns the expected data when median adornment provided", () => {

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kMedianType } from "./median-adornment-types"
 
 describe("DataInteractive medianAdornmentHandler", () => {
   const handler = medianAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -23,7 +22,7 @@ describe("DataInteractive medianAdornmentHandler", () => {
     }
     
     mockMedianAdornment = {
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       measures: mockMeasuresMap,
       type: kMedianType
@@ -43,7 +42,6 @@ describe("DataInteractive medianAdornmentHandler", () => {
 
   it("get returns the expected data when median adornment provided", () => {
     const result = handler.get?.(mockMedianAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ median: 10 })

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
@@ -1,0 +1,52 @@
+import { medianAdornmentHandler } from "./median-adornment-handler"
+import { kMedianType } from "./median-adornment-types"
+
+describe("DataInteractive medianAdornmentHandler", () => {
+  const handler = medianAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockMedianAdornment: any
+  let mockInvalidAdornment: any
+  const mockMeasuresMap = new Map([
+    ["{}", { value: 10 }]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockMedianAdornment = {
+      id: adornmentId,
+      isVisible: true,
+      measures: mockMeasuresMap,
+      type: kMedianType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kMedianType} adornment`)
+  })
+
+  it("get returns the expected data when median adornment provided", () => {
+    const result = handler.get?.(mockMedianAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({ median: 10 })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
@@ -1,0 +1,24 @@
+import { getSnapshot } from "@concord-consortium/mobx-state-tree"
+import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { IAdornmentModel } from "../../adornment-models"
+import { isMedianAdornment } from "./median-adornment-model"
+import { t } from "../../../../../utilities/translation/translate"
+
+export const medianAdornmentHandler: DIAdornmentHandler = {
+  get(adornment: IAdornmentModel) {
+    if (!isMedianAdornment(adornment)) return { success: false, values: { error: "Not a median adornment" } }
+
+    const fullAdornmentSnapshot = {
+      ...getSnapshot(adornment),
+      // Add volatile measure values to snapshot.
+      measures: Object.fromEntries(
+        Array.from(adornment.measures.entries()).map(([key, measure]) => 
+          [key, { ...getSnapshot(measure), value: measure.value }]
+        )
+      ),
+      labelTitle: t(adornment.labelTitle)
+    }
+
+    return fullAdornmentSnapshot
+  }
+}

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
@@ -2,12 +2,12 @@ import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/ado
 import { IAdornmentModel } from "../../adornment-models"
 import { isMedianAdornment } from "./median-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { kMedianType } from "./median-adornment-types"
 
 export const medianAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMedianAdornment(adornment)) return { success: false, values: { error: `Not a ${kMedianType} adornment` } }
+    if (!isMedianAdornment(adornment)) return adornmentMismatchResult(kMedianType)
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
@@ -11,12 +11,12 @@ export const medianAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
       const median = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData<any> = { median }
+      const dataItem: AdornmentData = { median }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
@@ -3,10 +3,11 @@ import { IAdornmentModel } from "../../adornment-models"
 import { isMedianAdornment } from "./median-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { kMedianType } from "./median-adornment-types"
 
 export const medianAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMedianAdornment(adornment)) return { success: false, values: { error: "Not a median adornment" } }
+    if (!isMedianAdornment(adornment)) return { success: false, values: { error: `Not a ${kMedianType} adornment` } }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
@@ -25,6 +25,6 @@ export const medianAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-registration.tsx
@@ -1,16 +1,16 @@
 import React from "react"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { registerAdornmentContentInfo } from "../../adornment-content-info"
 import { AdornmentCheckbox } from "../../components/adornment-checkbox"
 import { UnivariateMeasureAdornmentSimpleComponent } from "../univariate-measure-adornment-simple-component"
 import { exportUnivariateMeasure } from "../univariate-measure-adornment-utils"
+import { medianAdornmentHandler } from "./median-adornment-handler"
 import { isMedianAdornment, MedianAdornmentModel } from "./median-adornment-model"
 import {
   kMedianClass, kMedianLabelKey, kMedianPrefix, kMedianRedoAddKey, kMedianRedoRemoveKey,
   kMedianType, kMedianUndoAddKey, kMedianUndoRemoveKey
 } from "./median-adornment-types"
-import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { medianAdornmentHandler } from "./median-adornment-handler"
 
 const Controls = () => {
   return (

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-registration.tsx
@@ -9,6 +9,8 @@ import {
   kMedianClass, kMedianLabelKey, kMedianPrefix, kMedianRedoAddKey, kMedianRedoRemoveKey,
   kMedianType, kMedianUndoAddKey, kMedianUndoRemoveKey
 } from "./median-adornment-types"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { medianAdornmentHandler } from "./median-adornment-handler"
 
 const Controls = () => {
   return (
@@ -48,3 +50,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kMedianType
 })
+
+registerAdornmentHandler(kMedianType, medianAdornmentHandler)

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kNormalCurveType } from "./normal-curve-adornment-types"
 
 describe("DataInteractive normalCurveAdornmentHandler", () => {
   const handler = normalCurveAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -26,7 +25,7 @@ describe("DataInteractive normalCurveAdornmentHandler", () => {
       computeMean: jest.fn(() => 24),
       computeStandardDeviation: jest.fn(() => 20),
       computeStandardError: jest.fn(() => 4),
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       measures: mockMeasuresMap,
       type: kNormalCurveType
@@ -46,7 +45,6 @@ describe("DataInteractive normalCurveAdornmentHandler", () => {
 
   it("get returns the expected data when normalCurve adornment provided", () => {
     const result = handler.get?.(mockNormalCurveAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.test.ts
@@ -40,7 +40,7 @@ describe("DataInteractive normalCurveAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kNormalCurveType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kNormalCurveType} adornment.`)
   })
 
   it("get returns the expected data when normalCurve adornment provided", () => {

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.test.ts
@@ -1,0 +1,57 @@
+import { normalCurveAdornmentHandler } from "./normal-curve-adornment-handler"
+import { kNormalCurveType } from "./normal-curve-adornment-types"
+
+describe("DataInteractive normalCurveAdornmentHandler", () => {
+  const handler = normalCurveAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockNormalCurveAdornment: any
+  let mockInvalidAdornment: any
+  const mockMeasuresMap = new Map([
+    ["{}", { value: 24 }]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockNormalCurveAdornment = {
+      computeMean: jest.fn(() => 24),
+      computeStandardDeviation: jest.fn(() => 20),
+      computeStandardError: jest.fn(() => 4),
+      id: adornmentId,
+      isVisible: true,
+      measures: mockMeasuresMap,
+      type: kNormalCurveType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kNormalCurveType} adornment`)
+  })
+
+  it("get returns the expected data when normalCurve adornment provided", () => {
+    const result = handler.get?.(mockNormalCurveAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({
+      mean: 24, standardDeviation: 20, standardError: 4
+    })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
@@ -3,10 +3,13 @@ import { IAdornmentModel } from "../../adornment-models"
 import { isNormalCurveAdornment } from "./normal-curve-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { kNormalCurveType } from "./normal-curve-adornment-types"
 
 export const normalCurveAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isNormalCurveAdornment(adornment)) return { success: false, values: { error: "Not a normal curve adornment" } }
+    if (!isNormalCurveAdornment(adornment)) {
+      return { success: false, values: { error: `Not a ${kNormalCurveType} adornment` } }
+    }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
@@ -14,8 +17,7 @@ export const normalCurveAdornmentHandler: DIAdornmentHandler = {
 
     for (const cellKey of cellKeys) {
       const primaryAttrId = dataConfig?.primaryAttributeID
-      const cellKeyString = JSON.stringify(cellKey)
-      const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
+      const mean = adornment.computeMean(primaryAttrId, cellKey, dataConfig)
       const standardDeviation = adornment.computeStandardDeviation(primaryAttrId, cellKey, dataConfig)
       const standardError = adornment.computeStandardError(primaryAttrId, cellKey, dataConfig)
       const dataItem: AdornmentData<any> = { mean, standardDeviation, standardError }

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
@@ -2,14 +2,12 @@ import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/ado
 import { IAdornmentModel } from "../../adornment-models"
 import { isNormalCurveAdornment } from "./normal-curve-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { kNormalCurveType } from "./normal-curve-adornment-types"
 
 export const normalCurveAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isNormalCurveAdornment(adornment)) {
-      return { success: false, values: { error: `Not a ${kNormalCurveType} adornment` } }
-    }
+    if (!isNormalCurveAdornment(adornment)) return adornmentMismatchResult(kNormalCurveType)
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
@@ -1,21 +1,24 @@
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { IAdornmentModel } from "../../adornment-models"
-import { isMeanAdornment } from "./mean-adornment-model"
+import { isNormalCurveAdornment } from "./normal-curve-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 
-export const meanAdornmentHandler: DIAdornmentHandler = {
+export const normalCurveAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMeanAdornment(adornment)) return { success: false, values: { error: "Not a mean adornment" } }
+    if (!isNormalCurveAdornment(adornment)) return { success: false, values: { error: "Not a normal curve adornment" } }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData<any>[] = []
 
     for (const cellKey of cellKeys) {
+      const primaryAttrId = dataConfig?.primaryAttributeID
       const cellKeyString = JSON.stringify(cellKey)
       const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData<any> = { mean }
+      const standardDeviation = adornment.computeStandardDeviation(primaryAttrId, cellKey, dataConfig)
+      const standardError = adornment.computeStandardError(primaryAttrId, cellKey, dataConfig)
+      const dataItem: AdornmentData<any> = { mean, standardDeviation, standardError }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
@@ -13,14 +13,14 @@ export const normalCurveAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const primaryAttrId = dataConfig?.primaryAttributeID
       const mean = adornment.computeMean(primaryAttrId, cellKey, dataConfig)
       const standardDeviation = adornment.computeStandardDeviation(primaryAttrId, cellKey, dataConfig)
       const standardError = adornment.computeStandardError(primaryAttrId, cellKey, dataConfig)
-      const dataItem: AdornmentData<any> = { mean, standardDeviation, standardError }
+      const dataItem: AdornmentData = { mean, standardDeviation, standardError }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-handler.ts
@@ -29,6 +29,6 @@ export const normalCurveAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
@@ -68,6 +68,9 @@ export const NormalCurveAdornmentModel = UnivariateMeasureAdornmentModel
       }
       return results
     },
+    computeMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
+      // no op
+    }
   }))
 
 export interface INormalCurveAdornmentModelSnapshot extends SnapshotIn<typeof NormalCurveAdornmentModel> {}

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-registration.tsx
@@ -11,6 +11,8 @@ import {
   kNormalCurveUndoAddKey, kNormalCurveRedoAddKey, kNormalCurveRedoRemoveKey,
   kNormalCurveUndoRemoveKey, kGaussianFitLabelKey
 } from "./normal-curve-adornment-types"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { normalCurveAdornmentHandler } from "./normal-curve-adornment-handler"
 
 const Controls = () => {
   const { isGaussianFit } = useGraphOptions()
@@ -52,3 +54,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kNormalCurveType
 })
+
+registerAdornmentHandler(kNormalCurveType, normalCurveAdornmentHandler)

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-registration.tsx
@@ -1,18 +1,18 @@
 import React from "react"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { registerAdornmentContentInfo } from "../../adornment-content-info"
 import { AdornmentCheckbox } from "../../components/adornment-checkbox"
 import { useGraphOptions } from "../../hooks/use-graph-options"
 import { exportUnivariateMeasure } from "../univariate-measure-adornment-utils"
 import { NormalCurveAdornmentComponent } from "./normal-curve-adornment-component"
+import { normalCurveAdornmentHandler } from "./normal-curve-adornment-handler"
 import { isNormalCurveAdornment, NormalCurveAdornmentModel } from "./normal-curve-adornment-model"
 import {
   kNormalCurveClass, kNormalCurveLabelKey, kNormalCurveType, kNormalCurvePrefix,
   kNormalCurveUndoAddKey, kNormalCurveRedoAddKey, kNormalCurveRedoRemoveKey,
   kNormalCurveUndoRemoveKey, kGaussianFitLabelKey
 } from "./normal-curve-adornment-types"
-import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { normalCurveAdornmentHandler } from "./normal-curve-adornment-handler"
 
 const Controls = () => {
   const { isGaussianFit } = useGraphOptions()

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.test.ts
@@ -3,14 +3,14 @@ import { kPlottedValueType } from "./plotted-value-adornment-types"
 
 describe("DataInteractive plottedValueAdornmentHandler", () => {
   const handler = plottedValueAdornmentHandler
-  const adornmentId = "ADRN123"
+  const formula = { display: "y = 2x" }
 
   let mockGraphContent: any
   let mockDataConfig: any
   let mockPlottedValueAdornment: any
   let mockInvalidAdornment: any
   const mockPlottedValuesMap = new Map([
-    ["{}", {value: 1}]
+    ["{}", { value: 1 }]
   ])
 
   beforeEach(() => {
@@ -23,7 +23,9 @@ describe("DataInteractive plottedValueAdornmentHandler", () => {
     }
     
     mockPlottedValueAdornment = {
-      id: adornmentId,
+      error: "",
+      formula,
+      id: "ADRN123",
       isVisible: true,
       measures: mockPlottedValuesMap,
       type: kPlottedValueType
@@ -43,10 +45,11 @@ describe("DataInteractive plottedValueAdornmentHandler", () => {
 
   it("get returns the expected data when plotted value adornment provided", () => {
     const result = handler.get?.(mockPlottedValueAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
-    expect(result?.data[0]).toMatchObject({plottedValue: 1})
+    expect(result?.data[0]).toMatchObject({ plottedValue: 1 })
+    expect(result?.error).toBe("")
+    expect(result?.formula).toBe(JSON.stringify(formula.display))
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
   })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.test.ts
@@ -1,0 +1,52 @@
+import { plottedValueAdornmentHandler } from "./plotted-value-adornment-handler"
+import { kPlottedValueType } from "./plotted-value-adornment-types"
+
+describe("DataInteractive plottedValueAdornmentHandler", () => {
+  const handler = plottedValueAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockPlottedValueAdornment: any
+  let mockInvalidAdornment: any
+  const mockPlottedValuesMap = new Map([
+    ["{}", {value: 1}]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockPlottedValueAdornment = {
+      id: adornmentId,
+      isVisible: true,
+      measures: mockPlottedValuesMap,
+      type: kPlottedValueType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kPlottedValueType} adornment`)
+  })
+
+  it("get returns the expected data when plotted value adornment provided", () => {
+    const result = handler.get?.(mockPlottedValueAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({plottedValue: 1})
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.test.ts
@@ -40,7 +40,7 @@ describe("DataInteractive plottedValueAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kPlottedValueType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kPlottedValueType} adornment.`)
   })
 
   it("get returns the expected data when plotted value adornment provided", () => {

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
@@ -1,12 +1,14 @@
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { IAdornmentModel } from "../../adornment-models"
-import { isMeanAdornment } from "./mean-adornment-model"
+import { isPlottedValueAdornment } from "./plotted-value-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 
-export const meanAdornmentHandler: DIAdornmentHandler = {
+export const plottedValueAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMeanAdornment(adornment)) return { success: false, values: { error: "Not a mean adornment" } }
+    if (!isPlottedValueAdornment(adornment)) {
+      return { success: false, values: { error: "Not a plotted value adornment" } }
+    }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
@@ -14,8 +16,8 @@ export const meanAdornmentHandler: DIAdornmentHandler = {
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
-      const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData<any> = { mean }
+      const plottedValue = adornment.measures.get(cellKeyString)?.value ?? NaN
+      const dataItem: AdornmentData<any> = { plottedValue }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
@@ -3,11 +3,12 @@ import { IAdornmentModel } from "../../adornment-models"
 import { isPlottedValueAdornment } from "./plotted-value-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { kPlottedValueType } from "./plotted-value-adornment-types"
 
 export const plottedValueAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isPlottedValueAdornment(adornment)) {
-      return { success: false, values: { error: "Not a plotted value adornment" } }
+      return { success: false, values: { error: `Not a ${kPlottedValueType} adornment` } }
     }
 
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
@@ -11,6 +11,8 @@ export const plottedValueAdornmentHandler: DIAdornmentHandler = {
       return { success: false, values: { error: `Not a ${kPlottedValueType} adornment` } }
     }
 
+    const { error, formula: _formula } = adornment
+    const formula = JSON.stringify(_formula.display)
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData[] = []
@@ -27,6 +29,6 @@ export const plottedValueAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data, error, formula }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
@@ -2,14 +2,12 @@ import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/ado
 import { IAdornmentModel } from "../../adornment-models"
 import { isPlottedValueAdornment } from "./plotted-value-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { kPlottedValueType } from "./plotted-value-adornment-types"
 
 export const plottedValueAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isPlottedValueAdornment(adornment)) {
-      return { success: false, values: { error: `Not a ${kPlottedValueType} adornment` } }
-    }
+    if (!isPlottedValueAdornment(adornment)) return adornmentMismatchResult(kPlottedValueType)
 
     const { error, formula: _formula } = adornment
     const formula = JSON.stringify(_formula.display)

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-handler.ts
@@ -13,12 +13,12 @@ export const plottedValueAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
       const plottedValue = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData<any> = { plottedValue }
+      const dataItem: AdornmentData = { plottedValue }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.tsx
@@ -1,9 +1,11 @@
 import React from "react"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { exportAdornmentBase, registerAdornmentContentInfo } from "../../adornment-content-info"
 import { AdornmentCheckbox } from "../../components/adornment-checkbox"
 import { PlottedValueAdornmentBanner } from "./plotted-value-adornment-banner"
 import { PlottedValueComponent } from "./plotted-value-adornment-component"
+import { plottedValueAdornmentHandler } from "./plotted-value-adornment-handler"
 import { isPlottedValueAdornment, PlottedValueAdornmentModel } from "./plotted-value-adornment-model"
 import {
   kPlottedValueClass, kPlottedValueLabelKey, kPlottedValuePrefix, kPlottedValueRedoAddKey,
@@ -11,8 +13,6 @@ import {
   kPlottedValueUndoRemoveKey
 } from "./plotted-value-adornment-types"
 import { PlottedValueFormulaAdapter } from "./plotted-value-formula-adapter"
-import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { plottedValueAdornmentHandler } from "./plotted-value-adornment-handler"
 
 const Controls = () => {
   return (

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.tsx
@@ -11,6 +11,8 @@ import {
   kPlottedValueUndoRemoveKey
 } from "./plotted-value-adornment-types"
 import { PlottedValueFormulaAdapter } from "./plotted-value-formula-adapter"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { plottedValueAdornmentHandler } from "./plotted-value-adornment-handler"
 
 const Controls = () => {
   return (
@@ -59,3 +61,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kPlottedValueType
 })
+
+registerAdornmentHandler(kPlottedValueType, plottedValueAdornmentHandler)

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
@@ -38,7 +38,7 @@ describe("DataInteractive standardDeviationAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kStandardDeviationType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kStandardDeviationType} adornment.`)
   })
 
   it("get returns the expected data when standard deviation adornment provided", () => {

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kStandardDeviationType } from "./standard-deviation-adornment-types"
 
 describe("DataInteractive standardDeviationAdornmentHandler", () => {
   const handler = standardDeviationAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -24,7 +23,7 @@ describe("DataInteractive standardDeviationAdornmentHandler", () => {
     
     mockStandardDeviationAdornment = {
       computeMeasureRange: jest.fn(() => { return {min: 0, max: 20} }),
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       measures: mockMeasuresMap,
       type: kStandardDeviationType
@@ -44,7 +43,6 @@ describe("DataInteractive standardDeviationAdornmentHandler", () => {
 
   it("get returns the expected data when standard deviation adornment provided", () => {
     const result = handler.get?.(mockStandardDeviationAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ mean: 10, min: 0, max: 20 })

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
@@ -1,0 +1,53 @@
+import { standardDeviationAdornmentHandler } from "./standard-deviation-adornment-handler"
+import { kStandardDeviationType } from "./standard-deviation-adornment-types"
+
+describe("DataInteractive standardDeviationAdornmentHandler", () => {
+  const handler = standardDeviationAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockStandardDeviationAdornment: any
+  let mockInvalidAdornment: any
+  const mockMeasuresMap = new Map([
+    ["{}", { value: 10 }]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockStandardDeviationAdornment = {
+      computeMeasureRange: jest.fn(() => { return {min: 0, max: 20} }),
+      id: adornmentId,
+      isVisible: true,
+      measures: mockMeasuresMap,
+      type: kStandardDeviationType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kStandardDeviationType} adornment`)
+  })
+
+  it("get returns the expected data when standard deviation adornment provided", () => {
+    const result = handler.get?.(mockStandardDeviationAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({ mean: 10, min: 0, max: 20 })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
@@ -3,11 +3,12 @@ import { IGraphContentModel } from "../../../models/graph-content-model"
 import { IAdornmentModel } from "../../adornment-models"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { isStandardDeviationAdornment } from "./standard-deviation-adornment-model"
+import { kStandardDeviationType } from "./standard-deviation-adornment-types"
 
 export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isStandardDeviationAdornment(adornment)) {
-      return { success: false, values: { error: "Not a standard deviation adornment" } }
+      return { success: false, values: { error: `Not a ${kStandardDeviationType} adornment` } }
     }
 
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
@@ -29,6 +29,6 @@ export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
@@ -1,15 +1,13 @@
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { IAdornmentModel } from "../../adornment-models"
-import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { isStandardDeviationAdornment } from "./standard-deviation-adornment-model"
 import { kStandardDeviationType } from "./standard-deviation-adornment-types"
 
 export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isStandardDeviationAdornment(adornment)) {
-      return { success: false, values: { error: `Not a ${kStandardDeviationType} adornment` } }
-    }
+    if (!isStandardDeviationAdornment(adornment)) return adornmentMismatchResult(kStandardDeviationType)
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
@@ -1,0 +1,26 @@
+import { getSnapshot } from "@concord-consortium/mobx-state-tree"
+import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { IAdornmentModel } from "../../adornment-models"
+import { isStandardDeviationAdornment } from "./standard-deviation-adornment-model"
+import { t } from "../../../../../utilities/translation/translate"
+
+export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
+  get(adornment: IAdornmentModel) {
+    if (!isStandardDeviationAdornment(adornment)) {
+      return { success: false, values: { error: "Not a standard deviation adornment" } }
+    }
+
+    const fullAdornmentSnapshot = {
+      ...getSnapshot(adornment),
+      // Add volatile measure values to snapshot.
+      measures: Object.fromEntries(
+        Array.from(adornment.measures.entries()).map(([key, measure]) => 
+          [key, { ...getSnapshot(measure), value: measure.value }]
+        )
+      ),
+      labelTitle: t(adornment.labelTitle)
+    }
+
+    return fullAdornmentSnapshot
+  }
+}

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
@@ -13,14 +13,14 @@ export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const primaryAttrId = dataConfig?.primaryAttributeID
       const cellKeyString = JSON.stringify(cellKey)
       const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
       const { min, max } = adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)
-      const dataItem: AdornmentData<any> = { mean, min, max }
+      const dataItem: AdornmentData = { mean, min, max }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-registration.tsx
@@ -10,6 +10,8 @@ import {
   kStandardDeviationUndoAddKey, kStandardDeviationRedoAddKey, kStandardDeviationRedoRemoveKey,
   kStandardDeviationUndoRemoveKey
 } from "./standard-deviation-adornment-types"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { standardDeviationAdornmentHandler } from "./standard-deviation-adornment-handler"
 
 const Controls = () => {
   return (
@@ -49,3 +51,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kStandardDeviationType
 })
+
+registerAdornmentHandler(kStandardDeviationType, standardDeviationAdornmentHandler)

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-registration.tsx
@@ -1,17 +1,17 @@
 import React from "react"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { registerAdornmentContentInfo } from "../../adornment-content-info"
 import { AdornmentCheckbox } from "../../components/adornment-checkbox"
 import { UnivariateMeasureAdornmentSimpleComponent } from "../univariate-measure-adornment-simple-component"
 import { exportUnivariateMeasure } from "../univariate-measure-adornment-utils"
+import { standardDeviationAdornmentHandler } from "./standard-deviation-adornment-handler"
 import { isStandardDeviationAdornment, StandardDeviationAdornmentModel } from "./standard-deviation-adornment-model"
 import {
   kStandardDeviationClass, kStandardDeviationLabelKey, kStandardDeviationType, kStandardDeviationPrefix,
   kStandardDeviationUndoAddKey, kStandardDeviationRedoAddKey, kStandardDeviationRedoRemoveKey,
   kStandardDeviationUndoRemoveKey
 } from "./standard-deviation-adornment-types"
-import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { standardDeviationAdornmentHandler } from "./standard-deviation-adornment-handler"
 
 const Controls = () => {
   return (

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.test.ts
@@ -3,7 +3,6 @@ import { kStandardErrorType } from "./standard-error-adornment-types"
 
 describe("DataInteractive standardErrorAdornmentHandler", () => {
   const handler = standardErrorAdornmentHandler
-  const adornmentId = "ADRN123"
 
   let mockGraphContent: any
   let mockDataConfig: any
@@ -23,8 +22,9 @@ describe("DataInteractive standardErrorAdornmentHandler", () => {
     }
     
     mockStandardErrorAdornment = {
+      _numStErrs: 1,
       computeMeasureRange: jest.fn(() => { return {min: 20, max: 28} }),
-      id: adornmentId,
+      id: "ADRN123",
       isVisible: true,
       measures: mockMeasuresMap,
       type: kStandardErrorType
@@ -44,7 +44,7 @@ describe("DataInteractive standardErrorAdornmentHandler", () => {
 
   it("get returns the expected data when standard error adornment provided", () => {
     const result = handler.get?.(mockStandardErrorAdornment, mockGraphContent)
-    expect(result?.id).toBe(adornmentId)
+    expect(result?._numStErrs).toBe(1)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ standardError: 4, min: 20, max: 28 })

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.test.ts
@@ -39,7 +39,7 @@ describe("DataInteractive standardErrorAdornmentHandler", () => {
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a ${kStandardErrorType} adornment`)
+    expect(result?.values.error).toBe(`Not a(n) ${kStandardErrorType} adornment.`)
   })
 
   it("get returns the expected data when standard error adornment provided", () => {

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.test.ts
@@ -1,0 +1,53 @@
+import { standardErrorAdornmentHandler } from "./standard-error-adornment-handler"
+import { kStandardErrorType } from "./standard-error-adornment-types"
+
+describe("DataInteractive standardErrorAdornmentHandler", () => {
+  const handler = standardErrorAdornmentHandler
+  const adornmentId = "ADRN123"
+
+  let mockGraphContent: any
+  let mockDataConfig: any
+  let mockStandardErrorAdornment: any
+  let mockInvalidAdornment: any
+  const mockMeasuresMap = new Map([
+    ["{}", { value: 4 }]
+  ])
+
+  beforeEach(() => {
+    mockDataConfig = {
+      getAllCellKeys: jest.fn(() => [{}]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+    mockGraphContent = {
+      dataConfiguration: mockDataConfig
+    }
+    
+    mockStandardErrorAdornment = {
+      computeMeasureRange: jest.fn(() => { return {min: 20, max: 28} }),
+      id: adornmentId,
+      isVisible: true,
+      measures: mockMeasuresMap,
+      type: kStandardErrorType
+    }
+
+    mockInvalidAdornment = {
+      id: "ADRN456",
+      type: "invalid"
+    }
+  })
+
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a ${kStandardErrorType} adornment`)
+  })
+
+  it("get returns the expected data when standard error adornment provided", () => {
+    const result = handler.get?.(mockStandardErrorAdornment, mockGraphContent)
+    expect(result?.id).toBe(adornmentId)
+    expect(Array.isArray(result?.data)).toBe(true)
+    expect(result?.data).toHaveLength(1)
+    expect(result?.data[0]).toMatchObject({ standardError: 4, min: 20, max: 28 })
+    expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
@@ -11,6 +11,7 @@ export const standardErrorAdornmentHandler: DIAdornmentHandler = {
       return { success: false, values: { error: `Not a ${kStandardErrorType} adornment` } }
     }
 
+    const { _numStErrs } = adornment
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData[] = []
@@ -29,6 +30,6 @@ export const standardErrorAdornmentHandler: DIAdornmentHandler = {
       data.push(dataItem)
     }
 
-    return { id: adornment.id, data }
+    return { data, _numStErrs }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
@@ -1,21 +1,25 @@
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { IAdornmentModel } from "../../adornment-models"
-import { isMeanAdornment } from "./mean-adornment-model"
+import { isStandardErrorAdornment } from "./standard-error-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 
-export const meanAdornmentHandler: DIAdornmentHandler = {
+export const standardErrorAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMeanAdornment(adornment)) return { success: false, values: { error: "Not a mean adornment" } }
+    if (!isStandardErrorAdornment(adornment)) {
+      return { success: false, values: { error: "Not a standard error adornment" } }
+    }
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData<any>[] = []
 
     for (const cellKey of cellKeys) {
+      const primaryAttrId = dataConfig?.primaryAttributeID
       const cellKeyString = JSON.stringify(cellKey)
-      const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData<any> = { mean }
+      const standardError = adornment.measures.get(cellKeyString)?.value ?? NaN
+      const { min, max } = adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)
+      const dataItem: AdornmentData<any> = { standardError, min, max }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
@@ -13,14 +13,14 @@ export const standardErrorAdornmentHandler: DIAdornmentHandler = {
 
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData<any>[] = []
+    const data: AdornmentData[] = []
 
     for (const cellKey of cellKeys) {
       const primaryAttrId = dataConfig?.primaryAttributeID
       const cellKeyString = JSON.stringify(cellKey)
       const standardError = adornment.measures.get(cellKeyString)?.value ?? NaN
       const { min, max } = adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)
-      const dataItem: AdornmentData<any> = { standardError, min, max }
+      const dataItem: AdornmentData = { standardError, min, max }
     
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
@@ -2,14 +2,12 @@ import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/ado
 import { IAdornmentModel } from "../../adornment-models"
 import { isStandardErrorAdornment } from "./standard-error-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { kStandardErrorType } from "./standard-error-adornment-types"
 
 export const standardErrorAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isStandardErrorAdornment(adornment)) {
-      return { success: false, values: { error: `Not a ${kStandardErrorType} adornment` } }
-    }
+    if (!isStandardErrorAdornment(adornment)) return adornmentMismatchResult(kStandardErrorType)
 
     const { _numStErrs } = adornment
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-handler.ts
@@ -3,11 +3,12 @@ import { IAdornmentModel } from "../../adornment-models"
 import { isStandardErrorAdornment } from "./standard-error-adornment-model"
 import { IGraphContentModel } from "../../../models/graph-content-model"
 import { AdornmentData, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { kStandardErrorType } from "./standard-error-adornment-types"
 
 export const standardErrorAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isStandardErrorAdornment(adornment)) {
-      return { success: false, values: { error: "Not a standard error adornment" } }
+      return { success: false, values: { error: `Not a ${kStandardErrorType} adornment` } }
     }
 
     const dataConfig = graphContent.dataConfiguration

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.tsx
@@ -2,6 +2,7 @@ import {
   Flex, NumberDecrementStepper, NumberIncrementStepper, NumberInput, NumberInputField, NumberInputStepper
 } from "@chakra-ui/react"
 import React, { useCallback, useEffect } from "react"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
 import { logMessageWithReplacement } from "../../../../../lib/log-message"
 import { translate } from "../../../../../utilities/translation/translate"
 import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
@@ -10,6 +11,7 @@ import { registerAdornmentContentInfo } from "../../adornment-content-info"
 import { AdornmentCheckbox } from "../../components/adornment-checkbox"
 import { exportUnivariateMeasure } from "../univariate-measure-adornment-utils"
 import { StandardErrorAdornmentComponent } from "./standard-error-adornment-component"
+import { standardErrorAdornmentHandler } from "./standard-error-adornment-handler"
 import {
   isStandardErrorAdornment, IStandardErrorAdornmentModel, StandardErrorAdornmentModel
 } from "./standard-error-adornment-model"
@@ -18,8 +20,6 @@ import {
   kStandardErrorUndoAddKey, kStandardErrorRedoAddKey, kStandardErrorRedoRemoveKey,
   kStandardErrorUndoRemoveKey
 } from "./standard-error-adornment-types"
-import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { standardErrorAdornmentHandler } from "./standard-error-adornment-handler"
 
 const Controls = () => {
   const graphModel = useGraphContentModelContext()

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.tsx
@@ -18,6 +18,8 @@ import {
   kStandardErrorUndoAddKey, kStandardErrorRedoAddKey, kStandardErrorRedoRemoveKey,
   kStandardErrorUndoRemoveKey
 } from "./standard-error-adornment-types"
+import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { standardErrorAdornmentHandler } from "./standard-error-adornment-handler"
 
 const Controls = () => {
   const graphModel = useGraphContentModelContext()
@@ -129,3 +131,5 @@ registerAdornmentComponentInfo({
   order: 10,
   type: kStandardErrorType
 })
+
+registerAdornmentHandler(kStandardErrorType, standardErrorAdornmentHandler)

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-model.ts
@@ -71,8 +71,9 @@ export const UnivariateMeasureAdornmentModel = AdornmentModel
       // derived models should override if they have a range
       return {min: NaN, max: NaN}
     },
-    computeMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) {
+    computeMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IDataConfigurationModel): number {
       // derived models should override to compute their respective values
+      throw new Error("computeMeasureValue must be implemented in derived models")
     }
   }))
   .actions(self => ({

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.test.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.test.ts
@@ -1,4 +1,4 @@
-import { cellKeyToCategories } from "./adornment-handler-utils"
+import { adornmentMismatchResult, cellKeyToCategories } from "./adornment-handler-utils"
 
 describe("cellKeyToCategories", () => {
   let mockDataConfig: any
@@ -26,5 +26,17 @@ describe("cellKeyToCategories", () => {
     const cellKey2 = { ATTR1: "category value 2" }
     const result2 = cellKeyToCategories(cellKey2, mockDataConfig)
     expect(result2).toEqual({"Category Name": "category value 2"})
+  })
+})
+
+describe("adornmentMismatchResult", () => {
+  it("should return an error message", () => {
+    const result = adornmentMismatchResult("mockAdornmentType")
+    expect(result).toEqual({
+      success: false,
+      values: {
+        error: "Not a(n) mockAdornmentType adornment."
+      }
+    })
   })
 })

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.test.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.test.ts
@@ -1,0 +1,30 @@
+import { cellKeyToCategories } from "./adornment-handler-utils"
+
+describe("cellKeyToCategories", () => {
+  let mockDataConfig: any
+
+  beforeEach(() => {
+    mockDataConfig = {
+      dataset: {
+        getAttribute: jest.fn(() => { return { name: "Category Name" } })
+      },
+      getAllCellKeys: jest.fn(() => [{}, { "ATTR1": "category value 1" }]),
+      subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
+    }
+  })
+
+  it("should return an empty array if the cellKey is empty", () => {
+    const cellKey = {}
+    const result = cellKeyToCategories(cellKey, mockDataConfig)
+    expect(result).toEqual({})
+  })
+
+  it("should return an array of categories if the cellKey is not empty", () => {
+    const cellKey1 = { ATTR1: "category value 1" }
+    const result1 = cellKeyToCategories(cellKey1, mockDataConfig)
+    expect(result1).toEqual({"Category Name": "category value 1"})
+    const cellKey2 = { ATTR1: "category value 2" }
+    const result2 = cellKeyToCategories(cellKey2, mockDataConfig)
+    expect(result2).toEqual({"Category Name": "category value 2"})
+  })
+})

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
@@ -1,0 +1,20 @@
+import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
+import { kCountType, kPercentType } from "../count/count-adornment-types"
+import { kMeanType } from "../univariate-measures/mean/mean-adornment-types"
+import { kMedianType } from "../univariate-measures/median/median-adornment-types"
+
+export type AdornmentType = typeof kCountType | typeof kMeanType | typeof kMedianType | typeof kPercentType
+
+export type AdornmentData<T extends AdornmentType> = {
+  categories?: Record<string, string>
+} & Record<T, number | number[] | string | undefined | null | ((x: number) => void)>
+
+export const cellKeyToCategories = (cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) => {
+  const categories: Record<string, string> = {}
+  for (const [attributeId, categoryValue] of Object.entries(cellKey)) {
+    const attributeName = dataConfig.dataset?.getAttribute(attributeId)?.name || ""
+    categories[attributeName] = categoryValue
+  }
+
+  return categories
+}

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
@@ -1,13 +1,8 @@
 import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
-import { kCountType, kPercentType } from "../count/count-adornment-types"
-import { kMeanType } from "../univariate-measures/mean/mean-adornment-types"
-import { kMedianType } from "../univariate-measures/median/median-adornment-types"
 
-export type AdornmentType = typeof kCountType | typeof kMeanType | typeof kMedianType | typeof kPercentType
-
-export type AdornmentData<T extends AdornmentType> = {
-  categories?: Record<string, string>
-} & Record<T, number | number[] | string | undefined | null | ((x: number) => void)>
+export type AdornmentData = {
+  categories?: Record<string, string>;
+} & Record<string, number | number[] | string | undefined | null | ((x: number) => void)>
 
 export const cellKeyToCategories = (cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) => {
   const categories: Record<string, string> = {}

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
@@ -1,3 +1,5 @@
+import { errorResult } from "../../../../data-interactive/handlers/di-results"
+import { t } from "../../../../utilities/translation/translate"
 import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
 
 export type AdornmentData = {
@@ -12,4 +14,8 @@ export const cellKeyToCategories = (cellKey: Record<string, string>, dataConfig:
   }
 
   return categories
+}
+
+export const adornmentMismatchResult = (adornmentType: string) => {
+  return errorResult(t("V3.DI.Error.adornmentMismatch", { vars: [adornmentType] }))
 }

--- a/v3/src/data-interactive/handlers/adornment-handler.test.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.test.ts
@@ -1,3 +1,5 @@
+import { IAdornmentModel } from "../../components/graph/adornments/adornment-models"
+import { DIResources } from "../data-interactive-types"
 import { diAdornmentHandler } from "./adornment-handler"
 
 describe("DataInteractive AdornmentHandler", () => {
@@ -5,6 +7,17 @@ describe("DataInteractive AdornmentHandler", () => {
 
   it("get returns an error when no adornment provided", () => {
     const result = handler.get?.({})
+    expect(result?.success).toBe(false)
+  })
+
+  it("get returns an error when the specified adornment is not active", () => {
+    const mockAdornment = {
+      id: "ADRN123",
+      isVisible: false,
+      type: "Count"
+    } as IAdornmentModel
+    const mockResource: DIResources = { adornment: mockAdornment }
+    const result = handler.get?.(mockResource)
     expect(result?.success).toBe(false)
   })
 

--- a/v3/src/data-interactive/handlers/adornment-handler.test.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.test.ts
@@ -1,28 +1,7 @@
-import { CountAdornmentModel } from "../../components/graph/adornments/count/count-adornment-model"
 import { diAdornmentHandler } from "./adornment-handler"
 
 describe("DataInteractive AdornmentHandler", () => {
   const handler = diAdornmentHandler
-  const countAdornment = CountAdornmentModel.create({
-    id: "ADRN123",
-    isVisible: false,
-    percentType: "row",
-    showCount: false,
-    showPercent: false,
-    type: "Count"
-  })
-
-  it("get works as expected when provided with an adornment", () => {  
-    const result = handler.get?.({ adornment: countAdornment })
-    const { success, values } = result || {}
-    const getValue = (key: string) => {
-      return (values && typeof values === "object" && key in values) ? (values as Record<string, any>)[key] : undefined
-    }
-    expect(success).toBe(true)
-    expect(getValue("id")).toBe(countAdornment.id)
-    expect(getValue("type")).toBe(countAdornment.type)
-    expect(getValue("isVisible")).toBe(countAdornment.isVisible)
-  })
 
   it("get returns an error when no adornment provided", () => {
     const result = handler.get?.({})

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -39,7 +39,17 @@ export const diAdornmentHandler: DIHandler = {
       values = handler?.get(adornment, component.content)
     }
 
-    if (values) return { success: true, values }
+    if (values) {
+      return {
+        success: true,
+        values: {
+          id: adornment.id,
+          type: adornment.type,
+          isVisible: adornment.isVisible,
+          ...values
+        }
+      }
+    }
     return { success: false, values: { error: "Unsupported adornment type" } }
   }
 }

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -17,7 +17,7 @@ export const registerAdornmentHandler = (type: string, handler: DIAdornmentHandl
 export const diAdornmentHandler: DIHandler = {
   get(resources: DIResources) {
     const { adornment, component } = resources
-    if (!adornment) return adornmentNotFoundResult
+    if (!adornment?.isVisible) return adornmentNotFoundResult
     if (!isGraphContentModel(component?.content)) return { success: false, values: { error: "Not a graph component" } }
 
     let values: Maybe<Record<string, any>> 

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -1,8 +1,9 @@
 import { IAdornmentModel } from "../../components/graph/adornments/adornment-models"
 import { IGraphContentModel, isGraphContentModel } from "../../components/graph/models/graph-content-model"
+import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, DIResources } from "../data-interactive-types"
-import { adornmentNotFoundResult } from "./di-results"
+import { adornmentNotFoundResult, adornmentNotSupportedResult, errorResult } from "./di-results"
 
 export interface DIAdornmentHandler {
   get: (adornment: IAdornmentModel, component: IGraphContentModel) => Maybe<Record<string, any>>
@@ -29,8 +30,10 @@ export const resolveAdornmentType = (typeOrAlias: unknown) => {
 export const diAdornmentHandler: DIHandler = {
   get(resources: DIResources) {
     const { adornment, component } = resources
-    if (!adornment?.isVisible) return adornmentNotFoundResult
-    if (!isGraphContentModel(component?.content)) return { success: false, values: { error: "Not a graph component" } }
+    if (!isGraphContentModel(component?.content)) {
+      return errorResult(t("V3.DI.Error.unsupportedComponent", { vars: [component?.content.type] }))
+    }
+    if (!adornment) return adornmentNotFoundResult
 
     let values: Maybe<Record<string, any>>
     const handler = diAdornmentHandlers.get(adornment.type)
@@ -50,7 +53,8 @@ export const diAdornmentHandler: DIHandler = {
         }
       }
     }
-    return { success: false, values: { error: "Unsupported adornment type" } }
+
+    return adornmentNotSupportedResult
   }
 }
 

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -10,8 +10,20 @@ export interface DIAdornmentHandler {
 
 const diAdornmentHandlers = new Map<string, DIAdornmentHandler>()
 
-export const registerAdornmentHandler = (type: string, handler: DIAdornmentHandler) => {
+const diAdornmentTypeAliases = new Map<string, string>()
+
+export const registerAdornmentHandler = (type: string, handler: DIAdornmentHandler, alias?: string) => {
   diAdornmentHandlers.set(type, handler)
+  if (alias) diAdornmentTypeAliases.set(alias, type)
+  const trimType = type.replace(/\s/g, "")
+  // register trimmed (without spaces) types as aliases
+  if (trimType !== type) diAdornmentTypeAliases.set(trimType, type)
+}
+
+export const resolveAdornmentType = (typeOrAlias: unknown) => {
+  return typeof typeOrAlias === "string"
+          ? diAdornmentTypeAliases.get(typeOrAlias) ?? typeOrAlias
+          : typeOrAlias
 }
 
 export const diAdornmentHandler: DIHandler = {
@@ -20,7 +32,7 @@ export const diAdornmentHandler: DIHandler = {
     if (!adornment?.isVisible) return adornmentNotFoundResult
     if (!isGraphContentModel(component?.content)) return { success: false, values: { error: "Not a graph component" } }
 
-    let values: Maybe<Record<string, any>> 
+    let values: Maybe<Record<string, any>>
     const handler = diAdornmentHandlers.get(adornment.type)
 
     if (handler) {

--- a/v3/src/data-interactive/handlers/di-results.ts
+++ b/v3/src/data-interactive/handlers/di-results.ts
@@ -3,6 +3,7 @@ import { t } from "../../utilities/translation/translate"
 export const errorResult = (error: string) => ({ success: false as const, values: { error } })
 export const adornmentNotFoundResult = errorResult(t("V3.DI.Error.adornmentNotFound"))
 export const adornmentListNotFoundResult = errorResult(t("V3.DI.Error.adornmentListNotFound"))
+export const adornmentNotSupportedResult = errorResult(t("V3.DI.Error.adornmentNotSupported"))
 export const attributeNotFoundResult = errorResult(t("V3.DI.Error.attributeNotFound"))
 export const caseNotFoundResult = errorResult(t("V3.DI.Error.caseNotFound"))
 export const collectionNotFoundResult = errorResult(t("V3.DI.Error.collectionNotFound"))

--- a/v3/src/data-interactive/resource-parser-utils.ts
+++ b/v3/src/data-interactive/resource-parser-utils.ts
@@ -111,7 +111,7 @@ export function findTileFromNameOrId(nameOrId: string) {
   const { content } = appState.document
   if (content) {
     return Array.from(content.tileMap.values()).find(tile => {
-      if (tile.name === nameOrId || tile.id === nameOrId) return true
+      if (tile.matchTitleOrNameOrId(nameOrId)) return true
       const { content: { type } } = tile
       const tileInfo = getTileContentInfo(type)
       if (tileInfo?.prefix && tile.id === toV3Id(tileInfo.prefix, nameOrId)) return true

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -8,6 +8,7 @@ import { ITileModel } from "../models/tiles/tile-model"
 import { toV3CaseId, toV3GlobalId, toV3ItemId } from "../utilities/codap-utils"
 import { ActionName, DIResources, DIResourceSelector, DIParsedOperand } from "./data-interactive-types"
 import { getAttribute, getCollection } from "./data-interactive-utils"
+import { resolveAdornmentType } from "./handlers/adornment-handler"
 import { evaluateCaseFormula, findTileFromNameOrId, parseSearchQuery } from "./resource-parser-utils"
 
 /**
@@ -152,7 +153,7 @@ export function resolveResources(
     const adornmentTypeOrId = resourceSelector.adornment
     const adornments = result.component.content.adornmentsStore.adornments
     result.adornment = adornments.find((adornment) => {
-      return adornment.id === adornmentTypeOrId || adornment.type === adornmentTypeOrId
+      return adornment.id === adornmentTypeOrId || adornment.type === resolveAdornmentType(adornmentTypeOrId)
     })
   }
 

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -141,8 +141,10 @@
     "V3.DI.Error.invalidEvaluationRecord": "Invalid record for evaluation",
     "V3.DI.Error.couldNotParseQuery": "Unable to parse query.",
     "V3.DI.Error.unknownRequest": "unknown request: %@",
-    "V3.DI.Error.adornmentNotFound": "Adornment not found",
-    "V3.DI.Error.adornmentListNotFound": "Adornment list not found",
+    "V3.DI.Error.adornmentNotFound": "Adornment not found.",
+    "V3.DI.Error.adornmentNotSupported": "Unsupported adornment type",
+    "V3.DI.Error.adornmentListNotFound": "Adornment list not found.",
+    "V3.DI.Error.adornmentMismatch": "Not a(n) %@1 adornment.",
 
     // CFM/File menu
     "DG.fileMenu.menuItem.newDocument": "New",


### PR DESCRIPTION
[CODAP-68](https://concord-consortium.atlassian.net/browse/CODAP-68)

Certain values weren't being included in the information returned by the data interactive API adornment handlers. These changes would fix that.

[CODAP-68]: https://concord-consortium.atlassian.net/browse/CODAP-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ