### PR TITLE
CODAP-1055: fix count adornment alignment for binned y-primary plots

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -163,11 +163,23 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
               {"y-axis": primaryAttrRole === "y" && numBins > 1},
               {"binned-points-count": !!isBinnedPlot}
             )
-            const lowerPixels = isFiniteNumber(startFraction)
-                ? range[0] + startFraction * (range[1] - range[0]) : width * i,
-              upperPixels = isFiniteNumber(endFraction)
-                ? range[0] + endFraction * (range[1] - range[0]) : width * (i + 1),
-              widthPixels = upperPixels - lowerPixels
+            const hasFractions = isFiniteNumber(startFraction) && isFiniteNumber(endFraction)
+            // For x-primary the scale range is [0, length], so range[0] + f*(range[1]-range[0]) = f*length,
+            // which matches CSS `left`. For y-primary the d3 range is [length, 0], but the count div uses
+            // CSS `bottom` (measured from the bottom of the parent), so the lower pixel value should grow
+            // with the fraction. Compute pixels accordingly for each axis.
+            const axisLength = Math.abs(range[1] - range[0])
+            const lowerPixels = hasFractions
+              ? primaryAttrRole === "x"
+                ? range[0] + startFraction * (range[1] - range[0])
+                : startFraction * axisLength
+              : width * i
+            const upperPixels = hasFractions
+              ? primaryAttrRole === "x"
+                ? range[0] + endFraction * (range[1] - range[0])
+                : endFraction * axisLength
+              : width * (i + 1)
+            const widthPixels = upperPixels - lowerPixels
             const style = primaryAttrRole === "x"
               ? {left: `${lowerPixels}px`, width: `${widthPixels}px`}
               : {bottom: `${lowerPixels}px`, height: `${widthPixels}px`}

--- a/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.test.ts
+++ b/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.test.ts
@@ -1,5 +1,12 @@
 import { BinnedDotPlotModel } from "./binned-dot-plot-model"
 
+jest.mock("../../../data-display/data-display-value-utils", () => ({
+  dataDisplayGetNumericValue: (_dataset: unknown, caseID: string) => {
+    const valueMap: Record<string, number> = { c1: 0.5, c2: 3.5 }
+    return valueMap[caseID]
+  }
+}))
+
 describe("BinnedDotPlotModel", () => {
   it("binDetailsFromValues returns correct bin details", () => {
     const m = BinnedDotPlotModel.create()
@@ -16,6 +23,62 @@ describe("BinnedDotPlotModel", () => {
       minValue: 2.5,
       maxValue: 4,
       totalNumberOfBins: 9
+    })
+  })
+
+  describe("countAdornmentValues", () => {
+    // _binWidth=1, _binAlignment=0 with case values 0.5 and 3.5 yields totalNumberOfBins=4
+    // (minBinEdge=0, maxBinEdge=4)
+    function makeFixtureModel(primaryRole: "x" | "y", numberOfHorizontalRegions = 2) {
+      const m = BinnedDotPlotModel.create({ _binWidth: 1, _binAlignment: 0 })
+      const dataConfig = {
+        primaryRole,
+        primaryAttributeID: "attr1",
+        dataset: {} as any,
+        showMeasuresForSelection: false,
+        numberOfHorizontalRegions,
+        getCaseDataArray: () => [{ caseID: "c1" }, { caseID: "c2" }],
+        subPlotCases: () => []
+      }
+      m.setGraphContext(dataConfig as any)
+      return m
+    }
+
+    it("emits startFraction/endFraction on every bin", () => {
+      const m = makeFixtureModel("x")
+      const result = m.countAdornmentValues({ cellKey: {} })
+      expect(result.values).toHaveLength(4)
+      result.values.forEach((value, i) => {
+        expect(value.startFraction).toBeCloseTo(i / 4)
+        expect(value.endFraction).toBeCloseTo((i + 1) / 4)
+      })
+    })
+
+    it("multiplies numHorizontalRegions by totalNumberOfBins for x-primary", () => {
+      const m = makeFixtureModel("x", 2)
+      const result = m.countAdornmentValues({ cellKey: {} })
+      expect(result.numHorizontalRegions).toBe(8) // 2 horizontal regions * 4 bins
+    })
+
+    it("does not multiply numHorizontalRegions by totalNumberOfBins for y-primary", () => {
+      const m = makeFixtureModel("y", 2)
+      const result = m.countAdornmentValues({ cellKey: {} })
+      expect(result.numHorizontalRegions).toBe(2) // 2 horizontal regions, bins stack vertically
+    })
+
+    it("treats undefined primaryRole as x to match the component's default", () => {
+      const m = BinnedDotPlotModel.create({ _binWidth: 1, _binAlignment: 0 })
+      m.setGraphContext({
+        primaryRole: undefined,
+        primaryAttributeID: "attr1",
+        dataset: {} as any,
+        showMeasuresForSelection: false,
+        numberOfHorizontalRegions: 2,
+        getCaseDataArray: () => [{ caseID: "c1" }, { caseID: "c2" }],
+        subPlotCases: () => []
+      } as any)
+      const result = m.countAdornmentValues({ cellKey: {} })
+      expect(result.numHorizontalRegions).toBe(8) // 2 horizontal regions * 4 bins (x-primary default)
     })
   })
 })

--- a/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.ts
+++ b/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.ts
@@ -218,7 +218,8 @@ export const BinnedDotPlotModel = DotPlotModel
       }
       // Bins extend along the primary axis. Only multiply horizontal regions by the bin count when
       // bins run horizontally (primary axis = x); otherwise the cell width is shared by all bin counts.
-      const primaryIsX = dataConfig?.primaryRole === "x"
+      // Default to x when primaryRole is undefined to match the component's `?? "x"` convention.
+      const primaryIsX = (dataConfig?.primaryRole ?? "x") === "x"
       return {
         numHorizontalRegions: (dataConfig?.numberOfHorizontalRegions ?? 1) * (primaryIsX ? totalNumberOfBins : 1),
         values

--- a/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.ts
+++ b/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.ts
@@ -195,25 +195,32 @@ export const BinnedDotPlotModel = DotPlotModel
         }
       })
       for (let binIndex = 0; binIndex < totalNumberOfBins; binIndex++) {
+        const startFraction = binIndex / totalNumberOfBins
+        const endFraction = (binIndex + 1) / totalNumberOfBins
         if (!binCounts[binIndex]) {
-          values[binIndex] = { numerator: 0, denominator: 1 }
+          values[binIndex] = { numerator: 0, denominator: 1, startFraction, endFraction }
         }
         else {
           if (showMeasuresForSelection) {
             values[binIndex] = {
               numerator: binCounts[binIndex].numSelected,
-              denominator: binCounts[binIndex].numInBin
+              denominator: binCounts[binIndex].numInBin,
+              startFraction, endFraction
             }
           } else {
             values[binIndex] = {
               numerator: binCounts[binIndex].numInBin,
-              denominator: totalNumberOfCases
+              denominator: totalNumberOfCases,
+              startFraction, endFraction
             }
           }
         }
       }
+      // Bins extend along the primary axis. Only multiply horizontal regions by the bin count when
+      // bins run horizontally (primary axis = x); otherwise the cell width is shared by all bin counts.
+      const primaryIsX = dataConfig?.primaryRole === "x"
       return {
-        numHorizontalRegions: (dataConfig?.numberOfHorizontalRegions ?? 1) * totalNumberOfBins,
+        numHorizontalRegions: (dataConfig?.numberOfHorizontalRegions ?? 1) * (primaryIsX ? totalNumberOfBins : 1),
         values
       }
     }


### PR DESCRIPTION
Fixes CODAP-1055.

## Summary
On a graph with a categorical x-axis and a numeric y-axis configured as
"Group into Bins", enabling Count from the Measures menu rendered each bin's
count at the wrong band — visibly shifted by one bin, with a phantom row below
the bottommost bin (see ticket screenshots).

## Root cause
- `BinnedDotPlotModel.countAdornmentValues` emitted one `INumDenom` per bin
  without `startFraction`/`endFraction`, so the count adornment's fallback
  positioning (`width * i`) kicked in.
- `numHorizontalRegions` was always multiplied by `totalNumberOfBins`, which is
  only correct when bins run horizontally (primary axis = x). For y-primary it
  shrank `subPlotRegionWidth` and the fallback `width` to a fraction of the
  cell, putting bin counts at incorrect vertical offsets.
- The count adornment's pixel formula assumed the d3 range was `[0, length]`,
  which is true for the x scale but not for the y scale (`[length, 0]`). With
  fractions populated, y-primary positioning would still have come out negative.

## Fix
1. `BinnedDotPlotModel.countAdornmentValues` now sets `startFraction`/`endFraction`
   on every bin (`i / N` and `(i + 1) / N`), and only multiplies
   `numHorizontalRegions` by `totalNumberOfBins` for x-primary plots.
2. `CountAdornment` branches on `primaryAttrRole` when computing the lower/upper
   pixel positions: x-primary keeps the original formula, y-primary uses
   `fraction * axisLength` so CSS `bottom` grows with the data fraction.

## Out of scope
While verifying the fix, we noticed a pre-existing layout offset: the binned
axis places gridlines at bin **midpoints**, so the visible bands between
gridlines are offset by half a bin from the actual bin domains. Counts now
appear in the correct data-space bands, which makes the offset more visible at
the top/bottom of the plot. Will file a separate ticket.

## Test plan
- [x] `npm run build:tsc` clean
- [x] `npm test -- count-adornment binned-dot-plot` (24/24)
- [x] `npm test -- adornments dot-plot dot-chart` (232/232)
- [x] Visually verified the document linked in CODAP-1055
- [ ] CI lint + Cypress
- [ ] After CI green: request Copilot review and apply `run regression`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
