### PR TITLE
CODAP-725 Make DI Formula Engine Handler use Codap Custom Functions

### DIFF
--- a/v3/src/data-interactive/handlers/formula-engine-handler.test.ts
+++ b/v3/src/data-interactive/handlers/formula-engine-handler.test.ts
@@ -49,5 +49,13 @@ describe("formulaEngineHandler", () => {
     expect((diFormulaEngineHandler.notify?.({}, {
       request: "evalExpression", source: "π / a", records: [{ a: Math.PI }]
     }).values as any)?.[0]).toBeCloseTo(1)
+
+    // Make sure we're using our own custom functions (in mathjs, = is asignment, but we treat it as equality)
+    expect((diFormulaEngineHandler.notify?.({}, {
+      request: "evalExpression", source: "Sex = 'M'", records: [{ Sex: "F" }]
+    }).values as any)?.[0]).toBe(false)
+    expect((diFormulaEngineHandler.notify?.({}, {
+      request: "evalExpression", source: "Sex = 'F'", records: [{ Sex: "F" }]
+    }).values as any)?.[0]).toBe(true)
   })
 })

--- a/v3/src/data-interactive/handlers/formula-engine-handler.ts
+++ b/v3/src/data-interactive/handlers/formula-engine-handler.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "mathjs"
 import { math } from "../../models/formula/functions/math"
+import { displayToCanonical } from "../../models/formula/utils/canonicalization-utils"
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, diNotImplementedYet } from "../data-interactive-types"
@@ -21,7 +22,8 @@ export const diFormulaEngineHandler: DIHandler = {
 
     let compiledFormula: EvalFunction
     try {
-      compiledFormula = math.compile(formula)
+      const canonicalFormula = displayToCanonical(formula, { localNames: {}, dataSet: {} })
+      compiledFormula = math.compile(canonicalFormula)
     }
     catch (e) {
       return errorResult(String(e))

--- a/v3/src/data-interactive/handlers/formula-engine-handler.ts
+++ b/v3/src/data-interactive/handlers/formula-engine-handler.ts
@@ -1,6 +1,6 @@
 import { EvalFunction } from "mathjs"
 import { math } from "../../models/formula/functions/math"
-import { displayToCanonical } from "../../models/formula/utils/canonicalization-utils"
+import { preprocessDisplayFormula } from "../../models/formula/utils/canonicalization-utils"
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
 import { DIHandler, diNotImplementedYet } from "../data-interactive-types"
@@ -22,7 +22,7 @@ export const diFormulaEngineHandler: DIHandler = {
 
     let compiledFormula: EvalFunction
     try {
-      const canonicalFormula = displayToCanonical(formula, { localNames: {}, dataSet: {} })
+      const canonicalFormula = preprocessDisplayFormula(formula)
       compiledFormula = math.compile(canonicalFormula)
     }
     catch (e) {


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/CODAP-725

This PR makes the `diFormulaEngineHandler` use Codap's custom function definitions by calling `preprocessDisplayFormula` on formulas before evaluating them. This makes formulas like `Sex = "M"` evaluate correctly--in `mathjs` `=` is assignment, but in Codap `=` is equality.