### PR TITLE
CODAP-1340: fix 2x image scaling for map Open in Draw Tool

### DIFF
--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -111,6 +111,10 @@ export const SaveImageMenuList = ({tile}: IProps) => {
     return undefined
   }
 
+  // The menu item below is disabled because the Draw Tool plugin itself has severe issues
+  // in Safari (CODAP-1340 covered the scaling fix; the underlying Safari blocker remains).
+  // The handler is kept wired up so the feature can be re-enabled by removing `isDisabled`
+  // once Draw Tool works in all supported browsers.
   const handleOpenInDrawTool = async () => {
     if (!tile || !mapModel?.renderState) return
     const { displayElement } = mapModel.renderState
@@ -156,8 +160,8 @@ export const SaveImageMenuList = ({tile}: IProps) => {
 
   return (
     <InspectorMenuContent data-testid="save-image-menu-list">
-      <MenuItem data-testid="open-in-draw-tool" onAction={handleOpenInDrawTool}>
-        {t("DG.DataDisplayMenu.copyAsImage")}
+      <MenuItem data-testid="open-in-draw-tool" onAction={handleOpenInDrawTool} isDisabled={true}>
+        {t("DG.DataDisplayMenu.copyAsImage")}<span aria-hidden="true"> 🚧</span>
       </MenuItem>
       <MenuItem data-testid="export-png-image" onAction={handleExportPNG}>
         {t("DG.DataDisplayMenu.exportPngImage")}

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -29,9 +29,9 @@ function loadImage(src: string): Promise<HTMLImageElement> {
 // its output. Composite each visible WebGL point layer's static snapshot on top of the
 // html-to-image base (basemap, polygons, connecting-lines SVG, heatmap).
 async function compositeMapPng(
-  displayElement: HTMLElement, rendererArray: PointRendererArray
+  displayElement: HTMLElement, rendererArray: PointRendererArray, pixelRatio?: number
 ): Promise<string> {
-  const baseDataUri = await toPng(displayElement)
+  const baseDataUri = await toPng(displayElement, { pixelRatio })
   const baseImage = await loadImage(baseDataUri)
 
   const canvas = document.createElement("canvas")
@@ -78,7 +78,7 @@ export const SaveImageMenuList = ({tile}: IProps) => {
   const { setProgressMessage, clearProgressMessage } = useProgress()
   const mapModel = isMapContentModel(tile?.content) ? tile?.content : undefined
 
-  const getImageDataUri = async (format: ExportableFormat) => {
+  const getImageDataUri = async (format: ExportableFormat, pixelRatio?: number) => {
     if (!mapModel?.renderState) {
       return undefined
     }
@@ -89,7 +89,7 @@ export const SaveImageMenuList = ({tile}: IProps) => {
     setProgressMessage("Exporting map ...")
     try {
       dataUri = format === "png"
-        ? await compositeMapPng(displayElement, rendererArray)
+        ? await compositeMapPng(displayElement, rendererArray, pixelRatio)
         : await toSvg(displayElement)
     } catch (error) {
       console.error(`Error generating ${format.toUpperCase()} image:`, error)
@@ -111,13 +111,13 @@ export const SaveImageMenuList = ({tile}: IProps) => {
     return undefined
   }
 
-  // The menu item that invokes this handler is currently disabled (CODAP-1303): launching the
-  // Draw tool from the Map has significant bugs. Once those are resolved, remove `isDisabled`
-  // from the corresponding <MenuItem> below to re-enable.
   const handleOpenInDrawTool = async () => {
-    if (tile) {
-      const imageDataUri = await getImageDataUri("png")
-      await openInDrawTool(tile, imageDataUri || "")
+    if (!tile || !mapModel?.renderState) return
+    const { displayElement } = mapModel.renderState
+    const imageDataUri = await getImageDataUri("png", 1)
+    if (imageDataUri) {
+      const { width, height } = displayElement.getBoundingClientRect()
+      await openInDrawTool(tile, imageDataUri, { width, height })
     }
   }
 
@@ -156,8 +156,8 @@ export const SaveImageMenuList = ({tile}: IProps) => {
 
   return (
     <InspectorMenuContent data-testid="save-image-menu-list">
-      <MenuItem data-testid="open-in-draw-tool" onAction={handleOpenInDrawTool} isDisabled={true}>
-        {t("DG.DataDisplayMenu.copyAsImage")}<span aria-hidden="true"> 🚧</span>
+      <MenuItem data-testid="open-in-draw-tool" onAction={handleOpenInDrawTool}>
+        {t("DG.DataDisplayMenu.copyAsImage")}
       </MenuItem>
       <MenuItem data-testid="export-png-image" onAction={handleExportPNG}>
         {t("DG.DataDisplayMenu.exportPngImage")}

--- a/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/save-image-menu-list.tsx
@@ -112,9 +112,9 @@ export const SaveImageMenuList = ({tile}: IProps) => {
   }
 
   // The menu item below is disabled because the Draw Tool plugin itself has severe issues
-  // in Safari (CODAP-1340 covered the scaling fix; the underlying Safari blocker remains).
-  // The handler is kept wired up so the feature can be re-enabled by removing `isDisabled`
-  // once Draw Tool works in all supported browsers.
+  // in Safari (CODAP-1340 covered the scaling fix; the underlying Safari blocker remains,
+  // tracked by CODAP-1303). The handler is kept wired up so the feature can be re-enabled
+  // by removing `isDisabled` once Draw Tool works in all supported browsers.
   const handleOpenInDrawTool = async () => {
     if (!tile || !mapModel?.renderState) return
     const { displayElement } = mapModel.renderState


### PR DESCRIPTION
## Summary
- Fixes the ~2x image scaling that the Draw Tool would show when launched from a map (passes pixelRatio=1 through compositeMapPng to html-to-image, and forwards the map's bounding rect as the dimensions hint to openInDrawTool).
- Leaves the "Open in Draw Tool" menu item disabled for maps: the Draw Tool plugin has severe issues in Safari that are out of scope here. The handler is kept wired up so the feature can be re-enabled by removing isDisabled once Safari support is sorted.

Fixes CODAP-1340. Depends on #2580 (CODAP-1318); targets the CODAP-1318 branch and will retarget to `main` after that PR merges.

## Test plan
- [ ] Temporarily remove `isDisabled` from the menu item, open the Roller Coasters example, make a map with points + polygons + a point legend, choose "Copy as Image" — the Draw Tool tile matches the map's size and the points are present.
- [ ] Verify the same with multi-layer, heatmap, polygons-only, and points-only maps.
- [ ] "Export PNG Image" (file download path) still produces a full-resolution image on retina displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
