### PR TITLE
fix: attribute header has double tab stop (CODAP-1183)

### DIFF
--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -94,20 +94,42 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   // Make the grid element a Tab entry point that uses RDG's selectCell API to focus the first
   // attribute header (idx 1, rowIdx -1). This doesn't interfere with RDG's getCellToScroll
   // (which queries cells within rows, not the grid element itself).
+  //
+  // The grid's own tab stop is only active while focus is outside the grid. Once focus is
+  // inside, we disable it so Shift+Tab from within the grid skips over the grid element —
+  // otherwise the grid becomes a phantom tab stop between the first attribute header and
+  // the add-attribute "+" button.
   useEffect(function makeGridTabbable() {
     const grid = gridRef.current?.element
     if (!grid) return
 
     grid.tabIndex = 0
-    const handleFocus = (e: FocusEvent) => {
-      if (e.target !== grid) return
-      // idx 1 = first attribute column (skipping index column at 0)
-      // rowIdx -1 = the main header row
-      gridRef.current?.selectCell({ idx: 1, rowIdx: -1 })
+    const handleFocusIn = (e: FocusEvent) => {
+      if (e.target === grid) {
+        // Tab entered on the grid element itself → forward to the first attribute header.
+        // idx 1 = first attribute column (skipping index column at 0)
+        // rowIdx -1 = the main header row
+        gridRef.current?.selectCell({ idx: 1, rowIdx: -1 })
+      } else {
+        // A descendant of the grid received focus → disable the grid's tab stop so
+        // Shift+Tab from within skips the grid element.
+        grid.tabIndex = -1
+      }
     }
-    grid.addEventListener("focus", handleFocus)
+    const handleFocusOut = (e: FocusEvent) => {
+      // Focus has left the grid entirely → restore the grid's tab stop for the next entry.
+      const to = e.relatedTarget as Node | null
+      if (!to || !grid.contains(to)) {
+        grid.tabIndex = 0
+      }
+    }
+    grid.addEventListener("focusin", handleFocusIn)
+    grid.addEventListener("focusout", handleFocusOut)
 
-    return () => grid.removeEventListener("focus", handleFocus)
+    return () => {
+      grid.removeEventListener("focusin", handleFocusIn)
+      grid.removeEventListener("focusout", handleFocusOut)
+    }
   }, [gridRef.current?.element])
 
   useEffect(() => {

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -92,13 +92,17 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   // RDG assigns tabindex="0" to the first header cell for Tab entry into the grid.
   // Since that cell is the inert index column header, the grid has no focusable entry point.
   // Make the grid element a Tab entry point that uses RDG's selectCell API to focus the first
-  // attribute header (idx 1, rowIdx -1). This doesn't interfere with RDG's getCellToScroll
-  // (which queries cells within rows, not the grid element itself).
+  // attribute header (rowIdx -1). This doesn't interfere with RDG's getCellToScroll (which
+  // queries cells within rows, not the grid element itself).
+  //
+  // The first attribute column is at idx 1 when the index column is shown, or idx 0 when it
+  // is hidden (see use-columns.tsx — the index column is conditionally prepended).
   //
   // The grid's own tab stop is only active while focus is outside the grid. Once focus is
   // inside, we disable it so Shift+Tab from within the grid skips over the grid element —
   // otherwise the grid becomes a phantom tab stop between the first attribute header and
   // the add-attribute "+" button.
+  const isIndexHidden = caseTableModel?.isIndexHidden ?? false
   useEffect(function makeGridTabbable() {
     const grid = gridRef.current?.element
     if (!grid) return
@@ -107,9 +111,8 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
     const handleFocusIn = (e: FocusEvent) => {
       if (e.target === grid) {
         // Tab entered on the grid element itself → forward to the first attribute header.
-        // idx 1 = first attribute column (skipping index column at 0)
-        // rowIdx -1 = the main header row
-        gridRef.current?.selectCell({ idx: 1, rowIdx: -1 })
+        const firstAttrIdx = isIndexHidden ? 0 : 1
+        gridRef.current?.selectCell({ idx: firstAttrIdx, rowIdx: -1 })
       } else {
         // A descendant of the grid received focus → disable the grid's tab stop so
         // Shift+Tab from within skips the grid element.
@@ -118,8 +121,8 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
     }
     const handleFocusOut = (e: FocusEvent) => {
       // Focus has left the grid entirely → restore the grid's tab stop for the next entry.
-      const to = e.relatedTarget as Node | null
-      if (!to || !grid.contains(to)) {
+      const to = e.relatedTarget
+      if (!(to instanceof Node) || !grid.contains(to)) {
         grid.tabIndex = 0
       }
     }
@@ -130,7 +133,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
       grid.removeEventListener("focusin", handleFocusIn)
       grid.removeEventListener("focusout", handleFocusOut)
     }
-  }, [gridRef.current?.element])
+  }, [gridRef.current?.element, isIndexHidden])
 
   useEffect(() => {
     return registerCanAutoScrollCallback((element) => {

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -108,6 +108,8 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
     if (!grid) return
 
     grid.tabIndex = 0
+    // Two-phase cascade: Tab on grid fires focusin (target=grid) → selectCell → RDG focuses
+    // the attribute header cell → second focusin (target=descendant) sets grid.tabIndex = -1.
     const handleFocusIn = (e: FocusEvent) => {
       if (e.target === grid) {
         // Tab entered on the grid element itself → forward to the first attribute header.


### PR DESCRIPTION
[CODAP-1183](https://concord-consortium.atlassian.net/browse/CODAP-1183)

Fixes a phantom tab stop between the Case Table's Add Attribute "+" button and the first attribute header in the. Previously, `Shift+Tab` from the first attribute header landed on the grid wrapper element (showing a focus ring around the whole data grid) rather than walking past it to the "+" button.

React Data Grid assigns `tabindex="0"` to the first header cell as the grid's Tab entry point. In CODAP, that cell is the inert index column header, so the existing `makeGridTabbable` effect in `collection-table.tsx` gave the grid wrapper element its own `tabindex="0"` and a focus listener that forwarded `Tab` to the first attribute header. That handled forward `Tab` entry but left the grid wrapper itself as a reachable tab stop from within the grid, and so `Shift+Tab` from the attribute header landed on the grid wrapper.


These changes update the existing `makeGridTabbable` effect to remove the grid wrapper from the tab order while focus is inside the grid:

- Switches from a non-bubbling focus listener to `focusin`/`focusout` so descendant focus changes can be observed.
- On `focusin` to a descendant, sets `grid.tabIndex = -1` so `Shift+Tab` moves past the grid wrapper directly to the "+" button.
- On `focusout` to a target outside the grid, restores `grid.tabIndex = 0` so the next `Tab` still works.

Additionally, the hardcoded `idx: 1` is now derived from `caseTableModel?.isIndexHidden`: the first attribute column is at `idx: 0` when the index column is hidden and `idx: 1` when it's shown, matching the conditional ordering in `use-columns.tsx`.

[CODAP-1183]: https://concord-consortium.atlassian.net/browse/CODAP-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ