### PR TITLE
feat: Allow plugins to create, update, and delete specific graph adornments (CODAP-47)

### DIFF
--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -46,7 +46,7 @@ context("codap plugins", () => {
       "action": "fake",
       "resource": "dataContext[Mammals].collection[Cases].attribute[Order]"
     }`
-    webView.sendAPITesterCommand(cmd2, cmd1)
+    webView.sendAPITesterCommand(cmd2)
     webView.confirmAPITesterResponseContains(/"Unsupported action: fake\/attribute"/)
     webView.clearAPITesterResponses()
 
@@ -59,7 +59,7 @@ context("codap plugins", () => {
       }
     }`
     table.getAttributeHeader().contains("Order").should("be.visible")
-    webView.sendAPITesterCommand(cmd3, cmd2)
+    webView.sendAPITesterCommand(cmd3)
     table.getAttributeHeader().contains("Order").should("not.exist")
     webView.clearAPITesterResponses()
 
@@ -74,7 +74,7 @@ context("codap plugins", () => {
       ]
     }`
     table.getAttributeHeader().contains("Heartrate").should("not.exist")
-    webView.sendAPITesterCommand(cmd4, cmd3)
+    webView.sendAPITesterCommand(cmd4)
     table.getAttributeHeader().contains("Heartrate").should("exist")
     webView.clearAPITesterResponses()
 
@@ -84,7 +84,7 @@ context("codap plugins", () => {
       "resource": "dataContext[Mammals].collection[Cases].attribute[Heartrate]"
     }`
     table.getAttributeHeader().contains("Heartrate").should("exist")
-    webView.sendAPITesterCommand(cmd5, cmd4)
+    webView.sendAPITesterCommand(cmd5)
     table.getAttributeHeader().contains("Heartrate").should("not.exist")
     webView.clearAPITesterResponses()
 
@@ -93,7 +93,7 @@ context("codap plugins", () => {
       "action": "get",
       "resource": "collection[Cases].attribute[Order]"
     }`
-    webView.sendAPITesterCommand(cmd6, cmd5)
+    webView.sendAPITesterCommand(cmd6)
     webView.confirmAPITesterResponseContains(/"success":\s*true/)
     webView.clearAPITesterResponses()
 
@@ -102,7 +102,7 @@ context("codap plugins", () => {
       "action": "get",
       "resource": "dataContextList"
     }`
-    webView.sendAPITesterCommand(cmd7, cmd6)
+    webView.sendAPITesterCommand(cmd7)
     webView.confirmAPITesterResponseContains(/"values":\s\[\s{\s"name":\s*"Mammals"/)
     webView.clearAPITesterResponses()
   })
@@ -133,7 +133,7 @@ context("codap plugins", () => {
         }
       }`
       webView.clearAPITesterResponses()
-      webView.sendAPITesterCommand(cmd2, cmd1)
+      webView.sendAPITesterCommand(cmd2)
       webView.confirmAPITesterResponseContains(/"success":\s*true/)
       webView.clearAPITesterResponses()
       c.checkComponentFocused("table")
@@ -143,7 +143,7 @@ context("codap plugins", () => {
         "action": "delete",
         "resource": "component[${tableId}]"
       }`
-      webView.sendAPITesterCommand(cmd3, cmd2)
+      webView.sendAPITesterCommand(cmd3)
       webView.confirmAPITesterResponseContains(/"success":\s*true/)
       webView.clearAPITesterResponses()
       c.checkComponentDoesNotExist("table")
@@ -186,7 +186,7 @@ context("codap plugins", () => {
         "action": "get",
         "resource": "component[${graphId}].adornmentList"
       }`
-      webView.sendAPITesterCommand(cmd2, cmd1)
+      webView.sendAPITesterCommand(cmd2)
       webView.confirmAPITesterResponseContains(/"success":\s*true/)
       webView.getAPITesterResponse().then((value: any) => {
         const response = JSON.parse(value.eq(1).text())
@@ -213,7 +213,7 @@ context("codap plugins", () => {
         "action": "get",
         "resource": "component[${graphId}].adornment[Count]"
       }`
-      webView.sendAPITesterCommand(cmd3, cmd2)
+      webView.sendAPITesterCommand(cmd3)
       webView.confirmAPITesterResponseContains(/"success":\s*true/)
       webView.getAPITesterResponse().then((value: any) => {
         const response = JSON.parse(value.eq(1).text())
@@ -235,7 +235,7 @@ context("codap plugins", () => {
           "action": "get",
           "resource": "component[${graphId}].adornment[${meanId}]"
         }`
-        webView.sendAPITesterCommand(cmd4, cmd3)
+        webView.sendAPITesterCommand(cmd4)
         webView.confirmAPITesterResponseContains(/"success":\s*true/)
         webView.getAPITesterResponse().then((value: any) => {
           const response = JSON.parse(value.eq(1).text())
@@ -253,7 +253,7 @@ context("codap plugins", () => {
           "action": "get",
           "resource": "component[${graphId}].adornmentList"
         }`
-        webView.sendAPITesterCommand(cmd5, cmd4)
+        webView.sendAPITesterCommand(cmd5)
         webView.confirmAPITesterResponseContains(/"success":\s*true/)
         webView.getAPITesterResponse().then((value: any) => {
           const response = JSON.parse(value.eq(1).text())

--- a/v3/cypress/support/elements/web-view-tile.ts
+++ b/v3/cypress/support/elements/web-view-tile.ts
@@ -4,7 +4,7 @@ export const WebViewTileElements = {
   },
   enterUrl(url: string) {
     cy.get(`[data-testid=web-view-url-input]`).clear()
-    cy.get(`[data-testid=web-view-url-input]`).type(url)
+    cy.get(`[data-testid=web-view-url-input]`).type(url, { delay: 0 })
     cy.get(`[data-testid=OK-button]`).click()
   },
   getIFrame() {
@@ -41,12 +41,8 @@ export const WebViewTileElements = {
   // Data Interactive API Tester Functions
   // These will only work if you've opened the API Tester plugin, which can be found here:
   // https://concord-consortium.github.io/codap-data-interactives/DataInteractiveAPITester/index.html?lang=en
-  sendAPITesterCommand(command: string, oldCommand?: string) {
-    // Delete the old command if it's provided
-    if (oldCommand) {
-      WebViewTileElements.getIFrame().find(`.di-message-area`).clear()
-    }
-    WebViewTileElements.getIFrame().find(`.di-message-area`).type(command)
+  sendAPITesterCommand(command: string) {
+    WebViewTileElements.getIFrame().find(`.di-message-area`).clear().type(command, { delay: 0 })
     WebViewTileElements.getIFrame().find(`.di-send-button`).click()
   },
   getAPITesterResponse() {

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -81,6 +81,12 @@ describe("DataInteractive CountAdornmentHandler", () => {
     }
   })
 
+  it("get returns an error when an invalid adornment provided", () => {
+    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
+    expect(result?.success).toBe(false)
+    expect(result?.values.error).toBe(`Not a(n) ${kCountType} adornment.`)
+  })
+
   it("create returns the expected data when count adornment created", () => {
     const createRequestValues = {
       type: kCountType,
@@ -96,12 +102,6 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(values.showCount).toBe(true)
     expect(values.showPercent).toBe(false)
     expect(values.percentType).toBe("column")
-  })
-
-  it("get returns an error when an invalid adornment provided", () => {
-    const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
-    expect(result?.success).toBe(false)
-    expect(result?.values.error).toBe(`Not a(n) ${kCountType} adornment.`)
   })
 
   it("get returns the expected data when count adornment provided", () => {

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -127,4 +127,24 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(result?.data[0]).toMatchObject({ percent: "50%" })
   })
 
+  it("update returns an error when count adornment not found", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
+    const result = handler.update?.({ graphContent: mockGraphContent })
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
+  })
+
+  it("update successfully updates count adornment properties", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockCountAdornment)
+    const updateValues = {
+      showCount: false,
+      showPercent: true,
+      percentType: "column",
+      isVisible: true
+    }
+    const result = handler.update?.({ graphContent: mockGraphContent, values: updateValues })
+    expect(result?.success).toBe(true)
+  })
+
 })

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -1,11 +1,79 @@
+import { DIAdornmentValues, DICountAdornmentValues, isAdornmentValues }
+  from "../../../../data-interactive/data-interactive-adornment-types"
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { adornmentNotFoundResult } from "../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../models/graph-content-model"
+import { percentString } from "../../utilities/graph-utils"
 import { IAdornmentModel } from "../adornment-models"
-import { isCountAdornment } from "./count-adornment-model"
+import { getAdornmentContentInfo } from "../adornment-content-info"
+import { IAdornmentsBaseStore } from "../store/adornments-base-store"
 import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { ICountAdornmentModel, isCountAdornment } from "./count-adornment-model"
 import { kCountType } from "./count-adornment-types"
 
+const setAdornmentProperties = (adornment: ICountAdornmentModel, values: DIAdornmentValues) => {
+  if (isAdornmentValues(values)) {
+    const { isVisible, showCount, showPercent, percentType } = values as DICountAdornmentValues
+    if (isVisible !== undefined) {
+      adornment.setVisibility(isVisible)
+    }
+    if (showCount !== undefined) {
+      adornment.setShowCount(showCount)
+    }
+    if (showPercent !== undefined) {
+      adornment.setShowPercent(showPercent)
+    }
+    if (percentType !== undefined) {
+      adornment.setPercentType(percentType)
+    }
+  }
+}
+
 export const countAdornmentHandler: DIAdornmentHandler = {
+  create(args) {
+    const { graphContent, values } = args
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const dataConfig = graphContent.dataConfiguration
+    const cellKeys = dataConfig?.getAllCellKeys()
+    const data: AdornmentData[] = []
+    const existingCountAdornment = adornmentsStore.findAdornmentOfType<ICountAdornmentModel>(kCountType)
+    const componentContentInfo = getAdornmentContentInfo(kCountType)
+    const adornment = existingCountAdornment ?? componentContentInfo.modelClass.create() as ICountAdornmentModel
+
+    if (isAdornmentValues(values)) {
+      setAdornmentProperties(adornment, values)
+    }
+
+    if (!existingCountAdornment) {
+      adornmentsStore.addAdornment(adornment, { dataConfig })
+    }
+
+    adornment.setVisibility(true)
+
+    const { id, isVisible, showCount, showPercent, percentType, type } = adornment
+
+    for (const cellKey of cellKeys) {
+      const subPlotCases = dataConfig.subPlotCases(cellKey)
+      const dataItem: AdornmentData = {}
+      
+      if (showCount) {
+        dataItem.count = subPlotCases.length
+      }
+
+      if (showPercent) {
+        dataItem.percent = percentString(adornment.percentValue(subPlotCases.length, cellKey, dataConfig))
+      }
+    
+      if (Object.keys(cellKey).length > 0) {
+        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+      }
+    
+      data.push(dataItem)
+    }
+
+    return { success: true, values: { id, isVisible, showCount, showPercent, percentType, type, data }}
+  },
+
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isCountAdornment(adornment)) return adornmentMismatchResult(kCountType)
 
@@ -51,5 +119,18 @@ export const countAdornmentHandler: DIAdornmentHandler = {
     }
 
     return { data, percentType, showCount, showPercent }
+  },
+
+  update(args) {
+    const { graphContent, values } = args
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const existingCountAdornment = adornmentsStore.findAdornmentOfType<ICountAdornmentModel>(kCountType)
+    if (!existingCountAdornment) return adornmentNotFoundResult
+
+    if (isAdornmentValues(values)) {
+      setAdornmentProperties(existingCountAdornment, values)
+    }
+
+    return { success: true }
   }
 }

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -14,16 +14,16 @@ import { kCountType } from "./count-adornment-types"
 const setAdornmentProperties = (adornment: ICountAdornmentModel, values: DIAdornmentValues) => {
   if (isAdornmentValues(values)) {
     const { isVisible, showCount, showPercent, percentType } = values as DICountAdornmentValues
-    if (isVisible !== undefined) {
+    if (isVisible != null) {
       adornment.setVisibility(isVisible)
     }
-    if (showCount !== undefined) {
+    if (showCount != null) {
       adornment.setShowCount(showCount)
     }
-    if (showPercent !== undefined) {
+    if (showPercent != null) {
       adornment.setShowPercent(showPercent)
     }
-    if (percentType !== undefined) {
+    if (percentType != null) {
       adornment.setPercentType(percentType)
     }
   }
@@ -41,14 +41,13 @@ export const countAdornmentHandler: DIAdornmentHandler = {
     const adornment = existingCountAdornment ?? componentContentInfo.modelClass.create() as ICountAdornmentModel
 
     if (isAdornmentValues(values)) {
-      setAdornmentProperties(adornment, values)
+      const createValues = { ...values, isVisible: true }
+      setAdornmentProperties(adornment, createValues)
     }
 
     if (!existingCountAdornment) {
       adornmentsStore.addAdornment(adornment, { dataConfig })
     }
-
-    adornment.setVisibility(true)
 
     const { id, isVisible, showCount, showPercent, percentType, type } = adornment
 
@@ -101,13 +100,13 @@ export const countAdornmentHandler: DIAdornmentHandler = {
 
       if (showCount) {
         dataItem.count = regionCountValues.length > 1
-          ? regionCountValues.filter((value): value is number => value !== undefined)
+          ? regionCountValues.filter((value): value is number => value != null)
           : regionCountValues[0]
       }
 
       if (showPercent) {
         dataItem.percent = regionPercentValues.length > 1
-          ? regionPercentValues.filter((value): value is string => value !== undefined)
+          ? regionPercentValues.filter((value): value is string => value != null)
           : regionPercentValues[0]
       }
 

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
@@ -98,4 +98,21 @@ describe("DataInteractive lsrlAdornmentHandler", () => {
     expect(result?.showConfidenceBands).toBe(true)
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
   })
+
+  it("update returns an error when LSRL adornment not found", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
+    const result = handler.update?.({ graphContent: mockGraphContent })
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
+  })
+
+  it("update successfully updates count adornment properties", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockLSRLAdornment)
+    const updateValues = {
+      showConfidenceBands: true
+    }
+    const result = handler.update?.({ graphContent: mockGraphContent, values: updateValues })
+    expect(result?.success).toBe(true)
+  })
 })

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.test.ts
@@ -1,5 +1,32 @@
+import { types } from "mobx-state-tree"
 import { lsrlAdornmentHandler } from "./lsrl-adornment-handler"
 import { kLSRLType } from "./lsrl-adornment-types"
+
+jest.mock("../adornment-content-info", () => {
+  const mockCountModel = types.model("LSRLAdornmentModel", {
+    id: types.optional(types.string, "ADRN123"),
+    showConfidenceBands: types.optional(types.boolean, false),
+    type: types.optional(types.string, "LSRL"),
+    isVisible: types.optional(types.boolean, false),
+  }).actions(self => ({
+    setShowConfidenceBands(show: boolean) {
+      self.showConfidenceBands = show
+    },
+    setVisibility(isVisible: boolean) {
+      self.isVisible = isVisible
+    }
+  }))
+
+  return {
+    ...jest.requireActual("../adornment-content-info"),
+    getAdornmentContentInfo: jest.fn().mockReturnValue({
+      modelClass: mockCountModel,
+      plots: ["scatterPlot"],
+      prefix: "lsrl",
+      type: "LSRL",
+    }),
+  }
+})
 
 describe("DataInteractive lsrlAdornmentHandler", () => {
   const handler = lsrlAdornmentHandler
@@ -20,7 +47,12 @@ describe("DataInteractive lsrlAdornmentHandler", () => {
       subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
     }
     mockGraphContent = {
-      dataConfiguration: mockDataConfig
+      adornmentsStore: {
+        addAdornment: jest.fn((adornment: any, options: any) => null),
+        findAdornmentOfType: jest.fn()
+      },
+      dataConfiguration: mockDataConfig,
+      plotType: "scatterPlot"
     }
     
     mockLSRLAdornment = {
@@ -35,6 +67,19 @@ describe("DataInteractive lsrlAdornmentHandler", () => {
       id: "ADRN456",
       type: "invalid"
     }
+  })
+
+  it("create returns the expected data when LSRL adornment created", () => {
+    const createRequestValues = {
+      type: kLSRLType,
+      showConfidenceBands: true
+    }
+    const result = handler.create!({ graphContent: mockGraphContent, values: createRequestValues })
+    expect(result?.success).toBe(true)
+    expect(result?.values).toBeDefined()
+    const values = result?.values as any
+    expect(values.type).toBe(kLSRLType)
+    expect(values.showConfidenceBands).toBe(true)
   })
 
   it("get returns an error when an invalid adornment provided", () => {

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
@@ -1,21 +1,35 @@
-import { isAdornmentValues } from "../../../../data-interactive/data-interactive-adornment-types"
+import { DIAdornmentValues, DILsrlAdornmentValues, isAdornmentValues }
+  from "../../../../data-interactive/data-interactive-adornment-types"
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
 import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
   from "../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../models/graph-content-model"
-import { getAdornmentContentInfo } from "../adornment-content-info"
+import { getAdornmentContentInfo, isCompatibleWithPlotType } from "../adornment-content-info"
 import { IAdornmentModel } from "../adornment-models"
 import { IAdornmentsBaseStore } from "../store/adornments-base-store"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories, isAdornmentSupportedByPlotType }
-  from "../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 import { ILSRLAdornmentModel, isLSRLAdornment } from "./lsrl-adornment-model"
 import { kLSRLType } from "./lsrl-adornment-types"
+
+const setAdornmentProperties = (adornment: ILSRLAdornmentModel, values: DIAdornmentValues) => {
+  if (isAdornmentValues(values)) {
+    const { isVisible, showConfidenceBands } = values as DILsrlAdornmentValues
+    if (isVisible != null) {
+      adornment.setVisibility(isVisible)
+    }
+    if (showConfidenceBands != null) {
+      adornment.setShowConfidenceBands(showConfidenceBands)
+    }
+  }
+}
 
 export const lsrlAdornmentHandler: DIAdornmentHandler = {
   create(args) {
     const { graphContent, values } = args
-    const isAdornmentSupported = isAdornmentSupportedByPlotType(kLSRLType, graphContent.plotType)
-    if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
+
+    if (!isCompatibleWithPlotType(kLSRLType, graphContent.plotType)) {
+      return adornmentNotSupportedByPlotTypeResult
+    }
 
     const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
     const dataConfig = graphContent.dataConfiguration
@@ -25,15 +39,14 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
     const componentContentInfo = getAdornmentContentInfo(kLSRLType)
     const adornment = existingLsrlAdornment ?? componentContentInfo.modelClass.create() as ILSRLAdornmentModel
 
-    if (isAdornmentValues(values) && "showConfidenceBands" in values && values.showConfidenceBands !== undefined) {
-      adornment.setShowConfidenceBands(values.showConfidenceBands)
+    if (isAdornmentValues(values)) {
+      const createValues = { ...values, isVisible: true }
+      setAdornmentProperties(adornment, createValues)
     }
 
     if (!existingLsrlAdornment) {
       adornmentsStore.addAdornment(adornment, { dataConfig })
     }
-
-    adornment.setVisibility(true)
 
     for (const cellKey of cellKeys) {
       const cellKeyString = JSON.stringify(cellKey)
@@ -104,8 +117,8 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
     const existingLsrlAdornment = adornmentsStore.findAdornmentOfType<ILSRLAdornmentModel>(kLSRLType)
     if (!existingLsrlAdornment) return adornmentNotFoundResult
 
-    if (isAdornmentValues(values) && "showConfidenceBands" in values && values.showConfidenceBands !== undefined) {
-      existingLsrlAdornment.setShowConfidenceBands(values.showConfidenceBands)
+    if (isAdornmentValues(values)) {
+      setAdornmentProperties(existingLsrlAdornment, values)
     }
 
     return { success: true }

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-handler.ts
@@ -1,11 +1,68 @@
+import { isAdornmentValues } from "../../../../data-interactive/data-interactive-adornment-types"
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { IAdornmentModel } from "../adornment-models"
-import { isLSRLAdornment } from "./lsrl-adornment-model"
+import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
+  from "../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../models/graph-content-model"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { getAdornmentContentInfo } from "../adornment-content-info"
+import { IAdornmentModel } from "../adornment-models"
+import { IAdornmentsBaseStore } from "../store/adornments-base-store"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories, isAdornmentSupportedByPlotType }
+  from "../utilities/adornment-handler-utils"
+import { ILSRLAdornmentModel, isLSRLAdornment } from "./lsrl-adornment-model"
 import { kLSRLType } from "./lsrl-adornment-types"
 
 export const lsrlAdornmentHandler: DIAdornmentHandler = {
+  create(args) {
+    const { graphContent, values } = args
+    const isAdornmentSupported = isAdornmentSupportedByPlotType(kLSRLType, graphContent.plotType)
+    if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
+
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const dataConfig = graphContent.dataConfiguration
+    const cellKeys = dataConfig?.getAllCellKeys()
+    const data: AdornmentData[] = []
+    const existingLsrlAdornment = adornmentsStore.findAdornmentOfType<ILSRLAdornmentModel>(kLSRLType)
+    const componentContentInfo = getAdornmentContentInfo(kLSRLType)
+    const adornment = existingLsrlAdornment ?? componentContentInfo.modelClass.create() as ILSRLAdornmentModel
+
+    if (isAdornmentValues(values) && "showConfidenceBands" in values && values.showConfidenceBands !== undefined) {
+      adornment.setShowConfidenceBands(values.showConfidenceBands)
+    }
+
+    if (!existingLsrlAdornment) {
+      adornmentsStore.addAdornment(adornment, { dataConfig })
+    }
+
+    adornment.setVisibility(true)
+
+    for (const cellKey of cellKeys) {
+      const cellKeyString = JSON.stringify(cellKey)
+      const linesMap = adornment.lines?.get(cellKeyString)
+      if (!linesMap) continue
+    
+      const line = linesMap.get("__main__")
+      if (!line) continue
+    
+      const { category, intercept, rSquared, sdResiduals, slope } = line
+      const dataItem: AdornmentData = {
+        category,
+        intercept,
+        rSquared,
+        sdResiduals,
+        slope
+      }
+    
+      if (Object.keys(cellKey).length > 0) {
+        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+      }
+    
+      data.push(dataItem)
+    }
+
+    const { id, isVisible, showConfidenceBands, type } = adornment
+    return { success: true, values: { id, isVisible, showConfidenceBands, type, data } }
+  },
+
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isLSRLAdornment(adornment))  return adornmentMismatchResult(kLSRLType)
 
@@ -39,6 +96,19 @@ export const lsrlAdornmentHandler: DIAdornmentHandler = {
     }
 
     return { data, showConfidenceBands }
+  },
+
+  update(args) {
+    const { graphContent, values } = args
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const existingLsrlAdornment = adornmentsStore.findAdornmentOfType<ILSRLAdornmentModel>(kLSRLType)
+    if (!existingLsrlAdornment) return adornmentNotFoundResult
+
+    if (isAdornmentValues(values) && "showConfidenceBands" in values && values.showConfidenceBands !== undefined) {
+      existingLsrlAdornment.setShowConfidenceBands(values.showConfidenceBands)
+    }
+
+    return { success: true }
   }
 }
 

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
@@ -3,7 +3,7 @@ import { movableValueAdornmentHandler } from "./movable-value-adornment-handler"
 import { kMovableValueType } from "./movable-value-adornment-types"
 
 jest.mock("../adornment-content-info", () => {
-  const mockLsrlModel = types.model("MovableValueAdornmentModel", {
+  const mockMovableValueModel = types.model("MovableValueAdornmentModel", {
     id: types.optional(types.string, "ADRN123"),
     type: types.optional(types.string, "Movable Value"),
     isVisible: types.optional(types.boolean, false),
@@ -21,7 +21,7 @@ jest.mock("../adornment-content-info", () => {
   }))
 
   const mockContentInfo = {
-    modelClass: mockLsrlModel,
+    modelClass: mockMovableValueModel,
     plots: ["dotPlot"],
     prefix: "movable-value",
     type: "Movable Value",

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
@@ -1,4 +1,4 @@
-import { types } from "@concord-consortium/mobx-state-tree"
+import { types } from "mobx-state-tree"
 import { movableValueAdornmentHandler } from "./movable-value-adornment-handler"
 import { kMovableValueType } from "./movable-value-adornment-types"
 
@@ -36,35 +36,6 @@ jest.mock("../adornment-content-info", () => {
     })
   }
 })
-
-// jest.mock("../adornment-content-info", () => {
-//   const mockCountModel = types.model("MovableValueAdornmentModel", {
-//     id: types.optional(types.string, "ADRN123"),
-//     type: types.optional(types.string, "Movable Value"),
-//     isVisible: types.optional(types.boolean, false),
-//     values: types.map(types.number)
-//   }).actions(self => ({
-//     addValue(value: number) {
-//       self.values.set("{}", value)
-//     },
-//     replaceValue(value: number, key: string) {
-//       self.values.set(key, value)
-//     },
-//     setVisibility(isVisible: boolean) {
-//       self.isVisible = isVisible
-//     }
-//   }))
-
-//   return {
-//     ...jest.requireActual("../adornment-content-info"),
-//     getAdornmentContentInfo: jest.fn().mockReturnValue({
-//       modelClass: mockCountModel,
-//       plots: ["dotPlot"],
-//       prefix: "movable-value",
-//       type: "Movable Value",
-//     }),
-//   }
-// })
 
 describe("DataInteractive movableValueAdornmentHandler", () => {
   const handler = movableValueAdornmentHandler

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
@@ -61,6 +61,7 @@ describe("DataInteractive movableValueAdornmentHandler", () => {
     mockMovableValueAdornment = {
       id: "ADRN123",
       isVisible: true,
+      replaceValue: jest.fn(),
       type: kMovableValueType,
       values: mockValuesMap
     }
@@ -97,5 +98,23 @@ describe("DataInteractive movableValueAdornmentHandler", () => {
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({movableValues: [1, 3000000]})
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+
+  it("update returns an error when Movable Value adornment not found", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
+    const result = handler.update?.({ graphContent: mockGraphContent })
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
+  })
+
+  it("update successfully updates count adornment properties", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockMovableValueAdornment)
+    const updateValues = {
+      values: [["{}", 5]]
+    }
+    const result = handler.update?.({ graphContent: mockGraphContent, values: updateValues })
+    expect(result?.success).toBe(true)
+    expect(mockMovableValueAdornment.replaceValue).toHaveBeenCalledWith(5, "{}")
   })
 })

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.test.ts
@@ -1,10 +1,38 @@
+import { types } from "@concord-consortium/mobx-state-tree"
 import { movableValueAdornmentHandler } from "./movable-value-adornment-handler"
 import { kMovableValueType } from "./movable-value-adornment-types"
+
+jest.mock("../adornment-content-info", () => {
+  const mockCountModel = types.model("LSRLAdornmentModel", {
+    id: types.optional(types.string, "ADRN123"),
+    showConfidenceBands: types.optional(types.boolean, false),
+    type: types.optional(types.string, "LSRL"),
+    isVisible: types.optional(types.boolean, false),
+  }).actions(self => ({
+    setShowConfidenceBands(show: boolean) {
+      self.showConfidenceBands = show
+    },
+    setVisibility(isVisible: boolean) {
+      self.isVisible = isVisible
+    }
+  }))
+
+  return {
+    ...jest.requireActual("../adornment-content-info"),
+    getAdornmentContentInfo: jest.fn().mockReturnValue({
+      modelClass: mockCountModel,
+      plots: ["scatterPlot"],
+      prefix: "lsrl",
+      type: "LSRL",
+    }),
+  }
+})
 
 describe("DataInteractive movableValueAdornmentHandler", () => {
   const handler = movableValueAdornmentHandler
 
   let mockGraphContent: any
+  let mockWrongGraphContent: any
   let mockDataConfig: any
   let mockMovableValueAdornment: any
   let mockInvalidAdornment: any
@@ -17,10 +45,19 @@ describe("DataInteractive movableValueAdornmentHandler", () => {
       getAllCellKeys: jest.fn(() => [{}]),
       subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
     }
+  
     mockGraphContent = {
+      adornmentsStore: {
+        addAdornment: jest.fn((adornment: any, options: any) => null),
+        findAdornmentOfType: jest.fn()
+      },
       dataConfiguration: mockDataConfig
     }
-    
+  
+    mockWrongGraphContent = {
+      plotType: "linePlot"
+    }
+
     mockMovableValueAdornment = {
       id: "ADRN123",
       isVisible: true,
@@ -32,6 +69,20 @@ describe("DataInteractive movableValueAdornmentHandler", () => {
       id: "ADRN456",
       type: "invalid"
     }
+  })
+
+  it("create returns an error when the adornment is not supported by the plot type", () => {
+    const result = handler.create?.({graphContent: mockWrongGraphContent})
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe(`Adornment not supported by plot type.`)
+  })
+
+  it("delete returns an error when the movable value adornment is not found", () => {
+    const result = handler.delete?.({graphContent: mockGraphContent})
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
   })
 
   it("get returns an error when an invalid adornment provided", () => {

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
@@ -1,11 +1,65 @@
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult,
+  invalidValuesProvidedeResult, valuesRequiredResult } from "../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../models/graph-content-model"
-import { IAdornmentModel } from "../adornment-models"
-import { isMovableValueAdornment } from "./movable-value-adornment-model"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
+import { getAdornmentContentInfo } from "../adornment-content-info"
+import { IAdornmentModel, IUpdateCategoriesOptions } from "../adornment-models"
+import { IAdornmentsBaseStore } from "../store/adornments-base-store"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories, isAdornmentSupportedByPlotType }
+  from "../utilities/adornment-handler-utils"
+import { IMovableValueAdornmentModel, isMovableValueAdornment } from "./movable-value-adornment-model"
 import { kMovableValueType } from "./movable-value-adornment-types"
 
 export const movableValueAdornmentHandler: DIAdornmentHandler = {
+  create(args) {
+    const { graphContent } = args
+    const isAdornmentSupported = isAdornmentSupportedByPlotType(kMovableValueType, graphContent.plotType)
+    if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
+
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const dataConfig = graphContent.dataConfiguration
+    const cellKeys = dataConfig?.getAllCellKeys()
+    const data: AdornmentData[] = []
+    const existingMovableValueAdornment =
+      adornmentsStore.findAdornmentOfType<IMovableValueAdornmentModel>(kMovableValueType)
+    const componentContentInfo = getAdornmentContentInfo(kMovableValueType)
+    const adornment =
+      existingMovableValueAdornment ?? componentContentInfo.modelClass.create() as IMovableValueAdornmentModel
+
+    if (!existingMovableValueAdornment) {
+      const options: IUpdateCategoriesOptions = { ...graphContent.getUpdateCategoriesOptions(), addMovableValue: true }
+      adornmentsStore.addAdornment(adornment, options)
+    }
+
+    adornment.setVisibility(true)
+
+    for (const cellKey of cellKeys) {
+      const cellKeyString = JSON.stringify(cellKey)
+      const movableValues = adornment.values.get(cellKeyString)
+      const movableValuesValues = movableValues ? Object.values(movableValues).map(value => value) : []
+      const dataItem: AdornmentData = { movableValues: movableValuesValues }
+    
+      if (Object.keys(cellKey).length > 0) {
+        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+      }
+    
+      data.push(dataItem)
+    }
+
+    const { id, isVisible, type } = adornment
+    return { success: true, values: { id, isVisible, type, data } }
+  },
+
+  delete(args) {
+    const { graphContent } = args
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const adornment = adornmentsStore.findAdornmentOfType<IMovableValueAdornmentModel>(kMovableValueType)
+    if (!adornment) return adornmentNotFoundResult
+
+    adornment.deleteValue()
+    return { success: true }
+  },
+
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isMovableValueAdornment(adornment)) return adornmentMismatchResult(kMovableValueType)
 
@@ -27,5 +81,42 @@ export const movableValueAdornmentHandler: DIAdornmentHandler = {
     }
 
     return { data }
+  },
+
+  update(args) {
+    const { graphContent, values } = args
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const adornment = adornmentsStore.findAdornmentOfType<IMovableValueAdornmentModel>(kMovableValueType)
+    if (!adornment) return adornmentNotFoundResult
+  
+    const valuePairs = (typeof values === "object" && "values" in values && Array.isArray(values.values))
+      ? values.values
+      : null
+    if (!valuePairs) return valuesRequiredResult
+  
+    try {
+      const updates = new Map<string, number>(valuePairs)
+  
+      updates.forEach((newValue, cellKey) => {
+        if (typeof newValue !== "number") return
+  
+        if (cellKey === "{}") {
+          adornment.replaceValue(newValue, cellKey)
+          return
+        }
+  
+        const keyObj = JSON.parse(cellKey)
+        const [attrName] = Object.keys(keyObj)
+        const attrId = graphContent.dataConfiguration?.dataset?.getAttributeByName(attrName)?.id
+        if (!attrId) return
+
+        const internalKey = JSON.stringify({ [attrId]: keyObj[attrName] })
+        adornment.replaceValue(newValue, internalKey)
+      })
+  
+      return { success: true }
+    } catch {
+      return invalidValuesProvidedeResult
+    }
   }
 }

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
@@ -73,7 +73,7 @@ const Controls = () => {
 
 registerAdornmentContentInfo({
   type: kMovableValueType,
-  plots: ['dotPlot', 'linePlot'],
+  plots: ['dotPlot'],
   prefix: kMovableValuePrefix,
   modelClass: MovableValueAdornmentModel,
   exporter: (model, options) => {

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
@@ -73,7 +73,7 @@ const Controls = () => {
 
 registerAdornmentContentInfo({
   type: kMovableValueType,
-  plots: ['dotPlot'],
+  plots: ['dotPlot', 'linePlot'],
   prefix: kMovableValuePrefix,
   modelClass: MovableValueAdornmentModel,
   exporter: (model, options) => {

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
@@ -1,4 +1,4 @@
-import { types } from "@concord-consortium/mobx-state-tree"
+import { types } from "mobx-state-tree"
 import { meanAdornmentHandler } from "./mean-adornment-handler"
 import { kMeanType } from "./mean-adornment-types"
 

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
@@ -1,5 +1,29 @@
+import { types } from "@concord-consortium/mobx-state-tree"
 import { meanAdornmentHandler } from "./mean-adornment-handler"
 import { kMeanType } from "./mean-adornment-types"
+
+jest.mock("../../adornment-content-info", () => {
+  const mockMeanModel = types.model("MeanAdornmentModel", {
+    id: types.optional(types.string, "ADRN123"),
+    measures: types.map(types.model({ value: types.number })),
+    type: types.optional(types.string, "Mean"),
+    isVisible: types.optional(types.boolean, false),
+  }).actions(self => ({
+    setVisibility(isVisible: boolean) {
+      self.isVisible = isVisible
+    }
+  }))
+
+  return {
+    ...jest.requireActual("../../adornment-content-info"),
+    getAdornmentContentInfo: jest.fn().mockReturnValue({
+      modelClass: mockMeanModel,
+      plots: ["dotPlot"],
+      prefix: "mean",
+      type: "Mean",
+    }),
+  }
+})
 
 describe("DataInteractive meanAdornmentHandler", () => {
   const handler = meanAdornmentHandler
@@ -14,11 +38,23 @@ describe("DataInteractive meanAdornmentHandler", () => {
 
   beforeEach(() => {
     mockDataConfig = {
+      attributeID: jest.fn(() => "attr1"),
+      attributeType: jest.fn(() => "numeric"),
+      dataset: {
+        getCasesForAttributes: jest.fn(() => [1, 1]),
+        getNumeric: jest.fn(() => 1)
+      },
       getAllCellKeys: jest.fn(() => [{}]),
       subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
     }
     mockGraphContent = {
-      dataConfiguration: mockDataConfig
+      adornmentsStore: {
+        addAdornment: jest.fn((adornment: any, options: any) => null),
+        findAdornmentOfType: jest.fn(),
+        subPlotRegionBoundaries: jest.fn(() => [1, 2])
+      },
+      dataConfiguration: mockDataConfig,
+      plotType: "dotPlot"
     }
     
     mockMeanAdornment = {
@@ -34,6 +70,17 @@ describe("DataInteractive meanAdornmentHandler", () => {
     }
   })
 
+  it("create returns the expected data when mean adornment created", () => {
+    const createRequestValues = {
+      type: kMeanType,
+    }
+    const result = handler.create!({ graphContent: mockGraphContent, values: createRequestValues })
+    expect(result?.success).toBe(true)
+    expect(result?.values).toBeDefined()
+    const values = result?.values as any
+    expect(values.type).toBe(kMeanType)
+  })
+
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
@@ -46,5 +93,22 @@ describe("DataInteractive meanAdornmentHandler", () => {
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ mean: 10 })
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+
+  it("update returns an error when mean adornment not found", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
+    const result = handler.update?.({ graphContent: mockGraphContent })
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
+  })
+
+  it("update successfully updates count adornment properties", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockMeanAdornment)
+    const updateValues = {
+      isVisible: false
+    }
+    const result = handler.update?.({ graphContent: mockGraphContent, values: updateValues })
+    expect(result?.success).toBe(true)
   })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.test.ts
@@ -14,14 +14,20 @@ jest.mock("../../adornment-content-info", () => {
     }
   }))
 
+  const mockContentInfo = {
+    modelClass: mockMeanModel,
+    plots: ["dotPlot"],
+    prefix: "mean",
+    type: "Mean",
+  }
+
   return {
     ...jest.requireActual("../../adornment-content-info"),
-    getAdornmentContentInfo: jest.fn().mockReturnValue({
-      modelClass: mockMeanModel,
-      plots: ["dotPlot"],
-      prefix: "mean",
-      type: "Mean",
-    }),
+    getAdornmentContentInfo: jest.fn().mockReturnValue(mockContentInfo),
+    isCompatibleWithPlotType: jest.fn().mockImplementation((adornmentType: string, plotType: string) => {
+      const info = mockContentInfo
+      return info.plots.includes(plotType)
+    })
   }
 })
 
@@ -79,6 +85,17 @@ describe("DataInteractive meanAdornmentHandler", () => {
     expect(result?.values).toBeDefined()
     const values = result?.values as any
     expect(values.type).toBe(kMeanType)
+  })
+
+  it("create returns error when plot type is not compatible", () => {
+    mockGraphContent.plotType = "scatterPlot"
+    const createRequestValues = {
+      type: kMeanType,
+    }
+    const result = handler.create!({ graphContent: mockGraphContent, values: createRequestValues })
+    expect(result?.success).toBe(false)
+    const values = result?.values as { error: string }
+    expect(values.error).toBe("Adornment not supported by plot type.")
   })
 
   it("get returns an error when an invalid adornment provided", () => {

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
@@ -1,11 +1,52 @@
+import { isAdornmentValues } from "../../../../../data-interactive/data-interactive-adornment-types"
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { IAdornmentModel } from "../../adornment-models"
-import { isMeanAdornment } from "./mean-adornment-model"
+import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
+  from "../../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { getAdornmentContentInfo } from "../../adornment-content-info"
+import { IAdornmentModel } from "../../adornment-models"
+import { IAdornmentsBaseStore } from "../../store/adornments-base-store"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories, isAdornmentSupportedByPlotType }
+  from "../../utilities/adornment-handler-utils"
+import { IMeanAdornmentModel, isMeanAdornment } from "./mean-adornment-model"
 import { kMeanType } from "./mean-adornment-types"
 
 export const meanAdornmentHandler: DIAdornmentHandler = {
+  create(args) {
+    const { graphContent } = args
+    const isAdornmentSupported = isAdornmentSupportedByPlotType(kMeanType, graphContent.plotType)
+    if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
+
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const dataConfig = graphContent.dataConfiguration
+    const cellKeys = dataConfig?.getAllCellKeys()
+    const data: AdornmentData[] = []
+    const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IMeanAdornmentModel>(kMeanType)
+    const componentContentInfo = getAdornmentContentInfo(kMeanType)
+    const adornment = existingMeanAdornment ?? componentContentInfo.modelClass.create() as IMeanAdornmentModel
+
+    if (!existingMeanAdornment) {
+      adornmentsStore.addAdornment(adornment, { dataConfig })
+    }
+
+    adornment.setVisibility(true)
+
+    for (const cellKey of cellKeys) {
+      const cellKeyString = JSON.stringify(cellKey)
+      const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
+      const dataItem: AdornmentData = { mean }
+    
+      if (Object.keys(cellKey).length > 0) {
+        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+      }
+    
+      data.push(dataItem)
+    }
+
+    const { id, isVisible, type } = adornment
+    return { success: true, values: { id, isVisible, type, data } }
+  },
+
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isMeanAdornment(adornment)) return adornmentMismatchResult(kMeanType)
 
@@ -26,5 +67,18 @@ export const meanAdornmentHandler: DIAdornmentHandler = {
     }
 
     return { data }
+  },
+
+  update(args) {
+    const { graphContent, values } = args
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(kMeanType)
+    if (!existingMeanAdornment) return adornmentNotFoundResult
+
+    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible !== undefined) {
+      existingMeanAdornment.setVisibility(values.isVisible)
+    }
+
+    return { success: true }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
@@ -3,18 +3,17 @@ import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/ado
 import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
   from "../../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { getAdornmentContentInfo } from "../../adornment-content-info"
+import { getAdornmentContentInfo, isCompatibleWithPlotType } from "../../adornment-content-info"
 import { IAdornmentModel } from "../../adornment-models"
 import { IAdornmentsBaseStore } from "../../store/adornments-base-store"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories, isAdornmentSupportedByPlotType }
-  from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { IMeanAdornmentModel, isMeanAdornment } from "./mean-adornment-model"
 import { kMeanType } from "./mean-adornment-types"
 
 export const meanAdornmentHandler: DIAdornmentHandler = {
   create(args) {
     const { graphContent } = args
-    const isAdornmentSupported = isAdornmentSupportedByPlotType(kMeanType, graphContent.plotType)
+    const isAdornmentSupported = isCompatibleWithPlotType(kMeanType, graphContent.plotType)
     if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
 
     const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
@@ -75,7 +74,7 @@ export const meanAdornmentHandler: DIAdornmentHandler = {
     const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(kMeanType)
     if (!existingMeanAdornment) return adornmentNotFoundResult
 
-    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible !== undefined) {
+    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible != null) {
       existingMeanAdornment.setVisibility(values.isVisible)
     }
 

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-handler.ts
@@ -1,83 +1,11 @@
-import { isAdornmentValues } from "../../../../../data-interactive/data-interactive-adornment-types"
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
-  from "../../../../../data-interactive/handlers/di-results"
-import { IGraphContentModel } from "../../../models/graph-content-model"
-import { getAdornmentContentInfo, isCompatibleWithPlotType } from "../../adornment-content-info"
-import { IAdornmentModel } from "../../adornment-models"
-import { IAdornmentsBaseStore } from "../../store/adornments-base-store"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
-import { IMeanAdornmentModel, isMeanAdornment } from "./mean-adornment-model"
+import { isMeanAdornment } from "./mean-adornment-model"
 import { kMeanType } from "./mean-adornment-types"
+import { univariateMeasureAdornmentBaseHandler } from "../univariate-measure-adornment-base-handler"
 
-export const meanAdornmentHandler: DIAdornmentHandler = {
-  create(args) {
-    const { graphContent } = args
-    const isAdornmentSupported = isCompatibleWithPlotType(kMeanType, graphContent.plotType)
-    if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
-
-    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
-    const dataConfig = graphContent.dataConfiguration
-    const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData[] = []
-    const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IMeanAdornmentModel>(kMeanType)
-    const componentContentInfo = getAdornmentContentInfo(kMeanType)
-    const adornment = existingMeanAdornment ?? componentContentInfo.modelClass.create() as IMeanAdornmentModel
-
-    if (!existingMeanAdornment) {
-      adornmentsStore.addAdornment(adornment, { dataConfig })
-    }
-
-    adornment.setVisibility(true)
-
-    for (const cellKey of cellKeys) {
-      const cellKeyString = JSON.stringify(cellKey)
-      const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData = { mean }
-    
-      if (Object.keys(cellKey).length > 0) {
-        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
-      }
-    
-      data.push(dataItem)
-    }
-
-    const { id, isVisible, type } = adornment
-    return { success: true, values: { id, isVisible, type, data } }
-  },
-
-  get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMeanAdornment(adornment)) return adornmentMismatchResult(kMeanType)
-
-    const dataConfig = graphContent.dataConfiguration
-    const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData[] = []
-
-    for (const cellKey of cellKeys) {
-      const cellKeyString = JSON.stringify(cellKey)
-      const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData = { mean }
-    
-      if (Object.keys(cellKey).length > 0) {
-        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
-      }
-    
-      data.push(dataItem)
-    }
-
-    return { data }
-  },
-
-  update(args) {
-    const { graphContent, values } = args
-    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
-    const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(kMeanType)
-    if (!existingMeanAdornment) return adornmentNotFoundResult
-
-    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible != null) {
-      existingMeanAdornment.setVisibility(values.isVisible)
-    }
-
-    return { success: true }
-  }
-}
+export const meanAdornmentHandler: DIAdornmentHandler = univariateMeasureAdornmentBaseHandler({
+  adornmentType: kMeanType,
+  getMeasureValue: (adornment, cellKeyString) => adornment.measures.get(cellKeyString)?.value ?? NaN,
+  isAdornmentOfType: isMeanAdornment,
+  measureName: "mean",
+})

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
@@ -1,4 +1,4 @@
-import { types } from "@concord-consortium/mobx-state-tree"
+import { types } from "mobx-state-tree"
 import { medianAdornmentHandler } from "./median-adornment-handler"
 import { kMedianType } from "./median-adornment-types"
 

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
@@ -3,7 +3,7 @@ import { medianAdornmentHandler } from "./median-adornment-handler"
 import { kMedianType } from "./median-adornment-types"
 
 jest.mock("../../adornment-content-info", () => {
-  const mockMeanModel = types.model("MedianAdornmentModel", {
+  const mockMedianModel = types.model("MedianAdornmentModel", {
     id: types.optional(types.string, "ADRN123"),
     measures: types.map(types.model({ value: types.number })),
     type: types.optional(types.string, "Median"),
@@ -15,7 +15,7 @@ jest.mock("../../adornment-content-info", () => {
   }))
 
   const mockContentInfo = {
-    modelClass: mockMeanModel,
+    modelClass: mockMedianModel,
     plots: ["dotPlot"],
     prefix: "median",
     type: "Median",

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.test.ts
@@ -1,5 +1,29 @@
+import { types } from "@concord-consortium/mobx-state-tree"
 import { medianAdornmentHandler } from "./median-adornment-handler"
 import { kMedianType } from "./median-adornment-types"
+
+jest.mock("../../adornment-content-info", () => {
+  const mockMedianModel = types.model("MedianAdornmentModel", {
+    id: types.optional(types.string, "ADRN123"),
+    measures: types.map(types.model({ value: types.number })),
+    type: types.optional(types.string, "Median"),
+    isVisible: types.optional(types.boolean, false),
+  }).actions(self => ({
+    setVisibility(isVisible: boolean) {
+      self.isVisible = isVisible
+    }
+  }))
+
+  return {
+    ...jest.requireActual("../../adornment-content-info"),
+    getAdornmentContentInfo: jest.fn().mockReturnValue({
+      modelClass: mockMedianModel,
+      plots: ["dotPlot"],
+      prefix: "median",
+      type: "Median",
+    }),
+  }
+})
 
 describe("DataInteractive medianAdornmentHandler", () => {
   const handler = medianAdornmentHandler
@@ -14,11 +38,23 @@ describe("DataInteractive medianAdornmentHandler", () => {
 
   beforeEach(() => {
     mockDataConfig = {
+      attributeID: jest.fn(() => "attr1"),
+      attributeType: jest.fn(() => "numeric"),
+      dataset: {
+        getCasesForAttributes: jest.fn(() => [1, 1]),
+        getNumeric: jest.fn(() => 1)
+      },
       getAllCellKeys: jest.fn(() => [{}]),
       subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
     }
     mockGraphContent = {
-      dataConfiguration: mockDataConfig
+      adornmentsStore: {
+        addAdornment: jest.fn((adornment: any, options: any) => null),
+        findAdornmentOfType: jest.fn(),
+        subPlotRegionBoundaries: jest.fn(() => [1, 2])
+      },
+      dataConfiguration: mockDataConfig,
+      plotType: "dotPlot"
     }
     
     mockMedianAdornment = {
@@ -34,6 +70,17 @@ describe("DataInteractive medianAdornmentHandler", () => {
     }
   })
 
+  it("create returns the expected data when median adornment created", () => {
+    const createRequestValues = {
+      type: kMedianType,
+    }
+    const result = handler.create!({ graphContent: mockGraphContent, values: createRequestValues })
+    expect(result?.success).toBe(true)
+    expect(result?.values).toBeDefined()
+    const values = result?.values as any
+    expect(values.type).toBe(kMedianType)
+  })
+
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
@@ -46,5 +93,22 @@ describe("DataInteractive medianAdornmentHandler", () => {
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ median: 10 })
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+
+  it("update returns an error when median adornment not found", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
+    const result = handler.update?.({ graphContent: mockGraphContent })
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
+  })
+
+  it("update successfully updates count adornment properties", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockMedianAdornment)
+    const updateValues = {
+      isVisible: false
+    }
+    const result = handler.update?.({ graphContent: mockGraphContent, values: updateValues })
+    expect(result?.success).toBe(true)
   })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
@@ -3,11 +3,10 @@ import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/ado
 import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
   from "../../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { getAdornmentContentInfo } from "../../adornment-content-info"
+import { getAdornmentContentInfo, isCompatibleWithPlotType } from "../../adornment-content-info"
 import { IAdornmentModel } from "../../adornment-models"
 import { IAdornmentsBaseStore } from "../../store/adornments-base-store"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories, isAdornmentSupportedByPlotType }
-  from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { kMeanType } from "../mean/mean-adornment-types"
 import { IMedianAdornmentModel, isMedianAdornment } from "./median-adornment-model"
 import { kMedianType } from "./median-adornment-types"
@@ -15,7 +14,7 @@ import { kMedianType } from "./median-adornment-types"
 export const medianAdornmentHandler: DIAdornmentHandler = {
   create(args) {
     const { graphContent } = args
-    const isAdornmentSupported = isAdornmentSupportedByPlotType(kMeanType, graphContent.plotType)
+    const isAdornmentSupported = isCompatibleWithPlotType(kMeanType, graphContent.plotType)
     if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
 
     const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
@@ -76,7 +75,7 @@ export const medianAdornmentHandler: DIAdornmentHandler = {
     const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(kMedianType)
     if (!existingMeanAdornment) return adornmentNotFoundResult
 
-    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible !== undefined) {
+    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible != null) {
       existingMeanAdornment.setVisibility(values.isVisible)
     }
 

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
@@ -1,11 +1,53 @@
+import { isAdornmentValues } from "../../../../../data-interactive/data-interactive-adornment-types"
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { IAdornmentModel } from "../../adornment-models"
-import { isMedianAdornment } from "./median-adornment-model"
+import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
+  from "../../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
+import { getAdornmentContentInfo } from "../../adornment-content-info"
+import { IAdornmentModel } from "../../adornment-models"
+import { IAdornmentsBaseStore } from "../../store/adornments-base-store"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories, isAdornmentSupportedByPlotType }
+  from "../../utilities/adornment-handler-utils"
+import { kMeanType } from "../mean/mean-adornment-types"
+import { IMedianAdornmentModel, isMedianAdornment } from "./median-adornment-model"
 import { kMedianType } from "./median-adornment-types"
 
 export const medianAdornmentHandler: DIAdornmentHandler = {
+  create(args) {
+    const { graphContent } = args
+    const isAdornmentSupported = isAdornmentSupportedByPlotType(kMeanType, graphContent.plotType)
+    if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
+
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const dataConfig = graphContent.dataConfiguration
+    const cellKeys = dataConfig?.getAllCellKeys()
+    const data: AdornmentData[] = []
+    const existingMedianAdornment = adornmentsStore.findAdornmentOfType<IMedianAdornmentModel>(kMedianType)
+    const componentContentInfo = getAdornmentContentInfo(kMedianType)
+    const adornment = existingMedianAdornment ?? componentContentInfo.modelClass.create() as IMedianAdornmentModel
+
+    if (!existingMedianAdornment) {
+      adornmentsStore.addAdornment(adornment, { dataConfig })
+    }
+
+    adornment.setVisibility(true)
+
+    for (const cellKey of cellKeys) {
+      const cellKeyString = JSON.stringify(cellKey)
+      const median = adornment.measures.get(cellKeyString)?.value ?? NaN
+      const dataItem: AdornmentData = { median }
+    
+      if (Object.keys(cellKey).length > 0) {
+        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+      }
+    
+      data.push(dataItem)
+    }
+
+    const { id, isVisible, type } = adornment
+    return { success: true, values: { id, isVisible, type, data } }
+  },
+
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isMedianAdornment(adornment)) return adornmentMismatchResult(kMedianType)
 
@@ -26,5 +68,18 @@ export const medianAdornmentHandler: DIAdornmentHandler = {
     }
 
     return { data }
+  },
+
+  update(args) {
+    const { graphContent, values } = args
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(kMedianType)
+    if (!existingMeanAdornment) return adornmentNotFoundResult
+
+    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible !== undefined) {
+      existingMeanAdornment.setVisibility(values.isVisible)
+    }
+
+    return { success: true }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-handler.ts
@@ -1,84 +1,11 @@
-import { isAdornmentValues } from "../../../../../data-interactive/data-interactive-adornment-types"
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
-  from "../../../../../data-interactive/handlers/di-results"
-import { IGraphContentModel } from "../../../models/graph-content-model"
-import { getAdornmentContentInfo, isCompatibleWithPlotType } from "../../adornment-content-info"
-import { IAdornmentModel } from "../../adornment-models"
-import { IAdornmentsBaseStore } from "../../store/adornments-base-store"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
-import { kMeanType } from "../mean/mean-adornment-types"
-import { IMedianAdornmentModel, isMedianAdornment } from "./median-adornment-model"
+import { isMedianAdornment } from "./median-adornment-model"
 import { kMedianType } from "./median-adornment-types"
+import { univariateMeasureAdornmentBaseHandler } from "../univariate-measure-adornment-base-handler"
 
-export const medianAdornmentHandler: DIAdornmentHandler = {
-  create(args) {
-    const { graphContent } = args
-    const isAdornmentSupported = isCompatibleWithPlotType(kMeanType, graphContent.plotType)
-    if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
-
-    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
-    const dataConfig = graphContent.dataConfiguration
-    const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData[] = []
-    const existingMedianAdornment = adornmentsStore.findAdornmentOfType<IMedianAdornmentModel>(kMedianType)
-    const componentContentInfo = getAdornmentContentInfo(kMedianType)
-    const adornment = existingMedianAdornment ?? componentContentInfo.modelClass.create() as IMedianAdornmentModel
-
-    if (!existingMedianAdornment) {
-      adornmentsStore.addAdornment(adornment, { dataConfig })
-    }
-
-    adornment.setVisibility(true)
-
-    for (const cellKey of cellKeys) {
-      const cellKeyString = JSON.stringify(cellKey)
-      const median = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData = { median }
-    
-      if (Object.keys(cellKey).length > 0) {
-        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
-      }
-    
-      data.push(dataItem)
-    }
-
-    const { id, isVisible, type } = adornment
-    return { success: true, values: { id, isVisible, type, data } }
-  },
-
-  get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isMedianAdornment(adornment)) return adornmentMismatchResult(kMedianType)
-
-    const dataConfig = graphContent.dataConfiguration
-    const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData[] = []
-
-    for (const cellKey of cellKeys) {
-      const cellKeyString = JSON.stringify(cellKey)
-      const median = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const dataItem: AdornmentData = { median }
-    
-      if (Object.keys(cellKey).length > 0) {
-        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
-      }
-    
-      data.push(dataItem)
-    }
-
-    return { data }
-  },
-
-  update(args) {
-    const { graphContent, values } = args
-    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
-    const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(kMedianType)
-    if (!existingMeanAdornment) return adornmentNotFoundResult
-
-    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible != null) {
-      existingMeanAdornment.setVisibility(values.isVisible)
-    }
-
-    return { success: true }
-  }
-}
+export const medianAdornmentHandler: DIAdornmentHandler = univariateMeasureAdornmentBaseHandler({
+  adornmentType: kMedianType,
+  getMeasureValue: (adornment, cellKeyString) => adornment.measures.get(cellKeyString)?.value ?? NaN,
+  isAdornmentOfType: isMedianAdornment,
+  measureName: "median"
+})

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
@@ -1,4 +1,4 @@
-import { types } from "@concord-consortium/mobx-state-tree"
+import { types } from "mobx-state-tree"
 import { standardDeviationAdornmentHandler } from "./standard-deviation-adornment-handler"
 import { kStandardDeviationType } from "./standard-deviation-adornment-types"
 

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
@@ -3,7 +3,7 @@ import { standardDeviationAdornmentHandler } from "./standard-deviation-adornmen
 import { kStandardDeviationType } from "./standard-deviation-adornment-types"
 
 jest.mock("../../adornment-content-info", () => {
-  const mockMeanModel = types.model("StandardDeviationAdornmentModel", {
+  const mockStandardDeviationModel = types.model("StandardDeviationAdornmentModel", {
     id: types.optional(types.string, "ADRN123"),
     measures: types.map(types.model({ value: types.number })),
     type: types.optional(types.string, "Standard Deviation"),
@@ -18,7 +18,7 @@ jest.mock("../../adornment-content-info", () => {
   }))
 
   const mockContentInfo = {
-    modelClass: mockMeanModel,
+    modelClass: mockStandardDeviationModel,
     plots: ["dotPlot"],
     prefix: "standard-deviation",
     type: "Standard Deviation",

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.test.ts
@@ -1,5 +1,32 @@
+import { types } from "@concord-consortium/mobx-state-tree"
 import { standardDeviationAdornmentHandler } from "./standard-deviation-adornment-handler"
 import { kStandardDeviationType } from "./standard-deviation-adornment-types"
+
+jest.mock("../../adornment-content-info", () => {
+  const mockStandardDeviationModel = types.model("StandardDeviationAdornmentModel", {
+    id: types.optional(types.string, "ADRN123"),
+    measures: types.map(types.model({ value: types.number })),
+    type: types.optional(types.string, "Standard Deviation"),
+    isVisible: types.optional(types.boolean, false),
+  }).actions(self => ({
+    computeMeasureRange() {
+      return { min: 0, max: 20 }
+    },
+    setVisibility(isVisible: boolean) {
+      self.isVisible = isVisible
+    }
+  }))
+
+  return {
+    ...jest.requireActual("../../adornment-content-info"),
+    getAdornmentContentInfo: jest.fn().mockReturnValue({
+      modelClass: mockStandardDeviationModel,
+      plots: ["dotPlot"],
+      prefix: "standard-deviation",
+      type: "Standard Deviation",
+    }),
+  }
+})
 
 describe("DataInteractive standardDeviationAdornmentHandler", () => {
   const handler = standardDeviationAdornmentHandler
@@ -14,11 +41,23 @@ describe("DataInteractive standardDeviationAdornmentHandler", () => {
 
   beforeEach(() => {
     mockDataConfig = {
+      attributeID: jest.fn(() => "attr1"),
+      attributeType: jest.fn(() => "numeric"),
+      dataset: {
+        getCasesForAttributes: jest.fn(() => [1, 1]),
+        getNumeric: jest.fn(() => 1)
+      },
       getAllCellKeys: jest.fn(() => [{}]),
       subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
     }
     mockGraphContent = {
-      dataConfiguration: mockDataConfig
+      adornmentsStore: {
+        addAdornment: jest.fn((adornment: any, options: any) => null),
+        findAdornmentOfType: jest.fn(),
+        subPlotRegionBoundaries: jest.fn(() => [1, 2])
+      },
+      dataConfiguration: mockDataConfig,
+      plotType: "dotPlot"
     }
     
     mockStandardDeviationAdornment = {
@@ -35,6 +74,17 @@ describe("DataInteractive standardDeviationAdornmentHandler", () => {
     }
   })
 
+  it("create returns the expected data when standard-deviation adornment created", () => {
+    const createRequestValues = {
+      type: kStandardDeviationType,
+    }
+    const result = handler.create!({ graphContent: mockGraphContent, values: createRequestValues })
+    expect(result?.success).toBe(true)
+    expect(result?.values).toBeDefined()
+    const values = result?.values as any
+    expect(values.type).toBe(kStandardDeviationType)
+  })
+
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
@@ -47,5 +97,22 @@ describe("DataInteractive standardDeviationAdornmentHandler", () => {
     expect(result?.data).toHaveLength(1)
     expect(result?.data[0]).toMatchObject({ mean: 10, min: 0, max: 20 })
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
+  })
+
+  it("update returns an error when standard-deviation adornment not found", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
+    const result = handler.update?.({ graphContent: mockGraphContent })
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
+  })
+
+  it("update successfully updates count adornment properties", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockStandardDeviationAdornment)
+    const updateValues = {
+      isVisible: false
+    }
+    const result = handler.update?.({ graphContent: mockGraphContent, values: updateValues })
+    expect(result?.success).toBe(true)
   })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
@@ -1,11 +1,57 @@
+import { isAdornmentValues } from "../../../../../data-interactive/data-interactive-adornment-types"
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
+  from "../../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../../models/graph-content-model"
+import { getAdornmentContentInfo } from "../../adornment-content-info"
 import { IAdornmentModel } from "../../adornment-models"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
-import { isStandardDeviationAdornment } from "./standard-deviation-adornment-model"
+import { IAdornmentsBaseStore } from "../../store/adornments-base-store"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories, isAdornmentSupportedByPlotType }
+  from "../../utilities/adornment-handler-utils"
+import { kMeanType } from "../mean/mean-adornment-types"
+import { isStandardDeviationAdornment, IStandardDeviationAdornmentModel } from "./standard-deviation-adornment-model"
 import { kStandardDeviationType } from "./standard-deviation-adornment-types"
 
 export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
+  create(args) {
+    const { graphContent } = args
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const isAdornmentSupported = isAdornmentSupportedByPlotType(kMeanType, graphContent.plotType)
+    if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
+
+    const dataConfig = graphContent.dataConfiguration
+    const cellKeys = dataConfig?.getAllCellKeys()
+    const data: AdornmentData[] = []
+    const existingMedianAdornment =
+      adornmentsStore.findAdornmentOfType<IStandardDeviationAdornmentModel>(kStandardDeviationType)
+    const componentContentInfo = getAdornmentContentInfo(kStandardDeviationType)
+    const adornment =
+      existingMedianAdornment ?? componentContentInfo.modelClass.create() as IStandardDeviationAdornmentModel
+
+    if (!existingMedianAdornment) {
+      adornmentsStore.addAdornment(adornment, { dataConfig })
+    }
+
+    adornment.setVisibility(true)
+
+    for (const cellKey of cellKeys) {
+      const primaryAttrId = dataConfig?.primaryAttributeID
+      const cellKeyString = JSON.stringify(cellKey)
+      const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
+      const { min, max } = adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)
+      const dataItem: AdornmentData = { mean, min, max }
+    
+      if (Object.keys(cellKey).length > 0) {
+        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+      }
+    
+      data.push(dataItem)
+    }
+
+    const { id, isVisible, type } = adornment
+    return { success: true, values: { id, isVisible, type, data } }
+  },
+
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
     if (!isStandardDeviationAdornment(adornment)) return adornmentMismatchResult(kStandardDeviationType)
 
@@ -28,5 +74,18 @@ export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
     }
 
     return { data }
+  },
+
+  update(args) {
+    const { graphContent, values } = args
+    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+    const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(kStandardDeviationType)
+    if (!existingMeanAdornment) return adornmentNotFoundResult
+
+    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible !== undefined) {
+      existingMeanAdornment.setVisibility(values.isVisible)
+    }
+
+    return { success: true }
   }
 }

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
@@ -3,11 +3,10 @@ import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/ado
 import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
   from "../../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../../models/graph-content-model"
-import { getAdornmentContentInfo } from "../../adornment-content-info"
+import { getAdornmentContentInfo, isCompatibleWithPlotType } from "../../adornment-content-info"
 import { IAdornmentModel } from "../../adornment-models"
 import { IAdornmentsBaseStore } from "../../store/adornments-base-store"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories, isAdornmentSupportedByPlotType }
-  from "../../utilities/adornment-handler-utils"
+import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
 import { kMeanType } from "../mean/mean-adornment-types"
 import { isStandardDeviationAdornment, IStandardDeviationAdornmentModel } from "./standard-deviation-adornment-model"
 import { kStandardDeviationType } from "./standard-deviation-adornment-types"
@@ -16,7 +15,7 @@ export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
   create(args) {
     const { graphContent } = args
     const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
-    const isAdornmentSupported = isAdornmentSupportedByPlotType(kMeanType, graphContent.plotType)
+    const isAdornmentSupported = isCompatibleWithPlotType(kMeanType, graphContent.plotType)
     if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
 
     const dataConfig = graphContent.dataConfiguration
@@ -82,7 +81,7 @@ export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
     const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(kStandardDeviationType)
     if (!existingMeanAdornment) return adornmentNotFoundResult
 
-    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible !== undefined) {
+    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible != null) {
       existingMeanAdornment.setVisibility(values.isVisible)
     }
 

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-handler.ts
@@ -1,90 +1,17 @@
-import { isAdornmentValues } from "../../../../../data-interactive/data-interactive-adornment-types"
 import { DIAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
-import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
-  from "../../../../../data-interactive/handlers/di-results"
-import { IGraphContentModel } from "../../../models/graph-content-model"
-import { getAdornmentContentInfo, isCompatibleWithPlotType } from "../../adornment-content-info"
-import { IAdornmentModel } from "../../adornment-models"
-import { IAdornmentsBaseStore } from "../../store/adornments-base-store"
-import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../../utilities/adornment-handler-utils"
-import { kMeanType } from "../mean/mean-adornment-types"
-import { isStandardDeviationAdornment, IStandardDeviationAdornmentModel } from "./standard-deviation-adornment-model"
+import { isStandardDeviationAdornment } from "./standard-deviation-adornment-model"
 import { kStandardDeviationType } from "./standard-deviation-adornment-types"
+import { univariateMeasureAdornmentBaseHandler } from "../univariate-measure-adornment-base-handler"
 
-export const standardDeviationAdornmentHandler: DIAdornmentHandler = {
-  create(args) {
-    const { graphContent } = args
-    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
-    const isAdornmentSupported = isCompatibleWithPlotType(kMeanType, graphContent.plotType)
-    if (!isAdornmentSupported) return adornmentNotSupportedByPlotTypeResult
-
-    const dataConfig = graphContent.dataConfiguration
-    const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData[] = []
-    const existingMedianAdornment =
-      adornmentsStore.findAdornmentOfType<IStandardDeviationAdornmentModel>(kStandardDeviationType)
-    const componentContentInfo = getAdornmentContentInfo(kStandardDeviationType)
-    const adornment =
-      existingMedianAdornment ?? componentContentInfo.modelClass.create() as IStandardDeviationAdornmentModel
-
-    if (!existingMedianAdornment) {
-      adornmentsStore.addAdornment(adornment, { dataConfig })
-    }
-
-    adornment.setVisibility(true)
-
-    for (const cellKey of cellKeys) {
+export const standardDeviationAdornmentHandler: DIAdornmentHandler = univariateMeasureAdornmentBaseHandler({
+  adornmentType: kStandardDeviationType,
+  getAdditionalData: (adornment, cellKey, dataConfig) => {
+    if (isStandardDeviationAdornment(adornment)) {
       const primaryAttrId = dataConfig?.primaryAttributeID
-      const cellKeyString = JSON.stringify(cellKey)
-      const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const { min, max } = adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)
-      const dataItem: AdornmentData = { mean, min, max }
-    
-      if (Object.keys(cellKey).length > 0) {
-        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
-      }
-    
-      data.push(dataItem)
+      return adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)
     }
-
-    const { id, isVisible, type } = adornment
-    return { success: true, values: { id, isVisible, type, data } }
   },
-
-  get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
-    if (!isStandardDeviationAdornment(adornment)) return adornmentMismatchResult(kStandardDeviationType)
-
-    const dataConfig = graphContent.dataConfiguration
-    const cellKeys = dataConfig?.getAllCellKeys()
-    const data: AdornmentData[] = []
-
-    for (const cellKey of cellKeys) {
-      const primaryAttrId = dataConfig?.primaryAttributeID
-      const cellKeyString = JSON.stringify(cellKey)
-      const mean = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const { min, max } = adornment.computeMeasureRange(primaryAttrId, cellKey, dataConfig)
-      const dataItem: AdornmentData = { mean, min, max }
-    
-      if (Object.keys(cellKey).length > 0) {
-        dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
-      }
-    
-      data.push(dataItem)
-    }
-
-    return { data }
-  },
-
-  update(args) {
-    const { graphContent, values } = args
-    const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
-    const existingMeanAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(kStandardDeviationType)
-    if (!existingMeanAdornment) return adornmentNotFoundResult
-
-    if (isAdornmentValues(values) && "isVisible" in values && values.isVisible != null) {
-      existingMeanAdornment.setVisibility(values.isVisible)
-    }
-
-    return { success: true }
-  }
-}
+  getMeasureValue: (adornment, cellKeyString) => adornment.measures.get(cellKeyString)?.value ?? NaN,
+  isAdornmentOfType: isStandardDeviationAdornment,
+  measureName: "mean"
+})

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-handler.ts
@@ -1,0 +1,108 @@
+import { isAdornmentValues } from "../../../../data-interactive/data-interactive-adornment-types"
+import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { adornmentNotFoundResult, adornmentNotSupportedByPlotTypeResult }
+  from "../../../../data-interactive/handlers/di-results"
+import { IGraphContentModel } from "../../models/graph-content-model"
+import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
+import { getAdornmentContentInfo, isCompatibleWithPlotType } from "../adornment-content-info"
+import { IAdornmentModel } from "../adornment-models"
+import { IAdornmentsBaseStore } from "../store/adornments-base-store"
+import { AdornmentData, cellKeyToCategories, adornmentMismatchResult } from "../utilities/adornment-handler-utils"
+import { IUnivariateMeasureAdornmentModel } from "./univariate-measure-adornment-model"
+
+export interface IUnivariateMeasureAdornmentHandlerConfig {
+  adornmentType: string
+  isAdornmentOfType: (adornment: IAdornmentModel) => boolean
+  measureName: string
+  getMeasureValue: (adornment: IUnivariateMeasureAdornmentModel, cellKeyString: string) => number
+  getAdditionalData?: (
+    adornment: IAdornmentModel,
+    cellKey: Record<string, string>,
+    dataConfig: IGraphDataConfigurationModel
+  ) => Record<string, any> | undefined
+}
+
+export const univariateMeasureAdornmentBaseHandler = (
+  config: IUnivariateMeasureAdornmentHandlerConfig
+): DIAdornmentHandler => {
+  const { adornmentType, isAdornmentOfType, measureName, getMeasureValue, getAdditionalData } = config
+  return {
+    create(args) {
+      const { graphContent } = args
+      if (!isCompatibleWithPlotType(adornmentType, graphContent.plotType)) return adornmentNotSupportedByPlotTypeResult
+
+      const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+      const dataConfig = graphContent.dataConfiguration
+      const cellKeys = dataConfig?.getAllCellKeys()
+      const data: AdornmentData[] = []
+      const existingAdornment = adornmentsStore.findAdornmentOfType<IUnivariateMeasureAdornmentModel>(adornmentType)
+      const componentContentInfo = getAdornmentContentInfo(adornmentType)
+      const adornment =
+        existingAdornment ?? componentContentInfo.modelClass.create() as IUnivariateMeasureAdornmentModel
+
+      if (!existingAdornment) {
+        adornmentsStore.addAdornment(adornment, { dataConfig })
+      }
+
+      adornment.setVisibility(true)
+
+      for (const cellKey of cellKeys) {
+        const cellKeyString = JSON.stringify(cellKey)
+        const measureValue = getMeasureValue(adornment, cellKeyString)
+        const additionalData = getAdditionalData?.(adornment, cellKey, dataConfig) ?? {}
+        const dataItem: AdornmentData = {
+          ...additionalData,
+          [measureName]: measureValue
+        }
+      
+        if (Object.keys(cellKey).length > 0) {
+          dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+        }
+      
+        data.push(dataItem)
+      }
+
+      const { id, isVisible, type } = adornment
+      return { success: true, values: { id, isVisible, type, data } }
+    },
+
+    get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
+      if (!isAdornmentOfType(adornment)) return adornmentMismatchResult(adornmentType)
+
+      const dataConfig = graphContent.dataConfiguration
+      const cellKeys = dataConfig?.getAllCellKeys()
+      const data: AdornmentData[] = []
+
+      for (const cellKey of cellKeys) {
+        const cellKeyString = JSON.stringify(cellKey)
+        const measureValue = getMeasureValue(adornment as IUnivariateMeasureAdornmentModel, cellKeyString)
+        const additionalData = getAdditionalData?.(adornment, cellKey, dataConfig) ?? {}
+        const dataItem: AdornmentData = {
+          ...additionalData,
+          [measureName]: measureValue
+        }
+      
+        if (Object.keys(cellKey).length > 0) {
+          dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
+        }
+      
+        data.push(dataItem)
+      }
+
+      return { data }
+    },
+
+    update(args) {
+      const { graphContent, values } = args
+      const adornmentsStore = graphContent.adornmentsStore as IAdornmentsBaseStore
+      const existingAdornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(adornmentType)
+      if (!existingAdornment) return adornmentNotFoundResult
+
+      if (isAdornmentValues(values) && "isVisible" in values && values.isVisible != null) {
+        existingAdornment.setVisibility(values.isVisible)
+      }
+
+      return { success: true }
+    }
+  }
+}

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
@@ -21,8 +21,3 @@ export const cellKeyToCategories = (cellKey: Record<string, string>, dataConfig:
 export const adornmentMismatchResult = (adornmentType: string) => {
   return errorResult(t("V3.DI.Error.adornmentMismatch", { vars: [adornmentType] }))
 }
-
-export const isAdornmentSupportedByPlotType = (type: string, plotType: PlotType) => {
-  const info = getAdornmentContentInfo(type)
-  return info.plots.find(plot => plotType === plot)
-}

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
@@ -1,6 +1,8 @@
 import { errorResult } from "../../../../data-interactive/handlers/di-results"
 import { t } from "../../../../utilities/translation/translate"
 import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
+import { PlotType } from "../../graphing-types"
+import { getAdornmentContentInfo } from "../adornment-content-info"
 
 export type AdornmentData = {
   categories?: Record<string, string>;
@@ -18,4 +20,9 @@ export const cellKeyToCategories = (cellKey: Record<string, string>, dataConfig:
 
 export const adornmentMismatchResult = (adornmentType: string) => {
   return errorResult(t("V3.DI.Error.adornmentMismatch", { vars: [adornmentType] }))
+}
+
+export const isAdornmentSupportedByPlotType = (type: string, plotType: PlotType) => {
+  const info = getAdornmentContentInfo(type)
+  return info.plots.find(plot => plotType === plot)
 }

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
@@ -1,8 +1,6 @@
 import { errorResult } from "../../../../data-interactive/handlers/di-results"
 import { t } from "../../../../utilities/translation/translate"
 import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
-import { PlotType } from "../../graphing-types"
-import { getAdornmentContentInfo } from "../adornment-content-info"
 
 export type AdornmentData = {
   categories?: Record<string, string>;

--- a/v3/src/data-interactive/data-interactive-adornment-types.ts
+++ b/v3/src/data-interactive/data-interactive-adornment-types.ts
@@ -1,0 +1,16 @@
+import { SnapshotIn } from "@concord-consortium/mobx-state-tree"
+import { CountAdornmentModel } from "../components/graph/adornments/count/count-adornment-model"
+import { LSRLAdornmentModel } from "../components/graph/adornments/lsrl/lsrl-adornment-model"
+import { kCountType } from "../components/graph/adornments/count/count-adornment-types"
+import { kLSRLType } from "../components/graph/adornments/lsrl/lsrl-adornment-types"
+
+export type DICountAdornmentValues = Partial<SnapshotIn<typeof CountAdornmentModel>>
+type DILSRLAdornmentValues = Partial<SnapshotIn<typeof LSRLAdornmentModel>>
+
+export type DIAdornmentValues = DICountAdornmentValues | DILSRLAdornmentValues
+
+const adornmentTypes = new Set([kCountType, kLSRLType])
+
+export const isAdornmentValues = (val: unknown): val is DIAdornmentValues => {
+  return typeof val === "object" && val !== null && adornmentTypes.has((val as any).type)
+}

--- a/v3/src/data-interactive/data-interactive-adornment-types.ts
+++ b/v3/src/data-interactive/data-interactive-adornment-types.ts
@@ -3,15 +3,27 @@ import { CountAdornmentModel } from "../components/graph/adornments/count/count-
 import { kCountType } from "../components/graph/adornments/count/count-adornment-types"
 import { LSRLAdornmentModel } from "../components/graph/adornments/lsrl/lsrl-adornment-model"
 import { kLSRLType } from "../components/graph/adornments/lsrl/lsrl-adornment-types"
+import { MeanAdornmentModel } from "../components/graph/adornments/univariate-measures/mean/mean-adornment-model"
+import { kMeanType } from "../components/graph/adornments/univariate-measures/mean/mean-adornment-types"
+import { MedianAdornmentModel } from "../components/graph/adornments/univariate-measures/median/median-adornment-model"
+import { kMedianType } from "../components/graph/adornments/univariate-measures/median/median-adornment-types"
 import { MovableValueAdornmentModel } from "../components/graph/adornments/movable-value/movable-value-adornment-model"
 import { kMovableValueType } from "../components/graph/adornments/movable-value/movable-value-adornment-types"
+import { StandardDeviationAdornmentModel }
+  from "../components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-model"
+import { kStandardDeviationType }
+  from "../components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-types"
 
 export type DICountAdornmentValues = Partial<SnapshotIn<typeof CountAdornmentModel>>
 export type DILsrlAdornmentValues = Partial<SnapshotIn<typeof LSRLAdornmentModel>>
+export type DIMeanAdornmentValues = Partial<SnapshotIn<typeof MeanAdornmentModel>>
+export type DIMedianAdornmentValues = Partial<SnapshotIn<typeof MedianAdornmentModel>>
 export type DIMovableValueAdornmentValues = Partial<SnapshotIn<typeof MovableValueAdornmentModel>>
-export type DIAdornmentValues = DICountAdornmentValues | DILsrlAdornmentValues | DIMovableValueAdornmentValues
+export type DIStandardDeviationAdornmentValues = Partial<SnapshotIn<typeof StandardDeviationAdornmentModel>>
+export type DIAdornmentValues = DICountAdornmentValues | DILsrlAdornmentValues | DIMeanAdornmentValues |
+  DIMedianAdornmentValues | DIMovableValueAdornmentValues | DIStandardDeviationAdornmentValues
 
-const adornmentTypes = new Set([kCountType, kLSRLType, kMovableValueType])
+const adornmentTypes = new Set([kCountType, kLSRLType, kMeanType, kMedianType, kMovableValueType, kStandardDeviationType])
 
 export const isAdornmentValues = (val: unknown): val is DIAdornmentValues => {
   return typeof val === "object" && val !== null && adornmentTypes.has((val as any).type)

--- a/v3/src/data-interactive/data-interactive-adornment-types.ts
+++ b/v3/src/data-interactive/data-interactive-adornment-types.ts
@@ -1,15 +1,17 @@
 import { SnapshotIn } from "@concord-consortium/mobx-state-tree"
 import { CountAdornmentModel } from "../components/graph/adornments/count/count-adornment-model"
-import { LSRLAdornmentModel } from "../components/graph/adornments/lsrl/lsrl-adornment-model"
 import { kCountType } from "../components/graph/adornments/count/count-adornment-types"
+import { LSRLAdornmentModel } from "../components/graph/adornments/lsrl/lsrl-adornment-model"
 import { kLSRLType } from "../components/graph/adornments/lsrl/lsrl-adornment-types"
+import { MovableValueAdornmentModel } from "../components/graph/adornments/movable-value/movable-value-adornment-model"
+import { kMovableValueType } from "../components/graph/adornments/movable-value/movable-value-adornment-types"
 
 export type DICountAdornmentValues = Partial<SnapshotIn<typeof CountAdornmentModel>>
-type DILSRLAdornmentValues = Partial<SnapshotIn<typeof LSRLAdornmentModel>>
+export type DILsrlAdornmentValues = Partial<SnapshotIn<typeof LSRLAdornmentModel>>
+export type DIMovableValueAdornmentValues = Partial<SnapshotIn<typeof MovableValueAdornmentModel>>
+export type DIAdornmentValues = DICountAdornmentValues | DILsrlAdornmentValues | DIMovableValueAdornmentValues
 
-export type DIAdornmentValues = DICountAdornmentValues | DILSRLAdornmentValues
-
-const adornmentTypes = new Set([kCountType, kLSRLType])
+const adornmentTypes = new Set([kCountType, kLSRLType, kMovableValueType])
 
 export const isAdornmentValues = (val: unknown): val is DIAdornmentValues => {
   return typeof val === "object" && val !== null && adornmentTypes.has((val as any).type)

--- a/v3/src/data-interactive/data-interactive-data-set-types.ts
+++ b/v3/src/data-interactive/data-interactive-data-set-types.ts
@@ -1,3 +1,4 @@
+import { IAdornmentModelSnapshot } from "../components/graph/adornments/adornment-models"
 import { IValueType } from "../models/data/attribute-types"
 import { ICollectionLabels } from "../models/data/collection"
 import { ICodapV2Attribute, ICodapV2Collection, ICodapV2DataContext } from "../v2/codap-v2-data-set-types"
@@ -113,4 +114,13 @@ export interface DIUpdateItemResult {
 }
 export interface DIDeleteCollectionResult {
   collections?: number[]
+}
+export interface DICreateAdornment {
+  adornment: IAdornmentModelSnapshot
+}
+export interface DIDeleteAdornment {
+  type: string
+}
+export interface DIUpdateAdornment {
+  adornment: IAdornmentModelSnapshot
 }

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -1,5 +1,6 @@
 import { RequireAtLeastOne } from "type-fest"
 import { LoggableValue } from "../lib/log-message"
+import { IAdornmentModel } from "../components/graph/adornments/adornment-models"
 import { IAttribute } from "../models/data/attribute"
 import { ICollectionModel } from "../models/data/collection"
 import { IDataSet } from "../models/data/data-set"
@@ -8,11 +9,11 @@ import { IGlobalValue } from "../models/global/global-value"
 import { ITileModel } from "../models/tiles/tile-model"
 import { V2SpecificComponent } from "./data-interactive-component-types"
 import {
-  DIAllCases, DIAttribute, DIAttributeLocationValues, DICase, DICreateCollection,
-  DIDataContext, DIDeleteCollectionResult, DIGetCaseResult, DIItemValues, DINewCase,
-  DINotifyAttribute, DINotifyDataContext, DIResultAttributes, DIUpdateCase, DIUpdateItemResult
+  DIAllCases, DIAttribute, DIAttributeLocationValues, DICase, DICreateAdornment, DICreateCollection,
+  DIDataContext, DIDeleteAdornment, DIDeleteCollectionResult, DIGetCaseResult, DIItemValues, DINewCase,
+  DINotifyAttribute, DINotifyDataContext, DIResultAttributes, DIUpdateAdornment, DIUpdateCase, DIUpdateItemResult
 } from "./data-interactive-data-set-types"
-import { IAdornmentModel } from "../components/graph/adornments/adornment-models"
+import { DIAdornmentValues } from "./data-interactive-adornment-types"
 
 export type DIComponent = ITileModel
 export interface DIComponentInfo {
@@ -97,7 +98,7 @@ export interface DIResources {
 // types for values accepted as inputs by the API
 export type DISingleValues = DIAttribute | DINotifyAttribute | DIAttributeLocationValues | DICase | DIDataContext |
   DINotifyDataContext | DIGlobal | DIInteractiveFrame | DIItemValues | DICreateCollection | DINewCase | DIUpdateCase |
-  DINotification | DIItemSearchNotify | DILogMessage | DIUrl | V2SpecificComponent
+  DINotification | DIItemSearchNotify | DILogMessage | DIUrl | V2SpecificComponent | DIAdornmentValues
 export type DIValues = DISingleValues | DISingleValues[] | number | string[]
 
 // types returned as outputs by the API
@@ -105,7 +106,8 @@ export type DIResultSingleValues = DICase | DIComponentInfo |  DIDataDisplay | D
   | DIInteractiveFrame
 
 export type DIResultValues = DIResultSingleValues | DIResultSingleValues[] |
-  DIAllCases | DIDeleteCollectionResult | DIUpdateItemResult | DIResultAttributes | number | number[]
+  DIAllCases | DIDeleteCollectionResult | DIUpdateItemResult | DIResultAttributes | number | number[] |
+  DICreateAdornment | DIDeleteAdornment | DIUpdateAdornment | number | number[]
 
 export interface DIMetadata {
   dirtyDocument?: boolean

--- a/v3/src/data-interactive/handlers/adornment-handler.test.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.test.ts
@@ -5,6 +5,21 @@ import { diAdornmentHandler } from "./adornment-handler"
 describe("DataInteractive AdornmentHandler", () => {
   const handler = diAdornmentHandler
 
+  it("create returns an error when no values provided", () => {
+    const result = handler.create?.({})
+    expect(result?.success).toBe(false)
+  })
+
+  it("delete returns an error when no type provided", () => {
+    const result = handler.delete?.({})
+    expect(result?.success).toBe(false)
+  })
+
+  it("delete returns an error when type provided but matching adornment not found", () => {
+    const result = handler.delete?.({}, { type: "Count" })
+    expect(result?.success).toBe(false)
+  })
+
   it("get returns an error when no adornment provided", () => {
     const result = handler.get?.({})
     expect(result?.success).toBe(false)
@@ -18,6 +33,16 @@ describe("DataInteractive AdornmentHandler", () => {
     } as IAdornmentModel
     const mockResource: DIResources = { adornment: mockAdornment }
     const result = handler.get?.(mockResource)
+    expect(result?.success).toBe(false)
+  })
+
+  it("update returns an error when no values provided", () => {
+    const result = handler.update?.({})
+    expect(result?.success).toBe(false)
+  })
+
+  it("update returns an error when type provided but matching adornment not found", () => {
+    const result = handler.update?.({}, { type: "Count" })
     expect(result?.success).toBe(false)
   })
 

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -2,11 +2,24 @@ import { IAdornmentModel } from "../../components/graph/adornments/adornment-mod
 import { IGraphContentModel, isGraphContentModel } from "../../components/graph/models/graph-content-model"
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIHandler, DIResources } from "../data-interactive-types"
-import { adornmentNotFoundResult, adornmentNotSupportedResult, errorResult } from "./di-results"
+import { DIAttribute } from "../data-interactive-data-set-types"
+import { DIErrorResult, DIHandler, DIHandlerFnResult, DIResources, DIValues } from "../data-interactive-types"
+import { adornmentNotFoundResult, adornmentNotSupportedResult, valuesRequiredResult, errorResult } from "./di-results"
+
+interface ICreateArgs {
+  graphContent: IGraphContentModel
+  values?: DIValues
+}
 
 export interface DIAdornmentHandler {
+  create?: (args: ICreateArgs) => DIHandlerFnResult | DIErrorResult
+  delete?: (args: ICreateArgs) => DIHandlerFnResult | DIErrorResult
   get: (adornment: IAdornmentModel, component: IGraphContentModel) => Maybe<Record<string, any>>
+  update?: (args: ICreateArgs) => DIHandlerFnResult | DIErrorResult
+}
+
+const isTypeSpecified = (val: unknown): val is DIAttribute => {
+  return typeof val === "object" && val !== null && "type" in val && typeof val.type === "string"
 }
 
 const diAdornmentHandlers = new Map<string, DIAdornmentHandler>()
@@ -28,6 +41,53 @@ export const resolveAdornmentType = (typeOrAlias: unknown) => {
 }
 
 export const diAdornmentHandler: DIHandler = {
+  create(resources: DIResources, values?: DIValues) {
+    if (!values) return valuesRequiredResult
+
+    const { component } = resources
+    if (!isGraphContentModel(component?.content)) {
+      return errorResult(t("V3.DI.Error.unsupportedComponent", { vars: [component?.content.type] }))
+    }
+
+    const graphContent = component.content
+    if (isTypeSpecified(values) && values.type) {
+      const { type } = values
+      const handler = diAdornmentHandlers.get(type)
+      if (handler?.create) {
+        return handler.create({graphContent, values})
+      }
+
+      return errorResult(t("V3.DI.Error.adornmentRequestNotSupported", { vars: [type, "create"] }))
+    } else {
+      return valuesRequiredResult
+    }
+  },
+
+  delete(resources: DIResources, values?: DIValues) {
+    const { component } = resources
+    if (!isTypeSpecified(values) || !values.type) return valuesRequiredResult
+    if (!isGraphContentModel(component?.content)) {
+      return errorResult(t("V3.DI.Error.unsupportedComponent", { vars: [component?.content.type] }))
+    }
+  
+    const { type } = values
+    const graphContent = component.content
+    const adornmentsStore = graphContent.adornmentsStore
+    const adornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(type)
+  
+    if (!adornment) return adornmentNotFoundResult
+  
+    const handler = diAdornmentHandlers.get(type)
+  
+    if (handler?.delete) {
+      return handler.delete({ graphContent })
+    }
+  
+    // If the adornment doesn't have a delete handler, we just hide the adornment.
+    adornmentsStore.hideAdornment(type)
+    return { success: true }
+  },
+
   get(resources: DIResources) {
     const { adornment, component } = resources
     if (!isGraphContentModel(component?.content)) {
@@ -55,6 +115,28 @@ export const diAdornmentHandler: DIHandler = {
     }
 
     return adornmentNotSupportedResult
+  },
+
+  update(resources: DIResources, values?: DIValues) {
+    if (!values) return valuesRequiredResult
+
+    const { component } = resources
+    if (!isGraphContentModel(component?.content)) {
+      return errorResult(t("V3.DI.Error.unsupportedComponent", { vars: [component?.content.type] }))
+    }
+
+    const graphContent = component.content
+    if (isTypeSpecified(values) && values.type) {
+      const { type } = values as any
+      const handler = diAdornmentHandlers.get(type)
+      if (handler?.update) {
+        return handler.update({graphContent, values})
+      } else {
+        return errorResult(t("V3.DI.Error.adornmentRequestNotSupported", { vars: [type, "update"] }))
+      }
+    } else {
+      return valuesRequiredResult
+    }
   }
 }
 

--- a/v3/src/data-interactive/handlers/di-results.ts
+++ b/v3/src/data-interactive/handlers/di-results.ts
@@ -4,6 +4,7 @@ export const errorResult = (error: string) => ({ success: false as const, values
 export const adornmentNotFoundResult = errorResult(t("V3.DI.Error.adornmentNotFound"))
 export const adornmentListNotFoundResult = errorResult(t("V3.DI.Error.adornmentListNotFound"))
 export const adornmentNotSupportedResult = errorResult(t("V3.DI.Error.adornmentNotSupported"))
+export const adornmentNotSupportedByPlotTypeResult = errorResult(t("V3.DI.Error.adornmentNotSupportedByPlotType"))
 export const attributeNotFoundResult = errorResult(t("V3.DI.Error.attributeNotFound"))
 export const caseNotFoundResult = errorResult(t("V3.DI.Error.caseNotFound"))
 export const collectionNotFoundResult = errorResult(t("V3.DI.Error.collectionNotFound"))
@@ -13,6 +14,7 @@ export const dataContextNotFoundResult = errorResult(t("V3.DI.Error.dataContextN
 export const dataDisplayNotFoundResult = errorResult(t("V3.DI.Error.dataDisplayNotFound"))
 export const itemNotFoundResult = errorResult(t("V3.DI.Error.itemNotFound"))
 export const valuesRequiredResult = errorResult(t("V3.DI.Error.valuesRequired"))
+export const invalidValuesProvidedeResult = errorResult(t("V3.DI.Error.invalidValuesProvided"))
 
 export function fieldRequiredResult(action: string, resource: string, field: string) {
   return errorResult(t("V3.DI.Error.fieldRequired", { vars: [action, resource, field] }))

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -142,6 +142,7 @@
     "V3.DI.Error.notFound": "Not found",
     "V3.DI.Error.selectionListIllegalValues": "%@1 selectionList requires a list of case IDs.",
     "V3.DI.Error.valuesRequired": "A values object is required for this request.",
+    "V3.DI.Error.invalidValuesProvided": "Invalid values provided for update.",
     "V3.DI.Error.invalidEvaluationRecord": "Invalid record for evaluation",
     "V3.DI.Error.couldNotParseQuery": "Unable to parse query.",
     "V3.DI.Error.unknownRequest": "unknown request: %@",
@@ -149,6 +150,8 @@
     "V3.DI.Error.adornmentNotSupported": "Unsupported adornment type",
     "V3.DI.Error.adornmentListNotFound": "Adornment list not found.",
     "V3.DI.Error.adornmentMismatch": "Not a(n) %@1 adornment.",
+    "V3.DI.Error.adornmentNotSupportedByPlotType": "Adornment not supported by plot type.",
+    "V3.DI.Error.adornmentRequestNotSupported": "The %@1 adornment does not currently support %@2 requests.",
 
     // CFM/File menu
     "DG.fileMenu.menuItem.newDocument": "New",


### PR DESCRIPTION
[CODAP-47](https://concord-consortium.atlassian.net/browse/CODAP-47)

Adds `create`, `update`, and `delete` API endpoints for specific graph adornments. Support for all three endpoints has not been added for every single adornment type. These changes cover the adornments the DAVAI plugin will mainly be concerned with: Count/Percent, Least Squares Line, Mean, Median, Standard Deviation, and Movable Value. Support for the other adornments will have to be added later.

[CODAP-47]: https://concord-consortium.atlassian.net/browse/CODAP-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ