### PR TITLE
CODAP-617 Even out the binned dot plot stacks

### DIFF
--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -74,7 +74,7 @@ export class NumericAxisHelper extends AxisHelper {
     } else if (!hasDraggableNumericAxis) {
       const formatter = (value: number) => this.multiScale?.formatValueForScale(value) ?? ""
       const {tickValues, tickLabels} = this.axisProvider.nonDraggableAxisTicks(formatter) ||
-      {tickValues: [], tickLabels: []}
+        {tickValues: [], tickLabels: []}
       axisScale.tickValues(tickValues)
       axisScale.tickFormat((d, i) => tickLabels[i])
     }

--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -1,7 +1,7 @@
 import { format, ScaleLinear, select } from "d3"
 import { between } from "../../../utilities/math-utils"
 import { transitionDuration } from "../../data-display/data-display-types"
-import { computeBestNumberOfTicks } from "../axis-utils"
+import { computeBestNumberOfTicks, getStringBounds } from "../axis-utils"
 import { AxisScaleType, otherPlace } from "../axis-types"
 import { isNonDateNumericAxisModel } from "../models/numeric-axis-models"
 import { AxisHelper, IAxisHelperArgs } from "./axis-helper"
@@ -10,6 +10,7 @@ export interface INumericAxisHelperArgs extends IAxisHelperArgs {
   showScatterPlotGridLines: boolean
   showZeroAxisLine?: boolean
 }
+
 export class NumericAxisHelper extends AxisHelper {
   showScatterPlotGridLines: boolean
   showZeroAxisLine?: boolean
@@ -74,7 +75,7 @@ export class NumericAxisHelper extends AxisHelper {
     } else if (!hasDraggableNumericAxis) {
       const formatter = (value: number) => this.multiScale?.formatValueForScale(value) ?? ""
       const {tickValues, tickLabels} = this.axisProvider.nonDraggableAxisTicks(formatter) ||
-        {tickValues: [], tickLabels: []}
+      {tickValues: [], tickLabels: []}
       axisScale.tickValues(tickValues)
       axisScale.tickFormat((d, i) => tickLabels[i])
     }
@@ -97,39 +98,40 @@ export class NumericAxisHelper extends AxisHelper {
     this.showZeroAxisLine && this.renderZeroAxisLine()
     this.showScatterPlotGridLines && this.renderScatterPlotGridLines()
 
-    if (this.axisModel.place === 'bottom') {
+    if (this.axisModel.place === 'bottom' && !hasDraggableNumericAxis && this.multiScale && this.displayModel) {
+      const formatter = (value: number) => this.multiScale?.formatValueForScale(value) || ""
+      const {tickLabels} = this.displayModel.nonDraggableAxisTicks(formatter)
       // Detect overlapping tick labels
       const tickLabelsSelection = subAxisSelection.selectAll(".tick text")
-      requestAnimationFrame(() => {
-        let hasOverlap = false
-        let previousEnd = 0
-        let detectedNonZeroTextLength = false
+      let hasOverlap = false
+      let previousEnd = 0
+      let detectedNonZeroTextLength = false
 
-        tickLabelsSelection.each(function (_, i) {
-          const currentNode = this as SVGTextElement
-          const textWidth = currentNode.getComputedTextLength()
-          const currentStart = currentNode.getBoundingClientRect().left
-          const currentEnd = currentStart + textWidth
-          detectedNonZeroTextLength ||= textWidth > 0
+      tickLabelsSelection.each(function (_, i) {
+        const textWidth = getStringBounds(tickLabels[i]).width
+        const currentNode = this as SVGTextElement
+        const currentStart = currentNode.getBoundingClientRect().left
+        const currentEnd = currentStart + textWidth
+        detectedNonZeroTextLength ||= textWidth > 0
 
-          if (i > 0 && currentStart < previousEnd) {
-            hasOverlap = true
-          }
-          previousEnd = currentEnd
-        })
-
-        if (detectedNonZeroTextLength) {
-          // Rotate labels if overlap is detected
-          if (hasOverlap) {
-            tickLabelsSelection
-              .attr("transform", "rotate(-90)")
-              .style("text-anchor", "end")
-              .attr("x", -8)
-              .attr("y", -6)
-          }
-          this.axisModel.setLabelsAreRotated(hasOverlap)
+        if (i > 0 && currentStart < previousEnd) {
+          hasOverlap = true
         }
+        previousEnd = currentEnd
       })
+
+      if (detectedNonZeroTextLength) {
+        // Rotate labels if overlap is detected
+        if (hasOverlap) {
+          tickLabelsSelection
+            .attr("transform", "rotate(-90)")
+            .transition().duration(duration)
+            .style("text-anchor", "end")
+            .attr("x", -8)
+            .attr("y", -6)
+        }
+        this.axisModel.setLabelsAreRotated(hasOverlap)
+      }
     }
   }
 }

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -77,7 +77,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
       case 'percent':
       case 'numeric': {
         ticks = getTicks({d3Scale, isBinned, multiScale, displayModel})
-        desiredExtent += ['left', 'rightNumeric'].includes(axisPlace)
+        desiredExtent += ['left', 'rightNumeric'].includes(axisPlace) || axisModel?.labelsAreRotated
           ? Math.max(getStringBounds(ticks[0]).width, getStringBounds(ticks[ticks.length - 1]).width) + axisGap
           : numbersHeight + axisGap
         break

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -20,7 +20,7 @@ import { DateAxisHelper } from "../helper-models/date-axis-helper"
 import { NumericAxisHelper } from "../helper-models/numeric-axis-helper"
 import { useAxisLayoutContext } from "../models/axis-layout-context"
 import {IAxisModel} from "../models/axis-model"
-import { isAnyCategoricalAxisModel, isCategoricalAxisModel, isColorAxisModel } from "../models/categorical-axis-models"
+import { isAnyCategoricalAxisModel, isColorAxisModel } from "../models/categorical-axis-models"
 import { isAnyNumericAxisModel } from "../models/numeric-axis-models"
 import { useAxisProviderContext } from "./use-axis-provider-context"
 

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -15,6 +15,7 @@ export const AxisModel = types.model("AxisModel", {
   scale: types.optional(types.enumeration([...ScaleTypes]), "ordinal")
 })
   .volatile(self => ({
+    labelsAreRotated: false,
     transitionDuration: 0
   }))
   .views(self => ({
@@ -29,6 +30,9 @@ export const AxisModel = types.model("AxisModel", {
   .actions(self => ({
     setScale(scale: IScaleType) {
       self.scale = scale
+    },
+    setLabelsAreRotated(rotated: boolean) {
+      self.labelsAreRotated = rotated
     },
     setTransitionDuration(duration: number) {
       self.transitionDuration = duration

--- a/v3/src/components/graph/hooks/use-binned-plot-responders.ts
+++ b/v3/src/components/graph/hooks/use-binned-plot-responders.ts
@@ -17,6 +17,6 @@ export const useBinnedPlotResponders = (refreshPointPositions: (selected: boolea
         return isBinnedPlotModel(plot) ? [plot.binAlignment, plot.binWidth] : []
       },
       () => refreshPointPositions(false),
-      {name: "respondToGraphBinSettings", equals: comparer.structural}, graphModel)
+      {name: "respondToGraphBinSettings", equals: comparer.structural}, [graphModel, graphModel.plot])
   }, [dataset, graphModel, refreshPointPositions])
 }

--- a/v3/src/components/graph/hooks/use-dot-plot.ts
+++ b/v3/src/components/graph/hooks/use-dot-plot.ts
@@ -63,8 +63,7 @@ export const useDotPlot = (pixiPoints?: PixiPoints) => {
     numExtraPrimaryBands, pointDiameter, primaryAttrID, primaryAxisScale, primaryPlace, secondaryAttrID,
     secondaryBandwidth, totalNumberOfBins
   }
-  const { bins, binMap } = computeBinPlacements(binPlacementProps)
-  const overlap = 0
+  const { bins, binMap, overlap, numPointsInRow } = computeBinPlacements(binPlacementProps)
   const secondaryRangeIndex = primaryIsBottom ? 0 : 1
   const secondaryMax = Number(secondaryAxisScale.range()[secondaryRangeIndex])
   const secondarySign = primaryIsBottom ? -1 : 1
@@ -92,18 +91,19 @@ export const useDotPlot = (pixiPoints?: PixiPoints) => {
     let primaryScreenCoord = primaryCoord + extraPrimaryCoord
 
     if (binWidth !== undefined && !isHistogram) {
+      const { indexInBin } = binMap[anID]
       const caseValue = dataDisplayGetNumericValue(dataset, anID, primaryAttrID) ?? -1
       const binForCase = determineBinForCase(caseValue, binWidth, minBinEdge)
       primaryScreenCoord = adjustCoordForStacks({
         anID, axisType: "primary", binForCase, binMap, bins, pointDiameter, secondaryBandwidth,
-        screenCoord: primaryScreenCoord, primaryIsBottom
+        screenCoord: primaryScreenCoord, primaryIsBottom, indexInBin, numPointsInRow
       })
     }
 
     return primaryScreenCoord
   }, [binMap, binWidth, bins, dataset, extraPrimaryAttrID, extraPrimaryAxisScale, isHistogram,
       minBinEdge, numExtraPrimaryBands, pointDiameter, primaryAttrID, primaryAxisScale, primaryIsBottom,
-      secondaryBandwidth, totalNumberOfBins])
+      secondaryBandwidth, totalNumberOfBins, numPointsInRow])
 
   const getSecondaryScreenCoord = useCallback((anID: string) => {
     if (!binMap[anID]) return 0
@@ -111,24 +111,19 @@ export const useDotPlot = (pixiPoints?: PixiPoints) => {
     const { category: secondaryCat, extraCategory: extraSecondaryCat, indexInBin } = binMap[anID]
     const secondaryCoordProps = {
       baseCoord, dataConfig, extraSecondaryAxisScale, extraSecondaryBandwidth, extraSecondaryCat, indexInBin, layout,
-      numExtraSecondaryBands, overlap, pointDiameter, primaryIsBottom, secondaryAxisExtent, secondaryNumericScale,
-      secondaryAxisScale, secondaryBandwidth, secondaryCat, secondarySign, isHistogram
+      numExtraSecondaryBands, overlap, numPointsInRow, pointDiameter, primaryIsBottom, secondaryAxisExtent,
+      secondaryNumericScale, secondaryAxisScale, secondaryBandwidth, secondaryCat, secondarySign, isHistogram
     }
     let secondaryScreenCoord = computeSecondaryCoord(secondaryCoordProps)
 
     if (binWidth !== undefined && !isHistogram) {
-      const onePixelOffset = primaryIsBottom ? -1 : 1
-      const casePrimaryValue = dataDisplayGetNumericValue(dataset, anID, primaryAttrID) ?? -1
-      const binForCase = determineBinForCase(casePrimaryValue, binWidth, minBinEdge)
-      secondaryScreenCoord = adjustCoordForStacks({
-        anID, axisType: "secondary", binForCase, binMap, bins, pointDiameter, secondaryBandwidth,
-        screenCoord: secondaryScreenCoord, primaryIsBottom
-      }) + onePixelOffset
+      secondaryScreenCoord += primaryIsBottom ? -1 : 1
     }
     return secondaryScreenCoord
-  }, [baseCoord, binMap, binWidth, bins, dataConfig, dataset, extraSecondaryAxisScale, extraSecondaryBandwidth,
-      isHistogram, layout, minBinEdge, numExtraSecondaryBands, pointDiameter, primaryAttrID, primaryIsBottom,
-      secondaryAxisExtent, secondaryAxisScale, secondaryBandwidth, secondaryNumericScale, secondarySign])
+  }, [baseCoord, binMap, binWidth, dataConfig, extraSecondaryAxisScale, extraSecondaryBandwidth,
+      isHistogram, layout, numExtraSecondaryBands, numPointsInRow, overlap, pointDiameter,
+      primaryIsBottom, secondaryAxisExtent, secondaryAxisScale, secondaryBandwidth,
+      secondaryNumericScale, secondarySign])
 
   return {
     dataset, dataConfig, getPrimaryScreenCoord, getSecondaryScreenCoord, graphModel, isAnimating, layout, pointColor,

--- a/v3/src/components/graph/hooks/use-dot-plot.ts
+++ b/v3/src/components/graph/hooks/use-dot-plot.ts
@@ -91,7 +91,7 @@ export const useDotPlot = (pixiPoints?: PixiPoints) => {
     let primaryScreenCoord = primaryCoord + extraPrimaryCoord
 
     if (binWidth !== undefined && !isHistogram) {
-      const { indexInBin } = binMap[anID]
+      const { indexInBin } = binMap[anID] || {}
       const caseValue = dataDisplayGetNumericValue(dataset, anID, primaryAttrID) ?? -1
       const binForCase = determineBinForCase(caseValue, binWidth, minBinEdge)
       primaryScreenCoord = adjustCoordForStacks({

--- a/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot.tsx
+++ b/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot.tsx
@@ -32,10 +32,12 @@ export const BinnedDotPlot = observer(function BinnedDotPlot({pixiPoints, aboveP
   const binnedPlot = isBinnedDotPlotModel(graphModel.plot) ? graphModel.plot : undefined
   const instanceId = useInstanceIdContext()
   const kMinBinScreenWidth = 20
+  const primaryAxisModel = graphModel.getNumericAxis(primaryPlace)
   const binBoundariesRef = useRef<SVGGElement>(null)
   const primaryAxisScaleCopy = useRef<ScaleLinear<number, number>>(primaryAxisScale.copy())
   const lowerBoundaryRef = useRef<number>(0)
   const logFn = useRef<Maybe<LogMessageFn>>()
+  let handleDragBinBoundaryEnd: () => void = useCallback(() => {}, [])
 
   const { onDrag, onDragEnd, onDragStart } = useDotPlotDragDrop()
   usePixiDragHandlers(pixiPoints, {start: onDragStart, drag: onDrag, end: onDragEnd})
@@ -80,8 +82,8 @@ export const BinnedDotPlot = observer(function BinnedDotPlot({pixiPoints, aboveP
   const handleDragBinBoundaryStart = useCallback((event: MouseEvent, binIndex: number) => {
     if (!dataConfig || !isFiniteNumber(binnedPlot?.binAlignment) || !isFiniteNumber(binnedPlot?.binWidth)) return
     logFn.current = logModelChangeFn(
-                      "dragBinBoundary from { alignment: %@, width: %@ } to { alignment: %@, width: %@ }",
-                      () => ({ alignment: binnedPlot.binAlignment, width: binnedPlot.binWidth }))
+      "dragBinBoundary from { alignment: %@, width: %@ } to { alignment: %@, width: %@ }",
+      () => ({ alignment: binnedPlot.binAlignment, width: binnedPlot.binWidth }))
     primaryAxisScaleCopy.current = primaryAxisScale.copy()
     binnedPlot.setDragBinIndex(binIndex)
     const { binWidth, minBinEdge } = binnedPlot.binDetails()
@@ -100,22 +102,6 @@ export const BinnedDotPlot = observer(function BinnedDotPlot({pixiPoints, aboveP
     binnedPlot.setActiveBinWidth(worldBinWidth)
   }, [binnedPlot, dataConfig, primaryIsBottom])
 
-  const handleDragBinBoundaryEnd = useCallback(() => {
-    if (!binnedPlot) return
-    binnedPlot.applyModelChange(
-      () => {
-        if (binnedPlot.binAlignment && binnedPlot.binWidth) {
-          binnedPlot.endBinBoundaryDrag(binnedPlot.binAlignment, binnedPlot.binWidth)
-        }
-        lowerBoundaryRef.current = 0
-      }, {
-        undoStringKey: "DG.Undo.graph.dragBinBoundary",
-        redoStringKey: "DG.Redo.graph.dragBinBoundary",
-        log: logFn.current
-      }
-    )
-  }, [binnedPlot])
-
   const addBinBoundaryDragHandlers = useCallback(() => {
     const binBoundariesArea = select(binBoundariesRef.current)
     const binBoundaryCovers = binBoundariesArea.selectAll<SVGPathElement, unknown>("path.draggable-bin-boundary-cover")
@@ -129,6 +115,25 @@ export const BinnedDotPlot = observer(function BinnedDotPlot({pixiPoints, aboveP
     })
   }, [handleDragBinBoundary, handleDragBinBoundaryEnd, handleDragBinBoundaryStart])
 
+  handleDragBinBoundaryEnd = useCallback(() => {
+    if (!binnedPlot) return
+    binnedPlot.setDragBinIndex(-1)
+    drawBinBoundaries()
+    addBinBoundaryDragHandlers()
+    binnedPlot.applyModelChange(
+      () => {
+        if (binnedPlot.binAlignment && binnedPlot.binWidth) {
+          binnedPlot.endBinBoundaryDrag(binnedPlot.binAlignment, binnedPlot.binWidth)
+        }
+        lowerBoundaryRef.current = 0
+      }, {
+        undoStringKey: "DG.Undo.graph.dragBinBoundary",
+        redoStringKey: "DG.Redo.graph.dragBinBoundary",
+        log: logFn.current
+      }
+    )
+  }, [addBinBoundaryDragHandlers, binnedPlot, drawBinBoundaries])
+
   const refreshPointPositions = useCallback((selectedOnly: boolean) => {
     if (!dataConfig || !binnedPlot) return
 
@@ -136,6 +141,7 @@ export const BinnedDotPlot = observer(function BinnedDotPlot({pixiPoints, aboveP
     const { maxBinEdge, minBinEdge } = binnedPlot.binDetails()
 
     // Set the domain of the primary axis to the extent of the bins
+    primaryAxis?.setAllowRangeToShrink(true)  // Otherwise we get slop we don't want
     primaryAxis?.setDomain(minBinEdge, maxBinEdge)
 
     // Draw lines to delineate the bins in the plot
@@ -178,6 +184,18 @@ export const BinnedDotPlot = observer(function BinnedDotPlot({pixiPoints, aboveP
       }, {name: "enforceMinBinPixelWidth"}, binnedPlot
     )
   }, [binnedPlot, primaryAxisScale])
+
+  useEffect(function respondToAxisLabelRotation()  {
+    if (primaryAxisModel) {
+      const disposer = mstReaction(
+        () => primaryAxisModel.labelsAreRotated,
+        () => {
+          refreshPointPositions(false)
+        }, {name: "primaryAxisModel.labelsAreRotated"}, primaryAxisModel
+      )
+      return () => disposer()
+    }
+  }, []);
 
   return (
     abovePointsGroupRef?.current && createPortal(

--- a/v3/src/components/graph/plots/dot-plot/dot-plot-utils.ts
+++ b/v3/src/components/graph/plots/dot-plot/dot-plot-utils.ts
@@ -129,7 +129,7 @@ export const computeSecondaryCoord = (props: IComputeSecondaryCoord) => {
 
   const subPlotCells = layout && new SubPlotCells(layout, dataConfig)
   const secondaryNumericUnitLength = subPlotCells ? subPlotCells.secondaryNumericUnitLength : 0
-  const { row} = computeRowAndColumn(indexInBin, numPointsInRow)
+  const { row } = computeRowAndColumn(indexInBin, numPointsInRow)
   if (primaryIsBottom) {
     extraCoord = secondaryAxisExtent - extraSecondaryBandwidth - extraCoord
     catCoord = extraSecondaryBandwidth - secondaryBandwidth - catCoord

--- a/v3/src/components/slider/slider-component-handler.ts
+++ b/v3/src/components/slider/slider-component-handler.ts
@@ -1,4 +1,4 @@
-import { MergeExclusive, SetRequired } from "type-fest"
+import { SetRequired } from "type-fest"
 import { applySnapshot, getSnapshot } from "mobx-state-tree"
 import { cloneDeep } from "lodash"
 import { V2Slider } from "../../data-interactive/data-interactive-component-types"


### PR DESCRIPTION
[#CODAP-617] Bug fix: Binned dot plot stacks of points should be even

* The reason for the unevenness in the stacks of points was that the algorithm was adding points one column at a time until the points reached the end of the available space and then starting over again with a new column.
* The correct algorithm is similar to that used in displaying dot charts where we compute a number of points per row and add points essentially a row at a time.
* The code is complex, partly because it mixes together dot plots, binned dot plots and histograms. I considered a complete refactor but then found there was a reasonably straightforward way to modify the existing code.
* Fixed an `mstReaction` in `useBinnedPlotResponders` to get disposed when the binned plot component goes away.
* Fixed a problem whereby the lower/upper bounds of the binning axis was different than that specified by the bins
* By measuring the tick labels for a horizontal binning axis we can detect overlap and rotate the labels. And we have to respond to that by refreshing the points.
* There's some subtlety involved in making sure each of the bin boundaries has drag handlers since they come and go during a drag.