### PR TITLE
CODAP-1329: sort date-typed legend attributes chronologically

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -473,7 +473,10 @@ export const DataConfigurationModel = types
         const caseDataArray = self.getUnsortedCaseDataArray(caseArrayNumber),
           legendAttrID = self.attributeID('legend')
         if (legendAttrID) {
-          if (self.attributeType("legend") === "numeric") {
+          const legendType = self.attributeType("legend")
+          if (legendType === "numeric" || legendType === "date") {
+            // dataDisplayGetNumericValue returns epoch-seconds for date attrs, so the same
+            // numeric comparator orders date legends chronologically.
             caseDataArray.sort((cd1: CaseData, cd2: CaseData) => {
               const cd1Value = dataDisplayGetNumericValue(self.dataset, cd1.caseID, legendAttrID, true) ?? NaN,
                 cd2Value = dataDisplayGetNumericValue(self.dataset, cd2.caseID, legendAttrID, true) ?? NaN

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-utils.test.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-utils.test.ts
@@ -1,0 +1,50 @@
+import { sortLegendCategories } from "./bar-chart-utils"
+
+describe("sortLegendCategories", () => {
+  it("returns a new array without mutating the input (numeric legend)", () => {
+    const original = ["3", "1", "2"]
+    const snapshot = [...original]
+    const result = sortLegendCategories(original, "numeric")
+    expect(result).not.toBe(original)
+    expect(original).toEqual(snapshot)
+  })
+
+  it("returns a new array without mutating the input (date legend)", () => {
+    const original = ["Feb 2020", "Jan 2020", "Mar 2020"]
+    const snapshot = [...original]
+    const result = sortLegendCategories(original, "date")
+    expect(result).not.toBe(original)
+    expect(original).toEqual(snapshot)
+  })
+
+  it("returns a new array without mutating the input (categorical legend)", () => {
+    const original = ["banana", "apple", "cherry"]
+    const snapshot = [...original]
+    const result = sortLegendCategories(original, "categorical")
+    expect(result).not.toBe(original)
+    expect(original).toEqual(snapshot)
+  })
+
+  it("sorts numeric legend categories in descending order", () => {
+    expect(sortLegendCategories(["1", "3", "2", "10"], "numeric")).toEqual(["10", "3", "2", "1"])
+  })
+
+  it("sorts date legend categories chronologically, most recent first", () => {
+    expect(sortLegendCategories(["Feb 2020", "Jan 2020", "Mar 2020"], "date"))
+      .toEqual(["Mar 2020", "Feb 2020", "Jan 2020"])
+  })
+
+  it("leaves categorical legend categories in their original order", () => {
+    expect(sortLegendCategories(["banana", "apple", "cherry"], "categorical"))
+      .toEqual(["banana", "apple", "cherry"])
+  })
+
+  it("leaves categories in their original order when the legend type is undefined", () => {
+    expect(sortLegendCategories(["b", "a", "c"], undefined)).toEqual(["b", "a", "c"])
+  })
+
+  it("sorts unparseable numeric values to the end", () => {
+    expect(sortLegendCategories(["2", "not-a-number", "1"], "numeric"))
+      .toEqual(["2", "1", "not-a-number"])
+  })
+})

--- a/v3/src/components/graph/plots/bar-chart/bar-chart-utils.ts
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart-utils.ts
@@ -1,0 +1,25 @@
+import { AttributeType } from "../../../../models/data/attribute-types"
+import { numericSortComparator } from "../../../../utilities/data-utils"
+import { convertToDate } from "../../../../utilities/date-utils"
+
+// Returns a new array of legend category strings sorted for display. The input is left untouched:
+// callers pass the CategorySet's shared observable `values` array, which must not be sorted in place.
+// Numeric and date legends are sorted descending; NaN values (categories without a numeric/date
+// value) are handled by numericSortComparator. Other legend types keep their original order.
+export function sortLegendCategories(legendCats: readonly string[], legendType?: AttributeType): string[] {
+  const sortedLegendCats = Array.from(legendCats)
+  if (legendType === "numeric") {
+    sortedLegendCats.sort((cat1, cat2) => {
+      return numericSortComparator({ a: Number(cat1), b: Number(cat2), order: "desc" })
+    })
+  } else if (legendType === "date") {
+    // Precompute one epoch key per category so convertToDate isn't re-parsed on every comparison.
+    const dateKeys = new Map(legendCats.map(cat => [cat, convertToDate(cat)?.valueOf() ?? NaN]))
+    sortedLegendCats.sort((cat1, cat2) => {
+      return numericSortComparator({
+        a: dateKeys.get(cat1) ?? NaN, b: dateKeys.get(cat2) ?? NaN, order: "desc"
+      })
+    })
+  }
+  return sortedLegendCats
+}

--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { logStringifiedObjectMessage } from "../../../../lib/log-message"
 import { numericSortComparator } from "../../../../utilities/data-utils"
+import { convertToDate } from "../../../../utilities/date-utils"
 import { t } from "../../../../utilities/translation/translate"
 import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { tileNotification } from "../../../../models/tiles/tile-notifications"
@@ -116,11 +117,18 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
                   caseGroups.get(caseGroupKey).push(aCase)
                 })
 
-                // If the legend attribute is numeric, sort legendCats in descending order making sure to handle any NaN
-                // values for cases that don't have a numeric value for the legend attribute.
-                if (dataConfig.attributeType("legend") === "numeric") {
+                // If the legend attribute is numeric or date, sort legendCats in descending order. NaN values
+                // (cases that don't have a numeric/date value for the legend attribute) are handled by the comparator.
+                const legendType = dataConfig.attributeType("legend")
+                if (legendType === "numeric") {
                   legendCats.sort((cat1: string, cat2: string) => {
                     return numericSortComparator({a: Number(cat1), b: Number(cat2), order: "desc"})
+                  })
+                } else if (legendType === "date") {
+                  legendCats.sort((cat1: string, cat2: string) => {
+                    const a = convertToDate(cat1)?.valueOf() ?? NaN
+                    const b = convertToDate(cat2)?.valueOf() ?? NaN
+                    return numericSortComparator({a, b, order: "desc"})
                   })
                 }
                 const cellMap = dataConfig.cellMap(primarySplitAttrRole, secondarySplitAttrRole)

--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -3,8 +3,6 @@ import { observer } from "mobx-react-lite"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { logStringifiedObjectMessage } from "../../../../lib/log-message"
-import { numericSortComparator } from "../../../../utilities/data-utils"
-import { convertToDate } from "../../../../utilities/date-utils"
 import { t } from "../../../../utilities/translation/translate"
 import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { tileNotification } from "../../../../models/tiles/tile-notifications"
@@ -17,6 +15,7 @@ import { useGraphLayoutContext } from "../../hooks/use-graph-layout-context"
 import { usePlotResponders } from "../../hooks/use-plot"
 import { setPointCoordinates } from "../../utilities/graph-utils"
 import { barCompressionFactorForCase, barCoverDimensions, renderBarCovers } from "../bar-utils"
+import { sortLegendCategories } from "./bar-chart-utils"
 import { isBarChartModel } from "./bar-chart-model"
 
 export const BarChart = observer(function BarChart({ abovePointsGroupRef, renderer }: IPlotProps) {
@@ -89,6 +88,9 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
         : []
       const primCatsCount = primCatsArray.length
       const legendCats = dataConfig.categorySetForAttrRole("legend")?.values ?? []
+      // sortLegendCategories returns a sorted copy: `legendCats` is the CategorySet's shared
+      // observable array, so sorting it in place would corrupt its canonical ordering and index map.
+      const sortedLegendCats = sortLegendCategories(legendCats, dataConfig.attributeType("legend"))
       Object.entries(catMap).forEach(([primeCat, secCats]) => {
         Object.entries(secCats).forEach(([secCat, primSplitCats]) => {
           Object.entries(primSplitCats).forEach(([primeSplitCat, secSplitCats]) => {
@@ -117,26 +119,10 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
                   caseGroups.get(caseGroupKey).push(aCase)
                 })
 
-                // If the legend attribute is numeric or date, sort legendCats in descending order. NaN values
-                // (cases that don't have a numeric/date value for the legend attribute) are handled by the comparator.
-                const legendType = dataConfig.attributeType("legend")
-                if (legendType === "numeric") {
-                  legendCats.sort((cat1: string, cat2: string) => {
-                    return numericSortComparator({a: Number(cat1), b: Number(cat2), order: "desc"})
-                  })
-                } else if (legendType === "date") {
-                  // Precompute one epoch key per category so convertToDate isn't re-parsed on every sort comparison.
-                  const dateKeys = new Map(legendCats.map(cat => [cat, convertToDate(cat)?.valueOf() ?? NaN]))
-                  legendCats.sort((cat1: string, cat2: string) => {
-                    return numericSortComparator({
-                      a: dateKeys.get(cat1) ?? NaN, b: dateKeys.get(cat2) ?? NaN, order: "desc"
-                    })
-                  })
-                }
                 const cellMap = dataConfig.cellMap(primarySplitAttrRole, secondarySplitAttrRole)
 
                 // For each legend value, create a bar cover
-                legendCats.forEach((legendCat: string) => {
+                sortedLegendCats.forEach((legendCat: string) => {
                   const matchingCases =
                     caseGroups.get(`${legendCat}-${primeCat}-${exPrimeCatKey}-${exSecCatKey}`) ?? []
                   const maxInCell = minInCell + matchingCases.length

--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -125,10 +125,12 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
                     return numericSortComparator({a: Number(cat1), b: Number(cat2), order: "desc"})
                   })
                 } else if (legendType === "date") {
+                  // Precompute one epoch key per category so convertToDate isn't re-parsed on every sort comparison.
+                  const dateKeys = new Map(legendCats.map(cat => [cat, convertToDate(cat)?.valueOf() ?? NaN]))
                   legendCats.sort((cat1: string, cat2: string) => {
-                    const a = convertToDate(cat1)?.valueOf() ?? NaN
-                    const b = convertToDate(cat2)?.valueOf() ?? NaN
-                    return numericSortComparator({a, b, order: "desc"})
+                    return numericSortComparator({
+                      a: dateKeys.get(cat1) ?? NaN, b: dateKeys.get(cat2) ?? NaN, order: "desc"
+                    })
                   })
                 }
                 const cellMap = dataConfig.cellMap(primarySplitAttrRole, secondarySplitAttrRole)


### PR DESCRIPTION
## Summary

Follow-up to CODAP-1320 / PR #2574; companion to CODAP-1328. Two sites
gated legend ordering on `attributeType === "numeric"` and dropped
date legends through to default (lexicographic) order:

- **`data-configuration-model.getCaseDataArray`** — the canonical
  case-order used across data-display tiles (graph, map, etc.). Now
  accepts `"date"` alongside `"numeric"`; `dataDisplayGetNumericValue`
  already returns epoch-seconds for date attrs, so the same comparator
  orders date legends chronologically.

- **`bar-chart` `legendCats` sort** — for date legends, convert each
  category string via `convertToDate` (loose parsing also handles
  formats like `"Jan 2020"` and `"2020"`) before applying the existing
  descending numeric sort.

Fixes CODAP-1329.

## Test plan

- [ ] Scatter plot with a date legend attribute: legend swatches appear
      in chronological order, not lexicographic. Verify with date
      strings that lexical and chronological order disagree (e.g.
      `"Jan 2020"`, `"Feb 2020"`, `"Mar 2020"`).
- [ ] Bar chart with a date legend attribute: stacked legend segments
      within each bar are chronological top-to-bottom.
- [ ] Existing numeric-legend behavior unchanged on graph and bar chart.
- [ ] Categorical-legend behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)