### PR TITLE
CODAP-1281: keep binned axis domain at [minBinEdge, maxBinEdge]

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -397,7 +397,9 @@ export const useSubAxis = ({
         // The plot owns a binned numeric axis's domain ([minBinEdge, maxBinEdge]),
         // set in respondToPlotChange and during bin-boundary drag. Don't overwrite
         // it with data-extent niceBounds; doing so widens the domain past the bins
-        // and makes the top/bottom bands visually larger than the rest.
+        // and makes the top/bottom bands visually larger than the rest. The
+        // graph-content-model's caseDataHash reaction handles bin-edge sync on
+        // hide/unhide and other case-data changes for binned plots.
         return
       }
       const currentAxisDomain = axisModel.domain

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -393,6 +393,13 @@ export const useSubAxis = ({
       multiScale?.setCategoricalDomain(categoryValues)
       renderSubAxis()
     } else if (isAnyNumericAxisModel(axisModel)) {
+      if (axisProvider.hasBinnedNumericAxis(axisModel)) {
+        // The plot owns a binned numeric axis's domain ([minBinEdge, maxBinEdge]),
+        // set in respondToPlotChange and during bin-boundary drag. Don't overwrite
+        // it with data-extent niceBounds; doing so widens the domain past the bins
+        // and makes the top/bottom bands visually larger than the rest.
+        return
+      }
       const currentAxisDomain = axisModel.domain
       const multiScale = layout.getAxisMultiScale(axisPlace)
       const allowToShrink = axisModel.allowRangeToShrink

--- a/v3/src/components/graph/models/graph-content-model.test.ts
+++ b/v3/src/components/graph/models/graph-content-model.test.ts
@@ -1,4 +1,4 @@
-import { getSnapshot } from "mobx-state-tree"
+import { applySnapshot, getSnapshot } from "mobx-state-tree"
 import { diComponentHandler } from "../../../data-interactive/handlers/component-handler"
 import { DIComponentInfo } from "../../../data-interactive/data-interactive-types"
 import { appState } from "../../../models/app-state"
@@ -183,6 +183,60 @@ describe("GraphContentModel", () => {
       await new Promise(resolve => setTimeout(resolve, 0))
       expect(xAxis.max).toBe(binDetails().maxBinEdge)
       expect(xAxis.max).toBeGreaterThanOrEqual(9)
+
+      diComponentHandler.delete!({ component: tile })
+    })
+
+    // The setGraphContext mstReaction with fireImmediately: true is the load-time repair —
+    // it resets a binned plot's primary axis to [minBinEdge, maxBinEdge] when the plotType
+    // changes (which happens at construction time and on snapshot rehydration). Without
+    // this fix, a doc saved with a stale niced primary-axis domain would rehydrate with
+    // the wrong domain. We can't easily reproduce a full document rehydration in a unit
+    // test, but applySnapshot replicates the relevant mechanism: replacing the plot via
+    // a snapshot bypasses setPlot's explicit respondToPlotChange call, so only the
+    // mstReaction can reset the axis.
+    it("resets the primary axis to bin edges when plot type rehydrates as binned via applySnapshot", async () => {
+      (isInquirySpaceMode as jest.Mock).mockReturnValue(false)
+      const documentContent = appState.document.content!
+      const { dataset: _dataset } = setupTestDataset({ datasetName: "binnedLoadTestData" })
+      const dataset = documentContent.createDataSet(getSnapshot(_dataset)).sharedDataSet.dataSet
+      dataset.addCases(testCases, { canonicalize: true })
+      dataset.validateCases()
+
+      const result = diComponentHandler.create!(
+        {}, { type: "graph", dataContext: "binnedLoadTestData", xAttributeName: "a3" }
+      )
+      const tile = documentContent.tileMap.get(
+        toV3Id(kGraphIdPrefix, (result.values as DIComponentInfo).id!)
+      )!
+      const content = tile.content as IGraphContentModel
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // Start with a regular dotPlot — the primary axis settles at niced bounds
+      // (e.g., [0.5, 7.5]) which are wider than the bin extent (1..7) for this data.
+      content.setPlotType("dotPlot")
+      const dotPlotXAxis = content.getAxis("bottom") as IBaseNumericAxisModel
+      const stalePlotMax = dotPlotXAxis.max // niced wider value
+
+      // Take a snapshot, switch the plot type to binnedDotPlot in the snapshot, but
+      // KEEP the dotPlot's wider niced axis. Applying this snapshot is analogous to
+      // rehydrating a saved doc whose binned graph had a stale niced domain.
+      const snap = getSnapshot(content) as any
+      const corruptedSnap = {
+        ...snap,
+        plot: { type: "binnedDotPlot" } // bin width/alignment defaulted from data
+      }
+      applySnapshot(content, corruptedSnap)
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // After the snapshot is applied, plotType change fires the setGraphContext
+      // mstReaction, which calls respondToPlotChange — resetting the primary axis to
+      // the current bin extent.
+      const xAxis = content.getAxis("bottom") as IBaseNumericAxisModel
+      const { binDetails } = content.plot as any
+      const correctMax = binDetails().maxBinEdge
+      expect(xAxis.max).toBe(correctMax)
+      expect(correctMax).toBeLessThan(stalePlotMax) // confirms the axis was reset, not preserved
 
       diComponentHandler.delete!({ component: tile })
     })

--- a/v3/src/components/graph/models/graph-content-model.test.ts
+++ b/v3/src/components/graph/models/graph-content-model.test.ts
@@ -81,5 +81,110 @@ describe("GraphContentModel", () => {
       // Clean up
       diComponentHandler.delete!({ component: tile })
     })
+
+    // The asymmetric behavior — extend on add/show, leave alone on remove/hide — mirrors
+    // the established addCases/removeCases asymmetry. On hide the bin extent shrinks but
+    // the axis stays put (so the user sees the same axis they saw before hiding); on show
+    // the axis grows to keep newly-visible outliers from falling outside the plot.
+    it("leaves the primary axis alone when cases are hidden (no shrink)", async () => {
+      (isInquirySpaceMode as jest.Mock).mockReturnValue(false)
+      const documentContent = appState.document.content!
+      const { dataset: _dataset } = setupTestDataset({ datasetName: "binnedHideTestData" })
+      const dataset = documentContent.createDataSet(getSnapshot(_dataset)).sharedDataSet.dataSet
+      dataset.addCases(testCases, { canonicalize: true })
+      dataset.validateCases()
+
+      const result = diComponentHandler.create!(
+        {}, { type: "graph", dataContext: "binnedHideTestData", xAttributeName: "a3" }
+      )
+      const tile = documentContent.tileMap.get(
+        toV3Id(kGraphIdPrefix, (result.values as DIComponentInfo).id!)
+      )!
+      const content = tile.content as IGraphContentModel
+      await new Promise(resolve => setTimeout(resolve, 0))
+      content.setPlotType("binnedDotPlot")
+
+      // Add an outlier; axis extends to fit it.
+      dataset.addCases([{ a3: 9 }], { canonicalize: true })
+      const xAxis = content.getAxis("bottom") as IBaseNumericAxisModel
+      const { binDetails } = content.plot as any
+      const wideMax = xAxis.max
+      expect(wideMax).toBe(binDetails().maxBinEdge)
+      expect(wideMax).toBeGreaterThanOrEqual(9)
+
+      // Hide the outlier — bin extent shrinks, but the axis stays put.
+      const dataConfig = content.graphPointLayerModel.dataConfiguration
+      const a3 = dataset.getAttributeByName("a3")!
+      const outlierCaseId = dataConfig.getCaseDataArray(0)
+        .map(c => c.caseID)
+        .find(id => Number(dataset.getValue(id, a3.id)) === 9)!
+      dataConfig.setHiddenCases([outlierCaseId])
+      // In the live app, mobx reactions flush the hiddenCases → invalidateCases →
+      // filteredCases → caseDataHash chain before render. In jest, trigger the
+      // invalidation explicitly so subsequent reads of binDetails see the new visible set.
+      dataConfig.invalidateCases()
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(binDetails().maxBinEdge).toBeLessThan(wideMax) // bins shrank
+      expect(xAxis.max).toBe(wideMax)                       // but the axis didn't
+
+      // Unhide — bins regrow to the previous extent. Axis was already wide enough,
+      // so no change here.
+      dataConfig.setHiddenCases([])
+      dataConfig.invalidateCases()
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(xAxis.max).toBe(wideMax)
+      expect(binDetails().maxBinEdge).toBe(wideMax)
+
+      diComponentHandler.delete!({ component: tile })
+    })
+
+    // The Copilot-flagged scenario: previously-hidden outliers, when shown, can extend
+    // the bin extent past the current axis. Without the caseDataHash extend-only reaction,
+    // the unhidden outliers would render outside the axis range.
+    it("extends the primary axis when previously-hidden cases unhide past the current bin edge",
+       async () => {
+      (isInquirySpaceMode as jest.Mock).mockReturnValue(false)
+      const documentContent = appState.document.content!
+      const { dataset: _dataset } = setupTestDataset({ datasetName: "binnedShowTestData" })
+      const dataset = documentContent.createDataSet(getSnapshot(_dataset)).sharedDataSet.dataSet
+      dataset.addCases(testCases, { canonicalize: true })
+      dataset.addCases([{ a3: 9 }], { canonicalize: true })
+      dataset.validateCases()
+
+      const result = diComponentHandler.create!(
+        {}, { type: "graph", dataContext: "binnedShowTestData", xAttributeName: "a3" }
+      )
+      const tile = documentContent.tileMap.get(
+        toV3Id(kGraphIdPrefix, (result.values as DIComponentInfo).id!)
+      )!
+      const content = tile.content as IGraphContentModel
+      const dataConfig = content.graphPointLayerModel.dataConfiguration
+      const a3 = dataset.getAttributeByName("a3")!
+      const outlierCaseId = dataConfig.getCaseDataArray(0)
+        .map(c => c.caseID)
+        .find(id => Number(dataset.getValue(id, a3.id)) === 9)!
+
+      // Hide the outlier BEFORE switching to binned. setPlot's respondToPlotChange will
+      // initialize the axis against the visible cases only (1..6).
+      dataConfig.setHiddenCases([outlierCaseId])
+      dataConfig.invalidateCases()
+      await new Promise(resolve => setTimeout(resolve, 0))
+      content.setPlotType("binnedDotPlot")
+
+      const xAxis = content.getAxis("bottom") as IBaseNumericAxisModel
+      const { binDetails } = content.plot as any
+      const narrowMax = xAxis.max
+      expect(narrowMax).toBe(binDetails().maxBinEdge)
+      expect(narrowMax).toBeLessThan(9) // outlier is outside the initial axis
+
+      // Unhide — bin extent grows past narrowMax. The axis must extend to follow.
+      dataConfig.setHiddenCases([])
+      dataConfig.invalidateCases()
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(xAxis.max).toBe(binDetails().maxBinEdge)
+      expect(xAxis.max).toBeGreaterThanOrEqual(9)
+
+      diComponentHandler.delete!({ component: tile })
+    })
   })
 })

--- a/v3/src/components/graph/models/graph-content-model.test.ts
+++ b/v3/src/components/graph/models/graph-content-model.test.ts
@@ -1,5 +1,15 @@
+import { getSnapshot } from "mobx-state-tree"
+import { diComponentHandler } from "../../../data-interactive/handlers/component-handler"
+import { DIComponentInfo } from "../../../data-interactive/data-interactive-types"
+import { appState } from "../../../models/app-state"
+import { setupTestDataset, testCases } from "../../../test/dataset-test-utils"
+import { toV3Id } from "../../../utilities/codap-utils"
 import { isInquirySpaceMode } from "../../../utilities/url-params"
-import { GraphContentModel } from "./graph-content-model"
+import { IBaseNumericAxisModel } from "../../axis/models/base-numeric-axis-model"
+import { kGraphIdPrefix } from "../graph-defs"
+import { GraphContentModel, IGraphContentModel } from "./graph-content-model"
+
+import "../graph-registration"
 
 jest.mock("../../../utilities/url-params", () => {
   const originalModule = jest.requireActual("../../../utilities/url-params")
@@ -18,5 +28,58 @@ describe("GraphContentModel", () => {
     ;(isInquirySpaceMode as jest.Mock).mockReturnValue(true)
     const graphModel2 = GraphContentModel.create({})
     expect(graphModel2.showParentToggles).toBe(true)
+  })
+
+  // CODAP-1281: when cases are added to a dataset (including the initial replay on attach),
+  // the addCases reaction in afterAttachToDocument used to call setNiceDomain on every numeric
+  // axis, including the binned plot's primary, which widened the domain past the bin extent
+  // and produced half-bin slivers at the top/bottom of the plot. The fix calls
+  // respondToPlotChange for binned plots and skips setNiceDomain on the binned primary axis.
+  describe("addCases reaction with binned dot plot", () => {
+    it("keeps the primary axis at [minBinEdge, maxBinEdge] when cases are added", async () => {
+      (isInquirySpaceMode as jest.Mock).mockReturnValue(false)
+      const documentContent = appState.document.content!
+      const { dataset: _dataset } = setupTestDataset({ datasetName: "binnedTestData" })
+      const dataset = documentContent.createDataSet(getSnapshot(_dataset)).sharedDataSet.dataSet
+      dataset.addCases(testCases, { canonicalize: true })
+      dataset.validateCases()
+
+      // Create a graph with a3 (numeric, values 1..6) on the x axis
+      const result = diComponentHandler.create!(
+        {}, { type: "graph", dataContext: "binnedTestData", xAttributeName: "a3" }
+      )
+      expect(result.success).toBe(true)
+      const tile = documentContent.tileMap.get(
+        toV3Id(kGraphIdPrefix, (result.values as DIComponentInfo).id!)
+      )!
+      const content = tile.content as IGraphContentModel
+
+      // Let afterAttachToDocument's awaits resolve so the addCases reaction is wired up.
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // Switch to a binned dot plot. setPlot calls respondToPlotChange, which initializes
+      // bin width/alignment and sets the primary axis to [minBinEdge, maxBinEdge].
+      content.setPlotType("binnedDotPlot")
+
+      const xAxis = content.getAxis("bottom") as IBaseNumericAxisModel
+      const { binDetails } = content.plot as any
+      const { minBinEdge: initialMinBinEdge, maxBinEdge: initialMaxBinEdge } = binDetails()
+      expect(xAxis.min).toBe(initialMinBinEdge)
+      expect(xAxis.max).toBe(initialMaxBinEdge)
+
+      // Add another case that extends the data range past the existing bins.
+      dataset.addCases([{ a3: 9 }], { canonicalize: true })
+
+      // Without the fix, setNiceDomain would have widened the domain past the new bin extent
+      // (e.g., niceBounds(1, 9) ≈ [-0.5, 10.5]). With the fix, the domain tracks the bin edges
+      // recomputed from the new data extent.
+      const { minBinEdge: newMinBinEdge, maxBinEdge: newMaxBinEdge } = binDetails()
+      expect(xAxis.min).toBe(newMinBinEdge)
+      expect(xAxis.max).toBe(newMaxBinEdge)
+      expect(newMaxBinEdge).toBeGreaterThanOrEqual(9)
+
+      // Clean up
+      diComponentHandler.delete!({ component: tile })
+    })
   })
 })

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -35,7 +35,7 @@ import {
 import { computePointRadius } from "../../data-display/data-display-utils"
 import { IGetTipTextProps } from "../../data-display/data-tip-types"
 import { AxisHelper } from "../../axis/helper-models/axis-helper"
-import { IAxisProvider } from "../../axis/models/axis-provider"
+import { IAxisProviderBase } from "../../axis/models/axis-provider"
 import {IAdornmentModel, IUpdateCategoriesOptions} from "../adornments/adornment-models"
 import {AdornmentsStore} from "../adornments/store/adornments-store"
 import { isUnivariateMeasureAdornment } from "../adornments/univariate-measures/univariate-measure-adornment-model"
@@ -226,11 +226,12 @@ export const GraphContentModel = DataDisplayContentModel
           // its own domain (and grow bins to fit new data), then skip the binned
           // primary axis below.
           if (self.plot.hasBinnedNumericAxis) {
-            // Captured-self in this onAction callback isn't typed as IAxisProvider
-            // even though it satisfies the interface at runtime; chain-sibling
-            // actions like setAxisHelper aren't visible here.
+            // The captured self doesn't satisfy IAxisProviderBase here because
+            // setAxisHelper is defined in the same .actions block as this callback,
+            // so it isn't visible on self yet. The cast through unknown is required;
+            // at runtime self does provide every method on the interface.
             self.plot.respondToPlotChange({
-              axisProvider: self as unknown as IAxisProvider,
+              axisProvider: self as unknown as IAxisProviderBase,
               primaryPlace: self.primaryPlace,
               secondaryPlace: self.secondaryPlace
             })

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -35,6 +35,7 @@ import {
 import { computePointRadius } from "../../data-display/data-display-utils"
 import { IGetTipTextProps } from "../../data-display/data-tip-types"
 import { AxisHelper } from "../../axis/helper-models/axis-helper"
+import { IAxisProvider } from "../../axis/models/axis-provider"
 import {IAdornmentModel, IUpdateCategoriesOptions} from "../adornments/adornment-models"
 import {AdornmentsStore} from "../adornments/store/adornments-store"
 import { isUnivariateMeasureAdornment } from "../adornments/univariate-measures/univariate-measure-adornment-model"
@@ -219,10 +220,26 @@ export const GraphContentModel = DataDisplayContentModel
       // Expand numeric axis domains when new cases are added (e.g., via plugin API)
       addDisposer(self, self.dataConfiguration.onAction((actionCall) => {
         if (actionCall.name === "addCases") {
+          // Binned plots own [minBinEdge, maxBinEdge] on the primary axis; running
+          // setNiceDomain on it would re-nice the domain past the bins and produce
+          // the half-bin sliver at top/bottom (CODAP-1281). Let the plot resync
+          // its own domain (and grow bins to fit new data), then skip the binned
+          // primary axis below.
+          if (self.plot.hasBinnedNumericAxis) {
+            // Captured-self in this onAction callback isn't typed as IAxisProvider
+            // even though it satisfies the interface at runtime; chain-sibling
+            // actions like setAxisHelper aren't visible here.
+            self.plot.respondToPlotChange({
+              axisProvider: self as unknown as IAxisProvider,
+              primaryPlace: self.primaryPlace,
+              secondaryPlace: self.secondaryPlace
+            })
+          }
           AxisPlaces.forEach((axisPlace: AxisPlace) => {
             const axis = self.getAxis(axisPlace),
               role = axisPlaceToAttrRole[axisPlace]
             if (isAnyNumericAxisModel(axis)) {
+              if (self.plot.hasBinnedNumericAxis && axisPlace === self.primaryPlace) return
               const numericValues = self.plot.numericValuesForRole(role)
               setNiceDomain(numericValues, axis, self.plot.axisDomainOptions)
             }
@@ -292,7 +309,20 @@ export const GraphContentModel = DataDisplayContentModel
       }
       mstReaction(
         () => self.plotType,
-        () => self.plot.setGraphContext(self.dataConfiguration, self.plotGraphApi),
+        () => {
+          self.plot.setGraphContext(self.dataConfiguration, self.plotGraphApi)
+          // setPlot calls respondToPlotChange when the plot type changes, but on
+          // document load nothing else does — so a doc that saved a stale (niced)
+          // primary-axis domain would rehydrate with that wrong domain. Re-run it
+          // here so binned plots reset to [minBinEdge, maxBinEdge] on load.
+          if (self.dataConfiguration && self.plot.hasBinnedNumericAxis) {
+            self.plot.respondToPlotChange({
+              axisProvider: self,
+              primaryPlace: self.primaryPlace,
+              secondaryPlace: self.secondaryPlace
+            })
+          }
+        },
         { name: "GraphContentModel.afterCreate.setGraphContext", fireImmediately: true }, self)
     },
     beforeDestroy() {

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -324,6 +324,29 @@ export const GraphContentModel = DataDisplayContentModel
           }
         },
         { name: "GraphContentModel.afterCreate.setGraphContext", fireImmediately: true }, self)
+      // Extend (never shrink) a binned plot's primary axis when the visible-case extent
+      // grows past the current axis — i.e., when cases are added or unhidden. This mirrors
+      // the established asymmetry between addCases (extends) and removeCases (no change),
+      // and applies it to hide (no change) and show (extends). caseDataHash reflects the
+      // visible-case set that binDetails() reads, so it covers all four data-change paths.
+      // The addCases handler in afterAttachToDocument still handles niceBounds for
+      // non-primary numeric axes; this reaction is binned-primary-only.
+      mstReaction(
+        () => self.dataConfiguration?.caseDataHash,
+        () => {
+          if (!self.dataConfiguration || !self.plot.hasBinnedNumericAxis) return
+          const primaryAxis = self.getNumericAxis(self.primaryPlace)
+          if (!primaryAxis) return
+          const { minBinEdge, maxBinEdge } = (self.plot as any).binDetails()
+          if (!isFinite(minBinEdge) || !isFinite(maxBinEdge)) return
+          const [curMin, curMax] = primaryAxis.domain
+          const newMin = Math.min(curMin, minBinEdge)
+          const newMax = Math.max(curMax, maxBinEdge)
+          if (newMin !== curMin || newMax !== curMax) {
+            primaryAxis.setDomain(newMin, newMax)
+          }
+        },
+        { name: "GraphContentModel.afterCreate.binnedPlotCaseDataHash" }, self)
     },
     beforeDestroy() {
       self.formulaAdapters.forEach(adapter => {

--- a/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.test.ts
+++ b/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot-model.test.ts
@@ -81,4 +81,71 @@ describe("BinnedDotPlotModel", () => {
       expect(result.numHorizontalRegions).toBe(8) // 2 horizontal regions * 4 bins (x-primary default)
     })
   })
+
+  describe("respondToPlotChange", () => {
+    // CODAP-1281: respondToPlotChange must set the primary axis to the bin extent so that
+    // bin bands render uniformly. Other code paths (addCases, useSubAxis) rely on this.
+    it("sets the primary axis domain to [minBinEdge, maxBinEdge]", () => {
+      // _binWidth=1, _binAlignment=0 with case values 0.5 and 3.5 yields minBinEdge=0, maxBinEdge=4
+      const m = BinnedDotPlotModel.create({ _binWidth: 1, _binAlignment: 0 })
+      m.setGraphContext({
+        primaryRole: "x",
+        primaryAttributeID: "attr1",
+        dataset: {} as any,
+        showMeasuresForSelection: false,
+        numberOfHorizontalRegions: 1,
+        getCaseDataArray: () => [{ caseID: "c1" }, { caseID: "c2" }],
+        subPlotCases: () => []
+      } as any)
+
+      const setDomain = jest.fn()
+      const setAllowRangeToShrink = jest.fn()
+      const primaryAxis = { setDomain, setAllowRangeToShrink }
+      const axisProvider = {
+        getAxis: () => primaryAxis,
+        getNumericAxis: () => primaryAxis,
+        getAxisHelper: () => undefined,
+        setAxisHelper: () => undefined
+      }
+
+      m.respondToPlotChange({
+        axisProvider: axisProvider as any,
+        primaryPlace: "bottom",
+        secondaryPlace: "left"
+      })
+
+      expect(setAllowRangeToShrink).toHaveBeenCalledWith(true)
+      expect(setDomain).toHaveBeenCalledWith(0, 4)
+    })
+
+    it("preserves saved binWidth/binAlignment when neither primaryAttrChanged nor isBinnedPlotChanged is set", () => {
+      // Saved bins (binWidth=1, alignment=0) should survive an addCases-style call
+      const m = BinnedDotPlotModel.create({ _binWidth: 1, _binAlignment: 0 })
+      m.setGraphContext({
+        primaryRole: "x",
+        primaryAttributeID: "attr1",
+        dataset: {} as any,
+        showMeasuresForSelection: false,
+        numberOfHorizontalRegions: 1,
+        getCaseDataArray: () => [{ caseID: "c1" }, { caseID: "c2" }],
+        subPlotCases: () => []
+      } as any)
+
+      const axisProvider = {
+        getAxis: () => undefined,
+        getNumericAxis: () => ({ setDomain: jest.fn(), setAllowRangeToShrink: jest.fn() }),
+        getAxisHelper: () => undefined,
+        setAxisHelper: () => undefined
+      }
+
+      m.respondToPlotChange({
+        axisProvider: axisProvider as any,
+        primaryPlace: "bottom",
+        secondaryPlace: "left"
+      })
+
+      expect(m.binWidth).toBe(1)
+      expect(m.binAlignment).toBe(0)
+    })
+  })
 })


### PR DESCRIPTION
Fixes CODAP-1281.

## Summary
On a binned dot plot the topmost and bottommost bin bands rendered ~1.5×
the height of the middle bands. DOM measurements showed the d3 scale's
effective domain was `[-25, 475]` instead of `[minBinEdge, maxBinEdge] =
[0, 450]` — exactly half a bin width of padding on each side.

## Root cause
The binned plot's `respondToPlotChange` correctly set the domain to
`[0, 450]`. Two override paths then clobbered it:

1. **`addCases`** in `graph-content-model.ts:220-231` — when the dataset
   attaches and reports its existing cases via `addCases`, the handler ran
   `setNiceDomain` on every numeric axis. `computeNiceNumericBounds(10, 430)`
   = `[-25, 475]`, replacing the bin-edge domain. (Also re-fires whenever
   cases are added later.)
2. **`use-sub-axis.ts updateDomainAndRenderSubAxis`** — fires on
   `caseDataHash` changes (hide/unhide cases) and ran the same niceBounds
   computation, with the same result.

## Fix
- `graph-content-model.ts` `addCases` handler: for binned plots, call
  `respondToPlotChange` (which re-runs `binDetails()` so bins extend with
  new data and resets `setDomain(minBinEdge, maxBinEdge)`), and skip
  `setNiceDomain` on the binned primary axis.
- `graph-content-model.ts` `setGraphContext` mstReaction: also call
  `respondToPlotChange` for binned plots. `setPlot` already does this on
  plot-type change, but on document load nothing else did — so a doc saved
  with a stale niced domain rehydrated wrong.
- `use-sub-axis.ts updateDomainAndRenderSubAxis`: early-return for binned
  axes so case-visibility reactions don't re-nice.

## Notes / out of scope
- A `self as unknown as IAxisProvider` cast is needed in the addCases
  handler. The same `axisProvider: self` works inside the `setGraphContext`
  mstReaction callback in the same actions chain — the `onAction` capture
  doesn't see chain-sibling actions like `setAxisHelper`. Restructuring to
  avoid the cast is more change than the fix warrants.
- `setNiceDomain` is also called from `handleRemoveAttribute` (`graph.tsx`)
  and `rescale` (`graph-content-model.ts`). Neither produces the
  user-visible bug per the diagnostic logs; left alone here.
- `binnedAxisTicks` (in `binned-dot-plot-model.ts`) is dead code
  (never called). Cleanup candidate for a separate PR.

## Test plan
- [x] `npm run build:tsc` clean
- [x] `npm test -- axis adornments dot-plot binned graph-content`
      (287/287 passing)
- [x] Visually verified: bands uniform top-to-bottom on the CODAP-1055 doc
      and on a fresh binned graph created from scratch
- [ ] CI lint + Cypress
- [ ] After CI green: request Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
