### PR TITLE
fix: invalidate sub-plot assignments when attribute values change

### DIFF
--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -90,6 +90,7 @@ export interface IMatchCirclesProps {
 export function matchCirclesToData(props: IMatchCirclesProps) {
   const { dataConfiguration, pixiPoints, startAnimation, pointRadius, pointColor, pointStrokeColor,
           pointDisplayType = "points" } = props
+  // TODO: eliminate dependence on GraphDataConfigurationModel
   const allCaseData: CaseDataWithSubPlot[] = isGraphDataConfigurationModel(dataConfiguration)
     ? dataConfiguration.caseDataWithSubPlot
     : dataConfiguration.joinedCaseDataArrays

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -122,7 +122,7 @@ export const Graph = observer(function Graph({graphController, setGraphRef, pixi
 
   useEffect(function handleSubPlotsUpdate() {
     return mstReaction(
-      () => graphModel.dataConfiguration.caseDataWithSubPlot,
+      () => graphModel.dataConfiguration.categoricalAttrsWithChangeCounts,
       () => {
         updateCellMasks({ dataConfig: graphModel.dataConfiguration, layout, pixiPoints })
       }, {name: "Graph.handleSubPlotsUpdate"}, graphModel

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -116,7 +116,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
 
   useEffect(function respondToCategorySetChanges() {
     return mstReaction(() => {
-      return dataConfiguration.allCategoriesForRoles
+      return dataConfiguration.categoricalAttrsWithChangeCounts
     }, () => {
       startAnimation()
       callRefreshPointPositions({ updateMasks: true })

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -274,6 +274,12 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     },
   }))
   .views(self => ({
+    get categoricalAttrsWithChangeCounts() {
+      return self.categoricalAttrs.map(attrEntry => {
+        const attr = self.dataset?.getAttribute(attrEntry.attrId)
+        return { ...attrEntry, changeCount: attr?.changeCount ?? 0 }
+      })
+    },
     getCategoriesOptions() {
       // Helper used often by adornments that usually ask about the same categories and their specifics.
       const xAttrType = self.attributeType("x")
@@ -792,7 +798,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
           { name: "GraphDataConfigurationModel yAttrDescriptions reaction", equals: comparer.structural }
         ))
         addDisposer(self, reaction(
-          () => self.getAllCellKeys(),
+          () => self.categoricalAttrsWithChangeCounts,
           () => self.clearGraphSpecificCasesCache(),
           { name: "GraphDataConfigurationModel getCellKeys reaction", equals: comparer.structural }
         ))


### PR DESCRIPTION
[[CODAP-337](https://concord-consortium.atlassian.net/browse/CODAP-337)]

In #1865, a graph rendering/masking bug which resulted in some points not being displayed was fixed. In testing that fix, another scenario was identified that resulted in a similar symptom of some points not being displayed. Under the hood, however, the two bugs have different root causes. The bug fixed in #1865 was a straight rendering bug -- the model provided the right data to the graph which simply failed to render it correctly. The remaining issue is a model/cache invalidation bug in which stale data was being passed to the graph. It turns out that some of our reactive code was relying on things like the set of categories to be plotted changing to perform some necessary computations. In the scenario described in the bug report, the values of a computed attribute were changed, but the set of categories was the same and so some necessary invalidations were bypassed. With this PR, instead of relying on the set of categories to be plotted, we react to any changes to the categorical attributes being plotted. The new `GraphDataConfigurationModel` property -- `categoricalAttrsWithChangeCounts` is more efficient to compute and to compare than some of the other properties previously being observed (e.g. `caseDataWithSubPlot`, `allCategoriesForRoles`, `getAllCellKeys`) and so we use it preferentially where it makes sense.

[CODAP-337]: https://concord-consortium.atlassian.net/browse/CODAP-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ