### PR TITLE
CODAP-1296: fix calculator display when result matches prior value

### DIFF
--- a/v3/cypress/e2e/calculator.spec.ts
+++ b/v3/cypress/e2e/calculator.spec.ts
@@ -104,6 +104,12 @@ context("Calculator", () => {
     calc.typeExpression("+5{enter}")
     calc.checkCalculatorDisplay("15")
   })
+  it("collapses expression when new result equals the previous result", () => {
+    calc.typeExpression("2*0{enter}")
+    calc.checkCalculatorDisplay("0")
+    calc.typeExpression("*0{enter}")
+    calc.checkCalculatorDisplay("0")
+  })
   it("clears with Escape key", () => {
     calc.typeExpression("123")
     calc.checkCalculatorDisplay("123")

--- a/v3/src/components/calculator/calculator.tsx
+++ b/v3/src/components/calculator/calculator.tsx
@@ -96,6 +96,9 @@ export const CalculatorComponent = ({ tile }: ITileBaseProps) => {
       const compiled = math.compile(canonicalFormula)
       const solution = compiled.evaluate({ "π": Math.PI })
       const solutionStr = String(solution)
+      // Update local state explicitly: model sync won't trigger if model value is unchanged
+      // (e.g. evaluating 0*0 when previous result was already 0).
+      setCalcValue(solutionStr)
       if (isValidModel) {
         calculatorModel?.applyModelChange(() => {
           calculatorModel.setValue(solutionStr)
@@ -107,6 +110,7 @@ export const CalculatorComponent = ({ tile }: ITileBaseProps) => {
       }
     } catch (error: any) {
       const errorMessage = error?.message ? `#${error.message}` : "#Error"
+      setCalcValue(errorMessage)
       if (isValidModel) {
         calculatorModel?.applyModelChange(() => {
           calculatorModel.setValue(errorMessage)


### PR DESCRIPTION
## Summary
- Calculator's display string is synced from the model via an autorun, which fires only when the model value changes. When a new expression evaluates to the same string already in the model (e.g. `0*0` after `2*0=0`), the autorun didn't fire and the display kept showing the typed expression instead of collapsing to the result.
- Set the local display state explicitly in the evaluate path, matching the existing pattern in `clearValue`.
- Adds a Cypress test that reproduces the bug.

Fixes [CODAP-1296](https://concord-consortium.atlassian.net/browse/CODAP-1296).

## Test plan
- [ ] Open the Calculator
- [ ] Type `2*0` then Enter — display collapses to `0`
- [ ] Type `*0` then Enter — display collapses to `0` (was: stuck on `0*0`)
- [ ] Cypress `calculator.spec.ts` passes (locally: 17/17 ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CODAP-1296]: https://concord-consortium.atlassian.net/browse/CODAP-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ