### PR TITLE
CODAP-741 Fix axis layout problems

### DIFF
--- a/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
+++ b/v3/cypress/e2e/pixi-interaction/graph-pixi-interaction.spec.ts
@@ -323,7 +323,7 @@ context("Graph UI with Pixi interaction", () => {
       gch.getGraphTileId().then((tileId: string) => {
         // Known inputs:
         const pointIndex = 3
-        const expectedX = 165
+        const expectedX = 167
         const expectedY = 67
 
         gch.checkPointPosition(tileId, pointIndex, expectedX, expectedY)
@@ -331,7 +331,7 @@ context("Graph UI with Pixi interaction", () => {
       gch.getGraphTileId().then((tileId: string) => {
         // Known inputs:
         const pointIndex = 8
-        const expectedX = 324
+        const expectedX = 327
         const expectedY = 140
 
         gch.checkPointPosition(tileId, pointIndex, expectedX, expectedY)

--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -226,13 +226,14 @@ export const getCoordFunctions = (props: IGetCoordFunctionsProps): ICoordFunctio
  */
 export const computeBestNumberOfTicks = (scale: ScaleLinear<number, number>): number => {
   const formatter = scale.tickFormat()
+  const kLabelGap = 4 // Minimum gap between labels in pixels
 
   // Helper function to detect collisions between tick labels
   const hasCollision = (values: number[]) => {
     return values.some((value, i) => {
       if (i === values.length - 1) return false
       const delta = scale(values[i + 1]) - scale(values[i])
-      const length = (measureText(formatter(values[i])) + measureText(formatter(values[i + 1]))) / 2
+      const length = (measureText(formatter(values[i])) + measureText(formatter(values[i + 1]))) / 2 + kLabelGap
       return length > delta
     })
   }


### PR DESCRIPTION
[#CODAP-741] Bug fix: Graph: Axis label covers the axis scale labels

I wasn’t able to reproduce the described bug, even on a Chromebook. But I found two new bugs and fixed them:
1. Putting age on the y-axis of a new graph caused the y-axis attribute label to overlap with the numeric values on the axis.
2. Putting age on the x-axis resulted in numeric labels that slightly collide with each other.

* The first bug required some machinations around getting the actual tick values that get displayed and use those to compute the desired axis extent.
* The second bug was fixed by adding a 4 pixel gap between numeric values on a horizontal axis in the collision detection algorithm.