### PR TITLE
fix: don't close formula editor on outside click [CODAP-96]

### DIFF
--- a/v3/src/components/codap-modal.tsx
+++ b/v3/src/components/codap-modal.tsx
@@ -15,7 +15,7 @@ interface IProps {
 }
 
 export const CodapModal = forwardRef(({
-  children, initialRef, isOpen, onClick, onClose, modalWidth, modalHeight
+  children, initialRef, isOpen, closeOnOverlayClick, onClick, onClose, modalWidth, modalHeight
 }: IProps, ref: React.Ref<HTMLElement> | undefined) => {
 
   return (
@@ -23,6 +23,7 @@ export const CodapModal = forwardRef(({
       data-testid="codap-modal"
       initialFocusRef={initialRef}
       isOpen={isOpen}
+      closeOnOverlayClick={closeOnOverlayClick}
       onClose={onClose}
       size="xs"
     >

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -134,6 +134,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     <FormulaEditorContext.Provider value={formulaEditorState}>
       <CodapModal
         isOpen={isOpen}
+        closeOnOverlayClick={false}
         onClose={closeModal}
         modalWidth={`${dimensions.width}px`}
         modalHeight={`${dimensions.height}px`}


### PR DESCRIPTION
[[CODAP-96](https://concord-consortium.atlassian.net/browse/CODAP-96)] **Formula editor** closes unexpectedly when clicking outside the modal

[CODAP-96]: https://concord-consortium.atlassian.net/browse/CODAP-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ