### PR TITLE
Codap-101 Import Dataset Metadata

### DIFF
--- a/v3/cypress/e2e/table.spec.ts
+++ b/v3/cypress/e2e/table.spec.ts
@@ -105,7 +105,7 @@ context("case table ui", () => {
     it("should open dataset information button and make changes", () => {
       const newInfoName = "Animals",
         newSource = "The Internet",
-        importDate = "May 4",
+        importDate = "May 4, 2021",
         newDescription = "All about mammals"
 
       // Enter new dataset information
@@ -116,7 +116,7 @@ context("case table ui", () => {
       // Checks that the new description information is filled in
       cy.get("[data-testid='dataset-name-input']").should("have.value", newInfoName)
       cy.get("[data-testid='dataset-source-input']").should("have.value", newSource)
-      cy.get("[data-testid='dataset-date-input']").should("have.value", importDate)
+      cy.get("[data-testid='dataset-date-input']").should("have.value", "5/4/2021")
       cy.get("[data-testid=dataset-description-input]").should("have.value", newDescription)
     })
     it("select a case and delete the case from inspector menu", () => {

--- a/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
@@ -4,6 +4,7 @@ import { Button, FormControl, FormLabel, Input, ModalBody, ModalCloseButton, Mod
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
 import { useDataSetMetadata } from "../../../hooks/use-data-set-metadata"
 import { updateDataContextNotification } from "../../../models/data/data-set-notifications"
+import { formatDate } from "../../../utilities/date-utils"
 import { t } from "../../../utilities/translation/translate"
 import { CodapModal } from "../../codap-modal"
 
@@ -20,14 +21,14 @@ export const DatasetInfoModal = ({showInfoModal, setShowInfoModal}: IProps) => {
   const [datasetTitle, setDatasetTitle] = useState(data?.displayTitle || "")
   const [description, setDescription] = useState(metadata?.description || "")
   const [source, setSource] = useState(metadata?.source || "")
-  const [importDate, setImportDate] = useState(metadata?.importDate || "")
+  const [importDate, setImportDate] = useState(formatDate(metadata?.importDate || "") || "")
 
   const handleCloseInfoModal = () => {
     data?.applyModelChange(() => {
       data.setUserTitle(datasetTitle)
       metadata?.setDescription(description)
       metadata?.setSource(source)
-      metadata?.setImportDate(importDate)
+      metadata?.setImportDate(new Date(importDate).toISOString())
       setShowInfoModal(false)
     }, {
       notify: () => updateDataContextNotification(data)

--- a/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/dataset-info-modal.tsx
@@ -21,14 +21,28 @@ export const DatasetInfoModal = ({showInfoModal, setShowInfoModal}: IProps) => {
   const [datasetTitle, setDatasetTitle] = useState(data?.displayTitle || "")
   const [description, setDescription] = useState(metadata?.description || "")
   const [source, setSource] = useState(metadata?.source || "")
-  const [importDate, setImportDate] = useState(formatDate(metadata?.importDate || "") || "")
+  let initialImportDate = ""
+  try {
+    // Display a formatted date if we can interpret the import date as a date
+    initialImportDate = formatDate(metadata?.importDate || "") || ""
+  } catch (error) {
+    // Otherwise, just use the string
+    initialImportDate = metadata?.importDate || ""
+  }
+  const [importDate, setImportDate] = useState(initialImportDate)
 
   const handleCloseInfoModal = () => {
     data?.applyModelChange(() => {
       data.setUserTitle(datasetTitle)
       metadata?.setDescription(description)
       metadata?.setSource(source)
-      metadata?.setImportDate(new Date(importDate).toISOString())
+      try {
+        // Save an ISO string if we can parse the submitted string as a date
+        metadata?.setImportDate(new Date(importDate).toISOString())
+      } catch (error) {
+        // Otherwise, just save the string
+        metadata?.setImportDate(importDate)
+      }
       setShowInfoModal(false)
     }, {
       notify: () => updateDataContextNotification(data)

--- a/v3/src/data-interactive/handlers/data-context-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.test.ts
@@ -7,7 +7,6 @@ import { getMetadataFromDataSet } from "../../models/shared/shared-data-utils"
 import { getSharedModelManager } from "../../models/tiles/tile-environment"
 import { setupTestDataset } from "../../test/dataset-test-utils"
 import { toV2Id } from "../../utilities/codap-utils"
-import { formatDate } from "../../utilities/date-utils"
 import { ICodapV2DataContext } from "../../v2/codap-v2-data-context-types"
 import { DIDataContext, DIUpdateDataContext } from "../data-interactive-data-set-types"
 import { DIValues } from "../data-interactive-types"
@@ -71,7 +70,7 @@ describe("DataInteractive DataContextHandler", () => {
     expect(metadata).toBeDefined()
     expect(metadata?.description).toBe(description)
     expect(metadata?.source).toBe(source)
-    expect(metadata?.importDate).toBe(formatDate(importDate))
+    expect(metadata?.importDate).toBe(importDate)
     const collection1 = dataset.getCollectionByName("collection1")
     expect(collection1).toBeDefined()
     const collection1Metadata = metadata?.collections.get(collection1!.id)

--- a/v3/src/data-interactive/handlers/data-context-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.test.ts
@@ -42,9 +42,12 @@ describe("DataInteractive DataContextHandler", () => {
     expect(gDataBroker.length).toBe(0)
 
     // Can create a more complex dataset
+    const source = "dataSet Source"
+    const importDate = "2023-10-01T00:00:00Z"
     const singleCase = "case"
     const pluralCase = "cases"
     const result3 = handler.create?.({}, {
+      metadata: { description, importDate, source },
       collections: [
         {
           name: "collection1",
@@ -65,6 +68,9 @@ describe("DataInteractive DataContextHandler", () => {
     expect(dataset.collections.length).toBe(2)
     const metadata = getMetadataFromDataSet(dataset)
     expect(metadata).toBeDefined()
+    expect(metadata?.description).toBe(description)
+    expect(metadata?.source).toBe(source)
+    expect(metadata?.importDate).toBe("9/30/2023, 5:00:00 PM")
     const collection1 = dataset.getCollectionByName("collection1")
     expect(collection1).toBeDefined()
     const collection1Metadata = metadata?.collections.get(collection1!.id)

--- a/v3/src/data-interactive/handlers/data-context-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.test.ts
@@ -5,12 +5,13 @@ import { createDefaultTileOfType } from "../../models/codap/add-default-content"
 import { gDataBroker } from "../../models/data/data-broker"
 import { getMetadataFromDataSet } from "../../models/shared/shared-data-utils"
 import { getSharedModelManager } from "../../models/tiles/tile-environment"
+import { setupTestDataset } from "../../test/dataset-test-utils"
 import { toV2Id } from "../../utilities/codap-utils"
+import { formatDate } from "../../utilities/date-utils"
 import { ICodapV2DataContext } from "../../v2/codap-v2-data-context-types"
 import { DIDataContext, DIUpdateDataContext } from "../data-interactive-data-set-types"
 import { DIValues } from "../data-interactive-types"
 import { diDataContextHandler } from "./data-context-handler"
-import { setupTestDataset } from "../../test/dataset-test-utils"
 
 import "../../components/web-view/web-view-registration"
 
@@ -70,7 +71,7 @@ describe("DataInteractive DataContextHandler", () => {
     expect(metadata).toBeDefined()
     expect(metadata?.description).toBe(description)
     expect(metadata?.source).toBe(source)
-    expect(metadata?.importDate).toBe("9/30/2023, 5:00:00 PM")
+    expect(metadata?.importDate).toBe(formatDate(importDate))
     const collection1 = dataset.getCollectionByName("collection1")
     expect(collection1).toBeDefined()
     const collection1Metadata = metadata?.collections.get(collection1!.id)

--- a/v3/src/data-interactive/handlers/data-context-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.ts
@@ -9,6 +9,7 @@ import { addSetAsideCases, replaceSetAsideCases, restoreSetAsideCases } from "..
 import { getMetadataFromDataSet } from "../../models/shared/shared-data-utils"
 import { getFormulaManager } from "../../models/tiles/tile-environment"
 import { toV3CaseId } from "../../utilities/codap-utils"
+import { formatDate } from "../../utilities/date-utils"
 import { hasOwnProperty } from "../../utilities/js-utils"
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
@@ -19,7 +20,6 @@ import { getAttribute } from "../data-interactive-utils"
 import { findTileFromNameOrId } from "../resource-parser-utils"
 import { createCollection } from "./di-handler-utils"
 import { attributeNotFoundResult, dataContextNotFoundResult, errorResult, fieldRequiredResult } from "./di-results"
-import { formatDate } from "../../utilities/date-utils"
 
 const requestRequiredResult = fieldRequiredResult("Notify", "dataContext", "request")
 

--- a/v3/src/data-interactive/handlers/data-context-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.ts
@@ -9,7 +9,6 @@ import { addSetAsideCases, replaceSetAsideCases, restoreSetAsideCases } from "..
 import { getMetadataFromDataSet } from "../../models/shared/shared-data-utils"
 import { getFormulaManager } from "../../models/tiles/tile-environment"
 import { toV3CaseId } from "../../utilities/codap-utils"
-import { formatDate } from "../../utilities/date-utils"
 import { hasOwnProperty } from "../../utilities/js-utils"
 import { t } from "../../utilities/translation/translate"
 import { registerDIHandler } from "../data-interactive-handler"
@@ -41,10 +40,7 @@ export const diDataContextHandler: DIHandler = {
 
       // Set metadata
       const { sharedMetadata } = gDataBroker.addDataSet(dataSet)
-      if (metadata?.importDate) {
-        const formattedDate = formatDate(metadata.importDate)
-        if (formattedDate) sharedMetadata.setImportDate(formattedDate)
-      }
+      sharedMetadata.setImportDate(metadata?.importDate)
       sharedMetadata.setSource(metadata?.source)
       sharedMetadata.setDescription(metadata?.description ?? description)
 

--- a/v3/src/data-interactive/handlers/data-context-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.ts
@@ -25,7 +25,7 @@ const requestRequiredResult = fieldRequiredResult("Notify", "dataContext", "requ
 export const diDataContextHandler: DIHandler = {
   create(_resources: DIResources, _values?: DIValues) {
     const values = _values as DIDataContext
-    const { collections, description, name: _name, title } = values
+    const { collections, description, metadata, name: _name, title } = values
     const name = _name || gDataBroker.newDataSetName
     const document = appState.document
 
@@ -36,9 +36,16 @@ export const diDataContextHandler: DIHandler = {
     return document.applyModelChange(() => {
       // Create dataset
       const dataSet = DataSet.create({ name, _title: title })
-      const { sharedMetadata } = gDataBroker.addDataSet(dataSet)
-      sharedMetadata.setDescription(description)
       getFormulaManager(document)?.addDataSet(dataSet)
+
+      // Set metadata
+      const { sharedMetadata } = gDataBroker.addDataSet(dataSet)
+      if (metadata?.importDate) {
+        const date = new Date(metadata.importDate)
+        sharedMetadata.setImportDate(date.toLocaleString("en-US", { hour12: true }))
+      }
+      sharedMetadata.setSource(metadata?.source)
+      sharedMetadata.setDescription(metadata?.description ?? description)
 
       if (collections?.length) {
         // remove the default collection

--- a/v3/src/data-interactive/handlers/data-context-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-handler.ts
@@ -19,6 +19,7 @@ import { getAttribute } from "../data-interactive-utils"
 import { findTileFromNameOrId } from "../resource-parser-utils"
 import { createCollection } from "./di-handler-utils"
 import { attributeNotFoundResult, dataContextNotFoundResult, errorResult, fieldRequiredResult } from "./di-results"
+import { formatDate } from "../../utilities/date-utils"
 
 const requestRequiredResult = fieldRequiredResult("Notify", "dataContext", "request")
 
@@ -41,8 +42,8 @@ export const diDataContextHandler: DIHandler = {
       // Set metadata
       const { sharedMetadata } = gDataBroker.addDataSet(dataSet)
       if (metadata?.importDate) {
-        const date = new Date(metadata.importDate)
-        sharedMetadata.setImportDate(date.toLocaleString("en-US", { hour12: true }))
+        const formattedDate = formatDate(metadata.importDate)
+        if (formattedDate) sharedMetadata.setImportDate(formattedDate)
       }
       sharedMetadata.setSource(metadata?.source)
       sharedMetadata.setDescription(metadata?.description ?? description)


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/CODAP-101

This PR adds support for dataset metadata (`source`, `importDate`, and `description`) when handling `create dataContext` API requests.