### PR TITLE
fix: switching plot type results in adornmentList API confusion (CODAP-342)

### DIFF
--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -152,7 +152,7 @@ context("codap plugins", () => {
 
   it('will handle adornment-related requests', () => {
 
-    // Activate the Count and Mean adornments on the graph.
+    // Activate the Count/Percent and Mean adornments on the graph.
     c.selectTile("graph", 0)
     ah.openAxisAttributeMenu("bottom")
     ah.selectMenuAttribute("Sleep", "bottom")
@@ -188,11 +188,14 @@ context("codap plugins", () => {
       webView.confirmAPITesterResponseContains(/"success":\s*true/)
       webView.getAPITesterResponse().then((value: any) => {
         const response = JSON.parse(value.eq(1).text())
-        expect(response.values.length).to.equal(2)
+        expect(response.values.length).to.equal(3)
         const countInfo = response.values[0]
-        const meanInfo = response.values[1]
+        const percentInfo = response.values[1]
+        const meanInfo = response.values[2]
         expect(countInfo.type).to.equal("Count")
         expect(countInfo.isVisible).to.equal(true)
+        expect(percentInfo.type).to.equal("Percent")
+        expect(percentInfo.isVisible).to.equal(false)
         expect(meanInfo.type).to.equal("Mean")
         expect(meanInfo.isVisible).to.equal(true)
         const meanId = meanInfo.id
@@ -232,6 +235,29 @@ context("codap plugins", () => {
           expect(meanInfo.id).to.be.a("string")
           expect(meanInfo.data[0]).to.haveOwnProperty("mean")
           expect(meanInfo.data[0].mean).to.be.a("number")
+        })
+        webView.clearAPITesterResponses()
+
+        cy.log("Handle get adornmentList requests after plot type change")
+        ah.openAxisAttributeMenu("left")
+        ah.selectMenuAttribute("LifeSpan", "left")
+        const cmd5 = `{
+          "action": "get",
+          "resource": "component[${graphId}].adornmentList"
+        }`
+        webView.sendAPITesterCommand(cmd5, cmd4)
+        webView.confirmAPITesterResponseContains(/"success":\s*true/)
+        webView.getAPITesterResponse().then((value: any) => {
+          const response = JSON.parse(value.eq(1).text())
+          // The previously activated Mean and Movable Value adornments should not be listed
+          // since they do not support scatter plots.
+          expect(response.values.length).to.equal(2)
+          const countInfo = response.values[0]
+          const percentInfo = response.values[1]
+          expect(countInfo.type).to.equal("Count")
+          expect(countInfo.isVisible).to.equal(true)
+          expect(percentInfo.type).to.equal("Percent")
+          expect(percentInfo.isVisible).to.equal(false)
         })
         webView.clearAPITesterResponses()
       })

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -1,7 +1,7 @@
 import { getAdornmentContentInfo } from "../components/graph/adornments/adornment-content-info"
 import { IAdornmentModel } from "../components/graph/adornments/adornment-models"
 import { isCountAdornment } from "../components/graph/adornments/count/count-adornment-model"
-import { kPercentType } from "../components/graph/adornments/count/count-adornment-types"
+import { kCountType, kPercentType } from "../components/graph/adornments/count/count-adornment-types"
 import { isGraphContentModel } from "../components/graph/models/graph-content-model"
 import { appState } from "../models/app-state"
 import { IAttribute } from "../models/data/attribute"
@@ -165,15 +165,20 @@ export function resolveResources(
     const graphPlotType = result.component?.content.plotType
     const adornmentList = result.component.content.adornmentsStore.adornments.reduce((list, adornment) => {
       if (isCountAdornment(adornment)) {
-        // If the Count adornment is present, we add a separate Percent adornment item to the list. Even though
-        // Percent is part of the Count adornment, clients may not be aware of that since the UI presents them
-        // as separate entities.
+        // If the Count adornment is present, we add separate Count and Percent adornment items to the list.
+        // Even though Percent is part of the Count adornment, clients may not be aware of that since the UI
+        // presents them as separate entities.
+        const countAdornment = {
+          ...adornment,
+          isVisible: adornment.showCount && adornment.isVisible,
+          type: kCountType
+        }
         const percentAdornment = {
           ...adornment,
-          isVisible: adornment.showPercent,
+          isVisible: adornment.showPercent && adornment.isVisible,
           type: kPercentType
         }
-        list.push(adornment, percentAdornment)
+        list.push(countAdornment, percentAdornment)
       } else {
         const adornmentPlotTypes = getAdornmentContentInfo(adornment.type)?.plots
         const isGraphPlotTypeSupported = adornmentPlotTypes?.includes(graphPlotType)


### PR DESCRIPTION
[CODAP-342](https://concord-consortium.atlassian.net/browse/CODAP-342)

This fixes an issue where adornments activated in one plot configuration, were still being listed for `adornmentList` requests after the plot had changed to a type that those adornments don't support. It also adds a listing for a "Percent" adornment. Even though Percent is part of Count, plugin developers may not be aware of that since the CODAP UI presents Count and Percent as totally separate options.

[CODAP-342]: https://concord-consortium.atlassian.net/browse/CODAP-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ