### PR TITLE
CODAP-704 Make sure api request to create scatterplot correctly computes axis bounds

### DIFF
--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -178,6 +178,7 @@ export const graphComponentHandler: DIComponentHandler = {
     // We use an environment with a provisionalDataSet and Metadata so the dummy model can be set up with
     // them, even though they are not part of the same MST tree.
     const graphModel = GraphContentModel.create(graphContent, { provisionalDataSet, provisionalMetadata })
+    graphModel.dataConfiguration.synchronizeFilteredCases()  // kludgy workaround to ensure axis bounds will be correct
     syncModelWithAttributeConfiguration(graphModel, new GraphLayout())
 
     // Layers will get mangled in the model because it's not in the same tree as the dataset,


### PR DESCRIPTION
[#CODAP-704] Bug fix: Create graph scatterplot through plugin API chooses unusable axis bounds

* This seems to be an order of operations problem whereby the attempt to compute axis bounds is made before the data configuration's filtered cases have been set up. We fix by forcing the filtered cases computation early in the process.