### PR TITLE
CODAP-737 Fix attribute menu becoming inaccessible on component resize

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -16,6 +16,7 @@ interface IProps {
   place: GraphPlace,
   target: SVGGElement | null
   portal: HTMLElement | null
+  layoutBounds: string  // Used to signal need to re-render because layout has changed
   onChangeAttribute: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
   onRemoveAttribute: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
@@ -31,7 +32,7 @@ const removeAttrItemLabelKeys: Record<string, string> = {
 }
 
 export const AxisOrLegendAttributeMenu =
-  observer(function AxisOrLegendAttributeMenu({ place, target, portal,
+  observer(function AxisOrLegendAttributeMenu({ place, target, portal, layoutBounds,
                                       onChangeAttribute, onRemoveAttribute, onTreatAttributeAs }: IProps) {
   const dataConfiguration = useDataConfigurationContext()
   const metadata = dataConfiguration?.metadata

--- a/v3/src/components/data-display/components/attribute-label.tsx
+++ b/v3/src/components/data-display/components/attribute-label.tsx
@@ -26,15 +26,14 @@ export const AttributeLabel = forwardRef((props: IProps, labelRef: ForwardedRef<
   const portal = labelElt?.closest(kPortalClassSelector) as HTMLElement ?? null
   const contentModel = useBaseDataDisplayModelContext()
   const layout = useDataDisplayLayout()
-  const [ , setLayoutBounds] = useState("")
+  const [ layoutBounds, setLayoutBounds] = useState("")
 
   useEffect(() => {
     return mstAutorun(() => {
       // accessing layout triggers autorun on change
       const bounds = layout.getComputedBounds(place)
-      const layoutBounds = JSON.stringify(bounds)
       // trigger re-render on layout position change
-      setLayoutBounds(layoutBounds)
+      setLayoutBounds(JSON.stringify(bounds))
       // render label and trigger autorun on change to observables within
       refreshLabel()
     }, { name: "AttributeLabel.autorun [refreshLabel]" }, contentModel)
@@ -48,6 +47,7 @@ export const AttributeLabel = forwardRef((props: IProps, labelRef: ForwardedRef<
           target={labelElt}
           portal={portal}
           place={place}
+          layoutBounds={layoutBounds}
           onChangeAttribute={onChangeAttribute}
           onRemoveAttribute={onRemoveAttribute}
           onTreatAttributeAs={onTreatAttributeAs}


### PR DESCRIPTION
[#CODAP-737] Bug fix: Graph axis label becomes inaccessible

* Note: The bug also occurred for a map or graph legend attribute label. The cause of the bug was a lack of rerendering of the `AxisOrLegendAttributeMenu` component on resize of graph or map component.
* The fix is to pass the stringified layout bounds computed in attribute-label.tsx to the `AxisOrLegendAttributeMenu` to trigger rerender when it changes.