### PR TITLE
fix: table vertical scroll on attribute drag (CODAP-566)

### DIFF
--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -15,7 +15,7 @@ $collection-title-font-color: black;
   flex-direction: column;
 
   // Prevent vertical scrolling in the table during attribute drags so
-  // keyboard drag can move past the table without scrolling through every row.
+  // keyboard drags can move past the table without scrolling through every row.
   // Scoped to preserve horizontal auto-scroll on .case-table-content.
   &.dragging {
     .rdg, .collection-table-spacer {

--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -14,11 +14,13 @@ $collection-title-font-color: black;
   display: flex;
   flex-direction: column;
 
-  // Prevent vertical scrolling in the RDG grid during attribute drags so
-  // keyboard drags can move past the table without scrolling through every row.
-  // Scoped to .rdg to preserve horizontal auto-scroll on .case-table-content.
-  &.dragging .rdg {
-    overflow-y: hidden !important;
+  // Prevent vertical scrolling in the table during attribute drags so
+  // keyboard drag can move past the table without scrolling through every row.
+  // Scoped to preserve horizontal auto-scroll on .case-table-content.
+  &.dragging {
+    .rdg, .collection-table-spacer {
+      overflow-y: hidden !important;
+    }
   }
 
   .case-table-content {
@@ -158,7 +160,6 @@ $collection-title-font-color: black;
         background: white;
         display: flex;
         flex-direction: column;
-        overflow-y: hidden;
 
         &.parentMost {
           width: 30px;

--- a/v3/src/components/case-table/case-table.scss
+++ b/v3/src/components/case-table/case-table.scss
@@ -158,6 +158,7 @@ $collection-title-font-color: black;
         background: white;
         display: flex;
         flex-direction: column;
+        overflow-y: hidden;
 
         &.parentMost {
           width: 30px;


### PR DESCRIPTION
[CODAP-566](https://concord-consortium.atlassian.net/browse/CODAP-566)

Fixes an issue where a hierarchical table's content would scroll vertically during an attribute drag. 

A [change to ‎case-table.scss](https://github.com/concord-consortium/codap/pull/2514/changes#diff-43024c515431d2d4f0b1571141c7f815bd6a3b668d78e032c8db12652d05c394) in #2514 prevented vertical scrolling caused by the `.rdg` element but did not take into account a similar issue that could be caused by overflow in `.collection-table-spacer`. This change applies the same `overflow-y: hidden` fix to `.collection-table-spacer`.

[CODAP-566]: https://concord-consortium.atlassian.net/browse/CODAP-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ