### PR TITLE
Codap-893 Marquee Deselect

### DIFF
--- a/v3/src/components/data-display/components/background.tsx
+++ b/v3/src/components/data-display/components/background.tsx
@@ -82,7 +82,7 @@ export const Background = forwardRef<SVGGElement | HTMLDivElement, IProps>((prop
     startY = useRef(0),
     width = useRef(0),
     height = useRef(0),
-    needsToClear = useRef(true),
+    needsToClearSelection = useRef(false),
     selectionTree = useRef<RTree | null>(null),
     previousMarqueeRect = useRef<rTreeRect>()
 
@@ -104,21 +104,17 @@ export const Background = forwardRef<SVGGElement | HTMLDivElement, IProps>((prop
     width.current = 0
     height.current = 0
     marqueeState.setMarqueeRect({x: startX.current, y: startY.current, width: 0, height: 0})
-    needsToClear.current = !event.shiftKey
+    needsToClearSelection.current = !event.shiftKey
   }, [bgRef, marqueeState, pixiPointsArray])
 
   const onDrag = useCallback((event: { dx: number; dy: number }) => {
     if ((event.dx === 0 && event.dy === 0) || datasetsArray.length === 0) return
 
-    if (needsToClear.current) {
-      pixiPointsArray.forEach(pixiPoints => {
-        pixiPoints?.forEachPoint((_point: PIXI.Sprite, metadata: IPixiPointMetadata) => {
-          const dataset = datasetsMap[metadata.datasetID].dataset
-          if (dataset.selection.size <= 0) return
-          selectAllCases(dataset, false)
-        })
+    if (needsToClearSelection.current) {
+      datasetsArray.forEach(data => {
+        if (data.selection.size > 0) selectAllCases(data, false)
       })
-      needsToClear.current = false
+      needsToClearSelection.current = false
     }
 
     previousMarqueeRect.current = rectNormalize(
@@ -152,7 +148,7 @@ export const Background = forwardRef<SVGGElement | HTMLDivElement, IProps>((prop
     })
 
     clearDatasetsMapArrays()
-  }, [clearDatasetsMapArrays, datasetsArray.length, datasetsMap, marqueeState, pixiPointsArray])
+  }, [clearDatasetsMapArrays, datasetsArray, datasetsMap, marqueeState])
 
   const onDragEnd = useCallback(() => {
     marqueeState.setMarqueeRect({x: 0, y: 0, width: 0, height: 0})


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/CODAP-893

This PR fixes a bug where starting a normal (no shift) marquee selection on an unfocused graph tile was not clearing the original selection. The main problem is that we were relying on `usePixiPointerDownDeselect` to handle deselection, but this only handles the initial `pointerDown` event. When the tile isn't previously focused, we focus it on `pointerDown`, and don't necessarily want to clear the selection.

The solution is to deselect an additional time on the first `onDrag` event. This will happen whether the tile was initially focused or not. I briefly looked into only making this fire when the tile was not initially focused, but it wasn't clear how to determine if the tile was focused within the `Background` component.

While working in `background.tsx`, I couldn't help but clean this file up a decent amount. The changes relevant to the actual bug fix can be found by searching for the `needsToClearSelection` ref.

One other issue came to mind as I was working on this PR: it would be worth reviewing how we're logging while changing the selection. For example, we're constantly logging while the marquee is changing the selection.