### PR TITLE
CODAP-99 Attribute menu for date axis allows "treat as categorical"

### DIFF
--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -78,7 +78,9 @@ export class NumericAxisHelper extends AxisHelper {
       {tickValues: [], tickLabels: []}
       axisScale.tickValues(tickValues)
       axisScale.tickFormat((d, i) => tickLabels[i])
-    }
+    } /*else if (this.isVertical && hasDraggableNumericAxis) {
+
+    }*/
     if (this.axisModel.integersOnly) {
       // Note: This has the desirable effect of removing the decimal point from the tick labels,
       // but it doesn't prevent the tick marks from showing for fractional values or grid lines


### PR DESCRIPTION
[#CODAP-99] Bug fix: The attribute menu for a date axis should show "Treat as Categorical" rather than "Treat as Numeric"

* It proved possible to take care of this entirely at the `AxisOrLegendAttributeMenu` level. We were also able to make the menu say "Treat as Date" to bring the axis back from categorical to date.