### PR TITLE
Codap-696 Export Graphs as SVG

### DIFF
--- a/v3/src/components/data-display/models/data-display-render-state.ts
+++ b/v3/src/components/data-display/models/data-display-render-state.ts
@@ -1,21 +1,18 @@
-import { graphSnapshot } from "../../graph/utilities/image-utils"
+import { graphSnapshot, IGraphSvgOptions } from "../../graph/utilities/image-utils"
 import { PixiPointsArray } from "../pixi/pixi-points"
 
 export class DataDisplayRenderState {
   pixiPointsArray: PixiPointsArray
   displayElement: HTMLElement
-  getTitle?: (() => string | undefined)
   dataUri?: string
 
   constructor(
     pixiPointsArray: PixiPointsArray,
     displayElement: HTMLElement,
-    getTitle?: () => string,
     dataUri?: string
   ) {
     this.pixiPointsArray = pixiPointsArray
     this.displayElement = displayElement
-    this.getTitle = getTitle
     this.dataUri = dataUri
   }
 
@@ -23,22 +20,25 @@ export class DataDisplayRenderState {
     this.dataUri = dataUri
   }
 
-  async updateSnapshot() {
-    const title = this.getTitle?.() || ""
+  get imageOptions(): IGraphSvgOptions | undefined {
     const pixiPoints = this.pixiPointsArray?.[0]
     if (!this.displayElement || !pixiPoints) return
 
     const width = this.displayElement.getBoundingClientRect().width ?? 0
     const height = this.displayElement.getBoundingClientRect().height ?? 0
-    const svgElementsToImageOptions = {
+    return {
       rootEl: this.displayElement,
       graphWidth: width,
       graphHeight: height,
-      graphTitle: title,
-      asDataURL: true,
       pixiPoints
     }
-    const graphImage = await graphSnapshot(svgElementsToImageOptions)
+  }
+
+  async updateSnapshot() {
+    const { imageOptions } = this
+    if (!imageOptions) return
+
+    const graphImage = await graphSnapshot({ ...imageOptions, asDataURL: true })
     const dataUri = typeof graphImage === "string" ? graphImage : undefined
     if (dataUri) {
       this.setDataUri(dataUri)

--- a/v3/src/components/graph/components/camera-menu-list.tsx
+++ b/v3/src/components/graph/components/camera-menu-list.tsx
@@ -69,10 +69,7 @@ export const CameraMenuList = () => {
     const svgString = graphSvg(imageOptions)
 
     if (svgString) {
-      // const svgBlob = new Blob([svgString], { type: "image/svg+xml" })
-      // const svgUrl = URL.createObjectURL(svgBlob)
-      // cfm?.client.saveSecondaryFileAsDialog(svgUrl, "svg", "image/svg+xml", () => null)
-      cfm?.client.saveSecondaryFileAsDialog(svgString, "svg", "image/svg+xml", () => null)
+      cfm?.client.saveSecondaryFileAsDialog(svgString, "svg", "text/plain", () => null)
     }
   }
 

--- a/v3/src/components/graph/components/camera-menu-list.tsx
+++ b/v3/src/components/graph/components/camera-menu-list.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react"
 import { MenuItem, MenuList, useToast } from "@chakra-ui/react"
-import { t } from "../../../utilities/translation/translate"
-import { useTileModelContext } from "../../../hooks/use-tile-model-context"
-import { isGraphContentModel } from "../models/graph-content-model"
 import { useCfmContext } from "../../../hooks/use-cfm-context"
+import { useTileModelContext } from "../../../hooks/use-tile-model-context"
+import { t } from "../../../utilities/translation/translate"
+import { isGraphContentModel } from "../models/graph-content-model"
+import { graphSvg } from "../utilities/image-utils"
 
 export const CameraMenuList = () => {
   const tile = useTileModelContext().tile
@@ -60,7 +61,19 @@ export const CameraMenuList = () => {
   }
 
   const handleExportSVG = () => {
-    handleMenuItemClick("Export SVG Image clicked")
+    if (!graphModel?.renderState) return
+
+    const { imageOptions } = graphModel.renderState
+    if (!imageOptions) return
+
+    const svgString = graphSvg(imageOptions)
+
+    if (svgString) {
+      // const svgBlob = new Blob([svgString], { type: "image/svg+xml" })
+      // const svgUrl = URL.createObjectURL(svgBlob)
+      // cfm?.client.saveSecondaryFileAsDialog(svgUrl, "svg", "image/svg+xml", () => null)
+      cfm?.client.saveSecondaryFileAsDialog(svgString, "svg", "image/svg+xml", () => null)
+    }
   }
 
   return (

--- a/v3/src/components/graph/components/camera-menu-list.tsx
+++ b/v3/src/components/graph/components/camera-menu-list.tsx
@@ -66,6 +66,8 @@ export const CameraMenuList = () => {
     const { imageOptions } = graphModel.renderState
     if (!imageOptions) return
 
+    // TODO: The current strategy for turning a graph into an SVG involves wrapping the whole tile in a foreignObject,
+    // which will not render in Word, Notes, etc.
     const svgString = graphSvg(imageOptions)
 
     if (svgString) {

--- a/v3/src/components/graph/components/graph-component.tsx
+++ b/v3/src/components/graph/components/graph-component.tsx
@@ -8,7 +8,6 @@ import { registerTileCollisionDetection } from "../../../lib/dnd-kit/dnd-detect-
 import { useDataSet } from '../../../hooks/use-data-set'
 import { DataSetContext } from '../../../hooks/use-data-set-context'
 import { InstanceIdContext, useNextInstanceId } from "../../../hooks/use-instance-id-context"
-import { getTitle } from '../../../models/tiles/tile-content-info'
 import { AxisProviderContext } from '../../axis/hooks/use-axis-provider-context'
 import { AxisLayoutContext } from "../../axis/models/axis-layout-context"
 import { kTitleBarHeight } from "../../constants"
@@ -31,7 +30,6 @@ registerTileCollisionDetection(kGraphIdBase, graphCollisionDetection)
 
 export const GraphComponent = observer(function GraphComponent({tile}: ITileBaseProps) {
   const graphModel = isGraphContentModel(tile?.content) ? tile?.content : undefined
-  const title = (tile && getTitle?.(tile)) || tile?.title || ""
   const instanceId = useNextInstanceId("graph")
   const {data} = useDataSet(graphModel?.dataset)
   const layout = useInitGraphLayout(graphModel)
@@ -54,12 +52,12 @@ export const GraphComponent = observer(function GraphComponent({tile}: ITileBase
   const setGraphRef = useCallback((ref: HTMLDivElement | null) => {
     graphRef.current = ref
     const elementParent = ref?.parentElement
-    const dataUri = graphModel?.renderState?.dataUri ?? undefined
+    const dataUri = graphModel?.renderState?.dataUri
     if (elementParent) {
-      const renderState = new DataDisplayRenderState(pixiPointsArray, elementParent, () => title, dataUri)
+      const renderState = new DataDisplayRenderState(pixiPointsArray, elementParent, dataUri)
       graphModel?.setRenderState(renderState)
     }
-  }, [graphModel, pixiPointsArray, title])
+  }, [graphModel, pixiPointsArray])
 
   useEffect(() => {
     (width != null) && width >= 0 && (height != null) &&

--- a/v3/src/components/graph/utilities/image-utils.ts
+++ b/v3/src/components/graph/utilities/image-utils.ts
@@ -14,7 +14,7 @@ const disallowedElementClasses = new Set([
   "header-right",
 ])
 
-interface IGraphSvgOptions {
+export interface IGraphSvgOptions {
   rootEl: HTMLElement
   graphWidth: number
   graphHeight: number

--- a/v3/src/components/graph/utilities/image-utils.ts
+++ b/v3/src/components/graph/utilities/image-utils.ts
@@ -107,7 +107,7 @@ export function graphSvg({ rootEl, graphWidth, graphHeight, pixiPoints }: IGraph
 
   // Remove elements we don't want to include in the snapshot
   const isAllowedElement = (_element: Element): boolean => {
-    if (!(_element instanceof HTMLInputElement || _element instanceof HTMLTextAreaElement)) return true
+    if (_element instanceof HTMLInputElement || _element instanceof HTMLTextAreaElement) return false
     return Array.from(_element.classList).every((className) => !disallowedElementClasses.has(className))
   }
 


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/CODAP-696

This PR enables exporting graphs as SVGs. The bulk of this PR breaks apart recent work to render graphs as PNGs, reusing much of it to render an SVG.

Unfortunately, the current approach for creating SVGs involves wrapping the tile's HTML in a `foreignObject` element, and several applications commonly used to display these SVGs (Word, Notes, etc) will not render `foreignObjects`. Despite this glaring inadequacy, we plan on moving forward with this approach for the time being with the hope of fixing this problem sometime in the future.

Additional improvements in this PR:
- Title information was removed from function calls to export tile images, since the new algorithm includes the tile's title naturally.
- A bug in the function that determines if an element should be included in the exported image has been fixed. This bug was making it so no elements were ever removed. I'm not sure how this bug was introduced. It would be easy to miss if I didn't call it out here, because it's buried in the code that was shifted around without many other changes.