### PR TITLE
CODAP-1225: fix autosave edit-focus-loss in case-table cells

### DIFF
--- a/v3/patches/react-data-grid+7.0.0-beta.44.patch
+++ b/v3/patches/react-data-grid+7.0.0-beta.44.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-data-grid/lib/bundle.cjs b/node_modules/react-data-grid/lib/bundle.cjs
-index 43bf414..f43c52c 100644
+index 43bf414..2e5a598 100644
 --- a/node_modules/react-data-grid/lib/bundle.cjs
 +++ b/node_modules/react-data-grid/lib/bundle.cjs
 @@ -175,7 +175,7 @@ function getNextSelectedCellPosition({
@@ -124,7 +124,7 @@ index 43bf414..f43c52c 100644
      const {
        keyCode
      } = event;
-@@ -2638,7 +2645,16 @@ function DataGrid(props, ref) {
+@@ -2638,7 +2645,19 @@ function DataGrid(props, ref) {
          }));
        }
      };
@@ -132,17 +132,20 @@ index 43bf414..f43c52c 100644
 +    // Patched: compare via rowKeyGetter if available so row objects that
 +    // legitimately represent the same case (but as a new object reference)
 +    // are not treated as stale. Falls back to ref equality when no keyGetter
-+    // is set.
++    // is set. If the selected row index is now out of bounds, treat it as
++    // stale and close the editor before invoking rowKeyGetter.
 +    const currentRow = rows[selectedPosition.rowIdx];
 +    const originalRow = selectedPosition.originalRow;
-+    const stale = rowKeyGetter
-+      ? rowKeyGetter(currentRow) !== rowKeyGetter(originalRow)
-+      : currentRow !== originalRow;
++    const stale = currentRow === undefined
++      ? true
++      : rowKeyGetter
++        ? rowKeyGetter(currentRow) !== rowKeyGetter(originalRow)
++        : currentRow !== originalRow;
 +    if (stale) {
        closeEditor(false);
      }
      return /*#__PURE__*/jsxRuntime.jsx(EditCell, {
-@@ -3322,5 +3338,6 @@ exports.renderSortPriority = renderSortPriority;
+@@ -3322,5 +3341,6 @@ exports.renderSortPriority = renderSortPriority;
  exports.renderToggleGroup = renderToggleGroup;
  exports.renderValue = renderValue;
  exports.textEditor = textEditor;
@@ -150,7 +153,7 @@ index 43bf414..f43c52c 100644
  exports.useRowSelection = useRowSelection;
  //# sourceMappingURL=bundle.cjs.map
 diff --git a/node_modules/react-data-grid/lib/bundle.js b/node_modules/react-data-grid/lib/bundle.js
-index 0214c29..5719092 100644
+index 0214c29..71f0c57 100644
 --- a/node_modules/react-data-grid/lib/bundle.js
 +++ b/node_modules/react-data-grid/lib/bundle.js
 @@ -171,7 +171,7 @@ function getNextSelectedCellPosition({
@@ -275,7 +278,7 @@ index 0214c29..5719092 100644
      const {
        keyCode
      } = event;
-@@ -2634,7 +2641,16 @@ function DataGrid(props, ref) {
+@@ -2634,7 +2641,19 @@ function DataGrid(props, ref) {
          }));
        }
      };
@@ -283,17 +286,20 @@ index 0214c29..5719092 100644
 +    // Patched: compare via rowKeyGetter if available so row objects that
 +    // legitimately represent the same case (but as a new object reference)
 +    // are not treated as stale. Falls back to ref equality when no keyGetter
-+    // is set.
++    // is set. If the selected row index is now out of bounds, treat it as
++    // stale and close the editor before invoking rowKeyGetter.
 +    const currentRow = rows[selectedPosition.rowIdx];
 +    const originalRow = selectedPosition.originalRow;
-+    const stale = rowKeyGetter
-+      ? rowKeyGetter(currentRow) !== rowKeyGetter(originalRow)
-+      : currentRow !== originalRow;
++    const stale = currentRow === undefined
++      ? true
++      : rowKeyGetter
++        ? rowKeyGetter(currentRow) !== rowKeyGetter(originalRow)
++        : currentRow !== originalRow;
 +    if (stale) {
        closeEditor(false);
      }
      return /*#__PURE__*/jsx(EditCell, {
-@@ -3303,5 +3319,5 @@ function textEditor({
+@@ -3303,5 +3322,5 @@ function textEditor({
    });
  }
  

--- a/v3/patches/react-data-grid+7.0.0-beta.44.patch
+++ b/v3/patches/react-data-grid+7.0.0-beta.44.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-data-grid/lib/bundle.cjs b/node_modules/react-data-grid/lib/bundle.cjs
-index 43bf414..708f5f8 100644
+index 43bf414..f43c52c 100644
 --- a/node_modules/react-data-grid/lib/bundle.cjs
 +++ b/node_modules/react-data-grid/lib/bundle.cjs
 @@ -175,7 +175,7 @@ function getNextSelectedCellPosition({
@@ -124,7 +124,25 @@ index 43bf414..708f5f8 100644
      const {
        keyCode
      } = event;
-@@ -3322,5 +3329,6 @@ exports.renderSortPriority = renderSortPriority;
+@@ -2638,7 +2645,16 @@ function DataGrid(props, ref) {
+         }));
+       }
+     };
+-    if (rows[selectedPosition.rowIdx] !== selectedPosition.originalRow) {
++    // Patched: compare via rowKeyGetter if available so row objects that
++    // legitimately represent the same case (but as a new object reference)
++    // are not treated as stale. Falls back to ref equality when no keyGetter
++    // is set.
++    const currentRow = rows[selectedPosition.rowIdx];
++    const originalRow = selectedPosition.originalRow;
++    const stale = rowKeyGetter
++      ? rowKeyGetter(currentRow) !== rowKeyGetter(originalRow)
++      : currentRow !== originalRow;
++    if (stale) {
+       closeEditor(false);
+     }
+     return /*#__PURE__*/jsxRuntime.jsx(EditCell, {
+@@ -3322,5 +3338,6 @@ exports.renderSortPriority = renderSortPriority;
  exports.renderToggleGroup = renderToggleGroup;
  exports.renderValue = renderValue;
  exports.textEditor = textEditor;
@@ -132,7 +150,7 @@ index 43bf414..708f5f8 100644
  exports.useRowSelection = useRowSelection;
  //# sourceMappingURL=bundle.cjs.map
 diff --git a/node_modules/react-data-grid/lib/bundle.js b/node_modules/react-data-grid/lib/bundle.js
-index 0214c29..b2bf059 100644
+index 0214c29..5719092 100644
 --- a/node_modules/react-data-grid/lib/bundle.js
 +++ b/node_modules/react-data-grid/lib/bundle.js
 @@ -171,7 +171,7 @@ function getNextSelectedCellPosition({
@@ -257,10 +275,28 @@ index 0214c29..b2bf059 100644
      const {
        keyCode
      } = event;
-@@ -3303,5 +3310,5 @@ function textEditor({
+@@ -2634,7 +2641,16 @@ function DataGrid(props, ref) {
+         }));
+       }
+     };
+-    if (rows[selectedPosition.rowIdx] !== selectedPosition.originalRow) {
++    // Patched: compare via rowKeyGetter if available so row objects that
++    // legitimately represent the same case (but as a new object reference)
++    // are not treated as stale. Falls back to ref equality when no keyGetter
++    // is set.
++    const currentRow = rows[selectedPosition.rowIdx];
++    const originalRow = selectedPosition.originalRow;
++    const stale = rowKeyGetter
++      ? rowKeyGetter(currentRow) !== rowKeyGetter(originalRow)
++      : currentRow !== originalRow;
++    if (stale) {
+       closeEditor(false);
+     }
+     return /*#__PURE__*/jsx(EditCell, {
+@@ -3303,5 +3319,5 @@ function textEditor({
    });
  }
-
+ 
 -export { DataGridDefaultRenderersProvider, RowComponent$1 as Row, SELECT_COLUMN_KEY, SelectCellFormatter, SelectColumn, ToggleGroup, TreeDataGrid$1 as TreeDataGrid, DataGrid$1 as default, renderCheckbox, renderHeaderCell, renderSortIcon, renderSortPriority, renderToggleGroup, renderValue, textEditor, useRowSelection };
 +export { DataGridDefaultRenderersProvider, RowComponent$1 as Row, SELECT_COLUMN_KEY, SelectCellFormatter, SelectColumn, ToggleGroup, TreeDataGrid$1 as TreeDataGrid, DataGrid$1 as default, renderCheckbox, renderHeaderCell, renderSortIcon, renderSortPriority, renderToggleGroup, renderValue, textEditor, textEditorClassname, useRowSelection };
  //# sourceMappingURL=bundle.js.map
@@ -289,11 +325,11 @@ index 4b927bd..c6ffa4e 100644
      onColumnsReorder?: Maybe<(sourceColumnKey: string, targetColumnKey: string) => void>;
      /**
 @@ -439,6 +443,8 @@ export declare type SortDirection = 'ASC' | 'DESC';
-
+ 
  export declare function textEditor<TRow, TSummaryRow>({ row, column, onRowChange, onClose }: RenderEditCellProps<TRow, TSummaryRow>): JSX_2.Element;
-
+ 
 +export declare const textEditorClassname: string;
 +
  export declare function ToggleGroup<R, SR>({ groupKey, isExpanded, tabIndex, toggleGroup }: RenderGroupCellProps<R, SR>): JSX_2.Element;
-
+ 
  export declare const TreeDataGrid: <R, SR = unknown, K extends Key = Key>(props: TreeDataGridProps<R, SR, K> & RefAttributes<DataGridHandle>) => JSX.Element;

--- a/v3/src/components/case-table/use-selected-cell.test.tsx
+++ b/v3/src/components/case-table/use-selected-cell.test.tsx
@@ -100,6 +100,59 @@ describe("useSelectedCell", () => {
     expect(mockScrollRowIntoView).toHaveBeenCalledTimes(2)
   })
 
+  it("navigateToNextRow invokes selectCell synchronously (no setTimeout)", () => {
+    // Regression guard for CODAP-1225: navigateToNextRow must move selection
+    // synchronously so a keystroke between Enter and the selection move cannot
+    // enter edit mode on the old cell.
+    columns = [{ name: "Column1", key: "column-1" }]
+    rows = [{ __id__: "row-0" }, { __id__: "row-1" }, { __id__: "row-2" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>
+            {children}
+          </DataSetContext.Provider>
+        )
+      })
+    result.current.handleSelectedCellChange({
+      rowIdx: 0, row: rows[0], column: columns[0] as TCalculatedColumn
+    })
+
+    result.current.navigateToNextRow()
+
+    // Assert selectCell was called BEFORE any timers ran — i.e. synchronously.
+    expect(gridRef.current.selectCell).toHaveBeenCalledTimes(1)
+    expect(gridRef.current.selectCell).toHaveBeenCalledWith({ idx: 0, rowIdx: 1 }, true)
+    expect(mockScrollRowIntoView).toHaveBeenCalledWith(1)
+  })
+
+  it("navigateToNextCell invokes selectCell synchronously (no setTimeout)", () => {
+    // Regression guard for CODAP-1225 (Tab variant): navigateToNextCell must
+    // move selection synchronously for the same reason as navigateToNextRow.
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "Column1", key: "column-1" },
+      { name: "Column2", key: "column-2" }
+    ]
+    rows = [{ __id__: "row-0" }, { __id__: "row-1" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>
+            {children}
+          </DataSetContext.Provider>
+        )
+      })
+    result.current.handleSelectedCellChange({
+      rowIdx: 0, row: rows[0], column: columns[1] as TCalculatedColumn
+    })
+
+    result.current.navigateToNextCell()
+
+    expect(gridRef.current.selectCell).toHaveBeenCalledTimes(1)
+    expect(gridRef.current.selectCell).toHaveBeenCalledWith({ idx: 2, rowIdx: 0 }, true)
+  })
+
   it("defers navigation via useEffect when target row doesn't exist yet", () => {
     columns = [
       { name: "Index", key: "__index__" },

--- a/v3/src/components/case-table/use-selected-cell.test.tsx
+++ b/v3/src/components/case-table/use-selected-cell.test.tsx
@@ -124,6 +124,11 @@ describe("useSelectedCell", () => {
     expect(gridRef.current.selectCell).toHaveBeenCalledTimes(1)
     expect(gridRef.current.selectCell).toHaveBeenCalledWith({ idx: 0, rowIdx: 1 }, true)
     expect(mockScrollRowIntoView).toHaveBeenCalledWith(1)
+
+    // Also guard against a regression that reintroduces setTimeout *alongside*
+    // the sync call: flushing pending timers must not trigger a second navigation.
+    jest.runAllTimers()
+    expect(gridRef.current.selectCell).toHaveBeenCalledTimes(1)
   })
 
   it("navigateToNextCell invokes selectCell synchronously (no setTimeout)", () => {
@@ -151,6 +156,11 @@ describe("useSelectedCell", () => {
 
     expect(gridRef.current.selectCell).toHaveBeenCalledTimes(1)
     expect(gridRef.current.selectCell).toHaveBeenCalledWith({ idx: 2, rowIdx: 0 }, true)
+
+    // Flushing pending timers must not trigger a second navigation — guards
+    // against a reintroduced setTimeout alongside the sync call.
+    jest.runAllTimers()
+    expect(gridRef.current.selectCell).toHaveBeenCalledTimes(1)
   })
 
   it("defers navigation via useEffect when target row doesn't exist yet", () => {

--- a/v3/src/components/case-table/use-selected-cell.ts
+++ b/v3/src/components/case-table/use-selected-cell.ts
@@ -61,12 +61,11 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
       const rowIdx = Math.max(0, selectedCell.current.rowIdx + (back ? -1 : 1))
       const nav = { idx, rowIdx }
       pendingNavigation.current = nav
-      // setTimeout so it occurs after handling of current event completes.
-      // If the target row doesn't exist yet (e.g. input row just created a new case
-      // and the grid hasn't re-rendered), the useEffect fallback will handle it.
-      setTimeout(() => {
-        attemptNavigation(nav, rows)
-      })
+      // Navigate synchronously so a keystroke between the Enter handler and selection
+      // move cannot enter edit mode on the old cell. If the target row doesn't exist yet
+      // (e.g. input row just created a new case and the grid hasn't re-rendered),
+      // attemptNavigation returns false and the useEffect fallback will handle it.
+      attemptNavigation(nav, rows)
     }
   }, [attemptNavigation, columns, rows])
 
@@ -90,11 +89,8 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
         : rightmost ? currentRowIdx + 1 : currentRowIdx
       const nav = { idx, rowIdx }
       pendingNavigation.current = nav
-      // setTimeout so it occurs after handling of current event completes.
-      // If the target row doesn't exist yet, the useEffect fallback will handle it.
-      setTimeout(() => {
-        attemptNavigation(nav, rows)
-      })
+      // Navigate synchronously; see navigateToNextRow for rationale.
+      attemptNavigation(nav, rows)
     }
   }, [attemptNavigation, columns, rows])
 
@@ -130,9 +126,9 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
     }
   }, [blockingDataset, refreshSelectedCellDebounced])
 
-  // In Safari, the setTimeout in navigateToNextRow/navigateToNextCell may fire before
-  // the grid has re-rendered with new rows (e.g. after input row creates a new case).
-  // This effect retries pending navigation when rows change.
+  // When sync navigation in navigateToNextRow/Cell finds the target row doesn't yet
+  // exist (e.g. after input row creates a new case and the grid hasn't re-rendered),
+  // this effect retries pending navigation when rows change.
   useEffect(() => {
     if (pendingNavigation.current && rows) {
       attemptNavigation(pendingNavigation.current, rows)


### PR DESCRIPTION
The original bug report hypothesized that Google Drive auto-save was the trigger for the loss of edit focus. After working with @bfinzer (the reporter) and then extensive attempts to reproduce locally, the hypothesis here is that the underlying bug is a simple RDG/React race condition where, at best, the auto-save may have the effect of widening the window for the race condition to occur. For reasons I still don't understand, the bug was easier to reproduce for @bfinzer than for me. The reproducible case that worked best for me was to try to rapidly change the contents of a sequence of values of a given an attribute by quickly typing a sequence like {a}{enter}, {b}{enter}, {c}{enter}, ... for as long as it took for the edits to eventually fail. As described below, the fix replaces the use of setTimeout, which inherently invites a race condition, with a synchronous update, that should be more robust in any case.

## Summary
- Fixes CODAP-1225: intermittent value-loss and focus-loss during rapid
  {char}{enter} cycles in case-table cells.
- Two interacting root causes addressed:
  1. `useSelectedCell`: `navigateToNextRow`/`navigateToNextCell` now call
     `attemptNavigation` synchronously instead of via `setTimeout`,
     closing the race window where a keystroke between the Enter commit
     and selection move could enter edit mode on the old cell. The
     existing useEffect retry still handles the input-row-creates-new-case
     edge case.
  2. `react-data-grid` stale-row check (via patch-package): compares row
     identity via `rowKeyGetter(row)` instead of reference equality, so a
     reconstructed row object representing the same case is not treated
     as stale. Prevents the editor being closed after `resetRowCache`
     rebuilds row references following a commit.

## Test plan
- [ ] New jest unit tests verify `navigateToNextRow` and
      `navigateToNextCell` invoke `selectCell` synchronously (regression
      guard against reintroducing setTimeout).
- [ ] Manual repro against a Google Drive document: rapid {char}{enter}
      cycles in hierarchical case-table — no value loss, no focus loss.
- [ ] Existing `use-selected-cell`, `case-table-component`, and
      `cell-text-editor` tests continue to pass.
- [ ] Full Cypress regression suite once `run regression` label is
      applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)