### PR TITLE
CODAP-621 Convert % to mod in formulas

### DIFF
--- a/v3/src/models/formula/utils/canonicalization-utils.test.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.test.ts
@@ -97,6 +97,12 @@ describe("customizeDisplayFormula", () => {
     expect(customizeDisplayFormula("π")).toEqual("pi")
     expect(customizeDisplayFormula("∞")).toEqual("Infinity")
   })
+  it("replaces % with mod", () => {
+    expect(customizeDisplayFormula("a % 1")).toEqual("a  mod  1")
+    expect(customizeDisplayFormula("a%1")).toEqual("a mod 1")
+    expect(customizeDisplayFormula("a % -1")).toEqual("a  mod  -1")
+    expect(customizeDisplayFormula("a%-1")).toEqual("a mod -1")
+  })
 })
 
 describe("formulaIndexOf", () => {

--- a/v3/src/models/formula/utils/canonicalization-utils.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.ts
@@ -34,7 +34,8 @@ const customizations: Record<string, CustomizationFn> = {
     const nodeText = formula.substring(cursor.from, cursor.to)
     const replaceMap: Record<string, string> = {
       "×": "*",
-      "÷": "/"
+      "÷": "/",
+      "%": " mod "
     }
     const replacement = replaceMap[nodeText]
     return replacement ? { from: cursor.from, to: cursor.to, replacement } : undefined


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/CODAP-621

This PR converts "%" to " mod " in formulas before evaluating them. This fixes a bug in `mathjs` where the `%` symbol is being interpreted as the unary % more often than it should. We don't want to support the unary % in Codap anyway.