### PR TITLE
CODAP-1285: fix percentile() argument to use [0,1] range

### DIFF
--- a/v3/src/models/formula/functions/univariate-stats-functions.test.ts
+++ b/v3/src/models/formula/functions/univariate-stats-functions.test.ts
@@ -121,23 +121,23 @@ describe("min", () => {
 describe("percentile", () => {
   it("returns correct value", () => {
     expect(evaluate("percentile(Speed, 0)")).toBeCloseTo(1)
-    expect(evaluate("percentile(Speed, 50)")).toBeCloseTo(49)
-    expect(evaluate("percentile(Speed, 100)")).toBeCloseTo(110)
+    expect(evaluate("percentile(Speed, 0.5)")).toBeCloseTo(49)
+    expect(evaluate("percentile(Speed, 1)")).toBeCloseTo(110)
   })
 
   it("supports filter expression", () => {
     expect(evaluate("percentile(Speed, 0, Diet = 'plants')")).toBeCloseTo(40)
-    expect(evaluate("percentile(Speed, 50, Diet = 'plants')")).toBeCloseTo(50)
-    expect(evaluate("percentile(Speed, 100, Diet = 'plants')")).toBeCloseTo(98)
+    expect(evaluate("percentile(Speed, 0.5, Diet = 'plants')")).toBeCloseTo(50)
+    expect(evaluate("percentile(Speed, 1, Diet = 'plants')")).toBeCloseTo(98)
   })
 
   it("ignores non-numeric values", () => {
-    expect(evaluate("percentile(Diet, 50)")).toEqual(UNDEF_RESULT)
+    expect(evaluate("percentile(Diet, 0.5)")).toEqual(UNDEF_RESULT)
   })
 
   it("supports single value argument", () => {
-    expect(evaluate("percentile(1, 50, true)")).toEqual(1)
-    expect(evaluate("percentile(1, 50, false)")).toEqual(UNDEF_RESULT)
+    expect(evaluate("percentile(1, 0.5, true)")).toEqual(1)
+    expect(evaluate("percentile(1, 0.5, false)")).toEqual(UNDEF_RESULT)
   })
 })
 

--- a/v3/src/models/formula/functions/univariate-stats-functions.ts
+++ b/v3/src/models/formula/functions/univariate-stats-functions.ts
@@ -144,7 +144,7 @@ export const univariateStatsFunctions: Record<string, IFormulaMathjsFunction> = 
       const [pIsValid, p] = scope.withLocalContext(() => checkNumber(evaluateNode(percentileArg, scope)))
       if (!pIsValid) return UNDEF_RESULT
 
-      return quantileOfSortedArray(cached.sorted, p / 100) ?? UNDEF_RESULT
+      return quantileOfSortedArray(cached.sorted, p) ?? UNDEF_RESULT
     }
   },
 


### PR DESCRIPTION
## Summary

- The `percentile()` formula function was passing `p / 100` to `quantileOfSortedArray`, treating the argument as if it were in the range [0, 100]. The user-facing docs and the underlying utility expect a value in [0, 1].
- Drop the spurious `/ 100` and update the tests to use the correct range.
- Brings v3 to parity with v2.

Fixes CODAP-1285.

Follow-up: filed CODAP-1287 to address asymmetric out-of-range handling (`p > 1` silently clamps to max) — out of scope for this fix.

## Test plan

- [ ] CI lint + build pass
- [ ] `univariate-stats-functions.test.ts` passes (verified locally)
- [ ] Spot-check `percentile(Speed, 0.5)` returns the median in a real document