### PR TITLE
CODAP-720 Fix layout of non-numeric axes

### DIFF
--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -61,7 +61,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
     if (dataConfiguration?.placeCanHaveZeroExtent(axisPlace)) {
       return 0
     }
-    const _axisModel = axisProvider?.getNumericAxis?.(axisPlace)
+    const _axisModel = axisProvider?.getAxis?.(axisPlace)
     const attrRole = graphPlaceToAttrRole[axisPlace]
     const axisType = _axisModel?.type ?? 'empty'
     const isColor = isColorAxisModel(_axisModel) || axisAttributeType === 'color'


### PR DESCRIPTION
[#CODAP-720] Bug fix: With categorical axes, the categories overlap the attribute label

* This problem was introduced when a change in use-axis.ts `computeDesiredExtent` inadvertently began using an axis model computed with `getNumericAxis` which could never be other than undefined or numeric and therefore never went through the portion of the code that computes extent for other than numeric axes.