### PR TITLE
CODAP-1290: case card and formula observer reactivity

### DIFF
--- a/v3/src/components/case-card/case-attr-view.tsx
+++ b/v3/src/components/case-card/case-attr-view.tsx
@@ -36,6 +36,11 @@ export const CaseAttrView = observer(function CaseAttrView (props: ICaseAttrView
   const caseId = groupedCase?.__id__ ?? ""
   const cardModel = useCaseCardModel()
   const { data, metadata } = cardModel || {}
+  // Establish a MobX dependency on the attribute's mutation counter so this observer
+  // re-renders when values change (e.g. slider-driven formula recomputes). The data
+  // accessors below read non-observable volatile arrays. (CODAP-1290)
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  attr?.changeCount
   const cellStrValue = isCollectionSummarized
                         ? cardModel?.summarizedValues(attr, collection)
                         : data?.getStrValue(caseId, id)

--- a/v3/src/components/case-card/case-card-model.test.ts
+++ b/v3/src/components/case-card/case-card-model.test.ts
@@ -1,0 +1,79 @@
+import { reaction } from "mobx"
+import { createCodapDocument } from "../../models/codap/create-codap-document"
+import { toCanonical } from "../../models/data/data-set"
+import { linkTileToDataSet } from "../../models/document/data-set-linking"
+import { DataSetMetadata } from "../../models/shared/data-set-metadata"
+import { SharedDataSet } from "../../models/shared/shared-data-set"
+import { TileModel } from "../../models/tiles/tile-model"
+import { CaseCardModel } from "./case-card-model"
+import "./case-card-registration"
+
+function setupCardWithDataSet() {
+  const document = createCodapDocument(undefined, { noGlobals: true })
+  const cardContent = CaseCardModel.create()
+  const tile = TileModel.create({ content: cardContent })
+  document.addTile(tile)
+  const sharedDataSet = SharedDataSet.create()
+  document.content?.addSharedModel(sharedDataSet)
+  const sharedMetadata = DataSetMetadata.create()
+  document.content?.addSharedModel(sharedMetadata)
+  sharedMetadata.setData(sharedDataSet.dataSet)
+  linkTileToDataSet(tile, sharedDataSet.dataSet)
+  return { cardContent, data: sharedDataSet.dataSet }
+}
+
+describe("CaseCardModel reactivity", () => {
+  // CODAP-1290: Case card value displays don't update when values change externally
+  // (e.g. computed values updated by dragging a slider). The summarizedValues view
+  // must establish a MobX dependency that fires when underlying attribute values
+  // mutate so observers re-render.
+  it("summarizedValues reacts to numeric attribute value mutations", () => {
+    const { cardContent, data } = setupCardWithDataSet()
+    const xAttr = data.addAttribute({ name: "x" })
+    data.addCases(toCanonical(data, [{ x: 1 }, { x: 2 }, { x: 3 }]))
+    const collection = data.collections[0]
+
+    const summaryListener = jest.fn()
+    const dispose = reaction(
+      () => cardContent.summarizedValues(xAttr, collection),
+      () => summaryListener()
+    )
+
+    expect(cardContent.summarizedValues(xAttr, collection)).toBe("1-3")
+    expect(summaryListener).toHaveBeenCalledTimes(0)
+
+    // Simulate a slider-driven formula recompute mutating one case's value.
+    const firstCaseId = data.items[0].__id__
+    data.setComputedCaseValues([{ __id__: firstCaseId, [xAttr.id]: 99 }], [xAttr.id])
+
+    expect(cardContent.summarizedValues(xAttr, collection)).toBe("2-99")
+    expect(summaryListener).toHaveBeenCalledTimes(1)
+
+    dispose()
+  })
+
+  it("summarizedValues reacts to categorical attribute value mutations", () => {
+    const { cardContent, data } = setupCardWithDataSet()
+    const cAttr = data.addAttribute({ name: "color" })
+    data.addCases(toCanonical(data, [{ color: "red" }, { color: "red" }, { color: "blue" }]))
+    data.validateCases()
+    const collection = data.collections[0]
+
+    const summaryListener = jest.fn()
+    const dispose = reaction(
+      () => cardContent.summarizedValues(cAttr, collection),
+      () => summaryListener()
+    )
+
+    expect(cardContent.summarizedValues(cAttr, collection)).toBe("red, blue")
+    expect(summaryListener).toHaveBeenCalledTimes(0)
+
+    const lastCaseId = data.items[2].__id__
+    data.setComputedCaseValues([{ __id__: lastCaseId, [cAttr.id]: "green" }], [cAttr.id])
+
+    expect(cardContent.summarizedValues(cAttr, collection)).toBe("red, green")
+    expect(summaryListener).toHaveBeenCalledTimes(1)
+
+    dispose()
+  })
+})

--- a/v3/src/components/case-card/case-card-model.ts
+++ b/v3/src/components/case-card/case-card-model.ts
@@ -72,6 +72,11 @@ export const CaseCardModel = TileContentModel
         .filter(groupedCase => !!groupedCase)
     },
     summarizedValues(attr: IAttribute, collection: ICollectionModel) {
+      // Establish a MobX dependency on the attribute's mutation counter so this view
+      // re-evaluates when individual values change. Volatile strValues/numValues are
+      // not deep-observable; changeCount is bumped by setValue/setComputedValues.
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      attr.changeCount
       // Returns a string summarizing the selected values of the attribute
       if (attr.isNumeric) {
         const numericValues = attr.numValues.filter((_v, i) => attr.isValueNumeric(i))

--- a/v3/src/models/formula/formula-manager.test.ts
+++ b/v3/src/models/formula/formula-manager.test.ts
@@ -2,9 +2,13 @@ import { observable, runInAction } from "mobx"
 import { castToSnapshot, types } from "mobx-state-tree"
 import { DataSet, IDataSet } from "../data/data-set"
 import { createDataSet } from "../data/data-set-conversion"
+import { GlobalValue } from "../global/global-value"
+import { GlobalValueManager } from "../global/global-value-manager"
 import { Formula, IFormula } from "./formula"
 import { FormulaManager } from "./formula-manager"
-import { CASE_INDEX_FAKE_ATTR_ID, idToCanonical, localAttrIdToCanonical } from "./utils/name-mapping-utils"
+import {
+  CASE_INDEX_FAKE_ATTR_ID, globalValueIdToCanonical, idToCanonical, localAttrIdToCanonical
+} from "./utils/name-mapping-utils"
 import { AttributeFormulaAdapter } from "./attribute-formula-adapter"
 
 const formulaDisplay = "1 + 2 + foo"
@@ -157,6 +161,44 @@ describe("FormulaManager", () => {
         const newAttr = dataSet.attrFromName("foo")
         expect(formula.display).toEqual("1 + 2 + foo")
         expect(formula.canonical).toEqual(`1 + 2 + ${localAttrIdToCanonical(newAttr?.id || "")}`)
+        expect(adapter.recalculateFormula).toHaveBeenCalledTimes(3)
+      })
+    })
+
+    // CODAP-1290 follow-up: when a formula references a global by name and the global is created
+    // afterward, the formula's canonical form is updated and a recalculation is triggered, but
+    // subsequent global-value changes are missed because the formula's static dependency list was
+    // captured at registration time when the global did not exist.
+    describe("when a global value referenced by name is added after the formula", () => {
+      it("recalculates the formula when the newly-added global's value subsequently changes", () => {
+        const formulaManager = new FormulaManager()
+        const dataSet = createDataSet({ name: "Cases", attributes: [{ name: "result" }] })
+        const formula = Formula.create({ display: "slider1 + 1" })
+        Container.create({
+          dataSet: castToSnapshot(dataSet),
+          formula
+        }, { formulaManager })
+        const adapter = getFakeAdapter(formula, dataSet)
+        const globalValueManager = GlobalValueManager.create()
+        formulaManager.addDataSet(dataSet)
+        formulaManager.addGlobalValueManager(globalValueManager)
+        formulaManager.addAdapters([adapter])
+
+        // Slider doesn't exist yet — `slider1` is unresolved in the canonical form.
+        expect(formula.canonical).toEqual("slider1 + 1")
+        expect(adapter.recalculateFormula).toHaveBeenCalledTimes(1)
+
+        // Add the slider as a global value. The formula's canonical form should be re-resolved
+        // (this part already works) and the formula recalculates once.
+        const slider = GlobalValue.create({ name: "slider1", _value: 5 })
+        globalValueManager.addValue(slider)
+        expect(formula.canonical).toEqual(`${globalValueIdToCanonical(slider.id)} + 1`)
+        expect(adapter.recalculateFormula).toHaveBeenCalledTimes(2)
+
+        // The bug: changing the slider's value should now trigger a recalculation, but the
+        // formula's global-value observer was registered with no dependencies (the slider didn't
+        // exist at registration time), so the change is silently missed.
+        slider.setValue(10)
         expect(adapter.recalculateFormula).toHaveBeenCalledTimes(3)
       })
     })

--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -348,6 +348,11 @@ export class FormulaManager implements IFormulaManager {
       const oldCanonical = formula.canonical
       this.updateFormulaCanonicalExpression(formulaId)
       if (oldCanonical !== formula.canonical) {
+        // The dependency set may have changed (e.g. a previously-unresolved symbol now
+        // resolves to a newly-added global value or attribute). Tear down and re-register
+        // observers from the new canonical form so subsequent value changes are tracked.
+        this.formulaMetadata.get(formulaId)?.dispose?.()
+        this.setupFormulaObservers(formulaId)
         this.recalculateFormula(formula.id)
       }
     }


### PR DESCRIPTION
## Summary

Fixes CODAP-1290 — case card values (both per-case and summary) didn't update when values were changed externally (e.g. by dragging a slider that drives a formula). Two distinct issues were uncovered during investigation, fixed in two commits:

- **Case card reactivity** (commit 1): the per-element value accessors on `Attribute` (`strValue`, `value`, `numValue`) read volatile arrays whose mutations are not deeply observable. The case card relied on `observer()` to refresh, so reads silently registered no MobX dependency. Touched `attr.changeCount` in `CaseAttrView` and `summarizedValues` so the existing mutation counter (already tracked by `length` and `type`) drives re-evaluation. Avoids imposing tracking overhead on hot graph / map / collection paths that share the accessors.

- **Formula observer registration** (commit 2): if a formula referenced a global value by name before that global existed (e.g. formula authored before a slider was created), the formula's static dependency list was captured empty at registration time. Adding the global later correctly re-resolved the canonical form and triggered a one-shot recalc, but the dependency-keyed observers were never refreshed — subsequent value changes were silently missed. `setupFormulaObservers`'s `updateDisplay` closure now disposes and re-registers observers when the canonical form changes.

## Test plan

- [x] Unit tests added for both fixes (`case-card-model.test.ts`; `formula-manager.test.ts` new "global value referenced by name added after the formula" case)
- [x] `npm test -- formula` (460/460 pass) and `npm test -- case-card` (9/9 pass)
- [x] `npm run lint` and `npm run build:tsc` clean
- [ ] Manual verification in dev server: open a case card on a slider-driven formula attribute, drag the slider, confirm both the displayed value and (where applicable) the summary update
- [ ] Manual verification of the formula-after-slider scenario: create slider first → formula should update on drag; then create formula first → slider afterward → formula should still update on drag (the second commit's fix)
- [ ] Cypress regression run via `run regression` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
