### PR TITLE
chore: visible dropdown to choose attributes on graphs (CODAP-1137)

### DIFF
--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -376,7 +376,7 @@ export function renderLabelBackground<GElement extends BaseType>(
   if (!textBBox) return
 
   const paddingX = labelPaddingX
-  const paddingY = 2
+  const paddingY = 4
   const arrowWidth = 24
 
   const rectWidth = textBBox.width + paddingX + arrowWidth

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.scss
@@ -26,7 +26,6 @@
 
     &:focus-visible {
       @include vars.focus-outline;
-      background-color: transparent;
     }
 
     // "Selected" (currently assigned) attribute

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
@@ -211,11 +211,13 @@ describe("AxisOrLegendAttributeMenu", () => {
       expect(svgTarget.classList.contains("hovered")).toBe(false)
     })
 
-    it("adds 'focused' class on keyboard-visible focus and removes on blur", () => {
+    it("adds 'focused' class on keyboard-visible focus and removes on blur", async () => {
+      const user = userEvent.setup()
       renderMenu({ target: svgTarget })
       const button = screen.getByTestId("axis-legend-attribute-button-bottom")
 
-      act(() => { button.focus() })
+      await user.tab()
+      expect(document.activeElement).toBe(button)
       expect(svgTarget.classList.contains("focused")).toBe(true)
 
       act(() => { button.blur() })

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
@@ -211,7 +211,7 @@ describe("AxisOrLegendAttributeMenu", () => {
       expect(svgTarget.classList.contains("hovered")).toBe(false)
     })
 
-    it("adds 'focused' class on focus and removes on blur", () => {
+    it("adds 'focused' class on keyboard-visible focus and removes on blur", () => {
       renderMenu({ target: svgTarget })
       const button = screen.getByTestId("axis-legend-attribute-button-bottom")
 

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -361,8 +361,11 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
     target?.classList.remove("hovered")
   }
 
-  const handleFocusCapture = () => {
-    target?.classList.add("focused")
+  const handleFocusCapture = (event: React.FocusEvent<HTMLDivElement>) => {
+    // Only show the focus ring for keyboard-driven focus, not mouse clicks.
+    if (event.target.matches(":focus-visible")) {
+      target?.classList.add("focused")
+    }
   }
 
   const handleBlurCapture = () => {


### PR DESCRIPTION
[CODAP-1137](https://concord-consortium.atlassian.net/browse/CODAP-1137)

This is a follow-up to #2513 that fixes some relatively minor issues identified during design review. The changes...

- Increase the axis/legend label top and bottom padding from 2px to 4px
- Ensure focus ring styling isn't added for mouse events
- Ensure attribute menu items get gray background when in keyboard focus

[CODAP-1137]: https://concord-consortium.atlassian.net/browse/CODAP-1137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ