### PR TITLE
CODAP 816 Use V2 document background

### DIFF
--- a/v3/src/components/container/container.scss
+++ b/v3/src/components/container/container.scss
@@ -5,7 +5,7 @@
   isolation: isolate;
   width: 100%;
   height: calc(100% - vars.$menu-bar-height - vars.$tool-shelf-height);
-  background: url("../../assets/bg-grid-grey-v3.png");
+  background: url("../../assets/bg-grid-grey.png");
   position: relative;
 
   .component-placeholder {


### PR DESCRIPTION
[#CODAP-816] Feature: Return to document background used in V2

We no longer need the slight differentiation provided by the V3 background we were using.
* Changed `container.scss` to refer to `bg-grid-grey.png` as in V2