### PR TITLE
CODAP-1238: fix attribute menu caret position in Safari

### DIFF
--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -399,19 +399,16 @@ export function renderLabelBackground<GElement extends BaseType>(
   const arrowX = textBBox.x + textBBox.width
   const arrowY = textBBox.y + (textBBox.height - arrowWidth) / 2
 
-  const arrowSelection = gSelection.selectAll('svg.attribute-label-arrow')
+  // Safari/WebKit doesn't apply the transform attribute to a nested <svg> element, so we
+  // use a <g> and fold the (arrowX, arrowY) position into its transform via translate.
+  const arrowTransform = `${transform} translate(${arrowX}, ${arrowY})`.trim()
+  const arrowSelection = gSelection.selectAll('g.attribute-label-arrow')
     .data([1])
     .join((enter: any) => {
-      const arrow = enter.append('svg')
-        .attr('class', 'attribute-label-arrow')
-        .attr('viewBox', '0 0 24 24')
-        .attr('width', arrowWidth)
-        .attr('height', arrowWidth)
+      const arrow = enter.append('g').attr('class', 'attribute-label-arrow')
       arrow.append('path').attr('d', 'm12 15-5-5h10z')
       return arrow
     })
-    .attr('x', arrowX)
-    .attr('y', arrowY)
-  if (transform) arrowSelection.attr('transform', transform)
+    .attr('transform', arrowTransform)
   if (visibility) arrowSelection.style('visibility', visibility)
 }


### PR DESCRIPTION
## Summary
Fixes [CODAP-1238](https://concord-consortium.atlassian.net/browse/CODAP-1238). The dropdown-arrow caret next to a graph axis attribute label was rendering near the middle of the plot in Safari instead of being anchored to the axis label. Clicking near the misplaced caret would open the axis attribute menu.

Root cause: Safari/WebKit does not apply the `transform` attribute to nested `<svg>` elements, so the caret's `translate`/`rotate` (used to position it next to its rotated/translated label) had no effect. Chrome and Firefox apply the transform per SVG2 and rendered correctly.

Fix: in `renderLabelBackground`, replace the nested `<svg>` arrow with a `<g>` and fold the `(arrowX, arrowY)` offset into its transform via `translate`. CSS selectors only target `.attribute-label-arrow path`, so they continue to work without changes.

## Test plan
- [ ] Open Roller Coasters in Safari — caret on each axis is anchored to its attribute label
- [ ] Open Roller Coasters in Chrome — caret position unchanged from previous behavior
- [ ] Verify caret positioning on both vertical (left) and horizontal (bottom) axes
- [ ] Verify with both the empty "Drag an attribute" cue and a real attribute label
- [ ] Verify the caret flips when the attribute menu is open (CSS `g.menu-open` rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CODAP-1238]: https://concord-consortium.atlassian.net/browse/CODAP-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ