### PR TITLE
Codap-775 Fix Dropping on Overlapping Tiles

### DIFF
--- a/v3/src/lib/dnd-kit/dnd-detect-collision.ts
+++ b/v3/src/lib/dnd-kit/dnd-detect-collision.ts
@@ -53,7 +53,7 @@ export const dndDetectCollision: CollisionDetection = (args) => {
           // filter the drop zones to those appropriate for the relevant tile
           const containers =
             args.droppableContainers.filter(({id: containerId}) => droppableRegex.test(`${containerId}`))
-          // apply the collection detection function specified by the tile
+          // apply the collision detection function specified by the tile
           return detect({ ...args, droppableContainers: containers })
         }
       }

--- a/v3/src/lib/dnd-kit/dnd-detect-collision.ts
+++ b/v3/src/lib/dnd-kit/dnd-detect-collision.ts
@@ -1,6 +1,8 @@
 import escapeStringRegexp from "escape-string-regexp"
 import { CollisionDetection, pointerWithin, rectIntersection } from "@dnd-kit/core"
 
+const prefixRegex = /[A-Za-z-]+-\d+/
+
 interface CollisionDetectionEntry {
   baseId: string
   overlayRegex: RegExp
@@ -16,20 +18,19 @@ export const registerTileCollisionDetection = (baseId: string, detect: Collision
   gTileCollisionDetectionRegistry.push({ baseId, overlayRegex, droppableRegex, detect })
 }
 
-export const dndDetectCollision: CollisionDetection = (_args) => {
-  // sort the containers by z-index of the tile
-  const sortedContainers = _args.droppableContainers.slice().sort((aContainer, bContainer) => {
-    const aTileNode = aContainer.node.current?.closest("[data-tile-z-index]")
-    const aTileZIndex = aTileNode ? parseInt(aTileNode.getAttribute("data-tile-z-index") || "0", 10) : 0
-    const bTileNode = bContainer.node.current?.closest("[data-tile-z-index]")
-    const bTileZIndex = bTileNode ? parseInt(bTileNode.getAttribute("data-tile-z-index") || "0", 10) : 0
-    return bTileZIndex - aTileZIndex
-  })
-  const args = { ..._args, droppableContainers: sortedContainers }
-
+export const dndDetectCollision: CollisionDetection = (args) => {
   // first determine the component we're in using pointerWithin (for pointer sensor) or
   // rectIntersection (for keyboard sensor)
   const collisions = args.pointerCoordinates ? pointerWithin(args) : rectIntersection(args)
+
+  // sort collisions by z-index of the tile
+  const sortedCollisions = collisions.slice().sort((aCollision, bCollision) => {
+    const aTileNode = aCollision.data?.droppableContainer.node.current?.closest("[data-tile-z-index]")
+    const aTileZIndex = aTileNode ? parseInt(aTileNode.getAttribute("data-tile-z-index") || "0", 10) : 0
+    const bTileNode = bCollision.data?.droppableContainer.node.current?.closest("[data-tile-z-index]")
+    const bTileZIndex = bTileNode ? parseInt(bTileNode.getAttribute("data-tile-z-index") || "0", 10) : 0
+    return bTileZIndex - aTileZIndex
+  })
 
   // if this is a tile drag, then ignore all collisions other than the container
   if (args.active.data.current?.type === "tile") {
@@ -38,18 +39,26 @@ export const dndDetectCollision: CollisionDetection = (_args) => {
   }
 
   // check for registered tile-specific collision handlers
-  for (const collision of collisions) {
-    const { id: collisionId } = collision
-    // find the first tile handler overlay that matches the collision
-    const handler = gTileCollisionDetectionRegistry.find(({overlayRegex}) => overlayRegex.test(`${collisionId}`))
-    if (handler) {
-      const { droppableRegex, detect } = handler
-      // filter the drop zones to those appropriate for the relevant tile
-      const containers = sortedContainers.filter(({id: containerId}) => droppableRegex.test(`${containerId}`))
-      // apply the collection detection function specified by the tile
-      return detect({ ...args, droppableContainers: containers })
+  if (sortedCollisions.length > 0) {
+    // find the prefix for the first tile collision
+    const prefix = `${sortedCollisions[0].id}`.match(prefixRegex)?.[0]
+    if (prefix) {
+      // find all collisions for the first tile
+      const tileCollisions = sortedCollisions.filter(c => `${c.id}`.startsWith(prefix))
+      for (const collision of tileCollisions) {
+        const { id: collisionId } = collision
+        const handler = gTileCollisionDetectionRegistry.find(({overlayRegex}) => overlayRegex.test(`${collisionId}`))
+        if (handler) {
+          const { droppableRegex, detect } = handler
+          // filter the drop zones to those appropriate for the relevant tile
+          const containers =
+            args.droppableContainers.filter(({id: containerId}) => droppableRegex.test(`${containerId}`))
+          // apply the collection detection function specified by the tile
+          return detect({ ...args, droppableContainers: containers })
+        }
+      }
     }
   }
 
-  return collisions
+  return sortedCollisions
 }


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/CODAP-775

This PR fixes a bug where certain tiles would steal an attribute drop from other tiles, even when below them.

There were two problems with the existing code:
- Previously, the containers were sorted by tile z-index before checking for collisions. But this did not guarantee that the resulting collisions were in the same order. Now we sort the collisions after they are found.
- Previously, we'd use the first tile-specific collision handler we could find. That means that we'd ignore tiles that didn't have a special handler. Now, we determine all collisions for the top tile, then only look for a special handler for it. If we don't find one, we just return the collisions in tile order.