### PR TITLE
CODAP-679 Numeric graph y-axis not adjusting layout when scale changes

### DIFF
--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -139,11 +139,12 @@ export const useAxis = (axisPlace: AxisPlace) => {
           if (domain) {
             multiScale?.setNumericDomain(domain)
           }
+          layout.setDesiredExtent(axisPlace, computeDesiredExtent())
         }, { name: "useAxis.axisDomainSync", equals: comparer.structural }, axisProvider)
     }
   }, [axisPlace, axisProvider, isNumeric, multiScale])
 
-  // update desired extent as needed
+  // update desired extent as needed, but note that the axisModel domain is not called during this auto run
   useEffect(() => {
     return mstAutorun(() => {
       layout.setDesiredExtent(axisPlace, computeDesiredExtent())


### PR DESCRIPTION
[#CODAP-679] Bug fix: Graph y-axis not adjusting layout to accommodate large numbers

* Probably we were previously relying on an `mstAutorun` in use-axis.ts to call the graph layout's `setDesiredExtent`. But at some point this autorun no longer accessed the axisModel's domain and so was no longer being called when the axis domain changed. We fix by adding a call to `layout.setDesiredExtent` in the mstReaction set up in `axisDomainSync`.