### PR TITLE
CODAP-862 Fix for movable line causing invalid document

### DIFF
--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
@@ -92,12 +92,14 @@ export const MovableLineAdornmentModel = AdornmentModel
 .actions(self => ({
   updateCategories(options: IUpdateCategoriesOptions) {
     const { resetPoints, dataConfig, interceptLocked, xAxis, yAxis } = options
-    dataConfig.getAllCellKeys().forEach(cellKey => {
-      const instanceKey = self.instanceKey(cellKey)
-      if (!self.lines.get(instanceKey) || resetPoints) {
-        self.setInitialLine(xAxis, yAxis, instanceKey, interceptLocked)
-      }
-    })
+    if (dataConfig.xAndYAreNumeric) {
+      dataConfig.getAllCellKeys().forEach(cellKey => {
+        const instanceKey = self.instanceKey(cellKey)
+        if (!self.lines.get(instanceKey) || resetPoints) {
+          self.setInitialLine(xAxis, yAxis, instanceKey, interceptLocked)
+        }
+      })
+    }
   }
 }))
 

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -294,6 +294,10 @@ export const GraphDataConfigurationModel = DataConfigurationModel
       const attrTypes = self.attrTypes
       return (isCategoricalAttributeType(attrTypes.left) ? 1 : 0) + (isCategoricalAttributeType(attrTypes.bottom)
         ? 1 : 0)
+    },
+    get xAndYAreNumeric() {
+      const attrTypes = self.attrTypes
+      return attrTypes.bottom === "numeric" && attrTypes.left === "numeric"
     }
   }))
   .views(self => ({

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -433,15 +433,17 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
 */
 export function computeSlopeAndIntercept(xAxis?: IAxisModel, yAxis?: IAxisModel, interceptLocked=false) {
   const xLower = isAnyNumericAxisModel(xAxis) ? xAxis.min : 0,
-    xUpper = isAnyNumericAxisModel(xAxis) ? xAxis.max : 0,
+    xUpper = isAnyNumericAxisModel(xAxis) ? xAxis.max : 1,
     yLower = isAnyNumericAxisModel(yAxis) ? yAxis.min : 0,
-    yUpper = isAnyNumericAxisModel(yAxis) ? yAxis.max : 0  
+    yUpper = isAnyNumericAxisModel(yAxis) ? yAxis.max : 1
 
   // Make the default a bit steeper, so it's less likely to look like
   // it fits a typical set of points
   const adjustedXUpper = xLower + (xUpper - xLower) / 2,
     slope = (yUpper - yLower) / (adjustedXUpper - xLower),
-    intercept = interceptLocked ? 0 : yLower - slope * xLower
+    intercept = interceptLocked ? 0
+      : isFinite(slope) ? yLower - slope * xLower
+        : adjustedXUpper
 
   return {slope, intercept}
 }


### PR DESCRIPTION
[#CODAP-862] Bug fix: Switching bottom axis to categorical after adding a moveable line causes an invalid document

* The switch to categorical was causing the movable-line-adornment-model.ts in `updateCategories` to add specious lines. We fix by detecting that the data configuration does not have numeric attributes for both x and y axes and bailing if that is so.

Note: In CLUE a patch was added through a `preProcessSnapshot` for its `MovableLineInstance` to take care of possible specious lines. We do not follow this path for CODAP because the specious lines should not appear.