### PR TITLE
Codap 889 v2 import bug

### DIFF
--- a/v3/src/components/axis/models/multi-scale.ts
+++ b/v3/src/components/axis/models/multi-scale.ts
@@ -208,11 +208,11 @@ export class MultiScale {
       return format('.9')(roundedNumber)
     }
 
-    const formatDatePrecisionArr = [DatePrecision.Year, DatePrecision.Month, DatePrecision.Day, DatePrecision.Hour]
+    const formatDatePrecisionArr = ["year", "month", "day", "hour"]
     const formatSliderInputDate = (n: number): string => {
       if (isDate && formatDatePrecisionArr.includes(dateMultipleOfUnit as DatePrecision)) {
         return formatDate(n * 1000, dateMultipleOfUnit as DatePrecision) ?? ''
-      } else { return formatDate(n * 1000, DatePrecision.Minute) ?? '' }
+      } else { return formatDate(n * 1000, "minute") ?? '' }
     }
 
     return isDate

--- a/v3/src/components/case-tile-common/attribute-menu/edit-attribute-properties-modal.tsx
+++ b/v3/src/components/case-tile-common/attribute-menu/edit-attribute-properties-modal.tsx
@@ -5,7 +5,7 @@ import { useDataSet } from "../../../hooks/use-data-set"
 import { logMessageWithReplacement } from "../../../lib/log-message"
 import { AttributeType, attributeTypes } from "../../../models/data/attribute-types"
 import { updateAttributesNotification } from "../../../models/data/data-set-notifications"
-import { DatePrecision } from "../../../utilities/date-utils"
+import { DatePrecision, datePrecisions } from "../../../utilities/date-utils"
 import { uniqueName } from "../../../utilities/js-utils"
 import { t } from "../../../utilities/translation/translate"
 import { CodapModal } from "../../codap-modal"
@@ -120,7 +120,7 @@ export const EditAttributePropertiesModal = ({ attributeId, isOpen, onClose }: I
       return (
         <Select size="xs" ml={5} value={toDatePrecisionStr(precision)} data-testid="attr-precision-select"
                         onChange={(e) => setPrecision(toDatePrecision(e.target.value))}>
-          {Object.values(DatePrecision).map(p => {
+          {datePrecisions.map(p => {
             return (
               <option value={p} key={`precision-${p}`} data-testid={`attr-precision-option-${p}`}>
                 {p}

--- a/v3/src/components/component-title-bar.tsx
+++ b/v3/src/components/component-title-bar.tsx
@@ -30,7 +30,7 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
   const [isHovering, setIsHovering] = useState(false)
   const blankTitle = "_____"
   const hasDraggedRef = useRef(false)
-  const pointerStart = useRef<{x: number, y: number} | null>(null);
+  const pointerStart = useRef<{x: number, y: number} | null>(null)
 
   // Input sizing is based on https://stackoverflow.com/questions/8100770/auto-scaling-inputtype-text-to-width-of-value
   const [inputWidth, setInputWidth] = useState(2 * kInputPadding)

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -1,7 +1,9 @@
 import { axisBottom, format, max, min, NumberValue, range, scaleLinear, ScaleQuantile, ScaleQuantize, select } from "d3"
 import { measureTextExtent } from "../../../../../hooks/use-measure-text"
+import {
+  determineLevels, formatDate, kDatePrecisionNone, mapLevelToPrecision
+} from "../../../../../utilities/date-utils"
 import { neededSigDigitsArrayForBinBoundaries } from "../../../../../utilities/math-utils"
-import { DatePrecision, determineLevels, formatDate, mapLevelToPrecision } from "../../../../../utilities/date-utils"
 import { kChoroplethHeight, kDataDisplayFont } from "../../../data-display-types"
 
 export type ChoroplethLegendProps = {
@@ -60,7 +62,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     domainValues = scale.domain(),
     significantDigits = neededSigDigitsArrayForBinBoundaries(fullBoundaries, domainValues),
     dateLevels = isDate ? determineLevels(minValue, maxValue) : {increment: 1, outerLevel: 0, innerLevel: 0},
-    datePrecision = isDate ? mapLevelToPrecision(dateLevels.innerLevel + 1) : DatePrecision.None
+    datePrecision = isDate ? mapLevelToPrecision(dateLevels.innerLevel + 1) : kDatePrecisionNone
 
   const thresholdFormat = isDate ? (date: number) => formatDate(date * 1000, datePrecision) ?? ''
     : format(tickFormatSpec)

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -30,7 +30,7 @@ import { addDisposer, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { kAttrIdPrefix, typeV3Id } from "../../utilities/codap-utils"
 import { parseColor } from "../../utilities/color-utils"
 import { isDateString } from "../../utilities/date-parser"
-import { DatePrecision } from "../../utilities/date-utils"
+import { DatePrecision, datePrecisions } from "../../utilities/date-utils"
 import { extractNumeric } from "../../utilities/math-utils"
 import { cachedFnFactory } from "../../utilities/mst-utils"
 import { isDevelopment, isProduction } from "../../utilities/environment-utils"
@@ -56,7 +56,7 @@ export const Attribute = V2Model.named("Attribute").props({
   userType: types.maybe(types.enumeration([...attributeTypes])),
   // userFormat: types.maybe(types.string),
   units: types.maybe(types.string),
-  precision: types.maybe(types.union(types.number, types.enumeration(Object.values(DatePrecision)))),
+  precision: types.maybe(types.union(types.number, types.enumeration(datePrecisions))),
   formula: types.maybe(Formula),
   // simple array -- _not_ MST all the way down to the array elements
   // due to its frozen nature, clients should _not_ use `values` directly

--- a/v3/src/utilities/date-utils.ts
+++ b/v3/src/utilities/date-utils.ts
@@ -17,18 +17,15 @@ export const dateUnits = ["year", "month", "day", "hour", "minute", "second", "m
 export type DateUnit = typeof dateUnits[number]
 
 export function isDateUnit(value: any): value is DateUnit {
-  return dateUnits.includes(value)
+  return typeof value === "string"  && (dateUnits as readonly string[]).includes(value)
 }
 
-export enum DatePrecision {
-  None = '',
-  Millisecond = 'millisecond',
-  Second = 'second',
-  Minute = 'minute',
-  Hour = 'hour',
-  Day = 'day',
-  Month = 'month',
-  Year = 'year'
+export const kDatePrecisionNone = ""
+export const datePrecisions = [kDatePrecisionNone, ...dateUnits] as const
+export type DatePrecision = typeof datePrecisions[number]
+
+export function isDatePrecision(value: any): value is DatePrecision {
+  return typeof value === "string" && (datePrecisions as readonly string[]).includes(value)
 }
 
 // Constants for converting between units of time and milliseconds
@@ -123,25 +120,25 @@ export function determineLevels(iMinDate: number, iMaxDate: number) {
 }
 
 export function mapLevelToPrecision(iLevel: EDateTimeLevel) {
-  let tPrecision = DatePrecision.None
+  let tPrecision: DatePrecision = kDatePrecisionNone
   switch (iLevel) {
     case EDateTimeLevel.eSecond:
-      tPrecision = DatePrecision.Second
+      tPrecision = "second"
       break
     case EDateTimeLevel.eMinute:
-      tPrecision = DatePrecision.Minute
+      tPrecision = "minute"
       break
     case EDateTimeLevel.eHour:
-      tPrecision = DatePrecision.Hour
+      tPrecision = "hour"
       break
     case EDateTimeLevel.eDay:
-      tPrecision = DatePrecision.Day
+      tPrecision = "day"
       break
     case EDateTimeLevel.eMonth:
-      tPrecision = DatePrecision.Month
+      tPrecision = "month"
       break
     case EDateTimeLevel.eYear:
-      tPrecision = DatePrecision.Year
+      tPrecision = "year"
       break
   }
   return tPrecision
@@ -167,17 +164,17 @@ export function checkDate(value: any): [false] | [true, Date] {
  * @param precision {number}
  * @return {string}
  */
-export function formatDate(x: Date | number | string | null, precision: DatePrecision = DatePrecision.None):
+export function formatDate(x: Date | number | string | null, precision: DatePrecision = kDatePrecisionNone):
   string | null {
   const formatPrecisions: Partial<Record<DatePrecision, Intl.DateTimeFormatOptions>> = {
-    [DatePrecision.Year]: { year: 'numeric' },
-    [DatePrecision.Month]: { year: 'numeric', month: 'numeric' },
-    [DatePrecision.Day]: { year: 'numeric', month: 'numeric', day: 'numeric' },
-    [DatePrecision.Hour]: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric' },
-    [DatePrecision.Minute]: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' },
-    [DatePrecision.Second]: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric',
+    year: { year: 'numeric' },
+    month: { year: 'numeric', month: 'numeric' },
+    day: { year: 'numeric', month: 'numeric', day: 'numeric' },
+    hour: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric' },
+    minute: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' },
+    second: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric',
       second: 'numeric' },
-    [DatePrecision.Millisecond]: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric',
+    millisecond: { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric',
       minute: 'numeric', second: 'numeric', fractionalSecondDigits: 3 } as Intl.DateTimeFormatOptions
   }
 

--- a/v3/src/v2/codap-v2-data-set-importer.ts
+++ b/v3/src/v2/codap-v2-data-set-importer.ts
@@ -11,6 +11,8 @@ import { kSharedDataSetType, SharedDataSet } from "../models/shared/shared-data-
 import { getMetadataFromDataSet } from "../models/shared/shared-data-utils"
 import { ISharedModelManager } from "../models/shared/shared-model-manager"
 import { kItemIdPrefix, toV3AttrId, toV3CaseId, toV3CollectionId, toV3DataSetId, v3Id } from "../utilities/codap-utils"
+import { DatePrecision, isDatePrecision } from "../utilities/date-utils"
+import { isFiniteNumber } from "../utilities/math-utils"
 import {
   ICodapV2Attribute, ICodapV2Case, ICodapV2Collection, ICodapV2DataContext, ICodapV2DataContextStorage,
   ICodapV2GameContext, ICodapV2SetAsideItem, isV2SetAsideItem, v3TypeFromV2TypeString
@@ -25,6 +27,14 @@ interface V2CaseIdInfo {
 
 // This supports importing ICodapV2DataContext and ICodapV2GameContext
 type ImportableContext = ICodapV2DataContext | ICodapV2GameContext
+
+function validateV2Precision(v2Precision: number | string | null | undefined): Maybe<number | DatePrecision> {
+  if (v2Precision == null) return undefined
+  if (typeof v2Precision === "number") return v2Precision
+  if (isDatePrecision(v2Precision)) return v2Precision
+  const convertedPrecision = +v2Precision
+  if (isFiniteNumber(convertedPrecision)) return convertedPrecision
+}
 
 export class CodapV2DataSetImporter {
   private guidMap
@@ -149,8 +159,8 @@ export class CodapV2DataSetImporter {
       const userType = v3TypeFromV2TypeString(v2Type)
       const formula = v2Formula ? { display: v2Formula } : undefined
       const editable = v2Editable == null || !!v2Editable
-      const precision = v2Precision != null && v2Precision !== ""
-                          ? +v2Precision
+      const precision = v2Precision != null
+                          ? validateV2Precision(v2Precision)
                           : decimals != null && decimals !== ""
                             ? +decimals
                             : undefined


### PR DESCRIPTION
[[CODAP-889](https://concord-consortium.atlassian.net/browse/CODAP-889)] Unable to open document error on codap3 document

The root of the problem was a bug in the v2 import that failed to handle attributes of type `date` with a date precision specified. Confusingly, no error occurred on the initial import, but if the document was then saved as a v3 document, opening of the resulting v3 document would fail.

Although not strictly required to fix the bug, I took this opportunity to clarify the relationship between `DateUnit` and `DatePrecision`. Previously, the former was implemented as a simple TypeScript string union, while the latter was implemented as a TypeScript enumeration. Now they're both TypeScript string unions with the only difference being that `DatePrecision` supports the empty string in addition to the other standard `DateUnit`s.