### PR TITLE
Codap 78 attr hover indicator

### DIFF
--- a/v3/src/components/case-card/case-attr-view.scss
+++ b/v3/src/components/case-card/case-attr-view.scss
@@ -20,7 +20,7 @@
 
     .codap-column-header-content {
       &:hover {
-        color: #1b5798 !important;
+        color: #1b5798 !important; // overrides Charkraui default color
         span {
           text-decoration: underline;
         }

--- a/v3/src/components/case-card/case-attr-view.scss
+++ b/v3/src/components/case-card/case-attr-view.scss
@@ -17,6 +17,15 @@
     padding: 1px 8px 2px 4px;
     position: relative;
     white-space: nowrap;
+
+    .codap-column-header-content {
+      &:hover {
+        color: #1b5798 !important;
+        span {
+          text-decoration: underline;
+        }
+      }
+    }
   }
 
   .case-card-attr-value {

--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -226,6 +226,10 @@ $table-body-font-size: 8pt;
           align-items: center;
           justify-content: center;
           color: #555555 !important;
+          &:hover {
+            text-decoration: underline;
+            color: #1b5798 !important;
+          }
 
           input {
             height: calc(100% - 6px)

--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -225,7 +225,7 @@ $table-body-font-size: 8pt;
           display: flex;
           align-items: center;
           justify-content: center;
-          color: #555555 !important;
+          color: #555555 !important; //overrides chakra's default color
           &:hover {
             text-decoration: underline;
             color: #1b5798 !important;


### PR DESCRIPTION
Adds hover styling to attribute headers in case table and card. Attribute text should be blue and underlined when hovered.