### PR TITLE
CODAP-753 Refresh the Sampler plugin URL

### DIFF
--- a/v3/src/components/tool-shelf/standard-plugins.json
+++ b/v3/src/components/tool-shelf/standard-plugins.json
@@ -6,7 +6,7 @@
     "description-string": "DG.plugin.Sampler.description",
     "width": 232,
     "height": 400,
-    "path": "/TP-Sampler/index.html",
+    "path": "https://sampler.concord.org/",
     "icon": "/TP-Sampler/icon-sampler.svg",
     "visible": "true",
     "aegis": "ESTEEM",


### PR DESCRIPTION
[#CODAP-753] Bug fix: The Sampler plugin has a stale URL

* Changed URL to point to the current Sampler.

Note that the URL for the icon still points to /TP-Sampler/ (as it also does in V2)