### PR TITLE
CODAP-678 Rescale with >1 y-axis attributes problems

### DIFF
--- a/v3/src/components/graph/graph-component-handler.test.ts
+++ b/v3/src/components/graph/graph-component-handler.test.ts
@@ -194,8 +194,8 @@ describe("DataInteractive ComponentHandler Graph", () => {
     const y2Axis = tileContent.getAxis("rightNumeric") as IBaseNumericAxisModel
     expect(xAxis.min).toBe(-.5)
     expect(xAxis.max).toBe(7.5)
-    expect(yAxis.min).toBe(-6.5)
-    expect(yAxis.max).toBe(1.5)
+    expect(yAxis.min).toBe(-7)
+    expect(yAxis.max).toBe(9)
     expect(y2Axis.min).toBe(-.5)
     expect(y2Axis.max).toBe(7.5)
     const updateBoundsResult = update({ component: tile }, {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -142,7 +142,24 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     },
     get primaryAttributeType(): AttributeType {
       return self.primaryRole && self.attributeType(self.primaryRole) || "categorical"
-    }
+    },
+    /**
+     * This is overridden in derived class where 'y' is a special role
+     */
+    numericValuesForAttrRole(role: AttrRole) {
+      if (role !== 'y') {
+        return self._numericValuesForAttrRole(role)
+      }
+      const values:number[] = []
+      const yAttributeIDs = self.yAttributeIDs
+      yAttributeIDs.forEach(attrID => {
+        const attrValues = self.numericValuesForAttribute(attrID)
+        if (attrValues) {
+          values.push(...attrValues)
+        }
+      })
+      return values
+    },
   }))
   .actions(self => ({
     _setAttributeDescription(iRole: GraphAttrRole, iDesc?: IAttributeDescriptionSnapshot) {
@@ -784,7 +801,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       } else {
         self._setAttributeDescription(role, desc)
       }
-      self.numericValuesForAttrRole.invalidate(role)  // No harm in invalidating even if not numeric
+      self._numericValuesForAttrRole.invalidate(role)  // No harm in invalidating even if not numeric
       self.cellMap.invalidateAll()
     },
     addYAttribute(desc: IAttributeDescriptionSnapshot, index?: number) {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -144,7 +144,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       return self.primaryRole && self.attributeType(self.primaryRole) || "categorical"
     },
     /**
-     * This is overridden in derived class where 'y' is a special role
+     * This is overridden to handle multiple 'y' attributes
      */
     numericValuesForAttrRole(role: AttrRole) {
       if (role !== 'y') {
@@ -801,7 +801,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       } else {
         self._setAttributeDescription(role, desc)
       }
-      self._numericValuesForAttrRole.invalidate(role)  // No harm in invalidating even if not numeric
+      self.numericValuesForAttribute.invalidate(role)  // No harm in invalidating even if not numeric
       self.cellMap.invalidateAll()
     },
     addYAttribute(desc: IAttributeDescriptionSnapshot, index?: number) {

--- a/v3/src/components/graph/models/graph-model-utils.ts
+++ b/v3/src/components/graph/models/graph-model-utils.ts
@@ -121,7 +121,7 @@ function setupAxes(graphModel: IGraphContentModel, layout: GraphLayout) {
         newAxisModel.setAllowRangeToShrink(true)
         const values = isDateAxisModel(newAxisModel)
                         ? stringValuesToDateSeconds(attribute?.strValues || [])
-                        : attribute?.numValues || []
+                        : dataConfig.numericValuesForAttrRole(graphPlaceToAttrRole[place])
         setNiceDomain(values, newAxisModel, graphModel.plot.axisDomainOptions)
       }
 


### PR DESCRIPTION
[#CODAP-678] Bug fix: Rescale not behaving properly when graph y-axis has more than one attribute

* There are two parts to the problem: (1) The **Rescale** button was not rescaling sufficiently to include the values of other than the first y-attribute. (2) The y-axis was not rescaling when an additional attribute was added to the y-axis.
* We fix the first problem by noting that data-configuration-model.ts was not equipped to deal with multiple y-attributes, which, after all, has to be done in graph-data-configuration-model.ts where multiple y-attributes are known about. So, we make it possible to override `numericValuesForAttrRole` and, in graph-data-configuration-model.ts, when the role is 'y', iterate through the attributes and include all the values found.
* For the second problem we note that graph-model-utils.ts `setupAxis` was using the values for a single attribute regardless of the role for the axis. We fix this by calling numericValuesForAttrRole.
* Because we've modified the routines for computing axis min and max we have to adjust the values in graph-component-handler.test.ts