### PR TITLE
CODAP-670 Box plot responds dynamically to point drag

### DIFF
--- a/v3/src/components/graph/adornments/store/adornments-base-store.ts
+++ b/v3/src/components/graph/adornments/store/adornments-base-store.ts
@@ -5,7 +5,8 @@ import { AdornmentModelUnion, kDefaultFontSize } from "../adornment-types"
 import { IAdornmentModel, IUpdateCategoriesOptions } from "../adornment-models"
 import { IMovableValueAdornmentModel } from "../movable-value/movable-value-adornment-model"
 import { kMovableValueType } from "../movable-value/movable-value-adornment-types"
-import { IUnivariateMeasureAdornmentModel } from "../univariate-measures/univariate-measure-adornment-model"
+import { isUnivariateMeasureAdornment, IUnivariateMeasureAdornmentModel }
+  from "../univariate-measures/univariate-measure-adornment-model"
 import { kNormalCurveType } from "../univariate-measures/normal-curve/normal-curve-adornment-types"
 import { kStandardErrorType } from "../univariate-measures/standard-error/standard-error-adornment-types"
 
@@ -28,6 +29,15 @@ export const AdornmentsBaseStore = types.model("AdornmentsBaseStore", {
   get activeUnivariateMeasures() {
     return self.adornments.filter(adornment => adornment.isUnivariateMeasure && adornment.isVisible) as
             IUnivariateMeasureAdornmentModel[]
+  },
+  mapOfUnivariateAdornmentVisibility() {
+    const map = new Map<string, { isVisible: boolean, needsRecomputation: boolean }>()
+    self.adornments.forEach(adornment => {
+      if (isUnivariateMeasureAdornment(adornment)) {
+        map.set(adornment.type, {isVisible: adornment.isVisible, needsRecomputation: adornment.needsRecomputation})
+      }
+    })
+    return map
   },
   findAdornmentOfType<T extends IAdornmentModel = IAdornmentModel>(type: string): T | undefined {
     return self.adornments.find(adornment => adornment.type === type) as T

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
@@ -3,6 +3,7 @@ import { select, Selection } from "d3"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { t } from "../../../../../utilities/translation/translate"
+import { selectCases, setSelectedCases } from "../../../../../models/data/data-set-utils"
 import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
 import { useGraphDataConfigurationContext } from "../../../hooks/use-graph-data-configuration-context"
 import { useGraphLayoutContext } from "../../../hooks/use-graph-layout-context"
@@ -304,9 +305,9 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       if (!dataConfig || !attrId || !dataConfig.dataset || min === undefined || max === undefined) return
       const casesToSelect = model.getCasesWithValuesInRange(attrId, cellKey, dataConfig, min, max)
       if (event.shiftKey) {
-        dataConfig.dataset.selectCases(casesToSelect)
+        selectCases(casesToSelect, dataConfig.dataset)
       } else {
-        dataConfig.dataset.setSelectedCases(casesToSelect)
+        setSelectedCases(casesToSelect, dataConfig.dataset)
       }
     }
 
@@ -458,8 +459,8 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     addAdornmentElements(newValueObj, newLabelsObj)
   }, [model.isVisible, labelRef, addAdornmentElements])
 
-  if (!model.isVisible || ['linePlot', 'binnedDotPlot'].includes(graphModel.plot.type)) {
-    return  // Don't display box plot adornments on binned dot plots or line plots
+  if (!model.isVisible || !graphModel.plot.canShowBoxPlotAndNormalCurve) {
+    return
   }
 
   return (

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
@@ -458,7 +458,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     addAdornmentElements(newValueObj, newLabelsObj)
   }, [model.isVisible, labelRef, addAdornmentElements])
 
-  if (['linePlot', 'binnedDotPlot'].includes(graphModel.plot.type)) {
+  if (!model.isVisible || ['linePlot', 'binnedDotPlot'].includes(graphModel.plot.type)) {
     return  // Don't display box plot adornments on binned dot plots or line plots
   }
 

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
@@ -3,6 +3,7 @@ import { select, Selection } from "d3"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { t } from "../../../../../utilities/translation/translate"
+import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
 import { useGraphDataConfigurationContext } from "../../../hooks/use-graph-data-configuration-context"
 import { useGraphLayoutContext } from "../../../hooks/use-graph-layout-context"
 import { useAdornmentAttributes } from "../../../hooks/use-adornment-attributes"
@@ -34,6 +35,7 @@ interface IBoxPlotValue extends IValue {
 export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentComponent (props: IAdornmentComponentProps) {
   const {cellKey={}, cellCoords, containerId, plotHeight, plotWidth,
     xAxis, yAxis, spannerRef} = props
+  const graphModel = useGraphContentModelContext()
   const model = props.model as IBoxPlotAdornmentModel
   const layout = useGraphLayoutContext()
   const dataConfig = useGraphDataConfigurationContext()
@@ -136,11 +138,8 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
 
   const addWhiskers = useCallback((valueObj: IBoxPlotValue, range: IRange, showOutliers=false) => {
     if (!dataConfig || !attrId || !range.min || !range.max) return
-    const lowerOutliers = model.lowerOutliers(attrId, cellKey, dataConfig)
-    const upperOutliers = model.upperOutliers(attrId, cellKey, dataConfig)
-    const minValue = model.minWhiskerValue(attrId, cellKey, dataConfig)
-    const maxValue = model.maxWhiskerValue(attrId, cellKey, dataConfig)
-    if (minValue === maxValue || !isFinite(minValue) || !isFinite(maxValue)) return
+    const { minWhiskerValue, maxWhiskerValue, lowerOutliers, upperOutliers} = model.getBoxPlotParams(cellKey)
+    if (minWhiskerValue === maxWhiskerValue || !isFinite(minWhiskerValue) || !isFinite(maxWhiskerValue)) return
 
     const lineLowerClass = clsx("measure-line", "box-plot-line", `${helper.measureSlug}-whisker-lower`)
     const coverLowerClass = clsx("measure-cover", "box-plot-cover", `${helper.measureSlug}-whisker-lower`)
@@ -150,7 +149,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     const coverLowerId = helper.generateIdString("whisker-lower-cover")
     const lineUpperId = helper.generateIdString("whisker-upper")
     const coverUpperId = helper.generateIdString("whisker-upper-cover")
-    const whiskerCoords = calculateWhiskerCoords(minValue, maxValue, range.min, range.max)
+    const whiskerCoords = calculateWhiskerCoords(minWhiskerValue, maxWhiskerValue, range.min, range.max)
     const whiskerLowerLineSpecs = {
       isVertical: isVertical.current,
       lineClass: lineLowerClass,
@@ -301,6 +300,16 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       fullHeightLinesRef.current?.classed("highlighted", visible)
     }
 
+    const selectRange = ([min, max]: number[], event: MouseEvent) => {
+      if (!dataConfig || !attrId || !dataConfig.dataset || min === undefined || max === undefined) return
+      const casesToSelect = model.getCasesWithValuesInRange(attrId, cellKey, dataConfig, min, max)
+      if (event.shiftKey) {
+        dataConfig.dataset.selectCases(casesToSelect)
+      } else {
+        dataConfig.dataset.setSelectedCases(casesToSelect)
+      }
+    }
+
     const container = select(labelRef.current)
     const textId = helper.generateIdString("label")
     const labels = textContent.split("\n")
@@ -313,6 +322,17 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       null, // valueObj.range causes problems when part of this array. Not sure why.
       valueObj.iciCover
     ]
+    const { median, lowerQuartile, upperQuartile,
+      minWhiskerValue, maxWhiskerValue, lowerOutliers, upperOutliers} = model.getBoxPlotParams(cellKey)
+    const selectionBounds = [
+      [minWhiskerValue, lowerQuartile],
+      [lowerQuartile, median],
+      [],
+      [median, upperQuartile],
+      [upperQuartile, maxWhiskerValue],
+      [],
+      []
+    ]
 
     for (let i = 0; i < labels.length; i++) {
       labelsObj.label = container.append("div")
@@ -322,38 +342,40 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
         .attr("data-testid", `${textId}-${i}`)
       covers[i]?.on("mouseover", (e) => toggleBoxPlotLabels(`${textId}-${i}`, true, e))
         .on("mouseout", (e) => toggleBoxPlotLabels(`${textId}-${i}`, false, e))
+        .on("click", (e) => selectRange(selectionBounds[i], e))
     }
     valueObj.range?.on("mouseover", (e) => toggleBoxPlotLabels(`${textId}-${5}`, true, e))
       .on("mouseout", (e) => toggleBoxPlotLabels(`${textId}-${5}`, false, e))
+      .on("click", (e) => selectRange([lowerQuartile, upperQuartile], e))
     valueObj.iciCover?.on("mouseover", (e) => toggleICILabels(`${textId}-${6}`, true, e))
       .on("mouseout", (e) => toggleICILabels(`${textId}-${6}`, false, e))
 
     if (model.showOutliers) {
       if (!attrId || !dataConfig) return
 
-      const lowerOutliers = model.lowerOutliers(attrId, cellKey, dataConfig)
-      const upperOutliers = model.upperOutliers(attrId, cellKey, dataConfig)
       for (let i = 0; i < lowerOutliers.length; i++) {
         const coverId = helper.generateIdString("outlier-cover")
         labelsObj.label = container.append("div")
-          .text(lowerOutliers[i])
+          .text(helper.formatValueForScale(isVertical.current, lowerOutliers[i]))
           .attr("class", "measure-tip measure-labels-tip box-plot-label")
           .attr("id", `${textId}-lower-outlier-${i}`)
           .attr("data-testid", `${textId}-${i}`)
         select(`#${coverId}-lower-${i}`)
           .on("mouseover", (e) => toggleBoxPlotLabels(`${textId}-lower-outlier-${i}`, true, e))
           .on("mouseout", (e) => toggleBoxPlotLabels(`${textId}-lower-outlier-${i}`, false, e))
+          .on("click", (e) => selectRange([lowerOutliers[i], lowerOutliers[i]], e))
       }
       for (let i = 0; i < upperOutliers.length; i++) {
         const coverId = helper.generateIdString("outlier-cover")
         labelsObj.label = container.append("div")
-          .text(upperOutliers[i])
+          .text(helper.formatValueForScale(isVertical.current, upperOutliers[i]))
           .attr("class", "measure-tip measure-labels-tip box-plot-label")
           .attr("id", `${textId}-upper-outlier-${i}`)
           .attr("data-testid", `${textId}-${i}`)
         select(`#${coverId}-upper-${i}`)
           .on("mouseover", (e) => toggleBoxPlotLabels(`${textId}-upper-outlier-${i}`, true, e))
           .on("mouseout", (e) => toggleBoxPlotLabels(`${textId}-upper-outlier-${i}`, false, e))
+          .on("click", (e) => selectRange([upperOutliers[i], upperOutliers[i]], e))
       }
     }
   }, [attrId, cellKey, dataConfig, helper, labelRef, model, toggleBoxPlotLabels])
@@ -377,19 +399,15 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     }
 
     if (!attrId || !dataConfig) return
-    const value = model.measureValue(attrId, cellKey, dataConfig)
+    const value = model.getBoxPlotParams(cellKey).median
     if (value === undefined || isNaN(value)) return
 
-    const { coords, coverClass, coverId, displayValue, lineClass, lineId, measureRange } =
+    const { coords, coverClass, coverId, lineClass, lineId, measureRange } =
       helper.adornmentSpecs(attrId, dataConfig, value, isVertical.current, cellCounts, secondaryAxisX, secondaryAxisY)
-    const translationVars = [
-      model.minWhiskerValue(attrId, cellKey, dataConfig),
-      measureRange.min, // Q1
-      displayValue, // median
-      measureRange.max, // Q3
-      model.maxWhiskerValue(attrId, cellKey, dataConfig),
-      model.iqr(attrId, cellKey, dataConfig)
-    ]
+    const { median, lowerQuartile, upperQuartile, iqr,
+            minWhiskerValue, maxWhiskerValue } = model.getBoxPlotParams(cellKey)
+    const translationVars = [ minWhiskerValue, lowerQuartile, median, upperQuartile, maxWhiskerValue, iqr ]
+      .map(v => helper.formatValueForScale(isVertical.current, v))
     let textContent = `${t(model.labelTitle, { vars: translationVars })}`
 
     if ((measureRange?.min || measureRange?.min === 0) && (measureRange?.max || measureRange?.max === 0)) {
@@ -439,6 +457,10 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
 
     addAdornmentElements(newValueObj, newLabelsObj)
   }, [model.isVisible, labelRef, addAdornmentElements])
+
+  if (['linePlot', 'binnedDotPlot'].includes(graphModel.plot.type)) {
+    return  // Don't display box plot adornments on binned dot plots or line plots
+  }
 
   return (
     <UnivariateMeasureAdornmentBaseComponent

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.test.ts
@@ -33,6 +33,13 @@ describe("DataInteractive boxPlotAdornmentHandler", () => {
       showOutliers: true,
       type: kBoxPlotType,
       upperQuartile: jest.fn(() => 15),
+      getBoxPlotParams: jest.fn(() => ({
+        median: 10,
+        minWhiskerValue: 0,
+        maxWhiskerValue: 20,
+        lowerQuartile: 5,
+        upperQuartile: 15
+      })),
     }
 
     mockInvalidAdornment = {

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-handler.ts
@@ -13,16 +13,9 @@ export const boxPlotAdornmentHandler: DIAdornmentHandler = {
     const dataConfig = graphContent.dataConfiguration
     const cellKeys = dataConfig?.getAllCellKeys()
     const data: AdornmentData[] = []
-    const primaryAttrId = dataConfig?.primaryAttributeID
-
     for (const cellKey of cellKeys) {
-      const cellKeyString = JSON.stringify(cellKey)
-      const cellCaseValues = adornment.getCaseValues(primaryAttrId, cellKey, dataConfig)
-      const median = adornment.measures.get(cellKeyString)?.value ?? NaN
-      const lower = adornment.minWhiskerValue(primaryAttrId, cellKey, dataConfig)
-      const upper = adornment.maxWhiskerValue(primaryAttrId, cellKey, dataConfig)
-      const lowerQuartile = adornment.lowerQuartile(cellCaseValues)
-      const upperQuartile = adornment.upperQuartile(cellCaseValues)
+      const { median, minWhiskerValue: lower, maxWhiskerValue: upper,
+        lowerQuartile, upperQuartile } = adornment.getBoxPlotParams(cellKey)
       const interquartileRange = upperQuartile - lowerQuartile
       const dataItem: AdornmentData = {
         interquartileRange,

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
@@ -1,5 +1,5 @@
-import { observable } from "mobx"
-import { Instance, SnapshotIn, types } from "mobx-state-tree"
+import { comparer, observable, reaction } from "mobx"
+import { addDisposer, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { median } from "mathjs"
 import { quantileOfSortedArray } from "../../../../../utilities/math-utils"
 import { UnivariateMeasureAdornmentModel } from "../univariate-measure-adornment-model"
@@ -193,6 +193,16 @@ export const BoxPlotAdornmentModel = UnivariateMeasureAdornmentModel
           self.updateBoxPlotParams(boxPlotParams, instanceKey)
         }
       })
+      self.setNeedsRecomputation(false)
+    },
+    afterCreate() {
+      addDisposer(self, reaction(
+        () => [self.showOutliers, self.showICI],
+        () => self.setNeedsRecomputation(true),
+        { name: "BoxPlotAdornmentModel.afterCreate.showOutliers", fireImmediately: true,
+          equals: comparer.structural}
+      ))
+
     }
   }))
 

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
@@ -1,10 +1,39 @@
+import { observable } from "mobx"
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { median } from "mathjs"
 import { quantileOfSortedArray } from "../../../../../utilities/math-utils"
 import { UnivariateMeasureAdornmentModel } from "../univariate-measure-adornment-model"
 import { kBoxPlotType, kBoxPlotValueTitleKey } from "./box-plot-adornment-types"
 import { IGraphDataConfigurationModel } from "../../../models/graph-data-configuration-model"
-import { IAdornmentModel } from "../../adornment-models"
+import { IAdornmentModel, IUpdateCategoriesOptions } from "../../adornment-models"
+
+type BoxPlotParams = {
+  median: number
+  lowerQuartile: number
+  upperQuartile: number
+  iqr: number
+  minWhiskerValue: number
+  maxWhiskerValue: number
+  lowerOutliers: number[]
+  upperOutliers: number[]
+}
+
+export const BoxPlotParamInstance = types.model("BoxPlotParamInstance", {
+})
+  .volatile(self => ({
+    boxPlotParams: {} as BoxPlotParams,
+    isValid: false
+  }))
+  .actions(self => ({
+    setBoxPlotParams(boxPlotParams: BoxPlotParams) {
+      self.boxPlotParams = boxPlotParams
+      self.isValid = true
+    },
+    setIsValid(isValid: boolean) {
+      self.isValid = isValid
+    }
+  }))
+export interface IBoxPlotParamInstance extends Instance<typeof BoxPlotParamInstance> {}
 
 export const BoxPlotAdornmentModel = UnivariateMeasureAdornmentModel
   .named("BoxPlotAdornmentModel")
@@ -16,6 +45,31 @@ export const BoxPlotAdornmentModel = UnivariateMeasureAdornmentModel
     // document, the ICI will be shown.
     showICI: false  // show informal confidence interval
   })
+  .volatile(() => ({
+    boxPlotParams: observable.map<string, IBoxPlotParamInstance>({}, { deep: false }),
+  }))
+  .actions(self => ({
+    addBoxPlotParams(boxPlotParams: BoxPlotParams, key="{}") {
+      const newBoxPlotParam = BoxPlotParamInstance.create()
+      newBoxPlotParam.setBoxPlotParams(boxPlotParams)
+      self.boxPlotParams.set(key, newBoxPlotParam)
+    },
+    updateBoxPlotParams(boxPlotParams: BoxPlotParams, key="{}") {
+      const boxPlotParam = self.boxPlotParams.get(key)
+      if (boxPlotParam) {
+        boxPlotParam.setBoxPlotParams(boxPlotParams)
+      }
+      else {
+        this.addBoxPlotParams(boxPlotParams, key)
+      }
+    },
+    removeBoxPlotParam(key: string) {
+      self.boxPlotParams.delete(key)
+    },
+    invalidateBoxPlotParams() {
+      self.boxPlotParams.forEach(boxPlotParam => boxPlotParam.setIsValid(false))
+    }
+  }))
   .views(() => ({
     get hasRange() {
       return true
@@ -46,56 +100,9 @@ export const BoxPlotAdornmentModel = UnivariateMeasureAdornmentModel
     }
   }))
   .views(self => ({
-    // Returns the minimum value to use in constructing the whisker line. If we're showing outliers, we need to return
-    // the lowest non-outlier value since outliers are not part of the line.
-    minWhiskerValue(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
-      const caseValues = self.getCaseValues(attrId, cellKey, dataConfig).filter(v => !Number.isNaN(v))
-      if (self.showOutliers) {
-        // If we're showing outliers, the min is the lowest non-outlier value.
-        const interquartileRange = self.interquartileRange(caseValues)
-        const lowerQuartile = self.lowerQuartile(caseValues)
-        const min = lowerQuartile - 1.5 * interquartileRange
-        return Math.min(...caseValues.filter(v => v >= min))
-      }
-      return Math.min(...caseValues)
-    },
-    // Returns the maximum value to use in constructing the whisker line. If we're showing outliers, we need to return
-    // the greatest non-outlier value since outliers are not part of the line.
-    maxWhiskerValue(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
-      const caseValues = self.getCaseValues(attrId, cellKey, dataConfig).filter(v => !Number.isNaN(v))
-      if (self.showOutliers) {
-        // If we're showing outliers, the max is the highest non-outlier value.
-        const interquartileRange = self.interquartileRange(caseValues)
-        const upperQuartile = self.upperQuartile(caseValues)
-        const max = upperQuartile + 1.5 * interquartileRange
-        return Math.max(...caseValues.filter(v => v <= max))
-      }
-      return Math.max(...caseValues)
-    },
-    computeMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
-      const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
-      if (caseValues.length === 0) return NaN
-      return median(caseValues)
-    }
-  }))
-  .views(self => ({
     computeMeasureRange(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
       const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
       return { min: self.lowerQuartile(caseValues), max: self.upperQuartile(caseValues) }
-    },
-    lowerOutliers(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
-      const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
-      const interquartileRange = self.interquartileRange(caseValues)
-      const lowerQuartile = self.lowerQuartile(caseValues)
-      const min = lowerQuartile - 1.5 * interquartileRange
-      return caseValues.filter(v => v < min).sort((a, b) => a - b)
-    },
-    upperOutliers(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
-      const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
-      const interquartileRange = self.interquartileRange(caseValues)
-      const upperQuartile = self.upperQuartile(caseValues)
-      const max = upperQuartile + 1.5 * interquartileRange
-      return caseValues.filter(v => v > max).sort((a, b) => a - b)
     },
     computeICIRange(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
       const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
@@ -103,6 +110,80 @@ export const BoxPlotAdornmentModel = UnivariateMeasureAdornmentModel
       const interquartileRange = self.interquartileRange(caseValues)
       const ici = 1.5 * interquartileRange / Math.sqrt(caseValues.length)
       return { min: medianValue - ici, max: medianValue + ici }
+    },
+    computeBoxPlotParamValue(attrId: string, cellKey: Record<string, string>,
+                             dataConfig: IGraphDataConfigurationModel) {
+      const caseValues = self.getCaseValues(attrId, cellKey, dataConfig)
+      const numValues = caseValues.length
+      const interquartileRange = self.interquartileRange(caseValues)
+      const lowerQuartile = self.lowerQuartile(caseValues)
+      const upperQuartile = self.upperQuartile(caseValues)
+      // Returns the minimum value to use in constructing the whisker line. If we're showing outliers, we need to return
+      // the lowest non-outlier value since outliers are not part of the line.
+      const minWhiskerValue = () =>{
+        if (self.showOutliers) {
+          // If we're showing outliers, the min is the lowest non-outlier value.
+          const min = lowerQuartile - 1.5 * interquartileRange
+          return Math.min(...caseValues.filter(v => v >= min))
+        }
+        return Math.min(...caseValues)
+      }
+      // Returns the maximum value to use in constructing the whisker line. If we're showing outliers, we need to return
+      // the greatest non-outlier value since outliers are not part of the line.
+      const maxWhiskerValue = () => {
+        if (self.showOutliers) {
+          // If we're showing outliers, the max is the highest non-outlier value.
+          const max = upperQuartile + 1.5 * interquartileRange
+          return Math.max(...caseValues.filter(v => v <= max))
+        }
+        return Math.max(...caseValues)
+      }
+      const lowerOutliers = () => {
+        const min = lowerQuartile - 1.5 * interquartileRange
+        return caseValues.filter(v => v < min).sort((a, b) => a - b)
+      }
+      const upperOutliers = () => {
+        const max = upperQuartile + 1.5 * interquartileRange
+        return caseValues.filter(v => v > max).sort((a, b) => a - b)
+      }
+
+      const boxPlotParams: BoxPlotParams = {
+        median: numValues > 0 ? median(caseValues) : NaN,
+        lowerQuartile: self.getQuantileValue(25, caseValues),
+        upperQuartile: self.getQuantileValue(75, caseValues),
+        iqr: self.interquartileRange(caseValues),
+        minWhiskerValue: minWhiskerValue(),
+        maxWhiskerValue: maxWhiskerValue(),
+        lowerOutliers: lowerOutliers(),
+        upperOutliers: upperOutliers()
+      }
+      return boxPlotParams
+    }
+  }))
+  .views(self => ({
+    getBoxPlotParams(cellKey: Record<string, string>) {
+      const instanceKey = self.instanceKey(cellKey)
+      const boxPlotParam = self.boxPlotParams.get(instanceKey)
+      return boxPlotParam?.isValid ? boxPlotParam.boxPlotParams : {
+        median: NaN,
+        lowerQuartile: NaN,
+        upperQuartile: NaN,
+        iqr: NaN,
+        minWhiskerValue: NaN,
+        maxWhiskerValue: NaN,
+        lowerOutliers: [],
+        upperOutliers: []
+      }
+    },
+    // For the following note that the range is inclusive, so we can include cases matching a single value
+    getCasesWithValuesInRange(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel,
+                              min: number, max: number) {
+      const dataset = dataConfig.dataset
+      const casesInPlot = dataConfig.filterCasesForDisplay(dataConfig.subPlotCases(cellKey))
+      return casesInPlot.filter(caseId => {
+        const caseValue = dataset?.getNumeric(caseId, attrId)
+        return caseValue != null && caseValue >= min && caseValue <= max
+      })
     }
   }))
   .actions(self => ({
@@ -111,6 +192,20 @@ export const BoxPlotAdornmentModel = UnivariateMeasureAdornmentModel
     },
     setShowICI(showICI: boolean) {
       self.showICI = showICI
+    },
+    updateCategories(options: IUpdateCategoriesOptions) {
+      const { dataConfig, resetPoints } = options
+      const { xAttrId, yAttrId, xAttrType } = dataConfig.getCategoriesOptions()
+      const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
+      dataConfig.getAllCellKeys().forEach(cellKey => {
+        const instanceKey = self.instanceKey(cellKey)
+        const boxPlotParams = self.computeBoxPlotParamValue(attrId, cellKey, dataConfig)
+        if (!self.boxPlotParams.get(instanceKey) || resetPoints) {
+          self.addBoxPlotParams(boxPlotParams, instanceKey)
+        } else {
+          self.updateBoxPlotParams(boxPlotParams, instanceKey)
+        }
+      })
     }
   }))
 

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
@@ -366,8 +366,8 @@ export const NormalCurveAdornmentComponent = observer(
       }
     }, [])
 
-    if (['linePlot', 'binnedDotPlot'].includes(graphModel.plot.type)) {
-      return  // Can't display a normal curve on a binned dot plot
+    if (!graphModel.plot.canShowBoxPlotAndNormalCurve) {
+      return
     }
 
     return (

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
@@ -113,6 +113,9 @@ export const NormalCurveAdornmentModel = UnivariateMeasureAdornmentModel
       }
       return results
     },
+    computeMeasureValue(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
+      // no-op  but required for the base class
+    },
     computeCurveParamValue(attrId: string, cellKey: Record<string, string>, dataConfig: IGraphDataConfigurationModel) {
       // We'll store the mean and standard deviation in the measures map, so we can use them to compute the normal curve
       return { sampleMean: this.computeMean(attrId, cellKey, dataConfig),
@@ -141,6 +144,13 @@ export const NormalCurveAdornmentModel = UnivariateMeasureAdornmentModel
           self.addCurveParam(sampleMean, sampleStdDev, instanceKey)
         } else {
           self.updateCurveParamValues(sampleMean, sampleStdDev, instanceKey)
+        }
+        // We still need to update the measure value since it has the label coordinates
+        const value = Number(self.computeMeasureValue(attrId, cellKey, dataConfig))
+        if (!self.measures.get(instanceKey) || resetPoints) {
+          self.addMeasure(value, instanceKey)
+        } else {
+          self.updateMeasureValue(value, instanceKey)
         }
       })
     }

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
@@ -1,4 +1,5 @@
 import { mean, std } from "mathjs"
+import { observable } from "mobx"
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { IGraphDataConfigurationModel } from "../../../models/graph-data-configuration-model"
 import { IAdornmentModel, IUpdateCategoriesOptions } from "../../adornment-models"
@@ -31,7 +32,7 @@ export const NormalCurveAdornmentModel = UnivariateMeasureAdornmentModel
     labelTitle: types.optional(types.literal(kNormalCurveValueTitleKey), kNormalCurveValueTitleKey),
   })
   .volatile(() => ({
-    curveParams: new Map<string, ICurveParamInstance>(),
+    curveParams: observable.map<string, ICurveParamInstance>({}, { deep: false }),
   }))
   .actions(self => ({
     addCurveParam(sampleMean: number, sampleStdDev: number, key="{}") {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -274,7 +274,8 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     },
     get leftBottomCategoricalAttrCount() {
       const attrTypes = self.attrTypes
-      return (isCategoricalAttributeType(attrTypes.left) ? 1 : 0) + (isCategoricalAttributeType(attrTypes.bottom) ? 1 : 0)
+      return (isCategoricalAttributeType(attrTypes.left) ? 1 : 0) + (isCategoricalAttributeType(attrTypes.bottom)
+        ? 1 : 0)
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.ts
+++ b/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.ts
@@ -38,6 +38,9 @@ export const BinnedDotPlotModel = DotPlotModel
     },
     get binWidth() {
       return self.activeBinWidth ?? self._binWidth
+    },
+    get canShowBoxPlotAndNormalCurve(): boolean {
+      return false
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/plots/dot-plot/dot-plot-model.ts
+++ b/v3/src/components/graph/plots/dot-plot/dot-plot-model.ts
@@ -24,5 +24,8 @@ export const DotPlotModel = PlotModel
     },
     get showDisplayTypeSelection() {
       return true
+    },
+    get canShowBoxPlotAndNormalCurve(): boolean {
+      return true
     }
   }))

--- a/v3/src/components/graph/plots/histogram/histogram-model.ts
+++ b/v3/src/components/graph/plots/histogram/histogram-model.ts
@@ -38,6 +38,9 @@ export const HistogramModel = BinnedDotPlotModel
     },
     get showGridLines() {
       return true
+    },
+    get canShowBoxPlotAndNormalCurve(): boolean {
+      return true
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/plots/line-plot/line-plot-model.ts
+++ b/v3/src/components/graph/plots/line-plot/line-plot-model.ts
@@ -14,5 +14,8 @@ export const LinePlotModel = DotPlotModel
     },
     get showZeroLine() {
       return true
+    },
+    get canShowBoxPlotAndNormalCurve(): boolean {
+      return false
     }
   }))

--- a/v3/src/components/graph/plots/plot-model.ts
+++ b/v3/src/components/graph/plots/plot-model.ts
@@ -106,6 +106,9 @@ export const PlotModel = types
     },
     get showZeroLine(): boolean {
       return false
+    },
+    get canShowBoxPlotAndNormalCurve(): boolean {
+      return false
     }
   }))
   .views(self => ({


### PR DESCRIPTION
[#CODAP-670] Bug fix: Box plot not responding properly to dragging poings

* The box plot component observes its model and re-renders when model properties change. But the only model property currently being computed dynamically is the median. Consequently the box plot doesn't re-render until the median changes. So, we reconfigure `BoxPlotAdornmentModel` to store all the numeric values required by the component as properties following the pattern set forth in univariate-measure, overriding `updateCategories` to recompute box plot values and store them.
* Also, we prevent a box plot from displaying if the plot is a binnedDotPlot or a linePlot.
* Finally, we add click handlers for the box plot elements to select cases in the corresponding range
* And we fix a lint error in graph-data-configuration-model.ts