### PR TITLE
CODAP-1249: use collection title for map layer palette labels

### DIFF
--- a/v3/cypress/e2e/map.spec.ts
+++ b/v3/cypress/e2e/map.spec.ts
@@ -191,9 +191,9 @@ context("Map UI", () => {
     map.getHeatmapCanvas().should("exist")
 
     // Hidden when layer is hidden
-    map.getInspectorPalette().contains("RollerCoastersWithLatLong").click()
+    map.getInspectorPalette().contains(/cases/i).click()
     map.getHeatmapCanvas().should("not.exist")
-    map.getInspectorPalette().contains("RollerCoastersWithLatLong").click()
+    map.getInspectorPalette().contains(/cases/i).click()
     map.getHeatmapCanvas().should("exist")
 
     // Hidden when points are hidden
@@ -290,9 +290,9 @@ context("Map UI", () => {
 
     cy.log("Can hide pins using the layers menu")
     map.getDisplayConfigButton().click()
-    map.getInspectorPalette().contains("New Dataset").click()
+    map.getInspectorPalette().contains(/cases/i).click()
     map.getMapPins().should("not.exist")
-    map.getInspectorPalette().contains("New Dataset").click()
+    map.getInspectorPalette().contains(/cases/i).click()
     map.getMapPin().should("exist")
 
     cy.log("Can remove a pin using the remove pin button")

--- a/v3/src/components/map/components/inspector-panel/map-layers-palette.tsx
+++ b/v3/src/components/map/components/inspector-panel/map-layers-palette.tsx
@@ -60,7 +60,7 @@ export const MapLayersPalette = observer(function MapLayersPalette(
                 })
               }}
             >
-              {layer.dataConfiguration.dataset?.name ?? t("DG.Inspector.defaultLayerName")}
+              {layer.titleCollection?.title ?? t("DG.Inspector.defaultLayerName")}
             </PaletteCheckbox>
             {renderOneFormatControl(layer)}
           </div>)

--- a/v3/src/components/map/components/inspector-panel/map-measure-palette.tsx
+++ b/v3/src/components/map/components/inspector-panel/map-measure-palette.tsx
@@ -32,7 +32,7 @@ export const MapMeasurePalette = observer(function MapMeasurePalette(
                role="group" aria-labelledby={`map-values-label-${layer.id}`}>
             <div className="map-values-layer-label" id={`map-values-label-${layer.id}`}
                  data-testid={`map-values-layer-label-${layer.id}`}>
-              {layer.dataConfiguration.dataset?.name}
+              {(pointLayer ?? pinLayer)?.titleCollection?.title}
             </div>
             {pointLayer && (
               <>

--- a/v3/src/components/map/components/inspector-panel/map-measure-palette.tsx
+++ b/v3/src/components/map/components/inspector-panel/map-measure-palette.tsx
@@ -32,7 +32,7 @@ export const MapMeasurePalette = observer(function MapMeasurePalette(
                role="group" aria-labelledby={`map-values-label-${layer.id}`}>
             <div className="map-values-layer-label" id={`map-values-label-${layer.id}`}
                  data-testid={`map-values-layer-label-${layer.id}`}>
-              {(pointLayer ?? pinLayer)?.titleCollection?.title}
+              {(pointLayer ?? pinLayer)?.titleCollection?.title ?? t("DG.Inspector.defaultLayerName")}
             </div>
             {pointLayer && (
               <>

--- a/v3/src/components/map/models/map-content-model.test.ts
+++ b/v3/src/components/map/models/map-content-model.test.ts
@@ -276,4 +276,84 @@ describe("MapContentModel", () => {
       expect(mapContent.layers[0].dataConfiguration.dataset?.id).toBe(dataSet2.id)
     })
   })
+
+  describe("titleCollection (CODAP-1249)", () => {
+    // Each map layer's palette label should reflect the *collection* holding the
+    // layer's spatial attributes (matching v2 behavior), not the dataset name.
+    // For imported v2 docs where the data context's title differs from its name,
+    // this also exercises the v2NameTitleToV3Title import path indirectly: the
+    // collection's `title` getter falls back through `_title` then `name`.
+
+    async function attachDataset(dataSet: ReturnType<typeof DataSet.create>) {
+      const sharedDataSet = SharedDataSet.create()
+      sharedDataSet.setDataSet(dataSet)
+      const metadata = DataSetMetadata.create({ data: dataSet.id })
+      sharedModelManager.addSharedModel(sharedDataSet)
+      sharedModelManager.addSharedModel(metadata)
+      await new Promise(resolve => setTimeout(resolve, 0))
+    }
+
+    it("returns the leaf collection for a hierarchical point layer", async () => {
+      // Mirrors the Roller Coasters example: parent States, child Roller Coasters
+      // with the lat/long attributes.
+      const dataSet = DataSet.create({ name: "rc_internal", _title: "Roller Coasters DS" })
+      dataSet.childCollection.setName("Roller Coasters")
+      const parent = dataSet.addCollection({ name: "States" })
+      dataSet.addAttribute({ name: "State" }, { collection: parent.id })
+      dataSet.addAttribute({ id: "lat", name: "Latitude" })
+      dataSet.addAttribute({ id: "long", name: "Longitude" })
+
+      await attachDataset(dataSet)
+
+      expect(mapContent.layers.length).toBe(1)
+      const layer = mapContent.layers[0]
+      if (!isMapPointLayerModel(layer)) throw new Error("expected MapPointLayerModel")
+      expect(layer.titleCollection?.name).toBe("Roller Coasters")
+      // No _title set on the collection, so title falls back to name.
+      expect(layer.titleCollection?.title).toBe("Roller Coasters")
+    })
+
+    it("prefers the collection's _title over its name when set", async () => {
+      const dataSet = DataSet.create({ name: "ds" })
+      dataSet.childCollection.setName("internal_name")
+      dataSet.childCollection.setTitle("User-Visible Title")
+      dataSet.addAttribute({ id: "lat", name: "Latitude" })
+      dataSet.addAttribute({ id: "long", name: "Longitude" })
+
+      await attachDataset(dataSet)
+
+      const layer = mapContent.layers[0]
+      if (!isMapPointLayerModel(layer)) throw new Error("expected MapPointLayerModel")
+      expect(layer.titleCollection?.title).toBe("User-Visible Title")
+    })
+
+    it("returns the leaf collection for a hierarchical polygon layer", async () => {
+      const dataSet = DataSet.create({ name: "boundaries_ds" })
+      dataSet.childCollection.setName("Districts")
+      const parent = dataSet.addCollection({ name: "Regions" })
+      dataSet.addAttribute({ name: "Region" }, { collection: parent.id })
+      dataSet.addAttribute({ id: "boundary", name: "Boundary", userType: "boundary" })
+
+      await attachDataset(dataSet)
+
+      const layer = mapContent.layers[0]
+      if (!isMapPolygonLayerModel(layer)) throw new Error("expected MapPolygonLayerModel")
+      expect(layer.titleCollection?.name).toBe("Districts")
+    })
+
+    it("returns the leaf collection for a hierarchical pin layer", async () => {
+      const dataSet = DataSet.create({ name: "pins_ds" })
+      dataSet.childCollection.setName("Sites")
+      const parent = dataSet.addCollection({ name: "Categories" })
+      dataSet.addAttribute({ name: "Category" }, { collection: parent.id })
+      dataSet.addAttribute({ id: "pinLat", name: "PinLat" })
+      dataSet.addAttribute({ id: "pinLong", name: "PinLong" })
+
+      await attachDataset(dataSet)
+
+      const layer = mapContent.layers[0]
+      if (!isMapPinLayerModel(layer)) throw new Error("expected MapPinLayerModel")
+      expect(layer.titleCollection?.name).toBe("Sites")
+    })
+  })
 })

--- a/v3/src/components/map/models/map-layer-model.ts
+++ b/v3/src/components/map/models/map-layer-model.ts
@@ -1,5 +1,6 @@
 /**
- * MapLayerModel serves as a base model for map layers: MapPolygonLayerModel and MapPointLayerModel.
+ * MapLayerModel serves as a base model for map layers: MapPolygonLayerModel,
+ * MapPointLayerModel, and MapPinLayerModel.
  */
 import {Instance, types} from "mobx-state-tree"
 import {ICollectionModel} from "../../../models/data/collection"

--- a/v3/src/components/map/models/map-layer-model.ts
+++ b/v3/src/components/map/models/map-layer-model.ts
@@ -2,6 +2,7 @@
  * MapLayerModel serves as a base model for map layers: MapPolygonLayerModel and MapPointLayerModel.
  */
 import {Instance, types} from "mobx-state-tree"
+import {ICollectionModel} from "../../../models/data/collection"
 import {DataDisplayLayerModel, IDataDisplayLayerModel} from "../../data-display/models/data-display-layer-model"
 import {DisplayItemDescriptionModel} from "../../data-display/models/display-item-description-model"
 import {isMapLayerType} from "../map-types"
@@ -13,6 +14,9 @@ export const MapLayerModel = DataDisplayLayerModel
     displayItemDescription: types.optional(DisplayItemDescriptionModel, () => DisplayItemDescriptionModel.create()),
   })
   .views(self => ({
+    get titleCollection(): Maybe<ICollectionModel> {
+      return undefined
+    }
   }))
   .actions(self => ({
     setVisibility(isVisible: boolean) {

--- a/v3/src/components/map/models/map-pin-layer-model.ts
+++ b/v3/src/components/map/models/map-pin-layer-model.ts
@@ -1,4 +1,5 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
+import { ICollectionModel } from "../../../models/data/collection"
 import { IDataSet } from "../../../models/data/data-set"
 import { getMetadataFromDataSet } from "../../../models/shared/shared-data-utils"
 import { computePointRadius } from "../../data-display/data-display-utils"
@@ -45,6 +46,10 @@ export const MapPinLayerModel = MapLayerModel
     },
     get pointDescription() {
       return self.displayItemDescription
+    },
+    get titleCollection(): Maybe<ICollectionModel> {
+      const pinLatId = self.dataConfiguration.attributeID('pinLat')
+      return pinLatId ? self.dataConfiguration.dataset?.getCollectionForAttribute(pinLatId) : undefined
     }
   }))
 

--- a/v3/src/components/map/models/map-point-layer-model.ts
+++ b/v3/src/components/map/models/map-point-layer-model.ts
@@ -1,4 +1,5 @@
 import {Instance, SnapshotIn, types} from "mobx-state-tree"
+import {ICollectionModel} from "../../../models/data/collection"
 import {IDataDisplayLayerModel} from "../../data-display/models/data-display-layer-model"
 import {kMapPointLayerType} from "../map-types"
 import {MapLayerModel} from "./map-layer-model"
@@ -53,6 +54,10 @@ export const MapPointLayerModel = MapLayerModel
     },
     get pointDescription() {
       return self.displayItemDescription
+    },
+    get titleCollection(): Maybe<ICollectionModel> {
+      const latId = self.dataConfiguration.attributeID('lat')
+      return latId ? self.dataConfiguration.dataset?.getCollectionForAttribute(latId) : undefined
     }
   }))
 

--- a/v3/src/components/map/models/map-polygon-layer-model.ts
+++ b/v3/src/components/map/models/map-polygon-layer-model.ts
@@ -3,6 +3,7 @@
  */
 import {Instance, SnapshotIn, types} from "mobx-state-tree"
 import {GeoJSON} from "leaflet"
+import {ICollectionModel} from "../../../models/data/collection"
 import {IDataSet} from "../../../models/data/data-set"
 import {getMetadataFromDataSet} from "../../../models/shared/shared-data-utils"
 import {IDataDisplayLayerModel} from "../../data-display/models/data-display-layer-model"
@@ -35,6 +36,10 @@ export const MapPolygonLayerModel = MapLayerModel
     },
     get polygonDescription() {
       return self.displayItemDescription
+    },
+    get titleCollection(): Maybe<ICollectionModel> {
+      const polygonId = self.dataConfiguration.attributeID('polygon')
+      return polygonId ? self.dataConfiguration.dataset?.getCollectionForAttribute(polygonId) : undefined
     }
   }))
 


### PR DESCRIPTION
## Summary

- Map Layers and Data inspector palettes now show the user-visible title of the collection holding each layer's spatial attribute, matching v2.
- Previously they read `dataset.name`, which is the internal name and can diverge from the user-visible title for imported v2 documents (the v2 importer maps v2 `title` to V3 `_title`, not `name`).
- New `titleCollection` view on `MapLayerModel`, overridden by each subtype to resolve via the appropriate spatial attribute role (`lat` / `polygon` / `pinLat`).

Fixes CODAP-1249.

## Test plan

- [x] `npm run build:tsc` clean
- [x] `npm test -- src/components/map src/v2` — 83 tests pass, including 4 new regression tests in `map-content-model.test.ts` covering each layer subtype and the `_title`-vs-`name` fallback
- [ ] Manual: imported v2 document with hierarchical data shows the leaf collection name (e.g., "Roller Coasters") in the Layers and Data palettes
