### PR TITLE
CODAP-100 Problems with adornment labels and hover tips

### DIFF
--- a/v3/src/components/graph/adornments/adornment-component-info.ts
+++ b/v3/src/components/graph/adornments/adornment-component-info.ts
@@ -11,6 +11,7 @@ export interface IAdornmentComponentProps {
   plotWidth: number
   xAxis?: IBaseNumericAxisModel
   yAxis?: IBaseNumericAxisModel
+  labelsDivRef?: React.RefObject<HTMLDivElement>
   spannerRef?: React.RefObject<SVGSVGElement>
 }
 

--- a/v3/src/components/graph/adornments/components/adornment.tsx
+++ b/v3/src/components/graph/adornments/components/adornment.tsx
@@ -14,11 +14,12 @@ interface IProps {
   adornment: IAdornmentModel
   cellKey: Record<string, string>
   cellCoords: { row: number, col: number }
+  labelsDivRef: React.RefObject<HTMLDivElement>
   spannerRef: React.RefObject<SVGSVGElement>
 }
 
 export const Adornment = observer(function Adornment({adornment, cellKey: _cellKey,
-                                                       cellCoords, spannerRef}: IProps) {
+                                                       cellCoords, labelsDivRef, spannerRef}: IProps) {
   const cellKey = useDeepCompareMemo(() => _cellKey, [_cellKey])
   const graphModel = useGraphContentModelContext()
   const { subPlotWidth, subPlotHeight } = useSubplotExtent()
@@ -58,6 +59,7 @@ export const Adornment = observer(function Adornment({adornment, cellKey: _cellK
         plotWidth={subPlotWidth}
         xAxis={graphModel.getNumericAxis('bottom')}
         yAxis={graphModel.getNumericAxis('left')}
+        labelsDivRef={labelsDivRef}
         spannerRef={spannerRef}
       />
     </div>

--- a/v3/src/components/graph/adornments/components/adornments.tsx
+++ b/v3/src/components/graph/adornments/components/adornments.tsx
@@ -26,6 +26,8 @@ export const Adornments = observer(function Adornments() {
   const { isTileSelected } = useTileSelectionContext()
   const adornments = graphModel.adornmentsStore.adornments
   const { left, top, width, height } = layout.computedBounds.plot
+  const labelsDivRef = useRef<HTMLDivElement>(null)
+  const spannerDivRef = useRef<HTMLDivElement>(null)
   const spannerRef = useRef<SVGSVGElement>(null)
 
   useEffect(function handleAdornmentBannerCountChange() {
@@ -130,6 +132,7 @@ export const Adornments = observer(function Adornments() {
                           adornment={adornment}
                           cellKey={cellKey}
                           cellCoords={cellCoords}
+                          labelsDivRef={labelsDivRef}
                           spannerRef={spannerRef}
                         />
                 })
@@ -162,9 +165,14 @@ export const Adornments = observer(function Adornments() {
       <div className={containerClass} data-testid={kGraphAdornmentsClass} style={outerGridStyle}>
         {outerGridCells}
       </div>
-      <div className={'adornment-spanner'} style={outerGridStyle}>
+      {/*The following div can be used by adornments to display divs that will not be clipped by grid cells*/}
+      <div className={'adornment-spanner'} style={outerGridStyle} ref={spannerDivRef}>
+        {
+          graphModel.adornmentsStore.showMeasureLabels &&
+           <div className="measure-labels" id={`measure-labels-${graphModel.id}`} ref={labelsDivRef} />
+        }
         {/*The following svg can be used by adornments that need to draw outside their grid cell*/}
-        <svg className="spanner-svg" ref={spannerRef}/>
+        <svg className="spanner-svg measure-container" ref={spannerRef}/>
       </div>
     </>
   )

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
@@ -41,12 +41,12 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
   const layout = useGraphLayoutContext()
   const dataConfig = useGraphDataConfigurationContext()
   const { xAttrId, yAttrId, xAttrType } = useAdornmentAttributes()
+  const isVerticalRef = useRef(!!(xAttrType && xAttrType === "numeric"))
   const { cellCounts } = useAdornmentCells(model, cellKey)
   const helper = useMemo(() => {
-    return new UnivariateMeasureAdornmentHelper(cellKey, layout, model, containerId)
+    return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model, containerId)
   }, [cellKey, containerId, layout, model])
   const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
-  const isVertical = useRef(!!(xAttrType && xAttrType === "numeric"))
   const boxPlotOffset = 5
   const secondaryAxisX = plotWidth / cellCounts.x / 2 - boxPlotOffset
   const secondaryAxisY = plotHeight / cellCounts.y / 2 - boxPlotOffset
@@ -80,10 +80,10 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       .attr("d", "M0, -3 V3 M-3, 0 H3")
       .attr("transform", (d: number) => {
         const index = outliers.indexOf(d)
-        const x = isVertical.current
+        const x = isVerticalRef.current
           ? helper.xScale(outliers[index]) / cellCounts.x
           : secondaryAxisX
-        const y = isVertical.current
+        const y = isVerticalRef.current
           ? secondaryAxisY
           : helper.yScale(outliers[index]) / cellCounts.y
         return `translate(${x}, ${y})`
@@ -107,13 +107,13 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
         .attr("ry", 3)
         .attr("x", (d: number) => {
           const index = outliers.indexOf(d)
-          return isVertical.current
+          return isVerticalRef.current
             ? helper.xScale(outliers[index]) / cellCounts.x - outlierOffset
             : secondaryAxisX - outlierOffset
         })
         .attr("y", (d: number) => {
           const index = outliers.indexOf(d)
-          return isVertical.current
+          return isVerticalRef.current
             ? secondaryAxisY - outlierOffset
             : helper.yScale(outliers[index]) / cellCounts.y - outlierOffset
         })
@@ -123,16 +123,16 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     const subplotWidth = plotWidth / cellCounts.x
     const subplotHeight = plotHeight / cellCounts.y
     const lower = {
-      x1: !isVertical.current ? subplotWidth / 2 : helper.xScale(minVal) / cellCounts.x,
-      x2: !isVertical.current ? subplotWidth / 2 : helper.xScale(rangeMin) / cellCounts.x,
-      y1: isVertical.current ? subplotHeight / 2 : helper.yScale(minVal) / cellCounts.y,
-      y2: isVertical.current ? subplotHeight / 2 : helper.yScale(rangeMin) / cellCounts.y
+      x1: !isVerticalRef.current ? subplotWidth / 2 : helper.xScale(minVal) / cellCounts.x,
+      x2: !isVerticalRef.current ? subplotWidth / 2 : helper.xScale(rangeMin) / cellCounts.x,
+      y1: isVerticalRef.current ? subplotHeight / 2 : helper.yScale(minVal) / cellCounts.y,
+      y2: isVerticalRef.current ? subplotHeight / 2 : helper.yScale(rangeMin) / cellCounts.y
     }
     const upper = {
-      x1: !isVertical.current ? subplotWidth / 2 : helper.xScale(rangeMax) / cellCounts.x,
-      x2: !isVertical.current ? subplotWidth / 2 : helper.xScale(maxVal) / cellCounts.x,
-      y1: isVertical.current ? subplotHeight / 2 : helper.yScale(rangeMax) / cellCounts.y,
-      y2: isVertical.current ? subplotHeight / 2 : helper.yScale(maxVal) / cellCounts.y
+      x1: !isVerticalRef.current ? subplotWidth / 2 : helper.xScale(rangeMax) / cellCounts.x,
+      x2: !isVerticalRef.current ? subplotWidth / 2 : helper.xScale(maxVal) / cellCounts.x,
+      y1: isVerticalRef.current ? subplotHeight / 2 : helper.yScale(rangeMax) / cellCounts.y,
+      y2: isVerticalRef.current ? subplotHeight / 2 : helper.yScale(maxVal) / cellCounts.y
     }
     return {lower, upper}
   }, [cellCounts, helper, plotHeight, plotWidth])
@@ -152,7 +152,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     const coverUpperId = helper.generateIdString("whisker-upper-cover")
     const whiskerCoords = calculateWhiskerCoords(minWhiskerValue, maxWhiskerValue, range.min, range.max)
     const whiskerLowerLineSpecs = {
-      isVertical: isVertical.current,
+      isVertical: isVerticalRef.current,
       lineClass: lineLowerClass,
       lineId: lineLowerId,
       offset: -5,
@@ -163,7 +163,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     }
     const whiskerLowerCoverSpecs = {...whiskerLowerLineSpecs, lineClass: coverLowerClass, lineId: coverLowerId}
     const whiskerUpperLineSpecs = {
-      isVertical: isVertical.current,
+      isVertical: isVerticalRef.current,
       lineClass: lineUpperClass,
       lineId: lineUpperId,
       offset: -5,
@@ -189,10 +189,10 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       const subplotWidth = plotWidth / cellCounts.x
       const subplotHeight = plotHeight / cellCounts.y
       return {
-        x1: !isVertical.current ? subplotWidth / 2 : helper.xScale(iciRange.min) / cellCounts.x,
-        x2: !isVertical.current ? subplotWidth / 2 : helper.xScale(iciRange.max) / cellCounts.x,
-        y1: isVertical.current ? subplotHeight / 2 : helper.yScale(iciRange.min) / cellCounts.y,
-        y2: isVertical.current ? subplotHeight / 2 : helper.yScale(iciRange.max) / cellCounts.y
+        x1: !isVerticalRef.current ? subplotWidth / 2 : helper.xScale(iciRange.min) / cellCounts.x,
+        x2: !isVerticalRef.current ? subplotWidth / 2 : helper.xScale(iciRange.max) / cellCounts.x,
+        y1: isVerticalRef.current ? subplotHeight / 2 : helper.yScale(iciRange.min) / cellCounts.y,
+        y2: isVerticalRef.current ? subplotHeight / 2 : helper.yScale(iciRange.max) / cellCounts.y
       }
     }
 
@@ -201,14 +201,14 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
         graphHeight = layout.plotHeight,
         cellWidth = graphWidth / cellCounts.x,
         cellHeight = graphHeight / cellCounts.y,
-        lowerCoord = isVertical.current ? helper.xScale(iciRange.min) / cellCounts.x
+        lowerCoord = isVerticalRef.current ? helper.xScale(iciRange.min) / cellCounts.x
           : helper.yScale(iciRange.min) / cellCounts.y,
-        upperCoord = isVertical.current ? helper.xScale(iciRange.max) / cellCounts.x
+        upperCoord = isVerticalRef.current ? helper.xScale(iciRange.max) / cellCounts.x
           : helper.yScale(iciRange.max) / cellCounts.y,
-        templatePath = isVertical.current
+        templatePath = isVerticalRef.current
           ? `M%@,%@ v%@ M%@,%@ v%@`
           : `M%@,%@ h%@ M%@,%@ h%@`,
-        replacementVars = isVertical.current
+        replacementVars = isVerticalRef.current
           ? [
             lowerCoord + cellCoords.col * cellWidth, 0, graphHeight,
             upperCoord + cellCoords.col * cellWidth, 0, graphHeight
@@ -229,7 +229,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     const iciCoverId = helper.generateIdString("ici-cover")
     const iciCoords = calculateIciCoords()
     const iciSpecs = {
-      isVertical: isVertical.current,
+      isVertical: isVerticalRef.current,
       lineClass: iciClass,
       lineId: iciId,
       offset: -5,
@@ -264,16 +264,16 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
         const subplotHeight = plotHeight / cellCounts.y
         const offset = 2 * boxPlotOffset
         return {
-          x1: !isVertical.current ? subplotWidth / 2 - offset : helper.xScale(value) / cellCounts.x,
-          x2: !isVertical.current ? subplotWidth / 2 + offset : helper.xScale(value) / cellCounts.x,
-          y1: isVertical.current ? subplotHeight / 2 - offset : helper.yScale(value) / cellCounts.y,
-          y2: isVertical.current ? subplotHeight / 2 + offset : helper.yScale(value) / cellCounts.y
+          x1: !isVerticalRef.current ? subplotWidth / 2 - offset : helper.xScale(value) / cellCounts.x,
+          x2: !isVerticalRef.current ? subplotWidth / 2 + offset : helper.xScale(value) / cellCounts.x,
+          y1: isVerticalRef.current ? subplotHeight / 2 - offset : helper.yScale(value) / cellCounts.y,
+          y2: isVerticalRef.current ? subplotHeight / 2 + offset : helper.yScale(value) / cellCounts.y
         }
       }
 
       const qCoords = calculateQCoords(qValue)
       return {
-        isVertical: isVertical.current,
+        isVertical: isVerticalRef.current,
         lineClass: qCoverClass,
         lineId: qCoverId,
         offset: -5,
@@ -357,7 +357,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       for (let i = 0; i < lowerOutliers.length; i++) {
         const coverId = helper.generateIdString("outlier-cover")
         labelsObj.label = container.append("div")
-          .text(helper.formatValueForScale(isVertical.current, lowerOutliers[i]))
+          .text(helper.formatValueForScale(lowerOutliers[i]))
           .attr("class", "measure-tip measure-labels-tip box-plot-label")
           .attr("id", `${textId}-lower-outlier-${i}`)
           .attr("data-testid", `${textId}-${i}`)
@@ -369,7 +369,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       for (let i = 0; i < upperOutliers.length; i++) {
         const coverId = helper.generateIdString("outlier-cover")
         labelsObj.label = container.append("div")
-          .text(helper.formatValueForScale(isVertical.current, upperOutliers[i]))
+          .text(helper.formatValueForScale(upperOutliers[i]))
           .attr("class", "measure-tip measure-labels-tip box-plot-label")
           .attr("id", `${textId}-upper-outlier-${i}`)
           .attr("data-testid", `${textId}-${i}`)
@@ -385,14 +385,14 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
 
     const addMedian = () => {
       const lineSpecs = {
-        isVertical: isVertical.current,
+        isVertical: isVerticalRef.current,
         lineClass,
         lineId,
         offset: boxPlotOffset * -1,
-        x1: !isVertical.current ? coords.x1 - boxPlotOffset : coords.x1,
-        x2: !isVertical.current ? coords.x2 + boxPlotOffset * 3 : coords.x1,
-        y1: isVertical.current ? coords.y1 - boxPlotOffset : coords.y1,
-        y2: isVertical.current ? coords.y2 + boxPlotOffset * 3 : coords.y1
+        x1: !isVerticalRef.current ? coords.x1 - boxPlotOffset : coords.x1,
+        x2: !isVerticalRef.current ? coords.x2 + boxPlotOffset * 3 : coords.x1,
+        y1: isVerticalRef.current ? coords.y1 - boxPlotOffset : coords.y1,
+        y2: isVerticalRef.current ? coords.y2 + boxPlotOffset * 3 : coords.y1
       }
       const coverSpecs = {...lineSpecs, lineClass: coverClass, lineId: coverId}
       valueObj.line = helper.newLine(valueRef.current, lineSpecs)
@@ -404,11 +404,11 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     if (value === undefined || isNaN(value)) return
 
     const { coords, coverClass, coverId, lineClass, lineId, measureRange } =
-      helper.adornmentSpecs(attrId, dataConfig, value, isVertical.current, cellCounts, secondaryAxisX, secondaryAxisY)
+      helper.adornmentSpecs(attrId, dataConfig, value, cellCounts, secondaryAxisX, secondaryAxisY)
     const { median, lowerQuartile, upperQuartile, iqr,
             minWhiskerValue, maxWhiskerValue } = model.getBoxPlotParams(cellKey)
     const translationVars = [ minWhiskerValue, lowerQuartile, median, upperQuartile, maxWhiskerValue, iqr ]
-      .map(v => helper.formatValueForScale(isVertical.current, v))
+      .map(v => helper.formatValueForScale(v))
     let textContent = `${t(model.labelTitle, { vars: translationVars })}`
 
     if ((measureRange?.min || measureRange?.min === 0) && (measureRange?.max || measureRange?.max === 0)) {
@@ -417,7 +417,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
         coords,
         coverClass,
         extentForSecondaryAxis: "20px",
-        isVertical: isVertical.current,
+        isVertical: isVerticalRef.current,
         lineClass,
         lineOffset: boxPlotOffset * -1,
         rangeMin: measureRange.min,
@@ -438,8 +438,8 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       const iciRange = model.computeICIRange(attrId, cellKey, dataConfig)
       addICI(valueObj)
       textContent += `\n${t('ICI: [%@, %@]',
-        { vars: [helper.formatValueForScale(isVertical.current, iciRange.min),
-            helper.formatValueForScale(isVertical.current, iciRange.max)] })}`
+        { vars: [helper.formatValueForScale(iciRange.min),
+            helper.formatValueForScale(iciRange.max)] })}`
     }
     addBoxPlotLabels(textContent, valueObj, labelsObj)
   }, [addBoxPlotLabels, addICI, addWhiskers, addQCovers, attrId, cellCounts, cellKey, dataConfig,
@@ -475,7 +475,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       xAxis={xAxis}
       yAxis={yAxis}
       refreshValues={refreshValues}
-      setIsVertical={(adornmentIsVertical: boolean) => { isVertical.current = adornmentIsVertical }}
+      setIsVertical={(adornmentIsVertical: boolean) => { isVerticalRef.current = adornmentIsVertical }}
     />
   )
 })

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-component.tsx
@@ -8,7 +8,8 @@ import { UnivariateMeasureAdornmentSimpleComponent } from "../univariate-measure
 
 export const PlottedValueComponent = observer(
   function PlottedValueComponent (props: IAdornmentComponentProps) {
-    const {cellKey={}, containerId, model, plotHeight, plotWidth, xAxis, yAxis} = props
+    const {cellKey={}, containerId, model, plotHeight, plotWidth,
+      spannerRef, labelsDivRef, xAxis, yAxis} = props
     const graphModel = useGraphContentModelContext()
 
     // Refresh values on Plotted Value expression changes
@@ -30,6 +31,8 @@ export const PlottedValueComponent = observer(
         model={model}
         plotHeight={plotHeight}
         plotWidth={plotWidth}
+        spannerRef={spannerRef}
+        labelsDivRef={labelsDivRef}
         xAxis={xAxis}
         yAxis={yAxis}
       />

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -3,10 +3,11 @@ import { drag, select, selectAll } from "d3"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { t } from "../../../../utilities/translation/translate"
+import { isFiniteNumber } from "../../../../utilities/math-utils";
 import { IMeasureInstance, IUnivariateMeasureAdornmentModel } from "./univariate-measure-adornment-model"
 import { measureText } from "../../../../hooks/use-measure-text"
 import { IAdornmentComponentProps } from "../adornment-component-info"
-import { ILabel, IValue } from "./univariate-measure-adornment-types"
+import { IValue } from "./univariate-measure-adornment-types"
 import { UnivariateMeasureAdornmentHelper } from "./univariate-measure-adornment-helper"
 import { UnivariateMeasureAdornmentBaseComponent } from "./univariate-measure-adornment-base-component"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
@@ -14,18 +15,20 @@ import { useAdornmentCells } from "../../hooks/use-adornment-cells"
 
 export const UnivariateMeasureAdornmentSimpleComponent = observer(
   function UnivariateMeasureAdornmentSimpleComponent (props: IAdornmentComponentProps) {
-    const {cellKey={}, containerId, plotHeight, plotWidth, xAxis, yAxis} = props
+    const {cellKey={}, containerId, plotHeight, plotWidth,
+      xAxis, yAxis, spannerRef, labelsDivRef} = props
     const model = props.model as IUnivariateMeasureAdornmentModel
     const {
       dataConfig, layout, adornmentsStore,
-      numericAttrId, showLabel, isVertical, valueRef,
+      numericAttrId, showLabel, isVerticalRef, valueRef,
       labelRef, defaultLabelTopOffset } = useAdornmentAttributes()
     const { cellCounts } = useAdornmentCells(model, cellKey)
     const helper = useMemo(() => {
-      return new UnivariateMeasureAdornmentHelper(cellKey, layout, model, containerId)
-    }, [cellKey, containerId, layout, model])
+      return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model,
+        containerId, defaultLabelTopOffset)
+    }, [cellKey, containerId, defaultLabelTopOffset, isVerticalRef, layout, model])
     const isBlockingOtherMeasure = dataConfig &&
-      helper.blocksOtherMeasure({adornmentsStore, attrId: numericAttrId, dataConfig, isVertical: isVertical.current})
+      helper.blocksOtherMeasure({adornmentsStore, attrId: numericAttrId, dataConfig})
     const valueObjRef = useRef<IValue>({})
 
     const highlightCovers = useCallback((highlight: boolean) => {
@@ -34,8 +37,8 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
     }, [containerId, helper])
 
     const highlightLabel = useCallback((labelId: string, highlight: boolean) => {
-      const label = select(`#${labelId}`)
-      label.classed("highlighted", highlight)
+      const labelDiv = select(`#${labelId}`)
+      labelDiv.classed("highlighted", highlight)
       highlightCovers(highlight)
     }, [highlightCovers])
 
@@ -54,23 +57,22 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
     }, [containerId, highlightCovers, isBlockingOtherMeasure])
 
     const addLabels = useCallback((
-      labelObj: ILabel, measure: IMeasureInstance, textContent: string, valueObj: IValue,
+      measure: IMeasureInstance, textContent: string, valueObj: IValue,
       plotValue: number, range?: number
     ) => {
-      const labelSelection = select(labelRef.current)
+      if (!labelsDivRef?.current) return
+      const labelSelection = select(labelsDivRef.current)
       const labelCoords = measure.labelCoords
-      let labelLeft = labelCoords
-        ? labelCoords.x
-        : isVertical.current
-          ? helper.xScalePct(plotValue)
-          : 0
-      if (range != null && isVertical.current) labelLeft = helper.xScalePct(range)
-      const labelTop = labelCoords ? labelCoords.y : helper.yRangePct(defaultLabelTopOffset(model))
+      const valueToLabel = isFiniteNumber(range) ? range : plotValue
+      const { left, top } =
+        (dataConfig && helper.measureLabelCoordinates(dataConfig, valueToLabel)) || { left: 0, top: 0 }
+      const labelLeft = labelCoords ? labelCoords.x : left
+      const labelTop = labelCoords ? labelCoords.y : top
       const labelId =
         `${helper.measureSlug}-measure-labels-tip-${containerId}${helper.classFromKey ? `-${helper.classFromKey}` : ""}`
       const labelClass = clsx("measure-labels-tip", `measure-labels-tip-${helper.measureSlug}`)
 
-      labelObj.label = labelSelection.append("div")
+      valueObj.label = labelSelection.append("div")
         .attr("class", labelClass)
         .attr("id", labelId)
         .attr("data-testid", labelId)
@@ -78,13 +80,13 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
         .style("top", `${100 * labelTop}%`)
         .html(textContent)
 
-      labelObj.label.call(
+      valueObj.label.call(
         drag<HTMLDivElement, unknown>()
           .on("drag", (e) => helper.handleMoveLabel(e, labelId))
           .on("end", (e) => helper.handleEndMoveLabel(e, labelId))
       )
 
-      labelObj.label.on("mouseover", () => highlightCovers(true))
+      valueObj.label.on("mouseover", () => highlightCovers(true))
         .on("mouseout", () => highlightCovers(false))
 
       if (!range && range !== 0) {
@@ -97,38 +99,34 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       valueObj.rangeMaxCover?.on("mouseover", () => highlightLabel(labelId, true))
         .on("mouseout", () => highlightLabel(labelId, false))
 
-    }, [containerId, defaultLabelTopOffset, helper, highlightCovers, highlightLabel, isVertical, labelRef, model])
+    },
+      [containerId, dataConfig, helper, highlightCovers, highlightLabel, isVerticalRef, labelsDivRef])
 
     const addTextTip = useCallback((plotValue: number, textContent: string, valueObj: IValue, range?: number) => {
-      const selection = select(valueRef.current)
+      if (!spannerRef?.current) return
+      const totalPlotWidth = layout.plotWidth || 0
+      const totalPlotHeight = layout.plotHeight || 0
+      const selection = select(spannerRef.current)
       const textId = helper.generateIdString("tip")
       const textClass = clsx(
         "measure-tip",
         `${helper.measureSlug}-tip`,
         { "show-on-overlap-hover": isBlockingOtherMeasure }
       )
-      const textTipWidth = measureText(textContent, "10px Lato, sans-serif")
+      const textTipWidth = measureText(textContent, "12px Lato, sans-serif") + 5 // Add 5px for padding
       const lineOffset = 5
-      const topOffset = plotHeight / cellCounts.y * .25 // 25% of the height of the subplot
-      const rangeOffset = range && range !== plotValue
-        ? isVertical.current
-          ? helper.xScale(range) - helper.xScale(plotValue)
-          : helper.yScale(range) - helper.yScale(plotValue)
-        : 0
-      let x = isVertical.current
-          ? helper.xScale(plotValue) / cellCounts.x + lineOffset
-          : plotWidth - plotWidth/2 - textTipWidth/2
-      if ((range || range === 0) && isVertical.current) {
-        x = (helper.xScale(plotValue) + rangeOffset) / cellCounts.x + lineOffset
-      }
-      let y = isVertical.current ? topOffset : helper.yScale(plotValue) / cellCounts.y - lineOffset
-      if ((range || range === 0) && !isVertical.current) {
-        y = (helper.yScale(plotValue) + rangeOffset) / cellCounts.y - lineOffset
-      }
-
-      // If x plus the approximate width of the text tip would extend beyond the right boundary of the subplot, set x to
-      // plotWidth minus the text tip width or zero, whichever is greater.
-      if (x + textTipWidth > plotWidth) x = Math.max(plotWidth - textTipWidth, 0)
+      const topOffset = totalPlotHeight / cellCounts.y * .25 // 25% of the height of the subplot
+      const valueToLabel = isFiniteNumber(range) ? range : plotValue
+      // (left, top) are proportion coordinates for the label. Adjust for tip.
+      const { left, top } =
+      (dataConfig && helper.measureLabelCoordinates(dataConfig, valueToLabel)) || { left: 0, top: 0 }
+      const bandWidth = totalPlotWidth / cellCounts.x
+      let x = isVerticalRef.current
+          ? Math.min(left * totalPlotWidth + lineOffset, totalPlotWidth - textTipWidth)
+          : Math.min(totalPlotWidth - textTipWidth,
+              left * totalPlotWidth + bandWidth - bandWidth/2 - textTipWidth/2)
+      let y = isVerticalRef.current ? topOffset + top * totalPlotHeight
+        : top * totalPlotHeight + helper.yScale(plotValue) / cellCounts.y - lineOffset
 
       valueObj.text = selection.append("text")
         .text(textContent)
@@ -145,10 +143,10 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       valueObj.rangeMaxCover?.on("mouseover", () => toggleTextTip(textId, true))
         .on("mouseout", () => toggleTextTip(textId, false))
 
-    }, [cellCounts.x, cellCounts.y, helper, isBlockingOtherMeasure, isVertical, plotHeight, plotWidth,
-      toggleTextTip, valueRef])
+    }, [cellCounts.x, cellCounts.y, dataConfig, helper, isBlockingOtherMeasure, isVerticalRef,
+              plotHeight, plotWidth, spannerRef, toggleTextTip])
 
-    const addAdornmentElements = useCallback((measure: IMeasureInstance, valueObj: IValue, labelObj: ILabel) => {
+    const addAdornmentElements = useCallback((measure: IMeasureInstance, valueObj: IValue) => {
       if (!numericAttrId || !dataConfig) return
       const value = model.measureValue(numericAttrId, cellKey, dataConfig)
       if (value === undefined || isNaN(value)) return
@@ -157,7 +155,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       const primaryAttr = primaryAttrId ? dataConfig?.dataset?.attrFromID(primaryAttrId) : undefined
       const primaryAttrUnits = primaryAttr?.units
       const { coords, coverClass, coverId, displayRange, displayValue, lineClass, lineId, measureRange, plotValue } =
-        helper.adornmentSpecs(numericAttrId, dataConfig, value, isVertical.current, cellCounts)
+        helper.adornmentSpecs(numericAttrId, dataConfig, value, cellCounts)
 
       const translationVars = [
         `${(measureRange.min || measureRange.min === 0) && displayRange ? `${displayRange}` : `${displayValue}`}`
@@ -169,7 +167,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
 
       // Add the main value line
       const lineSpecs = {
-        isVertical: isVertical.current,
+        isVertical: isVerticalRef.current,
         lineClass,
         lineId,
         x1: coords.x1,
@@ -191,7 +189,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
           cellCounts,
           coords,
           coverClass,
-          isVertical: isVertical.current,
+          isVertical: isVerticalRef.current,
           lineClass,
           rangeMin: measureRange.min,
           rangeMax: measureRange.max,
@@ -202,39 +200,41 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       // If showLabels is true, then the Show Measure Labels option is selected, so we add a label to the adornment,
       // otherwise we add a text tip that only appears when the user mouses over the value line or the range boundaries.
       if (showLabel) {
-        addLabels(labelObj, measure, textContent, valueObj, plotValue, measureRange.max)
+        addLabels(measure, textContent, valueObj, plotValue, measureRange.max)
       } else {
         addTextTip(plotValue, textContent, valueObj, measureRange.max)
       }
-    }, [numericAttrId, dataConfig, model, cellKey, helper, isVertical, cellCounts, valueRef, showLabel,
+    }, [numericAttrId, dataConfig, model, cellKey, helper, isVerticalRef, cellCounts, valueRef, showLabel,
               addLabels, addTextTip])
+
+    const removeElements = useCallback(() => {
+      const currentValueObj = valueObjRef.current
+      Object.values(currentValueObj).forEach((aSelection) => aSelection?.remove())
+      valueObjRef.current = {}
+    }, [])
 
     // Add the lines and their associated covers and labels
     const refreshValues = useCallback(() => {
+      // We're creating a new set of elements, so remove the old ones
+      removeElements()
       if (!model.isVisible) return
       const measure = model?.measures.get(helper.instanceKey)
-      // We're creating a new set of elements, so remove the old ones
-      Object.values(valueObjRef.current).forEach((aSelection) => aSelection.remove())
-      valueObjRef.current = {}
-      const newLabelObj: ILabel = {}
       const selection = select(valueRef.current)
-      const labelSelection = select(labelRef.current)
 
       // Remove the previous value's elements
       selection.html(null)
-      labelSelection.html(null)
 
       if (measure) {
-        addAdornmentElements(measure, valueObjRef.current, newLabelObj)
+        addAdornmentElements(measure, valueObjRef.current)
       }
-    }, [addAdornmentElements, helper.instanceKey, labelRef, model.isVisible, model?.measures, valueRef])
+    }, [addAdornmentElements, helper.instanceKey, model.isVisible, model?.measures, removeElements, valueRef])
 
     useEffect(() => {
       // Clean up any existing elements
       return () => {
-        Object.values(valueObjRef.current).forEach((aSelection) => aSelection?.remove())
+        removeElements()
       }
-    }, [])
+    }, [removeElements])
 
     return (
       <UnivariateMeasureAdornmentBaseComponent
@@ -246,7 +246,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
         showLabel={!!showLabel}
         valueRef={valueRef}
         refreshValues={refreshValues}
-        setIsVertical={(adornmentIsVertical: boolean) => { isVertical.current = adornmentIsVertical }}
+        setIsVertical={(adornmentIsVertical: boolean) => { isVerticalRef.current = adornmentIsVertical }}
         xAxis={xAxis}
         yAxis={yAxis}
       />

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -3,7 +3,7 @@ import { drag, select, selectAll } from "d3"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { t } from "../../../../utilities/translation/translate"
-import { isFiniteNumber } from "../../../../utilities/math-utils";
+import { isFiniteNumber } from "../../../../utilities/math-utils"
 import { IMeasureInstance, IUnivariateMeasureAdornmentModel } from "./univariate-measure-adornment-model"
 import { measureText } from "../../../../hooks/use-measure-text"
 import { IAdornmentComponentProps } from "../adornment-component-info"
@@ -15,7 +15,7 @@ import { useAdornmentCells } from "../../hooks/use-adornment-cells"
 
 export const UnivariateMeasureAdornmentSimpleComponent = observer(
   function UnivariateMeasureAdornmentSimpleComponent (props: IAdornmentComponentProps) {
-    const {cellKey={}, containerId, plotHeight, plotWidth,
+    const {cellKey={}, containerId,
       xAxis, yAxis, spannerRef, labelsDivRef} = props
     const model = props.model as IUnivariateMeasureAdornmentModel
     const {
@@ -100,7 +100,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
         .on("mouseout", () => highlightLabel(labelId, false))
 
     },
-      [containerId, dataConfig, helper, highlightCovers, highlightLabel, isVerticalRef, labelsDivRef])
+      [containerId, dataConfig, helper, highlightCovers, highlightLabel, labelsDivRef])
 
     const addTextTip = useCallback((plotValue: number, textContent: string, valueObj: IValue, range?: number) => {
       if (!spannerRef?.current) return
@@ -121,11 +121,11 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       const { left, top } =
       (dataConfig && helper.measureLabelCoordinates(dataConfig, valueToLabel)) || { left: 0, top: 0 }
       const bandWidth = totalPlotWidth / cellCounts.x
-      let x = isVerticalRef.current
+      const x = isVerticalRef.current
           ? Math.min(left * totalPlotWidth + lineOffset, totalPlotWidth - textTipWidth)
           : Math.min(totalPlotWidth - textTipWidth,
               left * totalPlotWidth + bandWidth - bandWidth/2 - textTipWidth/2)
-      let y = isVerticalRef.current ? topOffset + top * totalPlotHeight
+      const y = isVerticalRef.current ? topOffset + top * totalPlotHeight
         : top * totalPlotHeight + helper.yScale(plotValue) / cellCounts.y - lineOffset
 
       valueObj.text = selection.append("text")
@@ -144,7 +144,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
         .on("mouseout", () => toggleTextTip(textId, false))
 
     }, [cellCounts.x, cellCounts.y, dataConfig, helper, isBlockingOtherMeasure, isVerticalRef,
-              plotHeight, plotWidth, spannerRef, toggleTextTip])
+              layout.plotHeight, layout.plotWidth, spannerRef, toggleTextTip])
 
     const addAdornmentElements = useCallback((measure: IMeasureInstance, valueObj: IValue) => {
       if (!numericAttrId || !dataConfig) return

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-types.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-types.ts
@@ -61,4 +61,5 @@ export interface IValue {
   rangeMax?: Selection<SVGLineElement, unknown, null, undefined>
   rangeMinCover?: Selection<SVGLineElement, unknown, null, undefined>
   rangeMaxCover?: Selection<SVGLineElement, unknown, null, undefined>
+  label?: Selection<HTMLDivElement, unknown, null, undefined>
 }

--- a/v3/src/components/graph/hooks/use-adornment-attributes.ts
+++ b/v3/src/components/graph/hooks/use-adornment-attributes.ts
@@ -24,7 +24,7 @@ export const useAdornmentAttributes = () => {
   const xAttrName = xAttr?.name ?? ""
   const yAttrName = yAttr?.name ?? ""
   const showLabel = adornmentsStore?.showMeasureLabels
-  const isVertical = useRef(!!(xAttrType && xAttrType === "numeric"))
+  const isVerticalRef = useRef(!!(xAttrType && xAttrType === "numeric"))
   const valueRef = useRef<SVGGElement>(null)
   const labelRef = useRef<HTMLDivElement>(null)
   const kLabelLineHeight = 20
@@ -35,5 +35,5 @@ export const useAdornmentAttributes = () => {
   }, [adornmentsStore, isGaussianFit])
 
   return { graphModel, dataConfig, layout, adornmentsStore, xAttrType, xAttrId, yAttrId, xAttrName, yAttrName,
-    numericAttrId, xScale, yScale, showLabel, isVertical, valueRef, labelRef, defaultLabelTopOffset }
+    numericAttrId, xScale, yScale, showLabel, isVerticalRef, valueRef, labelRef, defaultLabelTopOffset }
 }


### PR DESCRIPTION
[#CODAP-100] Bug fix: Adornments are not showing in graph hover

* If measure labels are showing, we add a `div` to the 'adornment-spanner' div, with reference `labelsDivRef` so that measure labels are not cut off by subplot masking.
* This requires more complicated computation of default positions of the measure labels. This computation is now done entirely in the helper with a `measureLabelCoordinates` method.
* Constrain the computed coordinates to lie within the graph's plot area.
* Refactored univariate-measure-adornment-helper.ts to not require `isVertical` in its various methods, but rather include the isVertical reference as a construction parameter.
* Placed measure hover tips in `spnnerRef` so they aren't clipped. This required some adjustments of coordinate computations.