### PR TITLE
CODAP-914 Don't show html formatting in hover tips

### DIFF
--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -164,6 +164,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       const valueContent = `${t(model.labelTitle, { vars: translationVars })}`
       const unitContent = primaryAttrUnits ? ` <span class="units">${primaryAttrUnits}</span>` : ""
       const textContent = `${valueContent}${unitContent}`
+      const tipContent = `${valueContent} ${primaryAttrUnits}`  // No formatting in tip
 
       // Add the main value line
       const lineSpecs = {
@@ -202,7 +203,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       if (showLabel) {
         addLabels(measure, textContent, valueObj, plotValue, measureRange.max)
       } else {
-        addTextTip(plotValue, textContent, valueObj, measureRange.max)
+        addTextTip(plotValue, tipContent, valueObj, measureRange.max)
       }
     }, [numericAttrId, dataConfig, model, cellKey, helper, isVerticalRef, cellCounts, valueRef, showLabel,
               addLabels, addTextTip])

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -153,7 +153,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
 
       const primaryAttrId = dataConfig?.primaryAttributeID
       const primaryAttr = primaryAttrId ? dataConfig?.dataset?.attrFromID(primaryAttrId) : undefined
-      const primaryAttrUnits = primaryAttr?.units
+      const primaryAttrUnits = primaryAttr?.units || ""
       const { coords, coverClass, coverId, displayRange, displayValue, lineClass, lineId, measureRange, plotValue } =
         helper.adornmentSpecs(numericAttrId, dataConfig, value, cellCounts)
 
@@ -164,7 +164,7 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       const valueContent = `${t(model.labelTitle, { vars: translationVars })}`
       const unitContent = primaryAttrUnits ? ` <span class="units">${primaryAttrUnits}</span>` : ""
       const textContent = `${valueContent}${unitContent}`
-      const tipContent = `${valueContent} ${primaryAttrUnits}`  // No formatting in tip
+      const tipContent = `${valueContent}${primaryAttrUnits}`  // No formatting in tip
 
       // Add the main value line
       const lineSpecs = {


### PR DESCRIPTION
[#CODAP-914] Bug fix: Hover labels for univariate measures like mean are including html tags

* The problem was caused by adding formatting to the units in measure labels. Unfortunately, univariate measure hover tips were using the same string but, since they're rendered with svg, we can't do the formatting. The fix is to distinguish between the string used for labels and the string used for hover tips.