### PR TITLE
CODAP-1297: keep missing-value cases hidden after undoing axis attribute change

### DIFF
--- a/v3/doc/dataset-validation-and-reactivity.md
+++ b/v3/doc/dataset-validation-and-reactivity.md
@@ -62,6 +62,14 @@ DataSet, CollectionModel, Attribute, and DataSetMetadata are MST models.
 FilteredCases is a plain class that uses MobX decorators directly.
 CategorySet is an MST model with private MobX state.
 
+Downstream consumers — notably `DataConfigurationModel` (the graph/dataConfig
+layer that owns `FilteredCases` instances) — are out of scope for this doc,
+but exhibit the same reactivity patterns and run into the same classes of
+bugs: their own observable state (e.g. `_attributeDescriptions`) can be
+mutated by patch-driven paths that bypass the action wrappers that would
+otherwise invalidate caches. CODAP-1297 is the canonical example (see
+Worked examples).
+
 ## The case-validation pipeline
 
 Whenever items, hidden flags, filter results, or grouping-attribute values
@@ -159,6 +167,19 @@ observable-write happens only inside `invalidate()` (which callers must
 invoke from an action), and the getter has no side effects on observables
 at all. Prefer `observableCachedFnFactory` when adding a new derived value
 that has its own invalidation lifecycle.
+
+A fourth, lighter-weight variant trades the dedicated version counter for a
+derived snapshot. A getter like
+`attributeDescriptionsStr = JSON.stringify(this.attributeDescriptions)` on
+`DataConfigurationModel` (or `caseDataHash` on the same model) exposes the
+*contents* of a small observable structure as a primitive that is cheap to
+compare. Reactions that observe it fire on any change — value, structure,
+or otherwise — without anyone having to remember to bump a counter. Use
+this when there is no dedicated version, the source is a small-ish
+observable structure (a map, an array of descriptions), and the reaction
+consumer wants "fire on any change to this state, regardless of how it
+changed." The cost is JSON recomputation on every underlying change — fine
+for small structures, not for large ones.
 
 ### `CollectionModel`
 
@@ -548,6 +569,36 @@ correctly.
 **General lesson.** "Read a value off an Attribute" is a non-reactive
 operation. To make it reactive, depend on `changeCount`.
 
+### Graph dataConfig FilteredCases stale after axis-attribute undo (CODAP-1297)
+
+**Symptom.** After replacing an axis attribute on a graph and clicking
+undo, dots for cases with missing values on the restored attribute didn't
+disappear — they piled up at the axis edge.
+
+**Why.** `DataConfigurationModel.setAttribute` (an MST action) mutates
+`_attributeDescriptions` *and* calls `FilteredCases.invalidateCases()` to
+bump `_caseIdsVersion`. MST undo replays the patches via `applyPatch`
+against `_attributeDescriptions` directly (`tree.ts:144`), bypassing the
+action wrapper. The version counter wasn't bumped, so the cached `caseIds`
+— computed against the *previous* attribute — stayed valid; cases that
+should now be filtered out (NaN values on the restored attribute) remained
+in the array and got plotted with NaN → axis-edge.
+
+**Fix (PR #2560).** Add reactions that close the loop regardless of how
+`_attributeDescriptions` changes. In `DataConfigurationModel`, generalize
+the existing legend-only reaction to watch `attributeDescriptionsStr` (a
+JSON-stringified snapshot) and call `invalidateCases()`. The graph
+subclass overrides `attributeDescriptionsStr` to omit `y[1+]` and
+`rightNumeric`, so the subclass's existing `allYAttributeDescriptions`
+reaction also gets an `invalidateCases()` call.
+
+**General lesson.** If an action both mutates state *and* invalidates a
+downstream cache, add a reaction on the mutated state. The action's
+explicit call still has a job (synchronous invalidation for nested-action
+callers — the reaction is queued until the outer action ends) but it can
+no longer be the sole guarantor of cache freshness. Undo and any other
+patch-driven path will desync the action and the cache.
+
 ## Common pitfalls
 
 1. **Reading `attribute.strValues[i]` or `numValues[i]` in an observer.**
@@ -590,6 +641,15 @@ operation. To make it reactive, depend on `changeCount`.
 7. **Mutating `setAsideItemIds` outside an action.** The `onPatch` handler
    keeps a mirror set in sync and triggers `invalidateCases`; mutations
    from outside an action skip the patch and desynchronize the mirror.
+
+8. **Relying on an action wrapper to invalidate a downstream cache when
+   undo may bypass it.** If an MST action both mutates state and
+   explicitly calls `invalidateCases()` (or any sibling cache-version
+   bump) on a derived consumer, undo's `applyPatch` replays the state
+   mutation but skips the action body — so the explicit call never fires
+   and the cache silently desyncs. Pair the explicit call with a reaction
+   on the mutated state so the loop closes regardless of how the mutation
+   arrived. (See worked example: CODAP-1297.)
 
 ## Reference: which methods invalidate, and how
 

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -1004,13 +1004,14 @@ export const DataConfigurationModel = types
           equals: comparer.structural
         }
       ))
-      // respond to change of legend attribute
+      // respond to change of any attribute description (including via undo/redo, which
+      // bypasses the setAttribute action that would otherwise call invalidateCases)
       addDisposer(self, reaction(
-        () => JSON.stringify(self.attributeDescriptionForRole("legend")),
+        () => self.attributeDescriptionsStr,
         () => {
           self.invalidateCases()
         },
-        {name: "DataConfigurationModel.afterCreate.reaction [legend attribute]"}
+        {name: "DataConfigurationModel.afterCreate.reaction [attribute descriptions]"}
       ))
       // Invalidate cases when items change in data set.
       addDisposer(self, reaction(

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -1,5 +1,5 @@
 import { reaction } from "mobx"
-import {Instance, types} from "mobx-state-tree"
+import {applyPatch, Instance, types} from "mobx-state-tree"
 import { DataSet, toCanonical } from "../../../models/data/data-set"
 import {DataSetMetadata} from "../../../models/shared/data-set-metadata"
 import { kMain } from "../../data-display/data-display-types"
@@ -341,6 +341,48 @@ describe("DataConfigurationModel", () => {
     expect(config.columnCases({})).toEqual([])
     expect(config.columnCases({ nId: "n1" })).toEqual(caseIdsFromItemIds(["c1"]))
     expect(config.columnCases({ nId: "n3" })).toEqual(caseIdsFromItemIds(["c3"]))
+  })
+
+  it("invalidates filteredCases when _attributeDescriptions mutate without setAttribute (CODAP-1297)", () => {
+    // Regression: MST undo replays patches that mutate _attributeDescriptions directly,
+    // bypassing setAttribute()'s call to invalidateCases(). A reaction on
+    // attributeDescriptionsStr must catch this so cached caseIds are recomputed.
+    const config = tree.config
+    config.setDataset(tree.data, tree.metadata)
+
+    config.setAttribute("x", { attributeID: "xId", type: "numeric" })
+    expect(config.filteredCases[0].caseIds).toEqual(caseIdsFromItemIds(["c1", "c2"]))
+
+    config.setAttribute("x", { attributeID: "yId", type: "numeric" })
+    expect(config.filteredCases[0].caseIds).toEqual(caseIdsFromItemIds(["c1", "c3"]))
+
+    // Simulate undo: mutate the underlying map directly, the way an MST patch replay would.
+    config._setAttributeDescription("x", { attributeID: "xId", type: "numeric" })
+    expect(config.filteredCases[0].caseIds).toEqual(caseIdsFromItemIds(["c1", "c2"]))
+  })
+
+  it("invalidates filteredCases for y[1+] when patch replay replaces it in place (CODAP-1297)", () => {
+    // Regression: when MST undo replays a JSON patch that replaces _yAttributeDescriptions[i]
+    // in place, FilteredCases at that index isn't destroyed/recreated and its cache must be
+    // invalidated. The parent class reaction on attributeDescriptionsStr only covers y[0];
+    // y[1+] needs invalidation via the graph subclass's allYAttributeDescriptions reaction.
+    const config = tree.config
+    config.setDataset(tree.data, tree.metadata)
+
+    config.setAttribute("x", { attributeID: "xId", type: "numeric" })
+    config.setAttribute("y", { attributeID: "yId", type: "numeric" })
+    config.addYAttribute({ attributeID: "xId", type: "numeric" })
+    // y[1] = xId: requires xId valid (c1, c2) and x = xId valid (c1, c2) → c1, c2
+    expect(config.filteredCases[1].caseIds).toEqual(caseIdsFromItemIds(["c1", "c2"]))
+
+    // Simulate undo: replace _yAttributeDescriptions[1] in place via MST patch.
+    applyPatch(config, {
+      op: "replace",
+      path: "/_yAttributeDescriptions/1",
+      value: { attributeID: "yId", type: "numeric" }
+    })
+    // y[1] = yId: requires yId valid (c1, c3) and x = xId valid (c1, c2) → c1
+    expect(config.filteredCases[1].caseIds).toEqual(caseIdsFromItemIds(["c1"]))
   })
 
   it("can create cell key", () => {

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -356,8 +356,12 @@ describe("DataConfigurationModel", () => {
     config.setAttribute("x", { attributeID: "yId", type: "numeric" })
     expect(config.filteredCases[0].caseIds).toEqual(caseIdsFromItemIds(["c1", "c3"]))
 
-    // Simulate undo: mutate the underlying map directly, the way an MST patch replay would.
-    config._setAttributeDescription("x", { attributeID: "xId", type: "numeric" })
+    // Simulate undo: replace _attributeDescriptions/x in place via MST patch.
+    applyPatch(config, {
+      op: "replace",
+      path: "/_attributeDescriptions/x",
+      value: { attributeID: "xId", type: "numeric" }
+    })
     expect(config.filteredCases[0].caseIds).toEqual(caseIdsFromItemIds(["c1", "c2"]))
   })
 

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -913,10 +913,16 @@ export const GraphDataConfigurationModel = DataConfigurationModel
           () => self.clearCasesCache(),
           { name: "GraphDataConfigurationModel primaryRole reaction" }
         ))
-        // synchronize filteredCases with attribute configuration
+        // synchronize filteredCases with attribute configuration. Also invalidate cases so that
+        // y[1+]/rightNumeric replacements (especially via undo, which bypasses setAttribute's
+        // invalidateCases) recompute their filtered caseIds; the parent class only watches
+        // attributeDescriptionsStr, which omits y[1+] and rightNumeric.
         addDisposer(self, reaction(
           () => self.allYAttributeDescriptions,
-          (allYAttributeDescriptions) => self.synchronizeFilteredCases(allYAttributeDescriptions),
+          (allYAttributeDescriptions) => {
+            self.synchronizeFilteredCases(allYAttributeDescriptions)
+            self.invalidateCases()
+          },
           { name: "GraphDataConfigurationModel yAttrDescriptions reaction", equals: comparer.structural }
         ))
         addDisposer(self, reaction(


### PR DESCRIPTION
## Summary

Fixes CODAP-1297. After replacing an axis attribute on a graph and clicking undo, dots for cases with missing values on the restored attribute did not disappear — they piled up at the axis edge.

## Root cause

`DataConfigurationModel.setAttribute()` calls `invalidateCases()` on the FilteredCases cache, but MST undo replays patches directly against `_attributeDescriptions`, bypassing that action wrapper. The cache stayed populated with caseIds computed against the *previous* attribute, so cases that were valid on the post-redo attribute (e.g. Height) but missing on the restored attribute (e.g. Sleep) remained in the array and got plotted with the restored numeric scale, where their NaN values mapped to the axis edge.

## Fix

Two reactions, one in the parent class and one in the graph subclass, are now responsible for cache invalidation regardless of how `_attributeDescriptions` / `_yAttributeDescriptions` are mutated:

- `data-configuration-model.ts`: generalized the existing legend-only reaction to watch `attributeDescriptionsStr`. Covers x, y[0], legend, caption, splits, lat, long, polygon — including attribute *type* changes (the JSON includes `type`).
- `graph-data-configuration-model.ts`: added `invalidateCases()` to the existing `allYAttributeDescriptions` reaction, which already watched the same data for `synchronizeFilteredCases`. Covers y[1+] and rightNumeric, which the parent class's reaction excludes.

## Tests

Two regression tests in `graph-data-configuration-model.test.ts` simulate MST patch replay (the actual undo mechanism — see `tree.ts:144`) — one for the user's exact repro on x, one for the multi-y / rightNumeric case. Both confirmed to fail without the fix and pass with it.

## Test plan

- [x] Manual repro verified in the browser (Mammals dataset, Lifespan/y, Sleep/x → replace x with Height → undo)
- [x] All Jest tests pass (2891)
- [x] Lint and TypeScript clean
- [ ] CI Cypress regression suite (will trigger once draft is moved to Ready for Review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
