### PR TITLE
CODAP-1341: fix CFM menu drop shadow and focus outline bugs

### DIFF
--- a/v3/src/index.scss
+++ b/v3/src/index.scss
@@ -13,11 +13,18 @@ body {
     box-shadow: none !important;
   }
 
-  /* The CFM menu list (File, Settings, etc.) is focused programmatically when
-     a menu opens via the mouse, and the browser resolves :focus-visible for it
-     inconsistently. So we don't style it off focus state: it keeps its
-     decorative drop shadow (excluded from the reset above) and shows no focus
-     outline here. Keyboard users navigate the menu items, not the container. */
+  /* .menu-list-container is the CFM menu list (File, Settings, etc.) — a class
+     owned by the @concord-consortium/cloud-file-manager package. It is focused
+     programmatically when a menu opens via the mouse, and the browser resolves
+     :focus-visible for it inconsistently, so we don't style it off focus state:
+     it keeps its decorative drop shadow (excluded from the reset above) and
+     shows no focus outline here. Keyboard users navigate the menu items, not
+     the container.
+
+     This fix lives in CODAP because the box-shadow reset above is CODAP's, but
+     CFM ideally would also style its own menu list to be resilient to any
+     consumer's focus reset — a CFM-side rule would complement this one as
+     defense in depth. */
   .menu-list-container:focus {
     outline: none;
   }

--- a/v3/src/index.scss
+++ b/v3/src/index.scss
@@ -6,10 +6,20 @@ html, body {
 body {
   user-select: none;
 
-  /* Remove outline for non-keyboard :focus */
-  *:focus:not(:focus-visible) {
-    // chakra uses box-shadow for focus highlight rather than outline
+  /* Remove the box-shadow focus highlight for non-keyboard :focus.
+     (Chakra draws focus highlights with box-shadow rather than outline.)
+     .menu-list-container is excluded — see the rule below. */
+  *:focus:not(:focus-visible):not(.menu-list-container) {
     box-shadow: none !important;
+  }
+
+  /* The CFM menu list (File, Settings, etc.) is focused programmatically when
+     a menu opens via the mouse, and the browser resolves :focus-visible for it
+     inconsistently. So we don't style it off focus state: it keeps its
+     decorative drop shadow (excluded from the reset above) and shows no focus
+     outline here. Keyboard users navigate the menu items, not the container. */
+  .menu-list-container:focus {
+    outline: none;
   }
 
   /* Show outline for keyboard :focus-visible */


### PR DESCRIPTION
## Summary

Fixes two related bugs in the CFM menus (File, Settings, Help, …):

1. **Missing drop shadow** — the menu's decorative drop shadow was absent when a menu first opened, appearing only after the user moused over it.
2. **Incorrect focus outline** — a blue keyboard focus outline sometimes appeared around the whole menu when it was opened with the *mouse*. A keyboard focus indicator showing on pointer interaction is a focus-behavior bug, not just a visual nit.

Both share a single root cause (below) and are fixed together.

## Root cause

`src/index.scss` has a global rule — `*:focus:not(:focus-visible) { box-shadow: none !important }` — that suppresses Chakra's box-shadow focus rings on non-keyboard focus.

When a CFM menu opens via mouse, React Aria gives the menu list container (`.menu-list-container`) programmatic keyboard focus, and the browser's native `:focus-visible` heuristic resolves that focus inconsistently:

- Usually the container is `:focus` but not `:focus-visible` → the rule fires and wipes out the menu's **decorative drop shadow**.
- Occasionally it resolves to `:focus-visible` → the shadow shows, but the browser draws a stray blue **keyboard focus outline** around the whole menu (noted as a related bug in a comment on CODAP-1341).

Both symptoms share this one root cause.

## Changes

`v3/src/index.scss`:

- Exclude `.menu-list-container` from the box-shadow reset, so the decorative drop shadow is preserved regardless of focus state.
- Remove the focus outline on `.menu-list-container` — the container is never a meaningful focus target (keyboard users navigate the menu *items*, which keep their own focus styling), so it shows only its decorative shadow and no focus ring.

## Testing

Verified manually for both a fresh mouse open and the (forced) flaky `:focus-visible` state: the drop shadow renders immediately and no focus outline appears. CSS-only change; no automated test added.

Fixes CODAP-1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)