### PR TITLE
CODAP-674-Investigate-and-fix-date-slider-spec

### DIFF
--- a/v3/cypress/e2e/slider.spec.ts
+++ b/v3/cypress/e2e/slider.spec.ts
@@ -1,6 +1,7 @@
 import { SliderTileElements as slider } from "../support/elements/slider-tile"
 import { ComponentElements as c } from "../support/elements/component-elements"
 import { ToolbarElements as toolbar } from "../support/elements/toolbar-elements"
+import { CfmElements as cfm } from "../support/elements/cfm"
 
 const sliderName = "v1"
 const newName = "v2"
@@ -10,10 +11,19 @@ const newSliderValue = "0.6"
 
 context("Slider UI", () => {
   beforeEach(function () {
-    const queryParams = "?sample=mammals&dashboard&mouseSensor"
-    const url = `${Cypress.config("index")}${queryParams}`
-    cy.visit(url)
+    cy.visit(Cypress.config("index"))
+    cy.get('[data-testid="Create New Document-button"]').click()
+    cfm.openExampleDocument("Mammals")
     cy.wait(2500)
+    // Close only the Mammals Sample Guide component
+    cy.contains('[data-testid="component-title-bar"]', "Mammals Sample Guide")
+      .parents('.codap-component')
+      .find('[data-testid="component-close-button"]')
+      .first()
+      .click({ force: true })
+    // Open a new slider from the tool shelf
+    c.getIconFromToolShelf("slider").click()
+    slider.getSliderTile().should("be.visible")
   })
   it("basic Slider UI", () => {
     cy.log("populates default title, variable name and value and checks tooltips")
@@ -24,8 +34,8 @@ context("Slider UI", () => {
     slider.getSliderThumbIcon().should("be.visible")
     slider.getSliderAxis().should("be.visible")
 
-    // // undo should work after opening the Slider
-    // // TODO: add back this code (blocker: #187612762)
+    // undo should work after opening the Slider
+    // TODO: add back this code (blocker: #187612762)
     // cy.log("check for undo/redo after opening Slider component")
     // // use force:true here because undo button is incorrectly faded out here
     // toolbar.getUndoTool().click({force: true})
@@ -269,8 +279,7 @@ context("Slider UI", () => {
     slider.getVariableName(0).should("have.text", sliderName)
     slider.getVariableName(1).should("have.text", newSliderName)
   })
-  // TODO: add this check back in CODAP-674
-  it.skip("checks slider with dates", () => {
+  it("checks slider with dates", () => {
     const today = new Date().toLocaleDateString("en-US") // Adjust locale as needed
     const minValue = "01/01/2023" // Set an example minimum date
     const maxValue = "12/31/2023" // Set an example maximum date
@@ -312,33 +321,30 @@ context("Slider UI", () => {
     // Wait and verify it reaches April 30
     slider.getVariableValue().should("contain", "4/30/2023")
   })
-  // Issues with the click occur here, skipping for now
+  // NOTE: The changeVariableValue helper isn't working reliably in these tests.
+  // Possible reasons: timing issues, focus not being set correctly, or the slider
+  // input's reactivity/model rejecting or clamping values.
+  // This helper works in other tests, so the issue may be specific to the state or timing in this test context.
   it.skip("checks editing variable value in one slider only affects that slider", () => {
-    const newVariableValue = "100"
+    const newVariableValue = "0.5"
     c.getIconFromToolShelf("slider").click()
 
     slider.changeVariableValue(newVariableValue, 1)
     slider.getVariableValue(0).should("contain", initialSliderValue)
     slider.getVariableValue(1).should("contain", newVariableValue)
   })
-  // This test has become flaky. Skipping for now.
   it.skip("checks min max slider values", () => {
     slider.getVariableValue().should("contain", initialSliderValue)
-    // slider.changeVariableValue("12345678901234567890")
-    // slider.getVariableValue().should("contain", "1.235e+14")
+    slider.changeVariableValue("11.5") // max value for the slider
+    slider.getVariableValueInput().invoke('val').should('eq', '11.5')
 
-    // slider.changeVariableValue("0.12345678901234567890")
-    // slider.getVariableValue().should("contain", "0")
+    slider.changeVariableValue("0") // min value for the slider
+    slider.getVariableValueInput().invoke('val').should('eq', '0')
 
-    // slider.changeVariableValue("0.006")
-    // slider.getVariableValue().should("contain", "0")
-
-    slider.changeVariableValue("abc")
-    slider.getVariableValue().should("contain", "")
+    slider.changeVariableValue("5")
+    slider.getVariableValueInput().invoke('val').should('eq', '5')
   })
-  // This test is covered now in earlier tests. Skipping
-  // this one for now.
-  it.skip("reuses slider names after existing ones are closed", () => {
+  it("reuses slider names after existing ones are closed", () => {
     c.closeComponent("slider")
     c.checkComponentDoesNotExist("slider")
     c.getIconFromToolShelf("slider").click()

--- a/v3/cypress/e2e/slider.spec.ts
+++ b/v3/cypress/e2e/slider.spec.ts
@@ -321,11 +321,7 @@ context("Slider UI", () => {
     // Wait and verify it reaches April 30
     slider.getVariableValue().should("contain", "4/30/2023")
   })
-  // NOTE: The changeVariableValue helper isn't working reliably in these tests.
-  // Possible reasons: timing issues, focus not being set correctly, or the slider
-  // input's reactivity/model rejecting or clamping values.
-  // This helper works in other tests, so the issue may be specific to the state or timing in this test context.
-  it.skip("checks editing variable value in one slider only affects that slider", () => {
+  it("checks editing variable value in one slider only affects that slider", () => {
     const newVariableValue = "0.5"
     c.getIconFromToolShelf("slider").click()
 
@@ -333,16 +329,30 @@ context("Slider UI", () => {
     slider.getVariableValue(0).should("contain", initialSliderValue)
     slider.getVariableValue(1).should("contain", newVariableValue)
   })
-  it.skip("checks min max slider values", () => {
+  it("checks min max slider values", () => {
+    const MAX_VALUE = 11.5
+    const MIN_VALUE = 0
+    const MID_VALUE = 5
+
     slider.getVariableValue().should("contain", initialSliderValue)
-    slider.changeVariableValue("11.5") // max value for the slider
-    slider.getVariableValueInput().invoke('val').should('eq', '11.5')
 
-    slider.changeVariableValue("0") // min value for the slider
-    slider.getVariableValueInput().invoke('val').should('eq', '0')
+    // Set to max value
+    cy.log('Setting value to max')
+    slider.changeVariableValue(MAX_VALUE)
+    cy.wait(1000) // Wait for any animations
+    slider.getVariableValueInput().should('have.value', MAX_VALUE.toString())
 
-    slider.changeVariableValue("5")
-    slider.getVariableValueInput().invoke('val').should('eq', '5')
+    // Set to min value
+    cy.log('Setting value to min')
+    slider.changeVariableValue(MIN_VALUE)
+    cy.wait(1000) // Wait for any animations
+    slider.getVariableValueInput().should('have.value', MIN_VALUE.toString())
+
+    // Set to middle value
+    cy.log('Setting value to middle')
+    slider.changeVariableValue(MID_VALUE)
+    cy.wait(1000) // Wait for any animations
+    slider.getVariableValueInput().should('have.value', MID_VALUE.toString())
   })
   it("reuses slider names after existing ones are closed", () => {
     c.closeComponent("slider")

--- a/v3/cypress/support/elements/slider-tile.ts
+++ b/v3/cypress/support/elements/slider-tile.ts
@@ -23,10 +23,14 @@ export const SliderTileElements = {
   },
   changeVariableValue(value: number | string, index = 0) {
     this.getVariableValueInput(index)
-    .dblclick()
-    .clear()
-    .type(`${value}{enter}`)
-    this.getVariableValueInput(index).should("have.value", `${value}`)
+      .click({ force: true })
+      .dblclick({ force: true })
+      .clear()
+      .type(`${value}`, { delay: 100 })
+      .blur()
+    cy.wait(200)
+    this.getVariableValueInput(index)
+      .should('have.value', `${value}`)
   },
   getPlayButton(index = 0) {
     return this.getSliderTile(index).find("[data-testid=slider-play-pause]")

--- a/v3/cypress/support/elements/slider-tile.ts
+++ b/v3/cypress/support/elements/slider-tile.ts
@@ -16,7 +16,7 @@ export const SliderTileElements = {
     this.getVariableNameInput(index).type(`${name}{enter}`)
   },
   getVariableValue(index = 0) {
-    return this.getSliderTile(index).find("[data-testid=slider-variable-value-text-input]").invoke("attr", "value")
+    return this.getVariableValueInput(index).invoke('val')
   },
   getVariableValueInput(index = 0) {
     return this.getSliderTile(index).find("[data-testid=slider-variable-value-text-input]")
@@ -24,11 +24,15 @@ export const SliderTileElements = {
   changeVariableValue(value: number | string, index = 0) {
     this.getVariableValueInput(index)
       .click({ force: true })
+    cy.wait(500)
+    this.getVariableValueInput(index)
       .dblclick({ force: true })
-      .clear()
-      .type(`${value}`, { delay: 100 })
+    this.getVariableValueInput(index)
+      .clear({ force: true })
+    this.getVariableValueInput(index)
+      .type(`${value}`, { delay: 200, force: true })
+    this.getVariableValueInput(index)
       .blur()
-    cy.wait(200)
     this.getVariableValueInput(index)
       .should('have.value', `${value}`)
   },


### PR DESCRIPTION
[CODAP-365](https://concord-consortium.atlassian.net/browse/CODAP-674)

This spec improves robustness by opening the sample Mammals document (rather than the `?sample=mammals` url parameter) and making sure the slider isn't all the way to the right edge of the screen. 

Previously, in the the `?sample=mammals` url parameter configuration, the slider spec looked like this when working in the Ruler menu in Cypress:

<img width="500" alt="Screenshot 2025-05-16 at 2 07 13 PM" src="https://github.com/user-attachments/assets/2ff33493-92d6-4fe4-9700-7ee1e8f8ae70" />

Which meant that it was covering a lot of unwanted elements while running tests. In the updated spec, the inspector menu no longer obstructs the slider.

Note that the function `changeVariableValue()` seems to be not working but debugging didn't quite get reliable results.

[CODAP-365]: https://concord-consortium.atlassian.net/browse/CODAP-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ