### PR TITLE
fix: right axis behaves strangely (CODAP-1270)

### DIFF
--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -9,7 +9,7 @@ import {useDataSetContext} from "../../../hooks/use-data-set-context"
 import {getDragAttributeInfo} from "../../../hooks/use-drag-drop"
 import { DEBUG_RENDERERS } from "../../../lib/debug"
 import { logStringifiedObjectMessage } from "../../../lib/log-message"
-import { AttributeType, isCategoricalAttributeType } from "../../../models/data/attribute-types"
+import { AttributeType, isCategoricalAttributeType, isNumericAttributeType } from "../../../models/data/attribute-types"
 import {IDataSet} from "../../../models/data/data-set"
 import {isUndoingOrRedoing} from "../../../models/history/tree-types"
 import { getTileModel } from "../../../models/tiles/tile-model"
@@ -314,7 +314,21 @@ export const Graph = observer(function Graph({
       // We need to call setNumberOfCategoriesLimit early to avoid potential performance bottlenecks
       isCategoricalAttributeType(treatAs) && isAxisPlace(place) &&
         setNumberOfCategoriesLimit(graphModel.dataConfiguration, place, layout)
-      graphModel.dataConfiguration.setAttributeType(graphPlaceToAttrRole[place], treatAs)
+      const role = graphPlaceToAttrRole[place]
+      graphModel.dataConfiguration.setAttributeType(role, treatAs)
+      // The Y2 axis (rightNumeric) is only meaningful when both x and y are numeric.
+      // If retyping x or y to a non-numeric kind via "Treat as Categorical" has collapsed
+      // the configuration off scatter, the existing rightNumeric attribute is orphaned,
+      // so clear it. (Mirror of the cleanup in graphContentModel.setAttributeID for the
+      // drag-drop path; kept here rather than in setAttributeType so the DI-API update
+      // flow — which also calls setAttributeType — is unaffected.)
+      if ((role === 'x' || role === 'y') && graphModel.dataConfiguration.attributeID('rightNumeric')) {
+        const xType = graphModel.dataConfiguration.attributeType('x')
+        const yType = graphModel.dataConfiguration.attributeType('y')
+        if (!isNumericAttributeType(xType) || !isNumericAttributeType(yType)) {
+          graphModel.dataConfiguration.setAttribute('rightNumeric')
+        }
+      }
       graphController?.handleAttributeAssignment()
     }, {
       undoStringKey: "V3.Undo.attributeTreatAs",

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -570,6 +570,13 @@ export const GraphContentModel = DataDisplayContentModel
       } else {
         self.dataConfiguration.setAttribute(role, {attributeID})
       }
+      if ((role === 'x' || role === 'y') && self.dataConfiguration.attributeID('rightNumeric')) {
+        const xType = self.dataConfiguration.attributeType('x')
+        const yType = self.dataConfiguration.attributeType('y')
+        if (!isNumericAttributeType(xType) || !isNumericAttributeType(yType)) {
+          self.dataConfiguration.setAttribute('rightNumeric')
+        }
+      }
       const newPrimaryRole = self.dataConfiguration.primaryRole
       const newPrimaryAttrId = newPrimaryRole ? self.dataConfiguration.attributeID(newPrimaryRole) : undefined
       self.plot.respondToPlotChange({

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -279,4 +279,55 @@ describe("GraphController", () => {
     expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
     expect(isNumericAxisModel(model.axes.get("rightNumeric"))).toBe(true)
   })
+
+  // Companion to the rightNumeric/rightSplit mutual-exclusion guard: the Y2 axis is also
+  // orphaned when the plot itself collapses off scatter (because x or y stops being
+  // numeric). Drag-drop reaches this through setAttributeID; the "Treat As" menu reaches
+  // it through dataConfiguration.setAttributeType. Both should clear rightNumeric.
+  it("clears rightNumeric when x or y becomes non-numeric via setAttributeID", () => {
+    ;({ tree, model, controller, data } = setup())
+    setAttributeId("x", "xId")
+    setAttributeId("y", "yId")
+    setAttributeId("rightNumeric", "y2Id")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+    expect(isNumericAxisModel(model.axes.get("rightNumeric"))).toBe(true)
+
+    // Dropping a categorical attribute on x collapses the plot off scatter, so the
+    // orphaned Y2 attribute and axis should be cleared.
+    setAttributeId("x", "cId")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
+    expect(model.axes.get("rightNumeric")).toBeUndefined()
+
+    // Symmetric: re-establish a scatter, then drop categorical on y.
+    setAttributeId("x", "xId")
+    setAttributeId("rightNumeric", "y2Id")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+    setAttributeId("y", "cId")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
+    expect(model.axes.get("rightNumeric")).toBeUndefined()
+  })
+
+  it("clears rightNumeric when x or y is retyped non-numeric via setAttributeType", () => {
+    ;({ tree, model, controller, data } = setup())
+    setAttributeId("x", "xId")
+    setAttributeId("y", "yId")
+    setAttributeId("rightNumeric", "y2Id")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+
+    // "Treat as Categorical" on x reaches dataConfiguration.setAttributeType directly.
+    model.dataConfiguration.setAttributeType("x", "categorical")
+    controller.handleAttributeAssignment()
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
+    expect(model.axes.get("rightNumeric")).toBeUndefined()
+
+    // Symmetric: re-establish a scatter, then retype y to categorical.
+    model.dataConfiguration.setAttributeType("x", "numeric")
+    controller.handleAttributeAssignment()
+    setAttributeId("rightNumeric", "y2Id")
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+    model.dataConfiguration.setAttributeType("y", "categorical")
+    controller.handleAttributeAssignment()
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
+    expect(model.axes.get("rightNumeric")).toBeUndefined()
+  })
 })

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -281,9 +281,12 @@ describe("GraphController", () => {
   })
 
   // Companion to the rightNumeric/rightSplit mutual-exclusion guard: the Y2 axis is also
-  // orphaned when the plot itself collapses off scatter (because x or y stops being
-  // numeric). Drag-drop reaches this through setAttributeID; the "Treat As" menu reaches
-  // it through dataConfiguration.setAttributeType. Both should clear rightNumeric.
+  // orphaned when the plot collapses off scatter (because x or y stops being numeric).
+  // Drag-drop reaches the cleanup through setAttributeID and is verified here. The
+  // "Treat As" menu reaches it through graph.tsx's handleTreatAttrAs (UI layer); we
+  // intentionally do NOT clean up at the data-configuration layer so DI-API plugins
+  // that call setAttributeType directly retain their full configuration — see the
+  // companion test below.
   it("clears rightNumeric when x or y becomes non-numeric via setAttributeID", () => {
     ;({ tree, model, controller, data } = setup())
     setAttributeId("x", "xId")
@@ -307,27 +310,20 @@ describe("GraphController", () => {
     expect(model.axes.get("rightNumeric")).toBeUndefined()
   })
 
-  it("clears rightNumeric when x or y is retyped non-numeric via setAttributeType", () => {
+  it("preserves rightNumeric when setAttributeType is called directly", () => {
     ;({ tree, model, controller, data } = setup())
     setAttributeId("x", "xId")
     setAttributeId("y", "yId")
     setAttributeId("rightNumeric", "y2Id")
     expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
 
-    // "Treat as Categorical" on x reaches dataConfiguration.setAttributeType directly.
     model.dataConfiguration.setAttributeType("x", "categorical")
     controller.handleAttributeAssignment()
-    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
-    expect(model.axes.get("rightNumeric")).toBeUndefined()
-
-    // Symmetric: re-establish a scatter, then retype y to categorical.
-    model.dataConfiguration.setAttributeType("x", "numeric")
-    controller.handleAttributeAssignment()
-    setAttributeId("rightNumeric", "y2Id")
     expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
+
+    model.dataConfiguration.setAttributeType("x", "numeric")
     model.dataConfiguration.setAttributeType("y", "categorical")
     controller.handleAttributeAssignment()
-    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
-    expect(model.axes.get("rightNumeric")).toBeUndefined()
+    expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("y2Id")
   })
 })

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -1,6 +1,6 @@
 import {comparer, reaction} from "mobx"
 import {addDisposer, getSnapshot, Instance, SnapshotIn, types} from "mobx-state-tree"
-import { AttributeType, isCategoricalAttributeType } from "../../../models/data/attribute-types"
+import { AttributeType, isCategoricalAttributeType, isNumericAttributeType } from "../../../models/data/attribute-types"
 import {IDataSet} from "../../../models/data/data-set"
 import {typedId} from "../../../utilities/js-utils"
 import { isFiniteNumber } from "../../../utilities/math-utils"
@@ -859,6 +859,13 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         self._attributeDescriptions.get(role)?.setType(type)
       }
       self._setAttributeType(type, plotNumber)
+      if ((role === 'x' || role === 'y') && self.attributeID('rightNumeric')) {
+        const xType = self.attributeType('x')
+        const yType = self.attributeType('y')
+        if (!isNumericAttributeType(xType) || !isNumericAttributeType(yType)) {
+          this.setAttribute('rightNumeric')
+        }
+      }
     }
   }))
   .actions(self => ({

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -1,6 +1,6 @@
 import {comparer, reaction} from "mobx"
 import {addDisposer, getSnapshot, Instance, SnapshotIn, types} from "mobx-state-tree"
-import { AttributeType, isCategoricalAttributeType, isNumericAttributeType } from "../../../models/data/attribute-types"
+import { AttributeType, isCategoricalAttributeType } from "../../../models/data/attribute-types"
 import {IDataSet} from "../../../models/data/data-set"
 import {typedId} from "../../../utilities/js-utils"
 import { isFiniteNumber } from "../../../utilities/math-utils"
@@ -859,13 +859,6 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         self._attributeDescriptions.get(role)?.setType(type)
       }
       self._setAttributeType(type, plotNumber)
-      if ((role === 'x' || role === 'y') && self.attributeID('rightNumeric')) {
-        const xType = self.attributeType('x')
-        const yType = self.attributeType('y')
-        if (!isNumericAttributeType(xType) || !isNumericAttributeType(yType)) {
-          this.setAttribute('rightNumeric')
-        }
-      }
     }
   }))
   .actions(self => ({


### PR DESCRIPTION
[CODAP-1270](https://concord-consortium.atlassian.net/browse/CODAP-1270)

This is a follow-up to #2564 which didn't cover one detail of the reported bug: a numeric attribute on the right axis would remain when a categorical was placed on the x axis.

- `setAttributeID` (drag-drop path) now clears `rightNumeric` when the new x/y type leaves the configuration off bivariate-numeric.
- `setAttributeType` (Treat As path) does the same after a retype.

The existing axis-removal branch in `setupAxes` drops the orphaned axis once the attribute is gone, so no axis-cleanup change was needed.

DI-API behavior is intentionally unchanged — direct `dataConfiguration.setAttribute` calls still preserve `rightNumeric` for plugin / v2-import contracts.

[CODAP-1270]: https://concord-consortium.atlassian.net/browse/CODAP-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ