### PR TITLE
chore: launchFromLara, lara param support (CODAP-1324)

### DIFF
--- a/v3/src/lib/cfm/handle-cfm-event.test.ts
+++ b/v3/src/lib/cfm/handle-cfm-event.test.ts
@@ -236,6 +236,76 @@ describe("handleCFMEvent", () => {
     spy.mockRestore()
   })
 
+  describe("openedFile + embedded LARA context", () => {
+    let savedUrlParams: any
+
+    beforeEach(() => {
+      // Snapshot the *current* params, then actively clear the three we care about so
+      // leftover state from a prior test elsewhere can't make our negative assertions
+      // pass for the wrong reason.
+      savedUrlParams = { ...urlParamsModule.urlParams }
+      delete urlParamsModule.urlParams.interactiveApi
+      delete urlParamsModule.urlParams.launchFromLara
+      delete urlParamsModule.urlParams.lara
+    })
+
+    afterEach(() => {
+      // Restore each param we may have touched
+      delete urlParamsModule.urlParams.interactiveApi
+      delete urlParamsModule.urlParams.launchFromLara
+      delete urlParamsModule.urlParams.lara
+      Object.assign(urlParamsModule.urlParams, savedUrlParams)
+    })
+
+    const v2Doc = {
+      appName: "DG",
+      appVersion: "2.0.0",
+      appBuildNum: "555",
+      components: [],
+      contexts: []
+    } as unknown as ICodapV2DocumentJson
+
+    const makeEvent = () => ({
+      type: "openedFile",
+      data: { content: v2Doc, metadata: { filename: "file.codap" } },
+      callback: jest.fn() as ClientEventCallback
+    } as CloudFileManagerClientEvent)
+
+    // Each test verifies BOTH paths of the autoSave gate:
+    //   1. The "disable" branch (autoSave(-1)) is NOT called
+    //   2. The "enable" branch (autoSave(kCFMAutoSaveInterval)) IS called
+    // This matches the assertion style used by "handles the openedFile message with
+    // a v2 document saved by v3" at the top of this test file and catches both
+    // "called with wrong interval" and "never called" regressions.
+
+    it("keeps autoSave enabled for v2 doc when interactiveApi is present", async () => {
+      urlParamsModule.urlParams.interactiveApi = null  // present without value
+      const mockCfmClient =
+        { closeFile: jest.fn(), autoSave: jest.fn() } as unknown as CloudFileManagerClient
+      await handleCFMEvent(mockCfmClient, makeEvent())
+      expect(mockCfmClient.autoSave).not.toHaveBeenCalledWith(-1)
+      expect(mockCfmClient.autoSave).toHaveBeenCalledWith(kCFMAutoSaveInterval)
+    })
+
+    it("keeps autoSave enabled for v2 doc when launchFromLara is present with a value", async () => {
+      urlParamsModule.urlParams.launchFromLara = "base64payload"
+      const mockCfmClient =
+        { closeFile: jest.fn(), autoSave: jest.fn() } as unknown as CloudFileManagerClient
+      await handleCFMEvent(mockCfmClient, makeEvent())
+      expect(mockCfmClient.autoSave).not.toHaveBeenCalledWith(-1)
+      expect(mockCfmClient.autoSave).toHaveBeenCalledWith(kCFMAutoSaveInterval)
+    })
+
+    it("keeps autoSave enabled for v2 doc when lara is present with a value", async () => {
+      urlParamsModule.urlParams.lara = "1"
+      const mockCfmClient =
+        { closeFile: jest.fn(), autoSave: jest.fn() } as unknown as CloudFileManagerClient
+      await handleCFMEvent(mockCfmClient, makeEvent())
+      expect(mockCfmClient.autoSave).not.toHaveBeenCalledWith(-1)
+      expect(mockCfmClient.autoSave).toHaveBeenCalledWith(kCFMAutoSaveInterval)
+    })
+  })
+
   describe("`openedFile` message with invalid documents", () => {
     let setDocumentSpy: jest.SpyInstance
     let mockCfmClient: CloudFileManagerClient

--- a/v3/src/lib/cfm/handle-cfm-event.ts
+++ b/v3/src/lib/cfm/handle-cfm-event.ts
@@ -5,7 +5,7 @@ import pkg from "../../../package.json"
 import { appState } from "../../models/app-state"
 import { uiState } from "../../models/ui-state"
 import { t } from "../../utilities/translation/translate"
-import { removeDevUrlParams, urlParams } from "../../utilities/url-params"
+import { hasInteractiveApiContext, removeDevUrlParams, urlParams } from "../../utilities/url-params"
 import { displayVersion } from "../../utilities/version-utils"
 import { isCodapV2Document } from "../../v2/codap-v2-types"
 import { DEBUG_CFM_EVENTS, DEBUG_CFM_NO_AUTO_SAVE } from "../debug"
@@ -112,14 +112,15 @@ export async function handleCFMEvent(cfmClient: CloudFileManagerClient, event: C
           // should use a more advanced mechanism to determine which application saved
           // the document. In the meantime we just look at the appVersion. If it isn't
           // a v3 appVersion, then we assume this is a v2 document.
-          // If CFM file menu is hidden because of the interactiveApi url parameter then
-          // we keep autoSave enabled.
+          // If CFM file menu is hidden because the app is launched in embedded-LARA context
+          // (interactiveApi, launchFromLara, or lara URL params; see hasInteractiveApiContext)
+          // then we keep autoSave enabled.
           // Note: if auto save is disabled by the debug flag DEBUG_CFM_NO_AUTO_SAVE,
           // that will override this, and is handled by the value of kCFMAutoSaveInterval
           // computed above.
           // Note: in some v2 documents the appVersion is not set
           const loadedDocumentWasSavedByV3 = !!resolvedDocument.appVersion?.startsWith("3.")
-          shouldAutoSaveDocument = loadedDocumentWasSavedByV3 || urlParams.interactiveApi !== undefined
+          shouldAutoSaveDocument = loadedDocumentWasSavedByV3 || hasInteractiveApiContext()
           if (!shouldAutoSaveDocument) {
             // eslint-disable-next-line no-console
             console.log("Disabling autoSave for v2 document that was saved by CODAPv2",

--- a/v3/src/lib/cfm/use-cloud-file-manager.ts
+++ b/v3/src/lib/cfm/use-cloud-file-manager.ts
@@ -9,7 +9,7 @@ import { isCodapDocument } from "../../models/codap/create-codap-document"
 import { persistentState } from "../../models/persistent-state"
 import { gLocale } from "../../utilities/translation/locale"
 import { t } from "../../utilities/translation/translate"
-import { removeDevUrlParams, urlParams } from "../../utilities/url-params"
+import { hasInteractiveApiContext, removeDevUrlParams } from "../../utilities/url-params"
 import { CONFIG_SAVE_AS_V2 } from "../config"
 import { DEBUG_CFM_LOCAL_STORAGE } from "../debug"
 import { Logger } from "../logger"
@@ -308,8 +308,8 @@ export function useCloudFileManager(optionsArg: CFMAppOptions, hookOptions?: IUs
 
     const _options: CFMAppOptions = {
       autoSaveInterval: kCFMAutoSaveInterval,
-      // When running in the Activity Player, hide the hamburger menu
-      hideMenuBar: urlParams.interactiveApi !== undefined,
+      // When running in the Activity Player or any other embedded-LARA context, hide the hamburger menu
+      hideMenuBar: hasInteractiveApiContext(),
       ui: {
         menuBar: getMenuBar(cfm),
         menuAnchorIcon: FileMenuIcon,

--- a/v3/src/utilities/url-params.test.ts
+++ b/v3/src/utilities/url-params.test.ts
@@ -143,4 +143,60 @@ describe("urlParams", () => {
     expect(getGuideIndex()).toBeUndefined()
   })
 
+  describe("hasInteractiveApiContext", () => {
+    const { hasInteractiveApiContext } = require("./url-params")
+
+    it("returns false when no relevant params are present", () => {
+      setUrlParams("")
+      expect(hasInteractiveApiContext()).toBe(false)
+
+      setUrlParams("?other=value")
+      expect(hasInteractiveApiContext()).toBe(false)
+    })
+
+    it("returns true when interactiveApi is present (any form)", () => {
+      setUrlParams("?interactiveApi")          // present without value
+      expect(hasInteractiveApiContext()).toBe(true)
+
+      setUrlParams("?interactiveApi=")         // present with empty value
+      expect(hasInteractiveApiContext()).toBe(true)
+
+      setUrlParams("?interactiveApi=anything") // present with value
+      expect(hasInteractiveApiContext()).toBe(true)
+    })
+
+    it("returns true when launchFromLara has a truthy value", () => {
+      setUrlParams("?launchFromLara=abc123")
+      expect(hasInteractiveApiContext()).toBe(true)
+    })
+
+    it("returns false when launchFromLara is present but empty/valueless", () => {
+      // Mirrors v2's `!!getUrlParameter('launchFromLara')`: null/empty are falsy
+      setUrlParams("?launchFromLara")
+      expect(hasInteractiveApiContext()).toBe(false)
+
+      setUrlParams("?launchFromLara=")
+      expect(hasInteractiveApiContext()).toBe(false)
+    })
+
+    it("returns true when lara has a truthy value", () => {
+      setUrlParams("?lara=foo")
+      expect(hasInteractiveApiContext()).toBe(true)
+    })
+
+    it("returns false when lara is present but empty/valueless", () => {
+      setUrlParams("?lara")
+      expect(hasInteractiveApiContext()).toBe(false)
+
+      setUrlParams("?lara=")
+      expect(hasInteractiveApiContext()).toBe(false)
+    })
+
+    it("returns true when multiple relevant params are present (OR semantics)", () => {
+      // Guard against a future refactor changing `||` to `&&` or adding precedence checks.
+      setUrlParams("?interactiveApi=&launchFromLara=abc123&lara=foo")
+      expect(hasInteractiveApiContext()).toBe(true)
+    })
+  })
+
 })

--- a/v3/src/utilities/url-params.ts
+++ b/v3/src/utilities/url-params.ts
@@ -129,8 +129,11 @@ export interface UrlParams {
   inbounds?: string | null
   /*
    * Indicates CODAP is running in the Activity Player. Used by the CFM and to configure
-   * the CFM.
-   * value: ignored
+   * the CFM. Treated equivalently to `launchFromLara` and `lara` for the purpose of hiding
+   * the CFM menu and keeping auto-save enabled (see `hasInteractiveApiContext()`).
+   * value: presence in any form (with or without a value) is the signal — null, "", or a string.
+   *        This differs from `launchFromLara` and `lara`, which require a truthy string value
+   *        to trigger. All three mirror v2's hideCFMMenu logic (apps/dg/core.js:354-359).
    */
   interactiveApi?: string | null
   /*
@@ -149,6 +152,22 @@ export interface UrlParams {
    * value: locale string, e.g. `en-US` or `es`
    */
   "lang-override"?: string | null
+  /*
+   * [V2] Indicates CODAP is running embedded in LARA/Activity Player (legacy form).
+   * Treated equivalently to `launchFromLara` and `interactiveApi` for the purpose
+   * of hiding the CFM menu and keeping auto-save enabled for v2 documents.
+   * value: typically a truthy string; presence-with-value is what triggers the signal
+   *        (mirrors v2's `!!getUrlParameter('lara')` check)
+   */
+  lara?: string | null
+  /*
+   * [V2] Indicates CODAP is running embedded via the CFM autolaunch wrapper
+   * (typical AP/LARA launch). Treated equivalently to `lara` and `interactiveApi`
+   * for the purpose of hiding the CFM menu and keeping auto-save enabled.
+   * value: base64-encoded launch payload from the autolaunch wrapper; presence-with-value
+   *        is what triggers the signal (mirrors v2's `!!getUrlParameter('launchFromLara')`)
+   */
+  launchFromLara?: string | null
   /*
    * Specifies the type of tile container. Defaults to "free", which is the standard free layout used by CODAP.
    * Limited/provisional support for "mosaic" layout, in which tiles are connected and cannot overlap.
@@ -258,6 +277,23 @@ export function removeDevUrlParams() {
 
 export function isInquirySpaceMode() {
   return urlParams.app === "is"
+}
+
+/*
+ * Returns true when any of the three URL params used to signal an embedded-LARA
+ * launch is present. Mirrors v2's hideCFMMenu predicate (apps/dg/core.js):
+ *   - interactiveApi is "present" if it appears in the query string in any form
+ *     (matches v2's `!!interactiveApi || interactiveApi === null` check)
+ *   - launchFromLara / lara are "present" only when their value is truthy
+ *     (matches v2's `!!getUrlParameter(...)` check)
+ * Use this anywhere V3 needs to know whether it is running embedded in LARA
+ * or the CFM autolaunch wrapper.
+ */
+export function hasInteractiveApiContext(): boolean {
+  if (urlParams.interactiveApi !== undefined) return true
+  if (urlParams.launchFromLara) return true
+  if (urlParams.lara) return true
+  return false
 }
 
 export function getDataInteractiveUrl(url: string) {


### PR DESCRIPTION
[CODAP-1324](https://concord-consortium.atlassian.net/browse/CODAP-1324)

V2 treats `launchFromLara`, `lara`, and `interactiveApi` as equivalent signals that CODAP is running embedded in LARA / Activity Player. Previous to these changes, V3 recognized only `interactiveApi`. So when the CFM autolaunch wrapper launched V3 via a URL with params like `?documentServer=…&launchFromLara=<base64>`, V3-side code that gates CFM menu visibility and v2-doc auto-save behavior did not detect the embedded context.

This PR closes that gap:

- Adds `launchFromLara` and `lara` to the `UrlParams` interface, and expands the doc comment on `interactiveApi` to explain the equivalence and the (intentional) semantic difference between the three params.
- Introduces a single helper, `hasInteractiveApiContext()` in `src/utilities/url-params.ts`, that mirrors V2's `hideCFMMenu` predicate exactly: `interactiveApi` triggers on any form of presence (including `?interactiveApi` with no value), while `launchFromLara` and `lara` require a truthy value (matching V2's `!!getUrlParameter(...)`).
- Replaces the two app-level call sites that previously checked `urlParams.interactiveApi !== undefined`:
    - `src/lib/cfm/handle-cfm-event.ts` — keeps auto-save enabled for v2 documents loaded in an embedded-LARA context.
    - `src/lib/cfm/use-cloud-file-manager.ts` — sets the CFM `hideMenuBar` option.

The DI handler at `src/data-interactive/handlers/interactive-api-handler.ts` is intentionally left alone — it reports the availability of the `interactiveApi` resource type to plugins and is a different signal from LARA-context detection.

Out of scope: the CFM autolaunch wrapper itself, the CloudFront Function that handles the V2→V3 redirect (CODAP-1323), and `documentServer` handling (already covered by CFM's `lara` provider).

[CODAP-1324]: https://concord-consortium.atlassian.net/browse/CODAP-1324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ