### PR TITLE
CODAP-1318: include points in map PNG export

### DIFF
--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -386,7 +386,10 @@ export function renderLabelBackground<GElement extends BaseType>(
 
   const rectSelection = gSelection.selectAll('rect.attribute-label-bg')
     .data([1])
-    .join((enter: any) => enter.append('rect').attr('class', 'attribute-label-bg'))
+    // fill/stroke set as presentation attrs so export pipelines that don't inline CSS
+    // don't fall back to the SVG default of black fill. CSS class rules still override.
+    .join((enter: any) => enter.append('rect').attr('class', 'attribute-label-bg')
+      .attr('fill', 'transparent').attr('stroke', 'transparent'))
     .attr('x', rectX)
     .attr('y', rectY)
     .attr('width', rectWidth)

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.test.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.test.ts
@@ -58,6 +58,14 @@ jest.mock("pixi.js", () => {
   class MockRenderer {
     view = { canvas: document.createElement("canvas") }
     gl = { isContextLost: () => false }
+    extract = {
+      canvas: jest.fn(() => {
+        const canvas = document.createElement("canvas")
+        canvas.width = 200
+        canvas.height = 150
+        return canvas
+      })
+    }
     resize() {}
     render() {}
     generateTexture() { return new MockTexture() }
@@ -568,6 +576,38 @@ describe("PixiPointRenderer", () => {
       expect(sharedState.getPoint(id2)?.subPlotNum).toBe(4)
       expect(sharedState.getPoint(id3)?.subPlotNum).toBe(8)
 
+      pixiRenderer.dispose()
+    })
+  })
+
+  describe("snapshotCanvas", () => {
+    it("returns null when renderer is not initialized", () => {
+      const pixiRenderer = new PixiPointRenderer()
+      expect(pixiRenderer.snapshotCanvas()).toBeNull()
+    })
+
+    it("returns the canvas extracted from PIXI's extract API when initialized", async () => {
+      const pixiRenderer = new PixiPointRenderer()
+      await pixiRenderer.init()
+      const snapshot = pixiRenderer.snapshotCanvas()
+      expect(snapshot).not.toBeNull()
+      expect(snapshot?.width).toBe(200)
+      expect(snapshot?.height).toBe(150)
+      pixiRenderer.dispose()
+    })
+
+    it("returns null and warns when the extract call throws", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
+      const pixiRenderer = new PixiPointRenderer()
+      await pixiRenderer.init()
+      const mockExtract = (pixiRenderer as any).renderer.extract.canvas as jest.Mock
+      mockExtract.mockImplementationOnce(() => { throw new Error("WebGL context lost") })
+      expect(pixiRenderer.snapshotCanvas()).toBeNull()
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[PixiPointRenderer] snapshotCanvas extract failed:",
+        expect.any(Error)
+      )
+      warnSpy.mockRestore()
       pixiRenderer.dispose()
     })
   })

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -104,6 +104,13 @@ export class PixiPointRenderer extends PointRendererBase {
     return "webgl"
   }
 
+  // The live WebGL canvas reads as empty from external pipelines (e.g. html-to-image),
+  // so extract a static snapshot via PIXI's extract API instead.
+  override snapshotCanvas(): HTMLCanvasElement | null {
+    if (!this.renderer) return null
+    return this.renderer.extract.canvas(this.stage) as HTMLCanvasElement
+  }
+
   get anyTransitionActive(): boolean {
     return PixiTransition.anyTransitionActive(this.targetProp)
   }

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -105,10 +105,17 @@ export class PixiPointRenderer extends PointRendererBase {
   }
 
   // The live WebGL canvas reads as empty from external pipelines (e.g. html-to-image),
-  // so extract a static snapshot via PIXI's extract API instead.
+  // so extract a static snapshot via PIXI's extract API instead. The extract call can
+  // throw on context loss or partial init, so callers see a null snapshot on failure
+  // rather than a thrown error.
   override snapshotCanvas(): HTMLCanvasElement | null {
     if (!this.renderer) return null
-    return this.renderer.extract.canvas(this.stage) as HTMLCanvasElement
+    try {
+      return this.renderer.extract.canvas(this.stage) as HTMLCanvasElement
+    } catch (e) {
+      console.warn("[PixiPointRenderer] snapshotCanvas extract failed:", e)
+      return null
+    }
   }
 
   get anyTransitionActive(): boolean {

--- a/v3/src/components/data-display/renderer/point-renderer-base.ts
+++ b/v3/src/components/data-display/renderer/point-renderer-base.ts
@@ -77,6 +77,15 @@ export abstract class PointRendererBase {
    */
   abstract get capability(): RendererCapability
 
+  /**
+   * Return a canvas snapshot of the rendered content for use by image-export pipelines.
+   * Default returns the live canvas; WebGL renderers override to extract a static snapshot
+   * (a live WebGL canvas is empty when read by external pipelines like html-to-image).
+   */
+  snapshotCanvas(): HTMLCanvasElement | null {
+    return this.canvas
+  }
+
   // ===== Abstract methods (subclasses must implement) =====
 
   /**

--- a/v3/src/components/graph/utilities/image-utils.test.ts
+++ b/v3/src/components/graph/utilities/image-utils.test.ts
@@ -22,22 +22,17 @@ mockCanvas.width = 100
 mockCanvas.height = 100
 mockCanvas.getBoundingClientRect = jest.fn(() => mockRect())
 
-// Mock renderer with PIXI-specific properties accessed via (renderer as any) in image-utils.ts
-// and canvas property for the new exportGraphToPng approach
+// Mock renderer simulating a PIXI/WebGL renderer: snapshotCanvas() returns an extracted canvas
+const mockExtractedCanvas = (() => {
+  const canvas = document.createElement("canvas")
+  canvas.toDataURL = jest.fn(() => "data:image/png;base64,")
+  canvas.width = 100
+  canvas.height = 100
+  return canvas
+})()
 const mockRenderer = {
   canvas: mockCanvas,
-  renderer: {
-    extract: {
-      canvas: jest.fn(() => {
-        const canvas = document.createElement("canvas")
-        canvas.toDataURL = jest.fn(() => "data:image/png;base64,")
-        canvas.width = 100
-        canvas.height = 100
-        return canvas
-      })
-    }
-  },
-  stage: {}
+  snapshotCanvas: jest.fn(() => mockExtractedCanvas)
 } as unknown as PointRendererBase
 
 beforeAll(() => {
@@ -205,9 +200,10 @@ describe("exportGraphToPng", () => {
   })
 
   it("should use canvas directly for non-PIXI renderer", async () => {
+    // Canvas-2D renderer: snapshotCanvas() returns the live canvas (the base-class default)
     const canvasOnlyRenderer = {
       canvas: mockCanvas,
-      // No renderer.extract or stage — triggers the Canvas 2D fallback path
+      snapshotCanvas: jest.fn(() => mockCanvas)
     } as unknown as PointRendererBase
     const result = await exportGraphToPng({
       ...defaultOptions,
@@ -247,12 +243,7 @@ describe("exportGraphToPng", () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
     const failingRenderer = {
       canvas: mockCanvas,
-      renderer: {
-        extract: {
-          canvas: jest.fn(() => { throw new Error("WebGL context lost") })
-        }
-      },
-      stage: {}
+      snapshotCanvas: jest.fn(() => { throw new Error("WebGL context lost") })
     } as unknown as PointRendererBase
     const result = await exportGraphToPng({
       ...defaultOptions,

--- a/v3/src/components/graph/utilities/image-utils.ts
+++ b/v3/src/components/graph/utilities/image-utils.ts
@@ -219,29 +219,16 @@ async function exportGraphToCanvas(options: IExportGraphToPngOptions): Promise<I
   }
 
   // 3. Points/bars canvas (from renderer)
-  // For WebGL (PIXI), we need to use the extract API to get the rendered content
-  // For Canvas 2D, we can draw directly from the canvas element
+  // For WebGL, snapshotCanvas() extracts a static snapshot; for Canvas 2D it returns the
+  // live canvas. Either way, drawImage handles the result.
   const pointsCanvas = renderer.canvas
   if (pointsCanvas && pointsCanvas.width > 0 && pointsCanvas.height > 0) {
     try {
-      // Get the position of the canvas relative to the graph element
       const canvasRect = pointsCanvas.getBoundingClientRect()
       const canvasX = canvasRect.left - graphRect.left
       const canvasY = canvasRect.top - graphRect.top
 
-      // Check if this is a PIXI renderer (has extract API)
-      const pixiRenderer = (renderer as any).renderer
-      const pixiStage = (renderer as any).stage
-      let sourceCanvas: HTMLCanvasElement | null = null
-
-      if (pixiRenderer?.extract?.canvas && pixiStage) {
-        // WebGL/PIXI: Extract the rendered content to a new canvas
-        sourceCanvas = pixiRenderer.extract.canvas(pixiStage) as HTMLCanvasElement
-      } else {
-        // Canvas 2D: Use the canvas directly
-        sourceCanvas = pointsCanvas
-      }
-
+      const sourceCanvas = renderer.snapshotCanvas()
       if (sourceCanvas) {
         // Canvas uses devicePixelRatio scaling - draw from full size to logical size
         ctx.drawImage(

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -50,18 +50,23 @@ async function compositeMapPng(
     for (const renderer of rendererArray) {
       // Canvas-2D renderers are already captured by html-to-image, so only composite WebGL layers
       if (!renderer?.canvas || !renderer.isVisible || renderer.capability !== "webgl") continue
-      const sourceCanvas = renderer.snapshotCanvas()
-      if (!sourceCanvas || sourceCanvas.width === 0 || sourceCanvas.height === 0) continue
-      const canvasRect = renderer.canvas.getBoundingClientRect()
-      if (canvasRect.width <= 0 || canvasRect.height <= 0) continue
-      ctx.drawImage(
-        sourceCanvas,
-        0, 0, sourceCanvas.width, sourceCanvas.height,
-        (canvasRect.left - displayRect.left) * scaleX,
-        (canvasRect.top - displayRect.top) * scaleY,
-        canvasRect.width * scaleX,
-        canvasRect.height * scaleY
-      )
+      try {
+        const sourceCanvas = renderer.snapshotCanvas()
+        if (!sourceCanvas || sourceCanvas.width === 0 || sourceCanvas.height === 0) continue
+        const canvasRect = renderer.canvas.getBoundingClientRect()
+        if (canvasRect.width <= 0 || canvasRect.height <= 0) continue
+        ctx.drawImage(
+          sourceCanvas,
+          0, 0, sourceCanvas.width, sourceCanvas.height,
+          (canvasRect.left - displayRect.left) * scaleX,
+          (canvasRect.top - displayRect.top) * scaleY,
+          canvasRect.width * scaleX,
+          canvasRect.height * scaleY
+        )
+      } catch (e) {
+        // Skip a failing layer rather than aborting the whole export
+        console.warn("Failed to composite map point layer:", e)
+      }
     }
   }
 

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -16,27 +16,18 @@ interface IProps {
   tile?: ITileModel
 }
 
-// html-to-image cannot capture WebGL canvases, so PIXI-rendered points are missing from
-// its output. Use PIXI's extract API to snapshot each point layer ourselves and composite
-// it onto the html-to-image base (basemap, polygons, connecting-lines SVG, heatmap).
-function extractPixiCanvas(renderer: NonNullable<PointRendererArray[number]>): HTMLCanvasElement | null {
-  const pixiRenderer = (renderer as any).renderer
-  const pixiStage = (renderer as any).stage
-  if (pixiRenderer?.extract?.canvas && pixiStage) {
-    return pixiRenderer.extract.canvas(pixiStage) as HTMLCanvasElement
-  }
-  return null
-}
-
 function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image()
     img.onload = () => resolve(img)
-    img.onerror = () => reject(new Error("Failed to load base map image"))
+    img.onerror = () => reject(new Error("Failed to load map image"))
     img.src = src
   })
 }
 
+// html-to-image cannot capture WebGL canvases, so PIXI-rendered points are missing from
+// its output. Composite each visible WebGL point layer's static snapshot on top of the
+// html-to-image base (basemap, polygons, connecting-lines SVG, heatmap).
 async function compositeMapPng(
   displayElement: HTMLElement, rendererArray: PointRendererArray
 ): Promise<string> {
@@ -57,8 +48,9 @@ async function compositeMapPng(
     const scaleX = canvas.width / displayRect.width
     const scaleY = canvas.height / displayRect.height
     for (const renderer of rendererArray) {
-      if (!renderer?.canvas || !renderer.isVisible) continue
-      const sourceCanvas = extractPixiCanvas(renderer)
+      // Canvas-2D renderers are already captured by html-to-image, so only composite WebGL layers
+      if (!renderer?.canvas || !renderer.isVisible || renderer.capability !== "webgl") continue
+      const sourceCanvas = renderer.snapshotCanvas()
       if (!sourceCanvas || sourceCanvas.width === 0 || sourceCanvas.height === 0) continue
       const canvasRect = renderer.canvas.getBoundingClientRect()
       if (canvasRect.width <= 0 || canvasRect.height <= 0) continue

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -6,6 +6,7 @@ import { useProgress } from "../../../../hooks/use-progress"
 import { ITileModel } from "../../../../models/tiles/tile-model"
 import { t } from "../../../../utilities/translation/translate"
 import { openInDrawTool } from "../../../data-display/data-display-image-utils"
+import { PointRendererArray } from "../../../data-display/renderer"
 import { InspectorMenuContent } from "../../../inspector-panel"
 import { isMapContentModel } from "../../models/map-content-model"
 
@@ -13,6 +14,66 @@ type ExportableFormat = "png" | "svg"
 
 interface IProps {
   tile?: ITileModel
+}
+
+// html-to-image cannot capture WebGL canvases, so PIXI-rendered points are missing from
+// its output. Use PIXI's extract API to snapshot each point layer ourselves and composite
+// it onto the html-to-image base (basemap, polygons, connecting-lines SVG, heatmap).
+function extractPixiCanvas(renderer: NonNullable<PointRendererArray[number]>): HTMLCanvasElement | null {
+  const pixiRenderer = (renderer as any).renderer
+  const pixiStage = (renderer as any).stage
+  if (pixiRenderer?.extract?.canvas && pixiStage) {
+    return pixiRenderer.extract.canvas(pixiStage) as HTMLCanvasElement
+  }
+  return null
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error("Failed to load base map image"))
+    img.src = src
+  })
+}
+
+async function compositeMapPng(
+  displayElement: HTMLElement, rendererArray: PointRendererArray
+): Promise<string> {
+  const baseDataUri = await toPng(displayElement)
+  const baseImage = await loadImage(baseDataUri)
+
+  const canvas = document.createElement("canvas")
+  canvas.width = baseImage.naturalWidth
+  canvas.height = baseImage.naturalHeight
+  const ctx = canvas.getContext("2d")
+  if (!ctx) throw new Error("Failed to get 2D canvas context for PNG export")
+
+  ctx.drawImage(baseImage, 0, 0)
+
+  const displayRect = displayElement.getBoundingClientRect()
+  if (displayRect.width > 0 && displayRect.height > 0) {
+    // html-to-image scales by pixelRatio, so compute scale from the base image dimensions
+    const scaleX = canvas.width / displayRect.width
+    const scaleY = canvas.height / displayRect.height
+    for (const renderer of rendererArray) {
+      if (!renderer?.canvas || !renderer.isVisible) continue
+      const sourceCanvas = extractPixiCanvas(renderer)
+      if (!sourceCanvas || sourceCanvas.width === 0 || sourceCanvas.height === 0) continue
+      const canvasRect = renderer.canvas.getBoundingClientRect()
+      if (canvasRect.width <= 0 || canvasRect.height <= 0) continue
+      ctx.drawImage(
+        sourceCanvas,
+        0, 0, sourceCanvas.width, sourceCanvas.height,
+        (canvasRect.left - displayRect.left) * scaleX,
+        (canvasRect.top - displayRect.top) * scaleY,
+        canvasRect.width * scaleX,
+        canvasRect.height * scaleY
+      )
+    }
+  }
+
+  return canvas.toDataURL("image/png")
 }
 
 export const SaveImageMenuList = ({tile}: IProps) => {
@@ -24,15 +85,15 @@ export const SaveImageMenuList = ({tile}: IProps) => {
     if (!mapModel?.renderState) {
       return undefined
     }
-    const {displayElement} = mapModel.renderState
+    const {displayElement, rendererArray} = mapModel.renderState
     let dataUri: string|undefined = undefined
 
     // TODO: add translation for progress message
     setProgressMessage("Exporting map ...")
     try {
-      dataUri = await (format === "png"
-        ? toPng(displayElement)
-        : toSvg(displayElement))
+      dataUri = format === "png"
+        ? await compositeMapPng(displayElement, rendererArray)
+        : await toSvg(displayElement)
     } catch (error) {
       console.error(`Error generating ${format.toUpperCase()} image:`, error)
     }


### PR DESCRIPTION
## Summary
- The map's PNG export used `html-to-image`'s `toPng`, which doesn't capture
  WebGL canvases — so PIXI-rendered points were missing from the output.
- `compositeMapPng` now keeps `toPng` for the basemap, polygons,
  connecting-lines SVG, and heatmap, then draws each visible point layer's
  PIXI-extracted canvas on top, scaling for `html-to-image`'s pixel ratio.
- Iterates `rendererArray`, so maps with multiple point layers work.
  Invisible layers (e.g. heatmap mode) are skipped.
- Set explicit `fill="transparent"` and `stroke="transparent"` on the
  attribute-label-bg SVG rect (axis-utils.ts) so a PNG export still
  renders correctly when CSS inlining drops the rule. Affects all
  attribute labels app-wide but is invisible at runtime — class-selector
  CSS still overrides these defaults.

Fixes CODAP-1318

## Test plan
- [ ] Roller Coasters example: map with basemap + polygons + points → PNG contains all three.
- [ ] Points-only map → points appear.
- [ ] Polygons-only map → no regression.
- [ ] Heatmap mode → heatmap exports correctly.
- [ ] Map with multiple point layers → all layers export.
- [ ] Map with a legend → legend attribute name renders as text in the PNG (not a black rect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
