### PR TITLE
CODAP-757 Fix categorical axis labeling bug

### DIFF
--- a/v3/src/components/axis/helper-models/categorical-axis-helper.ts
+++ b/v3/src/components/axis/helper-models/categorical-axis-helper.ts
@@ -132,7 +132,10 @@ export class CategoricalAxisHelper extends AxisHelper {
               .attr('class', 'category-label')
               .attr('x', (d, i) => fns.getLabelX(i))
               .attr('y', (d, i) => fns.getLabelY(i))
-              .text((d: CatObject, i) => elideStringToFit(String(categories[i]), maxCategoryLabelExtent))
+              .text((d: CatObject, i) => {
+                return collision ? elideStringToFit(String(categories[i]), maxCategoryLabelExtent)
+                  : categories[i]
+              })
             }
           return update
         }


### PR DESCRIPTION
[#CODAP-757] Bug fix: Short category labels on graph axes only show up as "…"

* A previous commit made the mistaken assumption that all category labels on graph axes needed to be elided. But, in fact, only in those situations in which there is a "collision" of labels so that the labels are oriented perpendicular to the axis, does elision need to be considered. (Elision will only take place, of course, if there is insufficient room for the label.)