### PR TITLE
CODAP-112 Don't show data tips when something else is on top

### DIFF
--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -689,11 +689,8 @@ export class PixiPoints {
     const handlePointerOver = (pointerEvent: PIXI.FederatedPointerEvent) => {
       const elementOnTop = document.elementFromPoint(pointerEvent.clientX, pointerEvent.clientY)
       const pointerState = PointerState.getInstance()
-      if (elementOnTop !== this.canvas || pointerState.pointerIsDown()) { // If the element on top is not the canvas, we don't want to do anything.
+      if (elementOnTop !== this.canvas || pointerState.pointerIsDown()) {
         return
-      }
-      if (pointerState.pointerIsDown()) {
-        return // Skip if the pointer is down
       }
       if (this.displayType === "bars") {
         if (!this.pointsFusedIntoBars) {

--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -687,7 +687,11 @@ export class PixiPoints {
     let draggingActive = false
 
     const handlePointerOver = (pointerEvent: PIXI.FederatedPointerEvent) => {
+      const elementOnTop = document.elementFromPoint(pointerEvent.clientX, pointerEvent.clientY)
       const pointerState = PointerState.getInstance()
+      if (elementOnTop !== this.canvas || pointerState.pointerIsDown()) { // If the element on top is not the canvas, we don't want to do anything.
+        return
+      }
       if (pointerState.pointerIsDown()) {
         return // Skip if the pointer is down
       }


### PR DESCRIPTION
[#CODAP-112] Bug fix: Graph hover tip appears in graph that is behind the component where the mouse is

* In pixi-points.ts `handlePointerOver` we now check to see if there is a DOM element on top that is not the pixi canvas. If so, we bail without displaying any data tip.