### PR TITLE
fix: MST warning on dragging last attribute of collection

### DIFF
--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1,7 +1,7 @@
 import { isEqual, isEqualWith } from "lodash"
 import { applyAction, clone, destroy, getSnapshot, onAction, onSnapshot } from "mobx-state-tree"
 import { uniqueName } from "../../utilities/js-utils"
-import { DataSet, fromCanonical, isFilterFormulaDataSet, toCanonical } from "./data-set"
+import { DataSet, fromCanonical, isFilterFormulaDataSet, nullItemData, toCanonical } from "./data-set"
 import { createDataSet } from "./data-set-conversion"
 import { ICaseID } from "./data-set-types"
 
@@ -79,6 +79,14 @@ test("Canonicalization", () => {
   expect(toCanonical(ds, { foo: "bar", ...a1Case })).toEqual(a1Canonical)
   expect(mockConsoleWarn).toHaveBeenCalledTimes(1)
   mockConsole.mockRestore()
+})
+
+test("nullItemData", () => {
+  expect(nullItemData.itemIds()).toEqual([])
+  expect(nullItemData.isHidden("id")).toBe(false)
+  expect(nullItemData.getValue("id", "attr")).toBe("")
+  expect(nullItemData.addItemInfo("id", "attr")).toBeUndefined()
+  expect(nullItemData.invalidate()).toBeUndefined()
 })
 
 test("DataSet volatile caching", () => {


### PR DESCRIPTION
[[CODAP-715](https://concord-consortium.atlassian.net/browse/CODAP-715)] mobx-state-tree error when dragging an attribute down a collection

Dragging the last attribute from a collection removes that collection from the data set. In this scenario, a stale `parent` link to the removed collection was being accessed before being updated. We now call `syncCollectionLinks()` immediately upon removing a collection to prevent such stale accesses.

[CODAP-715]: https://concord-consortium.atlassian.net/browse/CODAP-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ