### PR TITLE
CODAP-323 Fixing bugs with hiding cases that display polygons in maps

### DIFF
--- a/v3/src/components/map/models/map-polygon-layer-model.ts
+++ b/v3/src/components/map/models/map-polygon-layer-model.ts
@@ -16,6 +16,7 @@ export const MapPolygonLayerModel = MapLayerModel
     type: types.optional(types.literal(kMapPolygonLayerType), kMapPolygonLayerType),
   })
   .volatile(() => ({
+    // Key is case ID
     features: {} as Record<string, GeoJSON>
   }))
   .actions(self => ({

--- a/v3/src/components/map/models/map-polygon-layer-model.ts
+++ b/v3/src/components/map/models/map-polygon-layer-model.ts
@@ -16,7 +16,7 @@ export const MapPolygonLayerModel = MapLayerModel
     type: types.optional(types.literal(kMapPolygonLayerType), kMapPolygonLayerType),
   })
   .volatile(() => ({
-    features: [] as GeoJSON[]
+    features: {} as Record<string, GeoJSON>
   }))
   .actions(self => ({
     afterCreate() {


### PR DESCRIPTION
[#CODAP-323] Bug fix: Map polygons created for each child case instead of one per parent

* This is a second pass through this bug fix. In the first pass we fixed things so that only one polygon per case at the collection level of the polygon was added to the map instead of one polygon per child case and therefore multiple polygons per case at the level of the polygon.
  * In this second pass we fix problems brought about by storing polygons in the model in an array of features and relying on array indices to be stable even when cases are hidden.
  * The fix is to store polygons (features) in a map where the keys are case IDs. This method is guaranteed to be stable in the face of changes as to which polygons are hidden.