### PR TITLE
Fix for invalid transition from bars to points

### DIFF
--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -777,7 +777,9 @@ export class PixiPoints {
       return
     }
     // If the display type has changed, we need to prepare for the transition between types
-    if (this.displayType !== displayType && this.points.length > 0) {
+    // But we can't do so if the number of cases to plot is not equal to the number of points we have because
+    // there will be a mismatch between caseIDs held onto by the points and the caseIDs of the cases we're plotting.
+    if (this.displayType !== displayType && this.points.length > 0 && this.points.length === caseData.length) {
       this.displayTypeTransitionState.isActive = true
       this.forEachPoint(point => {
         this.pointTransitionStates.set(point, { hasTransitioned: false })


### PR DESCRIPTION
[#CODAP-365] Bug fix: Bar chart point compression when changing graph axis

* A performance-oriented shortcut was getting in the way of properly matching the pixiPoint points with the current cases being plotted in the situation when the attribute change takes us from a child collection to a parent collection. By adding the requirement in the shortcut that the number of cases being plotted equals the current number of pixi points, we still allow the shortcut for the critical situations but bypass it when we really need to reconstitute the pixi points.