### PR TITLE
Improve performance of large .csv imports [CODAP-630]

### DIFF
--- a/v3/cypress/support/elements/cfm.ts
+++ b/v3/cypress/support/elements/cfm.ts
@@ -4,6 +4,7 @@ interface IDocumentOptions {
 export const CfmElements = {
   openLocalDoc(filename: string) {
     cy.get('#codap-app-id').selectFile(filename, { action: 'drag-drop' })
+    cy.wait(1000) // Wait for the document to load
   },
   openLocalDocWithUserEntry(filename: string) {
     cy.get('#user-entry-drop-overlay').selectFile(filename, { action: 'drag-drop' })

--- a/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
@@ -110,7 +110,7 @@ export const RulerMenuList = observer(function RulerMenuList() {
       itemKey: "DG.Inspector.getCaseDataFromClipboard",
       handleClick: () => {
         if (data) {
-          navigator.clipboard.readText().then(text => initiateImportFromCsv(text, data))
+          navigator.clipboard.readText().then(text => initiateImportFromCsv({ text, data }))
         }
       }
     }

--- a/v3/src/components/case-tile-common/inspector-panel/trash-menu-list.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/trash-menu-list.tsx
@@ -9,32 +9,31 @@ import { t } from "../../../utilities/translation/translate"
 
 export const TrashMenuList = observer(function TrashMenuList() {
   const data = useDataSetContext()
-  let deletableItems: string[] = []
-  let deletableSelectedItems: string[] = []
-  let deletableUnselectedItems: string[] = []
-  if (data) {
-    deletableItems = data.itemIds.filter(itemId => isItemEditable(data, itemId))
-    deletableSelectedItems = Array.from(data.selection).filter(itemId => isItemEditable(data, itemId))
-    const deletableSelectedItemsSet = new Set(deletableSelectedItems)
-    deletableUnselectedItems = deletableItems.filter(itemId => !deletableSelectedItemsSet.has(itemId))
-  }
-  const disableDeleteAllItems = deletableItems.length < 1
-  const disableDeleteSelectedItems = deletableSelectedItems.length < 1
-  const disableDeleteUnselectedItems = deletableUnselectedItems.length < 1
+
+  const selectedItemIds = Array.from(data?.selection ?? [])
+  const disableDeleteSelectedItems = !data || !selectedItemIds.some(itemId => isItemEditable(data, itemId))
+  const disableDeleteUnselectedItems = !data?.itemIds.some(itemId =>
+                                      isItemEditable(data, itemId) && !data.selection.has(itemId))
+  const disableDeleteAllItems = disableDeleteSelectedItems && disableDeleteUnselectedItems
 
   const handleSelectAllCases = () => {
     selectAllCases(data)
   }
 
   const handleDeleteSelectedCases = () => {
+    const deletableSelectedItems = data?.itemIds.filter(itemId =>
+                                      isItemEditable(data, itemId) && data.selection.has(itemId)) ?? []
     data && removeCasesWithCustomUndoRedo(data, deletableSelectedItems)
   }
 
   const handleDeleteUnselectedCases = () => {
+    const deletableUnselectedItems = data?.itemIds.filter(itemId =>
+                                      isItemEditable(data, itemId) && !data.selection.has(itemId)) ?? []
     data && removeCasesWithCustomUndoRedo(data, deletableUnselectedItems)
   }
 
   const handleDeleteAllCases = () => {
+    const deletableItems = data?.itemIds.filter(itemId => isItemEditable(data, itemId)) ?? []
     data && removeCasesWithCustomUndoRedo(data, deletableItems)
   }
 

--- a/v3/src/hooks/use-drop-handler.test.ts
+++ b/v3/src/hooks/use-drop-handler.test.ts
@@ -3,7 +3,7 @@ import { useDropHandler } from "./use-drop-handler"
 
 const mockData = [{ a: 1, b: 2 }, { a: 3, b: 4 }]
 const mockFilename = "mockFile.csv"
-const mockInitiateImportFromCsvFile = jest.fn()
+const mockInitiateImportFromCsv = jest.fn()
 
 jest.mock("papaparse", () => ({
   // mock parse() to return mock data
@@ -14,7 +14,7 @@ jest.mock("papaparse", () => ({
 
 jest.mock("../utilities/csv-import", () => {
   return {
-    initiateImportFromCsvFile: (file: File) => mockInitiateImportFromCsvFile(file)
+    initiateImportFromCsv: (file: File) => mockInitiateImportFromCsv(file)
   }
 })
 
@@ -49,9 +49,10 @@ describe("useDropHandler", () => {
     const { rerender, result } = renderHook(() => useDropHandler(params))
     rerender()  // make sure effect has a chance to run
     expect(result.current).toBeTruthy()
-    fireEvent.dragOver(result.current!)
+    if (!result.current) throw new Error("Hook did not return a valid element")
+    fireEvent.dragOver(result.current)
     expect(handler).not.toHaveBeenCalled()
-    fireEvent.drop(result.current!)
+    fireEvent.drop(result.current)
     expect(handler).not.toHaveBeenCalled()
   })
 
@@ -61,13 +62,14 @@ describe("useDropHandler", () => {
     const { rerender, result } = renderHook(() => useDropHandler(params))
     rerender()  // make sure effect has a chance to run
     expect(result.current).toBeTruthy()
-    fireEvent.dragOver(result.current!)
+    if (!result.current) throw new Error("Hook did not return a valid element")
+    fireEvent.dragOver(result.current)
     expect(handler).not.toHaveBeenCalled()
-    expect(mockInitiateImportFromCsvFile).not.toHaveBeenCalled()
-    fireEvent.drop(result.current!, { dataTransfer: mockDataTransferWithItems })
+    expect(mockInitiateImportFromCsv).not.toHaveBeenCalled()
+    fireEvent.drop(result.current, { dataTransfer: mockDataTransferWithItems })
     expect(handler).not.toHaveBeenCalled()
-    expect(mockInitiateImportFromCsvFile).toHaveBeenCalled()
-    const file = mockInitiateImportFromCsvFile.mock.calls[0][0] as File
+    expect(mockInitiateImportFromCsv).toHaveBeenCalled()
+    const file = mockInitiateImportFromCsv.mock.calls[0][0].file as File
     expect(file.name).toBe(mockFilename)
   })
 
@@ -77,9 +79,10 @@ describe("useDropHandler", () => {
     const { rerender, result } = renderHook(() => useDropHandler(params))
     rerender()  // make sure effect has a chance to run
     expect(result.current).toBeTruthy()
-    fireEvent.dragOver(result.current!)
+    if (!result.current) throw new Error("Hook did not return a valid element")
+    fireEvent.dragOver(result.current)
     expect(handler).not.toHaveBeenCalled()
-    fireEvent.drop(result.current!, { dataTransfer: mockDataTransferWithoutItems })
+    fireEvent.drop(result.current, { dataTransfer: mockDataTransferWithoutItems })
     expect(handler).not.toHaveBeenCalled()
   })
 })

--- a/v3/src/hooks/use-drop-handler.ts
+++ b/v3/src/hooks/use-drop-handler.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react"
 import { IDataSet } from "../models/data/data-set"
-import { convertParsedCsvToDataSet, CsvParseResult, importCsvFile } from "../utilities/csv-import"
+import {
+  convertParsedCsvToDataSet, CsvParseResult, importCsvFile, initiateImportFromCsvFile
+} from "../utilities/csv-import"
+
+const USE_IMPORTER_PLUGIN_FOR_CSV_FILE = true
 
 export interface IDropHandler {
   selector: string
@@ -25,6 +29,7 @@ export const useDropHandler = ({
 
     function dropHandler(event: DragEvent) {
 
+      // For local .csv import
       function onCompleteCsvImport(results: CsvParseResult, aFile: any) {
         const ds = convertParsedCsvToDataSet(results, aFile.name)
         onImportDataSet?.(ds)
@@ -47,8 +52,14 @@ export const useDropHandler = ({
                 file && onImportDocument?.(file)
                 break
               case "csv":
-                importCsvFile(file, onCompleteCsvImport)
-                break
+                if (USE_IMPORTER_PLUGIN_FOR_CSV_FILE) {
+                  // For .csv import via Importer plugin
+                  file && initiateImportFromCsvFile(file)
+                }
+                else {
+                  // For local .csv import without Importer plugin
+                  importCsvFile(file, onCompleteCsvImport)
+                }
             }
           }
           else if (item.kind === "string" && item.type === "text/uri-list") {

--- a/v3/src/hooks/use-drop-handler.ts
+++ b/v3/src/hooks/use-drop-handler.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react"
 import { IDataSet } from "../models/data/data-set"
 import {
-  convertParsedCsvToDataSet, CsvParseResult, importCsvFile, initiateImportFromCsvFile
+  convertParsedCsvToDataSet, CsvParseResult, importCsvFile, initiateImportFromCsv
 } from "../utilities/csv-import"
 
 const USE_IMPORTER_PLUGIN_FOR_CSV_FILE = true
@@ -54,7 +54,7 @@ export const useDropHandler = ({
               case "csv":
                 if (USE_IMPORTER_PLUGIN_FOR_CSV_FILE) {
                   // For .csv import via Importer plugin
-                  file && initiateImportFromCsvFile(file)
+                  file && initiateImportFromCsv({ file })
                 }
                 else {
                   // For local .csv import without Importer plugin

--- a/v3/src/models/boundaries/boundary-types.ts
+++ b/v3/src/models/boundaries/boundary-types.ts
@@ -25,6 +25,15 @@ export const isBoundaryValue = (iValue: object | string): boolean => {
       obj.type === 'FeatureCollection' || obj.type === 'Feature' || obj.jsonBoundaryObject)
 }
 
+export const isBoundaryString = (iValue: string): boolean => {
+  // stringified objects must be enclosed in braces
+  if (iValue[0] !== '{' || iValue[iValue.length - 1] !== '}') return false
+  const obj = boundaryObjectFromBoundaryValue(iValue)
+  return obj != null &&
+    !!(obj.geometry || obj.coordinates || obj.features ||
+      obj.type === 'FeatureCollection' || obj.type === 'Feature' || obj.jsonBoundaryObject)
+}
+
 export interface BoundaryInfo {
   name: string
   format: string

--- a/v3/src/models/codap/create-codap-document.test.ts
+++ b/v3/src/models/codap/create-codap-document.test.ts
@@ -8,6 +8,8 @@ import "../shared/shared-data-set-registration"
 // eslint-disable-next-line no-var
 var mockNodeIdCount = 0
 jest.mock("../../utilities/js-utils", () => ({
+  hashOrderedStringSet: () => 12345678,
+  hashStringSet: () => 12345678,
   typedId: () => `test-${++mockNodeIdCount}`,
   uniqueOrderedId: () => `order-${++mockNodeIdCount}`
 }))
@@ -92,7 +94,11 @@ describe("createCodapDocument", () => {
                 id: "test-7",
                 name: "Cases",
                 attributes: ["test-8"],
-                _groupKeyCaseIds: []
+                _groupKeyCaseIds: [
+                  ["test-9", "test-12"],
+                  ["test-10", "test-13"],
+                  ["test-11", "test-14"]
+                ]
               }],
               id: "test-5",
               snapSelection: []

--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -110,7 +110,7 @@ describe("Attribute", () => {
 
     attribute.setUnits("m")
     expect(attribute.units).toBe("m")
-    expect(attribute.getNumericCount()).toBe(0)
+    expect(attribute.isInferredNumericType()).toBe(false)
     expect(attribute.type).toBeUndefined()
 
     attribute.addValue("1")
@@ -124,7 +124,7 @@ describe("Attribute", () => {
     expect(attribute.value(2)).toBe(3)
     expect(attribute.numValue(1)).toBe(2)
     expect(attribute.numValue(2)).toBe(3)
-    expect(attribute.getNumericCount()).toBe(3)
+    expect(attribute.isInferredNumericType()).toBe(true)
 
     attribute.addValue(0, 0)
     expect(attribute.length).toBe(4)
@@ -161,7 +161,7 @@ describe("Attribute", () => {
     expect(attribute.value(1)).toBe(2)
     expect(attribute.numValue(0)).toBe(0)
     expect(attribute.numValue(1)).toBe(2)
-    expect(attribute.getNumericCount()).toBe(6)
+    expect(attribute.isInferredNumericType()).toBe(true)
     expect(attribute.type).toBe("numeric")
 
     // undefined/empty values are ignored when determining type
@@ -220,28 +220,18 @@ describe("Attribute", () => {
     expect(lengthListener).toHaveBeenCalledTimes(1)
     lengthDisposer()
 
-    // value changes should trigger emptyCount reevaluation
-    const emptyCountListener = jest.fn()
-    const emptyCountDisposer = reaction(() => a.getEmptyCount(), () => emptyCountListener())
-    expect(a.getEmptyCount()).toBe(0)
-    expect(emptyCountListener).toHaveBeenCalledTimes(0)
-    a.setValue(2, "")
-    expect(a.getEmptyCount()).toBe(1)
-    expect(emptyCountListener).toHaveBeenCalledTimes(1)
-    emptyCountDisposer()
-
-    // value changes should trigger numericCount reevaluation
-    const numericCountListener = jest.fn()
-    const numericCountDisposer = reaction(() => a.getNumericCount(), () => numericCountListener())
-    expect(a.getNumericCount()).toBe(3)
-    expect(numericCountListener).toHaveBeenCalledTimes(0)
+    // value changes should not trigger type reevaluation
+    const numericTypeListener = jest.fn()
+    const numericTypeDisposer = reaction(() => a.isInferredNumericType(), () => numericTypeListener())
+    expect(a.isInferredNumericType()).toBe(true)
+    expect(numericTypeListener).toHaveBeenCalledTimes(0)
     a.setValue(2, "3")
-    expect(a.getNumericCount()).toBe(4)
-    expect(numericCountListener).toHaveBeenCalledTimes(1)
-    numericCountDisposer()
+    expect(a.isInferredNumericType()).toBe(true)
+    expect(numericTypeListener).toHaveBeenCalledTimes(0)
+    numericTypeDisposer()
 
-    const colorCountListener = jest.fn()
-    const colorCountDisposer = reaction(() => a.getStrictColorCount(), () => colorCountListener())
+    const colorTypeListener = jest.fn()
+    const colorTypeDisposer = reaction(() => a.isInferredColorType(), () => colorTypeListener())
     const typeListener = jest.fn()
     const typeDisposer = reaction(() => a.type, () => typeListener())
     expect(a.type).toBe("numeric")
@@ -250,21 +240,21 @@ describe("Attribute", () => {
     expect(a.type).toBe("categorical")
     expect(typeListener).toHaveBeenCalledTimes(1)
     // color type
-    expect(a.getStrictColorCount()).toBe(0)
+    expect(a.isInferredColorType()).toBe(false)
     a.setValue(0, "#ff0000")
-    expect(a.getStrictColorCount()).toBe(1)
+    expect(a.isInferredColorType()).toBe(false)
     a.setValue(1, "#00f")
-    expect(a.getStrictColorCount()).toBe(2)
+    expect(a.isInferredColorType()).toBe(false)
     expect(a.type).toBe("categorical")
     a.setValue(2, "rgb(0, 255, 0)")
-    expect(a.getStrictColorCount()).toBe(3)
+    expect(a.isInferredColorType()).toBe(false)
     expect(a.type).toBe("categorical")
     a.setValue(3, "rgba(0, 255, 0, 0.5)")
-    expect(a.getStrictColorCount()).toBe(4)
+    expect(a.isInferredColorType()).toBe(true)
     expect(a.type).toBe("color")
     expect(typeListener).toHaveBeenCalledTimes(2)
     typeDisposer()
-    colorCountDisposer()
+    colorTypeDisposer()
   })
 
   test("Serialization (development)", () => {

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -31,7 +31,7 @@ import { parseColor } from "../../utilities/color-utils"
 import { isDateString } from "../../utilities/date-parser"
 import { DatePrecision } from "../../utilities/date-utils"
 import { cachedFnFactory } from "../../utilities/mst-utils"
-import { isBoundaryValue, kPolygonNames } from "../boundaries/boundary-types"
+import { isBoundaryString, kPolygonNames } from "../boundaries/boundary-types"
 import { Formula, IFormula } from "../formula/formula"
 import { applyModelChange } from "../history/apply-model-change"
 import { withoutUndo } from "../history/without-undo"
@@ -133,7 +133,7 @@ export const Attribute = V2Model.named("Attribute").props({
     return self.strValues.reduce((prev, current) => isDateString(current) ? ++prev : prev, 0)
   }),
   getBoundaryCount: cachedFnFactory<number>(() => {
-    return self.strValues.reduce((prev, current) => isBoundaryValue(current) ? ++prev : prev, 0)
+    return self.strValues.reduce((prev, current) => isBoundaryString(current) ? ++prev : prev, 0)
   }),
   get hasFormula() {
     return !!self.formula && !self.formula.empty

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -104,36 +104,53 @@ export const Attribute = V2Model.named("Attribute").props({
   get datePrecision() {
     return typeof self.precision === "string" ? self.precision : undefined
   },
-  getEmptyCount: cachedFnFactory<number>(() => {
-    // Note that `self.changeCount` is absolutely not necessary here. However, historically, this function used to be
-    // a MobX computed property, and `self.changeCount` was used to invalidate the cache. Also, there are tests
-    // (and possibly some features?) that depend on MobX reactivity. Hence, this is left here for now.
-    self.changeCount // eslint-disable-line @typescript-eslint/no-unused-expressions
-    return self.strValues.reduce((prev, current) => current === "" ? ++prev : prev, 0)
+  isInferredNumericType: cachedFnFactory<boolean>(() => {
+    let numCount = 0
+    const isEveryValueNumericOrEmpty = self.strValues.every((strValue, index) => {
+      if (strValue == null || strValue === "") return true
+      if (isFinite(self.numValues[index])) {
+        ++numCount
+        return true
+      }
+      return false
+    })
+    return numCount > 0 && isEveryValueNumericOrEmpty
   }),
-  getNumericCount: cachedFnFactory<number>(() => {
-    // Note that `self.changeCount` is absolutely not necessary here. However, historically, this function used to be
-    // a MobX computed property, and `self.changeCount` was used to invalidate the cache. Also, there are tests
-    // (and possibly some features?) that depend on MobX reactivity. Hence, this is left here for now.
-    self.changeCount // eslint-disable-line @typescript-eslint/no-unused-expressions
-    return self.numValues.reduce((prev, current) => isFinite(current) ? ++prev : prev, 0)
+  isInferredColorType: cachedFnFactory<boolean>(() => {
+    let colorCount = 0
+    const isEveryValueColorOrEmpty = self.strValues.every((strValue, index) => {
+      if (strValue == null || strValue === "") return true
+      if (parseColor(strValue)) {
+        ++colorCount
+        return true
+      }
+      return false
+    })
+    return colorCount > 0 && isEveryValueColorOrEmpty
   }),
-  getStrictColorCount: cachedFnFactory<number>(() => {
-    // Note that `self.changeCount` is absolutely not necessary here. However, historically, this function used to be
-    // a MobX computed property, and `self.changeCount` was used to invalidate the cache. Also, there are tests
-    // (and possibly some features?) that depend on MobX reactivity. Hence, this is left here for now.
-    self.changeCount // eslint-disable-line @typescript-eslint/no-unused-expressions
-    return self.strValues.reduce((prev, current) => parseColor(current) ? ++prev : prev, 0)
+  isInferredDateType: cachedFnFactory<boolean>(() => {
+    let dateCount = 0
+    const isEveryValueDateOrEmpty = self.strValues.every((strValue, index) => {
+      if (strValue == null || strValue === "") return true
+      if (isDateString(strValue)) {
+        ++dateCount
+        return true
+      }
+      return false
+    })
+    return dateCount > 0 && isEveryValueDateOrEmpty
   }),
-  getDateCount: cachedFnFactory<number>(() => {
-    // Note that `self.changeCount` is absolutely not necessary here. However, historically, this function used to be
-    // a MobX computed property, and `self.changeCount` was used to invalidate the cache. Also, there are tests
-    // (and possibly some features?) that depend on MobX reactivity. Hence, this is left here for now.
-    self.changeCount // eslint-disable-line @typescript-eslint/no-unused-expressions
-    return self.strValues.reduce((prev, current) => isDateString(current) ? ++prev : prev, 0)
-  }),
-  getBoundaryCount: cachedFnFactory<number>(() => {
-    return self.strValues.reduce((prev, current) => isBoundaryString(current) ? ++prev : prev, 0)
+  isInferredBoundaryType: cachedFnFactory<boolean>(() => {
+    let boundaryCount = 0
+    const isEveryValueBoundaryOrEmpty = self.strValues.every((strValue, index) => {
+      if (strValue == null || strValue === "") return true
+      if (isBoundaryString(strValue)) {
+        ++boundaryCount
+        return true
+      }
+      return false
+    })
+    return boundaryCount > 0 && isEveryValueBoundaryOrEmpty
   }),
   get hasFormula() {
     return !!self.formula && !self.formula.empty
@@ -150,11 +167,10 @@ export const Attribute = V2Model.named("Attribute").props({
 }))
 .actions(self => ({
   incChangeCount() {
-    self.getEmptyCount.invalidate()
-    self.getNumericCount.invalidate()
-    self.getStrictColorCount.invalidate()
-    self.getBoundaryCount.invalidate()
-    self.getDateCount.invalidate()
+    self.isInferredNumericType.invalidate()
+    self.isInferredColorType.invalidate()
+    self.isInferredBoundaryType.invalidate()
+    self.isInferredDateType.invalidate()
     ++self.changeCount
   },
   setCid(cid?: string) {
@@ -221,22 +237,17 @@ export const Attribute = V2Model.named("Attribute").props({
     self.changeCount  // eslint-disable-line @typescript-eslint/no-unused-expressions
     if (this.length === 0) return
 
-    // only infer color if all non-empty values are strict colors
-    const colorCount = self.getStrictColorCount()
-    if (colorCount > 0 && colorCount === this.length - self.getEmptyCount()) return "color"
-
     // only infer numeric if all non-empty values are numeric (CODAP2)
-    const numCount = self.getNumericCount()
-    if (numCount > 0 && numCount === this.length - self.getEmptyCount()) return "numeric"
+    if (self.isInferredNumericType()) return "numeric"
 
     // only infer date if all non-empty values are dates
-    const dateCount = self.getDateCount()
-    if (dateCount > 0 && dateCount === this.length - self.getEmptyCount()) return "date"
+    if (self.isInferredDateType()) return "date"
+
+    // only infer color if all non-empty values are strict colors
+    if (self.isInferredColorType()) return "color"
 
     // only infer boundary if all non-empty values are boundaries or if the attribute has a special name
-    const boundaryCount = self.getBoundaryCount()
-    const allValuesAreBoundaries = boundaryCount > 0 && boundaryCount === this.length - self.getEmptyCount()
-    if (kPolygonNames.includes(self.title) || allValuesAreBoundaries) {
+    if (kPolygonNames.includes(self.title) || self.isInferredBoundaryType()) {
       return "boundary"
     }
 
@@ -326,8 +337,19 @@ export const Attribute = V2Model.named("Attribute").props({
   },
   setValue(index: number, value: IValueType, options?: ISetValueOptions) {
     if ((index >= 0) && (index < self.strValues.length)) {
-      self.strValues[index] = self.importValue(value)
-      self.numValues[index] = self.toNumeric(self.strValues[index])
+      if (typeof value === "string") {
+        const trimmedValue = value.trim()
+        self.strValues[index] = trimmedValue
+        self.numValues[index] = self.toNumeric(trimmedValue)
+      }
+      else if (typeof value === "number") {
+        self.strValues[index] = value.toString()
+        self.numValues[index] = value
+      }
+      else {
+        self.strValues[index] = self.importValue(value)
+        self.numValues[index] = self.toNumeric(self.strValues[index])
+      }
       if (!options?.noInvalidate) self.incChangeCount()
     }
   },

--- a/v3/src/models/data/collection-properties.md
+++ b/v3/src/models/data/collection-properties.md
@@ -1,0 +1,10 @@
+|Property|Description|Appended Items|Inserted Items|
+|--------|-----------|--------------|--------------|
+|`groupKeyCaseIds: new Map<string, string>()`|map from group key (stringified attribute values) => case id|Simple insert|Simple insert|
+|`caseIds: [] as string[]`|case ids in case table/render order|Append cases|Clear and recreate|
+|`caseIdToIndexMap: new Map<string, number>()`|map from case id to case index|Append cases|Clear and recreate|
+|`caseIdToGroupKeyMap: new Map<string, string>()`|map from case id to group key (stringified attribute values)|Simple insert|Simple insert|
+|`caseGroupMap: new Map<string, CaseInfo>()`|map from group key (stringified attribute values) to CaseInfo|Simple insert|Simple insert|
+|`prevCaseIds: undefined as Maybe<string[]>`|previous case ids in case table/render order; used to track case ids no longer in use|Not needed|Not needed|
+|`prevCaseIdToGroupKeyMap: undefined as Maybe<Map<string, string>>`|previous map from case id to group key (stringified attribute values); used for remapping case ids when values change|Not needed|Not needed|
+|`prevCaseGroupMap: undefined as Maybe<Map<string, CaseInfo>>`|previous map from group key (stringified attribute values) to CaseInfo; used for remapping case ids when values change|Not needed|Not needed|

--- a/v3/src/models/data/data-set-collections.test.ts
+++ b/v3/src/models/data/data-set-collections.test.ts
@@ -84,7 +84,6 @@ describe("DataSet collections", () => {
     expect(data.collections[0].attributes.map(attr => attr!.id)).toEqual(["aId"])
     expect(data.childCollection.attributes.map(attr => attr!.id)).toEqual(["bId", "cId"])
 
-    expect(collection.id).toBe("test-3")
     expect(attributesByCollection()).toEqual([["aId"], ["bId", "cId"]])
     expect(data.getCollection(collection.id)).toBe(collection)
     const aCases = data.getCasesForAttributes(["aId"])
@@ -102,7 +101,6 @@ describe("DataSet collections", () => {
     expect(data.childCollection.attributes.map(attr => attr!.id)).toEqual(["cId"])
     expect(attributesByCollection()).toEqual([["aId", "bId"], ["cId"]])
 
-    expect(collection.id).toBe("test-3")
     const aCases = data.getCasesForAttributes(["aId"])
     expect(aCases.length).toBe(9)
     expect(data.getCasesForCollection(collection.id)).toEqual(aCases)

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -178,7 +178,9 @@ export const DataSet = V2Model.named("DataSet").props({
   // cached result of filter formula evaluation for each item ID
   filteredOutItemIds: observable.set<string>(),
   filterFormulaError: "",
-  itemData: nullItemData
+  itemData: nullItemData,
+  // flag indicating that items are being appended, enabling certain optimizations
+  isAppendingItems: false
 }))
 .extend(self => {
   const _validationCount = observable.box<number>(0)
@@ -587,6 +589,25 @@ export const DataSet = V2Model.named("DataSet").props({
       })
       self.setValidCases()
     }
+  },
+  validateNewCases(itemIds: string[]) {
+    const newCaseIdsForCollections = new Map<string, string[]>()
+    self.collections.forEach((collection, index) => {
+      // update the cases
+      const { newCaseIds } = collection.updateCaseGroups(itemIds)
+      newCaseIdsForCollections.set(collection.id, newCaseIds)
+    })
+    self.collections.forEach((collection, index) => {
+      // complete the case groups, including sorting child collection cases into groups
+      const parentCaseGroups = index > 0 ? self.collections[index - 1].caseGroups : undefined
+      collection.completeCaseGroups(parentCaseGroups)
+      // update the caseGroupMap
+      collection.caseGroupMap.forEach(group => self.caseInfoMap.set(group.groupedCase.__id__, group))
+    })
+    self.itemIdChildCaseMap.clear()
+    Array.from(self.childCollection.caseGroupMap.values()).forEach(caseGroup => {
+      self.itemIdChildCaseMap.set(caseGroup.childItemIds[0] ?? caseGroup.hiddenChildItemIds[0], caseGroup)
+    })
   }
 }))
 .views(self => ({
@@ -991,6 +1012,7 @@ export const DataSet = V2Model.named("DataSet").props({
       // latter, whether it should be named addCases or addItems.
       addCases(cases: ICaseCreation[], options?: IAddCasesOptions) {
         const { before, after } = options || {}
+        let didAppendItems = false
 
         const beforePosition = before
           ? self.getItemIndex(before) ?? self.getItemIndex(self.caseInfoMap.get(before)?.childItemIds[0] ?? "")
@@ -1029,11 +1051,16 @@ export const DataSet = V2Model.named("DataSet").props({
           })
         }
         else {
+          self.isAppendingItems = true
+
           self._itemIds.push(...ids)
           // append values to each attribute
           self.attributesMap.forEach(attr => {
             attr.setLength(self._itemIds.length)
           })
+
+          self.isAppendingItems = false
+          didAppendItems = true
         }
         // add the itemInfo for the appended cases
         ids.forEach((caseId, index) => {
@@ -1058,6 +1085,11 @@ export const DataSet = V2Model.named("DataSet").props({
 
         // invalidate the affected attributes
         attrs.forEach(attrId => self.getAttribute(attrId)?.incChangeCount())
+
+        if (didAppendItems) {
+          self.validateNewCases(ids)
+        }
+
         return ids
       },
 
@@ -1277,10 +1309,13 @@ export const DataSet = V2Model.named("DataSet").props({
       ))
 
       // when items are added/removed...
-      // use MST's onPatch mechanism to respond to additions/removals of items and their undo/redo
+      // use MST's onPatch mechanism to respond to removals of items or undoing their creation.
       addDisposer(self, onPatch(self, ({ op, path, value }) => {
         if (/_itemIds(\/\d+)?$/.test(path)) {
-          self.invalidateCases()
+          // we don't need a full invalidation if we're appending items
+          if (op !== "add" || !self.isAppendingItems) {
+            self.invalidateCases()
+          }
         }
       }))
 

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -590,7 +590,7 @@ export const DataSet = V2Model.named("DataSet").props({
       self.setValidCases()
     }
   },
-  validateNewCases(itemIds: string[]) {
+  validateCasesForNewItems(itemIds: string[]) {
     const newCaseIdsForCollections = new Map<string, string[]>()
     self.collections.forEach((collection, index) => {
       // update the cases
@@ -1087,7 +1087,7 @@ export const DataSet = V2Model.named("DataSet").props({
         attrs.forEach(attrId => self.getAttribute(attrId)?.incChangeCount())
 
         if (didAppendItems) {
-          self.validateNewCases(ids)
+          self.validateCasesForNewItems(ids)
         }
 
         return ids

--- a/v3/src/utilities/csv-import.ts
+++ b/v3/src/utilities/csv-import.ts
@@ -56,3 +56,21 @@ export function initiateImportFromCsv(csvContent: string, dataset: IDataSet) {
     content: webViewModelSnap
   })
 }
+
+export function initiateImportFromCsvFile(file: File) {
+  // The importer plugin is used to import a csv file into a dataset.
+  const webViewModelSnap: IWebViewSnapshot = {
+    type: kWebViewTileType,
+    subType: "plugin",
+    url: getImporterPluginUrl(),
+    state: {
+      contentType: 'text/csv',
+      name: "Importer",
+      file
+    }
+  }
+  appState.document.content?.insertTileSnapshotInDefaultRow({
+    _title: "Importer",
+    content: webViewModelSnap
+  })
+}

--- a/v3/src/utilities/csv-import.ts
+++ b/v3/src/utilities/csv-import.ts
@@ -38,7 +38,16 @@ export function convertParsedCsvToDataSet(results: CsvParseResult, filename: str
   return ds
 }
 
-export function initiateImportFromCsv(csvContent: string, dataset: IDataSet) {
+interface IImportFromCsvContentArgs {
+  text: string
+  data: IDataSet
+}
+interface IImportFromCsvFileArgs {
+  file: File
+}
+type IImportFromCsvArgs = IImportFromCsvContentArgs | IImportFromCsvFileArgs
+
+export function initiateImportFromCsv(options: IImportFromCsvArgs) {
   // The importer plugin is used to import a csv string into a dataset.
   const webViewModelSnap: IWebViewSnapshot = {
     type: kWebViewTileType,
@@ -46,27 +55,10 @@ export function initiateImportFromCsv(csvContent: string, dataset: IDataSet) {
     url: getImporterPluginUrl(),
     state: {
       contentType: 'text/csv',
-      targetDatasetName: dataset.name,
       name: "Importer",
-      text: csvContent
-    }
-  }
-  appState.document.content?.insertTileSnapshotInDefaultRow({
-    _title: "Importer",
-    content: webViewModelSnap
-  })
-}
-
-export function initiateImportFromCsvFile(file: File) {
-  // The importer plugin is used to import a csv file into a dataset.
-  const webViewModelSnap: IWebViewSnapshot = {
-    type: kWebViewTileType,
-    subType: "plugin",
-    url: getImporterPluginUrl(),
-    state: {
-      contentType: 'text/csv',
-      name: "Importer",
-      file
+      file: "file" in options ? options.file : undefined,
+      targetDatasetName: "data" in options ? options.data.name : undefined,
+      text: "text" in options ? options.text : undefined
     }
   }
   appState.document.content?.insertTileSnapshotInDefaultRow({


### PR DESCRIPTION
[[CODAP-630](https://concord-consortium.atlassian.net/browse/CODAP-630)] Improve performance of large .csv imports

This PR addresses a number of performance bottlenecks in importing large .csv files. V2 (and now V3) invoke the Importer plugin to import .csv files. The Importer plugin offers several capabilities, notably including the ability to sub-sample from large files. It also batches up the imported items into blocks of 200 cases for sending to CODAP, so from a performance perspective it's really a large number of small incremental imports. For instance, the `us-cities.csv` file I used for testing has ~45K rows, which means ~225 blocks of items are communicated to CODAP. We will probably want to fold the features of the Importer plugin into CODAP itself at some point, but in the meantime this makes for a useful point of comparison. Also, adding items incrementally is a common use case in other scenarios, e.g. the Sampler, probes, etc., so it is a use case worth optimizing even if we eventually move away from the Importer plugin. Here are the total import times for importing the `us-cities.csv` file:

|Version|Time|
|-------|-----|
|V3 before this PR|3:45|
|V3 after this PR|0:25|
|V2|0:20|

Note that there still may be some performance gains to be had with further investigation, but this is a solid step in the right direction.

Here are some of the bottlenecks addressed in this PR:
- The code for grouping items into cases treats appended items as a special case for which it doesn't have to clear its internal caches and start the grouping process from scratch.
- Reduces work done to determine whether the type of an attribute can be inferred.
- Reduces work done to determine whether a given string can be interpreted as a boundary.
- The case table inspector minimizes the work done to determine which delete items to enable.

[CODAP-630]: https://concord-consortium.atlassian.net/browse/CODAP-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ