### PR TITLE
CODAP-839 Fix parent visibility toggles for case plot

### DIFF
--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -455,9 +455,10 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
     return self.collections.find(coll => coll.getAttribute(attributeId))
   }
 
+  // returns index of collection containing attribute, or last collection if attribute not given
   function getCollectionIndexForAttribute(attributeId: string): number | undefined {
     const id = getCollectionForAttribute(attributeId)?.id
-    return id ? getCollectionIndex(id) : undefined
+    return id ? getCollectionIndex(id) : self.collections.length - 1
   }
 
   function getUniqueCollectionName(name: string) {


### PR DESCRIPTION
[#CODAP-839] Bug fix: Parent visibility toggles not consistently toggling

* This problem was only occurring when there were no attributes assigned to the graph and the cause was an assumption in `Dataset.getCollectionIndexForAttribute` that if no attribute id were passed in, the result should be undefined. We alter that to return the index of the childmost collection instead.