### PR TITLE
Percent Bar Charts

### DIFF
--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -1,6 +1,6 @@
 import { format, ScaleLinear, select } from "d3"
 import { between } from "../../../utilities/math-utils"
-import { isNumericOrCountAxisModel } from "../models/axis-model"
+import { isNumericOrCountOrPercentAxisModel } from "../models/axis-model"
 import { transitionDuration } from "../../data-display/data-display-types"
 import { computeBestNumberOfTicks } from "../axis-utils"
 import { AxisScaleType, otherPlace } from "../axis-types"
@@ -58,7 +58,7 @@ export class NumericAxisHelper extends AxisHelper {
     const numericScale = this.multiScale?.scaleType === "linear"
       ? this.multiScale.numericScale?.copy().range(this.newRange) as ScaleLinear<number, number>
       : undefined
-    if (!isNumericOrCountAxisModel(this.axisModel) || !numericScale || !this.subAxisElt) return
+    if (!isNumericOrCountOrPercentAxisModel(this.axisModel) || !numericScale || !this.subAxisElt) return
 
     const subAxisSelection = select(this.subAxisElt)
     // Simplest if we remove everything and start again. Without this, #188523090 caused trouble

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -69,6 +69,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
     let ticks: string[] = []
     switch (axisType) {
       case 'count':
+      case 'percent':
       case 'numeric': {
         ticks = getTicks({d3Scale, isBinned, multiScale, displayModel})
         desiredExtent += ['left', 'rightNumeric'].includes(axisPlace)

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -245,6 +245,7 @@ export const useSubAxis = ({
           helper = new EmptyAxisHelper(helperProps)
           break
         case 'count':
+        case 'percent':
         case 'numeric':
           helper = new NumericAxisHelper(
             { ...helperProps, showScatterPlotGridLines, showZeroAxisLine })

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -200,7 +200,7 @@ export function isCountAxisModel(axisModel?: IAxisModel): axisModel is ICountAxi
 }
 
 export function isNumericOrCountOrPercentAxisModel(axisModel?: IAxisModel):
-    axisModel is INumericAxisModel | IDateAxisModel | ICountAxisModel | IPercentAxisModel {
+    axisModel is INumericAxisModel | ICountAxisModel | IPercentAxisModel {
   return isNumericAxisModel(axisModel) || isCountAxisModel(axisModel) || isPercentAxisModel(axisModel)
 }
 

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -162,18 +162,36 @@ export function isNumericAxisModel(axisModel?: IAxisModel): axisModel is INumeri
   return axisModel?.type === "numeric"
 }
 
+export const PercentAxisModel = BaseNumericAxisModel
+  .named("PercentAxisModel")
+  .props({
+    type: types.optional(types.literal("percent"), "percent")
+  })
+  .views(self => ({
+    get lockZero() {
+      return true
+    },
+  }))
+export interface IPercentAxisModel extends Instance<typeof PercentAxisModel> {}
+export interface IPercentAxisModelSnapshot extends SnapshotIn<typeof PercentAxisModel> {}
+export function isPercentAxisModel(axisModel?: IAxisModel): axisModel is IPercentAxisModel {
+  return axisModel?.type === "percent"
+}
+
+// ToDo: It _should_ be possible to have CountAxisModel inherit from PercentAxisModel and get rid of lockZero
+//  but it causes a strange typescript error in graph-content-model.ts
 export const CountAxisModel = BaseNumericAxisModel
   .named("CountAxisModel")
   .props({
     type: types.optional(types.literal("count"), "count")
   })
   .views(self => ({
-    get integersOnly() {
-      return true
-    },
     get lockZero() {
       return true
     },
+    get integersOnly() {
+      return true
+    }
   }))
 export interface ICountAxisModel extends Instance<typeof CountAxisModel> {}
 export interface ICountAxisModelSnapshot extends SnapshotIn<typeof CountAxisModel> {}
@@ -181,8 +199,9 @@ export function isCountAxisModel(axisModel?: IAxisModel): axisModel is ICountAxi
   return axisModel?.type === "count"
 }
 
-export function isNumericOrCountAxisModel(axisModel?: IAxisModel): axisModel is INumericAxisModel | IDateAxisModel {
-  return isNumericAxisModel(axisModel) || isCountAxisModel(axisModel)
+export function isNumericOrCountOrPercentAxisModel(axisModel?: IAxisModel):
+    axisModel is INumericAxisModel | IDateAxisModel {
+  return isNumericAxisModel(axisModel) || isCountAxisModel(axisModel) || isPercentAxisModel(axisModel)
 }
 
 export const DateAxisModel = BaseNumericAxisModel
@@ -210,17 +229,18 @@ export function isDateAxisModel(axisModel?: IAxisModel): axisModel is IDateAxisM
 }
 
 export function isBaseNumericAxisModel(axisModel?: IAxisModel): axisModel is INumericAxisModel | IDateAxisModel {
-  return isNumericAxisModel(axisModel) || isCountAxisModel(axisModel) || isDateAxisModel(axisModel)
+  return isNumericAxisModel(axisModel) || isCountAxisModel(axisModel) || isPercentAxisModel(axisModel) ||
+    isDateAxisModel(axisModel)
 }
 
 export const AxisModelUnion =
-  types.union(EmptyAxisModel, CategoricalAxisModel, NumericAxisModel, CountAxisModel, DateAxisModel)
+  types.union(EmptyAxisModel, CategoricalAxisModel, NumericAxisModel, CountAxisModel, PercentAxisModel, DateAxisModel)
 export type IAxisModelUnion =
-  IEmptyAxisModel | ICategoricalAxisModel | INumericAxisModel | ICountAxisModel | IDateAxisModel
+  IEmptyAxisModel | ICategoricalAxisModel | INumericAxisModel | ICountAxisModel | IPercentAxisModel | IDateAxisModel
 export type IAxisModelSnapshotUnion = IEmptyAxisModelSnapshot | ICategoricalAxisModelSnapshot |
-  INumericAxisModelSnapshot | ICountAxisModelSnapshot | IDateAxisModelSnapshot
+  INumericAxisModelSnapshot | ICountAxisModelSnapshot | IPercentAxisModelSnapshot | IDateAxisModelSnapshot
 
 export function isAxisModelInUnion(model: IAxisModel): model is IAxisModelUnion {
   return isEmptyAxisModel(model) || isCategoricalAxisModel(model) ||
-          isNumericAxisModel(model) || isCountAxisModel(model) || isDateAxisModel(model)
+          isNumericAxisModel(model) || isCountAxisModel(model) || isPercentAxisModel(model) || isDateAxisModel(model)
 }

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -200,7 +200,7 @@ export function isCountAxisModel(axisModel?: IAxisModel): axisModel is ICountAxi
 }
 
 export function isNumericOrCountOrPercentAxisModel(axisModel?: IAxisModel):
-    axisModel is INumericAxisModel | IDateAxisModel {
+    axisModel is INumericAxisModel | IDateAxisModel | ICountAxisModel | IPercentAxisModel {
   return isNumericAxisModel(axisModel) || isCountAxisModel(axisModel) || isPercentAxisModel(axisModel)
 }
 

--- a/v3/src/components/graph/components/graph-attribute-label.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label.tsx
@@ -62,15 +62,14 @@ export const GraphAttributeLabel =
       }
       const attrIDs = getAttributeIDs()
       const secondaryPlace = dataConfiguration?.secondaryRole === "x" ? "bottom" : "left"
-      if (graphModel.pointsFusedIntoBars && place === secondaryPlace) {
-        return t("DG.CountAxisView.countLabel")
+      if (place === secondaryPlace && graphModel?.plot.hasCountPercentFormulaAxis) {
+        return graphModel?.plot.countPercentFormulaAxisLabel || ''
       }
       return attrIDs.map(anID => dataset?.attrFromID(anID))
                     .filter(attr => attr?.name !== '')
                     .map(attr => `${attr?.name}${attr?.units ? ` (${attr?.units})` : ""}`.trim())
                     .join(', ')
-    }, [dataConfiguration?.secondaryRole, dataset, getAttributeIDs, getClickHereCue,
-      graphModel.pointsFusedIntoBars, place])
+    }, [dataConfiguration?.secondaryRole, dataset, getAttributeIDs, getClickHereCue, graphModel?.plot, place])
 
     const refreshAxisTitle = useCallback(() => {
 

--- a/v3/src/components/graph/components/inspector-panel/graph-measure-palette.tsx
+++ b/v3/src/components/graph/components/inspector-panel/graph-measure-palette.tsx
@@ -37,7 +37,7 @@ export const GraphMeasurePalette = observer(function GraphMeasurePalette({
       buttonRect={buttonRect}
     >
       <Flex className="palette-form" direction="column">
-        <Box className="form-title">Show ...</Box>
+        <Box className="form-title">{t("DG.Inspector.displayShow")}</Box>
         {graphModel && measures?.map(measureOrGroup => {
           if (isGroupItem(measureOrGroup)) {
             return (

--- a/v3/src/components/graph/graphing-types.ts
+++ b/v3/src/components/graph/graphing-types.ts
@@ -53,7 +53,7 @@ export function isUnivariateNumericPlotType(plotType: PlotType): boolean {
   return ["dotPlot", "binnedDotPlot", "histogram", "linePlot"].includes(plotType)
 }
 
-export const BreakdownTypes = ["count", "percent"] as const
+export const BreakdownTypes = ["count", "percent", "formula"] as const
 export type BreakdownType = typeof BreakdownTypes[number]
 
 export const kGraphClass = "graph-plot"

--- a/v3/src/components/graph/hooks/use-chart-dots.ts
+++ b/v3/src/components/graph/hooks/use-chart-dots.ts
@@ -5,6 +5,7 @@ import { setPointSelection } from "../../data-display/data-display-utils"
 import { useDataDisplayAnimation } from "../../data-display/hooks/use-data-display-animation"
 import { SubPlotCells } from "../models/sub-plot-cells"
 import { PixiPoints } from "../../data-display/pixi/pixi-points"
+import { barCompressionFactorForCase } from "../plots/bar-utils"
 import { useGraphContentModelContext } from "./use-graph-content-model-context"
 import { useGraphDataConfigurationContext } from "./use-graph-data-configuration-context"
 import { useGraphLayoutContext } from "./use-graph-layout-context"
@@ -60,9 +61,10 @@ export const useChartDots = (pixiPoints?: PixiPoints) => {
     const cellIndex = cellIndices[anID]
     if (!cellIndex) return 0
 
+    const barHeightFactor = barCompressionFactorForCase(anID, graphModel)
     const { row } = cellIndices[anID]
     const { s, es } = cellIndices[anID].cell
-    const barHeight = secondaryNumericUnitLength
+    const barHeight = secondaryNumericUnitLength * barHeightFactor
     const baseHeight = pointsFusedIntoBars
       ? (row + baselineOffset) * barHeight - barHeight
       : (row + baselineOffset) * pointDiameter + row * overlap

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -198,10 +198,10 @@ export const GraphContentModel = DataDisplayContentModel
       // At the plot level we can't install a new axis. But a plot can change in such a way that it
       // requires a new secondary axis. When our plot is patched, we pass the patch to it and allow it to
       // tell us about any required new secondary axis.
+      // Todo: Kirk will figure out how to do the right thing with disposing stuff
       addDisposer(self, onPatch(self.plot, (patch) => {
         const newSecondaryAxis = self.plot.newSecondaryAxisRequired(patch)
         if (newSecondaryAxis) {
-          console.log("installing new secondary axis")
           this.setAxis(self.secondaryPlace, newSecondaryAxis)
         }
       }))

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -4,7 +4,7 @@
  */
 import {isEqual} from "lodash"
 import { comparer, reaction, when } from "mobx"
-import {addDisposer, getSnapshot, Instance, SnapshotIn, types} from "mobx-state-tree"
+import { addDisposer, getSnapshot, Instance, onPatch, SnapshotIn, types } from "mobx-state-tree"
 import { isNumericAttributeType } from "../../../models/data/attribute-types"
 import {IDataSet} from "../../../models/data/data-set"
 import {applyModelChange} from "../../../models/history/apply-model-change"
@@ -22,7 +22,7 @@ import {GraphPlace} from "../../axis-graph-shared"
 import {AxisPlace, AxisPlaces, IAxisTicks, ScaleNumericBaseType, TickFormatter} from "../../axis/axis-types"
 import {
   AxisModelUnion, EmptyAxisModel, IAxisModel, IAxisModelSnapshot, IAxisModelSnapshotUnion, IAxisModelUnion,
-  INumericAxisModelSnapshot, isAxisModelInUnion, isBaseNumericAxisModel
+  INumericAxisModelSnapshot, isAxisModelInUnion, isBaseNumericAxisModel, isPercentAxisModel
 } from "../../axis/models/axis-model"
 import { CaseData } from "../../data-display/d3-types"
 import {DataDisplayContentModel} from "../../data-display/models/data-display-content-model"
@@ -127,6 +127,9 @@ export const GraphContentModel = DataDisplayContentModel
     get secondaryAxis() {
       return this.getAxis(this.secondaryPlace)
     },
+    get secondaryAxisIsPercent() {
+      return isPercentAxisModel(this.secondaryAxis)
+    },
     getAxis(place: AxisPlace) {
       return self.axes.get(place)
     },
@@ -186,6 +189,23 @@ export const GraphContentModel = DataDisplayContentModel
     }
   }))
   .actions(self => ({
+    setAxis(place: AxisPlace, axis: IAxisModel) {
+      if (isAxisModelInUnion(axis)) {
+        self.axes.set(place, axis)
+      }
+    },
+    installPlotPatchDisposer() {
+      // At the plot level we can't install a new axis. But a plot can change in such a way that it
+      // requires a new secondary axis. When our plot is patched, we pass the patch to it and allow it to
+      // tell us about any required new secondary axis.
+      addDisposer(self, onPatch(self.plot, (patch) => {
+        const newSecondaryAxis = self.plot.newSecondaryAxisRequired(patch)
+        if (newSecondaryAxis) {
+          console.log("installing new secondary axis")
+          this.setAxis(self.secondaryPlace, newSecondaryAxis)
+        }
+      }))
+    },
     async afterAttachToDocument() {
       if (!self.tileEnv?.sharedModelManager?.isReady) {
         await when(() => !!self.tileEnv?.sharedModelManager?.isReady)
@@ -202,6 +222,7 @@ export const GraphContentModel = DataDisplayContentModel
       )
 
       self.installSharedModelManagerSync()
+      this.installPlotPatchDisposer()
 
       // update adornments when case data changes
       addDisposer(self, mstAutorun(function updateAdornments() {
@@ -221,6 +242,7 @@ export const GraphContentModel = DataDisplayContentModel
           }
       }, {name: "GraphContentModel.afterAttachToDocument.updateAdornments", equals: comparer.structural},
         self.dataConfiguration))
+
     },
     beforeDestroy() {
       self.formulaAdapters.forEach(adapter => {
@@ -248,6 +270,8 @@ export const GraphContentModel = DataDisplayContentModel
           self.plot.resetSettings({ isBinnedPlotChanged: prevPlotWasBinned !== self.plot.isBinned })
         }
       }
+      self.installPlotPatchDisposer()
+
     },
     setPlotType(type: PlotType) {
       if (type !== self.plot.type) {
@@ -417,11 +441,6 @@ export const GraphContentModel = DataDisplayContentModel
         })
       }
     },
-    setAxis(place: AxisPlace, axis: IAxisModel) {
-      if (isAxisModelInUnion(axis)) {
-        self.axes.set(place, axis)
-      }
-    },
     removeAxis(place: AxisPlace) {
       self.axes.delete(place)
     },
@@ -446,7 +465,7 @@ export const GraphContentModel = DataDisplayContentModel
     },
     setGraphProperties(props: GraphProperties) {
       (Object.keys(props.axes) as AxisPlace[]).forEach(aKey => {
-        this.setAxis(aKey, props.axes[aKey])
+        self.setAxis(aKey, props.axes[aKey])
       })
       self.setPlotType(props.plotType)
     },
@@ -554,11 +573,15 @@ export const GraphContentModel = DataDisplayContentModel
         const attrType = self.dataConfiguration.attributeType(role)
         return !!attrType && ["numeric", "date"].includes(attrType)
       }
+      function isCategoricalRole(role?: GraphAttrRole) {
+        return role && self.dataConfiguration.attributeType(role) === 'categorical'
+      }
       const numericAttrCount = PrimaryAttrRoles.map(role => isNumericRole(role))
                                   .filter(Boolean).length
       let newPlotType: Maybe<PlotType>
       if (numericAttrCount === 0) {
-        if (!self.plot.isCategorical) {
+        const secondaryAttrIsCategorical = isCategoricalRole(self.dataConfiguration.secondaryRole)
+        if (!self.plot.isCategorical || (self.plotType === "barChart" && secondaryAttrIsCategorical)) {
           newPlotType = "dotChart"
         }
       }

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -198,7 +198,6 @@ export const GraphContentModel = DataDisplayContentModel
       // At the plot level we can't install a new axis. But a plot can change in such a way that it
       // requires a new secondary axis. When our plot is patched, we pass the patch to it and allow it to
       // tell us about any required new secondary axis.
-      // Todo: Kirk will figure out how to do the right thing with disposing stuff
       addDisposer(self, onPatch(self.plot, (patch) => {
         const newSecondaryAxis = self.plot.newSecondaryAxisRequired(patch)
         if (newSecondaryAxis) {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -45,7 +45,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     showMeasuresForSelection: types.maybe(types.boolean),
   })
   .views(self => ({
-    get secondaryRole(): Maybe<AttrRole> {
+    get secondaryRole(): Maybe<'x' | 'y'> {
       return self.primaryRole === 'x' ? 'y'
         : self.primaryRole === 'y' ? 'x'
           : undefined
@@ -332,19 +332,19 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         const primaryValue = totalNumberOfBins > 0
                                ? Math.floor((Number(aValue.primary) - minValue) / binWidth)
                                : aValue.primary
-        if (bins[primaryValue] === undefined) {
-          bins[primaryValue] = {}
+        if (bins[aValue.extraPrimary] === undefined) {
+          bins[aValue.extraPrimary] = {}
         }
-        if (bins[primaryValue][aValue.secondary] === undefined) {
-          bins[primaryValue][aValue.secondary] = {}
+        if (bins[aValue.extraPrimary][aValue.extraSecondary] === undefined) {
+          bins[aValue.extraPrimary][aValue.extraSecondary] = {}
         }
-        if (bins[primaryValue][aValue.secondary][aValue.extraPrimary] === undefined) {
-          bins[primaryValue][aValue.secondary][aValue.extraPrimary] = {}
+        if (bins[aValue.extraPrimary][aValue.extraSecondary][primaryValue] === undefined) {
+          bins[aValue.extraPrimary][aValue.extraSecondary][primaryValue] = {}
         }
-        if (bins[primaryValue][aValue.secondary][aValue.extraPrimary][aValue.extraSecondary] === undefined) {
-          bins[primaryValue][aValue.secondary][aValue.extraPrimary][aValue.extraSecondary] = 0
+        if (bins[aValue.extraPrimary][aValue.extraSecondary][primaryValue][aValue.secondary] === undefined) {
+          bins[aValue.extraPrimary][aValue.extraSecondary][primaryValue][aValue.secondary] = 0
         }
-        bins[primaryValue][aValue.secondary][aValue.extraPrimary][aValue.extraSecondary]++
+        bins[aValue.extraPrimary][aValue.extraSecondary][primaryValue][aValue.secondary]++
       })
 
       return bins
@@ -354,15 +354,41 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     maxOverAllCells(extraPrimaryAttrRole: AttrRole, extraSecondaryAttrRole: AttrRole) {
       const bins = self.cellMap(extraPrimaryAttrRole, extraSecondaryAttrRole)
       // Find and return the maximum value in the bins
-      return Object.keys(bins).reduce((hMax, hKey) => {
-        return Math.max(hMax, Object.keys(bins[hKey]).reduce((vMax, vKey) => {
-          return Math.max(vMax, Object.keys(bins[hKey][vKey]).reduce((epMax, epKey) => {
-            return Math.max(epMax, Object.keys(bins[hKey][vKey][epKey]).reduce((esMax, esKey) => {
-              return Math.max(esMax, bins[hKey][vKey][epKey][esKey])
+      return Object.keys(bins).reduce((epMax, epKey) => {
+        return Math.max(epMax, Object.keys(bins[epKey]).reduce((esMax, esKey) => {
+          return Math.max(esMax, Object.keys(bins[epKey][esKey]).reduce((pMax, pKey) => {
+            return Math.max(pMax, Object.keys(bins[epKey][esKey][pKey]).reduce((sMax, sKey) => {
+              return Math.max(sMax, bins[epKey][esKey][pKey][sKey])
             }, 0))
           }, 0))
         }, 0))
       }, 0)
+    },
+    maxPercentAllCells(extraPrimaryAttrRole: AttrRole, extraSecondaryAttrRole: AttrRole) {
+      if (self.attributeID('legend')) return 100  // because we divide the full bar into categories
+      const bins = self.cellMap(extraPrimaryAttrRole, extraSecondaryAttrRole)
+      // Each ep/es pair defines a "subPlot" with a total number of cases and a cell with a max percentage
+      let maxPercent = 0
+      for (const epKey in bins) {
+        const epBin = bins[epKey]
+        for (const esKey in epBin) {
+          const esBin = epBin[esKey]
+          let numCasesInSubPlot = 0
+          let maxCasesInCell = 0
+          for (const pKey in esBin) {
+            const pBin = esBin[pKey]
+            for (const sKey in pBin) {
+              const sBin = pBin[sKey]
+              numCasesInSubPlot += sBin
+              maxCasesInCell = Math.max(maxCasesInCell, sBin)
+            }
+          }
+          const subPlotMaxPercent = numCasesInSubPlot === 0 ? 0
+            : Math.max(maxPercent, 100 * maxCasesInCell / numCasesInSubPlot)
+          maxPercent = Math.max(maxPercent, subPlotMaxPercent)
+        }
+      }
+      return maxPercent
     },
     maxCellLength(
       extraPrimaryAttrRole: AttrRole, extraSecondaryAttrRole: AttrRole,
@@ -371,15 +397,15 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       const bins = self.cellMap(extraPrimaryAttrRole, extraSecondaryAttrRole, binWidth, minValue, totalNumberOfBins)
       // Find and return the length of the record in bins with the most elements
       let maxInBin = 0
-      for (const pKey in bins) {
-        const pBin = bins[pKey]
-        for (const sKey in pBin) {
-          const sBin = pBin[sKey]
-          for (const epKey in sBin) {
-            const epBin = sBin[epKey]
-            for (const esKey in epBin) {
-              const esBin = epBin[esKey]
-              maxInBin = Math.max(maxInBin, esBin)
+      for (const epKey in bins) {
+        const epBin = bins[epKey]
+        for (const esKey in epBin) {
+          const esBin = epBin[esKey]
+          for (const pKey in esBin) {
+            const pBin = esBin[pKey]
+            for (const sKey in pBin) {
+              const sBin = pBin[sKey]
+              maxInBin = Math.max(maxInBin, sBin)
             }
           }
         }
@@ -504,6 +530,21 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       },
       name: "subPlotCases"
     }),
+    subPlotKeyFromExtraCategories(extraPrimaryCategory: string, extraSecondaryCategory: string) {
+      const primaryAttrRole = self.primaryRole ?? "x"
+      const primaryIsBottom = primaryAttrRole === "x"
+      const extraPrimaryRole = primaryIsBottom ? "topSplit" : "rightSplit"
+      const extraPrimaryAttrID = self.attributeID(extraPrimaryRole) ?? ""
+      const extraSecondaryRole = primaryIsBottom ? "rightSplit" : "topSplit"
+      const extraSecondaryAttrID = self.attributeID(extraSecondaryRole) ?? ""
+      const key: Record<string, string> = {}
+      extraSecondaryAttrID && (key[extraSecondaryAttrID] = extraSecondaryCategory)
+      extraPrimaryAttrID && (key[extraPrimaryAttrID] = extraPrimaryCategory)
+      return key
+    },
+    numCasesInSubPlotGivenCategories(extraPrimaryCategory: string, extraSecondaryCategory: string) {
+      return this.subPlotCases(this.subPlotKeyFromExtraCategories(extraPrimaryCategory, extraSecondaryCategory)).length
+    },
     cellCases: cachedFnWithArgsFactory({
       key: (cellKey: Record<string, string>) => JSON.stringify(cellKey),
       calculate: (cellKey: Record<string, string>) => {

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
@@ -22,6 +22,7 @@ export const BarChartModel = DotChartModel
   .actions(self => ({
     setBreakdownType(type: BreakdownType) {
       self.breakdownType = type
+      if (type !== 'formula') self.expression = undefined
     },
     setExpression(expression: IFormula) {
       self.expression = expression

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
@@ -1,12 +1,12 @@
 import { format } from "d3-format"
-import { Instance, SnapshotIn, types } from "mobx-state-tree"
+import { IJsonPatch, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { AttributeType } from "../../../../models/data/attribute-types"
-import { Formula } from "../../../../models/formula/formula"
+import { Formula, IFormula } from "../../../../models/formula/formula"
 import { t } from "../../../../utilities/translation/translate"
 import { AxisPlace } from "../../../axis/axis-types"
 import { IAxisModel } from "../../../axis/models/axis-model"
 import { PointDisplayType } from "../../../data-display/data-display-types"
-import { BreakdownTypes } from "../../graphing-types"
+import { BreakdownType, BreakdownTypes } from "../../graphing-types"
 import { DotChartModel } from "../dot-chart/dot-chart-model"
 import { IBarTipTextProps, IPlotModel, typesPlotType } from "../plot-model"
 
@@ -16,9 +16,17 @@ export const BarChartModel = DotChartModel
   .named("BarChartModel")
   .props({
     type: typesPlotType("barChart"),
-    breakdownType: types.maybe(types.enumeration([...BreakdownTypes])),
+    breakdownType: types.optional(types.enumeration([...BreakdownTypes]), "count"),
     expression: types.maybe(Formula)
   })
+  .actions(self => ({
+    setBreakdownType(type: BreakdownType) {
+      self.breakdownType = type
+    },
+    setExpression(expression: IFormula) {
+      self.expression = expression
+    }
+  }))
   .views(self => ({
     get displayType(): PointDisplayType {
       return "bars"
@@ -26,8 +34,20 @@ export const BarChartModel = DotChartModel
     get hasPointsFusedIntoBars(): boolean {
       return true
     },
-    get hasCountAxis(): boolean {
+    get hasCountPercentFormulaAxis(): boolean {
       return true
+    },
+    get countPercentFormulaAxisLabel(): string {
+      switch (self.breakdownType) {
+        case "count":
+          return t("DG.CountAxisView.countLabel")
+        case "percent":
+          return t("DG.CountAxisView.percentLabel")
+        case "formula":
+          return self.expression?.display ?? ""
+        default:
+          return ''
+      }
     },
     get hasDraggableNumericAxis() {
       return true
@@ -36,10 +56,27 @@ export const BarChartModel = DotChartModel
       return !!self.expression && !self.expression.empty
     },
     getValidSecondaryAxis(place: AxisPlace, attrType?: AttributeType, axisModel?: IAxisModel): IAxisModel {
-      return self.getValidCountAxis(place, attrType, axisModel)
+      switch (self.breakdownType) {
+        case "count":
+          return self.getValidCountAxis(place, attrType, axisModel)
+        case "percent":
+          return self.getValidPercentAxis(place, attrType, axisModel)
+        default:
+          return self.getValidNumericOrDateAxis(place, attrType, axisModel)
+      }
     },
     get showZeroLine() {
       return true
+    },
+    get showBreakdownTypes(): boolean {
+      return true
+    },
+    newSecondaryAxisRequired(patch: IJsonPatch): false | IAxisModel {
+      if (patch.path.includes("breakdownType")) {
+        const secondaryPlace = self.dataConfiguration?.secondaryRole === "x" ? "bottom" : "left"
+        return this.getValidSecondaryAxis(secondaryPlace)
+      }
+      return false
     },
     barTipText(props: IBarTipTextProps) {
       const { dataset } = self.dataConfiguration ?? {}
@@ -78,6 +115,6 @@ export const BarChartModel = DotChartModel
   }))
 export interface IBarChartModel extends Instance<typeof BarChartModel> {}
 export interface IBarChartSnapshot extends SnapshotIn<typeof BarChartModel> {}
-export function isBarChartModel(model: IPlotModel): model is IBarChartModel {
-  return model.type === "barChart"
+export function isBarChartModel(model?: IPlotModel): model is IBarChartModel {
+  return model?.type === "barChart"
 }

--- a/v3/src/components/graph/plots/bar-utils.ts
+++ b/v3/src/components/graph/plots/bar-utils.ts
@@ -19,10 +19,13 @@ export interface IBarCoverDimensionsProps {
   maxInCell: number
   minInCell?: number
   primCatsCount: number
+  isPercentAxis: boolean
+  numInSubPlot: number
 }
 
 export const barCoverDimensions = (props: IBarCoverDimensionsProps) => {
-  const { subPlotCells, cellIndices, maxInCell, minInCell = 0, primCatsCount } = props
+  const { subPlotCells, cellIndices, maxInCell, minInCell = 0, primCatsCount,
+    isPercentAxis, numInSubPlot} = props
   const { numPrimarySplitBands, numSecondarySplitBands, primaryCellWidth, primaryIsBottom, primarySplitCellWidth,
           secondaryCellHeight, secondaryNumericScale } = subPlotCells
   const { p: primeCatIndex, ep: primeSplitCatIndex, es: secSplitCatIndex } = cellIndices
@@ -34,8 +37,10 @@ export const barCoverDimensions = (props: IBarCoverDimensionsProps) => {
   const offsetPrimary = primaryIsBottom
           ? primeCatIndex * primaryCellWidth + offsetPrimarySplit
           : primaryInvertedIndex * primaryCellWidth + offsetPrimarySplit
-  const secondaryCoord = secondaryNumericScale?.(maxInCell) ?? 0
-  const secondaryBaseCoord = secondaryNumericScale?.(minInCell) ?? 0
+  const maxValue = isPercentAxis ? 100 * maxInCell / numInSubPlot : maxInCell
+  const minValue = isPercentAxis ? 100 * minInCell / numInSubPlot : minInCell
+  const secondaryCoord = secondaryNumericScale?.(maxValue) ?? 0
+  const secondaryBaseCoord = secondaryNumericScale?.(minValue) ?? 0
   const secondaryIndex = primaryIsBottom
           ? numSecondarySplitBands - 1 - secSplitCatIndex
           : secSplitCatIndex
@@ -79,4 +84,12 @@ export const renderBarCovers = (props: IRenderBarCoverProps) => {
         dataConfig && handleClickOnBar({event, dataConfig, barCover: d})
       })
     )
+}
+
+export const barCompressionFactorForCase = (caseID: string, graphModel?: IGraphContentModel) => {
+
+  const getNumSubPlotCases = () => {
+    return graphModel?.dataConfiguration.subPlotCases(graphModel?.dataConfiguration.subPlotKey(caseID)).length ?? 0
+  }
+  return graphModel?.secondaryAxisIsPercent ? 100 / getNumSubPlotCases() : 1
 }

--- a/v3/src/components/graph/plots/histogram/histogram-model.ts
+++ b/v3/src/components/graph/plots/histogram/histogram-model.ts
@@ -21,8 +21,11 @@ export const HistogramModel = BinnedDotPlotModel
     get hasPointsFusedIntoBars(): boolean {
       return true
     },
-    get hasCountAxis(): boolean {
+    get hasCountPercentFormulaAxis(): boolean {
       return true
+    },
+    get countPercentFormulaAxisLabel(): string {
+      return t("DG.CountAxisView.countLabel")
     },
     get hasBinnedNumericAxis(): boolean {
       return false

--- a/v3/src/components/graph/plots/plot-model.ts
+++ b/v3/src/components/graph/plots/plot-model.ts
@@ -121,9 +121,9 @@ export const PlotModel = types
     barTipText(props: IBarTipTextProps) {
       return ""
     },
-    newSecondaryAxisRequired(patch: IJsonPatch): false | IAxisModel {
+    newSecondaryAxisRequired(patch: IJsonPatch): undefined | IAxisModel {
       // Derived classes may override to return true if a new secondary axis is required
-      return false
+      return undefined
     }
   }))
   .views(self => ({

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -490,7 +490,7 @@
     "DG.Undo.graph.dissolveRectanglesToDots": "Undo dissolving rectangles into dots",
     "DG.Redo.graph.dissolveRectanglesToDots": "Redo dissolving rectangles into dots",
     "DG.Undo.graph.changeBreakdownType": "Undo changing scale type",
-    "DG.Redo.graph.changeBreakdownType": "Undo changing scale type",
+    "DG.Redo.graph.changeBreakdownType": "Redo changing scale type",
     "DG.Undo.graph.showAsBinnedPlot": "Undo grouping dots into bins",
     "DG.Redo.graph.showAsBinnedPlot": "Redo grouping dots into bins",
     "DG.Undo.graph.showAsDotPlot": "Undo ungrouping dots from bins",


### PR DESCRIPTION
[#CODAP-290] Feature: The perpendicular axis of a bar chart can show percentages and the heights of the bars (assuming no legend) is the percentage for each category.

* We add "formula" as a breakdown type
* In display-config-palette.tsx we detect that we should show breakdown types and, if so, append the list of breakdown types as radio buttons
* Introduce PercentAxisModel
* Put responsibility for producing an axis label for count, percent or formula in BarChartModel
* We fix a bug whereby adding a categorical attribute to the "secondary" (x or y) axis of a bar chart was not changing the plot to a dot chart when it should because we don't support multiple count axes on x or y when there is also a categorical attribute on the axis.
* We fix another bug whereby splitting a bar chart on the top or right was not computing new bounds for the count axis.
* We need to be able to compute the maximum percent when the breakdownType is that. This led to a reordering of the cells in graph-data-configuration-model.ts cellMap so that it's easier to compute the maximum percent for each sub-plot.
* We add PercentAxisModel and install an `onPatch` in `GraphContentModel` that allows the graph model's plot to let the graph model know that a new axis model is needed for the secondary place.
* Similarly, in order to synchronize the axis scale with the axis model, we install an mstReaction in GraphController that carries this out when either the 'left' or 'bottom' axis changes
* When displaying percent bar charts, the thickness of a rectangle for a case depends on the number of cases in the sub-plot. Unfortunately, because we're iterating through cases irrespective of sub-plot, this requires determining the sub-plot of each case and the number of cases in that sub-plot.
* Also when displaying bar charts, the bar covers have to be adjusted to take into account the number of cases in the sub-plot.