### PR TITLE
fix: Getting Started with CODAP 2 example document

### DIFF
--- a/v3/src/components/web-view/web-view-utils.test.ts
+++ b/v3/src/components/web-view/web-view-utils.test.ts
@@ -3,16 +3,20 @@ import { kRelativeGuideRoot, kRelativePluginRoot, kRelativeURLRoot, processWebVi
 
 const kTestUrls: Array<{ original: string, processed: string }> = [
   {
-    original: `https://concord-consortium.github.io/codap-data-interactives/Markov/`,
+    original: "https://concord-consortium.github.io/codap-data-interactives/Markov/",
     processed: `${kRootDataGamesPluginUrl}/Markov/index.html`
   },
   {
-    original: `../../../../extn/plugins/onboarding/`,
+    original: "../../../../extn/plugins/onboarding/",
     processed: `${kCodap3RootPluginsUrl}/onboarding/index.html`
   },
   {
-    original: `https://test/`,
-    processed: `https://test/index.html`
+    original: "../../../../extn/plugins/onboarding/onboarding_2.html",
+    processed: `${kCodap3RootPluginsUrl}/onboarding/onboarding_2.html`
+  },
+  {
+    original: "https://test/",
+    processed: "https://test/index.html"
   },
   {
     original: `${kRelativePluginRoot}/index.html`,
@@ -31,8 +35,8 @@ const kTestUrls: Array<{ original: string, processed: string }> = [
     processed: `${kRootGuideUrl}/Markov/markov_getstarted.html`
   },
   {
-    original: `http://index.html`,
-    processed: `https://index.html`
+    original: "http://index.html",
+    processed: "https://index.html"
   }
 ]
 

--- a/v3/src/components/web-view/web-view-utils.ts
+++ b/v3/src/components/web-view/web-view-utils.ts
@@ -6,11 +6,17 @@ export const kRelativeURLRoot = "%_url_%/guides"
 
 // Old/new plugin URL mappings stored as tuples of [oldUrl, newUrl] so that we can use
 // a substring match against the old URL to find the new URL.
-const kMappedUrls: Array<[string, string]> = [
+const kFullyReplacedUrls: Array<[RegExp, string]> = [
   // v3 version of Markov has been deployed to s3, but not all data games have been migrated
-  ["//concord-consortium.github.io/codap-data-interactives/Markov", `${kRootDataGamesPluginUrl}/Markov/`],
+  [/\/concord-consortium.github.io\/codap-data-interactives\/Markov\/?/, `${kRootDataGamesPluginUrl}/Markov/`],
   // onboarding plugins are proxied so that drag/drop works, so we used the proxied url
-  ["/plugins/onboarding/", `${kCodap3RootPluginsUrl}/onboarding/`],
+  [/\/plugins\/onboarding\/?$/, `${kCodap3RootPluginsUrl}/onboarding/`],
+]
+
+const kReplaceToken = "_$@_"
+const kPartiallyReplacedUrls: Array<[RegExp, string]> = [
+  // onboarding plugins are proxied so that drag/drop works, so we used the proxied url
+  [/\/plugins\/onboarding\/(.+)$/, `${kCodap3RootPluginsUrl}/onboarding/${kReplaceToken}`],
 ]
 
 export function processWebViewUrl(url: string) {
@@ -18,9 +24,16 @@ export function processWebViewUrl(url: string) {
 
   // Many plugins were hosted on GitHub pages at http://concord-consortium.github.io/codap-data-interactives/
   // or other sites but are now hosted on s3, so we have to change the URL to point to the new location.
-  const mappedUrl = kMappedUrls.find(([oldUrl]) => updatedUrl.includes(oldUrl))
-  if (mappedUrl) {
-    updatedUrl = mappedUrl[1]
+  const fullyReplacedUrlEntry = kFullyReplacedUrls.find(([urlRegex]) => urlRegex.test(updatedUrl))
+  if (fullyReplacedUrlEntry) {
+    updatedUrl = fullyReplacedUrlEntry[1]
+  }
+
+  for (const [urlRegex, newUrl] of kPartiallyReplacedUrls) {
+    const execResult: RegExpExecArray | null = urlRegex.exec(updatedUrl)
+    if (execResult && execResult.length > 1) {
+      updatedUrl = newUrl.replace(kReplaceToken, execResult[1])
+    }
   }
 
   // Some plugins relied on index.html being the default file loaded when pointing to a directory.

--- a/v3/src/components/web-view/web-view-utils.ts
+++ b/v3/src/components/web-view/web-view-utils.ts
@@ -30,7 +30,7 @@ export function processWebViewUrl(url: string) {
   }
 
   for (const [urlRegex, newUrl] of kPartiallyReplacedUrls) {
-    const execResult: RegExpExecArray | null = urlRegex.exec(updatedUrl)
+    const execResult = urlRegex.exec(updatedUrl)
     if (execResult && execResult.length > 1) {
       updatedUrl = newUrl.replace(kReplaceToken, execResult[1])
     }


### PR DESCRIPTION
The URL used for the `Getting Started with CODAP` document (`../../../../extn/plugins/onboarding/`), is a substring match for the url used for the `Getting Started with CODAP 2` document (`../../../../extn/plugins/onboarding/onboarding_2.html`), so we have to be careful about how the string-matching works when converting old urls to new ones. Toward that end, with this PR we switch from simple string-matching to regex-matching and support both full- and partial-string matching.