### PR TITLE
CODAP-804 add new release targets for beta, ai4vs, and update staging

### DIFF
--- a/.github/workflows/release-v3-ai4vs.yml
+++ b/.github/workflows/release-v3-ai4vs.yml
@@ -1,0 +1,27 @@
+# This ai4vs release is separate from the beta, staging, and production releases
+# so we can control the timing of the ai4vs release independently.
+name: Release v3 ai4vs
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The git tag for the version to use for ai4vs
+        required: true
+env:
+  BUCKET: models-resources
+  PREFIX: codap3
+  SRC_FILE: index-top.html
+  DEST_FILE: ai4vs
+  workingDirectory: v3
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: >
+          aws s3 cp
+          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
+          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/${{ env.DEST_FILE }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.V3_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.V3_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/release-v3-beta.yml
+++ b/.github/workflows/release-v3-beta.yml
@@ -1,0 +1,27 @@
+# This beta release is separate from the staging and production releases
+# so we can control the timing of the beta release independently.
+name: Release v3 Beta
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The git tag for the version to use for beta
+        required: true
+env:
+  BUCKET: models-resources
+  PREFIX: codap3
+  SRC_FILE: index-top.html
+  DEST_FILE: beta
+  workingDirectory: v3
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: >
+          aws s3 cp
+          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
+          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/${{ env.DEST_FILE }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.V3_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.V3_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/release-v3-staging.yml
+++ b/.github/workflows/release-v3-staging.yml
@@ -1,25 +1,29 @@
+# Update codap3.concord.org/index-staging.html and codap3.cocnord.org/staging
 name: Release v3 Staging
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: The git tag for the version to use for index.html
+        description: The git tag for the version to use for index-staging.html
         required: true
 env:
   BUCKET: models-resources
   PREFIX: codap3
   SRC_FILE: index-top.html
-  DEST_FILE: index-staging.html
   workingDirectory: v3
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.V3_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.V3_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
-          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/${{ env.DEST_FILE }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.V3_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.V3_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
+          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/index-staging.html
+      - run: >
+          aws s3 cp
+          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
+          s3://${{ env.BUCKET }}/${{ env.PREFIX }}/staging


### PR DESCRIPTION
It seems like it works to have extension-less files in S3. So these updates use that to support the following URLs:
- codap3.concord.org/staging
- codap3.concord.org/beta
- codap3.concord.org/ai4vs