### PR TITLE
CODAP-735 Fix display of negative mean and median

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -226,7 +226,7 @@ export class UnivariateMeasureAdornmentHelper {
     cellCounts: Record<string, number>, secondaryAxisX=0, secondaryAxisY=0
   ) => {
     const displayValue = this.formatValueForScale(isVertical, value)
-    const plotValue = Number(displayValue.replace("\u2212", "-"))  // replace en-dash with minus sign
+    const plotValue = value
     const measureRange: IRange = attrId && this.model.hasRange
       ? this.model.computeMeasureRange(attrId, this.cellKey, dataConfig)
       : {}

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -226,7 +226,7 @@ export class UnivariateMeasureAdornmentHelper {
     cellCounts: Record<string, number>, secondaryAxisX=0, secondaryAxisY=0
   ) => {
     const displayValue = this.formatValueForScale(isVertical, value)
-    const plotValue = Number(displayValue)
+    const plotValue = Number(displayValue.replace("\u2212", "-"))  // replace en-dash with minus sign
     const measureRange: IRange = attrId && this.model.hasRange
       ? this.model.computeMeasureRange(attrId, this.cellKey, dataConfig)
       : {}


### PR DESCRIPTION
[#CODAP-735] Bug fix: mean and median adornments not drawn correctly when negative

* The display value string for the adornment was formatted with "\u2212" for a negative sign, but then this didn't convert to a number for plotting since it's not a minus sign but an en-dash. We elect to continue to use the display value string, but first replace any en-dash with minus sign.