### PR TITLE
fix: graph response to category order change

### DIFF
--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -116,7 +116,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
 
   useEffect(function respondToCategorySetChanges() {
     return mstReaction(() => {
-      return dataConfiguration.categoricalAttrsWithChangeCounts
+      return [dataConfiguration.allCategoriesForRoles, dataConfiguration.categoricalAttrsWithChangeCounts]
     }, () => {
       startAnimation()
       callRefreshPointPositions({ updateMasks: true })


### PR DESCRIPTION
[[CODAP-341](https://concord-consortium.atlassian.net/browse/CODAP-341)]

Follow-up to #1865, #1867, and #1868. Some reactions need to be sensitive to category order as well as changes to presence/absence of categories and changes to categorical data.

Note that even with this fix, the user experience is still not ideal -- due to to clipping the points disappear during the animation and then reappear in their correct location once the animation is complete. @bfinzer and I have talked about the fact that the right thing to do is to disable clipping during category dragging and the subsequent animation and then reenable it once animation is complete. This sort of architectural reform will not be simple, however, and so I think it's best to separate it from this story and PR.

[CODAP-341]: https://concord-consortium.atlassian.net/browse/CODAP-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ