### PR TITLE
CODAP-354 fixed the check for percent adornments

### DIFF
--- a/v3/cypress/e2e/adornments.spec.ts
+++ b/v3/cypress/e2e/adornments.spec.ts
@@ -4,7 +4,7 @@ import { AxisElements as ae } from "../support/elements/axis-elements"
 import { ToolbarElements as toolbar } from "../support/elements/toolbar-elements"
 import { FormulaHelper as fh } from "../support/helpers/formula-helper"
 
-const expectedPercents = ["0", "100", "0", "0", "100", "0", "29.17", "33.33", "37.5"]
+const expectedPercents = [0, 100, 0, 0, 100, 0, 29, 33, 37]
 
 context("Graph adornments", () => {
   beforeEach(function () {
@@ -118,10 +118,13 @@ context("Graph adornments", () => {
 
     // Verify the approximate values of the percentages
     cy.get("[data-testid^=graph-count]").should("have.length", expectedPercents.length)
-      .each(($el, index) => {
-        const expected = expectedPercents[index]
-        cy.wrap($el).invoke("text").should("contain", expected)
+    .each(($el, index) => {
+      const expected = expectedPercents[index]
+      cy.wrap($el).invoke("text").then(text => {
+        const actual = parseFloat(text.replace("%", ""))
+        expect(actual).to.be.closeTo(expected, 1)  // Tolerance of 1 is safe due to CODAP-359
       })
+    })
   
     // Hide the percent values
     graph.getInspectorPalette()

--- a/v3/cypress/e2e/adornments.spec.ts
+++ b/v3/cypress/e2e/adornments.spec.ts
@@ -4,6 +4,8 @@ import { AxisElements as ae } from "../support/elements/axis-elements"
 import { ToolbarElements as toolbar } from "../support/elements/toolbar-elements"
 import { FormulaHelper as fh } from "../support/helpers/formula-helper"
 
+const expectedPercents = ["0", "100", "0", "0", "100", "0", "29.17", "33.33", "37.5"]
+
 context("Graph adornments", () => {
   beforeEach(function () {
     const queryParams = "?sample=mammals&dashboard&mouseSensor"
@@ -113,6 +115,13 @@ context("Graph adornments", () => {
     // Verify that at least one percent value is shown
     cy.get("[data-testid^=graph-count]").should("have.length.at.least", 1)
     cy.get("[data-testid^=graph-count]").first().should("contain.text", "%")
+
+    // Verify the approximate values of the percentages
+    cy.get("[data-testid^=graph-count]").should("have.length", expectedPercents.length)
+      .each(($el, index) => {
+        const expected = expectedPercents[index]
+        cy.wrap($el).invoke("text").should("contain", expected)
+      })
   
     // Hide the percent values
     graph.getInspectorPalette()

--- a/v3/cypress/e2e/adornments.spec.ts
+++ b/v3/cypress/e2e/adornments.spec.ts
@@ -91,45 +91,49 @@ context("Graph adornments", () => {
     toolbar.getRedoTool().click()
     cy.get("[data-testid=adornment-wrapper]").should("have.class", "hidden")
   })
-  // TODO: Reinstate this skipped test. Even though it passes locally, it fails in CI with an error saying
-  // the element with data-testid of `graph-adornments-grid__cell` cannot be found.
-  it.skip("adds a percent to graph when Percent checkbox is checked", () => {
+  it("should add a percent to graph when Percent checkbox is checked with undo/redo", () => {
     c.selectTile("graph", 0)
     cy.dragAttributeToTarget("table", "Diet", "bottom")
     cy.dragAttributeToTarget("table", "Habitat", "left")
+  
     graph.getDisplayValuesButton().click()
     graph.getInspectorPalette().should("be.visible")
-    graph.getInspectorPalette().find("[data-testid=adornment-checkbox-count-percent]").should("be.visible").click()
-    cy.wait(250)
+    graph.getInspectorPalette()
+      .find("[data-testid=adornment-checkbox-count-percent]")
+      .should("be.visible")
+      .click()
+  
+    // Wait for adornments to render
     cy.get("[data-testid=graph-adornments-grid]").should("exist")
-    cy.get("[data-testid=graph-adornments-grid]")
-      .find("[data-testid=graph-adornments-grid__cell]").should("have.length", 9)
     cy.get("[data-testid=adornment-wrapper]").should("have.length", 9)
-    cy.get("[data-testid=adornment-wrapper]").should("have.class", "visible")
-    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("exist")
-    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").first().should("have.text", "0%")
-    cy.wait(250)
-    graph.getInspectorPalette().find("[data-testid=adornment-checkbox-count-percent]").click()
-    cy.wait(250)
-    cy.get("[data-testid=adornment-wrapper]").should("have.class", "hidden")
-
-    // add tests for undo and redo for percent checkbox
+    cy.get("[data-testid=adornment-wrapper]").each(($el) => {
+      cy.wrap($el).should("have.class", "visible")
+    })
+  
+    // Verify that at least one percent value is shown
+    cy.get("[data-testid^=graph-count]").should("have.length.at.least", 1)
+    cy.get("[data-testid^=graph-count]").first().should("contain.text", "%")
+  
+    // Hide the percent values
+    graph.getInspectorPalette()
+      .find("[data-testid=adornment-checkbox-count-percent]")
+      .click()
+    cy.get("[data-testid=adornment-wrapper]").each(($el) => {
+      cy.wrap($el).should("have.class", "hidden")
+    })
+  
+    // Undo: percent should return
     toolbar.getUndoTool().click()
-    cy.wait(250)
-
-    // The percent should be visible again after an undo
-    cy.get("[data-testid=graph-adornments-grid]").should("exist")
-    cy.get("[data-testid=graph-adornments-grid]")
-      .find("[data-testid=graph-adornments-grid__cell]").should("have.length", 9)
-    cy.get("[data-testid=adornment-wrapper]").should("have.length", 9)
-    cy.get("[data-testid=adornment-wrapper]").should("have.class", "visible")
-    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").should("exist")
-    cy.get("[data-testid=graph-adornments-grid]").find("*[data-testid^=graph-count]").first().should("have.text", "0%")
-
-    // The percent should be hidden after a redo
+    cy.get("[data-testid=adornment-wrapper]").each(($el) => {
+      cy.wrap($el).should("have.class", "visible")
+    })
+    cy.get("[data-testid^=graph-count]").first().should("contain.text", "%")
+  
+    // Redo: percent should be hidden again
     toolbar.getRedoTool().click()
-    cy.wait(250)
-    cy.get("[data-testid=adornment-wrapper]").should("have.class", "hidden")
+    cy.get("[data-testid=adornment-wrapper]").each(($el) => {
+      cy.wrap($el).should("have.class", "hidden")
+    })
   })
   it("adds mean adornment to graph when Mean checkbox is checked", () => {
     c.selectTile("graph", 0)


### PR DESCRIPTION
[CODAP-354](https://concord-consortium.atlassian.net/browse/CODAP-354)

I decided to fix the percent adornment test today to prevent regressions in future builds.

Changes include:
- Replaced the flaky graph-adornments-grid__cell selector with more stable checks on [data-testid=adornment-wrapper].
- Confirmed percent values using [data-testid^=graph-count] to verify actual content is rendered as expected.
- Added a lightweight check to ensure the percent values aren’t all 100%. The expected values reflect what I saw when doing the test by hand.
- Introduced a small tolerance in the value checks to account for rounding differences, as per [CODAP-359](https://concord-consortium.atlassian.net/browse/CODAP-359), which notes that percent rounding behavior should match v2.

If desired, I can add more detailed checks in another story to validate the percent columns and cell display when radials are toggled on. For now, I just wanted to get a reliable test working in CI.

[CODAP-354]: https://concord-consortium.atlassian.net/browse/CODAP-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CODAP-359]: https://concord-consortium.atlassian.net/browse/CODAP-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ