### PR TITLE
CODAP-141: skip save-before-language-change in CFM

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -16,7 +16,7 @@
         "@codemirror/commands": "^6.10.3",
         "@codemirror/language": "^6.12.3",
         "@codemirror/view": "^6.41.1",
-        "@concord-consortium/cloud-file-manager": "~2.2.9",
+        "@concord-consortium/cloud-file-manager": "~2.2.10",
         "@concord-consortium/log-monitor": "^1.0.0",
         "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@concord-consortium/slate-editor": "^0.12.0",
@@ -4285,9 +4285,9 @@
       }
     },
     "node_modules/@concord-consortium/cloud-file-manager": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.9.tgz",
-      "integrity": "sha512-D+jMXr9mL0sFNhv1b/81DEX1DZN37pFVP13kPYDyih/26kZ+AbBE2q5sDRaWpGwiDoC6gYerwyfjd3Up7EsHXA==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.10.tgz",
+      "integrity": "sha512-hF63yemoCJ2CandV3TnUQVB/7pVmAAdEdk8JJO+1In+2lSYyiq2jH3hlNpF7UrMN4EeRhtxhjo2jX+6cQ7hO/Q==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/v3/package.json
+++ b/v3/package.json
@@ -197,7 +197,7 @@
     "@codemirror/commands": "^6.10.3",
     "@codemirror/language": "^6.12.3",
     "@codemirror/view": "^6.41.1",
-    "@concord-consortium/cloud-file-manager": "~2.2.9",
+    "@concord-consortium/cloud-file-manager": "~2.2.10",
     "@concord-consortium/log-monitor": "^1.0.0",
     "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
     "@concord-consortium/slate-editor": "^0.12.0",

--- a/v3/src/lib/cfm/use-cloud-file-manager.ts
+++ b/v3/src/lib/cfm/use-cloud-file-manager.ts
@@ -325,6 +325,8 @@ export function useCloudFileManager(optionsArg: CFMAppOptions, hookOptions?: IUs
         renderRoot(rootRef.current, content)
       },
       appSetsWindowTitle: true, // CODAP takes responsibility for the window title
+      // CODAP v3 does not reload on language change, so the save-before-change behavior is unnecessary.
+      saveOnLanguageChange: false,
       wrapFileContent: false,
       isClientContent(content: unknown) {
         if (!content || typeof content !== "object") return false


### PR DESCRIPTION
## Summary

- Fixes CODAP-141 — the "[object Object]" alert that appeared when changing
  languages with a saved document open (notably in Activity Player embeds).
- Bumps `@concord-consortium/cloud-file-manager` from `~2.2.9` to `~2.2.10`,
  picking up the upstream callback-shape fix in CFM's `changeLanguage()`.
- Wires up the new `saveOnLanguageChange` appOption (added in CFM 2.2.10) and
  sets it to `false` for CODAP v3. CODAP v3 does not reload the page on
  language change, so the save-before-change flow was unnecessary anyway.

Fixes CODAP-141.

## Test plan

- [ ] CI green (lint, build, limited Cypress)
- [ ] Manual: open a document from Google Drive, switch languages via the
      Languages menu, confirm the language changes with no dialog and no
      `[object Object]` alert.
- [ ] Regression: change languages with no document loaded and with a local
      document loaded — both should remain seamless.
- [ ] Activity Player embed (the original repro): confirm the `[object Object]`
      modal no longer appears after selecting a different language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
