### PR TITLE
fixes bug where slider does not update slider value at the end of the run if the scale type is date

### DIFF
--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -78,7 +78,7 @@ export const SliderModel = TileContentModel
 
       // The bounds check for date scale type happens in the use-slider-animation
       // so we skip the bounds check if the axis is a date axis here
-      if (self.multipleOf && self.increment && self.scaleType !== "date") {
+      if (self.multipleOf && self.increment) {
         value = Math.round(value / self.increment) * self.increment
         value = value > self.axis.max ? value - self.increment : value
         value = value < self.axis.min ? value + self.increment : value

--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -76,7 +76,9 @@ export const SliderModel = TileContentModel
         else return num
       }
 
-      if (self.multipleOf && self.increment) {
+      // The bounds check for date scale type happens in the use-slider-animation
+      // so we skip the bounds check if the axis is a date axis here
+      if (self.multipleOf && self.increment && self.scaleType !== "date") {
         value = Math.round(value / self.increment) * self.increment
         value = value > self.axis.max ? value - self.increment : value
         value = value < self.axis.min ? value + self.increment : value

--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -76,8 +76,6 @@ export const SliderModel = TileContentModel
         else return num
       }
 
-      // The bounds check for date scale type happens in the use-slider-animation
-      // so we skip the bounds check if the axis is a date axis here
       if (self.multipleOf && self.increment) {
         value = Math.round(value / self.increment) * self.increment
         value = value > self.axis.max ? value - self.increment : value

--- a/v3/src/components/slider/slider-model.ts
+++ b/v3/src/components/slider/slider-model.ts
@@ -108,6 +108,9 @@ export const SliderModel = TileContentModel
     setValue(value: number) {
       self.globalValue.setValue(self.constrainValue(value))
     },
+    setValidatedValue(value: number) {
+      self.globalValue.setValue(value)
+    },
   }))
   .actions(self => ({
     setDynamicValueIfDynamic(value: number) {

--- a/v3/src/components/slider/use-slider-animation.tsx
+++ b/v3/src/components/slider/use-slider-animation.tsx
@@ -49,7 +49,7 @@ export const useSliderAnimation = ({sliderModel, running, setRunning}: IUseSlide
   const updateSlider = useCallback((val: number, min: FixValueFn, max: FixValueFn) => {
     if (sliderModel) {
       sliderModel.applyModelChange(
-        () => sliderModel.setValue(sliderModel.validateValue(val, min, max)),
+        () => sliderModel.setValidatedValue(sliderModel.validateValue(val, min, max)),
         { notify: () => valueChangeNotification(sliderModel.value, sliderModel.name) }
       )
     }


### PR DESCRIPTION
We were containing the slider value twice and so the last value of a date scale wasn't getting updated in the slider model.

Demo here: https://codap3.concord.org/branch/fix-slider-data-value/