### PR TITLE
fix: Connecting lines don't appear in each subplot (CODAP-868)

### DIFF
--- a/v3/cypress/e2e/bivariate-adornments.spec.ts
+++ b/v3/cypress/e2e/bivariate-adornments.spec.ts
@@ -261,6 +261,7 @@ context("Graph adornments", () => {
     c.selectTile("graph", 0)
     cy.dragAttributeToTarget("table", "Sleep", "bottom")
     cy.dragAttributeToTarget("table", "Speed", "left")
+    cy.dragAttributeToTarget("table", "Diet", "top")
     graph.getDisplayValuesButton().click()
 
     graph.getInspectorPalette().should("be.visible")
@@ -271,17 +272,17 @@ context("Graph adornments", () => {
     //   cy.wrap(dot).should("have.attr", "r", 6)
     // })
     cy.get("[data-testid=adornment-checkbox-connecting-lines]").click()
-    cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("exist")
+    cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("exist").and("have.length", 3)
     // TODO: Update the below once the connecting lines and related dot animation is re-instated
     // cy.get(".graph-dot").each((dot: SVGCircleElement) => {
     //   cy.wrap(dot).should("have.attr", "r", 3)
     // })
     // Since the circle elements for the graph's case dots overlay the lines' path element in various places, we
     // use force: true so we don't need to figure out exactly where to click.
-    cy.get("*[data-testid^=connecting-lines-graph]").find("path").click({force: true})
-    cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("have.attr", "stroke-width", "4")
-    cy.get("*[data-testid^=connecting-lines-graph]").find("path").click({force: true})
-    cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("have.attr", "stroke-width", "2")
+    cy.get("*[data-testid^=connecting-lines-graph]").find("path").first().click({force: true})
+    cy.get("*[data-testid^=connecting-lines-graph]").find("path").first().should("have.attr", "stroke-width", "4")
+    cy.get("*[data-testid^=connecting-lines-graph]").find("path").first().click({force: true})
+    cy.get("*[data-testid^=connecting-lines-graph]").find("path").first().should("have.attr", "stroke-width", "2")
     graph.getDisplayValuesButton().click()
     cy.get("[data-testid=adornment-checkbox-connecting-lines]").click()
     cy.get("*[data-testid^=adornment-checkbox-connecting-lines]").find("path").should("not.exist")
@@ -296,10 +297,10 @@ context("Graph adornments", () => {
 
     // Connecting lines should be visible again after an undo
     cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("exist")
-    cy.get("*[data-testid^=connecting-lines-graph]").find("path").click({force: true})
-    cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("have.attr", "stroke-width", "4")
-    cy.get("*[data-testid^=connecting-lines-graph]").find("path").click({force: true})
-    cy.get("*[data-testid^=connecting-lines-graph]").find("path").should("have.attr", "stroke-width", "2")
+    cy.get("*[data-testid^=connecting-lines-graph]").find("path").first().click({force: true})
+    cy.get("*[data-testid^=connecting-lines-graph]").find("path").first().should("have.attr", "stroke-width", "4")
+    cy.get("*[data-testid^=connecting-lines-graph]").find("path").first().click({force: true})
+    cy.get("*[data-testid^=connecting-lines-graph]").find("path").first().should("have.attr", "stroke-width", "2")
     cy.wait(250)
 
     // Connecting lines should be hidden after a redo. this piece is a bit flaky so commented out for now.

--- a/v3/src/components/data-display/hooks/use-connecting-lines.ts
+++ b/v3/src/components/data-display/hooks/use-connecting-lines.ts
@@ -149,7 +149,6 @@ export const useConnectingLines = (props: IProps) => {
     const { connectingLines, parentAttrID, cellKey, parentAttrName, showConnectingLines } = prepareLineProps
     if (!dataConfig) return
 
-    connectingLinesArea.selectAll("path").remove()
     // In a graph, each plot can have multiple groups of connecting lines. The number of groups is determined by the
     // number of Y attributes or the presence of a parent attribute and the number of unique values for that attribute.
     // If there are multiple Y attributes, the number of groups matches the number of Y attributes. Otherwise, if
@@ -180,7 +179,7 @@ export const useConnectingLines = (props: IProps) => {
     })
 
     return { allLineCaseIds, lineGroups, parentAttrID, parentAttrName, showConnectingLines }
-  }, [connectingLinesArea, dataConfig, isCaseInSubPlot, yAttrCount])
+  }, [dataConfig, isCaseInSubPlot, yAttrCount])
 
   const renderConnectingLines = useCallback((renderLineProps: IPrepareLineProps) => {
     const { pointColorAtIndex } = renderLineProps

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -193,6 +193,12 @@ export const ScatterPlot = observer(function ScatterPlot({ pixiPoints }: IPlotPr
     const pointsHaveBeenReduced = pointDescription.pointsHaveBeenReduced
     const kPointSizeReductionFactor = 0.5
 
+    // Remove all existing connecting lines before rendering new ones to prevent duplicates
+    if (connectingLinesRef.current) {
+      const connectingLinesArea = select(connectingLinesRef.current)
+      connectingLinesArea.selectAll("path").remove()
+    }
+
     cellKeys?.forEach((cellKey) => {
       renderConnectingLines({
         cellKey, connectingLines, parentAttrID, parentAttrName, pointColorAtIndex, showConnectingLines

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -6,6 +6,7 @@ import * as PIXI from "pixi.js"
 import {useMap} from "react-leaflet"
 import simpleheat from "simpleheat"
 import {useDebouncedCallback} from "use-debounce"
+import { select } from "d3"
 import {isSelectionAction, isSetCaseValuesAction} from "../../../models/data/data-set-actions"
 import { firstVisibleParentAttribute, idOfChildmostCollectionForAttributes } from "../../../models/data/data-set-utils"
 import {defaultSelectedStroke, defaultSelectedStrokeWidth, defaultStrokeWidth} from "../../../utilities/color-utils"
@@ -249,6 +250,12 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, set
     const parentAttrID = parentAttr?.id
     const parentAttrName = parentAttr?.name
     const pointColorAtIndex = mapModel.pointDescription.pointColorAtIndex
+
+    // Remove all existing connecting lines before rendering new ones to prevent duplicates
+    if (connectingLinesRef.current) {
+      const connectingLinesArea = select(connectingLinesRef.current)
+      connectingLinesArea.selectAll("path").remove()
+    }
 
     renderConnectingLines({ connectingLines, parentAttrID, parentAttrName, pointColorAtIndex, showConnectingLines })
   }, [connectingLinesForCases, dataConfiguration, dataset, mapModel.pointDescription.pointColorAtIndex,


### PR DESCRIPTION
[CODAP-868](https://concord-consortium.atlassian.net/browse/CODAP-868)

These changes fix a bug where connecting lines only appeared in the last subplot of a subdivided plot.

Previously, when `ScatterPlot` called `renderConnectingLines` multiple times for multiple subplots, each call cleared the previous subplot's lines because `prepareConnectingLines` ran:

```
connectingLinesArea.selectAll("path").remove()
```

This change moves that removal of lines to `refreshConnectingLines` (in both `ScatterPlot` and `MapPointLayer`), just before `renderConnectingLines` is called. That way, duplicates are still prevented (during tile resizing, for example) without removing lines from other subplots.

[CODAP-868]: https://concord-consortium.atlassian.net/browse/CODAP-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ