### PR TITLE
CODAP-672 normalize pin longitude

### DIFF
--- a/v3/cypress/e2e/map.spec.ts
+++ b/v3/cypress/e2e/map.spec.ts
@@ -231,10 +231,19 @@ context("Map UI", () => {
     table.getNumOfRows().should("eq", "2") // Headers + input row
     map.getAddPinButton().click()
     map.getAddPinButton().should("have.class", "active")
-    map.getPinLayer().click()
+    // Note: Leaflet decides Cypress click() is a double click so it zooms the map
+    // at the location of the click. At least sometimes this double click happens before
+    // the actual click, so the map is zoomed and then the pin is added to the zoomed map.
+    // The location of the click is set so we can verify the pin longitude is normalized.
+    map.getPinLayer().click(50, 210)
     map.getAddPinButton().should("not.have.class", "active")
     map.getMapPin().should("exist")
     table.getNumOfRows().should("eq", "3")
+    table.getCell(4, 2).invoke("text").then(text => {
+      // Unicode minus
+      const normalized = text.replace(/\u2212/g, "-")
+      expect(parseFloat(normalized)).to.be.within(-180, 180)
+    })
 
     // Can select a pin
     table.getSelectedRows().should("have.length", 0)

--- a/v3/cypress/support/elements/component-elements.ts
+++ b/v3/cypress/support/elements/component-elements.ts
@@ -35,9 +35,11 @@ export const ComponentElements = {
     return cy.get(`.codap-component[data-testid$=${component}]`)
   },
   getComponentTile(component: string, index = 0) {
-    return this.getComponentSelector(component).then(element => {
-      return element.eq(index)
-    })
+    // This was using a then, but that prevents retrying the chain
+    // queries after this one.
+    // If we want to explicitly prevent retrying we should make that
+    // explicit in the method name.
+    return this.getComponentSelector(component).eq(index)
   },
   getComponentTitleBar(component: string, index = 0) {
     return this.getComponentTile(component, index).find(".component-title-bar")

--- a/v3/src/components/map/components/map-pin-layer.tsx
+++ b/v3/src/components/map/components/map-pin-layer.tsx
@@ -101,8 +101,12 @@ export const MapPinLayer = observer(function MapPinLayer({ mapLayerModel }: IMap
       const layerBB = layerRef.current?.getBoundingClientRect()
       if (!layerBB || !dataset) return
       const { lat, lng } = map.containerPointToLatLng([e.clientX - layerBB.x, e.clientY - layerBB.y])
+      // Normalize the longitude to be between -180 and 180
+      // The first modulo ensures the value is between -360 and 360,
+      // the second modulo ensures the value is between 0 and 360
+      const normalizedLng = ((lng + 180) % 360 + 360) % 360 - 180
       const color = kPinColors[colorIndex]
-      const newItem: ICaseCreation = { [pinLatId]: lat, [pinLongId]: lng }
+      const newItem: ICaseCreation = { [pinLatId]: lat, [pinLongId]: normalizedLng }
       if (colorId) newItem[colorId] = color
       insertCasesWithCustomUndoRedo(dataset, [newItem])
     }
@@ -145,7 +149,7 @@ export const MapPinLayer = observer(function MapPinLayer({ mapLayerModel }: IMap
         const { x, y } = map.latLngToContainerPoint([lat, long])
         const pinX = x - mapPinWidth / 2
         const pinY = y - mapPinHeight
-        
+
         const color = colorId ? dataset.getStrValue(__id__, colorId) : kPinColors[index % kPinColors.length]
         return (
           <MapPin


### PR DESCRIPTION
This normalizes the pin longitude between -180 and 180. 
The pin cypress test was updated to verify this works.

One thing I noticed while tracking down issues with the cypress test was that the cypress helper `getComponentTile` was using a `then` which prevents re-tries. I updated it, it might allow us to remove some wait statements if it was taking a while for a tile to show up.