### PR TITLE
feat: v2 import/export for plugins

### DIFF
--- a/v3/src/components/calculator/calculator-registration.ts
+++ b/v3/src/components/calculator/calculator-registration.ts
@@ -51,14 +51,14 @@ registerV2TileImporter(kV2CalculatorDGType, ({ v2Component, insertTile }) => {
   if (!isV2CalculatorComponent(v2Component)) return
 
   const { guid, componentStorage } = v2Component
-  const { name = "", title = "" } = componentStorage || {}
+  const { name = "", title, userSetTitle } = componentStorage || {}
 
   const content: ICalculatorSnapshot = {
     type: kCalculatorTileType,
     name
   }
   const calculatorTileSnap: ITileModelSnapshotIn = {
-    id: toV3Id(kCalculatorIdPrefix, guid), name, _title: title, content
+    id: toV3Id(kCalculatorIdPrefix, guid), name, _title: title, userSetTitle, content
   }
   const calculatorTile = insertTile(calculatorTileSnap)
 

--- a/v3/src/components/case-card/case-card-registration.ts
+++ b/v3/src/components/case-card/case-card-registration.ts
@@ -73,7 +73,7 @@ registerV2TileImporter("DG.CaseCard", ({ v2Component, v2Document, getCaseData, i
 
   const {
     guid,
-    componentStorage: { name, title = "", _links_, isActive, columnWidthPct, columnWidthMap, cannotClose }
+    componentStorage: { name, title, userSetTitle, _links_, isActive, columnWidthPct, columnWidthMap, cannotClose }
   } = v2Component
 
   const content: SetRequired<ICaseCardSnapshot, "attributeColumnWidths"> = {
@@ -101,7 +101,7 @@ registerV2TileImporter("DG.CaseCard", ({ v2Component, v2Document, getCaseData, i
   }
 
   const cardTileSnap: ITileModelSnapshotIn = {
-    id: toV3Id(kCaseCardIdPrefix, guid), name, _title: title, content, cannotClose
+    id: toV3Id(kCaseCardIdPrefix, guid), name, _title: title, userSetTitle, content, cannotClose
   }
   const transform: LayoutTransformFn = (options: IFreeTileInRowOptions) => {
     const { width, ...others } = options

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -99,7 +99,7 @@ registerV2TileImporter("DG.TableView", ({ v2Component, v2Document, getCaseData, 
   const {
     guid,
     componentStorage: {
-      name, title = "", _links_, isActive, attributeWidths, cannotClose, rowHeights,
+      name, title, userSetTitle, _links_, isActive, attributeWidths, cannotClose, rowHeights,
       horizontalScrollOffset, isIndexHidden
     }
   } = v2Component
@@ -142,7 +142,7 @@ registerV2TileImporter("DG.TableView", ({ v2Component, v2Document, getCaseData, 
   })
 
   const tableTileSnap: ITileModelSnapshotIn = {
-    id: toV3Id(kCaseTableIdPrefix, guid), name, _title: title, content, cannotClose
+    id: toV3Id(kCaseTableIdPrefix, guid), name, _title: title, userSetTitle, content, cannotClose
   }
   const tableTile = insertTile(tableTileSnap)
 

--- a/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
@@ -24,7 +24,7 @@ export const DatasetInfoModal = ({showInfoModal, setShowInfoModal}: IProps) => {
 
   const handleCloseInfoModal = () => {
     data?.applyModelChange(() => {
-      data.setTitle(datasetTitle)
+      data.setUserTitle(datasetTitle)
       metadata?.setDescription(description)
       metadata?.setSource(source)
       metadata?.setImportDate(importDate)

--- a/v3/src/components/component-title-bar.test.tsx
+++ b/v3/src/components/component-title-bar.test.tsx
@@ -52,7 +52,7 @@ describe("ComponentTitleBar", () => {
     expect(titleRenderCounter).toHaveBeenCalledTimes(1)
     expect(childRenderCounter).toHaveBeenCalledTimes(1)
     // change the title
-    act(() => tile.setTitle("newTitle"))
+    act(() => tile.setUserTitle("newTitle"))
     // ComponentTitleBar is re-rendered, but not parent or children
     expect(screen.getByText("newTitle")).toBeInTheDocument()
     expect(screen.getByText("Parent calls: 1")).toBeInTheDocument()

--- a/v3/src/components/component-title-bar.tsx
+++ b/v3/src/components/component-title-bar.tsx
@@ -30,7 +30,7 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
   const handleChangeTitle = (nextValue?: string) => {
     if (tile != null && nextValue !== undefined) {
       tile.applyModelChange(() => {
-        tile.setTitle(nextValue)
+        tile.setUserTitle(nextValue)
       }, {
         notify: updateTileNotification("titleChange", { from: title, to: nextValue }, tile),
         log: logMessageWithReplacement("Title changed to: %@", {nextValue}, "component"),

--- a/v3/src/components/graph/v2-graph-importer.ts
+++ b/v3/src/components/graph/v2-graph-importer.ts
@@ -43,7 +43,7 @@ export function v2GraphImporter({v2Component, v2Document, getCaseData, insertTil
     guid,
 
     componentStorage: {
-      name, title = "", _links_: links, plotModels, hiddenCases: _hiddenCaseIds, cannotClose,
+      name, title, userSetTitle, _links_: links, plotModels, hiddenCases: _hiddenCaseIds, cannotClose,
       pointColor, transparency, strokeColor, strokeTransparency, pointSizeMultiplier,
       strokeSameAsFill, isTransparent, displayOnlySelected, enableNumberToggle, numberToggleLastMode,
       plotBackgroundImage, plotBackgroundImageLockInfo, numberOfLegendQuantiles, legendQuantilesAreLocked
@@ -201,7 +201,7 @@ export function v2GraphImporter({v2Component, v2Document, getCaseData, insertTil
   }
 
   const graphTileSnap: ITileModelSnapshotIn =
-      { id: toV3Id(kGraphIdPrefix, guid), name, _title: title, content, cannotClose }
+      { id: toV3Id(kGraphIdPrefix, guid), name, _title: title, userSetTitle, content, cannotClose }
   const graphTile = insertTile(graphTileSnap)
 
   // link shared model

--- a/v3/src/components/map/v2-map-importer.ts
+++ b/v3/src/components/map/v2-map-importer.ts
@@ -20,7 +20,7 @@ import {IMapPolygonLayerModelSnapshot} from "./models/map-polygon-layer-model"
 export function v2MapImporter({v2Component, v2Document, getCaseData, insertTile}: V2TileImportArgs) {
   if (!isV2MapComponent(v2Component)) return
 
-  const { guid, componentStorage: { name, title = "", mapModelStorage, cannotClose } } = v2Component
+  const { guid, componentStorage: { name, title, userSetTitle, mapModelStorage, cannotClose } } = v2Component
   const { center, zoom, baseMapLayerName: v2BaseMapLayerName } = mapModelStorage
   const baseMapKeyMap: Record<string, BaseMapKey> = { Topographic: 'topo', Streets: 'streets', Oceans: 'oceans' }
   const baseMapLayerName = baseMapKeyMap[v2BaseMapLayerName]
@@ -134,6 +134,6 @@ export function v2MapImporter({v2Component, v2Document, getCaseData, insertTile}
   }
 
   const mapTileSnap: ITileModelSnapshotIn =
-          { id: toV3Id(kMapIdPrefix, guid), name, _title: title, content, cannotClose }
+          { id: toV3Id(kMapIdPrefix, guid), name, _title: title, userSetTitle, content, cannotClose }
   return insertTile(mapTileSnap)
 }

--- a/v3/src/components/slider/slider-registration.ts
+++ b/v3/src/components/slider/slider-registration.ts
@@ -125,8 +125,8 @@ registerV2TileImporter("DG.SliderView", ({ v2Component, v2Document, getGlobalVal
   const {
     guid: componentGuid,
     componentStorage: {
-      name, title: v2Title = "", _links_, lowerBound, upperBound, animationDirection, animationMode,
-      restrictToMultiplesOf, maxPerSecond, userTitle, userSetTitle, cannotClose, v3
+      name, title, _links_, lowerBound, upperBound, animationDirection, animationMode,
+      restrictToMultiplesOf, maxPerSecond, userSetTitle, cannotClose, v3
     }
   } = v2Component
   const globalId = _links_.model.id
@@ -162,9 +162,8 @@ registerV2TileImporter("DG.SliderView", ({ v2Component, v2Document, getGlobalVal
     _animationRate: maxPerSecond ?? undefined,
     axis: { type: axisType, place: "bottom", min: axisMin, max: axisMax }
   }
-  const title = v2Title && (userTitle || userSetTitle) ? v2Title : undefined
   const sliderTileSnap: ITileModelSnapshotIn = {
-    id: toV3Id(kSliderIdPrefix, componentGuid), name, _title: title, content, cannotClose
+    id: toV3Id(kSliderIdPrefix, componentGuid), name, _title: title, userSetTitle, content, cannotClose
   }
   const sliderTile = insertTile(sliderTileSnap)
 

--- a/v3/src/components/text/text-registration.ts
+++ b/v3/src/components/text/text-registration.ts
@@ -114,14 +114,14 @@ registerV2TileExporter(kTextTileType, ({ tile }) => {
 registerV2TileImporter(kV2TextDGType, ({ v2Component, insertTile }) => {
   if (!isV2TextComponent(v2Component)) return
 
-  const { guid, componentStorage: { title = "", text, cannotClose } } = v2Component
+  const { guid, componentStorage: { title, userSetTitle, text, cannotClose } } = v2Component
 
   const content: SetRequired<ITextSnapshot, "type"> = {
     type: kTextTileType,
     value: importTextToModelValue(text)
   }
   const textTileSnap: ITileModelSnapshotIn =
-          { id: toV3Id(kTextIdPrefix, guid), _title: title, content, cannotClose }
+          { id: toV3Id(kTextIdPrefix, guid), _title: title, userSetTitle, content, cannotClose }
   const textTile = insertTile(textTileSnap)
 
   return textTile

--- a/v3/src/components/web-view/web-view-model.ts
+++ b/v3/src/components/web-view/web-view-model.ts
@@ -29,15 +29,22 @@ export const WebViewModel = TileContentModel
     pageIndex: 0,
     pages: types.array(WebPageModel),
     // for games/plugins
+    // TODO: should this be a safeReference instead?
+    dataContextId: types.maybe(types.string),
     state: types.frozen<unknown>(),
     // fields controlled by plugins (like Collaborative) via interactiveFrame requests
+    // allows the user to delete empty attributes, even if preventAttributeDeletion is true
     allowEmptyAttributeDeletion: kDefaultAllowEmptyAttributeDeletion,
     blockAPIRequestsWhileEditing: kDefaultBlockAPIRequestsWhileEditing,
+    // prevent the user from deleting attributes (see exception for empty attributes above)
     preventAttributeDeletion: kDefaultPreventAttributeDeletion,
     preventBringToFront: kDefaultPreventBringToFront,
     preventDataContextReorg: kDefaultPreventDataContextReorg,
     preventTopLevelReorg: kDefaultPreventTopLevelReorg,
-    respectEditableItemAttribute: kDefaultRespectEditableItemAttribute
+    // this property is referenced in the v2 code but does not appear to ever be set
+    respectEditableItemAttribute: kDefaultRespectEditableItemAttribute,
+    // whether this web view was imported (in part) from a v2 DG.GameContext
+    hasV2GameContext: types.maybe(types.literal(true))
   })
   .volatile(self => ({
     dataInteractiveController: undefined as iframePhone.IframePhoneRpcEndpoint | undefined,

--- a/v3/src/components/web-view/web-view-registration.ts
+++ b/v3/src/components/web-view/web-view-registration.ts
@@ -5,12 +5,13 @@ import { IFreeTileLayout } from "../../models/document/free-tile-row"
 import { registerTileComponentInfo } from "../../models/tiles/tile-component-info"
 import { registerTileContentInfo } from "../../models/tiles/tile-content-info"
 import { ITileModelSnapshotIn } from "../../models/tiles/tile-model"
-import { toV3Id } from "../../utilities/codap-utils"
+import { toV2Id, toV3DataSetId, toV3Id } from "../../utilities/codap-utils"
 import { t } from "../../utilities/translation/translate"
+import { isCodapV2GameContext } from "../../v2/codap-v2-data-context-types"
 import { registerV2TileImporter, V2TileImportArgs } from "../../v2/codap-v2-tile-importers"
 import { registerV2TileExporter, V2ExportedComponent, V2TileExportFn } from "../../v2/codap-v2-tile-exporters"
 import {
-  ICodapV2GameViewComponent, ICodapV2GuideViewComponent, ICodapV2WebViewComponent,
+  guidLink, ICodapV2GameViewComponent, ICodapV2GuideViewComponent, ICodapV2WebViewComponent,
   isV2GameViewComponent, isV2GuideViewComponent, isV2ImageViewComponent, isV2WebViewComponent
 } from "../../v2/codap-v2-types"
 import { kV2GameType, kV2GuideViewType, kV2ImageComponentViewType, kV2WebViewType, kWebViewTileType,
@@ -48,19 +49,35 @@ registerTileComponentInfo({
   renderWhenHidden: true
 })
 
-const exportFn: V2TileExportFn = ({ tile, row }) => {
-  // This really should be a WebView Model. We shouldn't be called unless
-  // the tile type is kWebViewTileType which is what isWebViewModel is using.
+const exportFn: V2TileExportFn = ({ tile, row, gameContextMetadataMap }) => {
   const webViewContent = isWebViewModel(tile.content) ? tile.content : undefined
   const url = webViewContent?.url ?? ""
   if (webViewContent?.isPlugin) {
+    const { allowEmptyAttributeDeletion, preventAttributeDeletion, preventBringToFront,
+            preventDataContextReorg, preventTopLevelReorg, state } = webViewContent
+    const _links_ = webViewContent.dataContextId
+      ? { _links_: { context: guidLink("DG.DataContextRecord", toV2Id(webViewContent.dataContextId)) } }
+      : undefined
+    if (gameContextMetadataMap && webViewContent.hasV2GameContext && webViewContent.dataContextId) {
+      gameContextMetadataMap[webViewContent.dataContextId] = {
+        gameName: tile.name || undefined,
+        gameUrl: url || undefined,
+        gameState: state ?? undefined
+      }
+    }
     const v2GameView: V2ExportedComponent<ICodapV2GameViewComponent> = {
       type: "DG.GameView",
       componentStorage: {
         currentGameUrl: url,
         currentGameName: tile.name,
-        savedGameState: webViewContent?.state ?? undefined
-        // TODO_V2_EXPORT add the rest of the game properties
+        savedGameState: state ?? undefined,
+        ...(allowEmptyAttributeDeletion === false ? { allowEmptyAttributeDeletion: false } : {}),
+        allowInitGameOverride: true, // unused by v2, but exported for compatibility
+        ...(preventAttributeDeletion ? { preventAttributeDeletion } : {}),
+        preventBringToFront,
+        ...(preventDataContextReorg ? { preventDataContextReorg } : {}),
+        ...(preventTopLevelReorg ? { preventTopLevelReorg } : {}),
+        ..._links_
       }
     }
     return v2GameView
@@ -114,15 +131,8 @@ function addWebViewSnapshot(args: V2TileImportArgs, name?: string, _content?: Pa
   const webViewTileSnap: ITileModelSnapshotIn = {
     id: toV3Id(kWebViewIdPrefix, guid),
     name,
-    // Note: when a game view is imported the userSetTitle is often
-    // false, and often the title property is set to title which the plugin provided
-    // to CODAPv2. This value is also set in componentStorage.currentGameName. This
-    // currentGameName value is imported as the name field above.
-    // If round tripping a v2 document through v3 the title will be lost because
-    // of this. The name will be preserved though. Even when the name was not preserved
-    // CODAPv2 seemed to handle this correctly and updated the the title when the document
-    // is loaded.
-    _title: (userSetTitle && title) || undefined,
+    _title: title,
+    userSetTitle,
     content,
     cannotClose
   }
@@ -145,16 +155,36 @@ function importWebView(args: V2TileImportArgs) {
 registerV2TileImporter("DG.WebView", importWebView)
 
 function importGameView(args: V2TileImportArgs) {
-  const { v2Component } = args
+  const { v2Component, v2Document } = args
   if (!isV2GameViewComponent(v2Component)) return
 
   // parse the v2 content
-  const { componentStorage: { currentGameUrl, currentGameName, savedGameState} } = v2Component
+  const { componentStorage: {
+    _links_, currentGameUrl, currentGameName, allowEmptyAttributeDeletion, preventAttributeDeletion,
+    preventBringToFront, preventDataContextReorg, preventTopLevelReorg, savedGameState
+  } } = v2Component
+  const linkedDataContextId = _links_?.context?.id
+  const linkedDataContext = linkedDataContextId ? v2Document.getV2DataContext(linkedDataContextId) : undefined
+  const linkedGameContext = isCodapV2GameContext(linkedDataContext) ? linkedDataContext : undefined
+
+  const gameName = currentGameName ?? linkedGameContext?.contextStorage?.gameName ?? undefined
+  const gameUrl = currentGameUrl ?? linkedGameContext?.contextStorage?.gameUrl ?? undefined
+  const gameState = savedGameState ?? linkedGameContext?.contextStorage?.gameState ?? undefined
 
   // create webView model
   // Note: a renamed GameView has the componentStorage.currentGameName set to the value
   // provided by the plugin, only the componentStorage.title is updated
-  return addWebViewSnapshot(args, currentGameName, { state: savedGameState, url: processWebViewUrl(currentGameUrl) })
+  return addWebViewSnapshot(args, gameName, {
+    url: processWebViewUrl(gameUrl),
+    dataContextId: linkedDataContextId ? toV3DataSetId(linkedDataContextId) : undefined,
+    state: gameState,
+    allowEmptyAttributeDeletion,
+    preventAttributeDeletion,
+    preventBringToFront,
+    preventDataContextReorg,
+    preventTopLevelReorg,
+    hasV2GameContext: linkedGameContext ? true : undefined
+  })
 }
 registerV2TileImporter("DG.GameView", importGameView)
 

--- a/v3/src/data-interactive/data-interactive-type-utils.test.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.test.ts
@@ -29,7 +29,7 @@ describe("DataInteractiveTypeUtils", () => {
     const c3Id = toV2Id(data.collections[1].cases[2].__id__)
     const c4Id = toV2Id(data.collections[1].cases[3].__id__)
 
-    const dataExport = convertDataSetToV2(data, true)
+    const dataExport = convertDataSetToV2(data, { exportCases: true })
     expect(dataExport).toEqual({
       document: 1,
       guid: 2,

--- a/v3/src/data-interactive/data-interactive-type-utils.ts
+++ b/v3/src/data-interactive/data-interactive-type-utils.ts
@@ -5,14 +5,15 @@ import { IDataSet } from "../models/data/data-set"
 import { ICase, IGetCaseOptions } from "../models/data/data-set-types"
 import { v2ModelSnapshotFromV2ModelStorage } from "../models/data/v2-model"
 import { IGlobalValue } from "../models/global/global-value"
+import { IV2CollectionDefaults } from "../models/shared/data-set-metadata"
 import { getMetadataFromDataSet } from "../models/shared/shared-data-utils"
 import { kAttrIdPrefix, maybeToV2Id, toV2Id, toV2ItemId, toV3AttrId } from "../utilities/codap-utils"
-import { IV2CollectionDefaults } from "../models/shared/data-set-metadata"
-import { ICodapV2DataContextV3 } from "../v2/codap-v2-types"
 import {
   ICodapV2Attribute, ICodapV2Case, ICodapV2CategoryMap, ICodapV2CollectionV3, ICodapV2DataContextSelectedCase,
   v3TypeFromV2TypeString
 } from "../v2/codap-v2-data-context-types"
+import { GameContextMetadataMap } from "../v2/codap-v2-tile-exporters"
+import { ICodapV2DataContextV3 } from "../v2/codap-v2-types"
 import { DIGetCaseResult, DIAttribute } from "./data-interactive-data-set-types"
 import { DIResources, DISingleValues } from "./data-interactive-types"
 import { getCaseValues } from "./data-interactive-utils"
@@ -187,20 +188,28 @@ export function convertCollectionToV2(collection: ICollectionModel, options?: CC
   }
 }
 
-export function convertDataSetToV2(dataSet: IDataSet, exportCases = false): ICodapV2DataContextV3 {
+export interface IConvertDataSetToV2Options {
+  exportCases?: boolean
+  gameContextMetadataMap?: GameContextMetadataMap
+}
+
+export function convertDataSetToV2(dataSet: IDataSet, options?: IConvertDataSetToV2Options): ICodapV2DataContextV3 {
   const { name, _title, id } = dataSet
+  const { exportCases = false, gameContextMetadataMap } = options || {}
   const v3Metadata = getMetadataFromDataSet(dataSet)
   const { description, source, importDate, isAttrConfigChanged, isAttrConfigProtected } = v3Metadata || {}
   const v2Id = toV2Id(id)
   const itemOptions: IGetCaseOptions = { canonical: false, numeric: true }
-  let foundDefaultsInCollection = false
+  const gameContextMetadata = gameContextMetadataMap?.[id]
+  let isGameContext = gameContextMetadata != null
   dataSet.validateCases()
 
   const selectedCases: ICodapV2DataContextSelectedCase[] = []
   const collections: ICodapV2CollectionV3[] =
     dataSet.collections.map(collection => {
       const defaults = v3Metadata?.collections.get(collection.id)?.defaults
-      foundDefaultsInCollection ||= defaults?.isNonEmpty || false
+      // if there are collection defaults, we assume this is a game context
+      isGameContext ||= defaults?.isNonEmpty || false
       collection.caseIds.forEach(caseId => {
         if (dataSet.isCaseSelected(caseId)) {
           selectedCases.push({ type: "DG.Case", id: toV2Id(caseId) })
@@ -209,11 +218,11 @@ export function convertDataSetToV2(dataSet: IDataSet, exportCases = false): ICod
       return convertCollectionToV2(collection, { dataSet, exportCases, defaults })
     })
   const v2Metadata = v3Metadata?.hasDataContextMetadata
-                    ? { metadata: { description, source, importDate} }
+                    ? { metadata: { description, source, importDate } }
                     : undefined
 
   return {
-    type: foundDefaultsInCollection ? "DG.GameContext" : "DG.DataContext",
+    type: isGameContext ? "DG.GameContext" : "DG.DataContext",
     document: 1,
     guid: v2Id,
     id: v2Id,
@@ -226,7 +235,10 @@ export function convertDataSetToV2(dataSet: IDataSet, exportCases = false): ICod
     setAsideItems: dataSet._itemIds
                     .filter(itemId => dataSet.isItemSetAside(itemId))
                     .map(itemId => ({ id: toV2ItemId(itemId), values: dataSet.getItem(itemId, itemOptions) ?? {} })),
-    contextStorage: { _links_: { selectedCases } }
+    contextStorage: {
+      _links_: { selectedCases },
+      ...(gameContextMetadata ?? {})
+    }
   }
 }
 

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -67,7 +67,7 @@ import { compareValues } from "../../utilities/data-utils"
 import { hashOrderedStringSet, hashStringSet } from "../../utilities/js-utils"
 import { gLocale } from "../../utilities/translation/locale"
 import { t } from "../../utilities/translation/translate"
-import { V2Model } from "./v2-model"
+import { V2UserTitleModel } from "./v2-user-title-model"
 
 // remnant of derived DataSet implementation that isn't in active use
 interface IEnvContext {
@@ -139,7 +139,7 @@ export const nullItemData: IItemData = {
   invalidate: () => {}
 } as IItemData
 
-export const DataSet = V2Model.named("DataSet").props({
+export const DataSet = V2UserTitleModel.named("DataSet").props({
   id: typeV3Id("DATA"),
   sourceID: types.maybe(types.string),
   // ordered parent-most to child-most

--- a/v3/src/models/data/v2-model.test.ts
+++ b/v3/src/models/data/v2-model.test.ts
@@ -9,7 +9,6 @@ describe("V2Model", () => {
     expect(m.name).toBe("")
     expect(m._title).toBeUndefined()
     expect(m.title).toBe("")
-    expect(m.userSetTitle).toBe(false)
     expect(m.matchNameOrId("")).toBe(false)
     expect(m.matchTitleOrNameOrId("")).toBe(false)
 
@@ -18,7 +17,6 @@ describe("V2Model", () => {
     expect(m.name).toBe("name")
     expect(m._title).toBeUndefined()
     expect(m.title).toBe("name")
-    expect(m.userSetTitle).toBe(false)
     expect(m.matchNameOrId("")).toBe(false)
     expect(m.matchNameOrId("name")).toBe(true)
     expect(m.matchTitleOrNameOrId("")).toBe(false)
@@ -29,7 +27,6 @@ describe("V2Model", () => {
     expect(m.name).toBe("name")
     expect(m._title).toBe("title")
     expect(m.title).toBe("title")
-    expect(m.userSetTitle).toBe(true)
     expect(m.matchNameOrId("")).toBe(false)
     expect(m.matchNameOrId("name")).toBe(true)
     expect(m.matchNameOrId("title")).toBe(false)

--- a/v3/src/models/data/v2-model.ts
+++ b/v3/src/models/data/v2-model.ts
@@ -11,9 +11,6 @@ export const V2Model = types.model("V2Model", {
   get title() {
     return self._title ?? self.name
   },
-  get userSetTitle() {
-    return self._title != null
-  },
   matchNameOrId(nameOrId: string | number) {
     /* eslint-disable eqeqeq */
     return (!!self.name && self.name == nameOrId) ||

--- a/v3/src/models/data/v2-user-title-model.test.ts
+++ b/v3/src/models/data/v2-user-title-model.test.ts
@@ -1,0 +1,13 @@
+import { V2UserTitleModel } from "./v2-user-title-model"
+
+describe("V2UserTitleModel", () => {
+  it("should create a model with a user-settable title", () => {
+    const model = V2UserTitleModel.create({ name: "Title" })
+    expect(model._title).toBeUndefined()
+    expect(model.title).toBe("Title")
+    expect(model.userSetTitle).toBeUndefined()
+    model.setUserTitle("User Title")
+    expect(model.title).toBe("User Title")
+    expect(model.userSetTitle).toBe(true)
+  })
+})

--- a/v3/src/models/data/v2-user-title-model.ts
+++ b/v3/src/models/data/v2-user-title-model.ts
@@ -1,0 +1,13 @@
+import { types } from "mobx-state-tree"
+import { V2Model } from "./v2-model"
+
+export const V2UserTitleModel = V2Model.named("V2UserTitleModel")
+.props({
+  userSetTitle: types.maybe(types.boolean)
+})
+.actions(self => ({
+  setUserTitle(title: string) {
+    self._title = title
+    self.userSetTitle = true
+  }
+}))

--- a/v3/src/models/tiles/tile-model.ts
+++ b/v3/src/models/tiles/tile-model.ts
@@ -4,7 +4,7 @@ import { getParent, getSnapshot, getType,
 import { applyModelChange } from "../history/apply-model-change"
 import { StringBuilder } from "../../utilities/string-builder"
 import { v3Id, typeV3Id } from "../../utilities/codap-utils"
-import { V2Model } from "../data/v2-model"
+import { V2UserTitleModel } from "../data/v2-user-title-model"
 import { DisplayUserTypeEnum } from "../stores/user-types"
 import { ITileContentModel } from "./tile-content"
 import { getTileContentInfo, ITileExportOptions } from "./tile-content-info"
@@ -48,15 +48,7 @@ export function getTileModel(tileContentModel: ITileContentModel) {
   }
 }
 
-export function getTileTitleFromContent(tileContentModel: ITileContentModel) {
-  return getTileModel(tileContentModel)?.title
-}
-
-export function setTileTitleFromContent(tileContentModel: ITileContentModel, title: string) {
-  getTileModel(tileContentModel)?.setTitle(title)
-}
-
-export const TileModel = V2Model.named("TileModel")
+export const TileModel = V2UserTitleModel.named("TileModel")
   .props({
     // if not provided, will be generated
     id: typeV3Id("TILE"),

--- a/v3/src/test/v2/markov-example.codap
+++ b/v3/src/test/v2/markov-example.codap
@@ -1,0 +1,308 @@
+{
+    "name": "Markov Sample",
+    "guid": 1,
+    "components": [
+        {
+            "type": "DG.GameView",
+            "guid": 2,
+            "componentStorage": {
+                "currentGameName": "Markov",
+                "currentGameUrl": "http://concord-consortium.github.io/codap-data-interactives/Markov/",
+                "allowInitGameOverride": true,
+                "preventBringToFront": false,
+                "preventDataContextReorg": true,
+                "_links_": {
+                    "context": {
+                        "type": "DG.DataContextRecord",
+                        "id": 3
+                    }
+                },
+                "title": "Markov",
+                "userSetTitle": false,
+                "cannotClose": false
+            },
+            "layout": {
+                "width": 550,
+                "height": 340,
+                "zIndex": 3,
+                "isVisible": true
+            },
+            "savedHeight": null
+        },
+        {
+            "type": "DG.GuideView",
+            "guid": 16,
+            "componentStorage": {
+                "title": "Markov Sample Guide",
+                "items": [
+                    {
+                        "itemTitle": "Getting Started",
+                        "url": "%_url_%/guides/Markov/markov_getstarted.html"
+                    }
+                ],
+                "currentItemIndex": 0,
+                "isVisible": true,
+                "name": "Markov Sample Guide"
+            },
+            "layout": {
+                "left": 3,
+                "top": 350,
+                "width": 566,
+                "height": 475,
+                "isVisible": true,
+                "zIndex": 3
+            },
+            "savedHeight": null
+        }
+    ],
+    "contexts": [
+        {
+            "type": "DG.GameContext",
+            "document": 1,
+            "guid": 3,
+            "flexibleGroupingChangeFlag": false,
+            "name": "Data_Set_1",
+            "title": "Games/Turns",
+            "collections": [
+                {
+                    "areParentChildLinksConfigured": true,
+                    "attrs": [
+                        {
+                            "name": "game",
+                            "type": "numeric",
+                            "title": "game",
+                            "defaultMin": 1,
+                            "defaultMax": 5,
+                            "description": "game number",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 5,
+                            "precision": 0,
+                            "unit": null
+                        },
+                        {
+                            "name": "turns",
+                            "type": "numeric",
+                            "title": "turns",
+                            "defaultMin": 0,
+                            "defaultMax": 10,
+                            "description": "number of turns in the game",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 6,
+                            "precision": 0,
+                            "unit": null
+                        },
+                        {
+                            "name": "winner",
+                            "type": "nominal",
+                            "title": "winner",
+                            "description": "who won? You or Markov?",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 7,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "level",
+                            "type": "nominal",
+                            "title": "level",
+                            "description": "what level of the game was played",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 8,
+                            "precision": 2,
+                            "unit": null
+                        }
+                    ],
+                    "cases": [],
+                    "childAttrName": null,
+                    "defaults": {
+                        "xAttr": "game",
+                        "yAttr": "score"
+                    },
+                    "guid": 4,
+                    "name": "Games",
+                    "title": "Games",
+                    "type": "DG.Collection"
+                },
+                {
+                    "areParentChildLinksConfigured": true,
+                    "attrs": [
+                        {
+                            "name": "turn",
+                            "type": "numeric",
+                            "title": "turn",
+                            "defaultMin": 0,
+                            "defaultMax": 10,
+                            "description": "the turn number in the game",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 10,
+                            "precision": 0,
+                            "unit": null
+                        },
+                        {
+                            "name": "markovs_move",
+                            "type": "nominal",
+                            "title": "markovs_move",
+                            "description": "the move markov made this turn",
+                            "_categoryMap": {
+                                "R": "red",
+                                "P": "blue",
+                                "S": "green",
+                                "__order": [
+                                    "R",
+                                    "P",
+                                    "S"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 11,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "your_move",
+                            "type": "nominal",
+                            "title": "your_move",
+                            "description": "the move you made this turn",
+                            "_categoryMap": {
+                                "R": "red",
+                                "P": "blue",
+                                "S": "green",
+                                "__order": [
+                                    "R",
+                                    "P",
+                                    "S"
+                                ]
+                            },
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 12,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "result",
+                            "type": "nominal",
+                            "title": "result",
+                            "description": "did you win or lose this turn?",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 13,
+                            "precision": 2,
+                            "unit": null
+                        },
+                        {
+                            "name": "up_down",
+                            "type": "numeric",
+                            "title": "up_down",
+                            "defaultMin": -1,
+                            "defaultMax": 1,
+                            "description": "the number of steps up or down Madeline moved",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 14,
+                            "precision": 0,
+                            "unit": null
+                        },
+                        {
+                            "name": "previous_2_markov_moves",
+                            "type": "nominal",
+                            "title": "previous_2_markov_moves",
+                            "description": "the two moves Markov made prior to this one",
+                            "blockDisplayOfEmptyCategories": true,
+                            "editable": false,
+                            "hidden": false,
+                            "guid": 15,
+                            "precision": 2,
+                            "unit": null
+                        }
+                    ],
+                    "cases": [],
+                    "childAttrName": null,
+                    "defaults": {
+                        "xAttr": "previous_2_markov_moves",
+                        "yAttr": "markovs_move"
+                    },
+                    "guid": 9,
+                    "name": "Turns",
+                    "parent": 4,
+                    "title": "Turns",
+                    "type": "DG.Collection"
+                }
+            ],
+            "description": "",
+            "preventReorg": false,
+            "setAsideItems": [],
+            "contextStorage": {
+                "gameName": "Markov",
+                "gameState": {
+                    "gameNumber": 0,
+                    "currentLevel": "Tethys",
+                    "levelsMap": {
+                        "Tethys": true,
+                        "Deimos": true,
+                        "Phobos": true,
+                        "Callisto": true
+                    },
+                    "strategy": {
+                        "RR": {
+                            "move": "",
+                            "weight": 2
+                        },
+                        "RP": {
+                            "move": "",
+                            "weight": 2
+                        },
+                        "RS": {
+                            "move": "",
+                            "weight": 2
+                        },
+                        "PP": {
+                            "move": "",
+                            "weight": 2
+                        },
+                        "PR": {
+                            "move": "",
+                            "weight": 2
+                        },
+                        "PS": {
+                            "move": "",
+                            "weight": 2
+                        },
+                        "SS": {
+                            "move": "",
+                            "weight": 2
+                        },
+                        "SR": {
+                            "move": "",
+                            "weight": 2
+                        },
+                        "SP": {
+                            "move": "",
+                            "weight": 2
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "globalValues": [],
+    "appName": "DG",
+    "appVersion": "2.0",
+    "appBuildNum": "0449",
+    "metadata": {}
+}

--- a/v3/src/v2/codap-v2-data-context-types.ts
+++ b/v3/src/v2/codap-v2-data-context-types.ts
@@ -207,8 +207,9 @@ export interface ICodapV2GameContextStorage extends ICodapV2DataContextStorage {
   gameState?: any
 }
 
-export type CodapV2Context = ICodapV2DataContext | ICodapV2GameContext | ICodapV2ExternalContext
-export const isV2ExternalContext = (context?: CodapV2Context): context is ICodapV2ExternalContext =>
+export type CodapV2InternalContext = ICodapV2DataContext | ICodapV2GameContext
+export type CodapV2Context = CodapV2InternalContext | ICodapV2ExternalContext
+export const isV2ExternalContext = (context: Maybe<CodapV2Context>): context is ICodapV2ExternalContext =>
   !!context && !("type" in context) && ("externalDocumentId" in context)
-export const isV2InternalContext = (context?: CodapV2Context): context is ICodapV2DataContext | ICodapV2GameContext =>
+export const isV2InternalContext = (context: Maybe<CodapV2Context>): context is CodapV2InternalContext =>
   !!context && ("type" in context)

--- a/v3/src/v2/codap-v2-data-context-types.ts
+++ b/v3/src/v2/codap-v2-data-context-types.ts
@@ -186,6 +186,9 @@ export interface ICodapV2GameContext extends Omit<ICodapV2DataContext, "type"> {
   type: "DG.GameContext"
   contextStorage: ICodapV2GameContextStorage
 }
+export function isCodapV2GameContext(context?: CodapV2Context): context is ICodapV2GameContext {
+  return !!context && "type" in context && context.type === "DG.GameContext"
+}
 
 export interface ICodapV2DataContextSelectedCase {
   type: "DG.Case"
@@ -205,7 +208,7 @@ export interface ICodapV2GameContextStorage extends ICodapV2DataContextStorage {
 }
 
 export type CodapV2Context = ICodapV2DataContext | ICodapV2GameContext | ICodapV2ExternalContext
-export const isV2ExternalContext = (context: CodapV2Context): context is ICodapV2ExternalContext =>
-  !("type" in context) && ("externalDocumentId" in context)
-export const isV2InternalContext = (context: CodapV2Context): context is ICodapV2DataContext | ICodapV2GameContext =>
-  ("type" in context)
+export const isV2ExternalContext = (context?: CodapV2Context): context is ICodapV2ExternalContext =>
+  !!context && !("type" in context) && ("externalDocumentId" in context)
+export const isV2InternalContext = (context?: CodapV2Context): context is ICodapV2DataContext | ICodapV2GameContext =>
+  !!context && ("type" in context)

--- a/v3/src/v2/codap-v2-data-set-importer.ts
+++ b/v3/src/v2/codap-v2-data-set-importer.ts
@@ -87,13 +87,17 @@ export class CodapV2DataSetImporter {
   importCollections(data: IDataSet, metadata: IDataSetMetadata, collections: ICodapV2Collection[]) {
     let prevCollection: ICollectionModel | undefined
     collections.forEach((collection, index) => {
-      const { attrs = [], cases = [], guid, name = "", title, caseName, labels: v2Labels } = collection
+      const { attrs = [], cases = [], guid, name = "", title, caseName, defaults, labels: v2Labels } = collection
+      const v3CollectionId = toV3CollectionId(guid)
       const _title = v2NameTitleToV3Title(name, title)
       const v3Labels: ICollectionLabelsSnapshot = { ...v2Labels }
       if (caseName && !v3Labels.singleCase) v3Labels.singleCase = caseName
 
+      if (defaults) {
+        metadata.setCollectionDefaults(v3CollectionId, defaults)
+      }
       if (isNonEmptyCollectionLabels(v3Labels)) {
-        metadata.setCollectionLabels(toV3CollectionId(guid), v3Labels)
+        metadata.setCollectionLabels(v3CollectionId, v3Labels)
       }
 
       // assumes hierarchical collections are in order parent => child

--- a/v3/src/v2/codap-v2-document.ts
+++ b/v3/src/v2/codap-v2-document.ts
@@ -55,7 +55,8 @@ export class CodapV2Document {
 
   getV2DataContext(v2Id: number) {
     const entry = this.guidMap.get(v2Id)
-    return entry?.type === "DG.DataContext" ? entry.object as CodapV2Context : undefined
+    if (!entry?.type) return
+    return ["DG.DataContext", "DG.GameContext"].includes(entry.type) ? entry.object as CodapV2Context : undefined
   }
 
   getV2Collection(v2Id: number) {

--- a/v3/src/v2/codap-v2-tile-exporters.ts
+++ b/v3/src/v2/codap-v2-tile-exporters.ts
@@ -10,10 +10,18 @@ export interface V2ExporterOutput {
   componentStorage?: CodapV2ComponentStorage
 }
 
+interface IGameContextMetadata {
+  gameName?: string
+  gameUrl?: string
+  gameState?: any
+}
+export type GameContextMetadataMap = Record<string, IGameContextMetadata>
+
 export interface V2TileExportArgs {
   tile: ITileModel
   row?: IFreeTileRow
   sharedModelManager?: ISharedModelManager
+  gameContextMetadataMap?: GameContextMetadataMap
 }
 interface V2TileExportFnOptions {
   suppressName?: boolean

--- a/v3/src/v2/codap-v2-types.ts
+++ b/v3/src/v2/codap-v2-types.ts
@@ -109,42 +109,17 @@ export interface ICodapV2GameViewStorage extends ICodapV2BaseComponentStorage {
   currentGameUrl: string
   savedGameState?: unknown
   currentGameName?: string
-  // TODO_V2_IMPORT allowInitGameOverride is not imported
-  // it occurs in at least 12,500 files in cfm-shared
-  // there are no instances of it being set to false
-  // it might not be optional
+  // ignore: initialized to true but not used by v2 code
   allowInitGameOverride?: boolean
-  // TODO_V2_IMPORT preventBringToFront is not imported
-  // it occurs in at least 19,7000 files in cfm-shared
-  // there are at least 8,000 instances where it is false
-  // it might not be optional
   preventBringToFront?: boolean
-  // TODO_V2_IMPORT preventDataContextReorg is not imported
-  // there are at least 20,000 instances where it is false
-  // and at least 20,000 instances where it is true
-  // it might not be optional
   preventDataContextReorg?: boolean
-  // TODO_V2_IMPORT preventTopLevelReorg is not imported
-  // there are only 11 instances in 9 files where it is true
-  // and at least 20,000 instances where it is false
-  // it might not be optional
   preventTopLevelReorg?: boolean
-  // TODO_V2_IMPORT preventAttributeDeletion is not imported
-  // there are only 4 instances in 3 files where it is true
-  // and at least 20,000 instances where it is false
-  // it might not be optional
   preventAttributeDeletion?: boolean
-  // TODO_V2_IMPORT allowEmptyAttributeDeletion is not imported
-  // there are only 41 instances in 33 files where it is true
-  // and at least 20,000 instances where it is false
-  // it might not be optional
   allowEmptyAttributeDeletion?: boolean
-  // TODO_V2_IMPORT _links_ is not imported
-  // unknown how many times it is used in this location
   _links_?: {
     context?: IGuidLink<"DG.DataContextRecord">
   }
-  // currentGameFormulas occurs 62 times in cfm-shared and is always null
+  // ignore: occurs 62 times in cfm-shared and is always null
   currentGameFormulas?: null
 }
 

--- a/v3/src/v2/export-v2-document.ts
+++ b/v3/src/v2/export-v2-document.ts
@@ -1,6 +1,6 @@
 import build from "../../build_number.json"
 import pkg from "../../package.json"
-import { convertDataSetToV2 } from "../data-interactive/data-interactive-type-utils"
+import { convertDataSetToV2, IConvertDataSetToV2Options } from "../data-interactive/data-interactive-type-utils"
 import { IDocumentModel } from "../models/document/document"
 import { isFreeTileRow } from "../models/document/free-tile-row"
 import { getSharedDataSets } from "../models/shared/shared-data-utils"
@@ -8,7 +8,7 @@ import { getSharedModelManager } from "../models/tiles/tile-environment"
 import { getGlobalValueManager } from "../models/global/global-value-manager"
 import { toV2Id } from "../utilities/codap-utils"
 import { ICodapV2DataContext } from "./codap-v2-data-context-types"
-import { exportV2Component } from "./codap-v2-tile-exporters"
+import { exportV2Component, GameContextMetadataMap } from "./codap-v2-tile-exporters"
 import { CodapV2Component, ICodapV2DocumentJson } from "./codap-v2-types"
 
 interface IV2DocumentExportOptions {
@@ -22,15 +22,18 @@ export function exportV2Document(document: IDocumentModel, options?: IV2Document
 
   // export the components
   const components: CodapV2Component[] = []
+  const gameContextMetadataMap: GameContextMetadataMap = {}
   document.content?.tileMap.forEach(tile => {
-    const component = exportV2Component({ tile, row, sharedModelManager })
+    // components can add game context metadata, which will be used below when the contexts are exported
+    const component = exportV2Component({ tile, row, sharedModelManager, gameContextMetadataMap })
     if (component) components.push(component)
   })
 
   // export the data contexts
   const contexts: ICodapV2DataContext[] = []
   getSharedDataSets(document).forEach(sharedData => {
-    const data = convertDataSetToV2(sharedData.dataSet, true) as ICodapV2DataContext
+    const _options: IConvertDataSetToV2Options = { exportCases: true, gameContextMetadataMap }
+    const data = convertDataSetToV2(sharedData.dataSet, _options) as ICodapV2DataContext
     contexts.push(data)
   })
 


### PR DESCRIPTION
[[CODAP-318](https://concord-consortium.atlassian.net/browse/CODAP-318)] Plugins v2 import/export

- import/export plugin-settable properties of `WebViewModel`, e.g. `preventAttributeDeletion`, etc.
- import/export `DG.GameContext` (derived class of `DG.DataContext`)
- import/export link between `WebViewModel` and data context
- import/export `userSetTitle` property of components
  - previous efforts assumed that if `_title` ≠ `name` then it must have been user-set, but plugins can set the title as well, so we need to explicitly track whether the user has set the title.
- import/export default attributes for a collection (often set by plugins)

[CODAP-318]: https://concord-consortium.atlassian.net/browse/CODAP-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ