### PR TITLE
CODAP-1282: prevent stale title from carrying across formula editor reopens

### DIFF
--- a/v3/src/components/common/edit-formula-modal.test.tsx
+++ b/v3/src/components/common/edit-formula-modal.test.tsx
@@ -1,3 +1,4 @@
+import { ComponentProps } from "react"
 import { render, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { EditFormulaModal } from "./edit-formula-modal"
@@ -16,22 +17,26 @@ jest.mock("./formula-editor", () => ({
   }
 }))
 
+type ModalProps = ComponentProps<typeof EditFormulaModal>
+
+const baseProps: Omit<ModalProps, "applyFormula"> = {
+  titleLabel: "Attribute name",
+  onClose: () => {},
+  value: "",
+  titleInput: "A",
+  isOpen: true
+}
+
+function setup(overrides: Partial<ModalProps> = {}) {
+  const user = userEvent.setup()
+  const props: ModalProps = { ...baseProps, applyFormula: jest.fn(), ...overrides }
+  const view = render(<EditFormulaModal {...props} />)
+  return { user, applyFormula: props.applyFormula as jest.Mock, props, ...view }
+}
+
 describe("EditFormulaModal", () => {
   it("does not carry over the previous attribute's name when reopened for a different attribute", async () => {
-    const user = userEvent.setup()
-    const applyFormula = jest.fn()
-    const noop = () => {}
-
-    const props = {
-      applyFormula,
-      titleLabel: "Attribute name",
-      onClose: noop,
-      value: ""
-    }
-
-    const { rerender } = render(
-      <EditFormulaModal {...props} titleInput="A" isOpen={true} />
-    )
+    const { user, applyFormula, props, rerender } = setup()
 
     // Edit attribute A's name to "newA"
     const input = await screen.findByDisplayValue("A")
@@ -43,12 +48,11 @@ describe("EditFormulaModal", () => {
     expect(applyFormula).toHaveBeenLastCalledWith("", "newA")
 
     // Simulate the parent closing the modal then reopening it for attribute B
-    rerender(<EditFormulaModal {...props} titleInput="A" isOpen={false} />)
-    rerender(<EditFormulaModal {...props} titleInput="B" isOpen={true} />)
+    rerender(<EditFormulaModal {...props} isOpen={false} />)
+    rerender(<EditFormulaModal {...props} titleInput="B" />)
 
     // Apply without touching the attribute name input
-    const applyButton = await screen.findByRole("button", { name: "Apply" })
-    await user.click(applyButton)
+    await user.click(await screen.findByRole("button", { name: "Apply" }))
 
     // The current attribute is B, so applyFormula must receive B's name —
     // not the "newA" left over from the previous session.
@@ -56,17 +60,7 @@ describe("EditFormulaModal", () => {
   })
 
   it("discards in-session title edits when the modal is canceled and reopened for the same attribute", async () => {
-    const user = userEvent.setup()
-    const applyFormula = jest.fn()
-    const props = {
-      applyFormula,
-      titleLabel: "Attribute name",
-      onClose: () => {},
-      value: "",
-      titleInput: "A"
-    }
-
-    const { rerender } = render(<EditFormulaModal {...props} isOpen={true} />)
+    const { user, applyFormula, props, rerender } = setup()
 
     const input = await screen.findByDisplayValue("A")
     await user.clear(input)
@@ -85,17 +79,7 @@ describe("EditFormulaModal", () => {
   })
 
   it("clears the autocomplete-open state when the modal is closed", async () => {
-    const user = userEvent.setup()
-    render(
-      <EditFormulaModal
-        applyFormula={jest.fn()}
-        titleLabel="Attribute name"
-        onClose={() => {}}
-        value=""
-        titleInput="A"
-        isOpen={true}
-      />
-    )
+    const { user } = setup()
 
     const autocompleteRef = (globalThis as any).__capturedIsAutoCompleteMenuOpen
     expect(autocompleteRef).toBeDefined()
@@ -113,46 +97,17 @@ describe("EditFormulaModal", () => {
   it("enables the title input when titleInput is an empty string", () => {
     // Attribute names can be trimmed to "" by Attribute.setName(). When that happens,
     // the formula editor must still allow editing the name to fix it.
-    render(
-      <EditFormulaModal
-        applyFormula={jest.fn()}
-        titleLabel="Attribute name"
-        onClose={() => {}}
-        value=""
-        titleInput=""
-        isOpen={true}
-      />
-    )
+    setup({ titleInput: "" })
     expect(screen.getByTestId("attr-name-input")).not.toBeDisabled()
   })
 
   it("disables the title input when no titleInput prop is provided (e.g. filter formula)", () => {
-    render(
-      <EditFormulaModal
-        applyFormula={jest.fn()}
-        titleLabel="Filter formula"
-        onClose={() => {}}
-        value=""
-        isOpen={true}
-      />
-    )
+    setup({ titleInput: undefined, titleLabel: "Filter formula" })
     expect(screen.getByTestId("attr-name-input")).toBeDisabled()
   })
 
   it("passes the in-session edited attribute name (trimmed) to applyFormula", async () => {
-    const user = userEvent.setup()
-    const applyFormula = jest.fn()
-
-    render(
-      <EditFormulaModal
-        applyFormula={applyFormula}
-        titleLabel="Attribute name"
-        onClose={() => {}}
-        value=""
-        titleInput="A"
-        isOpen={true}
-      />
-    )
+    const { user, applyFormula } = setup()
 
     const input = await screen.findByDisplayValue("A")
     await user.clear(input)

--- a/v3/src/components/common/edit-formula-modal.test.tsx
+++ b/v3/src/components/common/edit-formula-modal.test.tsx
@@ -2,12 +2,9 @@ import { render, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { EditFormulaModal } from "./edit-formula-modal"
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 jest.mock("./formula-editor", () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   FormulaEditor: ({ isAutoCompleteMenuOpen }: any) => {
     // Capture the ref so a test can assert on it after closeModal runs.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(globalThis as any).__capturedIsAutoCompleteMenuOpen = isAutoCompleteMenuOpen
     return (
       <button
@@ -100,7 +97,6 @@ describe("EditFormulaModal", () => {
       />
     )
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const autocompleteRef = (globalThis as any).__capturedIsAutoCompleteMenuOpen
     expect(autocompleteRef).toBeDefined()
 

--- a/v3/src/components/common/edit-formula-modal.test.tsx
+++ b/v3/src/components/common/edit-formula-modal.test.tsx
@@ -114,6 +114,35 @@ describe("EditFormulaModal", () => {
     expect(autocompleteRef.current).toBe(false)
   })
 
+  it("enables the title input when titleInput is an empty string", () => {
+    // Attribute names can be trimmed to "" by Attribute.setName(). When that happens,
+    // the formula editor must still allow editing the name to fix it.
+    render(
+      <EditFormulaModal
+        applyFormula={jest.fn()}
+        titleLabel="Attribute name"
+        onClose={() => {}}
+        value=""
+        titleInput=""
+        isOpen={true}
+      />
+    )
+    expect(screen.getByTestId("attr-name-input")).not.toBeDisabled()
+  })
+
+  it("disables the title input when no titleInput prop is provided (e.g. filter formula)", () => {
+    render(
+      <EditFormulaModal
+        applyFormula={jest.fn()}
+        titleLabel="Filter formula"
+        onClose={() => {}}
+        value=""
+        isOpen={true}
+      />
+    )
+    expect(screen.getByTestId("attr-name-input")).toBeDisabled()
+  })
+
   it("passes the in-session edited attribute name (trimmed) to applyFormula", async () => {
     const user = userEvent.setup()
     const applyFormula = jest.fn()

--- a/v3/src/components/common/edit-formula-modal.test.tsx
+++ b/v3/src/components/common/edit-formula-modal.test.tsx
@@ -2,8 +2,21 @@ import { render, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { EditFormulaModal } from "./edit-formula-modal"
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 jest.mock("./formula-editor", () => ({
-  FormulaEditor: () => <div data-testid="formula-editor-stub" />
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  FormulaEditor: ({ isAutoCompleteMenuOpen }: any) => {
+    // Capture the ref so a test can assert on it after closeModal runs.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).__capturedIsAutoCompleteMenuOpen = isAutoCompleteMenuOpen
+    return (
+      <button
+        data-testid="open-autocomplete-stub"
+        type="button"
+        onClick={() => { isAutoCompleteMenuOpen.current = true }}
+      />
+    )
+  }
 }))
 
 describe("EditFormulaModal", () => {
@@ -72,6 +85,33 @@ describe("EditFormulaModal", () => {
     // Apply without touching the title input — cancel should have discarded "newA"
     await user.click(screen.getByRole("button", { name: "Apply" }))
     expect(applyFormula).toHaveBeenLastCalledWith("", "A")
+  })
+
+  it("clears the autocomplete-open state when the modal is closed", async () => {
+    const user = userEvent.setup()
+    render(
+      <EditFormulaModal
+        applyFormula={jest.fn()}
+        titleLabel="Attribute name"
+        onClose={() => {}}
+        value=""
+        titleInput="A"
+        isOpen={true}
+      />
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const autocompleteRef = (globalThis as any).__capturedIsAutoCompleteMenuOpen
+    expect(autocompleteRef).toBeDefined()
+
+    // Simulate the FormulaEditor opening its autocomplete tooltip
+    await user.click(screen.getByTestId("open-autocomplete-stub"))
+    expect(autocompleteRef.current).toBe(true)
+
+    // Closing the modal should clear the autocomplete-open ref so a stale `true`
+    // doesn't suppress the Escape handler on the next open.
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    expect(autocompleteRef.current).toBe(false)
   })
 
   it("passes the in-session edited attribute name (trimmed) to applyFormula", async () => {

--- a/v3/src/components/common/edit-formula-modal.test.tsx
+++ b/v3/src/components/common/edit-formula-modal.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { EditFormulaModal } from "./edit-formula-modal"
+
+jest.mock("./formula-editor", () => ({
+  FormulaEditor: () => <div data-testid="formula-editor-stub" />
+}))
+
+describe("EditFormulaModal", () => {
+  it("does not carry over the previous attribute's name when reopened for a different attribute", async () => {
+    const user = userEvent.setup()
+    const applyFormula = jest.fn()
+    const noop = () => {}
+
+    const props = {
+      applyFormula,
+      titleLabel: "Attribute name",
+      onClose: noop,
+      value: ""
+    }
+
+    const { rerender } = render(
+      <EditFormulaModal {...props} titleInput="A" isOpen={true} />
+    )
+
+    // Edit attribute A's name to "newA"
+    const input = await screen.findByDisplayValue("A")
+    await user.clear(input)
+    await user.type(input, "newA")
+
+    // Apply: should pass the edited name through
+    await user.click(screen.getByRole("button", { name: "Apply" }))
+    expect(applyFormula).toHaveBeenLastCalledWith("", "newA")
+
+    // Simulate the parent closing the modal then reopening it for attribute B
+    rerender(<EditFormulaModal {...props} titleInput="A" isOpen={false} />)
+    rerender(<EditFormulaModal {...props} titleInput="B" isOpen={true} />)
+
+    // Apply without touching the attribute name input
+    const applyButton = await screen.findByRole("button", { name: "Apply" })
+    await user.click(applyButton)
+
+    // The current attribute is B, so applyFormula must receive B's name —
+    // not the "newA" left over from the previous session.
+    expect(applyFormula).toHaveBeenLastCalledWith("", "B")
+  })
+
+  it("passes the in-session edited attribute name (trimmed) to applyFormula", async () => {
+    const user = userEvent.setup()
+    const applyFormula = jest.fn()
+
+    render(
+      <EditFormulaModal
+        applyFormula={applyFormula}
+        titleLabel="Attribute name"
+        onClose={() => {}}
+        value=""
+        titleInput="A"
+        isOpen={true}
+      />
+    )
+
+    const input = await screen.findByDisplayValue("A")
+    await user.clear(input)
+    await user.type(input, "  renamed  ")
+    await user.click(screen.getByRole("button", { name: "Apply" }))
+
+    expect(applyFormula).toHaveBeenCalledWith("", "renamed")
+  })
+})

--- a/v3/src/components/common/edit-formula-modal.test.tsx
+++ b/v3/src/components/common/edit-formula-modal.test.tsx
@@ -45,6 +45,35 @@ describe("EditFormulaModal", () => {
     expect(applyFormula).toHaveBeenLastCalledWith("", "B")
   })
 
+  it("discards in-session title edits when the modal is canceled and reopened for the same attribute", async () => {
+    const user = userEvent.setup()
+    const applyFormula = jest.fn()
+    const props = {
+      applyFormula,
+      titleLabel: "Attribute name",
+      onClose: () => {},
+      value: "",
+      titleInput: "A"
+    }
+
+    const { rerender } = render(<EditFormulaModal {...props} isOpen={true} />)
+
+    const input = await screen.findByDisplayValue("A")
+    await user.clear(input)
+    await user.type(input, "newA")
+
+    // Cancel discards in-session edits
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    // Parent closes then reopens for the same attribute (titleInput unchanged)
+    rerender(<EditFormulaModal {...props} isOpen={false} />)
+    rerender(<EditFormulaModal {...props} isOpen={true} />)
+
+    // Apply without touching the title input — cancel should have discarded "newA"
+    await user.click(screen.getByRole("button", { name: "Apply" }))
+    expect(applyFormula).toHaveBeenLastCalledWith("", "A")
+  })
+
   it("passes the in-session edited attribute name (trimmed) to applyFormula", async () => {
     const user = userEvent.setup()
     const applyFormula = jest.fn()

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -77,6 +77,8 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     setShowValuesMenu(false)
     setShowFunctionMenu(false)
     setFormula(value || "")
+    setTitle(titleInput ?? "")
+    setPrevTitleInput(titleInput)
     onClose?.()
     setDimensions({ width: minWidth, height: minHeight })
   }

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -16,7 +16,10 @@ import ResizeHandle from "../../assets/icons/icon-corner-resize-handle.svg"
 import styles from './edit-formula-modal.scss'
 
 interface IProps {
-  applyFormula: (formula: string, attrName: string) => void
+  // The `title` is the optional secondary value (e.g. an attribute name) edited alongside the
+  // formula. Only some clients use it; most clients pass a `(formula) => void` callback and
+  // ignore the second argument.
+  applyFormula: (formula: string, title?: string) => void
   finalFocusRef?: React.RefObject<HTMLElement>
   formulaPrompt?: string
   isOpen: boolean
@@ -39,7 +42,6 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   const insertButtonsHeight = 35
 
   const modalContentRef = React.useRef<HTMLDivElement>(null)
-  const attrNameInputRef = useRef<HTMLInputElement>(null)
   const formulaEditorContainerRef = useRef<HTMLLabelElement>(null)
   const insertValueButtonRef = useRef<HTMLButtonElement>(null)
   const insertFunctionButtonRef = useRef<HTMLButtonElement>(null)
@@ -49,18 +51,25 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   const { formula, setFormula } = formulaEditorState
   const [dimensions, setDimensions] = useState({ width: minWidth, height: minHeight })
   const editorHeight = dimensions.height - headerHeight - footerHeight - insertButtonsHeight
-  const attrInputRef = useRef("")
+  const [title, setTitle] = useState(titleInput ?? "")
   const isAutoCompleteMenuOpen = useRef(false)
-  // Sync formula state from value prop using React's recommended "adjust state during render" pattern
+  // Sync formula and title state from props using React's recommended
+  // "adjust state during render" pattern. Without this, a title typed during a
+  // previous editing session would carry over and overwrite the next session's title on Apply.
   // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
   const [prevValue, setPrevValue] = useState(value)
   if (value !== prevValue) {
     setPrevValue(value)
     setFormula(value || "")
   }
+  const [prevTitleInput, setPrevTitleInput] = useState(titleInput)
+  if (titleInput !== prevTitleInput) {
+    setPrevTitleInput(titleInput)
+    setTitle(titleInput ?? "")
+  }
 
   const applyAndClose = () => {
-    applyFormula(formula, attrInputRef.current)
+    applyFormula(formula, title.trim())
     closeModal()
   }
 
@@ -155,11 +164,6 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     document.body.addEventListener("pointerup", onPointerUp, { capture: true })
   }, [dimensions.height, dimensions.width, minHeight, minWidth])
 
-  const handleAttributeNameInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    const trimmedValue = e.target.value.trim()
-    attrInputRef.current = trimmedValue
-  }
-
   return (
     <FormulaEditorContext.Provider value={formulaEditorState}>
       <CodapModal
@@ -175,17 +179,24 @@ export const EditFormulaModal = observer(function EditFormulaModal({
       >
         <ModalBody className="formula-modal-body" onKeyDown={handleKeyDown}>
           <FormControl display="flex" flexDirection="column" className="formula-form-control">
+            {/*
+              TODO: rename the `attr-name-form-label` and `attr-name-input` className/data-testid
+              to a generic `title-form-label` / `title-input`. The title is not always an
+              attribute name (this modal is shared across multiple callers). Touches the SCSS,
+              the focus selector in formula-editor.tsx (`input.attr-name-input:not(:disabled)`),
+              and several Cypress selectors — keep `edit-attribute-properties-modal.tsx`'s
+              independent `attr-name-input` testid as-is.
+            */}
             <FormLabel display="flex" flexDirection="row"
                       className="attr-name-form-label">
               <span className="title-label">{titleLabel}</span>
               <input
-                ref={attrNameInputRef}
                 className="attr-name-input"
-                defaultValue={titleInput}
+                value={title}
+                onChange={e => setTitle(e.target.value)}
                 data-testid="attr-name-input"
                 aria-label={titleLabel}
                 disabled={!titleInput}
-                onBlur={handleAttributeNameInputBlur}
               />
               <span>=</span>
             </FormLabel>

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -199,7 +199,10 @@ export const EditFormulaModal = observer(function EditFormulaModal({
                 onChange={e => setTitle(e.target.value)}
                 data-testid="attr-name-input"
                 aria-label={titleLabel}
-                disabled={!titleInput}
+                // Disable only when there's no title prop at all (most callers).
+                // Allow editing when titleInput is "", since Attribute.setName()
+                // can trim a name to "" and the user needs a way to fix it.
+                disabled={titleInput == null}
               />
               <span>=</span>
             </FormLabel>

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -79,6 +79,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     setFormula(value || "")
     setTitle(titleInput ?? "")
     setPrevTitleInput(titleInput)
+    isAutoCompleteMenuOpen.current = false
     onClose?.()
     setDimensions({ width: minWidth, height: minHeight })
   }


### PR DESCRIPTION
## Summary
- Fixes a bug in `EditFormulaModal` where the title input value (e.g. an attribute
  name) cached on blur persisted across modal opens. Reopening for a different
  attribute and clicking Apply without touching the title input would overwrite
  the new attribute's name with the previously edited one.
- Switches the title input to controlled state synced from the `titleInput` prop,
  mirroring the existing formula/value sync pattern.
- Renames the internal state and prop parameter from attribute-specific names to
  generic `title` — this modal is shared across multiple callers, only one of
  which is editing an attribute name. Marks `applyFormula`'s second argument
  optional to match what callers actually pass. A TODO is left for a follow-up
  rename of the `attr-name-input` className/data-testid.

Fixes CODAP-1282

## Test plan
- [ ] CI: lint, build, limited Cypress
- [ ] CI: full Cypress suite (after `run regression` label applied)
- [ ] Manual repro: open formula editor for attribute A → rename → Apply →
      open formula editor for attribute B → edit only the formula → Apply.
      Expected: B's name unchanged. Before this fix, B was renamed to A's new name.
- [ ] Spot-check other formula-editor callers still work (filter formula bar,
      plotted function/value adornments, etc.) — they pass `(formula) => void`
      and ignore the optional `title` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)