### PR TITLE
CODAP-822 Guide button functionality

### DIFF
--- a/v3/src/components/case-card/case-card-registration.ts
+++ b/v3/src/components/case-card/case-card-registration.ts
@@ -33,7 +33,7 @@ registerTileContentInfo({
     const data = tile.content && getTileDataSet(tile.content)
     return data?.displayTitle || t("DG.DocumentController.caseTableTitle")
   },
-  hideOnClose: true
+  hideOnClose: () => true
 })
 
 registerTileComponentInfo({

--- a/v3/src/components/case-table/case-table-registration.ts
+++ b/v3/src/components/case-table/case-table-registration.ts
@@ -32,7 +32,7 @@ registerTileContentInfo({
     const data = tile.content && getTileDataSet(tile.content)
     return data?.displayTitle ?? tile.title ?? t("DG.DocumentController.caseTableTitle")
   },
-  hideOnClose: true
+  hideOnClose: () => true
 })
 
 registerTileComponentInfo({

--- a/v3/src/components/container/container.tsx
+++ b/v3/src/components/container/container.tsx
@@ -36,7 +36,7 @@ export const Container: React.FC = observer(function Container() {
       sharedModels?.forEach(model => {
         manager?.removeTileSharedModel(tile?.content, model)
       })
-      tileId && documentContent?.deleteTile(tileId)
+      tileId && documentContent?.deleteOrHideTile(tileId)
     }, {
       notify: deleteTileNotification(tile),
       log: logMessageWithReplacement("Close component: %@", {tileType: tile?.content.type}, "component"),

--- a/v3/src/components/tool-shelf/guide-button.tsx
+++ b/v3/src/components/tool-shelf/guide-button.tsx
@@ -1,0 +1,79 @@
+import React from "react"
+import { observer } from "mobx-react-lite"
+import { clsx } from "clsx"
+import { Menu, MenuButton, MenuItem, MenuList, useDisclosure } from "@chakra-ui/react"
+import { useDocumentContent } from "../../hooks/use-document-content"
+import { persistentState } from "../../models/persistent-state"
+import { getSpecialLangFontClassName, t } from "../../utilities/translation/translate"
+import GuideIcon from "../../assets/icons/icon-guide.svg"
+import { logMessageWithReplacement } from "../../lib/log-message"
+import { isWebViewModel } from "../web-view/web-view-model"
+import { ToolShelfButtonTag } from "./tool-shelf-button"
+import { handleSelectTile } from "./tool-shelf-utilities"
+
+import "./tool-shelf.scss"
+
+interface IProps {
+  guideTileId: string
+}
+
+export const GuideButton = observer(function GuideButton(props: IProps) {
+  const { guideTileId } = props
+  const documentContent = useDocumentContent()
+  const langClass = getSpecialLangFontClassName()
+  const {isOpen, onOpen, onClose} = useDisclosure()
+  const webViewModel = documentContent?.getTile(guideTileId)?.content
+  if (!isWebViewModel(webViewModel) || !webViewModel.isGuide) return null
+
+  const showGuidePage = (url:string) => {
+    if (url !== webViewModel.url) {
+      documentContent?.applyModelChange(() => {
+        handleSelectTile(guideTileId, documentContent)
+        webViewModel.setUrl(url)
+      }, {
+        undoStringKey: "DG.Undo.guide.navigate",
+        redoStringKey: "DG.Redo.guide.navigate",
+        log: logMessageWithReplacement("Show guide page: %@", {url}, "document")
+      })
+    }
+  }
+
+  const placement = persistentState.toolbarPosition === "Top" ? "bottom-end" : "right-end"
+  return (
+    <>
+      <Menu isLazy autoSelect={false} isOpen={isOpen} onOpen={onOpen} onClose={onClose} placement={placement}>
+        <MenuButton
+          className={clsx("tool-shelf-button", "tool-shelf-menu", langClass, {"menu-open": isOpen})}
+          title={t("DG.ToolButtonData.guideMenu.toolTip")}
+          data-testid="tool-shelf-button-guide"
+        >
+          <GuideIcon className="icon-guide"/>
+          <ToolShelfButtonTag
+            className="tool-shelf-tool-label"
+            label={t("DG.ToolButtonData.guideMenu.title")}
+          />
+        </MenuButton>
+        <MenuList className="tool-shelf-menu-list top-menu" data-testid="guide-menu" >
+          <MenuItem
+            key={"show-guide"}
+            className="tool-shelf-menu-item"
+            data-testid="show-guide-item"
+            onClick={() => handleSelectTile(guideTileId, documentContent)}
+          >
+            {`${t("DG.ToolButtonData.guideMenu.showGuide")}`}
+          </MenuItem>
+          {webViewModel.pages.map((page, index) => {
+            return (
+              <MenuItem key={index} data-testid="guide-page-list-item"
+                        className="tool-shelf-menu-item"
+                        onClick={()=>showGuidePage(page.url || "")}
+              >
+                {page.title}
+              </MenuItem>
+            )
+          })}
+        </MenuList>
+      </Menu>
+    </>
+  )
+})

--- a/v3/src/components/tool-shelf/tiles-list-button.tsx
+++ b/v3/src/components/tool-shelf/tiles-list-button.tsx
@@ -5,13 +5,13 @@ import { Menu, MenuButton, MenuItem, MenuList, useDisclosure } from "@chakra-ui/
 import { useDocumentContent } from "../../hooks/use-document-content"
 import { persistentState } from "../../models/persistent-state"
 import { uiState } from "../../models/ui-state"
-import { isFreeTileLayout } from "../../models/document/free-tile-row"
 import { getSpecialLangFontClassName, t } from "../../utilities/translation/translate"
 import { ToolShelfButtonTag } from "./tool-shelf-button"
 import { getTileComponentIcon } from "../../models/tiles/tile-component-info"
 import { getTileContentInfo } from "../../models/tiles/tile-content-info"
 import WebViewIcon from "../../assets/icons/icon-media-tool.svg"
 import TileListIcon from "../../assets/icons/icon-tile-list.svg"
+import { handleSelectTile } from "./tool-shelf-utilities"
 
 import "./tool-shelf.scss"
 
@@ -20,13 +20,6 @@ export const TilesListShelfButton = observer(function TilesListShelfButton() {
   const tilesArr = documentContent?.tileMap ? Array.from(documentContent.tileMap.values()) : []
   const langClass = getSpecialLangFontClassName()
   const {isOpen, onOpen, onClose} = useDisclosure()
-
-  const handleSelectTile = (tileId: string) => {
-    uiState.setFocusedTile(tileId)
-    const tileRow = documentContent?.findRowContainingTile(tileId)
-    const tileLayout = tileRow?.getTileLayout(tileId)
-    isFreeTileLayout(tileLayout) && tileLayout.setMinimized(false)
-  }
 
   const handleFocus = (tileId: string) => {
     uiState.setHoveredTile(tileId)
@@ -61,7 +54,7 @@ export const TilesListShelfButton = observer(function TilesListShelfButton() {
             const title = tileInfo?.getTitle(tile)
             return (
               <MenuItem key={tile?.id} data-testid="tiles-list-menu-item" className="tool-shelf-menu-item"
-                  onClick={()=>handleSelectTile(tile.id) }
+                  onClick={()=>handleSelectTile(tile.id, documentContent) }
                   onFocus={()=>handleFocus(tile.id)} // Handle focus similar to pointer over
                   onBlur={()=>handleBlur(tile.id)} // Handle blur similar to pointer leave
               >

--- a/v3/src/components/tool-shelf/tool-shelf-utilities.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf-utilities.tsx
@@ -24,13 +24,14 @@ export const handleSelectTile = (tileId: string, documentContent?: IDocumentCont
   const tileRow = documentContent?.findRowContainingTile(tileId)
   const tileLayout = tileRow?.getTileLayout(tileId)
   if (isFreeTileLayout(tileLayout) && (tileLayout.isHidden || tileLayout.isMinimized)) {
+    const type = documentContent?.getTile(tileId)?.content.type || "tile"
     documentContent?.applyModelChange(() => {
       tileLayout.setHidden(false)
       tileLayout.setMinimized(false)
     }, {
-      undoStringKey: "DG.Undo.guide.show",
-      redoStringKey: "DG.Redo.guide.show",
-      log: logMessageWithReplacement("Show Guide", {}, "document")
+      undoStringKey: "V3.Undo.tile.show",
+      redoStringKey: "V3.Redo.tile.show",
+      log: logMessageWithReplacement("Show %@", {type}, "document")
     })
   }
 }

--- a/v3/src/components/tool-shelf/tool-shelf-utilities.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf-utilities.tsx
@@ -1,5 +1,7 @@
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { IDocumentContentModel } from "../../models/document/document-content"
+import { uiState } from "../../models/ui-state"
+import { isFreeTileLayout } from "../../models/document/free-tile-row"
 import { kWebViewTileType } from "../web-view/web-view-defs"
 import { isWebViewModel } from "../web-view/web-view-model"
 
@@ -16,3 +18,20 @@ export const showWebView = (url: string, documentContent?: IDocumentContentModel
     log: logMessageWithReplacement("Show web view: %@", {url}, "document")
   })
 }
+
+export const handleSelectTile = (tileId: string, documentContent?: IDocumentContentModel) => {
+  uiState.setFocusedTile(tileId)
+  const tileRow = documentContent?.findRowContainingTile(tileId)
+  const tileLayout = tileRow?.getTileLayout(tileId)
+  if (isFreeTileLayout(tileLayout) && (tileLayout.isHidden || tileLayout.isMinimized)) {
+    documentContent?.applyModelChange(() => {
+      tileLayout.setHidden(false)
+      tileLayout.setMinimized(false)
+    }, {
+      undoStringKey: "DG.Undo.guide.show",
+      redoStringKey: "DG.Redo.guide.show",
+      log: logMessageWithReplacement("Show Guide", {}, "document")
+    })
+  }
+}
+

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -30,9 +30,10 @@ export function isShelfTileComponent(info?: ITileComponentInfo): info is IShelfT
   return !!info && "shelf" in info && info.shelf != null
 }
 
-function hasGuideTile(document: IDocumentModel): boolean {
+function hasGuideTile(document: IDocumentModel) {
   const tiles = document?.content?.getTilesOfType(kWebViewTileType) ?? []
-  return tiles.some(tile => isWebViewModel(tile.content) && tile.content.isGuide)
+  const guideTile = tiles.find(tile => isWebViewModel(tile.content) && tile.content.isGuide)
+  return guideTile?.id ?? ''
 }
 
 interface IRightButtonEntry {
@@ -87,8 +88,7 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
         ? [{
           icon: <GuideIcon className="icon-guide"/>,
           labelKey: "DG.ToolButtonData.guideMenu.title",
-          hintKey: "DG.ToolButtonData.guideMenu.toolTip",
-          isDisabled: () => true
+          hintKey: "DG.ToolButtonData.guideMenu.toolTip"
         }]
         : []
     )

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -21,6 +21,7 @@ import { isWebViewModel } from "../web-view/web-view-model"
 import { TilesListShelfButton } from "./tiles-list-button"
 import { PluginsButton } from "./plugins-button"
 import { ToolShelfButton, ToolShelfTileButton } from "./tool-shelf-button"
+import { GuideButton} from "./guide-button"
 
 import "./tool-shelf.scss"
 
@@ -51,6 +52,7 @@ interface IProps {
 }
 export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
   const undoManager = document?.treeManagerAPI?.undoManager
+  const guideTileId = hasGuideTile(document)
   const rightButtons: IRightButtonEntry[] = [
     {
       className: "undo-button",
@@ -84,12 +86,13 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
     },
     // only show the guide button if there is a guide tile in the document
     ...(
-      hasGuideTile(document)
+      guideTileId
         ? [{
           icon: <GuideIcon className="icon-guide"/>,
           labelKey: "DG.ToolButtonData.guideMenu.title",
-          hintKey: "DG.ToolButtonData.guideMenu.toolTip"
-        }]
+          hintKey: "DG.ToolButtonData.guideMenu.toolTip",
+          button: <GuideButton key={t("DG.ToolButtonData.guideMenu.title")} guideTileId={guideTileId} />
+      }]
         : []
     )
   ]

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -31,7 +31,7 @@ export function isShelfTileComponent(info?: ITileComponentInfo): info is IShelfT
   return !!info && "shelf" in info && info.shelf != null
 }
 
-function hasGuideTile(document: IDocumentModel) {
+function getGuideTileId(document: IDocumentModel) {
   const tiles = document?.content?.getTilesOfType(kWebViewTileType) ?? []
   const guideTile = tiles.find(tile => isWebViewModel(tile.content) && tile.content.isGuide)
   return guideTile?.id ?? ''
@@ -52,7 +52,7 @@ interface IProps {
 }
 export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
   const undoManager = document?.treeManagerAPI?.undoManager
-  const guideTileId = hasGuideTile(document)
+  const guideTileId = getGuideTileId(document)
   const rightButtons: IRightButtonEntry[] = [
     {
       className: "undo-button",

--- a/v3/src/components/web-view/web-view-registration.ts
+++ b/v3/src/components/web-view/web-view-registration.ts
@@ -46,6 +46,7 @@ registerTileContentInfo({
   type: kWebViewTileType,
   prefix: kWebViewIdPrefix,
   modelClass: WebViewModel,
+  hideOnClose: (content) => isWebViewModel(content) && content.isGuide,
   defaultContent: () => ({ type: kWebViewTileType }),
   defaultName: () => t("DG.WebView.defaultTitle"),
   getTitle: (tile) => tile.title || t("DG.WebView.defaultTitle"),

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -200,11 +200,13 @@ export const DocumentContentModel = BaseDocumentContentModel
     deleteOrHideTile(tileId: string) {
       const tile = self.getTile(tileId)
       const tileInfo = getTileContentInfo(tile?.content.type)
-      if (tileInfo?.hideOnClose || tileInfo?.isSingleton) {
-        const tileLayout = self.getTileLayoutById(tileId)
-        if (isFreeTileLayout(tileLayout)) {
-          tileLayout.setHidden(true)
-          return
+      if (tileInfo) {
+        if (tileInfo.isSingleton  || (tileInfo.hideOnClose?.(tile?.content))) {
+          const tileLayout = self.getTileLayoutById(tileId)
+          if (isFreeTileLayout(tileLayout)) {
+            tileLayout.setHidden(true)
+            return
+          }
         }
       }
       self.deleteTile(tileId)

--- a/v3/src/models/tiles/tile-content-info.ts
+++ b/v3/src/models/tiles/tile-content-info.ts
@@ -37,7 +37,7 @@ export interface ITileContentInfo {
   getTitle: (tile: ITileLikeModel) => string | undefined;
   getV2Type?: (content: ITileContentModel) => string;
   isSingleton?: boolean; // Only one instance of a tile is open per document (e.g. calculator and guide)
-  hideOnClose?: boolean;
+  hideOnClose?: (content?: ITileContentModel) => boolean;
   addSidecarNotes?: boolean;
   defaultHeight?: number;
   exportNonDefaultHeight?: boolean;

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -132,6 +132,10 @@
     "V3.Undo.webView.changeUrl": "Undo changing web page url",
     "V3.Redo.webView.changeUrl": "Redo changing web page url",
 
+    // Miscellaneous V3 strings that are not present in V2 and will eventually require translation.
+    "V3.Undo.tile.show": "Undo showing tile",
+    "V3.Redo.tile.show": "Redo showing tile",
+
     // V3 plugin strings that are not present in V2 and will eventually require translation.
     "V3.Undo.plugin.create": "Undo adding %@ plugin",
     "V3.Redo.plugin.create": "Redo adding %@ plugin",


### PR DESCRIPTION
[#CODAP-822] Feature: When a Guide is present in a document the Guide button should be present, enabled and functional

* Made it so the Guide button is present and enabled when a guide exists
* Defined a `GuideButton` component and gave it the ability to show the guide and set the page from those available
* Moved handleSelectTile from tiles-list-button.tsx to guide-button.tsx
* Made `ITileContentInfo.hideOnClose` a function so that the guide subType of `WebViewModel` could override the default.
* Required `Container.handleCloseTile` to go through `DocumentContentModel.deleteOrHideTile` so that a guide is hidden rather than deleted.