### PR TITLE
CODAP-703 Export to V2 includes plugin-created collection defaults

### DIFF
--- a/v3/src/data-interactive/handlers/di-handler-utils.ts
+++ b/v3/src/data-interactive/handlers/di-handler-utils.ts
@@ -38,13 +38,17 @@ export function createAttribute(value: DIAttribute, dataContext: IDataSet, colle
 export function createCollection(v2collection: DICollection, data: IDataSet, metadata: IDataSetMetadata) {
   // TODO How should we handle duplicate names?
   // TODO How should we handle missing names?
-  const { attrs, cid, labels, name: collectionName, title: collectionTitle } = v2collection
+  const { attrs, cid, labels, name: collectionName,
+    title: collectionTitle, defaults } = v2collection
   const _title = v2NameTitleToV3Title(collectionName ?? "", collectionTitle)
   const options: IAddCollectionOptions = { after: data.childCollection?.id }
   const collection = data.addCollection({ id: cid, name: collectionName, _title }, options)
 
   if (isNonEmptyCollectionLabels(labels)) {
     metadata.setCollectionLabels(collection.id, labels)
+  }
+  if (defaults) {
+    metadata.setCollectionDefaults(collection.id, defaults)
   }
 
   attrs?.forEach(attr => {

--- a/v3/src/v2/codap-v2-data-context-types.ts
+++ b/v3/src/v2/codap-v2-data-context-types.ts
@@ -1,5 +1,6 @@
 import { SetOptional } from "type-fest"
 import { AttributeType } from "../models/data/attribute-types"
+import { IV2CollectionDefaults } from "../models/shared/data-set-metadata"
 
 type ColorString = string // e.g. "#ff5586" or "rgb(85,85,255)"
 type ICodapV2CategoryOrder = { __order: string[] }
@@ -84,10 +85,7 @@ export interface ICodapV2Collection {
   collapseChildren?: boolean | null
   // TODO_V2_IMPORT_EXTRACT: defaults does not seem to be imported
   // There are 825 cases where it is defined in cfm-shared
-  defaults?: {
-    xAttr: string
-    yAttr: string
-  }
+  defaults?: IV2CollectionDefaults
   guid: number
   id?: number
   labels?: {
@@ -133,7 +131,7 @@ export interface ICodapV2DataContextMetadata {
 }
 
 export interface ICodapV2DataContext {
-  type: "DG.DataContext"
+  type: "DG.DataContext" | "DG.GameContext"
   document?: number // id of containing document
   guid: number
   // Ignored: when present it is always redundant with guid


### PR DESCRIPTION
[#CODAP-703] Bug fix: The dataset created by Markov, when exported to V2 needs have DG.GameContext as its type

* A prerequisite to getting the export to work is, during the creation of the plugin-created data context, to notice that a collection has defaults and to store those defaults in the collection metadata. Then, on export to V2, we can both include these defaults in the V2 collection and set the type of the V2 data context as "DG.GameContext".