### PR TITLE
CODAP-1308: don't dirty the document on leaflet→model sync

### DIFF
--- a/v3/src/components/map/models/map-content-model.test.ts
+++ b/v3/src/components/map/models/map-content-model.test.ts
@@ -1,10 +1,12 @@
 import { Map as LeafletMap } from "leaflet"
 import { DataSet } from "../../../models/data/data-set"
+import { createCodapDocument } from "../../../models/codap/create-codap-document"
 import { DocumentContentModel, IDocumentContentModel } from "../../../models/document/document-content"
 import { FreeTileRow } from "../../../models/document/free-tile-row"
 import {
   ISharedModelDocumentManager, SharedModelDocumentManager
 } from "../../../models/document/shared-model-document-manager"
+import { TreeManagerType } from "../../../models/history/tree-manager"
 import { SharedDataSet } from "../../../models/shared/shared-data-set"
 import { DataSetMetadata } from "../../../models/shared/data-set-metadata"
 import { kMapTileType } from "../map-defs"
@@ -354,6 +356,55 @@ describe("MapContentModel", () => {
       const layer = mapContent.layers[0]
       if (!isMapPinLayerModel(layer)) throw new Error("expected MapPinLayerModel")
       expect(layer.titleCollection?.name).toBe("Sites")
+    })
+  })
+
+  // CODAP-1308: Leaflet emits its own center/zoom values once the map renders,
+  // even when the saved view is being restored. Those round-trip values are
+  // synced back into the model via syncCenterAndZoomFromMapWithoutUndo and
+  // were dirtying the document on open.
+  describe("syncCenterAndZoomFromMapWithoutUndo (CODAP-1308)", () => {
+    it("does not bump revisionId when leaflet syncs back to the model", async () => {
+      // Use a real CODAP document so a TreeManager / TreeMonitor are wired up
+      // (the default test setup uses a bare DocumentContentModel and so has no
+      // history/dirty tracking).
+      const doc = createCodapDocument()
+      const content = doc.content!
+      const tile = content.insertTileSnapshotInDefaultRow({ content: { type: kMapTileType } })!
+      const map = isMapContentModel(tile.content) ? tile.content : undefined
+      if (!map) throw new Error("expected MapContentModel")
+
+      // Enable monitoring so history entries actually get recorded.
+      doc.treeMonitor?.enableMonitoring()
+      const treeManager = doc.treeManagerAPI as TreeManagerType
+
+      // Wire up a leaflet that returns values different from the model's
+      // defaults so the action does mutate model state.
+      map.setLeafletMap({
+        ...mockLeafletMap,
+        getCenter: jest.fn(() => ({ lat: 1.234, lng: 5.678 })),
+        getZoom: jest.fn(() => 7)
+      } as unknown as LeafletMap)
+
+      // Capture the baseline *after* the leaflet hookup; setLeafletMap may
+      // itself record a history entry.
+      await new Promise(resolve => setTimeout(resolve, 0))
+      const baselineRevisionId = treeManager.revisionId
+
+      map.syncCenterAndZoomFromMapWithoutUndo()
+
+      // Wait for the action to finalize (history entries complete on a
+      // microtask).
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // The model received the new values...
+      expect(map.center.lat).toBeCloseTo(1.234)
+      expect(map.center.lng).toBeCloseTo(5.678)
+      expect(map.zoom).toBe(7)
+      // ...but the document was not dirtied: revisionId is unchanged.
+      // (The entry still goes into history — that's intentional under
+      // `noDirty` — but it must not bump the dirty-tracking revisionId.)
+      expect(treeManager.revisionId).toBe(baselineRevisionId)
     })
   })
 })

--- a/v3/src/components/map/models/map-content-model.ts
+++ b/v3/src/components/map/models/map-content-model.ts
@@ -226,7 +226,10 @@ export const MapContentModel = DataDisplayContentModel
       }
     },
     syncCenterAndZoomFromMapWithoutUndo() {
-      withoutUndo()
+      // Leaflet may emit small center/zoom adjustments after the map renders
+      // (e.g. floating-point precision when restoring a saved view). These
+      // round-trip syncs aren't user changes and shouldn't dirty the document.
+      withoutUndo({ noDirty: true })
       this.syncCenterAndZoomFromMap()
     },
     rescale(undoStringKey = "", redoStringKey = "") {


### PR DESCRIPTION
## Summary

Fixes CODAP-1308: V2 documents were reported as "Unsaved" on open whenever they contained a map tile. Leaflet emits small center/zoom adjustments after the map renders (floating-point precision around the projection), and `MapContentModel.syncCenterAndZoomFromMapWithoutUndo` was using `withoutUndo()` to skip undo but not `{ noDirty: true }` to skip dirtying — so the round-trip sync would bump `revisionId` and mark the doc dirty.

The image-vs-no-image variant noted in the bug rejection was incidental: the image affected surrounding layout enough that Leaflet rounded to different values, producing (or not) the sync patch.

## Changes

- `MapContentModel.syncCenterAndZoomFromMapWithoutUndo`: pass `{ noDirty: true }` to `withoutUndo()`. The action still records in history for traceability but does not dirty the document.
- New unit test that wires a real `TreeManager`/`TreeMonitor` under a map tile, drives the sync with a mock Leaflet returning non-default center/zoom, and asserts `revisionId` is unchanged. Verified the test fails on the unfixed code.

## Test plan

- [ ] CI passes (lint, build, unit tests)
- [ ] Open "Birgit Animated V2.codap" (attached to CODAP-1308): expect "Saved", not "Unsaved"
- [ ] Open another V2 doc with a map but no image: expect "Saved"
- [ ] Open a V3 doc with a map: still "Saved" on open
- [ ] Pan/zoom the map: doc transitions to "Unsaved" (real user changes still dirty)
- [ ] Undo/redo of map pan/zoom still works as before
