### PR TITLE
CODAP-83 add recover deleted formula

### DIFF
--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -575,6 +575,7 @@ context("case table ui", () => {
         // restored formula is re-evaluated resulting in a different value
         expect(random3).not.to.eq(random2)
       })
+      table.closeAttributeMenu()
 
       cy.log("Delete formula, then use recover formula")
       table.openAttributeMenu("Height")

--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -546,7 +546,8 @@ context("case table ui", () => {
         expect(random2 < 1).to.eq(true)
         expect(random2).not.to.eq(random1)
       })
-      // Delete formula, verify values remain
+
+      cy.log("Delete formula, verify values remain")
       table.openAttributeMenu("Height")
       table.selectMenuItemFromAttributeMenu("Delete Formula (Keeping Values)")
       table.getGridCell(2, 5).then(cell => {
@@ -555,21 +556,44 @@ context("case table ui", () => {
         expect(value < 1).to.eq(true)
         expect(value).to.eq(random2)
       })
-      // verify that formula was deleted
+
+      cy.log("Verify that formula was deleted")
       table.openAttributeMenu("Height")
       table.getAttributeMenuItem("Rerandomize").should("be.disabled")
       table.getAttributeMenuItem("Delete Formula (Keeping Values)").should("be.disabled")
-      // Undo formula deletion
+
+      cy.log("Undo formula deletion")
+      let random3 = 0
       toolbar.getUndoTool().click()
       table.openAttributeMenu("Height")
       table.getAttributeMenuItem("Rerandomize").should("be.enabled")
       table.getAttributeMenuItem("Delete Formula (Keeping Values)").should("be.enabled")
       table.getGridCell(2, 5).then(cell => {
+        random3 = +cell.text()
+        expect(random3 >= 0).to.eq(true)
+        expect(random3 < 1).to.eq(true)
+        // restored formula is re-evaluated resulting in a different value
+        expect(random3).not.to.eq(random2)
+      })
+
+      cy.log("Delete formula, then use recover formula")
+      table.openAttributeMenu("Height")
+      table.selectMenuItemFromAttributeMenu("Delete Formula (Keeping Values)")
+      table.getGridCell(2, 5).then(cell => {
+        const value = +cell.text()
+        expect(value >= 0).to.eq(true)
+        expect(value < 1).to.eq(true)
+        // after deleting the formula the values should still match
+        expect(value).to.eq(random3)
+      })
+      table.openAttributeMenu("Height")
+      table.selectMenuItemFromAttributeMenu("Recover Deleted Formula")
+      table.getGridCell(2, 5).then(cell => {
         const value = +cell.text()
         expect(value >= 0).to.eq(true)
         expect(value < 1).to.eq(true)
         // restored formula is re-evaluated resulting in a different value
-        expect(value).not.to.eq(random2)
+        expect(value).to.not.eq(random3)
       })
     })
     it("verify sorting", () => {

--- a/v3/cypress/support/elements/table-tile.ts
+++ b/v3/cypress/support/elements/table-tile.ts
@@ -113,6 +113,9 @@ export const TableTileElements = {
   openAttributeMenu(name: string, collectionIndex = 1) {
     this.getAttribute(name, collectionIndex).click({force: true})
   },
+  closeAttributeMenu() {
+    cy.get("[data-testid=attribute-menu-list][style*='visibility: visible']").type("{esc}")
+  },
   getAttributeMenuItem(item: string) {
     return cy.get("[data-testid=attribute-menu-list] button").contains(item)
   },

--- a/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
@@ -103,7 +103,11 @@ const AttributeMenuListComponent = forwardRef<HTMLDivElement, IProps>(
       isEnabled: () => !metadata?.isEditProtected(attributeId) && !!attribute?.hasFormula,
       handleClick: () => {
         data?.applyModelChange(() => {
-          attribute?.clearFormula()
+          if (!metadata) {
+            console.warn(`Metadata not found for data set: ${data?.id}`)
+            return
+          }
+          metadata.deleteAttributeFormula(attributeId)
         }, {
           // TODO Should also broadcast notify component edit formula notification
           undoStringKey: "DG.Undo.caseTable.editAttributeFormula",
@@ -114,11 +118,16 @@ const AttributeMenuListComponent = forwardRef<HTMLDivElement, IProps>(
     },
     {
       itemKey: "DG.TableController.headerMenuItems.recoverFormula",
-      isEnabled: () =>
-        !metadata?.isEditProtected(attributeId) && !attribute?.hasFormula && !!attribute?.hasRecoverableFormula,
+      isEnabled: () => !metadata?.isEditProtected(attributeId) &&
+          !attribute?.hasFormula &&
+          !!metadata?.getAttributeDeletedFormula(attributeId),
       handleClick: () => {
         data?.applyModelChange(() => {
-          attribute?.recoverFormula()
+          if (!metadata) {
+            console.warn(`Metadata not found for data set: ${data?.id}`)
+            return
+          }
+          metadata.recoverAttributeFormula(attributeId)
         }, {
           undoStringKey: "DG.Undo.caseTable.editAttributeFormula",
           redoStringKey: "DG.Undo.caseTable.editAttributeFormula",

--- a/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
@@ -113,7 +113,18 @@ const AttributeMenuListComponent = forwardRef<HTMLDivElement, IProps>(
       }
     },
     {
-      itemKey: "DG.TableController.headerMenuItems.recoverFormula"
+      itemKey: "DG.TableController.headerMenuItems.recoverFormula",
+      isEnabled: () =>
+        !metadata?.isEditProtected(attributeId) && !attribute?.hasFormula && !!attribute?.hasRecoverableFormula,
+      handleClick: () => {
+        data?.applyModelChange(() => {
+          attribute?.recoverFormula()
+        }, {
+          undoStringKey: "DG.Undo.caseTable.editAttributeFormula",
+          redoStringKey: "DG.Undo.caseTable.editAttributeFormula",
+          log: logMessageWithReplacement("Recover formula for attribute %@", { name: attribute?.name })
+        })
+      }
     },
     {
       itemKey: "DG.TableController.headerMenuItems.randomizeAttribute",

--- a/v3/src/data-interactive/data-interactive-type-utils.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.ts
@@ -126,7 +126,7 @@ export function convertAttributeToV2(attribute: IAttribute, dataContext?: IDataS
     renameable: (attribute && !metadata?.isRenameProtected(attribute.id)) ?? true,
     deleteable: (attribute && !metadata?.isDeleteProtected(attribute.id)) ?? true,
     formula: attribute.formula?.display,
-    deletedFormula: (attribute && metadata?.attributes.get(attribute.id)?.deletedFormula) || undefined,
+    deletedFormula: (attribute && metadata?.getAttributeDeletedFormula(attribute.id)) || undefined,
     guid: v2Id,
     id: v2Id,
     precision,

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -57,7 +57,6 @@ export const Attribute = V2Model.named("Attribute").props({
   units: types.maybe(types.string),
   precision: types.maybe(types.union(types.number, types.enumeration(Object.values(DatePrecision)))),
   formula: types.maybe(Formula),
-  recoverableFormulaText: types.maybe(types.string),
   // simple array -- _not_ MST all the way down to the array elements
   // due to its frozen nature, clients should _not_ use `values` directly
   // volatile `strValues` and `numValues` can be accessed directly, but
@@ -158,9 +157,6 @@ export const Attribute = V2Model.named("Attribute").props({
   }),
   get hasFormula() {
     return !!self.formula && !self.formula.empty
-  },
-  get hasRecoverableFormula() {
-    return !!self.recoverableFormulaText
   },
   get hasValidFormula() {
     return !!self.formula?.valid
@@ -309,14 +305,8 @@ export const Attribute = V2Model.named("Attribute").props({
     self.precision = precision
   },
   clearFormula() {
-    if (self.formula && !self.formula.empty) {
-      self.recoverableFormulaText = self.formula.display
-    }
     self.formula = undefined
   },
-  // NOTE: this behavior is slightly different from v2. In v3 if the formula is set to an empty string,
-  // we'll save the formula in recoverableFormulaText. In v2 the formula will not be recoverable in
-  // this case.
   setDisplayExpression(displayFormula: string) {
     if (displayFormula) {
       if (!self.formula) {
@@ -417,14 +407,6 @@ export const Attribute = V2Model.named("Attribute").props({
     for (let i = self.strValues.length - 1; i >= 0; --i) {
       self.strValues[i] = ""
       self.numValues[i] = self.toNumeric(self.strValues[i])
-    }
-  }
-}))
-.actions(self => ({
-  recoverFormula() {
-    if (self.recoverableFormulaText) {
-      self.setDisplayExpression(self.recoverableFormulaText)
-      self.recoverableFormulaText = undefined
     }
   }
 }))

--- a/v3/src/models/shared/data-set-metadata.ts
+++ b/v3/src/models/shared/data-set-metadata.ts
@@ -217,6 +217,9 @@ export const DataSetMetadata = SharedModel
     },
     getAttributeBinningType(attrId: string) {
       return self.attributes.get(attrId)?.scale?.binningType || "quantile"
+    },
+    getAttributeDeletedFormula(attrId: string) {
+      return self.attributes.get(attrId)?.deletedFormula
     }
   }))
   .actions(self => ({
@@ -390,12 +393,25 @@ export const DataSetMetadata = SharedModel
         scale.binningType = binningType
       }
     },
-    setDeletedFormula(attrId: string, formula?: string) {
+    setDeletedFormula(attrId: string, formula: Maybe<string>) {
       const attrMetadata = self.requireAttributeMetadata(attrId)
       attrMetadata.deletedFormula = formula || undefined
     }
   }))
   .actions(self => ({
+    deleteAttributeFormula(attrId: string) {
+      const attribute = self.getAttribute(attrId)
+      self.setDeletedFormula(attrId, attribute?.formula?.display)
+      attribute?.clearFormula()
+    },
+    recoverAttributeFormula(attrId: string) {
+      const formula = self.getAttributeDeletedFormula(attrId)
+      if (!formula) {
+        console.warn(`Deleted formula not found for attributeId: ${attrId}`)
+        return
+      }
+      self.getAttribute(attrId)?.setDisplayExpression(formula)
+    },
     removeCollectionLabels(collId: string) {
       const collMetadata = self.collections.get(collId)
       if (collMetadata) {

--- a/v3/src/v2/codap-v2-data-set-importer.ts
+++ b/v3/src/v2/codap-v2-data-set-importer.ts
@@ -171,7 +171,7 @@ export class CodapV2DataSetImporter {
           metadata.setAttributeDefaultRange(attribute.id, defaultMin, defaultMax)
         }
         if (deletedFormula) {
-          metadata.setDeletedFormula(deletedFormula)
+          metadata.setDeletedFormula(attribute.id, deletedFormula)
         }
       }
     })


### PR DESCRIPTION
This should work the same as CODAPv2.  I tested opening a v2 doc with a deleted formula and could recover it in v3. I also tested saving a doc with a deleted formula in v3 and opening in v2 and I was able to recover the formula.

It uses the dataset metadata to store the deleted formula which was already setup and not being used.
There was a bug in the import code for these deleted formulas which I fixed. I changed the typing of the setDeletedFormula function to prevent that kind of mistake in the future.