### PR TITLE
CODAP-1216: wire up missing French, Dutch, and Polish translations

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -16,7 +16,7 @@
         "@codemirror/commands": "^6.10.3",
         "@codemirror/language": "^6.12.3",
         "@codemirror/view": "^6.41.1",
-        "@concord-consortium/cloud-file-manager": "~2.2.8",
+        "@concord-consortium/cloud-file-manager": "~2.2.9",
         "@concord-consortium/log-monitor": "^1.0.0",
         "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@concord-consortium/slate-editor": "^0.12.0",
@@ -4285,9 +4285,9 @@
       }
     },
     "node_modules/@concord-consortium/cloud-file-manager": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.8.tgz",
-      "integrity": "sha512-sb41I32HiUGG5QdThToqtSdAGIGZ8stpZ8Tl7E60bC/Q56lIMX9q0z9nQx5/Ny9Lnxvy8iLfBY6YW5m/gibcVA==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.9.tgz",
+      "integrity": "sha512-D+jMXr9mL0sFNhv1b/81DEX1DZN37pFVP13kPYDyih/26kZ+AbBE2q5sDRaWpGwiDoC6gYerwyfjd3Up7EsHXA==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/v3/package.json
+++ b/v3/package.json
@@ -197,7 +197,7 @@
     "@codemirror/commands": "^6.10.3",
     "@codemirror/language": "^6.12.3",
     "@codemirror/view": "^6.41.1",
-    "@concord-consortium/cloud-file-manager": "~2.2.8",
+    "@concord-consortium/cloud-file-manager": "~2.2.9",
     "@concord-consortium/log-monitor": "^1.0.0",
     "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
     "@concord-consortium/slate-editor": "^0.12.0",

--- a/v3/src/utilities/translation/languages.test.ts
+++ b/v3/src/utilities/translation/languages.test.ts
@@ -7,7 +7,7 @@ describe("bundled languages", () => {
     const scriptPath = path.join(__dirname, "../../../scripts/strings-pull-project.sh")
     const scriptContent = fs.readFileSync(scriptPath, "utf8")
 
-    const match = scriptContent.match(/^LANGUAGES=\(([^)]*)\)/m)
+    const match = scriptContent.match(/^\s*LANGUAGES\s*=\s*\(([\s\S]*?)\)/m)
     expect(match).not.toBeNull()
     const pulledLangs = Array.from(match![1].matchAll(/"([^"]+)"/g))
       .map(m => m[1])

--- a/v3/src/utilities/translation/languages.test.ts
+++ b/v3/src/utilities/translation/languages.test.ts
@@ -1,0 +1,22 @@
+import fs from "fs"
+import path from "path"
+import { kBundledLanguageKeys } from "./languages"
+
+describe("bundled languages", () => {
+  it("stay in sync with the POEditor pull script", () => {
+    const scriptPath = path.join(__dirname, "../../../scripts/strings-pull-project.sh")
+    const scriptContent = fs.readFileSync(scriptPath, "utf8")
+
+    const match = scriptContent.match(/^LANGUAGES=\(([^)]*)\)/m)
+    expect(match).not.toBeNull()
+    const pulledLangs = Array.from(match![1].matchAll(/"([^"]+)"/g))
+      .map(m => m[1])
+      .sort()
+
+    // V3 owns en-US and pushes it to POEditor; the pull script fetches only
+    // the translations, so exclude en-US from the bundled set for comparison.
+    const bundledNonEnglish = kBundledLanguageKeys.filter(k => k !== "en-US").sort()
+
+    expect(bundledNonEnglish).toEqual(pulledLangs)
+  })
+})

--- a/v3/src/utilities/translation/languages.ts
+++ b/v3/src/utilities/translation/languages.ts
@@ -50,6 +50,11 @@ const languageFiles: LanguageFileEntry[] = [
   {key: 'zh-TW',    contents: zhTW}     // Traditional Chinese (Taiwan)
 ]
 
+// Exported for a test that asserts this list stays in sync with the POEditor
+// pull script's LANGUAGES array (scripts/strings-pull-project.sh). Bundled
+// non-English entries must match what the pull script fetches.
+export const kBundledLanguageKeys: string[] = languageFiles.map(f => f.key)
+
 export const translations: Record<string, LanguageFileContent> = {}
 
 languageFiles.forEach((langFile) => {

--- a/v3/src/utilities/translation/languages.ts
+++ b/v3/src/utilities/translation/languages.ts
@@ -51,8 +51,9 @@ const languageFiles: LanguageFileEntry[] = [
 ]
 
 // Exported for a test that asserts this list stays in sync with the POEditor
-// pull script's LANGUAGES array (scripts/strings-pull-project.sh). Bundled
-// non-English entries must match what the pull script fetches.
+// pull script's LANGUAGES array (scripts/strings-pull-project.sh). Includes
+// `en-US`; the test filters it out since the pull script fetches only
+// translated entries.
 export const kBundledLanguageKeys: string[] = languageFiles.map(f => f.key)
 
 export const translations: Record<string, LanguageFileContent> = {}

--- a/v3/src/utilities/translation/languages.ts
+++ b/v3/src/utilities/translation/languages.ts
@@ -3,11 +3,14 @@ import de from "./lang/de.json"
 import el from "./lang/el.json"
 import es from './lang/es.json'
 import fa from "./lang/fa.json"
+import fr from "./lang/fr.json"
 import he from "./lang/he.json"
 import ja from "./lang/ja.json"
 import ko from "./lang/ko.json"
 import nb from "./lang/nb.json"
+import nl from "./lang/nl.json"
 import nn from "./lang/nn.json"
+import pl from "./lang/pl.json"
 import ptBR from "./lang/pt-BR.json"
 import th from "./lang/th.json"
 import tr from "./lang/tr.json"
@@ -32,11 +35,14 @@ const languageFiles: LanguageFileEntry[] = [
   {key: 'en-US',    contents: enUS},    // US English
   {key: 'es',       contents: es},      // Spanish
   {key: 'fa',       contents: fa},      // Farsi (Persian)
+  {key: 'fr',       contents: fr},      // French
   {key: 'he',       contents: he},      // Hebrew
   {key: 'ja',       contents: ja},      // Japanese
   {key: 'ko',       contents: ko},      // Korean
   {key: 'nb',       contents: nb},      // Norwegian Bokmål
+  {key: 'nl',       contents: nl},      // Dutch
   {key: 'nn',       contents: nn},      // Norwegian Nynorsk
+  {key: 'pl',       contents: pl},      // Polish
   {key: 'pt-BR',    contents: ptBR},    // Brazilian Portuguese
   {key: 'th',       contents: th},      // Thai
   {key: 'tr',       contents: tr},      // Turkish


### PR DESCRIPTION
## Summary
- The `strings:pull` script fetches 17 languages from POEditor (including `fr`, `nl`, and `pl`), but `languages.ts` was only importing 14 of them, so the French, Dutch, and Polish translation JSON files were being fetched but never wired into the build.
- Added imports and `languageFiles` entries for `fr`, `nl`, and `pl` so they're included in the build and available for selection from the CFM Languages menu (which already lists all three).

## Test plan
- [ ] CI: lint, type-check, and build pass.
- [ ] Launch the app, use the CFM Languages menu to switch to French, Dutch, and Polish, and confirm strings render in the selected language rather than falling back to English.

Fixes CODAP-1216
