### PR TITLE
feat: improve performance of computed value propagation

### DIFF
--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -543,7 +543,7 @@ context("case table ui", () => {
       table.getGridCell(2, 5).then(cell => {
         random2 = +cell.text()
         expect(random2 >= 0).to.eq(true)
-        expect(random2 < 1).to.eq(true)
+        expect(random2 <= 1).to.eq(true)
         expect(random2).not.to.eq(random1)
       })
       // Delete formula, verify values remain
@@ -552,7 +552,7 @@ context("case table ui", () => {
       table.getGridCell(2, 5).then(cell => {
         const value = +cell.text()
         expect(value >= 0).to.eq(true)
-        expect(value < 1).to.eq(true)
+        expect(value <= 1).to.eq(true)
         expect(value).to.eq(random2)
       })
       // verify that formula was deleted

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -417,7 +417,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
     const prevCaseHasSelectedChild = !!data && !!prevCaseId && isAnyChildSelected(data, prevCaseId)
     const hasSelectedChild = !!data && isAnyChildSelected(data, row.__id__)
     const nextCaseHasSelectedChild = !!data && !!nextCaseId && isAnyChildSelected(data, nextCaseId)
-    const parentCaseChildren = data?.getParentCase(row.__id__, collectionId)?.childCaseIds ?? []
+    const parentCaseChildren = data?.getParentCaseInfo(row.__id__, collectionId)?.childCaseIds ?? []
     const isLastChild = parentCaseChildren[parentCaseChildren.length - 1] === row.__id__
 
     return clsx({

--- a/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
@@ -121,6 +121,7 @@ const AttributeMenuListComponent = forwardRef<HTMLDivElement, IProps>(
       handleClick: () => {
         data?.applyModelChange(() => {
           attribute?.formula?.rerandomize()
+          data.validateCases({ force: true })
         })
       }
     },

--- a/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
@@ -79,6 +79,7 @@ export const RulerMenuList = observer(function RulerMenuList() {
               attr.formula.rerandomize()
             }
           })
+          data.validateCases({ force: true })
         })
       }
     },

--- a/v3/src/data-interactive/data-interactive-type-utils.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.ts
@@ -45,7 +45,7 @@ export function convertCaseToV2FullCase(c: ICase, dataContext: IDataSet) {
   const collectionId = _collection?.id
   const caseGroup = dataContext.caseInfoMap.get(caseId)
 
-  const parent = maybeToV2Id(dataContext.getParentCase(caseId, collectionId)?.groupedCase.__id__)
+  const parent = maybeToV2Id(dataContext.getParentCaseInfo(caseId, collectionId)?.groupedCase.__id__)
 
   const collectionIndex = collectionId ? dataContext.getCollectionIndex(collectionId) : -1
   const parentCollection = collectionIndex > 0 ? dataContext.collections[collectionIndex - 1] : undefined
@@ -79,7 +79,7 @@ export function getCaseRequestResultValues(c: ICase, dataContext: IDataSet): DIG
   const caseGroup = dataContext.caseInfoMap.get(caseId)
   const collectionId = caseGroup?.collectionId ?? dataContext.childCollection.id
 
-  const parent = maybeToV2Id(dataContext.getParentCase(caseId, collectionId)?.groupedCase.__id__)
+  const parent = maybeToV2Id(dataContext.getParentCaseInfo(caseId, collectionId)?.groupedCase.__id__)
 
   const _collection = dataContext.getCollection(collectionId)
   const collection = _collection ? {
@@ -162,7 +162,7 @@ export function convertCollectionToV2(collection: ICollectionModel, options?: CC
     cases = {
       cases: collection.cases.map(aCase => {
         const v2CaseId = toV2Id(aCase.__id__)
-        const parentCase = dataSet?.getParentCase(aCase.__id__, collection.id)
+        const parentCase = dataSet?.getParentCaseInfo(aCase.__id__, collection.id)
         const v2ParentCaseId = parentCase ? toV2Id(parentCase.groupedCase.__id__) : undefined
         const values: ICodapV2Case["values"] = {}
         collection.dataAttributesArray.forEach(attr => {

--- a/v3/src/data-interactive/handlers/all-cases-handler.ts
+++ b/v3/src/data-interactive/handlers/all-cases-handler.ts
@@ -27,7 +27,7 @@ export const diAllCasesHandler: DIHandler = {
 
     const cases = dataContext.getCasesForCollection(collection.id).map(({ __id__ }, index) => {
       const pseudoCase = dataContext.caseInfoMap.get(__id__)
-      const parentCase = dataContext.getParentCase(__id__, collection.id)
+      const parentCase = dataContext.getParentCaseInfo(__id__, collection.id)
       const parent = maybeToV2Id(parentCase?.groupedCase.__id__)
       const children: number[] = []
       if (pseudoCase) {

--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -70,7 +70,7 @@ describe("CollectionModel", () => {
     })
 
     expect(c1.getCaseGroup("foo")).toBeUndefined()
-    expect(c1.findParentCaseGroup("foo")).toBeUndefined()
+    expect(c1.findParentCaseInfo("foo")).toBeUndefined()
     c1.completeCaseGroups([{} as any])
   })
 
@@ -254,7 +254,7 @@ describe("CollectionModel", () => {
         // update the cases
         collection.updateCaseGroups()
 
-        expect(collection.findParentCaseGroup("foo")).toBeUndefined()
+        expect(collection.findParentCaseInfo("foo")).toBeUndefined()
       })
 
       root.collections.forEach((collection, index) => {
@@ -268,7 +268,7 @@ describe("CollectionModel", () => {
     expect(c1.caseIds.length).toBe(2)
     expect(c1.cases.length).toBe(2)
     expect(c2.caseIds).toEqual(caseIdsForItems(["i0", "i2", "i4", "i1", "i3", "i5"], 1))
-    expect(c2.findParentCaseGroup("foo")).toBeUndefined()
+    expect(c2.findParentCaseInfo("foo")).toBeUndefined()
     expect(c1.caseGroups[0].childCaseIds).toEqual(caseIdsForItems(["i0", "i2", "i4"], 1))
     expect(c1.caseGroups[0].childItemIds).toEqual(["i0", "i2", "i4"])
     expect(c1.caseGroups[1].childCaseIds).toEqual(caseIdsForItems(["i1", "i3", "i5"], 1))
@@ -285,7 +285,7 @@ describe("CollectionModel", () => {
         expect(c2.hasCase(childCaseId)).toBe(true)
         expect(c2.getCaseIndex(childCaseId)).toBe(index)
         expect(c2.getCaseGroup(childCaseId)!.childItemIds).toEqual([itemId])
-        expect(c1.findParentCaseGroup(childCaseId)).toBe(c1.caseGroups[+itemBaseId % 2])
+        expect(c1.findParentCaseInfo(childCaseId)).toBe(c1.caseGroups[+itemBaseId % 2])
       })
     }
 
@@ -373,7 +373,7 @@ describe("CollectionModel", () => {
     expect(c1.caseIds.length).toBe(2)
     expect(c1.cases.length).toBe(2)
     expect(c2.caseIds).toEqual(caseIdsForItems(["i1", "i3", "i5", "i4"], 1))
-    expect(c2.findParentCaseGroup("foo")).toBeUndefined()
+    expect(c2.findParentCaseInfo("foo")).toBeUndefined()
     expect(c1.caseGroups[0].childCaseIds).toEqual(caseIdsForItems(["i1", "i3", "i5"], 1))
     expect(c1.caseGroups[0].childItemIds).toEqual(["i1", "i3", "i5"])
     expect(c1.caseGroups[1].childCaseIds).toEqual(caseIdsForItems(["i4"], 1))

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -457,7 +457,7 @@ export const CollectionModel = V2Model
   }
 })
 .views(self => ({
-  findParentCaseGroup(childCaseId: string): Maybe<CaseInfo> {
+  findParentCaseInfo(childCaseId: string): Maybe<CaseInfo> {
     //consider building a child -> parent case id map if performance is an issue
     return self.caseGroups.find(group => group.childCaseIds?.includes(childCaseId))
   }

--- a/v3/src/models/data/data-set-collections.test.ts
+++ b/v3/src/models/data/data-set-collections.test.ts
@@ -63,18 +63,18 @@ describe("DataSet collections", () => {
     expect(data.collections.length).toEqual(1)
     expect(data.childCollection.attributes.map(attr => attr!.id)).toEqual(["aId", "bId", "cId"])
     // case caches are updated when cases are added/removed
-    const childCases = data.childCases()
+    const childCases = data.childCases
     expect(noSymbols(childCases)).toEqual(allCases)
     data.addCases([{ __id__: "4-5-6", aId: 4, bId: 5, cId: 6 }])
     data.validateCases()
     const allCases2 = data.items.map(({ __id__ }) => ({ __id__: data.getItemChildCaseId(__id__) }))
     expect(allCases2).not.toEqual(allCases)
-    const childCases2 = data.childCases()
+    const childCases2 = data.childCases
     expect(childCases2).not.toEqual(childCases)
     expect(noSymbols(childCases2)).toEqual(allCases2)
     data.removeCases(["4-5-6"])
     const allCases3 = data.items.map(({ __id__ }) => ({ __id__: data.getItemChildCaseId(__id__) }))
-    const childCases3 = data.childCases()
+    const childCases3 = data.childCases
     expect(childCases3).toEqual(childCases)
     expect(noSymbols(childCases3)).toEqual(allCases3)
   })

--- a/v3/src/models/formula/attribute-formula-adapter.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.ts
@@ -115,13 +115,14 @@ export class AttributeFormulaAdapter extends FormulaManagerAdapter {
       return
     }
 
+    const { attributeId } = extraMetadata
     const dataSet = this.api.getDatasets().get(extraMetadata.dataSetId)
     if (!dataSet) {
       throw new Error(`Dataset with id "${extraMetadata.dataSetId}" not found`)
     }
     const results = this.computeFormula(formulaContext, extraMetadata, casesToRecalculateDesc)
     if (results && results.length > 0) {
-      dataSet.setCaseValues(results)
+      dataSet.setAttributeValues(attributeId, results)
     }
   }
 
@@ -197,10 +198,7 @@ export class AttributeFormulaAdapter extends FormulaManagerAdapter {
       } catch (e: any) {
         formulaValue = formulaError(e.message)
       }
-      return {
-        __id__: c.__id__,
-        [attributeId]: formulaValue
-      }
+      return [c.__id__, formulaValue] as [string, FValue]
     })
   }
 
@@ -209,10 +207,7 @@ export class AttributeFormulaAdapter extends FormulaManagerAdapter {
     const { dataSet } = formulaContext
     const { attributeId } = extraMetadata
     const allCases = dataSet.getCasesForAttributes([attributeId])
-    dataSet.setCaseValues(allCases.map(c => ({
-      __id__: c.__id__,
-      [attributeId]: errorMsg
-    })))
+    dataSet.setAttributeValues(attributeId, allCases.map(c => [c.__id__, errorMsg]))
   }
 
   setupFormulaObservers(formulaContext: IFormulaContext, extraMetadata: IAttrFormulaExtraMetadata) {

--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -289,6 +289,10 @@ export class FormulaManager implements IFormulaManager {
     const recalculate = (casesToRecalculate: CaseList) => {
       this.recalculateFormula(formulaId, casesToRecalculate)
     }
+    const recalculateInvalidate = (casesToRecalculate: CaseList) => {
+      this.recalculateFormula(formulaId, casesToRecalculate)
+      dataSet.validateCases({ force: true })
+    }
     const updateDisplay = () => {
       this.updateFormulaDisplayExpression(formulaId)
       // Note that when attribute is removed or renamed, this can also affect the formula's canonical form.
@@ -305,7 +309,7 @@ export class FormulaManager implements IFormulaManager {
 
     const disposeLocalAttributeObservers = observeLocalAttributes(dependencies, dataSet, recalculate)
     const disposeBoundaryObservers = observeBoundaries(dependencies, this.boundaryManager, recalculate)
-    const disposeGlobalValueObservers = observeGlobalValues(dependencies, this.globalValueManager, recalculate)
+    const disposeGlobalObservers = observeGlobalValues(dependencies, this.globalValueManager, recalculateInvalidate)
     const disposeLookupObservers = observeLookupDependencies(dependencies, this.dataSets, recalculate)
     const disposeNameChangeObservers = observeSymbolNameChanges(this.dataSets, this.globalValueManager, updateDisplay)
     const disposeAdapterSpecificObservers = adapter.setupFormulaObservers?.(formulaContext, extraMetadata)
@@ -315,7 +319,7 @@ export class FormulaManager implements IFormulaManager {
       dispose: () => {
         disposeLocalAttributeObservers()
         disposeBoundaryObservers()
-        disposeGlobalValueObservers()
+        disposeGlobalObservers()
         disposeLookupObservers()
         disposeNameChangeObservers()
         disposeAdapterSpecificObservers?.()


### PR DESCRIPTION
The essence of the problem was that computed values were being propagated to each attribute with a formula via a call to `DataSet.setCaseValues()`, which triggers a lot of MST overhead (e.g. action-tracking middleware) as well as potentially triggering clients like case tables and graphs to respond as well. Thus, when using the sampler to generate items, the items would be created, clients would respond to the `addCases` change, then the formula engine would respond by evaluating the formula and calling `setCaseValues` for each attribute with a formula, which caused additional rounds of MST middleware and client responses.

To address this, we add a new `DataSet.setAttributeValues` method which is classified as a `view` rather than an `action` for MST purposes, so that it doesn't trigger action-tracking middleware. Furthermore, `DataSet.setAttributeValues` makes a single call to `Attribute.setValues` rather than calling `Attribute.setValue` for every item, which results in further performance gains. Essentially what we're saying here is that formula evaluation and caching is under-the-hood shuffling of values that should not be treated the same way user-triggered changes are treated (which is what `DataSet.setCaseValues` is used for).

While adding jest tests for the new code and checking test coverage, I noticed that there were other aspects of the `DataSet`, particularly involving hierarchical data sets, that were lacking in test coverage so I added some additional tests there as well. While adding those tests, I found some code that was unclear, some methods that were poorly named, etc., and so I made a few other unrelated changes in the interest of general code hygiene. Specifically, this PR:

- adds `setAttributeValues` as a `view` method of the `DataSet`.
- calls `DataSet.setAttributeValues` from the `AttributeFormulaAdapter`.
- adds explicit invalidation when re-randomizing formulas (so clients can respond).
- adds explicit invalidation when an attribute formula depends on a global/slider value.
- renames `DataSet.getParentCase` to `DataSet.getParentCaseInfo` because it returns metadata about the case rather than the case itself.
- makes `DataSet.childCases` a `get`ter.
- fixes `DataSet.removeCases` so it handles removing parent cases properly.