### PR TITLE
CODAP-682 Masks not being updated when cases are hidden

### DIFF
--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -145,7 +145,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           return
         }
         callMatchCirclesToData()
-        callRefreshPointPositions()
+        callRefreshPointPositions({ updateMasks: true })
       }, {name: "respondToHiddenCasesChange"}, dataConfiguration
     )
     return () => disposer()


### PR DESCRIPTION
[#CODAP-682] Bug fix: Graph: half the nodes (dots) were cut off when “set aside”

[#CODAP-716] Bug fix: Dot plot refresh issue when hiding cases

[#CODAP-698] Bug fix: Graph: hiding (Hide Selected Cases) marquee-selected nodes/points in the graph also hides other unselected nodes/points

* These three bugs are duplicates, fixed by setting `updateMasks` to true when calling `callRefreshPointPositions` in `respondToHiddenCasesChange` in use-plot.ts