### PR TITLE
CODAP-51 Restriction of "percent" option in graph ruler menu

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
@@ -20,10 +20,10 @@ const Controls = () => {
   const dataConfig = useGraphDataConfigurationContext()
   const adornmentsStore = graphModel.adornmentsStore
   const existingAdornment = adornmentsStore.findAdornmentOfType<ICountAdornmentModel>(kCountType)
-  const shouldShowPercentOption = dataConfig?.categoricalAttrCount || adornmentsStore.subPlotsHaveRegions ||
+  const leftBottomCategoricalAttrCount = dataConfig?.leftBottomCategoricalAttrCount ?? 0
+  const shouldShowPercentOption = leftBottomCategoricalAttrCount || adornmentsStore.subPlotsHaveRegions ||
                                   graphModel.plotType === "binnedDotPlot"
-  const categoricalAttrCount = dataConfig?.categoricalAttrCount ?? 0
-  const shouldShowPercentTypeOptions = categoricalAttrCount > 1
+  const shouldShowPercentTypeOptions = leftBottomCategoricalAttrCount > 1
   const [enablePercentOptions, setEnablePercentOptions] = useState(existingAdornment?.showPercent)
   const [percentTypeValue, setPercentTypeValue] = useState(
     existingAdornment && isCountAdornment(existingAdornment) ? existingAdornment.percentType : "row"

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -274,7 +274,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     },
     get leftBottomCategoricalAttrCount() {
       const attrTypes = self.attrTypes
-      return (attrTypes.left === "categorical" ? 1 : 0) + (attrTypes.bottom === "categorical" ? 1 : 0)
+      return (isCategoricalAttributeType(attrTypes.left) ? 1 : 0) + (isCategoricalAttributeType(attrTypes.bottom) ? 1 : 0)
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -272,6 +272,10 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       const yHasCategorical = attrTypes.left === "categorical"
       return (xHasCategorical && !yHasCategorical) || (!xHasCategorical && yHasCategorical)
     },
+    get leftBottomCategoricalAttrCount() {
+      const attrTypes = self.attrTypes
+      return (attrTypes.left === "categorical" ? 1 : 0) + (attrTypes.bottom === "categorical" ? 1 : 0)
+    }
   }))
   .views(self => ({
     get categoricalAttrsWithChangeCounts() {


### PR DESCRIPTION
[#CODAP-51] Bug fix: It should not be allowed to display percentages based on categorical attributes on top and right

* V2 doesn't allow computation of percents in a graph unless there is a categorical attribute on the bottom and/or the left. V3 was giving the user the option if there was a categorical attribute on the top and/or right. We choose to follow V2 in this regard to prevent even more cognitive load for the user (and the developer!)