### PR TITLE
Categorical legend selection sends notification to plugin

### DIFF
--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -2,7 +2,7 @@ import {drag, select} from "d3"
 import React, {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {mstReaction} from "../../../../utilities/mst-reaction"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
-import { setSelectedCases } from "../../../../models/data/data-set-utils"
+import { setSelectedCases, selectCases } from "../../../../models/data/data-set-utils"
 import {axisGap} from "../../../axis/axis-types"
 import { transitionDuration } from "../../data-display-types"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
@@ -65,7 +65,7 @@ export const CategoricalLegend =
       if (caseIds) {
         // This is breaking the graph-legend cypress test
         // setOrExtendSelection(caseIds, dataConfiguration?.dataset, event.shiftKey)
-        if (event.shiftKey) setSelectedCases(caseIds, dataConfiguration?.dataset)
+        if (event.shiftKey) selectCases(caseIds, dataConfiguration?.dataset)
         else setSelectedCases(caseIds, dataConfiguration?.dataset)
       }
     }, [dataConfiguration])

--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -2,6 +2,7 @@ import {drag, select} from "d3"
 import React, {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {mstReaction} from "../../../../utilities/mst-reaction"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
+import { setSelectedCases } from "../../../../models/data/data-set-utils"
 import {axisGap} from "../../../axis/axis-types"
 import { transitionDuration } from "../../data-display-types"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
@@ -64,8 +65,8 @@ export const CategoricalLegend =
       if (caseIds) {
         // This is breaking the graph-legend cypress test
         // setOrExtendSelection(caseIds, dataConfiguration?.dataset, event.shiftKey)
-        if (event.shiftKey) dataConfiguration?.dataset?.selectCases(caseIds)
-        else dataConfiguration?.dataset?.setSelectedCases(caseIds)
+        if (event.shiftKey) setSelectedCases(caseIds, dataConfiguration?.dataset)
+        else setSelectedCases(caseIds, dataConfiguration?.dataset)
       }
     }, [dataConfiguration])
 


### PR DESCRIPTION
Changes categorical legend selection to go through the selectCases notification path instead of directly to dataConfiguration.dataset so that plugins can get notified when there is a selection. This is needed by the NEOPlugin.