### PR TITLE
CODAP-949 New plugin api for fusing dots into rectangles

### DIFF
--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -332,7 +332,8 @@ export const graphComponentHandler: DIComponentHandler = {
       filterFormula, hiddenCases, numberToggleLastMode: showOnlyLastCase, pointColor,
       pointSize, showConnectingLines, showMeasuresForSelection, strokeColor, strokeSameAsFill, transparent,
       xAttributeType, xLowerBound, xUpperBound, yAttributeID, yAttributeIDs, yAttributeName, yAttributeNames,
-      yAttributeType, yLowerBound, yUpperBound, y2AttributeType, y2LowerBound, y2UpperBound
+      yAttributeType, yLowerBound, yUpperBound, y2AttributeType, y2LowerBound, y2UpperBound,
+      pointsAreFusedIntoBars
     } = values as V2GetGraph
     const attributeInfo = getAttributeInfo(values)
     const { dataConfiguration, pointDescription } = content
@@ -461,6 +462,13 @@ export const graphComponentHandler: DIComponentHandler = {
     if (strokeColor != null) pointDescription.setPointStrokeColor(strokeColor)
     if (strokeSameAsFill != null) pointDescription.setPointStrokeSameAsFill(strokeSameAsFill)
     if (transparent != null) content.setIsTransparent(transparent)
+    if (pointsAreFusedIntoBars != null) {
+      const pointsCanBeFused = content.pointsCanBeFusedIntoBars()
+      if (pointsAreFusedIntoBars && !pointsCanBeFused) {
+        return errorResult(t("V3.DI.Error.cannotFusePointsIntoBars"))
+      }
+      content.fusePointsIntoBars(pointsAreFusedIntoBars)
+    }
 
     return { success: true }
   }

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -564,6 +564,14 @@ export const GraphContentModel = DataDisplayContentModel
       }
       self.setPlotType(newPlotType)
     },
+    pointsCanBeFusedIntoBars(): boolean {
+      const primaryRole = self.dataConfiguration.primaryRole
+      const primaryType = primaryRole ? self.dataConfiguration.attributeType(primaryRole) : undefined
+      const secondaryRole = self.dataConfiguration.secondaryRole
+      const secondaryType = secondaryRole ? self.dataConfiguration.attributeType(secondaryRole) : undefined
+      return self.plot.displayType !== "bars" && secondaryType === undefined &&
+        (isCategoricalAttributeType(primaryType) || isNumericAttributeType(primaryType))
+    },
     fusePointsIntoBars(fuseIntoBars: boolean) {
       if (fuseIntoBars !== (self.plot.displayType === "bars")) {
         const transformMap: Partial<Record<PlotType, PlotType>> = {

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -108,6 +108,7 @@ export interface V2Graph extends V2Component {
   y2AttributeType?: string
   y2LowerBound?: number
   y2UpperBound?: number
+  pointsAreFusedIntoBars?: boolean
 }
 export interface V2GetGraph extends V2Graph {
   xLowerBound?: number

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -173,6 +173,7 @@
     "V3.DI.Error.componentNotCreated": "Could not create component",
     "V3.DI.Error.downloadCSV": "Failed to download and import CSV: %{url}",
     "V3.DI.Error.illegalAttributeAssignment": "Cannot assign %@1 to %@2",
+    "V3.DI.Error.cannotFusePointsIntoBars": "Current plot type does not support fusing points into bars",
     "V3.DI.Error.componentNotFound": "Component not found",
     "V3.DI.Error.unsupportedComponent": "Unsupported component type %@",
     "V3.DI.Error.globalCreation": "error creating global value",


### PR DESCRIPTION
[#CODAP-949] Feature: Plugin API allows "Fuse Dots into Rectangles"

* We add `pointesAreFusedIntoBars` to `V2Graph` so that this becomes a property specifiable in the update of a graph component.
* In graph-component-handler.ts `update` we detect the presence of this property and pass it to the `GraphContentModel` using the existing `fusePointsIntoBars`. If the property is true, we preflight by calling the new method `pointsCanBeFusedIntoBars` and return an error if this is not true.
* Also started a branch, `V3-changes-to-wiki` in the `codap.wiki` project to document this new api.