### PR TITLE
CODAP-1273: restore trig and string() functions in formulas

### DIFF
--- a/v3/src/lib/functions.test.ts
+++ b/v3/src/lib/functions.test.ts
@@ -1,0 +1,21 @@
+import { typedFnRegistry } from "../models/formula/functions/math"
+import { fnDisplayToCanonical } from "../models/formula/utils/canonicalization-utils"
+import { functionCategoryInfoArray } from "./functions"
+
+// Every function documented in function-strings.json5 is exposed to users via the
+// formula editor's "Functions" menu. This test guards against the kind of regression
+// that originally hit CODAP-1273 (trig and string functions silently dropped after
+// a mathjs bundle-trimming change): if a documented function is not registered in
+// CODAP's fnRegistry, it cannot be evaluated in formulas, and the test fails.
+describe("function-strings.json5 vs. fnRegistry", () => {
+  const documentedFunctions = functionCategoryInfoArray.flatMap(category =>
+    category.functions.map(fn => ({ category: category.category, name: fn.displayName }))
+  )
+
+  it.each(documentedFunctions)("registers $name (from $category)", ({ name }) => {
+    // Some user-facing names are registered under a canonical alias to avoid colliding with
+    // mathjs internals (e.g., "number" → "_number_"). Accept either form.
+    const registryKey = fnDisplayToCanonical[name] ?? name
+    expect(typedFnRegistry[registryKey]).toBeDefined()
+  })
+})

--- a/v3/src/models/formula/functions/math.ts
+++ b/v3/src/models/formula/functions/math.ts
@@ -23,6 +23,7 @@ import { lookupFunctions } from "./lookup-functions"
 import { operators } from "./operators"
 import { otherFunctions } from "./other-functions"
 import { stringFunctions } from "./string-functions"
+import { trigFunctions } from "./trig-functions"
 import { univariateStatsFunctions } from "./univariate-stats-functions"
 
 export const math = create({
@@ -98,6 +99,8 @@ export const fnRegistry = {
   ...operators,
 
   ...arithmeticFunctions,
+
+  ...trigFunctions,
 
   ...logicFunctions,
 

--- a/v3/src/models/formula/functions/other-functions.test.ts
+++ b/v3/src/models/formula/functions/other-functions.test.ts
@@ -83,6 +83,24 @@ describe("number", () => {
   })
 })
 
+describe("string", () => {
+  it("converts numbers to strings", () => {
+    expect(math.evaluate("string(42)")).toEqual("42")
+    expect(math.evaluate("string(-3.14)")).toEqual("-3.14")
+    expect(math.evaluate("string(0)")).toEqual("0")
+  })
+  it("returns string arguments unchanged", () => {
+    expect(math.evaluate("string('hello')")).toEqual("hello")
+  })
+  it("converts booleans to 'true'/'false'", () => {
+    expect(math.evaluate("string(true)")).toEqual("true")
+    expect(math.evaluate("string(false)")).toEqual("false")
+  })
+  it("returns UNDEF_RESULT for empty input", () => {
+    expect(math.evaluate("string('')")).toEqual(UNDEF_RESULT)
+  })
+})
+
 describe("greatCircleDistance", () => {
   it("returns empty if not enough numeric arguments are provided", () => {
     expect(math.compile("greatCircleDistance()").evaluate()).toBe(UNDEF_RESULT)

--- a/v3/src/models/formula/functions/other-functions.ts
+++ b/v3/src/models/formula/functions/other-functions.ts
@@ -93,6 +93,15 @@ export const otherFunctions: Record<string, IFormulaMathjsFunction> = {
     }
   },
 
+  // Mirrors v2's string() type-conversion function. Empty values propagate as UNDEF_RESULT;
+  // anything else uses JS String() coercion. Unlike _number_, this name does not need to be
+  // aliased: mathjs's parser/evaluate factories do not declare 'string' as a dependency, so
+  // overriding it does not perturb any internal closures.
+  string: {
+    numOfRequiredArguments: 1,
+    evaluate: (arg: FValue) => isValueEmpty(arg) ? UNDEF_RESULT : String(arg)
+  },
+
   /**
     Returns the great circle distance between the two lat/long points on the earth's surface.
     @param    {Number}  The latitude in degrees of the first point

--- a/v3/src/models/formula/functions/trig-functions.test.ts
+++ b/v3/src/models/formula/functions/trig-functions.test.ts
@@ -1,0 +1,47 @@
+import { math } from "./math"
+import { UNDEF_RESULT } from "./function-utils"
+
+describe("trig functions", () => {
+  it("provides sin", () => {
+    expect(math.evaluate("sin(0)")).toBeCloseTo(0)
+    expect(math.evaluate("sin(pi / 2)")).toBeCloseTo(1)
+    expect(math.evaluate("sin(pi)")).toBeCloseTo(0)
+  })
+  it("provides cos", () => {
+    expect(math.evaluate("cos(0)")).toBeCloseTo(1)
+    expect(math.evaluate("cos(pi / 2)")).toBeCloseTo(0)
+    expect(math.evaluate("cos(pi)")).toBeCloseTo(-1)
+  })
+  it("provides tan", () => {
+    expect(math.evaluate("tan(0)")).toBeCloseTo(0)
+    expect(math.evaluate("tan(pi / 4)")).toBeCloseTo(1)
+  })
+  it("provides asin", () => {
+    expect(math.evaluate("asin(0)")).toBeCloseTo(0)
+    expect(math.evaluate("asin(1)")).toBeCloseTo(Math.PI / 2)
+    expect(math.evaluate("asin(-1)")).toBeCloseTo(-Math.PI / 2)
+  })
+  it("provides acos", () => {
+    expect(math.evaluate("acos(1)")).toBeCloseTo(0)
+    expect(math.evaluate("acos(0)")).toBeCloseTo(Math.PI / 2)
+    expect(math.evaluate("acos(-1)")).toBeCloseTo(Math.PI)
+  })
+  it("provides atan", () => {
+    expect(math.evaluate("atan(0)")).toBeCloseTo(0)
+    expect(math.evaluate("atan(1)")).toBeCloseTo(Math.PI / 4)
+  })
+  it("provides atan2", () => {
+    expect(math.evaluate("atan2(0, 1)")).toBeCloseTo(0)
+    expect(math.evaluate("atan2(1, 0)")).toBeCloseTo(Math.PI / 2)
+    expect(math.evaluate("atan2(1, 1)")).toBeCloseTo(Math.PI / 4)
+  })
+  it("coerces numeric strings", () => {
+    expect(math.evaluate("sin('0')")).toBeCloseTo(0)
+    expect(math.evaluate("atan2('1', '1')")).toBeCloseTo(Math.PI / 4)
+  })
+  it("returns UNDEF_RESULT for non-numeric input", () => {
+    expect(math.evaluate("sin('')")).toBe(UNDEF_RESULT)
+    expect(math.evaluate("cos('abc')")).toBe(UNDEF_RESULT)
+    expect(math.evaluate("atan2('', 1)")).toBe(UNDEF_RESULT)
+  })
+})

--- a/v3/src/models/formula/functions/trig-functions.ts
+++ b/v3/src/models/formula/functions/trig-functions.ts
@@ -1,0 +1,42 @@
+import { numericFnFactory, numericMultiArgsFnFactory } from "./arithmetic-functions"
+
+// Trig functions are not in the minimal mathjs evaluate/parse/compile dependency set, so they must be
+// defined here and registered through CODAP's fnRegistry. The numericFnFactory wrappers ensure
+// non-numeric attribute values (empty strings, etc.) propagate as UNDEF_RESULT rather than throwing
+// or returning NaN. Set matches v2's documented trig functions (apps/dg/formula/basic_functions.js).
+export const trigFunctions = {
+  acos: {
+    numOfRequiredArguments: 1,
+    evaluate: numericFnFactory(Math.acos)
+  },
+
+  asin: {
+    numOfRequiredArguments: 1,
+    evaluate: numericFnFactory(Math.asin)
+  },
+
+  atan: {
+    numOfRequiredArguments: 1,
+    evaluate: numericFnFactory(Math.atan)
+  },
+
+  atan2: {
+    numOfRequiredArguments: 2,
+    evaluate: numericMultiArgsFnFactory(Math.atan2, { numOfRequiredArgs: 2 })
+  },
+
+  cos: {
+    numOfRequiredArguments: 1,
+    evaluate: numericFnFactory(Math.cos)
+  },
+
+  sin: {
+    numOfRequiredArguments: 1,
+    evaluate: numericFnFactory(Math.sin)
+  },
+
+  tan: {
+    numOfRequiredArguments: 1,
+    evaluate: numericFnFactory(Math.tan)
+  },
+}

--- a/v3/src/models/formula/utils/canonicalization-utils.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.ts
@@ -188,7 +188,7 @@ export const formulaIndexOf = (formula: string, name: string, isStringConstant: 
 
 // Maps user-facing function names to internal canonical names that avoid collisions with mathjs internals.
 // For example, "number" collides with mathjs's internal number() used by the parser for numeric conversion.
-const fnDisplayToCanonical: Record<string, string> = { number: "_number_" }
+export const fnDisplayToCanonical: Record<string, string> = { number: "_number_" }
 const fnCanonicalToDisplay: Record<string, string> = { _number_: "number" }
 
 // Function replaces all the symbol names typed by user (display names) with the symbol canonical names that


### PR DESCRIPTION
## Summary

- Restore trig functions (`sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`) in formulas via a new `trig-functions.ts` module using the existing `numericFnFactory` pattern.
- Restore `string()` type conversion in `other-functions.ts` mirroring v2 semantics.
- Add `src/lib/functions.test.ts`: a regression-guard that iterates every function documented in `function-strings.json5` (the formula editor's Functions menu source) and asserts each is registered in `typedFnRegistry`. This would have caught the original regression.

Both functions were silently dropped by [PR #2361](https://github.com/concord-consortium/codap/pull/2361) when mathjs's `create(all)` was replaced with a minimal `create()` for bundle size — `string()` and trig were relying on mathjs's built-in implementations that the slim `create()` no longer includes.

Fixes CODAP-1273.

## Test plan

- [x] All Jest unit tests pass (2830 total, +103 new)
- [x] trig-functions.test.ts: 9 tests covering each function plus numeric-string coercion and empty/non-numeric input
- [x] string() tests in other-functions.test.ts: 4 tests (numbers, strings, booleans, empty)
- [x] functions.test.ts: 99 tests asserting every documented function resolves in typedFnRegistry
- [x] Manual testing: trig functions evaluate correctly in formulas
- [x] Manual testing: string() evaluates correctly in formulas
- [ ] CI pass (lint, build, limited Cypress)
- [ ] Apply `run regression` label → full Cypress regression passes
