### PR TITLE
CODAP-874 Fix dynamic response of LSRL

### DIFF
--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
@@ -376,6 +376,15 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
       handleHighlightLineAndEquation, handleMoveEquation, model, plotHeight, plotWidth, showConfidenceBands,
       updateConfidenceBands, updateEquations, xAxis, yAxis])
 
+  // Refresh values on changes to model's computed values
+  useEffect(function refreshInterceptLockChange() {
+    return mstReaction(
+      () => model.changeCount,
+      () => {
+        buildElements()
+      }, { name: "LSRLAdornmentComponent.refreshInterceptLockChange" }, model)
+  }, [buildElements, model, model.changeCount])
+
   // Refresh values on interceptLocked change
   useEffect(function refreshInterceptLockChange() {
     return mstReaction(

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -77,7 +77,9 @@ export const LSRLAdornmentModel = AdornmentModel
 })
 .volatile(() => ({
   // first key is cell key; second key is legend category (or kMain)
-  lines: new Map<string, Map<string, ILSRLInstance>>()
+  lines: new Map<string, Map<string, ILSRLInstance>>(),
+  // Used for notification
+  changeCount: 0
 }))
 .views(self => ({
   // each cell contains a map of lines, where the key is the legend category (or kMain)
@@ -179,6 +181,9 @@ export const LSRLAdornmentModel = AdornmentModel
     const caseValues = self.getCaseValues(xAttrId, yAttrId, cellKey, dataConfig, cat)
     const { intercept, rSquared, slope, sdResiduals } = leastSquaresLinearRegression(caseValues, isInterceptLocked)
     return { intercept, rSquared, slope, sdResiduals }
+  },
+  incrementChangeCount() {
+    self.changeCount++
   }
 }))
 .actions(self => ({
@@ -199,6 +204,7 @@ export const LSRLAdornmentModel = AdornmentModel
         self.updateLines(lineProps, instanceKey, legendCat)
       })
     })
+    self.incrementChangeCount()
   },
   setLabel(cellKey: Record<string, string>, category: string, label: ILineLabelInstance) {
     const key = self.instanceKey(cellKey)

--- a/v3/src/components/graph/plots/dot-plot/dot-line-plot.tsx
+++ b/v3/src/components/graph/plots/dot-plot/dot-line-plot.tsx
@@ -1,7 +1,6 @@
 import {ScaleBand, ScaleLinear} from "d3"
 import {observer} from "mobx-react-lite"
 import React, {useCallback, useEffect} from "react"
-import { mstAutorun } from "../../../../utilities/mst-autorun"
 import {mstReaction} from "../../../../utilities/mst-reaction"
 import { setNiceDomain } from "../../../axis/axis-domain-utils"
 import { AxisPlace } from "../../../axis/axis-types"


### PR DESCRIPTION
[#CODAP-874] Bug fix: LSRL isn't updating during drag of points

* Probably during some performance optimization back in early May, response to point dragging broke for the LSRL. The fix is to introduce a volatile `changeCount` in the `LSRLAdornmentModel` which gets incremented when it recomputes. This gives the lsrl adornment component something to react to.
* We also take this opportunity to fix a lint error in dot-line-plot.tsx