### PR TITLE
CODAP-844 Add notification for tile minimization

### DIFF
--- a/v3/src/components/container/free-tile-component.tsx
+++ b/v3/src/components/container/free-tile-component.tsx
@@ -45,12 +45,13 @@ export const FreeTileComponent = observer(function FreeTileComponent({ row, tile
   }, [])
 
   const handleMinimizeTile = useCallback(() => {
+    const logString = isMinimized ? "Expanded component" : "Minimized component"
     if (setMinimized) {
       tile.applyModelChange(() => {
         setMinimized(!isMinimized)
       }, {
         notify: updateTileNotification("toggle minimize component", {}, tile),
-        log: logMessageWithReplacement("Component minimized: %@", {isMinimized}, "component"),
+        log: logMessageWithReplacement(logString, {}, "component"),
         undoStringKey: "DG.Undo.component.minimize",
         redoStringKey: "DG.Redo.component.minimize"
       })


### PR DESCRIPTION
[#CODAP-844] Bug fix: Minimize and close buttons should notify plugins

* The close button was already notifying.
* Added applyModelChange to free-tile-component.tsx `handleMinimizeTile` with full suite of options