### PR TITLE
CODAP 733 added a spec that connecting lines should not exist with Show Parent Visibility Toggles

### DIFF
--- a/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
+++ b/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
@@ -150,6 +150,34 @@ context("Graph UI with Pixi interaction", () => {
         gch.validateGraphPointCount(tileId, 24) // 24 points in graph
       })
     })
+
+    it("should not show connecting lines without pixi points when Display Only Selected Cases is enabled", () => {
+      // Set up graph with Speed on y-axis and Height on x-axis
+      ah.openAxisAttributeMenu("left")
+      ah.selectMenuAttribute("Speed", "left") // Speed => y-axis
+      ah.openAxisAttributeMenu("bottom")
+      ah.selectMenuAttribute("Height", "bottom") // Height => x-axis
+      cy.wait(500)
+
+      // Enable Display Only Selected Cases
+      graph.getHideShowButton().click()
+      cy.get("[data-testid=display-selected-cases]").click()
+      cy.wait(500)
+
+      // Enable connecting lines
+      graph.getDisplayValuesButton().click()
+      cy.get("[data-testid=adornment-checkbox-connecting-lines]").click()
+      cy.wait(500)
+
+      // Verify connecting lines do not exist
+      cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("not.exist")
+
+      // Verify no pixi points exist
+      gch.getGraphTileId().then((tileId) => {
+        gch.validateGraphPointCount(tileId, 0) // 0 points in graph
+      })
+    })
+
     it("shows parent visibility toggles and verifies point count with Show Parent Visibility Toggles selected", () => {
       ah.openAxisAttributeMenu("bottom")
       ah.selectMenuAttribute("Sleep", "bottom") // Sleep => x-axis
@@ -176,13 +204,6 @@ context("Graph UI with Pixi interaction", () => {
         .find("button").contains("Spotted Hyena").should("have.class", "case-hidden")
       gch.getGraphTileId().then((tileId) => {
         gch.validateGraphPointCount(tileId, 23) // 23 points in graph
-      })
-      cy.get("[data-testid=parent-toggles-case-buttons-list]")
-        .find("button").contains("Spotted Hyena").click()
-      cy.get("[data-testid=parent-toggles-case-buttons-list]")
-        .find("button").contains("Spotted Hyena").should("not.have.class", "case-hidden")
-      gch.getGraphTileId().then((tileId) => {
-        gch.validateGraphPointCount(tileId, 24) // 24 points in graph
       })
       cy.get("[data-testid=parent-toggles-case-buttons-list]")
         .find("button").contains("Red Fox").should("exist").and("be.visible")


### PR DESCRIPTION
[CODAP-733](https://concord-consortium.atlassian.net/browse/CODAP-733)

# Add test for connecting lines with Display Only Selected Cases

## Description
Adds test to verify that connecting lines are not displayed when "Display Only Selected Cases" is enabled and no points are visible, even when connecting lines option is enabled.

## Changes
- Added test case in `graph-pixi-interaction.spec.ts` that verifies:
  1. Graph setup with Speed/Height axes
  2. Display Only Selected Cases enabled
  3. Connecting lines option enabled
  4. No connecting lines or points displayed

## Testing
- [x] Test passes locally

[CODAP-733]: https://concord-consortium.atlassian.net/browse/CODAP-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ