### PR TITLE
CODAP-844 Dot plot crash on setting point size to zero

### DIFF
--- a/v3/src/components/graph/plots/dot-plot/dot-plot-utils.ts
+++ b/v3/src/components/graph/plots/dot-plot/dot-plot-utils.ts
@@ -164,7 +164,7 @@ export const computeBinPlacements = (props: IComputeBinPlacements) => {
   const bins: Record<string, Record<string, Record<string, string[][]>>> = {}
   const binMap: Record<string, BinMap> = {}
 
-  if (primaryAxisScale) {
+  if (primaryAxisScale && pointDiameter > 0) {
     dataConfig?.getCaseDataArray(0).forEach((aCaseData: CaseData) => {
       const anID = aCaseData.caseID
       const caseValue = dataDisplayGetNumericValue(dataset, anID, primaryAttrID) ?? -1

--- a/v3/src/components/web-view/component-handler-web-view.test.ts
+++ b/v3/src/components/web-view/component-handler-web-view.test.ts
@@ -1,4 +1,3 @@
-import { kTitleBarHeight } from "../constants"
 import { V2Game, V2WebView } from "../../data-interactive/data-interactive-component-types"
 import { DIComponentInfo } from "../../data-interactive/data-interactive-types"
 import { diComponentHandler } from "../../data-interactive/handlers/component-handler"

--- a/v3/src/data-interactive/handlers/interactive-frame-handler.test.ts
+++ b/v3/src/data-interactive/handlers/interactive-frame-handler.test.ts
@@ -1,4 +1,3 @@
-import { kTitleBarHeight } from "../../components/constants"
 import { kDefaultWebViewHeight, kDefaultWebViewWidth } from "../../components/web-view/web-view-registration"
 import { kWebViewTileType } from "../../components/web-view/web-view-defs"
 import {


### PR DESCRIPTION
[#CODAP-884] Bug fix: Dot plot crash on setting point diameter to zero

* In dot-plot-utils.ts `computeBinPlacements` the number of bins was being computed as infinite when `pointDiameter` === 0. In this situation we bail from the computation since nothing is going to be display anyway.
* Also fixed two lint errors from prior commit