### PR TITLE
chore: update to CFM 2.2.12

### DIFF
--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -16,7 +16,7 @@
         "@codemirror/commands": "^6.10.3",
         "@codemirror/language": "^6.12.3",
         "@codemirror/view": "^6.41.1",
-        "@concord-consortium/cloud-file-manager": "~2.2.11",
+        "@concord-consortium/cloud-file-manager": "~2.2.12",
         "@concord-consortium/log-monitor": "^1.0.0",
         "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@concord-consortium/slate-editor": "^0.12.0",
@@ -4285,9 +4285,9 @@
       }
     },
     "node_modules/@concord-consortium/cloud-file-manager": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.11.tgz",
-      "integrity": "sha512-sCopIGBWmCmreh/roF7Rb89qitOW3wImQbtLqNeI3hl+xbUvqoRS7SNUD8TmyeOyBLbQI7hBg78V9Q0gEBAMQg==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/cloud-file-manager/-/cloud-file-manager-2.2.12.tgz",
+      "integrity": "sha512-1gqp3djBBqlXkyPWqFpbhBoY8M6YhI8mE4CtUdcs4jkEQN1BeSE9UVGTYI0meR/ZSr+NXE4jnGEPrjuDSIn4sQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",

--- a/v3/package.json
+++ b/v3/package.json
@@ -197,7 +197,7 @@
     "@codemirror/commands": "^6.10.3",
     "@codemirror/language": "^6.12.3",
     "@codemirror/view": "^6.41.1",
-    "@concord-consortium/cloud-file-manager": "~2.2.11",
+    "@concord-consortium/cloud-file-manager": "~2.2.12",
     "@concord-consortium/log-monitor": "^1.0.0",
     "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
     "@concord-consortium/slate-editor": "^0.12.0",


### PR DESCRIPTION
Updates the @concord-consortium/cloud-file-manager dependency to 2.2.12.

This release includes two bug fixes:
- CFM-18: lower attachment threshold so large saves succeed (concord-consortium/cloud-file-manager#429)
- CODAP-1341: suppress focus outline on CFM menu list container (concord-consortium/cloud-file-manager#430)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
