### PR TITLE
CODAP-1344: tighten gap between bottom axis label and legend

### DIFF
--- a/v3/cypress/e2e/axis-splits.spec.ts
+++ b/v3/cypress/e2e/axis-splits.spec.ts
@@ -77,7 +77,9 @@ context("Test graph axes with split, multi-y, bars, and overflow configurations"
       .should("have.text", "Height")
     cy.get("[data-testid=graph]").find("[data-testid=attribute-label-multi-y]").should("have.length", 0)
     ah.verifyYAxisTickMarksDisplayed()
-    ah.verifyAxisTickLabel("left", "0", 0)
+    // Single y-attribute: the full-height left axis fits a finer tick interval than the
+    // split (two-y) cases above and below, so its first tick is "-0.5" rather than "0".
+    ah.verifyAxisTickLabel("left", "-0.5", 0)
 
     // Redo the last change (Sleep => left split)
     toolbar.getRedoTool().click()

--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -4,6 +4,7 @@ import {axisBottom, axisLeft, axisRight, axisTop,
 export const axisGap = 5
 export const labelMargin = 13   // whitespace outside the label background rect (between rect and axis bounds)
 export const labelPaddingX = 8  // horizontal padding inside the label background rect (between rect edge and text)
+export const labelPaddingY = 4  // vertical padding inside the label background rect (between rect edge and text)
 
 // "rightCat" and "top" can only be categorical axes. "rightNumeric" can only be numeric
 export const AxisPlaces = ["bottom", "left", "rightCat", "top", "rightNumeric"] as const

--- a/v3/src/components/axis/axis-utils.ts
+++ b/v3/src/components/axis/axis-utils.ts
@@ -9,7 +9,7 @@ import { determineLevels } from "../../utilities/date-utils"
 import { GraphLayout } from "../graph/models/graph-layout"
 import { ITileModel } from "../../models/tiles/tile-model"
 import { kAxisGap, kAxisTickLength, kDefaultFontHeight } from "./axis-constants"
-import {AxisPlace, labelPaddingX} from "./axis-types"
+import {AxisPlace, labelPaddingX, labelPaddingY} from "./axis-types"
 import { updateAxisNotification } from "./models/axis-notifications"
 import { IBaseNumericAxisModel } from "./models/base-numeric-axis-model"
 
@@ -376,7 +376,7 @@ export function renderLabelBackground<GElement extends BaseType>(
   if (!textBBox) return
 
   const paddingX = labelPaddingX
-  const paddingY = 4
+  const paddingY = labelPaddingY
   const arrowWidth = 24
 
   const rectWidth = textBBox.width + paddingX + arrowWidth

--- a/v3/src/components/axis/hooks/use-axis.ts
+++ b/v3/src/components/axis/hooks/use-axis.ts
@@ -9,7 +9,7 @@ import { useDataConfigurationContext } from "../../data-display/hooks/use-data-c
 import { useDataDisplayModelContextMaybe } from "../../data-display/hooks/use-data-display-model"
 import { IDataDisplayContentModel } from "../../data-display/models/data-display-content-model"
 import { kColorAxisExtent, kQualitativeAxisExtent } from "../axis-constants"
-import { AxisPlace, AxisScaleType, axisGap, axisPlaceToAxisFn, labelMargin } from "../axis-types"
+import { AxisPlace, AxisScaleType, axisGap, axisPlaceToAxisFn, labelMargin, labelPaddingY } from "../axis-types"
 import {
   collisionExists, computeBestNumberOfTicks,
   computeBestNumberOfVerticalAxisTicks,
@@ -83,8 +83,14 @@ export const useAxis = (axisPlace: AxisPlace) => {
       numbersHeight = getStringBounds('0').height,
       repetitions = multiScale?.repetitions ?? 1,
       d3Scale = multiScale?.scale ?? (isNumeric ? scaleLinear() : scaleOrdinal())
-    // labelMargin above and below the attribute label
-    let desiredExtent = axisTitleHeight + 2 * labelMargin
+    // For the bottom axis, the legend (or tile edge) sits immediately below, so we use
+    // only labelPaddingY below the label (aligning the label rect with the axis bounds
+    // edge) and a tighter labelPaddingY * 2 above. Other axes keep the larger labelMargin
+    // on both sides.
+    const isBottom = axisPlace === 'bottom'
+    const aboveLabelSpace = isBottom ? labelPaddingY * 2 : labelMargin
+    const belowLabelSpace = isBottom ? labelPaddingY : labelMargin
+    let desiredExtent = axisTitleHeight + aboveLabelSpace + belowLabelSpace
     let ticks: string[] = []
     switch (axisType) {
       case 'count':

--- a/v3/src/components/data-display/components/legend/categorical-legend-model.ts
+++ b/v3/src/components/data-display/components/legend/categorical-legend-model.ts
@@ -2,12 +2,11 @@ import { makeAutoObservable } from "mobx"
 import { measureText } from "../../../../hooks/use-measure-text"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import { missingColor } from "../../../../utilities/color-utils"
-import { axisGap } from "../../../axis/axis-types"
+import { axisGap, labelPaddingY } from "../../../axis/axis-types"
 import { getStringBounds } from "../../../axis/axis-utils"
 import { kMain, kDataDisplayFont } from "../../data-display-types"
 import { IDataConfigurationModel } from "../../models/data-configuration-model"
 import { DataDisplayLayout } from "../../models/data-display-layout"
-import { kLegendLabelTopPadding } from "./legend-common"
 
 import vars from "../../../vars.scss"
 
@@ -28,7 +27,9 @@ interface Layout {
 
 export const keySize = 15
 export const padding = 5
-export const labelHeight = getStringBounds('Wy', vars.labelFont).height + axisGap + kLegendLabelTopPadding
+// y-coordinate at which the first row of category keys is drawn. Sits axisGap below the
+// attribute label's background rect, whose height is labelText + 2 * labelPaddingY.
+export const labelHeight = getStringBounds('Wy', vars.labelFont).height + 2 * labelPaddingY + axisGap
 
 export class CategoricalLegendModel {
   dragInfo = {

--- a/v3/src/components/data-display/components/legend/color-legend.tsx
+++ b/v3/src/components/data-display/components/legend/color-legend.tsx
@@ -1,10 +1,10 @@
 import { reaction } from "mobx"
 import { observer } from "mobx-react-lite"
 import { useCallback, useEffect } from "react"
-import {axisGap} from "../../../axis/axis-types"
+import {axisGap, labelPaddingY} from "../../../axis/axis-types"
 import {getStringBounds} from "../../../axis/axis-utils"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
-import { IBaseLegendProps, kLegendLabelTopPadding } from "./legend-common"
+import { IBaseLegendProps } from "./legend-common"
 
 import vars from "../../../vars.scss"
 
@@ -22,7 +22,9 @@ export const ColorLegend = observer(function ColorLegend({layerIndex, setDesired
     const computeDesiredExtent = () => {
       if (dataConfiguration?.placeCanHaveZeroExtent('legend')) return 0
 
-      return labelHeight + 2 * axisGap + kLegendLabelTopPadding
+      // Reserve space for the attribute label's background rect (labelHeight + 2 *
+      // labelPaddingY) plus a small buffer below it.
+      return labelHeight + 2 * labelPaddingY + 2 * axisGap
     }
 
     setDesiredExtent(layerIndex, computeDesiredExtent())

--- a/v3/src/components/data-display/components/legend/legend-attribute-label.tsx
+++ b/v3/src/components/data-display/components/legend/legend-attribute-label.tsx
@@ -2,13 +2,12 @@ import {useCallback, useEffect, useRef} from "react"
 import {select} from "d3"
 import {AttributeType} from "../../../../models/data/attribute-types"
 import {IDataSet} from "../../../../models/data/data-set"
-import {axisGap, labelPaddingX} from "../../../axis/axis-types"
+import {axisGap, labelPaddingX, labelPaddingY} from "../../../axis/axis-types"
 import {GraphPlace} from "../../../axis-graph-shared"
 import {getStringBounds, renderLabelBackground} from "../../../axis/axis-utils"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
 import {useTileSelectionContext} from "../../../../hooks/use-tile-selection-context"
 import {AttributeLabel} from "../attribute-label"
-import { kLegendLabelTopPadding } from "./legend-common"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 
 import vars from "../../../vars.scss"
@@ -32,7 +31,11 @@ export const LegendAttributeLabel =
         labelFont = vars.labelFont,
         labelBounds = getStringBounds(attributeName, labelFont),
         tX = axisGap + labelPaddingX,  // offset so rect left edge aligns with legend keys
-        tY = labelBounds.height / 2 + kLegendLabelTopPadding
+        // With dominant-baseline: central, tY sets the vertical center of the text. Placing
+        // the center at labelBounds.height/2 + labelPaddingY puts the background rect's top
+        // edge at y=0 (the legend bounds top) — no overflow that could be clipped by the
+        // SVG viewport on hover, and no excess whitespace above the label.
+        tY = labelBounds.height / 2 + labelPaddingY
 
       const gSelection = select(labelRef.current)
       gSelection.classed('tile-selected', isTileSelected())
@@ -94,6 +97,7 @@ export const LegendAttributeLabel =
               enter.append('text')
                 .attr('class', className)
                 .attr('text-anchor', 'start')
+                .attr('dominant-baseline', 'central')
                 .attr('data-testid', className)
           )
         refreshLegendTitle()

--- a/v3/src/components/data-display/components/legend/legend-common.ts
+++ b/v3/src/components/data-display/components/legend/legend-common.ts
@@ -2,5 +2,3 @@ export interface IBaseLegendProps {
   layerIndex: number
   setDesiredExtent: (layerIndex: number, extent: number) => void
 }
-
-export const kLegendLabelTopPadding = 12

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -2,13 +2,13 @@ import { observer } from "mobx-react-lite"
 import { useCallback, useEffect, useState } from "react"
 import { setOrExtendSelection } from "../../../../models/data/data-set-utils"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
-import { axisGap } from "../../../axis/axis-types"
+import { axisGap, labelPaddingY } from "../../../axis/axis-types"
 import { getStringBounds } from "../../../axis/axis-utils"
 import { kChoroplethHeight } from "../../data-display-types"
 import { useDataConfigurationContext } from "../../hooks/use-data-configuration-context"
 import { useDataDisplayLayout } from "../../hooks/use-data-display-layout"
 import { choroplethLegend } from "./choropleth-legend/choropleth-legend"
-import { IBaseLegendProps, kLegendLabelTopPadding } from "./legend-common"
+import { IBaseLegendProps } from "./legend-common"
 
 import vars from "../../../vars.scss"
 
@@ -32,7 +32,9 @@ export const NumericLegend =
         if (dataConfiguration?.placeCanHaveZeroExtent('legend')) {
           return 0
         }
-        return labelHeight + kChoroplethHeight + numberHeight + 2 * axisGap + kLegendLabelTopPadding
+        // The label's background rect spans labelHeight + 2 * labelPaddingY vertically
+        // (paddingY above and below the text), so the choropleth needs to clear that.
+        return labelHeight + 2 * labelPaddingY + kChoroplethHeight + numberHeight + 2 * axisGap
       }
 
       if (!choroplethElt || !dataConfiguration) return
@@ -42,7 +44,7 @@ export const NumericLegend =
         {
           isDate: dataConfiguration.attributeType('legend') === 'date',
           width: tileWidth,
-          marginLeft: 6, marginTop: labelHeight + kLegendLabelTopPadding, marginRight: 6, ticks: 5,
+          marginLeft: 6, marginTop: labelHeight + 2 * labelPaddingY, marginRight: 6, ticks: 5,
           clickHandler: (bin: number, extend: boolean) => {
             const dataset = dataConfiguration.dataset
             const binCases = dataConfiguration.getCasesForLegendBin(bin)

--- a/v3/src/components/graph/components/graph-attribute-label.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label.tsx
@@ -9,7 +9,7 @@ import { useTileSelectionContext } from "../../../hooks/use-tile-selection-conte
 import { AttributeType } from "../../../models/data/attribute-types"
 import { IDataSet } from "../../../models/data/data-set"
 import { GraphPlace, isVertical } from "../../axis-graph-shared"
-import { labelMargin } from "../../axis/axis-types"
+import { labelMargin, labelPaddingY } from "../../axis/axis-types"
 import { getStringBounds, renderLabelBackground } from "../../axis/axis-utils"
 import { AttributeLabel } from "../../data-display/components/attribute-label"
 import { graphPlaceToAttrRole } from "../../data-display/data-display-types"
@@ -215,13 +215,20 @@ export const GraphAttributeLabel =
         // With dominant-baseline: central, tY sets the visual center of the text.
         // Place center at labelMargin + labelBounds.height/2 from the outer edge.
         labelCenter = labelMargin + labelBounds.height / 2,
+        // For the bottom axis, position the label so its background rect aligns with the
+        // bottom edge of the axis bounds (no labelMargin below). The legend (or tile edge)
+        // immediately below provides any further visual separation. The +1 is a sub-pixel
+        // safety margin: labelBounds.height can be fractional, and without it the rect's
+        // bottom can spill 0.25–0.5 px past the bounds edge and be clipped by the legend's
+        // background.
+        bottomLabelCenter = labelPaddingY + labelBounds.height / 2 + 1,
         tX = place === 'left' ? labelCenter
           : place === 'legend' ? bounds.left
             : ['rightNumeric', 'rightCat'].includes(place) ? bounds.width - labelCenter
               : halfRange,
         tY = isVertical(place) ? halfRange
           : place === 'legend' ? labelBounds.height / 2
-            : place === 'top' ? labelCenter : bounds.height - labelCenter,
+            : place === 'top' ? labelCenter : bounds.height - bottomLabelCenter,
         tRotation = isVertical(place) ? ` rotate(-90,${tX},${tY})` : ''
 
       select(labelRef.current).selectAll(`text.${unusedClassName}`).remove()


### PR DESCRIPTION
## Summary
- Eliminate the excess whitespace between the x-axis attribute label and the legend's attribute label (visible as a large empty band when a graph has both an x-axis attribute and a categorical/numeric legend).
- The bottom axis now positions its label rect at the axis bounds edge (no labelMargin below) and uses a tighter above-label margin.
- The legend's "Attribute Name" label uses dominant-baseline: central so its rect lines up exactly with the top of the legend bounds — no SVG-viewport clipping when the rect is shown on hover/focus.
- Replace `kLegendLabelTopPadding` (12px constant added above the legend label) with the existing `labelPaddingY` (now exported from axis-types), giving consistent label-rect math across categorical / color / numeric legends.

Fixes CODAP-1344

## Test plan
- [ ] Open a document with a graph that has an x-axis attribute and a categorical legend (e.g. the Three Points doc on the Jira issue); confirm the gap between "value" and "Attribute Name" is small.
- [ ] Hover the x-axis label and the legend label; confirm the highlighted rect renders fully (no clipping at top/bottom).
- [ ] Switch the legend to a numeric attribute; confirm the choropleth bar appears below the legend label rather than overlapping it.
- [ ] Switch the legend to an attribute whose type is treated as color; confirm the legend still has reasonable height.