### PR TITLE
chore: performance tweaks to reduce re-renders, etc.

### DIFF
--- a/v3/src/components/case-card/case-card-header.tsx
+++ b/v3/src/components/case-card/case-card-header.tsx
@@ -18,7 +18,7 @@ interface ICaseHeaderProps {
   level: number
 }
 
-export const CaseCardHeader = observer(function CaseView(props: ICaseHeaderProps) {
+export const CaseCardHeader = observer(function CaseCardHeader(props: ICaseHeaderProps) {
   const { cases, level } = props
   const cardModel = useCaseCardModel()
   const data = cardModel?.data

--- a/v3/src/components/case-card/case-view.tsx
+++ b/v3/src/components/case-card/case-view.tsx
@@ -80,7 +80,6 @@ export const CaseView = observer(function CaseView(props: ICaseViewProps) {
   }
 
   return (
-    <>
     <div className={`case-card-view fadeIn ${colorCycleClass(level, collectionCount)}`} data-testid="case-card-view">
       {level === 0 && <CaseCardCollectionSpacer onDrop={handleNewCollectionDrop} collectionId={collectionId}/>}
       <CaseCardHeader cases={cases} level={level}/>
@@ -101,6 +100,5 @@ export const CaseView = observer(function CaseView(props: ICaseViewProps) {
         }
       </div>
     </div>
-    </>
   )
 })

--- a/v3/src/components/case-table/row-drag-overlay.tsx
+++ b/v3/src/components/case-table/row-drag-overlay.tsx
@@ -1,5 +1,5 @@
 import { DragOverlay, Modifier } from "@dnd-kit/core"
-import React from "react"
+import React, { useMemo } from "react"
 import DragIndicator from "../../assets/icons/drag-indicator.svg"
 import { ICase } from "../../models/data/data-set-types"
 import { kDefaultRowHeight, kInputRowKey } from "./case-table-types"
@@ -31,7 +31,7 @@ export function RowDragOverlay ({ rows, width }: IProps) {
   }
 
   const height = collectionTableModel?.rowHeight ?? kDefaultRowHeight
-  const style = { height, width: width ?? "100%" }
+  const style: React.CSSProperties = useMemo(() => ({ height, width: width ?? "100%" }), [height, width])
   return (
     <DragOverlay
       className="dnd-kit-drag-overlay"

--- a/v3/src/components/case-tile-common/attribute-header-divider.tsx
+++ b/v3/src/components/case-tile-common/attribute-header-divider.tsx
@@ -10,7 +10,7 @@ import { IDividerProps, kIndexColumnKey } from "./case-tile-types"
 import { kAttributeDividerDropZoneBaseId } from "../case-table/case-table-drag-drop"
 import { useAttributeHeaderDividerContext } from "./use-attribute-header-divider-context"
 
-export const AttributeHeaderDivider = ({ before = false, columnKey, cellElt, getDividerBounds }: IDividerProps) => {
+function AttributeHeaderDivider_({ before = false, columnKey, cellElt, getDividerBounds }: IDividerProps) {
   const collectionId = useCollectionContext()
   const droppableId = `${kAttributeDividerDropZoneBaseId}:${collectionId}:${columnKey}`
   const dataset = useDataSetContext()
@@ -54,3 +54,5 @@ export const AttributeHeaderDivider = ({ before = false, columnKey, cellElt, get
       ), containerElt)
     : null
 }
+
+export const AttributeHeaderDivider = React.memo(AttributeHeaderDivider_)

--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -2,7 +2,7 @@ import { Tooltip, Menu, MenuButton, Input, VisuallyHidden, SystemStyleObject } f
 import { useDndContext } from "@dnd-kit/core"
 import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
-import React, { useEffect, useMemo, useRef, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { clsx } from "clsx"
 import { useAdjustHeaderForOverflow } from "../../hooks/use-adjust-header-overflow"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
@@ -165,14 +165,14 @@ export const AttributeHeader = observer(function AttributeHeader({
     setIsFocused(false)
     uiState.setAttrIdToEdit?.()
   }
-  const handleRenameAttribute = () => {
+  const handleRenameAttribute = useCallback(() => {
     setEditingAttrId(attributeId)
     setEditingAttrName(attrName)
-  }
+  }, [attrName, attributeId])
 
-  const handleModalOpen = (open: boolean) => {
+  const handleModalOpen = useCallback((open: boolean) => {
     setModalIsOpen(open)
-  }
+  }, [])
 
   const handleInputBlur = (e: any) => {
     if (isFocused) {

--- a/v3/src/components/drag-drop/attribute-drag-overlay.tsx
+++ b/v3/src/components/drag-drop/attribute-drag-overlay.tsx
@@ -1,5 +1,5 @@
 import { Active, DragOverlay, Modifier, Modifiers, useDndContext } from "@dnd-kit/core"
-import React, { CSSProperties } from "react"
+import React, { CSSProperties, useMemo } from "react"
 import { getDragAttributeInfo } from "../../hooks/use-drag-drop"
 
 import "./attribute-drag-overlay.scss"
@@ -27,16 +27,17 @@ export function AttributeDragOverlay ({
 
   const activeDragId = getOverlayDragId(active, dragIdPrefix, dragIdExcludeRegEx)
   const attr = activeDragId && dragAttrId ? dataSet?.attrFromID(dragAttrId) : undefined
-  const handleDropAnimation = (/*params: any*/) => {
-    /**
-     * If there has been no drop we would like to animate the overlay back to its original position.
-     * Otherwise, we don't want to animate it at all.
-     */
-  }
+  // const handleDropAnimation = (/*params: any*/) => {
+  //   /**
+  //    * If there has been no drop we would like to animate the overlay back to its original position.
+  //    * Otherwise, we don't want to animate it at all.
+  //    */
+  // }
 
   // Drags initiated by plugins can specify the size of the overlay
-  const style: CSSProperties | undefined = overlayHeight && overlayWidth
-    ? { height: `${overlayHeight}px`, width: `${overlayWidth}px` } : undefined
+  const style: CSSProperties | undefined = useMemo(() => overlayHeight && overlayWidth
+    ? { height: `${overlayHeight}px`, width: `${overlayWidth}px` }
+    : undefined, [overlayHeight, overlayWidth])
 
   // Drags initiated by plugins have to be offset based on the location of the plugin
   const modifier: Modifier | undefined = (xOffset || yOffset) ? (args => {
@@ -52,7 +53,7 @@ export function AttributeDragOverlay ({
   return (
     <DragOverlay
       className="dnd-kit-drag-overlay"
-      dropAnimation={handleDropAnimation}
+      // dropAnimation={handleDropAnimation}
       modifiers={modifiers}
       style={style}
     >
@@ -64,3 +65,6 @@ export function AttributeDragOverlay ({
     </DragOverlay>
   )
 }
+
+// This DnDKit component shows up as `Unknown` in tools like WhyDidYouRender
+DragOverlay.displayName = "DragOverlay"

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -27,10 +27,12 @@ interface IProps {
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
 }
 
+const trueFn = () => true
+
 export const GraphAxis = observer(function GraphAxis(
   {place, onDropAttribute, onRemoveAttribute, onTreatAttributeAs}: IProps) {
   const dataConfig = useGraphDataConfigurationContext(),
-    isDropAllowed = dataConfig?.placeCanAcceptAttributeIDDrop ?? (() => true),
+    isDropAllowed = dataConfig?.placeCanAcceptAttributeIDDrop ?? trueFn,
     graphModel = useGraphContentModelContext(),
     axisModel = graphModel.getAxis?.(place),
     instanceId = useInstanceIdContext(),
@@ -43,14 +45,14 @@ export const GraphAxis = observer(function GraphAxis(
       parentEltRef.current = elt?.closest(kGraphClassSelector) as HTMLDivElement ?? null
       _setWrapperElt(elt)
     }, [])
-  const handleIsActive = (active: Active) => {
+  const handleIsActive = useCallback((active: Active) => {
     const {dataSet, attributeId: droppedAttrId} = getDragAttributeInfo(active) || {}
     if (isDropAllowed) {
       return isDropAllowed(place, dataSet, droppedAttrId)
     } else {
       return !!droppedAttrId
     }
-  }
+  }, [isDropAllowed, place])
   useDropHandler(droppableId, active => {
     const {dataSet, attributeId: droppedAttrId} = getDragAttributeInfo(active) || {}
     dataSet && droppedAttrId && isDropAllowed(place, dataSet, droppedAttrId) &&


### PR DESCRIPTION
[[CODAP-697](https://concord-consortium.atlassian.net/browse/CODAP-697)] Chromebook Performance

This PR includes a number of small tweaks that were identified with tools like WhyDidYouRender to reduce the number of components that re-render unnecessarily in situations like during a drag. Most of them are unlikely to have much effect individually but hopefully they have some effect cumulatively. The one potential exception is the wrapping of `rowClass` in `CollectionTable` in `useCallback`, which could potentially have resulted in the table doing much more work than necessary when re-rendering.