### PR TITLE
CODAP-1173: fix nonempty case count for formula-driven attributes

### DIFF
--- a/v3/doc/dataset-validation-and-reactivity.md
+++ b/v3/doc/dataset-validation-and-reactivity.md
@@ -1,0 +1,628 @@
+# DataSet Validation & Reactivity
+
+> **Audience:** Developers writing or reviewing code that observes data —
+> components, adornments, formula machinery, plugin handlers — plus anyone
+> reviewing changes to the `data/` model layer.
+>
+> **Companion docs:** [hierarchical-data.md](./hierarchical-data.md) (the
+> conceptual model: items vs. cases vs. collections),
+> [collection-properties.md](../src/models/data/collection-properties.md)
+> (table of per-collection grouping structures and how they update).
+
+## Why this exists
+
+The DataSet/Collection/Attribute layer carries a lot of caching. Cases are
+grouped lazily from items, and the grouping is expensive to recompute, so we
+maintain plain (non-observable) caches and gate them behind a small set of
+observable version counters. That works, but the cache-and-version pattern is
+non-obvious: a UI component that "just reads the data" can silently fail to
+re-render because the read it took did not establish the right MobX
+dependency.
+
+This document catalogs:
+
+1. The **validation markers** (observable counters and plain flags) that
+   gate the cached state.
+2. The **observable surfaces** clients should read, and which of them
+   establish dependencies for which kinds of change.
+3. **Worked examples** showing how to choose the right observable for a
+   given reactive need.
+
+## Quick orientation
+
+- An **item** is a row of raw values; items are the source of truth.
+  `DataSet._itemIds` and `Attribute.strValues / numValues` hold them.
+- A **case** is a group of one or more items that share values across the
+  grouping attributes of a collection. With one (child) collection only, each
+  case corresponds to one item (the case and the item have distinct ids).
+- A **collection** is a set of attributes that participate in grouping at
+  one level of the hierarchy. `DataSet.collections` is the parent-to-child
+  ordered list.
+- The case structures (`caseInfoMap`, per-collection `caseGroupMap`,
+  `caseIds`, `caseIdToIndexMap`, etc.) are *derived* from items + grouping
+  attributes. See [hierarchical-data.md](./hierarchical-data.md) for the
+  conceptual model and [collection-properties.md](../src/models/data/collection-properties.md)
+  for what each per-collection map holds.
+
+The rest of this doc focuses on **how the derived state is invalidated and
+revalidated** — that's where the markers live.
+
+## The actors
+
+| Actor                       | Role                                                                       | Key file                                       |
+|-----------------------------|----------------------------------------------------------------------------|------------------------------------------------|
+| `DataSet`                   | Root; owns items, attributes, collections, and the validation pipeline.    | `src/models/data/data-set.ts`                  |
+| `CollectionModel`           | One level of the grouping hierarchy; owns its case-group caches.           | `src/models/data/collection.ts`                |
+| `Attribute`                 | A "column"; holds the actual value arrays.                                 | `src/models/data/attribute.ts`                 |
+| `DataSetMetadata`           | Selection-independent display state (hidden, collapsed, categories).       | `src/models/shared/data-set-metadata.ts`       |
+| `FilteredCases`             | Per-tile case filter (e.g. graph dataConfig); observes a DataSet.          | `src/models/data/filtered-cases.ts`            |
+| `CategorySet`               | Cached category order/colors for one categorical attribute.                | `src/models/data/category-set.ts`              |
+
+DataSet, CollectionModel, Attribute, and DataSetMetadata are MST models.
+FilteredCases is a plain class that uses MobX decorators directly.
+CategorySet is an MST model with private MobX state.
+
+## The case-validation pipeline
+
+Whenever items, hidden flags, filter results, or grouping-attribute values
+change, the cached case structures are marked stale. They are *not*
+recomputed eagerly; they are recomputed the next time something reads them.
+The pipeline:
+
+```
+mutation
+  └─> DataSet.invalidateCases([regrouping])
+        ├─ sets _isValidCases = false
+        ├─ if regrouping=true:
+        │     - sets _needsRegrouping = true
+        │     - calls collection.invalidateCaseGroups() on each collection
+        │       (which sets _needsFullRebuild = true)
+        └─ else (value-only):
+              - sets _needsValueRevalidation = true
+        └─ bumps _caseValidationVersion (the observable signal)
+
+read
+  └─> DataSet.validateCases()           // called by getCasesForCollection,
+        ├─ early-out if _isValidCases   //   getStrValue, getValue, etc.
+        ├─ if _needsRegrouping:
+        │     - clears caseInfoMap, itemInfoMap
+        │     - per collection: updateCaseGroups() then completeCaseGroups()
+        │       (the latter bumps Collection._groupingChangeVersion)
+        │     - clears _needsRegrouping
+        ├─ else if _needsValueRevalidation:
+        │     - per collection: recomputeNonEmptyCases()
+        │       (bumps Collection._valueChangeVersion only)
+        │     - clears _needsValueRevalidation
+        └─ setValidCases()
+              - bumps _caseValidationVersion
+              - clears _isValidCases pending-flag false
+```
+
+A second, additive path exists for **appended items**. `addCases` calls
+`validateCasesForNewItems(newIds)`, which invokes
+`collection.invalidateCaseGroupsForNewCases(newIds)` and lets
+`completeCaseGroups` take its append branch (concatenation rather than full
+rebuild). This avoids an O(N) walk per append.
+
+## Validation markers — full catalog
+
+### `DataSet`
+
+| Marker                           | Type            | Set by                                                                | Cleared by                  | Read by (getter)         |
+|----------------------------------|-----------------|-----------------------------------------------------------------------|-----------------------------|--------------------------|
+| `_caseValidationVersion`         | `observable.box`| `invalidateCases`, `setValidCases`, `invalidateItemIds`               | (counter; never cleared)    | `isValidCases`, `validationCount`, `needsRegrouping`, `needsValueRevalidation`, `itemIds`, `items` |
+| `_isValidCases`                  | plain `boolean` | `setValidCases` (true) / `invalidateCases` (false)                    | by `setValidCases`          | `isValidCases`           |
+| `_needsRegrouping`               | plain `boolean` | `invalidateCases(true)` (true)                                        | `clearNeedsRegrouping` (after rebuild) | `needsRegrouping`        |
+| `_needsValueRevalidation`        | plain `boolean` | `invalidateCases(false)` (true)                                       | `clearNeedsValueRevalidation` (after recompute) | `needsValueRevalidation` |
+| `_validationCount`               | plain `number`  | bumped in `setValidCases`                                             | (counter)                   | `validationCount`         |
+| `_isValidItemIds` / `_invalidateItemIds()` | plain        | `invalidateItemIds`                                                   | `_validateItemIds` (lazy)   | `isValidItemIds`, `itemIds`, `items` |
+| `_itemIdsHash`                   | `observableCachedFnFactory` | invalidated by `_invalidateItemIds`; incrementally invalidated by `appendItemIdsToCache` | (lazy recompute on read)  | `itemIdsHash`             |
+| `_itemIdsOrderedHash`            | `observableCachedFnFactory` | invalidated by `_invalidateItemIds`; incrementally invalidated by `appendItemIdsToCache` | (lazy recompute on read)  | `itemIdsOrderedHash`      |
+
+**Why the observable counter and the plain flags are split.** The plain
+flags are *gates* — they decide whether `validateCases` should do work. The
+observable counter is the *signal* — it tells reactive readers that
+something changed, regardless of whether the work has happened yet.
+
+The split is here for a specific reason: **MobX computed values (and MST
+view getters) must be pure derivations**. A view that writes to an
+observable — even via `runInAction` — silently breaks MobX's dependency
+tracking. Reactions can fail to re-evaluate when their dependencies change.
+This bit us in [CODAP-1086](https://concord-consortium.atlassian.net/browse/CODAP-1086)
+(observable hash caches written from a view) and prompted the broader audit
+in [CODAP-1117](https://concord-consortium.atlassian.net/browse/CODAP-1117).
+The earlier design held cache-validity state in `observable.box`es that
+were read *and written* from inside view getters. The current design moves
+that state into plain (non-observable) variables — getters can write to
+plain variables freely without violating MobX purity — and adds observable
+counters (`_caseValidationVersion` on DataSet, `_groupingChangeVersion` and
+`_valueChangeVersion` on Collection) that are bumped *only from action
+contexts* and read from getters to establish the MobX dependency. Lazy
+validation still works (the getter checks the plain flag and computes if
+needed), but the observable surface is now action-write / view-read only.
+
+That same constraint is also why every flag-returning getter
+(`needsRegrouping`, `needsValueRevalidation`, `isValidCases`,
+`isValidItemIds`) reads `_caseValidationVersion.get()` before returning the
+plain flag: without that read, the getter is a closure with no observable,
+and MobX memoizes its first return value forever. Following this pattern
+when adding new flag getters is required, not optional.
+
+The `_itemIdsHash` / `_itemIdsOrderedHash` rows above use a third variant:
+`observableCachedFnFactory` (in `utilities/mst-utils.ts`). It packages the
+same idea — a `_version` `observable.box` bumped only by `invalidate()`
+plus a non-observable `_lastVersion` field that the getter writes — into a
+single helper. The getter reads `_version.get()` first (establishing the
+MobX dependency), compares it to `_lastVersion`, and recomputes lazily if
+they differ. It's the most disciplined pattern of the three: the
+observable-write happens only inside `invalidate()` (which callers must
+invoke from an action), and the getter has no side effects on observables
+at all. Prefer `observableCachedFnFactory` when adding a new derived value
+that has its own invalidation lifecycle.
+
+### `CollectionModel`
+
+| Marker                       | Type             | Set by                                          | Cleared by                              | Read by (getter)                  |
+|------------------------------|------------------|-------------------------------------------------|-----------------------------------------|-----------------------------------|
+| `_groupingChangeVersion`     | `observable.box` | `completeCaseGroups` (after rebuild or append) | (counter)                               | `caseGroups`, `cases`, `nonEmptyCases`, `caseIdsHash`, `caseIdsOrderedHash` |
+| `_valueChangeVersion`        | `observable.box` | `recomputeNonEmptyCases`                        | (counter)                               | `nonEmptyCases` only              |
+| `_needsFullRebuild`          | plain `boolean`  | starts true; `invalidateCaseGroups` sets true  | `completeCaseGroups` (rebuild path) sets false | (private; gates rebuild path)     |
+| `_pendingNewCaseIds`         | plain `string[]?`| `invalidateCaseGroupsForNewCases`               | `completeCaseGroups`                    | (private; gates append path)      |
+
+**Why two version observables on Collection.** The split exists so that
+formula recomputation touching only child-collection attributes can
+update `nonEmptyCases` without invalidating `caseGroups` / `cases` /
+hashes — which would force every `<table>` row, every `<graph>` axis, and
+every legend to re-render needlessly. Only `nonEmptyCases` reads
+`_valueChangeVersion`; the other four grouping-derived views ignore it.
+
+**The subsumption invariant.** A grouping change *includes* a value change:
+the rebuild path inside `completeCaseGroups` recomputes `_nonEmptyCases` as
+part of its work. So the rebuild path bumps **only** `_groupingChangeVersion`
+— it must not also bump `_valueChangeVersion`, because that would tell
+`nonEmptyCases` readers there are *two* invalidations and rebreak the same
+caches twice. The `recomputeNonEmptyCases` action returns early if a full
+rebuild is pending (`_needsFullRebuild`), for the same reason: it would walk
+caches that are about to be discarded.
+
+### `Attribute`
+
+`Attribute` does not participate in case validation directly — it holds
+*values*, not cases. Its single mutation signal is:
+
+| Marker          | Type              | Set by                                                                 | Read by                                                                                       |
+|-----------------|-------------------|------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `changeCount`   | volatile `number` | `incChangeCount` (called from `setValue`, `setValues`, `addValue(s)`, `removeValues`, `setComputedValues`, `orderValues`, `clearValues`) | `length` (always), `type` (when `userType` unset), CategorySet's `mstReaction`, ad-hoc consumers |
+
+`changeCount` is the **canonical "values changed" signal**. It's bumped by
+both ordinary value setters (which run as MST actions) and by
+`setComputedValues` (which writes directly to the volatile `strValues` /
+`numValues` arrays without an action, for formula-engine speed). Because
+the value arrays themselves are volatile and not deeply observable —
+`strValue(i)` and `numValue(i)` read plain JS array elements, which MobX
+does not track — `changeCount` is the only correct dependency for
+"react when values change."
+
+**Action-middleware visibility.** `setComputedValues` writes directly to
+the volatile arrays and does not run as an MST action. Code that uses
+`onAction` / `onAnyAction` to observe value changes on a DataSet
+(FilteredCases, formula observers, plugin notifications) sees only the
+umbrella DataSet action — `setComputedCaseValues` or `setCaseValues` —
+not the per-attribute writes inside. The umbrella action carries
+`affectedAttributes` in its arguments, which is enough for most
+listeners; instrumentation that needs per-attribute granularity should
+read that arg list rather than expecting a per-attribute action event.
+
+> **Methods that do *not* bump `changeCount`, by design:**
+>
+> - `setComputedValue` (singular). Callers batch and bump themselves;
+>   `setComputedValues` is the batch wrapper that bumps once at the end.
+> - `setUserType`, `setPrecision`, `setDisplayExpression`, `clearFormula`.
+>   These don't change values. The next `setComputedValues` (formula
+>   recompute) will bump.
+> - `initializeVolatileState`. Runs only from `afterCreate` (before any
+>   consumer can subscribe) and `afterApplySnapshot` (after a full MST
+>   tree replacement, where higher-level invalidations fire anyway).
+
+### `DataSetMetadata`
+
+DataSetMetadata is plain MST: every observable property is tracked
+automatically. There is no separate validation pipeline. Notable surfaces:
+
+- `selection` (on `DataSet`, not metadata, but commonly co-observed):
+  `observable.set<string>` of selected item/case ids.
+- `setAsideItemIdsSet`, `filteredOutItemIds`: observable sets backing the
+  hidden-cases and filter-formula state on `DataSet`.
+- `collections.<id>.collapsed`: per-collection map of collapsed parent-case
+  ids on `DataSetMetadata`.
+- `attributes.<id>` and `provisionalCategories`: see CategorySet below.
+
+### `FilteredCases`
+
+A plain class (MobX decorators, not MST). It represents a per-tile,
+*purpose-filtered* subset of a DataSet's cases — distinct from the raw
+DataSet, which contains every case. The canonical use case is plottable
+data: a graph showing weight vs. height can only plot cases that have
+valid (non-empty, numeric) values for both attributes. The graph's
+dataConfig constructs a `FilteredCases` whose predicate excludes cases
+that don't meet that requirement, and observes `caseIds` / `caseIdSet`
+to drive rendering. Tables and other clients that display the data
+as-is don't need this layer and read DataSet directly.
+
+It maintains its own cache and listens to the source DataSet via
+`onAnyAction`:
+
+| Marker                | Type                        | Bumped by                                            | Read by                |
+|-----------------------|-----------------------------|------------------------------------------------------|------------------------|
+| `_caseIdsVersion`     | `@observable number`        | `invalidateCases` action                             | `caseIds`, `caseIdSet` |
+| `_lastValidatedVersion` | plain `number`            | the `validateCaseIds` getter, after recompute        | (private)              |
+
+The before/after action listeners diff each value change to decide whether
+the change moved a case across the filter boundary; only filter-crossing
+changes call `invalidateCases`. Pure-pass-through value edits don't
+invalidate the cache.
+
+### `CategorySet`
+
+| Marker         | Type                | Bumped by                                                                  | Read by                       |
+|----------------|---------------------|----------------------------------------------------------------------------|-------------------------------|
+| `_isValid`     | `observable.box`    | `invalidate` action (called from `mstReaction(() => attr.changeCount)`, also by `onPatch /moves`) | `values`, `index(value)`      |
+| `observableValues` | `observable.array` | `refresh()` (replace, inside `runInAction`) when `_isValid` is false    | `values`                      |
+
+CategorySet is the canonical example of "react to value changes via
+`changeCount`": it observes the attribute's `changeCount`, invalidates
+itself, and rebuilds the category list lazily on next read.
+
+## Choosing the right observable
+
+This is the part that usually trips people up. Here's the decision tree.
+
+### "I need to react to **a value change**"
+
+If you're rendering one cell, one case-card field, one summary, one
+adornment label, etc., you almost always want **`attribute.changeCount`**.
+Read it once at the top of the observer (the unused-expression pattern works
+fine — see the example below). Don't try to depend on the value array
+itself; it's not deeply observable.
+
+```tsx
+export const CaseAttrView = observer(function CaseAttrView ({ attr, ... }) {
+  // Establish a MobX dependency on the attribute's mutation counter so this
+  // observer re-renders when values change (e.g. slider-driven formula
+  // recomputes). The data accessors below read non-observable volatile
+  // arrays. (CODAP-1290)
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  attr?.changeCount
+  const cellStrValue = data?.getStrValue(caseId, id)
+  // ...
+})
+```
+
+If you're rendering a **derived view of all values** (a sort, a category
+list, a min/max), build it on top of an existing reactive surface
+(`CategorySet.values`, `attribute.length`, `attribute.type`) rather than
+walking the array yourself with no `changeCount` read.
+
+### "I need to react to **case structure** changes (counts, ordering, presence)"
+
+Use the **DataSet getters** rather than reaching into the collection:
+
+- `data.getCasesForCollection(id)` → `readonly ICase[]`
+- `data.getNonEmptyCasesForCollection(id)` → `readonly ICase[]`
+- `data.getCasesForAttributes(attrIds)` → `ICase[]` — cases from the
+  child-most collection containing any of the listed attributes. Walks
+  child → parent and returns the first match (the most-detailed case-
+  level view that includes any of those attributes). See
+  [hierarchical-data.md](./hierarchical-data.md) for the rationale.
+- `data.itemIds`, `data.items` → arrays of items
+
+These call `validateCases()` first (so you get fresh data) and read both
+`DataSet._caseValidationVersion` and the relevant Collection version
+counters. That dual dependency is what `CollectionTitle` relies on:
+
+```tsx
+// Read through the dataset's getter methods (rather than `collection.cases`
+// / `collection.nonEmptyCases` directly) so this observer establishes a
+// MobX dependency on the dataset's validation observable. Without that
+// dependency the title would not re-render after a value-only invalidation
+// (e.g. formula recompute via setComputedCaseValues), and the displayed
+// nonEmptyCases count would stay stale.
+const visibleCaseCount  = showCount ? (data?.getCasesForCollection(collectionId).length ?? 0) : 0
+const nonEmptyCaseCount = showCount ? (data?.getNonEmptyCasesForCollection(collectionId).length ?? 0) : 0
+```
+
+(Reading `collection.cases` directly *does* establish a dependency on
+`Collection._groupingChangeVersion`, but only that — and it skips the
+DataSet's `validateCases()` gating, so you can race against a pending
+rebuild.)
+
+### "I need to react to **item set or order** changes"
+
+Read **`data.itemIdsOrderedHash`** (sensitive to order) or
+**`data.itemIdsHash`** (set-only; ignores order). Both are observable
+hashes recomputed lazily from the visible item IDs (after applying
+set-aside and filter-formula exclusions). They're cheap to depend on —
+the comparison is one number — and they update on item add, remove,
+hide / unhide, filter-formula change, and reorder.
+
+The canonical consumer is the formula machinery, which watches
+`itemIdsOrderedHash` to recompute all formulas on any item-set or
+ordering change (order-sensitive functions like `first`, `last`, `prev`,
+`next` need it):
+
+```ts
+// formula-observers.ts:37
+mstReaction(
+  () => localDataSet.itemIdsOrderedHash,
+  () => recalculateCallback("ALL_CASES"),
+  { name: "FormulaObservers.itemsReaction" }, localDataSet
+)
+```
+
+Use the unordered `itemIdsHash` if your reaction shouldn't fire on a pure
+reorder (sort) — e.g. anything that aggregates without depending on
+position.
+
+### "I need to react to **selection** changes"
+
+Three surfaces, with different granularity:
+
+- **`data.selection.has(itemId)` / `data.isCaseSelected(caseId)`** —
+  fine-grained per-item / per-case dependency. MobX `observable.set`
+  tracks `.has(key)` reads per-key, so a reaction only fires when *that
+  specific* item's membership flips. Use this when rendering a per-row
+  selected highlight, computing a per-case state, etc. — most consumers.
+- **`data.selection`** (whole set) — fires on any membership change.
+  Use when you need to enumerate the selected items (computing an
+  aggregate, building a selected-cases list).
+- **`data.selectionChanges`** — a coarse `number` counter bumped by
+  `selectAll` / `selectCases` / `setSelectedCases`. Functionally similar
+  to depending on the whole `selection` set, but the dependency surface
+  is one number rather than a set, which matters when the consumer
+  performs an expensive side effect (re-render-everything, refresh point
+  colors across the whole graph) and doesn't need to know which items
+  changed. The case-card render (`case-card.tsx:82`) and the graph
+  point-selection refresh (`use-plot.ts:286`) are the canonical
+  consumers.
+
+In practice: prefer `isCaseSelected(id)` for per-row rendering;
+prefer `selectionChanges` when the work is a global refresh and the
+intent is "react to any selection change."
+
+### "I need to react to **hidden-attribute / hidden-case / collapsed-case** changes"
+
+- Hidden attributes: `metadata.isHidden(attrId)`.
+- Hidden (set-aside) cases: `data.setAsideItemIdsSet` (observable set).
+  Note: setting items aside *also* triggers `invalidateCases(true)` and a
+  full regroup, so case-structure observers will refresh. Hide/show is
+  also reflected in `data.itemIds`, `data.itemIdsHash`, and
+  `data.itemIdsOrderedHash` (the hashes are computed from the *visible*
+  item IDs, after set-aside and filter-formula exclusions are applied),
+  so a reaction watching one of those will also fire on hide/show.
+- Collapsed parent cases: `metadata.isCollapsed(caseId)` /
+  `metadata.collapsedCaseIdsHash`.
+
+### "I need to react to **filter-formula** changes"
+
+- The filter formula text: `data.filterFormula`.
+- The filtered-out result: `data.filteredOutItemIds` (observable set), and
+  changes here trigger a full `invalidateCases(true)`. So observers of
+  case structure will refresh automatically.
+- For per-tile filter (e.g. graph dataConfig): construct a `FilteredCases`
+  and read its `caseIds` / `caseIdSet`.
+
+### "I need to react to **categories**"
+
+`metadata.getCategorySet(attrId)?.values` returns the observable category
+list. The list is lazily refreshed off `attribute.changeCount`, so adding
+or recomputing values is reflected.
+
+## Action-based observability (`onAnyAction`)
+
+Everything above is *reactivity*: subscribe to an observable, react when
+it changes. There's a complementary mechanism that fires on each MST
+action call, with access to the action's name and serialized arguments.
+CODAP uses it where a consumer needs to see *which* action fired with
+*what* arguments — granularity that pure reactivity discards.
+
+### What it is
+
+A convention wrapper around MST's `onAction`, defined in
+`utilities/mst-utils.ts`:
+
+```ts
+export function onAnyAction(target, listener, options?) {
+  return onAction(target, listener, { attachAfter: true, allActions: true, ...options })
+}
+```
+
+Two flag flips matter:
+
+- `attachAfter: true` — stock MST option. Fire *after* the action
+  completes, so the listener sees post-mutation state.
+- `allActions: true` — **CODAP-specific MST extension.** Stock MST's
+  `onAction` only fires for top-level (outermost) actions; nested
+  actions are silent. We added the `allActions` flag in our
+  [`@concord-consortium/mobx-state-tree` fork](https://github.com/concord-consortium/mobx-state-tree)
+  to fire the listener for nested actions too. (Submitting it back
+  upstream is on the to-do list.) This is critical in CODAP because
+  most user-facing changes are wrapped in
+  `data.applyModelChange(() => data.setCaseValues(...))` so the history
+  service can capture them: `applyModelChange` is the top-level action;
+  `setCaseValues` is a nested action inside it. Without `allActions`,
+  stock MST would only report the outer `applyModelChange` and the
+  listener would have no idea what changed inside. With it, the
+  listener sees the inner action and its arguments (`affectedAttributes`,
+  the case list, etc.) — exactly what `FilteredCases` and the formula
+  observers need.
+
+### What it gives you
+
+Per-call granularity. The serialized action call carries the action
+name (`setCaseValues`, `setComputedCaseValues`, ...) and its arguments —
+enough to drive change-diffing, value-change cascades, plugin
+notifications, and performance traces. `FilteredCases` registers
+*before* and *after* listeners and diffs filter membership across each
+case-value-change action; the formula machinery uses it to identify
+which cases need recomputation.
+
+### What it doesn't give you
+
+- **Mutations outside MST actions.** `Attribute.setComputedValues` (the
+  formula-recompute fast path) writes directly to volatile arrays
+  without an action wrapper. Action listeners see only the umbrella
+  `setComputedCaseValues` on the DataSet, not the per-attribute writes
+  inside. (See "Action-middleware visibility" in the Attribute section
+  above.)
+- **Undo / redo replay** — the important one. Undo/redo applies inverse
+  changes through MST's patch system or through a custom undo/redo
+  patcher; in either case the replay isn't (necessarily) an MST action
+  dispatch, and `onAnyAction` listeners do *not* fire. Some
+  CODAP-specific custom patchers happen to re-invoke the original
+  model action during replay (e.g. `setCaseValuesCustomUndoRedoPatcher`
+  in `data-set-undo.ts` calls `data.setCaseValues(...)` again, which
+  *is* an action and *does* fire listeners), but most don't, and you
+  shouldn't assume one does without checking. **If your consumer needs
+  to update on undo/redo, don't rely on action listeners alone** —
+  pair them with reactivity (`mstReaction` on a relevant observable),
+  or with `onPatch` if you specifically want patch-level info.
+
+### Choosing between reactivity and action listeners
+
+| If you need... | Use... |
+|---|---|
+| "react when value X changes, however it changed (including undo/redo)" | reactivity — `observer()`, `mstReaction`, `autorun` |
+| "see each call to a specific action with its args, for diffing or plugin notifications" | `onAnyAction` |
+| "react on undo/redo regardless of replay strategy" | reactivity (or `onPatch` for patch-level info) |
+| both kinds of fidelity | both, side by side |
+
+`FilteredCases` is the canonical "use both" consumer: action listeners
+diff filter membership on case-value changes (what reactivity alone
+couldn't do efficiently), and the observable `_caseIdsVersion` ensures
+downstream readers track the cache via reactivity for the full set of
+invalidation paths.
+
+## Worked examples
+
+### Case-table title nonEmptyCases count (CODAP-1173)
+
+**Symptom.** When every attribute in a collection was formula-driven, the
+case-table title reported "0 nonempty cases" even after the formula
+populated values.
+
+**Why.** Two separate problems:
+
+1. `Collection.isNonEmptyCaseGroup` walked `dataAttributesArray`, which
+   excludes formula attributes. With no non-formula attributes present, the
+   walk could never find a non-empty value.
+2. `CollectionTitle` read `collection.cases.length` /
+   `collection.nonEmptyCases.length` directly, skipping `validateCases()`
+   and missing the value-only invalidation path entirely.
+
+**Fix.** Switch `isNonEmptyCaseGroup` to `attributesArray`. Route
+`CollectionTitle` reads through `data.getCasesForCollection` /
+`data.getNonEmptyCasesForCollection`. Split Collection's cache version
+into grouping and value observables so a value-only invalidation can wake
+`nonEmptyCases` readers without invalidating every grouping-derived view.
+
+**General lesson.** If a derived count or list seems stuck, suspect a
+read that bypasses the validation gate. Prefer the DataSet getters.
+
+### Case-card per-cell value reactivity (CODAP-1290, in flight)
+
+**Symptom.** A formula attribute on a case card showed stale values when a
+slider-driven recompute fired.
+
+**Why.** `CaseAttrView` and `summarizedValues` read `attr.strValue(i)` /
+`attr.numValue(i)`. Those accessors index into `attr.strValues` /
+`attr.numValues`, which are volatile arrays — *the array reference is
+observable, but reading element `[i]` is a plain JS read*. MobX recorded no
+dependency, so the `observer()` wrapper never re-ran when
+`setComputedValues` mutated the arrays in place.
+
+**Fix (PR #2556, separate branch).** Touch `attr.changeCount` once in the
+observer, before the cell read. `setComputedValues` already bumps
+`changeCount` after writing the batch, so the dependency now fires
+correctly.
+
+**General lesson.** "Read a value off an Attribute" is a non-reactive
+operation. To make it reactive, depend on `changeCount`.
+
+## Common pitfalls
+
+1. **Reading `attribute.strValues[i]` or `numValues[i]` in an observer.**
+   MobX records no dependency. Use `attr.changeCount` (or any view that
+   does — `length`, `type`, CategorySet's `values`).
+
+2. **Reading `collection.cases` / `nonEmptyCases` directly in an
+   observer.** You will track Collection's grouping-version observable but
+   skip the DataSet's `_caseValidationVersion`, so you race against
+   `validateCases`. Use `data.getCasesForCollection(id)` /
+   `data.getNonEmptyCasesForCollection(id)` instead.
+
+3. **Returning a plain flag from a getter without reading an observable
+   first.** The getter is a closure — MobX memoizes its first return
+   value forever. Every flag-returning getter on DataSet
+   (`needsRegrouping`, `needsValueRevalidation`, `isValidCases`,
+   `isValidItemIds`) reads `_caseValidationVersion.get()` before returning.
+   Follow the pattern when you add a new one.
+
+4. **Bumping the wrong version observable on a value-only update.** If
+   you bump `_groupingChangeVersion` after a child-only value change, every
+   table row, every graph axis, every legend re-renders. Bump
+   `_valueChangeVersion` instead — only `nonEmptyCases` reads it.
+
+5. **Calling `setComputedValue` (singular) without `incChangeCount`.**
+   Singular `setComputedValue` is a batched primitive that does not bump
+   `changeCount`. Either call `setComputedValues` (plural; bumps once) or
+   call `incChangeCount` yourself after the batch.
+
+6. **Skipping `affectedAttributes` in `setCaseValues` /
+   `setComputedCaseValues` when you can supply it.** With it, both methods
+   decide whether grouping is affected and skip the full regroup when the
+   change is child-only — a large speedup for formula-driven dot-plot
+   drags, scatter-plot drags, and case-table cell edits. Without it, the
+   safe thing is a full regroup. Pass an exhaustive list when you know it;
+   pass `undefined` when you don't. (Non-exhaustive lists are unsafe — if
+   a parent-collection attribute changes but isn't listed, grouping won't
+   be refreshed.)
+
+7. **Mutating `setAsideItemIds` outside an action.** The `onPatch` handler
+   keeps a mirror set in sync and triggers `invalidateCases`; mutations
+   from outside an action skip the patch and desynchronize the mirror.
+
+## Reference: which methods invalidate, and how
+
+| Method                                  | Path                              | Calls                                                  |
+|-----------------------------------------|-----------------------------------|--------------------------------------------------------|
+| `addCases` (append at end)              | additive append                   | `validateCasesForNewItems(newIds)` → `Collection.invalidateCaseGroupsForNewCases` |
+| `addCases` (insert)                     | full regroup                      | onPatch → `invalidateCases(true)`                      |
+| `removeCases` / `removeItem`            | full regroup                      | onPatch on `_itemIds` → `invalidateCases(true)`        |
+| `setCaseValues(cases, attrIds?)`        | regroup if any attrId is in a parent collection (or if no attrIds supplied); else value-only | `invalidateCases(needsRegrouping)` |
+| `setComputedCaseValues(cases, attrIds)` | regroup if any attrId is in a parent collection; else value-only | `invalidateCases(needsRegrouping)`                     |
+| `removeAttribute`                       | full regroup                      | `invalidateCases(true)`                                |
+| `moveAttributeToNewCollection`          | full regroup                      | `invalidateCases(true)`                                |
+| `moveItems`                             | full regroup                      | onPatch → `invalidateCases(true)`                      |
+| `hideCasesOrItems` / `showHiddenCasesAndItems` | full regroup               | onPatch on `setAsideItemIds` → `invalidateCases(true)` |
+| `setFilterFormula` / `clearFilterFormula` | full regroup                    | `invalidateCases(true)`                                |
+| `updateFilterFormulaResults`            | full regroup                      | `invalidateCases(true)`                                |
+| `syncCollectionLinks`                   | full regroup                      | `invalidateCases(true)`                                |
+| `setUserType` / `setPrecision`          | none (metadata only)              | —                                                      |
+| `Attribute.setValue` / `setValues`      | none directly; value change only  | `incChangeCount` (DataSet not invalidated by attribute methods alone) |
+| `Attribute.setComputedValues`           | none directly; value change only  | `incChangeCount`                                       |
+
+## Open questions / future work
+
+- **Broader adoption of `affectedAttributes`.** Callers that mutate child-
+  collection attributes can now pass `affectedAttributes` to `setCaseValues`
+  to skip the full regroup. Case-table cell edits and the dot/scatter drag
+  paths supply it; other call sites still pass `undefined` and pay the
+  full-regroup cost. Auditing remaining call sites is open work.
+- **Per-attribute fine-grained reactivity.** `changeCount` is collection-
+  wide on the attribute. A consumer rendering one cell wakes on every
+  value change to that column. For very wide datasets we may eventually
+  want per-cell or per-range observability — but the memory/perf cost
+  of element-level observability is what motivated the current design.
+- **Observer-tracking on `setAsideItemIds`.** The current `onPatch` mirror
+  is fragile (pitfall #7); a cleaner approach would replace the array
+  with an observable set as the source of truth.

--- a/v3/doc/hierarchical-data.md
+++ b/v3/doc/hierarchical-data.md
@@ -6,7 +6,15 @@ Early versions of CODAP did not support hierarchical data. `Case`s were containe
 
 ## v3
 
-With this understanding, the v3 representation is quite different. Collections are really just grouping mechanisms. The `collections` property of the `DataSet` is an array of `CollectionModel`s, which are essentially just references to the attributes grouped at a given level of the hierarchy. For rendering the case table or a graph, we need to know the cases that exist at each level of the hierarchy once grouping has been taken into account. This information is maintained in the `caseInfoMap` property, which is a map of `CaseInfo` objects keyed by case id.
+With this understanding, the v3 representation is quite different. The conceptual layering is:
+
+- **Items** are the source of truth. Each item is a row of values, addressable by `__id__`. They live on the `DataSet` (`_itemIds`, with values stored on `Attribute`s).
+- **Collections** are grouping mechanisms. The `collections` property of `DataSet` is an array of `CollectionModel`s in **parent-to-child order** (so `collections[0]` is the root and `collections[length - 1]` is the child-most, accessible as `dataSet.childCollection`). Each collection holds references to the attributes that participate in grouping at that level.
+- **Cases** are constructed by grouping items. They live *on collections*, not on the DataSet directly. A case in a parent collection groups items that share values across that collection's attributes; a case in the child-most collection corresponds one-to-one with an item.
+
+Cases and items are different identities (they have different ids), even when they correspond one-to-one in a single-collection dataset.
+
+For rendering the case table or a graph, we need to know the cases that exist at each level of the hierarchy once grouping has been taken into account. This information is maintained in the `caseInfoMap` property, which is a map of `CaseInfo` objects keyed by case id.
 
 ```typescript
 // represents a case in a collection which has a set of common grouped values
@@ -25,8 +33,20 @@ export interface CaseInfo {
 }
 ```
 
-The `DataSet`'s `validateCases()` method performs the actual grouping, delegating to the individual collections (`updateCaseGroups()`, `completeCaseGroups()`) the grouping of attributes into cases based on the attributes in each collection. This occurs whenever the data changes in any way which could potentially invalidate the groupings. In theory, not all changes require a full rebuild, e.g. the values of a case could change in a way that didn't change the groupings, but such optimizations are left as considerations for another day. The grouping code iterates through the flat items (at least) once per collection, so it could be considered `O(Cxi)`, but since the number of collections will generally be small we assume this won't be a performance problem in the near term.
+The `DataSet`'s `validateCases()` method performs the actual grouping, delegating to the individual collections (`updateCaseGroups()`, `completeCaseGroups()`) the grouping of attributes into cases based on the attributes in each collection. This occurs whenever the data changes in any way which could potentially invalidate the groupings. The grouping code iterates through the flat items (at least) once per collection, so it could be considered `O(Cxi)`, but since the number of collections will generally be small we assume this won't be a performance problem in the near term.
+
+Two narrower invalidation paths avoid the full O(C×i) rebuild when possible: an *additive* path for appended items (used when plugins stream in new cases — see `validateCasesForNewItems`), and a *value-revalidation* path for child-collection value changes that can flip case emptiness without affecting groupings (used after formula recomputation — see `recomputeNonEmptyCases`). For the markers and observable surfaces that drive these paths, see [dataset-validation-and-reactivity.md](./dataset-validation-and-reactivity.md).
 
 A consequence of this new arrangement is that as groupings of items into cases changed, new case ids would frequently be generated, with the result that while item ids were more persistent than their v2 counterparts, v3 case ids were initially more ephemeral. Since then the v3 code has taken several steps to persist case ids so that they should now be at least as persistent as v2 case ids. First, the mapping from a given set of parent case values (the `groupKey` internally) to case id is cached so that the same set of parent case values will always correspond to the same case id. Second, when changes that would otherwise result in generation of new case ids result in cases representing the same set of items as a previous case, the previous case id is reused.
 
-Clients, e.g. tables and graphs, can use functions like `getCasesForAttribute()` and `getCasesForCollection()` to retrieve the cases to consider for a given attribute or collection. `DataSet` functions used by clients (e.g. value-accessing methods, `isCaseSelected()`, `selectCases()`, `setSelectedCases()`, `setCaseValues()`) have generally been extended to handle cases or items interchangeably to simplify use by clients.
+Clients, e.g. tables and graphs, retrieve the cases relevant to their needs using `DataSet` accessors:
+
+- `getCasesForCollection(collectionId)` — cases in a specific collection.
+- `getNonEmptyCasesForCollection(collectionId)` — same, filtered to non-empty cases (the meaning of "non-empty" varies; see the reactivity doc).
+- `getCasesForAttributes(attributeIds)` — cases from the *child-most* collection that contains any of the listed attributes. The function walks child → parent and returns the first match.
+
+The rationale for the child-most rule: when a graph plots Y vs. X with one attribute in a parent collection and the other in a child, the number of cases to plot is the number in the child collection. Parent-collection attribute values can always be replicated down to the child cases, but the reverse isn't true (a child value can't be sensibly aggregated up to the parent without choosing an aggregation function). So `getCasesForAttributes(["weight", "mammal_class"])` returns one case per individual mammal (the child collection), not one per class (the parent), even though `mammal_class` lives only on the parent.
+
+These accessors call `validateCases()` first, so they always return current groupings. Clients should generally prefer them over reading `collection.cases` directly (the difference matters for reactivity — see [dataset-validation-and-reactivity.md](./dataset-validation-and-reactivity.md)).
+
+`DataSet` functions used by clients (e.g. value-accessing methods, `isCaseSelected()`, `selectCases()`, `setSelectedCases()`, `setCaseValues()`) have generally been extended to handle cases or items interchangeably to simplify use by clients.

--- a/v3/src/components/case-table/use-rows.ts
+++ b/v3/src/components/case-table/use-rows.ts
@@ -271,7 +271,10 @@ export const useRows = (gridElement: HTMLDivElement | null) => {
 
     // handle updating cases (editing cells of existing cases)
     if (data && casesToUpdate.length) {
-      applyCaseValueChanges(data, casesToUpdate, getPendingLogMessage("editCellValue"))
+      // Each case-table cell edit changes exactly one column's value, so passing the edited
+      // column id as affectedAttributes lets setCaseValues skip the regrouping path when the
+      // edit is on a child-collection attribute.
+      applyCaseValueChanges(data, casesToUpdate, getPendingLogMessage("editCellValue"), [changes.column.key])
       return
     }
 

--- a/v3/src/components/case-tile-common/case-tile-utils.ts
+++ b/v3/src/components/case-tile-common/case-tile-utils.ts
@@ -166,13 +166,15 @@ export function toggleCardTable(documentContent: IDocumentContentModel, tileID: 
   }
 }
 
-export function applyCaseValueChanges(data: IDataSet, cases: ICase[], log?: ILogMessage | LogMessageFn) {
+export function applyCaseValueChanges(
+  data: IDataSet, cases: ICase[], log?: ILogMessage | LogMessageFn, affectedAttributes?: string[]
+) {
   const updatedCaseIds = cases.map(aCase => aCase.__id__)
   const newCaseIds: string[] = []
   data.applyModelChange(() => {
     if (cases.length > 0) {
       const allCaseIDs = new Set<string>(data.caseInfoMap.keys())
-      setCaseValuesWithCustomUndoRedo(data, cases)
+      setCaseValuesWithCustomUndoRedo(data, cases, affectedAttributes)
 
       // Changing values can result in new cases if grouping changes occur
       Array.from(data.caseInfoMap.keys()).forEach(caseId => {

--- a/v3/src/components/case-tile-common/collection-title.tsx
+++ b/v3/src/components/case-tile-common/collection-title.tsx
@@ -29,8 +29,13 @@ export const CollectionTitle =
   const collection = data?.getCollection(collectionId)
   const collectionName = collection?.name || t("DG.AppController.createDataSet.collectionName")
   const { isTileSelected } = useTileSelectionContext()
-  const visibleCaseCount = collection?.cases.length ?? 0
-  const nonEmptyCaseCount = collection?.nonEmptyCases.length ?? 0
+  // Read through the dataset's getter methods (rather than `collection.cases` /
+  // `collection.nonEmptyCases` directly) so this observer establishes a MobX dependency
+  // on the dataset's validation observable. Without that dependency the title would not
+  // re-render after a value-only invalidation (e.g. formula recompute via
+  // setComputedCaseValues), and the displayed nonEmptyCases count would stay stale.
+  const visibleCaseCount = data?.getCasesForCollection(collectionId).length ?? 0
+  const nonEmptyCaseCount = data?.getNonEmptyCasesForCollection(collectionId).length ?? 0
   const hasEmptyCases = visibleCaseCount - nonEmptyCaseCount > 0
   const hiddenCaseCount = (collection?.allCaseIds.size ?? 0) - visibleCaseCount
   const tileRef = useRef<HTMLDivElement | null>(null)

--- a/v3/src/components/case-tile-common/collection-title.tsx
+++ b/v3/src/components/case-tile-common/collection-title.tsx
@@ -34,10 +34,13 @@ export const CollectionTitle =
   // on the dataset's validation observable. Without that dependency the title would not
   // re-render after a value-only invalidation (e.g. formula recompute via
   // setComputedCaseValues), and the displayed nonEmptyCases count would stay stale.
-  const visibleCaseCount = data?.getCasesForCollection(collectionId).length ?? 0
-  const nonEmptyCaseCount = data?.getNonEmptyCasesForCollection(collectionId).length ?? 0
+  // Only compute the counts when showCount is true; otherwise we'd trigger validateCases
+  // (potentially expensive for large datasets) just to throw the result away. CaseCardHeader
+  // renders this component with showCount={false} on every card render.
+  const visibleCaseCount = showCount ? (data?.getCasesForCollection(collectionId).length ?? 0) : 0
+  const nonEmptyCaseCount = showCount ? (data?.getNonEmptyCasesForCollection(collectionId).length ?? 0) : 0
+  const hiddenCaseCount = showCount ? ((collection?.allCaseIds.size ?? 0) - visibleCaseCount) : 0
   const hasEmptyCases = visibleCaseCount - nonEmptyCaseCount > 0
-  const hiddenCaseCount = (collection?.allCaseIds.size ?? 0) - visibleCaseCount
   const tileRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const titleRef = useRef<HTMLDivElement>(null)

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -532,12 +532,14 @@ export const Attribute = V2Model.named("Attribute").props({
         self.strValues[i] = _strValues[indices[i]]
         self.numValues[i] = _numValues[indices[i]]
       }
+      self.incChangeCount()
     },
     clearValues() {
       for (let i = self.strValues.length - 1; i >= 0; --i) {
         self.strValues[i] = ""
         self.numValues[i] = self.toNumeric(self.strValues[i])
       }
+      self.incChangeCount()
     }
   }))
   .actions(applyModelChange)

--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -532,6 +532,152 @@ describe("CollectionModel", () => {
     disposeCases()
   })
 
+  it("recomputeNonEmptyCases refreshes _nonEmptyCases from current attribute values", () => {
+    // Build a single collection with one attribute. The collection needs to know about
+    // its attribute because isNonEmptyCaseGroup walks self.dataAttributesArray.
+    const Model = types.model("Model", {
+      attributes: types.array(Attribute),
+      collections: types.array(CollectionModel)
+    })
+    const a1 = Attribute.create({ id: "a1", name: "a1" })
+    const root = Model.create({ attributes: [a1], collections: [{ id: "c1", name: "c1" }] })
+    const [c1] = root.collections
+    c1.addAttribute(a1)
+
+    // Mutable values map so we can simulate values flipping post-build, mimicking what
+    // setComputedValues does when a formula evaluates after the initial validateCases.
+    let values: Record<string, string> = { i0: "", i1: "", i2: "" }
+    const itemData: IItemData = {
+      itemIds: () => ["i0", "i1", "i2"],
+      isHidden: () => false,
+      getValue: (itemId: string) => values[itemId] ?? "",
+      addItemInfo: () => null,
+      invalidate: () => null
+    }
+    syncCollectionLinks([c1], itemData)
+
+    // Initial rebuild with all-empty values: no non-empty cases.
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+    expect(c1.cases.length).toBe(3)
+    expect(c1.nonEmptyCases.length).toBe(0)
+
+    // Values become non-empty (without any grouping change). recomputeNonEmptyCases
+    // walks the existing _caseGroups and refreshes the cache.
+    values = { i0: "10", i1: "20", i2: "30" }
+    c1.recomputeNonEmptyCases()
+    expect(c1.nonEmptyCases.length).toBe(3)
+
+    // Values back to empty: cache reflects the new state on the next recompute.
+    values = { i0: "", i1: "", i2: "" }
+    c1.recomputeNonEmptyCases()
+    expect(c1.nonEmptyCases.length).toBe(0)
+  })
+
+  it("recomputeNonEmptyCases is a no-op while a full rebuild is pending", () => {
+    // Same setup as the previous test.
+    const Model = types.model("Model", {
+      attributes: types.array(Attribute),
+      collections: types.array(CollectionModel)
+    })
+    const a1 = Attribute.create({ id: "a1", name: "a1" })
+    const root = Model.create({ attributes: [a1], collections: [{ id: "c1", name: "c1" }] })
+    const [c1] = root.collections
+    c1.addAttribute(a1)
+
+    let values: Record<string, string> = { i0: "", i1: "", i2: "" }
+    const itemData: IItemData = {
+      itemIds: () => ["i0", "i1", "i2"],
+      isHidden: () => false,
+      getValue: (itemId: string) => values[itemId] ?? "",
+      addItemInfo: () => null,
+      invalidate: () => null
+    }
+    syncCollectionLinks([c1], itemData)
+
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+    expect(c1.nonEmptyCases.length).toBe(0)
+    const initialNonEmptyRef = c1.nonEmptyCases
+
+    // Mark a full rebuild pending and update the values. recomputeNonEmptyCases must defer
+    // to the upcoming rebuild — walking _caseGroups (which are about to be discarded) could
+    // produce a transiently wrong result.
+    values = { i0: "10", i1: "20", i2: "30" }
+    c1.invalidateCaseGroups()
+    c1.recomputeNonEmptyCases()
+    // The cached array is unchanged (same reference, same length).
+    expect(c1.nonEmptyCases).toBe(initialNonEmptyRef)
+    expect(c1.nonEmptyCases.length).toBe(0)
+
+    // Once the pending full rebuild runs, _nonEmptyCases reflects the new values.
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+    expect(c1.nonEmptyCases.length).toBe(3)
+  })
+
+  it("value-only invalidations do not invalidate grouping-affected views", () => {
+    // This test pins down the architectural contract behind the split observable design:
+    // a value-only update (recomputeNonEmptyCases) must not invalidate caseGroups/cases
+    // observers — only nonEmptyCases observers. If the two observables were collapsed
+    // back together, this test would fail.
+    const Model = types.model("Model", {
+      attributes: types.array(Attribute),
+      collections: types.array(CollectionModel)
+    })
+    const a1 = Attribute.create({ id: "a1", name: "a1" })
+    const root = Model.create({ attributes: [a1], collections: [{ id: "c1", name: "c1" }] })
+    const [c1] = root.collections
+    c1.addAttribute(a1)
+
+    let values: Record<string, string> = { i0: "", i1: "", i2: "" }
+    const itemData: IItemData = {
+      itemIds: () => ["i0", "i1", "i2"],
+      isHidden: () => false,
+      getValue: (itemId: string) => values[itemId] ?? "",
+      addItemInfo: () => null,
+      invalidate: () => null
+    }
+    syncCollectionLinks([c1], itemData)
+
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+
+    // Counters track how many times each tracked expression is re-evaluated by MobX.
+    // The default reaction comparer compares by reference, so collapsing observables back
+    // would surface here as caseGroupsEvalCount climbing on a value-only update.
+    let caseGroupsEvalCount = 0
+    let nonEmptyEvalCount = 0
+    const disposeCaseGroups = reaction(
+      () => { caseGroupsEvalCount++; return c1.caseGroups },
+      () => { /* no-op effect */ }
+    )
+    const disposeNonEmpty = reaction(
+      () => { nonEmptyEvalCount++; return c1.nonEmptyCases },
+      () => { /* no-op effect */ }
+    )
+    const baselineCaseGroupsEvalCount = caseGroupsEvalCount   // 1 from initial reaction setup
+    const baselineNonEmptyEvalCount = nonEmptyEvalCount       // 1 from initial reaction setup
+
+    // Value-only update: nonEmptyCases re-evaluates, caseGroups does not.
+    values = { i0: "10", i1: "20", i2: "30" }
+    c1.recomputeNonEmptyCases()
+    expect(caseGroupsEvalCount).toBe(baselineCaseGroupsEvalCount)
+    expect(nonEmptyEvalCount).toBeGreaterThan(baselineNonEmptyEvalCount)
+
+    // A subsequent regrouping update re-evaluates both — confirms the grouping path still
+    // notifies all grouping-affected views.
+    const beforeRegroup = { caseGroups: caseGroupsEvalCount, nonEmpty: nonEmptyEvalCount }
+    c1.invalidateCaseGroups()
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+    expect(caseGroupsEvalCount).toBeGreaterThan(beforeRegroup.caseGroups)
+    expect(nonEmptyEvalCount).toBeGreaterThan(beforeRegroup.nonEmpty)
+
+    disposeCaseGroups()
+    disposeNonEmpty()
+  })
+
   it("additive invalidation appends correctly without full rebuild", () => {
     const c1 = CollectionModel.create({ name: "c1" })
     let items = ["i0", "i1"]

--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -534,7 +534,7 @@ describe("CollectionModel", () => {
 
   it("recomputeNonEmptyCases refreshes _nonEmptyCases from current attribute values", () => {
     // Build a single collection with one attribute. The collection needs to know about
-    // its attribute because isNonEmptyCaseGroup walks self.dataAttributesArray.
+    // its attribute because isNonEmptyCaseGroup walks self.attributesArray.
     const Model = types.model("Model", {
       attributes: types.array(Attribute),
       collections: types.array(CollectionModel)

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -558,12 +558,18 @@ export const CollectionModel = V2Model
           const newCaseGroups = newCaseIds.map(caseId => self.getCaseGroup(caseId))
           _caseGroups = [..._caseGroups, ...newCaseGroups.filter(group => !!group)]
 
-          const newCases = newCaseGroups.map(caseGroup => caseGroup?.groupedCase)
-          _cases = [..._cases, ...newCases.filter(aCase => !!aCase)]
+          const newCases = newCaseGroups
+                            .map(caseGroup => caseGroup?.groupedCase)
+                            .filter(aCase => !!aCase)
+          _cases = [..._cases, ...newCases]
 
-          const newNonEmptyCases = newCaseGroups.map(group => {
-            return group && self.isNonEmptyCaseGroup(group) ? group.groupedCase : undefined
-          }).filter(aCase => !!aCase)
+          // Parent collections: every case is non-empty by definition (isNonEmptyCaseGroup
+          // short-circuits to true), so reuse newCases rather than running the filter.
+          const newNonEmptyCases = self.child
+            ? newCases
+            : newCaseGroups
+                .map(group => group && self.isNonEmptyCaseGroup(group) ? group.groupedCase : undefined)
+                .filter(aCase => !!aCase)
           _nonEmptyCases = [..._nonEmptyCases, ...newNonEmptyCases]
         }
         // REBUILD path: full recompute from volatile state
@@ -576,9 +582,15 @@ export const CollectionModel = V2Model
                       .map(group => group?.groupedCase)
                       .filter(groupedCase => !!groupedCase)
 
-          _nonEmptyCases = _caseGroups.map(group => {
-            return group && self.isNonEmptyCaseGroup(group) ? group.groupedCase : undefined
-          }).filter(aCase => !!aCase)
+          // Parent collections: every case is non-empty by definition (isNonEmptyCaseGroup
+          // short-circuits to true), so _nonEmptyCases content equals _cases. A shallow copy
+          // preserves reference-identity semantics (each rebuild produces a fresh array, so
+          // identity-comparing reactions on nonEmptyCases still fire when caseGroups change).
+          _nonEmptyCases = self.child
+            ? [..._cases]
+            : _caseGroups
+                .map(group => group && self.isNonEmptyCaseGroup(group) ? group.groupedCase : undefined)
+                .filter(aCase => !!aCase)
 
           _needsFullRebuild = false
         }
@@ -610,9 +622,12 @@ export const CollectionModel = V2Model
       // Used after child-collection attribute values change (e.g. formula recomputation), where
       // emptiness can flip but groupings cannot. Skipped if a full rebuild is already pending —
       // completeCaseGroups will refresh _nonEmptyCases anyway, and walking stale _caseGroups
-      // would produce a transiently wrong result.
+      // would produce a transiently wrong result. Also a no-op on parent collections, where
+      // every case is non-empty by definition (isNonEmptyCaseGroup short-circuits to true), so
+      // a value-only change can never flip emptiness — DataSet.validateCases already filters to
+      // the childmost collection, but this guard documents the action's contract.
       recomputeNonEmptyCases() {
-        if (_needsFullRebuild) return
+        if (_needsFullRebuild || self.child) return
         _nonEmptyCases = _caseGroups
           .filter(group => self.isNonEmptyCaseGroup(group))
           .map(group => group.groupedCase)

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -454,13 +454,12 @@ export const CollectionModel = V2Model
     if (!caseGroup?.childItemIds.length) return false
     // cases with multiple child items are non-empty (shouldn't happen for child collections)
     if (caseGroup.childItemIds.length > 1) return true
-    // for child collections, determine non-empty status by checking child item values
+    // For child collections, determine non-empty status by checking child item values across
+    // all attributes — including formula-driven ones. Formula-evaluated values count as
+    // non-empty by definition (a case with a computed value is not empty), so we check
+    // attributesArray rather than dataAttributesArray (which excludes formula attrs).
     const childItemId = caseGroup.childItemIds[0]
-    const childItemHasNonEmptyValue = self.dataAttributesArray.some(attr => {
-      const value = self.itemData.getValue(childItemId, attr.id)
-      return isValueNonEmpty(value)
-    })
-    return childItemHasNonEmptyValue
+    return self.attributesArray.some(attr => isValueNonEmpty(self.itemData.getValue(childItemId, attr.id)))
   },
   addChildCase(parentCaseId: string, childCaseId: string) {
     const groupKey = self.caseIdToGroupKeyMap.get(parentCaseId)

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -486,12 +486,19 @@ export const CollectionModel = V2Model
   let _caseIdsHash = 0
   let _caseIdsOrderedHash = 0
 
-  // Single observable version counter — incremented by completeCaseGroups() after updating
-  // plain variables, so that MobX reactions only fire when fresh data is available.
-  // Note: this is a pragmatic compromise — writing to an observable from a view via runInAction
-  // is not ideal, but avoids the circular read/write pattern of the old code (5 observable boxes
+  // Two observable version counters track when cached views need re-evaluation:
+  //   _groupingChangeVersion — bumped by completeCaseGroups() after a full rebuild. All
+  //     grouping-affected views invalidate together (caseGroups, cases, nonEmptyCases, hashes).
+  //   _valueChangeVersion — bumped by recomputeNonEmptyCases() when child-collection
+  //     attribute values change without affecting groupings (e.g. formula recomputation).
+  //     Only views derived from values read this; other views ignore it.
+  // Invariant: a grouping change subsumes a value change — the rebuild path refreshes
+  // _nonEmptyCases as part of completeCaseGroups, so it bumps only _groupingChangeVersion.
+  // Note: writing to these observables from a view via runInAction is a pragmatic compromise,
+  // but it avoids the circular read/write pattern of the old code (multiple observable boxes
   // read then written in the same view) and ensures reactions never see stale cached data.
-  const _cacheVersion = observable.box(0)
+  const _groupingChangeVersion = observable.box(0)
+  const _valueChangeVersion = observable.box(0)
 
   // Invalidation state (plain, not observable)
   let _needsFullRebuild = true   // starts true: no valid data yet
@@ -500,23 +507,24 @@ export const CollectionModel = V2Model
   return {
     views: {
       get caseGroups() {
-        _cacheVersion.get()
+        _groupingChangeVersion.get()
         return _caseGroups
       },
       get cases() {
-        _cacheVersion.get()
+        _groupingChangeVersion.get()
         return _cases
       },
       get nonEmptyCases() {
-        _cacheVersion.get()
+        _groupingChangeVersion.get()
+        _valueChangeVersion.get()
         return _nonEmptyCases
       },
       get caseIdsHash() {
-        _cacheVersion.get()
+        _groupingChangeVersion.get()
         return _caseIdsHash
       },
       get caseIdsOrderedHash() {
-        _cacheVersion.get()
+        _groupingChangeVersion.get()
         return _caseIdsOrderedHash
       },
       completeCaseGroups(parentCases: Maybe<CaseInfo[]>) {
@@ -581,7 +589,7 @@ export const CollectionModel = V2Model
 
         // Signal to MobX that cached data has been updated.
         // Must happen AFTER plain variables are updated so reactions see fresh data.
-        runInAction(() => _cacheVersion.set(_cacheVersion.get() + 1))
+        runInAction(() => _groupingChangeVersion.set(_groupingChangeVersion.get() + 1))
       }
     },
     actions: {
@@ -598,6 +606,18 @@ export const CollectionModel = V2Model
         if (!_needsFullRebuild) {
           _pendingNewCaseIds = newCaseIds
         }
+      },
+      // Re-derive _nonEmptyCases from the existing _caseGroups without redoing any grouping.
+      // Used after child-collection attribute values change (e.g. formula recomputation), where
+      // emptiness can flip but groupings cannot. Skipped if a full rebuild is already pending —
+      // completeCaseGroups will refresh _nonEmptyCases anyway, and walking stale _caseGroups
+      // would produce a transiently wrong result.
+      recomputeNonEmptyCases() {
+        if (_needsFullRebuild) return
+        _nonEmptyCases = _caseGroups
+          .filter(group => self.isNonEmptyCaseGroup(group))
+          .map(group => group.groupedCase)
+        _valueChangeVersion.set(_valueChangeVersion.get() + 1)
       }
     }
   }

--- a/v3/src/models/data/data-set-undo.test.ts
+++ b/v3/src/models/data/data-set-undo.test.ts
@@ -90,6 +90,33 @@ describe("DataSet undo/redo", () => {
     expect(undoManager?.redoEntry?.clientData).toBeUndefined()
   })
 
+  // The forward setCaseValuesWithCustomUndoRedo edit can pass affectedAttributes to engage the
+  // regrouping-skip optimization in setCaseValues. The custom undo/redo patch must persist that
+  // list so undo/redo replays carry the optimization through to the inverse operation, which is
+  // the more common workflow (edit → undo → redo) and where the perf win matters most.
+  it("preserves affectedAttributes through undo/redo so the regrouping-skip optimization carries through", async () => {
+    const { data, whenTreeManagerIsReady, undoManager } = setupDocument()
+
+    // Both attributes live in the (only) child collection, so an edit to aId is a child-only
+    // change and setCaseValues should call invalidateCases(false) — leaving needsRegrouping
+    // unchanged at false.
+    data.applyModelChange(
+      () => setCaseValuesWithCustomUndoRedo(data, [{ __id__: "ITEM0", aId: 99 }], ["aId"]),
+      { undoStringKey: "Undo edit value", redoStringKey: "Redo edit value" })
+    expect(data.needsRegrouping).toBe(false)
+    await whenTreeManagerIsReady()
+
+    undoManager?.undo()
+    await whenTreeManagerIsReady()
+    expect(data.getItem("ITEM0")).toEqual({ __id__: "ITEM0", aId: 1, bId: 2 })
+    expect(data.needsRegrouping).toBe(false)
+
+    undoManager?.redo()
+    await whenTreeManagerIsReady()
+    expect(data.getItem("ITEM0")).toEqual({ __id__: "ITEM0", aId: 99, bId: 2 })
+    expect(data.needsRegrouping).toBe(false)
+  })
+
   it("can undo/redo inserting cases at the end", async () => {
     const { data, whenTreeManagerIsReady, undoManager } = setupDocument()
 

--- a/v3/src/models/data/data-set-undo.ts
+++ b/v3/src/models/data/data-set-undo.ts
@@ -20,6 +20,11 @@ export interface ISetCaseValuesCustomPatch extends ICustomPatch {
     dataId: string  // DataSet id
     before: IItem[]
     after: IItem[]
+    // The attribute ids whose values may have changed in the original setCaseValues call.
+    // Persisted so that undo/redo can carry the regrouping-skip optimization through to the
+    // inverse operation (omitted for backward compatibility with patches created before this
+    // field was added — undefined falls through to defensive regrouping).
+    affectedAttributes?: string[]
   }
 }
 function isSetCaseValuesCustomPatch(patch: ICustomPatch): patch is ISetCaseValuesCustomPatch {
@@ -30,13 +35,13 @@ const setCaseValuesCustomUndoRedoPatcher: ICustomUndoRedoPatcher = {
   undo: (node: IAnyStateTreeNode, patch: ICustomPatch, entry: HistoryEntryType) => {
     if (isSetCaseValuesCustomPatch(patch)) {
       const data = resolveIdentifier<typeof DataSet>(DataSet, node, patch.data.dataId)
-      data?.setCaseValues(patch.data.before)
+      data?.setCaseValues(patch.data.before, patch.data.affectedAttributes)
     }
   },
   redo: (node: IAnyStateTreeNode, patch: ICustomPatch, entry: HistoryEntryType) => {
     if (isSetCaseValuesCustomPatch(patch)) {
       const data = resolveIdentifier<typeof DataSet>(DataSet, node, patch.data.dataId)
-      data?.setCaseValues(patch.data.after)
+      data?.setCaseValues(patch.data.after, patch.data.affectedAttributes)
     }
   }
 }
@@ -52,7 +57,7 @@ export function setCaseValuesWithCustomUndoRedo(data: IDataSet, cases: ICase[], 
   const after = data.getItems(itemIds)
   withCustomUndoRedo<ISetCaseValuesCustomPatch>({
     type: "DataSet.setCaseValues",
-    data: { dataId: data.id, before, after }
+    data: { dataId: data.id, before, after, affectedAttributes }
   }, setCaseValuesCustomUndoRedoPatcher)
 }
 

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1100,6 +1100,66 @@ test("setComputedCaseValues for child-collection attributes refreshes nonEmptyCa
   expect(data.getNonEmptyCasesForCollection(data.childCollection.id).length).toBe(3)
 })
 
+// When a caller of setCaseValues supplies affectedAttributes, the dataset can apply the
+// same regrouping-skip optimization used by setComputedCaseValues. This is the same shape
+// as the CODAP-1173 formula path but exercised via the user-edit code path (case table /
+// case card cell edits, plugin DI updates that opt into the contract, etc.).
+test("setCaseValues with child-only affectedAttributes skips regrouping", () => {
+  const data = DataSet.create({ name: "data" })
+  const parentCollection = data.addCollection({ name: "Parent" })
+  data.addAttribute({ name: "group" }, { collection: parentCollection.id })
+  const childAttr = data.addAttribute({ name: "val" })
+  data.addCases(toCanonical(data, [
+    { group: "A", val: 1 },
+    { group: "B", val: 2 }
+  ]))
+  data.validateCases()
+  expect(data.needsRegrouping).toBe(false)
+
+  data.setCaseValues(
+    [{ __id__: data.itemIds[0], [childAttr.id]: 99 }],
+    [childAttr.id]
+  )
+  expect(data.needsRegrouping).toBe(false)
+})
+
+test("setCaseValues with parent-collection affectedAttributes triggers regrouping", () => {
+  const data = DataSet.create({ name: "data" })
+  const parentCollection = data.addCollection({ name: "Parent" })
+  const parentAttr = data.addAttribute({ name: "group" }, { collection: parentCollection.id })
+  data.addAttribute({ name: "val" })
+  data.addCases(toCanonical(data, [
+    { group: "A", val: 1 },
+    { group: "B", val: 2 }
+  ]))
+  data.validateCases()
+  expect(data.needsRegrouping).toBe(false)
+
+  data.setCaseValues(
+    [{ __id__: data.itemIds[0], [parentAttr.id]: "C" }],
+    [parentAttr.id]
+  )
+  expect(data.needsRegrouping).toBe(true)
+})
+
+test("setCaseValues without affectedAttributes regroups defensively", () => {
+  const data = DataSet.create({ name: "data" })
+  const parentCollection = data.addCollection({ name: "Parent" })
+  data.addAttribute({ name: "group" }, { collection: parentCollection.id })
+  const childAttr = data.addAttribute({ name: "val" })
+  data.addCases(toCanonical(data, [
+    { group: "A", val: 1 },
+    { group: "B", val: 2 }
+  ]))
+  data.validateCases()
+  expect(data.needsRegrouping).toBe(false)
+
+  // Caller doesn't supply affectedAttributes — even though only a child-collection attr
+  // is written, the dataset can't know that, so it must regroup.
+  data.setCaseValues([{ __id__: data.itemIds[0], [childAttr.id]: 99 }])
+  expect(data.needsRegrouping).toBe(true)
+})
+
 test("setComputedCaseValues triggers regrouping for parent collection attributes", () => {
   const data = DataSet.create({ name: "data" })
   const parentCollection = data.addCollection({ name: "Parent" })

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1073,6 +1073,33 @@ test("setComputedCaseValues skips regrouping for child collection attributes", (
   expect(data.needsRegrouping).toBe(false)
 })
 
+// Regression test for CODAP-1173: when all attributes of a child (or single) collection are
+// formula-driven, snapshot values are empty until the formula evaluates. The initial
+// validateCases() therefore caches nonEmptyCases as []. setComputedCaseValues then writes
+// the formula's results but, because the affected attribute lives in the child collection,
+// it skips the regrouping path — and nonEmptyCases must still refresh because the new values
+// can flip cases from empty to non-empty.
+test("setComputedCaseValues for child-collection attributes refreshes nonEmptyCases", () => {
+  const data = DataSet.create({ name: "data" })
+  const formulaAttr = data.addAttribute({ name: "Test" })
+  // Three items with empty values, mirroring a freshly loaded document whose only attribute
+  // has a formula whose results are not yet evaluated.
+  data.addCases(toCanonical(data, [{ Test: "" }, { Test: "" }, { Test: "" }]))
+  // Initial validation populates the nonEmptyCases cache with all-empty values.
+  expect(data.getNonEmptyCasesForCollection(data.childCollection.id).length).toBe(0)
+
+  // Formula evaluation writes results via setComputedCaseValues for the child-collection attr.
+  const [id1, id2, id3] = data.itemIds
+  data.setComputedCaseValues([
+    { __id__: id1, [formulaAttr.id]: 10 },
+    { __id__: id2, [formulaAttr.id]: 20 },
+    { __id__: id3, [formulaAttr.id]: 30 }
+  ], [formulaAttr.id])
+
+  // All three cases now have non-empty values, so the count must reflect that.
+  expect(data.getNonEmptyCasesForCollection(data.childCollection.id).length).toBe(3)
+})
+
 test("setComputedCaseValues triggers regrouping for parent collection attributes", () => {
   const data = DataSet.create({ name: "data" })
   const parentCollection = data.addCollection({ name: "Parent" })

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1143,6 +1143,62 @@ test("autorun reading getNonEmptyCasesForCollection updates after setComputedCas
   dispose()
 })
 
+// Value-only invalidations (regrouping=false) leave item visibility/order untouched, so the
+// dataset's itemIds cache must NOT be discarded — that would force consumers (case table,
+// filters, etc.) to rebuild on every formula recompute and give back part of the perf win.
+test("setCaseValues with child-only affectedAttributes does not invalidate the itemIds cache", () => {
+  const data = DataSet.create({ name: "data" })
+  const childAttr = data.addAttribute({ name: "val" })
+  data.addCases(toCanonical(data, [{ val: "a" }, { val: "b" }, { val: "c" }]))
+  data.validateCases()
+  const itemIdsBefore = data.itemIds
+
+  data.setCaseValues([{ __id__: data.itemIds[0], [childAttr.id]: "x" }], [childAttr.id])
+
+  // Same array reference proves the cache wasn't rebuilt; a regrouping invalidation would
+  // have set _isValidItemIds = false and the next read would have produced a new array.
+  expect(data.itemIds).toBe(itemIdsBefore)
+})
+
+// In a hierarchical dataset, parent-collection cases short-circuit isNonEmptyCaseGroup on
+// self.child and so their nonEmpty status is invariant across value-only updates. The
+// value-revalidation branch therefore must touch only the childmost collection — both to
+// avoid wasted work and to avoid notifying parent observers. Pinning this with a reaction
+// counter so a regression that re-iterates all collections would surface here.
+test("setComputedCaseValues on a child attr does not refresh parent-collection nonEmptyCases", () => {
+  const data = DataSet.create({ name: "data" })
+  const parentCollection = data.addCollection({ name: "Parent" })
+  data.addAttribute({ name: "group" }, { collection: parentCollection.id })
+  const childAttr = data.addAttribute({ name: "val" })
+  data.addCases(toCanonical(data, [
+    { group: "A", val: "" },
+    { group: "A", val: "" },
+    { group: "B", val: "" }
+  ]))
+  data.validateCases()
+
+  const parent = data.getCollection(parentCollection.id)!
+  const child = data.childCollection
+  let parentEvalCount = 0
+  let childEvalCount = 0
+  const disposeParent = autorun(() => { parentEvalCount++; void parent.nonEmptyCases })
+  const disposeChild = autorun(() => { childEvalCount++; void child.nonEmptyCases })
+  const baselineParent = parentEvalCount
+  const baselineChild = childEvalCount
+
+  data.setComputedCaseValues(
+    data.itemIds.map(id => ({ __id__: id, [childAttr.id]: 99 })),
+    [childAttr.id]
+  )
+  data.validateCases() // run the value-revalidation branch
+
+  expect(childEvalCount).toBeGreaterThan(baselineChild)   // child observers re-run
+  expect(parentEvalCount).toBe(baselineParent)            // parent observers don't
+
+  disposeParent()
+  disposeChild()
+})
+
 test("setCaseValues with child-only affectedAttributes skips regrouping", () => {
   const data = DataSet.create({ name: "data" })
   const parentCollection = data.addCollection({ name: "Parent" })

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1,4 +1,5 @@
 import { isEqual, isEqualWith } from "lodash"
+import { autorun } from "mobx"
 import { applyAction, clone, destroy, getSnapshot, onAction, onSnapshot } from "mobx-state-tree"
 import { uniqueName } from "../../utilities/js-utils"
 import { onAnyAction } from "../../utilities/mst-utils"
@@ -1082,10 +1083,15 @@ test("setComputedCaseValues skips regrouping for child collection attributes", (
 test("setComputedCaseValues for child-collection attributes refreshes nonEmptyCases", () => {
   const data = DataSet.create({ name: "data" })
   const formulaAttr = data.addAttribute({ name: "Test" })
-  // Three items with empty values, mirroring a freshly loaded document whose only attribute
-  // has a formula whose results are not yet evaluated.
+  // Marking the attribute as formula-driven matters: the original CODAP-1173 bug only
+  // surfaced when every attribute in the (child) collection had a formula. Without the
+  // formula here, the attribute would fall into Collection.dataAttributesArray and the
+  // initial validation would already see "empty" values via the regular path; the bug
+  // requires Collection.attributesArray (formula-included) to be the attribute source.
+  formulaAttr.setDisplayExpression("0")
+  // Three items with empty values, mirroring a freshly loaded document whose only
+  // attribute has a formula whose results are not yet evaluated.
   data.addCases(toCanonical(data, [{ Test: "" }, { Test: "" }, { Test: "" }]))
-  // Initial validation populates the nonEmptyCases cache with all-empty values.
   expect(data.getNonEmptyCasesForCollection(data.childCollection.id).length).toBe(0)
 
   // Formula evaluation writes results via setComputedCaseValues for the child-collection attr.
@@ -1096,7 +1102,10 @@ test("setComputedCaseValues for child-collection attributes refreshes nonEmptyCa
     { __id__: id3, [formulaAttr.id]: 30 }
   ], [formulaAttr.id])
 
-  // All three cases now have non-empty values, so the count must reflect that.
+  // All three cases now have non-empty (formula-derived) values, so the count must reflect
+  // that. This exercises both the value-revalidation cache refresh (setComputedCaseValues
+  // calls invalidateCases(false), which schedules a recompute) and the formula-aware
+  // emptiness check in isNonEmptyCaseGroup.
   expect(data.getNonEmptyCasesForCollection(data.childCollection.id).length).toBe(3)
 })
 
@@ -1104,6 +1113,36 @@ test("setComputedCaseValues for child-collection attributes refreshes nonEmptyCa
 // same regrouping-skip optimization used by setComputedCaseValues. This is the same shape
 // as the CODAP-1173 formula path but exercised via the user-edit code path (case table /
 // case card cell edits, plugin DI updates that opt into the contract, etc.).
+// CODAP-1173 follow-on: an early version of the fix made validateCases() recompute
+// _nonEmptyCases via a new branch, but a production reader (the case-table title bar)
+// reads `collection.nonEmptyCases` directly — that getter does NOT trigger validateCases.
+// Reactive consumers must read through the dataset's getNonEmptyCasesForCollection so
+// they pick up the MobX dependency on the dataset's validation observable, which is what
+// invalidateCases(false) bumps. This test guards the reactive path: the autorun simulates
+// the title bar's render, and must observe the refreshed count after setComputedCaseValues.
+test("autorun reading getNonEmptyCasesForCollection updates after setComputedCaseValues", () => {
+  const data = DataSet.create({ name: "data" })
+  const formulaAttr = data.addAttribute({ name: "Test" })
+  data.addCases(toCanonical(data, [{ Test: "" }, { Test: "" }, { Test: "" }]))
+
+  let observedCount = -1
+  const dispose = autorun(() => {
+    observedCount = data.getNonEmptyCasesForCollection(data.childCollection.id).length
+  })
+  expect(observedCount).toBe(0)
+
+  const [id1, id2, id3] = data.itemIds
+  data.setComputedCaseValues([
+    { __id__: id1, [formulaAttr.id]: 10 },
+    { __id__: id2, [formulaAttr.id]: 20 },
+    { __id__: id3, [formulaAttr.id]: 30 }
+  ], [formulaAttr.id])
+
+  expect(observedCount).toBe(3)
+
+  dispose()
+})
+
 test("setCaseValues with child-only affectedAttributes skips regrouping", () => {
   const data = DataSet.create({ name: "data" })
   const parentCollection = data.addCollection({ name: "Parent" })

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -310,12 +310,18 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
         return _itemIdsOrderedHash()
       },
       get needsRegrouping() {
+        // Establish a MobX dependency on _caseValidationVersion so this getter is not
+        // memoized as a no-dependency computed (which would cache its first return value
+        // forever). _caseValidationVersion is bumped by every invalidateCases / setValidCases.
+        _caseValidationVersion.get()
         return _needsRegrouping
       },
       clearNeedsRegrouping() {
         _needsRegrouping = false
       },
       get needsValueRevalidation() {
+        // See needsRegrouping for why _caseValidationVersion.get() is required.
+        _caseValidationVersion.get()
         return _needsValueRevalidation
       },
       clearNeedsValueRevalidation() {

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -332,9 +332,10 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
       invalidateCases(regrouping = true) {
         prf.measure("DataSet.invalidateCases", () => {
           _isValidCases = false
-          _invalidateItemIds()
           if (regrouping) {
             _needsRegrouping = true
+            // grouping changes can affect which items are visible / their order
+            _invalidateItemIds()
             // invalidate each collection's case group cache
             self.collections.forEach(c => c.invalidateCaseGroups())
           }
@@ -342,6 +343,8 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
             // Values may have changed without affecting groupings — schedule a value-only
             // revalidation. Harmless if _needsRegrouping is already pending; the regrouping
             // branch in validateCases() will clear this flag without doing redundant work.
+            // Note: the itemIds cache is intentionally NOT invalidated — child-collection
+            // attribute value changes don't change which items are visible or their order.
             _needsValueRevalidation = true
           }
           // Bump observable version so MobX re-evaluates isValidCases/validationCount computeds
@@ -754,7 +757,11 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
           self.clearNeedsValueRevalidation()
         }
         else if (self.needsValueRevalidation) {
-          self.collections.forEach(collection => collection.recomputeNonEmptyCases())
+          // Only the childmost collection's nonEmpty status can change as a result of value
+          // updates — parent collections always report their cases as non-empty (see
+          // Collection.isNonEmptyCaseGroup, which short-circuits when self.child is set), so
+          // recomputing them is wasted work and would needlessly notify parent observers.
+          self.childCollection.recomputeNonEmptyCases()
           self.clearNeedsValueRevalidation()
         }
         self.setValidCases()

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -1037,6 +1037,17 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
     }
   }
 
+  // Returns true if any of the given attribute ids belong to a non-child (parent) collection.
+  // Parent-collection attribute values determine case grouping, so writes that touch them must
+  // trigger a regrouping. Writes that touch only child-collection attributes can take the
+  // value-revalidation fast path. Used by both setCaseValues and setComputedCaseValues.
+  function _attrIdsAffectGrouping(attrIds: Iterable<string>) {
+    for (const attrId of attrIds) {
+      if (self.getCollectionForAttribute(attrId) !== self.childCollection) return true
+    }
+    return false
+  }
+
   return {
     /*
      * public views
@@ -1330,10 +1341,14 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
       // Supports items or cases, but not mixing the two.
       // For cases, will set the values of all items in the group
       // regardless of whether the attribute is grouped or not.
-      // `affectedAttributes` are not used in the function, but are present as a potential
-      // optimization for responders, as all arguments are available to `onAction` listeners.
-      // For instance, a scatter plot that is dragging many points but affecting only two
-      // attributes can indicate that, which can enable more efficient responses.
+      //
+      // `affectedAttributes` is also a contract used to drive a regrouping-skip optimization:
+      // when supplied, callers guarantee that any value change made by this call is to one of
+      // the listed attributes. With that guarantee the dataset can skip the regrouping path
+      // when no listed attribute belongs to a parent collection (parent-collection values
+      // determine case grouping, child-collection values do not). Passing an incomplete list
+      // will result in stale groupings — when in doubt, omit the argument and the dataset will
+      // regroup defensively. The argument is also surfaced to onAction listeners as before.
       setCaseValues(cases: ICase[], affectedAttributes?: string[]) {
         const items = prf.measure("DataSet.setCaseValues[getItemsForCases]", () =>
           self.getItemsForCases(cases)
@@ -1361,8 +1376,14 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
           })
         }
 
-        // only changes to parent collection attributes invalidate grouping
-        items.length && self.invalidateCases()
+        if (items.length) {
+          // With an exhaustive affectedAttributes contract we can skip regrouping when only
+          // child-collection attrs were touched. Without the contract we must regroup.
+          const needsRegrouping = affectedAttributes
+            ? _attrIdsAffectGrouping(affectedAttributes)
+            : true
+          self.invalidateCases(needsRegrouping)
+        }
       },
 
       // Write formula-computed values directly to volatile arrays, bypassing per-item MST actions.
@@ -1375,15 +1396,9 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
         const items = self.getItemsForCases(cases)
         // Capture the Map locally to avoid repeated MST proxy access in the inner loop
         const { itemInfoMap } = self
-        // Only regroup if a computed attribute is in a parent collection,
-        // since parent collection values determine case grouping.
-        let needsRegrouping = false
         for (const attrId of affectedAttributes) {
           const attr = self.getAttribute(attrId)
           if (!attr) continue
-          if (!needsRegrouping && self.getCollectionForAttribute(attrId) !== self.childCollection) {
-            needsRegrouping = true
-          }
           const indices: number[] = []
           const values: IValueType[] = []
           for (const item of items) {
@@ -1397,7 +1412,7 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
             attr.setComputedValues(indices, values)
           }
         }
-        self.invalidateCases(needsRegrouping)
+        self.invalidateCases(_attrIdsAffectGrouping(affectedAttributes))
       },
 
       removeCases(caseIDs: string[]) {

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -217,14 +217,23 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
   // Plain variables (NOT observable — no MobX involvement for cache guards)
   let _validationCount = 0
   let _isValidCases = false
+  // Two invalidation flags distinguish what kind of work the next validateCases() must do:
+  //   _needsRegrouping — case groupings have changed; collections must rebuild fully.
+  //   _needsValueRevalidation — child-collection values have changed without affecting
+  //     groupings (e.g. formula recomputation); only value-derived caches like
+  //     Collection._nonEmptyCases need to refresh.
+  // Regrouping subsumes value revalidation, so when both are pending the regrouping branch
+  // runs and the value-revalidation flag is cleared as a no-op.
   let _needsRegrouping = false
+  let _needsValueRevalidation = false
   let _isValidItemIds = false
   // Item IDs removed during validation — flushed by setValidCases() in its runInAction
   let _pendingSelectionDeletes: string[] = []
 
   // Single observable counter — bumped by setValidCases() after validation completes.
-  // Same pragmatic compromise as Collection._cacheVersion: a view writes one observable
-  // via runInAction so that MobX reactions fire only after cached data is fully updated.
+  // Same pragmatic compromise as Collection._groupingChangeVersion: a view writes one
+  // observable via runInAction so that MobX reactions fire only after cached data is fully
+  // updated.
   const _caseValidationVersion = observable.box(0)
 
   // cached filtered item IDs (excludes hidden/filtered items)
@@ -305,6 +314,12 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
       },
       clearNeedsRegrouping() {
         _needsRegrouping = false
+      },
+      get needsValueRevalidation() {
+        return _needsValueRevalidation
+      },
+      clearNeedsValueRevalidation() {
+        _needsValueRevalidation = false
       }
     },
     actions: {
@@ -316,6 +331,12 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
             _needsRegrouping = true
             // invalidate each collection's case group cache
             self.collections.forEach(c => c.invalidateCaseGroups())
+          }
+          else {
+            // Values may have changed without affecting groupings — schedule a value-only
+            // revalidation. Harmless if _needsRegrouping is already pending; the regrouping
+            // branch in validateCases() will clear this flag without doing redundant work.
+            _needsValueRevalidation = true
           }
           // Bump observable version so MobX re-evaluates isValidCases/validationCount computeds
           _caseValidationVersion.set(_caseValidationVersion.get() + 1)
@@ -722,6 +743,13 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
             self.deferSelectionDelete(itemsToValidate)
           }
           self.clearNeedsRegrouping()
+          // The full rebuild already refreshed _nonEmptyCases, so any pending value-only
+          // revalidation is satisfied.
+          self.clearNeedsValueRevalidation()
+        }
+        else if (self.needsValueRevalidation) {
+          self.collections.forEach(collection => collection.recomputeNonEmptyCases())
+          self.clearNeedsValueRevalidation()
         }
         self.setValidCases()
       })


### PR DESCRIPTION
## Summary

Case-table title reported "0 nonempty cases" when every attribute in a
collection was formula-driven (per user's document attached to
the Jira story). Three coexisting bugs are addressed in this PR:

- **Formula-attribute filter** (`Collection.isNonEmptyCaseGroup`): used
  `dataAttributesArray`, which excludes formula attributes by design;
  with no non-formula attributes present, every case was reported empty
  regardless of computed value. Switched to `attributesArray` so
  formula-evaluated values count as non-empty.
- **MobX-memoized validation flags** (`DataSet.needsRegrouping`,
  `DataSet.needsValueRevalidation`): plain-closure-variable getters had
  no observable dependency, so MobX cached their first return values
  indefinitely and `validateCases` would take the wrong branch. Added a
  `_caseValidationVersion.get()` read to each, matching the existing
  pattern on `isValidCases` / `validationCount`.
- **Title-bar reactivity** (`CollectionTitle`): read
  `collection.cases.length` / `.nonEmptyCases.length` directly, which
  doesn't trigger validation or establish a MobX dep on the dataset's
  validation observable. Routed reads through
  `data.getCasesForCollection` / `getNonEmptyCasesForCollection`.

Earlier commits on the branch:
- Refresh `nonEmptyCases` on child-collection value changes — split
  Collection's cache version into grouping vs. value observables, added
  a `recomputeNonEmptyCases` action, added a `_needsValueRevalidation`
  flag and `validateCases` branch.
- Extend the regrouping-skip optimization from `setComputedCaseValues`
  to `setCaseValues` when callers supply an exhaustive
  `affectedAttributes`; tightened the contract; wired the optimization
  through case-table cell edits.

Fixes CODAP-1173

## Test plan

- [ ] Open the test document attached to CODAP-1173 and confirm the
      case-table title reports the correct nonempty case count (10) rather
      than 0.
- [ ] Edit a regular (non-formula) cell in the case table and confirm
      the count still updates correctly.
- [ ] Edit a parent-collection attribute value and confirm regrouping
      still happens.
- [ ] Drag points in a dot plot / scatter plot — the same
      `setCaseValues` optimization path is in use.
- [ ] CI lint / build / Jest unit suites pass.
- [ ] Cypress regression suite passes (apply `run regression` label
      before requesting review).
