### PR TITLE
CODAP-660 Fix binned dot plot display

### DIFF
--- a/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot.tsx
+++ b/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot.tsx
@@ -185,17 +185,8 @@ export const BinnedDotPlot = observer(function BinnedDotPlot({pixiPoints, aboveP
     )
   }, [binnedPlot, primaryAxisScale])
 
-  useEffect(function respondToAxisLabelRotation()  {
-    if (primaryAxisModel) {
-      return mstReaction(
-        () => primaryAxisModel.labelsAreRotated,
-        () => {
-          refreshPointPositions(false)
-        }, {name: "primaryAxisModel.labelsAreRotated"}, primaryAxisModel
-      )
-    }
-  }, [primaryAxisModel, refreshPointPositions])
-
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  primaryAxisModel?.labelsAreRotated  // Observe labelsAreRotated to force re-render
   return (
     abovePointsGroupRef?.current && createPortal(
       <><g data-testid={`bin-ticks-${instanceId}`} className="bin-ticks" ref={binBoundariesRef}/></>,


### PR DESCRIPTION
[#CODAP-660] Bug fix: Binning dot plot in fresh graph doesn't show all points

* The bug was due to the need for a rerender when the rotation of the bin labels changing, so we add a reference to primaryAxisMode.labelsAreRotated in the BinnedDotPlot component so that it can be observed and produce the desired rerender. It turns out that this fixes another, unrecorded bug, whereby points were disappearing off the top of a binned dot plot because overlap was not being correctly computed.