### PR TITLE
CODAP-1348: recompute formulas for datasets re-added to a document

### DIFF
--- a/v3/src/models/document/create-document-model.test.ts
+++ b/v3/src/models/document/create-document-model.test.ts
@@ -1,0 +1,119 @@
+import { when } from "mobx"
+import { Instance } from "mobx-state-tree"
+import { createCodapDocument } from "../codap/create-codap-document"
+import { createDataSet } from "../data/data-set-conversion"
+import { AttributeFormulaAdapter } from "../formula/attribute-formula-adapter"
+import { FormulaManager } from "../formula/formula-manager"
+import { TreeManager } from "../history/tree-manager"
+import { kSharedDataSetType, SharedDataSet } from "../shared/shared-data-set"
+import { getFormulaManager, getSharedModelManager } from "../tiles/tile-environment"
+
+// register the attribute formula adapter so createFormulaAdapters() installs it
+// (in the app this happens via app.tsx)
+beforeAll(() => {
+  AttributeFormulaAdapter.register()
+})
+
+// safety net: restore any console spy even if a test fails before restoring it itself
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+// CODAP-1348: The FormulaManager only computes formulas for datasets in its `dataSets`
+// registry. Datasets can be added to a document after it is created by paths that bypass
+// the explicit addDataSet() calls -- notably applySnapshot() when a Story Builder "moment"
+// is restored, and undo of a dataset deletion. createDocumentModel installs a reaction that
+// keeps the registry in sync with the document's shared datasets, so formula attributes in
+// such datasets are recomputed (Story Builder restore) and stay live (undo).
+
+describe("createDocumentModel formula manager dataset sync (CODAP-1348)", () => {
+
+  // The formula adapters are installed asynchronously (via setTimeout) by createDocumentModel.
+  async function flushFormulaAdapters(formulaManager: FormulaManager) {
+    await when(() => formulaManager.areAdaptersInitialized, { timeout: 1000 })
+  }
+
+  // wait for any pending action/undo/redo to be processed by the tree manager
+  async function whenTreeManagerIsReady(treeManager: Instance<typeof TreeManager>) {
+    await when(() => treeManager.activeHistoryEntries.length === 0, { timeout: 1000 })
+  }
+
+  // a shared dataset with a `double` attribute computed by the formula `x * 2`
+  function makeSharedDataSetWithFormula() {
+    const data = createDataSet({
+      attributes: [
+        { id: "xId", name: "x" },
+        { id: "doubleId", name: "double", formula: { display: "x * 2" } }
+      ]
+    })
+    data.addCases([{ __id__: "c1", xId: 5 }])
+    data.validateCases()
+    const sharedDataSet = SharedDataSet.create()
+    sharedDataSet.setDataSet(data)
+    return { sharedDataSet, data }
+  }
+
+  it("computes formula attributes for a dataset added to the document after creation", async () => {
+    const document = createCodapDocument()
+    const formulaManager = getFormulaManager(document) as FormulaManager
+    await flushFormulaAdapters(formulaManager)
+    const sharedModelManager = getSharedModelManager(document)!
+
+    // add a shared dataset directly, without an explicit formulaManager.addDataSet() call
+    // (this is how applySnapshot adds a dataset when restoring a Story Builder moment)
+    const { sharedDataSet, data } = makeSharedDataSetWithFormula()
+    sharedModelManager.addSharedModel(sharedDataSet)
+
+    expect(formulaManager.dataSets.has(data.id)).toBe(true)
+    expect(data.getNumeric("c1", "doubleId")).toBe(10)
+  })
+
+  it("keeps formula attributes live after a dataset deletion is undone", async () => {
+    const document = createCodapDocument()
+    const formulaManager = getFormulaManager(document) as FormulaManager
+    await flushFormulaAdapters(formulaManager)
+    const sharedModelManager = getSharedModelManager(document)!
+    const treeManager = document.treeManagerAPI as Instance<typeof TreeManager>
+    const undoManager = document.treeManagerAPI?.undoManager
+
+    const { sharedDataSet, data } = makeSharedDataSetWithFormula()
+    const dataSetId = data.id
+    sharedModelManager.addSharedModel(sharedDataSet)
+    expect(data.getNumeric("c1", "doubleId")).toBe(10)
+
+    document.treeMonitor?.enableMonitoring()
+
+    // Delete the dataset. Removing a shared model emits one expected warning -- the
+    // shared-model change handler runs for the entry that was just removed and can't
+    // resolve it. Capture and assert it so the passing test stays silent while any other
+    // (unexpected) warning would still surface.
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined)
+    document.applyModelChange(
+      () => sharedModelManager.removeSharedModel(dataSetId),
+      { undoStringKey: "Undo delete dataset", redoStringKey: "Redo delete dataset" }
+    )
+    await whenTreeManagerIsReady(treeManager)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Tree.handleSharedModelChanges failed to find model at:",
+      expect.stringContaining("/content/sharedModelMap/")
+    )
+    warnSpy.mockRestore()
+    expect(sharedModelManager.getSharedModelsByType(kSharedDataSetType).length).toBe(0)
+
+    // undo the deletion
+    undoManager?.undo()
+    await whenTreeManagerIsReady(treeManager)
+    const restored = sharedModelManager.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)[0]
+    expect(restored).toBeDefined()
+
+    // the re-created dataset must be re-registered with the formula manager so its formula
+    // attribute stays live and recomputes when a dependency changes
+    expect(formulaManager.dataSets.has(restored.dataSet.id)).toBe(true)
+    document.applyModelChange(
+      () => restored.dataSet.setCaseValues([{ __id__: "c1", xId: 7 }]),
+      { undoStringKey: "Undo edit value", redoStringKey: "Redo edit value" }
+    )
+    expect(restored.dataSet.getNumeric("c1", "doubleId")).toBe(14)
+  })
+})

--- a/v3/src/models/document/create-document-model.ts
+++ b/v3/src/models/document/create-document-model.ts
@@ -1,4 +1,4 @@
-import { reaction } from "mobx"
+import { comparer, reaction } from "mobx"
 import { addDisposer, onAction } from "mobx-state-tree"
 import { Logger } from "../../lib/logger"
 import { createFormulaAdapters } from "../formula/formula-adapter-registry"
@@ -47,8 +47,22 @@ export const createDocumentModel = (snapshot?: IDocumentModelSnapshot) => {
   if (document.content) {
     sharedModelManager.setDocument(document.content)
   }
-  sharedModelManager.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
-    .forEach((model: ISharedDataSet) => formulaManager.addDataSet(model.dataSet))
+
+  // Keep the formula manager's set of datasets synchronized with the document's shared
+  // datasets. A reaction (rather than a one-time registration) is required because
+  // datasets can be added to the document after creation by paths that bypass the
+  // explicit formulaManager.addDataSet() calls -- notably applySnapshot() when a Story
+  // Builder "moment" is restored, and undo of a dataset deletion. An unregistered dataset
+  // is invisible to the formula adapters, so its formula attributes are never recomputed:
+  // after a moment restore they come back empty (the values are not serialized), and after
+  // an undo the formula is left stale (CODAP-1348). Dataset removal is handled by a
+  // disposer installed by addDataSet().
+  addDisposer(document, reaction(
+    () => sharedModelManager.getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)
+            .map((model: ISharedDataSet) => model.dataSet),
+    dataSets => dataSets.forEach(dataSet => formulaManager.addDataSet(dataSet)),
+    { name: "createDocumentModel.syncFormulaManagerDataSets", equals: comparer.shallow, fireImmediately: true }
+  ))
 
   // configure logging
   fullEnvironment.log = function({ message, args, category }) {

--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -58,6 +58,10 @@ export class FormulaManager implements IFormulaManager {
   }
 
   @action addDataSet(dataSet: IDataSet) {
+    // addDataSet may be called more than once for the same dataset (e.g. an explicit
+    // caller plus the document's dataset-sync reaction); registering twice would leak a
+    // redundant disposer, so treat a repeat registration as a no-op.
+    if (this.dataSets.has(dataSet.id)) return
     this.dataSets.set(dataSet.id, dataSet)
     // remove the DataSet if it is destroyed
     addDisposer(dataSet, () => this.removeDataSet(dataSet.id))

--- a/v3/src/v2/v2-document-round-trip.test.ts
+++ b/v3/src/v2/v2-document-round-trip.test.ts
@@ -1,0 +1,53 @@
+import { createCodapDocument } from "../models/codap/create-codap-document"
+import { createDataSet } from "../models/data/data-set-conversion"
+import { serializeCodapV2Document } from "../models/document/serialize-document"
+import { kSharedDataSetType, SharedDataSet } from "../models/shared/shared-data-set"
+import { getSharedModelManager } from "../models/tiles/tile-environment"
+import { CodapV2Document } from "./codap-v2-document"
+import { importV2Document } from "./import-v2-document"
+
+// CODAP-1348: A Story Builder "moment" is a CODAP document serialized to v2 JSON; restoring
+// a moment converts that JSON back to v3 via importV2Document (the data-bearing step of
+// document-handler's asyncUpdate). This verifies the v2 save/import round-trip preserves raw
+// (non-formula) attribute values -- so a blank restored formula column (e.g. NOAA Weather's
+// `when`) is caused by the formula not being recomputed, not by the round-trip dropping the
+// formula's input attributes.
+
+describe("v2 document round-trip (CODAP-1348)", () => {
+  it("preserves raw attribute values through a v2 save/import round-trip", async () => {
+    // a document with a dataset: raw attr `x` with values + a formula attr `double`
+    const document = createCodapDocument()
+    const sharedModelManager = getSharedModelManager(document)!
+    const data = createDataSet({
+      attributes: [
+        { name: "x" },
+        { name: "double", formula: { display: "x * 2" } }
+      ]
+    })
+    const xId = data.attrFromName("x")!.id
+    data.addCases([{ __id__: "c1", [xId]: 3 }, { __id__: "c2", [xId]: 5 }])
+    data.validateCases()
+    const sharedDataSet = SharedDataSet.create()
+    sharedDataSet.setDataSet(data)
+    sharedModelManager.addSharedModel(sharedDataSet)
+
+    // Save: serialize the document to v2 JSON (what Story Builder stores for a moment).
+    const v2Json = await serializeCodapV2Document(document)
+
+    // Restore: convert the v2 JSON back to a v3 document (the data-bearing step of
+    // document-handler's asyncUpdate when a moment is restored).
+    const v3Document = importV2Document(new CodapV2Document(v2Json))
+    const restoredData = getSharedModelManager(v3Document)!
+      .getSharedModelsByType<typeof SharedDataSet>(kSharedDataSetType)[0]?.dataSet
+    expect(restoredData).toBeDefined()
+
+    // the raw (non-formula) attribute values must survive the round-trip
+    const xAttr = restoredData.attrFromName("x")
+    expect(xAttr?.strValues).toEqual(["3", "5"])
+
+    // the formula attribute's definition survives too (its values are recomputed, not stored)
+    const doubleAttr = restoredData.attrFromName("double")
+    expect(doubleAttr?.hasFormula).toBe(true)
+    expect(doubleAttr?.formula?.display).toBe("x * 2")
+  })
+})


### PR DESCRIPTION
## Summary

When a Story Builder "moment" is restored, the document handler applies the restored state with `applySnapshot()`. If the moment contains a dataset that isn't currently in the document, `applySnapshot` creates a new `DataSet` instance — but nothing registered it with the `FormulaManager`. `addDataSet()` was only called at document creation, by the Data Interactive `create dataContext` handler, and by the case table tool-shelf button — never on the snapshot-application path.

An unregistered dataset is invisible to the formula adapters, so its formula attributes are never recomputed. Because formula-computed values are intentionally not serialized, formula columns such as NOAA Weather's `when` came back empty after a moment restore. Undo of a dataset deletion has the same gap, leaving the formula stale.

## Changes

- `createDocumentModel` installs a reaction that keeps the `FormulaManager`'s dataset registry in sync with the document's shared datasets, replacing the one-time registration. Datasets re-added by `applySnapshot` (moment restore) or by undo are registered and their formulas recomputed.
- `FormulaManager.addDataSet` is made idempotent so the reaction and the existing explicit callers can't double-register or leak disposers.
- New tests: `create-document-model.test.ts` (formula recompute for a dataset added after document creation, and after a deletion is undone); `v2-document-round-trip.test.ts` (raw attribute values survive a v2 save/import round-trip).

## Notes

On the webpack dev server, restoring a dataset can additionally drop raw (non-formula) values — a separate, dev-build-only artifact (the undo/snapshot machinery records MST snapshots without `prepareSnapshot()`, and `Attribute.values` is `undefined` in development). It does not occur in a production build and is out of scope for this PR; it will be tracked as a separate lower-priority issue ([CODAP-1350](https://codap3.concord.org/branch/sync-formula-datasets/)).

Fixes CODAP-1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CODAP-1350]: https://concord-consortium.atlassian.net/browse/CODAP-1350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ