### PR TITLE
CODAP-1295: fix plugin create notifications carrying wrong tile id

### DIFF
--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -62,12 +62,27 @@ const CaseTableToolShelfMenuList = observer(
       // the new tile is created at 0,0. The correct fix for this issue is to prevent scrolling to show the new table.
       // const options: INewTileOptions = { animateCreation: true, markNewlyCreated: true }
       const options: INewTileOptions = { markNewlyCreated: true }
-      tile = createDefaultTileOfType(kCaseTableTileType, options)
-      if (!tile) return
-      const { sharedData, sharedMetadata } = gDataBroker.addDataSet(ds, tile.id)
+      const orphanTile = createDefaultTileOfType(kCaseTableTileType, options)
+      if (!orphanTile) return
+      const { sharedData, sharedMetadata } = gDataBroker.addDataSet(ds, orphanTile.id)
       // Add dataset to the formula manager
       getFormulaManager(document)?.addDataSet(ds)
       createTableOrCardForDataset(sharedData, sharedMetadata, kCaseTableTileType, options)
+      // orphanTile is never inserted into a row — it exists only to (a) verify the
+      // case-table tile type is creatable and (b) seed sharedData.providerId via
+      // gDataBroker.addDataSet. The visible tile is created inside
+      // createTableOrCardForDataset and registered on sharedMetadata.
+      //
+      // Notify with the visible tile so plugins receive the id of the actual workspace
+      // component (otherwise highlight / { component: <id> } lookups by plugins fail —
+      // the orphan id resolves in tileMap but document.getElementById returns null).
+      //
+      // Note: sharedData.providerId is currently dead state — no reader exists in the
+      // codebase. So even though the orphan id is being stored there, it doesn't cause
+      // an observable bug today. A future cleanup could drop the orphan tile and
+      // sharedData.providerId entirely once we confirm nothing relies on the field.
+      const actualTileId = sharedMetadata.caseTableTileId
+      tile = actualTileId ? content.tileMap.get(actualTileId) : undefined
     }, {
       notify: [ dataContextCountChangedNotification, () => createTileNotification(tile) ],
       undoStringKey: "V3.Undo.caseTable.create",

--- a/v3/src/data-interactive/handlers/component-handler.test.ts
+++ b/v3/src/data-interactive/handlers/component-handler.test.ts
@@ -231,4 +231,26 @@ describe("DataInteractive ComponentHandler", () => {
       expect(uiState.focusedTile).toBe(graphTile.id)
     })
   })
+
+  it("broadcasts a create notification with the new tile's id (regression: notify callback timing)", () => {
+    // Bug 2 from CODAP-1231: `notify: createTileNotification(tile)` was evaluated
+    // immediately when the options literal was constructed — at which point `tile`
+    // was still undefined inside the actionFn closure. createTileNotification(undefined)
+    // returns undefined, so plugin-created components fired no create notification.
+    // The fix wraps it in a function: `notify: () => createTileNotification(tile)`,
+    // so it runs AFTER applyModelChange's actionFn assigns `tile`.
+    const broadcastSpy = jest.spyOn(documentContent, "broadcastMessage")
+
+    const result = handler.create!({}, { type: "graph" })
+    expect(result.success).toBe(true)
+    const newId = (result.values as DIComponentInfo).id
+
+    const createCall = broadcastSpy.mock.calls.find(([msg]) =>
+      msg?.values?.operation === "create" &&
+      msg?.values?.id === newId
+    )
+    expect(createCall).toBeDefined()
+
+    broadcastSpy.mockRestore()
+  })
 })

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -90,7 +90,10 @@ export const diComponentHandler: DIHandler = {
           }
         }
       }, {
-        notify: createTileNotification(tile)
+        // Wrap in a function so it runs AFTER applyModelChange's actionFn assigns `tile`.
+        // Evaluating createTileNotification(tile) inline would call it with tile=undefined,
+        // producing no notification (createTileNotification returns undefined for falsy tile).
+        notify: () => createTileNotification(tile)
       })
     }
 


### PR DESCRIPTION
## Summary

Extracts two plugin-API bug fixes from PR #2532 (CODAP-1231) so they can ship in V3.0.0 ahead of the stacked tour API rewrite, which targets a post-3.0.0 `cisco-tours` branch.

Both bugs caused plugin `{ component: <id> }` lookups to fail because the plugin received a tile id that didn't resolve to a workspace component:

- **Bug 1** (`case-table-tool-shelf-button.tsx`): `handleCreateNewCaseTable` was broadcasting the orphan tile id (used only as a `providerId` for `gDataBroker.addDataSet`) instead of the visible tile's id. The orphan tile is never inserted into the document, so plugin lookups via `document.getElementById` returned null. Fix: notify with `sharedMetadata.caseTableTileId`.
- **Bug 2** (`component-handler.ts`): `notify: createTileNotification(tile)` was evaluated immediately when the options object literal was constructed — `tile` was still `undefined` inside the `applyModelChange` actionFn closure, so `createTileNotification(undefined)` short-circuited and no create notification was emitted at all. Fix: wrap in a thunk so it runs after the actionFn assigns `tile`.

Includes a regression test for Bug 2 (`component-handler.test.ts`). Bug 1's regression test was deliberately not extracted from PR #2532 to minimize merge conflicts when the tour API rewrite eventually lands.

Fixes CODAP-1295.

## Test plan

- [ ] CI passes (lint, build, jest, cypress)
- [ ] Verify plugin highlight via `{ component: <id> }` works against a newly-created case table from the tool shelf
- [ ] Verify plugin highlight via `{ component: <id> }` works against a plugin-created component (graph, table, etc.)
