### PR TITLE
CODAP-136 Get the normal curve adornment to respond dynamically to point dragging

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
@@ -63,8 +63,7 @@ export const NormalCurveAdornmentComponent = observer(
     const computeMeanAndStdDev: () => ({ mean: number; stdDev: number, numStdErrs:number,
                                         stdError: number | undefined }) =
       useCallback(() => {
-        const sampleMean = dataConfig ? model.computeMean(numericAttrId, cellKey, dataConfig) : NaN
-        const sampleStdDev = dataConfig ? model.computeStandardDeviation(numericAttrId, cellKey, dataConfig) : NaN
+        const { sampleMean, sampleStdDev } = model.getCurveParamValue(cellKey)
         if (!useGaussianFit) {
           return {mean: sampleMean, stdDev: sampleStdDev, numStdErrs: 1, stdError: undefined}
         } else {
@@ -86,7 +85,7 @@ export const NormalCurveAdornmentComponent = observer(
 
     const highlightCovers = useCallback((highlight: boolean) => {
       const cover = valueObjRef.current.normalCurveHoverCover,
-        coverClassName = `standard-error-hover-cover${highlight ? ' highlighted' : ''}`
+        coverClassName = `normal-curve-hover-cover${highlight ? ' highlighted' : ''}`
       cover?.attr("class", coverClassName)
     }, [])
 

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
@@ -366,7 +366,7 @@ export const NormalCurveAdornmentComponent = observer(
       }
     }, [])
 
-    if (graphModel.plotType === "binnedDotPlot") {
+    if (['linePlot', 'binnedDotPlot'].includes(graphModel.plot.type)) {
       return  // Can't display a normal curve on a binned dot plot
     }
 

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
@@ -366,6 +366,10 @@ export const NormalCurveAdornmentComponent = observer(
       }
     }, [])
 
+    if (graphModel.plotType === "binnedDotPlot") {
+      return  // Can't display a normal curve on a binned dot plot
+    }
+
     return (
       <UnivariateMeasureAdornmentBaseComponent
         classFromKey={helper.classFromKey}

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
@@ -22,21 +22,24 @@ export const CurveParamInstance = types.model("CurveParamInstance", {
       self.isValid = isValid
     }
   }))
+export interface ICurveParamInstance extends Instance<typeof CurveParamInstance> {}
 
 export const NormalCurveAdornmentModel = UnivariateMeasureAdornmentModel
   .named("NormalCurveAdornmentModel")
   .props({
     type: types.optional(types.literal(kNormalCurveType), kNormalCurveType),
-    curveParams: types.map(CurveParamInstance), // keys are InstanceKey
     labelTitle: types.optional(types.literal(kNormalCurveValueTitleKey), kNormalCurveValueTitleKey),
   })
+  .volatile(() => ({
+    curveParams: new Map<string, ICurveParamInstance>(),
+  }))
   .actions(self => ({
     addCurveParam(sampleMean: number, sampleStdDev: number, key="{}") {
       const newCurveParam = CurveParamInstance.create()
       newCurveParam.setSampleMeanAndStdDev(sampleMean, sampleStdDev)
       self.curveParams.set(key, newCurveParam)
     },
-    updateCurveParamValue(sampleMean: number, sampleStdDev: number, key="{}") {
+    updateCurveParamValues(sampleMean: number, sampleStdDev: number, key="{}") {
       const curveParam = self.curveParams.get(key)
       if (curveParam) {
         curveParam.setSampleMeanAndStdDev(sampleMean, sampleStdDev)
@@ -119,7 +122,7 @@ export const NormalCurveAdornmentModel = UnivariateMeasureAdornmentModel
     getCurveParamValue(cellKey: Record<string, string>) {
       const instanceKey = self.instanceKey(cellKey)
       const curveParam = self.curveParams.get(instanceKey)
-      if (curveParam && curveParam.isValid) {
+      if (curveParam?.isValid) {
         return { sampleMean: curveParam.sampleMean, sampleStdDev: curveParam.sampleStdDev }
       }
       return { sampleMean: NaN, sampleStdDev: NaN }
@@ -136,7 +139,7 @@ export const NormalCurveAdornmentModel = UnivariateMeasureAdornmentModel
         if (!self.curveParams.get(instanceKey) || resetPoints) {
           self.addCurveParam(sampleMean, sampleStdDev, instanceKey)
         } else {
-          self.updateCurveParamValue(sampleMean, sampleStdDev, instanceKey)
+          self.updateCurveParamValues(sampleMean, sampleStdDev, instanceKey)
         }
       })
     }

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
@@ -1,16 +1,57 @@
 import { mean, std } from "mathjs"
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { IGraphDataConfigurationModel } from "../../../models/graph-data-configuration-model"
-import { IAdornmentModel } from "../../adornment-models"
+import { IAdornmentModel, IUpdateCategoriesOptions } from "../../adornment-models"
 import { UnivariateMeasureAdornmentModel } from "../univariate-measure-adornment-model"
 import { kNormalCurveValueTitleKey, kNormalCurveType } from "./normal-curve-adornment-types"
+
+export const CurveParamInstance = types.model("CurveParamInstance", {
+})
+  .volatile(self => ({
+    sampleMean: NaN,
+    sampleStdDev: NaN,
+    isValid: false
+  }))
+  .actions(self => ({
+    setSampleMeanAndStdDev(sampleMean: number, sampleStdDev: number) {
+      self.sampleMean = sampleMean
+      self.sampleStdDev = sampleStdDev
+      self.isValid = true
+    },
+    setIsValid(isValid: boolean) {
+      self.isValid = isValid
+    }
+  }))
 
 export const NormalCurveAdornmentModel = UnivariateMeasureAdornmentModel
   .named("NormalCurveAdornmentModel")
   .props({
     type: types.optional(types.literal(kNormalCurveType), kNormalCurveType),
+    curveParams: types.map(CurveParamInstance), // keys are InstanceKey
     labelTitle: types.optional(types.literal(kNormalCurveValueTitleKey), kNormalCurveValueTitleKey),
   })
+  .actions(self => ({
+    addCurveParam(sampleMean: number, sampleStdDev: number, key="{}") {
+      const newCurveParam = CurveParamInstance.create()
+      newCurveParam.setSampleMeanAndStdDev(sampleMean, sampleStdDev)
+      self.curveParams.set(key, newCurveParam)
+    },
+    updateCurveParamValue(sampleMean: number, sampleStdDev: number, key="{}") {
+      const curveParam = self.curveParams.get(key)
+      if (curveParam) {
+        curveParam.setSampleMeanAndStdDev(sampleMean, sampleStdDev)
+      }
+      else {
+        this.addCurveParam(sampleMean, sampleStdDev, key)
+      }
+    },
+    removeCurveParam(key: string) {
+      self.curveParams.delete(key)
+    },
+    invalidateCurveParams() {
+      self.curveParams.forEach(curveParam => curveParam.setIsValid(false))
+    }
+  }))
   .views(self => ({
     get labelLines() {
       return 2  // But if it's a gaussian fit it's 3 (or 4 if showing standard error) and we do special handling
@@ -68,8 +109,36 @@ export const NormalCurveAdornmentModel = UnivariateMeasureAdornmentModel
       }
       return results
     },
-    computeMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
-      // no op
+    computeCurveParamValue(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
+      // We'll store the mean and standard deviation in the measures map, so we can use them to compute the normal curve
+      return { sampleMean: this.computeMean(attrId, cellKey, dataConfig),
+        sampleStdDev: this.computeStandardDeviation(attrId, cellKey, dataConfig) }
+    },
+  }))
+  .views(self => ({
+    getCurveParamValue(cellKey: Record<string, string>) {
+      const instanceKey = self.instanceKey(cellKey)
+      const curveParam = self.curveParams.get(instanceKey)
+      if (curveParam && curveParam.isValid) {
+        return { sampleMean: curveParam.sampleMean, sampleStdDev: curveParam.sampleStdDev }
+      }
+      return { sampleMean: NaN, sampleStdDev: NaN }
+    }
+  }))
+  .actions(self => ({
+    updateCategories(options: IUpdateCategoriesOptions) {
+      const { dataConfig, resetPoints } = options
+      const { xAttrId, yAttrId, xAttrType } = dataConfig.getCategoriesOptions()
+      const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
+      dataConfig.getAllCellKeys().forEach(cellKey => {
+        const instanceKey = self.instanceKey(cellKey)
+        const { sampleMean, sampleStdDev } = self.computeCurveParamValue(attrId, cellKey, dataConfig)
+        if (!self.curveParams.get(instanceKey) || resetPoints) {
+          self.addCurveParam(sampleMean, sampleStdDev, instanceKey)
+        } else {
+          self.updateCurveParamValue(sampleMean, sampleStdDev, instanceKey)
+        }
+      })
     }
   }))
 

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.scss
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-base-component.scss
@@ -86,7 +86,7 @@
     stroke: #027d34;
     stroke-width: 6px;
     opacity: 0.001;
-    pointer-events: all;
+    pointer-events: visibleStroke;
 
     &:hover, &.highlighted {
       opacity: .2;


### PR DESCRIPTION
[#CODAP-136] Bug fix: Normal curve doesn't respond dynamically to drag of points

* The problem was that the normal-curve-adornment-component wasn't behaving like other univariate adornment components that observe changes in model level computed properties. Instead, the model was being asked to compute the curve parameters every time the component rerendered. Since display of a normal curve requires both a sample mean and a sample standard deviation, we couldn't easily extend the single parameter adornment pattern. Instead, we created a CurveParamInstance to take the place of a MeasureInstance and cache sampleMean and sampleStdDev in these. The component asks for these cached values, thus observing them, and rerendering when they change.
* For another bug fix, we note that it was impossible to click or hover on points underneath the curve. This was fixed with a one line change to univariate-measure-adornment-base-component.scss.