### PR TITLE
CODAP-640 Attribute Menu Z-Index

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -1,0 +1,3 @@
+.attribute-label-menu {
+  z-index: 16;
+}

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -12,6 +12,8 @@ import { IDataSet } from "../../../models/data/data-set"
 import {IUseDraggableAttribute, useDraggableAttribute} from "../../../hooks/use-drag-drop"
 import {useInstanceIdContext} from "../../../hooks/use-instance-id-context"
 
+import "./axis-or-legend-attribute-menu.scss"
+
 interface IProps {
   place: GraphPlace,
   target: SVGGElement | null


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/CODAP-640

This PR fixes an issue where attribute menus were rendering below tile menus and tile resize buttons. The solution is to set the z-index of the `AxisOrLegendAttributeMenu`.