### PR TITLE
CODAP-1252: eliminate redundant prepareSnapshot/completeSnapshot calls

### DIFF
--- a/v3/src/models/document/serialize-document.test.ts
+++ b/v3/src/models/document/serialize-document.test.ts
@@ -1,0 +1,82 @@
+import { CONFIG_SAVE_AS_V2 } from "../../lib/config"
+import { createCodapDocument } from "../codap/create-codap-document"
+import {
+  ISerializedDocument, serializeCodapDocument, serializeCodapV2Document, serializeCodapV3Document, serializeDocument
+} from "./serialize-document"
+
+describe("serializeDocument", () => {
+  it("calls prepareSnapshot before, and completeSnapshot after, the serialize function", async () => {
+    const doc = createCodapDocument()
+    const order: string[] = []
+    jest.spyOn(doc.content!, "prepareSnapshot").mockImplementation(async () => { order.push("prepare") })
+    jest.spyOn(doc.content!, "completeSnapshot").mockImplementation(() => { order.push("complete") })
+    const serializeFn = jest.fn(() => { order.push("serialize"); return "result" })
+
+    const result = await serializeDocument(doc, serializeFn)
+
+    expect(result).toBe("result")
+    expect(order).toEqual(["prepare", "serialize", "complete"])
+    expect(serializeFn).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls completeSnapshot even when the serialize function throws", async () => {
+    const doc = createCodapDocument()
+    const completeSpy = jest.spyOn(doc.content!, "completeSnapshot")
+    const error = new Error("serialize failed")
+
+    await expect(serializeDocument(doc, () => { throw error })).rejects.toBe(error)
+
+    expect(completeSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("serializeCodapV2Document", () => {
+  it("calls prepareSnapshot and completeSnapshot exactly once per call", async () => {
+    const doc = createCodapDocument()
+    const prepareSpy = jest.spyOn(doc.content!, "prepareSnapshot")
+    const completeSpy = jest.spyOn(doc.content!, "completeSnapshot")
+
+    await serializeCodapV2Document(doc)
+
+    expect(prepareSpy).toHaveBeenCalledTimes(1)
+    expect(completeSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("serializeCodapV3Document", () => {
+  it("calls prepareSnapshot and completeSnapshot exactly once per call", async () => {
+    const doc = createCodapDocument()
+    const prepareSpy = jest.spyOn(doc.content!, "prepareSnapshot")
+    const completeSpy = jest.spyOn(doc.content!, "completeSnapshot")
+
+    await serializeCodapV3Document(doc)
+
+    expect(prepareSpy).toHaveBeenCalledTimes(1)
+    expect(completeSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("serializeCodapDocument", () => {
+  // Regression test for CODAP-1252. Before the fix, serializeCodapDocument wrapped its
+  // v2/v3 dispatch in serializeDocument(), but the dispatched serializer also wraps
+  // its work in serializeDocument(), so prepare/complete ran twice per save.
+  it("calls prepareSnapshot and completeSnapshot exactly once per call", async () => {
+    const doc = createCodapDocument()
+    const prepareSpy = jest.spyOn(doc.content!, "prepareSnapshot")
+    const completeSpy = jest.spyOn(doc.content!, "completeSnapshot")
+
+    await serializeCodapDocument(doc)
+
+    expect(prepareSpy).toHaveBeenCalledTimes(1)
+    expect(completeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns the same result as a direct call to the configured serializer", async () => {
+    const doc = createCodapDocument()
+    const viaDispatch = await serializeCodapDocument(doc)
+    const direct = CONFIG_SAVE_AS_V2
+                    ? await serializeCodapV2Document<ISerializedDocument>(doc)
+                    : await serializeCodapV3Document<ISerializedDocument>(doc)
+    expect(viaDispatch).toEqual(direct)
+  })
+})

--- a/v3/src/models/document/serialize-document.test.ts
+++ b/v3/src/models/document/serialize-document.test.ts
@@ -19,6 +19,22 @@ describe("serializeDocument", () => {
     expect(serializeFn).toHaveBeenCalledTimes(1)
   })
 
+  it("waits for an async serialize function to settle before completeSnapshot runs", async () => {
+    const doc = createCodapDocument()
+    const order: string[] = []
+    jest.spyOn(doc.content!, "completeSnapshot").mockImplementation(() => { order.push("complete") })
+    const serializeFn = jest.fn(async () => {
+      await Promise.resolve()
+      order.push("serialize-resolved")
+      return "result"
+    })
+
+    const result = await serializeDocument(doc, serializeFn)
+
+    expect(result).toBe("result")
+    expect(order).toEqual(["serialize-resolved", "complete"])
+  })
+
   it("calls completeSnapshot even when the serialize function throws", async () => {
     const doc = createCodapDocument()
     const completeSpy = jest.spyOn(doc.content!, "completeSnapshot")

--- a/v3/src/models/document/serialize-document.ts
+++ b/v3/src/models/document/serialize-document.ts
@@ -35,9 +35,10 @@ export async function serializeCodapV3Document<T = ISerializedV3Document>(docume
 
 // serialize a document in v2 or v3 format depending on configuration
 export async function serializeCodapDocument(document: IDocumentModel): Promise<ISerializedDocument> {
-  const serializeFn = CONFIG_SAVE_AS_V2
-                        // export as v2 if configured to do so
-                        ? serializeCodapV2Document<ISerializedDocument>
-                        : serializeCodapV3Document<ISerializedDocument>
-  return serializeDocument(document, serializeFn)
+  // Dispatch directly to the v2/v3 serializer; each wraps its work in
+  // serializeDocument(), so an outer wrapper here would run prepareSnapshot()/
+  // completeSnapshot() twice per save.
+  return CONFIG_SAVE_AS_V2
+    ? serializeCodapV2Document<ISerializedDocument>(document)
+    : serializeCodapV3Document<ISerializedDocument>(document)
 }

--- a/v3/src/models/document/serialize-document.ts
+++ b/v3/src/models/document/serialize-document.ts
@@ -9,12 +9,16 @@ export type ISerializedV3Document = IDocumentModelSnapshot & {revisionId?: strin
 export type ISerializedV2Document = ICodapV2DocumentJson & {revisionId?: string}
 export type ISerializedDocument = ISerializedV3Document | ISerializedV2Document
 
-export async function serializeDocument<T>(document: IDocumentModel, serializeFn: (doc: IDocumentModel) => T) {
+export async function serializeDocument<T>(
+  document: IDocumentModel,
+  serializeFn: (doc: IDocumentModel) => T | Promise<T>
+): Promise<T> {
   try {
     await document.prepareSnapshot()
 
-    // perform the serialization of the prepared document
-    return serializeFn(document)
+    // perform the serialization of the prepared document; await so completeSnapshot()
+    // doesn't run until the serializer settles, even if serializeFn returns a Promise
+    return await serializeFn(document)
   }
   finally {
     document.completeSnapshot()


### PR DESCRIPTION
## Summary
- `serializeCodapDocument` was wrapping its v2/v3 dispatch in `serializeDocument()`, while the dispatched serializer (`serializeCodapV2Document` / `serializeCodapV3Document`) also wraps its work in `serializeDocument()` — so `prepareSnapshot()` / `completeSnapshot()` ran twice on every save (CFM autosave, Google Drive autosave, manual Save).
- Fix: dispatch directly to the chosen serializer so each pair runs exactly once. Eliminates a duplicate iframe-phone round-trip to every WebView plugin tile for `interactiveState`, and a duplicate pass through `DataSet.prepareSnapshot()` (`validateCases`, attribute walks).
- Adds a regression test that fails when the outer wrapper is reintroduced, plus coverage for the v2/v3 helpers and the cleanup-on-throw contract.

Fixes CODAP-1252.

## Test plan
- [ ] CI: lint, build, jest pass
- [ ] New `serialize-document.test.ts` confirms `prepareSnapshot`/`completeSnapshot` each run exactly once per `serializeCodapDocument` call (verified to fail when the fix is reverted)
- [ ] Manual: open a document with a WebView/plugin tile, trigger Save (or autosave); confirm a single `interactiveState` request to the plugin per save instead of two
- [ ] Manual: round-trip a document via Save then Open; content unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)