### PR TITLE
CODAP-902 Open graph image in Draw Tool plugin

### DIFF
--- a/v3/src/constants.ts
+++ b/v3/src/constants.ts
@@ -19,3 +19,8 @@ export const kImporterPluginUrl = "/Importer/index.html?lang=en-US"
 export function getImporterPluginUrl() {
   return `${getPluginsRootUrl()}${kImporterPluginUrl}`
 }
+
+export const kDrawToolPluginUrl = "/DrawTool/index.html?lang=en-US"
+export function getDrawToolPluginUrl() {
+  return `${getPluginsRootUrl()}${kDrawToolPluginUrl}`
+}


### PR DESCRIPTION
[#CODAP-902] Feature: Graphs and maps respond to the "Open in Draw Tool" menu item under the Image icon to open a draw tool plugin with the graph image

* Enabled the menu item in the "camera" menu for "Open in Draw Tool"
* Refactored camera-menu-list `handleExportPNG` pulling out `getImageString` so that it can be reused by new function `openInDrawTool`
* Added `getDrawToolPluginUrl` to constants.ts
* Defined `openInDrawTool` in camera-menu-list.tsx to open the Draw Tool plugin, pass it the image and position it in an open space in the document.

Note: I split off the corresponding story for maps since maps don't yet allow export as 'png'.