### PR TITLE
CODAP-701 Improve performance when categorical axis has very large number of categories

### DIFF
--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -7,6 +7,10 @@ export const axisGap = 5
 export const AxisPlaces = ["bottom", "left", "rightCat", "top", "rightNumeric"] as const
 export type AxisPlace = typeof AxisPlaces[number]
 
+export function isAxisPlace(place: string): place is AxisPlace {
+  return (AxisPlaces as readonly string[]).includes(place)
+}
+
 export function otherPlace(aPlace: AxisPlace): AxisPlace {
   return ['bottom', 'top'].includes(aPlace) ? 'left' : 'bottom'
 }

--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -1,11 +1,13 @@
 import {ScaleLinear} from "d3"
+import {MutableRefObject} from "react"
 import { determineLevels } from "../../utilities/date-utils"
-import {kAxisGap, kAxisTickLength} from "./axis-constants"
-import {kDataDisplayFont} from "../data-display/data-display-types"
-import {AxisPlace} from "./axis-types"
 import {measureText, measureTextExtent} from "../../hooks/use-measure-text"
 import {ICategorySet} from "../../models/data/category-set"
-import {MutableRefObject} from "react"
+import { kAxisGap, kAxisTickLength, kDefaultFontHeight } from "./axis-constants"
+import { axisPlaceToAttrRole, kDataDisplayFont } from "../data-display/data-display-types"
+import { IDataConfigurationModel } from "../data-display/models/data-configuration-model"
+import {AxisPlace} from "./axis-types"
+import { GraphLayout } from "../graph/models/graph-layout"
 
 export const getStringBounds = (s = 'Wy', font = kDataDisplayFont) => {
   return measureTextExtent(s, font)
@@ -28,6 +30,18 @@ export const collisionExists = (props: ICollisionProps) => {
   return centerCategoryLabels ? labelWidths.some((width, i) => {
     return i > 0 && width / 2 + labelWidths[i - 1] / 2 > narrowedBandwidth
   }) : labelWidths.some(width => width > narrowedBandwidth)
+}
+
+/**
+ * Having this utility function makes it possible to set the number of categories limit for a categorical
+ * axis early in the process of treating an attribute as categorical so that, if there is a large number of categories,
+ * we can limit the computation involved in figuring out which cases belong to which subplot.
+ */
+export const setNumberOfCategoriesLimit = (dataConfig: IDataConfigurationModel, axisPlace: AxisPlace,
+                                           layout: GraphLayout) => {
+  const axisLength = layout.getAxisLength(axisPlace),
+    numCategoriesLimit = Math.floor(axisLength / kDefaultFontHeight)
+  dataConfig?.setNumberOfCategoriesLimitForRole(axisPlaceToAttrRole[axisPlace], numCategoriesLimit)
 }
 
 interface ILabelPlacement {

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -1,8 +1,8 @@
 import { axisBottom, format, max, min, NumberValue, range, scaleLinear, ScaleQuantile, ScaleQuantize, select } from "d3"
-import { kChoroplethHeight } from "../../../data-display-types"
+import { measureTextExtent } from "../../../../../hooks/use-measure-text"
 import { neededSigDigitsArrayForBinBoundaries } from "../../../../../utilities/math-utils"
 import { DatePrecision, determineLevels, formatDate, mapLevelToPrecision } from "../../../../../utilities/date-utils"
-import { getStringBounds } from "../../../../axis/axis-utils"
+import { kChoroplethHeight, kDataDisplayFont } from "../../../data-display-types"
 
 export type ChoroplethLegendProps = {
   isDate?: boolean,
@@ -72,7 +72,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     tickFormat = (i: NumberValue) => thresholdFormat(thresholds[Number(i)]),
     minMaxFormat = isDate ? thresholdFormat
       : (d: number, i: number) => format(`.${significantDigits[i === 0 ? 0 : 5]}r`)(d),
-    minStringWidth = getStringBounds(minMaxFormat(minValue, 0)).width,
+    minStringWidth = measureTextExtent(minMaxFormat(minValue, 0), kDataDisplayFont).width,
     onlyShowMinMax = minStringWidth > 3 * width / 20 - 10
 
   svg.append("g")


### PR DESCRIPTION
[#CODAP-701] Bug fix: Rendering categorical axes can take a long time

* The bottleneck was due to an order of operations problem in response to assigning a categorical attribute to an axis and/or treating a numeric attribute as categorical when the number of categories is very large. Until it is known how many categories will fit on an axis, the computation to find out which cases belong to each "subplot" may need to be done for each of the categorical values. We improve things by setting the limit to the number of categories that can be displayed on an axis *before* the actual assignment or treating-as-categorical of the attribute is done. This has the effect of greatly limiting the computation involved.