### PR TITLE
CODAP-1272: keep inspector palette open when color popover dismisses

### DIFF
--- a/v3/src/components/data-display/inspector/point-color-setting.tsx
+++ b/v3/src/components/data-display/inspector/point-color-setting.tsx
@@ -68,12 +68,15 @@ export const PointColorSetting = observer(function PointColorSetting({ closeTrig
         <div className="color-picker-thumb-swatch"
           style={{ "--swatch-color": swatchBackgroundColor } as React.CSSProperties} />
       </Button>
+      {/* isNonModal so React Aria doesn't render a viewport-covering underlay; the underlay
+          intercepts outside clicks and would close the surrounding inspector palette. */}
       <Popover
         ref={popoverRef}
         className={({defaultClassName}) => `${defaultClassName} color-picker-popover`}
         shouldFlip={false}
         offset={popoverOffset}
         aria-label={t("V3.Inspector.colorPicker.dialogLabel")}
+        isNonModal
       >
         <ColorPickerPalette swatchBackgroundColor={swatchBackgroundColor} onColorChange={onColorChange}
           inputValue={inputValue} onUpdateValue={updateValue}


### PR DESCRIPTION
## Summary
- Set the color picker `<Popover>` (point/stroke/background colors) to `isNonModal` so React Aria doesn't render a full-viewport underlay that swallows outside clicks.
- Without the underlay, an outside click reaches its real target (e.g., a label inside the format palette). The InspectorPanel's `useOutsidePointerDown` then sees the click as *inside* its ref and correctly leaves the palette open. Only the popover dismisses.

Fixes [CODAP-1272](https://concord-consortium.atlassian.net/browse/CODAP-1272). Regression from CODAP-1150 (Chakra → React Aria color picker migration).

## Test plan
- [ ] Open a graph, click Format, click a color swatch (point, stroke, or background).
- [ ] Click somewhere else inside the format palette (e.g., the palette header, a label, the "Stroke same color as fill" checkbox).
- [ ] Confirm only the color popover closes; the format palette stays open.
- [ ] Click outside the inspector panel entirely — both the popover and the format palette close (existing behavior).
- [ ] Repeat on a map: open layers menu, change layer color, click elsewhere in the layers menu.
- [ ] Press Escape while popover is open — popover closes, palette stays open.
- [ ] Verify CI Cypress tests pass (especially graph format-related specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CODAP-1272]: https://concord-consortium.atlassian.net/browse/CODAP-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ