### PR TITLE
CODAP-1338: match v2 iframe permissions for plugins

### DIFF
--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -245,7 +245,8 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
         { webViewModel.isImage
             ? <WebViewImage src={webViewModel.url} alt={imageAlt} />
             : <iframe className="codap-web-view-iframe" ref={iframeRef} src={iframeSrc}
-                title={iframeTitle} onLoad={announceLoaded} />
+                title={iframeTitle} onLoad={announceLoaded}
+                allow="geolocation; microphone; camera; bluetooth; clipboard-read; clipboard-write; fullscreen" />
         }
       </div>
       <WebViewDropOverlay />

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -244,6 +244,10 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
         )}
         { webViewModel.isImage
             ? <WebViewImage src={webViewModel.url} alt={imageAlt} />
+            // `allow` is applied to every web view, not just plugins: the attribute is read only at iframe load,
+            // so by the time the iframePhone handshake identifies a plugin (e.g. for web views created by
+            // dragging a plugin tab URL onto CODAP), we'd have to reload and lose plugin state to add
+            // permissions. Matches v2 behavior; browser still requires user consent for sensitive APIs.
             : <iframe className="codap-web-view-iframe" ref={iframeRef} src={iframeSrc}
                 title={iframeTitle} onLoad={announceLoaded}
                 allow="geolocation; microphone; camera; bluetooth; clipboard-read; clipboard-write; fullscreen" />


### PR DESCRIPTION
## Summary
- Adds an `allow="geolocation; microphone; camera; bluetooth; clipboard-read; clipboard-write; fullscreen"` attribute to the plugin web-view iframe so plugins have the same permissions they had in CODAPv2.
- Fixes plugins that rely on Web Bluetooth (e.g. the Databot multi-sensor logger), the clipboard, fullscreen, or device sensors, which were silently blocked by Permissions Policy in v3.
- The legacy `allowfullscreen` attribute is omitted; the `fullscreen` directive in `allow` has been supported by all current major browsers for 5+ years (Firefox 80+, Chrome 60+, Safari 11.1+, Edge 79+) and is the modern Permissions Policy form.

Fixes CODAP-1338.

## Test plan
- [x] Open the dev server with the Databot bluetooth plugin: `http://localhost:8083/?di=https://vizeey.app/CODAP/databot_multi_sensor/databot_multi_sensor.html`
- [x] Select a sensor in Motion & Physics, click Connect → browser's Bluetooth chooser should open (rather than the plugin reporting that bluetooth is blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)