### PR TITLE
CODAP-111 Fix for remaining problem from prior PR showing attribute description on hover over axis or legend label

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -60,7 +60,7 @@ export const AxisOrLegendAttributeMenu =
     handler: () => onCloseRef.current?.(),
     info: { name: "AxisOrLegendAttributeMenu", attrId, attrName: attribute?.name }
   })
-  const description = attribute ? attribute.description : ''
+  const description = attribute?.description || ''
   let orientation = ''
   switch (place) {
     case 'left':


### PR DESCRIPTION
[#CODAP-111] Bug fix: If the attribute description is undefined hover over attribute label should not show "undefined"

* A simple logic error in computing the description string in axis-or-legend-attribute-menu.tsx