### PR TITLE
CODAP-853 Synch moment title with text component title

### DIFF
--- a/v3/src/components/calculator/v2-calculator-importer.ts
+++ b/v3/src/components/calculator/v2-calculator-importer.ts
@@ -1,0 +1,18 @@
+import {ITileModelSnapshotIn} from "../../models/tiles/tile-model"
+import {toV3AttrId, toV3Id} from "../../utilities/codap-utils"
+import {V2TileImportArgs} from "../../v2/codap-v2-tile-importers"
+import { isV2CalculatorComponent } from "../../v2/codap-v2-types"
+import { kCalculatorIdPrefix } from "./calculator-registration"
+
+export function v2CalculatorImporter({v2Component, v2Document, getCaseData, insertTile}: V2TileImportArgs) {
+  if (isV2CalculatorComponent(v2Component)) {
+
+/*
+    const {guid, componentStorage: {name, title, userSetTitle, cannotClose}} = v2Component
+
+    const calculatorTileSnap: ITileModelSnapshotIn =
+      {id: toV3Id(kCalculatorIdPrefix, guid), name, _title: title, userSetTitle, content, cannotClose}
+    return insertTile(calculatorTileSnap)
+*/
+  }
+}

--- a/v3/src/components/graph/graph-registration.ts
+++ b/v3/src/components/graph/graph-registration.ts
@@ -12,9 +12,8 @@ import { registerV2TileExporter } from "../../v2/codap-v2-tile-exporters"
 import { registerV2PostImportSnapshotProcessor, registerV2TileImporter } from "../../v2/codap-v2-tile-importers"
 import { ComponentTitleBar } from "../component-title-bar"
 import { PlottedFunctionFormulaAdapter } from "./adornments/plotted-function/plotted-function-formula-adapter"
-import {
-  PlottedValueFormulaAdapter
-} from "./adornments/univariate-measures/plotted-value/plotted-value-formula-adapter"
+import { PlottedValueFormulaAdapter }
+  from "./adornments/univariate-measures/plotted-value/plotted-value-formula-adapter"
 import { GraphComponent } from "./components/graph-component"
 import { GraphInspector } from "./components/graph-inspector"
 import { graphComponentHandler } from "./graph-component-handler"

--- a/v3/src/components/text/text-registration.ts
+++ b/v3/src/components/text/text-registration.ts
@@ -114,14 +114,14 @@ registerV2TileExporter(kTextTileType, ({ tile }) => {
 registerV2TileImporter(kV2TextDGType, ({ v2Component, insertTile }) => {
   if (!isV2TextComponent(v2Component)) return
 
-  const { guid, componentStorage: { title, userSetTitle, text, cannotClose } } = v2Component
+  const { guid, componentStorage: { name = "", title, userSetTitle, text, cannotClose } } = v2Component
 
   const content: SetRequired<ITextSnapshot, "type"> = {
     type: kTextTileType,
     value: importTextToModelValue(text)
   }
   const textTileSnap: ITileModelSnapshotIn =
-          { id: toV3Id(kTextIdPrefix, guid), _title: title, userSetTitle, content, cannotClose }
+          { id: toV3Id(kTextIdPrefix, guid), _title: title, name, userSetTitle, content, cannotClose }
   const textTile = insertTile(textTileSnap)
 
   return textTile

--- a/v3/src/components/web-view/web-view-registration.ts
+++ b/v3/src/components/web-view/web-view-registration.ts
@@ -207,7 +207,7 @@ function importGuideView(args: V2TileImportArgs) {
   if (!isV2GuideViewComponent(v2Component)) return
 
   // parse the v2 content
-  const {componentStorage: {title, items, currentItemIndex, currentItemTitle, currentURL}} = v2Component
+  const {componentStorage: {name = "", items, currentItemIndex, currentItemTitle, currentURL}} = v2Component
   // create webView model
   const pages = items?.map((i) => ({
     title: i.itemTitle ?? undefined,
@@ -224,7 +224,7 @@ function importGuideView(args: V2TileImportArgs) {
   if (pageIndex == null) {
     pageIndex = 0 // fallback to first page
   }
-  return addWebViewSnapshot(args, title, { url: processWebViewUrl(pages[pageIndex]?.url ?? ""), pageIndex, pages })
+  return addWebViewSnapshot(args, name, { url: processWebViewUrl(pages[pageIndex]?.url ?? ""), pageIndex, pages })
 }
 registerV2TileImporter("DG.GuideView", importGuideView)
 

--- a/v3/src/data-interactive/handlers/document-handler.ts
+++ b/v3/src/data-interactive/handlers/document-handler.ts
@@ -205,7 +205,6 @@ export const diDocumentHandler: DIHandler = {
 
     reinstateDatasets().then(() => {
       reinstateComponents()
-    })
 
       // The 500ms timeout here gives the document time to settle down.
       // Especially any changes to center and zoom of a map

--- a/v3/src/data-interactive/handlers/document-handler.ts
+++ b/v3/src/data-interactive/handlers/document-handler.ts
@@ -205,6 +205,7 @@ export const diDocumentHandler: DIHandler = {
 
     reinstateDatasets().then(() => {
       reinstateComponents()
+    })
 
       // The 500ms timeout here gives the document time to settle down.
       // Especially any changes to center and zoom of a map


### PR DESCRIPTION
[#CODAP-853] Bug fix: Story Builder moment title not synching with associated text component title

* The V2 importer for text components was neglecting to pull the name of the component from the componentStorage and to include it in the snapshot. As a result story builder's requests to update the text component's title were failing because SB was assuming that the name of the text component was a stable key for identifying it.
* The V2 importer for guide views was making a similar mistake but different in that it was treating the title as the name and ignoring the name.