### PR TITLE
CODAP-1262: fix dot chart sometimes failing to add a category

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -353,17 +353,22 @@ export const useSubAxis = ({
     }, {name: "useSubAxis.installDomainSync"}, axisProvider)
   }, [axisPlace, axisProvider, layout, renderSubAxis])
 
-  // Refresh when category set, if any, changes
+  // Refresh when the categories actually shown on the axis change. This must observe
+  // categoryArrayForAttrRole (the intersection of the categorySet with plotted cases),
+  // not categorySet.valuesArray (the union of all strValues). Otherwise, when a value
+  // that was already in strValues from earlier unplotted cases first appears in a
+  // plotted case, the union doesn't change but the axis's effective categories do —
+  // and the axis would silently fail to add the new tick.
   useEffect(function installCategorySetSync() {
     if (isCategorical) {
-      const disposer = mstReaction(() => {
-        return (dataConfig?.categorySetForAttrRole(axisPlaceToAttrRole[axisPlace]))?.valuesArray
-      }, () => {
-        setupCategories()
-        swapInProgress.current = true
-        renderSubAxis()
-        swapInProgress.current = false
-      }, {name: "useSubAxis [categories]", equals: comparer.structural}, dataConfig)
+      const disposer = mstReaction(
+        () => dataConfig?.categoryArrayForAttrRole(axisPlaceToAttrRole[axisPlace]),
+        () => {
+          setupCategories()
+          swapInProgress.current = true
+          renderSubAxis()
+          swapInProgress.current = false
+        }, {name: "useSubAxis [categories]", equals: comparer.structural}, dataConfig)
       return () => disposer()
     }
   }, [renderSubAxis, isCategorical, setupCategories, dataConfig, axisPlace])
@@ -409,11 +414,17 @@ export const useSubAxis = ({
 
   useEffect(function respondToHiddenCasesChange() {
     if (dataConfig) {
-      const axisModel = axisProvider?.getAxis?.(axisPlace)
+      // Scope is `dataConfig` only — NOT [axisModel, dataConfig]. The axis model is
+      // replaced (not mutated) during axis-type transitions (e.g. empty → categorical).
+      // Including it as a scope node would cause mstReaction to auto-dispose this
+      // reaction the first time the axis type changes, leaving the axis unable to
+      // respond to subsequent hidden-cases changes. The data-fn does not read the
+      // axis model directly; updateDomainAndRenderSubAxis re-fetches the current
+      // model on every call via axisProvider.getAxis(axisPlace).
       return mstReaction(
         () => dataConfig.caseDataHash,
         () => updateDomainAndRenderSubAxis(),
-        {name: "useSubAxis.respondToHiddenCasesChange"}, [axisModel, dataConfig]
+        {name: "useSubAxis.respondToHiddenCasesChange"}, dataConfig
       )
     }
   }, [axisPlace, axisProvider, dataConfig, updateDomainAndRenderSubAxis])

--- a/v3/src/models/data/filtered-cases.test.ts
+++ b/v3/src/models/data/filtered-cases.test.ts
@@ -157,7 +157,8 @@ describe("DerivedDataSet", () => {
     // handleAction listener since addCases isn't isCaseValueChangeAction).
     const filtered = new FilteredCases({ source: data })
 
-    // Warm the cache so _isValidCaseIds is true before reaction installs.
+    // Force an initial caseIds read to warm the cached/versioned state before the
+    // reaction is installed.
     expect(filtered.caseIds.length).toBe(3)
 
     const trigger = jest.fn()

--- a/v3/src/models/data/filtered-cases.test.ts
+++ b/v3/src/models/data/filtered-cases.test.ts
@@ -1,4 +1,4 @@
-import { reaction } from "mobx"
+import { computed, makeObservable, reaction } from "mobx"
 import { DataSet, IDataSet, toCanonical } from "./data-set"
 import { FilteredCases } from "./filtered-cases"
 
@@ -147,6 +147,62 @@ describe("DerivedDataSet", () => {
     expect(filtered.caseIds.length).toBe(1)
     expect(filtered.caseIds).toEqual(["c3"])
     expect(trigger).toHaveBeenCalledTimes(2)
+
+    filtered.destroy()
+  })
+
+  it("triggers direct reactions on caseIds when invalidateCases is called externally", () => {
+    // Mirrors how DataConfigurationModel.invalidateCases() externally invalidates a
+    // FilteredCases on dataset addCases (which doesn't trigger FilteredCases' own
+    // handleAction listener since addCases isn't isCaseValueChangeAction).
+    const filtered = new FilteredCases({ source: data })
+
+    // Warm the cache so _isValidCaseIds is true before reaction installs.
+    expect(filtered.caseIds.length).toBe(3)
+
+    const trigger = jest.fn()
+    reaction(() => filtered.caseIds, () => trigger())
+    expect(trigger).toHaveBeenCalledTimes(0)
+
+    // Adding cases doesn't notify FilteredCases (addCases isn't a value-change action).
+    data.addCases(toCanonical(data, [{ __id__: "c4", x: 4, y: 4 }]))
+
+    // Production code (DataConfigurationModel) explicitly calls invalidateCases here.
+    filtered.invalidateCases()
+
+    expect(filtered.caseIds.length).toBe(4)
+    expect(trigger).toHaveBeenCalledTimes(1)
+
+    filtered.destroy()
+  })
+
+  it("triggers reactions through an intermediate computed when invalidateCases is called externally", () => {
+    // Mirrors the production caseDataHash path: a @computed that transitively reads
+    // FilteredCases.caseIds, with a reaction observing the computed.
+    const filtered = new FilteredCases({ source: data })
+
+    class HashWrapper {
+      constructor(public f: FilteredCases) {
+        makeObservable(this, { caseIdsHash: computed })
+      }
+      get caseIdsHash() {
+        return this.f.caseIds.join(",")
+      }
+    }
+    const wrapper = new HashWrapper(filtered)
+
+    // Warm both the FilteredCases cache and the wrapper computed.
+    expect(wrapper.caseIdsHash).toBe("c1,c2,c3")
+
+    const trigger = jest.fn()
+    reaction(() => wrapper.caseIdsHash, () => trigger())
+    expect(trigger).toHaveBeenCalledTimes(0)
+
+    data.addCases(toCanonical(data, [{ __id__: "c4", x: 4, y: 4 }]))
+    filtered.invalidateCases()
+
+    expect(wrapper.caseIdsHash).toBe("c1,c2,c3,c4")
+    expect(trigger).toHaveBeenCalledTimes(1)
 
     filtered.destroy()
   })

--- a/v3/src/models/data/filtered-cases.ts
+++ b/v3/src/models/data/filtered-cases.ts
@@ -1,4 +1,4 @@
-import { action, computed, makeObservable, observable, runInAction } from "mobx"
+import { action, computed, makeObservable, observable } from "mobx"
 import { addDisposer, ISerializedActionCall } from "mobx-state-tree"
 import { typedId } from "../../utilities/js-utils"
 import { onAnyAction } from "../../utilities/mst-utils"
@@ -34,10 +34,20 @@ export class FilteredCases {
   private prevCaseIdSet = new Set<string>()
   private disposers: Array<() => void>
 
-  // Manual caching for caseIds and caseIdSet to avoid recomputation outside reactive context
+  // Manual caching for caseIds and caseIdSet to avoid recomputation outside reactive context.
+  //
+  // We follow the same pattern as cachedFnWithArgsFactory: an observable version counter that
+  // is ONLY written by invalidateCases (an action), and a non-observable last-validated-version
+  // that is written from inside the getter. This guarantees MobX dependency tracking is clean —
+  // any reactive context that reads caseIds will observe `_caseIdsVersion` and properly fire when
+  // invalidateCases() bumps it. The previous implementation used a boolean `_isValidCaseIds` that
+  // was both read and written from inside `caseIds` (via runInAction), which violates MobX's
+  // "no side effects in computeds" rule and causes some computed observers to silently miss
+  // invalidation.
   private _cachedCaseIds: string[] = []
   private _cachedCaseIdSet: Set<string> = new Set()
-  @observable private _isValidCaseIds = false
+  @observable private _caseIdsVersion = 0
+  private _lastValidatedVersion = -1
 
   constructor({ source, collectionID, casesArrayNumber = 0, filter, onSetCaseValues }: IProps) {
     this.source = source
@@ -68,11 +78,13 @@ export class FilteredCases {
   }
 
   private validateCaseIds() {
-    if (!this._isValidCaseIds) {
+    // Reading the observable version establishes the MobX dependency without writing.
+    const version = this._caseIdsVersion
+    if (version !== this._lastValidatedVersion) {
       this._cachedCaseIds = this.rawCaseIds
             .filter(id => !this.filter || (this.source && this.filter(this.source, id, this.casesArrayNumber)))
       this._cachedCaseIdSet = new Set(this._cachedCaseIds)
-      runInAction(() => { this._isValidCaseIds = true })
+      this._lastValidatedVersion = version
     }
   }
 
@@ -94,7 +106,7 @@ export class FilteredCases {
   setCasesArrayNumber(casesArrayNumber: number) {
     if (this.casesArrayNumber === casesArrayNumber) return
     this.casesArrayNumber = casesArrayNumber
-    this._isValidCaseIds = false
+    this._caseIdsVersion++
   }
 
   @action
@@ -106,7 +118,7 @@ export class FilteredCases {
 
   @action
   invalidateCases() {
-    this._isValidCaseIds = false
+    this._caseIdsVersion++
   }
 
   private handleBeforeAction = (actionCall: ISerializedActionCall) => {

--- a/v3/src/utilities/mst-reaction.test.ts
+++ b/v3/src/utilities/mst-reaction.test.ts
@@ -1,0 +1,86 @@
+import { destroy, types } from "mobx-state-tree"
+import { mstReaction } from "./mst-reaction"
+
+const Counter = types.model("Counter", {
+  value: types.number
+}).actions(self => ({
+  inc() { self.value += 1 }
+}))
+
+const Container = types.model("Container", {
+  a: types.maybe(Counter),
+  b: types.maybe(Counter)
+}).actions(self => ({
+  destroyA() { self.a && destroy(self.a) },
+  destroyB() { self.b && destroy(self.b) }
+}))
+
+describe("mstReaction", () => {
+  it("fires effect-fn when the observed observable changes", () => {
+    const c = Container.create({ a: { value: 0 }, b: { value: 0 } })
+    const trigger = jest.fn()
+    const dispose = mstReaction(() => c.a!.value, () => trigger(), { name: "test" }, c.a!)
+
+    c.a!.inc()
+    expect(trigger).toHaveBeenCalledTimes(1)
+
+    dispose()
+  })
+
+  it("auto-disposes when its single scope model is destroyed", () => {
+    const c = Container.create({ a: { value: 0 }, b: { value: 0 } })
+    const trigger = jest.fn()
+    mstReaction(() => c.b!.value, () => trigger(), { name: "test" }, c.b!)
+
+    c.b!.inc()
+    expect(trigger).toHaveBeenCalledTimes(1)
+
+    c.destroyB()
+
+    // After destroy, the reaction should be gone. We can't change c.b.value
+    // anymore (it's destroyed), so just verify no further triggers occurred.
+    expect(trigger).toHaveBeenCalledTimes(1)
+  })
+
+  it("auto-disposes when ANY model in a multi-element scope is destroyed, " +
+     "even if the data-fn does not depend on it", () => {
+    // This is the gotcha that broke useSubAxis.respondToHiddenCasesChange:
+    // its scope was [axisModel, dataConfig], but the data-fn only read
+    // dataConfig.caseDataHash. When axisModel was replaced (axis-type
+    // transition), MST destroyed the old instance, and mstReaction
+    // auto-disposed the entire reaction — leaving the axis silent for the
+    // rest of its life.
+    const c = Container.create({ a: { value: 0 }, b: { value: 0 } })
+    const trigger = jest.fn()
+    // data-fn only reads c.b.value, but scope includes c.a.
+    mstReaction(() => c.b!.value, () => trigger(), { name: "test" }, [c.a!, c.b!])
+
+    c.b!.inc()
+    expect(trigger).toHaveBeenCalledTimes(1)
+
+    // Destroy the unrelated scope element a.
+    c.destroyA()
+
+    // The reaction is now disposed even though c.b is still alive and the
+    // data-fn never depended on c.a.
+    c.b!.inc()
+    expect(trigger).toHaveBeenCalledTimes(1)
+  })
+
+  it("survives destruction of an unrelated model when scope contains only the relevant one", () => {
+    // This is the fix shape: list only the model whose lifetime should bound
+    // the reaction. If unrelated nodes can be destroyed/replaced, do not put
+    // them in the scope.
+    const c = Container.create({ a: { value: 0 }, b: { value: 0 } })
+    const trigger = jest.fn()
+    mstReaction(() => c.b!.value, () => trigger(), { name: "test" }, c.b!)
+
+    c.b!.inc()
+    expect(trigger).toHaveBeenCalledTimes(1)
+
+    c.destroyA()
+
+    c.b!.inc()
+    expect(trigger).toHaveBeenCalledTimes(2)
+  })
+})

--- a/v3/src/utilities/mst-reaction.test.ts
+++ b/v3/src/utilities/mst-reaction.test.ts
@@ -73,7 +73,7 @@ describe("mstReaction", () => {
     // them in the scope.
     const c = Container.create({ a: { value: 0 }, b: { value: 0 } })
     const trigger = jest.fn()
-    mstReaction(() => c.b!.value, () => trigger(), { name: "test" }, c.b!)
+    const dispose = mstReaction(() => c.b!.value, () => trigger(), { name: "test" }, c.b!)
 
     c.b!.inc()
     expect(trigger).toHaveBeenCalledTimes(1)
@@ -82,5 +82,7 @@ describe("mstReaction", () => {
 
     c.b!.inc()
     expect(trigger).toHaveBeenCalledTimes(2)
+
+    dispose()
   })
 })


### PR DESCRIPTION
## Summary

Fixes [CODAP-1262](https://concord-consortium.atlassian.net/browse/CODAP-1262).

The Markov example sometimes failed to add a required Y-axis category when new
cases were added — the graph would render with all data but missing one or
more category ticks until the tile was resized. Newly created graphs displayed
correctly, so the bug lived in the live-update reactive path, not initial
layout.

Three subtle reactivity bugs combined to drop the new category whenever a
previously-unplotted strValue first became plotted:

1. **`useSubAxis.installCategorySetSync`** observed `categorySet.valuesArray`
   (the union of all unique strValues for the attribute, including unplotted
   ones), but the axis actually plots `categoryArrayForAttrRole` (the
   intersection of the categorySet with visible plotted cases). When a value
   already in strValues from an earlier unplotted case first appeared in a
   plotted case, the union didn't change but the intersection did — so the
   reaction was silently a no-op. Switched to observing
   `categoryArrayForAttrRole(role)`.

2. **`useSubAxis.respondToHiddenCasesChange`** passed `[axisModel, dataConfig]`
   as the `mstReaction` scope, but `mstReaction` auto-disposes when *any*
   scope node is destroyed. CODAP replaces (rather than mutates) the axis
   model on type transitions like `empty → categorical`, so this reaction
   was destroyed the first time the axis was configured and never
   re-installed. Dropped `axisModel` from the scope; the data-fn doesn't
   read it, and `updateDomainAndRenderSubAxis` re-fetches the current model
   on every call.

3. **`FilteredCases.validateCaseIds()`** wrote to `_isValidCaseIds` from
   inside the `caseIds` getter via `runInAction`, violating MobX's
   "no side effects in computeds" rule. This made dependency tracking on
   `caseIds` unreliable for some reactive consumers (notably anyone reading
   `dataConfig.caseDataHash`). Replaced the read-then-written boolean with
   an observable version counter pattern (matching `cachedFnWithArgsFactory`):
   `_caseIdsVersion` is observable and only written by `invalidateCases`;
   `_lastValidatedVersion` is non-observable and checked inside the getter.

## Test plan

- [ ] Open the Markov example, configure the standard graph
      (markovs_move v. previous_2_markov_moves), run the simulation, verify
      all categories appear on both axes as cases accumulate
- [ ] Verify the bug no longer reproduces — repeated runs that previously
      sometimes dropped the "S" category should now always include it
- [ ] Smoke test other graphs: numeric ↔ categorical axis swaps, drag to
      reorder categories, hidden cases, color legend on a categorical
      attribute
- [ ] Resize the graph tile after adding cases — categories should stay
      stable (resize was the previous workaround; with the fix, resize
      shouldn't be needed but also shouldn't change anything)
- [ ] Existing automated tests pass:
      `mst-reaction.test.ts` (new — 4 tests),
      `filtered-cases.test.ts` (with 2 added regression tests),
      full src suite (2716 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CODAP-1262]: https://concord-consortium.atlassian.net/browse/CODAP-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ