### PR TITLE
fix: formula editor button styling

### DIFF
--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -79,13 +79,14 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   }
 
   const footerButtons = [{
+    variant: "v3Clear",
     label: t("DG.AttrFormView.cancelBtnTitle"),
     tooltip: t("DG.AttrFormView.cancelBtnTooltip"),
     onClick: closeModal
   }, {
+    variant: "v3Default",
     label: t("DG.AttrFormView.applyBtnTitle"),
-    onClick: applyAndClose,
-    default: true
+    onClick: applyAndClose
   }]
 
   function handleKeyDown(event: React.KeyboardEvent) {
@@ -160,8 +161,10 @@ export const EditFormulaModal = observer(function EditFormulaModal({
           </FormControl>
           <Flex className="formula-insert-buttons-container" flexDirection="row" justifyContent="flex-start">
             <Box position="relative">
-              <Button className={clsx("formula-editor-button", "insert-value", {"menu-open": showValuesMenu})}
-                      size="xs" ml="5" onClick={handleInsertValuesOpen} data-testid="formula-insert-value-button">
+              <Button variant="v3"
+                className={clsx("formula-editor-button", "insert-value", {"menu-open": showValuesMenu})}
+                size="xs" ml="5" onClick={handleInsertValuesOpen} data-testid="formula-insert-value-button"
+              >
                 {t("DG.AttrFormView.operandMenuTitle")}
               </Button>
               {showValuesMenu &&
@@ -169,7 +172,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
               }
             </Box>
             <Box position="relative">
-              <Button
+              <Button variant="v3"
                 className={clsx("formula-editor-button", "insert-function", {"menu-open": showFunctionMenu})}
                 size="xs" ml="5" onClick={handleInsertFunctionsOpen} data-testid="formula-insert-function-button"
               >
@@ -188,8 +191,8 @@ export const EditFormulaModal = observer(function EditFormulaModal({
                 <Tooltip key={idx} label={b.tooltip} h="20px" fontSize="12px" color="white" openDelay={1000}
                   placement="bottom" bottom="15px" left="15px" data-testid="modal-tooltip"
                 >
-                  <Button key={key} size="xs" variant={`${b.default ? "default" : ""}`} ml="5" onClick={b.onClick}
-                        _hover={{backgroundColor: "#72bfca", color: "white"}} data-testid={`${b.label}-button`}>
+                  <Button key={key} size="xs" variant={b.variant} ml="5" onClick={b.onClick}
+                        data-testid={`${b.label}-button`}>
                     {b.label}
                   </Button>
                 </Tooltip>

--- a/v3/src/theme.ts
+++ b/v3/src/theme.ts
@@ -48,6 +48,30 @@ export const theme = extendTheme({
           backgroundColor: "tealLight2",
           color: "white",
         },
+        v3: {
+          backgroundColor: "#d3f4ff",
+          color: "labelText",
+          border: "1px solid lightgray",
+          borderRadius: "4px",
+          _hover: { backgroundColor: "#bbefff", color: "labelText" },
+          _active: { backgroundColor: "#a5e3f6", color: "labelText" }
+        },
+        v3Clear: {
+          backgroundColor: "white",
+          color: "labelText",
+          border: "1px solid lightgray",
+          borderRadius: "4px",
+          _hover: { backgroundColor: "#bbefff", color: "labelText" },
+          _active: { backgroundColor: "#a5e3f6", color: "labelText" }
+        },
+        v3Default: {
+          backgroundColor: "#bbefff",
+          color: "labelText",
+          border: "1px solid lightgray",
+          borderRadius: "4px",
+          _hover: { backgroundColor: "#93d5e4", color: "labelText" },
+          _active: { backgroundColor: "#72bfca", color: "labelText" }
+        }
       }
     },
     FormLabel: {


### PR DESCRIPTION
[[CODAP-823](https://concord-consortium.atlassian.net/browse/CODAP-823)] The formula editor buttons for Insert Value and Insert Function have lost their formatting

Note that there is a larger re-styling discussion happening around the formula editor. This is not that. I took a few of the colors from the in-progress spec, but the goal here is just to get the buttons to look and act like buttons.