### PR TITLE
feat: visible dropdown to choose attributes on graphs (CODAP-1137)

### DIFF
--- a/v3/cypress/e2e/adornments.spec.ts
+++ b/v3/cypress/e2e/adornments.spec.ts
@@ -461,7 +461,7 @@ context("Graph adornments", () => {
       // @ts-expect-error -- type definition is incorrect: return value is property value not chained element
       .should("have.css", "left").should((left: string) => {
         expect(left).to.include("px")
-        expect(parseInt(left, 10)).to.be.within(271, 273)
+        expect(parseInt(left, 10)).to.be.within(260, 275)
       })
     // TODO: Test drag and drop of label and saving of dropped coordinates
     cy.get("[data-testid=adornment-checkbox-show-measure-labels]").click()

--- a/v3/cypress/e2e/axis.spec.ts
+++ b/v3/cypress/e2e/axis.spec.ts
@@ -294,7 +294,8 @@ context("Test graph axes with various attribute types", () => {
     ah.verifyXAxisTickMarksDisplayed()
     ah.verifyYAxisTickMarksDisplayed()
     // With multiple y-attributes, each gets its own separate label
-    cy.get("[data-testid=graph]").find("[data-testid=attribute-label]").should("have.text", "LifeSpan")
+    cy.get("[data-testid=graph]").find(".axis-wrapper.bottom [data-testid=attribute-label]")
+      .should("have.text", "LifeSpan")
     cy.get("[data-testid=graph]").find("[data-testid=attribute-label-multi-y]").should("have.length", 2)
     cy.get("[data-testid=graph]").find("[data-testid=attribute-label-multi-y]").eq(0).should("have.text", "Height")
     cy.get("[data-testid=graph]").find("[data-testid=attribute-label-multi-y]").eq(1).should("have.text", "Sleep")
@@ -309,9 +310,10 @@ context("Test graph axes with various attribute types", () => {
     toolbar.getUndoTool().click()
     cy.wait(500)
     // After undo, only one y-attribute remains, so it uses the standard attribute-label
-    cy.get("[data-testid=graph]")
-      .find("[data-testid=attribute-label]")
-      .should("have.text", "LifeSpanHeight")
+    cy.get("[data-testid=graph]").find(".axis-wrapper.bottom [data-testid=attribute-label]")
+      .should("have.text", "LifeSpan")
+    cy.get("[data-testid=graph]").find(".axis-wrapper.left [data-testid=attribute-label]")
+      .should("have.text", "Height")
     cy.get("[data-testid=graph]").find("[data-testid=attribute-label-multi-y]").should("have.length", 0)
     ah.verifyYAxisTickMarksDisplayed()
     ah.verifyAxisTickLabel("left", "0", 0)
@@ -320,7 +322,8 @@ context("Test graph axes with various attribute types", () => {
     toolbar.getRedoTool().click()
     cy.wait(500)
     // After redo, multiple y-attributes restored, each gets its own label
-    cy.get("[data-testid=graph]").find("[data-testid=attribute-label]").should("have.text", "LifeSpan")
+    cy.get("[data-testid=graph]").find(".axis-wrapper.bottom [data-testid=attribute-label]")
+      .should("have.text", "LifeSpan")
     cy.get("[data-testid=graph]").find("[data-testid=attribute-label-multi-y]").should("have.length", 2)
     cy.get("[data-testid=graph]").find("[data-testid=attribute-label-multi-y]").eq(0).should("have.text", "Height")
     cy.get("[data-testid=graph]").find("[data-testid=attribute-label-multi-y]").eq(1).should("have.text", "Sleep")

--- a/v3/cypress/e2e/bivariate-adornments.spec.ts
+++ b/v3/cypress/e2e/bivariate-adornments.spec.ts
@@ -273,9 +273,6 @@ context("Graph adornments", () => {
 
   it("adds connecting lines to the plot when the Connecting Lines checkbox is checked", () => {
     c.selectTile("graph", 0)
-    c.getResizeControl("graph").focus()
-      .type("{rightarrow}".repeat(10) + "{downarrow}".repeat(10))
-    cy.wait(500)
     cy.dragAttributeToTarget("table", "Sleep", "bottom")
     cy.dragAttributeToTarget("table", "Speed", "left")
     cy.dragAttributeToTarget("table", "Diet", "top")

--- a/v3/cypress/e2e/bivariate-adornments.spec.ts
+++ b/v3/cypress/e2e/bivariate-adornments.spec.ts
@@ -273,6 +273,9 @@ context("Graph adornments", () => {
 
   it("adds connecting lines to the plot when the Connecting Lines checkbox is checked", () => {
     c.selectTile("graph", 0)
+    c.getResizeControl("graph").focus()
+      .type("{rightarrow}".repeat(10) + "{downarrow}".repeat(10))
+    cy.wait(500)
     cy.dragAttributeToTarget("table", "Sleep", "bottom")
     cy.dragAttributeToTarget("table", "Speed", "left")
     cy.dragAttributeToTarget("table", "Diet", "top")

--- a/v3/cypress/e2e/graph.spec.ts
+++ b/v3/cypress/e2e/graph.spec.ts
@@ -765,7 +765,7 @@ context("Graph UI", () => {
       // TODO: See comment above regarding number of bars.
       // cy.get("[data-testid=bar-cover]").should("exist").and("have.length", 9)
       cy.get("[data-testid=bar-cover]").should("exist")
-      cy.get("[data-testid=axis-legend-attribute-button-top").click()
+      cy.get("[data-testid=axis-legend-attribute-button-top]").click()
       cy.get("[role=menuitem]").contains("Remove Side-by-side Layout by Diet").click()
       graph.getDisplayConfigButton().click()
       cy.get("[data-testid=bar-chart-checkbox]").click()

--- a/v3/cypress/support/helpers/axis-helper.ts
+++ b/v3/cypress/support/helpers/axis-helper.ts
@@ -2,7 +2,7 @@ import { AxisElements as ae } from "../elements/axis-elements"
 
 export const AxisHelper = {
   verifyDefaultAxisLabel(axis: string) {
-    ae.getDefaultAxisLabel(axis).should("have.text", "Click here, or drag an attribute here.")
+    ae.getDefaultAxisLabel(axis).should("have.text", "Drag an attribute or click here")
   },
   verifyAxisLabel(axis: string, name: string) {
     ae.getAxisLabel(axis).should("have.text", name)

--- a/v3/src/assets/icons/dropdown-arrow-icon.svg
+++ b/v3/src/assets/icons/dropdown-arrow-icon.svg
@@ -1,6 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-    <g fill="none">
-        <path d="M0 0h24v24H0z"/>
-        <path fill="#006C8E" d="m12 15-5-5h10z"/>
-    </g>
-</svg>

--- a/v3/src/assets/icons/dropdown-arrow-icon.svg
+++ b/v3/src/assets/icons/dropdown-arrow-icon.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none">
+        <path d="M0 0h24v24H0z"/>
+        <path fill="#006C8E" d="m12 15-5-5h10z"/>
+    </g>
+</svg>

--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -2,6 +2,7 @@ import {axisBottom, axisLeft, axisRight, axisTop,
   ScaleBand, ScaleContinuousNumeric, ScaleOrdinal, select, Selection} from "d3"
 
 export const axisGap = 5
+export const labelPadding = 13  // whitespace above and below axis attribute labels
 
 // "rightCat" and "top" can only be categorical axes. "rightNumeric" can only be numeric
 export const AxisPlaces = ["bottom", "left", "rightCat", "top", "rightNumeric"] as const

--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -2,7 +2,8 @@ import {axisBottom, axisLeft, axisRight, axisTop,
   ScaleBand, ScaleContinuousNumeric, ScaleOrdinal, select, Selection} from "d3"
 
 export const axisGap = 5
-export const labelPadding = 13  // whitespace above and below axis attribute labels
+export const labelMargin = 13   // whitespace outside the label background rect (between rect and axis bounds)
+export const labelPaddingX = 8  // horizontal padding inside the label background rect (between rect edge and text)
 
 // "rightCat" and "top" can only be categorical axes. "rightNumeric" can only be numeric
 export const AxisPlaces = ["bottom", "left", "rightCat", "top", "rightNumeric"] as const

--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -377,7 +377,7 @@ export function renderLabelBackground<GElement extends BaseType>(
 
   const paddingX = labelPaddingX
   const paddingY = 2
-  const arrowWidth = 24  // icon container size matching dropdown-arrow-icon.svg viewBox
+  const arrowWidth = 24
 
   const rectWidth = textBBox.width + paddingX + arrowWidth
   const rectHeight = textBBox.height + paddingY * 2

--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -1,4 +1,4 @@
-import {ScaleContinuousNumeric, ScaleLinear} from "d3"
+import {BaseType, ScaleContinuousNumeric, ScaleLinear, Selection} from "d3"
 import { MutableRefObject } from "react"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { IDataConfigurationModel } from "../data-display/models/data-configuration-model"
@@ -9,7 +9,7 @@ import { determineLevels } from "../../utilities/date-utils"
 import { GraphLayout } from "../graph/models/graph-layout"
 import { ITileModel } from "../../models/tiles/tile-model"
 import { kAxisGap, kAxisTickLength, kDefaultFontHeight } from "./axis-constants"
-import {AxisPlace} from "./axis-types"
+import {AxisPlace, labelPaddingX} from "./axis-types"
 import { updateAxisNotification } from "./models/axis-notifications"
 import { IBaseNumericAxisModel } from "./models/base-numeric-axis-model"
 
@@ -355,4 +355,63 @@ export function zoomAxis(
         {lower: newLower, upper: newUpper}, "plot")
     }
   )
+}
+
+interface IRenderLabelBackgroundOptions<GElement extends BaseType> {
+  gSelection: Selection<GElement, unknown, any, any>
+  textSelector: string
+  transform?: string
+  visibility?: string
+}
+
+/**
+ * Renders a background rect and dropdown arrow behind/after an axis or legend label text element.
+ * The rect provides hover/focus/selected visual states via CSS classes on the parent <g>.
+ */
+export function renderLabelBackground<GElement extends BaseType>(
+  { gSelection, textSelector, transform = '', visibility }: IRenderLabelBackgroundOptions<GElement>
+) {
+  const textNode = gSelection.select(textSelector).node() as SVGTextElement | null
+  const textBBox = textNode?.getBBox()
+  if (!textBBox) return
+
+  const paddingX = labelPaddingX
+  const paddingY = 2
+  const arrowWidth = 24  // icon container size matching dropdown-arrow-icon.svg viewBox
+
+  const rectWidth = textBBox.width + paddingX + arrowWidth
+  const rectHeight = textBBox.height + paddingY * 2
+  const rectX = textBBox.x - paddingX
+  const rectY = textBBox.y - paddingY
+
+  const rectSelection = gSelection.selectAll('rect.attribute-label-bg')
+    .data([1])
+    .join((enter: any) => enter.append('rect').attr('class', 'attribute-label-bg'))
+    .attr('x', rectX)
+    .attr('y', rectY)
+    .attr('width', rectWidth)
+    .attr('height', rectHeight)
+    .attr('rx', 4)
+  if (transform) rectSelection.attr('transform', transform)
+  if (visibility) rectSelection.style('visibility', visibility)
+  rectSelection.lower()
+
+  const arrowX = textBBox.x + textBBox.width
+  const arrowY = textBBox.y + (textBBox.height - arrowWidth) / 2
+
+  const arrowSelection = gSelection.selectAll('svg.attribute-label-arrow')
+    .data([1])
+    .join((enter: any) => {
+      const arrow = enter.append('svg')
+        .attr('class', 'attribute-label-arrow')
+        .attr('viewBox', '0 0 24 24')
+        .attr('width', arrowWidth)
+        .attr('height', arrowWidth)
+      arrow.append('path').attr('d', 'm12 15-5-5h10z')
+      return arrow
+    })
+    .attr('x', arrowX)
+    .attr('y', arrowY)
+  if (transform) arrowSelection.attr('transform', transform)
+  if (visibility) arrowSelection.style('visibility', visibility)
 }

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -8,9 +8,7 @@
   }
 
   button:focus-visible {
-    outline: 2px solid vars.$focus-outline-color;
-    outline-offset: 2px;
-    border-radius: 2px;
+    outline: none;
   }
 }
 

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -1,8 +1,8 @@
 @use "../../vars";
 
 .attribute-label-menu {
-  display: flex;
   align-items: center;
+  display: flex;
   touch-action: none;
 
   button {
@@ -18,15 +18,15 @@
 
 // Dropdown menu list styling (!important overrides Chakra UI's default MenuList styles)
 .axis-legend-menu {
-  padding: 7px !important;
   border-radius: 4px !important;
   box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.25) !important;
+  padding: 7px !important;
 
   [role="menuitem"] {
-    height: 30px;
-    padding: 7px 10px;
     font-size: 14px;
     font-weight: normal;
+    height: 30px;
+    padding: 7px 10px;
 
     &:hover, &:focus {
       background-color: vars.$charcoal-light-5;

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -3,10 +3,6 @@
 .attribute-label-menu {
   touch-action: none;
 
-  button {
-    position: relative !important;
-  }
-
   button:focus-visible {
     outline: none;
   }

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -1,42 +1,52 @@
 @use "../../vars";
 
 .attribute-label-menu {
+  display: flex;
+  align-items: center;
   touch-action: none;
+
+  button {
+    position: relative !important;
+  }
 
   button:focus-visible {
     outline: 2px solid vars.$focus-outline-color;
     outline-offset: 2px;
     border-radius: 2px;
   }
-
-  .axis-label-dropdown-arrow {
-    position: absolute;
-    right: -14px;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 12px;
-    height: 12px;
-    color: vars.$icon-fill-dark;
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.15s ease;
-  }
-
-  &:hover .axis-label-dropdown-arrow,
-  &:focus-within .axis-label-dropdown-arrow {
-    opacity: 1;
-  }
 }
 
-// For vertical axes, position the arrow below instead of to the right
-.axis-legend-attribute-menu.left,
-.axis-legend-attribute-menu.rightCat,
-.axis-legend-attribute-menu.rightNumeric {
-  .attribute-label-menu .axis-label-dropdown-arrow {
-    right: 50%;
-    top: auto;
-    bottom: -14px;
-    transform: translateX(50%);
+// Dropdown menu list styling (!important overrides Chakra UI's default MenuList styles)
+.axis-legend-menu {
+  padding: 7px !important;
+  border-radius: 4px !important;
+  box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.25) !important;
+
+  [role="menuitem"] {
+    height: 30px;
+    padding: 7px 10px;
+    font-size: 14px;
+    font-weight: normal;
+
+    &:hover, &:focus {
+      background-color: vars.$charcoal-light-5;
+    }
+
+    &:focus-visible {
+      @include vars.focus-outline;
+      background-color: transparent;
+    }
+
+    // "Selected" (currently assigned) attribute
+    &[aria-checked="true"] {
+      background-color: vars.$charcoal-light-5;
+    }
+  }
+
+  // Chakra uses this class for hover highlight
+  .chakra-menu__menuitem-option:hover,
+  .chakra-menu__menuitem:hover {
+    background-color: vars.$charcoal-light-5;
   }
 }
 

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -1,8 +1,6 @@
 @use "../../vars";
 
 .attribute-label-menu {
-  align-items: center;
-  display: flex;
   touch-action: none;
 
   button {
@@ -17,16 +15,16 @@
 }
 
 // Dropdown menu list styling (!important overrides Chakra UI's default MenuList styles)
-.axis-legend-menu {
+.axis-legend-menu, .axis-legend-submenu {
   border-radius: 4px !important;
   box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.25) !important;
-  padding: 7px !important;
+  padding: 6px 2px !important;
 
   [role="menuitem"] {
     font-size: 14px;
     font-weight: normal;
     height: 30px;
-    padding: 7px 10px;
+    padding: 0 10px;
 
     &:hover, &:focus {
       background-color: vars.$charcoal-light-5;

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
@@ -148,7 +148,7 @@ describe("AxisOrLegendAttributeMenu", () => {
       renderMenu({ place: "bottom" })
       const button = screen.getByTestId("axis-legend-attribute-button-bottom")
       const label = button.getAttribute("aria-label")!
-      expect(label).toContain("horizontal")
+      expect(label).toContain("Drag an attribute or click here")
       // Should not contain an attribute name
       expect(label).not.toContain("Height")
     })
@@ -181,6 +181,89 @@ describe("AxisOrLegendAttributeMenu", () => {
       act(() => { menuItems[0].focus() })
       // scrollIntoView is mocked in setupTests.ts
       expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: "nearest" })
+    })
+  })
+
+  describe("CSS class relay to SVG target", () => {
+    let svgTarget: SVGGElement
+
+    beforeEach(() => {
+      // Create an SVG <g> element to serve as the target
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+      svgTarget = document.createElementNS("http://www.w3.org/2000/svg", "g")
+      svg.appendChild(svgTarget)
+      document.body.appendChild(svg)
+    })
+
+    afterEach(() => {
+      svgTarget.closest("svg")?.remove()
+    })
+
+    it("adds 'hovered' class on pointer enter and removes on pointer leave", async () => {
+      const user = userEvent.setup()
+      renderMenu({ target: svgTarget })
+      const overlay = screen.getByTestId("attribute-label-menu-bottom")
+
+      await user.hover(overlay)
+      expect(svgTarget.classList.contains("hovered")).toBe(true)
+
+      await user.unhover(overlay)
+      expect(svgTarget.classList.contains("hovered")).toBe(false)
+    })
+
+    it("adds 'focused' class on focus and removes on blur", () => {
+      renderMenu({ target: svgTarget })
+      const button = screen.getByTestId("axis-legend-attribute-button-bottom")
+
+      act(() => { button.focus() })
+      expect(svgTarget.classList.contains("focused")).toBe(true)
+
+      act(() => { button.blur() })
+      expect(svgTarget.classList.contains("focused")).toBe(false)
+    })
+
+    it("adds 'menu-open' class when menu opens and removes when it closes", async () => {
+      const user = userEvent.setup()
+      renderMenu({ target: svgTarget })
+      const button = screen.getByTestId("axis-legend-attribute-button-bottom")
+
+      // Open menu
+      await user.click(button)
+      expect(svgTarget.classList.contains("menu-open")).toBe(true)
+
+      // Close menu by clicking button again
+      await user.click(button)
+      expect(svgTarget.classList.contains("menu-open")).toBe(false)
+    })
+
+    it("removes 'focused' class when menu closes", async () => {
+      const user = userEvent.setup()
+      renderMenu({ target: svgTarget })
+      const button = screen.getByTestId("axis-legend-attribute-button-bottom")
+
+      // Open menu (which may set focused via focus events)
+      await user.click(button)
+      svgTarget.classList.add("focused")  // simulate focus state
+      expect(svgTarget.classList.contains("menu-open")).toBe(true)
+
+      // Close menu
+      await user.click(button)
+      expect(svgTarget.classList.contains("focused")).toBe(false)
+    })
+
+    it("cleans up all classes on unmount", async () => {
+      const user = userEvent.setup()
+      const { unmount } = renderMenu({ target: svgTarget })
+      const overlay = screen.getByTestId("attribute-label-menu-bottom")
+
+      // Set up some classes
+      await user.hover(overlay)
+      expect(svgTarget.classList.contains("hovered")).toBe(true)
+
+      unmount()
+      expect(svgTarget.classList.contains("hovered")).toBe(false)
+      expect(svgTarget.classList.contains("focused")).toBe(false)
+      expect(svgTarget.classList.contains("menu-open")).toBe(false)
     })
   })
 

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
@@ -148,7 +148,7 @@ describe("AxisOrLegendAttributeMenu", () => {
       renderMenu({ place: "bottom" })
       const button = screen.getByTestId("axis-legend-attribute-button-bottom")
       const label = button.getAttribute("aria-label")!
-      expect(label).toContain("Drag an attribute or click here")
+      expect(label).toContain("horizontal")
       // Should not contain an attribute name
       expect(label).not.toContain("Height")
     })

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -1,7 +1,7 @@
 import { clsx } from "clsx"
 import { observer } from "mobx-react-lite"
 import { Menu, MenuItem, MenuList, MenuButton, MenuDivider, Portal } from "@chakra-ui/react"
-import React, { CSSProperties, useCallback, useRef, useState } from "react"
+import React, { CSSProperties, useCallback, useEffect, useRef, useState } from "react"
 import { useDocumentContainerContext } from "../../../hooks/use-document-container-context"
 import { useFreeTileLayoutContext } from "../../../hooks/use-free-tile-layout-context"
 import { IUseDraggableAttribute, useDraggableAttribute } from "../../../hooks/use-drag-drop"
@@ -22,7 +22,6 @@ import { GraphPlace } from "../../axis-graph-shared"
 import { graphPlaceToAttrRole } from "../../data-display/data-display-types"
 import { useDataConfigurationContext } from "../../data-display/hooks/use-data-configuration-context"
 
-import DropdownArrow from "../../../assets/icons/arrow.svg"
 import RightArrow from "../../../assets/icons/arrow-right.svg"
 
 import "./axis-or-legend-attribute-menu.scss"
@@ -189,9 +188,6 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
   const onCloseMenuRef = useRef<() => void>()
   const [openCollectionId, setOpenCollectionId] = React.useState<string | null>(null)
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const adjustedMainMenuHeight = useMenuHeightAdjustment({
-    menuRef: mainMenuListRef, containerRef, isOpen: isMenuOpen
-  })
 
   // Delayed submenu switching to prevent accidental switches when moving to a submenu
   // that appears above/below the trigger item
@@ -252,6 +248,21 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
     setIsMenuOpen(false)
   }
 
+  // Sync menu-open class with actual menu state, and clean up focused on close
+  useEffect(() => {
+    if (isMenuOpen) {
+      target?.classList.add('menu-open')
+    } else {
+      target?.classList.remove('menu-open')
+      target?.classList.remove('focused')
+    }
+    return () => {
+      target?.classList.remove('menu-open')
+      target?.classList.remove('focused')
+      target?.classList.remove('hovered')
+    }
+  }, [isMenuOpen, target])
+
   useOutsidePointerDown({
     ref: menuRef,
     handler: handleCloseMenu,
@@ -278,7 +289,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
       : t("DG.AxisView.emptyLegendAriaLabel")
     : attribute?.name
       ? t("DG.AxisView.axisAriaLabel", { vars: [orientation, attribute.name] })
-      : t("DG.AxisView.emptyAxisAriaLabel", { vars: [orientation] })
+      : t("DG.AxisView.emptyGraphCue")
 
   const handleMenuItemFocus = useMenuItemScrollIntoView()
   const handleMainMenuKeyDown = useSubmenuOpenOnArrowRight("collection-id", handleOpenSubmenu)
@@ -339,6 +350,22 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
     }
   }
 
+  const handlePointerEnter = useCallback(() => {
+    target?.classList.add('hovered')
+  }, [target])
+
+  const handlePointerLeave = useCallback(() => {
+    target?.classList.remove('hovered')
+  }, [target])
+
+  const handleFocusCapture = useCallback(() => {
+    target?.classList.add('focused')
+  }, [target])
+
+  const handleBlurCapture = useCallback(() => {
+    target?.classList.remove('focused')
+  }, [target])
+
   return (
     <div className={clsx("axis-legend-attribute-menu", place)} ref={menuRef} title={description + clickLabel}>
       <Menu placement="auto" onOpen={handleOpenMenu}>
@@ -348,17 +375,19 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
           }
           onCloseMenuRef.current = onClose
           return (
-            <div className="attribute-label-menu" ref={setDragNodeRef}
+            <div className={`attribute-label-menu ${place}`} ref={setDragNodeRef}
                 style={overlayStyle} {...attributes} {...listeners}
+                onPointerEnter={handlePointerEnter}
+                onPointerLeave={handlePointerLeave}
+                onFocusCapture={handleFocusCapture}
+                onBlurCapture={handleBlurCapture}
                 data-testid={`attribute-label-menu-${place}`}>
               <MenuButton style={buttonStyle} aria-label={ariaLabel}
                            data-testid={`axis-legend-attribute-button-${place}`}>
                 {attribute?.name}
               </MenuButton>
-              <DropdownArrow className="axis-label-dropdown-arrow" aria-hidden="true" />
               <Portal containerRef={containerRef}>
                 <MenuList ref={mainMenuListRef} className="axis-legend-menu"
-                          maxH={adjustedMainMenuHeight ?? maxMenuHeight} overflowY="auto"
                           onFocus={handleMenuItemFocus}
                           onKeyDown={handleMainMenuKeyDown}
                           data-testid={`axis-legend-attribute-menu-list-${place}`}>

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -248,7 +248,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
     setIsMenuOpen(false)
   }
 
-  // Sync menu-open class with actual menu state, and clean up focused on close
+  // Sync menu-open class with actual menu state, and clean up all visual state classes on close/unmount
   useEffect(() => {
     if (isMenuOpen) {
       target?.classList.add("menu-open")

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -181,7 +181,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
   const treatAs = (nativeType === 'date' && attrType === 'categorical') ? 'date'
     : ['numeric', 'date'].includes(attrType) ? "categorical" : "numeric"
   const overlayStyle: CSSProperties = { position: "absolute", ...useOverlayBounds({target, portal}) }
-  const buttonStyle: CSSProperties = { position: "absolute", width: "100%", height: "100%", color: "transparent" }
+  const buttonStyle: CSSProperties = { width: "100%", height: "100%", color: "transparent" }
   const menuRef = useRef<HTMLDivElement>(null)
   const mainMenuListRef = useRef<HTMLDivElement>(null)
   const [isMenuOpen, setIsMenuOpen] = useState(false)

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -151,7 +151,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
 }: IProps) {
   const containerRef = useDocumentContainerContext()
   const layout = useFreeTileLayoutContext()
-  const maxMenuHeight = `min(${layout?.height ?? 300}px, 50vh)`
+  const maxMenuHeight = `min(${layout?.height ?? 340}px, 50vh)`
   const dataConfiguration = useDataConfigurationContext()
   const isAttributeAllowed = dataConfiguration?.placeCanAcceptAttributeIDDrop
     ? (aPlace: GraphPlace, data: IDataSet, anAttrId: string) =>
@@ -188,6 +188,9 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
   const onCloseMenuRef = useRef<() => void>()
   const [openCollectionId, setOpenCollectionId] = React.useState<string | null>(null)
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const adjustedMainMenuHeight = useMenuHeightAdjustment({
+    menuRef: mainMenuListRef, containerRef, isOpen: isMenuOpen
+  })
 
   // Delayed submenu switching to prevent accidental switches when moving to a submenu
   // that appears above/below the trigger item
@@ -388,6 +391,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
               </MenuButton>
               <Portal containerRef={containerRef}>
                 <MenuList ref={mainMenuListRef} className="axis-legend-menu"
+                          maxH={adjustedMainMenuHeight ?? maxMenuHeight} overflowY="auto"
                           onFocus={handleMenuItemFocus}
                           onKeyDown={handleMainMenuKeyDown}
                           data-testid={`axis-legend-attribute-menu-list-${place}`}>

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -289,7 +289,7 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
       : t("DG.AxisView.emptyLegendAriaLabel")
     : attribute?.name
       ? t("DG.AxisView.axisAriaLabel", { vars: [orientation, attribute.name] })
-      : t("DG.AxisView.emptyGraphCue")
+      : t("DG.AxisView.emptyAxisAriaLabel", { vars: [orientation] })
 
   const handleMenuItemFocus = useMenuItemScrollIntoView()
   const handleMainMenuKeyDown = useSubmenuOpenOnArrowRight("collection-id", handleOpenSubmenu)

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -251,15 +251,15 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
   // Sync menu-open class with actual menu state, and clean up focused on close
   useEffect(() => {
     if (isMenuOpen) {
-      target?.classList.add('menu-open')
+      target?.classList.add("menu-open")
     } else {
-      target?.classList.remove('menu-open')
-      target?.classList.remove('focused')
+      target?.classList.remove("menu-open")
+      target?.classList.remove("focused")
     }
     return () => {
-      target?.classList.remove('menu-open')
-      target?.classList.remove('focused')
-      target?.classList.remove('hovered')
+      target?.classList.remove("menu-open")
+      target?.classList.remove("focused")
+      target?.classList.remove("hovered")
     }
   }, [isMenuOpen, target])
 
@@ -350,21 +350,21 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
     }
   }
 
-  const handlePointerEnter = useCallback(() => {
-    target?.classList.add('hovered')
-  }, [target])
+  const handlePointerEnter = () => {
+    target?.classList.add("hovered")
+  }
 
-  const handlePointerLeave = useCallback(() => {
-    target?.classList.remove('hovered')
-  }, [target])
+  const handlePointerLeave = () => {
+    target?.classList.remove("hovered")
+  }
 
-  const handleFocusCapture = useCallback(() => {
-    target?.classList.add('focused')
-  }, [target])
+  const handleFocusCapture = () => {
+    target?.classList.add("focused")
+  }
 
-  const handleBlurCapture = useCallback(() => {
-    target?.classList.remove('focused')
-  }, [target])
+  const handleBlurCapture = () => {
+    target?.classList.remove("focused")
+  }
 
   return (
     <div className={clsx("axis-legend-attribute-menu", place)} ref={menuRef} title={description + clickLabel}>

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -9,7 +9,7 @@ import { useDataConfigurationContext } from "../../data-display/hooks/use-data-c
 import { useDataDisplayModelContextMaybe } from "../../data-display/hooks/use-data-display-model"
 import { IDataDisplayContentModel } from "../../data-display/models/data-display-content-model"
 import { kColorAxisExtent, kQualitativeAxisExtent } from "../axis-constants"
-import { AxisPlace, AxisScaleType, axisGap, axisPlaceToAxisFn } from "../axis-types"
+import { AxisPlace, AxisScaleType, axisPlaceToAxisFn, labelPadding } from "../axis-types"
 import {
   collisionExists, computeBestNumberOfTicks,
   computeBestNumberOfVerticalAxisTicks,
@@ -83,7 +83,8 @@ export const useAxis = (axisPlace: AxisPlace) => {
       numbersHeight = getStringBounds('0').height,
       repetitions = multiScale?.repetitions ?? 1,
       d3Scale = multiScale?.scale ?? (isNumeric ? scaleLinear() : scaleOrdinal())
-    let desiredExtent = axisTitleHeight + 2 * axisGap
+    // labelPadding above and below the attribute label, plus a gap between tick labels and the label
+    let desiredExtent = axisTitleHeight + 2 * labelPadding
     let ticks: string[] = []
     switch (axisType) {
       case 'count':
@@ -91,8 +92,8 @@ export const useAxis = (axisPlace: AxisPlace) => {
       case 'numeric': {
         ticks = getTicks({d3Scale, isBinned, isVertical, multiScale, displayModel})
         desiredExtent += isVertical || _axisModel?.labelsAreRotated
-          ? Math.max(...ticks.map(tick => getStringBounds(tick).width)) + axisGap
-          : numbersHeight + axisGap
+          ? Math.max(...ticks.map(tick => getStringBounds(tick).width)) + labelPadding
+          : numbersHeight + labelPadding
         break
       }
       case 'qualitative': {
@@ -115,7 +116,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
       case 'date': {
         if (isDateAxisModel(_axisModel)) {
           const [min, max] = _axisModel.domain
-          desiredExtent += getNumberOfLevelsForDateAxis(min, max) * numbersHeight + axisGap
+          desiredExtent += getNumberOfLevelsForDateAxis(min, max) * numbersHeight + labelPadding
         }
         break
       }

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -9,7 +9,7 @@ import { useDataConfigurationContext } from "../../data-display/hooks/use-data-c
 import { useDataDisplayModelContextMaybe } from "../../data-display/hooks/use-data-display-model"
 import { IDataDisplayContentModel } from "../../data-display/models/data-display-content-model"
 import { kColorAxisExtent, kQualitativeAxisExtent } from "../axis-constants"
-import { AxisPlace, AxisScaleType, axisPlaceToAxisFn, labelPadding } from "../axis-types"
+import { AxisPlace, AxisScaleType, axisPlaceToAxisFn, labelMargin } from "../axis-types"
 import {
   collisionExists, computeBestNumberOfTicks,
   computeBestNumberOfVerticalAxisTicks,
@@ -83,8 +83,8 @@ export const useAxis = (axisPlace: AxisPlace) => {
       numbersHeight = getStringBounds('0').height,
       repetitions = multiScale?.repetitions ?? 1,
       d3Scale = multiScale?.scale ?? (isNumeric ? scaleLinear() : scaleOrdinal())
-    // labelPadding above and below the attribute label, plus a gap between tick labels and the label
-    let desiredExtent = axisTitleHeight + 2 * labelPadding
+    // labelMargin above and below the attribute label, plus a gap between tick labels and the label
+    let desiredExtent = axisTitleHeight + 2 * labelMargin
     let ticks: string[] = []
     switch (axisType) {
       case 'count':
@@ -92,8 +92,8 @@ export const useAxis = (axisPlace: AxisPlace) => {
       case 'numeric': {
         ticks = getTicks({d3Scale, isBinned, isVertical, multiScale, displayModel})
         desiredExtent += isVertical || _axisModel?.labelsAreRotated
-          ? Math.max(...ticks.map(tick => getStringBounds(tick).width)) + labelPadding
-          : numbersHeight + labelPadding
+          ? Math.max(...ticks.map(tick => getStringBounds(tick).width)) + labelMargin
+          : numbersHeight + labelMargin
         break
       }
       case 'qualitative': {
@@ -116,7 +116,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
       case 'date': {
         if (isDateAxisModel(_axisModel)) {
           const [min, max] = _axisModel.domain
-          desiredExtent += getNumberOfLevelsForDateAxis(min, max) * numbersHeight + labelPadding
+          desiredExtent += getNumberOfLevelsForDateAxis(min, max) * numbersHeight + labelMargin
         }
         break
       }

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -9,7 +9,7 @@ import { useDataConfigurationContext } from "../../data-display/hooks/use-data-c
 import { useDataDisplayModelContextMaybe } from "../../data-display/hooks/use-data-display-model"
 import { IDataDisplayContentModel } from "../../data-display/models/data-display-content-model"
 import { kColorAxisExtent, kQualitativeAxisExtent } from "../axis-constants"
-import { AxisPlace, AxisScaleType, axisPlaceToAxisFn, labelMargin } from "../axis-types"
+import { AxisPlace, AxisScaleType, axisGap, axisPlaceToAxisFn, labelMargin } from "../axis-types"
 import {
   collisionExists, computeBestNumberOfTicks,
   computeBestNumberOfVerticalAxisTicks,
@@ -92,8 +92,8 @@ export const useAxis = (axisPlace: AxisPlace) => {
       case 'numeric': {
         ticks = getTicks({d3Scale, isBinned, isVertical, multiScale, displayModel})
         desiredExtent += isVertical || _axisModel?.labelsAreRotated
-          ? Math.max(...ticks.map(tick => getStringBounds(tick).width)) + labelMargin
-          : numbersHeight + labelMargin
+          ? Math.max(...ticks.map(tick => getStringBounds(tick).width)) + axisGap
+          : numbersHeight + axisGap
         break
       }
       case 'qualitative': {
@@ -116,7 +116,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
       case 'date': {
         if (isDateAxisModel(_axisModel)) {
           const [min, max] = _axisModel.domain
-          desiredExtent += getNumberOfLevelsForDateAxis(min, max) * numbersHeight + labelMargin
+          desiredExtent += getNumberOfLevelsForDateAxis(min, max) * numbersHeight + axisGap
         }
         break
       }

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -83,7 +83,7 @@ export const useAxis = (axisPlace: AxisPlace) => {
       numbersHeight = getStringBounds('0').height,
       repetitions = multiScale?.repetitions ?? 1,
       d3Scale = multiScale?.scale ?? (isNumeric ? scaleLinear() : scaleOrdinal())
-    // labelMargin above and below the attribute label, plus a gap between tick labels and the label
+    // labelMargin above and below the attribute label
     let desiredExtent = axisTitleHeight + 2 * labelMargin
     let ticks: string[] = []
     switch (axisType) {

--- a/v3/src/components/data-display/components/attribute-label.scss
+++ b/v3/src/components/data-display/components/attribute-label.scss
@@ -2,7 +2,7 @@
 
 .attribute-label {
   font: vars.$label-font !important;
-  fill: #222; // default fill for single-attribute labels
+  fill: vars.$default-font-color; // default fill for single-attribute labels
 
   // Multi-y-attribute labels: D3 sets fill color dynamically to match point color
   &.multi-y {

--- a/v3/src/components/data-display/components/attribute-label.scss
+++ b/v3/src/components/data-display/components/attribute-label.scss
@@ -10,21 +10,21 @@
   }
 }
 
-// Background rect behind axis label text — always present, invisible by default
 .attribute-label-bg {
   fill: transparent;
   stroke: transparent;
   stroke-width: 1;
 }
 
-// Dropdown arrow next to axis label text — always present, hidden by default
 .attribute-label-arrow path {
   fill: transparent;
 }
 
-// Arrow visible when tile is selected (without background/border)
-g.tile-selected .attribute-label-arrow path {
-  fill: vars.$accent;
+// Arrow becomes visible in any active state
+g.tile-selected, g.hovered, g.focused, g.menu-open {
+  .attribute-label-arrow path {
+    fill: vars.$accent;
+  }
 }
 
 // Flip arrow when menu is open
@@ -40,10 +40,6 @@ g.hovered, g.focused {
     fill: vars.$accent-light-3;
     stroke: vars.$accent;
   }
-
-  .attribute-label-arrow path {
-    fill: vars.$accent;
-  }
 }
 
 // Selected state (menu open) — darker background
@@ -51,9 +47,5 @@ g.menu-open {
   .attribute-label-bg {
     fill: vars.$accent-light-2;
     stroke: vars.$accent;
-  }
-
-  .attribute-label-arrow path {
-    fill: vars.$accent;
   }
 }

--- a/v3/src/components/data-display/components/attribute-label.scss
+++ b/v3/src/components/data-display/components/attribute-label.scss
@@ -1,12 +1,59 @@
 @use "../../vars";
 
 .attribute-label {
-  text-decoration: underline;
   font: vars.$label-font !important;
-  fill: blue; // default fill for single-attribute labels
+  fill: #222; // default fill for single-attribute labels
 
   // Multi-y-attribute labels: D3 sets fill color dynamically to match point color
   &.multi-y {
     fill: unset;
+  }
+}
+
+// Background rect behind axis label text — always present, invisible by default
+.attribute-label-bg {
+  fill: transparent;
+  stroke: transparent;
+  stroke-width: 1;
+}
+
+// Dropdown arrow next to axis label text — always present, hidden by default
+.attribute-label-arrow path {
+  fill: transparent;
+}
+
+// Arrow visible when tile is selected (without background/border)
+g.tile-selected .attribute-label-arrow path {
+  fill: vars.$accent;
+}
+
+// Flip arrow when menu is open
+g.menu-open .attribute-label-arrow path {
+  transform-box: fill-box;
+  transform-origin: center;
+  transform: scaleY(-1);
+}
+
+// Hover and focus states
+g.hovered, g.focused {
+  .attribute-label-bg {
+    fill: vars.$accent-light-3;
+    stroke: vars.$accent;
+  }
+
+  .attribute-label-arrow path {
+    fill: vars.$accent;
+  }
+}
+
+// Selected state (menu open) — darker background
+g.menu-open {
+  .attribute-label-bg {
+    fill: vars.$accent-light-2;
+    stroke: vars.$accent;
+  }
+
+  .attribute-label-arrow path {
+    fill: vars.$accent;
   }
 }

--- a/v3/src/components/data-display/components/attribute-label.scss
+++ b/v3/src/components/data-display/components/attribute-label.scss
@@ -42,6 +42,12 @@ g.hovered, g.focused {
   }
 }
 
+// Keyboard focus ring on the SVG rect (replaces the HTML button's focus outline for alignment)
+g.focused .attribute-label-bg {
+  stroke: vars.$focus-outline-color;
+  stroke-width: 2;
+}
+
 // Selected state (menu open) — darker background
 g.menu-open {
   .attribute-label-bg {

--- a/v3/src/components/data-display/components/legend/legend-attribute-label.tsx
+++ b/v3/src/components/data-display/components/legend/legend-attribute-label.tsx
@@ -6,6 +6,7 @@ import {axisGap} from "../../../axis/axis-types"
 import {GraphPlace} from "../../../axis-graph-shared"
 import {getStringBounds} from "../../../axis/axis-utils"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
+import {useTileSelectionContext} from "../../../../hooks/use-tile-selection-context"
 import {AttributeLabel} from "../attribute-label"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 
@@ -18,6 +19,7 @@ interface IAttributeLabelProps {
 export const LegendAttributeLabel =
   function LegendAttributeLabel({ onChangeAttribute }: IAttributeLabelProps) {
     const dataConfiguration = useDataConfigurationContext(),
+      {isTileSelected} = useTileSelectionContext(),
       labelRef = useRef<SVGGElement>(null),
       className = 'attribute-label'
 
@@ -28,9 +30,13 @@ export const LegendAttributeLabel =
         attributeUnits = (attributeID ? dataset?.attrFromID(attributeID)?.units : '') ?? '',
         labelFont = vars.labelFont,
         labelBounds = getStringBounds(attributeName, labelFont),
-        tX = axisGap,
-        tY = labelBounds.height / 2 + axisGap
-      select(labelRef.current)
+        tX = axisGap + 8,  // offset by paddingX so rect left edge aligns with legend keys
+        tY = labelBounds.height / 2
+
+      const gSelection = select(labelRef.current)
+      gSelection.classed('tile-selected', isTileSelected())
+
+      gSelection
         .selectAll(`text.${className}`)
         .data([1])
         .join(
@@ -43,7 +49,55 @@ export const LegendAttributeLabel =
               .attr('y', tY)
               .text(`${attributeName}${attributeUnits ? ` (${attributeUnits})` : ''}`)
         )
-    }, [dataConfiguration])
+
+      // Add background rect and dropdown arrow (same pattern as axis labels)
+      const textNode = gSelection.select(`text.${className}`).node() as SVGTextElement | null
+      const textBBox = textNode?.getBBox()
+
+      if (textBBox) {
+        const paddingX = 8
+        const paddingY = 2
+        const arrowWidth = 24
+
+        const rectWidth = textBBox.width + paddingX + arrowWidth
+        const rectHeight = textBBox.height + paddingY * 2
+        const rectX = textBBox.x - paddingX
+        const rectY = textBBox.y - paddingY
+
+        gSelection.selectAll('rect.attribute-label-bg')
+          .data([1])
+          .join(
+            (enter) => enter.append('rect').attr('class', 'attribute-label-bg'),
+            (update) => update
+          )
+          .attr('x', rectX)
+          .attr('y', rectY)
+          .attr('width', rectWidth)
+          .attr('height', rectHeight)
+          .attr('rx', 4)
+          .lower()
+
+        const arrowX = textBBox.x + textBBox.width
+        const arrowY = textBBox.y + (textBBox.height - arrowWidth) / 2
+
+        gSelection.selectAll('svg.attribute-label-arrow')
+          .data([1])
+          .join(
+            (enter) => {
+              const arrow = enter.append('svg')
+                .attr('class', 'attribute-label-arrow')
+                .attr('viewBox', '0 0 24 24')
+                .attr('width', arrowWidth)
+                .attr('height', arrowWidth)
+              arrow.append('path').attr('d', 'm12 15-5-5h10z')
+              return arrow
+            },
+            (update) => update
+          )
+          .attr('x', arrowX)
+          .attr('y', arrowY)
+      }
+    }, [dataConfiguration, isTileSelected])
 
     const handleRemoveAttribute = useCallback(() => {
       dataConfiguration?.applyModelChange(

--- a/v3/src/components/data-display/components/legend/legend-attribute-label.tsx
+++ b/v3/src/components/data-display/components/legend/legend-attribute-label.tsx
@@ -2,9 +2,9 @@ import {useCallback, useEffect, useRef} from "react"
 import {select} from "d3"
 import {AttributeType} from "../../../../models/data/attribute-types"
 import {IDataSet} from "../../../../models/data/data-set"
-import {axisGap} from "../../../axis/axis-types"
+import {axisGap, labelPaddingX} from "../../../axis/axis-types"
 import {GraphPlace} from "../../../axis-graph-shared"
-import {getStringBounds} from "../../../axis/axis-utils"
+import {getStringBounds, renderLabelBackground} from "../../../axis/axis-utils"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {useTileSelectionContext} from "../../../../hooks/use-tile-selection-context"
 import {AttributeLabel} from "../attribute-label"
@@ -30,7 +30,7 @@ export const LegendAttributeLabel =
         attributeUnits = (attributeID ? dataset?.attrFromID(attributeID)?.units : '') ?? '',
         labelFont = vars.labelFont,
         labelBounds = getStringBounds(attributeName, labelFont),
-        tX = axisGap + 8,  // offset by paddingX so rect left edge aligns with legend keys
+        tX = axisGap + labelPaddingX,  // offset so rect left edge aligns with legend keys
         tY = labelBounds.height / 2
 
       const gSelection = select(labelRef.current)
@@ -50,53 +50,7 @@ export const LegendAttributeLabel =
               .text(`${attributeName}${attributeUnits ? ` (${attributeUnits})` : ''}`)
         )
 
-      // Add background rect and dropdown arrow (same pattern as axis labels)
-      const textNode = gSelection.select(`text.${className}`).node() as SVGTextElement | null
-      const textBBox = textNode?.getBBox()
-
-      if (textBBox) {
-        const paddingX = 8
-        const paddingY = 2
-        const arrowWidth = 24
-
-        const rectWidth = textBBox.width + paddingX + arrowWidth
-        const rectHeight = textBBox.height + paddingY * 2
-        const rectX = textBBox.x - paddingX
-        const rectY = textBBox.y - paddingY
-
-        gSelection.selectAll('rect.attribute-label-bg')
-          .data([1])
-          .join(
-            (enter) => enter.append('rect').attr('class', 'attribute-label-bg'),
-            (update) => update
-          )
-          .attr('x', rectX)
-          .attr('y', rectY)
-          .attr('width', rectWidth)
-          .attr('height', rectHeight)
-          .attr('rx', 4)
-          .lower()
-
-        const arrowX = textBBox.x + textBBox.width
-        const arrowY = textBBox.y + (textBBox.height - arrowWidth) / 2
-
-        gSelection.selectAll('svg.attribute-label-arrow')
-          .data([1])
-          .join(
-            (enter) => {
-              const arrow = enter.append('svg')
-                .attr('class', 'attribute-label-arrow')
-                .attr('viewBox', '0 0 24 24')
-                .attr('width', arrowWidth)
-                .attr('height', arrowWidth)
-              arrow.append('path').attr('d', 'm12 15-5-5h10z')
-              return arrow
-            },
-            (update) => update
-          )
-          .attr('x', arrowX)
-          .attr('y', arrowY)
-      }
+      renderLabelBackground({ gSelection, textSelector: `text.${className}` })
     }, [dataConfiguration, isTileSelected])
 
     const handleRemoveAttribute = useCallback(() => {

--- a/v3/src/components/data-display/components/legend/legend.scss
+++ b/v3/src/components/data-display/components/legend/legend.scss
@@ -1,5 +1,9 @@
 @use "../../../vars";
 
+.multi-legend .legend-component {
+  overflow: visible;
+}
+
 .legend-component {
   position: relative;
   width: 100%;
@@ -24,7 +28,7 @@
     font: 12px sans-serif;
   }
 
-  rect {
+  rect:not(.attribute-label-bg) {
     opacity: 0.85;
     stroke: #315B7D;
   }
@@ -37,6 +41,11 @@
   display: flex;
   flex-direction: column;
   background-color: vars.$background-fill;
+  overflow: visible;
+
+  .legend {
+    overflow: visible;
+  }
 }
 
 .legend-rect-selected {
@@ -46,12 +55,4 @@
 
 .choropleth-rect {
   cursor: pointer;
-}
-
-.legend-categories {
-
-}
-
-.key {
-
 }

--- a/v3/src/components/graph/components/graph-attribute-label.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label.tsx
@@ -199,8 +199,6 @@ export const GraphAttributeLabel =
           .attr('dominant-baseline', 'central')
           .attr('data-testid', className)
           .attr("transform", labelTransform + tRotation)
-          .attr('class', className)
-          .attr('data-testid', className)
           .style('visibility', visibility)
           .attr('x', tX)
           .attr('y', tY)

--- a/v3/src/components/graph/components/graph-attribute-label.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label.tsx
@@ -5,87 +5,17 @@ import { t } from "../../../utilities/translation/translate"
 import { useGraphDataConfigurationContext } from "../hooks/use-graph-data-configuration-context"
 import { useGraphContentModelContext } from "../hooks/use-graph-content-model-context"
 import { useGraphLayoutContext } from "../hooks/use-graph-layout-context"
+import { useTileSelectionContext } from "../../../hooks/use-tile-selection-context"
 import { AttributeType } from "../../../models/data/attribute-types"
 import { IDataSet } from "../../../models/data/data-set"
 import { GraphPlace, isVertical } from "../../axis-graph-shared"
-import { labelPadding } from "../../axis/axis-types"
+import { labelMargin } from "../../axis/axis-types"
+import { getStringBounds, renderLabelBackground } from "../../axis/axis-utils"
 import { AttributeLabel } from "../../data-display/components/attribute-label"
 import { graphPlaceToAttrRole } from "../../data-display/data-display-types"
-import { useTileSelectionContext } from "../../../hooks/use-tile-selection-context"
-import { getStringBounds } from "../../axis/axis-utils"
 import { ClickableAxisLabel } from "./clickable-axis-label"
 
 import vars from "../../vars.scss"
-
-interface IRenderLabelBackgroundOptions {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  gSelection: any  // D3 Selection<SVGGElement | null, ...> — typed as any to avoid variance issues
-  textSelector: string
-  transform?: string
-  visibility?: string
-}
-
-/**
- * Renders a background rect and dropdown arrow behind/after an axis or legend label text element.
- * The rect provides hover/focus/selected visual states via CSS classes on the parent <g>.
- * The arrow uses the same path as dropdown-arrow-icon.svg (10x5 triangle in a 24x24 viewBox).
- */
-function renderLabelBackground(
-  { gSelection, textSelector, transform = '', visibility }: IRenderLabelBackgroundOptions
-) {
-  const textNode = gSelection.select(textSelector).node() as SVGTextElement | null
-  const textBBox = textNode?.getBBox()
-  if (!textBBox) return
-
-  const paddingX = 8
-  const paddingY = 2
-  const arrowWidth = 24  // icon container size matching dropdown-arrow-icon.svg viewBox
-
-  // Background rect: left padding + text + arrow (arrow's 24x24 container provides right padding)
-  const rectWidth = textBBox.width + paddingX + arrowWidth
-  const rectHeight = textBBox.height + paddingY * 2
-  const rectX = textBBox.x - paddingX
-  const rectY = textBBox.y - paddingY
-
-  const rectSelection = gSelection.selectAll('rect.attribute-label-bg')
-    .data([1])
-    .join(
-      (enter: any) => enter.append('rect').attr('class', 'attribute-label-bg'),
-      (update: any) => update
-    )
-    .attr('x', rectX)
-    .attr('y', rectY)
-    .attr('width', rectWidth)
-    .attr('height', rectHeight)
-    .attr('rx', 4)
-  if (transform) rectSelection.attr('transform', transform)
-  if (visibility) rectSelection.style('visibility', visibility)
-  rectSelection.lower()  // Ensure rect renders behind text
-
-  // Dropdown arrow: nested <svg> using the same path as dropdown-arrow-icon.svg
-  // Place directly after text — the icon's built-in padding provides sufficient spacing
-  const arrowX = textBBox.x + textBBox.width
-  const arrowY = textBBox.y + (textBBox.height - arrowWidth) / 2
-
-  const arrowSelection = gSelection.selectAll('svg.attribute-label-arrow')
-    .data([1])
-    .join(
-      (enter: any) => {
-        const arrow = enter.append('svg')
-          .attr('class', 'attribute-label-arrow')
-          .attr('viewBox', '0 0 24 24')
-          .attr('width', arrowWidth)
-          .attr('height', arrowWidth)
-        arrow.append('path').attr('d', 'm12 15-5-5h10z')
-        return arrow
-      },
-      (update: any) => update
-    )
-    .attr('x', arrowX)
-    .attr('y', arrowY)
-  if (transform) arrowSelection.attr('transform', transform)
-  if (visibility) arrowSelection.style('visibility', visibility)
-}
 
 interface IAttributeLabelProps {
   place: GraphPlace
@@ -285,8 +215,8 @@ export const GraphAttributeLabel =
         labelBounds = getStringBounds(label, labelFont),
         labelTransform = `translate(${bounds.left}, ${bounds.top})`,
         // With dominant-baseline: central, tY sets the visual center of the text.
-        // Place center at labelPadding + labelBounds.height/2 from the outer edge.
-        labelCenter = labelPadding + labelBounds.height / 2,
+        // Place center at labelMargin + labelBounds.height/2 from the outer edge.
+        labelCenter = labelMargin + labelBounds.height / 2,
         tX = place === 'left' ? labelCenter
           : place === 'legend' ? bounds.left
             : ['rightNumeric', 'rightCat'].includes(place) ? bounds.width - labelCenter

--- a/v3/src/components/graph/components/graph-attribute-label.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label.tsx
@@ -8,6 +8,7 @@ import { useGraphLayoutContext } from "../hooks/use-graph-layout-context"
 import { AttributeType } from "../../../models/data/attribute-types"
 import { IDataSet } from "../../../models/data/data-set"
 import { GraphPlace, isVertical } from "../../axis-graph-shared"
+import { labelPadding } from "../../axis/axis-types"
 import { AttributeLabel } from "../../data-display/components/attribute-label"
 import { graphPlaceToAttrRole } from "../../data-display/data-display-types"
 import { useTileSelectionContext } from "../../../hooks/use-tile-selection-context"
@@ -15,6 +16,76 @@ import { getStringBounds } from "../../axis/axis-utils"
 import { ClickableAxisLabel } from "./clickable-axis-label"
 
 import vars from "../../vars.scss"
+
+interface IRenderLabelBackgroundOptions {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  gSelection: any  // D3 Selection<SVGGElement | null, ...> — typed as any to avoid variance issues
+  textSelector: string
+  transform?: string
+  visibility?: string
+}
+
+/**
+ * Renders a background rect and dropdown arrow behind/after an axis or legend label text element.
+ * The rect provides hover/focus/selected visual states via CSS classes on the parent <g>.
+ * The arrow uses the same path as dropdown-arrow-icon.svg (10x5 triangle in a 24x24 viewBox).
+ */
+function renderLabelBackground(
+  { gSelection, textSelector, transform = '', visibility }: IRenderLabelBackgroundOptions
+) {
+  const textNode = gSelection.select(textSelector).node() as SVGTextElement | null
+  const textBBox = textNode?.getBBox()
+  if (!textBBox) return
+
+  const paddingX = 8
+  const paddingY = 2
+  const arrowWidth = 24  // icon container size matching dropdown-arrow-icon.svg viewBox
+
+  // Background rect: left padding + text + arrow (arrow's 24x24 container provides right padding)
+  const rectWidth = textBBox.width + paddingX + arrowWidth
+  const rectHeight = textBBox.height + paddingY * 2
+  const rectX = textBBox.x - paddingX
+  const rectY = textBBox.y - paddingY
+
+  const rectSelection = gSelection.selectAll('rect.attribute-label-bg')
+    .data([1])
+    .join(
+      (enter: any) => enter.append('rect').attr('class', 'attribute-label-bg'),
+      (update: any) => update
+    )
+    .attr('x', rectX)
+    .attr('y', rectY)
+    .attr('width', rectWidth)
+    .attr('height', rectHeight)
+    .attr('rx', 4)
+  if (transform) rectSelection.attr('transform', transform)
+  if (visibility) rectSelection.style('visibility', visibility)
+  rectSelection.lower()  // Ensure rect renders behind text
+
+  // Dropdown arrow: nested <svg> using the same path as dropdown-arrow-icon.svg
+  // Place directly after text — the icon's built-in padding provides sufficient spacing
+  const arrowX = textBBox.x + textBBox.width
+  const arrowY = textBBox.y + (textBBox.height - arrowWidth) / 2
+
+  const arrowSelection = gSelection.selectAll('svg.attribute-label-arrow')
+    .data([1])
+    .join(
+      (enter: any) => {
+        const arrow = enter.append('svg')
+          .attr('class', 'attribute-label-arrow')
+          .attr('viewBox', '0 0 24 24')
+          .attr('width', arrowWidth)
+          .attr('height', arrowWidth)
+        arrow.append('path').attr('d', 'm12 15-5-5h10z')
+        return arrow
+      },
+      (update: any) => update
+    )
+    .attr('x', arrowX)
+    .attr('y', arrowY)
+  if (transform) arrowSelection.attr('transform', transform)
+  if (visibility) arrowSelection.style('visibility', visibility)
+}
 
 interface IAttributeLabelProps {
   place: GraphPlace
@@ -36,6 +107,7 @@ const SingleYAttributeLabel = observer(function SingleYAttributeLabel({
   const graphModel = useGraphContentModelContext()
   const dataConfiguration = useGraphDataConfigurationContext()
   const layout = useGraphLayoutContext()
+  const {isTileSelected} = useTileSelectionContext()
   const dataset = dataConfiguration?.dataset
   const labelRef = useRef<SVGGElement>(null)
 
@@ -69,6 +141,7 @@ const SingleYAttributeLabel = observer(function SingleYAttributeLabel({
     const circleRadius = 5
 
     const gSelection = select(labelRef.current)
+    gSelection.classed('tile-selected', isTileSelected())
 
     // Update or create the text element
     gSelection.selectAll('text.attribute-label.multi-y')
@@ -87,6 +160,11 @@ const SingleYAttributeLabel = observer(function SingleYAttributeLabel({
       .attr('x', tX)
       .attr('y', tY)
       .text(label)
+
+    renderLabelBackground({
+      gSelection, textSelector: 'text.attribute-label.multi-y',
+      transform: labelTransform + tRotation
+    })
 
     // Update or create the circle element
     // Position the circle as a bullet point before the rotated text
@@ -107,7 +185,7 @@ const SingleYAttributeLabel = observer(function SingleYAttributeLabel({
       .attr('cy', circleY)
       .attr('r', circleRadius)
       .style('fill', color)
-  }, [getLabel, graphModel.pointDescription, labelIndex, layout, place, totalLabels])
+  }, [getLabel, graphModel.pointDescription, isTileSelected, labelIndex, layout, place, totalLabels])
 
   return (
     <AttributeLabel
@@ -184,10 +262,11 @@ export const GraphAttributeLabel =
 
     const refreshAxisTitle = useCallback(() => {
 
-      const updateSelection = (selection:  any) => {
+      const updateTextSelection = (selection:  any) => {
         return selection
           .attr('class', className)
           .attr('text-anchor', 'middle')
+          .attr('dominant-baseline', 'central')
           .attr('data-testid', className)
           .attr("transform", labelTransform + tRotation)
           .attr('class', className)
@@ -205,29 +284,41 @@ export const GraphAttributeLabel =
         label = getLabel(),
         labelBounds = getStringBounds(label, labelFont),
         labelTransform = `translate(${bounds.left}, ${bounds.top})`,
-        tX = place === 'left' ? labelBounds.height
+        // With dominant-baseline: central, tY sets the visual center of the text.
+        // Place center at labelPadding + labelBounds.height/2 from the outer edge.
+        labelCenter = labelPadding + labelBounds.height / 2,
+        tX = place === 'left' ? labelCenter
           : place === 'legend' ? bounds.left
-            : ['rightNumeric', 'rightCat'].includes(place) ? bounds.width - labelBounds.height / 2
+            : ['rightNumeric', 'rightCat'].includes(place) ? bounds.width - labelCenter
               : halfRange,
         tY = isVertical(place) ? halfRange
           : place === 'legend' ? labelBounds.height / 2
-            : place === 'top' ? labelBounds.height : bounds.height - labelBounds.height / 2,
+            : place === 'top' ? labelCenter : bounds.height - labelCenter,
         tRotation = isVertical(place) ? ` rotate(-90,${tX},${tY})` : ''
 
       select(labelRef.current).selectAll(`text.${unusedClassName}`).remove()
 
-      const labelTextSelection = select(labelRef.current).selectAll(`text.${className}`)
+      const gSelection = select(labelRef.current)
+      gSelection.classed('tile-selected', isTileSelected())
+
+      // Render the text first so we can measure it
+      const labelTextSelection = gSelection.selectAll(`text.${className}`)
       labelTextSelection
         .data([1])
         .join(
           (enter) =>
             enter.append('text')
               .attr('text-anchor', 'middle')
-              .call(updateSelection),
+              .call(updateTextSelection),
           (update) =>
-            update.call(updateSelection),
+            update.call(updateTextSelection),
           )
-    }, [getClickHereCue, getLabel, layout, place])
+
+      renderLabelBackground({
+        gSelection, textSelector: `text.${className}`,
+        transform: labelTransform + tRotation, visibility
+      })
+    }, [getClickHereCue, getLabel, isTileSelected, layout, place])
 
     const plotDefinedAxisClickHandler = graphModel.plot.axisLabelClickHandler(graphPlaceToAttrRole[place])
 

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -69,8 +69,9 @@ export const GraphAxis = observer(function GraphAxis(
       if (wrapperElt) {
         const bounds = layout.getComputedBounds(place),
           graphWidth = layout.tileWidth,
-          left = ['bottom', 'top'].includes(place) ? 0 : bounds.left,
-          width = ['bottom', 'top'].includes(place) ? graphWidth : bounds.width,
+          isHorizontal = ['bottom', 'top'].includes(place),
+          left = isHorizontal ? 0 : bounds.left,
+          width = isHorizontal ? graphWidth : bounds.width,
           transform = `translate(${left}, ${bounds.top})`
         select(wrapperElt)
           .selectAll<SVGRectElement, number>('rect.axis-background')

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -12,7 +12,7 @@
   height: calc(100% - vars.$title-bar-height);
 
   .empty-label {
-    fill: #222;
+    fill: vars.$default-font-color;
     font: vars.$empty-label-font;
   }
 

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -12,7 +12,7 @@
   height: calc(100% - vars.$title-bar-height);
 
   .empty-label {
-    fill: #999;
+    fill: #222;
     font: vars.$empty-label-font;
   }
 

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -18,7 +18,7 @@ import {onAnyAction} from "../../../utilities/mst-utils"
 import { t } from "../../../utilities/translation/translate"
 import { setNiceDomain } from "../../axis/axis-domain-utils"
 import {GraphPlace} from "../../axis-graph-shared"
-import { AxisPlace, AxisPlaces, isAxisPlace } from "../../axis/axis-types"
+import { AxisPlace, AxisPlaces, isAxisPlace, isHorizontal } from "../../axis/axis-types"
 import { IBaseNumericAxisModel } from "../../axis/models/base-numeric-axis-model"
 import { If } from "../../common/if"
 import { PointRendererArray, RendererCapability } from "../../data-display/renderer"
@@ -382,11 +382,8 @@ export const Graph = observer(function Graph({
   const renderGraphAxes = () => {
     // Render horizontal axes first so vertical axes (and their labels) appear on top
     // of the full-width horizontal axis backgrounds
-    const horizontalFirst = (a: AxisPlace, b: AxisPlace) => {
-      const aIsH = ['bottom', 'top'].includes(a) ? 0 : 1
-      const bIsH = ['bottom', 'top'].includes(b) ? 0 : 1
-      return aIsH - bIsH
-    }
+    const horizontalFirst = (a: AxisPlace, b: AxisPlace) =>
+      (isHorizontal(a) ? 0 : 1) - (isHorizontal(b) ? 0 : 1)
     const places = AxisPlaces.filter((place: AxisPlace) => {
       return !!graphModel.getAxis(place)
     }).sort(horizontalFirst)

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -380,9 +380,16 @@ export const Graph = observer(function Graph({
   }
 
   const renderGraphAxes = () => {
+    // Render horizontal axes first so vertical axes (and their labels) appear on top
+    // of the full-width horizontal axis backgrounds
+    const horizontalFirst = (a: AxisPlace, b: AxisPlace) => {
+      const aIsH = ['bottom', 'top'].includes(a) ? 0 : 1
+      const bIsH = ['bottom', 'top'].includes(b) ? 0 : 1
+      return aIsH - bIsH
+    }
     const places = AxisPlaces.filter((place: AxisPlace) => {
       return !!graphModel.getAxis(place)
-    })
+    }).sort(horizontalFirst)
     return places.map((place: AxisPlace) => {
       return <GraphAxis key={place}
                         place={place}

--- a/v3/src/components/graph/graph-registration.ts
+++ b/v3/src/components/graph/graph-registration.ts
@@ -109,8 +109,8 @@ registerTileComponentInfo({
     undoStringKey: "DG.Undo.graphComponent.create",
     redoStringKey: "DG.Redo.graphComponent.create"
   },
-  defaultWidth: 300,
-  defaultHeight: 300
+  defaultWidth: 340,
+  defaultHeight: 340
 })
 
 registerV2TileExporter(kGraphTileType, v2GraphExporter)

--- a/v3/src/components/vars.scss
+++ b/v3/src/components/vars.scss
@@ -45,7 +45,7 @@ $minimize-transition: height 0.4s ease-in-out 0s;
 $label-font: 500 14px Roboto, sans-serif;
 $letter-spacing: 0.2px;
 $label-color: #222222;
-$empty-label-font: 12px Roboto, sans-serif;
+$empty-label-font: 14px Roboto, sans-serif;
 $background-fill: #f9f9f9;
 $icon-fill-light: #d3f4ff;
 $icon-fill-medium: #bfefff;

--- a/v3/src/models/codap/add-default-content.ts
+++ b/v3/src/models/codap/add-default-content.ts
@@ -34,7 +34,7 @@ export function addDefaultComponents() {
   const kFullWidth = 580
   const kWidth25 = kFullWidth / 4
   const kWidth75 = kFullWidth * 3 / 4
-  const kFullHeight = 300
+  const kFullHeight = 340
   const kHalfHeight = kFullHeight / 2
   const kGap = 10
 

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -758,7 +758,7 @@
     "DG.DataDisplayModel.HideConnectingLine": "Hide Connecting Lines",
 
     // DG.AxisView
-    "DG.AxisView.emptyGraphCue": "Click here, or drag an attribute here.",
+    "DG.AxisView.emptyGraphCue": "Drag an attribute or click here",
 
     // DG.CellAxis
     "DG.CellAxis.other": "OTHER",


### PR DESCRIPTION
[CODAP-1137](https://concord-consortium.atlassian.net/browse/CODAP-1137)

Redesigns axis and legend attribute labels on graphs to match [updated design spec](https://app.zeplin.io/project/5e4baae7fb685faac9bf4a0a/screen/69ceb1fd67eb6e06894c573c).

- Adds SVG background rect and dropdown arrow to axis/legend labels with hover, focus, and selected visual states
- Adjusts style of the attribute selection menu (padding, border-radius, box shadow, menu item focus ring)
- Adds whitespace around axis labels via `labelMargin`
- Increases default graph dimensions from 300x300 to 340x340
- Updates axis rendering order so vertical axis labels aren't obscured by horizontal axis backgrounds

[CODAP-1137]: https://concord-consortium.atlassian.net/browse/CODAP-1137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ