### PR TITLE
fix: AnnouncementBanner fetch URL bypasses CloudFront edge caching

### DIFF
--- a/v3/src/components/announcement-banner/announcement-banner.tsx
+++ b/v3/src/components/announcement-banner/announcement-banner.tsx
@@ -1,12 +1,18 @@
 import React, { useEffect, useLayoutEffect, useState } from "react"
-import { kCodapResourcesUrl } from "../../constants"
 import {
   BannerConfig, dismissBanner, fetchBannerConfig, isValidButtonUrl, parseMessageWithLinks
 } from "./announcement-banner-utils"
 
 import "./announcement-banner.scss"
 
-const kAnnouncementBannerUrl = `${kCodapResourcesUrl}/notifications/v3-announcement-banner.json`
+// Fetch directly from codap-resources.concord.org (CloudFront distribution
+// E1RS9TZVZBEEEC) rather than via codap.concord.org/codap-resources/* (E3H9X49AG3GYSO).
+// The latter caches at the edge for 1 day under the S3-CORS policy, ignoring origin
+// Cache-Control: no-cache headers on the banner JSON. The former honors no-cache properly.
+// Other codap-resources paths (plugins, examples) still go through codap.concord.org
+// where they benefit from caching and same-domain plugin requirements.
+const kAnnouncementBannerUrl =
+  "https://codap-resources.concord.org/notifications/v3-announcement-banner.json"
 
 export function AnnouncementBanner() {
   const [config, setConfig] = useState<BannerConfig | null>(null)


### PR DESCRIPTION
## Summary

- Changes `AnnouncementBanner`'s fetch URL from the codap.concord.org-proxied path to `codap-resources.concord.org` directly, so banner content updates take effect immediately instead of being held for ~24 hours by the S3-CORS cache policy on the codap.concord.org distribution.
- Other `codap-resources/*` consumers (plugins, examples) are unchanged — they continue to use `kCodapResourcesUrl` so plugins keep their same-domain serving requirement.

Discovered while updating the live V3 banner content for the upcoming additional beta build: even after S3 was updated and a CloudFront invalidation was issued, dev builds continued to receive the previous JSON because the `codap.concord.org` distribution caches under the S3-CORS policy (DefaultTTL 86400) regardless of origin `Cache-Control: no-cache` headers. Fetching from `codap-resources.concord.org` (distribution E1RS9TZVZBEEEC, which honors origin headers) avoids the issue.

## Test plan

- [ ] Verify the banner content matches `s3://codap-resources/notifications/v3-announcement-banner.json` (currently the beta content).
- [ ] Update the S3 file with `--cache-control "no-cache, no-store, must-revalidate"`, then reload V3 in a fresh browser — banner should reflect the new content immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
