### PR TITLE
fix: case names for collapsed cases in table [CODAP-363]

### DIFF
--- a/v3/cypress/fixtures/hierarchical.json
+++ b/v3/cypress/fixtures/hierarchical.json
@@ -13,7 +13,7 @@
               "move": "newCollection"
             }
           ],
-          "childCases": [ "9 cases", "11 cases", "7 cases"],
+          "childCases": ["9 Cases", "11 Cases", "7 Cases"],
           "totalChildren": 27
         }
       ]
@@ -31,7 +31,7 @@
               "move": "newCollection"
             }
           ],
-          "childCases": [ "1 case", "2 cases", "3 cases"],
+          "childCases": ["1 Case", "2 Cases", "3 Cases"],
           "totalChildren": 27
         }
       ]
@@ -53,7 +53,7 @@
               "move": "prevCollection"
             }
           ],
-          "childCases": ["7 cases", "8 cases", "2 cases", "9 cases", "1 case"],
+          "childCases": ["7 Cases", "8 Cases", "2 Cases", "9 Cases", "1 Case"],
           "totalChildren": 27
         }
       ]
@@ -75,7 +75,7 @@
               "move": "prevCollection"
             }
           ],
-          "childCases": ["1 case", "2 cases", "3 cases"],
+          "childCases": ["1 Case", "2 Cases", "3 Cases"],
           "totalChildren": 27
         }
       ]
@@ -93,7 +93,7 @@
               "move": "newCollection"
             }
           ],
-          "childCases": ["9 cases", "11 cases", "7 cases"],
+          "childCases": ["9 Cases", "11 Cases", "7 Cases"],
           "totalChildren": 27
         },
         {
@@ -106,7 +106,7 @@
               "move": "newCollection"
             }
           ],
-          "childCases": ["3 cases", "1 case", "1 case"],
+          "childCases": ["3 Diets", "1 Diet", "1 Diet"],
           "totalChildren": 5
         }
       ]
@@ -125,7 +125,7 @@
               "move": "newCollection"
             }
           ],
-          "childCases": ["1 case", "2 cases", "24 cases"],
+          "childCases": ["1 Case", "2 Cases", "24 Cases"],
           "totalChildren": 27
         },
         {
@@ -138,7 +138,7 @@
               "move": "newCollection"
             }
           ],
-          "childCases": ["1 case", "2 cases"],
+          "childCases": ["1 Case", "2 Cases"],
           "totalChildren": 20
         }
       ]

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -120,7 +120,11 @@ export const App = observer(function App() {
         if (_sample) {
           try {
             const data = await importSample(_sample)
-            appState.document.content?.importDataSet(data, { createDefaultTile: !isDashboard })
+            const options: IImportDataSetOptions = {
+              createDefaultTile: !isDashboard,
+              width: isDashboard ? undefined : 1024 // default width for case table
+            }
+            appState.document.content?.importDataSet(data, options)
           }
           catch (e) {
             console.warn(`Failed to import sample "${_sample}"`)

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -122,7 +122,7 @@ export const App = observer(function App() {
             const data = await importSample(_sample)
             const options: IImportDataSetOptions = {
               createDefaultTile: !isDashboard,
-              width: isDashboard ? undefined : 1024 // default width for case table
+              width: isDashboard ? undefined : 1024 // default width for sample case table
             }
             appState.document.content?.importDataSet(data, options)
           }

--- a/v3/src/components/case-table/use-index-column.tsx
+++ b/v3/src/components/case-table/use-index-column.tsx
@@ -4,13 +4,14 @@ import { clsx } from "clsx"
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { useCollectionContext } from "../../hooks/use-collection-context"
-import { useDataSetContext } from "../../hooks/use-data-set-context"
-import { useDataSetMetadata } from "../../hooks/use-data-set-metadata"
+import { useDataSet } from "../../hooks/use-data-set"
 import { DEBUG_CASE_IDS } from "../../lib/debug"
 import { ICollectionModel } from "../../models/data/collection"
 import { IDataSet } from "../../models/data/data-set"
 import { symIndex, symParent } from "../../models/data/data-set-types"
-import { getCollectionAttrs, selectCases, setSelectedCases } from "../../models/data/data-set-utils"
+import {
+  getCaseNameForCount, getCollectionAttrs, selectCases, setSelectedCases
+} from "../../models/data/data-set-utils"
 import { IDataSetMetadata } from "../../models/shared/data-set-metadata"
 import { preventCollectionReorg } from "../../utilities/plugin-utils"
 import { t } from "../../utilities/translation/translate"
@@ -43,8 +44,7 @@ function indexColumnSpan(args: TColSpanArgs, { data, metadata, collection }: ICo
 }
 
 export const useIndexColumn = () => {
-  const data = useDataSetContext()
-  const metadata = useDataSetMetadata()
+  const { data, metadata } = useDataSet()
   const collectionId = useCollectionContext()
   const collection = data?.getCollection(collectionId)
   const disableMenu = preventCollectionReorg(data, collectionId)
@@ -120,6 +120,9 @@ interface IIndexCellProps {
   onPointerDown?: (evt: React.PointerEvent | React.MouseEvent) => void
 }
 export function IndexCell({ caseId, disableMenu, index, collapsedCases, onClick, onPointerDown }: IIndexCellProps) {
+  const { data, metadata } = useDataSet()
+  const collectionId = useCollectionContext()
+  const collection = data?.getCollection(collectionId)
   const [menuButton, setMenuButton] = useState<HTMLButtonElement | null>(null)
   const cellElt: HTMLDivElement | null = menuButton?.closest(".rdg-cell") ?? null
   // Find the parent CODAP component to display the index menu above the grid
@@ -183,10 +186,9 @@ export function IndexCell({ caseId, disableMenu, index, collapsedCases, onClick,
   }
 
   // cell contents
-  const casesStr = t(collapsedCases === 1 ? "DG.DataContext.singleCaseName" : "DG.DataContext.pluralCaseName")
   const caseIdStr = DEBUG_CASE_IDS ? `: ${caseId}` : ""
   const cellContents = collapsedCases
-                        ? `${collapsedCases} ${casesStr}`
+                        ? `${collapsedCases} ${getCaseNameForCount(metadata, collection, collapsedCases)}`
                         : index != null ? `${index + 1}${caseIdStr}` : ""
   const handleClick = collapsedCases ? onClick : undefined
 

--- a/v3/src/models/data/data-set-utils.test.ts
+++ b/v3/src/models/data/data-set-utils.test.ts
@@ -1,9 +1,10 @@
 import { setupTestDataset } from "../../test/dataset-test-utils"
 import { AppHistoryService } from "../history/app-history-service"
+import { DataSetMetadata } from "../shared/data-set-metadata"
 import { IAttribute } from "./attribute"
-import { ICollectionModel } from "./collection"
+import { CollectionModel, ICollectionModel } from "./collection"
 import { DataSet, IDataSet } from "./data-set"
-import { getCollectionAttrs, getNextCase, getPreviousCase, moveAttribute } from "./data-set-utils"
+import { getCaseNameForCount, getCollectionAttrs, getNextCase, getPreviousCase, moveAttribute } from "./data-set-utils"
 
 function names(attrs: IAttribute[]) {
   return attrs.map(({ name }) => name)
@@ -32,6 +33,25 @@ describe("DataSetUtils", () => {
     expect(data.childCollection).toBe(collection)
     expect(data.getCollection(origChildCollectionId)).toBeUndefined()
     expect(getCollectionAttrNames(data.childCollection, data)).toEqual(["a", "b"])
+  })
+
+  it("getCaseNameForCount works as expected", () => {
+    // defaults to "case"/"cases"
+    expect(getCaseNameForCount(undefined, undefined, 0)).toBe("cases")
+    expect(getCaseNameForCount(undefined, undefined, 1)).toBe("case")
+    expect(getCaseNameForCount(undefined, undefined, 2)).toBe("cases")
+    // will use collection title if available
+    const collection = CollectionModel.create({ id: "cId", _title: "Tests" })
+    expect(getCaseNameForCount(undefined, collection, 0)).toBe("Tests")
+    expect(getCaseNameForCount(undefined, collection, 1)).toBe("Test")
+    expect(getCaseNameForCount(undefined, collection, 2)).toBe("Tests")
+    // will use collection labels if available
+    const metadata = DataSetMetadata.create()
+    metadata.setSingleCase(collection.id, "Group")
+    metadata.setPluralCase(collection.id, "Groups")
+    expect(getCaseNameForCount(metadata, collection, 0)).toBe("Groups")
+    expect(getCaseNameForCount(metadata, collection, 1)).toBe("Group")
+    expect(getCaseNameForCount(metadata, collection, 2)).toBe("Groups")
   })
 
   it("moveAttribute works as expected", () => {

--- a/v3/src/models/data/data-set-utils.ts
+++ b/v3/src/models/data/data-set-utils.ts
@@ -1,5 +1,8 @@
 import { isAlive } from "mobx-state-tree"
+import { singular } from "pluralize"
 import { logMessageWithReplacement } from "../../lib/log-message"
+import { t } from "../../utilities/translation/translate"
+import { IDataSetMetadata } from "../shared/data-set-metadata"
 import { getMetadataFromDataSet } from "../shared/shared-data-utils"
 import { INotify } from "../history/history-service"
 import { IAttribute } from "./attribute"
@@ -31,6 +34,19 @@ export function collectionCaseIndexFromId(caseId: string, data?: IDataSet, colle
   // for now, linear search through pseudo-cases; could index if performance becomes a problem.
   const found = cases.findIndex(aCase => aCase.__id__ === caseId)
   return found >= 0 ? found : undefined
+}
+
+export function getCaseNameForCount(
+  metadata: Maybe<IDataSetMetadata>, collection: Maybe<ICollectionModel>, count: number
+): string {
+  // patterned after analogous v2 function
+  const collectionMetadata = collection?.id ? metadata?.collections.get(collection.id) : undefined
+  const collectionLabels = collectionMetadata?.labels
+  const pluralName = collectionLabels?.pluralCase || collection?.title
+  const singleName = collectionLabels?.singleCase || (pluralName ? singular(pluralName) : undefined)
+  return count === 1
+          ? singleName || t("DG.DataContext.singleCaseName")
+          : pluralName || t("DG.DataContext.pluralCaseName")
 }
 
 export function isAnyChildSelected(data: IDataSet, caseId: string): boolean {

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -44,6 +44,7 @@ import { isFreeTileLayout, isFreeTileRow } from "./free-tile-row"
 export interface IImportDataSetOptions {
   createDefaultTile?: boolean // default true
   defaultTileType?: string    // default kCaseTableTileType
+  width?: number              // default width
 }
 
 export const DocumentContentModel = BaseDocumentContentModel
@@ -219,12 +220,12 @@ export const DocumentContentModel = BaseDocumentContentModel
       getFormulaManager(self)?.addDataSet(ds)
     },
     importDataSet(data: IDataSet, options?: IImportDataSetOptions) {
-      const { createDefaultTile = true, defaultTileType = kCaseTableTileType } = options || {}
+      const { createDefaultTile = true, defaultTileType = kCaseTableTileType, width } = options || {}
       // add data set
       const { sharedData } = gDataBroker.addDataSet(data)
       if (sharedData.dataSet && createDefaultTile) {
         // create the corresponding case table
-        const newTile = self.createOrShowTile(defaultTileType)
+        const newTile = self.createOrShowTile(defaultTileType, { width })
         if (newTile) {
           // link the case table to the new data set
           linkTileToDataSet(newTile, sharedData.dataSet)


### PR DESCRIPTION
[[CODAP-363](https://concord-consortium.atlassian.net/browse/CODAP-363)] The displayed text for collapsed cases in the case table should match v2

While fixing the cypress tests, I also increased the size of the default case table when using `?sample=...`. A number of our cypress tests rely on dragging `Diet` and `Habitat` with `?sample=mammals`, but those attributes aren't visible with the default width of the table.

[CODAP-363]: https://concord-consortium.atlassian.net/browse/CODAP-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ