### PR TITLE
CODAP-1219: send 2-letter base language to plugin iframes

### DIFF
--- a/v3/src/components/web-view/use-data-interactive-controller.ts
+++ b/v3/src/components/web-view/use-data-interactive-controller.ts
@@ -32,10 +32,13 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
 
   // React to locale changes outside the main useEffect so that:
   // - Localized plugins: bump localeVersion to trigger useEffect re-run (the iframe src
-  //   is recomputed by the observer in web-view.tsx using gLocale.current).
+  //   is recomputed by the observer in web-view.tsx using gLocale.currentBaseLanguage,
+  //   the 2-letter base language for V2 plugin compatibility).
   // - Other plugins: send a localeChanged notification via the existing controller.
   useEffect(() => {
     // Track the 2-letter base language to match V2 behavior; see web-view.tsx for context.
+    // The notification carries both `lang` (2-letter base) and `locale` (full BCP-47) so
+    // plugins that need region or script info can read either.
     const localeDisposer = reaction(
       () => gLocale.currentBaseLanguage,
       (lang) => {
@@ -43,7 +46,8 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
           setLocaleVersion(v => v + 1)
         } else if (webViewModel?.isPlugin) {
           webViewModel.broadcastMessage(
-            { action: "notify", resource: "global", values: { operation: "localeChanged", lang } },
+            { action: "notify", resource: "global",
+              values: { operation: "localeChanged", lang, locale: gLocale.current } },
             () => debugLog(DEBUG_PLUGINS, "Reply to localeChanged notification")
           )
         }

--- a/v3/src/components/web-view/use-data-interactive-controller.ts
+++ b/v3/src/components/web-view/use-data-interactive-controller.ts
@@ -35,8 +35,9 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
   //   is recomputed by the observer in web-view.tsx using gLocale.current).
   // - Other plugins: send a localeChanged notification via the existing controller.
   useEffect(() => {
+    // Track the 2-letter base language to match V2 behavior; see web-view.tsx for context.
     const localeDisposer = reaction(
-      () => gLocale.current,
+      () => gLocale.currentBaseLanguage,
       (lang) => {
         if (webViewModel?.needsLocaleReload) {
           setLocaleVersion(v => v + 1)

--- a/v3/src/components/web-view/use-data-interactive-controller.ts
+++ b/v3/src/components/web-view/use-data-interactive-controller.ts
@@ -36,18 +36,18 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
   //   the 2-letter base language for V2 plugin compatibility).
   // - Other plugins: send a localeChanged notification via the existing controller.
   useEffect(() => {
-    // Track the 2-letter base language to match V2 behavior; see web-view.tsx for context.
-    // The notification carries both `lang` (2-letter base) and `locale` (full BCP-47) so
-    // plugins that need region or script info can read either.
+    // Track the full locale so region/script-only changes (e.g. zh-Hans → zh-TW) propagate.
+    // The notification carries both `lang` (2-letter base, for V2 plugin compatibility — see
+    // web-view.tsx) and `locale` (full BCP-47) so plugins can read either.
     const localeDisposer = reaction(
-      () => gLocale.currentBaseLanguage,
-      (lang) => {
+      () => gLocale.current,
+      (locale) => {
         if (webViewModel?.needsLocaleReload) {
           setLocaleVersion(v => v + 1)
         } else if (webViewModel?.isPlugin) {
           webViewModel.broadcastMessage(
             { action: "notify", resource: "global",
-              values: { operation: "localeChanged", lang, locale: gLocale.current } },
+              values: { operation: "localeChanged", lang: gLocale.currentBaseLanguage, locale } },
             () => debugLog(DEBUG_PLUGINS, "Reply to localeChanged notification")
           )
         }

--- a/v3/src/components/web-view/web-view-utils.test.ts
+++ b/v3/src/components/web-view/web-view-utils.test.ts
@@ -1,6 +1,6 @@
 import { kCodapResourcesUrl, kRootDataGamesPluginUrl, kRootGuideUrl, kRootPluginsUrl } from "../../constants"
 import {
-  appendLangParam, getNameFromURL, kRelativeGuideRoot, kRelativePluginRoot, kRelativeURLRoot,
+  appendLangParam, appendLocaleParam, getNameFromURL, kRelativeGuideRoot, kRelativePluginRoot, kRelativeURLRoot,
   normalizeUrlScheme, processWebViewUrl
 } from "./web-view-utils"
 
@@ -208,5 +208,28 @@ describe("appendLangParam", () => {
       .toBe("https://example.com/plugin/index.html?lang=es")
     expect(appendLangParam("  /codap-resources/plugins/Sampler/index.html  ", "es"))
       .toBe("/codap-resources/plugins/Sampler/index.html?lang=es")
+  })
+})
+
+describe("appendLocaleParam", () => {
+  it("appends ?locale= to URLs with no query params", () => {
+    expect(appendLocaleParam("https://example.com/plugin/index.html", "en-US"))
+      .toBe("https://example.com/plugin/index.html?locale=en-US")
+  })
+  it("appends &locale= alongside an existing lang param", () => {
+    expect(appendLocaleParam("https://example.com/plugin/index.html?lang=en", "en-US"))
+      .toBe("https://example.com/plugin/index.html?lang=en&locale=en-US")
+  })
+  it("replaces existing locale param", () => {
+    expect(appendLocaleParam("https://example.com/plugin/index.html?locale=en-GB", "en-US"))
+      .toBe("https://example.com/plugin/index.html?locale=en-US")
+  })
+  it("appends locale param to relative URLs without affecting an existing lang param", () => {
+    expect(appendLocaleParam("../plugin/index.html?lang=zh", "zh-Hans"))
+      .toBe("../plugin/index.html?lang=zh&locale=zh-Hans")
+  })
+  it("returns the URL unchanged for data: URLs", () => {
+    expect(appendLocaleParam("data:image/png;base64,abc", "en-US"))
+      .toBe("data:image/png;base64,abc")
   })
 })

--- a/v3/src/components/web-view/web-view-utils.test.ts
+++ b/v3/src/components/web-view/web-view-utils.test.ts
@@ -232,4 +232,13 @@ describe("appendLocaleParam", () => {
     expect(appendLocaleParam("data:image/png;base64,abc", "en-US"))
       .toBe("data:image/png;base64,abc")
   })
+  it("URL-encodes values containing special characters in relative URLs", () => {
+    // Defensive: prevent a malformed locale from injecting additional query params.
+    expect(appendLocaleParam("../plugin/index.html", "en&evil=1"))
+      .toBe("../plugin/index.html?locale=en%26evil%3D1")
+  })
+  it("URL-encodes values containing special characters in absolute URLs", () => {
+    expect(appendLocaleParam("https://example.com/plugin/index.html", "en&evil=1"))
+      .toBe("https://example.com/plugin/index.html?locale=en%26evil%3D1")
+  })
 })

--- a/v3/src/components/web-view/web-view-utils.test.ts
+++ b/v3/src/components/web-view/web-view-utils.test.ts
@@ -241,4 +241,8 @@ describe("appendLocaleParam", () => {
     expect(appendLocaleParam("https://example.com/plugin/index.html", "en&evil=1"))
       .toBe("https://example.com/plugin/index.html?locale=en%26evil%3D1")
   })
+  it("collapses duplicate param entries to a single value (matches URLSearchParams.set)", () => {
+    expect(appendLocaleParam("../plugin/index.html?locale=en-US&locale=fr", "es"))
+      .toBe("../plugin/index.html?locale=es")
+  })
 })

--- a/v3/src/components/web-view/web-view-utils.ts
+++ b/v3/src/components/web-view/web-view-utils.ts
@@ -107,8 +107,10 @@ function setUrlQueryParam(url: string, name: string, value: string): string {
       // fall through to string manipulation
     }
   }
-  // For relative or malformed URLs, use string manipulation to preserve the path form
-  const param = `${name}=${value}`
+  // For relative or malformed URLs, use string manipulation to preserve the path form.
+  // Encode the value to match URLSearchParams behavior on the absolute-URL path and to
+  // prevent characters like `&` or `#` from injecting additional query params.
+  const param = `${name}=${encodeURIComponent(value)}`
   // Split off hash fragment so we don't accidentally drop it
   const hashIndex = trimmedUrl.indexOf("#")
   const [base, hash] = hashIndex >= 0

--- a/v3/src/components/web-view/web-view-utils.ts
+++ b/v3/src/components/web-view/web-view-utils.ts
@@ -107,21 +107,19 @@ function setUrlQueryParam(url: string, name: string, value: string): string {
       // fall through to string manipulation
     }
   }
-  // For relative or malformed URLs, use string manipulation to preserve the path form.
-  // Encode the value to match URLSearchParams behavior on the absolute-URL path and to
-  // prevent characters like `&` or `#` from injecting additional query params.
-  const param = `${name}=${encodeURIComponent(value)}`
-  // Split off hash fragment so we don't accidentally drop it
+  // For relative or malformed URLs, parse the query portion with URLSearchParams so
+  // we match the absolute-URL semantics: encoding is handled, and `set()` removes
+  // any existing duplicate entries before assigning a single value.
   const hashIndex = trimmedUrl.indexOf("#")
   const [base, hash] = hashIndex >= 0
     ? [trimmedUrl.slice(0, hashIndex), trimmedUrl.slice(hashIndex)]
     : [trimmedUrl, ""]
-  // Replace existing param if present
-  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  const replacedBase = base.replace(new RegExp(`([?&])${escaped}=[^&]*`), `$1${param}`)
-  if (replacedBase !== base) return replacedBase + hash
-  // No existing param — append before the hash
-  return base + (base.includes("?") ? "&" : "?") + param + hash
+  const queryStart = base.indexOf("?")
+  const path = queryStart >= 0 ? base.slice(0, queryStart) : base
+  const params = new URLSearchParams(queryStart >= 0 ? base.slice(queryStart + 1) : "")
+  params.set(name, value)
+  const newQuery = params.toString()
+  return newQuery ? `${path}?${newQuery}${hash}` : `${path}${hash}`
 }
 
 /**

--- a/v3/src/components/web-view/web-view-utils.ts
+++ b/v3/src/components/web-view/web-view-utils.ts
@@ -92,33 +92,50 @@ export function processWebViewUrl(url: string) {
 }
 
 /**
- * Append or replace the `lang` query parameter on a plugin URL.
+ * Append or replace a query parameter on a plugin URL.
  * Skips data: URLs and empty strings.
  */
-export function appendLangParam(url: string, lang: string): string {
+function setUrlQueryParam(url: string, name: string, value: string): string {
   const trimmedUrl = url?.trim()
   if (!trimmedUrl || trimmedUrl.startsWith("data:")) return url
   if (/^https?:\/\//.test(trimmedUrl)) {
     try {
       const parsed = new URL(trimmedUrl)
-      parsed.searchParams.set("lang", lang)
+      parsed.searchParams.set(name, value)
       return parsed.toString()
     } catch {
       // fall through to string manipulation
     }
   }
   // For relative or malformed URLs, use string manipulation to preserve the path form
-  const langParam = `lang=${lang}`
+  const param = `${name}=${value}`
   // Split off hash fragment so we don't accidentally drop it
   const hashIndex = trimmedUrl.indexOf("#")
   const [base, hash] = hashIndex >= 0
     ? [trimmedUrl.slice(0, hashIndex), trimmedUrl.slice(hashIndex)]
     : [trimmedUrl, ""]
-  // Replace existing lang param if present
-  const replacedBase = base.replace(/([?&])lang=[^&]*/, `$1${langParam}`)
+  // Replace existing param if present
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const replacedBase = base.replace(new RegExp(`([?&])${escaped}=[^&]*`), `$1${param}`)
   if (replacedBase !== base) return replacedBase + hash
-  // No existing lang param — append before the hash
-  return base + (base.includes("?") ? "&" : "?") + langParam + hash
+  // No existing param — append before the hash
+  return base + (base.includes("?") ? "&" : "?") + param + hash
+}
+
+/**
+ * Append or replace the `lang` query parameter on a plugin URL.
+ * Skips data: URLs and empty strings.
+ */
+export function appendLangParam(url: string, lang: string): string {
+  return setUrlQueryParam(url, "lang", lang)
+}
+
+/**
+ * Append or replace the `locale` query parameter on a plugin URL.
+ * Skips data: URLs and empty strings.
+ */
+export function appendLocaleParam(url: string, locale: string): string {
+  return setUrlQueryParam(url, "locale", locale)
 }
 
 export function normalizeUrlScheme(url: string): string {

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -10,7 +10,7 @@ import { useDataInteractiveController } from "./use-data-interactive-controller"
 import { kWebViewBodyClass } from "./web-view-defs"
 import { WebViewDropOverlay } from "./web-view-drop-overlay"
 import { isWebViewModel } from "./web-view-model"
-import { appendLangParam } from "./web-view-utils"
+import { appendLangParam, appendLocaleParam } from "./web-view-utils"
 
 import "./web-view.scss"
 
@@ -152,12 +152,13 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
 
   useDataInteractiveController(iframeRef, tile)
 
-  // Append ?lang= to all plugins that need reload on locale change.
+  // Append ?lang= and &locale= to all plugins that need reload on locale change.
   // Plugins can opt out by setting handlesLocaleChange: true via interactiveFrame.update.
-  // Use the 2-letter base language to match V2 behavior; some plugins (e.g. Simmer) crash
-  // if given a region-qualified locale like "en-US" they don't have strings for.
+  // `lang` is the 2-letter base language to match V2 behavior; some plugins (e.g. Simmer)
+  // crash if given a region-qualified locale they don't have strings for. Plugins that need
+  // region or script information (e.g. zh-Hans vs zh-TW) can read `locale` instead.
   const iframeSrc = isWebViewModel(webViewModel) && webViewModel.needsLocaleReload
-    ? appendLangParam(webViewModel.url, gLocale.currentBaseLanguage)
+    ? appendLocaleParam(appendLangParam(webViewModel.url, gLocale.currentBaseLanguage), gLocale.current)
     : isWebViewModel(webViewModel) ? webViewModel.url : ""
 
   useEffect(() => {

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -154,8 +154,10 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
 
   // Append ?lang= to all plugins that need reload on locale change.
   // Plugins can opt out by setting handlesLocaleChange: true via interactiveFrame.update.
+  // Use the 2-letter base language to match V2 behavior; some plugins (e.g. Simmer) crash
+  // if given a region-qualified locale like "en-US" they don't have strings for.
   const iframeSrc = isWebViewModel(webViewModel) && webViewModel.needsLocaleReload
-    ? appendLangParam(webViewModel.url, gLocale.current)
+    ? appendLangParam(webViewModel.url, gLocale.currentBaseLanguage)
     : isWebViewModel(webViewModel) ? webViewModel.url : ""
 
   useEffect(() => {

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -82,7 +82,11 @@ export interface DIInteractiveFrame {
   subscribeToDocuments?: boolean
   title?: string
   version?: string
+  // Two-letter base language (e.g. "en", "es"). Maintained for V2 plugin compatibility.
   lang?: string
+  // Full BCP-47 locale (e.g. "en-US", "zh-Hans"). Plugins that need region or script
+  // information should read this in preference to `lang`.
+  locale?: string
   handlesLocaleChange?: boolean
 }
 

--- a/v3/src/data-interactive/handlers/interactive-frame-handler.test.ts
+++ b/v3/src/data-interactive/handlers/interactive-frame-handler.test.ts
@@ -14,6 +14,13 @@ import { diInteractiveFrameHandler } from "./interactive-frame-handler"
 
 describe("DataInteractive InteractiveFrameHandler", () => {
   const handler = diInteractiveFrameHandler
+
+  // Pin the locale so lang/locale assertions are deterministic regardless of
+  // any other test that may have called gLocale.setCurrent.
+  beforeEach(() => {
+    gLocale.setCurrent("en-US")
+  })
+
   it("get works", () => {
     expect(handler.get?.({}).success).toBe(false)
 

--- a/v3/src/data-interactive/handlers/interactive-frame-handler.test.ts
+++ b/v3/src/data-interactive/handlers/interactive-frame-handler.test.ts
@@ -8,6 +8,7 @@ import {
 import { appState } from "../../models/app-state"
 import { uiState } from "../../models/ui-state"
 import { toV2Id } from "../../utilities/codap-utils"
+import { gLocale } from "../../utilities/translation/locale"
 import { DIInteractiveFrame } from "../data-interactive-types"
 import { diInteractiveFrameHandler } from "./interactive-frame-handler"
 
@@ -37,7 +38,10 @@ describe("DataInteractive InteractiveFrameHandler", () => {
     expect(savedState).toBe(webView.state)
     expect(title).toBe(interactiveFrame.title)
     expect(version).toBe(webView.version)
-    expect((result.values as DIInteractiveFrame).lang).toBeTruthy()
+    // `lang` must be the 2-letter base language for V2 plugin compatibility (CODAP-1219).
+    // `locale` carries the full BCP-47 locale for plugins that need region/script info.
+    expect((result.values as DIInteractiveFrame).lang).toBe(gLocale.currentBaseLanguage)
+    expect((result.values as DIInteractiveFrame).locale).toBe(gLocale.current)
   })
 
   it("update works", () => {

--- a/v3/src/data-interactive/handlers/interactive-frame-handler.ts
+++ b/v3/src/data-interactive/handlers/interactive-frame-handler.ts
@@ -39,7 +39,10 @@ export const diInteractiveFrameHandler: DIHandler = {
       subscribeToDocuments,
       title: interactiveFrame.title,
       version,
-      lang: gLocale.current
+      // 2-letter base language for V2 plugin compatibility; full locale in `locale`.
+      // See web-view.tsx for context.
+      lang: gLocale.currentBaseLanguage,
+      locale: gLocale.current
     }
     return { success: true, values }
   },

--- a/v3/src/utilities/translation/locale.test.ts
+++ b/v3/src/utilities/translation/locale.test.ts
@@ -5,7 +5,7 @@ describe("Locale.currentBaseLanguage", () => {
   // param and in `localeChanged` notifications. Sending a region-qualified locale like
   // `en-US` causes some plugins (e.g. Simmer) to crash during initialization since their
   // string tables are keyed by 2-letter codes only. See CODAP-1219.
-  it("returns the 2-letter base for a region-qualified locale", () => {
+  it("returns the 2-letter base for a locale with region or script subtag", () => {
     const locale = new Locale()
     locale.setCurrent("en-US")
     expect(locale.currentBaseLanguage).toBe("en")

--- a/v3/src/utilities/translation/locale.test.ts
+++ b/v3/src/utilities/translation/locale.test.ts
@@ -1,0 +1,25 @@
+import { Locale } from "./locale"
+
+describe("Locale.currentBaseLanguage", () => {
+  // Plugins built for V2 expect a 2-letter language code on the iframe `?lang=` query
+  // param and in `localeChanged` notifications. Sending a region-qualified locale like
+  // `en-US` causes some plugins (e.g. Simmer) to crash during initialization since their
+  // string tables are keyed by 2-letter codes only. See CODAP-1219.
+  it("returns the 2-letter base for a region-qualified locale", () => {
+    const locale = new Locale()
+    locale.setCurrent("en-US")
+    expect(locale.currentBaseLanguage).toBe("en")
+    locale.setCurrent("pt-BR")
+    expect(locale.currentBaseLanguage).toBe("pt")
+    locale.setCurrent("zh-Hans")
+    expect(locale.currentBaseLanguage).toBe("zh")
+  })
+
+  it("returns 2-letter locales unchanged", () => {
+    const locale = new Locale()
+    locale.setCurrent("ja")
+    expect(locale.currentBaseLanguage).toBe("ja")
+    locale.setCurrent("es")
+    expect(locale.currentBaseLanguage).toBe("es")
+  })
+})


### PR DESCRIPTION
## Summary
- V3 was passing the full BCP-47 locale (e.g. `en-US`) to plugin iframes via the `?lang=` query param and the `localeChanged` notification. V2 always sent the 2-letter base (`en`) via `SC.Locale.currentLanguage`.
- Some plugins (Simmer in particular) crash during initialization when given a region-qualified locale they don't have strings for, which prevents them from restoring saved state on document open.
- Switch the `lang` value (URL query param, `interactiveFrame.get` response, and `localeChanged` notification) to `gLocale.currentBaseLanguage` to restore V2 compatibility.
- Introduce a parallel `locale` parameter that carries the full BCP-47 locale (e.g. `en-US`, `zh-Hans`) so plugins that need region or script info can read it. `locale` appears alongside `lang` in the iframe URL (`?lang=en&locale=en-US`), the `interactiveFrame.get` response, and the `localeChanged` notification.
- Track `gLocale.current` (full locale) in the locale-change reaction so region/script-only changes (e.g. `zh-Hans` → `zh-TW`) reliably trigger iframe reload and notification.
- Defensively URL-encode values in the `setUrlQueryParam` string-manipulation fallback to match the `URLSearchParams` behavior on the absolute-URL path.
- Add unit tests for `Locale.currentBaseLanguage`, `appendLocaleParam`, and the encoding behavior.

Fixes CODAP-1219.

## Notes
This is less a V3 bug than a long-standing ambiguity in the CODAP↔plugin contract for the `lang` URL param. Simmer reads it narrowly as a 2-letter language code, V2 happened to always pass that, and so plugins built against V2 implicitly took on that interpretation. Sending only the language and not the region means plugins can't distinguish between regional variants of a language (e.g. CODAP currently supports both `zh-Hans` and `zh-TW`); a richer contract would be `lang` = full locale. But making `lang` mean "full locale" now would break every plugin that adopted Simmer's narrower reading. The compromise here keeps `lang` strictly 2-letter for V2 compatibility, and adds a separate `locale` parameter that carries the full BCP-47 locale for plugins that opt in.

## Test plan
- [ ] Open `χ² distribution simulation.codap` in V3 and confirm the saved Blockly workspace restores in the Simmer plugin
- [ ] Confirm Simmer no longer logs `Cannot read properties of undefined (reading 'simmer')` during plugin init
- [ ] Confirm the iframe URL has `?lang=en&locale=en-US` when CODAP locale is `en-US`
- [ ] Confirm `interactiveFrame.get` returns both `lang` (2-letter) and `locale` (full BCP-47)
- [ ] CI: `npm run lint` and `npm test` pass
- [ ] CI: full Cypress regression after `run regression` label is applied
