### PR TITLE
Convert Unimplemented Menu Items from Toast to Under Construction

### DIFF
--- a/v3/src/components/beta/unimplemented-menu-item.scss
+++ b/v3/src/components/beta/unimplemented-menu-item.scss
@@ -1,0 +1,4 @@
+.construction-icon {
+  height: 16px;
+  width: 16px;
+}

--- a/v3/src/components/beta/unimplemented-menu-item.scss
+++ b/v3/src/components/beta/unimplemented-menu-item.scss
@@ -1,4 +1,0 @@
-.construction-icon {
-  height: 16px;
-  width: 16px;
-}

--- a/v3/src/components/beta/unimplemented-menu-item.tsx
+++ b/v3/src/components/beta/unimplemented-menu-item.tsx
@@ -1,0 +1,18 @@
+import { MenuItem } from "@chakra-ui/react"
+import React from "react"
+
+import ConstructionIcon from "../../assets/icons/icon-alert.svg"
+
+import "./unimplemented-menu-item.scss"
+
+interface IUnimplementedMenuItemProps {
+  label: string
+  testId?: string
+}
+export function UnimplementedMenuItem({ label, testId }: IUnimplementedMenuItemProps) {
+  return (
+    <MenuItem icon={<ConstructionIcon className="construction-icon" />} isDisabled data-testid={testId}>
+      {label}
+    </MenuItem>
+  )
+}

--- a/v3/src/components/beta/unimplemented-menu-item.tsx
+++ b/v3/src/components/beta/unimplemented-menu-item.tsx
@@ -8,7 +8,7 @@ interface IUnimplementedMenuItemProps {
 export function UnimplementedMenuItem({ label, testId }: IUnimplementedMenuItemProps) {
   return (
     <MenuItem isDisabled data-testid={testId}>
-      {`🚧 ${label}`}
+      {`${label} 🚧`}
     </MenuItem>
   )
 }

--- a/v3/src/components/beta/unimplemented-menu-item.tsx
+++ b/v3/src/components/beta/unimplemented-menu-item.tsx
@@ -1,18 +1,14 @@
 import { MenuItem } from "@chakra-ui/react"
 import React from "react"
 
-import ConstructionIcon from "../../assets/icons/icon-alert.svg"
-
-import "./unimplemented-menu-item.scss"
-
 interface IUnimplementedMenuItemProps {
   label: string
   testId?: string
 }
 export function UnimplementedMenuItem({ label, testId }: IUnimplementedMenuItemProps) {
   return (
-    <MenuItem icon={<ConstructionIcon className="construction-icon" />} isDisabled data-testid={testId}>
-      {label}
+    <MenuItem isDisabled data-testid={testId}>
+      {`🚧 ${label}`}
     </MenuItem>
   )
 }

--- a/v3/src/components/graph/components/camera-menu-list.tsx
+++ b/v3/src/components/graph/components/camera-menu-list.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react"
-import { MenuItem, MenuList, useToast } from "@chakra-ui/react"
+import React from "react"
+import { MenuItem, MenuList } from "@chakra-ui/react"
 import { useCfmContext } from "../../../hooks/use-cfm-context"
 import { useTileModelContext } from "../../../hooks/use-tile-model-context"
 import { t } from "../../../utilities/translation/translate"
+import { UnimplementedMenuItem } from "../../beta/unimplemented-menu-item"
 import { isGraphContentModel } from "../models/graph-content-model"
 import { graphSvg } from "../utilities/image-utils"
 
@@ -10,42 +11,6 @@ export const CameraMenuList = () => {
   const tile = useTileModelContext().tile
   const graphModel = isGraphContentModel(tile?.content) ? tile?.content : undefined
   const cfm = useCfmContext()
-  const [hasBackgroundImage, setHasBackgroundImage] = useState(false)
-  const [imageLocked, setImageLocked] = useState(false)
-  const toast = useToast()
-  const handleMenuItemClick = (menuItem: string) => {
-    toast({
-      title: 'Menu item clicked',
-      description: `You clicked on ${menuItem}`,
-      status: 'success',
-      duration: 5000,
-      isClosable: true,
-    })
-  }
-
-  const handleAddBackgroundImage = () => {
-    setHasBackgroundImage(true)
-    handleMenuItemClick("Add Background Image clicked")
-  }
-
-  const handleRemoveBackgroundImage = () => {
-    setHasBackgroundImage(false)
-    handleMenuItemClick("Remove Background Image clicked")
-  }
-
-  const handleUnlockImage = () => {
-    setImageLocked(false)
-    handleMenuItemClick("Unlock Image clicked")
-  }
-
-  const handleLockImage = () => {
-    setImageLocked(true)
-    handleMenuItemClick("Lock Image clicked")
-  }
-
-  const handleCopyImage = () => {
-    handleMenuItemClick("Copy Image clicked")
-  }
 
   const handleExportPNG = async () => {
     if (!graphModel?.renderState) return
@@ -77,27 +42,37 @@ export const CameraMenuList = () => {
 
   return (
     <MenuList data-testid="graph-camera-menu-list">
+      {/* TODO: This is left in for reference when we're ready to implement background images.
       {hasBackgroundImage
         ? <>
-            <MenuItem onClick={handleRemoveBackgroundImage} data-testid="remove-background-image">
-              {t("DG.DataDisplayMenu.removeBackgroundImage")}
-            </MenuItem>
+            <UnimplementedMenuItem
+              label={t("DG.DataDisplayMenu.addBackgroundImage")}
+              testId="add-background-image-disabled"
+            />
             {imageLocked
-              ? <MenuItem onClick={handleUnlockImage} data-testid="unlock-image">
-                  {t("DG.DataDisplayMenu.unlockImageFromAxes")}
-                </MenuItem>
-              : <MenuItem onClick={handleLockImage} data-testid="lock-image">
-                  {t("DG.DataDisplayMenu.lockImageToAxes")}
-                </MenuItem>
+              ? <UnimplementedMenuItem
+                  label={t("DG.DataDisplayMenu.unlockImageFromAxes")}
+                  testId="unlock-image"
+                />
+              : <UnimplementedMenuItem
+                  label={t("DG.DataDisplayMenu.lockImageToAxes")}
+                  testId="lock-image"
+                />
             }
           </>
-        : <MenuItem onClick={handleAddBackgroundImage} data-testid="add-background-image">
-            {t("DG.DataDisplayMenu.addBackgroundImage")}
-          </MenuItem>
-      }
-      <MenuItem data-testid="open-in-draw-tool" onClick={handleCopyImage}>
-        {t("DG.DataDisplayMenu.copyAsImage")}
-      </MenuItem>
+        : <UnimplementedMenuItem
+            label={t("DG.DataDisplayMenu.addBackgroundImage")}
+            testId="add-background-image"
+          />
+      } */}
+      <UnimplementedMenuItem
+        label={t("DG.DataDisplayMenu.addBackgroundImage")}
+        testId="add-background-image"
+      />
+      <UnimplementedMenuItem
+        label={t("DG.DataDisplayMenu.copyAsImage")}
+        testId="open-in-draw-tool"
+      />
       <MenuItem data-testid="export-png-image" onClick={handleExportPNG}>
         {t("DG.DataDisplayMenu.exportPngImage")}
       </MenuItem>

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -1,35 +1,20 @@
-import { MenuItem, MenuList, useToast } from "@chakra-ui/react"
+import { MenuList } from "@chakra-ui/react"
 import React from "react"
 import { ITileModel } from "../../../../models/tiles/tile-model"
 import { t } from "../../../../utilities/translation/translate"
+import { UnimplementedMenuItem } from "../../../beta/unimplemented-menu-item"
 
 interface IProps {
   tile?: ITileModel
 }
 
 export const SaveImageMenuList = ({tile}: IProps) => {
-  const toast = useToast()
-  const handleMenuItemClick = (menuItem: string) => {
-    toast({
-      title: 'Menu item clicked',
-      description: `You clicked on ${menuItem}`,
-      status: 'success',
-      duration: 5000,
-      isClosable: true,
-    })
-  }
 
   return (
     <MenuList data-testid="save-image-menu-list">
-      <MenuItem onClick={()=>handleMenuItemClick("Open in Draw Tool")}>
-        {t('DG.DataDisplayMenu.copyAsImage')}
-      </MenuItem>
-      <MenuItem onClick={()=>handleMenuItemClick("Export PNG Image")}>
-        {t('DG.DataDisplayMenu.exportPngImage')}
-      </MenuItem>
-      <MenuItem onClick={()=>handleMenuItemClick("Export SVG Image")}>
-        {t('DG.DataDisplayMenu.exportSvgImage')}
-      </MenuItem>
+      <UnimplementedMenuItem label={t('DG.DataDisplayMenu.copyAsImage')} />
+      <UnimplementedMenuItem label={t('DG.DataDisplayMenu.exportPngImage')} />
+      <UnimplementedMenuItem label={t('DG.DataDisplayMenu.exportSvgImage')} />
     </MenuList>
   )
 }


### PR DESCRIPTION
This PR makes menu items that haven't been implemented very obvious by graying them out and adding an icon, rather than making them look usable but only displaying a toast when clicked.