### PR TITLE
CODAP-71 Multiple connecting lines colors match points

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -20,7 +20,7 @@ import { DateAxisHelper } from "../helper-models/date-axis-helper"
 import { NumericAxisHelper } from "../helper-models/numeric-axis-helper"
 import { useAxisLayoutContext } from "../models/axis-layout-context"
 import {IAxisModel} from "../models/axis-model"
-import { isAnyCategoricalAxisModel, isCategoricalAxisModel, isColorAxisModel } from "../models/categorical-axis-models"
+import { isAnyCategoricalAxisModel, isColorAxisModel } from "../models/categorical-axis-models"
 import { isAnyNumericAxisModel } from "../models/numeric-axis-models"
 import { useAxisProviderContext } from "./use-axis-provider-context"
 

--- a/v3/src/components/data-display/hooks/use-connecting-lines.ts
+++ b/v3/src/components/data-display/hooks/use-connecting-lines.ts
@@ -110,7 +110,7 @@ export const useConnectingLines = (props: IProps) => {
       const color = legendAttribute && legendAttrType === "color" && categoryDataArray
                       ? categoryDataArray[linesIndex]
                       : parentAttrID && legendID ? pointColorAtIndex(linesIndex)
-                                                  : pointColorAtIndex(0)
+                                                  : pointColorAtIndex(cases[0].plotNum || 0)
 
       connectingLinesArea
         .append("path")

--- a/v3/src/components/data-display/models/display-item-description-model.ts
+++ b/v3/src/components/data-display/models/display-item-description-model.ts
@@ -8,6 +8,7 @@ export const DisplayItemDescriptionModel = types
     _itemStrokeColor: defaultStrokeColor,
     _itemStrokeSameAsFill: false,
     _pointSizeMultiplier: 1, // Not used when item is a polygon in which case it is set to -1
+    pointsHaveBeenReduced: false // Used in conjunction with connecting line point reduction
   })
   .volatile(() => ({
     _dynamicPointSizeMultiplier: undefined as number | undefined  // Used during slider drag
@@ -28,7 +29,10 @@ export const DisplayItemDescriptionModel = types
     },
     setDynamicPointSizeMultiplier(multiplier: number) {
       self._dynamicPointSizeMultiplier = multiplier
-    }
+    },
+    setPointsHaveBeenReduced(reduced: boolean) {
+      self.pointsHaveBeenReduced = reduced
+    },
   }))
   .views(self => ({
     get pointSizeMultiplier() {


### PR DESCRIPTION
[#CODAP-71] Bug fix: Connecting lines for multiple y-attributes should match point colors

* The fix of the quoted bug is a one-liner in use-connecting-lines.ts.
* But there are problems with the size of points whereby the points get scaled smaller more than once, and then, when connecting lines are removed, they get made too big.