### PR TITLE
CODAP2-287: detect V3 documents and show useful error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,16 @@ CODAP uses a hierarchical data model:
 - Test GUI available at `http://localhost:4020/dg/en/current/tests.html` when server is running
 - Production builds require the `makeCodapZip` script which also builds plugins from sibling repositories
 
+## Localized Strings
+
+The English strings source of truth is `lang/strings/en-US.json` (a JSONC file at the repo root that may contain comments). The SproutCore-format file at `apps/dg/english.lproj/strings.js` is a **generated artifact** — never edit it directly. To add or change a string:
+
+1. Edit `lang/strings/en-US.json`.
+2. Run `bin/strings-build.sh` from the repo root to regenerate `apps/dg/english.lproj/strings.js` (a sed wrapper that adds the `SC.stringsFor("en", {...})` envelope).
+3. Commit both files together.
+
+Translations for other locales (`apps/dg/<lang>.lproj/strings.js`) are picked up by `bin/strings-pull-project.sh` from the translation service after translators handle the new key — no need to edit those files manually.
+
 ## Related Repositories
 
 Full builds require these sibling directories:

--- a/apps/dg/english.lproj/strings.js
+++ b/apps/dg/english.lproj/strings.js
@@ -85,6 +85,7 @@ SC.stringsFor("en", {
     "DG.AppController.validateDocument.invalidDocument": "Invalid JSON Document: %@1",
     "DG.AppController.openDocument.error.general": "Unable to open document",
     "DG.AppController.openDocument.error.invalid_format": "CODAP can not read this type of document",
+    "DG.AppController.openDocument.error.v3Format": "This document was created with a newer version of CODAP. To open it, use the latest version of CODAP at <a href=\"https://codap.concord.org/app\" target=\"_blank\" rel=\"noopener noreferrer\">https://codap.concord.org/app</a>.",
     "DG.AppController.createDataSet.initialAttribute": "AttributeName",
     "DG.AppController.createDataSet.name": "New Dataset",
     "DG.AppController.createDataSet.collectionName": "Cases",

--- a/apps/dg/main.js
+++ b/apps/dg/main.js
@@ -185,6 +185,18 @@ DG.main = function main() {
 
     return (content.appName === DG.APPNAME) && !!content.appVersion && !!content.appBuildNum ? content : null;
   }
+
+  // A V3 document may reach resolveDocument either unwrapped (CFM stripped
+  // its envelope, leaving the V3 DocumentContent at the top level) or wrapped
+  // (the full V3 envelope, with the DocumentContent nested under a content
+  // property). Detect the V3 DocumentContent shape (tileMap + rowMap) in
+  // either position so detection is unaffected by CFM's unwrap behavior.
+  function isV3Document(content) {
+    if (!content) return false;
+    var v3Content = content.content || content;
+    return !!(v3Content.tileMap && v3Content.rowMap);
+  }
+
   function translateQueryParameters() {
     var startingDataInteractive = DG.get('startingDataInteractive');
     var diURLs = [];
@@ -644,6 +656,10 @@ DG.main = function main() {
             return;
           }
         }
+        if (isV3Document(iDocContents)) {
+          reject({ userMessage: 'DG.AppController.openDocument.error.v3Format'.loc() });
+          return;
+        }
         if (iDocContents.appName != null &&
             iDocContents.appVersion != null) {
           contentType = 'application/vnd.codap+json';
@@ -923,7 +939,9 @@ DG.main = function main() {
                     },  // then() error handler
                     function(iReason) {
                       DG.logWarn(iReason);
-                      event.callback('DG.AppController.openDocument.error.general'.loc());
+                      var userMessage = (iReason && typeof iReason === 'object' && iReason.userMessage)
+                          || 'DG.AppController.openDocument.error.general'.loc();
+                      event.callback(userMessage);
                       // we force the state to be clean to avoid the CFM overriding
                       // the file that failed to open with whatever was the previous
                       // document, then close the file.

--- a/lang/strings/en-US.json
+++ b/lang/strings/en-US.json
@@ -85,6 +85,7 @@
     "DG.AppController.validateDocument.invalidDocument": "Invalid JSON Document: %@1",
     "DG.AppController.openDocument.error.general": "Unable to open document",
     "DG.AppController.openDocument.error.invalid_format": "CODAP can not read this type of document",
+    "DG.AppController.openDocument.error.v3Format": "This document was created with a newer version of CODAP. To open it, use the latest version of CODAP at <a href=\"https://codap.concord.org/app\" target=\"_blank\" rel=\"noopener noreferrer\">https://codap.concord.org/app</a>.",
     "DG.AppController.createDataSet.initialAttribute": "AttributeName",
     "DG.AppController.createDataSet.name": "New Dataset",
     "DG.AppController.createDataSet.collectionName": "Cases",


### PR DESCRIPTION
## Summary

When CODAP V2 is asked to open a V3-format document, it now detects the V3
shape and shows a single, helpful message — "This document was created with
a newer version of CODAP. To open it, use the latest version of CODAP at
https://codap.concord.org/app." — instead of the generic "Unable to open
document" alert. The URL renders as a clickable link.

- **`isV3Document` helper** (`main.js`) — detects a V3 document by its
  `DocumentContent` shape (`tileMap` + `rowMap`), checking both the unwrapped
  and wrapped positions so detection is unaffected by CFM's envelope handling.
- **V3 detection branch** in `resolveDocument` — short-circuits with a
  structured `{ userMessage }` rejection before the existing content-type
  classification. A single hook covers all four ingest paths (file menu,
  drag-and-drop, `?url=`, Google Drive), which all funnel through `resolveDocument`.
- **Structured-rejection passthrough** in the `openedFile` reject handler —
  honors `iReason.userMessage` when present; existing string-rejecters keep
  falling through to the generic message (no behavior change for them).
- **New localized string** `DG.AppController.openDocument.error.v3Format` in
  `lang/strings/en-US.json` (source of truth), with `english.lproj/strings.js`
  regenerated via `bin/strings-build.sh`. The URL is wrapped in an `<a>` tag;
  CFM's alert dialog renders message HTML.
- **CLAUDE.md** — added a "Localized Strings" section documenting that
  `lang/strings/en-US.json` is the source of truth and `english.lproj/strings.js`
  is generated.

Fixes CODAP2-287.

## Test plan

V2's automated test runners (`npm test`, `npm run test:cypress`) are not
currently functional and were not repaired for this work, so verification
is manual. Verified:

- [x] Open a V3-saved document via File → Open (local file) → V3 message appears with clickable link
- [x] Drag-and-drop a V3-saved document → V3 message appears
- [x] Open a V3 document from Google Drive → V3 message appears
- [x] Open a V3 document via a shared document link → V3 message appears
- [x] Open a normal V2 document → loads normally, no alert (negative regression)

## Follow-up

While tracing CFM's document handling for this change, we found that CFM
auto-unwraps its envelope in a way that can strip a V3 document's own
envelope properties. That is out of scope here (V2 detection is robust to it
either way) and is tracked separately as CODAP-1331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
