### PR TITLE
Codap-768 Card Swipe Followup

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -36280,7 +36280,8 @@
       }
     },
     "domhandler": {
-      "version": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
       "dev": true,
       "requires": {

--- a/v3/src/components/case-card/case-view.tsx
+++ b/v3/src/components/case-card/case-view.tsx
@@ -71,12 +71,8 @@ export const CaseView = observer(function InnerCaseView({
       // The lowest level should animate
       if (level < cardModel.animationLevel) {
         cardModel.setAnimationLevel(level)
-        cardModel.setAnimationDirection(
-          previousSelectedCaseIndex.current === -1 && displayedCaseIndex === cases.length - 1
-            ? "left" // Special case for pushing the left button while in summarized view
-            : previousSelectedCaseIndex.current <= displayedCaseIndex
-              ? "right" : "left"
-        )
+        cardModel.setAnimationDirection(previousSelectedCaseIndex.current > displayedCaseIndex ? "right" : "left")
+        
         // Reset the animation after the proper duration
         cardModel.setAnimationTimeout(setTimeout(() => {
           cardModel.setAnimationLevel(Infinity)

--- a/v3/src/components/case-card/case-view.tsx
+++ b/v3/src/components/case-card/case-view.tsx
@@ -38,7 +38,7 @@ interface IRenderSingleCaseViewArgs {
   style?: React.CSSProperties
 }
 
-export const CaseView = observer(function InnerCaseView({
+export const CaseView = observer(function CaseView({
   cases, dummy, level, onNewCollectionDrop, onSelectCases
 }: ICaseViewProps) {
   const cardModel = useCaseCardModel()

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -618,44 +618,9 @@ export const DataSet = V2Model.named("DataSet").props({
     Array.from(self.childCollection.caseGroupMap.values()).forEach(caseGroup => {
       self.itemIdChildCaseMap.set(caseGroup.childItemIds[0] ?? caseGroup.hiddenChildItemIds[0], caseGroup)
     })
-  },
-  // The returned array is in collection order.
-  // Includes cases with ANY child items selected, not just those with all items selected.
-  get partiallySelectedCaseIdsByCollection(): Set<string>[] {
-    const selectedCaseIds: Set<string>[] = []
-    self.selection.forEach((itemId) => {
-      const caseIds = self.getItemCaseIds(itemId)
-      caseIds?.forEach((caseId, index) => {
-        const collection = self.collections[index]
-        if (!collection) return
-
-        if (!selectedCaseIds[index]) {
-          selectedCaseIds[index] = new Set<string>()
-        }
-        selectedCaseIds[index].add(caseId)
-      })
-    })
-
-    return selectedCaseIds
   }
 }))
 .views(self => ({
-  // The returned array includes arrays of the sorted indices of partially selected cases in each collection
-  // So selectedCaseIndices[i] contains an array of the indices of the cases partially selected in data.collections[i]
-  // Includes cases with ANY child items selected, not just those with all items selected.
-  get partiallySelectedCaseIndicesByCollection(): number[][] {
-    const { partiallySelectedCaseIdsByCollection: selectedCaseIds } = self
-
-    const selectedCaseIndices: number[][] = []
-    selectedCaseIds.forEach((caseIds, index) => {
-      const collection = self.collections[index]
-      if (!collection) return
-
-      selectedCaseIndices[index] = Array.from(caseIds).map(caseId => collection.getCaseIndex(caseId))
-        .filter(caseIndex => caseIndex != null).sort()
-    })
-    return selectedCaseIndices
-  },
   childCases() {
     self.validateCases()
     return self.collections[self.collections.length - 1].cases
@@ -770,9 +735,46 @@ export const DataSet = V2Model.named("DataSet").props({
   getGroupsForCollection(collectionId?: string) {
     self.validateCases()
     return self.getCollection(collectionId)?.caseGroups ?? []
+  },
+  // The returned array is in collection order.
+  // Includes cases with ANY child items selected, not just those with all items selected.
+  get partiallySelectedCaseIdsByCollection(): Set<string>[] {
+    self.validateCases()
+
+    const selectedCaseIds: Set<string>[] = []
+    self.selection.forEach((itemId) => {
+      const caseIds = self.getItemCaseIds(itemId)
+      caseIds?.forEach((caseId, index) => {
+        const collection = self.collections[index]
+        if (!collection) return
+
+        if (!selectedCaseIds[index]) {
+          selectedCaseIds[index] = new Set<string>()
+        }
+        selectedCaseIds[index].add(caseId)
+      })
+    })
+
+    return selectedCaseIds
   }
 }))
 .views(self => ({
+  // The returned array includes arrays of the sorted indices of partially selected cases in each collection
+  // So selectedCaseIndices[i] contains an array of the indices of the cases partially selected in data.collections[i]
+  // Includes cases with ANY child items selected, not just those with all items selected.
+  get partiallySelectedCaseIndicesByCollection(): number[][] {
+    const { partiallySelectedCaseIdsByCollection: selectedCaseIds } = self
+
+    const selectedCaseIndices: number[][] = []
+    selectedCaseIds.forEach((caseIds, index) => {
+      const collection = self.collections[index]
+      if (!collection) return
+
+      selectedCaseIndices[index] = Array.from(caseIds).map(caseId => collection.getCaseIndex(caseId))
+        .filter(caseIndex => caseIndex != null).sort()
+    })
+    return selectedCaseIndices
+  },
   getCasesForCollection(collectionId?: string): readonly ICase[] {
     self.validateCases()
     return self.getCollection(collectionId)?.cases ?? []


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/CODAP-768

This PR switches the direction cards flip.

It also runs `validateCases` before accessing the selected cases within collections, ensuring that the accessed information is up to date. The views in `data-set.ts` were shifted so `validateCases` is defined, but the only actual change to the code is the call to `validateCases`.