### PR TITLE
Codap-645 Undo/Redo Row Resize

### DIFF
--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -96,7 +96,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   const [selectionStartRowIdx, setSelectionStartRowIdx] = useState<number | null>(null)
   const initialPointerDownPosition = useRef({ x: 0, y: 0 })
   const kPointerMovementThreshold = 3
-  const rowHeight = caseTableModel?.getRowHeightForCollection(collectionId) ?? kDefaultRowHeight
+  const rowHeight = collectionTableModel?.rowHeight ?? kDefaultRowHeight
   const {active} = useTileDroppable(`${kCollectionTableBodyDropZoneBaseId}-${collectionId}`)
 
   useEffect(function setGridElement() {

--- a/v3/src/components/case-table/row-divider.tsx
+++ b/v3/src/components/case-table/row-divider.tsx
@@ -66,7 +66,6 @@ export const RowDivider = observer(function RowDivider({ rowId, before }: IRowDi
       const tempNewHeight = Math.max(kDefaultRowHeight, initialHeight.current + deltaY)
       const newHeight = kSnapToLineHeight * Math.round((tempNewHeight - 4) / kSnapToLineHeight) + 4
       collectionTableModel?.setRowHeight(newHeight)
-      caseTableModel?.setTempRowHeightForCollection(collectionId, newHeight)
     }
   }
 
@@ -75,7 +74,6 @@ export const RowDivider = observer(function RowDivider({ rowId, before }: IRowDi
     isResizing.current = false
     caseTableModel?.applyModelChange(() => {
       caseTableModel?.setRowHeightForCollection(collectionId, getRowHeight())
-      caseTableModel?.setTempRowHeightForCollection(collectionId, undefined)
     },
     {
       log: "Change row height",


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/CODAP-645

This PR fixes a bug where resizing a table row could not be undone/redone. The basic problem is that row heights are stored in `CaseTableModel.rowHeights` and `CollectionTableModel.rowHeight`, and their uses are a bit muddled. For the purposes of resizing rows:
- `CollectionTableModel.rowHeight` is initialized from `CaseTableModel.rowHeights`.
- `CollectionTableModel.rowHeight` determines the row height that is passed to RDG.
- `CollectionTableModel.rowHeight` is modified during a resize.
- `CaseTableModel.rowHeights` is updated at the end of a resize.

`CaseTableModel.rowHeights` was actually being updated during undo/redo, which you could test by changing the row height, undoing, saving the document, then loading the document. Further complicating things, `CollectionTableModel` is a mobx class, rather than a MST model, so it doesn't work with undo/redo. `CollectionTableModel.rowHeight` also must be defined, because it is used to determine a bunch of other values.

My solution to this issue is to introduce the volatile `CaseTableModel.tempRowHeights`, which are used to specify the row height during a resize. If defined, this is the value passed to RDG. If not defined, `CaseTableModel.rowHeights` is passed to RDG. This makes undo/redo work, but I'm not sure if there are problems with `CollectionTableModel.rowHeight` not being updated during an undo/redo.

Another possible solution is to set up a mobx reaction that sets `CollectionTableModel.rowHeight` whenever `CaseTableModel.rowHeights` changes.

While I was in there, I also defined some undo strings for resizing rows. Previously we were using keys for strings that weren't defined, so the keys were showing up as the undo/redo tooltips.