### PR TITLE
fix: Point disappearance on rearranging categorical plots (CODAP-371)

### DIFF
--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -211,7 +211,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     return mstReaction(
       () => graphModel.dataConfiguration.legendColorDomain,
       () => {
-        callRefreshPointPositions()
+        callRefreshPointPositions({ updateMasks: true })
       }, {name: "usePlot [legendColorChange]"}, graphModel)
   }, [graphModel, callRefreshPointPositions])
 


### PR DESCRIPTION
[[CODAP-371](https://concord-consortium.atlassian.net/browse/CODAP-371)]

Previous to this proposed change, when a graph with categorical attributes on the x and y axes had a categorical legend whose attribute matched one of those on the axes, and the categorical values of that attribute were re-ordered, the `usePlot [legendColorChange]` reaction/effect in `usePlotResponders` would fire, resulting in `callRefreshPointPositions` being called without `updateMasks` set to `true`. That meant the call to `updateCellMasks` in `callRefreshPointPositions` was skipped.

[CODAP-371]: https://concord-consortium.atlassian.net/browse/CODAP-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ