### PR TITLE
CODAP-1280: fix blank graphs for formula attributes on document open

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -869,16 +869,15 @@ export const DataConfigurationModel = types
       })
     },
     handleDataSetAction(actionCall: ISerializedActionCall) {
-      const cacheClearingActions = ["setCaseValues", "addCases", "removeCases", "removeAttribute"]
+      // setCaseValues, setComputedCaseValues, and removeAttribute self-invalidate via the dataset's
+      // own invalidateCases call, which we observe reactively (see the dataset.itemIds reaction).
+      // addCases and removeCases don't currently self-invalidate, so we have to do it here.
+      const cacheClearingActions = ["addCases", "removeCases"]
       if (cacheClearingActions.includes(actionCall.name)) {
         this.invalidateCases()
       }
       // forward all actions from dataset except "setCaseValues" which requires intervention
       if (actionCall.name === "setCaseValues") return
-      if (actionCall.name === "invalidateCollectionGroups") {
-        this._updateFilteredCasesCollectionID()
-        this.invalidateCases()
-      }
       self.handlers.forEach(handler => handler(actionCall))
     },
   }))

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -31,9 +31,9 @@ describe("CategorySet", () => {
     // attribute reference resolves to the free attribute
     expect(categories.attribute.name).toBe("aFree")
 
-    // attribute changes trigger invalidation for provisional category sets
+    // attribute value changes trigger invalidation for provisional category sets
     const provisionalSpy = jest.spyOn(categories, "invalidate")
-    data.attributes[0].clearFormula()
+    data.attributes[0].addValue("a")
     expect(provisionalSpy).toHaveBeenCalledTimes(1)
     provisionalSpy.mockRestore()
 
@@ -46,9 +46,9 @@ describe("CategorySet", () => {
     // attribute reference resolves to attribute in tree
     expect(tree.categories.attribute.name).toBe("aTree")
 
-    // attribute changes trigger invalidation for attached category sets
+    // attribute value changes trigger invalidation for attached category sets
     const attachedSpy = jest.spyOn(tree.categories, "invalidate")
-    tree.attribute.clearFormula()
+    tree.attribute.addValue("a")
     expect(attachedSpy).toHaveBeenCalledTimes(1)
     attachedSpy.mockRestore()
 
@@ -165,6 +165,24 @@ describe("CategorySet", () => {
     expect(categories.valuesArray).toEqual(["x", "y", "z", "b"])
     expect(categories.moves.length).toBe(6)
     expect(categories.lastMove?.fromIndex).toBe(originalFromIndex)
+  })
+
+  // Regression test: formula-computed values are written via Attribute.setComputedValues, which
+  // is a volatile method that doesn't fire its own MST action. The CategorySet must still invalidate
+  // and pick up the new categories — otherwise categorical scales backed by formula attributes are
+  // empty, points get NaN positions, and graphs render blank.
+  it("invalidates when formula-computed values are written via setComputedValues", () => {
+    const a = Attribute.create({ name: "a", values: ["a", "a", "a", "a"] })
+    const tree = Tree.create({
+      attribute: a,
+      categories: { attribute: a.id }
+    })
+    const categories = tree.categories
+    expect(categories.valuesArray).toEqual(["a"])
+
+    // simulate a formula recomputing the values
+    a.setComputedValues([0, 1, 2, 3], ["x", "y", "x", "y"])
+    expect(categories.valuesArray).toEqual(["x", "y"])
   })
 
   it("handles volatile category drags", () => {

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -247,14 +247,17 @@ export const CategorySet = types.model("CategorySet", {
     // changeCount, but they don't need to invalidate the cache either — the values themselves
     // don't change at that moment, and any subsequent recomputation goes through setComputedValues
     // which will bump changeCount and trigger this reaction.
-    if (isValidReference(() => self.attribute)) {
-      mstReaction(
-        () => self.attribute.changeCount,
-        () => self.invalidate(),
-        { name: "CategorySet.invalidateOnAttributeChangeCount" },
-        self
-      )
-    }
+    // The accessor guards against an invalid attribute reference (which can occur briefly while
+    // the attribute is being destroyed); the reaction is auto-disposed when this CategorySet
+    // is destroyed via the onInvalidated → removeCategorySet chain.
+    mstReaction(
+      () => isValidReference(() => self.attribute) ? self.attribute.changeCount : undefined,
+      changeCount => {
+        if (changeCount != null) self.invalidate()
+      },
+      { name: "CategorySet.invalidateOnAttributeChangeCount" },
+      self
+    )
   },
   move(value: string, beforeValue?: string) {
     const fromIndex = self.index(value)

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -1,12 +1,12 @@
 import { uniq } from "lodash"
 import { observable, runInAction } from "mobx"
 import {
-  addDisposer, getEnv, hasEnv, IAnyStateTreeNode, IDisposer, Instance, ISerializedActionCall, isValidReference,
+  addDisposer, getEnv, hasEnv, IAnyStateTreeNode, Instance, isValidReference,
   onPatch, resolveIdentifier, SnapshotIn, types
 } from "mobx-state-tree"
 import { kellyColors } from "../../utilities/color-utils"
 import { compareValues } from "../../utilities/data-utils"
-import { onAnyAction } from "../../utilities/mst-utils"
+import { mstReaction } from "../../utilities/mst-reaction"
 import { gLocale } from "../../utilities/translation/locale"
 import { Attribute, IAttribute } from "./attribute"
 import { IDataSet } from "./data-set"
@@ -62,7 +62,6 @@ export const CategorySet = types.model("CategorySet", {
   moves: types.array(types.frozen<ICategoryMove>())
 })
 .volatile(self => ({
-  provisionalAttributeActionDisposer: undefined as Maybe<IDisposer>,
   handleAttributeInvalidated: undefined as Maybe<(attrId: string) => void>,
   dragCategory: undefined as Maybe<string>,
   dragCategoryIndex: -1
@@ -233,39 +232,28 @@ export const CategorySet = types.model("CategorySet", {
   }
 }))
 .actions(self => ({
-  handleAttributeAction(action: ISerializedActionCall) {
-    const actionsInvalidatingCategories = [
-      "clearFormula", "setDisplayExpression", "addValue", "addValues", "setValue", "setValues", "removeValues"
-    ]
-    if (actionsInvalidatingCategories.includes(action.name)) {
-      self.invalidate()
-    }
-  }
-}))
-.actions(self => ({
   afterCreate() {
-    // invalidate the cached categories when necessary
-    // afterAttach isn't called for provisional category sets, so we need to listen here
-    const hasProvisionalDataSet = !!getProvisionalDataSet(self)
-    if (hasProvisionalDataSet && isValidReference(() => self.attribute)) {
-      const provisionalDisposer = onAnyAction(self.attribute, action => self.handleAttributeAction(action))
-      self.provisionalAttributeActionDisposer = provisionalDisposer
-      addDisposer(self, () => self.provisionalAttributeActionDisposer?.())
-    }
-
     addDisposer(self, onPatch(self, patch => {
       // invalidate the categories when the moves are changed
       if (patch.path.includes("/moves")) {
         self.invalidate()
       }
     }))
-  },
-  afterAttach() {
-    // invalidate the cached categories when necessary
+
+    // Invalidate the cached categories whenever the attribute's values change.
+    // Reacting to changeCount (the canonical "values changed" signal) covers all value-mutation
+    // paths, including the volatile setComputedValues path used by formula evaluation, which
+    // doesn't fire its own MST action. Note: clearFormula/setDisplayExpression don't bump
+    // changeCount, but they don't need to invalidate the cache either — the values themselves
+    // don't change at that moment, and any subsequent recomputation goes through setComputedValues
+    // which will bump changeCount and trigger this reaction.
     if (isValidReference(() => self.attribute)) {
-      self.provisionalAttributeActionDisposer?.()
-      self.provisionalAttributeActionDisposer = undefined
-      addDisposer(self, onAnyAction(self.attribute, action => self.handleAttributeAction(action)))
+      mstReaction(
+        () => self.attribute.changeCount,
+        () => self.invalidate(),
+        { name: "CategorySet.invalidateOnAttributeChangeCount" },
+        self
+      )
     }
   },
   move(value: string, beforeValue?: string) {

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1091,3 +1091,30 @@ test("setComputedCaseValues triggers regrouping for parent collection attributes
 
   expect(data.needsRegrouping).toBe(true)
 })
+
+// Removing an attribute changes the columnar structure of the dataset and can affect
+// downstream consumers (e.g., filtered cases, value caches in display models). The dataset
+// should self-invalidate so consumers can react via a single canonical signal rather than
+// every consumer listening for "removeAttribute" via onAnyAction.
+test("removeAttribute invalidates cases", () => {
+  const data = DataSet.create({ name: "data" })
+  data.addAttribute({ id: "aId", name: "a" })
+  data.addAttribute({ id: "bId", name: "b" })
+  data.addCases(toCanonical(data, [
+    { a: "x", b: 1 },
+    { a: "y", b: 2 }
+  ]))
+  // ensure cases are valid before removal
+  data.validateCases()
+  expect(data.isValidCases).toBe(true)
+  const validationCountBefore = data.validationCount
+
+  data.removeAttribute("bId")
+
+  // cases should be invalidated (so reactions on validationCount fire)
+  expect(data.isValidCases).toBe(false)
+
+  // re-validate and verify validationCount incremented
+  data.validateCases()
+  expect(data.validationCount).toBe(validationCountBefore + 1)
+})

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -1202,6 +1202,11 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
 
           // remove attribute from attributesMap
           self.attributesMap.delete(attribute.id)
+
+          // signal cache invalidation so consumers (e.g., data display value caches,
+          // filtered cases) can react via the canonical validation signal rather than
+          // each listening for the removeAttribute action specifically.
+          self.invalidateCases()
         }
         return result
       },


### PR DESCRIPTION
## Summary

Fixes [CODAP-1280](https://concord-consortium.atlassian.net/browse/CODAP-1280) — graphs in the StoryQ document (and any document with formula-driven categorical attributes) render blank when opened in builds since 3.0.0-beta.2832, with all points clustered at the upper-left corner.

**Root cause:** `CategorySet` listened for attribute MST actions by name (`setValue`, `setValues`, …), but the new `Attribute.setComputedValues` path introduced in CODAP-996 (#2499) writes to volatile arrays and only fires `incChangeCount`, which wasn't in the allowlist. Categorical scales kept their initial (empty) categories → points mapped to NaN positions → all points rendered at (0, 0).

**The actual fix:** replace `CategorySet`'s `onAnyAction` action-name allowlist with an `mstReaction` on `attribute.changeCount` — the canonical "values changed" signal that every value-mutation path (old and new) bumps. As a bonus, this drops the `afterCreate`/`afterAttach` listener-rebuild dance for provisional category sets.

**Cleanups identified during the investigation** (no observable behavior change, but documented and tested):
- `DataSet.removeAttribute` now self-invalidates via `invalidateCases`, so consumers can rely on the canonical reactive signal instead of the action name.
- `DataConfigurationModel.handleDataSetAction`'s `cacheClearingActions` list is trimmed accordingly, and a dead `invalidateCollectionGroups` branch is removed (no such action exists in the dataset).

## Test plan

- [ ] Open the StoryQ doc that reproduces the bug ([broken in 2832](https://codap3.concord.org/version/3.0.0-beta.2832/#shared=https%3A%2F%2Fcfm-shared.concord.org%2FYKSZKo3RcVOdqAjqZYj4%2Ffile.json)) on [this branch](https://codap3.concord.org/branch/storyq-empty-graphs/#shared=https%3A%2F%2Fcfm-shared.concord.org%2FYKSZKo3RcVOdqAjqZYj4%2Ffile.json) — all three graphs (Cword & Prediction, True vs. Predicted, Accuracy) should render with their data points.
- [ ] Verify graphs that don't use formula attributes still render (no regression).
- [ ] Verify formula-driven slider animations still update graphs in real time (the perf improvement from CODAP-996 should be unaffected).
- [ ] Case table continues to display formula-attribute values correctly (hierarchical and flat).
- [ ] CI: full Cypress suite (`run regression` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CODAP-1280]: https://concord-consortium.atlassian.net/browse/CODAP-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ