### PR TITLE
CODAP-503 Attribute menu clipping problem

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -112,7 +112,7 @@ export const AxisOrLegendAttributeMenu =
                         {treatAs === "date" && t("V3.DataDisplayMenu.treatAsDate")}
                       </MenuItem>
                     }
-                    { /** We add a spacer to prevent a ChakdraUI problem whereby the bottom item disappears **/
+                    { /** We add a spacer to prevent a ChakraUI problem whereby the bottom item disappears **/
                       place === 'bottom' && <MenuItem>&nbsp;</MenuItem>
                     }
                   </>

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -112,6 +112,9 @@ export const AxisOrLegendAttributeMenu =
                         {treatAs === "date" && t("V3.DataDisplayMenu.treatAsDate")}
                       </MenuItem>
                     }
+                    { /** We add a spacer to prevent a ChakdraUI problem whereby the bottom item disappears **/
+                      place === 'bottom' && <MenuItem>&nbsp;</MenuItem>
+                    }
                   </>
                 }
               </MenuList>


### PR DESCRIPTION
[#CODAP-503] Bug fix: Graph Attribute Menu clipped by window problem

* In certain situations the attribute menu for the bottom axis won't reliably display the bottom menu item. We work around this by adding a blank menu item at the bottom.
* (This problem is not particular to ChromeOS but the narrow height of the default Chromebook makes it more likely to occur.)