### PR TITLE
CODAP-1214: keep masks in sync during bar↔dot display-type transition

### DIFF
--- a/v3/src/components/data-display/renderer/pixi-point-renderer.test.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.test.ts
@@ -522,5 +522,53 @@ describe("PixiPointRenderer", () => {
 
       pixiRenderer.dispose()
     })
+
+    it("updates sprite masks and state subPlotNums during a bars→points transition (CODAP-1214)", async () => {
+      // CODAP-1214: a coincident subplot layout change (new categorical axis) must be picked up
+      // during a bars→points transition; otherwise sprites stay masked to their old bar-chart cells.
+      const sharedState = new PointsState()
+      const pixiRenderer = new PixiPointRenderer(sharedState)
+      await pixiRenderer.init()
+
+      // Start as a bar chart with all cases in subplot 0 (single categorical x-axis)
+      const barCases = [
+        createCaseData(0, "case1", 0),
+        createCaseData(0, "case2", 0),
+        createCaseData(0, "case3", 0)
+      ]
+      pixiRenderer.matchPointsToData("ds1", barCases, "bars", defaultStyle)
+
+      // Resize the renderer to create a 3x3 subplot layout (9 masks) — simulates the layout
+      // that would exist after a second categorical axis is added
+      pixiRenderer.resize(300, 300, 3, 3, 1, 1)
+      const subPlotMasks = (pixiRenderer as any).subPlotMasks as any[]
+      expect(subPlotMasks.length).toBe(9)
+
+      // Transition to dot chart with each case mapped to a different subplot
+      const dotCases = [
+        createCaseData(0, "case1", 0),
+        createCaseData(0, "case2", 4),
+        createCaseData(0, "case3", 8)
+      ]
+      pixiRenderer.matchPointsToData("ds1", dotCases, "points", defaultStyle)
+
+      const transitionState = (pixiRenderer as any).displayTypeTransitionState
+      expect(transitionState.isActive).toBe(true)
+
+      const sprites = (pixiRenderer as any).sprites as Map<string, any>
+      const id1 = sharedState.getPointIdForCaseData({ plotNum: 0, caseID: "case1" })!
+      const id2 = sharedState.getPointIdForCaseData({ plotNum: 0, caseID: "case2" })!
+      const id3 = sharedState.getPointIdForCaseData({ plotNum: 0, caseID: "case3" })!
+
+      expect(sprites.get(id1)?.mask).toBe(subPlotMasks[0])
+      expect(sprites.get(id2)?.mask).toBe(subPlotMasks[4])
+      expect(sprites.get(id3)?.mask).toBe(subPlotMasks[8])
+
+      expect(sharedState.getPoint(id1)?.subPlotNum).toBe(0)
+      expect(sharedState.getPoint(id2)?.subPlotNum).toBe(4)
+      expect(sharedState.getPoint(id3)?.subPlotNum).toBe(8)
+
+      pixiRenderer.dispose()
+    })
   })
 })

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -327,7 +327,13 @@ export class PixiPointRenderer extends PointRendererBase {
     // (The base class also sets this after we return, but we need it set for the code below.)
     this._displayType = displayType
 
-    if (this.displayTypeTransitionState.isActive) return
+    if (this.displayTypeTransitionState.isActive) {
+      // Sync subplot assignment even when deferring the rest: a coincident subplot layout change
+      // (e.g. adding a second categorical axis) would otherwise leave sprites masked to old cells.
+      this.state.updateSubPlotNumsFromCaseData(caseData)
+      this.applyMasks(caseData)
+      return
+    }
 
     // Sync state with case data
     const { added, removed } = this.state.syncWithCaseData(caseData, style)

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -332,6 +332,7 @@ export class PixiPointRenderer extends PointRendererBase {
       // (e.g. adding a second categorical axis) would otherwise leave sprites masked to old cells.
       this.state.updateSubPlotNumsFromCaseData(caseData)
       this.applyMasks(caseData)
+      this.doStartRendering()
       return
     }
 
@@ -754,7 +755,7 @@ export class PixiPointRenderer extends PointRendererBase {
         const sprite = this.sprites.get(pointId)
         if (sprite) {
           const subPlotNum = caseData.subPlotNum
-          sprite.mask = subPlotNum !== undefined ? this.subPlotMasks[subPlotNum] : null
+          sprite.mask = subPlotNum !== undefined ? (this.subPlotMasks[subPlotNum] ?? null) : null
         }
       }
     })


### PR DESCRIPTION
## Summary
- Fixes CODAP-1214: after configuring a bar chart and dragging a second categorical attribute to the y-axis, points for the newly-added categories (e.g. `water`, `both` of `Habitat`) were invisible.
- Root cause: `PixiPointRenderer.doMatchPointsToData` returned early whenever a display-type transition (bars↔points) was active, skipping the update of `state.subPlotNum` and the mask re-assignment. When a subplot layout change coincided with the transition, sprites kept their old bar-chart subplot assignments and were masked to cells that didn't cover their new positions.
- Fix: sync `subPlotNum` and re-apply masks before the early return so the deferred sprite animation doesn't leave the subplot layout stale.
- Added a unit test that reproduces the regression (fails without the fix).

## Test plan
- [ ] Open the Mammals example document
- [ ] Remove `Habitat` from the Diet graph
- [ ] Configure the Diet graph as a bar chart
- [ ] Drag `Habitat` to the y-axis → verify points appear in all three Habitat rows (`land`, `water`, `both`)
- [ ] Repeat the reverse: drop back to a single-axis bar chart and confirm normal bars↔dots transitions still animate cleanly
- [ ] CI green (lint, unit tests, full Cypress regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)