### PR TITLE
CODAP-841 Fix to allow graph/map attribute menus to render outside component boundaries

### DIFF
--- a/v3/src/components/codap-component.scss
+++ b/v3/src/components/codap-component.scss
@@ -9,6 +9,7 @@ $corner-drag-size: calc($border-drag-width * 2);
   outline: 1px solid vars.$focus-border-color;
   // With this next line, attribute menus are held inside the component boundaries, but bottom corners are rounded
   //overflow: hidden;
+  // todo: Attribute menus should be rendered in a portal so that the overflow: hidden can be reinstated
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
[#CODAP-841] Bug fix: Unable to access graph attribute menu

* The previous merge to main of the commenting out of `overflow: hidden` was an error in that it should have been held off to be part of this commit.
* We add a `todo` explaining that the `overflow: hidden` can be reinstated, thus producing rounded corners for components, once attribute menus are implemented to render in portals so that they are not constrained by component boundaries.