### PR TITLE
chore: silence act() warnings and gitignore local dev artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ v3/cypress/screenshots
 # Claude Code
 .claude/*
 !.claude/skills/
+
+# Local dev
+.yalc/
+yalc.lock
+frameworks/

--- a/v3/src/components/common/color-picker-palette.test.tsx
+++ b/v3/src/components/common/color-picker-palette.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react"
+import { act, render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { ColorPickerPalette } from "./color-picker-palette"
 
@@ -266,7 +266,7 @@ describe("ColorPickerPalette", () => {
     render(<ColorPickerPalette {...defaultProps} />)
 
     const swatch = screen.getByRole("option", { name: "Black" })
-    swatch.focus()
+    act(() => { swatch.focus() })
     await user.keyboard("{Escape}")
 
     expect(defaultProps.onReject).toHaveBeenCalled()

--- a/v3/src/components/tool-shelf/tool-shelf.test.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.test.tsx
@@ -186,9 +186,14 @@ describe("Tool shelf", () => {
       expect(buttons[2]).toHaveFocus()
       expect(buttons[2]).toHaveAttribute("tabindex", "0")
 
-      // Trigger a re-render by adding a tile (changes canUndo observable)
+      // Trigger a re-render by adding a tile (changes canUndo observable).
+      // The tree monitor's async recordAction dispatches an observer re-render
+      // after addTile returns, so flush pending tasks inside act().
       const tile = TileModel.create({ id: "tile-1", content: TestTileContent.create() })
-      act(() => document.addTile(tile))
+      await act(async () => {
+        document.addTile(tile)
+        await new Promise(resolve => setTimeout(resolve, 0))
+      })
 
       // Tabindex should still be on the third button after re-render
       expect(buttons[2]).toHaveAttribute("tabindex", "0")


### PR DESCRIPTION
## Summary
- Wrap direct `swatch.focus()` in `act()` in `color-picker-palette.test.tsx` so React Aria's `setFocusedKey` state update is covered.
- Switch the `addTile` `act()` in `tool-shelf.test.tsx` to an async variant that flushes pending microtasks, covering the tree monitor's fire-and-forget `recordAction` promise that re-renders `ToolShelf` after `addTile` returns.
- Gitignore `.yalc/`, `yalc.lock`, and `frameworks/` — local dev artifacts that shouldn't track.

Tests-only + gitignore change; no runtime behavior affected. Both test files previously emitted `Warning: An update to … was not wrapped in act(...)` on every run; both are now silent.

## Test plan
- [ ] `npm test -- color-picker-palette.test.tsx` — 22 tests pass, no act warnings
- [ ] `npm test -- tool-shelf.test.tsx` — 11 tests pass, no act warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
