### PR TITLE
CODAP-364 No data tips when pointer is down

### DIFF
--- a/v3/src/components/data-display/models/pointer-state.ts
+++ b/v3/src/components/data-display/models/pointer-state.ts
@@ -1,0 +1,41 @@
+/**
+ * This singleton class manages the pointer state for the application. The instigating reason
+ * for creating this class is to prevent pixi points from displaying data tips when the pointer is down.
+ */
+export class PointerState {
+  private static instance: PointerState
+  private isPointerDown = false
+
+  private constructor() {
+    window.addEventListener("pointerdown", this.handlePointerDown)
+    window.addEventListener("pointerup", this.handlePointerUp)
+  }
+
+  public static getInstance(): PointerState {
+    if (!PointerState.instance) {
+      PointerState.instance = new PointerState()
+    }
+    return PointerState.instance
+  }
+
+  private handlePointerDown = () => {
+    this.isPointerDown = true
+  }
+
+  private handlePointerUp = () => {
+    this.isPointerDown = false
+  }
+
+  public pointerIsDown(): boolean {
+    return this.isPointerDown
+  }
+
+  public destroy(): void {
+    window.removeEventListener("pointerdown", this.handlePointerDown)
+    window.removeEventListener("pointerup", this.handlePointerUp)
+    PointerState.instance = undefined!
+  }
+}
+
+// Ensure the PointerState instance is created at startup
+PointerState.getInstance()

--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -1,8 +1,9 @@
 import * as PIXI from "pixi.js"
-import { CaseData, CaseDataWithSubPlot } from "../d3-types"
-import { PixiTransition, TransitionPropMap, TransitionProp } from "./pixi-transition"
-import { hoverRadiusFactor, transitionDuration } from "../data-display-types"
 import { isFiniteNumber } from "../../../utilities/math-utils"
+import { PointerState } from "../models/pointer-state"
+import { CaseData, CaseDataWithSubPlot } from "../d3-types"
+import { hoverRadiusFactor, transitionDuration } from "../data-display-types"
+import { PixiTransition, TransitionPropMap, TransitionProp } from "./pixi-transition"
 
 const DEFAULT_Z_INDEX = 0
 const RAISED_Z_INDEX = 100
@@ -686,6 +687,10 @@ export class PixiPoints {
     let draggingActive = false
 
     const handlePointerOver = (pointerEvent: PIXI.FederatedPointerEvent) => {
+      const pointerState = PointerState.getInstance()
+      if (pointerState.pointerIsDown()) {
+        return // Skip if the pointer is down
+      }
       if (this.displayType === "bars") {
         if (!this.pointsFusedIntoBars) {
           const newStyle = { ...this.getMetadata(sprite).style, stroke: strokeColorHover }

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-component.tsx
@@ -140,20 +140,16 @@ export const MovablePointAdornment = observer(function MovablePointAdornment(pro
   // Set up the point and shadow
   useEffect(function createElements() {
     const selection = select(pointRef.current),
-      { x, y } = model.points.get(instanceKey) ??
-                  { x: model.getInitialPosition(xAxis), y: model.getInitialPosition(yAxis) },
+      // Note that we don't set cx and cy here because during restore the scales are not ready to return
+      // valid values. Plus, movePoint will be called to set the position of the point.
       newPointObject: IPointObject = {
         shadow: selection.append('circle')
-                  .attr('cx', xScale(x) / xSubAxesCount + 1)
-                  .attr('cy', yScale(y) / ySubAxesCount + 1)
                   .attr('r', 8)
                   .attr('fill', 'none')
                   .attr('stroke', '#a9a9a9')
                   .attr('stroke-width', 2),
         point: selection.append('circle')
                   .attr('data-testid', `movable-point${classFromKey ? `-${classFromKey}` : ""}`)
-                  .attr('cx', xScale(x) / xSubAxesCount)
-                  .attr('cy', yScale(y) / ySubAxesCount)
                   .attr('r', 8)
                   .attr('fill', '#ffff00')
                   .attr('stroke', '#000000')


### PR DESCRIPTION
[#CODAP-364] Bug fix: The graph point tooltips appear unnecessarily when the Moveable Point is moved on top of them

* From now on, data tips for points and bars will not show when the mouse is down. This is desirable because the mouse being down indicates that the user is doing something unrelated to querying a data value. We bring this about by adding a singleton class, PointerState, whose job it is to monitor whether the mouse is down or not. We make use of it in PixiPoints handlePointerOver.
* The MovablePointAdornment was producing an error on load of a document with a movable point in a graph. We fix this by noticing that the computation where the error is produced is actually redundant and can be eliminated.