### PR TITLE
fix: MST warnings on graph axis change

### DIFF
--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -328,9 +328,9 @@ context("Test graph axes with various attribute types", () => {
       const labelTexts = [...$labels].map(el => el.textContent?.trim())
       // Uniqueness
       const uniqueLabels = new Set(labelTexts)
-      expect(uniqueLabels.size).to.equal(labelTexts.length);
+      expect(uniqueLabels.size).to.equal(labelTexts.length)
       // Visibility
-      [...$labels].forEach(el => {
+      ;[...$labels].forEach(el => {
         const style = window.getComputedStyle(el)
         expect(style.display).to.not.equal("none")
         expect(style.visibility).to.not.equal("hidden")

--- a/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
+++ b/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
@@ -297,20 +297,21 @@ context("Graph UI with Pixi interaction", () => {
       gch.getGraphTileId().then((tileId: string) => {
         gch.checkPointsHaveUniquePositions(tileId) // Call the helper function
       })
+      // TODO: Checking pixel positions of points seems potentially flaky
       // here we check that some points are in the position we expect
       gch.getGraphTileId().then((tileId: string) => {
         // Known inputs:
         const pointIndex = 3
-        const expectedX = 166
-        const expectedY = 67
+        const expectedX = 170
+        const expectedY = 71
 
         gch.checkPointPosition(tileId, pointIndex, expectedX, expectedY)
       })
       gch.getGraphTileId().then((tileId: string) => {
         // Known inputs:
         const pointIndex = 8
-        const expectedX = 325
-        const expectedY = 140
+        const expectedX = 334
+        const expectedY = 149
 
         gch.checkPointPosition(tileId, pointIndex, expectedX, expectedY)
       })
@@ -318,7 +319,7 @@ context("Graph UI with Pixi interaction", () => {
         // Known inputs:
         const pointIndex = 20
         const expectedX = 67
-        const expectedY = 151
+        const expectedY = 160
 
         gch.checkPointPosition(tileId, pointIndex, expectedX, expectedY)
       })

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -56,15 +56,16 @@ export const useAxis = (axisPlace: AxisPlace) => {
     attrId = dataConfiguration?.attributeID(axisPlaceToAttrRole[axisPlace]) || "",
     axisAttribute = dataConfiguration?.dataset?.getAttribute(attrId),
     axisAttributeType = axisAttribute?.type
+
   const computeDesiredExtent = useCallback(() => {
     if (dataConfiguration?.placeCanHaveZeroExtent(axisPlace)) {
       return 0
     }
     const _axisModel = axisProvider?.getNumericAxis?.(axisPlace)
     const attrRole = graphPlaceToAttrRole[axisPlace]
-    const axisType = axisModel?.type ?? 'empty'
-    const isColor = isColorAxisModel(axisModel) || axisAttributeType === 'color'
-    const isBinned = axisModel ? axisProvider?.hasBinnedNumericAxis(axisModel) : false
+    const axisType = _axisModel?.type ?? 'empty'
+    const isColor = isColorAxisModel(_axisModel) || axisAttributeType === 'color'
+    const isBinned = _axisModel ? axisProvider?.hasBinnedNumericAxis(_axisModel) : false
     const labelFont = vars.labelFont,
       axisTitleHeight = getStringBounds("Xy", labelFont).height,
       numbersHeight = getStringBounds('0').height,
@@ -77,7 +78,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
       case 'percent':
       case 'numeric': {
         ticks = getTicks({d3Scale, isBinned, multiScale, displayModel})
-        desiredExtent += ['left', 'rightNumeric'].includes(axisPlace) || axisModel?.labelsAreRotated
+        desiredExtent += ['left', 'rightNumeric'].includes(axisPlace) || _axisModel?.labelsAreRotated
           ? Math.max(getStringBounds(ticks[0]).width, getStringBounds(ticks[ticks.length - 1]).width) + axisGap
           : numbersHeight + axisGap
         break
@@ -104,7 +105,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
       }
     }
     return desiredExtent
-  }, [axisAttributeType, axisModel, axisPlace, axisProvider, dataConfiguration, displayModel,
+  }, [axisAttributeType, axisPlace, axisProvider, dataConfiguration, displayModel,
       isNumeric, layout, multiScale])
 
   // update d3 scale and axis when scale type changes
@@ -142,7 +143,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
           layout.setDesiredExtent(axisPlace, computeDesiredExtent())
         }, { name: "useAxis.axisDomainSync", equals: comparer.structural }, axisProvider)
     }
-  }, [axisPlace, axisProvider, isNumeric, multiScale])
+  }, [axisPlace, axisProvider, computeDesiredExtent, isNumeric, layout, multiScale])
 
   // update desired extent as needed, but note that the axisModel domain is not called during this auto run
   useEffect(() => {


### PR DESCRIPTION
[[CODAP-701](https://concord-consortium.atlassian.net/browse/CODAP-701)] Treating a date plot as categorical breaks the graph axis (mobx-state-tree error)

This PR fixes the MST warnings, which are unrelated to the remaining axis issues.

[CODAP-701]: https://concord-consortium.atlassian.net/browse/CODAP-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ