### PR TITLE
CODAP-95 Graph display problems with changes in hierarchy

### DIFF
--- a/v3/src/components/data-display/components/legend/legend.tsx
+++ b/v3/src/components/data-display/components/legend/legend.tsx
@@ -38,7 +38,7 @@ export const Legend = observer(function Legend({
   const dataConfiguration = useDataConfigurationContext(),
     legendID = dataConfiguration?.attributeID("legend"),
     legendRef = useRef() as React.RefObject<SVGSVGElement>
-    if (!dataConfiguration?.isAllowableNonAxisAttribute(legendID)) return null
+  if (!dataConfiguration?.isAttributeAllowedForNonAxisRole(legendID)) return null
   const attrType = dataConfiguration?.attributeType('legend'),
     LegendComponent = dataConfiguration && legendComponentManager.getLegendComponent(dataConfiguration)
 

--- a/v3/src/components/data-display/components/legend/legend.tsx
+++ b/v3/src/components/data-display/components/legend/legend.tsx
@@ -36,9 +36,11 @@ export const Legend = observer(function Legend({
                                         layerIndex, setDesiredExtent, onDropAttribute
                                       }: ILegendProps) {
   const dataConfiguration = useDataConfigurationContext(),
-    attrType = dataConfiguration?.attributeType('legend'),
-    LegendComponent = dataConfiguration && legendComponentManager.getLegendComponent(dataConfiguration),
+    legendID = dataConfiguration?.attributeID("legend"),
     legendRef = useRef() as React.RefObject<SVGSVGElement>
+    if (!dataConfiguration?.isAllowableNonAxisAttribute(legendID)) return null
+  const attrType = dataConfiguration?.attributeType('legend'),
+    LegendComponent = dataConfiguration && legendComponentManager.getLegendComponent(dataConfiguration)
 
   // Only show the legend if there is a legend role specified in the dataConfiguration
   return attrType ? (

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -131,8 +131,23 @@ export const DataConfigurationModel = types
     get attributeDescriptionsStr() {
       return JSON.stringify(this.attributeDescriptions)
     },
+    isAllowableNonAxisAttribute(attrID?: string) {
+      if (!attrID) return false
+      // The legend and caption attributes are not allowed to be an attribute belonging
+      // to a collection that is a child of the childmost collection (using axis attributes).
+      const childmostCollectionID = this.childmostCollectionIDForAxisAttributes,
+        collections = self.dataset?.collections || []
+      let allowed = false
+      for (const collection of collections) {
+        allowed = collection.attributes.map(attr => attr?.id || '').includes(attrID)
+        if (allowed || collection.id === childmostCollectionID) break
+      }
+      return allowed
+    },
     attributeDescriptionForRole(role: AttrRole) {
-      return this.attributeDescriptions[role]
+      const attrDesc = this.attributeDescriptions[role]
+      return role !== "legend" || this.isAllowableNonAxisAttribute(attrDesc?.attributeID)
+        ? attrDesc : undefined
     },
     // returns empty string (rather than undefined) for roles without attributes
     attributeID(role: AttrRole) {
@@ -267,7 +282,10 @@ export const DataConfigurationModel = types
         .map(role => {
           return {role, attributeID: self.attributeID(role) || ''}
         })
-        .filter(pair => !!pair.attributeID)
+        .filter(pair => {
+          return (pair.role !== 'legend' && pair.role !== 'caption') ||
+            self.isAllowableNonAxisAttribute(pair.attributeID) && !!pair.attributeID
+        })
     },
     get uniqueTipAttributes() {
       const tipAttributes = this.tipAttributes,
@@ -793,7 +811,7 @@ export const DataConfigurationModel = types
           source: self.dataset,
           casesArrayNumber: self.filteredCases.length,
           filter: self.filterCase,
-          collectionID: idOfChildmostCollectionForAttributes(self.attributes, self.dataset),
+          collectionID: idOfChildmostCollectionForAttributes(self.axisAttributeIDs, self.dataset),
           onSetCaseValues: this.handleSetCaseValues
         }))
         self.setPointsNeedUpdating(true)
@@ -808,7 +826,7 @@ export const DataConfigurationModel = types
         self.filteredCases[0] = new FilteredCases({
           source: dataset,
           filter: self.filterCase,
-          collectionID: idOfChildmostCollectionForAttributes(self.attributes, dataset),
+          collectionID: idOfChildmostCollectionForAttributes(self.axisAttributeIDs, dataset),
           onSetCaseValues: this.handleSetCaseValues
         })
       }

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -131,7 +131,7 @@ export const DataConfigurationModel = types
     get attributeDescriptionsStr() {
       return JSON.stringify(this.attributeDescriptions)
     },
-    isAllowableNonAxisAttribute(attrID?: string) {
+    isAttributeAllowedForNonAxisRole(attrID?: string) {
       if (!attrID) return false
       // The legend and caption attributes are not allowed to be an attribute belonging
       // to a collection that is a child of the childmost collection (using axis attributes).
@@ -139,14 +139,14 @@ export const DataConfigurationModel = types
         collections = self.dataset?.collections || []
       let allowed = false
       for (const collection of collections) {
-        allowed = collection.attributes.map(attr => attr?.id || '').includes(attrID)
+        allowed = !!collection.getAttribute(attrID)
         if (allowed || collection.id === childmostCollectionID) break
       }
       return allowed
     },
     attributeDescriptionForRole(role: AttrRole) {
       const attrDesc = this.attributeDescriptions[role]
-      return role !== "legend" || this.isAllowableNonAxisAttribute(attrDesc?.attributeID)
+      return (role !== "legend" && role !== "caption") || this.isAttributeAllowedForNonAxisRole(attrDesc?.attributeID)
         ? attrDesc : undefined
     },
     // returns empty string (rather than undefined) for roles without attributes
@@ -284,7 +284,7 @@ export const DataConfigurationModel = types
         })
         .filter(pair => {
           return ((pair.role !== 'legend' && pair.role !== 'caption') ||
-            self.isAllowableNonAxisAttribute(pair.attributeID)) && !!pair.attributeID
+            self.isAttributeAllowedForNonAxisRole(pair.attributeID)) && !!pair.attributeID
         })
     },
     get uniqueTipAttributes() {

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -283,8 +283,8 @@ export const DataConfigurationModel = types
           return {role, attributeID: self.attributeID(role) || ''}
         })
         .filter(pair => {
-          return (pair.role !== 'legend' && pair.role !== 'caption') ||
-            self.isAllowableNonAxisAttribute(pair.attributeID) && !!pair.attributeID
+          return ((pair.role !== 'legend' && pair.role !== 'caption') ||
+            self.isAllowableNonAxisAttribute(pair.attributeID)) && !!pair.attributeID
         })
     },
     get uniqueTipAttributes() {

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -48,11 +48,14 @@ export function isAnyChildSelected(data: IDataSet, caseId: string): boolean {
  */
 export function idOfChildmostCollectionForAttributes(attrIDs: string[], data?: IDataSet) {
   if (!data) return undefined
-  const collections = data.collections
-  for (let i = collections.length - 1; i >= 0; --i) {
+  const collections = data.collections,
+    length = collections.length
+  for (let i = length - 1; i >= 0; --i) {
     const collection = collections[i]
     if (collection.attributes.some(attr => attrIDs.includes(attr?.id ?? ""))) return collection.id
   }
+  // If we didn't find one, return the id of the childmost collection
+  return length > 0 ? collections[length - 1].id : ''
 }
 
 export function firstVisibleParentAttribute(data?: IDataSet, collectionId?: string): IAttribute | undefined {

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -55,7 +55,7 @@ export function idOfChildmostCollectionForAttributes(attrIDs: string[], data?: I
     if (collection.attributes.some(attr => attrIDs.includes(attr?.id ?? ""))) return collection.id
   }
   // If we didn't find one, return the id of the childmost collection
-  return length > 0 ? collections[length - 1].id : ''
+  return length > 0 ? collections[length - 1].id : undefined
 }
 
 export function firstVisibleParentAttribute(data?: IDataSet, collectionId?: string): IAttribute | undefined {


### PR DESCRIPTION
[#CODAP-361] Bug fix: Graph legend incorrect after hierarchy change in table

[#CODAP-95] Bug fix: Legend colors not being shown, and graph not adapting to change in plotted attributes properly

* There are a number of bugs to fix here
  * In the Mammals sample document dragging **Diet** to the left to create a parent collection should be changing the number of cases in the **Diet** graph to 3, but it leaves all of them in place.
  * The data tip for points in graph where the cases are not childmost should not display values for childmost attributes; e.g. when there is a legend from an attribute that is more childmost than the axis attributes.
  * When the legend attribute in a graph happens to be more childmost than the axis attributes, nothing should be displayed in the category or numeric portion of the legend.

_Fixes_
* When we're adding `FilteredCases` to the `DataConfigurationModel` we should only be using attributes assigned to axes to determine the childmost collection.
* `DataConfigurationModel` `tipAttributes` should not include attributes that are more childMost than the axis attributes.
* The Legend component only displays if the legend attribute does not belong to a collection more childmost than the childmost collection determined from axis attributes.