### PR TITLE
CODAP-769 Improve category drag animation

### DIFF
--- a/v3/src/components/data-display/models/data-display-content-model.ts
+++ b/v3/src/components/data-display/models/data-display-content-model.ts
@@ -124,9 +124,12 @@ export const DataDisplayContentModel = TileContentModel
         clearTimeout(self.animationTimerId)
       }
     },
-    startAnimation() {
+    startAnimation(stoppingCallback?: () => void) {
       if (self.animationTimerId) clearTimeout(self.animationTimerId)
-      self.animationTimerId = window.setTimeout(() => this.stopAnimation(), 2000)
+      self.animationTimerId = window.setTimeout(() => {
+        this.stopAnimation()
+        if (stoppingCallback) stoppingCallback()
+      }, 2000)
     },
     stopAnimation() {
       self.animationTimerId = 0

--- a/v3/src/components/data-display/models/data-display-content-model.ts
+++ b/v3/src/components/data-display/models/data-display-content-model.ts
@@ -124,11 +124,11 @@ export const DataDisplayContentModel = TileContentModel
         clearTimeout(self.animationTimerId)
       }
     },
-    startAnimation(stoppingCallback?: () => void) {
+    startAnimation(onComplete?: () => void) {
       if (self.animationTimerId) clearTimeout(self.animationTimerId)
       self.animationTimerId = window.setTimeout(() => {
         this.stopAnimation()
-        if (stoppingCallback) stoppingCallback()
+        onComplete?.()
       }, 2000)
     },
     stopAnimation() {

--- a/v3/src/components/data-display/pixi/pixi-points.ts
+++ b/v3/src/components/data-display/pixi/pixi-points.ts
@@ -242,6 +242,14 @@ export class PixiPoints {
     }
   }
 
+  removeMasks() {
+    this.subPlotMasks.forEach(mask => mask.destroy())
+    this.subPlotMasks = []
+    for (const point of this.caseDataToPoint.values()) {
+      point.mask = null
+    }
+  }
+
   setVisibility(isVisible: boolean) {
     this.pointsContainer.visible = isVisible
     this.startRendering()

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -118,10 +118,16 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     return mstReaction(() => {
       return [dataConfiguration.allCategoriesForRoles, dataConfiguration.categoricalAttrsWithChangeCounts]
     }, () => {
-      startAnimation()
-      callRefreshPointPositions({ updateMasks: true })
+
+      const updateMasksCallback = () => {
+        if (!pixiPoints) return
+        updateCellMasks({ dataConfig: dataConfiguration, layout, pixiPoints })
+      }
+      pixiPoints?.removeMasks()
+      startAnimation(updateMasksCallback)
+      callRefreshPointPositions()
     }, {name: "usePlot.respondToCategorySetChanges", equals: comparer.structural}, dataConfiguration)
-  }, [callRefreshPointPositions, dataConfiguration, startAnimation])
+  }, [callRefreshPointPositions, dataConfiguration, layout, pixiPoints, startAnimation])
 
   // respond to attribute assignment changes
   useEffect(() => {

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -331,6 +331,10 @@ export function updateCellMasks({ dataConfig, layout, pixiPoints }: IUpdateCellM
   pixiPoints?.setPointsMask(dataConfig.caseDataWithSubPlot)
 }
 
+export function removeCellMasks(pixiPoints?: PixiPoints) {
+  pixiPoints?.removeMasks()
+}
+
 export interface ISetPointSelection {
   pixiPoints?: PixiPoints
   dataConfiguration: IDataConfigurationModel

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -331,10 +331,6 @@ export function updateCellMasks({ dataConfig, layout, pixiPoints }: IUpdateCellM
   pixiPoints?.setPointsMask(dataConfig.caseDataWithSubPlot)
 }
 
-export function removeCellMasks(pixiPoints?: PixiPoints) {
-  pixiPoints?.removeMasks()
-}
-
 export interface ISetPointSelection {
   pixiPoints?: PixiPoints
   dataConfiguration: IDataConfigurationModel


### PR DESCRIPTION
[#CODAP-769] Bug fix: Graph: Better animate category reordering in graphs

* The poor animations in which points disappeared and then reappeared was due to the fact that each pixi point has a mask assigned to it. When the categories are reordered, the points that are going to move are suddenly not in the "correct" sub-plot and are thus masked.
* The solution is to, before we start the animation, remove all masks and allow the points to be seen as they cross from one sub-plot to another. When the animation has finished, we reinstate the masks.
* This required 
  * adding a routine to pixi-points.ts to `removeMasks`
  * Passing an optional callback function parameter to `DataDisplayContentModel.startAnimation` to be invoked at the end of an animation
  * In use-plot.ts `respondToCategorySetChanges`, before starting the animation, removing the cell masks and passing a callback to startAnimation that will update the masks after the animation completes.