### PR TITLE
Codap-335 Update Map Handler

### DIFF
--- a/v3/src/components/map/map-component-handler.test.ts
+++ b/v3/src/components/map/map-component-handler.test.ts
@@ -58,5 +58,22 @@ describe("DataInteractive ComponentHandler Map", () => {
       const { dataContext } = values as V2Map
       expect(dataContext).toBe((mapTile.content as IMapContentModel).dataConfiguration?.dataset?.name)
     })
+
+    const updateResult = handler.update!({ component: tile }, {
+      center: [30, 34], zoom: 4, legendAttributeName: "a2"
+    })
+    expect(updateResult.success).toBe(true)
+    expect(tileContent.center.lat).toBe(30)
+    expect(tileContent.center.lng).toBe(34)
+    expect(tileContent.zoom).toBe(4)
+    // TODO Test that the legend attribute is updated. See above TODO for more details.
+    // expect(tileContent.dataConfiguration?.attributeDescriptionForRole("legend")?.attributeID).toBe("a2")
+
+    // Can update just the zoom without modifying the center
+    const updateResult2 = handler.update!({ component: tile }, { zoom: 5 })
+    expect(updateResult2.success).toBe(true)
+    expect(tileContent.center.lat).toBe(30)
+    expect(tileContent.center.lng).toBe(34)
+    expect(tileContent.zoom).toBe(5)
   })
 })

--- a/v3/src/components/map/map-component-handler.ts
+++ b/v3/src/components/map/map-component-handler.ts
@@ -1,0 +1,115 @@
+import { SetRequired } from "type-fest"
+import { V2Map } from "../../data-interactive/data-interactive-component-types"
+import { DIValues } from "../../data-interactive/data-interactive-types"
+import { DIComponentHandler } from "../../data-interactive/handlers/component-handler"
+import { appState } from "../../models/app-state"
+import {
+  getDataSetByNameOrId, getSharedCaseMetadataFromDataset, getSharedDataSets
+} from "../../models/shared/shared-data-utils"
+import { ITileContentModel } from "../../models/tiles/tile-content"
+import {
+  AttributeDescriptionsMapSnapshot, kDataConfigurationType
+} from "../data-display/models/data-configuration-model"
+import { kMapTileType } from "./map-defs"
+import { kMapPointLayerType, kMapPolygonLayerType } from "./map-types"
+import { IMapBaseLayerModelSnapshot } from "./models/map-base-layer-model"
+import { IMapModelContentSnapshot, isMapContentModel } from "./models/map-content-model"
+import { IMapPointLayerModelSnapshot } from "./models/map-point-layer-model"
+import { IMapPolygonLayerModelSnapshot } from "./models/map-polygon-layer-model"
+import {
+  boundaryAttributeFromDataSet, datasetHasBoundaryData, datasetHasLatLongData, latLongAttributesFromDataSet
+} from "./utilities/map-utils"
+
+export const mapComponentHandler: DIComponentHandler = {
+  create({ values }) {
+    const { document } = appState
+    const { center: _center, dataContext: _dataContext, legendAttributeName, zoom } = values as V2Map
+    const dataContext = getDataSetByNameOrId(document, _dataContext)
+    const legendAttributeId = legendAttributeName
+      ? dataContext?.getAttributeByName(legendAttributeName)?.id : undefined
+    const layers:
+      Array<IMapBaseLayerModelSnapshot | IMapPolygonLayerModelSnapshot | IMapPointLayerModelSnapshot> = []
+    let layerIndex = 0
+    getSharedDataSets(document).forEach(sharedDataSet => {
+      const dataset = sharedDataSet.dataSet
+      const metadata = getSharedCaseMetadataFromDataset(dataset)
+      if (metadata) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const LayerTypes = [kMapPointLayerType, kMapPolygonLayerType] as const
+        type LayerType = typeof LayerTypes[number]
+        const addLayer = (_type: LayerType, _attributeDescriptions: AttributeDescriptionsMapSnapshot) => {
+          layers.push({
+            dataConfiguration: {
+              _attributeDescriptions,
+              dataset: dataset.id,
+              metadata: metadata.id,
+              type: kDataConfigurationType
+            },
+            layerIndex: layerIndex++,
+            type: _type
+          })
+        }
+
+        // Point Layer
+        if (datasetHasLatLongData(dataset)) {
+          const { latId, longId } = latLongAttributesFromDataSet(dataset)
+          const _attributeDescriptions: AttributeDescriptionsMapSnapshot = {
+            lat: { attributeID: latId },
+            long: { attributeID: longId }
+          }
+          if (dataset.id === dataContext?.id && legendAttributeId) {
+            _attributeDescriptions.legend = { attributeID: legendAttributeId }
+          }
+          addLayer(kMapPointLayerType, _attributeDescriptions)
+
+        // Polygon Layer
+        } else if (datasetHasBoundaryData(dataset)) {
+          const _attributeDescriptions: AttributeDescriptionsMapSnapshot = {
+            polygon: { attributeID: boundaryAttributeFromDataSet(dataset) }
+          }
+          addLayer(kMapPolygonLayerType, _attributeDescriptions)
+        }
+      }
+    })
+
+    const center = _center ? { lat: _center[0], lng: _center[1] } : undefined
+    const content: SetRequired<IMapModelContentSnapshot, "type"> = {
+      type: kMapTileType,
+      center,
+      layers,
+      zoom
+    }
+    // If the center or zoom are specified, we need to prevent CODAP from automatically focusing the map
+    const options = center || zoom != null ? { transitionComplete: true } : undefined
+
+    return { content, options }
+  },
+
+  get(content) {
+    if (isMapContentModel(content)) {
+      return { dataContext: content.dataConfiguration?.dataset?.name }
+    }
+  },
+
+  update(content: ITileContentModel, values: DIValues) {
+    if (!isMapContentModel(content)) return { success: false }
+
+    // TODO: Finish implementing this function. See the Codap API docs for all properties that should be handled.
+    const { legendAttributeName, center: _center, zoom: _zoom } = values as V2Map
+    const { dataConfiguration } = content
+    const dataset = dataConfiguration?.dataset
+    if (dataset && legendAttributeName != null) {
+      const legendAttribute = dataset.getAttributeByName(legendAttributeName)
+      if (legendAttribute && dataConfiguration.placeCanAcceptAttributeIDDrop("legend", dataset, legendAttribute.id)) {
+        dataConfiguration.setAttribute("legend", { attributeID: legendAttribute.id })
+      }
+    }
+    if (_center != null || _zoom != null) {
+      const center = _center ? { lat: _center[0], lng: _center[1] } : content.center
+      const zoom = _zoom ?? content.zoom
+      content.setCenterAndZoom(center, zoom)
+    }
+
+    return { success: true }
+  }
+}

--- a/v3/src/components/map/map-registration.ts
+++ b/v3/src/components/map/map-registration.ts
@@ -1,34 +1,18 @@
-import { SetRequired } from "type-fest"
 import MapIcon from "../../assets/icons/icon-map.svg"
-import { V2Map } from "../../data-interactive/data-interactive-component-types"
 import { registerComponentHandler } from "../../data-interactive/handlers/component-handler"
-import { appState } from "../../models/app-state"
-import {
-  getDataSetByNameOrId, getSharedCaseMetadataFromDataset, getSharedDataSets
-} from "../../models/shared/shared-data-utils"
 import { registerTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { ITileLikeModel, registerTileContentInfo } from "../../models/tiles/tile-content-info"
 import { t } from "../../utilities/translation/translate"
 import { registerV2TileExporter } from "../../v2/codap-v2-tile-exporters"
 import { registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { ComponentTitleBar } from "../component-title-bar"
-import {
-  AttributeDescriptionsMapSnapshot, kDataConfigurationType
-} from "../data-display/models/data-configuration-model"
 import { MapComponent } from "./components/map-component"
 import { MapInspector } from "./components/map-inspector"
+import { mapComponentHandler } from "./map-component-handler"
 import {kMapIdPrefix, kMapTileClass, kMapTileType, kV2MapType} from "./map-defs"
-import {kDefaultMapHeight, kDefaultMapWidth, kMapPointLayerType, kMapPolygonLayerType} from "./map-types"
-import { IMapBaseLayerModelSnapshot } from "./models/map-base-layer-model"
-import {
-  createMapContentModel, IMapModelContentSnapshot, isMapContentModel, MapContentModel
-} from "./models/map-content-model"
-import { IMapPointLayerModelSnapshot } from "./models/map-point-layer-model"
-import { IMapPolygonLayerModelSnapshot } from "./models/map-polygon-layer-model"
+import {kDefaultMapHeight, kDefaultMapWidth} from "./map-types"
+import { createMapContentModel, MapContentModel } from "./models/map-content-model"
 import { MapFilterFormulaAdapter } from "./models/map-filter-formula-adapter"
-import {
-  boundaryAttributeFromDataSet, datasetHasBoundaryData, datasetHasLatLongData, latLongAttributesFromDataSet
-} from "./utilities/map-utils"
 import { v2MapExporter } from "./v2-map-exporter"
 import { v2MapImporter } from "./v2-map-importer"
 
@@ -67,73 +51,4 @@ registerTileComponentInfo({
 registerV2TileExporter(kMapTileType, v2MapExporter)
 registerV2TileImporter("DG.MapView", v2MapImporter)
 
-registerComponentHandler(kV2MapType, {
-  create({ values }) {
-    const { document } = appState
-    const { center: _center, dataContext: _dataContext, legendAttributeName, zoom } = values as V2Map
-    const dataContext = getDataSetByNameOrId(document, _dataContext)
-    const legendAttributeId = legendAttributeName
-      ? dataContext?.getAttributeByName(legendAttributeName)?.id : undefined
-    const layers:
-      Array<IMapBaseLayerModelSnapshot | IMapPolygonLayerModelSnapshot | IMapPointLayerModelSnapshot> = []
-    let layerIndex = 0
-    getSharedDataSets(document).forEach(sharedDataSet => {
-      const dataset = sharedDataSet.dataSet
-      const metadata = getSharedCaseMetadataFromDataset(dataset)
-      if (metadata) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const LayerTypes = [kMapPointLayerType, kMapPolygonLayerType] as const
-        type LayerType = typeof LayerTypes[number]
-        const addLayer = (_type: LayerType, _attributeDescriptions: AttributeDescriptionsMapSnapshot) => {
-          layers.push({
-            dataConfiguration: {
-              _attributeDescriptions,
-              dataset: dataset.id,
-              metadata: metadata.id,
-              type: kDataConfigurationType
-            },
-            layerIndex: layerIndex++,
-            type: _type
-          })
-        }
-
-        // Point Layer
-        if (datasetHasLatLongData(dataset)) {
-          const { latId, longId } = latLongAttributesFromDataSet(dataset)
-          const _attributeDescriptions: AttributeDescriptionsMapSnapshot = {
-            lat: { attributeID: latId },
-            long: { attributeID: longId }
-          }
-          if (dataset.id === dataContext?.id && legendAttributeId) {
-            _attributeDescriptions.legend = { attributeID: legendAttributeId }
-          }
-          addLayer(kMapPointLayerType, _attributeDescriptions)
-
-        // Polygon Layer
-        } else if (datasetHasBoundaryData(dataset)) {
-          const _attributeDescriptions: AttributeDescriptionsMapSnapshot = {
-            polygon: { attributeID: boundaryAttributeFromDataSet(dataset) }
-          }
-          addLayer(kMapPolygonLayerType, _attributeDescriptions)
-        }
-      }
-    })
-
-    const center = _center ? { lat: _center[0], lng: _center[1] } : undefined
-    const content: SetRequired<IMapModelContentSnapshot, "type"> = {
-      type: kMapTileType,
-      center,
-      layers,
-      zoom
-    }
-    // If the center or zoom are specified, we need to prevent CODAP from automatically focusing the map
-    const options = center || zoom != null ? { transitionComplete: true } : undefined
-
-    return { content, options }
-  },
-  get(content) {
-    if (isMapContentModel(content)) {
-      return { dataContext: content.dataConfiguration?.dataset?.name }
-    }
-  }
-})
+registerComponentHandler(kV2MapType, mapComponentHandler)


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/CODAP-335

This PR moves the `MapComponentHandler` into its own file and adds an `update` function to it. The `update` handler will be required to allow the NEO plugin to assign a geotiff to a map in Codap. This PR does not add that functionality. It just sets up the infrastructure for it, and handles some basic map features (`legendAttribute`, `center`, and `zoom`).