### PR TITLE
CODAP-1345: restore case card inspector

### DIFF
--- a/v3/src/components/case-card/case-card.scss
+++ b/v3/src/components/case-card/case-card.scss
@@ -9,7 +9,6 @@
 
 .codap-case-card {
   min-width: 150px;
-  overflow: auto hidden;
   position: relative;
 
   .attribute-drag-overlay {


### PR DESCRIPTION
## Summary
- Removes `overflow: auto hidden` from `.codap-case-card`, which was clipping the inspector panel (positioned at `right: -64px` relative to the tile).
- The inner `.case-card.react-data-card` already handles its own overflow, so the outer rule was redundant.

## Background
The inspector was previously rendered as a sibling outside `.codap-component`, so the clipping had no effect. #2507 (CODAP-1164, build 2832) moved the inspector inside the tile so the keyboard tab-trap could see it, exposing this latent bug. Regression range: builds 2805 → 2832.

The case table is unaffected because it scopes `overflow: auto hidden` to the inner `.case-table-content`, not to the outer `.codap-case-table`.

Fixes CODAP-1345

## Test plan
- [ ] Open a document with a case card; confirm the inspector panel is visible to the right of the tile when focused
- [ ] Confirm each inspector button (info, hide/show, ruler, trash) opens
- [ ] Confirm horizontal/vertical scrolling inside the card still works
- [ ] Confirm attribute drag preview inside the card still works
- [ ] Confirm case table inspector is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)