### PR TITLE
CODAP-832 Incorrect import/export of V2 date axis

### DIFF
--- a/v3/src/components/graph/v2-graph-exporter.ts
+++ b/v3/src/components/graph/v2-graph-exporter.ts
@@ -85,7 +85,7 @@ function getAttrRoleAndType(
         }
         else {
           // note: v2 writes out all secondary axis roles as eSecondaryCategorical, even with no attribute
-          v2Role = type === "numeric"
+          v2Role = type === "numeric" || type === "date"
                     ? isPrimary ? v2Roles.ePrimaryNumeric : v2Roles.eSecondaryCategorical
                     : isPrimary ? v2Roles.ePrimaryCategorical : v2Roles.eSecondaryCategorical
         }

--- a/v3/src/components/graph/v2-graph-importer.ts
+++ b/v3/src/components/graph/v2-graph-importer.ts
@@ -136,7 +136,9 @@ export function v2GraphImporter({v2Component, v2Document, getCaseData, insertTil
         case "DG.CellLinearAxisModel":
         case "DG.CountAxisModel":
         case "DG.FormulaAxisModel": {
-          const type = ["DG.CountAxisModel", "DG.FormulaAxisModel"].includes(axisClass) ? "count" : "numeric"
+          const type = ["DG.CountAxisModel", "DG.FormulaAxisModel"].includes(axisClass) ? "count"
+            : _attributeDescriptions[axisPlaceToAttrRole[v3Place]]?.type === "date" ? "date"
+            : "numeric"
           // V2 lowerBound or upperBound can be undefined or null, which will cause an MST exception and
           // failure to load. So we assign a default value of lowerBound = 0 and upperBound = 10 if they are undefined.
           axes[v3Place] = {place: v3Place, type, min: lowerBound ?? 0, max: upperBound ?? 10}


### PR DESCRIPTION
[#CODAP-832] Bug fix: Date graph axis labels display in scientific notation when opening existing document

* This was a V2 import bug whereby the fact that a V2 date axis does not have its own class was not being taken into account. We fix by detecting that the attribute is of type 'date' and setting the V3 axis model accordingly.
* It seems that the v2 graph exporter had a similar problem and was exporting a date axis as categorical. We fix by detecting that the data configuration is specifying that the attribute be treated as 'date' and specifying the V2 axis role as numeric.