### PR TITLE
fix: more graph caching/masking bugs

### DIFF
--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -116,7 +116,7 @@ export const Graph = observer(function Graph({graphController, setGraphRef, pixi
         .attr("width", `${Math.max(0, layout.plotWidth)}px`)
         .attr("height", `${Math.max(0, layout.plotHeight)}px`)
 
-      updateCellMasks({ dataConfig: graphModel.dataConfiguration, layout, pixiPoints, resize: true })
+      updateCellMasks({ dataConfig: graphModel.dataConfiguration, layout, pixiPoints })
     }
   }, [dataset, graphModel.dataConfiguration, layout, layout.plotHeight, layout.plotWidth, pixiPoints, xScale])
 
@@ -125,7 +125,7 @@ export const Graph = observer(function Graph({graphController, setGraphRef, pixi
       () => graphModel.dataConfiguration.categoricalAttrsWithChangeCounts,
       () => {
         updateCellMasks({ dataConfig: graphModel.dataConfiguration, layout, pixiPoints })
-      }, {name: "Graph.handleSubPlotsUpdate"}, graphModel
+      }, {name: "Graph.handleSubPlotsUpdate", equals: comparer.structural}, graphModel
     )
   }, [graphModel, layout, pixiPoints])
 

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -66,7 +66,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
   const callRefreshPointPositions = useDebouncedCallback((_props?: IRefreshProps) => {
     const { selectedOnly = false, updateMasks = false } = _props || {}
     if (updateMasks) {
-      updateCellMasks({ dataConfig: dataConfiguration, layout, pixiPoints, resize: true })
+      updateCellMasks({ dataConfig: dataConfiguration, layout, pixiPoints })
     }
     refreshPointPositions(selectedOnly)
   })

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -775,8 +775,8 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     const baseClearCasesCache = self.clearCasesCache
     return {
       clearCasesCache() {
-        self.clearGraphSpecificCasesCache()
         baseClearCasesCache()
+        self.clearGraphSpecificCasesCache()
       }
     }
   })
@@ -799,7 +799,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         ))
         addDisposer(self, reaction(
           () => self.categoricalAttrsWithChangeCounts,
-          () => self.clearGraphSpecificCasesCache(),
+          () => self.clearCasesCache(),
           { name: "GraphDataConfigurationModel getCellKeys reaction", equals: comparer.structural }
         ))
         baseAfterCreate()

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -324,14 +324,11 @@ interface IUpdateCellMasks {
   dataConfig: IGraphDataConfigurationModel
   layout: GraphLayout
   pixiPoints?: PixiPoints
-  resize?: boolean
 }
-export function updateCellMasks({ dataConfig, layout, pixiPoints, resize }: IUpdateCellMasks) {
-  if (resize) {
-    const { xCats, yCats, topCats, rightCats } = dataConfig.getCategoriesOptions()
-    pixiPoints?.resize(layout.plotWidth, layout.plotHeight,
-                      xCats.length || 1, yCats.length || 1, topCats.length || 1, rightCats.length || 1)
-  }
+export function updateCellMasks({ dataConfig, layout, pixiPoints }: IUpdateCellMasks) {
+  const { xCats, yCats, topCats, rightCats } = dataConfig.getCategoriesOptions()
+  pixiPoints?.resize(layout.plotWidth, layout.plotHeight,
+                    xCats.length || 1, yCats.length || 1, topCats.length || 1, rightCats.length || 1)
   pixiPoints?.setPointsMask(dataConfig.caseDataWithSubPlot)
 }
 

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -148,12 +148,12 @@ export const Attribute = V2Model.named("Attribute").props({
 }))
 .actions(self => ({
   incChangeCount() {
-    ++self.changeCount
     self.getEmptyCount.invalidate()
     self.getNumericCount.invalidate()
     self.getStrictColorCount.invalidate()
     self.getBoundaryCount.invalidate()
     self.getDateCount.invalidate()
+    ++self.changeCount
   },
   setCid(cid?: string) {
     self._cid = cid


### PR DESCRIPTION
[[CODAP-337](https://concord-consortium.atlassian.net/browse/CODAP-337)]

In previous episodes of this epic mini-series:
- #1865 fixed a graph rendering bug which resulted in points being masked incorrectly (e.g. not appearing)
- #1867 fixed a graph model bug which prevented cases being reassigned to subplots when the data changed (which could result in dots not appearing)

This PR extends the fix from #1867 to force the cell masks to be recomputed when the data changes. For review purposes the necessary changes in this PR are:
- The `GraphDataConfigurationModel` reaction that listens to `categoricalAttrsWithChangeCounts` calls `clearCasesCache()` instead of `clearGraphSpecificCasesCache()`.
  - This was apparently a prior optimization attempt to limit the amount of recomputation required in some paths, but `categoryArrayForAttrRole` was not invalidated by the prior approach and is required for correct operation, so we invalidate all caches when categorical attributes change.
- Prior `Graph` component code tried to distinguish between paths that required recomputation _and_ reassignment of cell masks from those that only required reassignment. This logic failed to recompute in situations where recomputation was required and so rather than trying to fix the logic we always recompute cell masks when reassigning them.

There are a smattering of other changes that aren't important for the bug-fix but that seem like improvements worth keeping.

Note: The easiest way to reproduce the bug is to add a _computed_ categorical legend attribute to the shared document in the linked bug. I'm not entirely sure why the _computed_ categorical legend attribute is required. 🤷 

[CODAP-337]: https://concord-consortium.atlassian.net/browse/CODAP-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ