### PR TITLE
CODAP-1328: accept date axes in univariate and count adornments

### DIFF
--- a/v3/src/components/graph/adornments/count/count-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-component.tsx
@@ -9,7 +9,7 @@ import { mstAutorun } from "../../../../utilities/mst-autorun"
 import { t } from "../../../../utilities/translation/translate"
 import { isFiniteNumber } from "../../../../utilities/math-utils"
 import { mstReaction } from "../../../../utilities/mst-reaction"
-import { isNumericAxisModel } from "../../../axis/models/numeric-axis-models"
+import { isAnyNumericAxisModel } from "../../../axis/models/numeric-axis-models"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
 import { useAdornmentCells } from "../../hooks/use-adornment-cells"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
@@ -31,6 +31,10 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
   const { xScale, yScale } = useAdornmentAttributes()
   const dataConfig = useGraphDataConfigurationContext()
   const showMeasuresForSelection = !!dataConfig?.showMeasuresForSelection
+  // Observe the selection count so the component re-renders on selection change.
+  // The useEffect below recomputes count values on every render but is not itself reactive,
+  // so without this read the per-cell counts go stale when the user selects/deselects cases.
+  const _selectionCount = showMeasuresForSelection ? dataConfig?.selection.length ?? 0 : 0
   const graphModel = useGraphContentModelContext()
   const isBinnedPlot = isBinnedDotPlotModel(graphModel.plot)
   const adornmentsStore = graphModel?.adornmentsStore
@@ -205,7 +209,7 @@ export const CountAdornment = observer(function CountAdornment(props: IAdornment
 
   useEffect(function respondToAxisDomainChange() {
     return mstReaction(
-      () => isNumericAxisModel(primaryAxisModel) ? primaryAxisModel?.domain.slice() : null,
+      () => isAnyNumericAxisModel(primaryAxisModel) ? primaryAxisModel?.domain.slice() : null,
       () => {
         forceUpdate()
       }, { name: "CountAdornment.respondToAxisDomainChange", equals: comparer.structural }, model

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-component.scss
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-component.scss
@@ -6,10 +6,11 @@
 .movable-value-label {
   color: #4682b4;
   height: 30px;
+  min-width: 50px;
   position: absolute;
   text-align: center;
   transform: translate(-50%, -55%);
-  width: 65px;
+  white-space: nowrap;
 
   &.horizontal {
     transform: translate(0, -30%);

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-component.scss
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-component.scss
@@ -9,7 +9,7 @@
   position: absolute;
   text-align: center;
   transform: translate(-50%, -55%);
-  width: 50px;
+  width: 65px;
 
   &.horizontal {
     transform: translate(0, -30%);

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-component.tsx
@@ -2,8 +2,10 @@ import {drag, select, Selection} from "d3"
 import {autorun} from "mobx"
 import { observer } from "mobx-react-lite"
 import {useCallback, useEffect, useRef} from "react"
+import { isNumericAttributeType } from "../../../../models/data/attribute-types"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import {useAxisLayoutContext} from "../../../axis/models/axis-layout-context"
+import { IDateAxisModel, isDateAxisModel } from "../../../axis/models/numeric-axis-models"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
 import { useAdornmentCells } from "../../hooks/use-adornment-cells"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
@@ -33,7 +35,7 @@ export const MovableValueAdornment = observer(function MovableValueAdornment(pro
   const [bottom, top] = yScale?.range() || [0, 1]
   const valueRef = useRef<SVGSVGElement>(null)
   const valueObjects = useRef<IValueObject[]>([])
-  const isVertical = useRef(!!(xAttrType && xAttrType === "numeric"))
+  const isVertical = useRef(isNumericAttributeType(xAttrType))
 
   const getValues = useCallback(() => {
     const { values } = model
@@ -84,7 +86,11 @@ export const MovableValueAdornment = observer(function MovableValueAdornment(pro
   const refreshValue = useCallback((value: number, valueObjIndex: number) => {
     if (!value || !valueObjects.current[valueObjIndex]) return
     const multiScale = isVertical.current ? layout.getAxisMultiScale("bottom") : layout.getAxisMultiScale("left")
-    const displayValue = multiScale ? multiScale.formatValueForScale(value) : valueLabelString(value)
+    const primaryAxis = isVertical.current ? xAxis : yAxis
+    const dateAxis: IDateAxisModel | undefined = isDateAxisModel(primaryAxis) ? primaryAxis : undefined
+    const displayValue = multiScale
+      ? multiScale.formatValueForScale(value, !!dateAxis, dateAxis?.precisionForDisplay)
+      : valueLabelString(value)
     const { line, cover, rect, valueLabel } = valueObjects.current[valueObjIndex]
     if (!line || !cover || !rect || !valueLabel) return
 
@@ -113,14 +119,14 @@ export const MovableValueAdornment = observer(function MovableValueAdornment(pro
       .classed("vertical", isVertical.current)
       .classed("horizontal", !isVertical.current)
       .html(displayValue)
-  }, [determineLineCoords, layout])
+  }, [determineLineCoords, layout, xAxis, yAxis])
 
   const handleDrag = useCallback((event: MouseEvent, index: number) => {
     const values = getValues()
     const preDragValue = values?.[index]
     const axisMin = isVertical.current ? xScale.domain()[0] : yScale.domain()[0]
     const axisMax = isVertical.current ? xScale.domain()[1] : yScale.domain()[1]
-    let newValue = xAttrType === "numeric"
+    let newValue = isNumericAttributeType(xAttrType)
       ? xScale.invert(event.x) * cellCounts.x
       : yScale.invert(event.y) * cellCounts.y
 
@@ -192,7 +198,7 @@ export const MovableValueAdornment = observer(function MovableValueAdornment(pro
   useEffect(function refreshAxisChange() {
     return autorun(() => {
       getAxisDomains(xAxis, yAxis)
-      isVertical.current = dataConfig?.attributeType("x") === "numeric"
+      isVertical.current = isNumericAttributeType(dataConfig?.attributeType("x"))
       adjustAllValues()
       renderFills()
     }, { name: "MovableValue.refreshAxisChange" })
@@ -215,7 +221,11 @@ export const MovableValueAdornment = observer(function MovableValueAdornment(pro
         const { x1, x2, y1, y2 } = determineLineCoords(values[i])
         const orientationClass = isVertical.current ? "vertical" : "horizontal"
         const multiScale = isVertical.current ? layout.getAxisMultiScale("bottom") : layout.getAxisMultiScale("left")
-        const displayValue = multiScale ? multiScale.formatValueForScale(values[i]) : valueLabelString(values[i])
+        const primaryAxis = isVertical.current ? xAxis : yAxis
+        const dateAxis: IDateAxisModel | undefined = isDateAxisModel(primaryAxis) ? primaryAxis : undefined
+        const displayValue = multiScale
+          ? multiScale.formatValueForScale(values[i], !!dateAxis, dateAxis?.precisionForDisplay)
+          : valueLabelString(values[i])
 
         newValueObject.rect = selection.append("rect")
           .attr("class", `movable-value-rect ${orientationClass}`)
@@ -244,7 +254,7 @@ export const MovableValueAdornment = observer(function MovableValueAdornment(pro
         renderFills()
       }
     }, { name: "MovableValue.createElements" })
-  }, [addDragHandlers, containerId, determineLineCoords, getValues, layout, renderFills])
+  }, [addDragHandlers, containerId, determineLineCoords, getValues, layout, renderFills, xAxis, yAxis])
 
   return (
     <svg

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
@@ -3,6 +3,7 @@ import { select, Selection } from "d3"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { t } from "../../../../../utilities/translation/translate"
+import { isNumericAttributeType } from "../../../../../models/data/attribute-types"
 import { selectCases, setSelectedCases } from "../../../../../models/data/data-set-utils"
 import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
 import { useGraphDataConfigurationContext } from "../../../hooks/use-graph-data-configuration-context"
@@ -42,12 +43,12 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
   const { plotWidth, plotHeight } = layout
   const dataConfig = useGraphDataConfigurationContext()
   const { xAttrId, yAttrId, xAttrType } = useAdornmentAttributes()
-  const isVerticalRef = useRef(!!(xAttrType && xAttrType === "numeric"))
+  const isVerticalRef = useRef(isNumericAttributeType(xAttrType))
   const { cellCounts } = useAdornmentCells(model, cellKey)
   const helper = useMemo(() => {
     return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model, containerId)
   }, [cellKey, containerId, layout, model])
-  const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
+  const attrId = xAttrId && isNumericAttributeType(xAttrType) ? xAttrId : yAttrId
   const boxPlotOffset = 5
   const secondaryAxisX = plotWidth / cellCounts.x / 2 - boxPlotOffset
   const secondaryAxisY = plotHeight / cellCounts.y / 2 - boxPlotOffset

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-component.tsx
@@ -46,8 +46,9 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
   const isVerticalRef = useRef(isNumericAttributeType(xAttrType))
   const { cellCounts } = useAdornmentCells(model, cellKey)
   const helper = useMemo(() => {
-    return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model, containerId)
-  }, [cellKey, containerId, layout, model])
+    return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model, containerId,
+      undefined, xAxis, yAxis)
+  }, [cellKey, containerId, layout, model, xAxis, yAxis])
   const attrId = xAttrId && isNumericAttributeType(xAttrType) ? xAttrId : yAttrId
   const boxPlotOffset = 5
   const secondaryAxisX = plotWidth / cellCounts.x / 2 - boxPlotOffset
@@ -407,8 +408,16 @@ export const BoxPlotAdornmentComponent = observer(function BoxPlotAdornmentCompo
       helper.adornmentSpecs(attrId, dataConfig, value, cellCounts, secondaryAxisX, secondaryAxisY)
     const { median, lowerQuartile, upperQuartile, iqr,
             minWhiskerValue, maxWhiskerValue } = model.getBoxPlotParams(cellKey)
-    const translationVars = [ minWhiskerValue, lowerQuartile, median, upperQuartile, maxWhiskerValue, iqr ]
-      .map(v => helper.formatValueForScale(v))
+    // IQR is a *duration*, not an absolute date — format it with a time unit on date axes;
+    // the other five are absolute values.
+    const translationVars = [
+      helper.formatValueForScale(minWhiskerValue),
+      helper.formatValueForScale(lowerQuartile),
+      helper.formatValueForScale(median),
+      helper.formatValueForScale(upperQuartile),
+      helper.formatValueForScale(maxWhiskerValue),
+      helper.formatDateDurationForScale(iqr)
+    ]
     let textContent = `${t(model.labelTitle, { vars: translationVars })}`
     // Special case in which median equals lower and/or upper quartile
     // We combine the labels for those two or three measures so the user sees all info

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-model.ts
@@ -1,6 +1,7 @@
 import { comparer, observable, reaction } from "mobx"
 import { addDisposer, Instance, SnapshotIn, types } from "mobx-state-tree"
 import { median } from "mathjs/number"
+import { isNumericAttributeType } from "../../../../../models/data/attribute-types"
 import { quantileOfSortedArray } from "../../../../../utilities/math-utils"
 import { UnivariateMeasureAdornmentModel } from "../univariate-measure-adornment-model"
 import { kBoxPlotType, kBoxPlotValueTitleKey } from "./box-plot-adornment-types"
@@ -183,7 +184,7 @@ export const BoxPlotAdornmentModel = UnivariateMeasureAdornmentModel
     updateCategories(options: IUpdateCategoriesOptions) {
       const { dataConfig, resetPoints } = options
       const { xAttrId, yAttrId, xAttrType } = dataConfig.getCategoriesOptions()
-      const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
+      const attrId = xAttrId && isNumericAttributeType(xAttrType) ? xAttrId : yAttrId
       dataConfig.getAllCellKeys().forEach(cellKey => {
         const instanceKey = self.instanceKey(cellKey)
         const boxPlotParams = self.computeBoxPlotParamValues(attrId, cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
@@ -47,8 +47,9 @@ export const NormalCurveAdornmentComponent = observer(
       labelRef, defaultLabelTopOffset
     } = useAdornmentAttributes()
     const helper = useMemo(() => {
-      return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model, containerId)
-    }, [cellKey, containerId, isVerticalRef, layout, model])
+      return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model, containerId,
+        undefined, xAxis, yAxis)
+    }, [cellKey, containerId, isVerticalRef, layout, model, xAxis, yAxis])
     const isHistogram = graphModel.plotType === "histogram"
     const binnedPlot = isBinnedPlotModel(graphModel.plot) ? graphModel.plot : undefined
     const useGaussianFit = isHistogram && getDocumentContentPropertyFromNode(graphModel, "gaussianFitEnabled")
@@ -305,7 +306,8 @@ export const NormalCurveAdornmentComponent = observer(
       const numericAttr = dataConfig?.dataset?.attrFromID(numericAttrId) ?? null
       const numericAttrUnits = numericAttr?.units
       const meanDisplayValue = helper.formatValueForScale(mean)
-      const sdDisplayValue = helper.formatValueForScale(stdDev)
+      // Standard deviation is a *duration* on a date axis, not an absolute date.
+      const sdDisplayValue = helper.formatDateDurationForScale(stdDev)
 
       addNormalCurve(selectionsObj)
 

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-model.ts
@@ -1,6 +1,7 @@
 import { mean, std } from "mathjs/number"
 import { observable } from "mobx"
 import { Instance, SnapshotIn, types } from "mobx-state-tree"
+import { isNumericAttributeType } from "../../../../../models/data/attribute-types"
 import { IGraphDataConfigurationModel } from "../../../models/graph-data-configuration-model"
 import { IAdornmentModel, IUpdateCategoriesOptions } from "../../adornment-models"
 import { UnivariateMeasureAdornmentModel } from "../univariate-measure-adornment-model"
@@ -129,7 +130,7 @@ type CurveParamInstance = {
     updateCategories(options: IUpdateCategoriesOptions) {
       const { dataConfig, resetPoints } = options
       const { xAttrId, yAttrId, xAttrType } = dataConfig.getCategoriesOptions()
-      const attrId = xAttrId && xAttrType === "numeric" ? xAttrId : yAttrId
+      const attrId = xAttrId && isNumericAttributeType(xAttrType) ? xAttrId : yAttrId
       dataConfig.getAllCellKeys().forEach(cellKey => {
         const instanceKey = self.instanceKey(cellKey)
         const { sampleMean, sampleStdDev } = self.computeCurveParamValue(attrId, cellKey, dataConfig)

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-component.tsx
@@ -34,8 +34,9 @@ export const StandardErrorAdornmentComponent = observer(
       numericAttrId, showLabel, isVerticalRef, valueRef,
       labelRef, defaultLabelTopOffset } = useAdornmentAttributes()
     const helper = useMemo(() => {
-      return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model, containerId)
-    }, [cellKey, containerId, isVerticalRef, layout, model])
+      return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model, containerId,
+        undefined, xAxis, yAxis)
+    }, [cellKey, containerId, isVerticalRef, layout, model, xAxis, yAxis])
     const {cellCounts} = useAdornmentCells(model, cellKey)
     const isBlockingOtherMeasure = dataConfig &&
       helper.blocksOtherMeasure({adornmentsStore, attrId: numericAttrId, dataConfig})

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-helper.ts
@@ -4,11 +4,13 @@ import { MutableRefObject } from "react"
 import { isFiniteNumber } from "../../../../utilities/math-utils"
 import { t } from "../../../../utilities/translation/translate"
 import { ScaleNumericBaseType } from "../../../axis/axis-types"
+import { IBaseNumericAxisModel } from "../../../axis/models/base-numeric-axis-model"
+import { IDateAxisModel, isDateAxisModel } from "../../../axis/models/numeric-axis-models"
 import { IDataConfigurationModel } from "../../../data-display/models/data-configuration-model"
 import { Point } from "../../../data-display/data-display-types"
 import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
 import { GraphLayout } from "../../models/graph-layout"
-import { valueLabelString } from "../../utilities/graph-utils"
+import { formatDateDuration, valueLabelString } from "../../utilities/graph-utils"
 import { IAdornmentsStore } from "../store/adornments-store"
 import { isBoxPlotAdornment } from "./box-plot/box-plot-adornment-model"
 import { kMeanType } from "./mean/mean-adornment-types"
@@ -35,6 +37,8 @@ export class UnivariateMeasureAdornmentHelper {
   measureSlug = ""
   model: IUnivariateMeasureAdornmentModel
   defaultLabelTopOffset: (adornmentModel: IUnivariateMeasureAdornmentModel) => number = () => 0
+  xAxis?: IBaseNumericAxisModel
+  yAxis?: IBaseNumericAxisModel
 
   constructor (
     cellKey: Record<string, string>,
@@ -42,7 +46,9 @@ export class UnivariateMeasureAdornmentHelper {
     layout: GraphLayout,
     model: IUnivariateMeasureAdornmentModel,
     containerId?: string,
-    defaultLabelTopOffset: (adornmentModel: IUnivariateMeasureAdornmentModel) => number = () => 0
+    defaultLabelTopOffset: (adornmentModel: IUnivariateMeasureAdornmentModel) => number = () => 0,
+    xAxis?: IBaseNumericAxisModel,
+    yAxis?: IBaseNumericAxisModel
   ) {
     this.cellKey = cellKey
     this.isVerticalRef = isVerticalRef
@@ -53,6 +59,8 @@ export class UnivariateMeasureAdornmentHelper {
     this.measureSlug = model.type.toLowerCase().replace(/ /g, "-")
     this.model = model
     this.defaultLabelTopOffset = defaultLabelTopOffset
+    this.xAxis = xAxis
+    this.yAxis = yAxis
   }
 
   // There is a convenient fiction in the types of these scales in that one of them is _actually_
@@ -75,14 +83,29 @@ export class UnivariateMeasureAdornmentHelper {
   }
 
   formatValueForScale(value: number | undefined) {
-    const multiScale = this.isVerticalRef.current
+    const isVertical = this.isVerticalRef.current
+    const multiScale = isVertical
       ? this.layout.getAxisMultiScale("bottom")
       : this.layout.getAxisMultiScale("left")
+    const primaryAxis = isVertical ? this.xAxis : this.yAxis
+    const dateAxis: IDateAxisModel | undefined = isDateAxisModel(primaryAxis) ? primaryAxis : undefined
     return value != null
       ? multiScale
-        ? multiScale.formatValueForScale(value)
+        ? multiScale.formatValueForScale(value, !!dateAxis, dateAxis?.precisionForDisplay)
         : valueLabelString(value)
       : ""
+  }
+
+  // For values that represent a *duration* on a date axis (e.g. box-plot IQR,
+  // normal-curve standard deviation, standard error) rather than an absolute date.
+  // Picks a human-scale time unit from the visible axis range and returns plain text
+  // like "30 days" or "2.5 hours". On non-date axes, falls back to formatValueForScale.
+  formatDateDurationForScale(value: number | undefined) {
+    if (value == null) return ""
+    const primaryAxis = this.isVerticalRef.current ? this.xAxis : this.yAxis
+    if (!isDateAxisModel(primaryAxis)) return this.formatValueForScale(value)
+    const [domainMin, domainMax] = primaryAxis.domain
+    return formatDateDuration(value, Math.abs(domainMax - domainMin))
   }
 
   // Calculate the coordinates for the line endpoints
@@ -242,7 +265,8 @@ export class UnivariateMeasureAdornmentHelper {
       ? this.model.computeMeasureRange(attrId, this.cellKey, dataConfig)
       : {}
     const rangeValue = measureRange.min != null ? value - measureRange.min : undefined
-    const displayRange = this.formatValueForScale(rangeValue)
+    // rangeValue is a *duration* (value − range-min), so format with time units on date axes.
+    const displayRange = this.formatDateDurationForScale(rangeValue)
     const {x: x1, y: y1} =
       this.calculateLineCoords(plotValue, 1, cellCounts, secondaryAxisX, secondaryAxisY)
     const {x: x2, y: y2} =
@@ -368,7 +392,8 @@ export class UnivariateMeasureAdornmentHelper {
     const primaryAttribute = primaryAttributeID
       ? dataConfiguration?.dataset?.attrFromID(primaryAttributeID) : undefined
     const primaryAttributeUnits = primaryAttribute?.units
-    const stdErrorString = this.formatValueForScale(numStErrs * stdErr)
+    // numStErrs * stdErr is a *duration* on a date axis (a half-range around the mean).
+    const stdErrorString = this.formatDateDurationForScale(numStErrs * stdErr)
     const numStdErrsString = numStErrs === 1 ? '' : parseFloat(numStErrs.toFixed(2)).toString()
     const substitutionVars = inHTML ? [`${numStdErrsString}`,
       '<sub style="vertical-align: sub">',

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -25,8 +25,8 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
     const { cellCounts } = useAdornmentCells(model, cellKey)
     const helper = useMemo(() => {
       return new UnivariateMeasureAdornmentHelper(cellKey, isVerticalRef, layout, model,
-        containerId, defaultLabelTopOffset)
-    }, [cellKey, containerId, defaultLabelTopOffset, isVerticalRef, layout, model])
+        containerId, defaultLabelTopOffset, xAxis, yAxis)
+    }, [cellKey, containerId, defaultLabelTopOffset, isVerticalRef, layout, model, xAxis, yAxis])
     const isBlockingOtherMeasure = dataConfig &&
       helper.blocksOtherMeasure({adornmentsStore, attrId: numericAttrId, dataConfig})
     const valueObjRef = useRef<IValue>({})

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -1,7 +1,7 @@
 import {ptInRect} from "../../data-display/data-display-utils"
 import { GraphLayout } from "../models/graph-layout"
 import {
-  dateTimeSlopeUnit, equationString, formatValue, kMinus, lineToAxisIntercepts,
+  dateTimeSlopeUnit, equationString, formatDateDuration, formatValue, kMinus, lineToAxisIntercepts,
   lsrlEquationString, valueLabelString
 } from "./graph-utils"
 
@@ -142,6 +142,16 @@ describe("dateTimeSlopeUnit", () => {
     expect(dateTimeSlopeUnit(86400 * 30).multiplier).toBe(86400)
     expect(dateTimeSlopeUnit(86400 * 365 * 5).label).toMatch(/year/)
     expect(dateTimeSlopeUnit(86400 * 365 * 5).multiplier).toBeCloseTo(86400 * 365.25)
+  })
+})
+
+describe("formatDateDuration", () => {
+  it("selects unit by x-axis range and scales the duration accordingly", () => {
+    expect(formatDateDuration(30, 60)).toMatch(/^30 seconds?$/)
+    expect(formatDateDuration(600, 3600)).toMatch(/^10 minutes?$/)
+    expect(formatDateDuration(7200, 86400)).toMatch(/^2 hours?$/)
+    expect(formatDateDuration(86400 * 30, 86400 * 30)).toMatch(/^30 days?$/)
+    expect(formatDateDuration(86400 * 365 * 5, 86400 * 365 * 5)).toMatch(/^5 years?$/)
   })
 })
 

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -147,11 +147,19 @@ describe("dateTimeSlopeUnit", () => {
 
 describe("formatDateDuration", () => {
   it("selects unit by x-axis range and scales the duration accordingly", () => {
-    expect(formatDateDuration(30, 60)).toMatch(/^30 seconds?$/)
-    expect(formatDateDuration(600, 3600)).toMatch(/^10 minutes?$/)
-    expect(formatDateDuration(7200, 86400)).toMatch(/^2 hours?$/)
-    expect(formatDateDuration(86400 * 30, 86400 * 30)).toMatch(/^30 days?$/)
-    expect(formatDateDuration(86400 * 365 * 5, 86400 * 365 * 5)).toMatch(/^5 years?$/)
+    expect(formatDateDuration(30, 60)).toBe("30 seconds")
+    expect(formatDateDuration(600, 3600)).toBe("10 minutes")
+    expect(formatDateDuration(7200, 86400)).toBe("2 hours")
+    expect(formatDateDuration(86400 * 30, 86400 * 30)).toBe("30 days")
+    expect(formatDateDuration(86400 * 365 * 5, 86400 * 365 * 5)).toBe("5 years")
+  })
+
+  it("uses the singular unit form when the scaled count is 1", () => {
+    expect(formatDateDuration(1, 60)).toBe("1 second")
+    expect(formatDateDuration(60, 3600)).toBe("1 minute")
+    expect(formatDateDuration(3600, 86400)).toBe("1 hour")
+    expect(formatDateDuration(86400, 86400 * 30)).toBe("1 day")
+    expect(formatDateDuration(86400 * 365.25, 86400 * 365 * 5)).toBe("1 year")
   })
 })
 

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -161,6 +161,12 @@ describe("formatDateDuration", () => {
     expect(formatDateDuration(86400, 86400 * 30)).toBe("1 day")
     expect(formatDateDuration(86400 * 365.25, 86400 * 365 * 5)).toBe("1 year")
   })
+
+  it("pluralizes from the rounded display value, not the raw scaled value", () => {
+    // 0.99998 rounds to "1" for display, so the unit should be singular too.
+    expect(formatDateDuration(0.99998, 60)).toBe("1 second")
+    expect(formatDateDuration(1.001, 60)).toBe("1 second")
+  })
 })
 
 describe("lsrlEquationString", () => {

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -3,6 +3,7 @@ import {IDataSet} from "../../../models/data/data-set"
 import {
   defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeWidth, defaultStrokeWidth
 } from "../../../utilities/color-utils"
+import { DateUnit, getDateUnitLabel } from "../../../utilities/date-utils"
 import { isFiniteNumber } from "../../../utilities/math-utils"
 import { t } from "../../../utilities/translation/translate"
 import {ScaleNumericBaseType} from "../../axis/axis-types"
@@ -331,30 +332,31 @@ function sigFigFractionDigits(value: number, sigFigs: number): number {
   return Math.max(0, sigFigs - 1 - magnitude)
 }
 
-// Same unit-selection thresholds as dateTimeSlopeUnit, but the label is a plain time
-// unit ("days") rather than a slope-style "per day". Used for duration-valued
-// adornment labels (IQR, stddev, stderr, MAD range) on date axes.
-function dateTimeDurationUnit(xRangeSeconds: number): { multiplier: number, label: string } {
+// Same unit-selection thresholds as dateTimeSlopeUnit, but returns the bare unit name
+// (e.g. "day") so callers can route the label through getDateUnitLabel for correct
+// singular/plural forms. Used for duration-valued adornment labels (IQR, stddev,
+// stderr, MAD range) on date axes.
+function dateTimeDurationUnit(xRangeSeconds: number): { multiplier: number, unit: DateUnit } {
   if (xRangeSeconds < 120) {
-    return { multiplier: 1, label: t("DG.ScatterPlotModel.secondsUnit") }
+    return { multiplier: 1, unit: "second" }
   } else if (xRangeSeconds < 60 * 60 * 2) { // 2 hours
-    return { multiplier: 60, label: t("DG.ScatterPlotModel.minutesUnit") }
+    return { multiplier: 60, unit: "minute" }
   } else if (xRangeSeconds < 3600 * 24 * 2) { // 2 days
-    return { multiplier: 3600, label: t("DG.ScatterPlotModel.hoursUnit") }
+    return { multiplier: 3600, unit: "hour" }
   } else if (xRangeSeconds < 3600 * 24 * 365) { // 365 days
-    return { multiplier: 3600 * 24, label: t("DG.ScatterPlotModel.daysUnit") }
+    return { multiplier: 3600 * 24, unit: "day" }
   }
-  return { multiplier: 3600 * 24 * 365.25, label: t("DG.ScatterPlotModel.yearsUnit") }
+  return { multiplier: 3600 * 24 * 365.25, unit: "year" }
 }
 
 // Formats a duration (in seconds) using a human-scale time unit picked from the visible
-// date-axis range, e.g. "30 days" or "2.5 hours". Used for box-plot IQR, normal-curve
+// date-axis range, e.g. "30 days" or "1 hour". Used for box-plot IQR, normal-curve
 // standard deviation, standard error, and similar duration-valued labels on date axes.
 export function formatDateDuration(durationSeconds: number, xRangeSeconds: number): string {
-  const { multiplier, label } = dateTimeDurationUnit(xRangeSeconds)
+  const { multiplier, unit } = dateTimeDurationUnit(xRangeSeconds)
   const scaled = durationSeconds / multiplier
   const formatted = formatValue(scaled, sigFigFractionDigits(scaled, 3))
-  return `${formatted} ${label}`
+  return `${formatted} ${getDateUnitLabel(unit, scaled)}`
 }
 
 // Slope-only equation form used when x is a date-time axis. The intercept (y at the Unix epoch)

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -355,8 +355,12 @@ function dateTimeDurationUnit(xRangeSeconds: number): { multiplier: number, unit
 export function formatDateDuration(durationSeconds: number, xRangeSeconds: number): string {
   const { multiplier, unit } = dateTimeDurationUnit(xRangeSeconds)
   const scaled = durationSeconds / multiplier
-  const formatted = formatValue(scaled, sigFigFractionDigits(scaled, 3))
-  return `${formatted} ${getDateUnitLabel(unit, scaled)}`
+  const fractionDigits = sigFigFractionDigits(scaled, 3)
+  // Pluralize based on the rounded value so the unit matches the displayed number
+  // (e.g. scaled=0.99998 rounds to "1" → "1 second", not "1 seconds").
+  const factor = 10 ** fractionDigits
+  const rounded = Math.round(scaled * factor) / factor
+  return `${formatValue(scaled, fractionDigits)} ${getDateUnitLabel(unit, rounded)}`
 }
 
 // Slope-only equation form used when x is a date-time axis. The intercept (y at the Unix epoch)

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -331,6 +331,32 @@ function sigFigFractionDigits(value: number, sigFigs: number): number {
   return Math.max(0, sigFigs - 1 - magnitude)
 }
 
+// Same unit-selection thresholds as dateTimeSlopeUnit, but the label is a plain time
+// unit ("days") rather than a slope-style "per day". Used for duration-valued
+// adornment labels (IQR, stddev, stderr, MAD range) on date axes.
+function dateTimeDurationUnit(xRangeSeconds: number): { multiplier: number, label: string } {
+  if (xRangeSeconds < 120) {
+    return { multiplier: 1, label: t("DG.ScatterPlotModel.secondsUnit") }
+  } else if (xRangeSeconds < 60 * 60 * 2) { // 2 hours
+    return { multiplier: 60, label: t("DG.ScatterPlotModel.minutesUnit") }
+  } else if (xRangeSeconds < 3600 * 24 * 2) { // 2 days
+    return { multiplier: 3600, label: t("DG.ScatterPlotModel.hoursUnit") }
+  } else if (xRangeSeconds < 3600 * 24 * 365) { // 365 days
+    return { multiplier: 3600 * 24, label: t("DG.ScatterPlotModel.daysUnit") }
+  }
+  return { multiplier: 3600 * 24 * 365.25, label: t("DG.ScatterPlotModel.yearsUnit") }
+}
+
+// Formats a duration (in seconds) using a human-scale time unit picked from the visible
+// date-axis range, e.g. "30 days" or "2.5 hours". Used for box-plot IQR, normal-curve
+// standard deviation, standard error, and similar duration-valued labels on date axes.
+export function formatDateDuration(durationSeconds: number, xRangeSeconds: number): string {
+  const { multiplier, label } = dateTimeDurationUnit(xRangeSeconds)
+  const scaled = durationSeconds / multiplier
+  const formatted = formatValue(scaled, sigFigFractionDigits(scaled, 3))
+  return `${formatted} ${label}`
+}
+
 // Slope-only equation form used when x is a date-time axis. The intercept (y at the Unix epoch)
 // is meaningless in that case, so V2 — and now V3 — hides it. Matches V2's kSlopeOnly format:
 //   "slope = {scaled-slope} {yUnit} {time-unit-label}"

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -790,6 +790,11 @@
     "DG.ScatterPlotModel.hoursLabel": "per hour", // used in equation for line when x is a datetime axis
     "DG.ScatterPlotModel.minutesLabel": "per minute", // used in equation for line when x is a datetime axis
     "DG.ScatterPlotModel.secondsLabel": "per second", // used in equation for line when x is a datetime axis
+    "DG.ScatterPlotModel.yearsUnit": "years", // duration unit used in adornment labels when x is a datetime axis
+    "DG.ScatterPlotModel.daysUnit": "days", // duration unit used in adornment labels when x is a datetime axis
+    "DG.ScatterPlotModel.hoursUnit": "hours", // duration unit used in adornment labels when x is a datetime axis
+    "DG.ScatterPlotModel.minutesUnit": "minutes", // duration unit used in adornment labels when x is a datetime axis
+    "DG.ScatterPlotModel.secondsUnit": "seconds", // duration unit used in adornment labels when x is a datetime axis
     "DG.ScatterPlotModel.LSRLCIBandInfo": "Shaded regions shows the range\n in which the true regression line\n lies at 95% confidence level.",
 
     // DG.BarChartModel

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -790,11 +790,6 @@
     "DG.ScatterPlotModel.hoursLabel": "per hour", // used in equation for line when x is a datetime axis
     "DG.ScatterPlotModel.minutesLabel": "per minute", // used in equation for line when x is a datetime axis
     "DG.ScatterPlotModel.secondsLabel": "per second", // used in equation for line when x is a datetime axis
-    "DG.ScatterPlotModel.yearsUnit": "years", // duration unit used in adornment labels when x is a datetime axis
-    "DG.ScatterPlotModel.daysUnit": "days", // duration unit used in adornment labels when x is a datetime axis
-    "DG.ScatterPlotModel.hoursUnit": "hours", // duration unit used in adornment labels when x is a datetime axis
-    "DG.ScatterPlotModel.minutesUnit": "minutes", // duration unit used in adornment labels when x is a datetime axis
-    "DG.ScatterPlotModel.secondsUnit": "seconds", // duration unit used in adornment labels when x is a datetime axis
     "DG.ScatterPlotModel.LSRLCIBandInfo": "Shaded regions shows the range\n in which the true regression line\n lies at 95% confidence level.",
 
     // DG.BarChartModel


### PR DESCRIPTION
## Summary

Follow-up to CODAP-1320 / PR #2574. Fixes four adornments that
over-restrictively checked for "numeric" attributes/axes and so
malfunctioned on date axes:

- **Box plot**: orientation + attrId both depended on `xAttrType === "numeric"`.
- **Normal curve**: model picked the wrong attribute for mean/stddev.
- **Movable value**: orientation and drag math depended on `xAttrType === "numeric"`.
- **Count**: `respondToAxisDomainChange` reaction never fired on date axes
  (gated by `isNumericAxisModel`).

Two additional fixes uncovered while testing on a date-attribute dot plot:

- Movable value label rendered raw seconds-since-epoch on a date axis
  (now passes `isDate` + `DateAxisModel.precisionForDisplay` to
  `formatValueForScale`; widened label CSS so dates fit on one line).
- Per-cell count text went stale on selection changes when
  "Show measures for selection" was on — the component had no
  selection-related observable in its render body, so no re-render
  fired (`useEffect` runs every render but is not reactive). Now
  observes `dataConfig.selection.length` in render.

Fixes CODAP-1328.

## Test plan

- [x] Lint, TS check, and Jest tests on the affected adornment files pass locally.
- [ ] Open a dot plot with a date attribute on x. Verify:
  - [ ] Box plot: vertical, statistics computed from the date attribute, IQR boxes positioned along the date axis.
  - [ ] Normal curve: vertical, mean/stddev derived from the date attribute.
  - [ ] Movable value: vertical, drag updates x value, label formatted as a date on one line.
  - [ ] Count adornment: text positions refresh on date-axis pan/zoom; per-cell counts refresh dynamically when selection changes with "Show measures for selection" on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
