### PR TITLE
CODAP-654 Fixes for various graph undo/redo problems

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -142,6 +142,7 @@ Various developer features can be enabled by adding a `debug` local storage key 
 - `map` print info about interactions with the map component
 - `pixiPoints` this adds a map of tileId keys to PixiPoint instances as `window.pixiPointsMap`. This is also always available in Cypress.
 - `plugins` enable some extra plugins in the plugin menu and print information about interactions with plugins.
+- `saveAsV2` this will cause the app to save documents in V2 format.
 - `undo` this will print information about each action that is added to the undo stack.
 
 ##### Why Did You Render?

--- a/v3/src/components/graph/adornments/line-label-instance.ts
+++ b/v3/src/components/graph/adornments/line-label-instance.ts
@@ -1,4 +1,4 @@
-import { types } from "mobx-state-tree"
+import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { Point, PointModel } from "./point-model"
 
 const kDefaultLabelHeight = 60
@@ -77,3 +77,5 @@ export const LineLabelInstance = types.model("LineLabelInstance", {
     self.plotHeight = plotHeight
   }
 }))
+export interface ILineLabelInstanceSnapshot extends SnapshotIn<typeof LineLabelInstance> {}
+export interface ILineLabelInstance extends Instance<typeof LineLabelInstance> {}

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
@@ -64,10 +64,6 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
     return dataConfig && model.getLines(xAttrId, yAttrId, cellKey, dataConfig, adornmentsStore?.interceptLocked)
   }, [cellKey, dataConfig, adornmentsStore?.interceptLocked, model, xAttrId, yAttrId])
 
-  const getLabels = useCallback(() => {
-    return dataConfig && model.getLabels(cellKey, dataConfig)
-  }, [cellKey, dataConfig, adornmentsStore?.interceptLocked, model, xAttrId, yAttrId])
-
   const fixEndPoints = useCallback((iLine: Selection<SVGLineElement, unknown, null, undefined>) => {
     if (
       !Number.isFinite(pointsOnAxes.current.pt1.x) || !Number.isFinite(pointsOnAxes.current.pt2.x) ||
@@ -130,9 +126,8 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
           // compute proportional position of center of label within container
           const x = (left + equationBounds.width / 2) / containerBounds.width
           const y = (top + equationBounds.height / 2) / containerBounds.height
-          const labels = getLabels()
           graphModel.applyModelChange(
-            () => labels?.get(category)?.setEquationCoords({ x, y }),
+            () => model.setLabelEquationCoords(cellKey, category, { x, y}),
             {
               undoStringKey: "DG.Undo.graph.repositionEquation",
               redoStringKey: "DG.Redo.graph.repositionEquation",
@@ -306,7 +301,7 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
       if (slope != null && intercept != null) {
         pointsOnAxes.current = lineToAxisIntercepts(slope, intercept, xDomain, yDomain)
 
-        // Set up the confidence band elements. We add them before the line™, so they don't interfere
+        // Set up the confidence band elements. We add them before the line, so they don't interfere
         // with the line's mouseover behavior.
         lineObj.confidenceBandCurve = selection.append("path")
           .attr("class", `lsrl-confidence-band lsrl-confidence-band-${classFromKey}`)

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -1,8 +1,8 @@
 import { kMain } from "../../../data-display/data-display-types"
 import { LSRLAdornmentModel, LSRLInstance } from "./lsrl-adornment-model"
+import { LineLabelInstance } from "../line-label-instance"
 
 const mockLSRLInstanceProps1 = {
-  equationCoords: {x: 1, y: 1},
   intercept: 1,
   interceptLocked: false,
   rSquared: 1,
@@ -10,7 +10,6 @@ const mockLSRLInstanceProps1 = {
   slope: 1
 }
 const mockLSRLInstanceProps2 = {
-  equationCoords: {x: 1, y: 1},
   intercept: 2,
   interceptLocked: false,
   rSquared: 2,
@@ -21,18 +20,19 @@ const mockLSRLInstanceProps2 = {
 describe("LSRLInstance", () => {
   it("is created with undefined equationCoords, intercept, rSquared, sdResiduals, and slope properties", () => {
     const lsrlInstance = LSRLInstance.create()
-    expect(lsrlInstance.equationCoords).toBeUndefined()
+    const lsrlLabel = LineLabelInstance.create()
+    expect(lsrlLabel.equationCoords).toBeUndefined()
     expect(lsrlInstance.intercept).toBeUndefined()
     expect(lsrlInstance.rSquared).toBeUndefined()
     expect(lsrlInstance.sdResiduals).toBeUndefined()
     expect(lsrlInstance.slope).toBeUndefined()
   })
   it("can have equationCoords properties set", () => {
-    const lsrlInstance = LSRLInstance.create()
-    expect(lsrlInstance.equationCoords).toBeUndefined()
-    lsrlInstance.setEquationCoords({x: 50, y: 50})
-    expect(lsrlInstance.equationCoords?.x).toEqual(50)
-    expect(lsrlInstance.equationCoords?.y).toEqual(50)
+    const lsrlLabel = LineLabelInstance.create()
+    expect(lsrlLabel.equationCoords).toBeUndefined()
+    lsrlLabel.setEquationCoords({x: 50, y: 50})
+    expect(lsrlLabel.equationCoords?.x).toEqual(50)
+    expect(lsrlLabel.equationCoords?.y).toEqual(50)
   })
   it("can have intercept properties set", () => {
     const lsrlInstance = LSRLInstance.create()
@@ -47,13 +47,13 @@ describe("LSRLInstance", () => {
     expect(lsrlInstance.rSquared).toEqual(1)
   })
   it("can have slope properties set", () => {
-    const lsrlInstance = LSRLInstance.create(mockLSRLInstanceProps1)
+    const lsrlInstance = LSRLInstance.create()
     expect(lsrlInstance.slope).toBeUndefined()
     lsrlInstance.setSlope(1)
     expect(lsrlInstance.slope).toEqual(1)
   })
   it("can have sdResiduals properties set", () => {
-    const lsrlInstance = LSRLInstance.create(mockLSRLInstanceProps1)
+    const lsrlInstance = LSRLInstance.create()
     expect(lsrlInstance.sdResiduals).toBeUndefined()
     lsrlInstance.setSdResiduals(1)
     expect(lsrlInstance.sdResiduals).toEqual(1)

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -165,9 +165,6 @@ export const LSRLAdornmentModel = AdornmentModel
     let linesInCell = self.lines.get(key)
     if (!linesInCell) {
       self.lines.set(key, new Map<string, ILSRLInstance>())
-      // todo: Somewhere we have to make sure there is a label for the given key, legendCat. But the line below
-      // gets called during reading in of a document and puts an undo action in this history.
-      // self.labels.set(key, {})
       linesInCell = self.lines.get(key)!
     }
     linesInCell.set(legendCat, createLSRLInstance(line))
@@ -202,6 +199,25 @@ export const LSRLAdornmentModel = AdornmentModel
         self.updateLines(lineProps, instanceKey, legendCat)
       })
     })
+  },
+  setLabel(cellKey: Record<string, string>, category: string, label: ILineLabelInstance) {
+    const key = self.instanceKey(cellKey)
+    let labelsInCell = self.labels.get(key)
+    if (!labelsInCell) {
+      self.labels.set(key, {})
+      labelsInCell = self.labels.get(key)!
+    }
+    labelsInCell.set(category, label)
+  },
+  setLabelEquationCoords(cellKey: Record<string, string>, category: string, equationCoords: Point) {
+    const key = self.instanceKey(cellKey)
+    const labelsInCell = self.labels.get(key)
+    let label = labelsInCell ? labelsInCell.get(category) : undefined
+    if (!label) {
+      label = LineLabelInstance.create({ equationCoords: { x: 0, y: 0 } })
+      this.setLabel(cellKey, category, label)
+    }
+    label.setEquationCoords(equationCoords)
   }
 }))
 .views(self => ({
@@ -231,19 +247,6 @@ export const LSRLAdornmentModel = AdornmentModel
       }
     })
     return linesInCell
-  },
-  getLabels(cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
-    const key = self.instanceKey(cellKey)
-    const labelsInCell = self.labels.get(key)
-    const legendCats = self.getLegendCategories(dataConfig)
-    legendCats.forEach(legendCat => {
-      const existingLabel = labelsInCell ? labelsInCell.get(legendCat) : undefined
-      if (!existingLabel) {
-        // todo: We can't do what's in the line below. Must be done in an action
-        // labelsInCell?.set(legendCat, {})
-      }
-    })
-    return labelsInCell
   }
 }))
 

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
@@ -113,10 +113,10 @@ registerAdornmentContentInfo({
         showConfidenceBands: adornment.showConfidenceBands,
         // v2 ignores top and right splits
         lsrls: options.legendCategories.map(cat => {
-          const lineInstance = adornment.firstLineInstance(cat)
+          const labelInstance = adornment.firstLabelInstance(cat)
           return {
             ...exportAdornmentBase(adornment, options),
-            equationCoords: lineInstance?.v2ExportCoords ?? null,
+            equationCoords: labelInstance?.v2ExportCoords ?? null,
             isInterceptLocked: options.isInterceptLocked,
             showConfidenceBands: adornment.showConfidenceBands
           }

--- a/v3/src/components/graph/adornments/store/adornments-base-store.ts
+++ b/v3/src/components/graph/adornments/store/adornments-base-store.ts
@@ -1,4 +1,5 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
+import { applyModelChange } from "../../../../models/history/apply-model-change"
 import { getAdornmentComponentInfo } from "../adornment-component-info"
 import { AdornmentModelUnion, kDefaultFontSize } from "../adornment-types"
 import { IAdornmentModel, IUpdateCategoriesOptions } from "../adornment-models"
@@ -119,6 +120,7 @@ export const AdornmentsBaseStore = types.model("AdornmentsBaseStore", {
     self.adornments.forEach(adornment => adornment.updateCategories(options))
   },
 }))
+  .actions(applyModelChange)
 
 export interface IAdornmentsBaseStore extends Instance<typeof AdornmentsBaseStore> {}
 export interface IAdornmentsBaseStoreSnapshot extends SnapshotIn<typeof AdornmentsBaseStore> {}

--- a/v3/src/components/graph/adornments/store/adornments-store-utils.ts
+++ b/v3/src/components/graph/adornments/store/adornments-store-utils.ts
@@ -84,8 +84,6 @@ export function getAdornmentsMenuItemsFromTheStore(theStore: IAdornmentsBaseStor
   // items that either augment/adjust other adornments' behavior (e.g. Show Measure Labels, Intercept Locked), or need
   // special handling outside the realm of adornments (e.g. Connecting Lines, Squares of Residuals).
   getMeasuresForPlot(plotType).map((measureOrGroup: IMeasure) => {
-    // const tileModel = displayModel && getTileModel(displayModel)
-
     // Add the Show Measure Labels option checkbox immediately before the first group item. Note that group items only
     // appear in the univariate plot's ruler.
     addItemIfCondition(measureOrGroup.type === "Group", {

--- a/v3/src/components/graph/adornments/store/adornments-store.test.ts
+++ b/v3/src/components/graph/adornments/store/adornments-store.test.ts
@@ -104,7 +104,7 @@ describe("AdornmentsStore", () => {
   })
   it("returns a list of adornment items for use in menus", () => {
     const adornmentsStore = AdornmentsStore.create()
-    const adornmentsMenuItems = adornmentsStore.getAdornmentsMenuItems("dotPlot", false)
+    const adornmentsMenuItems = adornmentsStore.getAdornmentsMenuItems(undefined,"dotPlot", false)
     expect(adornmentsMenuItems).toBeDefined()
     expect(adornmentsMenuItems?.length).toBeGreaterThan(0)
     expect(adornmentsMenuItems?.[0].title).toBe("DG.Inspector.graphCount")

--- a/v3/src/components/graph/adornments/store/adornments-store.ts
+++ b/v3/src/components/graph/adornments/store/adornments-store.ts
@@ -1,4 +1,5 @@
 import {Instance} from "mobx-state-tree"
+import { ITileModel } from "../../../../models/tiles/tile-model"
 import { PlotType } from "../../graphing-types"
 import {AdornmentsBaseStore} from "./adornments-base-store"
 import {getAdornmentsMenuItemsFromTheStore} from "./adornments-store-utils"
@@ -10,8 +11,8 @@ import {getAdornmentsMenuItemsFromTheStore} from "./adornments-store-utils"
 export const AdornmentsStore = AdornmentsBaseStore
   .named("AdornmentsStore")
   .views(self => ({
-    getAdornmentsMenuItems(plotType: PlotType, useGaussianOptions: boolean) {
-      return getAdornmentsMenuItemsFromTheStore(self, plotType, useGaussianOptions)
+    getAdornmentsMenuItems(tile: ITileModel | undefined, plotType: PlotType, useGaussianOptions: boolean) {
+      return getAdornmentsMenuItemsFromTheStore(self, tile, plotType, useGaussianOptions)
     },
   }))
 

--- a/v3/src/components/graph/adornments/v2-adornment-importer.ts
+++ b/v3/src/components/graph/adornments/v2-adornment-importer.ts
@@ -29,7 +29,7 @@ import { IMovablePointAdornmentModelSnapshot } from "./movable-point/movable-poi
 import { IMeasureInstanceSnapshot } from "./univariate-measures/univariate-measure-adornment-model"
 import { IMovableLineAdornmentModelSnapshot, IMovableLineInstanceSnapshot }
   from "./movable-line/movable-line-adornment-model"
-import { ILSRLAdornmentModelSnapshot, ILSRLInstanceSnapshot } from "./lsrl/lsrl-adornment-model"
+import { ILSRLAdornmentModelSnapshot } from "./lsrl/lsrl-adornment-model"
 import { IBoxPlotAdornmentModelSnapshot } from "./univariate-measures/box-plot/box-plot-adornment-model"
 import { ICountAdornmentModelSnapshot } from "./count/count-adornment-model"
 import { IMeanAdornmentModelSnapshot } from "./univariate-measures/mean/mean-adornment-model"
@@ -44,6 +44,7 @@ import { IStandardDeviationAdornmentModelSnapshot }
 import { IStandardErrorAdornmentModelSnapshot }
   from "./univariate-measures/standard-error/standard-error-adornment-model"
 import { INormalCurveAdornmentModelSnapshot } from "./univariate-measures/normal-curve/normal-curve-adornment-model"
+import { ILineLabelInstance, ILineLabelInstanceSnapshot } from "./line-label-instance";
 
 export interface IAdornmentImporterProps {
   data?: ISharedDataSet
@@ -127,8 +128,7 @@ function univariateMeasureInstances(adornment: ICodapV2UnivariateAdornment, prop
                     : NaN
                 : NaN
     const labelCoords = isFinite(x) && isFinite(y) ? { x, y } : undefined
-    const measureInstance = { labelCoords }
-    measures[key] = measureInstance
+    measures[key] = { labelCoords }
   })
 
   return measures
@@ -334,13 +334,13 @@ export const v2AdornmentImporter = ({
                               }
                             : undefined)
   if (lsrlAdornment) {
-    const lines: Record<string, Record<string, ILSRLInstanceSnapshot>> = {}
+    const labels: Record<string, Record<string, ILineLabelInstanceSnapshot>> = {}
     instanceKeys?.forEach((key: string) => {
-      const lsrlInstances: Record<string, ILSRLInstanceSnapshot> = {}
+      const labelInstances: Record<string, ILineLabelInstanceSnapshot> = {}
       lsrlAdornment.lsrls?.forEach((lsrl, index) => {
         const category = legendCats[index]
         const { equationCoords: inEquationCoords } = lsrl
-        lsrlInstances[category] = inEquationCoords
+        labelInstances[category] = inEquationCoords
                                     ? {
                                         equationCoords: {
                                           x: inEquationCoords.proportionCenterX,
@@ -351,13 +351,12 @@ export const v2AdornmentImporter = ({
                                       }
                                     : {}
       })
-      lines[key] = lsrlInstances
+      labels[key] = labelInstances
     })
     const lsrlAdornmentImport: ILSRLAdornmentModelSnapshot = {
       isVisible: lsrlAdornment.isVisible,
       showConfidenceBands: lsrlAdornment.showConfidenceBands,
-      type: kLSRLType,
-      lines
+      type: kLSRLType
     }
     interceptLocked = lsrlAdornment.isInterceptLocked
     v3Adornments.push(lsrlAdornmentImport)

--- a/v3/src/components/graph/adornments/v2-adornment-importer.ts
+++ b/v3/src/components/graph/adornments/v2-adornment-importer.ts
@@ -44,7 +44,7 @@ import { IStandardDeviationAdornmentModelSnapshot }
 import { IStandardErrorAdornmentModelSnapshot }
   from "./univariate-measures/standard-error/standard-error-adornment-model"
 import { INormalCurveAdornmentModelSnapshot } from "./univariate-measures/normal-curve/normal-curve-adornment-model"
-import { ILineLabelInstance, ILineLabelInstanceSnapshot } from "./line-label-instance";
+import { ILineLabelInstanceSnapshot } from "./line-label-instance"
 
 export interface IAdornmentImporterProps {
   data?: ISharedDataSet
@@ -356,9 +356,10 @@ export const v2AdornmentImporter = ({
     const lsrlAdornmentImport: ILSRLAdornmentModelSnapshot = {
       isVisible: lsrlAdornment.isVisible,
       showConfidenceBands: lsrlAdornment.showConfidenceBands,
-      type: kLSRLType
+      type: kLSRLType,
+      labels
     }
-    interceptLocked = lsrlAdornment.isInterceptLocked
+    interceptLocked = lsrlAdornment.isInterceptLocked // Just noting V3 doesn't track intercept locked at this level
     v3Adornments.push(lsrlAdornmentImport)
   }
 

--- a/v3/src/components/graph/components/inspector-panel/graph-measure-palette.tsx
+++ b/v3/src/components/graph/components/inspector-panel/graph-measure-palette.tsx
@@ -26,7 +26,7 @@ export const GraphMeasurePalette = observer(function GraphMeasurePalette({
   const useGaussianOptions = graphModel?.plotType === "histogram" &&
     getDocumentContentPropertyFromNode(graphModel, "gaussianFitEnabled")
   const measures =
-    graphModel?.adornmentsStore.getAdornmentsMenuItems(graphModel.plotType, useGaussianOptions)
+    graphModel?.adornmentsStore.getAdornmentsMenuItems(tile, graphModel.plotType, useGaussianOptions)
 
   return (
     <InspectorPalette


### PR DESCRIPTION
[#CODAP-654] Bug fix: Undo/Redo tool tips aren't showing/hiding connecting lines

* The clickHandler for the showConnectingLines checkbox should use an applyModelChange with appropriate notification, undo/redo strings and log message
* Using applyModelChange required passing in a ITileModel to getAdornmentMenuItems and down to getAdornmentsMenuItemsFromTheStore
* All the rest of the clickHandlers in adornments-store-utils.ts also required modification to use applyModelChange
* On another undo/redo front, the useEffect refreshInterceptLockChange in lsrl-adornment-component.tsx was setting up an mstReaction that was causing a model action as part of its accessor and thus causing another undo to be added to the history.
* When a document with a LSRL adornment was opened, undo actions were immediately added to the undo history. This was because the `lines` were a property of the model instead of volatile. Constructing them during document initialization was causing actions to be added to the undo history.
* In an aside, we added the `saveAsV2` debug property to README.md