### PR TITLE
CODAP-681 Long categories need truncation on axes

### DIFF
--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -1,6 +1,7 @@
 import {ScaleLinear} from "d3"
 import {MutableRefObject} from "react"
 import { determineLevels } from "../../utilities/date-utils"
+import vars from "../vars.scss"
 import {measureText, measureTextExtent} from "../../hooks/use-measure-text"
 import {ICategorySet} from "../../models/data/category-set"
 import { kAxisGap, kAxisTickLength, kDefaultFontHeight } from "./axis-constants"
@@ -11,6 +12,27 @@ import { GraphLayout } from "../graph/models/graph-layout"
 
 export const getStringBounds = (s = 'Wy', font = kDataDisplayFont) => {
   return measureTextExtent(s, font)
+}
+
+export const elideStringToFit = (s: string, maxWidth: number, font = kDataDisplayFont) => {
+  const bounds = measureTextExtent(s, font)
+  if (bounds.width <= maxWidth) return s
+
+  const ellipsis = '…'
+  const ellipsisWidth = measureTextExtent(ellipsis, font).width
+  const avgCharWidth = bounds.width / s.length
+  const extraLength = 5 // extra chars so we don't cut off too early
+  const estimatedLength = Math.floor((maxWidth - ellipsisWidth) / avgCharWidth) + extraLength
+
+  let ellidedString = s.slice(0, estimatedLength)
+  let currentWidth = measureTextExtent(ellidedString + ellipsis, font).width
+
+  while (currentWidth > maxWidth && ellidedString.length > 0) {
+    ellidedString = ellidedString.slice(0, -1)
+    currentWidth = measureTextExtent(ellidedString + ellipsis, font).width
+  }
+
+  return ellidedString + ellipsis
 }
 
 interface ICollisionProps {
@@ -155,7 +177,7 @@ export const getCoordFunctions = (props: IGetCoordFunctionsProps): ICoordFunctio
     rangeMin, rangeMax, subAxisLength,
     isRightCat, isTop, dragInfo} = props,
     bandWidth = subAxisLength / numCategories,
-    labelTextHeight = getStringBounds('12px sans-serif').height,
+    labelTextHeight = getStringBounds(vars.labelFont).height,
     indexOffset = centerCategoryLabels ? 0.5 : 0/*(axisIsVertical ? 1 : 0)*/,
     dI = dragInfo.current
   let labelXOffset = 0, labelYOffset = 0

--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -24,15 +24,15 @@ export const elideStringToFit = (s: string, maxWidth: number, font = kDataDispla
   const extraLength = 5 // extra chars so we don't cut off too early
   const estimatedLength = Math.floor((maxWidth - ellipsisWidth) / avgCharWidth) + extraLength
 
-  let ellidedString = s.slice(0, estimatedLength)
-  let currentWidth = measureTextExtent(ellidedString + ellipsis, font).width
+  let elidedString = s.slice(0, estimatedLength)
+  let currentWidth = measureTextExtent(elidedString + ellipsis, font).width
 
-  while (currentWidth > maxWidth && ellidedString.length > 0) {
-    ellidedString = ellidedString.slice(0, -1)
-    currentWidth = measureTextExtent(ellidedString + ellipsis, font).width
+  while (currentWidth > maxWidth && elidedString.length > 0) {
+    elidedString = elidedString.slice(0, -1)
+    currentWidth = measureTextExtent(elidedString + ellipsis, font).width
   }
 
-  return ellidedString + ellipsis
+  return elidedString + ellipsis
 }
 
 interface ICollisionProps {

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -149,6 +149,8 @@ export const useAxis = (axisPlace: AxisPlace) => {
   useEffect(() => {
     return mstAutorun(() => {
       layout.setDesiredExtent(axisPlace, computeDesiredExtent())
+      // detect changes to computed bounds
+      layout.getComputedBounds(axisPlace)
     }, {name: "useAxis.mstAutorun [setDesiredExtent]"}, axisModel)
   }, [axisModel, layout, axisPlace, computeDesiredExtent])
 }

--- a/v3/src/components/axis/models/axis-layout-context.ts
+++ b/v3/src/components/axis/models/axis-layout-context.ts
@@ -8,7 +8,6 @@ export interface IAxisLayout {
 
   // actual bounds of DOM element
   getAxisBounds: (place: AxisPlace) => AxisBounds | undefined
-  setAxisBounds: (place: AxisPlace, bounds?: AxisBounds) => void
 
   getAxisMultiScale: (place: AxisPlace) => MultiScale | undefined
   getAxisScale: (place: AxisPlace) => AxisScaleType | undefined
@@ -23,7 +22,6 @@ const nullAxisLayout: IAxisLayout = {
   setTileExtent: () => undefined,
   getAxisLength: () => 0,
   getAxisBounds: () => undefined,
-  setAxisBounds: () => undefined,
   getAxisMultiScale: () => undefined,
   getAxisScale: () => undefined,
   setAxisScaleType: () => undefined,

--- a/v3/src/components/axis/models/axis-layout-context.ts
+++ b/v3/src/components/axis/models/axis-layout-context.ts
@@ -16,6 +16,8 @@ export interface IAxisLayout {
   // desired/computed bounds via model
   getComputedBounds: (place: AxisPlace) => AxisBounds | undefined
   setDesiredExtent: (place: AxisPlace, extent: number) => void
+
+  getDesiredExtent: (place: AxisPlace) => number
 }
 
 const nullAxisLayout: IAxisLayout = {
@@ -26,7 +28,8 @@ const nullAxisLayout: IAxisLayout = {
   getAxisScale: () => undefined,
   setAxisScaleType: () => undefined,
   getComputedBounds: () => undefined,
-  setDesiredExtent: () => undefined
+  setDesiredExtent: () => undefined,
+  getDesiredExtent: () => 0
 }
 
 export const AxisLayoutContext = createContext(nullAxisLayout)

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -1,4 +1,6 @@
 import {action, computed, makeObservable, observable, override} from "mobx"
+import { measureTextExtent } from "../../../hooks/use-measure-text"
+import vars from "../../vars.scss"
 import {AxisPlace, AxisPlaces, AxisBounds, IScaleType} from "../../axis/axis-types"
 import {isVertical} from "../../axis-graph-shared"
 import {IAxisLayout} from "../../axis/models/axis-layout-context"
@@ -87,6 +89,20 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
   }
 
   @override setDesiredExtent(place: GraphExtentsPlace, extent: number) {
+    const labelHeight = measureTextExtent('Xy', vars.labelFont).height
+    switch (place) {
+      case 'left':
+      case 'rightNumeric':
+      case 'rightCat': {
+        extent = Math.min(extent, labelHeight + this.tileWidth / 3) // Maximum width for axis
+        break
+      }
+      case 'top':
+      case 'bottom': {
+        extent = Math.min(extent, labelHeight + this.tileHeight / 3) // Maximum height for axis
+        break
+      }
+    }
     this.desiredExtents.set(place, extent)
     this.updateScaleRanges(this.plotWidth, this.plotHeight)
   }

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -48,38 +48,6 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
     return this.axisBounds.get(place)
   }
 
-  @action setAxisBounds(place: AxisPlace, bounds: AxisBounds | undefined) {
-    if (bounds) {
-      // We allow the axis to draw gridlines for bivariate numeric plots. Unfortunately, the gridlines end up as
-      // part of the axis dom element so that we get in here with bounds that span the entire width or height of
-      // the plot. We tried workarounds to get gridlines that were _not_ part of the axis element with the result
-      // that the gridlines got out of sync with axis tick marks during drag. So we have this inelegant solution
-      // that shouldn't affect the top and right axes when we get them but it may be worthwhile to
-      // (TODO) figure out if there's a better way to render gridlines on background (or plot) so this isn't necessary.
-
-      // given state of the graph, we may need to adjust the drop areas' bounds
-      const newBounds = bounds
-      const legendHeight = this.getDesiredExtent('legend')
-
-      if (place === "bottom") {
-        newBounds.height = Math.min(bounds.height, this.tileHeight - this.getAxisLength('left') - legendHeight)
-        newBounds.top = this.plotHeight
-      }
-
-      if (place === "left") {
-        newBounds.height = Math.min(bounds.height, this.tileHeight - legendHeight)
-        // if gridlines are present, axis will grow to .width + plotWidth, so we recalculate
-        if (bounds.width > this.plotWidth) {
-          newBounds.width -= this.plotWidth
-        }
-      }
-
-      this.axisBounds.set(place, newBounds)
-    } else {
-      this.axisBounds.delete(place)
-    }
-  }
-
   getAxisMultiScale(place: AxisPlace) {
     return this.axisScales.get(place) ??
       new MultiScale({scaleType: "ordinal", orientation: "horizontal"})

--- a/v3/src/components/slider/slider-layout.ts
+++ b/v3/src/components/slider/slider-layout.ts
@@ -30,10 +30,6 @@ export class SliderAxisLayout implements IAxisLayout {
     return this.axisBounds
   }
 
-  @action setAxisBounds(place: AxisPlace, bounds?: AxisBounds) {
-    this.axisBounds = bounds
-  }
-
   getAxisMultiScale(place: AxisPlace) {
     return this.axisMultiScale
   }

--- a/v3/src/components/slider/slider-layout.ts
+++ b/v3/src/components/slider/slider-layout.ts
@@ -47,6 +47,10 @@ export class SliderAxisLayout implements IAxisLayout {
     this.desiredExtent = extent
   }
 
+  getDesiredExtent(place: AxisPlace) {
+    return this.desiredExtent ?? kDefaultSliderAxisHeight
+  }
+
   getComputedBounds(place: AxisPlace) {
     return {
       left: 0,


### PR DESCRIPTION
[#CODAP-681] Bug fix: Graph: sometimes the axis labels are so long in a graph that the graph itself cannot be displayed

* `GraphLayout.setAxisBounds` removed because it is not being called.
* Add `getDesiredExtent` to layout classes to use to determine how much to elide category labels
* Provide `elideStringToFit` for elision of category labels
* In `GraphLayout.setDesiredExtent` limit extent of axes so that categorical labels don't consume too much space
* in `use-axis.ts` make the axis responsive to changes in graph bounds