### PR TITLE
chore: temp disable map draw tool (CODAP-1303)

### DIFF
--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -5,7 +5,8 @@ import { useCfmContext } from "../../../../hooks/use-cfm-context"
 import { useProgress } from "../../../../hooks/use-progress"
 import { ITileModel } from "../../../../models/tiles/tile-model"
 import { t } from "../../../../utilities/translation/translate"
-import { openInDrawTool } from "../../../data-display/data-display-image-utils"
+// DISABLED FOR NOW (CODAP-1303): see commented-out draw-tool handler/menu item below
+// import { openInDrawTool } from "../../../data-display/data-display-image-utils"
 import { InspectorMenuContent } from "../../../inspector-panel"
 import { isMapContentModel } from "../../models/map-content-model"
 
@@ -53,12 +54,18 @@ export const SaveImageMenuList = ({tile}: IProps) => {
     return undefined
   }
 
+  /*
+
+  DISABLED FOR NOW (CODAP-1303): launching the Draw tool from the Map has significant bugs.
+  Re-enable once the underlying issues are resolved.
+
   const handleOpenInDrawTool = async () => {
     if (tile) {
       const imageDataUri = await getImageDataUri("png")
       await openInDrawTool(tile, imageDataUri || "")
     }
   }
+  */
 
   const handleExportPNG = async () => {
     const imageString = await getImageDataString("png")
@@ -95,9 +102,12 @@ export const SaveImageMenuList = ({tile}: IProps) => {
 
   return (
     <InspectorMenuContent data-testid="save-image-menu-list">
+      {/*
+      DISABLED FOR NOW (CODAP-1303): launching the Draw tool from the Map has significant bugs.
       <MenuItem data-testid="open-in-draw-tool" onAction={handleOpenInDrawTool}>
         {t("DG.DataDisplayMenu.copyAsImage")}
       </MenuItem>
+      */}
       <MenuItem data-testid="export-png-image" onAction={handleExportPNG}>
         {t("DG.DataDisplayMenu.exportPngImage")}
       </MenuItem>

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -5,8 +5,7 @@ import { useCfmContext } from "../../../../hooks/use-cfm-context"
 import { useProgress } from "../../../../hooks/use-progress"
 import { ITileModel } from "../../../../models/tiles/tile-model"
 import { t } from "../../../../utilities/translation/translate"
-// DISABLED FOR NOW (CODAP-1303): see commented-out draw-tool handler/menu item below
-// import { openInDrawTool } from "../../../data-display/data-display-image-utils"
+import { openInDrawTool } from "../../../data-display/data-display-image-utils"
 import { InspectorMenuContent } from "../../../inspector-panel"
 import { isMapContentModel } from "../../models/map-content-model"
 
@@ -54,18 +53,15 @@ export const SaveImageMenuList = ({tile}: IProps) => {
     return undefined
   }
 
-  /*
-
-  DISABLED FOR NOW (CODAP-1303): launching the Draw tool from the Map has significant bugs.
-  Re-enable once the underlying issues are resolved.
-
+  // The menu item that invokes this handler is currently disabled (CODAP-1303): launching the
+  // Draw tool from the Map has significant bugs. Once those are resolved, remove `isDisabled`
+  // from the corresponding <MenuItem> below to re-enable.
   const handleOpenInDrawTool = async () => {
     if (tile) {
       const imageDataUri = await getImageDataUri("png")
       await openInDrawTool(tile, imageDataUri || "")
     }
   }
-  */
 
   const handleExportPNG = async () => {
     const imageString = await getImageDataString("png")
@@ -102,12 +98,9 @@ export const SaveImageMenuList = ({tile}: IProps) => {
 
   return (
     <InspectorMenuContent data-testid="save-image-menu-list">
-      {/*
-      DISABLED FOR NOW (CODAP-1303): launching the Draw tool from the Map has significant bugs.
-      <MenuItem data-testid="open-in-draw-tool" onAction={handleOpenInDrawTool}>
-        {t("DG.DataDisplayMenu.copyAsImage")}
+      <MenuItem data-testid="open-in-draw-tool" onAction={handleOpenInDrawTool} isDisabled={true}>
+        {t("DG.DataDisplayMenu.copyAsImage")}<span aria-hidden="true"> 🚧</span>
       </MenuItem>
-      */}
       <MenuItem data-testid="export-png-image" onAction={handleExportPNG}>
         {t("DG.DataDisplayMenu.exportPngImage")}
       </MenuItem>


### PR DESCRIPTION
[CODAP-1303](https://concord-consortium.atlassian.net/browse/CODAP-1303)

Since there are significant bugs when launching the draw tool from the Map tile, it was decided to turn the feature off for now. 

These changes temporarily disable the draw tool option by commenting out the relevant code in `v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx`.

The draw tool option for the Graph is not affected.

[CODAP-1303]: https://concord-consortium.atlassian.net/browse/CODAP-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ