### PR TITLE
CODAP-1215: fix squares of residuals for plotted function

### DIFF
--- a/v3/cypress/e2e/bivariate-adornments.spec.ts
+++ b/v3/cypress/e2e/bivariate-adornments.spec.ts
@@ -284,6 +284,10 @@ context("Graph adornments", () => {
     cy.get("[data-testid=Apply-button]").click()
     cy.get("*[data-testid^=plotted-function-path]").should("exist")
 
+    // Re-open the inspector palette (it closes when the formula editor's Apply button is clicked)
+    graph.getDisplayValuesButton().click()
+    graph.getInspectorPalette().should("be.visible")
+
     // Enable Squares of Residuals — squares should render for the plotted function in steel blue
     cy.get("[data-testid=adornment-checkbox-squares-of-residuals]").find("input")
       .should("not.have.attr", "disabled")

--- a/v3/cypress/e2e/bivariate-adornments.spec.ts
+++ b/v3/cypress/e2e/bivariate-adornments.spec.ts
@@ -270,6 +270,35 @@ context("Graph adornments", () => {
     cy.get("*[data-testid^=movable-line-squares]").should("not.exist")
     cy.get("[data-testid=adornment-checkbox-squares-of-residuals]").find("input").should("have.attr", "disabled")
   })
+  it("renders squares of residuals for plotted function and clears the sum-of-squares text when toggled off", () => {
+    c.selectTile("graph", 0)
+    cy.dragAttributeToTarget("table", "Speed", "bottom")
+    cy.dragAttributeToTarget("table", "Mass", "left")
+    graph.getDisplayValuesButton().click()
+
+    // Add a plotted function with a constant value
+    graph.getInspectorPalette().find("[data-testid=adornment-checkbox-plotted-function]").click()
+    cy.get("[data-testid=plotted-function-control-value]").click()
+    cy.get("[data-testid=formula-editor-input] .cm-content").should("be.visible").and("have.focus")
+    cy.get("[data-testid=formula-editor-input] .cm-content").realType("10")
+    cy.get("[data-testid=Apply-button]").click()
+    cy.get("*[data-testid^=plotted-function-path]").should("exist")
+
+    // Enable Squares of Residuals — squares should render for the plotted function in steel blue
+    cy.get("[data-testid=adornment-checkbox-squares-of-residuals]").find("input")
+      .should("not.have.attr", "disabled")
+    cy.get("[data-testid=adornment-checkbox-squares-of-residuals]").click()
+    cy.get("*[data-testid^=function-squares]").should("exist")
+    cy.get("*[data-testid^=function-squares]").find("rect").should("have.length.greaterThan", 0)
+    cy.get("*[data-testid^=function-squares]").find("rect").first()
+      .should("have.attr", "stroke", "#4682b4")
+    cy.get("*[data-testid^=plotted-functions-residuals-]").should("contain.text", "Sum of squares")
+
+    // Toggle Squares of Residuals off — both the squares and the sum-of-squares text should disappear
+    cy.get("[data-testid=adornment-checkbox-squares-of-residuals]").click()
+    cy.get("*[data-testid^=function-squares]").should("not.exist")
+    cy.get("*[data-testid^=plotted-functions-residuals-]").should("be.empty")
+  })
 
   it("adds connecting lines to the plot when the Connecting Lines checkbox is checked", () => {
     c.selectTile("graph", 0)

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-component.tsx
@@ -65,10 +65,14 @@ export const PlottedFunctionAdornmentComponent = observer(function PlottedFuncti
   const plottedFunctionRef = useRef<SVGGElement>(null)
 
   const refreshResiduals = useCallback((plottedFunc: FormulaFn) => {
-    if (!showSumSquares || !dataConfig) return
+    if (!dataConfig) return
+    const residualsParagraph = select(residualsContainerSelector).select("p")
+    if (!showSumSquares) {
+      residualsParagraph.html("")
+      return
+    }
     const sumOfSquares = calculateSumOfSquares({ cellKey, dataConfig, computeY: plottedFunc })
     const string = residualsString(sumOfSquares, false)
-    const residualsParagraph = select(residualsContainerSelector).select("p")
 
     select(residualsContainerSelector)
       .style("width", `${plotWidth}px`)

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-model.ts
@@ -1,5 +1,6 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { Formula } from "../../../../models/formula/formula"
+import { withoutUndo } from "../../../../models/history/without-undo"
 import { migrateInstanceKeyMap } from "../../utilities/cell-key-utils"
 import { AdornmentModel, IAdornmentModel } from "../adornment-models"
 import { kPlottedFunctionType, kPlottedFunctionValueTitleKey, FormulaFn } from "./plotted-function-adornment-types"
@@ -40,6 +41,9 @@ export const PlottedFunctionAdornmentModel = AdornmentModel
       self.error = error
     },
     addPlottedFunction(formulaFunction: FormulaFn, key="{}") {
+      // The formula adapter calls this on every load to populate the volatile formula function.
+      // Treat it as derived state so it doesn't dirty the document.
+      withoutUndo({ noDirty: true, suppressWarning: true })
       const newPlottedFunction = PlottedFunctionInstance.create()
       newPlottedFunction.setValue(formulaFunction)
       self.plottedFunctions.set(key, newPlottedFunction)

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -248,9 +248,6 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
     }
 
     if (plottedFunctionModel?.isVisible) {
-      const funcs = plottedFunctionModel.plottedFunctions
-      const func = funcs.get('{}')?.formulaFunction
-      if (!func) return
       const caseSubsetDescriptions = dataConfiguration?.getAllCaseSubsetDescriptions() || []
       const funcSquares: ISquareOfResidual[] = residualSquaresForFunction(plottedFunctionModel, caseSubsetDescriptions)
       doUpdateSquares(functionSquaresRef.current, funcSquares, "#4682b4")

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -226,7 +226,6 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
       select(squaresElement).selectAll("*")
         .data(squares)
         .join("rect")
-        .attr("id", (d: ISquareOfResidual) => `#${instanceId}-${d.caseID}-ml-square`)
         .attr("x", (d: ISquareOfResidual) => d.x)
         .attr("y", (d: ISquareOfResidual) => d.y)
         .attr("width", (d: ISquareOfResidual) => d.side)
@@ -253,7 +252,7 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
       doUpdateSquares(functionSquaresRef.current, funcSquares, "#4682b4")
     }
 
-  }, [lsrl, movableLine, dataConfiguration, layout, instanceId, plottedFunctionModel])
+  }, [lsrl, movableLine, dataConfiguration, layout, plottedFunctionModel])
 
   const refreshAllPointPositions = useCallback((selectedOnly: boolean) => {
     const {getXCoord: getScreenX, getYCoord: getScreenY} = scatterPlotFuncs(layout, dataConfiguration),


### PR DESCRIPTION
## Summary
Fixes three issues with the "Squares of Residuals" option as it applies to plotted functions in scatterplots:
- Render the individual residual squares (not just the sum-of-squares text)
- Don't mark the document as "Unsaved" immediately on open
- Hide the sum-of-squares text when the option is toggled off

Fixes CODAP-1215.

## Test plan
- [ ] Open the `Squares bug.codap` attachment on CODAP-1215; the squares should render against the plotted function curve, not just the sum text.
- [ ] On open, the document title should NOT be flagged "Unsaved".
- [ ] Make any edit (e.g., move a tile) — the document SHOULD then be flagged "Unsaved".
- [ ] Toggle Squares of Residuals off — the sum-of-squares text should disappear.
- [ ] Movable Line and LSRL residual squares continue to work as before.
- [ ] CI: lint, build, and Cypress all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
