### PR TITLE
Codap-691 FireFox Plotted Function

### DIFF
--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
@@ -89,7 +89,7 @@ export const PlottedFunctionAdornmentComponent = observer(function PlottedFuncti
       formulaFunction, min: tPixelMin, max: tPixelMax, cellCounts, gap: kPixelGap, xScale, yScale
     })
     if (tPoints.length === 0) return
-    path.current = `M${tPoints[0].x},${tPoints[0].y},${curveBasis(tPoints)}`
+    path.current = `M${tPoints[0].x} ${tPoints[0].y} ${curveBasis(tPoints)}`
 
     const selection = select(plottedFunctionRef.current)
     selection.append("path")

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -650,7 +650,7 @@ export const pathBasis = (p0: Point, p1: Point, p2: Point, p3: Point) => {
   const b2 = weight(basis[2])
   const b3 = weight(basis[3])
 
-  return `C${b1.x},${b1.y},${b2.x},${b2.y},${b3.x},${b3.y}`
+  return `C${b1.x} ${b1.y} ${b2.x} ${b2.y} ${b3.x} ${b3.y}`
 }
 
 // This is a modified version of CODAP V2's SvgScene.curveBasis which was extracted from protovis

--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -7,9 +7,8 @@ import { ICase } from "../data/data-set-types"
 import { IGlobalValueManager } from "../global/global-value-manager"
 import { IFormula } from "./formula"
 import {
-  IFormulaExtraMetadata, IFormulaManagerAdapter, IFormulaMetadata,
-  IFormulaManager
-, CaseList } from "./formula-manager-types"
+  IFormulaExtraMetadata, IFormulaManagerAdapter, IFormulaMetadata, IFormulaManager, CaseList
+} from "./formula-manager-types"
 import { IFormulaAdapterApi } from "./formula-manager-adapter"
 import {
   observeBoundaries, observeGlobalValues, observeLocalAttributes, observeLookupDependencies, observeSymbolNameChanges


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/CODAP-691

The Jira story says that the problem is with plotted functions using "x", but in reality no plotted functions would render in FireFox. The problem is that commas were used when specifying the `path` for the plotted function, which does not follow the specification. I guess Chrome was ok with this, but FireFox wasn't. The solution was to change the commas to spaces.