### PR TITLE
CODAP-833 Failure to swap scatterplot axes properly

### DIFF
--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -137,10 +137,9 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
     const disposer = mstReaction(
       () => GraphAttrRoles.map((aRole) => dataConfiguration?.attributeID(aRole)),
       () => {
-        if (syncModelWithAttributeConfiguration(graphModel, layout)) {
-          startAnimation()
-          callRefreshPointPositions()
-        }
+        syncModelWithAttributeConfiguration(graphModel, layout)
+        startAnimation()
+        callRefreshPointPositions()
       }, {name: "usePlot [attribute assignment]"}, dataConfiguration
     )
     return () => disposer()

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -589,7 +589,7 @@ export const GraphContentModel = DataDisplayContentModel
     // returns true if the plot type changed
     syncPlotWithAttributeConfiguration(): boolean {
       const assignedAttrCount = PrimaryAttrRoles.map(role => !!self.dataConfiguration.attributeID(role))
-                                  .filter(Boolean).length
+        .filter(Boolean).length
       if (assignedAttrCount === 0) {
         if (self.plotType !== "casePlot") {
           self.setPlotType("casePlot")

--- a/v3/src/components/graph/models/graph-model-utils.ts
+++ b/v3/src/components/graph/models/graph-model-utils.ts
@@ -141,7 +141,6 @@ function setupAxes(graphModel: IGraphContentModel, layout: GraphLayout) {
 }
 
 export function syncModelWithAttributeConfiguration(graphModel: IGraphContentModel, layout: GraphLayout) {
-  const result = setPrimaryRoleAndPlotType(graphModel)
+  setPrimaryRoleAndPlotType(graphModel)
   setupAxes(graphModel, layout)
-  return result
 }


### PR DESCRIPTION
[#CODAP-833] Bug: Swapping attributes on graph axes not working in this document

* The attributes on the x and y axes had value such that the bounds for the two axes were the same, so one possible reaction that is often triggered wasn't being triggered.
* The mstReaction set up to detect changes in attribute assignment was calling `syncModelWithAttributeConfiguration` and only refreshing point positions if this function returned true, which in this situation it wasn't because there was no change in model required. Removing dependence on the result of this call fixes the bug.
* There was a bit of fussing to do with returned boolean values whereby I first thought I could remove them but found out otherwise by running jest tests.