### PR TITLE
CODAP-1314: show slope-only LSRL equation when x is date-time

### DIFF
--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
@@ -169,7 +169,7 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
       const attrNames = {x: xAttrName, y: yAttrName}
       const units = {x: xUnits, y: yUnits}
       const xIsDateTime = isDateAxisModel(xAxis)
-      const xAxisRange: [number, number] | undefined = xIsDateTime ? [xAxis.min, xAxis.max] : undefined
+      const xAxisRange: [number, number] | undefined = xIsDateTime ? [...xAxis.domain] : undefined
       const string = lsrlEquationString({
         attrNames, units, caseValues, intercept, interceptLocked, rSquared,
         showConfidenceBands, showR, showRSquared, slope, sumOfSquares, seSlope, seIntercept, layout,

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
@@ -14,6 +14,7 @@ import { useGraphContentModelContext } from "../../hooks/use-graph-content-model
 import { useGraphDataConfigurationContext } from "../../hooks/use-graph-data-configuration-context"
 import { useGraphLayoutContext } from "../../hooks/use-graph-layout-context"
 import { cellKeyToString } from "../../utilities/cell-key-utils"
+import { isDateAxisModel } from "../../../axis/models/numeric-axis-models"
 import {
   IAxisIntercepts, calculateSumOfSquares, curveBasis, lineToAxisIntercepts, lsrlEquationString
 } from "../../utilities/graph-utils"
@@ -167,9 +168,12 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
       const screenY = yScale((pointsOnAxes.current.pt1.y + pointsOnAxes.current.pt2.y) / 2) / ySubAxesCount
       const attrNames = {x: xAttrName, y: yAttrName}
       const units = {x: xUnits, y: yUnits}
+      const xIsDateTime = isDateAxisModel(xAxis)
+      const xAxisRange: [number, number] | undefined = xIsDateTime ? [xAxis.min, xAxis.max] : undefined
       const string = lsrlEquationString({
         attrNames, units, caseValues, intercept, interceptLocked, rSquared,
-        showConfidenceBands, showR, showRSquared, slope, sumOfSquares, seSlope, seIntercept, layout
+        showConfidenceBands, showR, showRSquared, slope, sumOfSquares, seSlope, seIntercept, layout,
+        xIsDateTime, xAxisRange
       })
       const equationSelector = `#lsrl-equation-${model.classNameFromKey(cellKey)}-${linesIndex}`
       const equation = equationDiv.select<HTMLDivElement>(equationSelector)
@@ -199,7 +203,7 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
       ++linesIndex
     })
   }, [adornmentsStore, cellKey, dataConfig, equationContainerSelector, getLines, layout, model,
-      plotHeight, plotWidth, showConfidenceBands, showR, showRSquared, showSumSquares, xAttrId, xAttrName,
+      plotHeight, plotWidth, showConfidenceBands, showR, showRSquared, showSumSquares, xAttrId, xAttrName, xAxis,
       xScale, xSubAxesCount, yAttrId, yAttrName, yScale, ySubAxesCount])
 
   const confidenceBandPaths = useCallback((caseValues: Point[], category = kMain) => {

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
@@ -11,6 +11,7 @@ import { useAdornmentCells } from "../../hooks/use-adornment-cells"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import {useGraphDataConfigurationContext} from "../../hooks/use-graph-data-configuration-context"
 import { useGraphLayoutContext } from "../../hooks/use-graph-layout-context"
+import { isDateAxisModel } from "../../../axis/models/numeric-axis-models"
 import {
   calculateSumOfSquares, computeSlopeAndIntercept, equationString, IAxisIntercepts, lineToAxisIntercepts
 } from "../../utilities/graph-utils"
@@ -87,8 +88,10 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
     const sumOfSquares = type === "display" && dataConfig && graphModel?.adornmentsStore.showSquaresOfResiduals
       ? calculateSumOfSquares({ cellKey, dataConfig, computeY: (x) => intercept + slope * x })
       : undefined
-    return equationString({slope, intercept, attrNames, units, sumOfSquares, layout})
-  }, [cellKey, dataConfig, graphModel, layout, xAttrId, xAttrName, yAttrId, yAttrName])
+    const xIsDateTime = isDateAxisModel(xAxis)
+    const xAxisRange: [number, number] | undefined = xIsDateTime ? [xAxis.min, xAxis.max] : undefined
+    return equationString({slope, intercept, attrNames, units, sumOfSquares, layout, xIsDateTime, xAxisRange})
+  }, [cellKey, dataConfig, graphModel, layout, xAttrId, xAttrName, xAxis, yAttrId, yAttrName])
 
   const refreshEquation = useCallback((slope: number, intercept: number) => {
     const lineInstance = model.lines.get(instanceKey)

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
@@ -89,7 +89,7 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
       ? calculateSumOfSquares({ cellKey, dataConfig, computeY: (x) => intercept + slope * x })
       : undefined
     const xIsDateTime = isDateAxisModel(xAxis)
-    const xAxisRange: [number, number] | undefined = xIsDateTime ? [xAxis.min, xAxis.max] : undefined
+    const xAxisRange: [number, number] | undefined = xIsDateTime ? [...xAxis.domain] : undefined
     return equationString({slope, intercept, attrNames, units, sumOfSquares, layout, xIsDateTime, xAxisRange})
   }, [cellKey, dataConfig, graphModel, layout, xAttrId, xAttrName, xAxis, yAttrId, yAttrName])
 

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -1,7 +1,8 @@
 import {ptInRect} from "../../data-display/data-display-utils"
 import { GraphLayout } from "../models/graph-layout"
 import {
-  equationString, formatValue, kMinus, lineToAxisIntercepts, lsrlEquationString, valueLabelString
+  dateTimeSlopeUnit, equationString, formatValue, kMinus, lineToAxisIntercepts,
+  lsrlEquationString, valueLabelString
 } from "./graph-utils"
 
 describe("formatValue", () => {
@@ -43,6 +44,104 @@ describe("equationString", () => {
       .toBe('<em>Speed</em> = 1 (<em>Lifespan</em>)')
     expect(equationString({slope: 1, intercept: -0.0001, attrNames, units, layout}))
       .toBe('<em>Speed</em> = 1 (<em>Lifespan</em>)')
+  })
+
+  // x-axis range expressed in seconds (since V3 stores date values as epoch seconds).
+  const oneHour = 3600
+  const oneDay = 86400
+  const oneYear = 86400 * 365.25
+
+  describe("date-time x-axis", () => {
+    // When the x-axis is date-time, the equation should show only the scaled slope with a
+    // sensible per-{time-unit} label — never the meaningless intercept (= y at the Unix epoch).
+    it("uses seconds when range < 120s", () => {
+      const result = equationString({
+        slope: 0.5, intercept: 100, attrNames, units: { y: "°C" }, layout,
+        xIsDateTime: true, xAxisRange: [0, 60]
+      })
+      expect(result).toBe(
+        '<em>slope</em> = 0.5 <span class="units">°C</span> <span class="units">per seconds</span>')
+      expect(result).not.toContain("Lifespan")
+    })
+    it("uses minutes when range < 2 hours", () => {
+      // 0.001 °C/sec × 60 = 0.06 °C/min
+      const result = equationString({
+        slope: 0.001, intercept: 0, attrNames, units: { y: "°C" }, layout,
+        xIsDateTime: true, xAxisRange: [0, oneHour]
+      })
+      expect(result).toContain('= 0.06 <span class="units">°C</span>')
+      expect(result).toContain('per minute')
+    })
+    it("uses hours when range < 2 days", () => {
+      // 1e-5 °C/sec × 3600 = 0.036 °C/hour
+      const result = equationString({
+        slope: 1e-5, intercept: 0, attrNames, units: { y: "°C" }, layout,
+        xIsDateTime: true, xAxisRange: [0, oneDay]
+      })
+      expect(result).toContain('= 0.036 <span class="units">°C</span>')
+      expect(result).toContain('per hour')
+    })
+    it("uses days when range < 365 days", () => {
+      // 1e-6 °C/sec × 86400 = 0.0864 °C/day
+      const result = equationString({
+        slope: 1e-6, intercept: 0, attrNames, units: { y: "°C" }, layout,
+        xIsDateTime: true, xAxisRange: [0, oneDay * 30]
+      })
+      expect(result).toContain('= 0.0864 <span class="units">°C</span>')
+      expect(result).toContain('per day')
+    })
+    it("uses years when range >= 365 days", () => {
+      // 1e-8 °C/sec × (86400 × 365.25) ≈ 0.316 °C/year
+      const result = equationString({
+        slope: 1e-8, intercept: 0, attrNames, units: { y: "°C" }, layout,
+        xIsDateTime: true, xAxisRange: [0, oneYear * 5]
+      })
+      expect(result).toContain('per year')
+    })
+    it("omits the y-unit when scaled slope rounds to 0", () => {
+      const result = equationString({
+        slope: 0, intercept: 100, attrNames, units: { y: "°C" }, layout,
+        xIsDateTime: true, xAxisRange: [0, oneDay * 30]
+      })
+      expect(result).toBe('<em>slope</em> = 0 <span class="units">per day</span>')
+    })
+    it("omits the y-unit span when y has no units", () => {
+      const result = equationString({
+        slope: 1e-6, intercept: 0, attrNames, units: {}, layout,
+        xIsDateTime: true, xAxisRange: [0, oneDay * 30]
+      })
+      expect(result).toBe('<em>slope</em> = 0.0864 <span class="units">per day</span>')
+    })
+    it("appends sum-of-squares when provided", () => {
+      const result = equationString({
+        slope: 1e-6, intercept: 0, attrNames, units: { y: "°C" }, layout,
+        xIsDateTime: true, xAxisRange: [0, oneDay * 30], sumOfSquares: 42
+      })
+      expect(result).toContain('per day')
+      expect(result).toContain('Sum of squares = 42')
+    })
+    it("falls through to standard form when xIsDateTime is false", () => {
+      const result = equationString({
+        slope: 1, intercept: 0, attrNames, units, layout,
+        xAxisRange: [0, oneDay]
+      })
+      expect(result).toBe('<em>Speed</em> = 1 (<em>Lifespan</em>)')
+    })
+  })
+})
+
+describe("dateTimeSlopeUnit", () => {
+  it("selects unit by x-axis range in seconds", () => {
+    expect(dateTimeSlopeUnit(60).label).toMatch(/seconds/)
+    expect(dateTimeSlopeUnit(60).multiplier).toBe(1)
+    expect(dateTimeSlopeUnit(3600).label).toMatch(/minute/)
+    expect(dateTimeSlopeUnit(3600).multiplier).toBe(60)
+    expect(dateTimeSlopeUnit(86400).label).toMatch(/hour/)
+    expect(dateTimeSlopeUnit(86400).multiplier).toBe(3600)
+    expect(dateTimeSlopeUnit(86400 * 30).label).toMatch(/day/)
+    expect(dateTimeSlopeUnit(86400 * 30).multiplier).toBe(86400)
+    expect(dateTimeSlopeUnit(86400 * 365 * 5).label).toMatch(/year/)
+    expect(dateTimeSlopeUnit(86400 * 365 * 5).multiplier).toBeCloseTo(86400 * 365.25)
   })
 })
 
@@ -114,6 +213,26 @@ describe("lsrlEquationString", () => {
     })
     expect(result).not.toContain("r =")
     expect(result).not.toContain("r<sup>2</sup>")
+  })
+
+  describe("date-time x-axis", () => {
+    const oneDay = 86400
+    it("uses slope-only form and still appends r² and sum-of-squares", () => {
+      const result = lsrlEquationString({
+        caseValues: [], slope: 1e-6, intercept: 12345, attrNames, units: { y: "°C" }, layout,
+        xIsDateTime: true, xAxisRange: [0, oneDay * 30],
+        rSquared: 0.25, showR: false, showRSquared: true, sumOfSquares: 7
+      })
+      // Slope-only form for the leading equation — no Speed/Lifespan and no intercept.
+      expect(result).toContain('<em>slope</em> = 0.0864 <span class="units">°C</span>')
+      expect(result).toContain('per day')
+      expect(result).not.toContain("Speed")
+      expect(result).not.toContain("Lifespan")
+      expect(result).not.toContain("12345")
+      // Trailing statistics still appended.
+      expect(result).toContain("r<sup>2</sup> = 0.25")
+      expect(result).toContain("Sum of squares = 7")
+    })
   })
 })
 

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -60,7 +60,7 @@ describe("equationString", () => {
         xIsDateTime: true, xAxisRange: [0, 60]
       })
       expect(result).toBe(
-        '<em>slope</em> = 0.5 <span class="units">°C</span> <span class="units">per seconds</span>')
+        '<em>slope</em> = 0.5 <span class="units">°C</span> <span class="units">per second</span>')
       expect(result).not.toContain("Lifespan")
     })
     it("uses minutes when range < 2 hours", () => {
@@ -132,7 +132,7 @@ describe("equationString", () => {
 
 describe("dateTimeSlopeUnit", () => {
   it("selects unit by x-axis range in seconds", () => {
-    expect(dateTimeSlopeUnit(60).label).toMatch(/seconds/)
+    expect(dateTimeSlopeUnit(60).label).toMatch(/second/)
     expect(dateTimeSlopeUnit(60).multiplier).toBe(1)
     expect(dateTimeSlopeUnit(3600).label).toMatch(/minute/)
     expect(dateTimeSlopeUnit(3600).multiplier).toBe(60)

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -321,6 +321,10 @@ export function dateTimeSlopeUnit(xRangeSeconds: number): { multiplier: number, 
 }
 
 // Returns the number of fractional digits needed to show `value` with `sigFigs` significant figures.
+// Note: this is slightly different from V2 behavior — V2 used toPrecision(3), which always renders
+// 3 sig figs (e.g., 1234.5 → "1.23e+3"). This helper picks fractional digits, so values >= 1000
+// render at native precision with grouping (e.g., 1234.5 → "1,235"). We prefer "1,235" over either
+// "1,230" (sig-fig rounded) or "1.23e+3" (scientific) for readability of moderately large slopes.
 function sigFigFractionDigits(value: number, sigFigs: number): number {
   if (!isFiniteNumber(value) || value === 0) return 0
   const magnitude = Math.floor(Math.log10(Math.abs(value)))

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -303,6 +303,45 @@ function formatEquationValue(equationValue: number, equationDigits: number, unit
   return units && parenthesizeUnits ? `(${numUnitsStr})` : numUnitsStr
 }
 
+// When the x-axis is a date-time axis, the slope of a line is in units of y-per-second
+// (since date values are stored as seconds since epoch). This helper picks a human-scale
+// time unit based on the visible x-axis range and returns the scale factor and label.
+// Mirrors V2's behavior in twoD_line_adornment.js (handleDateTime).
+export function dateTimeSlopeUnit(xRangeSeconds: number): { multiplier: number, label: string } {
+  if (xRangeSeconds < 120) {
+    return { multiplier: 1, label: t("DG.ScatterPlotModel.secondsLabel") }
+  } else if (xRangeSeconds < 60 * 60 * 2) { // 2 hours
+    return { multiplier: 60, label: t("DG.ScatterPlotModel.minutesLabel") }
+  } else if (xRangeSeconds < 3600 * 24 * 2) { // 2 days
+    return { multiplier: 3600, label: t("DG.ScatterPlotModel.hoursLabel") }
+  } else if (xRangeSeconds < 3600 * 24 * 365) { // 365 days
+    return { multiplier: 3600 * 24, label: t("DG.ScatterPlotModel.daysLabel") }
+  }
+  return { multiplier: 3600 * 24 * 365.25, label: t("DG.ScatterPlotModel.yearsLabel") }
+}
+
+// Returns the number of fractional digits needed to show `value` with `sigFigs` significant figures.
+function sigFigFractionDigits(value: number, sigFigs: number): number {
+  if (!isFiniteNumber(value) || value === 0) return 0
+  const magnitude = Math.floor(Math.log10(Math.abs(value)))
+  return Math.max(0, sigFigs - 1 - magnitude)
+}
+
+// Slope-only equation form used when x is a date-time axis. The intercept (y at the Unix epoch)
+// is meaningless in that case, so V2 — and now V3 — hides it. Matches V2's kSlopeOnly format:
+//   "slope = {scaled-slope} {yUnit} {time-unit-label}"
+function dateTimeSlopeOnlyString(slope: number, xRangeSeconds: number, yUnit?: string): string {
+  const { multiplier, label } = dateTimeSlopeUnit(xRangeSeconds)
+  const scaledSlope = slope * multiplier
+  const formattedSlope = formatValue(scaledSlope, sigFigFractionDigits(scaledSlope, 3))
+  // When the displayed scaled slope is "0" (or pure -0), hide the y-unit too — V2 treats this as
+  // "no meaningful rate", since multiplying zero by any unit conveys nothing useful.
+  const showYUnit = formattedSlope !== "0" && !!yUnit
+  const yUnitPart = showYUnit ? ` <span class="units">${yUnit}</span>` : ""
+  return `<em>${t("DG.ScatterPlotModel.slopeOnly")}</em> = ${formattedSlope}${yUnitPart} ` +
+    `<span class="units">${label}</span>`
+}
+
 interface IEquationString {
   attrNames: { x: string, y: string }
   units: { x?: string, y?: string }
@@ -310,6 +349,10 @@ interface IEquationString {
   layout: GraphLayout
   slope: number
   sumOfSquares?: number
+  // When set, the x-axis is a date-time axis with the given visible range (in seconds since epoch);
+  // the equation will be rendered in slope-only form rather than y = slope·x + intercept.
+  xIsDateTime?: boolean
+  xAxisRange?: [number, number]
 }
 
 export function residualsString(sumOfSquares: number, includeBreak = true) {
@@ -319,7 +362,20 @@ export function residualsString(sumOfSquares: number, includeBreak = true) {
     ? `${includeBreak ? '<br />' : ''}${t("DG.ScatterPlotModel.sumSquares")} = ${formattedSumOfSquares}` : ""
 }
 
-export function equationString({ slope, intercept, attrNames, units, sumOfSquares, layout }: IEquationString) {
+export function equationString(
+  { slope, intercept, attrNames, units, sumOfSquares, layout, xIsDateTime, xAxisRange }: IEquationString
+) {
+  const squaresMaxDec = !sumOfSquares || sumOfSquares > 100 ? 0 : 3
+  const formattedSumOfSquares = formatEquationValue(sumOfSquares || 0, squaresMaxDec)
+  const squaresPart = isFiniteNumber(sumOfSquares)
+    ? `<br />${t("DG.ScatterPlotModel.sumSquares")} = ${formattedSumOfSquares}`
+    : ""
+
+  if (xIsDateTime && xAxisRange && isFinite(slope)) {
+    const xRangeSeconds = xAxisRange[1] - xAxisRange[0]
+    return `${dateTimeSlopeOnlyString(slope, xRangeSeconds, units.y)}${squaresPart}`
+  }
+
   const slopeUnits = units.x && units.y
                       ? `${units.y}/${units.x}`
                       : units.y || (units.x ? `/${units.x}` : "")
@@ -330,14 +386,9 @@ export function equationString({ slope, intercept, attrNames, units, sumOfSquare
   const formattedSlope = slopeIsFinite
                           ? formatEquationValue(slope, neededFractionDigits.slopeDigits, slopeUnits, true)
                           : 0
-  const squaresMaxDec = !sumOfSquares || sumOfSquares > 100 ? 0 : 3
-  const formattedSumOfSquares = formatEquationValue(sumOfSquares || 0, squaresMaxDec)
   const xAttrString = attrNames.x.length > 1 ? `(<em>${attrNames.x}</em>)` : `<em>${attrNames.x}</em>`
   const interceptDisplaysAsZero = formatValue(intercept, neededFractionDigits.interceptDigits) === "0"
   const interceptString = !interceptDisplaysAsZero ? ` ${intercept > 0 ? "+" : ""} ${formattedIntercept}` : ""
-  const squaresPart = isFiniteNumber(sumOfSquares)
-    ? `<br />${t("DG.ScatterPlotModel.sumSquares")} = ${formattedSumOfSquares}`
-    : ""
 
   return slopeIsFinite
     ? `<em>${attrNames.y}</em> = ${formattedSlope} ${xAttrString}${interceptString}${squaresPart}`
@@ -358,7 +409,7 @@ interface ILsrlEquationString extends IEquationString {
 export const lsrlEquationString = (props: ILsrlEquationString) => {
   const { slope, intercept, attrNames, units, showConfidenceBands,
     rSquared, seSlope, seIntercept, interceptLocked = false, sumOfSquares, layout,
-    showR = false, showRSquared = false } = props
+    showR = false, showRSquared = false, xIsDateTime, xAxisRange } = props
   const slopeUnits = units.x && units.y
                       ? `${units.y}/${units.x}`
                       : units.y || (units.x ? `/${units.x}` : "")
@@ -374,9 +425,12 @@ export const lsrlEquationString = (props: ILsrlEquationString) => {
   const xAttrString = attrNames.x.length > 1 ? `(<em>${attrNames.x}</em>)` : `<em>${attrNames.x}</em>`
   const interceptDisplaysAsZero = formatValue(intercept, neededFractionDigits.interceptDigits) === "0"
   const interceptString = !interceptDisplaysAsZero ? ` ${intercept > 0 ? "+" : ""} ${formattedIntercept}` : ""
-  const equationPart = slopeIsFinite
-    ? `<em>${attrNames.y}</em> = ${formattedSlope} ${xAttrString}${interceptString}`
-    : `<em>${slope === 0 ? attrNames.y : attrNames.x}</em> = ${formattedIntercept}`
+  const dateTimeForm = xIsDateTime && xAxisRange && isFinite(slope)
+  const equationPart = dateTimeForm
+    ? dateTimeSlopeOnlyString(slope, xAxisRange[1] - xAxisRange[0], units.y)
+    : slopeIsFinite
+      ? `<em>${attrNames.y}</em> = ${formattedSlope} ${xAttrString}${interceptString}`
+      : `<em>${slope === 0 ? attrNames.y : attrNames.x}</em> = ${formattedIntercept}`
   const rValue = rSquared != null && slope != null ? Math.sign(slope) * Math.sqrt(rSquared) : undefined
   const formattedR = rValue != null ? formatEquationValue(rValue, 4) : ""
   const rPart = showR && !interceptLocked && rValue != null ? `<br />r = ${formattedR}` : ""

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -334,8 +334,10 @@ function dateTimeSlopeOnlyString(slope: number, xRangeSeconds: number, yUnit?: s
   const { multiplier, label } = dateTimeSlopeUnit(xRangeSeconds)
   const scaledSlope = slope * multiplier
   const formattedSlope = formatValue(scaledSlope, sigFigFractionDigits(scaledSlope, 3))
-  // When the displayed scaled slope is "0" (or pure -0), hide the y-unit too — V2 treats this as
-  // "no meaningful rate", since multiplying zero by any unit conveys nothing useful.
+  // When the displayed scaled slope rounds to "0", hide the y-unit too — a "0 °C per day" rate
+  // doesn't convey anything that "0 per day" doesn't. (V2 has a similar-looking check, but its
+  // threshold string "0 " never matches toPrecision(3) output, so V2 effectively always shows
+  // the y-unit here. We diverge intentionally.)
   const showYUnit = formattedSlope !== "0" && !!yUnit
   const yUnitPart = showYUnit ? ` <span class="units">${yUnit}</span>` : ""
   return `<em>${t("DG.ScatterPlotModel.slopeOnly")}</em> = ${formattedSlope}${yUnitPart} ` +
@@ -365,13 +367,9 @@ export function residualsString(sumOfSquares: number, includeBreak = true) {
 export function equationString(
   { slope, intercept, attrNames, units, sumOfSquares, layout, xIsDateTime, xAxisRange }: IEquationString
 ) {
-  const squaresMaxDec = !sumOfSquares || sumOfSquares > 100 ? 0 : 3
-  const formattedSumOfSquares = formatEquationValue(sumOfSquares || 0, squaresMaxDec)
-  const squaresPart = isFiniteNumber(sumOfSquares)
-    ? `<br />${t("DG.ScatterPlotModel.sumSquares")} = ${formattedSumOfSquares}`
-    : ""
+  const squaresPart = isFiniteNumber(sumOfSquares) ? residualsString(sumOfSquares, true) : ""
 
-  if (xIsDateTime && xAxisRange && isFinite(slope)) {
+  if (xIsDateTime && xAxisRange && isFiniteNumber(slope)) {
     const xRangeSeconds = xAxisRange[1] - xAxisRange[0]
     return `${dateTimeSlopeOnlyString(slope, xRangeSeconds, units.y)}${squaresPart}`
   }
@@ -425,7 +423,7 @@ export const lsrlEquationString = (props: ILsrlEquationString) => {
   const xAttrString = attrNames.x.length > 1 ? `(<em>${attrNames.x}</em>)` : `<em>${attrNames.x}</em>`
   const interceptDisplaysAsZero = formatValue(intercept, neededFractionDigits.interceptDigits) === "0"
   const interceptString = !interceptDisplaysAsZero ? ` ${intercept > 0 ? "+" : ""} ${formattedIntercept}` : ""
-  const dateTimeForm = xIsDateTime && xAxisRange && isFinite(slope)
+  const dateTimeForm = xIsDateTime && xAxisRange && isFiniteNumber(slope)
   const equationPart = dateTimeForm
     ? dateTimeSlopeOnlyString(slope, xAxisRange[1] - xAxisRange[0], units.y)
     : slopeIsFinite

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -789,7 +789,7 @@
     "DG.ScatterPlotModel.daysLabel": "per day", // used in equation for line when x is a datetime axis
     "DG.ScatterPlotModel.hoursLabel": "per hour", // used in equation for line when x is a datetime axis
     "DG.ScatterPlotModel.minutesLabel": "per minute", // used in equation for line when x is a datetime axis
-    "DG.ScatterPlotModel.secondsLabel": "per seconds", // used in equation for line when x is a datetime axis
+    "DG.ScatterPlotModel.secondsLabel": "per second", // used in equation for line when x is a datetime axis
     "DG.ScatterPlotModel.LSRLCIBandInfo": "Shaded regions shows the range\n in which the true regression line\n lies at 95% confidence level.",
 
     // DG.BarChartModel


### PR DESCRIPTION
## Summary
- When the x-axis is a date-time attribute, scatterplot LSRL and movable-line equations now render as `slope = {scaledSlope} {yUnit} {per-time-label}` instead of the meaningless `y = slope·x + intercept` form. Matches V2's behavior from `twoD_line_adornment.js`.
- Added `dateTimeSlopeUnit(rangeInSeconds)` helper mirroring V2's seconds/minutes/hours/days/years bucket table.
- LSRL equation still appends r, r², σ_slope, σ_intercept, and sum-of-squares around the slope-only form.

Fixes [CODAP-1314](https://concord-consortium.atlassian.net/browse/CODAP-1314).

## Changes during Copilot review

- **`bdfa11dc9`** — Switched both adornments from `xAxis.min/max` to `xAxis.domain` so the slope-unit bucket tracks dynamic axis updates during drags/zooms.
- **`52e309d17`** — Added a comment on `sigFigFractionDigits` documenting the intentional V2 divergence for scaled slopes ≥ 1000. V3 renders `"1,235"` for `1234.5`; V2 would have rendered `"1.23e+3"`. We chose the more readable form.

One additional Copilot comment about TypeScript narrowing was investigated and verified to be a false positive — `build:tsc` with `strict: true` passes cleanly because TS 4.4+ propagates type narrowing through aliased const boolean conditions. Explained on the thread; no code change.

## Test plan
- [x] Unit tests cover each time-unit bucket, slope = 0, missing y-unit, sum-of-squares append, fall-through when x is not date-time, and LSRL r² appended in date-time form.
- [x] Verified in browser with the `LSRL with Date.codap` attachment.
- [ ] CI lint, type-check, and Cypress pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CODAP-1314]: https://concord-consortium.atlassian.net/browse/CODAP-1314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ