### PR TITLE
fix: Long component title overflow (CODAP-873)

### DIFF
--- a/v3/src/components/component-title-bar.scss
+++ b/v3/src/components/component-title-bar.scss
@@ -1,12 +1,24 @@
 @use "./vars";
 
+$min-button-width: 24px;
+$button-width: 34px;
+$title-padding-x: 10px;
+$title-margin-x: 10px;
+$title-text-min-width: 32px;
+$right-buttons: 2 * $button-width;
+$left-buttons: 1 * $button-width;
+$reserved-inline: $right-buttons + $left-buttons + 2 * ($title-padding-x + $title-margin-x);
+
 .component-title-bar {
-  flex-direction: row;
   align-items: center;
-  height: vars.$title-bar-height;
   background-color: vars.$title-bar-color;
-  width: 100%;
   border-radius: vars.$border-radius-top-corners;
+  container-name: titleBar;
+  container-type: inline-size;
+  flex-direction: row;
+  height: vars.$title-bar-height;
+  overflow: hidden;
+  width: 100%;
 
   &.focusTile {
     background-color: vars.$title-bar-focus-color;
@@ -38,10 +50,11 @@
       background-color: transparent;
       border-radius: 0;
       display: flex;
-      height: 34px;
+      height: vars.$title-bar-height;
       justify-content: center;
+      min-width: $min-button-width;
       padding: 0;
-      width: 34px;
+      width: $button-width;
 
       &:hover {
         background-color: #d3f4ff;
@@ -77,10 +90,7 @@
     .component-minimize-button {
       background-color: transparent;
       border: none;
-      height: vars.$title-bar-height;
-      width: 24px;
       padding: 0;
-      border-radius: 0;
     }
 
     .component-close-button {
@@ -99,17 +109,28 @@
   .title-text, .title-text-input {
     border-radius: vars.$border-radius-four-corners;
     cursor: text;
-    display: flex;
+    display: block;
     font-weight: 500;
-    justify-content: center;
     margin: auto;
-    padding: 0 10px;
+    max-width: calc(100% - #{$reserved-inline});
+    min-width: $title-text-min-width;
+    overflow: hidden;
+    padding: 0 $title-padding-x;
     text-align: center;
+    white-space: nowrap;
   }
 
   .title-text {
     border: 1px solid vars.$icon-fill-dark;
-    width: max-content;
+    width: fit-content;
+
+    span {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: 100%;
+    }
 
     &:hover {
       background-color: vars.$title-bar-color;
@@ -119,6 +140,7 @@
   .title-text-input {
     outline: 2px solid vars.$focus-outline-color;
     outline-offset: 0;
+    width: 100%;
   }
 
   .title-text-measure {
@@ -126,5 +148,37 @@
     overflow: hidden;
     position: absolute;
     white-space: pre;
+  }
+}
+
+// Small adjustments to buttons when the title bar gets very narrow.
+@container titleBar (max-width: 67px) {
+  .header-right {
+    .component-title-bar-button {
+      width: $min-button-width !important;
+    }
+    .component-minimize-button {
+      border-top-left-radius: 4px !important;
+      margin-right: 2px !important;
+    }
+  }
+}
+
+// When the title bar container width forces the title text element to its minimum width, we
+// should only display the ellipsis with no other text. Since `text-overflow: ellipsis` will
+// not result in the desired effect (it will instead show something like "T..."), we hide the
+// text and add the ellipsis character via ::after.
+@container titleBar (max-width: #{$reserved-inline + $title-text-min-width}) {
+  span {
+    position: relative;
+    visibility: hidden;
+  }
+  span::after {
+    content: "\2026"; // ellipsis character
+    left: 0;
+    place-content: center;
+    pointer-events: none;
+    position: absolute;
+    visibility: visible;
   }
 }

--- a/v3/src/components/component-title-bar.scss
+++ b/v3/src/components/component-title-bar.scss
@@ -2,12 +2,6 @@
 
 $min-button-width: 24px;
 $button-width: 34px;
-$title-padding-x: 10px;
-$title-margin-x: 10px;
-$title-text-min-width: 32px;
-$right-buttons: 2 * $button-width;
-$left-buttons: 1 * $button-width;
-$reserved-inline: $right-buttons + $left-buttons + 2 * ($title-padding-x + $title-margin-x);
 
 .component-title-bar {
   align-items: center;
@@ -109,19 +103,18 @@ $reserved-inline: $right-buttons + $left-buttons + 2 * ($title-padding-x + $titl
   .title-text, .title-text-input {
     border-radius: vars.$border-radius-four-corners;
     cursor: text;
-    display: block;
+    display: flex;
     font-weight: 500;
     margin: auto;
-    max-width: calc(100% - #{$reserved-inline});
-    min-width: $title-text-min-width;
+    max-width: calc(100% - 10px);
     overflow: hidden;
-    padding: 0 $title-padding-x;
+    padding: 0 10px;
     text-align: center;
-    white-space: nowrap;
   }
 
   .title-text {
     border: 1px solid vars.$icon-fill-dark;
+    white-space: nowrap;
     width: fit-content;
 
     span {
@@ -151,8 +144,9 @@ $reserved-inline: $right-buttons + $left-buttons + 2 * ($title-padding-x + $titl
   }
 }
 
-// Small adjustments to buttons when the title bar gets very narrow.
-@container titleBar (max-width: 67px) {
+// Ensure the buttons in `.header-right` don't extend beyond the title bar bounds
+// when the tile is narrower than the default width of the two buttons.
+@container titleBar (max-width: #{$button-width * 2}) {
   .header-right {
     .component-title-bar-button {
       width: $min-button-width !important;
@@ -161,24 +155,5 @@ $reserved-inline: $right-buttons + $left-buttons + 2 * ($title-padding-x + $titl
       border-top-left-radius: 4px !important;
       margin-right: 2px !important;
     }
-  }
-}
-
-// When the title bar container width forces the title text element to its minimum width, we
-// should only display the ellipsis with no other text. Since `text-overflow: ellipsis` will
-// not result in the desired effect (it will instead show something like "T..."), we hide the
-// text and add the ellipsis character via ::after.
-@container titleBar (max-width: #{$reserved-inline + $title-text-min-width}) {
-  span {
-    position: relative;
-    visibility: hidden;
-  }
-  span::after {
-    content: "\2026"; // ellipsis character
-    left: 0;
-    place-content: center;
-    pointer-events: none;
-    position: absolute;
-    visibility: visible;
   }
 }

--- a/v3/src/components/component-title-bar.test.tsx
+++ b/v3/src/components/component-title-bar.test.tsx
@@ -124,4 +124,32 @@ describe("ComponentTitleBar", () => {
     // The drag handler should not be called because stopPropagation prevents bubbling
     expect(mockOnMoveTilePointerDown).not.toHaveBeenCalled()
   })
+
+  it("only activates title edit mode on click with no drag", () => {
+    const tile = TileModel.create({ _title: "title", content: {} as any })
+    const mockOnMoveTilePointerDown = jest.fn()
+
+    render(
+      <DndContext>
+        <ComponentTitleBar
+          tile={tile}
+          onMoveTilePointerDown={mockOnMoveTilePointerDown}
+        />
+      </DndContext>
+    )
+
+    const titleText = screen.getByTestId("title-text")
+    fireEvent.pointerDown(titleText)
+    fireEvent.pointerMove(titleText, {clientX: 10, clientY: 10})
+    fireEvent.pointerUp(titleText)
+    expect(screen.queryByTestId("title-text-input")).not.toBeInTheDocument()
+
+    // Simulate a clean click (pointerDown + pointerUp without movement) to reset the drag state set by the call
+    // to pointerMove above. This is necessary here because `fireEvent.click()` does not trigger pointer events like
+    // an actual mouse click would.
+    fireEvent.pointerDown(titleText)
+    fireEvent.pointerUp(titleText)
+    fireEvent.click(titleText)
+    expect(screen.getByTestId("title-text-input")).toBeInTheDocument()
+  })
 })

--- a/v3/src/components/component-title-bar.test.tsx
+++ b/v3/src/components/component-title-bar.test.tsx
@@ -102,4 +102,26 @@ describe("ComponentTitleBar", () => {
     // The drag handler should not be called because stopPropagation prevents bubbling
     expect(mockOnMoveTilePointerDown).not.toHaveBeenCalled()
   })
+
+  it("prevents drag when editing title", () => {
+    const tile = TileModel.create({ _title: "title", content: {} as any })
+    const mockOnMoveTilePointerDown = jest.fn()
+
+    render(
+      <DndContext>
+        <ComponentTitleBar
+          tile={tile}
+          onMoveTilePointerDown={mockOnMoveTilePointerDown}
+        />
+      </DndContext>
+    )
+
+    const titleText = screen.getByTestId("title-text")
+    fireEvent.click(titleText)
+    const titleInput = screen.getByTestId("title-text-input")
+    expect(titleInput).toBeInTheDocument()
+    fireEvent.pointerDown(titleInput)
+    // The drag handler should not be called because stopPropagation prevents bubbling
+    expect(mockOnMoveTilePointerDown).not.toHaveBeenCalled()
+  })
 })

--- a/v3/src/components/component-title-bar.tsx
+++ b/v3/src/components/component-title-bar.tsx
@@ -30,6 +30,7 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
   const [isHovering, setIsHovering] = useState(false)
   const blankTitle = "_____"
   const hasDraggedRef = useRef(false)
+  const pointerStart = useRef<{x: number, y: number} | null>(null);
 
   // Input sizing is based on https://stackoverflow.com/questions/8100770/auto-scaling-inputtype-text-to-width-of-value
   const [inputWidth, setInputWidth] = useState(2 * kInputPadding)
@@ -75,12 +76,19 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
     setInputWidth(measureRef.current.offsetWidth + 2 * kInputPadding)
   }
 
-  const handleTitlePointerDown = () => {
+  const handleTitlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     hasDraggedRef.current = false
+    pointerStart.current = { x: e.clientX, y: e.clientY }
   }
 
-  const handleTitlePointerMove = () => {
-    hasDraggedRef.current = true
+  const handleTitlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (pointerStart.current) {
+      const dx = Math.abs(e.clientX - pointerStart.current.x)
+      const dy = Math.abs(e.clientY - pointerStart.current.y)
+      if (dx > 3 || dy > 3) { // 3px threshold
+        hasDraggedRef.current = true
+      }
+    }
   }
 
   const handleTitleClick = () => {

--- a/v3/src/components/component-title-bar.tsx
+++ b/v3/src/components/component-title-bar.tsx
@@ -29,6 +29,7 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
   const classes = clsx("component-title-bar", `${tileType}-title-bar`, {focusTile: uiState.isFocusedTile(tile?.id)})
   const [isHovering, setIsHovering] = useState(false)
   const blankTitle = "_____"
+  const hasDraggedRef = useRef(false)
 
   // Input sizing is based on https://stackoverflow.com/questions/8100770/auto-scaling-inputtype-text-to-width-of-value
   const [inputWidth, setInputWidth] = useState(2 * kInputPadding)
@@ -74,8 +75,16 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
     setInputWidth(measureRef.current.offsetWidth + 2 * kInputPadding)
   }
 
+  const handleTitlePointerDown = () => {
+    hasDraggedRef.current = false
+  }
+
+  const handleTitlePointerMove = () => {
+    hasDraggedRef.current = true
+  }
+
   const handleTitleClick = () => {
-    if (!preventTitleChange) {
+    if (!preventTitleChange && !hasDraggedRef.current) {
       setIsEditing(true)
       setEditingTitle(title)
       resizeInput(title)
@@ -127,7 +136,13 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
               value={editingTitle}
             />
           ) : ((title || isHovering) &&
-            <div className="title-text" data-testid="title-text" onClick={handleTitleClick}>
+            <div
+              className="title-text"
+              data-testid="title-text"
+              onClick={handleTitleClick}
+              onPointerDown={handleTitlePointerDown}
+              onPointerMove={handleTitlePointerMove}
+            >
               <span>{isHovering && title === "" ? blankTitle : title}</span>
             </div>
           )

--- a/v3/src/components/component-title-bar.tsx
+++ b/v3/src/components/component-title-bar.tsx
@@ -82,6 +82,10 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
     }
   }
 
+  const handleInputPointerDown = (e: React.PointerEvent<HTMLInputElement>) => {
+    e.stopPropagation()
+  }
+
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const { key } = e
     e.stopPropagation()
@@ -117,13 +121,14 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
               onFocus={(e) => e.target.select()}
               onInput={handleInput}
               onKeyDown={handleInputKeyDown}
+              onPointerDown={handleInputPointerDown}
               ref={inputRef}
               style={{ width: `${inputWidth}px` }}
               value={editingTitle}
             />
           ) : ((title || isHovering) &&
             <div className="title-text" data-testid="title-text" onClick={handleTitleClick}>
-              {isHovering && title === "" ? blankTitle : title}
+              <span>{isHovering && title === "" ? blankTitle : title}</span>
             </div>
           )
         }

--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -6,6 +6,7 @@ import { FreeTileLayoutContext } from "../../hooks/use-free-tile-layout-context"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { IFreeTileLayout, IFreeTileRow } from "../../models/document/free-tile-row"
 import { getTileComponentInfo } from "../../models/tiles/tile-component-info"
+import { kDefaultMinWidth } from "../../models/tiles/tile-layout"
 import { ITileModel } from "../../models/tiles/tile-model"
 import { updateTileNotification } from "../../models/tiles/tile-notifications"
 import { urlParams } from "../../utilities/url-params"
@@ -18,6 +19,10 @@ interface IProps {
   row: IFreeTileRow
   tile: ITileModel
   onCloseTile: (tileId: string) => void
+}
+
+const getSafeTileWidth = (width?: number) => {
+  return width != null ? Math.max(width, kDefaultMinWidth) : kDefaultMinWidth
 }
 
 export const FreeTileComponent = observer(function FreeTileComponent({ row, tile, onCloseTile}: IProps) {
@@ -73,17 +78,20 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
       }
 
       setChangingTileStyle({
-        left: resizingLeft, top: _tileLayout.y,
-        width: resizingWidth, height: resizingHeight,
+        left: resizingLeft,
+        top: _tileLayout.y,
+        width: getSafeTileWidth(resizingWidth),
+        height: resizingHeight,
         zIndex: _tileLayout.zIndex,
         transition: "none"
       })
     }
     const handlePointerUp = () => {
+      const newWidth = getSafeTileWidth(resizingWidth)
       document.body.removeEventListener("pointermove", handlePointerMove, { capture: true })
       document.body.removeEventListener("pointerup", handlePointerUp, { capture: true })
       row.applyModelChange(() => {
-        _tileLayout.setSize(resizingWidth, resizingHeight)
+        _tileLayout.setSize(newWidth, resizingHeight)
         _tileLayout.setPosition(resizingLeft, _tileLayout.y)
       }, {
         notify: () => updateTileNotification("resize", {}, tile),

--- a/v3/src/models/tiles/tile-layout.ts
+++ b/v3/src/models/tiles/tile-layout.ts
@@ -1,6 +1,7 @@
 import { types, Instance } from "mobx-state-tree"
 
-export const kDefaultMinWidth = 60
+// generally negotiated with app, e.g. single column width for table
+export const kDefaultMinWidth = 50
 
 export const TileLayoutModel = types
   .model("TileLayout", {

--- a/v3/src/models/tiles/tile-model.test.ts
+++ b/v3/src/models/tiles/tile-model.test.ts
@@ -1,6 +1,7 @@
 import { getSnapshot } from "mobx-state-tree"
-import { kDefaultMinWidth, TileModel } from "./tile-model"
+import { TileModel } from "./tile-model"
 import { getTileTypes, getTileContentInfo } from "./tile-content-info"
+import { kDefaultMinWidth } from "./tile-layout"
 import { IUnknownContentModel } from "./unknown-content"
 import { kUnknownTileType } from "./unknown-types"
 

--- a/v3/src/models/tiles/tile-model.ts
+++ b/v3/src/models/tiles/tile-model.ts
@@ -9,9 +9,7 @@ import { DisplayUserTypeEnum } from "../stores/user-types"
 import { ITileContentModel } from "./tile-content"
 import { getTileContentInfo, ITileExportOptions } from "./tile-content-info"
 import { TileContentUnion } from "./tile-content-union"
-
-// generally negotiated with app, e.g. single column width for table
-export const kDefaultMinWidth = 60
+import { kDefaultMinWidth } from "./tile-layout"
 
 export interface IDragTileItem {
   rowIndex: number;


### PR DESCRIPTION
[CODAP-873](https://concord-consortium.atlassian.net/browse/CODAP-873)

These changes prevent a bug that allowed tile title text and the tile title text input field to extend beyond the boundaries of a tile's title bar. ~~Included are some adjustments to styling that follow the [new spec](https://app.zeplin.io/project/5e4baae7fb685faac9bf4a0a/screen/6889160d875b3fae20982a54) except that we use a narrower minimum tile width.~~ Now when the title text is longer than the space available in the title bar, the text gets truncated.

As per discussion elsewhere, these changes also drop the minimum tile width value to 50 to match CODAP V2. This means that like in V2, at very narrow tile widths the title bar buttons and title text will overlap. That is understood and accepted by the project team.

There are some additional small changes related to issues uncovered in this work:

- Prevent tile dragging during title edit (in `ComponentTitleBar`).
- Prevent triggering of title edit mode after dragging tile by title text (in `ComponentTitleBar`).
- Enforce minimum tile width value on tile resize (in `FreeTileComponent`).
- Consolidate two `kDefaultMinWidth` variables. There was one in `v3/src/models/tiles/tile-layout.ts` and another in `v3/src/models/tiles/tile-model.ts`. Both were set to 60. 

[CODAP-873]: https://concord-consortium.atlassian.net/browse/CODAP-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ