### PR TITLE
CODAP-680 Prevent overlap of y-axis numeric axis numbers

### DIFF
--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -236,7 +236,8 @@ export const computeBestNumberOfTicks = (scale: ScaleLinear<number, number>): nu
 export const computeBestNumberOfVerticalAxisTicks = (scale: ScaleLinear<number, number>): number => {
   const numberHeight = measureTextExtent('0', kDataDisplayFont).height
   const axisLength = Math.abs(scale.range()[1] - scale.range()[0])
-  return Math.floor(axisLength / (numberHeight + 2))  // pixel of padding on top and bottom
+  // The following computation is a heuristic that results in good spacing and never just one tick
+  return Math.max(3, Math.floor(axisLength / (numberHeight * 1.5)))
 }
 
 export const isScaleLinear = (scale: any): scale is ScaleLinear<number, number> => {

--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -233,6 +233,12 @@ export const computeBestNumberOfTicks = (scale: ScaleLinear<number, number>): nu
   return Math.max(2, currentNumber)
 }
 
+export const computeBestNumberOfVerticalAxisTicks = (scale: ScaleLinear<number, number>): number => {
+  const numberHeight = measureTextExtent('0', kDataDisplayFont).height
+  const axisLength = Math.abs(scale.range()[1] - scale.range()[0])
+  return Math.floor(axisLength / (numberHeight + 2))  // pixel of padding on top and bottom
+}
+
 export const isScaleLinear = (scale: any): scale is ScaleLinear<number, number> => {
   return (scale as ScaleLinear<number, number>).interpolate !== undefined
 }

--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -1,7 +1,7 @@
 import { format, ScaleLinear, select } from "d3"
 import { between } from "../../../utilities/math-utils"
 import { transitionDuration } from "../../data-display/data-display-types"
-import { computeBestNumberOfTicks, getStringBounds } from "../axis-utils"
+import { computeBestNumberOfTicks, computeBestNumberOfVerticalAxisTicks, getStringBounds } from "../axis-utils"
 import { AxisScaleType, otherPlace } from "../axis-types"
 import { isNonDateNumericAxisModel } from "../models/numeric-axis-models"
 import { AxisHelper, IAxisHelperArgs } from "./axis-helper"
@@ -70,17 +70,18 @@ export class NumericAxisHelper extends AxisHelper {
 
     const axisScale = this.axis(numericScale).tickSizeOuter(0).tickFormat(format('.9'))
     const duration = this.isAnimating() ? transitionDuration : 0
-    if (!this.isVertical && hasDraggableNumericAxis) {
-      axisScale.tickValues(numericScale.ticks(computeBestNumberOfTicks(numericScale)))
-    } else if (!hasDraggableNumericAxis) {
+    if (!hasDraggableNumericAxis) {
       const formatter = (value: number) => this.multiScale?.formatValueForScale(value) ?? ""
       const {tickValues, tickLabels} = this.axisProvider.nonDraggableAxisTicks(formatter) ||
       {tickValues: [], tickLabels: []}
       axisScale.tickValues(tickValues)
       axisScale.tickFormat((d, i) => tickLabels[i])
-    } /*else if (this.isVertical && hasDraggableNumericAxis) {
-
-    }*/
+    }
+    else {
+      const numberOfTicks = this.isVertical ? computeBestNumberOfVerticalAxisTicks(numericScale)
+        : computeBestNumberOfTicks(numericScale)
+      axisScale.tickValues(numericScale.ticks(numberOfTicks))
+    }
     if (this.axisModel.integersOnly) {
       // Note: This has the desirable effect of removing the decimal point from the tick labels,
       // but it doesn't prevent the tick marks from showing for fractional values or grid lines

--- a/v3/src/components/axis/helper-models/numeric-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/numeric-axis-helper.ts
@@ -78,7 +78,9 @@ export class NumericAxisHelper extends AxisHelper {
       {tickValues: [], tickLabels: []}
       axisScale.tickValues(tickValues)
       axisScale.tickFormat((d, i) => tickLabels[i])
-    }
+    } /*else if (this.isVertical && hasDraggableNumericAxis) {
+
+    }*/
     if (this.axisModel.integersOnly) {
       // Note: This has the desirable effect of removing the decimal point from the tick labels,
       // but it doesn't prevent the tick marks from showing for fractional values or grid lines


### PR DESCRIPTION
[#CODAP-680] Bug fix: Numeric axis numbers overlap and become illegible

* This was a simple fix since the problem was only for vertical axis and the height of the numbers is constant. So, just a matter of how many fit.