### PR TITLE
fix: V2 doc won't open in V3 (group key import bug)

### DIFF
--- a/v3/src/v2/codap-v2-data-set-importer.ts
+++ b/v3/src/v2/codap-v2-data-set-importer.ts
@@ -1,5 +1,5 @@
 import { SetRequired } from "type-fest"
-import { ICollectionModel, ICollectionModelSnapshot } from "../models/data/collection"
+import { ICollectionModel, ICollectionModelSnapshot, makeGroupKey } from "../models/data/collection"
 import { IDataSet, toCanonical } from "../models/data/data-set"
 import { ICaseCreation, IItem } from "../models/data/data-set-types"
 import { importV2CategorySet, V2CategorySetInput } from "../models/data/v2-category-set-importer"
@@ -242,8 +242,7 @@ export class CodapV2DataSetImporter {
         const groupValues = v2CollectionInfo.groupAttrNames.map(name => {
           return caseValues[name] != null ? String(caseValues[name]) : ""
         })
-        const groupKey = JSON.stringify(groupValues)
-        v2CollectionInfo.groupKeyCaseIds.set(groupKey, v3CaseId)
+        groupKeyCaseIds.set(makeGroupKey(groupValues), v3CaseId)
       }
     })
     if (itemsToAdd.length) {


### PR DESCRIPTION
[[CODAP-941](https://concord-consortium.atlassian.net/browse/CODAP-941)] V2 doc won't open in V3

There are some subtleties here. To maintain persistent case ids, we must store the necessary mappings between item ids and values and their corresponding case ids. Specifically, for child collections item ids map directly to case ids, while for parent collections a set of values for the attributes in the collection is mapped to a case id. Internally, this is called the group key, and the serialized form of parent collection group keys has changed over time. Initially, it was just a `JSON.stringify`ed array of attribute values. In #2006 it was changed to be a tab-delimited "array" of values for performance reasons. There were two problems with the implementation in #2006, however. The first is that the choice of `[` and `]` to delimit the group key is a poor one given that it makes it ambiguous whether this is a `JSON.stringify`ed array or a newer group key. The second is that the code to import v2 documents was not updated to use the new group key format, resulting in v2 documents going through the legacy import path unnecessarily. With this PR we switch to using `\r` to delimit the beginning/end of parent group keys, and switch v2 import to use the new group key format. There is `preProcessSnapshot` code in the `CollectionModel` which handles the various legacy formats.

[CODAP-941]: https://concord-consortium.atlassian.net/browse/CODAP-941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ