### PR TITLE
CODAP-658 Caption should not be a hidden attribute

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -22,6 +22,7 @@ import {hashStringSets, typedId, uniqueId} from "../../../utilities/js-utils"
 import { isFiniteNumber } from "../../../utilities/math-utils"
 import {cachedFnWithArgsFactory} from "../../../utilities/mst-utils"
 import { numericSortComparator } from "../../../utilities/data-utils"
+import { getMetadataFromDataSet } from "../../../models/shared/shared-data-utils"
 import { AxisPlace } from "../../axis/axis-types"
 import {GraphPlace} from "../../axis-graph-shared"
 import { getScaleThresholds } from "../components/legend/choropleth-legend/choropleth-legend"
@@ -152,8 +153,9 @@ export const DataConfigurationModel = types
     // returns empty string (rather than undefined) for roles without attributes
     attributeID(role: AttrRole) {
       const defaultCaptionAttributeID = () => {
-        // We find the childmost collection and return the first attribute in that collection. If there is no
-        // childmost collection, we return the first attribute in the dataset.
+        // We find the childmost collection and return the first non-hidden attribute in that collection. If there is
+        // no childmost collection, we return the first non-hidden attribute in the dataset.
+        const metadata = getMetadataFromDataSet(self.dataset)
         const attrIDs = (['x', 'y', 'rightNumeric', 'topSplit', 'rightSplit', 'legend',
               'lat', 'long', 'polygon'] as const)
             .map(aRole => this.attributeID(aRole))
@@ -161,7 +163,8 @@ export const DataConfigurationModel = types
           childmostCollectionID = idOfChildmostCollectionForAttributes(attrIDs, self.dataset)
         if (childmostCollectionID) {
           const childmostCollection = self.dataset?.getCollection(childmostCollectionID),
-            childmostCollectionAttributes = childmostCollection?.attributes
+            childmostCollectionAttributes =
+              childmostCollection?.attributes.filter(attr => attr?.id && !metadata?.isHidden(attr?.id))
           if (childmostCollectionAttributes?.length) {
             const firstAttribute = childmostCollectionAttributes[0]
             return firstAttribute?.id


### PR DESCRIPTION
[#CODAP-658] Bug fix: Caption attributes in maps and graphs should not end up being hidden attributes

* Conveniently there is a routine in data-configuration-model.ts, `defaultCaptionAttributeID` whose job it is to compute the ID of the attribute to be used as a caption. So, we make sure the attribute so found is not hidden.