### PR TITLE
Codap 7 - Adds connecting line plugin API affordances

### DIFF
--- a/v3/src/components/data-display/hooks/use-connecting-lines.ts
+++ b/v3/src/components/data-display/hooks/use-connecting-lines.ts
@@ -104,7 +104,13 @@ export const useConnectingLines = (props: IProps) => {
       const lineCaseIds = allLineCaseIds[primaryAttrValue]
       const allCasesSelected = lineCaseIds?.every((caseID: string) => dataset?.isCaseSelected(caseID))
       const legendID = dataConfig?.attributeID("legend")
-      const color = parentAttrID && legendID ? pointColorAtIndex(linesIndex) : pointColorAtIndex(0)
+      const categoryDataArray = dataConfig?.categoryArrayForAttrRole("legend")
+      const legendAttribute = legendID ? dataset?.getAttribute(legendID) : undefined
+      const legendAttrType = legendAttribute?.type
+      const color = legendAttribute && legendAttrType === "color" && categoryDataArray
+                      ? categoryDataArray[linesIndex]
+                      : parentAttrID && legendID ? pointColorAtIndex(linesIndex)
+                                                  : pointColorAtIndex(0)
 
       connectingLinesArea
         .append("path")

--- a/v3/src/components/graph/adornments/store/adornments-base-store.ts
+++ b/v3/src/components/graph/adornments/store/adornments-base-store.ts
@@ -63,6 +63,9 @@ export const AdornmentsBaseStore = types.model("AdornmentsBaseStore", {
   toggleShowConnectingLines() {
     self.showConnectingLines = !self.showConnectingLines
   },
+  setShowConnectingLines(show: boolean) {
+      self.showConnectingLines = show
+  },
   toggleShowLabels() {
     self.showMeasureLabels = !self.showMeasureLabels
   },

--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -220,6 +220,15 @@ export const graphComponentHandler: DIComponentHandler = {
         }
       })
     }
+
+    // TODO: There is a race condition that causes a d3 error when we try to
+    // add the connecting lines on graph creation. So disabling this feature
+    // for now, and we use update graph to enable it.
+    // Enable connecting lines after the graph model is fully initialized
+    // if (showConnectingLines !== undefined) {
+    //     graphModel.adornmentsStore.setShowConnectingLines(showConnectingLines)
+    // }
+
     const result = { content: { ...getSnapshot(graphModel), layers: finalLayers } as ITileContentSnapshotWithType }
     // After we get the snapshot, destroy the model to stop all reactions
     destroy(graphModel)
@@ -297,11 +306,12 @@ export const graphComponentHandler: DIComponentHandler = {
       const strokeSameAsFill = pointDescription.pointStrokeSameAsFill
       const backgroundColor = content.plotBackgroundColor
       const transparent = content.isTransparent
+      const showConnectingLines = content.adornmentsStore.showConnectingLines
 
       return {
         backgroundColor, dataContext, displayOnlySelectedCases, enableNumberToggle, filterFormula, hiddenCases,
-        numberToggleLastMode, plotType, pointColor, pointSize, primaryAxis, showMeasuresForSelection,
-        strokeColor, strokeSameAsFill, transparent, captionAttributeID, captionAttributeName,
+        numberToggleLastMode, plotType, pointColor, pointSize, primaryAxis, showConnectingLines,
+        showMeasuresForSelection, strokeColor, strokeSameAsFill, transparent, captionAttributeID, captionAttributeName,
         legendAttributeID, legendAttributeName, rightSplitAttributeID, rightSplitAttributeName,
         topSplitAttributeID, topSplitAttributeName, type: "graph",
         xAttributeID, xAttributeName, xAttributeType, xLowerBound, xUpperBound,
@@ -317,9 +327,9 @@ export const graphComponentHandler: DIComponentHandler = {
     const {
       backgroundColor, dataContext: _dataContext, displayOnlySelectedCases, enableNumberToggle: showParentToggles,
       filterFormula, hiddenCases, numberToggleLastMode: showOnlyLastCase, pointColor,
-      pointSize, showMeasuresForSelection, strokeColor, strokeSameAsFill, transparent, xAttributeType, xLowerBound,
-      xUpperBound, yAttributeID, yAttributeIDs, yAttributeName, yAttributeNames, yAttributeType, yLowerBound,
-      yUpperBound, y2AttributeType, y2LowerBound, y2UpperBound
+      pointSize, showConnectingLines, showMeasuresForSelection, strokeColor, strokeSameAsFill, transparent,
+      xAttributeType, xLowerBound, xUpperBound, yAttributeID, yAttributeIDs, yAttributeName, yAttributeNames,
+      yAttributeType, yLowerBound, yUpperBound, y2AttributeType, y2LowerBound, y2UpperBound
     } = values as V2GetGraph
     const attributeInfo = getAttributeInfo(values)
     const { dataConfiguration, pointDescription } = content
@@ -437,6 +447,7 @@ export const graphComponentHandler: DIComponentHandler = {
     if (hiddenCases != null) dataConfiguration.setHiddenCases(hiddenCases.map(id => toV3CaseId(id)))
     if (pointColor != null) pointDescription.setPointColor(pointColor)
     if (pointSize != null) pointDescription.setPointSizeMultiplier(pointSize)
+    if (showConnectingLines != null) content.adornmentsStore.setShowConnectingLines(showConnectingLines)
     if (showMeasuresForSelection != null) dataConfiguration.setShowMeasuresForSelection(showMeasuresForSelection)
     if (showParentToggles != null) content.setShowParentToggles(showParentToggles)
     if (showOnlyLastCase != null) content.setShowOnlyLastCase(showOnlyLastCase)

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -83,6 +83,7 @@ export interface V2Graph extends V2Component {
   rightNumericAttributeName?: string | null
   rightSplitAttributeID?: number | null
   rightSplitAttributeName?: string | null
+  showConnectingLines?: boolean
   showMeasuresForSelection?: boolean
   strokeColor?: string
   strokeSameAsFill?: boolean


### PR DESCRIPTION
NEO Earth plugin required connecting lines to be the same color as the points as specified by the map pin color. This adds a check to see if legend attribute is of color type, and if it is use, that color for the connecting line.

This also adds the ability to update the graph to show the connecting lines through the API.