### PR TITLE
Codap-643 Default Dataset Title

### DIFF
--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -9,7 +9,7 @@ context("case table ui", () => {
   let lastRowIndex = -1
   let middleRowIndex = -1
   let numOfCases = "0"
-  const collectionName = "Mammals"
+  const collectionName = "Cases"
   const renamedCollectionName = "Animals"
   const newCollectionName = "New Dataset"
 
@@ -1078,7 +1078,7 @@ context("case table ui", () => {
       toolbar.getUndoTool().click()
 
       // Asserts table has been reopened
-      c.getComponentTitle("table").should("contain", "Mammals")
+      c.getComponentTitle("table").should("contain", collectionName)
 
       // Add redo for closing table
       toolbar.getRedoTool().click()

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -47,7 +47,7 @@ export const CaseTableToolShelfMenuList = observer(function CaseTableToolShelfMe
     document.applyModelChange(() => {
       const baseName = t("DG.AppController.createDataSet.name")
       const newName = uniqueName(baseName, name => !datasetNames.includes(name), " ")
-      const ds = DataSet.create({ name: newName })
+      const ds = DataSet.create({ name: newName, _title: newName })
       ds.addAttribute({ name: t("DG.AppController.createDataSet.initialAttribute") })
       const options: INewTileOptions = { animateCreation: true, markNewlyCreated: true }
       tile = createDefaultTileOfType(kCaseTableTileType, options)

--- a/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
@@ -17,14 +17,14 @@ interface IProps {
 export const DatasetInfoModal = ({showInfoModal, setShowInfoModal}: IProps) => {
   const data = useDataSetContext()
   const metadata = useDataSetMetadata()
-  const [datasetName, setDataSetName] = useState(data?.title || "")
+  const [datasetTitle, setDatasetTitle] = useState(data?.title || "")
   const [description, setDescription] = useState(metadata?.description || "")
   const [source, setSource] = useState(metadata?.source || "")
   const [importDate, setImportDate] = useState(metadata?.importDate || "")
 
   const handleCloseInfoModal = () => {
     data?.applyModelChange(() => {
-      data.setName(datasetName)
+      data.setTitle(datasetTitle)
       metadata?.setDescription(description)
       metadata?.setSource(source)
       metadata?.setImportDate(importDate)
@@ -57,8 +57,8 @@ export const DatasetInfoModal = ({showInfoModal, setShowInfoModal}: IProps) => {
         <FormControl display="flex" flexDirection="column" className="dataset-info-modal">
           <FormLabel h="20px" display="flex" flexDirection="row" alignItems="center">
             {t("DG.CaseTable.attributeEditor.name")}
-            <Input size="xs" ml={5} placeholder="name" value={datasetName} onFocus={(e) => e.target.select()}
-                onChange={event => setDataSetName(event.target.value)} data-testid="dataset-name-input"
+            <Input size="xs" ml={5} placeholder="name" value={datasetTitle} onFocus={(e) => e.target.select()}
+                onChange={event => setDatasetTitle(event.target.value)} data-testid="dataset-name-input"
                 onKeyDown={(e) => e.stopPropagation()}
             />
           </FormLabel>

--- a/v3/src/data-interactive/data-interactive-type-utils.test.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.test.ts
@@ -35,7 +35,7 @@ describe("DataInteractiveTypeUtils", () => {
       guid: 2,
       id: 2,
       name: "Data",
-      title: "Data",
+      title: "Parents/Children",
       type: "DG.DataContext",
       contextStorage: {
         _links_: {

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
@@ -73,7 +73,7 @@ describe("DataInteractive DataContextHandler", () => {
       // There is also an id field, but that is harder to test.
       expect(result.values).toMatchObject({
         name: "https://example.com/",
-        title: "https://example.com/"
+        title: "Cases"
       })
     })
   })

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -106,6 +106,10 @@ test("DataSet basic functionality", () => {
   dataset.setName("name")
   expect(dataset.name).toBe("name")
 
+  expect(dataset.title).toBe("Cases")
+  dataset.setTitle("title")
+  expect(dataset.title).toBe("title")
+
   expect(dataset.isInTransaction).toBe(false)
   dataset.beginTransaction()
   expect(dataset.isInTransaction).toBe(true)
@@ -399,6 +403,7 @@ test("hierarchical collection support", () => {
   expect(data.childCollection.name).toBe("Cases")
 
   const parentCollection = data.addCollection({ name: "ParentCollection" })
+  expect(data.title).toBe("ParentCollection/Cases")
   const parentCollectionId = parentCollection.id
   expect(data.collectionIds).toEqual([parentCollection.id, data.childCollection.id])
   expect(data.collections).toEqual([parentCollection, data.childCollection])

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -288,6 +288,9 @@ export const DataSet = V2Model.named("DataSet").props({
   return snap
 })
 .views(self => ({
+  get defaultTitle() {
+    return self.collections.map(collection => collection.name).join("/")
+  },
   isItemSetAside(itemId: string) {
     return self.setAsideItemIdsSet.has(itemId)
   },
@@ -296,6 +299,9 @@ export const DataSet = V2Model.named("DataSet").props({
   }
 }))
 .views(self => ({
+  get title() {
+    return self._title || self.defaultTitle || self.name
+  },
   isItemHidden(itemId: string) {
     return self.isItemSetAside(itemId) || self.isItemFilteredOut(itemId)
   }

--- a/v3/src/models/formula/formula-manager.test.ts
+++ b/v3/src/models/formula/formula-manager.test.ts
@@ -4,7 +4,7 @@ import { DataSet, IDataSet } from "../data/data-set"
 import { createDataSet } from "../data/data-set-conversion"
 import { Formula, IFormula } from "./formula"
 import { FormulaManager } from "./formula-manager"
-import { CASE_INDEX_FAKE_ATTR_ID, localAttrIdToCanonical } from "./utils/name-mapping-utils"
+import { CASE_INDEX_FAKE_ATTR_ID, idToCanonical, localAttrIdToCanonical } from "./utils/name-mapping-utils"
 import { AttributeFormulaAdapter } from "./attribute-formula-adapter"
 
 const formulaDisplay = "1 + 2 + foo"
@@ -185,11 +185,19 @@ describe("FormulaManager", () => {
   describe("getDisplayNameMap", () => {
     it("retrieves formula context and calculates display name map", () => {
       const { manager, formula, dataSet } = getManagerWithFakeAdapter()
+      const attrId = dataSet.attrFromName("foo")?.id || ""
       expect(manager.getDisplayNameMap(formula.id)).toEqual({
-        dataSet: {},
+        dataSet: {
+          Cases: {
+            attribute: {
+              foo: idToCanonical(attrId)
+            },
+            id: idToCanonical(dataSet.id)
+          }
+        },
         localNames: {
           caseIndex: localAttrIdToCanonical(CASE_INDEX_FAKE_ATTR_ID),
-          foo: localAttrIdToCanonical(dataSet.attrFromName("foo")?.id || ""),
+          foo: localAttrIdToCanonical(attrId),
         }
       })
     })
@@ -198,9 +206,12 @@ describe("FormulaManager", () => {
   describe("getCanonicalNameMap", () => {
     it("retrieves formula context and calculates canonical name map", () => {
       const { manager, formula, dataSet } = getManagerWithFakeAdapter()
+      const attrId = dataSet.attrFromName("foo")?.id || ""
       expect(manager.getCanonicalNameMap(formula.id)).toEqual({
+        [idToCanonical(attrId)]: "foo",
+        [idToCanonical(dataSet.id)]: "Cases",
         [localAttrIdToCanonical(CASE_INDEX_FAKE_ATTR_ID)]: "caseIndex",
-        [localAttrIdToCanonical(dataSet.attrFromName("foo")?.id || "")]: "foo"
+        [localAttrIdToCanonical(attrId)]: "foo"
       })
     })
   })

--- a/v3/src/models/formula/formula-manager.test.ts
+++ b/v3/src/models/formula/formula-manager.test.ts
@@ -36,7 +36,7 @@ const Container = types.model("Container", {
 
 const getManagerWithFakeAdapter = () => {
   const formulaManager = new FormulaManager()
-  const dataSet = createDataSet({ attributes: [{ name: "foo" }] })
+  const dataSet = createDataSet({ name: "Cases", attributes: [{ name: "foo" }] })
   const formula = Formula.create({ display: formulaDisplay })
   Container.create({
     dataSet: castToSnapshot(dataSet),

--- a/v3/src/models/formula/utils/name-mapping-utils.ts
+++ b/v3/src/models/formula/utils/name-mapping-utils.ts
@@ -69,19 +69,17 @@ export const getDisplayNameMap = (options: IDisplayNameMapOptions, useSafeSymbol
   displayNameMap.localNames.caseIndex = localAttrIdToCanonical(CASE_INDEX_FAKE_ATTR_ID)
 
   dataSets.forEach(dataSet => {
-    if (dataSet.title) {
-      // No LOCAL_ATTR prefix is necessary for external attributes. They always need to be resolved manually by custom
-      // mathjs functions (like "lookupByIndex"). Also, it's never necessary to use safe names, as these names
-      // are string constants, not symbols, so MathJS will not care about special characters there.
-      const dataSetKey = key(dataSet.title, false)
-      displayNameMap.dataSet[dataSetKey] = {
-        id: idToCanonical(dataSet.id),
-        attribute: {}
-      }
-      dataSet.attributes.forEach(attr => {
-        displayNameMap.dataSet[dataSetKey].attribute[key(attr.name, false)] = idToCanonical(attr.id)
-      })
+    // No LOCAL_ATTR prefix is necessary for external attributes. They always need to be resolved manually by custom
+    // mathjs functions (like "lookupByIndex"). Also, it's never necessary to use safe names, as these names
+    // are string constants, not symbols, so MathJS will not care about special characters there.
+    const dataSetKey = key(dataSet.name, false)
+    displayNameMap.dataSet[dataSetKey] = {
+      id: idToCanonical(dataSet.id),
+      attribute: {}
     }
+    dataSet.attributes.forEach(attr => {
+      displayNameMap.dataSet[dataSetKey].attribute[key(attr.name, false)] = idToCanonical(attr.id)
+    })
   })
 
   return displayNameMap


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/CODAP-643

This PR makes dataset titles follow the pattern set in v2. Specifically, if a dataset doesn't have an explicit title, its title is its collection names joined by "/"s. A dataset's name is only used if it has no collections, which I think can never happen.

This change broke a few tests which helped me uncover some minor bugs:
- Datasets created with the new table menu option now have titles. This matches v2 behavior.
- Updating the name via the Dataset Information form now updates the title instead of the name.
- The formula engine uses dataset names instead of titles for keys.