### PR TITLE
CODAP-1251: fix nested-button warning in case table tools menu

### DIFF
--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -108,15 +108,21 @@ const CaseTableToolShelfMenuList = observer(
               onClick={()=>createOrShowTableOrCardForDataset(dataset)} data-testid={`tool-shelf-table-${tileTitle}`}>
               <TableIcon className="menu-icon case-table-icon"/>
               {tileTitle}
-              <span className="menu-list-button tool-shelf-menu-trash" role="button"
-                  aria-label={t("DG.AppController.caseTableMenu.deleteDataSetToolTip")}
+              <span className="menu-list-button tool-shelf-menu-trash" role="button" tabIndex={0}
+                  aria-label={t("DG.AppController.caseTableMenu.deleteDataSetToolTip", { vars: [tileTitle] })}
                   onClick={(e) => {
                     e.stopPropagation()
                     handleOpenRemoveDataSetModal(dataset.dataSet.id)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      handleOpenRemoveDataSetModal(dataset.dataSet.id)
+                    }
                   }}>
                 <TrashIcon className="menu-icon" aria-hidden="true" />
               </span>
-
             </MenuItem>
           )
         })}

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -108,11 +108,14 @@ const CaseTableToolShelfMenuList = observer(
               onClick={()=>createOrShowTableOrCardForDataset(dataset)} data-testid={`tool-shelf-table-${tileTitle}`}>
               <TableIcon className="menu-icon case-table-icon"/>
               {tileTitle}
-              <Button className="menu-list-button tool-shelf-menu-trash"
+              <span className="menu-list-button tool-shelf-menu-trash" role="button"
                   aria-label={t("DG.AppController.caseTableMenu.deleteDataSetToolTip")}
-                  onClick={() => handleOpenRemoveDataSetModal(dataset.dataSet.id)}>
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleOpenRemoveDataSetModal(dataset.dataSet.id)
+                  }}>
                 <TrashIcon className="menu-icon" aria-hidden="true" />
-              </Button>
+              </span>
 
             </MenuItem>
           )

--- a/v3/src/components/tool-shelf/tool-shelf.scss
+++ b/v3/src/components/tool-shelf/tool-shelf.scss
@@ -284,6 +284,9 @@ $tool-shelf-border-width: 1px;
         &:active:not(:disabled) {
           background-color: vars.$icon-fill-medium;
         }
+        &:focus-visible {
+          @include vars.focus-outline();
+        }
 
         .menu-icon {
           margin: 0;

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -91,7 +91,7 @@
     "DG.AppController.caseTableMenu.openCaseTableToolTip": "Open case table for this data set",
     "DG.AppController.caseTableMenu.newDataSet": "Νew",
     "DG.AppController.caseTableMenu.newDataSetToolTip": "Create a new data set",
-    "DG.AppController.caseTableMenu.deleteDataSetToolTip": "Delete and destroy this data set",
+    "DG.AppController.caseTableMenu.deleteDataSetToolTip": "Delete and destroy data set %@",
     "DG.AppController.caseTableMenu.clipboardDataset": "Νew from clipboard",
     "DG.AppController.caseTableMenu.clipboardDatasetToolTip": "Paste data set from clipboard",
 


### PR DESCRIPTION
## Summary
- Fixes CODAP-1251.
- The trash-icon Button in `CaseTableToolShelfMenuList` was rendered inside a Chakra `MenuItem`, producing a `<button>` inside `<button>` and a `validateDOMNesting` console warning whenever the dataset list was non-empty (i.e. immediately after creating the first new table).
- The nested Button also let trash clicks bubble to the MenuItem's `onClick`, so deleting a dataset would also try to open it.
- Replaces the inner `<Button>` with a `<span role="button">` and adds `stopPropagation` on click — eliminates the DOM warning and the click-bubbling bug while preserving the existing styling.

### Accessibility (from accesslint audit)
- Adds `tabIndex={0}` and an `onKeyDown` handler for Enter/Space so the `role="button"` is honest to assistive tech (screen-reader users in browse/virtual-cursor mode can find and activate it).
- Includes the dataset name in the `aria-label` (`"Delete and destroy data set %@"`) so AT users hear which dataset the trash refers to.
- Adds a `:focus-visible` outline on `.menu-list-button` so the control has a visible focus indicator.

## Not in this PR (filed as CODAP-1288)
- **Sighted keyboard reachability of the trash control.** Chakra v2 Menu owns roving focus on its `MenuItem`s, so an inner focusable element is never reached from within the menu. Properly fixing this requires restructuring the per-dataset row into separate, independently focusable menu items (or a per-row sub-action menu) — a design-review-eligible change tracked as CODAP-1288.

## Test plan
- [ ] Open a new document, click the **Tables** tool button, choose **New Empty Dataset**.
- [ ] Open the **Tables** menu again and confirm the new dataset appears with the trash icon — and that the browser console has no `validateDOMNesting` warning.
- [ ] Click the trash icon — confirm the delete-dataset modal opens **without** also opening the table.
- [ ] Click the dataset row (away from the trash) — confirm the table opens as before.
- [ ] Screen reader: navigate to the trash via virtual cursor (e.g., NVDA browse mode) — confirm it announces "Delete and destroy data set *{name}*, button" and Enter activates the delete modal.
