### PR TITLE
feat: count adornment get returns counts per region (CODAP-68)

### DIFF
--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -161,6 +161,7 @@ context("codap plugins", () => {
     graph.getInspectorPalette().find("[data-testid=adornment-checkbox-mean]").click()
     graph.getInspectorPalette().find("[data-testid=adornment-toggle-otherValues]").click()
     graph.getInspectorPalette().find("[data-testid=adornment-button-movable-value--add]").click()
+    graph.getInspectorPalette().find("[data-testid=adornment-checkbox-count-percent]").click()
 
     openAPITester()
   
@@ -198,7 +199,7 @@ context("codap plugins", () => {
         expect(countInfo.type).to.equal("Count")
         expect(countInfo.isVisible).to.equal(true)
         expect(percentInfo.type).to.equal("Percent")
-        expect(percentInfo.isVisible).to.equal(false)
+        expect(percentInfo.isVisible).to.equal(true)
         expect(meanInfo.type).to.equal("Mean")
         expect(meanInfo.isVisible).to.equal(true)
         expect(movableValueInfo.type).to.equal("Movable Value")
@@ -226,6 +227,12 @@ context("codap plugins", () => {
         expect(countInfo.data[0].count).to.have.length(2)
         expect(countInfo.data[0].count[0]).to.be.a("number")
         expect(countInfo.data[0].count[1]).to.be.a("number")
+        const percents = countInfo.data[0].percent
+        expect(percents).to.be.an("array").with.length(2)
+        percents.forEach((p: string) => expect(p).to.match(/^\d+(\.\d+)?%$/))
+        // The sum of all percent values should be ~100%
+        const total = percents.reduce((sum: number, p: string) => sum + parseFloat(p), 0)
+        expect(total).to.be.closeTo(100, 0.1)
       })
       webView.clearAPITesterResponses()
 
@@ -265,7 +272,7 @@ context("codap plugins", () => {
           expect(countInfo.type).to.equal("Count")
           expect(countInfo.isVisible).to.equal(true)
           expect(percentInfo.type).to.equal("Percent")
-          expect(percentInfo.isVisible).to.equal(false)
+          expect(percentInfo.isVisible).to.equal(true)
         })
         webView.clearAPITesterResponses()
       })

--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -190,7 +190,7 @@ context("codap plugins", () => {
       webView.confirmAPITesterResponseContains(/"success":\s*true/)
       webView.getAPITesterResponse().then((value: any) => {
         const response = JSON.parse(value.eq(1).text())
-        expect(response.values.length).to.equal(3)
+        expect(response.values.length).to.equal(4)
         const countInfo = response.values[0]
         const percentInfo = response.values[1]
         const meanInfo = response.values[2]

--- a/v3/cypress/e2e/plugin.spec.ts
+++ b/v3/cypress/e2e/plugin.spec.ts
@@ -152,13 +152,15 @@ context("codap plugins", () => {
 
   it('will handle adornment-related requests', () => {
 
-    // Activate the Count/Percent and Mean adornments on the graph.
+    // Activate the Count/Percent, Mean, and Movable Value adornments on the graph.
     c.selectTile("graph", 0)
     ah.openAxisAttributeMenu("bottom")
     ah.selectMenuAttribute("Sleep", "bottom")
     graph.getDisplayValuesButton().click()
     graph.getInspectorPalette().find("[data-testid=adornment-checkbox-count-count]").click()
     graph.getInspectorPalette().find("[data-testid=adornment-checkbox-mean]").click()
+    graph.getInspectorPalette().find("[data-testid=adornment-toggle-otherValues]").click()
+    graph.getInspectorPalette().find("[data-testid=adornment-button-movable-value--add]").click()
 
     openAPITester()
   
@@ -192,12 +194,15 @@ context("codap plugins", () => {
         const countInfo = response.values[0]
         const percentInfo = response.values[1]
         const meanInfo = response.values[2]
+        const movableValueInfo = response.values[3]
         expect(countInfo.type).to.equal("Count")
         expect(countInfo.isVisible).to.equal(true)
         expect(percentInfo.type).to.equal("Percent")
         expect(percentInfo.isVisible).to.equal(false)
         expect(meanInfo.type).to.equal("Mean")
         expect(meanInfo.isVisible).to.equal(true)
+        expect(movableValueInfo.type).to.equal("Movable Value")
+        expect(movableValueInfo.isVisible).to.equal(true)
         const meanId = meanInfo.id
         cy.wrap(meanId).as('meanId')
       })
@@ -216,8 +221,11 @@ context("codap plugins", () => {
         expect(countInfo.id).to.be.a("string")
         expect(countInfo.isVisible).to.be.a("boolean")
         expect(countInfo.type).to.eq("Count")
-        expect(countInfo.data[0]).to.haveOwnProperty("count")
-        expect(countInfo.data[0].count).to.be.a("number")
+        // Since there is a Movable Value present, the count should be an array containing two numbers.
+        expect(countInfo.data[0].count).to.be.a("array")
+        expect(countInfo.data[0].count).to.have.length(2)
+        expect(countInfo.data[0].count[0]).to.be.a("number")
+        expect(countInfo.data[0].count[1]).to.be.a("number")
       })
       webView.clearAPITesterResponses()
 

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -110,9 +110,7 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
       plotWidth,
       scale,
       subPlotRegionBoundaries: subPlotRegionBoundariesRef.current,
-      isBinnedDotPlot: !!binnedDotPlot,
-      showCount: model.showCount,
-      showPercent: model.showPercent
+      isBinnedDotPlot: !!binnedDotPlot
     })
   
     // If there are no bin boundaries or movable values present, we just show a single case count.
@@ -126,7 +124,7 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
     } else {
       setDisplayCount(
         <>
-          {regionCounts.map((c: any, i: number) => {
+          {regionCounts.map((c: IRegionCount, i: number) => {
             const className = clsx("sub-count",
               {"x-axis": primaryAttrRole === "x"},
               {"y-axis": primaryAttrRole === "y"},

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -43,12 +43,6 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
   const prevSubPlotRegionWidth = useRef(plotWidth)
   const [displayCount, setDisplayCount] = useState(<div>{textContent}</div>)
 
-  const regionText = useCallback((regionCount: Partial<IRegionCount>) => {
-    const regionPercent = percentString((regionCount.count ?? 0) / casesInPlot)
-    const regionDisplayPercent = model.showCount ? ` (${regionPercent})` : regionPercent
-    return `${model.showCount ? regionCount.count : ""}${model.showPercent ? regionDisplayPercent : ""}`
-  }, [casesInPlot, model.showCount, model.showPercent])
-
   const subPlotRegionBoundaries = useCallback(() => {
       // Sub plot regions can be defined by either bin boundaries when points are grouped into bins, or by
       // instances of the movable value adornment. It should not be possible to have both bin boundaries and
@@ -68,6 +62,14 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
   }, [adornmentsStore, binnedDotPlot, dataConfig, graphModel, instanceKey])
 
   const subPlotRegionBoundariesRef = useRef(subPlotRegionBoundaries())
+
+  const regionText = useCallback((regionCount: Partial<IRegionCount>) => {
+    const regionPercent = subPlotRegionBoundariesRef.current.length < 3
+      ? percentString(model.percentValue(casesInPlot, cellKey, dataConfig))
+      : regionCount.percent ?? "0%"
+    const regionDisplayPercent = model.showCount ? ` (${regionPercent})` : regionPercent
+    return `${model.showCount ? regionCount.count : ""}${model.showPercent ? regionDisplayPercent : ""}`
+  }, [casesInPlot, cellKey, dataConfig, model])
 
   const resizeText = useCallback(() => {
     const minFontSize = 3

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -63,10 +63,10 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
 
   const subPlotRegionBoundariesRef = useRef(subPlotRegionBoundaries())
 
-  const regionText = useCallback((regionCount: Partial<IRegionCount>) => {
-    const regionPercent = subPlotRegionBoundariesRef.current.length < 3
-      ? percentString(model.percentValue(casesInPlot, cellKey, dataConfig))
-      : regionCount.percent ?? "0%"
+  const regionText = useCallback((regionCount: Partial<IRegionCount>, regionIndex = 0) => {
+    const regionPercent = percentString(
+      model.percentValue(casesInPlot, cellKey, dataConfig, subPlotRegionBoundariesRef.current, regionIndex)
+    )
     const regionDisplayPercent = model.showCount ? ` (${regionPercent})` : regionPercent
     return `${model.showCount ? regionCount.count : ""}${model.showPercent ? regionDisplayPercent : ""}`
   }, [casesInPlot, cellKey, dataConfig, model])
@@ -138,7 +138,7 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
             const style = primaryAttrRole === "x"
               ? { left: `${c.leftOffset}px`, width: `${c.width}px` }
               : { bottom: `${c.bottomOffset}px`, height: `${c.height}px` }
-            const regionTextContent = regionText(c)
+            const regionTextContent = regionText(c, i)
             return (
               <div key={`count-instance-${i}`} className={className} style={style}>
                 {regionTextContent}

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -64,8 +64,8 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
           maxBinEdge
         ] : []
       }
-      return adornmentsStore?.subPlotRegionBoundaries(instanceKey, scale) ?? []
-  }, [adornmentsStore, binnedDotPlot, dataConfig, graphModel, instanceKey, scale])
+      return adornmentsStore?.subPlotRegionBoundaries(instanceKey) ?? []
+  }, [adornmentsStore, binnedDotPlot, dataConfig, graphModel, instanceKey])
 
   const subPlotRegionBoundariesRef = useRef(subPlotRegionBoundaries())
 
@@ -105,14 +105,17 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
     const regionCounts = model.computeRegionCounts({
       cellKey,
       dataConfig,
+      // Points whose values match a region's upper boundary are treated differently based on
+      // what defines the regions. For regions defined by bins, points matching the upper boundary
+      // are placed into the next bin. So we set `inclusiveMax` to false. Otherwise, such points
+      // are considered within the boundary and `inclusiveMax` is true.
       inclusiveMax: !binnedDotPlot,
       plotHeight,
       plotWidth,
       scale,
-      subPlotRegionBoundaries: subPlotRegionBoundariesRef.current,
-      isBinnedDotPlot: !!binnedDotPlot
+      subPlotRegionBoundaries: subPlotRegionBoundariesRef.current
     })
-  
+
     // If there are no bin boundaries or movable values present, we just show a single case count.
     if (regionCounts.length === 1) {
       const regionTextContent = regionText(regionCounts[0])

--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -14,7 +14,7 @@ import { percentString } from "../../utilities/graph-utils"
 import { IAdornmentComponentProps } from "../adornment-component-info"
 import { kDefaultFontSize } from "../adornment-types"
 import { getAxisDomains } from "../utilities/adornment-utils"
-import { ICountAdornmentModel, IRegionCount, IRegionCountParams } from "./count-adornment-model"
+import { ICountAdornmentModel, IRegionCount } from "./count-adornment-model"
 
 import "./count-adornment-component.scss"
 
@@ -42,6 +42,12 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
   const prevCellWidth = useRef(plotWidth)
   const prevSubPlotRegionWidth = useRef(plotWidth)
   const [displayCount, setDisplayCount] = useState(<div>{textContent}</div>)
+
+  const regionText = useCallback((regionCount: Partial<IRegionCount>) => {
+    const regionPercent = percentString((regionCount.count ?? 0) / casesInPlot)
+    const regionDisplayPercent = model.showCount ? ` (${regionPercent})` : regionPercent
+    return `${model.showCount ? regionCount.count : ""}${model.showPercent ? regionDisplayPercent : ""}`
+  }, [casesInPlot, model.showCount, model.showPercent])
 
   const subPlotRegionBoundaries = useCallback(() => {
       // Sub plot regions can be defined by either bin boundaries when points are grouped into bins, or by
@@ -96,46 +102,50 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
     //
     // It should not be possible to have both bin boundaries and movable values present at the same time.
 
-    if (subPlotRegionBoundariesRef.current.length < 3 || !graphModel.plot.isUnivariateNumeric) {
-      // If there are no bin boundaries or movable values present, we just show a single case count.
-      setDisplayCount(<div>{textContent}</div>)
-      return
-    }
-
-    const regionCountParams: IRegionCountParams = {
+    const regionCounts = model.computeRegionCounts({
       cellKey,
       dataConfig,
-      // Points whose values match a region's upper boundary are treated differently based on what defines the regions.
-      // For regions defined by bins, points matching the upper boundary are placed into the next bin. So we set
-      // `inclusiveMax` to false. Otherwise, such points are considered within the boundary and `inclusiveMax` is true.
       inclusiveMax: !binnedDotPlot,
       plotHeight,
       plotWidth,
       scale,
       subPlotRegionBoundaries: subPlotRegionBoundariesRef.current,
+      isBinnedDotPlot: !!binnedDotPlot,
+      showCount: model.showCount,
+      showPercent: model.showPercent
+    })
+  
+    // If there are no bin boundaries or movable values present, we just show a single case count.
+    if (regionCounts.length === 1) {
+      const regionTextContent = regionText(regionCounts[0])
+      setDisplayCount(
+        <div>
+          {regionTextContent}
+        </div>
+      )
+    } else {
+      setDisplayCount(
+        <>
+          {regionCounts.map((c: any, i: number) => {
+            const className = clsx("sub-count",
+              {"x-axis": primaryAttrRole === "x"},
+              {"y-axis": primaryAttrRole === "y"},
+              {"binned-points-count": !!binnedDotPlot}
+            )
+            const style = primaryAttrRole === "x"
+              ? { left: `${c.leftOffset}px`, width: `${c.width}px` }
+              : { bottom: `${c.bottomOffset}px`, height: `${c.height}px` }
+            const regionTextContent = regionText(c)
+            return (
+              <div key={`count-instance-${i}`} className={className} style={style}>
+                {regionTextContent}
+              </div>
+            )
+          })}
+        </>
+      )
     }
-    const counts: IRegionCount[] = model.regionCounts(regionCountParams)
-    const className = clsx("sub-count",
-      {"x-axis": primaryAttrRole === "x"},
-      {"y-axis": primaryAttrRole === "y"},
-      {"binned-points-count": !!binnedDotPlot}
-    )
-    setDisplayCount(
-      <>
-        {counts.map((c, i) => {
-          const style = primaryAttrRole === "x"
-            ? { left: `${c.leftOffset}px`, width: `${c.width}px` }
-            : { bottom: `${c.bottomOffset}px`, height: `${c.height}px` }
-          const regionPercent = percentString(c.count / casesInPlot)
-          const regionDisplayPercent = model.showCount ? ` (${regionPercent})` : regionPercent
-          const regionTextContent = `${model.showCount ? c.count : ""}${model.showPercent ? regionDisplayPercent : ""}`
-
-          return <div key={`count-instance-${i}`} className={className} style={style}>{regionTextContent}</div>
-        })}
-      </>
-    )
-  }, [binnedDotPlot, casesInPlot, cellKey, dataConfig, graphModel, model,
-      plotHeight, plotWidth, primaryAttrRole, scale, textContent])
+  }, [binnedDotPlot, cellKey, dataConfig, model, plotHeight, plotWidth, primaryAttrRole, regionText, scale])
 
   useEffect(function resizeTextOnCellWidthChange() {
     return mstAutorun(() => {

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -11,6 +11,12 @@ describe("DataInteractive CountAdornmentHandler", () => {
 
   beforeEach(() => {
     mockDataConfig = {
+      attributeID: jest.fn(() => "attr1"),
+      attributeType: jest.fn(() => "numeric"),
+      dataset: {
+        getCasesForAttributes: jest.fn(() => [1, 1]),
+        getNumeric: jest.fn(() => 1)
+      },
       getAllCellKeys: jest.fn(() => [{}]),
       subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])
     }
@@ -19,6 +25,7 @@ describe("DataInteractive CountAdornmentHandler", () => {
     }
     
     mockCountAdornment = {
+      computeRegionCounts: jest.fn(() => [{ count: 2, percent: "50%" }]),
       id: "ADRN123",
       isVisible: true,
       percentValue: jest.fn(() => 0.5),
@@ -49,7 +56,6 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(result?.showCount).toBe(true)
     expect(result?.showPercent).toBe(true)
     expect(mockDataConfig.getAllCellKeys).toHaveBeenCalled()
-    expect(mockDataConfig.subPlotCases).toHaveBeenCalled()
   })
 
   it("get only returns a count when showCount is true and showPercent is false", () => {

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -2,9 +2,29 @@ import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornm
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isCountAdornment } from "./count-adornment-model"
-import { percentString } from "../../utilities/graph-utils"
 import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 import { kCountType } from "./count-adornment-types"
+import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
+import { scaleLinear } from "d3"
+
+const createScale = (dataConfig: IGraphDataConfigurationModel) => {
+  const primaryRole = dataConfig?.primaryRole ?? "x"
+  const attrType = dataConfig?.attributeType(primaryRole)
+  const attrId = dataConfig?.attributeID(primaryRole)
+  if (!attrId) return null
+
+  const cases = dataConfig?.dataset?.getCasesForAttributes([attrId]) || []
+  const values = cases.map(c => dataConfig?.dataset?.getNumeric(c.__id__, attrId)).filter(v => v !== undefined)
+  if (values.length === 0) return null
+
+  const minValue = Math.min(...values)
+  const maxValue = Math.max(...values)
+
+  if (attrType === "numeric") {
+    return scaleLinear().domain([minValue, maxValue]).range([0, 1])
+  }
+  return null
+}
 
 export const countAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
@@ -12,19 +32,43 @@ export const countAdornmentHandler: DIAdornmentHandler = {
 
     const { percentType, showCount, showPercent } = adornment
     const dataConfig = graphContent.dataConfiguration
-    const cellKeys = dataConfig?.getAllCellKeys()
+    const cellKeys = dataConfig.getAllCellKeys()
     const data: AdornmentData[] = []
+    const scale = createScale(dataConfig)
 
     for (const cellKey of cellKeys) {
-      const subPlotCases = dataConfig.subPlotCases(cellKey)
       const dataItem: AdornmentData = {}
+      if (!scale) return { success: false, values: { error: "Failed to create scale" } }
+
+      const subPlotRegionBoundaries =
+        graphContent.adornmentsStore?.subPlotRegionBoundaries(JSON.stringify(cellKey), scale)
+
+      const regionCounts = adornment.computeRegionCounts({
+        cellKey,
+        dataConfig,
+        inclusiveMax: false,
+        plotHeight: 0,
+        plotWidth: 0,
+        scale,
+        subPlotRegionBoundaries,
+        isBinnedDotPlot: false,
+        showCount,
+        showPercent
+      })
+
+      const regionCountValues = regionCounts.map(c => c.count)
+      const regionPercentValues = regionCounts.map(c => c.percent)
       
       if (showCount) {
-        dataItem.count = subPlotCases.length
+        dataItem.count = regionCountValues.length > 1
+          ? regionCountValues.filter((value): value is number => value !== undefined)
+          : regionCountValues[0]
       }
 
       if (showPercent) {
-        dataItem.percent = percentString(adornment.percentValue(subPlotCases.length, cellKey, dataConfig))
+        dataItem.percent = regionPercentValues.length > 1
+          ? regionPercentValues.filter((value): value is string => value !== undefined)
+          : regionPercentValues[0]
       }
     
       if (Object.keys(cellKey).length > 0) {

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -1,31 +1,9 @@
-import { scaleLinear } from "d3"
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
-import { errorResult } from "../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isCountAdornment } from "./count-adornment-model"
 import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 import { kCountType } from "./count-adornment-types"
-import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
-
-const createScale = (dataConfig: IGraphDataConfigurationModel) => {
-  const primaryRole = dataConfig?.primaryRole ?? "x"
-  const attrType = dataConfig?.attributeType(primaryRole)
-  const attrId = dataConfig?.attributeID(primaryRole)
-  if (!attrId) return null
-
-  const cases = dataConfig?.dataset?.getCasesForAttributes([attrId]) || []
-  const values = cases.map(c => dataConfig?.dataset?.getNumeric(c.__id__, attrId)).filter(v => v !== undefined)
-  if (values.length === 0) return null
-
-  const minValue = Math.min(...values)
-  const maxValue = Math.max(...values)
-
-  if (attrType === "numeric") {
-    return scaleLinear().domain([minValue, maxValue]).range([0, 1])
-  }
-  return null
-}
 
 export const countAdornmentHandler: DIAdornmentHandler = {
   get(adornment: IAdornmentModel, graphContent: IGraphContentModel) {
@@ -35,14 +13,11 @@ export const countAdornmentHandler: DIAdornmentHandler = {
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig.getAllCellKeys()
     const data: AdornmentData[] = []
-    const scale = createScale(dataConfig)
 
     for (const cellKey of cellKeys) {
       const dataItem: AdornmentData = {}
-      if (!scale) return errorResult("Failed to create scale")
 
-      const subPlotRegionBoundaries =
-        graphContent.adornmentsStore?.subPlotRegionBoundaries(JSON.stringify(cellKey), scale)
+      const subPlotRegionBoundaries = graphContent.adornmentsStore?.subPlotRegionBoundaries(JSON.stringify(cellKey))
 
       const regionCounts = adornment.computeRegionCounts({
         cellKey,
@@ -50,14 +25,12 @@ export const countAdornmentHandler: DIAdornmentHandler = {
         inclusiveMax: false,
         plotHeight: 0,
         plotWidth: 0,
-        scale,
-        subPlotRegionBoundaries,
-        isBinnedDotPlot: false
+        subPlotRegionBoundaries
       })
 
       const regionCountValues = regionCounts.map(c => c.count)
       const regionPercentValues = regionCounts.map(c => c.percent)
-      
+
       if (showCount) {
         dataItem.count = regionCountValues.length > 1
           ? regionCountValues.filter((value): value is number => value !== undefined)
@@ -69,11 +42,11 @@ export const countAdornmentHandler: DIAdornmentHandler = {
           ? regionPercentValues.filter((value): value is string => value !== undefined)
           : regionPercentValues[0]
       }
-    
+
       if (Object.keys(cellKey).length > 0) {
         dataItem.categories = cellKeyToCategories(cellKey, dataConfig)
       }
-    
+
       data.push(dataItem)
     }
 

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -1,11 +1,12 @@
+import { scaleLinear } from "d3"
 import { DIAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { errorResult } from "../../../../data-interactive/handlers/di-results"
 import { IGraphContentModel } from "../../models/graph-content-model"
 import { IAdornmentModel } from "../adornment-models"
 import { isCountAdornment } from "./count-adornment-model"
 import { AdornmentData, adornmentMismatchResult, cellKeyToCategories } from "../utilities/adornment-handler-utils"
 import { kCountType } from "./count-adornment-types"
 import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
-import { scaleLinear } from "d3"
 
 const createScale = (dataConfig: IGraphDataConfigurationModel) => {
   const primaryRole = dataConfig?.primaryRole ?? "x"
@@ -38,7 +39,7 @@ export const countAdornmentHandler: DIAdornmentHandler = {
 
     for (const cellKey of cellKeys) {
       const dataItem: AdornmentData = {}
-      if (!scale) return { success: false, values: { error: "Failed to create scale" } }
+      if (!scale) return errorResult("Failed to create scale")
 
       const subPlotRegionBoundaries =
         graphContent.adornmentsStore?.subPlotRegionBoundaries(JSON.stringify(cellKey), scale)
@@ -51,9 +52,7 @@ export const countAdornmentHandler: DIAdornmentHandler = {
         plotWidth: 0,
         scale,
         subPlotRegionBoundaries,
-        isBinnedDotPlot: false,
-        showCount,
-        showPercent
+        isBinnedDotPlot: false
       })
 
       const regionCountValues = regionCounts.map(c => c.count)

--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -53,11 +53,13 @@ export const CountAdornmentModel = AdornmentModel
       const primaryAttrRole = dataConfig?.primaryRole ?? "x"
       const attrId = dataConfig?.attributeID(primaryAttrRole)
       if (!attrId) return []
+
       let width = 0
       let height = 0
       let prevWidth = 0
       let prevHeight = 0
       const counts: IRegionCount[] = []
+
       // Set scale copy range. The scale copy is used when computing the coordinates of each region's upper and lower
       // boundaries. We modify the range of the scale copy to match the sub plot's width and height so they are computed
       // correctly. The original scales use the entire plot's width and height, which won't work when there are multiple
@@ -72,21 +74,21 @@ export const CountAdornmentModel = AdornmentModel
       }
 
       for (let i = 0; i < subPlotRegionBoundaries.length - 1; i++) {
-        const [domainMin, domainMax] = scaleCopy?.domain() ?? [0, 0]
-        const lowerBoundary = subPlotRegionBoundaries[i] === -Infinity
-          ? domainMin
-          : subPlotRegionBoundaries[i]
-        const upperBoundary = subPlotRegionBoundaries[i + 1] === Infinity
-          ? domainMax
-          : subPlotRegionBoundaries[i + 1]        
+        // For case counts, use the actual boundaries (-Infinity/Infinity).
+        const lowerBoundary = subPlotRegionBoundaries[i]
+        const upperBoundary = subPlotRegionBoundaries[i + 1]
         const casesInRange = dataConfig?.casesInRange(lowerBoundary, upperBoundary, attrId, cellKey, inclusiveMax) ?? []
         const count = casesInRange.length
+
+        // For pixel calculations, use the scale's domain.
         if (scaleCopy) {
-          const pixelMin = scaleCopy(lowerBoundary)
-          const pixelMax = scaleCopy(upperBoundary)
+          const [domainMin, domainMax] = scaleCopy.domain()
+          const pixelMin = scaleCopy(Math.max(lowerBoundary === -Infinity ? domainMin : lowerBoundary, domainMin))
+          const pixelMax = scaleCopy(Math.min(upperBoundary === Infinity ? domainMax : upperBoundary, domainMax))
           width = primaryAttrRole === "x" ? Math.abs(pixelMax - pixelMin) : 0
           height = primaryAttrRole === "x" ? 0 : Math.abs(pixelMax - pixelMin)
         }
+
         const leftOffset = prevWidth
         const bottomOffset = prevHeight
         prevWidth += width

--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -72,8 +72,13 @@ export const CountAdornmentModel = AdornmentModel
       }
 
       for (let i = 0; i < subPlotRegionBoundaries.length - 1; i++) {
-        const lowerBoundary = subPlotRegionBoundaries[i]
-        const upperBoundary = subPlotRegionBoundaries[i + 1]
+        const [domainMin, domainMax] = scaleCopy?.domain() ?? [0, 0]
+        const lowerBoundary = subPlotRegionBoundaries[i] === -Infinity
+          ? domainMin
+          : subPlotRegionBoundaries[i]
+        const upperBoundary = subPlotRegionBoundaries[i + 1] === Infinity
+          ? domainMax
+          : subPlotRegionBoundaries[i + 1]        
         const casesInRange = dataConfig?.casesInRange(lowerBoundary, upperBoundary, attrId, cellKey, inclusiveMax) ?? []
         const count = casesInRange.length
         if (scaleCopy) {

--- a/v3/src/components/graph/adornments/count/count-adornment-model.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-model.ts
@@ -4,12 +4,12 @@ import { kCountType } from "./count-adornment-types"
 import {IGraphDataConfigurationModel} from "../../models/graph-data-configuration-model"
 import { ScaleNumericBaseType } from "../../../axis/axis-types"
 import { percentString } from "../../utilities/graph-utils"
-
 export interface IRegionCount {
   bottomOffset: number
-  count: number
+  count?: number
   height: number
   leftOffset: number
+  percent?: string
   width: number
 }
 export interface IRegionCountParams {
@@ -89,16 +89,18 @@ export const CountAdornmentModel = AdornmentModel
   }))
   .views(self => ({
     computeRegionCounts({
-      cellKey, dataConfig, plotHeight, plotWidth, scale, subPlotRegionBoundaries, isBinnedDotPlot,
-      showCount, showPercent
+      cellKey, dataConfig, plotHeight, plotWidth, scale, subPlotRegionBoundaries, isBinnedDotPlot
     }: IRegionCountParams) {
       const totalCases = dataConfig?.filterCasesForDisplay(dataConfig?.subPlotCases(cellKey)).length ?? 0
       if (subPlotRegionBoundaries.length < 3) {
-        const casesInPlot = dataConfig?.filterCasesForDisplay(dataConfig.subPlotCases(cellKey)).length ?? 0
-        const percent = percentString(casesInPlot / totalCases)
+        const percent = totalCases > 0 ? "100%" : "0%"
         return [{
-          count: showCount ? casesInPlot : undefined,
-          percent: showPercent ? percent : undefined
+          bottomOffset: 0,
+          count: self.showCount ? totalCases : undefined,
+          height: plotHeight,
+          leftOffset: 0,
+          percent: self.showPercent ? percent : undefined,
+          width: plotWidth
         }]
       }
     
@@ -117,7 +119,7 @@ export const CountAdornmentModel = AdornmentModel
       })
     
       return counts.map((c) => {
-        const regionPercent = percentString(c.count / totalCases)
+        const regionPercent = percentString((c.count ?? 0) / totalCases)
         return {
           bottomOffset: c.bottomOffset,
           count: c.count,

--- a/v3/src/components/graph/adornments/store/adornments-base-store.ts
+++ b/v3/src/components/graph/adornments/store/adornments-base-store.ts
@@ -1,5 +1,4 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
-import { ScaleNumericBaseType } from "../../../axis/axis-types"
 import { getAdornmentComponentInfo } from "../adornment-component-info"
 import { AdornmentModelUnion, kDefaultFontSize } from "../adornment-types"
 import { IAdornmentModel, IUpdateCategoriesOptions } from "../adornment-models"
@@ -89,15 +88,13 @@ export const AdornmentsBaseStore = types.model("AdornmentsBaseStore", {
     const movableValues = movableValueAdornment?.values
     return !!movableValues?.size
   },
-  subPlotRegionBoundaries(key: string, scale: ScaleNumericBaseType) {
+  subPlotRegionBoundaries(key: string) {
     // When Movable Values are present, they define regions within a sub-plot which may affect the behavior of other
     // adornments. The Count/Percent adornment, for example, will show a count/percent per region. This view can be
-    // used by those adornments to determine the sub-region boundaries. The boundaries are simply the numeric values
-    // of each movable value in addition to the primary axis' min and max values.
-    const [axisMin, axisMax] = scale.domain() as [number, number]
+    // used by those adornments to determine the sub-region boundaries.
     const movableValueAdornment = self.findAdornmentOfType<IMovableValueAdornmentModel>(kMovableValueType)
     const movableValues = movableValueAdornment?.valuesForKey(key) ?? []
-    return [axisMin, ...movableValues, axisMax].sort((a: number, b: number) => a - b)
+    return [-Infinity, ...movableValues, Infinity].sort((a: number, b: number) => a - b)
   },
   get activeBannerCount() {
     return self.adornments.filter(adornment => {

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
@@ -4,7 +4,7 @@ import { IDataConfigurationModel } from "../../../data-display/models/data-confi
 
 export type AdornmentData = {
   categories?: Record<string, string>;
-} & Record<string, number | number[] | string | undefined | null | ((x: number) => void)>
+} & Record<string, number | number[] | string | string[] | undefined | null | ((x: number) => void)>
 
 export const cellKeyToCategories = (cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) => {
   const categories: Record<string, string> = {}


### PR DESCRIPTION
[[CODAP-68](https://concord-consortium.atlassian.net/browse/CODAP-68)]

This is a redo of [this PR](https://github.com/concord-consortium/codap/pull/1878) which added support for counts per region to the Count/Percent adornment's `get` API handler response. Additional changes fix a bug that PR introduced where percent values were not always calculated correctly. That bug is described in this story: [[CODAP-353](https://concord-consortium.atlassian.net/browse/CODAP-353)].

[CODAP-68]: https://concord-consortium.atlassian.net/browse/CODAP-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CODAP-353]: https://concord-consortium.atlassian.net/browse/CODAP-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ