### PR TITLE
fix: double import when file dropped on user entry dialog

### DIFF
--- a/v3/src/hooks/use-drop-handler.ts
+++ b/v3/src/hooks/use-drop-handler.ts
@@ -19,7 +19,8 @@ export const useDropHandler = ({
   const eltRef = useRef<HTMLElement | null>(null)
 
   useEffect(function installListeners() {
-    eltRef.current = document.querySelector(selector)
+    const elt = document.querySelector<HTMLElement>(selector)
+    eltRef.current = elt
 
     function dragOverHandler(event: DragEvent) {
       // Prevent default behavior (Prevent file from being opened)
@@ -35,8 +36,10 @@ export const useDropHandler = ({
         onImportDataSet?.(ds)
       }
 
-      // Prevent default behavior (Prevent file from being opened)
+      // Prevent default behavior (Prevent file from being opened by browser)
       event.preventDefault()
+      // Prevent event from being handled more than once
+      event.stopPropagation()
       if (event.dataTransfer?.items) {
         // Use DataTransferItemList interface to access the file(s)
         for (let i = 0; i < event.dataTransfer.items.length; i++) {
@@ -94,12 +97,12 @@ export const useDropHandler = ({
       setIsDragOver?.(false)
     }
 
-    eltRef.current?.addEventListener('dragover', dragOverHandler)
-    eltRef.current?.addEventListener('drop', dropHandler)
+    elt?.addEventListener('dragover', dragOverHandler)
+    elt?.addEventListener('drop', dropHandler)
 
     return () => {
-      eltRef.current?.removeEventListener('dragover', dragOverHandler)
-      eltRef.current?.removeEventListener('drop', dropHandler)
+      elt?.removeEventListener('dragover', dragOverHandler)
+      elt?.removeEventListener('drop', dropHandler)
     }
   }, [onHandleUrlDrop, onImportDataSet, onImportDocument, selector, setIsDragOver])
 


### PR DESCRIPTION
To allow file drops to occur on the document window, the `useDropHandler()` hook attaches DOM event handlers for the `dragover` and `drop` events to the `codap-app-id` div. To support file drops when the user entry dialog is showing, the handlers are attached to the overlay div behind it that darkens the background instead. When the user entry dialog is shown or hidden the handlers are first disposed from their current div before being installed on the other one. The bug was occurring when the `drop` event was being handled once by the overlay and once by the application, even though those handlers are never installed at the same time. In any case, the fix is to call `stopPropagation()` so that the event is only handled once.