### PR TITLE
fix: formulas with first() and last() when items are sorted [CODAP-765]

### DIFF
--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -64,7 +64,7 @@ import { applyModelChange } from "../history/apply-model-change"
 import { withoutUndo } from "../history/without-undo"
 import { kAttrIdPrefix, kItemIdPrefix, typeV3Id, v3Id } from "../../utilities/codap-utils"
 import { compareValues } from "../../utilities/data-utils"
-import { hashStringSet } from "../../utilities/js-utils"
+import { hashOrderedStringSet, hashStringSet } from "../../utilities/js-utils"
 import { gLocale } from "../../utilities/translation/locale"
 import { t } from "../../utilities/translation/translate"
 import { V2Model } from "./v2-model"
@@ -338,8 +338,12 @@ export const DataSet = V2Model.named("DataSet").props({
     return attrs
   },
   get itemIdsHash() {
-    // observable hash of visible (not set aside, not filtered out) item ids
+    // observable order-independent hash of visible (not set aside, not filtered out) item ids
     return hashStringSet(self.itemIds)
+  },
+  get itemIdsOrderedHash() {
+    // observable order-dependent hash of visible (not set aside, not filtered out) item ids
+    return hashOrderedStringSet(self.itemIds)
   },
   get items(): readonly IItem[] {
     return self.itemIds.map(id => ({ __id__: id }))

--- a/v3/src/models/formula/formula-observers.test.ts
+++ b/v3/src/models/formula/formula-observers.test.ts
@@ -102,12 +102,25 @@ describe("observeLocalAttributes", () => {
       expect(recalculateCallback).toHaveBeenCalledTimes(1)
     })
 
+    it("should call recalculateCallback with sorted cases", () => {
+      const recalculateCallback = jest.fn()
+      dataSet.addAttribute({ id: "attr1", name: "attr1" })
+      const newCases = [{ __id__: "case1", attr1: 1 }, { __id__: "case2", attr2: 2 }]
+      dataSet.addCases(newCases)
+      // non-aggregate optimization has been removed for now
+      const dispose = observeLocalAttributes(formulaDependenciesWithoutAggregate, dataSet, recalculateCallback)
+      dataSet.sortByAttribute("attr1", "descending")
+      expect(recalculateCallback).toHaveBeenCalledWith("ALL_CASES")
+      dispose()
+    })
+
     it("should call recalculateCallback with updated cases", () => {
       const recalculateCallback = jest.fn()
-      observeLocalAttributes(formulaDependenciesWithoutAggregate, dataSet, recalculateCallback)
+      const dispose = observeLocalAttributes(formulaDependenciesWithoutAggregate, dataSet, recalculateCallback)
       const caseUpdates = [{ __id__: "case1", attr1: 1 }, { __id__: "case2", attr321: 2 }]
       dataSet.setCaseValues(caseUpdates)
       expect(recalculateCallback).toHaveBeenCalledWith([caseUpdates[0]])
+      dispose()
     })
   })
 

--- a/v3/src/models/formula/formula-observers.ts
+++ b/v3/src/models/formula/formula-observers.ts
@@ -34,7 +34,10 @@ export const observeLocalAttributes = (formulaDependencies: IFormulaDependency[]
   // If we needed to optimize the non-aggregate case, we could cache the items and then determine which ones
   // were added/removed ourselves, but it's not clear that it will be worth it.
   const disposeDatasetItemsObserver = mstReaction(
-    () => localDataSet.itemIdsHash,
+    // This recomputes all formulas when the order of items changes, which is only strictly necessary
+    // for order-dependent functions like first, last, prev, next, etc., but we don't currently have
+    // a way to track which formulas are order-dependent, so we just recalculate all of them.
+    () => localDataSet.itemIdsOrderedHash,
     () => recalculateCallback("ALL_CASES"),
     { name: "FormulaObservers.itemsReaction" }, localDataSet
   )


### PR DESCRIPTION
[[CODAP-765](https://concord-consortium.atlassian.net/browse/CODAP-765)] first() and last() don't recalculate upon sort

[CODAP-765]: https://concord-consortium.atlassian.net/browse/CODAP-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ