### PR TITLE
feat: measure label unit formatting (CODAP-896)

### DIFF
--- a/v3/src/components/graph/adornments/components/adornments.scss
+++ b/v3/src/components/graph/adornments/components/adornments.scss
@@ -44,3 +44,10 @@
   height: 100%;
   pointer-events: none;
 }
+
+[class*="equation-container"],
+.measure-labels {
+  .units {
+    color: gray;
+  }
+}

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
@@ -317,7 +317,7 @@ export const NormalCurveAdornmentComponent = observer(
       const sdValueString = t(kNormalCurveStdDevValueTitleKey, {vars: [sdDisplayValue]})
 
       const unitsString = `${numericAttrUnits ? ` ${numericAttrUnits}` : ""}`
-      const unitsContent = showLabel ? `<span style="color:grey">${unitsString}</span>` : unitsString
+      const unitsContent = showLabel ? `<span class="units">${unitsString}</span>` : unitsString
       const meanValueContent = showLabel
         ? `<p style = "color:${kNormalCurveStrokeColor}">${meanValueString}${unitsContent}</p>`
         : `${meanValueString}, `

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -372,7 +372,7 @@ export class UnivariateMeasureAdornmentHelper {
       '<sub style="vertical-align: sub">',
       '</sub>', stdErrorString] : [`${numStdErrsString}`, '', '', stdErrorString]
     const valueString = t(kStandardErrorValueTitleKey, {vars: substitutionVars}) +
-      (inHTML ? (primaryAttributeUnits ? ` ${primaryAttributeUnits}` : "") : "")
+      (inHTML ? (primaryAttributeUnits ? ` <span class="units">${primaryAttributeUnits}</span>` : "") : "")
     const unitsString = `${primaryAttributeUnits ? ` ${primaryAttributeUnits}` : ""}`
     const valueContent = inHTML ? `<p style = "color:${kErrorBarStrokeColor};">${valueString}</p>` : valueString
     return `${valueContent}${inHTML ? '' : unitsString}`

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -162,7 +162,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       ]
 
       const valueContent = `${t(model.labelTitle, { vars: translationVars })}`
-      const unitContent = `${primaryAttrUnits ? ` ${primaryAttrUnits}` : ""}`
+      const unitContent = primaryAttrUnits ? ` <span class="units">${primaryAttrUnits}</span>` : ""
       const textContent = `${valueContent}${unitContent}`
 
       // Add the main value line

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -296,7 +296,8 @@ export function formatValue(value: number, digits: number): string {
  */
 function formatEquationValue(equationValue: number, equationDigits: number, units = "", parenthesizeUnits = false) {
   const numStr = formatValue(equationValue, equationDigits)
-  const numUnitsStr = units ? `${numStr} ${units}` : numStr
+  const unitsStr = units ? `<span class="units">${units}</span>` : ""
+  const numUnitsStr = units ? `${numStr} ${unitsStr}` : numStr
   return units && parenthesizeUnits ? `(${numUnitsStr})` : numUnitsStr
 }
 
@@ -377,7 +378,6 @@ export const lsrlEquationString = (props: ILsrlEquationString) => {
 
   return `${equationPart}${rSquaredPart}${seSlopePart}${squaresPart}`
 }
-
 
 export function getScreenCoord(dataSet: IDataSet | undefined, id: string,
                                attrID: string, scale: ScaleNumericBaseType) {

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -296,8 +296,7 @@ export function formatValue(value: number, digits: number): string {
  */
 function formatEquationValue(equationValue: number, equationDigits: number, units = "", parenthesizeUnits = false) {
   const numStr = formatValue(equationValue, equationDigits)
-  const unitsStr = units ? `<span class="units">${units}</span>` : ""
-  const numUnitsStr = units ? `${numStr} ${unitsStr}` : numStr
+  const numUnitsStr = units ? `${numStr} <span class="units">${units}</span>` : numStr
   return units && parenthesizeUnits ? `(${numUnitsStr})` : numUnitsStr
 }
 


### PR DESCRIPTION
[CODAP-896](https://concord-consortium.atlassian.net/browse/CODAP-896)

Adds a `unit` class for styling unit text strings in graph measure labels.

[CODAP-896]: https://concord-consortium.atlassian.net/browse/CODAP-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ