### PR TITLE
Codap-694 Position New Tiles Within Viewport

### DIFF
--- a/v3/src/utilities/view-utils.ts
+++ b/v3/src/utilities/view-utils.ts
@@ -22,8 +22,8 @@ export const getPositionOfNewComponent = (componentSize: { width?: number, heigh
 
   const iOffset = { x: 0, y: 0 }
   const initialX = kGap + viewportLeft + iOffset.x
-    const tStartAtBottom = (iPosition === 'bottom')
-  const initialY = (tStartAtBottom ? viewportBottom - componentHeight - kGap : kGap) + iOffset.y
+  const tStartAtBottom = (iPosition === 'bottom')
+  const initialY = (tStartAtBottom ? viewportBottom - componentHeight - kGap : viewportTop + kGap) + iOffset.y
 
   const findEmptyLocationForRect = () => {
     let componentPosition = { x: initialX, y: initialY }


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/CODAP-694

This PR ensures that new tiles are added to the viewport, making them always visible to users.

I took the opportunity to clean up the `getPositionOfNewComponent` function a bit. There are still some very funky things about this function, like `iOffset`, which is always `0` for both x and y but is sprinkled throughout the function.