### PR TITLE
CODAP-57 Make tile transitionComplete a volatile property

### DIFF
--- a/v3/doc/map.md
+++ b/v3/doc/map.md
@@ -1,0 +1,69 @@
+# Creation behaviors
+
+## Map created from application toolbar
+
+When a map is created by the user clicking on the map toolbar button:
+- if there is no dataset with latitude longitude attributes, the map will automatically center on the user's current location.
+- if there is a dataset with latitude longitude attributes, the new map will fit the bounds of the points of this dataset.
+
+## Map created by a plugin
+When a map is created by the plugin api:
+- the plugin can specify a center and zoom for the map, this will override any changes below
+- if there is no dataset with latitude longitude attributes, the map will automatically center on the user's current location.
+- if there is a dataset with latitude longitude attributes, the new map will fit the bounds of the points of this dataset.
+
+# Other Map behaviors
+
+If a new layer is added to the map, this should rescale the map to fit the bounds of the points of this layer plus the points any existing layers. It isn't clear if this is working properly.
+
+If a new point is added to a dataset being shown on the map, the map will not automatically rescale to show this new point.
+
+Once the map has been created the map bounds should be preserved when it is reloaded or new points are added to it.
+
+# Current implementation
+
+There are 3 places the bounds of a map are stored:
+- `MapContentModel` is the MST object which is serialized into the document to save the map state.
+- `LeafletMapState` this proxies the actual Leaflet object as a MobX object, so changes to Leaflet can be observed by components and reactions.
+- `LeafletMap` this is the actual Leaflet object provided by the Leaflet library.
+
+## MapContentModel (map-content-model.ts)
+This has reactions for syncing the center and zoom from itself to the `LeafletMapState` and from the `LeafletMapState` to itself.
+
+A `rescale` action which should compute the bounds of the all of the points of all of the datasets shown on the map, and calls `LeafletMapState.adjustMapView` to update Leaflet itself. This update of Leaflet itself triggers the listeners added by `LeafletMapState` to `LeafletMap`. The `LeafletMapState` listeners then update the `LeafletMapState` properties. The sync method in `MapContentModel` then updates its properties.
+
+A reaction listens for changes to the layers and calls `rescale` when the layers change.
+
+## LeafletMapState (leaflet-map-state.ts)
+
+In addition to providing an observable MobX proxy of the LeafletMap, this object also handles creating undo-able actions when the user uses Leaflet's UI to pan and zoom the map.
+
+Because LeafletMap sends events as the user is panning or zooming the map, this would result in many undo-able actions for single pan or zoom operation. This is handled by using Leaflet's `movestart` `moveend`, and `zoomstart` `zoomend` events. The incremental `zoom` and `move` events do update the `zoom` and `center` properties of `LeafletMapState`. But these are not sync'd to the `MapContentModel` immediately because the syncing reaction in `MapContentModel` only updates itself when `LeafletMapState.isChanging` is false. This `isChanging` view becomes true when a `zoomstart` or `movestart` happens, and it goes back to false when the corresponding `zoomend` and `moveend` happen.
+
+The `LeafletMapState` is a way to separate out the proxy of the listener based Leaflet api to an observable MobX api from the map content model. While this approach reduces the code in the map content model, it does complicate things because there are now 3 places where the map state is stored: leaflet, contentModel, and leafletMapState.
+
+In most cases the React components use the `LeafletMapState` to make changes. The plugin api uses the `MapContentModel` to make changes. When methods on the `LeafletMapState` are called to change Leaflet, it does not update the properties in `LeafletMapState` directly. Instead the methods update the LeafletMap object and then events are fired by the LeafletMap object which listeners in `LeafletMapState` handle and update the `LeafletMapState` properties. So the `LeafletMap` is the source of truth.
+
+## MapInterior (map-interior.tsx)
+
+This is an observing component that calls `useMapModel()` and renders the main map layers.
+
+## useMapModel (use-map-model.ts)
+
+This hook handles the creation behaviors described above. It waits for the shared datasets of map to be initialized and the initial tile extents set.
+
+Importantly, this initialization will happen as soon as the map is rendered. If the map is being animated into place, the width and height of the map will start out as 0. Leaflet correctly handles the setting of its zoom and center properties even if the width and height of the map are 0. Leaflet cannot handle "fitting the bounds" of a latitude longitude range when the width and height are 0. Fitting the bounds at least needs the aspect ratio of the displayed map so Leaflet can compute the correct zoom which will show the range. See below for how this is handled.
+
+If the MapContentModel has a zoom set, then it updates Leaflet with the zoom and center values of the MapContentModel. This handles two cases:
+1. When a plugin sets the zoom and center
+2. When the MapContentModel is reloaded from a saved CODAP document
+It is fine to do this immediately because setting Leaflet's zoom and center is independent from the width and height of the displayed map.
+
+If there is no zoom set, and there are no layers, then the user's current position is used for the center value and a default zoom level is used for the zoom. This is also fine to do immediately because it is just setting the center and zoom.
+
+If there is no zoom set and there are layers, then we need to automatically adjust the map bounds to show the data. This is done by computing the latitude and longitude range of the points and then passing this range to Leaflet's `fitBounds` method. However as described above this has to wait until the map has finished animating into place. The waiting is done by waiting for the tile's `transitionComplete` property to be true. If the tile is not animating this will be true immediately after the first render of the tile. If the tile is animating this will become true when the animation is complete.
+
+## Undo Redo
+The `LeafletMapState` object stores a undoStringKey and redoStringKey. Whenever the component calls the actions on `LeafletMapState` it will set these keys if the change should be undo-able. Then when the reaction in the map content model observes a change in `LeafletMapState` it uses these keys to record the change in the content model as undo able.
+
+See above for info about the `isChanging` property of `LeafletMapState` which is a key part of preventing extra undo-able changes.

--- a/v3/src/components/case-table/use-selected-cell.ts
+++ b/v3/src/components/case-table/use-selected-cell.ts
@@ -21,8 +21,8 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
   const collectionTableModel = useCollectionTableModel()
   const selectedCell = useRef<Maybe<ISelectedCell>>()
   const blockUpdateSelectedCell = useRef(false)
-  const tile = useTileModelContext()
-  const tileIsFocused = tile.tileId === uiState.focusedTile
+  const { tileId } = useTileModelContext()
+  const tileIsFocused = tileId === uiState.focusedTile
 
   const handleSelectedCellChange = useCallback((args: TCellSelectArgs) => {
     const columnId = args.column?.key

--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -115,13 +115,20 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
   // the tile's dimensions. To prevent this, we add a transitionend handler that sets a flag on the tile model when the
   // transition completes. Child components can check this flag to avoid or counteract premature application of effects.
   useEffect(function addTransitionEndHandler() {
-    // applyModelChange is used to prevent an action from being added to the undo stack
-    const handleTransitionEnd = () => tile.applyModelChange(() => tile.setTransitionComplete(true))
+    const handleTransitionEnd = () => tile.setTransitionComplete(true)
+
+    // If we are not animating the creation of this tile, the transitionend event will never fire.
+    // So we set the tile's transitionComplete immediately to true.
+    if (disableAnimation || !row.animateCreationTiles.has(tileId)) {
+      handleTransitionEnd()
+      return
+    }
+
     const element = document.getElementById(`${tileId}`)
     element?.addEventListener("transitionend", handleTransitionEnd)
 
     return () => element?.removeEventListener("transitionend", handleTransitionEnd)
-  }, [tile, tileId])
+  }, [tile, tileId, disableAnimation, row.animateCreationTiles])
 
   if (!info || (tileLayout?.isHidden && !info.renderWhenHidden)) return null
 

--- a/v3/src/components/map/components/map-interior.tsx
+++ b/v3/src/components/map/components/map-interior.tsx
@@ -9,7 +9,6 @@ import {MapPointLayer} from "./map-point-layer"
 import {isMapPolygonLayerModel} from "../models/map-polygon-layer-model"
 import {MapPolygonLayer} from "./map-polygon-layer"
 import { DataConfigurationContext } from "../../data-display/hooks/use-data-configuration-context"
-import { useTileModelContext } from "../../../hooks/use-tile-model-context"
 import { isMapPinLayerModel } from "../models/map-pin-layer-model"
 import { MapPinLayer } from "./map-pin-layer"
 import { createOrUpdateLeafletGeoRasterLayer } from "../utilities/georaster-utils"
@@ -21,17 +20,8 @@ interface IProps {
 
 export const MapInterior = observer(function MapInterior({setPixiPointsLayer}: IProps) {
   const mapModel = useMapModelContext()
-  const { transitionComplete: tileTransitionComplete } = useTileModelContext()
 
   useMapModel()
-
-  // Ensure the map rescales when its tile's CSS transition is complete to compensate for any changes to the tile's
-  // size that may have occurred after the map was initially rendered.
-  useEffect(function rescaleOnTileTransitionEnd() {
-    if (tileTransitionComplete) {
-      mapModel.rescale()
-    }
-  }, [tileTransitionComplete, mapModel])
 
   // Add or update the GeoRaster layer when URL changes
   useEffect(() => {
@@ -41,7 +31,6 @@ export const MapInterior = observer(function MapInterior({setPixiPointsLayer}: I
       createOrUpdateLeafletGeoRasterLayer(mapModel)
     }, {name: "MapInterior.mstAutorun [createOrUpdateLeafletGeoRasterLayer]"}, mapModel)
   }, [mapModel])
-
 
   /**
    * Note that we don't have to worry about layer order because polygons will be sent to the back

--- a/v3/src/components/map/hooks/use-map-model.ts
+++ b/v3/src/components/map/hooks/use-map-model.ts
@@ -1,14 +1,17 @@
-import {useEffect} from "react"
-import {useMapEvents, useMap} from "react-leaflet"
-import {useMapModelContext} from "./use-map-model-context"
-import {useDataDisplayLayout} from "../../data-display/hooks/use-data-display-layout"
-import {kDefaultMapZoomForGeoLocation} from "../map-types"
-import {DEBUG_MAP, debugLog} from "../../../lib/debug"
+import { useEffect } from "react"
+import { when } from "mobx"
+import { useMapEvents, useMap } from "react-leaflet"
+import { DEBUG_MAP, debugLog } from "../../../lib/debug"
+import { useTileModelContext } from "../../../hooks/use-tile-model-context"
+import { useDataDisplayLayout } from "../../data-display/hooks/use-data-display-layout"
+import { kDefaultMapZoomForGeoLocation } from "../map-types"
+import { useMapModelContext } from "./use-map-model-context"
 
 export function useMapModel() {
-  const leafletMap = useMap(),
-    mapModel = useMapModelContext(),
-    layout = useDataDisplayLayout()
+  const leafletMap = useMap()
+  const mapModel = useMapModelContext()
+  const layout = useDataDisplayLayout()
+  const { tile } = useTileModelContext()
 
   useEffect(function initializeLeafletMap() {
     mapModel.setLeafletMap(leafletMap)
@@ -22,6 +25,7 @@ export function useMapModel() {
 
   // Initialize
   useEffect(function initializeLeafletMapView() {
+    const disposers: (() => void)[] = []
     // wait until everything is ready before initializing the map
     if (mapModel.isLeafletMapInitialized || !layout.isTileExtentInitialized || !mapModel.isSharedDataInitialized) {
       return
@@ -32,8 +36,8 @@ export function useMapModel() {
       mapModel.leafletMapState.adjustMapView({ center: [lat, lng], zoom: mapModel.zoom })
     }
     // In a newly created map, layers can be added automatically in MapContentModel's sharedDataSets
-    // reaction. We wait to perform the map initialization until this has been completed to avoid
-    // auto-positioning the map prematurely.
+    // reaction. We've waited for that to be complete by making sure isSharedDataInitialized is
+    // true. We need to wait for this to be complete to avoid auto-positioning the map prematurely.
     else if (mapModel.layers.length === 0) {
       // Auto-position to the user's current position, if available
       navigator.geolocation.getCurrentPosition?.((pos: GeolocationPosition) => {
@@ -45,6 +49,41 @@ export function useMapModel() {
         })
       })
     }
+    // When a newly create map is added to the document and there are datasets with map data, we
+    // want to rescale the map to fit the bounds of this data. However the calculation of the map
+    // center and zoom that fits the data requires knowing the map's final aspect ratio.
+    // When a newly created map is added to the document, sometimes it is animated into its final size
+    // and position, so the aspect ratio of the map is not known by Leaflet until the animation
+    // completes.
+    // The check above is not waiting for this animation to complete. This is intentional because the
+    // animating map looks better when its zoom and center are set while it is animating.
+    // So instead of having the cases above wait for the animation complete, we use a MobX `when`
+    // below to wait for this animation only in this specific case.
+    //
+    // NOTE: the animation in this case could be improved by computing the map center and zoom using a fake
+    // map with the final size. However that seems more complicated so doesn't seem worth it.
+    else {
+      const rescaleDisposer = when(
+        () => !!tile?.transitionComplete,
+        () => {
+          // Make sure the map still has no zoom and still has layers
+          if (mapModel.zoom < 0 && mapModel.layers.length > 0) {
+            mapModel.rescale()
+          }
+        }
+      )
+
+      disposers.push(rescaleDisposer)
+    }
     mapModel.setHasBeenInitialized()
-  }, [layout.isTileExtentInitialized, leafletMap, mapModel, mapModel.isSharedDataInitialized])
+
+    return () => {
+      disposers.forEach(disposer => disposer())
+    }
+  },
+  // Because we are setting mapModel.isLeafletMapInitialized and this code is skipped when
+  // isLeafletMapInitialized is set, it is better to not include it in the dependencies.
+  // Doing so would just cause an extra unnecessary render since the dependencies are observed
+  // by the component using this hook.
+  [layout.isTileExtentInitialized, leafletMap, mapModel, mapModel.isSharedDataInitialized, tile])
 }

--- a/v3/src/components/map/map-component-handler.ts
+++ b/v3/src/components/map/map-component-handler.ts
@@ -80,10 +80,7 @@ export const mapComponentHandler: DIComponentHandler = {
       layers,
       zoom
     }
-    // If the center or zoom are specified, we need to prevent CODAP from automatically focusing the map
-    const options = center || zoom != null ? { transitionComplete: true } : undefined
-
-    return { content, options }
+    return { content }
   },
 
   get(content) {

--- a/v3/src/components/map/map-types.ts
+++ b/v3/src/components/map/map-types.ts
@@ -40,6 +40,7 @@ export const
   kDefaultMapWidth = 530,
   kDefaultMapHeight = 335,
   kMapAttribution = '&copy; <a href="https://static.arcgis.com/attribution/World_Topo_Map">USGS, NOAA</a>',
+  kMaxZoomForFitBounds = 12,
   kDefaultMapZoomForGeoLocation = 8,
   // Constants for maps
   kDefaultMapFillOpacity = 0.5,

--- a/v3/src/components/map/models/map-content-model.ts
+++ b/v3/src/components/map/models/map-content-model.ts
@@ -334,6 +334,7 @@ export const MapContentModel = DataDisplayContentModel
       self.leafletMapState.setLeafletMap(leafletMap)
     },
     setHasBeenInitialized() {
+      // TODO: withoutUndo should be unnecessary since isLeafletMapInitialized is volatile
       withoutUndo()
       self.isLeafletMapInitialized = true
     },

--- a/v3/src/hooks/use-tile-model-context.ts
+++ b/v3/src/hooks/use-tile-model-context.ts
@@ -5,7 +5,6 @@ export const TileModelContext = createContext<ITileModel | undefined>(undefined)
 
 export const useTileModelContext = () => {
   const tile = useContext(TileModelContext)
-  const transitionComplete = tile?.transitionComplete ?? false
 
-  return { tile, tileId: tile?.id, transitionComplete }
+  return { tile, tileId: tile?.id }
 }

--- a/v3/src/models/codap/create-tile.ts
+++ b/v3/src/models/codap/create-tile.ts
@@ -16,7 +16,6 @@ export interface INewTileOptions {
   x?: number
   y?: number
   height?: number
-  transitionComplete?: boolean
   width?: number
 }
 
@@ -27,8 +26,7 @@ export function createTileSnapshotOfType(tileType: string, env?: ITileEnvironmen
   const content = options?.content ?? info?.defaultContent({ env })
   const cannotClose = options?.cannotClose
   const title = options?.title
-  const transitionComplete = options?.transitionComplete
-  return content ? { cannotClose, content, id, name, title, transitionComplete } : undefined
+  return content ? { cannotClose, content, id, name, title } : undefined
 }
 
 export function createTileOfType(tileType: string, env?: ITileEnvironment, options?: INewTileOptions) {

--- a/v3/src/models/tiles/tile-model.ts
+++ b/v3/src/models/tiles/tile-model.ts
@@ -57,10 +57,10 @@ export const TileModel = V2UserTitleModel.named("TileModel")
     // e.g. "TextContentModel", ...
     content: TileContentUnion,
     cannotClose: types.maybe(types.boolean),
-    transitionComplete: types.maybe(types.boolean)
   })
   .volatile(self => ({
-    isNewlyCreated: false
+    isNewlyCreated: false,
+    transitionComplete: false
   }))
   .preProcessSnapshot(snapshot => {
     // early development versions of v3 had a `title` property


### PR DESCRIPTION
Additionally, transitionComplete is now set to true immediately if the tile is not animated into its final size.

This change required changing the way the map rescaling code worked. The is a new map.md file describing how it should work. The problematic case was how the code was rescaling the map to fit the points of a dataset. This was relying on transitionComplete being a serialized property. transitionComplete was used to prevent a map created with a center and zoom from being rescaled. It was also used to prevent a map restored from serialized state from being rescaled again which would override any changes made by the user.

The fix for these issues is to have the code that automatically calls rescale to make sure the map doesn't already have a set zoom before rescaling. zoom is a serialized property and after a successful rescale it will be set.

Additionally the code which automatically rescales was moved into useMapModel in a MobX `when`.

Other Fixes:
- when a map is created by the plugin api in a document with a dataset with latitude and longitude attributes it will now automatically fit this data like CODAPv2 does. That is unless the plugin sets a zoom value for the new map.
- when a dataset has a single mappable point the map would zoom in too far and not have any map tiles to show at this zoom level. This was fixed by adding a maxZoom setting of 12. The value of 12 is kind of arbitrary. At this level the user can probably still see some cities or roads that might provide visual context. But that depends on where in the world the point is located.
- when the noComponentAnimation url param is used the text tile used to not automatically get focused and also not be focused when the tile was selected.
- when the text tile was created by the api it would also not get automatically focused and also not be focused when the tile was selected.

Other minor changes:
- update usage of useTileModelContext to be consistent
- when tile is created you can no longer specify transitionComplete. This required transitionComplete to be part of the serialized properties, and was only used by the map code.