### PR TITLE
CODAP-837 Splitting a histogram wasn't resulting in binned dot plot as it should

### DIFF
--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -606,16 +606,22 @@ export const GraphContentModel = DataDisplayContentModel
       }
       const numericAttrCount = PrimaryAttrRoles.map(role => isNumericRole(role))
                                   .filter(Boolean).length
+      const secondaryAttrIsCategorical = isCategoricalRole(self.dataConfiguration.secondaryRole)
       let newPlotType: Maybe<PlotType>
       if (numericAttrCount === 0) {
-        const secondaryAttrIsCategorical = isCategoricalRole(self.dataConfiguration.secondaryRole)
         if (!self.plot.isCategorical || (self.plotType === "barChart" && secondaryAttrIsCategorical)) {
           newPlotType = "dotChart"
         }
       }
       else if (numericAttrCount === 1) {
-        if (!self.plot.isUnivariateNumeric) {
-          newPlotType = "dotPlot"
+        if (!self.plot.isUnivariateNumeric || secondaryAttrIsCategorical) {
+          if (self.plotType === "histogram") {
+            // Histograms can't be split so we revert to binnedDotPlot
+            newPlotType = "binnedDotPlot"
+          }
+          else if (self.plotType !== "binnedDotPlot") { // Already binned? Leave it so.
+            newPlotType = "dotPlot"
+          }
         }
       }
       else if (numericAttrCount > 1) {


### PR DESCRIPTION
[#CODAP-837] Bug fix: Transition from a histogram to split binned plot fails

* `GraphContentModel.syncPlotWithAttributeConfiguration` wasn't catching the case in which there was a histogram and the user was attempting to split it with a categorical attribute on the secondary axis.