### PR TITLE
CODAP-322 & CODAP-323 Map polygon fixes

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -139,7 +139,8 @@ export const DataConfigurationModel = types
       const defaultCaptionAttributeID = () => {
         // We find the childmost collection and return the first attribute in that collection. If there is no
         // childmost collection, we return the first attribute in the dataset.
-        const attrIDs = (['x', 'y', 'rightNumeric', 'topSplit', 'rightSplit', 'legend', 'lat', 'long'] as const)
+        const attrIDs = (['x', 'y', 'rightNumeric', 'topSplit', 'rightSplit', 'legend',
+              'lat', 'long', 'polygon'] as const)
             .map(aRole => this.attributeID(aRole))
             .filter(id => !!id),
           childmostCollectionID = idOfChildmostCollectionForAttributes(attrIDs, self.dataset)

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -461,7 +461,8 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, set
 
   return (
     <>
-      <svg style={{height: "100%", position: "absolute", width: "100%", zIndex: 11}}>
+      <svg style={{height: "100%", position: "absolute", width: "100%", zIndex: 11,
+          visibility: showConnectingLines ? "visible" : "hidden"}}>
         <g data-testid={`connecting-lines-${instanceId}`} className="connecting-lines" ref={connectingLinesRef}/>
       </svg>
       <div ref={pixiContainerRef} className="map-dot-area"/>


### PR DESCRIPTION
[#CODAP-322] Bug fix: Unable to click/select polygon in map

* (Note that the bug only occurs if there are points in addition to polygons in the map.) The PixiPoints canvas forwards clicks to whatever element it find is directly beneath it. But it was finding the svg layer for connecting lines instead of Leaflet. We improve the situation by hiding the connecting lines layer if the connecting lines adornment is not showing. We expect that this is sufficient given the rarity of there being both polygons and connecting lines and the need to select polygons.

[#CODAP-323] Bug fix: Map polygons created for each child case instead of one per parent

* This bug was caused by the `DataConfigurationModel.attributeID.defaultCaptionAttributeID` failing to include 'polygon' as one of the roles. The result was that a childmost attribute was being chosen as the caption attribute ID and this caused the array of cases for creating polygons to be the childmost cases rather than the array to be drawn from the collection that actually contains the polygon attribute.