### PR TITLE
CODAP-826 left & right-numeric scales problem

### DIFF
--- a/v3/src/components/graph/graph-component-handler.test.ts
+++ b/v3/src/components/graph/graph-component-handler.test.ts
@@ -194,8 +194,8 @@ describe("DataInteractive ComponentHandler Graph", () => {
     const y2Axis = tileContent.getAxis("rightNumeric") as IBaseNumericAxisModel
     expect(xAxis.min).toBe(-.5)
     expect(xAxis.max).toBe(7.5)
-    expect(yAxis.min).toBe(-7)
-    expect(yAxis.max).toBe(9)
+    expect(yAxis.min).toBe(-6.5)
+    expect(yAxis.max).toBe(1.5)
     expect(y2Axis.min).toBe(-.5)
     expect(y2Axis.max).toBe(7.5)
     const updateBoundsResult = update({ component: tile }, {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -144,15 +144,16 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       return self.primaryRole && self.attributeType(self.primaryRole) || "categorical"
     },
     /**
-     * This is overridden to handle multiple 'y' attributes
+     * This is overridden to handle multiple 'y' attributes on the left axis
      */
     numericValuesForAttrRole(role: AttrRole) {
       if (role !== 'y') {
         return self._numericValuesForAttrRole(role)
       }
       const values:number[] = []
-      const yAttributeIDs = self.yAttributeIDs
-      yAttributeIDs.forEach(attrID => {
+      const leftYAttrDescriptions = self._yAttributeDescriptions
+      const leftYAttrIDs = leftYAttrDescriptions.map((d: IAttributeDescriptionSnapshot) => d.attributeID)
+      leftYAttrIDs.forEach(attrID => {
         const attrValues = self.numericValuesForAttribute(attrID, self.attributeType(role))
         if (attrValues) {
           values.push(...attrValues)


### PR DESCRIPTION
[#CODAP-826] Bug fix: The graph rescale button doesn't work properly with two numeric y axes

* `GraphDataConfigurationModel.numericValuesForAttrRole` was wrongly including values for a right numeric attribute in the values for a y attribute. We fix so that it only includes values for the attributes on the left axis.
* Adjusted graph-component-handler.test.ts because left y axis gets different bounds