### PR TITLE
CODAP-1306: emit V2-compatible commitEdit notification on text edit

### DIFF
--- a/v3/src/components/text/text-notifications.test.ts
+++ b/v3/src/components/text/text-notifications.test.ts
@@ -1,0 +1,51 @@
+import { TextModel } from "./text-model"
+import { commitEditNotification } from "./text-notifications"
+
+const v2Id = 12345
+const v2Type = "DG.TextView"
+
+jest.mock("../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
+    if (!tileModel) return undefined
+    return {
+      message: {
+        action: "notify",
+        resource: "component",
+        values: {
+          operation: updateType,
+          ...values,
+          id: v2Id,
+          type: v2Type
+        }
+      }
+    }
+  })
+}))
+
+describe("commitEditNotification", () => {
+  it("emits a commitEdit notification with title and JSON-stringified slate value", () => {
+    const textModel = TextModel.create()
+    textModel.setTextContent("Hello")
+    const tile = { title: "Notes", content: textModel } as any
+
+    const notification = commitEditNotification(textModel, tile)
+
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("commitEdit")
+    expect(notification?.message.values.title).toBe("Notes")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2Type)
+    // V2 contract: text is JSON.stringify of the slate exchange value, not plain text
+    const text = notification?.message.values.text
+    expect(typeof text).toBe("string")
+    const parsed = JSON.parse(text)
+    expect(parsed).toEqual(textModel.value)
+    expect(parsed.document).toBeDefined()
+  })
+
+  it("returns undefined when tile is missing", () => {
+    const textModel = TextModel.create()
+    expect(commitEditNotification(textModel, undefined)).toBeUndefined()
+  })
+})

--- a/v3/src/components/text/text-notifications.test.ts
+++ b/v3/src/components/text/text-notifications.test.ts
@@ -1,8 +1,9 @@
+import { kV2TextDIType } from "./text-defs"
 import { TextModel } from "./text-model"
 import { commitEditNotification } from "./text-notifications"
 
 const v2Id = 12345
-const v2Type = "DG.TextView"
+const v2Type = kV2TextDIType
 
 jest.mock("../../models/tiles/tile-notifications", () => ({
   updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {

--- a/v3/src/components/text/text-notifications.ts
+++ b/v3/src/components/text/text-notifications.ts
@@ -3,8 +3,9 @@ import { ITileModel } from "../../models/tiles/tile-model"
 import { ITextModel } from "./text-model"
 
 export function commitEditNotification(textModel: ITextModel, tile?: ITileModel) {
+  if (!tile) return
   return updateTileNotification("commitEdit", {
-    title: tile?.title,
+    title: tile.title,
     text: JSON.stringify(textModel.value)
   }, tile)
 }

--- a/v3/src/components/text/text-notifications.ts
+++ b/v3/src/components/text/text-notifications.ts
@@ -1,0 +1,10 @@
+import { updateTileNotification } from "../../models/tiles/tile-notifications"
+import { ITileModel } from "../../models/tiles/tile-model"
+import { ITextModel } from "./text-model"
+
+export function commitEditNotification(textModel: ITextModel, tile?: ITileModel) {
+  return updateTileNotification("commitEdit", {
+    title: tile?.title,
+    text: JSON.stringify(textModel.value)
+  }, tile)
+}

--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -8,10 +8,10 @@ import React, { useCallback, useEffect, useRef, useState } from "react"
 import { useMemo } from "use-memo-one"
 import { useTileInspectorContext } from "../../hooks/use-tile-inspector-context"
 import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
-import { updateTileNotification } from "../../models/tiles/tile-notifications"
 import { mstReaction } from "../../utilities/mst-reaction"
 import { ITileBaseProps } from "../tiles/tile-base-props"
 import { isTextModel, modelValueToEditorValue } from "./text-model"
+import { commitEditNotification } from "./text-notifications"
 import { TextTileInspectorContent } from "./text-tile-inspector-content"
 
 import "@concord-consortium/slate-editor/dist/index.css"
@@ -142,12 +142,7 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
         log: textDidChange ? () => `Edited text component: ${textModel.textContent}` : undefined,
         undoStringKey: "DG.Undo.textComponent.edit",
         redoStringKey: "DG.Redo.textComponent.edit",
-        notify: textDidChange
-          ? () => updateTileNotification("commitEdit", {
-              title: tile?.title,
-              text: JSON.stringify(textModel.value)
-            }, tile)
-          : undefined
+        notify: textDidChange ? () => commitEditNotification(textModel, tile) : undefined
       })
     }
   }

--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -142,7 +142,12 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
         log: textDidChange ? () => `Edited text component: ${textModel.textContent}` : undefined,
         undoStringKey: "DG.Undo.textComponent.edit",
         redoStringKey: "DG.Redo.textComponent.edit",
-        notify: textDidChange ? () => updateTileNotification("edit text", {}, tile) : undefined
+        notify: textDidChange
+          ? () => updateTileNotification("commitEdit", {
+              title: tile?.title,
+              text: JSON.stringify(textModel.value)
+            }, tile)
+          : undefined
       })
     }
   }


### PR DESCRIPTION
## Summary
- Story Builder's moment description edits were lost when navigating
  between moments because V3's text component emitted an `"edit text"`
  notification with no payload, while V2 plugins listen for the
  `commitEdit` operation and read `values.text` (and `values.title`).
- Match V2's API by emitting `commitEdit` with the JSON-stringified
  slate value and the tile title.

Fixes CODAP-1306.

## Test plan
- [ ] Open a new document and add the Story Builder plugin
- [ ] Edit the moment description (the narrative text box)
- [ ] Add a new moment
- [ ] Return to the initial moment → description edit is preserved
- [ ] Verify normal text-tile editing/undo still work as expected
