### PR TITLE
fix: right axis behaves strangely (CODAP-1270)

### DIFF
--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -58,7 +58,13 @@ export const DroppableAddAttribute = ({place, hasRightDropZone, onDrop}: IAddAtt
       return { height: Math.max(0, plotBounds.height - kDropZoneGap), top: plotBounds.top + kDropZoneGap }
     }
     if (placeKey === "top" || placeKey === "yPlus") {
-      const rightInset = hasRightDropZone ? kDropZoneSize + kDropZoneGap : 0
+      // Only inset by the portion of the right-edge drop zone that would actually overlap the
+      // top drop zone.
+      const rightAxisExtent =
+        layout.getDesiredExtent('rightNumeric') + layout.getDesiredExtent('rightCat')
+      const rightInset = hasRightDropZone
+        ? Math.max(0, kDropZoneSize + kDropZoneGap - rightAxisExtent)
+        : 0
       return { width: Math.max(0, plotBounds.width - kDropZoneGap - rightInset), left: plotBounds.left + kDropZoneGap }
     }
   })()

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -417,9 +417,16 @@ export const Graph = observer(function Graph({
       && !!dragAttrId
       && isDropAllowed("rightNumeric", dragDataSet, dragAttrId))
   )
+  // Only inset by the portion of the right-edge drop zone that would actually overlap the
+  // plot drop zone.
+  const rightAxisExtent =
+    layout.getDesiredExtent('rightNumeric') + layout.getDesiredExtent('rightCat')
+  const rightDropZoneInset = hasRightDropZone
+    ? Math.max(0, kDropZoneSize + kDropZoneGap - rightAxisExtent)
+    : 0
   const plotDropInsets: IDropInsets = {
     ...(hasTopDropZone ? { top: kDropZoneSize + kDropZoneGap } : {}),
-    ...(hasRightDropZone ? { right: kDropZoneSize + kDropZoneGap } : {})
+    ...(rightDropZoneInset > 0 ? { right: rightDropZoneInset } : {})
   }
 
   const renderDroppableAddAttributes = () => {

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -555,6 +555,16 @@ export const GraphContentModel = DataDisplayContentModel
       const prevPrimaryRole = self.dataConfiguration.primaryRole
       const prevPrimaryAttrId = prevPrimaryRole ? self.dataConfiguration.attributeID(prevPrimaryRole) : undefined
       self.setDataSet(dataSetID)
+      // The right side has two distinct attribute roles ('rightNumeric' for a Y2 axis and
+      // 'rightSplit' for a categorical splitter) backed by axis places that share the same
+      // screen real estate. Letting both coexist makes one axis paint over the other, so when
+      // assigning one we clear the other. Removals (empty attributeID) leave the other alone.
+      if (attributeID && (role === 'rightNumeric' || role === 'rightSplit')) {
+        const otherRole: GraphAttrRole = role === 'rightNumeric' ? 'rightSplit' : 'rightNumeric'
+        if (self.dataConfiguration.attributeID(otherRole)) {
+          self.dataConfiguration.setAttribute(otherRole)
+        }
+      }
       if (role === 'yPlus') {
         self.dataConfiguration.addYAttribute({attributeID})
       } else {

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -243,18 +243,40 @@ describe("GraphController", () => {
   })
 
   // Removing one right-axis attribute (assigning the empty string) should NOT touch the other.
-  // This exercises the attrId-truthiness guard so that removals don't cascade.
+  // The DI API and v2 import can produce a state with both set simultaneously by going through
+  // dataConfiguration.setAttribute directly (bypassing setAttributeID's mutual exclusion). We
+  // reproduce that state here, then exercise the attrId-truthiness guard by removing one role
+  // and asserting the populated counterpart survives.
   it("does not clear the other right-axis attribute on removal", () => {
     ({ tree, model, controller, data } = setup())
     setAttributeId("x", "xId")
     setAttributeId("y", "yId")
 
-    setAttributeId("rightNumeric", "y2Id")
+    // Populate both roles directly to simulate a DI-API / v2-imported graph.
+    model.dataConfiguration.setAttribute("rightNumeric", { attributeID: "y2Id" })
+    model.dataConfiguration.setAttribute("rightSplit", { attributeID: "cId" })
+    controller.handleAttributeAssignment()
+    controller.syncAxisScalesWithModel()
     expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+    expect(model.dataConfiguration.attributeID("rightSplit")).toBe("cId")
 
-    // Remove rightNumeric; rightSplit stays empty (it never had a value).
+    // Removing rightNumeric must leave rightSplit intact — without the attributeID guard in
+    // setAttributeID, the mutual-exclusion branch would cascade and clear rightSplit too.
     setAttributeId("rightNumeric", "")
     expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
+    expect(model.dataConfiguration.attributeID("rightSplit")).toBe("cId")
+    expect(isCategoricalAxisModel(model.axes.get("rightCat"))).toBe(true)
+
+    // Symmetric check: re-populate rightNumeric, then remove rightSplit.
+    model.dataConfiguration.setAttribute("rightNumeric", { attributeID: "y2Id" })
+    controller.handleAttributeAssignment()
+    controller.syncAxisScalesWithModel()
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+    expect(model.dataConfiguration.attributeID("rightSplit")).toBe("cId")
+
+    setAttributeId("rightSplit", "")
     expect(model.dataConfiguration.attributeID("rightSplit")).toBe("")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+    expect(isNumericAxisModel(model.axes.get("rightNumeric"))).toBe(true)
   })
 })

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -214,4 +214,47 @@ describe("GraphController", () => {
     expect(isNumericAxisModel(model.axes.get("left"))).toBe(true)
     expect(getScaleType("left")).toBe("linear")
   })
+
+  it("clears the other right-axis attribute when assigning rightSplit or rightNumeric", () => {
+    ({ tree, model, controller, data } = setup())
+    setAttributeId("x", "xId")
+    setAttributeId("y", "yId")
+
+    // Add a Y2 numeric attribute to the right axis.
+    setAttributeId("rightNumeric", "y2Id")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+    expect(model.dataConfiguration.attributeID("rightSplit")).toBe("")
+    expect(isNumericAxisModel(model.axes.get("rightNumeric"))).toBe(true)
+
+    // Now assign a categorical attribute to the right-split slot. The previous Y2 numeric
+    // attribute (and its axis) should be cleared so the new rightCat axis is unobscured.
+    setAttributeId("rightSplit", "cId")
+    expect(model.dataConfiguration.attributeID("rightSplit")).toBe("cId")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
+    expect(model.axes.get("rightNumeric")).toBeUndefined()
+    expect(isCategoricalAxisModel(model.axes.get("rightCat"))).toBe(true)
+
+    // And the reverse: assigning a numeric attribute to rightNumeric should clear rightSplit.
+    setAttributeId("rightNumeric", "y2Id")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+    expect(model.dataConfiguration.attributeID("rightSplit")).toBe("")
+    expect(model.axes.get("rightCat")).toBeUndefined()
+    expect(isNumericAxisModel(model.axes.get("rightNumeric"))).toBe(true)
+  })
+
+  // Removing one right-axis attribute (assigning the empty string) should NOT touch the other.
+  // This exercises the attrId-truthiness guard so that removals don't cascade.
+  it("does not clear the other right-axis attribute on removal", () => {
+    ({ tree, model, controller, data } = setup())
+    setAttributeId("x", "xId")
+    setAttributeId("y", "yId")
+
+    setAttributeId("rightNumeric", "y2Id")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+
+    // Remove rightNumeric; rightSplit stays empty (it never had a value).
+    setAttributeId("rightNumeric", "")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
+    expect(model.dataConfiguration.attributeID("rightSplit")).toBe("")
+  })
 })


### PR DESCRIPTION
Fixes an issue where dropping a categorical attribute on the right axis of a graph that was already occupied by a numerical attribute caused strange behavior: the plot would change as if the categorical attribute had been added, but the attribute label would not update and a transparent gap between the right axis label and the graph's right edge would appear.

The graph was allowing both attributes to exist simultaneously on the right axis.

The fix adds mutual-exclusion logic in the `setAttributeID` action:

- When assigning a non-empty attribute to rightNumeric or rightSplit, the other role is cleared first.
- A removal (empty `attributeID`) deliberately leaves the other role alone, so removing one doesn't cascade.
- The DI API (`graph-component-handler.ts`) calls `dataConfiguration.setAttribute()` directly, bypassing `setAttributeID`, so v2 import and plugin-driven graphs that intentionally set both attributes continue to work unchanged.

A tangentially-related bug in the calculation of top axis and plot drop zone widths in relation to the right axis is included (changes to `droppable-add-attribute.tsx` and `graph.tsx`).