### PR TITLE
CODAP-1240: fix case table tooltip positioning

### DIFF
--- a/v3/src/components/case-table/attribute-value-cell.tsx
+++ b/v3/src/components/case-table/attribute-value-cell.tsx
@@ -3,7 +3,6 @@ import { useDataSet } from "../../hooks/use-data-set"
 import { symParent } from "../../models/data/data-set-types"
 import { t } from "../../utilities/translation/translate"
 import { renderAttributeValue } from "../case-tile-common/attribute-format-utils"
-import { If } from "../common/if"
 import { kInputRowKey, symDom, TRenderCellProps } from "./case-table-types"
 import { useCollectionTableModel } from "./use-collection-table-model"
 
@@ -27,15 +26,22 @@ export function AttributeValueCell({ column, row }: TRenderCellProps) {
                               ? { value: "", content: null }
                               : renderAttributeValue(strValue, numValue, attr, { key, rowHeight, caseId })
   const dataTestId = `case-table-tooltip-${row.__id__}-${column.key}`
+  // Empty input-row cells don't need a tooltip (no value to show), but do need
+  // screen-reader instructions. Render content + VisuallyHidden directly.
+  // Normal cells pass `content` as Tooltip's single child so Popper can anchor
+  // against the .cell-content div's bounding rect.
+  if (isInputRow && !strValue) {
+    return (
+      <>
+        {content}
+        <VisuallyHidden>{t("V3.CaseTable.inputRowCellInstructions", { vars: [attrName] })}</VisuallyHidden>
+      </>
+    )
+  }
   return (
     <Tooltip label={value} fontSize="12px" color="white" data-testid={dataTestId}
       openDelay={1000} placement="bottom" whiteSpace="pre-wrap" maxW="400px">
-      <span style={{ display: "contents" }}>
-        {content}
-        <If condition={isInputRow && !strValue}>
-          <VisuallyHidden>{t("V3.CaseTable.inputRowCellInstructions", { vars: [attrName] })}</VisuallyHidden>
-        </If>
-      </span>
+      {content}
     </Tooltip>
   )
 }

--- a/v3/src/components/case-table/attribute-value-cell.tsx
+++ b/v3/src/components/case-table/attribute-value-cell.tsx
@@ -28,8 +28,6 @@ export function AttributeValueCell({ column, row }: TRenderCellProps) {
   const dataTestId = `case-table-tooltip-${row.__id__}-${column.key}`
   // Empty input-row cells don't need a tooltip (no value to show), but do need
   // screen-reader instructions. Render content + VisuallyHidden directly.
-  // Normal cells pass `content` as Tooltip's single child so Popper can anchor
-  // against the .cell-content div's bounding rect.
   if (isInputRow && !strValue) {
     return (
       <>
@@ -38,6 +36,11 @@ export function AttributeValueCell({ column, row }: TRenderCellProps) {
       </>
     )
   }
+  // No value means no tooltip to display (e.g. collapsed parent rows where
+  // content is also null). Skip the Tooltip wrapper entirely.
+  if (!value) return content
+  // Normal cells pass `content` as Tooltip's single child so Popper can anchor
+  // against the .cell-content div's bounding rect.
   return (
     <Tooltip label={value} fontSize="12px" color="white" data-testid={dataTestId}
       openDelay={1000} placement="bottom" whiteSpace="pre-wrap" maxW="400px">


### PR DESCRIPTION
## Summary

Fixes CODAP-1240. Data tips for long values in case table cells were appearing in the upper-left corner of the browser instead of near the cell.

The regression was introduced by CODAP-546 (#2442), which wrapped the `<Tooltip>`'s child in a `<span style="display: contents">` so a `<VisuallyHidden>` element could sit alongside the cell content inside Chakra's single-child Tooltip. `display: contents` restored the `.cell-content` flex-layout chain but also removed the span's bounding box — Chakra's Popper reads `getBoundingClientRect()` from the tooltip ref and got zeros, anchoring every tooltip at viewport (0, 0).

This PR:
- Passes `content` directly as the Tooltip's child for normal cells (restoring the pre-CODAP-546 anchor — Popper reads the real `.cell-content` div rect).
- Skips the Tooltip entirely for empty input-row cells (they have no value to display anyway) and renders `content` + `<VisuallyHidden>` as siblings so the screen-reader instructions still reach assistive tech.

## Test plan

- [ ] Open the Four Seals example document
- [ ] Hover over a `date` value long enough for the data tip to appear
- [ ] Verify the tooltip appears directly below the hovered cell, not in the upper-left corner
- [ ] Tab into an empty input-row cell with a screen reader; verify the cell instructions are still announced
- [ ] Hover a cell with a visible value and verify the tooltip still shows the full value below the cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)
