### PR TITLE
CODAP-831 Flip histogram rescale crash

### DIFF
--- a/v3/src/components/axis/components/numeric-axis-drag-rects.tsx
+++ b/v3/src/components/axis/components/numeric-axis-drag-rects.tsx
@@ -1,7 +1,7 @@
 import {observer} from "mobx-react-lite"
 import React, {useEffect, useRef} from "react"
 import { comparer, reaction } from "mobx"
-import {drag, ScaleContinuousNumeric, select} from "d3"
+import { drag, DragBehavior, ScaleContinuousNumeric, select, SubjectPosition } from "d3"
 import { logMessageWithReplacement } from "../../../lib/log-message"
 import { getTileModel } from "../../../models/tiles/tile-model"
 import { t } from "../../../utilities/translation/translate"
@@ -35,7 +35,10 @@ export const NumericAxisDragRects = observer(
       layout = useAxisLayoutContext(),
       displayModel = useDataDisplayModelContextMaybe()
 
+    console.log("NumericAxisDragRects render", axisModel.type, "lockZero =", lockZero, "place =", place)
+
     useEffect(function createRects() {
+      const rectElement = rectRef.current // Copy the ref value to a local variable
       let multiScale: MultiScale | undefined,
         d3Scale: ScaleContinuousNumeric<number, number>,
         d3ScaleAtStart: ScaleContinuousNumeric<number, number>,
@@ -45,6 +48,8 @@ export const NumericAxisDragRects = observer(
         dilationAnchorCoord: number,
         dragging = false,
         dilating = false
+
+      const dragBehaviors: Array<DragBehavior<SVGRectElement, RectIndices, SubjectPosition | RectIndices>> = []
 
       const onDragStart: D3Handler = function() {
           const subAxisLength = layout.getAxisLength(place) / numSubAxes,
@@ -134,7 +139,7 @@ export const NumericAxisDragRects = observer(
           dilating = false
         }
 
-      if (rectRef.current) {
+      if (rectElement) {
         // Add rects which the user can drag to dilate or translate the axis scale. If the data display
         // model has a fixed zero axis, only add one draggable rect. Otherwise, add three.
         const classPrefix = place === 'bottom' ? 'h' : 'v',
@@ -146,7 +151,8 @@ export const NumericAxisDragRects = observer(
                              : place === 'bottom'
                                ? ['lower-dilate', 'translate', 'upper-dilate']
                                : ['upper-dilate', 'translate', 'lower-dilate'],
-          dragBehavior = [drag<SVGRectElement, RectIndices>()  // lower
+          dragBehavior = [
+            drag<SVGRectElement, RectIndices>()  // lower
             .on("start", onDilateStart)
             .on("drag", onLowerDilateDrag)
             .on("end", onDragEnd),
@@ -159,7 +165,9 @@ export const NumericAxisDragRects = observer(
               .on("drag", onUpperDilateDrag)
               .on("end", onDragEnd)]
 
-        selectDragRects(rectRef.current)
+        dragBehaviors.push(...dragBehavior)
+
+        selectDragRects(rectElement)
           ?.data(numbering)// data signify lower, middle, upper rectangles
           .join(
             (enter) =>
@@ -176,7 +184,7 @@ export const NumericAxisDragRects = observer(
                 })
           )
         numbering.forEach((behaviorIndex, axisIndex) => {
-          const indexedRects = selectDragRects(rectRef.current, `.${classPrefix}-${classPostfixes[axisIndex]}`)
+          const indexedRects = selectDragRects(rectElement, `.${classPrefix}-${classPostfixes[axisIndex]}`)
           if (lockZero) {
             indexedRects?.call(
               drag<any, any>()
@@ -188,6 +196,15 @@ export const NumericAxisDragRects = observer(
             indexedRects?.call(dragBehavior[behaviorIndex])
           }
         })
+      }
+
+      return () => {
+        // Cleanup drag behaviors
+        if (rectElement) {
+          selectDragRects(rectElement)?.on(".drag", null)
+          selectDragRects(rectElement)?.remove()
+        }
+        dragBehaviors.forEach((behavior) => behavior.on("start", null).on("drag", null).on("end", null))
       }
     }, [axisModel, place, layout, numSubAxes, subAxisIndex, lockZero, displayModel])
 


### PR DESCRIPTION
[#CODAP-831] Bug fix: Crash after flipping histogram axes and rescaling count axis

* In numeric-axis-drag-rects.tsx we need to clean up the drag behaviors when the component goes away so we're not hanging onto axis models that are no longer part of the state tree.
* Also make sure the drag rects are removed from the dom.