### PR TITLE
CODAP-912 Use correct color for map boundary strokes

### DIFF
--- a/v3/src/components/map/components/map-polygon-layer.tsx
+++ b/v3/src/components/map/components/map-polygon-layer.tsx
@@ -50,7 +50,9 @@ export const MapPolygonLayer = function MapPolygonLayer(props: {
           : (isSelected ? kMapAreaNoLegendSelectedColor : displayItemDescription.itemColor),
         strokeColor = hasLegend
           ? (isSelected ? kMapAreaWithLegendSelectedBorderColor
-            : dataConfiguration.getLegendColorForCase(featureCaseID))
+            : (displayItemDescription.itemStrokeSameAsFill
+                ? dataConfiguration.getLegendColorForCase(featureCaseID)
+                : displayItemDescription.itemStrokeColor))
           : (isSelected ? kMapAreaNoLegendSelectedBorderColor : displayItemDescription.itemStrokeColor),
         opacity = kDefaultMapFillOpacity,
         weight = isSelected ? kMapAreaSelectedBorderWeight : kMapAreaUnselectedBorderWeight


### PR DESCRIPTION
[#CODAP-912] Bug fix: Map boundaries not being painted correctly when map has legend

* `refreshPolygonStyles` in map-polygon-layer.tsx was always returning the legend color for the case as the stroke color instead of only doing that when `itemStrokeSameAsFill` was true.