### PR TITLE
CODAP-86 Fix to ruler menu in presence of binned dot plot

### DIFF
--- a/v3/src/components/graph/adornments/adornment-ui-types.ts
+++ b/v3/src/components/graph/adornments/adornment-ui-types.ts
@@ -17,10 +17,10 @@ export function getMeasuresForPlot(plotType: PlotType): IMeasure[] {
       ]
     case "barChart":
     case "dotChart":
+    case "binnedDotPlot":
       return [
         {title: "DG.Inspector.graphCount", type: "Count"}
       ]
-    case "binnedDotPlot":
     case "dotPlot":
     case "histogram":
     case "linePlot":


### PR DESCRIPTION
[#CODAP-86] Bug fix: The ruler menu for binned dot plots should only show Count and Percent

* This was fixed with a trivial change in adornment-ui-types.ts