### PR TITLE
Change number of datasets for plugin created graphs

### DIFF
--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -22,7 +22,6 @@ import { IGraphDataConfigurationModel, kGraphDataConfigurationType } from "./mod
 import { GraphLayout } from "./models/graph-layout"
 import { syncModelWithAttributeConfiguration } from "./models/graph-model-utils"
 import { IGraphPointLayerModelSnapshot, kGraphPointLayerType } from "./models/graph-point-layer-model"
-import { a } from "react-dom-factories"
 
 interface AttributeInfo {
   id?: number | null

--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -22,6 +22,7 @@ import { IGraphDataConfigurationModel, kGraphDataConfigurationType } from "./mod
 import { GraphLayout } from "./models/graph-layout"
 import { syncModelWithAttributeConfiguration } from "./models/graph-model-utils"
 import { IGraphPointLayerModelSnapshot, kGraphPointLayerType } from "./models/graph-point-layer-model"
+import { a } from "react-dom-factories"
 
 interface AttributeInfo {
   id?: number | null
@@ -86,9 +87,11 @@ export const graphComponentHandler: DIComponentHandler = {
     let provisionalMetadata: IDataSetMetadata | undefined
     const sharedDataSets = getSharedDataSets(appState.document)
     // We currently only support one dataset in a graph, so we find the one specified by plugin
-    const sharedDataSet = sharedDataSets.find(sd => {
-      return sd.dataSet.name === _dataContext
-    })
+    const sharedDataSet = sharedDataSets.length === 1
+                            ? sharedDataSets[0]
+                            : sharedDataSets.find(sd => {
+                              return _dataContext && sd.dataSet.matchTitleOrNameOrId(_dataContext)
+                            })
     if (sharedDataSet) {
       const dataset = sharedDataSet.dataSet
       const metadata = getMetadataFromDataSet(dataset)

--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -183,7 +183,6 @@ export const graphComponentHandler: DIComponentHandler = {
     // so we have to copy that over into the constructed layers. We also make sure all attribute assignments
     // are legal here.
     const finalLayers: Array<IGraphPointLayerModelSnapshot> = []
-    console.log("layers", layers)
     for (let i = 0; i < layers.length; i++) {
       const dataConfiguration = graphModel.layers[i].dataConfiguration as IGraphDataConfigurationModel
       dataConfiguration.setShowMeasuresForSelection(showMeasuresForSelection ?? false)

--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -84,7 +84,12 @@ export const graphComponentHandler: DIComponentHandler = {
     const layers: Array<IGraphPointLayerModelSnapshot> = []
     let provisionalDataSet: IDataSet | undefined
     let provisionalMetadata: IDataSetMetadata | undefined
-    getSharedDataSets(appState.document).forEach(sharedDataSet => {
+    const sharedDataSets = getSharedDataSets(appState.document)
+    // We currently only support one dataset in a graph, so we find the one specified by plugin
+    const sharedDataSet = sharedDataSets.find(sd => {
+      return sd.dataSet.name === _dataContext
+    })
+    if (sharedDataSet) {
       const dataset = sharedDataSet.dataSet
       const metadata = getMetadataFromDataSet(dataset)
       if (metadata) {
@@ -150,7 +155,7 @@ export const graphComponentHandler: DIComponentHandler = {
           type: kGraphPointLayerType
         })
       }
-    })
+    }
 
     // Create a GraphContentModel, call syncModelWithAttributeConfiguration to set up its primary role,
     // plot type, and axes properly, then use its snapshot
@@ -178,6 +183,7 @@ export const graphComponentHandler: DIComponentHandler = {
     // so we have to copy that over into the constructed layers. We also make sure all attribute assignments
     // are legal here.
     const finalLayers: Array<IGraphPointLayerModelSnapshot> = []
+    console.log("layers", layers)
     for (let i = 0; i < layers.length; i++) {
       const dataConfiguration = graphModel.layers[i].dataConfiguration as IGraphDataConfigurationModel
       dataConfiguration.setShowMeasuresForSelection(showMeasuresForSelection ?? false)


### PR DESCRIPTION
Limits the dataset context added to a plugin created graph to the one specified by the plugin.

Having multiple datasets in the document with the NASA Earth Data plugin was causing problems when creating a graph from the plugin. The DI graph component handler was creating layers for each of the dataset, while CODAP only recognizes the first dataset in the data configuration model.