### PR TITLE
CODAP-1307: don't echo DI-API component changes back to source plugin

### DIFF
--- a/v3/src/components/slider/use-slider-axis-animation.ts
+++ b/v3/src/components/slider/use-slider-axis-animation.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react"
 import { isAlive } from "mobx-state-tree"
-import { IApplyModelChangeOptions } from "../../models/history/apply-model-change"
+import { IApplyModelChangeOptions } from "../../models/history/history-service"
 import { ISliderModel } from "./slider-model"
 
 const kAnimationDuration = 500 // ms

--- a/v3/src/data-interactive/handlers/component-handler.test.ts
+++ b/v3/src/data-interactive/handlers/component-handler.test.ts
@@ -253,4 +253,79 @@ describe("DataInteractive ComponentHandler", () => {
 
     broadcastSpy.mockRestore()
   })
+
+  describe("excludes source plugin from broadcast (CODAP-1307)", () => {
+    // Story Builder treats notifications about its own DI-API actions as document edits and
+    // marks the current moment as unsaved. When resources.interactiveFrame is the requesting
+    // plugin's tile, the create / update / delete handlers should pass excludeTileId so the
+    // broadcast skips that tile.
+
+    it("create passes excludeTileId from resources.interactiveFrame", () => {
+      // Use any tile to stand in for the plugin's interactive frame — the handler only reads its id.
+      const pluginTile = createTile("graph", kGraphIdPrefix)
+      const broadcastSpy = jest.spyOn(documentContent, "broadcastMessage")
+
+      const result = handler.create!({ interactiveFrame: pluginTile }, { type: "graph" })
+      expect(result.success).toBe(true)
+      const newId = (result.values as DIComponentInfo).id
+
+      const createCall = broadcastSpy.mock.calls.find(([msg]) =>
+        msg?.values?.operation === "create" && msg?.values?.id === newId
+      )
+      expect(createCall).toBeDefined()
+      // 4th arg of broadcastMessage is excludeTileId
+      expect(createCall?.[3]).toBe(pluginTile.id)
+
+      broadcastSpy.mockRestore()
+    })
+
+    it("delete passes excludeTileId from resources.interactiveFrame", () => {
+      const pluginTile = createTile("graph", kGraphIdPrefix)
+      const targetTile = createTile("graph", kGraphIdPrefix)
+      const broadcastSpy = jest.spyOn(documentContent, "broadcastMessage")
+
+      const result = handler.delete?.({ interactiveFrame: pluginTile, component: targetTile })
+      expect(result?.success).toBe(true)
+
+      const deleteCall = broadcastSpy.mock.calls.find(([msg]) =>
+        msg?.values?.operation === "delete"
+      )
+      expect(deleteCall).toBeDefined()
+      expect(deleteCall?.[3]).toBe(pluginTile.id)
+
+      broadcastSpy.mockRestore()
+    })
+
+    it("update on a different component passes excludeTileId from resources.interactiveFrame", () => {
+      const pluginTile = createTile("graph", kGraphIdPrefix)
+      const targetTile = createTile("graph", kGraphIdPrefix)
+      const broadcastSpy = jest.spyOn(documentContent, "broadcastMessage")
+
+      const result = handler.update?.({ interactiveFrame: pluginTile, component: targetTile }, { name: "Renamed" })
+      expect(result?.success).toBe(true)
+
+      const updateCall = broadcastSpy.mock.calls.find(([msg]) =>
+        msg?.values?.operation === "update"
+      )
+      expect(updateCall).toBeDefined()
+      expect(updateCall?.[3]).toBe(pluginTile.id)
+
+      broadcastSpy.mockRestore()
+    })
+
+    it("update on self sends no notification (existing self-update suppression preserved)", () => {
+      const tile = createTile("graph", kGraphIdPrefix)
+      const broadcastSpy = jest.spyOn(documentContent, "broadcastMessage")
+
+      const result = handler.update?.({ interactiveFrame: tile, component: tile }, { name: "Renamed" })
+      expect(result?.success).toBe(true)
+
+      const updateCall = broadcastSpy.mock.calls.find(([msg]) =>
+        msg?.values?.operation === "update"
+      )
+      expect(updateCall).toBeUndefined()
+
+      broadcastSpy.mockRestore()
+    })
+  })
 })

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -53,7 +53,7 @@ export function registerComponentHandler(type: string, handler: DIComponentHandl
 }
 
 export const diComponentHandler: DIHandler = {
-  create(_resources: DIResources, values?: DIValues) {
+  create(resources: DIResources, values?: DIValues) {
     if (!values) return valuesRequiredResult
 
     const { type, cannotClose, dimensions, position, name, title: _title } = values as V2Component
@@ -93,7 +93,11 @@ export const diComponentHandler: DIHandler = {
         // Wrap in a function so it runs AFTER applyModelChange's actionFn assigns `tile`.
         // Evaluating createTileNotification(tile) inline would call it with tile=undefined,
         // producing no notification (createTileNotification returns undefined for falsy tile).
-        notify: () => createTileNotification(tile)
+        notify: () => createTileNotification(tile),
+        // Don't echo the create back to the requesting plugin — Story Builder otherwise treats
+        // notifications about its own DI-API actions as document edits and marks the current
+        // moment as unsaved (CODAP-1307).
+        excludeTileId: resources.interactiveFrame?.id
       })
     }
 
@@ -108,7 +112,8 @@ export const diComponentHandler: DIHandler = {
     document.applyModelChange(() => {
       document.content?.deleteOrHideTile(component.id)
     }, {
-      notify: deleteTileNotification(component)
+      notify: deleteTileNotification(component),
+      excludeTileId: resources.interactiveFrame?.id
     })
 
     return { success: true }
@@ -184,8 +189,14 @@ export const diComponentHandler: DIHandler = {
 
     // We don't want to notify if the request to update is coming from the component itself. Doing so causes
     // Story Builder to mark the selected moment as changed.
+    // Also exclude the requesting plugin from cross-component updates (e.g. Story Builder updating its
+    // narrative text box) so it doesn't receive an echo of its own action — same root cause as
+    // CODAP-1307.
     const options = resources.interactiveFrame?.id === component.id ? { }
-      : { notify: updateTileNotification("update", values, component) }
+      : {
+          notify: updateTileNotification("update", values, component),
+          excludeTileId: resources.interactiveFrame?.id
+        }
     let result: DIHandlerFnResult | undefined
     component.applyModelChange(() => {
       if (!values || typeof values !== "object" || Array.isArray(values)) return

--- a/v3/src/data-interactive/notification-core-types.ts
+++ b/v3/src/data-interactive/notification-core-types.ts
@@ -32,6 +32,7 @@ export interface ICoreNotifyFunctionEnv {
   notify: (
     message: ICoreNotification["message"],
     callback: NotificationCallback,
-    notifyTileId?: string
+    notifyTileId?: string,
+    excludeTileId?: string
   ) => void
 }

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -56,8 +56,8 @@ export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
   }
 
   // configure notifications
-  fullEnvironment.notify = function(message, callback, targetTileId) {
-    document.content?.broadcastMessage(message, callback, targetTileId)
+  fullEnvironment.notify = function(message, callback, targetTileId, excludeTileId) {
+    document.content?.broadcastMessage(message, callback, targetTileId, excludeTileId)
   }
 
   historyService.setDependencies(fullEnvironment)

--- a/v3/src/models/document/document-content.test.ts
+++ b/v3/src/models/document/document-content.test.ts
@@ -34,4 +34,48 @@ describe("DocumentContent", () => {
     expect(ds?.attributes.length).toBe(2)
     expect(ds?.items.length).toBe(2)
   })
+
+  describe("broadcastMessage", () => {
+    const message = { action: "notify", resource: "componentChangeNotice", values: {} } as any
+
+    it("broadcasts to every tile when no targetTileId or excludeTileId is given", () => {
+      const tile1 = content.createTile("Test")!
+      const tile2 = content.createTile("Test")!
+      const spy1 = jest.spyOn(tile1.content, "broadcastMessage")
+      const spy2 = jest.spyOn(tile2.content, "broadcastMessage")
+
+      content.broadcastMessage(message, () => {})
+
+      expect(spy1).toHaveBeenCalledTimes(1)
+      expect(spy2).toHaveBeenCalledTimes(1)
+    })
+
+    it("skips the tile specified by excludeTileId (CODAP-1307)", () => {
+      const tile1 = content.createTile("Test")!
+      const tile2 = content.createTile("Test")!
+      const tile3 = content.createTile("Test")!
+      const spy1 = jest.spyOn(tile1.content, "broadcastMessage")
+      const spy2 = jest.spyOn(tile2.content, "broadcastMessage")
+      const spy3 = jest.spyOn(tile3.content, "broadcastMessage")
+
+      content.broadcastMessage(message, () => {}, undefined, tile2.id)
+
+      expect(spy1).toHaveBeenCalledTimes(1)
+      expect(spy2).not.toHaveBeenCalled()
+      expect(spy3).toHaveBeenCalledTimes(1)
+    })
+
+    it("excludeTileId can suppress delivery to a tile that would otherwise be the broadcast target", () => {
+      const tile1 = content.createTile("Test")!
+      const tile2 = content.createTile("Test")!
+      const spy1 = jest.spyOn(tile1.content, "broadcastMessage")
+      const spy2 = jest.spyOn(tile2.content, "broadcastMessage")
+
+      // targetTileId limits delivery to tile2; excludeTileId then skips tile2 — nothing receives.
+      content.broadcastMessage(message, () => {}, tile2.id, tile2.id)
+
+      expect(spy1).not.toHaveBeenCalled()
+      expect(spy2).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/v3/src/models/document/document-content.ts
+++ b/v3/src/models/document/document-content.ts
@@ -119,10 +119,14 @@ export const DocumentContentModel = BaseDocumentContentModel
       // TODO: do we need to do anything for rows?
       // It doesn't seem like rows actually do anything with prepareSnapshot
     },
-    broadcastMessage(message: TileBroadcastMessage, callback: TileBroadcastCallback, targetTileId?: string) {
+    broadcastMessage(
+      message: TileBroadcastMessage, callback: TileBroadcastCallback,
+      targetTileId?: string, excludeTileId?: string
+    ) {
       const tileIds = self.tileMap.keys()
       if (tileIds) {
         Array.from(tileIds).forEach(tileId => {
+          if (tileId === excludeTileId) return
           if (!targetTileId || tileId === targetTileId) {
             self.tileMap.get(tileId)?.content.broadcastMessage(message, callback)
           }

--- a/v3/src/models/history/app-history-service.ts
+++ b/v3/src/models/history/app-history-service.ts
@@ -19,7 +19,7 @@ export class AppHistoryService implements IHistoryService {
   }
 
   handleApplyModelChange(options?: IApplyModelChangeOptions) {
-    const { log, notify, notifyTileId, noDirty, undoStringKey, redoStringKey } = options || {}
+    const { log, notify, notifyTileId, excludeTileId, noDirty, undoStringKey, redoStringKey } = options || {}
 
     // Add strings to undoable action or keep out of the undo stack
     if (undoStringKey != null && redoStringKey != null) {
@@ -49,7 +49,7 @@ export class AppHistoryService implements IHistoryService {
           const __notification = typeof _notification === "function" ? _notification() : _notification
           if (__notification) {
             const { message, callback } = __notification
-            this.tileEnv.notify(message, callback ?? (() => null), notifyTileId)
+            this.tileEnv.notify(message, callback ?? (() => null), notifyTileId, excludeTileId)
           }
         }
       }

--- a/v3/src/models/history/apply-model-change.ts
+++ b/v3/src/models/history/apply-model-change.ts
@@ -6,6 +6,8 @@ export interface IApplyModelChangeOptions {
   log?: string | ILogMessage | (() => Maybe<string | ILogMessage>)
   notify?: INotify
   notifyTileId?: string
+  // tile to exclude from broadcast — e.g. the source plugin shouldn't get an echo of its own action
+  excludeTileId?: string
   // all changes dirty the document by default; specify noDirty to disable dirtying the document
   noDirty?: boolean
   // undo/redo strings indicate undo-ability; if not provided, the action is not undoable

--- a/v3/src/models/history/apply-model-change.ts
+++ b/v3/src/models/history/apply-model-change.ts
@@ -1,19 +1,5 @@
 import { IAnyStateTreeNode } from "mobx-state-tree"
-import { ILogMessage } from "../../lib/log-message"
-import { getHistoryService, INotify } from "./history-service"
-
-export interface IApplyModelChangeOptions {
-  log?: string | ILogMessage | (() => Maybe<string | ILogMessage>)
-  notify?: INotify
-  notifyTileId?: string
-  // tile to exclude from broadcast — e.g. the source plugin shouldn't get an echo of its own action
-  excludeTileId?: string
-  // all changes dirty the document by default; specify noDirty to disable dirtying the document
-  noDirty?: boolean
-  // undo/redo strings indicate undo-ability; if not provided, the action is not undoable
-  undoStringKey?: string
-  redoStringKey?: string
-}
+import { getHistoryService, IApplyModelChangeOptions } from "./history-service"
 
 // returns an object which defines the `applyModelChange` method on an MST model
 // designed to be passed to `.actions()`, i.e. `.actions(applyModelChange)`

--- a/v3/src/models/history/history-service.ts
+++ b/v3/src/models/history/history-service.ts
@@ -11,6 +11,8 @@ export interface IApplyModelChangeOptions {
   log?: string | ILogMessage | (() => Maybe<string | ILogMessage>)
   notify?: INotify
   notifyTileId?: string
+  // tile to exclude from broadcast — e.g. the source plugin shouldn't get an echo of its own action
+  excludeTileId?: string
   noDirty?: boolean
   undoStringKey?: string
   redoStringKey?: string

--- a/v3/src/models/history/history-service.ts
+++ b/v3/src/models/history/history-service.ts
@@ -13,7 +13,9 @@ export interface IApplyModelChangeOptions {
   notifyTileId?: string
   // tile to exclude from broadcast — e.g. the source plugin shouldn't get an echo of its own action
   excludeTileId?: string
+  // all changes dirty the document by default; specify noDirty to disable dirtying the document
   noDirty?: boolean
+  // undo/redo strings indicate undo-ability; if not provided, the action is not undoable
   undoStringKey?: string
   redoStringKey?: string
 }


### PR DESCRIPTION
## Summary
- Adds `excludeTileId` to the notification path (`applyModelChange` / `broadcastMessage` / `tileEnv.notify`) so a specific tile can be skipped during broadcast.
- `component.create`, `component.update`, and `component.delete` in the data-interactive API now pass `excludeTileId: resources.interactiveFrame?.id`, so the requesting plugin doesn't receive an echo of its own action.
- Fixes Story Builder marking its initial moment (and newly-added moments) as unsaved on a fresh document.

Fixes CODAP-1307.

## Test plan
- [ ] Add Story Builder to a fresh document - initial moment is **not** yellow
- [ ] Click "+" in Story Builder - new moment is **not** yellow
- [ ] Make a real edit (e.g., create a graph) - current moment **does** turn yellow
- [ ] Existing component-handler tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
