### PR TITLE
fix: category drag undo/redo [CODAP-105]

### DIFF
--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -112,6 +112,7 @@ export const getCategoricalLabelPlacement = (
 }
 
 export interface DragInfo {
+  initialIndexOfCategory: number
   indexOfCategory: number
   catName: string
   initialOffset: number

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -155,6 +155,8 @@ describe("CategorySet", () => {
     expect(catKellyColors()).toEqual(numKellyColors(4))
     categories.setColorForCategory("b", "red")
     expect(catKellyColors()).toEqual([...numKellyColors(3), "red"])
+    categories.setColorForCategory("b", "")
+    expect(catKellyColors()).toEqual(numKellyColors(4))
     // moving "b" before "z" combines moves
     const originalFromIndex = categories.lastMove?.fromIndex
     expect(categories.moves.length).toBe(6)
@@ -163,6 +165,20 @@ describe("CategorySet", () => {
     expect(categories.valuesArray).toEqual(["x", "y", "z", "b"])
     expect(categories.moves.length).toBe(6)
     expect(categories.lastMove?.fromIndex).toBe(originalFromIndex)
+  })
+
+  it("handles volatile category drags", () => {
+    const a = Attribute.create({ name: "a", values: ["a", "b", "c", "a", "b", "c"] })
+    expect(a.strValues).toEqual(["a", "b", "c", "a", "b", "c"])
+    const tree = Tree.create({
+      attribute: a,
+      categories: { attribute: a.id }
+    })
+    const categories = tree.categories
+    categories.setDragCategory("a", 2)
+    expect(categories.values).toEqual(["b", "c", "a"])
+    categories.setDragCategory()
+    expect(categories.values).toEqual(["a", "b", "c"])
   })
 
   it("tracks user color assignments", () => {


### PR DESCRIPTION
The primary issue was that during the drag the model was being updated continuously on every "tick" of the drag. This was fixed by introducing volatile `dragCategory` and `dragCategoryIndex` properties to the `CategorySet` which are updated during the drag so that the undoable/serializable change to the model is only made at the end of the drag.

In working on this I also clarified some of the indexing logic. When moving a value at index _i_ in an array before or after another object at index _j_, the destination index depends on whether the move is forward or backward. `CategorySet` has an internal function named `moveValueToIndex` which was performing some of the index correction logic. This made the `dragCategoryIndex` code more complicated than it needed to be. The index correction logically belongs in the clients that are mapping from before/after values to indices. This is facilitated by two new internal utility functions `afterDstIndex()` and `beforeDstIndex()`.

Finally, two reactive changes to handle undo/redo properly:
- switch from using `onAnyAction()` (MST) to `when` (MobX) to determine when to `promoteProvisionalCategorySet()`
- use an `onPatch` handler in the `CategorySet` so that categories are invalidated on undo/redo
