### PR TITLE
fix: Movable line misbehaviors (CODAP-863)

### DIFF
--- a/v3/cypress/e2e/adornments.spec.ts
+++ b/v3/cypress/e2e/adornments.spec.ts
@@ -549,7 +549,6 @@ context("Graph adornments", () => {
     toolbar.getRedoTool().click()
     cy.get("[data-testid=adornment-wrapper]").should("have.class", "hidden")
 
-
   })
   it("adds plotted value UI to graph when Plotted Value checkbox is checked", () => {
     c.selectTile("graph", 0)

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
@@ -366,8 +366,8 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
       const lineModel = model.lines.get(instanceKey)
       if (!lineObject.line || !lineModel) return
 
-      const slope = lineModel.dynamicSlope ?? lineModel.slope
-      const intercept = interceptLocked ? 0 : lineModel.dynamicIntercept ?? lineModel.intercept
+      const { slope, intercept: _intercept } = lineModel.slopeAndIntercept
+      const intercept = interceptLocked ? 0 : _intercept
       const { xDomain, yDomain } = getAxisDomains(xAxis, yAxis)
       pointsOnAxes.current = lineToAxisIntercepts(slope, intercept, xDomain, yDomain)
       updateLine()


### PR DESCRIPTION
[CODAP-863](https://concord-consortium.atlassian.net/browse/CODAP-863)

These changes fix a few Movable Line bugs.

**1. Line does not move when axis range modified by drag.**

The fix was to consolidate two `useEffect` blocks with overlapping dependencies into a single effect to ensure the line updates correctly when axis ranges are modified.

**2. When the graph is deselected, the middle “handle” of the line remains visible. All three handles should be hidden when the graph component is not selected.**

The fix was to not set `display: block` on the element inline when `interceptLocked` is false, but to instead remove the inline style and let the stylesheet handle the display.

**3. When equation is unpinned from the line, the line does not update during rotation or translation. It only updates once the line is dropped.**

The fix involves removing calls to `refreshEquation` from the line drag handlers, and updating the refresh `useEffect` (which also calls `refreshEquation`) to use the volatile slope and intercept properties when available.

[CODAP-863]: https://concord-consortium.atlassian.net/browse/CODAP-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ