### PR TITLE
CODAP-269: keep map data tip from being clipped by the component

### DIFF
--- a/v3/src/components/data-display/components/data-tip.tsx
+++ b/v3/src/components/data-display/components/data-tip.tsx
@@ -5,6 +5,7 @@ import { IDataSet } from "../../../models/data/data-set"
 import { IPoint, IPointMetadata, PointRendererBase } from "../renderer"
 import { urlParams } from "../../../utilities/url-params"
 import { IDataConfigurationModel } from "../models/data-configuration-model"
+import { Rect } from "../data-display-types"
 import { IGetTipTextProps, IShowDataTipProps } from "../data-tip-types"
 
 import "./data-tip.scss"
@@ -26,7 +27,7 @@ export interface IDataTipProps extends IDataTipBaseProps {
   renderer?: PointRendererBase
 }
 
-const createVirtualElement = (rect: { x: number, y: number, width: number, height: number }) => {
+const createVirtualElement = (rect: Rect) => {
   const { x, y, width, height } = rect
   return {
     getBoundingClientRect: () => ({
@@ -114,7 +115,7 @@ export const DataTip = (props: IDataTipProps) => {
         <div ref={refs.setFloating} style={floatingStyles} className="data-tip" data-testid="data-tip">
           {tipTextLines.current.map((line: string, i: number) => (
             <Fragment key={`dt-line-${i}`}>
-              {line}{i < tipTextLines.current.length && <br />}
+              {line}{i < tipTextLines.current.length - 1 && <br />}
             </Fragment>
           ))}
         </div>

--- a/v3/src/components/data-display/components/data-tip.tsx
+++ b/v3/src/components/data-display/components/data-tip.tsx
@@ -1,5 +1,5 @@
-import { Fragment, useCallback, useRef, useState } from "react"
-import { computePosition, flip, offset, shift, useFloating } from "@floating-ui/react"
+import { Fragment, useRef, useState } from "react"
+import { flip, FloatingPortal, offset, shift, useFloating } from "@floating-ui/react"
 import { useDataDisplayModelContext } from "../hooks/use-data-display-model"
 import { IDataSet } from "../../../models/data/data-set"
 import { IPoint, IPointMetadata, PointRendererBase } from "../renderer"
@@ -26,20 +26,18 @@ export interface IDataTipProps extends IDataTipBaseProps {
   renderer?: PointRendererBase
 }
 
-const createVirtualElement = (event: PointerEvent) => {
-  // The virtual element will be a single pixel positioned at the point of the mouse event.
-  const pointLeft = event.x
-  const pointTop = event.y
+const createVirtualElement = (rect: { x: number, y: number, width: number, height: number }) => {
+  const { x, y, width, height } = rect
   return {
     getBoundingClientRect: () => ({
-      left: pointLeft,
-      top: pointTop,
-      right: pointLeft + 1,
-      bottom: pointTop + 1,
-      width: 1,
-      height: 1,
-      x: pointLeft,
-      y: pointTop,
+      left: x,
+      top: y,
+      right: x + width,
+      bottom: y + height,
+      width,
+      height,
+      x,
+      y,
     })
   }
 }
@@ -57,48 +55,44 @@ export const DataTip = (props: IDataTipProps) => {
   const legendAttrID = dataConfiguration?.attributeID("legend")
   const tipTextLines = useRef<string[]>([])
   const [isTipOpen, setIsTipOpen] = useState(false)
-  const { context, refs, floatingStyles } = useFloating({open: isTipOpen, onOpenChange: setIsTipOpen})
-
-  const positionDataTip = useCallback(() => {
-    if (refs.reference.current && refs.floating.current) {
-      computePosition(refs.reference.current, refs.floating.current, {
-        placement: "top",
-        middleware: [
-          offset({mainAxis: 10}),
-          flip(),
-          shift({padding: 5})
-        ]
-      }).then(({x, y}) => {
-        refs.floating.current && Object.assign(refs.floating.current.style, {
-          transform: `translate(${x}px, ${y}px)`
-        })
-      })
-    }
-  }, [refs.floating, refs.reference])
+  // Let useFloating drive positioning. When setPositionReference is called, it re-runs the
+  // middleware and updates floatingStyles. This avoids the cross-browser timing issues of
+  // computing position manually via setTimeout/rAF after commit.
+  const { context, refs, floatingStyles } = useFloating({
+    open: isTipOpen,
+    onOpenChange: setIsTipOpen,
+    placement: "top",
+    middleware: [offset({mainAxis: 5}), flip(), shift({padding: 5})]
+  })
 
   const showDataTip = (showDataTipProps: IShowDataTipProps) => {
-    const {event, caseID, plotNum} = showDataTipProps
+    const {event, caseID, plotNum, anchorRect} = showDataTipProps
     event.stopPropagation()
-    // Get the text to display in the data tip
     const tipTextString = tipText({dataset, caseID, plotNum, getTipAttrs, legendAttrID, dataConfiguration, getTipText})
     if (!tipTextString) {
       // Can happen when there are no attributes and when only attribute is qualitative
       return
     }
     tipTextLines.current = tipTextString.split("<br>")
-    // Create the virtual element to use as a reference for positioning the data tip
-    const virtualElement = createVirtualElement(event)
-    refs.setPositionReference(virtualElement)
-    // Open the data tip
+    // Prefer the caller-supplied anchor rect (e.g. the hovered point's bounds) over the
+    // pointer location, so the tip's placement doesn't depend on the cursor's visual size.
+    const referenceRect = anchorRect ?? { x: event.x, y: event.y, width: 1, height: 1 }
+    refs.setPositionReference(createVirtualElement(referenceRect))
     context.onOpenChange(true)
-    // Reposition the tip immediately (important when moving between adjacent points)
-    setTimeout(() => {
-      positionDataTip()
-    }, 0)
   }
 
   const handlePointerOver = (event: PointerEvent, _point: IPoint, metadata: IPointMetadata) => {
-    showDataTip({event, caseID: metadata.caseID, plotNum: metadata.plotNum})
+    const canvasRect = renderer?.canvas?.getBoundingClientRect()
+    const radius = metadata.style?.radius ?? 0
+    const anchorRect = canvasRect && radius > 0
+      ? {
+          x: canvasRect.left + metadata.x - radius,
+          y: canvasRect.top + metadata.y - radius,
+          width: radius * 2,
+          height: radius * 2
+        }
+      : undefined
+    showDataTip({event, caseID: metadata.caseID, plotNum: metadata.plotNum, anchorRect})
   }
 
   const handlePointerLeave = (event: PointerEvent) => {
@@ -116,12 +110,14 @@ export const DataTip = (props: IDataTipProps) => {
 
   return (
     isTipOpen &&
-      <div ref={refs.setFloating} style={floatingStyles} className="data-tip" data-testid="data-tip">
-        {tipTextLines.current.map((line: string, i: number) => (
-          <Fragment key={`dt-line-${i}`}>
-            {line}{i < tipTextLines.current.length && <br />}
-          </Fragment>
-        ))}
-      </div>
+      <FloatingPortal>
+        <div ref={refs.setFloating} style={floatingStyles} className="data-tip" data-testid="data-tip">
+          {tipTextLines.current.map((line: string, i: number) => (
+            <Fragment key={`dt-line-${i}`}>
+              {line}{i < tipTextLines.current.length && <br />}
+            </Fragment>
+          ))}
+        </div>
+      </FloatingPortal>
   )
 }

--- a/v3/src/components/data-display/data-tip-types.ts
+++ b/v3/src/components/data-display/data-tip-types.ts
@@ -1,4 +1,5 @@
 import { IDataSet } from "../../models/data/data-set"
+import { Rect } from "./data-display-types"
 import { IDataConfigurationModel } from "./models/data-configuration-model"
 
 export interface IGetTipTextProps {
@@ -16,5 +17,5 @@ export interface IShowDataTipProps {
   // Optional viewport-space rect of the anchor (e.g. the hovered point). When provided,
   // the tip is positioned relative to this rect rather than the pointer location, so the
   // tip's placement is not affected by cursor-size differences across browsers.
-  anchorRect?: { x: number, y: number, width: number, height: number }
+  anchorRect?: Rect
 }

--- a/v3/src/components/data-display/data-tip-types.ts
+++ b/v3/src/components/data-display/data-tip-types.ts
@@ -13,4 +13,8 @@ export interface IShowDataTipProps {
   event: PointerEvent
   caseID: string
   plotNum: number
+  // Optional viewport-space rect of the anchor (e.g. the hovered point). When provided,
+  // the tip is positioned relative to this rect rather than the pointer location, so the
+  // tip's placement is not affected by cursor-size differences across browsers.
+  anchorRect?: { x: number, y: number, width: number, height: number }
 }


### PR DESCRIPTION
## Summary
- Data tips on map points were being clipped by Leaflet's `overflow:hidden` container (notably on Safari, where points near the edge had their tips partially or fully hidden). Render the tip through a `FloatingPortal` so it escapes the component's clip boundary.
- Previously the tip was anchored to the mouse pointer position (`event.x/y`), so its placement was affected by the browser's cursor size/hotspot — Chrome rendered the tip above the cursor, Safari rendered it below (occluded by the hand). Anchor the tip to the hovered point's viewport rect instead (derived from `renderer.canvas` + `metadata.x/y` + radius), so cursor differences no longer matter.
- Let `useFloating` own positioning via its `placement` + middleware options instead of calling `computePosition` manually after a `setTimeout(0)`/`requestAnimationFrame`. That manual approach was racing with React's commit phase and producing different results across browsers.

Fixes CODAP-269.

## Test plan
- [ ] Load a document with a map and hover points near the top/bottom/left/right edges of the map — the tip should float past the map boundary rather than being clipped.
- [ ] Verify in both Chrome and Safari; placement should be consistent (above the point) in both.
- [ ] Confirm graph tile data tips still behave correctly.
- [ ] `npm test` passes.
