### PR TITLE
feat: tool palette aligns with top of the component (CODAP-846)

### DIFF
--- a/v3/src/components/inspector-panel.scss
+++ b/v3/src/components/inspector-panel.scss
@@ -9,7 +9,7 @@ $inspector-panel-border-width: 2px;
   align-items: center;
   background-color: white;
   border: $inspector-panel-border-width solid vars.$focus-border-color;
-  border-radius: 0 5px 5px 5px;
+  border-radius: 5px;
   box-shadow: rgba(0, 0, 0, 0.25) 0px 1px 3px 0px;
   display: flex;
   flex-direction: column;
@@ -66,6 +66,7 @@ $inspector-panel-border-width: 2px;
     }
 
     &.top {
+      border-top-left-radius: 4px;
       border-top-right-radius: 4px;
       height: 56px;
       padding-top: 8px;

--- a/v3/src/components/inspector-panel.scss
+++ b/v3/src/components/inspector-panel.scss
@@ -3,18 +3,19 @@ $inspector-panel-width-very-narrow: 48px;
 $inspector-panel-width-narrow: 64px;
 $inspector-panel-width-medium: 72px;
 $inspector-panel-width-wide: 80px;
+$inspector-panel-border-width: 2px;
 
 .inspector-panel {
   align-items: center;
   background-color: white;
-  border: 2px solid vars.$focus-border-color;
+  border: $inspector-panel-border-width solid vars.$focus-border-color;
   border-radius: 0 5px 5px 5px;
   box-shadow: rgba(0, 0, 0, 0.25) 0px 1px 3px 0px;
   display: flex;
   flex-direction: column;
   min-height: 50px;
   position: absolute;
-  top: 32px;
+  top: -$inspector-panel-border-width;
   z-index: 15;
 
   &.very-narrow {


### PR DESCRIPTION
[CODAP-846](https://concord-consortium.atlassian.net/browse/CODAP-846)

This change will align the top of components' tool palette panels with the top of the components' title bars.

I'm a little on the fence about whether adding a variable is justified, but I think it makes sense and may save some trouble if the border width changes.

[CODAP-846]: https://concord-consortium.atlassian.net/browse/CODAP-846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ