### PR TITLE
fix: tile border resize handles sometimes inaccessible on first render

### DIFF
--- a/v3/cypress/e2e/map.spec.ts
+++ b/v3/cypress/e2e/map.spec.ts
@@ -265,7 +265,7 @@ context("Map UI", () => {
     table.getSelectedRows().should("have.length", 1)
 
     // Can deselect a pin by clicking on the map
-    map.getPinLayer().click("top")
+    map.getPinLayer().click()
     map.getMapPin().should("not.have.class", "selected-pin")
     table.getSelectedRows().should("have.length", 0)
     map.getMapPin().click()

--- a/v3/src/components/container/component-resize-widgets.tsx
+++ b/v3/src/components/container/component-resize-widgets.tsx
@@ -1,0 +1,73 @@
+import { Portal } from "@chakra-ui/react"
+import React, { useCallback, useEffect } from "react"
+import ResizeHandle from "../../assets/icons/icon-corner-resize-handle.svg"
+import { useTileContainerContext } from "../../hooks/use-tile-container-context"
+import { IFreeTileLayout } from "../../models/document/free-tile-row"
+import { ITileModel } from "../../models/tiles/tile-model"
+import { uiState } from "../../models/ui-state"
+import { ComponentResizeBorder } from "../component-resize-border"
+import { useForceUpdate } from "../../hooks/use-force-update"
+
+interface IProps {
+  tile: ITileModel
+  tileLayout?: IFreeTileLayout
+  componentRef: React.RefObject<HTMLDivElement | null>
+  isFixedWidth?: boolean
+  isFixedHeight?: boolean
+  handleResizePointerDown: (e: React.PointerEvent, _tileLayout: IFreeTileLayout, direction: string) => void
+}
+export function ComponentResizeWidgets(props: IProps) {
+  const { tile, tileLayout, componentRef, isFixedWidth, isFixedHeight, handleResizePointerDown } = props
+  const containerRef = useTileContainerContext()
+  const forceUpdate = useForceUpdate()
+
+  const handleBottomRightPointerDown = useCallback((e: React.PointerEvent) => {
+    tileLayout && handleResizePointerDown(e, tileLayout, "bottom-right")
+  }, [handleResizePointerDown, tileLayout])
+
+  const handleBottomLeftPointerDown = useCallback((e: React.PointerEvent) => {
+    tileLayout && handleResizePointerDown(e, tileLayout, "bottom-left")
+  }, [handleResizePointerDown, tileLayout])
+
+  const handleRightPointerDown = useCallback((e: React.PointerEvent) => {
+    tileLayout && handleResizePointerDown(e, tileLayout, "right")
+  }, [handleResizePointerDown, tileLayout])
+
+  const handleBottomPointerDown = useCallback((e: React.PointerEvent) => {
+    tileLayout && handleResizePointerDown(e, tileLayout, "bottom")
+  }, [handleResizePointerDown, tileLayout])
+
+  const handleLeftPointerDown = useCallback((e: React.PointerEvent) => {
+    tileLayout && handleResizePointerDown(e, tileLayout, "left")
+  }, [handleResizePointerDown, tileLayout])
+
+  useEffect(() => {
+    // trigger an initial re-render to ensure resize widgets are positioned correctly
+    forceUpdate()
+  }, [forceUpdate])
+
+  return (
+    <>
+      <Portal containerRef={containerRef}>
+        {!isFixedWidth &&
+          <ComponentResizeBorder edge="left" onPointerDown={handleLeftPointerDown}
+              componentRef={componentRef} containerRef={containerRef} />}
+        {!isFixedWidth &&
+          <ComponentResizeBorder edge="right" onPointerDown={handleRightPointerDown}
+              componentRef={componentRef} containerRef={containerRef} />}
+        {!isFixedHeight &&
+          <ComponentResizeBorder edge="bottom" onPointerDown={handleBottomPointerDown}
+              componentRef={componentRef} containerRef={containerRef} />}
+      </Portal>
+      {!(isFixedWidth && isFixedHeight) &&
+        <div className="codap-component-corner bottom-left" onPointerDown={handleBottomLeftPointerDown}/>
+      }
+      {!(isFixedWidth && isFixedHeight) &&
+        <div className="codap-component-corner bottom-right" onPointerDown={handleBottomRightPointerDown}>
+          {(uiState.isFocusedTile(tile.id)) &&
+            <ResizeHandle className="component-resize-handle"/>}
+        </div>
+      }
+    </>
+  )
+}

--- a/v3/src/components/container/component-resize-widgets.tsx
+++ b/v3/src/components/container/component-resize-widgets.tsx
@@ -1,12 +1,12 @@
 import { Portal } from "@chakra-ui/react"
 import React, { useCallback, useEffect } from "react"
 import ResizeHandle from "../../assets/icons/icon-corner-resize-handle.svg"
+import { useForceUpdate } from "../../hooks/use-force-update"
 import { useTileContainerContext } from "../../hooks/use-tile-container-context"
 import { IFreeTileLayout } from "../../models/document/free-tile-row"
 import { ITileModel } from "../../models/tiles/tile-model"
 import { uiState } from "../../models/ui-state"
 import { ComponentResizeBorder } from "../component-resize-border"
-import { useForceUpdate } from "../../hooks/use-force-update"
 
 interface IProps {
   tile: ITileModel

--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -1,19 +1,15 @@
-import { Portal } from "@chakra-ui/react"
 import { clsx } from "clsx"
 import { observer } from "mobx-react-lite"
 import React, { PointerEvent, useCallback, useEffect, useRef, useState } from "react"
-import ResizeHandle from "../../assets/icons/icon-corner-resize-handle.svg"
 import { ComponentWrapperContext } from "../../hooks/use-component-wrapper-context"
-import { useTileContainerContext } from "../../hooks/use-tile-container-context"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { IFreeTileLayout, IFreeTileRow } from "../../models/document/free-tile-row"
 import { getTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { ITileModel } from "../../models/tiles/tile-model"
-import { uiState } from "../../models/ui-state"
 import { urlParams } from "../../utilities/url-params"
 import { CodapComponent } from "../codap-component"
-import { ComponentResizeBorder } from "../component-resize-border"
 import { IChangingTileStyle, kTitleBarHeight } from "../constants"
+import { ComponentResizeWidgets } from "./component-resize-widgets"
 import { useTileDrag } from "./use-tile-drag"
 
 interface IProps {
@@ -23,7 +19,6 @@ interface IProps {
 }
 
 export const FreeTileComponent = observer(function FreeTileComponent({ row, tile, onCloseTile}: IProps) {
-  const containerRef = useTileContainerContext()
   const componentRef = useRef<HTMLDivElement | null>(null)
   const { id: tileId, content: { type: tileType } } = tile
   const [useDefaultCreationStyle, setUseDefaultCreationStyle] = useState(row.animateCreationTiles.has(tileId))
@@ -98,26 +93,6 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
     document.body.addEventListener("pointerup", handlePointerUp, { capture: true })
   }, [row])
 
-  const handleBottomRightPointerDown = useCallback((e: React.PointerEvent) => {
-    tileLayout && handleResizePointerDown(e, tileLayout, "bottom-right")
-  }, [handleResizePointerDown, tileLayout])
-
-  const handleBottomLeftPointerDown = useCallback((e: React.PointerEvent) => {
-    tileLayout && handleResizePointerDown(e, tileLayout, "bottom-left")
-  }, [handleResizePointerDown, tileLayout])
-
-  const handleRightPointerDown = useCallback((e: React.PointerEvent) => {
-    tileLayout && handleResizePointerDown(e, tileLayout, "right")
-  }, [handleResizePointerDown, tileLayout])
-
-  const handleBottomPointerDown = useCallback((e: React.PointerEvent) => {
-    tileLayout && handleResizePointerDown(e, tileLayout, "bottom")
-  }, [handleResizePointerDown, tileLayout])
-
-  const handleLeftPointerDown = useCallback((e: React.PointerEvent) => {
-    tileLayout && handleResizePointerDown(e, tileLayout, "left")
-  }, [handleResizePointerDown, tileLayout])
-
   const info = getTileComponentInfo(tileType)
   const style = changingTileStyle ??
                   (tileLayout?.isHidden && info?.renderWhenHidden
@@ -163,28 +138,9 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
               onMoveTilePointerDown={handleMoveTilePointerDown}
             />
             {!isMinimized &&
-              <>
-                <Portal containerRef={containerRef}>
-                  {!isFixedWidth &&
-                    <ComponentResizeBorder edge="left" onPointerDown={handleLeftPointerDown}
-                        componentRef={componentRef} containerRef={containerRef} />}
-                  {!isFixedWidth &&
-                    <ComponentResizeBorder edge="right" onPointerDown={handleRightPointerDown}
-                        componentRef={componentRef} containerRef={containerRef} />}
-                  {!isFixedHeight &&
-                    <ComponentResizeBorder edge="bottom" onPointerDown={handleBottomPointerDown}
-                        componentRef={componentRef} containerRef={containerRef} />}
-                </Portal>
-                {!(isFixedWidth && isFixedHeight) &&
-                  <div className="codap-component-corner bottom-left" onPointerDown={handleBottomLeftPointerDown}/>
-                }
-                {!(isFixedWidth && isFixedHeight) &&
-                  <div className="codap-component-corner bottom-right" onPointerDown={handleBottomRightPointerDown}>
-                    {(uiState.isFocusedTile(tile.id)) &&
-                      <ResizeHandle className="component-resize-handle"/>}
-                  </div>
-                }
-              </>
+              <ComponentResizeWidgets tile={tile} tileLayout={tileLayout} componentRef={componentRef}
+                isFixedWidth={isFixedWidth} isFixedHeight={isFixedHeight}
+                handleResizePointerDown={handleResizePointerDown} />
             }
           </>
         }


### PR DESCRIPTION
This was something I noticed while testing another story and it annoyed me enough to just address it. The tile border resize handles are positioned relative to the rendered tile, which means that the rendered dimensions of the tile must be available for correct positioning. Due to the nature of React refs, the tile dimensions may not be available on the first render, so we force an additional re-render on mount. We only want the additional re-render to affect the resize handles, however, not the tile itself, so the resize handles were moved into their own separate component (`ComponentResizeWidgets`) which makes the diffs seem more dramatic than they really are.