### PR TITLE
fix: plugin cannot place multiple pins (NASAEARTH-27)

### DIFF
--- a/v3/doc/dataset-validation-and-reactivity.md
+++ b/v3/doc/dataset-validation-and-reactivity.md
@@ -112,6 +112,26 @@ A second, additive path exists for **appended items**. `addCases` calls
 `completeCaseGroups` take its append branch (concatenation rather than full
 rebuild). This avoids an O(N) walk per append.
 
+The additive path and the full-rebuild path use **different semantics for
+`newCaseIds`**, the list returned by `updateCaseGroups` that drives the
+APPEND branch. In the additive path, `newCaseIds` must include every newly-
+created `caseGroupMap` entry — including ones whose case id was preserved
+across a prior `clearCases()` (see [collection-properties.md][cp]) — because
+APPEND consumes it as "what to extend `_cases` / `_caseGroups` with." In the
+full-rebuild path, `newCaseIds` is consumed instead by `getRemappedCaseIds`,
+which treats it as a list of remapping *candidates*; preserved-id cases must
+be omitted there because they are by definition not candidates for being
+remapped to a prior id. The push site in `Collection.updateCaseGroups`
+encodes both rules.
+
+A related invariant: APPEND and REBUILD are dual implementations of the same
+observable surface (`_cases`, `_caseGroups`, `_nonEmptyCases`). Any property
+REBUILD enforces by construction — notably "no hidden-only case groups",
+because REBUILD walks `self.caseIds` which already excludes them — APPEND
+must enforce by filtering, because it walks `newCaseIds` which doesn't.
+
+[cp]: ../src/models/data/collection-properties.md
+
 ## Validation markers — full catalog
 
 ### `DataSet`
@@ -650,6 +670,21 @@ patch-driven path will desync the action and the cache.
    and the cache silently desyncs. Pair the explicit call with a reaction
    on the mutated state so the loop closes regardless of how the mutation
    arrived. (See worked example: CODAP-1297.)
+
+9. **Changing what `Collection.updateCaseGroups` pushes to `newCaseIds`
+   without considering both consumers.** `newCaseIds` feeds two different
+   downstream branches with different requirements: `completeCaseGroups`'s
+   APPEND branch wants every newly-created `caseGroupMap` entry (so it can
+   extend the observable arrays correctly); `getRemappedCaseIds` wants only
+   brand-new group keys (preserved-id cases are not remapping candidates).
+   The current code uses an `isFullRebuild` switch to satisfy both. A
+   related invariant: APPEND and REBUILD must produce identical
+   `_cases` / `_caseGroups` sets — properties REBUILD enforces by walking
+   `self.caseIds` (e.g., excluding hidden-only groups) APPEND must enforce
+   by filtering `newCaseIds`. The `collection.test.ts` test
+   *"append path excludes hidden-only case groups so it matches the rebuild
+   path"* pins this. Bug history: NASAEARTH-27 (preserved-id parent groups
+   dropped from APPEND after delete-all + re-add).
 
 ## Reference: which methods invalidate, and how
 

--- a/v3/src/models/data/collection-properties.md
+++ b/v3/src/models/data/collection-properties.md
@@ -8,3 +8,12 @@
 |`prevCaseIds: undefined as Maybe<string[]>`|previous case ids in case table/render order; used to track case ids no longer in use|Not needed|Not needed|
 |`prevCaseIdToGroupKeyMap: undefined as Maybe<Map<string, string>>`|previous map from case id to group key (stringified attribute values); used for remapping case ids when values change|Not needed|Not needed|
 |`prevCaseGroupMap: undefined as Maybe<Map<string, CaseInfo>>`|previous map from group key (stringified attribute values) to CaseInfo; used for remapping case ids when values change|Not needed|Not needed|
+
+## What `clearCases()` preserves vs. wipes
+
+`clearCases()` (the first step of a full rebuild) is asymmetric across the maps above, and this asymmetry is load-bearing:
+
+- **Preserved:** `groupKeyCaseIds`. Surviving across rebuilds is how the same set of grouping values always maps to the same case id, so case ids persist across `delete allCases` + `addCases`, attribute reorderings, etc. See [hierarchical-data.md](../../../doc/hierarchical-data.md) for the rationale.
+- **Wiped (with a `prev*` snapshot kept for the remapping pass):** `caseIds`, `caseIdToIndexMap`, `caseIdToGroupKeyMap`, `caseGroupMap`. The snapshots feed `getRemappedCaseIds` so cases representing the same set of items can inherit their prior id rather than being treated as new.
+
+A practical consequence: after a full delete-all-cases + re-add, a "previously-seen" group key has `groupKeyCaseIds.get(key)` populated but `caseGroupMap.get(key) === undefined`. The next `updateCaseGroups()` pass must recreate the `caseGroupMap` entry and propagate it to `completeCaseGroups`'s APPEND consumer. Filtering by `!hadCaseIdForGroupKey` (i.e., "brand-new key only") in the additive path drops these preserved-id groups; only the full-rebuild path needs that filter, because its consumer (`getRemappedCaseIds`) treats `newCaseIds` differently — see the comment at the push site in `Collection.updateCaseGroups`.

--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -460,6 +460,48 @@ describe("CollectionModel", () => {
     expect(c1.cases.length).toBe(2)
   })
 
+  it("append path excludes hidden-only case groups so it matches the rebuild path", () => {
+    // The additive path can produce a newCaseIds entry whose only item is hidden — its
+    // caseGroup is created with isHidden=true but self.caseIds (which excludes hidden-only
+    // cases) doesn't get the entry. completeCaseGroups' APPEND branch must drop such
+    // groups, otherwise it would add hidden cases that the REBUILD branch (which walks
+    // self.caseIds) wouldn't include.
+    const c1 = CollectionModel.create({ name: "c1" })
+    let items = ["i0", "i1"]
+    const hiddenItems = new Set<string>()
+    const itemData: IItemData = {
+      itemIds: () => items,
+      isHidden: (itemId: string) => hiddenItems.has(itemId),
+      getValue: (itemId: string) => itemId,
+      addItemInfo: () => null,
+      invalidate: () => null
+    }
+    syncCollectionLinks([c1], itemData)
+
+    // initial rebuild with two visible items
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+    expect(c1.cases.length).toBe(2)
+    expect(c1.caseGroups.length).toBe(2)
+
+    // additive add of a hidden item — APPEND must drop its case group
+    items = ["i0", "i1", "i2"]
+    hiddenItems.add("i2")
+    const { newCaseIds } = c1.updateCaseGroups(["i2"])
+    const hiddenCaseId = c1.groupKeyCaseIds.get("i2")!
+    c1.invalidateCaseGroupsForNewCases(newCaseIds)
+    c1.completeCaseGroups(undefined)
+    // hidden case is tracked in allCaseIds and caseGroupMap but not in caseIds
+    expect(c1.allCaseIds.has(hiddenCaseId)).toBe(true)
+    expect(c1.caseGroupMap.get("i2")?.isHidden).toBe(true)
+    expect(c1.caseIds.length).toBe(2)
+    expect(c1.caseIds).not.toContain(hiddenCaseId)
+    // cases and caseGroups views must match: APPEND must drop the hidden new case so it
+    // mirrors REBUILD's walk of caseIds
+    expect(c1.cases.length).toBe(2)
+    expect(c1.caseGroups.length).toBe(2)
+  })
+
   it("empty newCaseIds falls through to rebuild path", () => {
     const c1 = CollectionModel.create({ name: "c1" })
     let items = ["i0", "i1"]

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -566,9 +566,9 @@ export const CollectionModel = V2Model
         if (!parentCases && !_needsFullRebuild && newCaseIds?.length) {
           // Exclude hidden-only case groups so this branch matches REBUILD's walk of
           // self.caseIds (which already excludes them).
-          const newCaseGroups: CaseInfo[] = newCaseIds
-                                              .map(caseId => self.getCaseGroup(caseId))
-                                              .filter(group => !!group && !group.isHidden) as CaseInfo[]
+          const newCaseGroups = newCaseIds
+                                  .map(caseId => self.getCaseGroup(caseId))
+                                  .filter((group): group is CaseInfo => !!group && !group.isHidden)
           _caseGroups = [..._caseGroups, ...newCaseGroups]
 
           const newCases = newCaseGroups.map(group => group.groupedCase)

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -306,6 +306,8 @@ export const CollectionModel = V2Model
     // For now, we treat appending items as a special case for which we don't need to start
     // from scratch. Eventually, we may be able to handle inserting items efficiently as well.
     const isAppendingItems = !!itemIds && !!isAppending
+    // newCaseIds semantics differ between rebuild and additive paths — see the push site.
+    const isFullRebuild = !itemIds
     if (!itemIds) {
       self.clearCases()
       itemIds = self.itemData.itemIds()
@@ -320,10 +322,17 @@ export const CollectionModel = V2Model
       const groupKey = self.groupKey(itemId)
       const hadCaseIdForGroupKey = !!self.groupKeyCaseIds.get(groupKey)
       const caseId = self.groupKeyCaseId(groupKey)
-      if (caseId && !hadCaseIdForGroupKey) newCaseIds.push(caseId)
       if (groupKey && caseId) {
         let caseGroup = self.caseGroupMap.get(groupKey)
         if (!caseGroup) {
+          // newCaseIds feeds two consumers: completeCaseGroups' append branch needs every
+          // newly-created caseGroupMap entry (including ones whose case ID was preserved
+          // across a prior wipe of caseGroupMap), while getRemappedCaseIds in the full-
+          // rebuild path must not see preserved-id cases or it'd treat them as candidates
+          // for remapping.
+          if (!isFullRebuild || !hadCaseIdForGroupKey) {
+            newCaseIds.push(caseId)
+          }
           self.allCaseIds.add(caseId)
           // cases with only hidden items aren't in caseIds and don't get indices
           const newCaseIndex = isItemHidden ? -1 : self.caseIds.length

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -564,12 +564,14 @@ export const CollectionModel = V2Model
         // Note: newCaseIds can be an empty array (e.g., when re-adding previously deleted items
         // whose group key mappings still exist), so check length to fall through to REBUILD.
         if (!parentCases && !_needsFullRebuild && newCaseIds?.length) {
-          const newCaseGroups = newCaseIds.map(caseId => self.getCaseGroup(caseId))
-          _caseGroups = [..._caseGroups, ...newCaseGroups.filter(group => !!group)]
+          // Exclude hidden-only case groups so this branch matches REBUILD's walk of
+          // self.caseIds (which already excludes them).
+          const newCaseGroups: CaseInfo[] = newCaseIds
+                                              .map(caseId => self.getCaseGroup(caseId))
+                                              .filter(group => !!group && !group.isHidden) as CaseInfo[]
+          _caseGroups = [..._caseGroups, ...newCaseGroups]
 
-          const newCases = newCaseGroups
-                            .map(caseGroup => caseGroup?.groupedCase)
-                            .filter(aCase => !!aCase)
+          const newCases = newCaseGroups.map(group => group.groupedCase)
           _cases = [..._cases, ...newCases]
 
           // Parent collections: every case is non-empty by definition (isNonEmptyCaseGroup
@@ -577,8 +579,8 @@ export const CollectionModel = V2Model
           const newNonEmptyCases = self.child
             ? newCases
             : newCaseGroups
-                .map(group => group && self.isNonEmptyCaseGroup(group) ? group.groupedCase : undefined)
-                .filter(aCase => !!aCase)
+                .filter(group => self.isNonEmptyCaseGroup(group))
+                .map(group => group.groupedCase)
           _nonEmptyCases = [..._nonEmptyCases, ...newNonEmptyCases]
         }
         // REBUILD path: full recompute from volatile state

--- a/v3/src/models/data/data-set-collections.test.ts
+++ b/v3/src/models/data/data-set-collections.test.ts
@@ -427,4 +427,42 @@ describe("DataSet collections", () => {
 
     disposer()
   })
+
+  it("regroups parent cases when re-added items mix previously-seen and new group keys", () => {
+    // After delete-all + re-add, items whose parent group key was seen in a prior cycle
+    // must still appear as parent cases — even when they're added alongside items whose
+    // group key is new in this cycle.
+    data.moveAttributeToNewCollection("aId")
+    data.validateCases()
+
+    // Cycle 1: clear and add items with a single parent group ("OLD")
+    data.removeCases(data.items.map(i => i.__id__))
+    data.validateCases()
+    const oldItems = Array.from({ length: 5 }, (_, i) => ({
+      __id__: `c1-${i}`, aId: "OLD", bId: `${i}`, cId: `${i}`
+    }))
+    data.addCases(oldItems)
+    data.validateCases()
+    const parentCollection = data.collections[0]
+    expect(parentCollection.cases.length).toBe(1)
+
+    // Cycle 2: delete all, then re-add items mixing the previously-seen "OLD" key with
+    // a new "NEW" key
+    data.removeCases(data.items.map(i => i.__id__))
+    data.validateCases()
+    expect(parentCollection.cases.length).toBe(0)
+
+    const mixedItems = [
+      ...Array.from({ length: 5 }, (_, i) => ({
+        __id__: `c2-old-${i}`, aId: "OLD", bId: `${i}`, cId: `${i}`
+      })),
+      ...Array.from({ length: 5 }, (_, i) => ({
+        __id__: `c2-new-${i}`, aId: "NEW", bId: `${i}`, cId: `${i}`
+      }))
+    ]
+    data.addCases(mixedItems)
+    data.validateCases()
+
+    expect(parentCollection.cases.length).toBe(2)
+  })
 })


### PR DESCRIPTION
[NASAEARTH-27](https://concord-consortium.atlassian.net/browse/NASAEARTH-27)

**Summary**

Fixes a regrouping bug where, after a `delete allCases` followed by `addCases` that mixes a previously-seen parent group key with a new one, the previously-seen group was silently dropped from the parent collection's cases array (even though its entry was correctly present in `caseGroupMap`).

The NEO plugin's "Add Pin" flow hit this every time the user placed a second pin: CODAP stored all items with 2 distinct (`label`, `pinColor`) tuples, but the parent collection reported `caseCount = 1`, so the table and graph only showed the latest pin. 

Bug reproducible [here](https://codap3.concord.org/branch/main/?di=https%3A%2F%2Fmodels-resources.concord.org%2Fneo-codap-plugin%2Fbranch%2Ftime-core-graph%2Findex.html). (Click "Get Data" in plugin, then add two pins to the map.)

Compare with deployed fix branch [here](https://codap3.concord.org/branch/fix-cannot-place-multiple-pins/?di=https%3A%2F%2Fmodels-resources.concord.org%2Fneo-codap-plugin%2Fbranch%2Ftime-core-graph%2Findex.html).

**Root Cause**

In `Collection.updateCaseGroups`, the additive path (`validateCasesForNewItems` → `updateCaseGroups(itemIds)`) only pushed a `caseId` to `newCaseIds` when its group key was new to `groupKeyCaseIds`. After `delete allCases` + `validateCases()` clears `caseGroupMap` but leaves `groupKeyCaseIds` populated, the next `addCases` creates fresh `caseGroupMap` entries for both old and new keys, but only the new key's case ID reaches `completeCaseGroups`' append branch, so the old-key case group is missing from `_caseGroups``.

**Fix**

In the additive path, push to `newCaseIds` for every newly-created `caseGroupMap` entry (not just those with a brand-new group key). The full-rebuild path keeps its original `!hadCaseIdForGroupKey` filter so `getRemappedCaseIds` doesn't treat preserved-id cases as remapping candidates.

[NASAEARTH-27]: https://concord-consortium.atlassian.net/browse/NASAEARTH-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ