### PR TITLE
fix: date string concatenation

### DIFF
--- a/v3/src/models/formula/functions/operators.ts
+++ b/v3/src/models/formula/functions/operators.ts
@@ -1,4 +1,4 @@
-import { checkDate } from '../../../utilities/date-utils'
+import { checkDate, formatDate } from '../../../utilities/date-utils'
 import { checkNumber } from '../../../utilities/math-utils'
 import { equal } from './function-utils'
 
@@ -133,6 +133,14 @@ export const operators = {
       }
       if (isANumber && isBDate) {
         return new Date(aNumber * 1000 + bDate.valueOf())
+      }
+
+      // concatenate a date with a string
+      if (isADate && typeof b === "string") {
+        return formatDate(aDate) + b
+      }
+      if (typeof a === "string" && isBDate) {
+        return a + formatDate(bDate)
       }
 
       // Numbers

--- a/v3/src/utilities/date-parser.ts
+++ b/v3/src/utilities/date-parser.ts
@@ -1,5 +1,5 @@
 import { isStdISODateString, parseStdISODateString } from "./date-iso-utils"
-import { isFiniteNumber } from "./math-utils"
+import { isFiniteNumber, isValueEmpty } from "./math-utils"
 import { t } from "./translation/translate"
 
 /**
@@ -238,12 +238,9 @@ export function isValidDateSpec(dateSpec: DateSpec) {
 }
 
 export function parseDateV2Compatible(iValue: any, iLoose?: boolean) {
-  if (iValue == null) {
-    return null
-  }
-  if (iValue instanceof Date) {
-    return iValue
-  }
+  if (isValueEmpty(iValue)) return null
+  if (iValue instanceof Date) return iValue
+
   iValue = String(iValue)
   if (isStdISODateString(iValue)) {
     return parseStdISODateString(iValue)
@@ -278,6 +275,8 @@ export function parseDateV2Compatible(iValue: any, iLoose?: boolean) {
 }
 
 export function parseDateV3(value: any) {
+  if (isValueEmpty(value)) return null
+
   // Built-in date parser might not be the best, but it likely supports more formats than we do currently and
   // it's only used in the loose mode.
   const date = new Date(value)
@@ -285,8 +284,10 @@ export function parseDateV3(value: any) {
 }
 
 export function parseDate(value: any, loose?: boolean) {
+  if (isValueEmpty(value)) return null
+
   const v2CompatibleParserResult = parseDateV2Compatible(value, loose)
-  // If the v2 compatible parser found a valid date, always return it for backwards compatibility
+  // If the v2 compatible parser found a valid date, always return it for backward compatibility
   if (v2CompatibleParserResult != null) {
     return v2CompatibleParserResult
   }

--- a/v3/src/utilities/math-utils.test.ts
+++ b/v3/src/utilities/math-utils.test.ts
@@ -1,5 +1,7 @@
 import {FormatLocaleDefinition, format, formatLocale} from "d3-format"
-import { between, isFiniteNumber, isValueNonEmpty, isNumber, extractNumeric, chooseDecimalPlaces } from "./math-utils"
+import {
+  between, checkNumber, chooseDecimalPlaces, extractNumeric, isFiniteNumber, isNumber, isValueNonEmpty
+} from "./math-utils"
 
 // default formatting except uses ASCII minus sign
 const asciiLocale = formatLocale({ minus: "-" } as FormatLocaleDefinition)
@@ -90,6 +92,22 @@ describe("math-utils", () => {
       expect(isNumber("abc")).toBe(false)
       expect(isNumber(null)).toBe(false)
       expect(isNumber(undefined)).toBe(false)
+    })
+  })
+
+  describe("checkNumber", () => {
+    it("should return [true, number] for numbers", () => {
+      expect(checkNumber(0)).toEqual([true, 0])
+      expect(checkNumber("0")).toEqual([true, 0])
+      expect(checkNumber(1.23)).toEqual([true, 1.23])
+      expect(checkNumber("1.23")).toEqual([true, 1.23])
+    })
+    it("should return [false] for non-numbers", () => {
+      expect(checkNumber("")).toEqual([false])
+      expect(checkNumber(" ")).toEqual([false])
+      expect(checkNumber("abc")).toEqual([false])
+      expect(checkNumber(null)).toEqual([false])
+      expect(checkNumber(undefined)).toEqual([false])
     })
   })
 

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -159,6 +159,7 @@ export const isNumber = (v: any) => isValueNonEmpty(v) && !isNaN(Number(v))
 export function checkNumber(value: any) : [false] | [true, number] {
   if (typeof value === "number") return [true, value]
   if (value == null || value === "") return [false]
+  if (typeof value === "string" && value.trim() === "") return [false]
   const result = Number(value)
   return isNaN(result) ? [false] : [true, result]
 }
@@ -173,7 +174,7 @@ export const extractNumeric = (v: any) => {
     return num
   }
 
-  // Based on the V2 implementation for the backward compatibility.
+  // Based on the V2 implementation for backward compatibility.
   if (typeof v === 'string') {
     const noNumberPattern = /[^.\d-]+/gm
     const firstNumericPattern = /(^-?\.?[\d]+(?:\.?[\d]*)?)/gm


### PR DESCRIPTION
[[CODAP-927](https://concord-consortium.atlassian.net/browse/CODAP-927)] Date-time formula computation not conforming to V2 standards

There were two issues:
1. Concatenation of dates and strings needs to be special-cased in the `add` (i.e. `+`) operator.
2. More subtly, the `checkNumber()` function, used to determine whether a value should be treated as a number, was treating `" "` as a number, because `Number(" ") === 0` 🤷.


[CODAP-927]: https://concord-consortium.atlassian.net/browse/CODAP-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ