### PR TITLE
CODAP-689 Box plot not displaying when it should

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
@@ -64,8 +64,7 @@ export const BoxPlotAdornmentModel = UnivariateMeasureAdornmentModel
     getQuantileValue(quantile: 25 | 75, caseValues: number[]) {
       const sortedCaseValues = caseValues.sort((a, b) => a - b)
       const quantileValue = quantileOfSortedArray(sortedCaseValues, quantile / 100)
-      // eslint-disable-next-line eqeqeq
-      return quantileValue == undefined ? NaN : quantileValue
+      return quantileValue == null ? NaN : quantileValue
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
@@ -64,7 +64,8 @@ export const BoxPlotAdornmentModel = UnivariateMeasureAdornmentModel
     getQuantileValue(quantile: 25 | 75, caseValues: number[]) {
       const sortedCaseValues = caseValues.sort((a, b) => a - b)
       const quantileValue = quantileOfSortedArray(sortedCaseValues, quantile / 100)
-      return quantileValue || NaN
+      // eslint-disable-next-line eqeqeq
+      return quantileValue == undefined ? NaN : quantileValue
     }
   }))
   .views(self => ({


### PR DESCRIPTION
[#CODAP-689] Bug fix: Graph: with box plots turned on, when changing the x-axis attribute, box plots were not displayed correctly (missing for some categories on the y axis)

* Simple logic error where we were allowing zero to masquerade as undefined