### PR TITLE
CODAP-792 Make rescale button for bar chart work

### DIFF
--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -459,16 +459,11 @@ export const GraphContentModel = DataDisplayContentModel
       if (self.plotType === 'casePlot') {
         this.incrementChangeCount()
       } else {
-        const {dataConfiguration} = self
         AxisPlaces.forEach((axisPlace: AxisPlace) => {
           const axis = self.getAxis(axisPlace),
             role = axisPlaceToAttrRole[axisPlace]
           if (isAnyNumericAxisModel(axis)) {
-            const epRole = dataConfiguration.primaryRole === 'x' ? 'topSplit' : 'rightSplit'
-            const esRole = dataConfiguration.primaryRole === 'x' ? 'rightSplit' : 'topSplit'
-            const numericValues = self.plotType === 'barChart'
-              ? [0, dataConfiguration.maxOverAllCells(epRole, esRole)]
-              : dataConfiguration.numericValuesForAttrRole(role)
+            const numericValues = self.plot.numericValuesForRole(role)
             axis.setAllowRangeToShrink(true)
             setNiceDomain(numericValues, axis, self.plot.axisDomainOptions)
           }

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -464,7 +464,11 @@ export const GraphContentModel = DataDisplayContentModel
           const axis = self.getAxis(axisPlace),
             role = axisPlaceToAttrRole[axisPlace]
           if (isAnyNumericAxisModel(axis)) {
-            const numericValues = dataConfiguration.numericValuesForAttrRole(role)
+            const epRole = dataConfiguration.primaryRole === 'x' ? 'topSplit' : 'rightSplit'
+            const esRole = dataConfiguration.primaryRole === 'x' ? 'rightSplit' : 'topSplit'
+            const numericValues = self.plotType === 'barChart'
+              ? [0, dataConfiguration.maxOverAllCells(epRole, esRole)]
+              : dataConfiguration.numericValuesForAttrRole(role)
             axis.setAllowRangeToShrink(true)
             setNiceDomain(numericValues, axis, self.plot.axisDomainOptions)
           }

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
@@ -211,7 +211,7 @@ export const BarChartModel = DotChartModel
         case "percent":
           return [0, dataConfiguration.maxPercentAllCells(epRole, esRole)]
         case "formula":
-          return this.getMinMaxOfFormulaValues().concat(0)
+          return [0, ...this.getMinMaxOfFormulaValues()]
         default:
           return []
       }

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-model.ts
@@ -198,6 +198,23 @@ export const BarChartModel = DotChartModel
           : firstCount === 1 ? "DG.BarChartModel.cellTipNoLegendSingular" : "DG.BarChartModel.cellTipNoLegendPlural"
         return t(translationKey, {vars})
       }
+    },
+    numericValuesForRole(role: GraphAttrRole) {
+      // What is returned depends on the breakdown type.
+      const dataConfiguration = self.dataConfiguration
+      if (!dataConfiguration) return []
+      const epRole = dataConfiguration.primaryRole === 'x' ? 'topSplit' : 'rightSplit'
+      const esRole = dataConfiguration.primaryRole === 'x' ? 'rightSplit' : 'topSplit'
+      switch (self.breakdownType) {
+        case "count":
+          return [0, dataConfiguration.maxOverAllCells(epRole, esRole)]
+        case "percent":
+          return [0, dataConfiguration.maxPercentAllCells(epRole, esRole)]
+        case "formula":
+          return this.getMinMaxOfFormulaValues().concat(0)
+        default:
+          return []
+      }
     }
   }))
   .actions(self => ({

--- a/v3/src/components/graph/plots/plot-model.ts
+++ b/v3/src/components/graph/plots/plot-model.ts
@@ -199,6 +199,10 @@ export const PlotModel = types
     },
     nonDraggableAxisTicks(formatter: TickFormatter): IAxisTicks {
       return { tickValues: [], tickLabels: [] }
+    },
+    numericValuesForRole(role: GraphAttrRole) {
+      // The default implementation returns the numeric values for the attribute corresponding to the role.
+      return self.dataConfiguration?.numericValuesForAttrRole(role) || []
     }
   }))
   .actions(self => ({


### PR DESCRIPTION
[#CODAP-792] Bug fix: The rescale button does nothing when the plot is a bar chart

* We need to special case the barChart in `GraphContentModel.rescale` so that we use the counts, percentages, or formula results of all the bars to determine the maximum for the `Count` axis. So we move responsibility for computing the numeric values appropriate to a given attribute role to the plot so that the `BarChartModel` can handle its breakdown types.