### PR TITLE
CODAP-1320: render movable line on date-time x-axis

### DIFF
--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-model.ts
@@ -1,6 +1,7 @@
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
 import { JsonNumber } from "../../../../utilities/json-number"
 import { IAxisModel } from "../../../axis/models/axis-model"
+import { isAnyNumericAxisModel } from "../../../axis/models/numeric-axis-models"
 import { Point } from "../../../data-display/data-display-types"
 import { migrateInstanceKeyMap, stringToCellKey } from "../../utilities/cell-key-utils"
 import { computeSlopeAndIntercept } from "../../utilities/graph-utils"
@@ -97,7 +98,10 @@ export const MovableLineAdornmentModel = AdornmentModel
 .actions(self => ({
   updateCategories(options: IUpdateCategoriesOptions) {
     const { resetPoints, dataConfig, interceptLocked, xAxis, yAxis } = options
-    if (dataConfig.xAndYAreNumeric) {
+    // Accept date/count/percent axes alongside numeric — mirrors the gate used by
+    // movable-point and movable-value, and aligns with V2's behavior of allowing a
+    // movable line on a date-time scatterplot.
+    if (isAnyNumericAxisModel(xAxis) && isAnyNumericAxisModel(yAxis)) {
       dataConfig.getAllCellKeys().forEach(cellKey => {
         const instanceKey = self.instanceKey(cellKey)
         if (!self.lines.get(instanceKey) || resetPoints) {

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -308,10 +308,6 @@ export const GraphDataConfigurationModel = DataConfigurationModel
         return self.attributeType(role) === "numeric"
       }).map(role => ({ role, attrId: self.attributeID(role) }))
     },
-    get xAndYAreNumeric() {
-      const attrTypes = self.attrTypes
-      return attrTypes.bottom === "numeric" && attrTypes.left === "numeric"
-    },
     get numberOfHorizontalRegions() {
       return self.primaryRole === 'x'
         ? this.primaryIsCategorical ? self.categoryArrayForAttrRole('x').length : 1


### PR DESCRIPTION
## Summary
- Movable line now appears when added to a scatterplot with a date-time x-axis. Previously the model gated initial-line creation on `xAndYAreNumeric`, which excluded date axes, so nothing rendered except an empty (yellow-backgrounded) equation `<p>`.
- Aligns the gate with the `isAnyNumericAxisModel` check already used by movable-point and movable-value adornments.
- Removed the orphan `xAndYAreNumeric` view; movable-line was its only caller.

Fixes [CODAP-1320](https://concord-consortium.atlassian.net/browse/CODAP-1320).

## Dependency
The slope-only equation rendering on date-time x-axes lands separately in [#2572 (CODAP-1314)](https://github.com/concord-consortium/codap/pull/2572). If this PR merges first, the line will draw correctly but the equation will briefly show the meaningless `y = slope·x + intercept` form until #2572 also lands. No file overlap between the two PRs — merges in either order are clean.

## Test plan
- [x] `npm test -- movable-line graph-data-configuration` passes (29 tests).
- [x] `npm run build:tsc` clean.
- [x] Lint clean.
- [x] Verified in browser with the `Movable Line with Date.codap` attachment — line draws.
- [ ] CI lint, type-check, and Cypress pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CODAP-1320]: https://concord-consortium.atlassian.net/browse/CODAP-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ