### PR TITLE
CODAP-907 Open image of map in draw tool

### DIFF
--- a/v3/src/components/data-display/data-display-image-utils.ts
+++ b/v3/src/components/data-display/data-display-image-utils.ts
@@ -1,0 +1,39 @@
+import { getTitle } from "../../models/tiles/tile-content-info"
+import { getTileInfo } from "../../models/document/tile-utils"
+import { getPositionOfNewComponent } from "../../utilities/view-utils"
+import { ITileModel } from "../../models/tiles/tile-model"
+import { IWebViewSnapshot } from "../web-view/web-view-model"
+import { kWebViewTileType } from "../web-view/web-view-defs"
+import { getDrawToolPluginUrl } from "../../constants"
+import { appState } from "../../models/app-state"
+import { isFreeTileRow } from "../../models/document/free-tile-row"
+
+export const openInDrawTool = async (tile: ITileModel, imageString: string) => {
+  const title = (tile && getTitle?.(tile)) || tile?.title || ""
+  const { dimensions = { width: 400, height: 300 } } = tile?.id ? getTileInfo(tile?.id || '') : {}
+  const computedPosition = getPositionOfNewComponent(dimensions)
+  const webViewModelSnap: IWebViewSnapshot = {
+    type: kWebViewTileType,
+    subType: "plugin",
+    url: getDrawToolPluginUrl(),
+  }
+  const drawTileModel = appState.document.content?.insertTileSnapshotInDefaultRow({
+    _title: `Draw: ${title}`,
+    content: webViewModelSnap
+  })
+  const drawContentModel = drawTileModel?.content
+  if (drawContentModel && imageString) {
+    // Give the draw tool a moment to initialize before passing the image to it
+    setTimeout(() => {
+      drawContentModel.broadcastMessage({
+        action: "update",
+        resource: 'backgroundImage',
+        values: { image: imageString }
+      }, () => null)
+      const row = appState.document.content?.findRowContainingTile(drawTileModel?.id)
+      const freeTileRow = row && isFreeTileRow(row) ? row : undefined
+      freeTileRow?.setTilePosition(drawTileModel?.id, computedPosition)
+    }, 500)
+  }
+}
+

--- a/v3/src/components/map/components/codap-map.tsx
+++ b/v3/src/components/map/components/codap-map.tsx
@@ -1,4 +1,4 @@
-import React, {MutableRefObject, useCallback, useEffect, useRef} from "react"
+import React, {useCallback, useEffect, useRef} from "react"
 import {observer} from "mobx-react-lite"
 import {clsx} from "clsx"
 import {MapContainer, TileLayer} from "react-leaflet"
@@ -25,17 +25,23 @@ import {MapGridSlider} from "./map-grid-slider"
 import "leaflet/dist/leaflet.css"
 import "./map.scss"
 interface IProps {
-  mapRef: MutableRefObject<HTMLDivElement | null>
+  setMapRef: (ref: HTMLDivElement | null) => void
 }
 
-export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
+export const CodapMap = observer(function CodapMap({setMapRef}: IProps) {
   const mapModel = useMapModelContext(),
     layout = useDataDisplayLayout(),
     mapHeight = layout.contentHeight,
     interiorDivRef = useRef<HTMLDivElement>(null),
     prevMapSize = useRef<{ width: number, height: number, legend: number }>({width: 0, height: 0, legend: 0}),
     forceUpdate = useForceUpdate(),
+    mapRef = useRef<HTMLDivElement | null>(null),
     {pixiPointsArray, setPixiPointsLayer} = usePixiPointsArray()
+
+  const mySetMapRef = (ref: HTMLDivElement | null) => {
+    mapRef.current = ref
+    setMapRef(ref)
+  }
 
   // trigger an additional render once references have been fulfilled
   useEffect(() => forceUpdate(), [forceUpdate])
@@ -117,7 +123,7 @@ export const CodapMap = observer(function CodapMap({mapRef}: IProps) {
   }, [mapModel, mapRef])
 
   return (
-    <div className={clsx('map-container', kPortalClass)} ref={mapRef} data-testid="map">
+    <div className={clsx('map-container', kPortalClass)} ref={mySetMapRef} data-testid="map">
       <div className="leaflet-wrapper" style={{height: mapHeight}} ref={interiorDivRef}>
         <MapContainer center={mapModel.center} zoom={mapModel.zoom} scrollWheelZoom={false}
                       zoomSnap={0} trackResize={true}>

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -1,18 +1,35 @@
-import { MenuList } from "@chakra-ui/react"
+import { MenuItem, MenuList } from "@chakra-ui/react"
 import React from "react"
 import { ITileModel } from "../../../../models/tiles/tile-model"
 import { t } from "../../../../utilities/translation/translate"
 import { UnimplementedMenuItem } from "../../../beta/unimplemented-menu-item"
+import { openInDrawTool } from "../../../data-display/data-display-image-utils"
+import { isMapContentModel } from "../../models/map-content-model"
 
 interface IProps {
   tile?: ITileModel
 }
 
 export const SaveImageMenuList = ({tile}: IProps) => {
+  const mapModel = isMapContentModel(tile?.content) ? tile?.content : undefined
+
+  const getImageString = async () => {
+    if (!mapModel?.renderState) return ''
+    // todo: updateSnapshot calls code that is clearly graph-specific. Does it work for maps?
+    await mapModel.renderState.updateSnapshot()
+    return mapModel.renderState.dataUri || ''
+  }
 
   return (
     <MenuList data-testid="save-image-menu-list">
-      <UnimplementedMenuItem label={t('DG.DataDisplayMenu.copyAsImage')} />
+      <MenuItem data-testid="open-in-draw-tool" onClick={ async () => {
+        if (tile) {
+          const imageString = await getImageString()
+          await openInDrawTool(tile, imageString)
+        }
+      }}>
+        {t("DG.DataDisplayMenu.copyAsImage")}
+      </MenuItem>
       <UnimplementedMenuItem label={t('DG.DataDisplayMenu.exportPngImage')} />
       <UnimplementedMenuItem label={t('DG.DataDisplayMenu.exportSvgImage')} />
     </MenuList>

--- a/v3/src/components/map/components/map-component.tsx
+++ b/v3/src/components/map/components/map-component.tsx
@@ -1,10 +1,12 @@
 import {useDroppable} from '@dnd-kit/core'
 import {observer} from "mobx-react-lite"
-import React, {useRef} from "react"
+import React, { useCallback, useRef } from "react"
 import {InstanceIdContext, useNextInstanceId} from "../../../hooks/use-instance-id-context"
 import {ITileBaseProps} from '../../tiles/tile-base-props'
 import {DataDisplayLayoutContext} from "../../data-display/hooks/use-data-display-layout"
 import {AttributeDragOverlay} from "../../drag-drop/attribute-drag-overlay"
+import { DataDisplayRenderState } from "../../data-display/models/data-display-render-state"
+import { usePixiPointsArray } from "../../data-display/hooks/use-pixi-points-array"
 import {isMapContentModel} from "../models/map-content-model"
 import {MapModelContext} from "../hooks/use-map-model-context"
 import {useInitMapLayout} from "../hooks/use-init-map-layout"
@@ -16,11 +18,24 @@ export const MapComponent = observer(function MapComponent({tile}: ITileBaseProp
   const instanceId = useNextInstanceId("map")
   const layout = useInitMapLayout(mapModel)
   const mapRef = useRef<HTMLDivElement | null>(null)
+  const {pixiPointsArray} = usePixiPointsArray({ addInitialPixiPoints: true })
 
   // used to determine when a dragged attribute is over the map component
   const dropId = `${instanceId}-component-drop-overlay`
   const {setNodeRef} = useDroppable({id: dropId})
   setNodeRef(mapRef.current ?? null)
+
+  // Todo: This routine is modeled on the one in graph-component.tsx. But it's not clear that this is correct.
+  // In particular, pixiPointsArray is also used in codap-map.tsx.
+  const setMapRef = useCallback((ref: HTMLDivElement | null) => {
+    mapRef.current = ref
+    const elementParent = ref?.parentElement
+    const dataUri = mapModel?.renderState?.dataUri
+    if (elementParent) {
+      const renderState = new DataDisplayRenderState(pixiPointsArray, elementParent, dataUri)
+      mapModel?.setRenderState(renderState)
+    }
+  }, [mapModel, pixiPointsArray])
 
   if (!mapModel) return null
 
@@ -28,7 +43,7 @@ export const MapComponent = observer(function MapComponent({tile}: ITileBaseProp
     <InstanceIdContext.Provider value={instanceId}>
       <DataDisplayLayoutContext.Provider value={layout}>
         <MapModelContext.Provider value={mapModel}>
-          <CodapMap mapRef={mapRef}/>
+          <CodapMap setMapRef={setMapRef}/>
           <AttributeDragOverlay dragIdPrefix={instanceId}/>
         </MapModelContext.Provider>
       </DataDisplayLayoutContext.Provider>


### PR DESCRIPTION
[#CODAP-907] Feature: Maps respond to the "Open in Draw Tool" menu item under the Image icon to open a draw tool plugin with the map image

Note: This PR brings about the opening of a map image in the draw tool. HOWEVER the image is incomplete. 

* Factored out `OpenInDrawTool` so that it can be called from save-image-menu-list.tsx.
* Provide mapModel with a renderState in map-component.tsx using the analogous code in graph-component.tsx.