### PR TITLE
Improve performance with sampler plugin [CODAP-36]

### DIFF
--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -106,7 +106,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
 
   // match relation colors to grid colors via CSS variables
   useEffect(() => {
-    const newRelationColors = { ...kDefaultRelationColors}
+    const newRelationColors = { ...kDefaultRelationColors }
     const relationSelectedFillColor = getStringCssVariable(gridElt, "--rdg-row-selected-background-color")
     if (relationSelectedFillColor) {
       newRelationColors.selectedFill = relationSelectedFillColor

--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -106,7 +106,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
 
   // match relation colors to grid colors via CSS variables
   useEffect(() => {
-    const newRelationColors = { ...relationColors}
+    const newRelationColors = { ...kDefaultRelationColors}
     const relationSelectedFillColor = getStringCssVariable(gridElt, "--rdg-row-selected-background-color")
     if (relationSelectedFillColor) {
       newRelationColors.selectedFill = relationSelectedFillColor
@@ -120,7 +120,6 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
       newRelationColors.selectedStroke = relationSelectedStrokeColor
     }
     setRelationColors(newRelationColors)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gridElt])
 
   // use resize observer to track changes in the height of the spacer div
@@ -128,13 +127,14 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
     if (!tableSpacerDiv) return
 
     const resizeObserver = new ResizeObserver(entries => {
-      if (entries.length > 0 && entries[0].contentRect.height !== tableSpacerHeight) {
+      if (entries.length > 0 && entries[0].contentRect.height > 0) {
         setTableSpacerHeight(entries[0].contentRect.height)
       }
     })
     resizeObserver.observe(tableSpacerDiv)
+
     return () => resizeObserver.disconnect()
-  }, [tableSpacerDiv, tableSpacerHeight])
+  }, [tableSpacerDiv])
 
   if (!data || !parentCases) return null
 

--- a/v3/src/hooks/use-adjust-header-overflow.ts
+++ b/v3/src/hooks/use-adjust-header-overflow.ts
@@ -4,7 +4,7 @@ import { measureText } from './use-measure-text'
 const kPaddingBuffer = 5 // Button width is 5px smaller because of parent padding
 
 // Hook to split headers into 2 rows and elide the 2nd line if it doesn't fit
-export function useAdjustHeaderForOverflow(attrbuteHeaderButtonEl: HTMLButtonElement | null,
+export function useAdjustHeaderForOverflow(attributeHeaderButtonEl: HTMLButtonElement | null,
                                             attrName: string, attrUnits?: string) {
   const attributeName = attrName.replace(/_/g, ' ')
   const candidateAttributeLabel = `${attributeName}${attrUnits}`.trim()
@@ -29,23 +29,23 @@ export function useAdjustHeaderForOverflow(attrbuteHeaderButtonEl: HTMLButtonEle
   }
 
   const calculateSplit = () => {
-    if (!attrbuteHeaderButtonEl) {
+    if (!attributeHeaderButtonEl) {
       setLine1('')
       setLine2('')
       setIsOverflowed(false)
       return
     }
 
-    const attributeButtonWidth = attrbuteHeaderButtonEl.clientWidth - kPaddingBuffer
-    const computedStyle = getComputedStyle(attrbuteHeaderButtonEl)
+    const attributeButtonWidth = attributeHeaderButtonEl.clientWidth - kPaddingBuffer
+    const computedStyle = getComputedStyle(attributeHeaderButtonEl)
     const style = [
       `font-style:${computedStyle.fontStyle}`,
       `font-variant:${computedStyle.fontVariant}`,
       `font-weight:${computedStyle.fontWeight}`,
       `font-size:${computedStyle.fontSize}`,
       `font-family:${computedStyle.fontFamily}`,
-      `width:${attrbuteHeaderButtonEl.clientWidth}px`,
-      `height:${attrbuteHeaderButtonEl.clientHeight}px`
+      `width:${attributeHeaderButtonEl.clientWidth}px`,
+      `height:${attributeHeaderButtonEl.clientHeight}px`
     ].join('')
     const fullTextWidth = measureText(candidateAttributeLabel, style)
     const words = candidateAttributeLabel.split(' ')
@@ -85,17 +85,17 @@ export function useAdjustHeaderForOverflow(attrbuteHeaderButtonEl: HTMLButtonEle
   }
 
   useEffect(() => {
-    if (!attrbuteHeaderButtonEl) return
+    if (!attributeHeaderButtonEl) return
     resizeObserverRef.current = new ResizeObserver(() => {
       calculateSplit()
     })
-    resizeObserverRef.current.observe(attrbuteHeaderButtonEl)
+    resizeObserverRef.current.observe(attributeHeaderButtonEl)
     return () => {
       resizeObserverRef.current?.disconnect()
     }
   // Adding calculateSplit to dependencies causes rerender problems on attribute rename
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [candidateAttributeLabel, attrbuteHeaderButtonEl])
+  }, [candidateAttributeLabel, attributeHeaderButtonEl])
 
   useEffect(()=> {
     calculateSplit()

--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -303,8 +303,8 @@ describe("CollectionModel", () => {
 
     // serializes group key => case id map appropriately
     c1.prepareSnapshot()
-    const aGroupKey = '["a"]'
-    const bGroupKey = '["b"]'
+    const aGroupKey = '[a]'
+    const bGroupKey = '[b]'
     const aCaseId = c1.caseIds[0]
     const bCaseId = c1.caseIds[1]
     expect(c1._groupKeyCaseIds).toEqual([[aGroupKey, aCaseId], [bGroupKey, bCaseId]])

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -133,13 +133,11 @@ export const CollectionModel = V2Model
   groupKey(itemId: string) {
     // only parent collections group cases; child collections "group" by itemId
     if (!self.child) return itemId
-    const allValues = self.allDataAttributes.map(attr => self.itemData.getValue(itemId, attr.id))
-    return JSON.stringify(allValues)
+    return `[${self.allDataAttributes.map(attr => self.itemData.getValue(itemId, attr.id)).join("\t")}]`
   },
   parentGroupKey(itemId: string) {
     if (!self.parent) return
-    const allValues = self.sortedParentDataAttrs.map(attr => self.itemData.getValue(itemId, attr.id))
-    return JSON.stringify(allValues)
+    return `[${self.sortedParentDataAttrs.map(attr => self.itemData.getValue(itemId, attr.id)).join("\t")}]`
   },
   groupKeyCaseId(groupKey?: string) {
     if (!groupKey) return undefined


### PR DESCRIPTION
The major performance gains came with #1988. This PR incrementally improves performance further when running with the sampler plugin. Addresses three relatively small performance bottlenecks identified by the profiler:
- `CollectionModel` concatenates its own group key rather than calling `JSON.stringify()`
- `CollectionTableSpacer` uses `useEffect`s to retrieve/set information it requires rather than calling `getBoundingClientRect()` and `getStringCssVariable()` on every render.

The overall effect is relatively small, on the order of 15 to 14 seconds on importing 200 samples of 5 items in my test case. Unfortunately, v3 is still not as fast as v2 in this test, but this is a step in the right direction.

Also fixes an unrelated typo that I encountered along the way.