### PR TITLE
CODAP-898 Box plot and hover tips placement 

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.scss
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.scss
@@ -75,10 +75,11 @@
   height: 100%;
   top: 0;
   width: 100%;
+}
 
-  &.box-plot-label {
-    background: #ffc;
-    box-shadow: 1px 1px 1px rgba(51, 51, 51, .7);
-    padding: 2px 4px;
-  }
+.box-plot-label {
+  background: #ffc;
+  box-shadow: 1px 1px 1px rgba(51, 51, 51, .7);
+  padding: 2px 4px;
+  pointer-events: none !important;  // to override measure-tip pointer-events
 }

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
@@ -34,11 +34,12 @@ interface IBoxPlotValue extends IValue {
 }
 
 export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentComponent (props: IAdornmentComponentProps) {
-  const {cellKey={}, cellCoords, containerId, plotHeight, plotWidth,
+  const {cellKey={}, cellCoords, containerId,
     xAxis, yAxis, spannerRef} = props
   const graphModel = useGraphContentModelContext()
   const model = props.model as IBoxPlotAdornmentModel
   const layout = useGraphLayoutContext()
+  const { plotWidth, plotHeight } = layout
   const dataConfig = useGraphDataConfigurationContext()
   const { xAttrId, yAttrId, xAttrType } = useAdornmentAttributes()
   const isVerticalRef = useRef(!!(xAttrType && xAttrType === "numeric"))
@@ -63,7 +64,7 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     const containerLeft = containerRect?.left || 0
     const containerTop = containerRect?.top || 0
     const labelLeft = elementRect.left - containerLeft - 30
-    const labelTop = elementRect.top - containerTop - 30
+    const labelTop = Math.max(0, elementRect.top - containerTop - 30)
 
     label.style("left", `${labelLeft}px`)
       .style("top", `${labelTop}px`)
@@ -197,8 +198,8 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
     }
 
     const fullHeightLinesPath = () => {
-      const graphWidth = layout.plotWidth,
-        graphHeight = layout.plotHeight,
+      const graphWidth = plotWidth,
+        graphHeight = plotHeight,
         cellWidth = graphWidth / cellCounts.x,
         cellHeight = graphHeight / cellCounts.y,
         lowerCoord = isVerticalRef.current ? helper.xScale(iciRange.min) / cellCounts.x
@@ -251,8 +252,8 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
         .attr("data-testid", `${helper.measureSlug}-error-bar`)
         .attr("d", fullHeightLinesPath())
     }
-  }, [dataConfig, attrId, helper, model, cellKey, spannerRef, plotWidth, cellCounts.x, cellCounts.y, plotHeight,
-            layout.plotWidth, layout.plotHeight, cellCoords.col, cellCoords.row])
+  }, [dataConfig, attrId, helper, model, cellKey, spannerRef, cellCounts.x, cellCounts.y,
+            plotWidth, plotHeight, cellCoords.col, cellCoords.row])
 
   const addQCovers = useCallback((valueObj: IBoxPlotValue) => {
 


### PR DESCRIPTION
[#CODAP-898] Bug fix: Box plot placement not correct when graph is split on both top and right

* The cited bug is fixed by noting that the plotWidth and plotHeight passed in refer to that of the subplot which was then being divided by the number of columns/rows. Instead we get the plotWidth/Height from the graph layout.
* A second problem that manifests when the box plot tips are close to the element is that pointer events are being intercepted by the tip and thus we get a flickering of the tip. We fix this by specifying pointer-events as "none" for the box plot tips. And this seems to require "!important" because of class nesting with style that specifies pointer-events as "all".