### PR TITLE
[CODAP-607]: Add 'primaryAxis' property to graphComponentHandler 'get' operation.

### DIFF
--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -282,7 +282,7 @@ export const graphComponentHandler: DIComponentHandler = {
         .map(description => dataset?.getAttribute(description.attributeID)?.name).filter(name => name != null)
 
       const { pointDescription } = content
-      const { displayOnlySelectedCases, showMeasuresForSelection } = dataConfiguration
+      const { displayOnlySelectedCases, showMeasuresForSelection, primaryRole: primaryAxis } = dataConfiguration
       const filterFormula = dataConfiguration.filterFormula?.display
       const hiddenCases = dataConfiguration.hiddenCases.map(id => toV2Id(id))
       const plotType = content.plotType
@@ -295,7 +295,7 @@ export const graphComponentHandler: DIComponentHandler = {
 
       return {
         backgroundColor, dataContext, displayOnlySelectedCases, enableNumberToggle, filterFormula, hiddenCases,
-        numberToggleLastMode, plotType, pointColor, pointSize, showMeasuresForSelection,
+        numberToggleLastMode, plotType, pointColor, pointSize, primaryAxis, showMeasuresForSelection,
         strokeColor, strokeSameAsFill, transparent, captionAttributeID, captionAttributeName,
         legendAttributeID, legendAttributeName, rightSplitAttributeID, rightSplitAttributeName,
         topSplitAttributeID, topSplitAttributeName, type: "graph",

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -78,6 +78,7 @@ export interface V2Graph extends V2Component {
   plotType?: string
   pointColor?: string
   pointSize?: number
+  primaryAxis?: string
   rightNumericAttributeID?: number | null
   rightNumericAttributeName?: string | null
   rightSplitAttributeID?: number | null


### PR DESCRIPTION
[CODAP-607](https://concord-consortium.atlassian.net/browse/CODAP-607?atlOrigin=eyJpIjoiNjVjODA2NWFhZjc3NGI1OWE5NmZiMTg0NjgwMzU0NmMiLCJwIjoiaiJ9)

This is being added in order to support the DAVAI plugin + any other plugins that will need to know which axis of the graph currently has the primary role.