### PR TITLE
Fix for failed cypress case card/table attribute test

### DIFF
--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -64,368 +64,354 @@ export const Attribute = V2Model.named("Attribute").props({
   // should not be modified directly.
   values: types.maybe(types.frozen<string[]>())
 })
-.preProcessSnapshot(snapshot => {
-  const { formula: inFormula, values: inValues, ...others } = snapshot
-  // early development versions of v3 had a `title` property
-  const _title = snapshot._title ?? ((snapshot as any).title || undefined)
-  // don't import empty formulas
-  const formula = inFormula?.display?.length ? inFormula : undefined
-  // map all non-string values to strings
-  const values = (inValues || []).map(v => importValueToString(v))
-  return { formula, values, ...others, _title }
-})
-.volatile(self => ({
-  strValues: [] as string[],
-  numValues: [] as number[],
-  changeCount: 0
-}))
-.views(self => {
-  const baseMatchNameOrId = self.matchNameOrId
-  return {
-    matchNameOrId(nameOrId: string | number) {
-      return self.id === nameOrId || baseMatchNameOrId(nameOrId)
+  .preProcessSnapshot(snapshot => {
+    const {formula: inFormula, values: inValues, ...others} = snapshot
+    // early development versions of v3 had a `title` property
+    const _title = snapshot._title ?? ((snapshot as any).title || undefined)
+    // don't import empty formulas
+    const formula = inFormula?.display?.length ? inFormula : undefined
+    // map all non-string values to strings
+    const values = (inValues || []).map(v => importValueToString(v))
+    return {formula, values, ...others, _title}
+  })
+  .volatile(self => ({
+    strValues: [] as string[],
+    numValues: [] as number[],
+    changeCount: 0
+  }))
+  .views(self => {
+    const baseMatchNameOrId = self.matchNameOrId
+    return {
+      matchNameOrId(nameOrId: string | number) {
+        return self.id === nameOrId || baseMatchNameOrId(nameOrId)
+      }
     }
-  }
-})
-.views(self => ({
-  importValue(value: IValueType) {
-    // may eventually want to do something more sophisticated here, like convert
-    // numeric values using an attribute-specific number of decimal places
-    return importValueToString(value)
-  },
-  get isNumeric() {
-    // An attribute is considered numeric if any of its values is a number.
-    return self.numValues.some(value => !isNaN(value))
-  },
-  toNumeric(value: string) {
-    if (value == null || value === "") return NaN
-    if (self.userType === "numeric") return extractNumeric(value) ?? NaN
-    return Number(value)
-  },
-  get numPrecision() {
-    return typeof self.precision === "number" ? self.precision : undefined
-  },
-  get datePrecision() {
-    return typeof self.precision === "string" ? self.precision : undefined
-  },
-  isInferredNumericType: cachedFnFactory<boolean>(() => {
-    let numCount = 0
-    const isEveryValueNumericOrEmpty = self.strValues.every((strValue, index) => {
-      if (strValue == null || strValue === "") return true
-      if (isFinite(self.numValues[index])) {
-        ++numCount
-        return true
-      }
-      return false
-    })
-    return numCount > 0 && isEveryValueNumericOrEmpty
-  }),
-  isInferredColorType: cachedFnFactory<boolean>(() => {
-    let colorCount = 0
-    const isEveryValueColorOrEmpty = self.strValues.every((strValue, index) => {
-      if (strValue == null || strValue === "") return true
-      if (parseColor(strValue)) {
-        ++colorCount
-        return true
-      }
-      return false
-    })
-    return colorCount > 0 && isEveryValueColorOrEmpty
-  }),
-  isInferredDateType: cachedFnFactory<boolean>(() => {
-    let dateCount = 0
-    const isEveryValueDateOrEmpty = self.strValues.every((strValue, index) => {
-      if (strValue == null || strValue === "") return true
-      if (isDateString(strValue)) {
-        ++dateCount
-        return true
-      }
-      return false
-    })
-    return dateCount > 0 && isEveryValueDateOrEmpty
-  }),
-  isInferredBoundaryType: cachedFnFactory<boolean>(() => {
-    let boundaryCount = 0
-    const isEveryValueBoundaryOrEmpty = self.strValues.every((strValue, index) => {
-      if (strValue == null || strValue === "") return true
-      if (isBoundaryString(strValue)) {
-        ++boundaryCount
-        return true
-      }
-      return false
-    })
-    return boundaryCount > 0 && isEveryValueBoundaryOrEmpty
-  }),
-  get hasFormula() {
-    return !!self.formula && !self.formula.empty
-  },
-  get hasValidFormula() {
-    return !!self.formula?.valid
-  },
-  get shouldSerializeValues() {
-    return !this.hasFormula
-  },
-  get cid() {
-    return self._cid ?? self.id
-  }
-}))
-.actions(self => ({
-  incChangeCount() {
-    self.isInferredNumericType.invalidate()
-    self.isInferredColorType.invalidate()
-    self.isInferredBoundaryType.invalidate()
-    self.isInferredDateType.invalidate()
-    ++self.changeCount
-  },
-  setCid(cid?: string) {
-    self._cid = cid
-  },
-  updateNumValues() {
-    // cache the numeric conversion of each value in volatile `numValues`
-    self.numValues = self.strValues.map(v => self.toNumeric(v))
-    self.isInferredNumericType.invalidate()
-  }
-}))
-.actions(self => ({
-  copyFrozenIntoVolatile() {
-    // frozen properties are not modifiable in development (because MST freezes them with Object.freeze),
-    // so we copy the data to volatile properties during runtime. Clients must call prepareSnapshot() before
-    // and completeSnapshot() after serialization for this to work under these conditions. MST doesn't
-    // actually freeze the values in production, so prepareSnapshot()/completeSnapshot() are NOPs in production.
-    if (isDevelopment()) {
-      // copy the frozen values into volatile `strValues`
-      self.strValues = [...(self.values || [])]
-      // clear frozen `values` so clients aren't tempted to access them and
-      // so we're not maintaining a triplicate copy of the data in memory.
-      self.values = undefined
-    }
-    else {
-      // in production mode, `strValues` can share the `values` array since it isn't frozen
-      if (!self.values) self.values = []
-      self.strValues = self.values
-    }
-  },
-  afterCreate() {
-    this.copyFrozenIntoVolatile()
-    addDisposer(self, reaction(
-      () => self.userType === "numeric",
-      () => self.updateNumValues(),
-      { name: "Attribute.userType.reaction", fireImmediately: true })
-    )
-/*
-    addDisposer(self, onSnapshot(self,
-      (snapshot) => {
-        // Copy the frozen values into the volatile arrays
-        this.copyFrozenIntoVolatile()
+  })
+  .views(self => ({
+    importValue(value: IValueType) {
+      // may eventually want to do something more sophisticated here, like convert
+      // numeric values using an attribute-specific number of decimal places
+      return importValueToString(value)
+    },
+    get isNumeric() {
+      // An attribute is considered numeric if any of its values is a number.
+      return self.numValues.some(value => !isNaN(value))
+    },
+    toNumeric(value: string) {
+      if (value == null || value === "") return NaN
+      if (self.userType === "numeric") return extractNumeric(value) ?? NaN
+      return Number(value)
+    },
+    get numPrecision() {
+      return typeof self.precision === "number" ? self.precision : undefined
+    },
+    get datePrecision() {
+      return typeof self.precision === "string" ? self.precision : undefined
+    },
+    isInferredNumericType: cachedFnFactory<boolean>(() => {
+      let numCount = 0
+      const isEveryValueNumericOrEmpty = self.strValues.every((strValue, index) => {
+        if (strValue == null || strValue === "") return true
+        if (isFinite(self.numValues[index])) {
+          ++numCount
+          return true
+        }
+        return false
       })
-    )
-*/
-  },
-  // should be called before retrieving snapshot (i.e. before serialization)
-  prepareSnapshot() {
-    if (isDevelopment() && self.shouldSerializeValues) {
-      // In development, values is undefined (see .afterCreate()). If the attribute values should be serialized
-      // (no formula), we need to temporarily update it to the current values.
-      withoutUndo({ suppressWarning: true })
-      self.values = [...self.strValues]
+      return numCount > 0 && isEveryValueNumericOrEmpty
+    }),
+    isInferredColorType: cachedFnFactory<boolean>(() => {
+      let colorCount = 0
+      const isEveryValueColorOrEmpty = self.strValues.every((strValue, index) => {
+        if (strValue == null || strValue === "") return true
+        if (parseColor(strValue)) {
+          ++colorCount
+          return true
+        }
+        return false
+      })
+      return colorCount > 0 && isEveryValueColorOrEmpty
+    }),
+    isInferredDateType: cachedFnFactory<boolean>(() => {
+      let dateCount = 0
+      const isEveryValueDateOrEmpty = self.strValues.every((strValue, index) => {
+        if (strValue == null || strValue === "") return true
+        if (isDateString(strValue)) {
+          ++dateCount
+          return true
+        }
+        return false
+      })
+      return dateCount > 0 && isEveryValueDateOrEmpty
+    }),
+    isInferredBoundaryType: cachedFnFactory<boolean>(() => {
+      let boundaryCount = 0
+      const isEveryValueBoundaryOrEmpty = self.strValues.every((strValue, index) => {
+        if (strValue == null || strValue === "") return true
+        if (isBoundaryString(strValue)) {
+          ++boundaryCount
+          return true
+        }
+        return false
+      })
+      return boundaryCount > 0 && isEveryValueBoundaryOrEmpty
+    }),
+    get hasFormula() {
+      return !!self.formula && !self.formula.empty
+    },
+    get hasValidFormula() {
+      return !!self.formula?.valid
+    },
+    get shouldSerializeValues() {
+      return !this.hasFormula
+    },
+    get cid() {
+      return self._cid ?? self.id
     }
-    if (isProduction() && !self.shouldSerializeValues) {
-      // In development, values is set to the volatile strValues (see .afterCreate()). If the attribute values should
-      // NOT be serialized (non-empty formula) we need to temporarily set it to undefined.
-      withoutUndo({ suppressWarning: true })
-      self.values = undefined
+  }))
+  .actions(self => ({
+    incChangeCount() {
+      self.isInferredNumericType.invalidate()
+      self.isInferredColorType.invalidate()
+      self.isInferredBoundaryType.invalidate()
+      self.isInferredDateType.invalidate()
+      ++self.changeCount
+    },
+    setCid(cid?: string) {
+      self._cid = cid
+    },
+    updateNumValues() {
+      // cache the numeric conversion of each value in volatile `numValues`
+      self.numValues = self.strValues.map(v => self.toNumeric(v))
+      self.isInferredNumericType.invalidate()
     }
-  },
-  // should be called after retrieving snapshot (i.e. after serialization)
-  completeSnapshot() {
-    if (isDevelopment() && self.shouldSerializeValues) {
-      // values should be set back to undefined in development mode.
-      withoutUndo({ suppressWarning: true })
-      self.values = undefined
-    }
-    if (isProduction() && !self.shouldSerializeValues) {
-      // values should be set back to the volatile strValues in production mode.
-      withoutUndo({ suppressWarning: true })
-      self.values = self.strValues
-    }
-  }
-}))
-.views(self => ({
-  get length() {
-    self.changeCount  // eslint-disable-line @typescript-eslint/no-unused-expressions
-    return self.strValues.length
-  },
-  get type() {
-    if (self.userType) return self.userType
-    self.changeCount  // eslint-disable-line @typescript-eslint/no-unused-expressions
-    if (this.length === 0) return
-
-    // only infer numeric if all non-empty values are numeric (CODAP2)
-    if (self.isInferredNumericType()) return "numeric"
-
-    // only infer date if all non-empty values are dates
-    if (self.isInferredDateType()) return "date"
-
-    // only infer color if all non-empty values are strict colors
-    if (self.isInferredColorType()) return "color"
-
-    // only infer boundary if all non-empty values are boundaries or if the attribute has a special name
-    if (kPolygonNames.includes(self.title) || self.isInferredBoundaryType()) {
-      return "boundary"
-    }
-
-    return "categorical"
-  },
-  value(index: number) {
-    const numValue = self.numValues[index]
-    return !isNaN(numValue) ? numValue : self.strValues[index]
-  },
-  isValueNumeric(index: number) {
-    return !isNaN(self.numValues[index])
-  },
-  numValue(index: number) {
-    return self.numValues[index]
-  },
-  strValue(index: number) {
-    return self.strValues[index]
-  },
-  boolean(index: number) {
-    return ["true", "yes"].includes(self.strValues[index].toLowerCase()) ||
-            (!isNaN(this.numValue(index)) ? this.numValue(index) !== 0 : false)
-  },
-  derive(name?: string) {
-    return { id: self.id, name: name || self.name, values: [] }
-  }
-}))
-.actions(self => ({
-  setName(newName: string) {
-    self.name = newName.trim()
-  },
-  setUnits(units?: string) {
-    self.units = units
-  },
-  setDescription(description?: string) {
-    self.description = description
-  },
-  setUserType(type?: AttributeType) {
-    self.userType = type
-  },
-  // setUserFormat(precision: string) {
-  //   self.userFormat = `.${precision}~f`
-  // },
-  setPrecision(precision?: number | DatePrecision) {
-    self.precision = precision
-  },
-  clearFormula() {
-    self.formula = undefined
-  },
-  setDisplayExpression(displayFormula: string) {
-    if (displayFormula) {
-      if (!self.formula) {
-        self.formula = Formula.create({ display: displayFormula })
+  }))
+  .actions(self => ({
+    afterCreate() {
+      // frozen properties are not modifiable in development (because MST freezes them with Object.freeze),
+      // so we copy the data to volatile properties during runtime. Clients must call prepareSnapshot() before
+      // and completeSnapshot() after serialization for this to work under these conditions. MST doesn't
+      // actually freeze the values in production, so prepareSnapshot()/completeSnapshot() are NOPs in production.
+      if (isDevelopment()) {
+        // copy the frozen values into volatile `strValues`
+        self.strValues = [...(self.values || [])]
+        // clear frozen `values` so clients aren't tempted to access them and
+        // so we're not maintaining a triplicate copy of the data in memory.
+        self.values = undefined
       }
       else {
-        self.formula.setDisplayExpression(displayFormula)
+        // in production mode, `strValues` can share the `values` array since it isn't frozen
+        if (!self.values) self.values = []
+        self.strValues = self.values
       }
-    }
-    else {
-      this.clearFormula()
-    }
-  },
-  addValue(value: IValueType = "", beforeIndex?: number) {
-    const strValue = self.importValue(value)
-    const numValue = self.toNumeric(strValue)
-    if ((beforeIndex != null) && (beforeIndex < self.strValues.length)) {
-      self.strValues.splice(beforeIndex, 0, strValue)
-      self.numValues.splice(beforeIndex, 0, numValue)
-    }
-    else {
-      self.strValues.push(strValue)
-      self.numValues.push(numValue)
-    }
-    self.incChangeCount()
-  },
-  addValues(values: IValueType[], beforeIndex?: number) {
-    const strValues = values.map(v => self.importValue(v))
-    const numValues = strValues.map(s => self.toNumeric(s))
-    if ((beforeIndex != null) && (beforeIndex < self.strValues.length)) {
-      self.strValues.splice(beforeIndex, 0, ...strValues)
-      self.numValues.splice(beforeIndex, 0, ...numValues)
-    }
-    else {
-      self.strValues.push(...strValues)
-      self.numValues.push(...numValues)
-    }
-    self.incChangeCount()
-  },
-  setValue(index: number, value: IValueType, options?: ISetValueOptions) {
-    if ((index >= 0) && (index < self.strValues.length)) {
-      if (typeof value === "string") {
-        const trimmedValue = value.trim()
-        self.strValues[index] = trimmedValue
-        self.numValues[index] = self.toNumeric(trimmedValue)
+      addDisposer(self, reaction(
+        () => self.userType === "numeric",
+        () => self.updateNumValues(),
+        { name: "Attribute.userType.reaction", fireImmediately: true })
+      )
+    },
+    // should be called before retrieving snapshot (i.e. before serialization)
+    prepareSnapshot() {
+      if (isDevelopment() && self.shouldSerializeValues) {
+        // In development, values is undefined (see .afterCreate()). If the attribute values should be serialized
+        // (no formula), we need to temporarily update it to the current values.
+        withoutUndo({suppressWarning: true})
+        self.values = [...self.strValues]
       }
-      else if (typeof value === "number") {
-        self.strValues[index] = value.toString()
-        self.numValues[index] = value
+      if (isProduction() && !self.shouldSerializeValues) {
+        // In development, values is set to the volatile strValues (see .afterCreate()). If the attribute values should
+        // NOT be serialized (non-empty formula) we need to temporarily set it to undefined.
+        withoutUndo({suppressWarning: true})
+        self.values = undefined
       }
-      else {
-        self.strValues[index] = self.importValue(value)
-        self.numValues[index] = self.toNumeric(self.strValues[index])
+    },
+    // should be called after retrieving snapshot (i.e. after serialization)
+    completeSnapshot() {
+      if (isDevelopment() && self.shouldSerializeValues) {
+        // values should be set back to undefined in development mode.
+        withoutUndo({suppressWarning: true})
+        self.values = undefined
       }
-      if (!options?.noInvalidate) self.incChangeCount()
-    }
-  },
-  setValues(indices: number[], values: IValueType[]) {
-    const length = indices.length <= values.length ? indices.length : values.length
-    for (let i = 0; i < length; ++i) {
-      const index = indices[i]
-      if ((index >= 0) && (index < self.strValues.length)) {
-        self.strValues[index] = self.importValue(values[i])
-        self.numValues[index] = self.toNumeric(self.strValues[index])
-      }
-    }
-    self.incChangeCount()
-  },
-  setLength(length: number) {
-    if (self.strValues.length < length) {
-      self.strValues = self.strValues.concat(new Array(length - self.strValues.length).fill(""))
-      if (isProduction()) {
-        // in production mode, `strValues` shares the `values` array since it isn't frozen
+      if (isProduction() && !self.shouldSerializeValues) {
+        // values should be set back to the volatile strValues in production mode.
+        withoutUndo({suppressWarning: true})
         self.values = self.strValues
       }
     }
-    if (self.numValues.length < length) {
-      self.numValues = self.numValues.concat(new Array(length - self.numValues.length).fill(NaN))
-    }
-  },
-  removeValues(index: number, count = 1) {
-    if ((index != null) && (index < self.strValues.length) && (count > 0)) {
-      self.strValues.splice(index, count)
-      self.numValues.splice(index, count)
-      self.incChangeCount()
-    }
-  },
-  // order the values of the attribute according to the provided indices
-  orderValues(indices: number[]) {
-    const _strValues = self.strValues.slice()
-    const _numValues = self.numValues.slice()
-    for (let i = 0; i < _strValues.length; ++i) {
-      self.strValues[i] = _strValues[indices[i]]
-      self.numValues[i] = _numValues[indices[i]]
-    }
-  },
-  clearValues() {
-    for (let i = self.strValues.length - 1; i >= 0; --i) {
-      self.strValues[i] = ""
-      self.numValues[i] = self.toNumeric(self.strValues[i])
-    }
-  }
-}))
-.actions(applyModelChange)
+  }))
+  .views(self => ({
+    get length() {
+      self.changeCount  // eslint-disable-line @typescript-eslint/no-unused-expressions
+      return self.strValues.length
+    },
+    get type() {
+      if (self.userType) return self.userType
+      self.changeCount  // eslint-disable-line @typescript-eslint/no-unused-expressions
+      if (this.length === 0) return
 
-export interface IAttribute extends Instance<typeof Attribute> {}
-export interface IAttributeSnapshot extends SnapshotIn<typeof Attribute> {}
+      // only infer numeric if all non-empty values are numeric (CODAP2)
+      if (self.isInferredNumericType()) return "numeric"
+
+      // only infer date if all non-empty values are dates
+      if (self.isInferredDateType()) return "date"
+
+      // only infer color if all non-empty values are strict colors
+      if (self.isInferredColorType()) return "color"
+
+      // only infer boundary if all non-empty values are boundaries or if the attribute has a special name
+      if (kPolygonNames.includes(self.title) || self.isInferredBoundaryType()) {
+        return "boundary"
+      }
+
+      return "categorical"
+    },
+    value(index: number) {
+      const numValue = self.numValues[index]
+      return !isNaN(numValue) ? numValue : self.strValues[index]
+    },
+    isValueNumeric(index: number) {
+      return !isNaN(self.numValues[index])
+    },
+    numValue(index: number) {
+      return self.numValues[index]
+    },
+    strValue(index: number) {
+      return self.strValues[index]
+    },
+    boolean(index: number) {
+      return ["true", "yes"].includes(self.strValues[index].toLowerCase()) ||
+        (!isNaN(this.numValue(index)) ? this.numValue(index) !== 0 : false)
+    },
+    derive(name?: string) {
+      return {id: self.id, name: name || self.name, values: []}
+    }
+  }))
+  .actions(self => ({
+    setName(newName: string) {
+      self.name = newName.trim()
+    },
+    setUnits(units?: string) {
+      self.units = units
+    },
+    setDescription(description?: string) {
+      self.description = description
+    },
+    setUserType(type?: AttributeType) {
+      self.userType = type
+    },
+    // setUserFormat(precision: string) {
+    //   self.userFormat = `.${precision}~f`
+    // },
+    setPrecision(precision?: number | DatePrecision) {
+      self.precision = precision
+    },
+    clearFormula() {
+      self.formula = undefined
+    },
+    setDisplayExpression(displayFormula: string) {
+      if (displayFormula) {
+        if (!self.formula) {
+          self.formula = Formula.create({display: displayFormula})
+        } else {
+          self.formula.setDisplayExpression(displayFormula)
+        }
+      } else {
+        this.clearFormula()
+      }
+    },
+    addValue(value: IValueType = "", beforeIndex?: number) {
+      const strValue = self.importValue(value)
+      const numValue = self.toNumeric(strValue)
+      if ((beforeIndex != null) && (beforeIndex < self.strValues.length)) {
+        self.strValues.splice(beforeIndex, 0, strValue)
+        self.numValues.splice(beforeIndex, 0, numValue)
+      } else {
+        self.strValues.push(strValue)
+        self.numValues.push(numValue)
+      }
+      self.incChangeCount()
+    },
+    addValues(values: IValueType[], beforeIndex?: number) {
+      const strValues = values.map(v => self.importValue(v))
+      const numValues = strValues.map(s => self.toNumeric(s))
+      if ((beforeIndex != null) && (beforeIndex < self.strValues.length)) {
+        self.strValues.splice(beforeIndex, 0, ...strValues)
+        self.numValues.splice(beforeIndex, 0, ...numValues)
+      } else {
+        self.strValues.push(...strValues)
+        self.numValues.push(...numValues)
+      }
+      self.incChangeCount()
+    },
+    setValue(index: number, value: IValueType, options?: ISetValueOptions) {
+      if ((index >= 0) && (index < self.strValues.length)) {
+        if (typeof value === "string") {
+          const trimmedValue = value.trim()
+          self.strValues[index] = trimmedValue
+          self.numValues[index] = self.toNumeric(trimmedValue)
+        } else if (typeof value === "number") {
+          self.strValues[index] = value.toString()
+          self.numValues[index] = value
+        } else {
+          self.strValues[index] = self.importValue(value)
+          self.numValues[index] = self.toNumeric(self.strValues[index])
+        }
+        if (!options?.noInvalidate) self.incChangeCount()
+      }
+    },
+    setValues(indices: number[], values: IValueType[]) {
+      const length = indices.length <= values.length ? indices.length : values.length
+      for (let i = 0; i < length; ++i) {
+        const index = indices[i]
+        if ((index >= 0) && (index < self.strValues.length)) {
+          self.strValues[index] = self.importValue(values[i])
+          self.numValues[index] = self.toNumeric(self.strValues[index])
+        }
+      }
+      self.incChangeCount()
+    },
+    setLength(length: number) {
+      if (self.strValues.length < length) {
+        self.strValues = self.strValues.concat(new Array(length - self.strValues.length).fill(""))
+        if (isProduction()) {
+          // in production mode, `strValues` shares the `values` array since it isn't frozen
+          self.values = self.strValues
+        }
+      }
+      if (self.numValues.length < length) {
+        self.numValues = self.numValues.concat(new Array(length - self.numValues.length).fill(NaN))
+      }
+    },
+    removeValues(index: number, count = 1) {
+      if ((index != null) && (index < self.strValues.length) && (count > 0)) {
+        self.strValues.splice(index, count)
+        self.numValues.splice(index, count)
+        self.incChangeCount()
+      }
+    },
+    // order the values of the attribute according to the provided indices
+    orderValues(indices: number[]) {
+      const _strValues = self.strValues.slice()
+      const _numValues = self.numValues.slice()
+      for (let i = 0; i < _strValues.length; ++i) {
+        self.strValues[i] = _strValues[indices[i]]
+        self.numValues[i] = _numValues[indices[i]]
+      }
+    },
+    clearValues() {
+      for (let i = self.strValues.length - 1; i >= 0; --i) {
+        self.strValues[i] = ""
+        self.numValues[i] = self.toNumeric(self.strValues[i])
+      }
+    }
+  }))
+  .actions(applyModelChange)
+
+export interface IAttribute extends Instance<typeof Attribute> {
+}
+
+export interface IAttributeSnapshot extends SnapshotIn<typeof Attribute> {
+}
 
 export interface IAttributeWithFormula extends IAttribute {
   formula: IFormula


### PR DESCRIPTION
Bug fix: Cypress tests for case-card and table failing

* A seemingly innocent refactor of attribute.ts `afterCreate` caused redo of create or delete attribute to no longer show the Redo button as enabled. The fix is to reinstate the previous version that doesn't have the refactor.