### PR TITLE
CODAP-375 Added a working (locally) Activity Player Cypress test

### DIFF
--- a/v3/cypress/config/cypress.dev.json
+++ b/v3/cypress/config/cypress.dev.json
@@ -1,4 +1,5 @@
 {
     "baseUrl": "https://codap3.concord.org",
-    "index": "/branch/main/"
+    "index": "/branch/main/",
+    "v3ActivityPlayerUrl": "https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring.lara.staging.concord.org%2Fapi%2Fv1%2Factivities%2F1178.json"
 }

--- a/v3/cypress/config/cypress.local.json
+++ b/v3/cypress/config/cypress.local.json
@@ -1,4 +1,5 @@
 {
     "baseUrl": "http://localhost:8080",
-    "index": "/"
+    "index": "/",
+    "v3ActivityPlayerUrl": "https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring.lara.staging.concord.org%2Fapi%2Fv1%2Factivities%2F1178.json"
 }

--- a/v3/cypress/config/cypress.staging.json
+++ b/v3/cypress/config/cypress.staging.json
@@ -1,4 +1,5 @@
 {
     "baseUrl": "https://codap3.concord.org",
-    "index": "index-staging.html"
+    "index": "index-staging.html",
+    "v3ActivityPlayerUrl": "https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring.lara.staging.concord.org%2Fapi%2Fv1%2Factivities%2F1178.json"
 }

--- a/v3/cypress/cypress.d.ts
+++ b/v3/cypress/cypress.d.ts
@@ -4,7 +4,7 @@ declare global {
   namespace Cypress {
     interface Cypress {
       // added to Cypress config via cypress.*.json configuration files
-      config(key: "index"): string
+      config(key: "index" | "v3ActivityPlayerUrl"): string
     }
     interface Chainable {
       /**

--- a/v3/cypress/e2e/cfm.spec.ts
+++ b/v3/cypress/e2e/cfm.spec.ts
@@ -138,4 +138,50 @@ context("CloudFileManager", () => {
     cfm.getLanguageMenuButton().click()
     cfm.getLanguageMenu().should("not.exist")
   })
+  it("should display in the Activity Player", () => {
+    // Ignore uncaught exceptions from the application for this test only
+    Cypress.on('uncaught:exception', (err) => {
+      // returning false here prevents Cypress from failing the test
+      return false
+    })
+
+    const activityPlayerUrl = Cypress.config("v3ActivityPlayerUrl")
+    cy.visit(activityPlayerUrl)
+
+    // Verify activity player loaded
+    cy.get("[data-cy='activity-title']", { timeout: 10000 })
+      .should("exist")
+      .and("contain.text", "Test CODAP v3")
+
+    cy.get("[data-cy='activity-nav-header']").should("exist")
+
+    // Navigate to page 8
+    cy.get("[data-cy='nav-pages-button']")
+      .filter("[aria-label='Page 8']")
+      .first()
+      .should("have.text", "8")
+      .click()
+      .then(() => {
+        // Wait for page content to load including iframe
+        cy.wait(15000)
+      })
+
+    // Verify iframe exists and has loaded
+    cy.get('iframe')
+      .should('be.visible')
+      .then($iframe => {
+        cy.wrap($iframe)
+          .should('have.prop', 'contentDocument')
+          .should('not.be.null')
+      })
+
+    // Verify content inside the iframe
+    cy.get('iframe')
+      .first()
+      .its('0.contentDocument.body')
+      .then(body => {
+        cy.wrap(body)
+          .should('contain.text', 'Hello from Activity Player')
+      })
+  })
 })


### PR DESCRIPTION
[CODAP-375](https://concord-consortium.atlassian.net/browse/CODAP-375)
- Full disclosure, I got help from Cursor to get this test working, mostly help with the iFrames.
- The main line of code I wanted to flag was the uncaught exception handling, I'm not sure that's something we can make an exception for in the case of the Activity Player. There may be a better way to handle the iFrame embedding issue.

## Changes
- Added new test to verify CODAP v3 display within the Activity Player
- Implemented iframe handling for Cypress tests

## Details
Added a new test that verifies CODAP v3 can properly display within the Activity Player. This test:
   - Navigates to the Activity Player
   - Verifies proper loading of the activity
   - Clicks to a specific page
   - Handles iframe content verification

## Testing
The test has been verified to run successfully in headless mode locally. 

Note: This test includes specific handling for uncaught exceptions that occur within the Activity Player, but keeps this exception handling isolated to just this test.