### PR TITLE
CODAP-807 enable logging when served from a host ending in .concord.org

### DIFF
--- a/v3/src/lib/logger.ts
+++ b/v3/src/lib/logger.ts
@@ -53,15 +53,13 @@ interface IAnalyticsService {
 type ILogListener = (logMessage: LogMessage) => void
 
 export class Logger {
-  public static isLoggingEnabled = DEBUG_LOGGER
+  public static isLoggingEnabled =
+    typeof window !== "undefined" && window.location.hostname.toLowerCase().endsWith(".concord.org")
+    || DEBUG_LOGGER
   private static _instance: Logger
   private static pendingMessages: PendingMessage[] = []
 
   public static initializeLogger(document: IDocumentModel) {
-  //Logging is enabled when origin server within this domain.
-    // const logFromServer = "concord.org"
-    // this.isLoggingEnabled = window.location.hostname.toLowerCase().endsWith(logFromServer) || DEBUG_LOGGER
-
     debugLog(DEBUG_LOGGER, "Logger#initializeLogger called.")
     this._instance = new Logger(document)
     this.sendPendingMessages()


### PR DESCRIPTION
this should also enable analytics when on a matching host