### PR TITLE
CODAP-116 Connecting lines not hiding when points are hidden

### DIFF
--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot-utils.ts
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot-utils.ts
@@ -53,7 +53,7 @@ export function scatterPlotFuncs(layout: GraphLayout, dataConfiguration?: IGraph
     const xValue = getXCoord(caseID)
     const yValue = getYCoord(caseID, plotNum)
     if (isFinite(xValue) && isFinite(yValue)) {
-      const caseData = dataset?.getItem(caseID, { numeric: false })
+      const caseData = dataset?.getFirstItemForCase(caseID, { numeric: false })
       if (caseData) {
         const lineCoords: [number, number] = [xValue, yValue]
         return { caseData, lineCoords, plotNum }
@@ -63,10 +63,9 @@ export function scatterPlotFuncs(layout: GraphLayout, dataConfiguration?: IGraph
 
   function connectingLinesForCases() {
     const lineDescriptions: IConnectingLineDescription[] = []
-    const dataset = dataConfiguration?.dataset
-    dataset?.items.forEach(c => {
+    dataConfiguration?.getCaseDataArray(0).forEach(c => {
       yAttrIDs.forEach((_yAttrID, plotNum) => {
-        const line = connectingLine(c.__id__, plotNum)
+        const line = connectingLine(c.caseID, plotNum)
         line && lineDescriptions.push(line)
       })
     })

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -69,7 +69,7 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, set
     const xValue = getScreenX(caseID)
     const yValue = getScreenY(caseID)
     if (isFinite(xValue) && isFinite(yValue)) {
-      const caseData = dataset?.getItem(caseID, { numeric: false })
+      const caseData = dataset?.getFirstItemForCase(caseID, { numeric: false })
       if (caseData) {
         const lineCoords: [number, number] = [xValue, yValue]
         return { caseData, lineCoords }
@@ -79,8 +79,8 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, set
 
   const connectingLinesForCases = useCallback(() => {
     const lineDescriptions: IConnectingLineDescription[] = []
-    dataset?.items.forEach(c => {
-        const cLine = connectingLine(c.__id__)
+    dataConfiguration?.getCaseDataArray(0).forEach(c => {
+        const cLine = connectingLine(c.caseID)
         cLine && lineDescriptions.push(cLine)
     })
     return lineDescriptions


### PR DESCRIPTION
[#CODAP-116] Bug fix: Connecting lines in map and graph do not hide when points are hidden

* The dataset was being used to get cases for the points to be connected whereas it should be the data configuration's notion of the cases being plotted. Changes were required separately for scatterplot and map point layer.