### PR TITLE
CODAP-850 Edit text should notify

### DIFF
--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -83,7 +83,7 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
         log: textDidChange ? () => `Edited text component: ${textModel.textContent}` : undefined,
         undoStringKey: "DG.Undo.textComponent.edit",
         redoStringKey: "DG.Redo.textComponent.edit",
-        notify: updateTileNotification("edit text", {}, tile)
+        notify: textDidChange ? () => updateTileNotification("edit text", {}, tile) : undefined
       })
     }
   }

--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "use-memo-one"
 import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { ITileBaseProps } from "../tiles/tile-base-props"
 import { mstReaction } from "../../utilities/mst-reaction"
+import { updateTileNotification } from "../../models/tiles/tile-notifications"
 import { isTextModel, modelValueToEditorValue } from "./text-model"
 import { TextToolbar } from "./text-toolbar"
 
@@ -81,7 +82,8 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
         // For now, we log just the text content, not the full JSON-stringified slate value.
         log: textDidChange ? () => `Edited text component: ${textModel.textContent}` : undefined,
         undoStringKey: "DG.Undo.textComponent.edit",
-        redoStringKey: "DG.Redo.textComponent.edit"
+        redoStringKey: "DG.Redo.textComponent.edit",
+        notify: updateTileNotification("edit text", {}, tile)
       })
     }
   }


### PR DESCRIPTION
[#CODAP-950] Bug fix: Editing text in a text component should notify plugins

* The notification was missing in text-tile.tsx `handleBlur`.