### PR TITLE
CODAP-229: update meta description for SEO

### DIFF
--- a/v3/src/index.html
+++ b/v3/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>CODAP V3</title>
-    <meta name="description" content="CODAP is designed to support students in learning and doing data science, and as a tool for curriculum developers and education researchers.">
+    <meta name="description" content="CODAP is a free, web-based app for learning and doing data science, used by students, curriculum developers, and education researchers.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:ital,wght@0,100..900;1,100..900&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Replace the existing generic meta description with SEO-friendlier copy that front-loads "free, web-based app" and "data science" — keywords searchers actually use and that appear bolded in Google SERP snippets.
- Wording chosen by Cynthia McIntyre after discussion on the Jira ticket.
- `<title>` is unchanged (remains "CODAP V3").

Fixes CODAP-229

## Test plan
- [ ] Verify the new meta description appears in `v3/src/index.html`
- [ ] Confirm CI passes (lint, build)