### PR TITLE
CODAP-97 Case plots response to change in number of cases bug fix

### DIFF
--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -182,12 +182,6 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           // If we're caching then only selected cases need to be updated in scatterplots. But for dotplots
           // we need to update all points because the unselected points positions change.
           callRefreshPointPositions({ selectedOnly: dataset.isCaching() && graphModel.plotType !== "dotPlot" })
-          // TODO: handling of add/remove cases was added specifically for the case plot.
-          // Bill has expressed a desire to refactor the case plot to behave more like the
-          // other plots, which already handle removal of cases (and perhaps addition of cases?)
-          // without this. Should check to see whether this is necessary down the road.
-        } else if (["addCases", "removeCases"].includes(action.name)) {
-          callRefreshPointPositions()
         }
       })
       return () => disposer()

--- a/v3/src/components/graph/plots/case-plot/case-plot.tsx
+++ b/v3/src/components/graph/plots/case-plot/case-plot.tsx
@@ -95,16 +95,6 @@ export const CasePlot = function CasePlot({ pixiPoints }: IPlotProps) {
     })
   }, [pixiPoints, graphModel, layout, dataConfiguration, dataset, isAnimating])
 
-  useEffect(function initDistribution() {
-    randomlyDistributePoints(dataConfiguration?.getCaseDataArray(0))
-    const disposer = dataConfiguration?.onAction(action => {
-      if (['addCases', 'removeCases'].includes(action.name)) {
-        randomlyDistributePoints(dataConfiguration?.getCaseDataArray(0))
-      }
-    }) || (() => true)
-    return () => disposer?.()
-  }, [dataConfiguration, dataset, randomlyDistributePoints])
-
   useEffect(function respondToModelChangeCount() {
     return mstReaction(
       () => graphModel.changeCount,
@@ -118,7 +108,22 @@ export const CasePlot = function CasePlot({ pixiPoints }: IPlotProps) {
   }, [dataConfiguration, graphModel,
       randomlyDistributePoints, refreshPointPositions, startAnimation])
 
+  useEffect(function respondToCasesCountChange() {
+    return mstReaction(
+      () => dataConfiguration?.caseDataHash,
+      () => {
+        randomlyDistributePoints(dataConfiguration?.getCaseDataArray(0))
+        startAnimation()
+        refreshPointPositions(false)
+      },
+      { name: "CaseDots.respondToCasesCountChange" }, dataConfiguration)
+  }, [dataConfiguration, randomlyDistributePoints, refreshPointPositions, startAnimation])
+
   usePlotResponders({pixiPoints, refreshPointPositions, refreshPointSelection})
+
+  useEffect(function initDistribution() {
+    randomlyDistributePoints(dataConfiguration?.getCaseDataArray(0))
+  }, [dataConfiguration, randomlyDistributePoints])
 
   return (
     <></>


### PR DESCRIPTION
[#CODAP-97] Bug fix: New points in case plots appear on top of each other at top left

* Case plots were not paying attention to changes in the number of cases being plotted. We fix this by adding an mstReaction whose accessor is the data configuration's caseDataHash and whose effect is to randomly position any newly added cases.
* We also take this opportunity to remove a long-standing special case for case plot in use-plot.