### PR TITLE
Codap-98 Axis Menus with Multiple Collections

### DIFF
--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -551,7 +551,7 @@ context("Test date axes with multiple y-axes", () => {
   it("will create a time series graph with multiple y-axes using date x-axis", () => {
     // Create graph with date on x-axis and chlorophyll on y-axis
     ah.openAxisAttributeMenu("bottom")
-    ah.selectMenuAttribute("date", "bottom")
+    ah.selectSubmenuAttribute("date", "Measurements", "bottom")
     cy.dragAttributeToTarget("table", "chlorophyll", "left")
 
     // Verify initial graph setup

--- a/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
+++ b/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
@@ -65,14 +65,14 @@ context("Graph UI with Pixi interaction", () => {
       // Drag Diet to parent in case table
       table.moveAttributeToParent("Diet", "newCollection")
       table.getNumOfRows(1).should("contain", 5) // five rows: top, plants, meat, both, bottom
-      gch.setAxisAndRetrieveTileId("Diet", "bottom").then((tileId) => {
+      gch.setAxisAndRetrieveTileId("Diet", "bottom", "Diets").then((tileId) => {
         gch.validateGraphPointCount(tileId, 3)
       })
 
       cy.log('Test for "Diet", "Habitat" univariate with hierarchy (5 points)')
       table.moveAttributeToParent("Habitat", "newCollection")
       table.getNumOfRows(1).should("contain", 5) // five rows: top, land, water, both, bottom
-      gch.setAxisAndRetrieveTileId("Diet", "bottom").then((tileId) => {
+      gch.setAxisAndRetrieveTileId("Diet", "bottom", "Diets").then((tileId) => {
         gch.validateGraphPointCount(tileId, 5)
       })
     })
@@ -564,10 +564,10 @@ context("Graph UI with Pixi interaction", () => {
       // Create a graph
       graph.getGraphTile().click()
       ah.openAxisAttributeMenu("bottom")
-      ah.selectMenuAttribute("date", "bottom") // Date => x-axis
+      ah.selectSubmenuAttribute("date", "Measurements", "bottom") // Date => x-axis
       cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "date")
       ah.openAxisAttributeMenu("left")
-      ah.selectMenuAttribute("animal_id", "left") // animal_id => y-axis
+      ah.selectSubmenuAttribute("animal_id", "Tracks", "left") // animal_id => y-axis
       ah.openAxisAttributeMenu("left")
       ah.treatAttributeAsNumeric("left")
       ah.openAxisAttributeMenu("left")

--- a/v3/cypress/e2e/smoke/single-codap-smoke.ts
+++ b/v3/cypress/e2e/smoke/single-codap-smoke.ts
@@ -119,7 +119,7 @@ context("codap single smoke test", () => {
     cy.log("Test date display in bottom axis of graph")
     ah.verifyDefaultAxisLabel("bottom")
     ah.openAxisAttributeMenu("bottom")
-    ah.selectMenuAttribute("date", "bottom") // Date => x-axis
+    ah.selectSubmenuAttribute("date", "Measurements", "bottom") // Date => x-axis
     cy.get('[data-testid="axis-legend-attribute-button-bottom"]').eq(0).should("have.text", "date")
     // Check that the date axis contains the year '2005'
     cy.get('[data-testid="axis-bottom"]')

--- a/v3/cypress/support/helpers/axis-helper.ts
+++ b/v3/cypress/support/helpers/axis-helper.ts
@@ -96,6 +96,16 @@ export const AxisHelper = {
       .click()
     cy.wait(2000)
   },
+  // Use this function when there are multiple datasets or a single dataset with multiple collections
+  selectSubmenuAttribute(attributeName: string, collectionName: string, axis: string) {
+    ae.getAttributeFromAttributeMenu(axis)
+      .contains(".collection-menu-item", collectionName)
+      .click()
+    ae.getAttributeFromAttributeMenu(axis)
+      .contains("button", attributeName)
+      .click()
+    cy.wait(2000)
+  },
   removeAttributeFromAxis(name: string, axis: string) {
     ae.getAttributeFromAttributeMenu(axis).contains(`Remove`).click()
   },

--- a/v3/cypress/support/helpers/graph-canvas-helper.ts
+++ b/v3/cypress/support/helpers/graph-canvas-helper.ts
@@ -16,10 +16,14 @@ export const GraphCanvasHelper = {
       })
   },
   // Helper function to set an attribute for the axis and retrieve the tile ID.
-  setAxisAndRetrieveTileId (attribute: string, axis: "bottom" | "left") {
+  setAxisAndRetrieveTileId (attribute: string, axis: "bottom" | "left", collectionName?: string) {
     cy.log(`Set ${attribute} on ${axis} axis`)
     ah.openAxisAttributeMenu(axis)
-    ah.selectMenuAttribute(attribute, axis)
+    if (collectionName) {
+      ah.selectSubmenuAttribute(attribute, collectionName, axis)
+    } else {
+      ah.selectMenuAttribute(attribute, axis)
+    }
     cy.wait(500)
 
     cy.log('Locate the graph element and retrieve its dynamic ID')

--- a/v3/src/assets/icons/arrow-right.svg
+++ b/v3/src/assets/icons/arrow-right.svg
@@ -1,0 +1,1 @@
+<svg class="svg-icon" style="width: 1em; height: 1em;vertical-align: middle;fill: currentColor;overflow: hidden;" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg"><path d="M256 102.4v819.2l512-409.6L256 102.4z"  /></svg>

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -5,3 +5,8 @@
 .collection-menu-button {
   width: 100%;
 }
+
+.collection-menu-item {
+  display: flex;
+  justify-content: space-between;
+}

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -1,3 +1,7 @@
 .attribute-label-menu {
   z-index: 16;
 }
+
+.collection-menu-button {
+  width: 100%;
+}

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -10,3 +10,7 @@
   display: flex;
   justify-content: space-between;
 }
+
+.collection-menu-arrow {
+  margin-left: 8px;
+}

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -39,6 +39,7 @@ export const AxisOrLegendAttributeMenu =
   const dataConfiguration = useDataConfigurationContext()
   const metadata = dataConfiguration?.metadata
   const data = dataConfiguration?.dataset
+  const collections = data?.collections || []
   const role = graphPlaceToAttrRole[place]
   const attrId = dataConfiguration?.attributeID(role) || ''
   const instanceId = useInstanceIdContext()
@@ -79,6 +80,29 @@ export const AxisOrLegendAttributeMenu =
   const clickLabel = place === 'legend' ? `—${t("DG.LegendView.attributeTooltip")}`
     : t("DG.AxisView.labelTooltip", { vars: [orientation]})
 
+  const renderMenuItems = () => {
+    if (!data) return null
+
+    if (collections.length === 1) {
+      const attrs = collections[0].attributes.filter(attr => !!attr)
+      return attrs.filter(attr => !metadata?.isHidden(attr.id)).map((attr) => {
+        return (
+          <MenuItem onClick={() => onChangeAttribute(place, data, attr.id)} key={attr.id}>
+            {attr.name}
+          </MenuItem>
+        )
+      })
+    } else {
+      return collections.map(collection => {
+        return (
+          <MenuItem key={collection.id}>
+            {collection.name}
+          </MenuItem>
+        )
+      })
+    }
+  }
+
   return (
     <div className={`axis-legend-attribute-menu ${place}`} ref={menuRef} title={description + clickLabel}>
       <Menu boundary="scrollParent">
@@ -92,13 +116,7 @@ export const AxisOrLegendAttributeMenu =
                 {attribute?.name}
               </MenuButton>
               <MenuList>
-                { data?.attributes?.filter(attr => !metadata?.isHidden(attr.id)).map((attr) => {
-                  return (
-                    <MenuItem onClick={() => onChangeAttribute(place, data, attr.id)} key={attr.id}>
-                      {attr.name}
-                    </MenuItem>
-                  )
-                })}
+                {renderMenuItems()}
                 { attribute &&
                   <>
                     <MenuDivider />

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -46,14 +46,13 @@ interface ICollectionMenuProps {
   onPointerOver?: React.PointerEventHandler<HTMLButtonElement>
   place: GraphPlace
 }
-
 const CollectionMenu = observer(function CollectionMenu({
   collection, data, isOpen, metadata, onChangeAttribute, onPointerOver, place
 }: ICollectionMenuProps) {
   return (
-    <MenuItem key={collection.id} onPointerOver={onPointerOver}>
-      {collection.name}
-      <Menu isOpen={isOpen}>
+    <>
+      <Menu isOpen={isOpen} placement="right-start">
+        <MenuButton as="div" className="collection-menu-button" />
         <MenuList>
           <MenuItemsForCollection
             collection={collection}
@@ -64,7 +63,15 @@ const CollectionMenu = observer(function CollectionMenu({
           />
         </MenuList>
       </Menu>
-    </MenuItem>
+      <MenuItem
+        as="div"
+        closeOnSelect={false}
+        key={collection.id}
+        onPointerOver={onPointerOver}
+      >
+        {collection.name}
+      </MenuItem>
+    </>
   )
 })
 
@@ -138,6 +145,11 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
   const clickLabel = place === 'legend' ? `—${t("DG.LegendView.attributeTooltip")}`
     : t("DG.AxisView.labelTooltip", { vars: [orientation]})
 
+  const handleChangeAttribute = (_place: GraphPlace, dataSet: IDataSet, _attrId: string) => {
+    onChangeAttribute(_place, dataSet, _attrId)
+    onCloseRef.current?.()
+  }
+
   const renderMenuItems = () => {
     if (!data) return null
 
@@ -147,7 +159,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
           collection={collections[0]}
           data={data}
           metadata={metadata}
-          onChangeAttribute={onChangeAttribute}
+          onChangeAttribute={handleChangeAttribute}
           place={place}
         />
       )
@@ -159,7 +171,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
           isOpen={openCollectionId === collection.id}
           key={collection.id}
           metadata={metadata}
-          onChangeAttribute={onChangeAttribute}
+          onChangeAttribute={handleChangeAttribute}
           onPointerOver={() => setOpenCollectionId(collection.id)}
           place={place}
         />
@@ -169,7 +181,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
 
   return (
     <div className={clsx("axis-legend-attribute-menu", place)} ref={menuRef} title={description + clickLabel}>
-      <Menu boundary="scrollParent">
+      <Menu boundary="scrollParent" onOpen={() => setOpenCollectionId(null)}>
         {({ onClose }) => {
           onCloseRef.current = onClose
           return (

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -106,14 +106,17 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
   place, target, portal, layoutBounds, onChangeAttribute, onRemoveAttribute, onTreatAttributeAs
 }: IProps) {
   const dataSets = Array.from(gDataBroker.dataSets.values())
-  const allCollectionInfo: ICollectionInfo[] = []
-  dataSets.forEach(data => {
+  const allCollectionInfo: (ICollectionInfo|string)[] = []
+  dataSets.forEach((data, index) => {
     const metadata = getMetadataFromDataSet(data)
     data.collections.forEach(collection => {
       if (isCollectionModel(collection)) {
         allCollectionInfo.push({ collection, data, metadata })
       }
     })
+    if (index < dataSets.length - 1) {
+      allCollectionInfo.push("divider")
+    }
   })
   const dataConfiguration = useDataConfigurationContext()
   const dataSet = dataConfiguration?.dataset
@@ -167,7 +170,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
   }
 
   const renderMenuItems = () => {
-    if (allCollectionInfo.length === 1) {
+    if (allCollectionInfo.length === 1 && typeof allCollectionInfo[0] !== 'string') {
       return (
         <MenuItemsForCollection
           collectionInfo={allCollectionInfo[0]}
@@ -176,18 +179,23 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
         />
       )
     } else {
+      let dividerCount = 0
       return allCollectionInfo.map(collectionInfo => {
-        const { collection } = collectionInfo
-        return (
-          <CollectionMenu
-            collectionInfo={collectionInfo}
-            isOpen={openCollectionId === collection.id}
-            key={collection.id}
-            onChangeAttribute={handleChangeAttribute}
-            onPointerOver={() => setOpenCollectionId(collection.id)}
-            place={place}
-          />
-        )
+        if (typeof collectionInfo === 'string') {
+          return <MenuDivider key={`divider-${dividerCount++}`} />
+        } else {
+          const { collection } = collectionInfo
+          return (
+            <CollectionMenu
+              collectionInfo={collectionInfo}
+              isOpen={openCollectionId === collection.id}
+              key={collection.id}
+              onChangeAttribute={handleChangeAttribute}
+              onPointerOver={() => setOpenCollectionId(collection.id)}
+              place={place}
+            />
+          )
+        }
       })
     }
   }

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -77,7 +77,7 @@ const CollectionMenu = observer(function CollectionMenu({
         onPointerOver={onPointerOver}
       >
         <span>{collection.name}</span>
-        <RightArrow />
+        <RightArrow className="collection-menu-arrow" />
       </MenuItem>
     </>
   )

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -17,6 +17,8 @@ import { GraphPlace } from "../../axis-graph-shared"
 import { graphPlaceToAttrRole } from "../../data-display/data-display-types"
 import { useDataConfigurationContext } from "../../data-display/hooks/use-data-configuration-context"
 
+import RightArrow from "../../../assets/icons/arrow-right.svg"
+
 import "./axis-or-legend-attribute-menu.scss"
 
 interface ICollectionInfo {
@@ -73,11 +75,13 @@ const CollectionMenu = observer(function CollectionMenu({
       </Menu>
       <MenuItem
         as="div"
+        className="collection-menu-item"
         closeOnSelect={false}
         key={collection.id}
         onPointerOver={onPointerOver}
       >
-        {collection.name}
+        <span>{collection.name}</span>
+        <RightArrow />
       </MenuItem>
     </>
   )

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -27,6 +27,7 @@ interface ICollectionInfo {
   metadata?: IDataSetMetadata
 }
 
+// MenuItems for all attributes in a single collection
 interface IMenuItemsForCollectionProps {
   collectionInfo: ICollectionInfo
   onChangeAttribute: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
@@ -44,6 +45,7 @@ function MenuItemsForCollection({ collectionInfo, onChangeAttribute, place }: IM
   })
 }
 
+// A MenuItem for a collection, which contains a submenu of the collection's attributes
 interface ICollectionMenuProps {
   collectionInfo: ICollectionInfo
   isOpen: boolean
@@ -81,16 +83,6 @@ const CollectionMenu = observer(function CollectionMenu({
   )
 })
 
-interface IProps {
-  place: GraphPlace,
-  target: SVGGElement | null
-  portal: HTMLElement | null
-  layoutBounds: string  // Used to signal need to re-render because layout has changed
-  onChangeAttribute: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
-  onRemoveAttribute: (place: GraphPlace, attrId: string) => void
-  onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
-}
-
 const removeAttrItemLabelKeys: Record<string, string> = {
   "x": "DG.DataDisplayMenu.removeAttribute_x",
   "y": "DG.DataDisplayMenu.removeAttribute_y",
@@ -100,6 +92,16 @@ const removeAttrItemLabelKeys: Record<string, string> = {
   "rightSplit": "DG.DataDisplayMenu.removeAttribute_right"
 }
 
+// The full menu
+interface IProps {
+  place: GraphPlace,
+  target: SVGGElement | null
+  portal: HTMLElement | null
+  layoutBounds: string  // Used to signal need to re-render because layout has changed
+  onChangeAttribute: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
+  onRemoveAttribute: (place: GraphPlace, attrId: string) => void
+  onTreatAttributeAs: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
+}
 export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttributeMenu({
   place, target, portal, layoutBounds, onChangeAttribute, onRemoveAttribute, onTreatAttributeAs
 }: IProps) {

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -106,7 +106,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
   place, target, portal, layoutBounds, onChangeAttribute, onRemoveAttribute, onTreatAttributeAs
 }: IProps) {
   const dataSets = Array.from(gDataBroker.dataSets.values())
-  const allCollectionInfo: (ICollectionInfo|string)[] = []
+  const allCollectionInfo: (ICollectionInfo|"divider")[] = []
   dataSets.forEach((data, index) => {
     const metadata = getMetadataFromDataSet(data)
     data.collections.forEach(collection => {
@@ -170,7 +170,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
   }
 
   const renderMenuItems = () => {
-    if (allCollectionInfo.length === 1 && typeof allCollectionInfo[0] !== 'string') {
+    if (allCollectionInfo.length === 1 && allCollectionInfo[0] !== "divider") {
       return (
         <MenuItemsForCollection
           collectionInfo={allCollectionInfo[0]}
@@ -181,7 +181,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
     } else {
       let dividerCount = 0
       return allCollectionInfo.map(collectionInfo => {
-        if (typeof collectionInfo === 'string') {
+        if (collectionInfo === "divider") {
           return <MenuDivider key={`divider-${dividerCount++}`} />
         } else {
           const { collection } = collectionInfo

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -8,10 +8,9 @@ import { useOutsidePointerDown } from "../../../hooks/use-outside-pointer-down"
 import { useOverlayBounds } from "../../../hooks/use-overlay-bounds"
 import { AttributeType } from "../../../models/data/attribute-types"
 import { ICollectionModel, isCollectionModel } from "../../../models/data/collection"
-import { gDataBroker } from "../../../models/data/data-broker"
 import { IDataSet } from "../../../models/data/data-set"
 import { IDataSetMetadata } from "../../../models/shared/data-set-metadata"
-import { getMetadataFromDataSet } from "../../../models/shared/shared-data-utils"
+import { getMetadataFromDataSet, getSharedDataSets } from "../../../models/shared/shared-data-utils"
 import { t } from "../../../utilities/translation/translate"
 import { GraphPlace } from "../../axis-graph-shared"
 import { graphPlaceToAttrRole } from "../../data-display/data-display-types"
@@ -105,7 +104,9 @@ interface IProps {
 export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttributeMenu({
   place, target, portal, layoutBounds, onChangeAttribute, onRemoveAttribute, onTreatAttributeAs
 }: IProps) {
-  const dataSets = Array.from(gDataBroker.dataSets.values())
+  const dataConfiguration = useDataConfigurationContext()
+  const dataSet = dataConfiguration?.dataset
+  const dataSets = dataSet ? getSharedDataSets(dataSet).map(sharedDataSet => sharedDataSet.dataSet) : []
   const allCollectionInfo: (ICollectionInfo|"divider")[] = []
   dataSets.forEach((data, index) => {
     const metadata = getMetadataFromDataSet(data)
@@ -118,8 +119,6 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
       allCollectionInfo.push("divider")
     }
   })
-  const dataConfiguration = useDataConfigurationContext()
-  const dataSet = dataConfiguration?.dataset
   const role = graphPlaceToAttrRole[place]
   const attrId = dataConfiguration?.attributeID(role) || ''
   const instanceId = useInstanceIdContext()


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/CODAP-98

This PR makes graph axis menus hierarchical when there are multiple collections in a document (either one dataset with multiple collections, or multiple datasets). I tried to replicate v2 behavior as much as I could:
- Submenus open when you hover over a collection item.
- Submenus close when you hover over another top level item, or if the top menu closes (like clicking the background or selecting an option).
- Clicking a top level collection item will not close the menu or modify the graph.

Remaining concerns:
- In v3, menu items are set up to drag the attribute assigned to the axis. This isn't how things work in v2, and I think we should remove this weird functionality. But I didn't do it as part of this PR.
- I'm accessing all of the datasets in the document using `gDataBroker`. Is there a better way of doing this?
- We're still using the `DataConfigurationContext` to find the dataset for the graph. This is then used to determine which attribute is assigned to the axis, as well as the buggy dragging behavior described above. This feels a bit weird to me, and prevents a graph from having attributes from different datasets on different axes. But it seems to reproduce v2 behavior.
- Keyboard controls don't work.