### PR TITLE
fix: create, update, delete graph adornments API handlers (CODAP-47)

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -10,7 +10,11 @@ jest.mock("../adornment-content-info", () => {
     showPercent: types.optional(types.boolean, false),
     percentType: types.optional(types.string, "row"),
     isVisible: types.optional(types.boolean, false),
-  }).actions(self => ({
+  }).views(self => ({
+    percentValue() {
+      return 0.5
+    }
+  })).actions(self => ({
     setShowCount(showCount: boolean) {
       self.showCount = showCount
     },
@@ -113,6 +117,46 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(values.showCount).toBe(true)
     expect(values.showPercent).toBe(false)
     expect(values.percentType).toBe("column")
+  })
+
+  it("create sets default `showCount` and `showPercent` based on type when values not provided", () => {
+    const countRequestValues = { type: kCountType }
+    const countResult = handler.create!({ graphContent: mockGraphContent, values: countRequestValues })
+    expect(countResult?.success).toBe(true)
+    const countValues = countResult?.values as any
+    expect(countValues.showCount).toBe(true)
+    expect(countValues.showPercent).toBe(false)
+
+    const percentRequestValues = { type: kPercentType }
+    const percentResult = handler.create!({ graphContent: mockGraphContent, values: percentRequestValues })
+    expect(percentResult?.success).toBe(true)
+    const percentValues = percentResult?.values as any
+    expect(percentValues.showCount).toBe(false)
+    expect(percentValues.showPercent).toBe(true)
+  })
+
+  it("create respects explicitly provided showCount and showPercent values", () => {
+    const bothTrueValues = {
+      type: kCountType,
+      showCount: true,
+      showPercent: true
+    }
+    const bothTrueResult = handler.create!({ graphContent: mockGraphContent, values: bothTrueValues })
+    expect(bothTrueResult?.success).toBe(true)
+    const bothTrueResultValues = bothTrueResult?.values as any
+    expect(bothTrueResultValues.showCount).toBe(true)
+    expect(bothTrueResultValues.showPercent).toBe(true)
+
+    const bothFalseValues = {
+      type: kCountType,
+      showCount: false,
+      showPercent: false
+    }
+    const bothFalseResult = handler.create!({ graphContent: mockGraphContent, values: bothFalseValues })
+    expect(bothFalseResult?.success).toBe(true)
+    const bothFalseResultValues = bothFalseResult?.values as any
+    expect(bothFalseResultValues.showCount).toBe(false)
+    expect(bothFalseResultValues.showPercent).toBe(false)
   })
 
   it("get returns an error when an invalid adornment provided", () => {

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -76,6 +76,8 @@ describe("DataInteractive CountAdornmentHandler", () => {
       percentValue: jest.fn(() => 0.5),
       percentType: "cell",
       setPercentType: jest.fn(),
+      setShowCount: jest.fn(),
+      setShowPercent: jest.fn(),
       setVisibility: jest.fn(),
       showCount: true,
       showPercent: true,
@@ -135,6 +137,27 @@ describe("DataInteractive CountAdornmentHandler", () => {
     const percentValues = percentResult?.values as any
     expect(percentValues.showCount).toBe(false)
     expect(percentValues.showPercent).toBe(true)
+  })
+
+  it("delete returns an error when count adornment not found", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
+    const result = handler.delete?.({ graphContent: mockGraphContent, values: { type: kCountType } })
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
+  })
+
+  it("delete successfully deletes count adornment properties", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockCountAdornment)
+    const result = handler.delete?.({ graphContent: mockGraphContent, values: { type: kCountType } })
+    expect(result?.success).toBe(true)
+  })
+
+  it("delete returns an error when invalid type provided", () => {
+    const result = handler.delete?.({ graphContent: mockGraphContent, values: { type: "invalid" } })
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
   })
 
   it("get returns an error when an invalid adornment provided", () => {

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -2,6 +2,9 @@ import { types } from "mobx-state-tree"
 import { countAdornmentHandler } from "./count-adornment-handler"
 import { kCountType, kPercentType } from "./count-adornment-types"
 
+// register adornment type aliases
+import "./count-adornment-registration"
+
 jest.mock("../adornment-content-info", () => {
   const mockCountModel = types.model("CountAdornmentModel", {
     id: types.optional(types.string, "ADRN123"),
@@ -68,7 +71,7 @@ describe("DataInteractive CountAdornmentHandler", () => {
       },
       dataConfiguration: mockDataConfig
     }
-    
+
     mockCountAdornment = {
       computeRegionCounts: jest.fn(() => [{ count: 2, percent: "50%" }]),
       id: "ADRN123",

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -75,6 +75,8 @@ describe("DataInteractive CountAdornmentHandler", () => {
       isVisible: true,
       percentValue: jest.fn(() => 0.5),
       percentType: "cell",
+      setPercentType: jest.fn(),
+      setVisibility: jest.fn(),
       showCount: true,
       showPercent: true,
       type: kCountType
@@ -135,30 +137,6 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(percentValues.showPercent).toBe(true)
   })
 
-  it("create respects explicitly provided showCount and showPercent values", () => {
-    const bothTrueValues = {
-      type: kCountType,
-      showCount: true,
-      showPercent: true
-    }
-    const bothTrueResult = handler.create!({ graphContent: mockGraphContent, values: bothTrueValues })
-    expect(bothTrueResult?.success).toBe(true)
-    const bothTrueResultValues = bothTrueResult?.values as any
-    expect(bothTrueResultValues.showCount).toBe(true)
-    expect(bothTrueResultValues.showPercent).toBe(true)
-
-    const bothFalseValues = {
-      type: kCountType,
-      showCount: false,
-      showPercent: false
-    }
-    const bothFalseResult = handler.create!({ graphContent: mockGraphContent, values: bothFalseValues })
-    expect(bothFalseResult?.success).toBe(true)
-    const bothFalseResultValues = bothFalseResult?.values as any
-    expect(bothFalseResultValues.showCount).toBe(false)
-    expect(bothFalseResultValues.showPercent).toBe(false)
-  })
-
   it("get returns an error when an invalid adornment provided", () => {
     const result = handler.get?.(mockInvalidAdornment, mockGraphContent)
     expect(result?.success).toBe(false)
@@ -199,10 +177,9 @@ describe("DataInteractive CountAdornmentHandler", () => {
   it("update successfully updates count adornment properties", () => {
     mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockCountAdornment)
     const updateValues = {
-      showCount: false,
-      showPercent: true,
       percentType: "column",
-      isVisible: true
+      isVisible: true,
+      type: kPercentType
     }
     const result = handler.update?.({ graphContent: mockGraphContent, values: updateValues })
     expect(result?.success).toBe(true)

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.test.ts
@@ -106,12 +106,9 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(values.error).toBe("The current plot type does not support Percent.")
   })
 
-  it("create returns the expected data when count adornment created", () => {
+  it("create returns the expected data for Count request", () => {
     const createRequestValues = {
-      type: kCountType,
-      showCount: true,
-      showPercent: false,
-      percentType: "column"
+      type: kCountType
     }
     const result = handler.create!({ graphContent: mockGraphContent, values: createRequestValues })
     expect(result?.success).toBe(true)
@@ -119,7 +116,19 @@ describe("DataInteractive CountAdornmentHandler", () => {
     const values = result?.values as any
     expect(values.type).toBe(kCountType)
     expect(values.showCount).toBe(true)
-    expect(values.showPercent).toBe(false)
+  })
+
+  it("create returns the expected data for Percent request", () => {
+    const createRequestValues = {
+      type: kPercentType,
+      percentType: "column"
+    }
+    const result = handler.create!({ graphContent: mockGraphContent, values: createRequestValues })
+    expect(result?.success).toBe(true)
+    expect(result?.values).toBeDefined()
+    const values = result?.values as any
+    expect(values.type).toBe(kPercentType)
+    expect(values.showPercent).toBe(true)
     expect(values.percentType).toBe("column")
   })
 
@@ -139,7 +148,7 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(percentValues.showPercent).toBe(true)
   })
 
-  it("delete returns an error when count adornment not found", () => {
+  it("delete returns an error when adornment not found", () => {
     mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
     const result = handler.delete?.({ graphContent: mockGraphContent, values: { type: kCountType } })
     expect(result?.success).toBe(false)
@@ -147,7 +156,7 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(values.error).toBe("Adornment not found.")
   })
 
-  it("delete successfully deletes count adornment properties", () => {
+  it("delete successfully deletes adornment", () => {
     mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockCountAdornment)
     const result = handler.delete?.({ graphContent: mockGraphContent, values: { type: kCountType } })
     expect(result?.success).toBe(true)
@@ -166,7 +175,7 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(result?.values.error).toBe(`Not a(n) ${kCountType} adornment.`)
   })
 
-  it("get returns the expected data when count adornment provided", () => {
+  it("get returns the expected data when valid adornment provided", () => {
     const result = handler.get?.(mockCountAdornment, mockGraphContent)
     expect(Array.isArray(result?.data)).toBe(true)
     expect(result?.data).toHaveLength(1)
@@ -189,7 +198,7 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(result?.data[0]).toMatchObject({ percent: "50%" })
   })
 
-  it("update returns an error when count adornment not found", () => {
+  it("update returns an error when adornment not found", () => {
     mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
     const result = handler.update?.({ graphContent: mockGraphContent })
     expect(result?.success).toBe(false)
@@ -197,7 +206,15 @@ describe("DataInteractive CountAdornmentHandler", () => {
     expect(values.error).toBe("Adornment not found.")
   })
 
-  it("update successfully updates count adornment properties", () => {
+  it("update returns an error when invalid properties provided", () => {
+    mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(null)
+    const result = handler.update?.({ graphContent: mockGraphContent, values: { invalidProperty: "invalid" } })
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
+  })
+
+  it("update successfully updates adornment properties", () => {
     mockGraphContent.adornmentsStore.findAdornmentOfType.mockReturnValue(mockCountAdornment)
     const updateValues = {
       percentType: "column",

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -15,15 +15,18 @@ import { kCountType } from "./count-adornment-types"
 
 const setAdornmentProperties = (adornment: ICountAdornmentModel, values: DIAdornmentValues) => {
   if (isAdornmentValues(values)) {
-    const { isVisible, showCount, showPercent, percentType } = values as DICountAdornmentValues
+    const { isVisible, percentType, showCount: _showCount, showPercent: _showPercent,
+            type } = values as DICountAdornmentValues
+    const hasShowCountOrPercent = _showCount !== undefined || _showPercent !== undefined
+    const showCount = _showCount || (type === "Count" && !hasShowCountOrPercent)
+    const showPercent = _showPercent ||
+                        (type === "Percent" as string && !hasShowCountOrPercent)
+    
+    adornment.setShowCount(showCount)
+    adornment.setShowPercent(showPercent)
+
     if (isVisible != null) {
       adornment.setVisibility(isVisible)
-    }
-    if (showCount != null) {
-      adornment.setShowCount(showCount)
-    }
-    if (showPercent != null) {
-      adornment.setShowPercent(showPercent)
     }
     if (percentType != null) {
       adornment.setPercentType(percentType)

--- a/v3/src/components/graph/adornments/count/count-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/count/count-adornment-handler.ts
@@ -92,10 +92,6 @@ export const countAdornmentHandler: DIAdornmentHandler = {
     const existingCountAdornment = adornmentsStore.findAdornmentOfType<ICountAdornmentModel>(kCountType)
     if (!existingCountAdornment) return adornmentNotFoundResult
 
-    if (typeof values !== "object" || !("type" in values)) {
-      return errorResult(t("V3.DI.Error.invalidValuesProvided"))
-    }
-
     const { type } = values as { type: string }
     const requestType = type as "Count" | "Percent" | undefined
 

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
@@ -44,9 +44,8 @@ export const movableValueAdornmentHandler: DIAdornmentHandler = {
     if (valuePairs) {
       try {
         const updates = new Map<string, number>(valuePairs)
-        updates.forEach((newValue, requestCellKey) => {
-          const cellKey = normalizeCellKey(requestCellKey, graphContent.dataConfiguration)
-          adornment.addValue(newValue, cellKey)
+        updates.forEach((newValue) => {
+          adornment.addValue(newValue)
         })
       } catch {
         return invalidValuesProvidedeResult

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-handler.ts
@@ -35,7 +35,7 @@ export const movableValueAdornmentHandler: DIAdornmentHandler = {
 
     const options: IUpdateCategoriesOptions = {
       ...graphContent.getUpdateCategoriesOptions(),
-      addMovableValue: !valuePairs // add a movable value with default value if value(s) not provided in request
+      addMovableValue: true
     }
 
     adornmentsStore.addAdornment(adornment, options)
@@ -44,8 +44,15 @@ export const movableValueAdornmentHandler: DIAdornmentHandler = {
     if (valuePairs) {
       try {
         const updates = new Map<string, number>(valuePairs)
-        updates.forEach((newValue) => {
-          adornment.addValue(newValue)
+        updates.forEach((newValue, requestCellKey) => {
+          if (typeof newValue !== "number") return
+
+          const cellKey = normalizeCellKey(requestCellKey, graphContent.dataConfiguration)
+          if (!cellKey) {
+            return errorResult(t("V3.DI.Error.invalidCellKey", { vars: [requestCellKey] }))
+          }
+
+          adornment.replaceValue(newValue, cellKey)
         })
       } catch {
         return invalidValuesProvidedeResult

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-model.ts
@@ -60,10 +60,8 @@ export const MovableValueAdornmentModel = AdornmentModel
     }
   }))
   .actions(self => ({
-    addValue(aValue?: number, aKey?: string) {
+    addValue(aValue?: number) {
       self.values.forEach((values, key) => {
-        if (aKey && key !== aKey) return
-
         const newValue = aValue == null ? self.newValue(`${key}`) : aValue
         const newValues = [...values]
         newValues.push(newValue)

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-model.ts
@@ -60,8 +60,10 @@ export const MovableValueAdornmentModel = AdornmentModel
     }
   }))
   .actions(self => ({
-    addValue(aValue?: number) {
+    addValue(aValue?: number, aKey?: string) {
       self.values.forEach((values, key) => {
+        if (aKey && key !== aKey) return
+
         const newValue = aValue == null ? self.newValue(`${key}`) : aValue
         const newValues = [...values]
         newValues.push(newValue)

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.test.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.test.ts
@@ -1,16 +1,15 @@
+import { Attribute } from "../../../../models/data/attribute"
 import { adornmentMismatchResult, cellKeyToCategories, normalizeCellKey } from "./adornment-handler-utils"
 
 describe("adornment-handler-utils", () => {
   let mockDataConfig: any
 
   beforeEach(() => {
+    const attributes = [Attribute.create({ id: "ATTR1", name: "Category Name" })]
     mockDataConfig = {
       dataset: {
-        getAttribute: jest.fn(() => ({ id: "ATTR1", name: "Category Name" })),
-        getAttributeByName: jest.fn((name: string) => {
-          const attributes = [{ id: "ATTR1", name: "Category Name" }]
-          return attributes.find(attr => attr.name === name)
-        })
+        attributes,
+        getAttribute: jest.fn((id: string) => attributes.find(attr => attr.id === id))
       },
       getAllCellKeys: jest.fn(() => [{}, { ATTR1: "category value 1" }]),
       subPlotCases: jest.fn(() => [{ id: "case1" }, { id: "case2" }])

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
@@ -23,7 +23,7 @@ export const adornmentMismatchResult = (adornmentType: string) => {
 /**
  * Converts a cell key that uses an attribute name to one that uses the associated attribute ID instead.
  * Example: given a cell key of { "Diet": "plants" }, it returns { "ATTR123": "plants" }.
- * 
+ *
  * @param requestCellKey: the cell key string value specified in an API request
  * @param dataset: the dataset associated with the graph
  * @returns a cell key string value with an attribute ID instead of a name, or undefined if the conversion fails
@@ -33,17 +33,12 @@ export const normalizeCellKey = (requestCellKey: string, dataConfig: IDataConfig
   const normalizedCellKey: Record<string, string> = {}
 
   for (const [attrNameOrId, value] of Object.entries(cellKey)) {
-    // If the key is already an ID, keep it as is.
-    if (/^ATTR\d+$/.test(attrNameOrId)) {
-      normalizedCellKey[attrNameOrId] = value
+    const foundAttr = dataConfig.dataset?.attributes.find(attr => attr.matchTitleOrNameOrId(attrNameOrId))
+    if (foundAttr) {
+      normalizedCellKey[foundAttr.id] = value
     } else {
-      const attrId = dataConfig.dataset?.getAttributeByName(attrNameOrId)?.id
-      if (attrId) {
-        normalizedCellKey[attrId] = value
-      } else {
-        // If any attribute name cannot be resolved to an ID, return undefined.
-        return undefined
-      }
+      // If any attribute name cannot be resolved to an ID, return undefined.
+      return undefined
     }
   }
 

--- a/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
+++ b/v3/src/components/graph/adornments/utilities/adornment-handler-utils.ts
@@ -1,9 +1,9 @@
+import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
 import { errorResult } from "../../../../data-interactive/handlers/di-results"
 import { t } from "../../../../utilities/translation/translate"
-import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
 
 export type AdornmentData = {
-  categories?: Record<string, string>;
+  categories?: Record<string, string>
 } & Record<string, number | number[] | string | string[] | undefined | null | ((x: number) => void)>
 
 export const cellKeyToCategories = (cellKey: Record<string, string>, dataConfig: IDataConfigurationModel) => {
@@ -18,4 +18,34 @@ export const cellKeyToCategories = (cellKey: Record<string, string>, dataConfig:
 
 export const adornmentMismatchResult = (adornmentType: string) => {
   return errorResult(t("V3.DI.Error.adornmentMismatch", { vars: [adornmentType] }))
+}
+
+/**
+ * Converts a cell key that uses an attribute name to one that uses the associated attribute ID instead.
+ * Example: given a cell key of { "Diet": "plants" }, it returns { "ATTR123": "plants" }.
+ * 
+ * @param requestCellKey: the cell key string value specified in an API request
+ * @param dataset: the dataset associated with the graph
+ * @returns a cell key string value with an attribute ID instead of a name, or undefined if the conversion fails
+ */
+export const normalizeCellKey = (requestCellKey: string, dataConfig: IDataConfigurationModel) => {
+  const cellKey: Record<string, string> = JSON.parse(requestCellKey)
+  const normalizedCellKey: Record<string, string> = {}
+
+  for (const [attrNameOrId, value] of Object.entries(cellKey)) {
+    // If the key is already an ID, keep it as is.
+    if (/^ATTR\d+$/.test(attrNameOrId)) {
+      normalizedCellKey[attrNameOrId] = value
+    } else {
+      const attrId = dataConfig.dataset?.getAttributeByName(attrNameOrId)?.id
+      if (attrId) {
+        normalizedCellKey[attrId] = value
+      } else {
+        // If any attribute name cannot be resolved to an ID, return undefined.
+        return undefined
+      }
+    }
+  }
+
+  return JSON.stringify(normalizedCellKey)
 }

--- a/v3/src/data-interactive/data-interactive-adornment-base-types.ts
+++ b/v3/src/data-interactive/data-interactive-adornment-base-types.ts
@@ -1,0 +1,22 @@
+// Separating these definitions avoids circular dependencies
+
+export interface DIAdornmentValuesBase {
+  type?: string; // The type of the adornment, e.g., "Count", "Percent", etc.
+  isVisible?: boolean; // Indicates whether the adornment is visible or not
+}
+
+export function isDIAdornmentValuesBase(val: unknown): val is DIAdornmentValuesBase {
+  return typeof val === "object" && val != null && ("type" in val && typeof val.type === "string")
+}
+
+const diAdornmentTypeAliases = new Map<string, string>()
+
+export function registerAdornmentTypeAlias(alias: string, type: string): void {
+  diAdornmentTypeAliases.set(alias, type)
+}
+
+export const resolveAdornmentType = (typeOrAlias: unknown): string => {
+  return typeof typeOrAlias === "string"
+          ? diAdornmentTypeAliases.get(typeOrAlias) ?? typeOrAlias
+          : String(typeOrAlias)
+}

--- a/v3/src/data-interactive/data-interactive-adornment-types.ts
+++ b/v3/src/data-interactive/data-interactive-adornment-types.ts
@@ -1,6 +1,6 @@
 import { SnapshotIn } from "@concord-consortium/mobx-state-tree"
 import { CountAdornmentModel } from "../components/graph/adornments/count/count-adornment-model"
-import { kCountType } from "../components/graph/adornments/count/count-adornment-types"
+import { kCountType, kPercentType } from "../components/graph/adornments/count/count-adornment-types"
 import { LSRLAdornmentModel } from "../components/graph/adornments/lsrl/lsrl-adornment-model"
 import { kLSRLType } from "../components/graph/adornments/lsrl/lsrl-adornment-types"
 import { MeanAdornmentModel } from "../components/graph/adornments/univariate-measures/mean/mean-adornment-model"
@@ -23,7 +23,7 @@ export type DIStandardDeviationAdornmentValues = Partial<SnapshotIn<typeof Stand
 export type DIAdornmentValues = DICountAdornmentValues | DILsrlAdornmentValues | DIMeanAdornmentValues |
   DIMedianAdornmentValues | DIMovableValueAdornmentValues | DIStandardDeviationAdornmentValues
 
-const kAdornmentTypes = [kCountType, kLSRLType, kMeanType, kMedianType, kMovableValueType, kStandardDeviationType]
+const kAdornmentTypes = [kCountType, kLSRLType, kMeanType, kMedianType, kMovableValueType, kPercentType, kStandardDeviationType]
 const adornmentTypes = new Set(kAdornmentTypes)
 
 export const isAdornmentValues = (val: unknown): val is DIAdornmentValues => {

--- a/v3/src/data-interactive/data-interactive-adornment-types.ts
+++ b/v3/src/data-interactive/data-interactive-adornment-types.ts
@@ -1,6 +1,6 @@
-import { SnapshotIn } from "@concord-consortium/mobx-state-tree"
+import { SnapshotIn } from "mobx-state-tree"
 import { CountAdornmentModel } from "../components/graph/adornments/count/count-adornment-model"
-import { kCountType, kPercentType } from "../components/graph/adornments/count/count-adornment-types"
+import { kCountType } from "../components/graph/adornments/count/count-adornment-types"
 import { LSRLAdornmentModel } from "../components/graph/adornments/lsrl/lsrl-adornment-model"
 import { kLSRLType } from "../components/graph/adornments/lsrl/lsrl-adornment-types"
 import { MeanAdornmentModel } from "../components/graph/adornments/univariate-measures/mean/mean-adornment-model"
@@ -13,6 +13,7 @@ import { StandardDeviationAdornmentModel }
   from "../components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-model"
 import { kStandardDeviationType }
   from "../components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-types"
+import { isDIAdornmentValuesBase, resolveAdornmentType } from "./data-interactive-adornment-base-types"
 
 export type DICountAdornmentValues = Partial<SnapshotIn<typeof CountAdornmentModel>>
 export type DILsrlAdornmentValues = Partial<SnapshotIn<typeof LSRLAdornmentModel>>
@@ -23,9 +24,9 @@ export type DIStandardDeviationAdornmentValues = Partial<SnapshotIn<typeof Stand
 export type DIAdornmentValues = DICountAdornmentValues | DILsrlAdornmentValues | DIMeanAdornmentValues |
   DIMedianAdornmentValues | DIMovableValueAdornmentValues | DIStandardDeviationAdornmentValues
 
-const kAdornmentTypes = [kCountType, kLSRLType, kMeanType, kMedianType, kMovableValueType, kPercentType, kStandardDeviationType]
+const kAdornmentTypes = [kCountType, kLSRLType, kMeanType, kMedianType, kMovableValueType, kStandardDeviationType]
 const adornmentTypes = new Set(kAdornmentTypes)
 
 export const isAdornmentValues = (val: unknown): val is DIAdornmentValues => {
-  return typeof val === "object" && val !== null && adornmentTypes.has((val as any).type)
+  return isDIAdornmentValuesBase(val) && adornmentTypes.has(resolveAdornmentType(val.type))
 }

--- a/v3/src/data-interactive/handlers/adornment-handler.test.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.test.ts
@@ -5,9 +5,46 @@ import { diAdornmentHandler } from "./adornment-handler"
 describe("DataInteractive AdornmentHandler", () => {
   const handler = diAdornmentHandler
 
+  it("create returns an error if the specified component is not a graph", () => {
+    const mockComponent = {
+      content: {
+        type: "Invalid Type"
+      },
+      type: "Invalid Type",
+    } as any
+    const mockValues = {
+      type: "Count"
+    }
+    const result = handler.create?.({ component: mockComponent }, mockValues)
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Unsupported component type Invalid Type")
+  })
+
   it("create returns an error when no values provided", () => {
     const result = handler.create?.({})
     expect(result?.success).toBe(false)
+  })
+
+  it("create returns an error when adornment doesn't support create", () => {
+    const mockGraphContent = {
+      adornmentsStore: {
+        addAdornment: jest.fn((adornment: any, options: any) => null),
+        findAdornmentOfType: jest.fn(),
+      },
+      type: "Graph"
+    } as any
+    const mockComponent = {
+      content: mockGraphContent,
+      type: "Graph",
+    } as any
+    const mockValues = {
+      type: "Mock Adornment"
+    }
+    const result = handler.create?.({ component: mockComponent }, mockValues)
+    expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("The Mock Adornment adornment does not currently support create requests.")
   })
 
   it("delete returns an error when no type provided", () => {

--- a/v3/src/data-interactive/handlers/adornment-handler.test.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.test.ts
@@ -42,8 +42,23 @@ describe("DataInteractive AdornmentHandler", () => {
   })
 
   it("update returns an error when type provided but matching adornment not found", () => {
-    const result = handler.update?.({}, { type: "Count" })
+    const mockGraphContent = {
+      adornmentsStore: {
+        addAdornment: jest.fn((adornment: any, options: any) => null),
+        findAdornmentOfType: jest.fn(),
+      },
+      type: "Graph"
+    } as any
+
+    const mockComponent = {
+      content: mockGraphContent,
+      type: "Graph",
+    } as any
+
+    const result = handler.update?.({component: mockComponent}, { type: "Mean" })
     expect(result?.success).toBe(false)
+    const values = result?.values as any
+    expect(values.error).toBe("Adornment not found.")
   })
 
 })

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -83,7 +83,7 @@ export const diAdornmentHandler: DIHandler = {
     const handler = diAdornmentHandlers.get(resolvedType)
   
     if (handler?.delete) {
-      return handler.delete({ graphContent })
+      return handler.delete({ graphContent, values })
     }
   
     // If the adornment doesn't have a delete handler, we just hide the adornment.

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -1,8 +1,10 @@
 import { IAdornmentModel } from "../../components/graph/adornments/adornment-models"
 import { IGraphContentModel, isGraphContentModel } from "../../components/graph/models/graph-content-model"
 import { t } from "../../utilities/translation/translate"
+import {
+  isDIAdornmentValuesBase, registerAdornmentTypeAlias, resolveAdornmentType
+} from "../data-interactive-adornment-base-types"
 import { registerDIHandler } from "../data-interactive-handler"
-import { DIAttribute } from "../data-interactive-data-set-types"
 import { DIErrorResult, DIHandler, DIHandlerFnResult, DIResources, DIValues } from "../data-interactive-types"
 import { adornmentNotFoundResult, adornmentNotSupportedResult, valuesRequiredResult, errorResult } from "./di-results"
 
@@ -18,26 +20,14 @@ export interface DIAdornmentHandler {
   update?: (args: ICreateArgs) => DIHandlerFnResult | DIErrorResult
 }
 
-const isTypeSpecified = (val: unknown): val is DIAttribute => {
-  return typeof val === "object" && val !== null && "type" in val && typeof val.type === "string"
-}
-
 const diAdornmentHandlers = new Map<string, DIAdornmentHandler>()
-
-const diAdornmentTypeAliases = new Map<string, string>()
 
 export const registerAdornmentHandler = (type: string, handler: DIAdornmentHandler, alias?: string) => {
   diAdornmentHandlers.set(type, handler)
-  if (alias) diAdornmentTypeAliases.set(alias, type)
+  if (alias) registerAdornmentTypeAlias(alias, type)
   const trimType = type.replace(/\s/g, "")
   // register trimmed (without spaces) types as aliases
-  if (trimType !== type) diAdornmentTypeAliases.set(trimType, type)
-}
-
-export const resolveAdornmentType = (typeOrAlias: unknown): string => {
-  return typeof typeOrAlias === "string"
-          ? diAdornmentTypeAliases.get(typeOrAlias) ?? typeOrAlias
-          : String(typeOrAlias)
+  if (trimType !== type) registerAdornmentTypeAlias(trimType, type)
 }
 
 export const diAdornmentHandler: DIHandler = {
@@ -50,7 +40,7 @@ export const diAdornmentHandler: DIHandler = {
     }
 
     const graphContent = component.content
-    if (isTypeSpecified(values) && values.type) {
+    if (isDIAdornmentValuesBase(values) && values.type) {
       const { type } = values
       const resolvedType = resolveAdornmentType(type) ?? type
       const handler = diAdornmentHandlers.get(resolvedType)
@@ -67,25 +57,25 @@ export const diAdornmentHandler: DIHandler = {
 
   delete(resources: DIResources, values?: DIValues) {
     const { component } = resources
-    if (!isTypeSpecified(values) || !values.type) return valuesRequiredResult
+    if (!isDIAdornmentValuesBase(values) || !values.type) return valuesRequiredResult
     if (!isGraphContentModel(component?.content)) {
       return errorResult(t("V3.DI.Error.unsupportedComponent", { vars: [component?.content.type] }))
     }
-  
+
     const { type } = values
     const resolvedType = resolveAdornmentType(type) ?? type
     const graphContent = component.content
     const adornmentsStore = graphContent.adornmentsStore
     const adornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(resolvedType)
-  
+
     if (!adornment) return adornmentNotFoundResult
-  
+
     const handler = diAdornmentHandlers.get(resolvedType)
-  
+
     if (handler?.delete) {
       return handler.delete({ graphContent, values })
     }
-  
+
     // If the adornment doesn't have a delete handler, we just hide the adornment.
     adornmentsStore.hideAdornment(resolvedType)
     return { success: true }
@@ -129,7 +119,7 @@ export const diAdornmentHandler: DIHandler = {
     }
 
     const graphContent = component.content
-    if (isTypeSpecified(values) && values.type) {
+    if (isDIAdornmentValuesBase(values) && values.type) {
       const { type } = values as any
       const resolvedType = resolveAdornmentType(type) ?? type
       const existingCountAdornment = graphContent.adornmentsStore.findAdornmentOfType<IAdornmentModel>(resolvedType)

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -132,6 +132,11 @@ export const diAdornmentHandler: DIHandler = {
     if (isTypeSpecified(values) && values.type) {
       const { type } = values as any
       const resolvedType = resolveAdornmentType(type) ?? type
+      const existingCountAdornment = graphContent.adornmentsStore.findAdornmentOfType<IAdornmentModel>(resolvedType)
+      if (!existingCountAdornment) {
+        return errorResult(t("V3.DI.Error.adornmentNotFound"))
+      }
+
       const handler = diAdornmentHandlers.get(resolvedType)
       if (handler?.update) {
         return handler.update({graphContent, values})

--- a/v3/src/data-interactive/handlers/adornment-handler.ts
+++ b/v3/src/data-interactive/handlers/adornment-handler.ts
@@ -42,7 +42,7 @@ export const diAdornmentHandler: DIHandler = {
     const graphContent = component.content
     if (isDIAdornmentValuesBase(values) && values.type) {
       const { type } = values
-      const resolvedType = resolveAdornmentType(type) ?? type
+      const resolvedType = resolveAdornmentType(type)
       const handler = diAdornmentHandlers.get(resolvedType)
 
       if (handler?.create) {
@@ -63,7 +63,7 @@ export const diAdornmentHandler: DIHandler = {
     }
 
     const { type } = values
-    const resolvedType = resolveAdornmentType(type) ?? type
+    const resolvedType = resolveAdornmentType(type)
     const graphContent = component.content
     const adornmentsStore = graphContent.adornmentsStore
     const adornment = adornmentsStore.findAdornmentOfType<IAdornmentModel>(resolvedType)
@@ -121,7 +121,7 @@ export const diAdornmentHandler: DIHandler = {
     const graphContent = component.content
     if (isDIAdornmentValuesBase(values) && values.type) {
       const { type } = values as any
-      const resolvedType = resolveAdornmentType(type) ?? type
+      const resolvedType = resolveAdornmentType(type)
       const existingCountAdornment = graphContent.adornmentsStore.findAdornmentOfType<IAdornmentModel>(resolvedType)
       if (!existingCountAdornment) {
         return errorResult(t("V3.DI.Error.adornmentNotFound"))

--- a/v3/src/data-interactive/resource-parser.ts
+++ b/v3/src/data-interactive/resource-parser.ts
@@ -10,9 +10,9 @@ import { GlobalValueManager } from "../models/global/global-value-manager"
 import { getSharedDataSets } from "../models/shared/shared-data-utils"
 import { ITileModel } from "../models/tiles/tile-model"
 import { toV3CaseId, toV3GlobalId, toV3ItemId } from "../utilities/codap-utils"
+import { resolveAdornmentType } from "./data-interactive-adornment-base-types"
 import { ActionName, DIResources, DIResourceSelector, DIParsedOperand } from "./data-interactive-types"
 import { getAttribute, getCollection } from "./data-interactive-utils"
-import { resolveAdornmentType } from "./handlers/adornment-handler"
 import { evaluateCaseFormula, findTileFromNameOrId, parseSearchQuery } from "./resource-parser-utils"
 
 /**

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -153,6 +153,7 @@
     "V3.DI.Error.adornmentMismatch": "Not a(n) %@1 adornment.",
     "V3.DI.Error.adornmentNotSupportedByPlotType": "Adornment not supported by plot type.",
     "V3.DI.Error.adornmentRequestNotSupported": "The %@1 adornment does not currently support %@2 requests.",
+    "V3.DI.Error.countAdornmentPercentNotSupported": "The current plot type does not support Percent.",
 
     // CFM/File menu
     "DG.fileMenu.menuItem.newDocument": "New",

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -154,6 +154,7 @@
     "V3.DI.Error.adornmentNotSupportedByPlotType": "Adornment not supported by plot type.",
     "V3.DI.Error.adornmentRequestNotSupported": "The %@1 adornment does not currently support %@2 requests.",
     "V3.DI.Error.countAdornmentPercentNotSupported": "The current plot type does not support Percent.",
+    "V3.DI.Error.invalidCellKey": "%@1 contains an invalid attribute name or ID.",
 
     // CFM/File menu
     "DG.fileMenu.menuItem.newDocument": "New",


### PR DESCRIPTION
[CODAP-47](https://concord-consortium.atlassian.net/browse/CODAP-47)

These changes fix the following issues uncovered in review.

- Any adornment: `update` request for an adornment that doesn't exist receives "success" response
- Percent adornment: `create` request always receives error response
- Movable Value: a few inconsistencies with `create` and `update` due to issues involving cell key values -- most importantly that `create` requests with specified numeric values per subplot for split plots resulted in multiple Movable Line instances per subplot instead of one instance per subplot.

[CODAP-47]: https://concord-consortium.atlassian.net/browse/CODAP-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ