### PR TITLE
feat: use floating-ui to maintain position of resize borders

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -20,7 +20,7 @@
         "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@concord-consortium/slate-editor": "^0.10.1",
         "@dnd-kit/core": "^6.3.1",
-        "@floating-ui/react": "^0.27.5",
+        "@floating-ui/react": "^0.27.12",
         "@lezer/common": "^1.2.3",
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.2",
@@ -4205,12 +4205,12 @@
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.5.tgz",
-      "integrity": "sha512-BX3jKxo39Ba05pflcQmqPPwc0qdNsdNi/eweAFtoIdrJWNen2sVEWMEac3i6jU55Qfx+lOcdMNKYn2CtWmlnOQ==",
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.12.tgz",
+      "integrity": "sha512-kKlWNrpIQxF1B/a2MZvE0/uyKby4960yjO91W7nVyNKmmfNi62xU9HCjL1M1eWzx/LFj/VPSwJVbwQk9Pq/68A==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/react-dom": "^2.1.3",
         "@floating-ui/utils": "^0.2.9",
         "tabbable": "^6.0.0"
       },
@@ -4220,9 +4220,9 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.3.tgz",
+      "integrity": "sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
@@ -28160,19 +28160,19 @@
       }
     },
     "@floating-ui/react": {
-      "version": "0.27.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.5.tgz",
-      "integrity": "sha512-BX3jKxo39Ba05pflcQmqPPwc0qdNsdNi/eweAFtoIdrJWNen2sVEWMEac3i6jU55Qfx+lOcdMNKYn2CtWmlnOQ==",
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.12.tgz",
+      "integrity": "sha512-kKlWNrpIQxF1B/a2MZvE0/uyKby4960yjO91W7nVyNKmmfNi62xU9HCjL1M1eWzx/LFj/VPSwJVbwQk9Pq/68A==",
       "requires": {
-        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/react-dom": "^2.1.3",
         "@floating-ui/utils": "^0.2.9",
         "tabbable": "^6.0.0"
       }
     },
     "@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.3.tgz",
+      "integrity": "sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==",
       "requires": {
         "@floating-ui/dom": "^1.0.0"
       }

--- a/v3/package.json
+++ b/v3/package.json
@@ -204,7 +204,7 @@
     "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
     "@concord-consortium/slate-editor": "^0.10.1",
     "@dnd-kit/core": "^6.3.1",
-    "@floating-ui/react": "^0.27.5",
+    "@floating-ui/react": "^0.27.12",
     "@lezer/common": "^1.2.3",
     "@lezer/highlight": "^1.2.1",
     "@lezer/lr": "^1.4.2",

--- a/v3/src/components/codap-component.scss
+++ b/v3/src/components/codap-component.scss
@@ -29,23 +29,14 @@ $corner-drag-size: calc($border-drag-width * 2);
   z-index: 11;
   touch-action: none;
   &.right {
-    bottom: $corner-drag-size;
-    right: 0;
-    top: vars.$title-bar-height;
     width: $border-drag-width;
     cursor: e-resize;
   }
   &.bottom {
-    bottom: 0;
-    right: $corner-drag-size;
-    left: $corner-drag-size;
     height: $border-drag-width;
     cursor: s-resize;
   }
   &.left {
-    bottom: $corner-drag-size;
-    left: 0;
-    top: vars.$title-bar-height;
     width: $border-drag-width;
     cursor: w-resize;
   }

--- a/v3/src/components/component-resize-border.tsx
+++ b/v3/src/components/component-resize-border.tsx
@@ -1,47 +1,55 @@
+import { autoUpdate, offset, size, useFloating } from "@floating-ui/react"
 import { clsx } from "clsx"
-import React from "react"
-import { kResizeBorderOverlap, kResizeBorderSize, kResizeHandleSize, kTitleBarHeight } from "./constants"
+import React, { useEffect } from "react"
+import { kResizeBorderOverlap } from "./constants"
 
 interface IProps {
-  componentRef: React.RefObject<HTMLDivElement | null>
-  containerRef: React.RefObject<HTMLElement | null>
+  componentRef: React.RefObject<HTMLElement | null>
   edge: "left" | "right" | "bottom"
   onPointerDown?: (e: React.PointerEvent<HTMLDivElement>) => void
 }
 
-export function ComponentResizeBorder({ componentRef, containerRef, edge, onPointerDown }: IProps) {
-  let top = 0
-  let left = 0
-  let width: Maybe<number>
-  let height: Maybe<number>
+export function ComponentResizeBorder({ componentRef, edge, onPointerDown }: IProps) {
 
-  const componentBounds = componentRef.current?.getBoundingClientRect()
-  const containerBounds = containerRef.current?.getBoundingClientRect()
-  if (componentBounds && containerBounds) {
-    switch (edge) {
-      case "left":
-        top = componentBounds.top - containerBounds.top + kTitleBarHeight
-        left = componentBounds.left - containerBounds.left - kResizeBorderSize + kResizeBorderOverlap
-        height = componentBounds.height - kTitleBarHeight
-        break
-      case "right":
-        top = componentBounds.top - containerBounds.top + kTitleBarHeight
-        left = componentBounds.right - containerBounds.left - kResizeBorderOverlap
-        height = componentBounds.height - kTitleBarHeight - kResizeHandleSize
-        break
-      case "bottom":
-        top = componentBounds.bottom - containerBounds.top - kResizeBorderOverlap
-        left = componentBounds.left - containerBounds.left
-        width = componentBounds.width - kResizeHandleSize
+  // Use floating-ui for positioning
+  const { elements: { reference }, refs: { setFloating, setReference }, floatingStyles, update } = useFloating({
+    placement: edge,
+    open: true,
+    middleware: [
+      offset(-kResizeBorderOverlap),
+      size({
+        apply({ rects, elements }) {
+          if (edge === "bottom") {
+            Object.assign(elements.floating.style, {
+              width: `${rects.reference.width}px`,
+            })
+          }
+          else {
+            Object.assign(elements.floating.style, {
+              height: `${rects.reference.height}px`,
+            })
+          }
+        },
+      })
+    ],
+    whileElementsMounted: autoUpdate
+  })
+
+  // Attach the reference ref to your component
+  useEffect(() => {
+    if (componentRef.current && reference !== componentRef.current) {
+      setReference(componentRef.current)
     }
-  }
+    // Note: explicit update shouldn't be required, but without it the border would track
+    // tile resizes correctly but not tile moves.
+    update()
+  })
 
   if (!onPointerDown) return null
 
   const classes = clsx("codap-component-border", edge)
-  const style: React.CSSProperties = { left, top, width, height }
 
   return (
-    <div className={classes} style={style} onPointerDown={onPointerDown}/>
+    <div ref={setFloating} className={classes} style={floatingStyles} onPointerDown={onPointerDown}/>
   )
 }

--- a/v3/src/components/container/component-resize-widgets.tsx
+++ b/v3/src/components/container/component-resize-widgets.tsx
@@ -1,7 +1,6 @@
 import { Portal } from "@chakra-ui/react"
-import React, { useCallback, useEffect } from "react"
+import React, { useCallback } from "react"
 import ResizeHandle from "../../assets/icons/icon-corner-resize-handle.svg"
-import { useForceUpdate } from "../../hooks/use-force-update"
 import { useTileContainerContext } from "../../hooks/use-tile-container-context"
 import { IFreeTileLayout } from "../../models/document/free-tile-row"
 import { ITileModel } from "../../models/tiles/tile-model"
@@ -19,7 +18,6 @@ interface IProps {
 export function ComponentResizeWidgets(props: IProps) {
   const { tile, tileLayout, componentRef, isFixedWidth, isFixedHeight, handleResizePointerDown } = props
   const containerRef = useTileContainerContext()
-  const forceUpdate = useForceUpdate()
 
   const handleBottomRightPointerDown = useCallback((e: React.PointerEvent) => {
     tileLayout && handleResizePointerDown(e, tileLayout, "bottom-right")
@@ -41,23 +39,15 @@ export function ComponentResizeWidgets(props: IProps) {
     tileLayout && handleResizePointerDown(e, tileLayout, "left")
   }, [handleResizePointerDown, tileLayout])
 
-  useEffect(() => {
-    // trigger an initial re-render to ensure resize widgets are positioned correctly
-    forceUpdate()
-  }, [forceUpdate])
-
   return (
     <>
       <Portal containerRef={containerRef}>
         {!isFixedWidth &&
-          <ComponentResizeBorder edge="left" onPointerDown={handleLeftPointerDown}
-              componentRef={componentRef} containerRef={containerRef} />}
+          <ComponentResizeBorder edge="left" onPointerDown={handleLeftPointerDown} componentRef={componentRef} />}
         {!isFixedWidth &&
-          <ComponentResizeBorder edge="right" onPointerDown={handleRightPointerDown}
-              componentRef={componentRef} containerRef={containerRef} />}
+          <ComponentResizeBorder edge="right" onPointerDown={handleRightPointerDown} componentRef={componentRef} />}
         {!isFixedHeight &&
-          <ComponentResizeBorder edge="bottom" onPointerDown={handleBottomPointerDown}
-              componentRef={componentRef} containerRef={containerRef} />}
+          <ComponentResizeBorder edge="bottom" onPointerDown={handleBottomPointerDown} componentRef={componentRef} />}
       </Portal>
       {!(isFixedWidth && isFixedHeight) &&
         <div className="codap-component-corner bottom-left" onPointerDown={handleBottomLeftPointerDown}/>


### PR DESCRIPTION
[[CODAP-752](https://concord-consortium.atlassian.net/browse/CODAP-752)] Tile border resize handles sometimes inaccessible

My previous attempt (#1991 ) solved the initial render problem but didn't track animating tiles properly (e.g. tiles created from the tool shelf which then animated into position). To fix the tracking problem, we switch from a bespoke implementation to one that uses `floating-ui`.


[CODAP-752]: https://concord-consortium.atlassian.net/browse/CODAP-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ