### PR TITLE
fix: make it easier to click case table scroll bar

### DIFF
--- a/v3/cypress/support/elements/component-elements.ts
+++ b/v3/cypress/support/elements/component-elements.ts
@@ -68,7 +68,7 @@ export const ComponentElements = {
     return this.getComponentTile(component, index).find("[data-testid=component-close-button]")
   },
   getResizeControl(component: string, index = 0) {
-    return this.getComponentTile(component, index).find(".codap-component-corner.bottom-right")
+    return this.getComponentTile(component, index).parent().find(".codap-component-corner.bottom-right")
   },
   checkToolTip(element: JQuery<HTMLElement>, tooltipText: string) {
     cy.wrap(element).invoke("attr", "title").should("contain", tooltipText)

--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -2,7 +2,6 @@ import { clsx } from "clsx"
 import { observer } from "mobx-react-lite"
 import { isAlive } from "mobx-state-tree"
 import React, { useRef, useState } from "react"
-import ResizeHandle from "../assets/icons/icon-corner-resize-handle.svg"
 import { CodapComponentContext } from "../hooks/use-codap-component-context"
 import { TileModelContext } from "../hooks/use-tile-model-context"
 import {
@@ -22,11 +21,6 @@ export interface IProps extends ITileBaseProps {
   isMinimized?: boolean
   onMinimizeTile?: () => void
   onCloseTile: (tileId: string) => void
-  onBottomRightPointerDown?: (e: React.PointerEvent) => void
-  onBottomLeftPointerDown?: (e: React.PointerEvent) => void
-  onRightPointerDown?: (e: React.PointerEvent) => void
-  onBottomPointerDown?: (e: React.PointerEvent) => void
-  onLeftPointerDown?: (e: React.PointerEvent) => void
 }
 
 class TileSelectionHandler implements ITileSelection {
@@ -63,10 +57,8 @@ class TileSelectionHandler implements ITileSelection {
   }
 }
 
-export const CodapComponent = observer(function CodapComponent({
-  tile, isMinimized, onMinimizeTile, onCloseTile, onBottomRightPointerDown, onBottomLeftPointerDown,
-  onRightPointerDown, onBottomPointerDown, onLeftPointerDown
-}: IProps) {
+export const CodapComponent = observer(function CodapComponent(props: IProps) {
+  const { tile, isMinimized, onMinimizeTile, onCloseTile } = props
   const info = getTileComponentInfo(tile.content.type)
   const codapComponentRef = useRef<HTMLDivElement | null>(null)
 
@@ -77,7 +69,7 @@ export const CodapComponent = observer(function CodapComponent({
 
   if (!info) return null
 
-  const { TitleBar, Component, tileEltClass, isFixedWidth, isFixedHeight } = info
+  const { TitleBar, Component, tileEltClass } = info
   const classes = clsx("codap-component", tileEltClass, { minimized: isMinimized },
                     { shadowed: uiState.isFocusedTile(tile.id) || uiState.isHoveredTile(tile.id) })
   return (
@@ -88,22 +80,6 @@ export const CodapComponent = observer(function CodapComponent({
             onFocus={handleFocusEvent} onPointerDownCapture={handleFocusEvent}>
             <TitleBar tile={tile} onMinimizeTile={onMinimizeTile} onCloseTile={onCloseTile}/>
             <Component tile={tile} isMinimized={isMinimized} />
-            {onRightPointerDown && !isFixedWidth && !isMinimized &&
-              <div className="codap-component-border right" onPointerDown={onRightPointerDown}/>}
-            {onBottomPointerDown && !isFixedHeight && !isMinimized &&
-              <div className="codap-component-border bottom" onPointerDown={onBottomPointerDown}/>}
-            {onLeftPointerDown && !isFixedWidth && !isMinimized &&
-              <div className="codap-component-border left" onPointerDown={onLeftPointerDown}/>}
-            {onBottomLeftPointerDown && !(isFixedWidth && isFixedHeight) && !isMinimized &&
-              <div className="codap-component-corner bottom-left" onPointerDown={onBottomLeftPointerDown}/>
-            }
-            {onBottomRightPointerDown && !(isFixedWidth && isFixedHeight) && !isMinimized &&
-              <div className="codap-component-corner bottom-right" onPointerDown={onBottomRightPointerDown}>
-                {(uiState.isFocusedTile(tile.id)) && !isMinimized &&
-                  <ResizeHandle className="component-resize-handle"/>}
-              </div>
-            }
-
           </div>
           <InspectorPanelWrapper tile={tile} isMinimized={isMinimized} />
         </CodapComponentContext.Provider>

--- a/v3/src/components/component-resize-border.tsx
+++ b/v3/src/components/component-resize-border.tsx
@@ -10,7 +10,8 @@ interface IProps {
 }
 
 export function ComponentResizeBorder({ componentRef, containerRef, edge, onPointerDown }: IProps) {
-  console.log("ComponentResizeBorder", "edge:", edge)
+  const kResizeBorderSize = 8
+  const kResizeHandleSize = 22
 
   let top = 0
   let left = 0
@@ -20,9 +21,6 @@ export function ComponentResizeBorder({ componentRef, containerRef, edge, onPoin
   const componentBounds = componentRef.current?.getBoundingClientRect()
   const containerBounds = containerRef.current?.getBoundingClientRect()
   if (componentBounds && containerBounds) {
-    const kResizeBorderSize = 8
-    const kResizeHandleSize = 22
-
     switch (edge) {
       case "left":
         top = componentBounds.top - containerBounds.top + kTitleBarHeight

--- a/v3/src/components/component-resize-border.tsx
+++ b/v3/src/components/component-resize-border.tsx
@@ -1,0 +1,52 @@
+import { clsx } from "clsx"
+import React from "react"
+import { kTitleBarHeight } from "./constants"
+
+interface IProps {
+  componentRef: React.RefObject<HTMLDivElement | null>
+  containerRef: React.RefObject<HTMLElement | null>
+  edge: "left" | "right" | "bottom"
+  onPointerDown?: (e: React.PointerEvent<HTMLDivElement>) => void
+}
+
+export function ComponentResizeBorder({ componentRef, containerRef, edge, onPointerDown }: IProps) {
+  console.log("ComponentResizeBorder", "edge:", edge)
+
+  let top = 0
+  let left = 0
+  let width: Maybe<number>
+  let height: Maybe<number>
+
+  const componentBounds = componentRef.current?.getBoundingClientRect()
+  const containerBounds = containerRef.current?.getBoundingClientRect()
+  if (componentBounds && containerBounds) {
+    const kResizeBorderSize = 8
+    const kResizeHandleSize = 22
+
+    switch (edge) {
+      case "left":
+        top = componentBounds.top - containerBounds.top + kTitleBarHeight
+        left = componentBounds.left - containerBounds.left - kResizeBorderSize
+        height = componentBounds.height - kTitleBarHeight
+        break
+      case "right":
+        top = componentBounds.top - containerBounds.top + kTitleBarHeight
+        left = componentBounds.right - containerBounds.left
+        height = componentBounds.height - kTitleBarHeight - kResizeHandleSize
+        break
+      case "bottom":
+        top = componentBounds.bottom - containerBounds.top
+        left = componentBounds.left - containerBounds.left
+        width = componentBounds.width - kResizeHandleSize
+    }
+  }
+
+  if (!onPointerDown) return null
+
+  const classes = clsx("codap-component-border", edge)
+  const style: React.CSSProperties = { left, top, width, height }
+
+  return (
+    <div className={classes} style={style} onPointerDown={onPointerDown}/>
+  )
+}

--- a/v3/src/components/component-resize-border.tsx
+++ b/v3/src/components/component-resize-border.tsx
@@ -1,6 +1,6 @@
 import { clsx } from "clsx"
 import React from "react"
-import { kTitleBarHeight } from "./constants"
+import { kResizeBorderOverlap, kResizeBorderSize, kResizeHandleSize, kTitleBarHeight } from "./constants"
 
 interface IProps {
   componentRef: React.RefObject<HTMLDivElement | null>
@@ -10,10 +10,6 @@ interface IProps {
 }
 
 export function ComponentResizeBorder({ componentRef, containerRef, edge, onPointerDown }: IProps) {
-  const kOverlap = 2
-  const kResizeBorderSize = 8
-  const kResizeHandleSize = 22
-
   let top = 0
   let left = 0
   let width: Maybe<number>
@@ -25,16 +21,16 @@ export function ComponentResizeBorder({ componentRef, containerRef, edge, onPoin
     switch (edge) {
       case "left":
         top = componentBounds.top - containerBounds.top + kTitleBarHeight
-        left = componentBounds.left - containerBounds.left - kResizeBorderSize + kOverlap
+        left = componentBounds.left - containerBounds.left - kResizeBorderSize + kResizeBorderOverlap
         height = componentBounds.height - kTitleBarHeight
         break
       case "right":
         top = componentBounds.top - containerBounds.top + kTitleBarHeight
-        left = componentBounds.right - containerBounds.left - kOverlap
+        left = componentBounds.right - containerBounds.left - kResizeBorderOverlap
         height = componentBounds.height - kTitleBarHeight - kResizeHandleSize
         break
       case "bottom":
-        top = componentBounds.bottom - containerBounds.top - kOverlap
+        top = componentBounds.bottom - containerBounds.top - kResizeBorderOverlap
         left = componentBounds.left - containerBounds.left
         width = componentBounds.width - kResizeHandleSize
     }

--- a/v3/src/components/component-resize-border.tsx
+++ b/v3/src/components/component-resize-border.tsx
@@ -10,6 +10,7 @@ interface IProps {
 }
 
 export function ComponentResizeBorder({ componentRef, containerRef, edge, onPointerDown }: IProps) {
+  const kOverlap = 2
   const kResizeBorderSize = 8
   const kResizeHandleSize = 22
 
@@ -24,16 +25,16 @@ export function ComponentResizeBorder({ componentRef, containerRef, edge, onPoin
     switch (edge) {
       case "left":
         top = componentBounds.top - containerBounds.top + kTitleBarHeight
-        left = componentBounds.left - containerBounds.left - kResizeBorderSize
+        left = componentBounds.left - containerBounds.left - kResizeBorderSize + kOverlap
         height = componentBounds.height - kTitleBarHeight
         break
       case "right":
         top = componentBounds.top - containerBounds.top + kTitleBarHeight
-        left = componentBounds.right - containerBounds.left
+        left = componentBounds.right - containerBounds.left - kOverlap
         height = componentBounds.height - kTitleBarHeight - kResizeHandleSize
         break
       case "bottom":
-        top = componentBounds.bottom - containerBounds.top
+        top = componentBounds.bottom - containerBounds.top - kOverlap
         left = componentBounds.left - containerBounds.left
         width = componentBounds.width - kResizeHandleSize
     }

--- a/v3/src/components/constants.ts
+++ b/v3/src/components/constants.ts
@@ -8,6 +8,9 @@ export const defaultItalicFont = `italic ${defaultFont}`
 export const defaultTileTitleFont = defaultItalicFont
 
 export const kTitleBarHeight = 25
+export const kResizeBorderOverlap = 2
+export const kResizeBorderSize = 8
+export const kResizeHandleSize = 22
 
 export const kDefaultTileWidth = 250
 export const kDefaultTileHeight = 250

--- a/v3/src/components/container/free-tile-row.tsx
+++ b/v3/src/components/container/free-tile-row.tsx
@@ -1,6 +1,7 @@
 import { clsx } from "clsx"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useRef } from "react"
+import { TileContainerContext } from "../../hooks/use-tile-container-context"
 import { IFreeTileRow } from "../../models/document/free-tile-row"
 import { ITileModel } from "../../models/tiles/tile-model"
 import { uiState } from "../../models/ui-state"
@@ -48,18 +49,20 @@ export const FreeTileRowComponent = observer(function FreeTileRowComponent(
     }
   }
 
-  const classes = clsx("free-tile-row", "tile-row", kDragContainerClass)
+  const classes = clsx("free-tile-row", "free-tile-container", "tile-row", kDragContainerClass)
 
   return (
-    <div className={classes} ref={rowRef} onPointerDown={handlePointerDown}>
-      {
-        row?.tileIds.map(tileId => {
-          const tile = getTile(tileId)
-          return (
-            tile && <FreeTileComponent row={row} tile={tile} onCloseTile={onCloseTile} key={tileId}/>
-          )
-        })
-      }
-    </div>
+    <TileContainerContext.Provider value={rowRef}>
+      <div className={classes} ref={rowRef} onPointerDown={handlePointerDown}>
+        {
+          row?.tileIds.map(tileId => {
+            const tile = getTile(tileId)
+            return (
+              tile && <FreeTileComponent row={row} tile={tile} onCloseTile={onCloseTile} key={tileId}/>
+            )
+          })
+        }
+      </div>
+    </TileContainerContext.Provider>
   )
 })

--- a/v3/src/hooks/use-tile-container-context.ts
+++ b/v3/src/hooks/use-tile-container-context.ts
@@ -1,0 +1,8 @@
+import { createContext, createRef, useContext } from "react"
+
+const defaultRef = createRef<HTMLElement | null>()
+export const TileContainerContext = createContext<React.RefObject<HTMLElement | null>>(defaultRef)
+
+export function useTileContainerContext() {
+  return useContext(TileContainerContext)
+}


### PR DESCRIPTION
The main issue was that our resize-border `<div>` was overlapping the scrollbar. The solution adopted here is to move the resize borders outside the content of the component. This eliminates the scrollbar conflict at the expense of possible being a bit confusing that you have to click outside the component to resize it. It would be less confusing if there were a visible border to click on, but I don't think we want an eight-pixel border around each component for esthetic reasons.

Architecturally, responsibility for resizing the component moves from `CodapComponent` (where it never really belonged) to the `FreeTileComponent`.