### PR TITLE
CODAP-99 Improved handling of attribute menu for date attribute

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -38,8 +38,11 @@ export const AxisOrLegendAttributeMenu = ({ place, target, portal,
   const attrId = dataConfiguration?.attributeID(role) || ''
   const instanceId = useInstanceIdContext()
   const attribute = attrId ? data?.attrFromID(attrId) : null
+  const nativeType = attribute?.type || ''
   const removeAttrItemLabel = t(removeAttrItemLabelKeys[role], {vars: [attribute?.name]})
-  const treatAs = dataConfiguration?.attributeType(role) === "numeric" ? "categorical" : "numeric"
+  const attrType = dataConfiguration?.attributeType(role) || ''
+  const treatAs = (nativeType === 'date' && attrType === 'categorical') ? 'date'
+    : ['numeric', 'date'].includes(attrType) ? "categorical" : "numeric"
   const overlayStyle: CSSProperties = { position: "absolute", ...useOverlayBounds({target, portal}) }
   const buttonStyle: CSSProperties = { position: "absolute", width: "100%", height: "100%", color: "transparent" }
   const menuRef = useRef<HTMLDivElement>(null)
@@ -86,6 +89,7 @@ export const AxisOrLegendAttributeMenu = ({ place, target, portal,
                       <MenuItem onClick={() => onTreatAttributeAs(place, attribute?.id, treatAs)}>
                         {treatAs === "categorical" && t("DG.DataDisplayMenu.treatAsCategorical")}
                         {treatAs === "numeric" && t("DG.DataDisplayMenu.treatAsNumeric")}
+                        {treatAs === "date" && t("V3.DataDisplayMenu.treatAsDate")}
                       </MenuItem>
                     }
                   </>

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -116,6 +116,7 @@
     "V3.Undo.attributeTreatAs": "Undo changing attribute treatment",
     "V3.Redo.attributeTreatAs": "Redo changing attribute treatment",
     "V3.map.legendDrop": "Color regions by values of %@",
+    "V3.DataDisplayMenu.treatAsDate": "Treat as Date",
 
     // V3 digital interactive error messages.
     // These should probably not be translated because plugins might be looking for specific


### PR DESCRIPTION
[#CODAP-99] Bug fix: The attribute menu for a date axis should show "Treat as Categorical" rather than "Treat as Numeric"

* It proved possible to take care of this entirely at the `AxisOrLegendAttributeMenu` level. We were also able to make the menu say "Treat as Date" to bring the axis back from categorical to date.