### PR TITLE
CODAP-302 Fix problems dragging attributes on touch device

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -1,6 +1,7 @@
 @use "../../vars";
 
 .attribute-label-menu {
+  touch-action: none;
   z-index: 16;
 }
 

--- a/v3/src/components/case-card/case-attr-view.scss
+++ b/v3/src/components/case-card/case-attr-view.scss
@@ -1,4 +1,5 @@
 .case-card-attr {
+  touch-action: none;
   height: 25px;
 
   &:nth-child(2) {


### PR DESCRIPTION
[#CODAP-302] Bug fix: Difficulty dragging attributes from graph on iPad

* The fix is to add `touch-action: none;` to the `attribute-label-menu` css style. This was already done for attribute labels in the case table and also for other dragging affordances.
* We also note that dragging attributes in the case card has the same problem. So we add the `touch-action: none;` line to `.case-card-attr` as well.