### PR TITLE
chore: style cfm dialogs with new color scheme (CODAP-1193)

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -16,7 +16,7 @@
         "@codemirror/commands": "^6.10.1",
         "@codemirror/language": "^6.12.1",
         "@codemirror/view": "^6.39.11",
-        "@concord-consortium/cloud-file-manager": "^2.2.7",
+        "@concord-consortium/cloud-file-manager": "github:concord-consortium/cloud-file-manager#CODAP-1193-new-teal-color-scheme",
         "@concord-consortium/log-monitor": "^1.0.0",
         "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@concord-consortium/slate-editor": "^0.12.0",
@@ -4322,8 +4322,7 @@
     },
     "node_modules/@concord-consortium/cloud-file-manager": {
       "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.7.tgz",
-      "integrity": "sha512-ZS2wAtAj32MZ3Kx8v7hc/WcRpQfjpsyYfFGT/mW5igW+YQxvg2XudgjrixpihOik/ghDrKi7YUJyKn4A0yEcNg==",
+      "resolved": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#3331d605acbd5cc5c3cf744185e22dc95af70e91",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",
@@ -36264,9 +36263,8 @@
       }
     },
     "@concord-consortium/cloud-file-manager": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.7.tgz",
-      "integrity": "sha512-ZS2wAtAj32MZ3Kx8v7hc/WcRpQfjpsyYfFGT/mW5igW+YQxvg2XudgjrixpihOik/ghDrKi7YUJyKn4A0yEcNg==",
+      "version": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#3331d605acbd5cc5c3cf744185e22dc95af70e91",
+      "from": "@concord-consortium/cloud-file-manager@github:concord-consortium/cloud-file-manager#CODAP-1193-new-teal-color-scheme",
       "requires": {
         "@aws-sdk/client-s3": "^3.980.0",
         "@concord-consortium/lara-interactive-api": "^1.12.0",

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -4322,7 +4322,7 @@
     },
     "node_modules/@concord-consortium/cloud-file-manager": {
       "version": "2.2.7",
-      "resolved": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#3331d605acbd5cc5c3cf744185e22dc95af70e91",
+      "resolved": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#8cce2b122f056dc72d4ca312d1da03a8af40a676",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",
@@ -36263,7 +36263,7 @@
       }
     },
     "@concord-consortium/cloud-file-manager": {
-      "version": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#3331d605acbd5cc5c3cf744185e22dc95af70e91",
+      "version": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#8cce2b122f056dc72d4ca312d1da03a8af40a676",
       "from": "@concord-consortium/cloud-file-manager@github:concord-consortium/cloud-file-manager#CODAP-1193-new-teal-color-scheme",
       "requires": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -4322,7 +4322,7 @@
     },
     "node_modules/@concord-consortium/cloud-file-manager": {
       "version": "2.2.7",
-      "resolved": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#8cce2b122f056dc72d4ca312d1da03a8af40a676",
+      "resolved": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#0c74ff41f02c19397384d811990e7243c5ba067c",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",
@@ -36263,7 +36263,7 @@
       }
     },
     "@concord-consortium/cloud-file-manager": {
-      "version": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#8cce2b122f056dc72d4ca312d1da03a8af40a676",
+      "version": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#0c74ff41f02c19397384d811990e7243c5ba067c",
       "from": "@concord-consortium/cloud-file-manager@github:concord-consortium/cloud-file-manager#CODAP-1193-new-teal-color-scheme",
       "requires": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -4322,7 +4322,7 @@
     },
     "node_modules/@concord-consortium/cloud-file-manager": {
       "version": "2.2.7",
-      "resolved": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#0c74ff41f02c19397384d811990e7243c5ba067c",
+      "resolved": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#68f139d73651d65dd8fd0c582d44258c592b47b1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",
@@ -36263,7 +36263,7 @@
       }
     },
     "@concord-consortium/cloud-file-manager": {
-      "version": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#0c74ff41f02c19397384d811990e7243c5ba067c",
+      "version": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#68f139d73651d65dd8fd0c582d44258c592b47b1",
       "from": "@concord-consortium/cloud-file-manager@github:concord-consortium/cloud-file-manager#CODAP-1193-new-teal-color-scheme",
       "requires": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -16,7 +16,7 @@
         "@codemirror/commands": "^6.10.1",
         "@codemirror/language": "^6.12.1",
         "@codemirror/view": "^6.39.11",
-        "@concord-consortium/cloud-file-manager": "github:concord-consortium/cloud-file-manager#CODAP-1193-new-teal-color-scheme",
+        "@concord-consortium/cloud-file-manager": "^2.2.8",
         "@concord-consortium/log-monitor": "^1.0.0",
         "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@concord-consortium/slate-editor": "^0.12.0",
@@ -4321,8 +4321,9 @@
       }
     },
     "node_modules/@concord-consortium/cloud-file-manager": {
-      "version": "2.2.7",
-      "resolved": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#68f139d73651d65dd8fd0c582d44258c592b47b1",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.8.tgz",
+      "integrity": "sha512-sb41I32HiUGG5QdThToqtSdAGIGZ8stpZ8Tl7E60bC/Q56lIMX9q0z9nQx5/Ny9Lnxvy8iLfBY6YW5m/gibcVA==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",
@@ -36263,8 +36264,9 @@
       }
     },
     "@concord-consortium/cloud-file-manager": {
-      "version": "git+ssh://git@github.com/concord-consortium/cloud-file-manager.git#68f139d73651d65dd8fd0c582d44258c592b47b1",
-      "from": "@concord-consortium/cloud-file-manager@github:concord-consortium/cloud-file-manager#CODAP-1193-new-teal-color-scheme",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.8.tgz",
+      "integrity": "sha512-sb41I32HiUGG5QdThToqtSdAGIGZ8stpZ8Tl7E60bC/Q56lIMX9q0z9nQx5/Ny9Lnxvy8iLfBY6YW5m/gibcVA==",
       "requires": {
         "@aws-sdk/client-s3": "^3.980.0",
         "@concord-consortium/lara-interactive-api": "^1.12.0",

--- a/v3/package.json
+++ b/v3/package.json
@@ -197,7 +197,7 @@
     "@codemirror/commands": "^6.10.1",
     "@codemirror/language": "^6.12.1",
     "@codemirror/view": "^6.39.11",
-    "@concord-consortium/cloud-file-manager": "github:concord-consortium/cloud-file-manager#CODAP-1193-new-teal-color-scheme",
+    "@concord-consortium/cloud-file-manager": "^2.2.8",
     "@concord-consortium/log-monitor": "^1.0.0",
     "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
     "@concord-consortium/slate-editor": "^0.12.0",

--- a/v3/package.json
+++ b/v3/package.json
@@ -197,7 +197,7 @@
     "@codemirror/commands": "^6.10.1",
     "@codemirror/language": "^6.12.1",
     "@codemirror/view": "^6.39.11",
-    "@concord-consortium/cloud-file-manager": "^2.2.7",
+    "@concord-consortium/cloud-file-manager": "github:concord-consortium/cloud-file-manager#CODAP-1193-new-teal-color-scheme",
     "@concord-consortium/log-monitor": "^1.0.0",
     "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
     "@concord-consortium/slate-editor": "^0.12.0",

--- a/v3/src/components/codap-modal-v3.scss
+++ b/v3/src/components/codap-modal-v3.scss
@@ -12,7 +12,7 @@ $modal-width: 350px;
     flex-direction: row;
     align-items: center;
     box-shadow: none;
-    background-color: #a5e3f6;
+    background-color: vars.$accent-light-2;
 
     .codap-modal-icon-container-v3 {
       width: 30px;
@@ -22,11 +22,10 @@ $modal-width: 350px;
       display: flex;
       align-items: center;
       justify-content: center;
-      margin-left: 5px;
     }
 
     .codap-header-title-v3 {
-      padding-left: 3px;
+      padding-left: 5px;
       width: calc(100% - $header-height);
       height: $header-height;
       font-size: 14px;
@@ -42,7 +41,6 @@ $modal-width: 350px;
 
     button {
       top: 0;
-      right: 0;
     }
   }
 
@@ -51,24 +49,10 @@ $modal-width: 350px;
     padding: 0 8px;
     box-sizing: border-box;
     width: inherit;
-
-    .chakra-numberinput {
-      box-sizing: content-box;
-    }
   }
 
   .chakra-modal__footer {
     background-color: white;
-    margin-top: 0;
-    padding-inline-end: 10px;
-
-    button {
-      border: solid 1px vars.$accent;
-      cursor: pointer;
-      font-size: 14px;
-      height: 30px;
-      padding: 10px;
-    }
   }
 
   .chakra-form__label {

--- a/v3/src/components/codap-modal-v3.scss
+++ b/v3/src/components/codap-modal-v3.scss
@@ -22,10 +22,11 @@ $modal-width: 350px;
       display: flex;
       align-items: center;
       justify-content: center;
+      margin-left: 5px;
     }
 
     .codap-header-title-v3 {
-      padding-left: 5px;
+      padding-left: 3px;
       width: calc(100% - $header-height);
       height: $header-height;
       font-size: 14px;
@@ -41,6 +42,7 @@ $modal-width: 350px;
 
     button {
       top: 0;
+      right: 0;
     }
   }
 
@@ -49,10 +51,24 @@ $modal-width: 350px;
     padding: 0 8px;
     box-sizing: border-box;
     width: inherit;
+
+    .chakra-numberinput {
+      box-sizing: content-box;
+    }
   }
 
   .chakra-modal__footer {
     background-color: white;
+    margin-top: 0;
+    padding-inline-end: 10px;
+
+    button {
+      border: solid 1px vars.$accent;
+      cursor: pointer;
+      font-size: 14px;
+      height: 30px;
+      padding: 10px;
+    }
   }
 
   .chakra-form__label {

--- a/v3/src/components/common/color-picker-palette.scss
+++ b/v3/src/components/common/color-picker-palette.scss
@@ -20,7 +20,7 @@ $palette-width: 235px;
   }
 
   &:active {
-    background-color: vars.$palette-header-bg;
+    background-color: vars.$accent-light-2;
   }
 
   &:focus-visible {

--- a/v3/src/components/component-title-bar.scss
+++ b/v3/src/components/component-title-bar.scss
@@ -5,7 +5,7 @@ $button-width: 34px;
 
 .component-title-bar {
   align-items: center;
-  background-color: vars.$title-bar-color;
+  background-color: vars.$accent-light-3;
   border-radius: vars.$border-radius-top-corners;
   container-name: titleBar;
   container-type: inline-size;
@@ -16,11 +16,11 @@ $button-width: 34px;
   width: 100%;
 
   &.focusTile {
-    background-color: vars.$title-bar-focus-color;
+    background-color: vars.$accent-light-1;
 
     .component-title-bar-button {
       &:hover {
-        background-color: vars.$title-bar-color;
+        background-color: vars.$accent-light-3;
       }
 
       &:active {
@@ -155,7 +155,7 @@ $button-width: 34px;
     }
 
     &:hover {
-      background-color: vars.$title-bar-color;
+      background-color: vars.$accent-light-3;
     }
 
     &:focus-visible {
@@ -197,7 +197,7 @@ $button-width: 34px;
     padding: 0;
 
     &:hover {
-      background-color: vars.$title-bar-focus-color;
+      background-color: vars.$accent-light-1;
     }
 
     &:active {

--- a/v3/src/components/inspector-panel.scss
+++ b/v3/src/components/inspector-panel.scss
@@ -152,7 +152,7 @@ $inspector-panel-border-width: 2px;
     align-items: center;
     gap: 5px;
     padding: 0 5px;
-    background-color: vars.$palette-header-bg;
+    background-color: vars.$accent-light-2;
     height: vars.$palette-header-height;
     border-radius: 2px 2px 0 0;
 
@@ -420,13 +420,13 @@ $inspector-panel-border-width: 2px;
       }
 
       &[data-hovered] {
-        background: vars.$title-bar-color;
+        background: vars.$accent-light-3;
         border-color: vars.$palette-icon-color;
       }
 
       &[data-pressed],
       &[aria-expanded="true"] {
-        background: vars.$palette-header-bg;
+        background: vars.$accent-light-2;
       }
 
       .select-arrow {

--- a/v3/src/components/map/components/inspector-panel/map-inspector.scss
+++ b/v3/src/components/map/components/inspector-panel/map-inspector.scss
@@ -65,7 +65,7 @@
             border-radius: 0;
           }
           &.selected {
-            background-color: vars.$palette-header-bg;
+            background-color: vars.$accent-light-2;
             font-weight: 700;
           }
         }

--- a/v3/src/components/menu-bar/user-entry-modal.scss
+++ b/v3/src/components/menu-bar/user-entry-modal.scss
@@ -1,4 +1,8 @@
+@use "../vars";
+
 .user-entry-modal-container {
+  border-radius: vars.$border-radius-four-corners;
+  color: vars.$label-color;
   font-family: "museo-sans", sans-serif;
   display: flex;
   align-items: center;
@@ -8,46 +12,47 @@
   width: 440px;
   max-width: 440px;
   background-color: #fff;
+  overflow: hidden;
 
   .user-entry-modal-header {
-    display: flex;
     align-items: center;
-    justify-content: center;
+    background: url(../../assets/cfm/file-new-icon.nosvgr.svg) no-repeat 5px 5px;
+    background-size: 24px 24px;
+    background-color: vars.$accent-light-2;
+    border-radius: vars.$border-radius-top-corners;
+    display: flex;
+    font-size: 14px;
+    font-weight: 500;
+    height: 34px;
+    padding: 10px 10px 10px 34px;
     width: 100%;
-    height: 30px;
-    background-color: #0b4e5d;
-    border-radius: var(--codap-radii-md) var(--codap-radii-md) 0 0;
-    color: white;
-    font-size: 12px;
-    font-weight: normal;
-    text-transform: uppercase;
-    padding: 10px;
   }
 
   .user-entry-modal-body {
+    border-radius: vars.$border-radius-bottom-corners;
     display: flex;
     flex-direction: column;
     justify-content: center;
     padding: 20px;
 
     .user-entry-button {
-      background-color: #72bfca;
-      color: white;
-      font-size: 15px;
-      text-transform: uppercase;
+      background-color: vars.$accent-light-3;
+      border: solid 1px vars.$accent;
+      border-radius: vars.$border-radius-four-corners;
+      font-size: 14px;
+      font-weight: 500;
+      height: 30px;
       margin: 10px;
 
-      &.default {
-        outline: 2px solid #0085f2;
-        outline-offset: 2px;
-      }
       &:focus-visible {
-        outline: 3px solid #0957d0;
+        outline: 3px solid vars.$focus-outline-color;
         outline-offset: 2px;
       }
       &:hover {
-        background: #3c94a1 !important;
-        color: white;
+        background: vars.$accent-light-2;
+      }
+      &:active {
+        background: vars.$accent-light-1;
       }
 
     }

--- a/v3/src/components/menu-bar/user-entry-modal.scss
+++ b/v3/src/components/menu-bar/user-entry-modal.scss
@@ -3,7 +3,6 @@
 .user-entry-modal-container {
   border-radius: vars.$border-radius-four-corners;
   color: vars.$label-color;
-  font-family: "museo-sans", sans-serif;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/v3/src/components/slider/inspector-panel/slider-settings-panel.scss
+++ b/v3/src/components/slider/inspector-panel/slider-settings-panel.scss
@@ -95,13 +95,13 @@
         padding: 2px 10px;
 
         &[data-hovered] {
-          background: vars.$title-bar-color;
+          background: vars.$accent-light-3;
           border-color: vars.$palette-icon-color;
         }
 
         &[data-pressed],
         &[aria-expanded="true"] {
-          background: vars.$palette-header-bg;
+          background: vars.$accent-light-2;
         }
 
         &[data-focus-visible] {

--- a/v3/src/components/vars.scss
+++ b/v3/src/components/vars.scss
@@ -4,9 +4,12 @@ $tool-shelf-height: 66px; // Horizontal tool shelf
 $beta-banner-height: 50px;
 
 $title-bar-height: 34px;
-$title-bar-color: #bbefff;
-$title-bar-focus-color: #8ddaf2;
 $header-height: 30px;
+
+$accent: #006c8e;
+$accent-light-1: #8ddaf2;
+$accent-light-2: #a5e3f6;
+$accent-light-3: #bbefff;
 
 $border-radius-top-corners: 4px 4px 0px 0px;
 $border-radius-four-corners: 4px;
@@ -46,7 +49,7 @@ $empty-label-font: 12px Roboto, sans-serif;
 $background-fill: #f9f9f9;
 $icon-fill-light: #d3f4ff;
 $icon-fill-medium: #bfefff;
-$icon-fill-dark: #006c8e;
+$icon-fill-dark: $accent; // #006c8e
 $tile-border-color: #0081a9;
 $focus-border-color: #1c9fc7;
 $focus-outline-color: #0957d0;
@@ -60,10 +63,9 @@ $focus-outline-color: #0957d0;
 // Inspector palette design tokens (from Zeplin specs)
 $palette-bg: #ffffff;
 $palette-border-color: $focus-border-color; // #1c9fc7
-$palette-header-bg: #a5e3f6;
 $palette-header-height: 34px;
 $palette-hover-bg: $icon-fill-light; // #d3f4ff
-$palette-icon-color: $icon-fill-dark; // #006c8e
+$palette-icon-color: $accent; // #006c8e
 $palette-pointer-size: 10px;
 $menu-item-hover-bg: #edf2f7;
 $menu-border-color: #e2e8f0;


### PR DESCRIPTION
[CODAP-1193](https://concord-consortium.atlassian.net/browse/CODAP-1193)

These changes augment [this CFM PR](https://github.com/concord-consortium/cloud-file-manager/pull/421) that updates styles for various dialogs:

- Open document
- Import document
- Save document
- Share document
- Rename document
- Confirmation for closing unsaved documents

They mostly apply complimentary styling to the "user entry" modal defined in this repository, and make some color variable names more generic for broader use across components.

**NOTE:** A new release of the updated CFM will be needed, and this PR should be updated to use that release before it is merged.

[CODAP-1193]: https://concord-consortium.atlassian.net/browse/CODAP-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ