### PR TITLE
CODAP-301 Prevent point dragging if attribute has formula

### DIFF
--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -30,6 +30,7 @@ export type PixiPointsArray = Array<Maybe<PixiPoints>>
 // "Type 'FederatedPointerEvent' is missing the following properties
 // from type 'PointerEvent': altitudeAngle, azimuthAngle"
 const toPointerEvent = (event: PIXI.FederatedPointerEvent) => event as unknown as PointerEvent
+const toFederatedPointerEvent = (event: PointerEvent) => event as unknown as PIXI.FederatedPointerEvent
 
 export type PixiPointEventHandler = (event: PointerEvent, point: PIXI.Sprite, metadata: IPixiPointMetadata) => void
 
@@ -760,6 +761,7 @@ export class PixiPoints {
           // Note that we don't call getMetadata here because the point can be removed by a click
           const metadata = this.pointMetadata.get(sprite)
           metadata && this.onPointDragEnd?.(pointerUpEvent, sprite, metadata)
+          handlePointerLeave(toFederatedPointerEvent(pointerUpEvent))
           window.removeEventListener("pointermove", onDrag)
           window.removeEventListener("pointerup", onDragEnd)
         }

--- a/v3/src/components/graph/hooks/use-dot-plot-drag-drop.ts
+++ b/v3/src/components/graph/hooks/use-dot-plot-drag-drop.ts
@@ -26,6 +26,7 @@ export const useDotPlotDragDrop = () => {
   const [dragID, setDragID] = useState('')
   const currPos = useRef(0)
   const didDrag = useRef(false)
+  const draggingAllowed = !dataset?.getAttribute(primaryAttrID)?.hasFormula
 
   /*
    * Drag handling. Dots in a dot plot can be dragged to change their position along
@@ -54,7 +55,7 @@ export const useDotPlotDragDrop = () => {
   const onDrag = (event: PointerEvent) => {
     if (primaryAxisScale && dragID) {
       const newPos = primaryIsBottom ? event.clientX : event.clientY
-      const deltaPixels = newPos - currPos.current
+      const deltaPixels = draggingAllowed ? newPos - currPos.current : 0
       currPos.current = newPos
       if (deltaPixels !== 0) {
         didDrag.current = true

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -109,10 +109,12 @@ export const ScatterPlot = observer(function ScatterPlot({ pixiPoints }: IPlotPr
   const onDrag = useCallback((event: PointerEvent) => {
     const xAxisScale = layout.getAxisScale('bottom') as ScaleLinear<number, number>
     const xAttrID = dataConfiguration?.attributeID('x') ?? ''
+    const canDragX = !dataset?.getAttribute(xAttrID)?.hasFormula
+    const canDragY = !dataset?.getAttribute(secondaryAttrIDsRef.current[plotNumRef.current])?.hasFormula
     if (dragID !== '') {
       const newPos = { x: event.clientX, y: event.clientY }
-      const dx = newPos.x - currPos.current.x
-      const dy = newPos.y - currPos.current.y
+      const dx = canDragX ? newPos.x - currPos.current.x : 0
+      const dy = canDragY ? newPos.y - currPos.current.y : 0
       currPos.current = newPos
       if (dx !== 0 || dy !== 0) {
         didDrag.current = true


### PR DESCRIPTION
[#CODAP-301] Bug fix: Should not be able to drag points whose coordinates are computed with formula

* Points can only be dragged in dot plots and scatter plots. So, in the drag routines for these plots we check to see if a relevant attribute has formula and, if so, zero out the delta in pixels so that the dragging doesn't affect the attribute values.
* It has been a long-standing irritation that points that are dragged don't necessarily go back to their original size. This is exacerbated by allowing the mouse to move far from the point during a drag. So we fix that by calling `handlePointerLeave` in `PixiPoints.onDragEnd`.