### PR TITLE
CODAP-1310: fix V2/V3 plugin-event incompatibilities

### DIFF
--- a/v3/src/components/case-table/cell-text-editor.test.tsx
+++ b/v3/src/components/case-table/cell-text-editor.test.tsx
@@ -9,6 +9,14 @@ jest.mock("../../hooks/use-data-set-context", () => ({
   useDataSetContext: () => mockUseDataSetContext()
 }))
 
+const mockSetPendingLogMessage = jest.fn()
+jest.mock("../../hooks/use-log-context", () => ({
+  useLoggingContext: () => ({
+    getPendingLogMessage: jest.fn(),
+    setPendingLogMessage: mockSetPendingLogMessage
+  })
+}))
+
 describe("CellTextEditor", () => {
   const row = { __id__: "rowId" }
   const column = { key: "columnKey" } as TCalculatedColumn
@@ -52,5 +60,26 @@ describe("CellTextEditor", () => {
     const editor = screen.getByTestId("cell-text-editor")
     expect(editor).toHaveAttribute("aria-label")
     expect(editor.getAttribute("aria-label")).toContain("Height")
+  })
+
+  it("records a pending log with V2-compatible editValue event format", async () => {
+    const data = DataSet.create({ name: "data" }, {historyService: new AppHistoryService()})
+    data.addAttribute({ id: "columnKey", name: "columnName" })
+    const [caseId] = data.addCases([{ columnKey: "1" }])
+    const rowWithRealId = { __id__: caseId }
+    mockUseDataSetContext.mockImplementation(() => data)
+    const user = userEvent.setup()
+    render(<CellTextEditor row={rowWithRealId} column={column} onRowChange={onRowChange} onClose={onClose}/>)
+    await user.keyboard("9")
+    expect(mockSetPendingLogMessage).toHaveBeenCalled()
+    const [, msg] = mockSetPendingLogMessage.mock.calls[mockSetPendingLogMessage.mock.calls.length - 1]
+    expect(msg.message).toMatch(/^editValue: \{ collection:/)
+    expect(msg.args).toEqual(expect.objectContaining({
+      collection: expect.any(String),
+      case: caseId,
+      attribute: "columnKey",
+      old: "1",
+      new: "9"
+    }))
   })
 })

--- a/v3/src/components/case-table/cell-text-editor.tsx
+++ b/v3/src/components/case-table/cell-text-editor.tsx
@@ -3,7 +3,7 @@ import { clsx } from "clsx"
 import { textEditorClassname } from "react-data-grid"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useLoggingContext } from "../../hooks/use-log-context"
-import { logStringifiedObjectMessage } from "../../lib/log-message"
+import { logMessageWithReplacement } from "../../lib/log-message"
 import { selectAllCases } from "../../models/data/data-set-utils"
 import { uiState } from "../../models/ui-state"
 import { blockAPIRequestsWhileEditing } from "../../utilities/plugin-utils"
@@ -50,8 +50,10 @@ export default function CellTextEditor({ row, column, onRowChange, onClose }: TR
   const handleChange = (value: string) => {
     valueRef.current = value
     onRowChange({ ...row, [column.key]: value })
-    setPendingLogMessage("editCellValue", logStringifiedObjectMessage("editCellValue: %@",
-      {attrId: column.key, caseId: row.__id__, from: initialValueRef.current, to: valueRef.current }))
+    setPendingLogMessage("editCellValue", logMessageWithReplacement(
+      "editValue: { collection: %@, case: %@, attribute: '%@', old: '%@', new: '%@' }",
+      { collection: data?.getCollectionForAttribute(column.key)?.name, case: row.__id__,
+        attribute: column.key, old: initialValueRef.current, new: valueRef.current }))
     if (blockAPIRequests && value !== initialValueRef.current) {
       // Only block API requests if the user has actually changed the value.
       uiState.setIsEditingBlockingCell()

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -244,7 +244,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
       notify: () => createAttributesNotification(attribute ? [attribute] : [], data),
       undoStringKey: "DG.Undo.caseTable.createAttribute",
       redoStringKey: "DG.Redo.caseTable.createAttribute",
-      log: logStringifiedObjectMessage("Create attribute: %@",
+      log: logStringifiedObjectMessage("attributeCreate: %@",
               {name: "newAttr", collection: data?.getCollection(collectionId)?.name, formula: ""}, "data")
     })
   }, [collectionId, data])

--- a/v3/src/components/case-table/color-cell-text-editor.tsx
+++ b/v3/src/components/case-table/color-cell-text-editor.tsx
@@ -3,7 +3,7 @@ import { Button, DialogTrigger, Popover } from "react-aria-components"
 import { textEditorClassname } from "react-data-grid"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useLoggingContext } from "../../hooks/use-log-context"
-import { logStringifiedObjectMessage } from "../../lib/log-message"
+import { logMessageWithReplacement } from "../../lib/log-message"
 import { selectAllCases } from "../../models/data/data-set-utils"
 import { uiState } from "../../models/ui-state"
 import { parseColor, parseColorToHex } from "../../utilities/color-utils"
@@ -91,13 +91,15 @@ export default function ColorCellTextEditor({ row, column, onRowChange, onClose 
   const updateValue = useCallback((value: string) => {
     setInputValue(value)
     onRowChange({ ...row, [column.key]: value })
-    setPendingLogMessage("editCellValue", logStringifiedObjectMessage("editCellValue: %@",
-      {attrId: column.key, caseId: row.__id__, from: initialInputValue.current, to: value }))
+    setPendingLogMessage("editCellValue", logMessageWithReplacement(
+      "editValue: { collection: %@, case: %@, attribute: '%@', old: '%@', new: '%@' }",
+      { collection: data?.getCollectionForAttribute(column.key)?.name, case: row.__id__,
+        attribute: column.key, old: initialInputValue.current, new: value }))
     if (blockAPIRequests && value !== initialInputValue.current) {
       // Only block API requests if the user has actually changed the value.
       uiState.setIsEditingBlockingCell()
     }
-  }, [blockAPIRequests, column.key, onRowChange, row, setPendingLogMessage])
+  }, [blockAPIRequests, column.key, data, onRowChange, row, setPendingLogMessage])
 
   // rejects any local changes and closes the editor
   const rejectValue = useCallback(() => {

--- a/v3/src/components/case-tile-common/case-tile-notifications.test.ts
+++ b/v3/src/components/case-tile-common/case-tile-notifications.test.ts
@@ -1,0 +1,40 @@
+import { toggleCardTableNotification } from "./case-tile-notifications"
+
+const v2Id = 99001
+
+jest.mock("../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
+    if (!tileModel) return undefined
+    return {
+      message: {
+        action: "notify",
+        resource: "component",
+        values: {
+          operation: updateType, ...values, id: v2Id,
+          type: tileModel.content.type === "CaseTable" ? "DG.CaseTable" : "DG.CaseCard"
+        }
+      }
+    }
+  })
+}))
+
+describe("toggleCardTableNotification", () => {
+  it("emits 'toggle table to card' when toggling from a case table", () => {
+    const tile = { id: "T1", content: { type: "CaseTable" } } as any
+    const notification = toggleCardTableNotification(tile)
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("toggle table to card")
+    expect(notification?.message.values.type).toBe("DG.CaseTable")
+  })
+
+  it("emits 'toggle card to table' when toggling from a case card", () => {
+    const tile = { id: "C1", content: { type: "CaseCard" } } as any
+    const notification = toggleCardTableNotification(tile)
+    expect(notification?.message.values.operation).toBe("toggle card to table")
+    expect(notification?.message.values.type).toBe("DG.CaseCard")
+  })
+
+  it("returns undefined when the tile is missing", () => {
+    expect(toggleCardTableNotification(undefined)).toBeUndefined()
+  })
+})

--- a/v3/src/components/case-tile-common/case-tile-notifications.ts
+++ b/v3/src/components/case-tile-common/case-tile-notifications.ts
@@ -1,0 +1,14 @@
+import { ITileModel } from "../../models/tiles/tile-model"
+import { updateTileNotification } from "../../models/tiles/tile-notifications"
+import { kCaseTableTileType } from "../case-table/case-table-defs"
+
+// V2 (titlebar_button_view.js) emits two distinct operations on the `component` resource when
+// toggling between the case table and case card. The `type` reflects the source tile;
+// updateTileNotification derives it from `tile.content.type` via kComponentTypeV3ToV2Map.
+export function toggleCardTableNotification(sourceTile?: ITileModel) {
+  if (!sourceTile) return
+  const operation = sourceTile.content.type === kCaseTableTileType
+    ? "toggle table to card"
+    : "toggle card to table"
+  return updateTileNotification(operation, {}, sourceTile)
+}

--- a/v3/src/components/case-tile-common/case-tile-title-bar.tsx
+++ b/v3/src/components/case-tile-common/case-tile-title-bar.tsx
@@ -13,6 +13,7 @@ import { kCaseCardTileType } from "../case-card/case-card-defs"
 import { kCaseTableTileType } from "../case-table/case-table-defs"
 import { ComponentTitleBar } from "../component-title-bar"
 import { ITileTitleBarProps } from "../tiles/tile-base-props"
+import { toggleCardTableNotification } from "./case-tile-notifications"
 import { toggleCardTable } from "./case-tile-utils"
 
 import "../component-title-bar.scss"
@@ -92,6 +93,7 @@ export const CaseTileTitleBar =
           newTileId = toggleCardTable(documentContent, tile.id)?.id
         }
       }, {
+        notify: () => toggleCardTableNotification(tile),
         log: logMessageWithReplacement("Toggle component: %@", {componentType: suffix}, "table"),
         undoStringKey: `DG.Undo.component.toggle${suffix}`,
         redoStringKey: `DG.Redo.component.toggle${suffix}`

--- a/v3/src/components/case-tile-common/case-tile-title-bar.tsx
+++ b/v3/src/components/case-tile-common/case-tile-title-bar.tsx
@@ -122,13 +122,14 @@ export const CaseTileTitleBar =
     const handleChangeTitle = (newTitle?: string) => {
       if (newTitle !== undefined) {
         // case table title reflects DataSet title
+        const oldTitle = data?.title ?? ""
         data?.applyModelChange(() => {
           data.setTitle(newTitle)
         }, {
           notify: () => updateDataContextNotification(data),
           undoStringKey: "DG.Undo.component.componentTitleChange",
           redoStringKey: "DG.Redo.component.componentTitleChange",
-          log: logMessageWithReplacement("Title changed to: %@", {newTitle}, "component")
+          log: logMessageWithReplacement("Change title '%@' to '%@'", {from: oldTitle, to: newTitle}, "component")
         })
       }
     }

--- a/v3/src/components/case-tile-common/case-tile-title-bar.tsx
+++ b/v3/src/components/case-tile-common/case-tile-title-bar.tsx
@@ -141,9 +141,9 @@ export const CaseTileTitleBar =
       }, {
         undoStringKey: `V3.Undo.case${suffix}.hide`,
         redoStringKey: `V3.Redo.case${suffix}.hide`,
-        log: logMessageWithReplacement("Close component: %@", { type: tileInfo.toggleSuffix }, "component")
+        log: logMessageWithReplacement("Close component: %@", {tileType: tile?.content.type}, "component")
       })
-    }, [documentContent, tile?.id, tileInfo])
+    }, [documentContent, tile?.content.type, tile?.id, tileInfo])
 
     const { Icon, otherSuffix } = tileInfo
     const translationKey = `DG.DocumentController.toggleToCase${otherSuffix}`

--- a/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
@@ -41,7 +41,7 @@ export const RulerMenuList = observer(function RulerMenuList() {
       notify: () => createAttributesNotification(attribute ? [attribute] : [], data),
       undoStringKey: "DG.Undo.caseTable.createAttribute",
       redoStringKey: "DG.Redo.caseTable.createAttribute",
-      log: logStringifiedObjectMessage("Create attribute: %@",
+      log: logStringifiedObjectMessage("attributeCreate: %@",
         {name: "newAttr", collection: data?.getCollection(collectionId)?.name, formula: ""}, "data")
     })
   }

--- a/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/ruler-menu-list.tsx
@@ -41,8 +41,8 @@ export const RulerMenuList = observer(function RulerMenuList() {
       notify: () => createAttributesNotification(attribute ? [attribute] : [], data),
       undoStringKey: "DG.Undo.caseTable.createAttribute",
       redoStringKey: "DG.Redo.caseTable.createAttribute",
-      log: logStringifiedObjectMessage("attributeCreate: %@",
-        {name: "newAttr", collection: data?.getCollection(collectionId)?.name, formula: ""})
+      log: logStringifiedObjectMessage("Create attribute: %@",
+        {name: "newAttr", collection: data?.getCollection(collectionId)?.name, formula: ""}, "data")
     })
   }
 

--- a/v3/src/components/common/edit-attribute-formula-modal.tsx
+++ b/v3/src/components/common/edit-attribute-formula-modal.tsx
@@ -5,9 +5,10 @@ import { logStringifiedObjectMessage } from "../../lib/log-message"
 import { appState } from "../../models/app-state"
 import { updateAttributesNotification, updateCasesNotification } from "../../models/data/data-set-notifications"
 import { setAttributeFormulaWithCustomUndoRedo } from "../../models/data/data-set-undo"
-import { getSharedDataSets } from "../../models/shared/shared-data-utils"
+import { getMetadataFromDataSet, getSharedDataSets } from "../../models/shared/shared-data-utils"
 import { uiState } from "../../models/ui-state"
 import { t } from "../../utilities/translation/translate"
+import { editFormulaNotification } from "./edit-formula-notifications"
 import { EditFormulaModal } from "./edit-formula-modal"
 
 export const EditAttributeFormulaModal = observer(function EditAttributeFormulaModal() {
@@ -32,11 +33,19 @@ export const EditAttributeFormulaModal = observer(function EditAttributeFormulaM
       dataSet?.applyModelChange(() => {
         setAttributeFormulaWithCustomUndoRedo(dataSet, attribute, formula, attrName)
       }, {
-        // TODO Should also broadcast notify component edit formula notification
-        notify: [
-          updateCasesNotification(dataSet),
-          updateAttributesNotification([attribute], dataSet)
-        ],
+        notify: () => {
+          const metadata = getMetadataFromDataSet(dataSet)
+          const caseTableTile = metadata?.caseTableTileId
+            ? appState.document.content?.getTile(metadata.caseTableTileId)
+            : undefined
+          const notifications = [
+            updateCasesNotification(dataSet),
+            updateAttributesNotification([attribute], dataSet)
+          ]
+          const editFormula = editFormulaNotification(caseTableTile)
+          if (editFormula) notifications.push(editFormula)
+          return notifications
+        },
         undoStringKey: "DG.Undo.caseTable.editAttributeFormula",
         redoStringKey: "DG.Redo.caseTable.editAttributeFormula",
         log: logStringifiedObjectMessage("Edit attribute formula: %@",

--- a/v3/src/components/common/edit-formula-notifications.test.ts
+++ b/v3/src/components/common/edit-formula-notifications.test.ts
@@ -1,0 +1,33 @@
+import { editFormulaNotification } from "./edit-formula-notifications"
+
+const v2Id = 54321
+const v2Type = "DG.CaseTable"
+
+jest.mock("../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
+    if (!tileModel) return undefined
+    return {
+      message: {
+        action: "notify",
+        resource: "component",
+        values: { operation: updateType, ...values, id: v2Id, type: v2Type }
+      }
+    }
+  })
+}))
+
+describe("editFormulaNotification", () => {
+  it("emits an 'edit formula' notification on the component resource", () => {
+    const tile = { id: "TABLE1", content: { type: "CaseTable" } } as any
+    const notification = editFormulaNotification(tile)
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("edit formula")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2Type)
+  })
+
+  it("returns undefined when the case-table tile is missing", () => {
+    expect(editFormulaNotification(undefined)).toBeUndefined()
+  })
+})

--- a/v3/src/components/common/edit-formula-notifications.ts
+++ b/v3/src/components/common/edit-formula-notifications.ts
@@ -1,0 +1,9 @@
+import { ITileModel } from "../../models/tiles/tile-model"
+import { updateTileNotification } from "../../models/tiles/tile-notifications"
+
+// V2 emits { action:'notify', resource:'component', values:{ operation:'edit formula', type:'DG.CaseTable' } }
+// from case_table_controller.js when an attribute's formula is created/edited via the case table.
+export function editFormulaNotification(caseTableTile?: ITileModel) {
+  if (!caseTableTile) return
+  return updateTileNotification("edit formula", {}, caseTableTile)
+}

--- a/v3/src/components/component-title-bar.tsx
+++ b/v3/src/components/component-title-bar.tsx
@@ -68,7 +68,7 @@ export const ComponentTitleBar = observer(function ComponentTitleBar(props: ITil
         tile.setUserTitle(nextValue)
       }, {
         notify: updateTileNotification("titleChange", { from: title, to: nextValue }, tile),
-        log: logMessageWithReplacement("Title changed to: %@", {nextValue}, "component"),
+        log: logMessageWithReplacement("Change title '%@' to '%@'", {from: title, to: nextValue}, "component"),
         undoStringKey: "DG.Undo.component.componentTitleChange",
         redoStringKey: "DG.Redo.component.componentTitleChange"
       })

--- a/v3/src/components/graph/adornments/adornment-content-info.ts
+++ b/v3/src/components/graph/adornments/adornment-content-info.ts
@@ -46,6 +46,9 @@ export interface IAdornmentContentInfo {
   parentType?: ParentAdornmentType
   type: string
   undoRedoKeys?: IAdornmentUndoRedoKeys
+  // When set, AdornmentCheckbox emits a `component`-resource notification with this operation
+  // string each time the adornment is toggled (matches V2 togglePlottedMean / togglePlottedMedian).
+  notificationOperation?: string
   exporter?: (model: IAdornmentModel, options: IAdornmentExporterOptions) => Maybe<V2AdornmentExportResult>
 }
 

--- a/v3/src/components/graph/adornments/components/adornment-checkbox.test.tsx
+++ b/v3/src/components/graph/adornments/components/adornment-checkbox.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { AdornmentCheckbox } from "./adornment-checkbox"
+
+// ---------------------------------------------------------------------------
+// Module mocks (must be declared before imports are resolved)
+// ---------------------------------------------------------------------------
+
+jest.mock("../../../../utilities/translation/translate", () => ({
+  t: (key: string) => key,
+}))
+
+jest.mock("../../../../lib/log-message", () => ({
+  logMessageWithReplacement: jest.fn(() => "log-msg"),
+}))
+
+const mockUpdateTileNotification = jest.fn()
+jest.mock("../../../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: (operation: string, values: unknown, tile: unknown) =>
+    mockUpdateTileNotification(operation, values, tile),
+}))
+
+// Mock tile returned by useTileModelContext
+const mockTile = { id: "TILE1", content: { type: "Graph" } } as any
+jest.mock("../../../../hooks/use-tile-model-context", () => ({
+  useTileModelContext: () => ({ tile: mockTile }),
+}))
+
+// ---------------------------------------------------------------------------
+// Per-test adornment content info — controlled via these mutable stubs
+// ---------------------------------------------------------------------------
+
+const adornmentInfoMap: Record<string, any> = {}
+jest.mock("../adornment-content-info", () => ({
+  getAdornmentContentInfo: (type: string) => adornmentInfoMap[type],
+}))
+
+// Mock graph model returned by useGraphContentModelContext
+const mockAdornments: any[] = []
+const mockApplyModelChange = jest.fn()
+const mockGraphModel = {
+  adornmentsStore: {
+    adornments: mockAdornments,
+    addAdornment: jest.fn(),
+    hideAdornment: jest.fn(),
+  },
+  getUpdateCategoriesOptions: () => ({}),
+  applyModelChange: mockApplyModelChange,
+} as any
+
+jest.mock("../../hooks/use-graph-content-model-context", () => ({
+  useGraphContentModelContext: () => mockGraphModel,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Simulate applyModelChange executing the action and calling notify() if present */
+function setupApplyModelChange() {
+  mockApplyModelChange.mockImplementation((action: () => void, options: any) => {
+    action()
+    if (typeof options?.notify === "function") {
+      options.notify()
+    }
+  })
+}
+
+/** Build an adornment info stub with an optional notificationOperation */
+function registerStub(type: string, notificationOperation?: string) {
+  adornmentInfoMap[type] = {
+    modelClass: { create: () => ({ type, isVisible: false }) },
+    undoRedoKeys: {
+      undoAdd: "undo-add",
+      redoAdd: "redo-add",
+      undoRemove: "undo-remove",
+      redoRemove: "redo-remove",
+    },
+    notificationOperation,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AdornmentCheckbox notifications", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAdornments.length = 0
+    setupApplyModelChange()
+
+    // Register the three adornment types used by the tests
+    registerStub("Mean", "togglePlottedMean")
+    registerStub("Median", "togglePlottedMedian")
+    registerStub("Count") // no notificationOperation
+  })
+
+  it("emits togglePlottedMean when the mean checkbox is toggled", async () => {
+    render(
+      <AdornmentCheckbox classNameValue="mean" labelKey="DG.Inspector.graphPlottedMean" type="Mean" />
+    )
+    await userEvent.click(screen.getByTestId("adornment-checkbox-mean"))
+    expect(mockUpdateTileNotification).toHaveBeenCalledWith("togglePlottedMean", expect.any(Object), mockTile)
+  })
+
+  it("emits togglePlottedMedian when the median checkbox is toggled", async () => {
+    render(
+      <AdornmentCheckbox classNameValue="median" labelKey="DG.Inspector.graphPlottedMedian" type="Median" />
+    )
+    await userEvent.click(screen.getByTestId("adornment-checkbox-median"))
+    expect(mockUpdateTileNotification).toHaveBeenCalledWith("togglePlottedMedian", expect.any(Object), mockTile)
+  })
+
+  it("does not emit a notification for an adornment with no notificationOperation", async () => {
+    render(
+      <AdornmentCheckbox classNameValue="count" labelKey="DG.Inspector.graphCount" type="Count" />
+    )
+    await userEvent.click(screen.getByTestId("adornment-checkbox-count"))
+    expect(mockUpdateTileNotification).not.toHaveBeenCalled()
+  })
+
+  it("passes isChecked:true when toggling on", async () => {
+    render(
+      <AdornmentCheckbox classNameValue="mean" labelKey="DG.Inspector.graphPlottedMean" type="Mean" />
+    )
+    await userEvent.click(screen.getByTestId("adornment-checkbox-mean"))
+    expect(mockUpdateTileNotification).toHaveBeenCalledWith(
+      "togglePlottedMean", { isChecked: true }, mockTile
+    )
+  })
+
+  it("passes isChecked:false when toggling off", async () => {
+    // Pre-populate adornments so the checkbox starts visible/on
+    const adornment = { type: "Mean", isVisible: true }
+    mockAdornments.push(adornment)
+
+    render(
+      <AdornmentCheckbox classNameValue="mean" labelKey="DG.Inspector.graphPlottedMean" type="Mean" />
+    )
+    // Click to uncheck (hide)
+    await userEvent.click(screen.getByTestId("adornment-checkbox-mean"))
+    expect(mockUpdateTileNotification).toHaveBeenCalledWith(
+      "togglePlottedMean", { isChecked: false }, mockTile
+    )
+  })
+})

--- a/v3/src/components/graph/adornments/components/adornment-checkbox.tsx
+++ b/v3/src/components/graph/adornments/components/adornment-checkbox.tsx
@@ -1,5 +1,7 @@
 import { observer } from "mobx-react-lite"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
+import { updateTileNotification } from "../../../../models/tiles/tile-notifications"
 import { t } from "../../../../utilities/translation/translate"
 import { PaletteCheckbox } from "../../../palette-checkbox"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
@@ -15,6 +17,7 @@ export const AdornmentCheckbox = observer(function AdornmentCheckbox({classNameV
   const graphModel = useGraphContentModelContext()
   const adornmentsStore = graphModel?.adornmentsStore
   const existingAdornment = adornmentsStore.adornments.find(a => a.type === type)
+  const { tile } = useTileModelContext()
 
   const handleSetting = (checked: boolean) => {
     const componentContentInfo = getAdornmentContentInfo(type)
@@ -26,6 +29,10 @@ export const AdornmentCheckbox = observer(function AdornmentCheckbox({classNameV
       redoRemove: "DG.mainPage.mainPane.redoButton.toolTip"
     }
     const undoRedoKeys = componentContentInfo.undoRedoKeys ?? defaultUndoRedoKeys
+    const notificationOperation = componentContentInfo.notificationOperation
+    const notify = (notificationOperation && tile)
+      ? () => updateTileNotification(notificationOperation, { isChecked: checked }, tile)
+      : undefined
 
     if (checked) {
       graphModel.applyModelChange(
@@ -33,7 +40,8 @@ export const AdornmentCheckbox = observer(function AdornmentCheckbox({classNameV
         {
           undoStringKey: undoRedoKeys.undoAdd,
           redoStringKey: undoRedoKeys.redoAdd,
-          log: logMessageWithReplacement(`Added %@`, {type: adornment.type})
+          log: logMessageWithReplacement(`Added %@`, {type: adornment.type}),
+          notify
         }
       )
     } else {
@@ -42,7 +50,8 @@ export const AdornmentCheckbox = observer(function AdornmentCheckbox({classNameV
         {
           undoStringKey: undoRedoKeys.undoRemove,
           redoStringKey: undoRedoKeys.redoRemove,
-          log: logMessageWithReplacement(`Removed %@`, {type: adornment.type})
+          log: logMessageWithReplacement(`Removed %@`, {type: adornment.type}),
+          notify
         }
       )
     }

--- a/v3/src/components/graph/adornments/store/adornments-store-utils.test.ts
+++ b/v3/src/components/graph/adornments/store/adornments-store-utils.test.ts
@@ -1,0 +1,62 @@
+import { getAdornmentsMenuItemsFromTheStore, IMeasureMenuItem } from "./adornments-store-utils"
+import { updateTileNotification } from "../../../../models/tiles/tile-notifications"
+
+jest.mock("../../../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: jest.fn()
+}))
+
+function findItem(items: any[], title: string): IMeasureMenuItem {
+  return items.find((i) => i.title === title) as IMeasureMenuItem
+}
+
+describe("adornment notification operation names match V2", () => {
+  const tile = { id: "TILE1", content: { type: "Graph" } } as any
+
+  function buildStore(overrides: Partial<any> = {}) {
+    return {
+      showMeasureLabels: false,
+      showConnectingLines: false,
+      interceptLocked: false,
+      showSquaresOfResiduals: false,
+      isShowingAdornment: () => false,
+      applyModelChange: jest.fn(),
+      toggleShowLabels: jest.fn(),
+      toggleShowConnectingLines: jest.fn(),
+      toggleInterceptLocked: jest.fn(),
+      toggleShowSquaresOfResiduals: jest.fn(),
+      ...overrides
+    } as any
+  }
+
+  beforeEach(() => (updateTileNotification as jest.Mock).mockClear())
+
+  it("emits 'show measure labels' when labels are currently hidden", () => {
+    const items = getAdornmentsMenuItemsFromTheStore(buildStore(), tile, "dotPlot", false)
+    findItem(items, "DG.Inspector.showLabels").clickHandler?.()
+    expect(updateTileNotification).toHaveBeenCalledWith("show measure labels", { isChecked: true }, tile)
+  })
+
+  it("emits 'hide measure labels' when labels are currently shown", () => {
+    const items = getAdornmentsMenuItemsFromTheStore(buildStore({ showMeasureLabels: true }), tile, "dotPlot", false)
+    findItem(items, "DG.Inspector.showLabels").clickHandler?.()
+    expect(updateTileNotification).toHaveBeenCalledWith("hide measure labels", { isChecked: false }, tile)
+  })
+
+  it("emits 'toggle connecting line' for the connecting-lines toggle", () => {
+    const items = getAdornmentsMenuItemsFromTheStore(buildStore(), tile, "scatterPlot", false)
+    findItem(items, "DG.Inspector.graphConnectingLine").clickHandler?.()
+    expect(updateTileNotification).toHaveBeenCalledWith("toggle connecting line", { isChecked: true }, tile)
+  })
+
+  it("emits 'toggle lock intercept' for the intercept-locked toggle", () => {
+    const items = getAdornmentsMenuItemsFromTheStore(buildStore(), tile, "scatterPlot", false)
+    findItem(items, "DG.Inspector.graphInterceptLocked").clickHandler?.()
+    expect(updateTileNotification).toHaveBeenCalledWith("toggle lock intercept", { isChecked: true }, tile)
+  })
+
+  it("emits 'toggle show squares' for the squares-of-residuals toggle", () => {
+    const items = getAdornmentsMenuItemsFromTheStore(buildStore(), tile, "scatterPlot", false)
+    findItem(items, "DG.Inspector.graphSquares").clickHandler?.()
+    expect(updateTileNotification).toHaveBeenCalledWith("toggle show squares", { isChecked: true }, tile)
+  })
+})

--- a/v3/src/components/graph/adornments/store/adornments-store-utils.ts
+++ b/v3/src/components/graph/adornments/store/adornments-store-utils.ts
@@ -95,8 +95,10 @@ export function getAdornmentsMenuItemsFromTheStore(theStore: IAdornmentsBaseStor
           theStore.toggleShowLabels()
         }, {
           notify: tile
-            ? updateGraphAdornmentNotification("toggle showing labels",
-              (theStore.showMeasureLabels), tile)
+            // operation names the action; isChecked is the resulting (post-toggle) state
+            ? updateGraphAdornmentNotification(
+              theStore.showMeasureLabels ? "hide measure labels" : "show measure labels",
+              !theStore.showMeasureLabels, tile)
             : undefined,
           undoStringKey: theStore.showMeasureLabels ? "DG.Undo.graph.hideMeasureLabels"
             : "DG.Undo.graph.showMeasureLabels",
@@ -127,8 +129,8 @@ export function getAdornmentsMenuItemsFromTheStore(theStore: IAdornmentsBaseStor
             theStore.toggleShowConnectingLines()
           }, {
             notify: tile
-              ? updateGraphAdornmentNotification("toggle show connecting lines",
-                (theStore.showConnectingLines), tile)
+              ? updateGraphAdornmentNotification("toggle connecting line",
+                !theStore.showConnectingLines, tile)
               : undefined,
             undoStringKey: theStore.showConnectingLines ? "DG.Undo.graph.hideConnectingLine"
               : "DG.Undo.graph.showConnectingLine",
@@ -156,8 +158,8 @@ export function getAdornmentsMenuItemsFromTheStore(theStore: IAdornmentsBaseStor
             theStore.toggleInterceptLocked()
           }, {
             notify: tile
-              ? updateGraphAdornmentNotification("toggle intercept locked",
-                (theStore.interceptLocked), tile)
+              ? updateGraphAdornmentNotification("toggle lock intercept",
+                !theStore.interceptLocked, tile)
               : undefined,
             undoStringKey: theStore.interceptLocked ? "DG.Undo.graph.unlockIntercept"
               : "DG.Undo.graph.lockIntercept",
@@ -188,8 +190,8 @@ export function getAdornmentsMenuItemsFromTheStore(theStore: IAdornmentsBaseStor
           theStore.toggleShowSquaresOfResiduals()
         }, {
           notify: tile
-            ? updateGraphAdornmentNotification("toggle showSquares",
-              (theStore.showSquaresOfResiduals), tile)
+            ? updateGraphAdornmentNotification("toggle show squares",
+              !theStore.showSquaresOfResiduals, tile)
             : undefined,
           undoStringKey: theStore.showSquaresOfResiduals ? "DG.Undo.graph.hideSquares"
             : "DG.Undo.graph.showSquares",

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-registration.test.ts
@@ -16,4 +16,9 @@ describe("MeanRegistration", () => {
     expect(meanComponentInfo?.Component).toBeDefined()
     expect(meanComponentInfo?.type).toBe(kMeanType)
   })
+
+  it("registers notificationOperation for togglePlottedMean", () => {
+    const meanContentInfo = getAdornmentContentInfo(kMeanType)
+    expect(meanContentInfo?.notificationOperation).toBe("togglePlottedMean")
+  })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/mean/mean-adornment-registration.tsx
@@ -27,6 +27,7 @@ registerAdornmentContentInfo({
   plots: ["dotPlot"],
   prefix: kMeanPrefix,
   modelClass: MeanAdornmentModel,
+  notificationOperation: "togglePlottedMean",
   undoRedoKeys: {
     undoAdd: kMeanUndoAddKey,
     redoAdd: kMeanRedoAddKey,

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-registration.test.ts
@@ -16,4 +16,9 @@ describe("MedianAdornmentRegistration", () => {
     expect(meanMedianComponentInfo?.Component).toBeDefined()
     expect(meanMedianComponentInfo?.type).toBe(kMedianType)
   })
+
+  it("registers notificationOperation for togglePlottedMedian", () => {
+    const meanMedianContentInfo = getAdornmentContentInfo(kMedianType)
+    expect(meanMedianContentInfo?.notificationOperation).toBe("togglePlottedMedian")
+  })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/median/median-adornment-registration.tsx
@@ -27,6 +27,7 @@ registerAdornmentContentInfo({
   plots: ["dotPlot"],
   prefix: kMedianPrefix,
   modelClass: MedianAdornmentModel,
+  notificationOperation: "togglePlottedMedian",
   undoRedoKeys: {
     undoAdd: kMedianUndoAddKey,
     redoAdd: kMedianRedoAddKey,

--- a/v3/src/components/graph/components/camera-menu-list.tsx
+++ b/v3/src/components/graph/components/camera-menu-list.tsx
@@ -33,7 +33,7 @@ export const CameraMenuList = observer(function CameraMenuList() {
             undoStringKey: "DG.Undo.graph.addBackgroundImage",
             redoStringKey: "DG.Redo.graph.addBackgroundImage",
             log: logMessageWithReplacement(`added background image`, {}),
-            notify: updateTileNotification("added background image", {}, tile)
+            notify: updateTileNotification("backgroundImage", { to: "added" }, tile)
           }
         )
       }
@@ -61,7 +61,7 @@ export const CameraMenuList = observer(function CameraMenuList() {
         undoStringKey: "DG.Undo.graph.removeBackgroundImage",
         redoStringKey: "DG.Redo.graph.removeBackgroundImage",
         log: logMessageWithReplacement(`removed background image`, {}),
-        notify: updateTileNotification("removed background image", {}, tile)
+        notify: updateTileNotification("backgroundImage", { to: "removed" }, tile)
       }
     )
   }
@@ -78,7 +78,8 @@ export const CameraMenuList = observer(function CameraMenuList() {
         undoStringKey: undoKey,
         redoStringKey: redoKey,
         log: logMessageWithReplacement(`${isLocked ? "unlocked" : "locked"} background image from axes`, {}),
-        notify: updateTileNotification("background locked to axes", { to: isLocked ? 'unlocked' : 'locked' }, tile)
+        notify: updateTileNotification(
+          isLocked ? "unlockBackgroundImage" : "lockBackgroundImage", {}, tile)
       }
     )
   }

--- a/v3/src/components/graph/components/inspector-panel/display-config-palette.test.tsx
+++ b/v3/src/components/graph/components/inspector-panel/display-config-palette.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { tileNotification } from "../../../../models/tiles/tile-notifications"
 import { DisplayConfigPalette } from "./display-config-palette"
 
 // Mock InspectorPalette to just render children
@@ -243,6 +244,31 @@ describe("DisplayConfigPalette", () => {
 
       await user.click(screen.getByTestId("bar-chart-checkbox"))
       expect(graphModel.applyModelChange).toHaveBeenCalled()
+      // unbinned plot → "switch bar and dot" with to: "bars"
+      expect(tileNotification).toHaveBeenCalledWith("switch bar and dot", { to: "bars" }, expect.anything())
+    })
+
+    it("emits toggle between histogram and dots notification for binned plot", async () => {
+      const user = userEvent.setup()
+      const binnedPlot = createMockBinnedPlot({
+        showDisplayTypeSelection: true,
+        showFusePointsIntoBars: true
+      })
+      const graphModel = createMockGraphModel(undefined, { plot: binnedPlot })
+      mockIsGraphContentModel.mockReturnValue(true)
+      mockIsBinnedPlotModel.mockReturnValue(true)
+      const tile = createMockTile(graphModel)
+
+      render(
+        <DisplayConfigPalette tile={tile} setShowPalette={mockSetShowPalette} />
+      )
+
+      await user.click(screen.getByTestId("bar-chart-checkbox"))
+      expect(graphModel.applyModelChange).toHaveBeenCalled()
+      // binned plot → "toggle between histogram and dots" with to: "histogram"
+      expect(tileNotification).toHaveBeenCalledWith(
+        "toggle between histogram and dots", { to: "histogram" }, expect.anything()
+      )
     })
   })
 

--- a/v3/src/components/graph/components/inspector-panel/display-config-palette.test.tsx
+++ b/v3/src/components/graph/components/inspector-panel/display-config-palette.test.tsx
@@ -24,9 +24,10 @@ jest.mock("../../../../utilities/mst-reaction", () => ({
   mstReaction: jest.fn()
 }))
 
-// Mock logMessageWithReplacement
+// Mock logMessageWithReplacement — capturing mock so tests can assert call args
+const mockLogMessageWithReplacement = jest.fn()
 jest.mock("../../../../lib/log-message", () => ({
-  logMessageWithReplacement: jest.fn()
+  logMessageWithReplacement: (...args: unknown[]) => mockLogMessageWithReplacement(...args)
 }))
 
 // Mock tileNotification
@@ -97,6 +98,7 @@ describe("DisplayConfigPalette", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockLogMessageWithReplacement.mockClear()
     mockIsGraphContentModel.mockReturnValue(false)
     mockIsBinnedPlotModel.mockReturnValue(false)
     mockIsBarChartModel.mockReturnValue(false)
@@ -191,6 +193,29 @@ describe("DisplayConfigPalette", () => {
       await user.clear(binWidthInput)
       await user.type(binWidthInput, "20{Enter}")
       expect(graphModel.applyModelChange).toHaveBeenCalled()
+    })
+
+    it("logs V2-compatible 'change %@ from %@ to %@' with stable arg keys on bin width change", async () => {
+      const user = userEvent.setup()
+      const binnedPlot = createMockBinnedPlot({ showDisplayTypeSelection: true })
+      // binWidth starts at 10 (from createMockBinnedPlot)
+      const graphModel = createMockGraphModel(undefined, { plot: binnedPlot })
+      mockIsGraphContentModel.mockReturnValue(true)
+      mockIsBinnedPlotModel.mockReturnValue(true)
+      const tile = createMockTile(graphModel)
+
+      render(
+        <DisplayConfigPalette tile={tile} setShowPalette={mockSetShowPalette} />
+      )
+
+      const binWidthInput = within(screen.getByTestId("graph-bin-width-setting")).getByRole("textbox")
+      await user.clear(binWidthInput)
+      await user.type(binWidthInput, "20{Enter}")
+
+      expect(mockLogMessageWithReplacement).toHaveBeenCalledWith(
+        "change %@ from %@ to %@",
+        { changedProperty: "binWidth", fromValue: 10, toValue: 20 }
+      )
     })
 
     it("commits bin alignment on blur", async () => {

--- a/v3/src/components/graph/components/inspector-panel/display-config-palette.tsx
+++ b/v3/src/components/graph/components/inspector-panel/display-config-palette.tsx
@@ -217,6 +217,12 @@ export const DisplayConfigPalette = observer(function DisplayConfigPanel(props: 
     const [undoStringKey, redoStringKey] = fuseIntoBars
       ? ["DG.Undo.graph.fuseDotsToRectangles", "DG.Redo.graph.fuseDotsToRectangles"]
       : ["DG.Undo.graph.dissolveRectanglesToDots", "DG.Redo.graph.dissolveRectanglesToDots"]
+    // A binned plot (binnedDotPlot / histogram) fuses dots into a histogram; an unbinned plot
+    // fuses dots into bars. V2 emits a distinct operation for each, but neither operation name
+    // states the direction — add a `to` discriminator naming the destination state.
+    const isBinned = !!graphModel?.plot.isBinned
+    const fuseOperation = isBinned ? "toggle between histogram and dots" : "switch bar and dot"
+    const to = fuseIntoBars ? (isBinned ? "histogram" : "bars") : "dots"
 
     graphModel?.applyModelChange(() => {
         graphModel?.fusePointsIntoBars(fuseIntoBars)
@@ -224,7 +230,7 @@ export const DisplayConfigPalette = observer(function DisplayConfigPanel(props: 
       },
       { undoStringKey, redoStringKey,
         log: logMessageWithReplacement("toggleShowAs: %@", { type: fuseIntoBars ? "BarChart" : "DotChart" }),
-        notify: tile ? tileNotification(`toggle between bars and dots`, {}, tile) : undefined
+        notify: tile ? tileNotification(fuseOperation, { to }, tile) : undefined
       }
     )
   }

--- a/v3/src/components/graph/components/inspector-panel/display-config-palette.tsx
+++ b/v3/src/components/graph/components/inspector-panel/display-config-palette.tsx
@@ -178,8 +178,8 @@ export const DisplayConfigPalette = observer(function DisplayConfigPanel(props: 
         setBinOption(option, value)
       }, {
         log: logMessageWithReplacement(
-                    "Changed %@ from %@ to %@",
-                    { option, [`${option}Initial`]: initialValue, [option]: value }),
+                    "change %@ from %@ to %@",
+                    { changedProperty: option, fromValue: initialValue, toValue: value }),
         undoStringKey: option === "binWidth" ? "DG.Undo.graph.changeBinWidth" : "DG.Undo.graph.changeBinAlignment",
         redoStringKey: option === "binWidth" ? "DG.Redo.graph.changeBinWidth" : "DG.Redo.graph.changeBinAlignment",
         notify: tile ? tileNotification(`change bin parameter`, {}, tile) : undefined
@@ -205,8 +205,8 @@ export const DisplayConfigPalette = observer(function DisplayConfigPanel(props: 
       setBinOption(option, value)
     }, {
       log: logMessageWithReplacement(
-                  "Changed %@ from %@ to %@",
-                  { option, [`${option}Initial`]: initialValue, [option]: value }),
+                  "change %@ from %@ to %@",
+                  { changedProperty: option, fromValue: initialValue, toValue: value }),
       undoStringKey: option === "binWidth" ? "DG.Undo.graph.changeBinWidth" : "DG.Undo.graph.changeBinAlignment",
       redoStringKey: option === "binWidth" ? "DG.Redo.graph.changeBinWidth" : "DG.Redo.graph.changeBinAlignment",
       notify: tile ? tileNotification(`change bin parameter`, {}, tile) : undefined
@@ -241,8 +241,8 @@ export const DisplayConfigPalette = observer(function DisplayConfigPanel(props: 
     } else {
       barChart?.applyModelChange(() => barChart?.setBreakdownType(breakdownType), {
         log: logMessageWithReplacement(
-          "Changed %@ from %@ to %@",
-          {option: "breakdownType", [`breakdownTypeInitial`]: barChart?.breakdownType, breakdownType}),
+          "change %@ from %@ to %@",
+          {changedProperty: "breakdownType", fromValue: barChart?.breakdownType, toValue: breakdownType}),
         undoStringKey: "DG.Undo.graph.changeBreakdownType",
         redoStringKey: "DG.Redo.graph.changeBreakdownType",
         notify: tile ? tileNotification(

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -50,7 +50,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
           tile),
         undoStringKey: "DG.Undo.hideUnselectedCases",
         redoStringKey: "DG.Redo.hideUnselectedCases",
-        log: "Hide unselected cases"
+        log: logMessageWithReplacement("Hide %@ unselected cases", {numUnselected: numberToHide})
       }
     )
   }

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -72,7 +72,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
       {
         undoStringKey: "DG.Undo.showAllCases",
         redoStringKey: "DG.Redo.showAllCases",
-        log: {message: "Show all cases", args: {category: "data"}}
+        log: {message: "Show all cases", args: {}, category: "data"}
       }
     )
   }

--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -6,6 +6,7 @@ import { observer } from "mobx-react-lite"
 import { addDisposer, onPatch } from "mobx-state-tree"
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import { useMemo } from "use-memo-one"
+import { logMessageWithReplacement } from "../../lib/log-message"
 import { useTileInspectorContext } from "../../hooks/use-tile-inspector-context"
 import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { mstReaction } from "../../utilities/mst-reaction"
@@ -139,7 +140,9 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
         // log only when the text actually changed, e.g. not on style changes
         // Note that logging of text changes was commented out in v2 in build 0601. ¯\_(ツ)_/¯
         // For now, we log just the text content, not the full JSON-stringified slate value.
-        log: textDidChange ? () => `Edited text component: ${textModel.textContent}` : undefined,
+        log: textDidChange
+          ? () => logMessageWithReplacement("Edited text component", { text: textModel.textContent })
+          : undefined,
         undoStringKey: "DG.Undo.textComponent.edit",
         redoStringKey: "DG.Redo.textComponent.edit",
         notify: textDidChange ? () => commitEditNotification(textModel, tile) : undefined

--- a/v3/src/models/tiles/tile-notifications.test.ts
+++ b/v3/src/models/tiles/tile-notifications.test.ts
@@ -70,3 +70,31 @@ describe("updateTileNotification", () => {
     expect(notification?.message.values.type).toBe(v2Type)
   })
 })
+
+describe("titleChange notification envelope", () => {
+  it("adds type to the outer envelope for the titleChange operation", () => {
+    const tileMock = { id: v3Id, content: { type: v3Type } } as ITileModel
+    const values = { from: "Old Title", to: "New Title" }
+
+    const notification = updateTileNotification("titleChange", values, tileMock)
+
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe(`component[${v2Id}]`)
+    // type is mirrored to the outer envelope AND kept in values
+    expect((notification?.message as any).type).toBe(v2Type)
+    expect(notification?.message.values.operation).toBe("titleChange")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.from).toBe("Old Title")
+    expect(notification?.message.values.to).toBe("New Title")
+    expect(notification?.message.values.type).toBe(v2Type)
+  })
+
+  it("keeps type inside values for non-titleChange operations", () => {
+    const tileMock = { id: v3Id, content: { type: v3Type } } as ITileModel
+
+    const notification = updateTileNotification("attributeChange", {}, tileMock)
+
+    expect((notification?.message as any).type).toBeUndefined()
+    expect(notification?.message.values.type).toBe(v2Type)
+  })
+})

--- a/v3/src/models/tiles/tile-notifications.ts
+++ b/v3/src/models/tiles/tile-notifications.ts
@@ -6,13 +6,21 @@ import { ITileModel } from "./tile-model"
 export const tileNotification = (
   operation: string, values: any, tile: ITileModel, callback?: (result: any) => void
 ) => {
-  const resource = operation === "titleChange" ? `component[${toV2Id(tile.id)}]` : "component"
+  const isTitleChange = operation === "titleChange"
+  const resource = isTitleChange ? `component[${toV2Id(tile.id)}]` : "component"
+  const v2Type = kComponentTypeV3ToV2Map[tile.content.type]
 
   values.operation = operation
   values.id = toV2Id(tile.id)
-  values.type = kComponentTypeV3ToV2Map[tile.content.type]
+  values.type = v2Type
 
-  return notification(resource, values, callback)
+  const result = notification(resource, values, callback)
+  // V2 (apps/dg/views/component_view.js) places `type` at the outer envelope level for
+  // titleChange, a peer of `action`/`resource`. Mirror it there for V2 plugins while
+  // keeping `type` in `values` for consistency with every other operation.
+  if (isTitleChange) (result.message as any).type = v2Type
+
+  return result
 }
 
 export function createTileNotification(tile?: ITileModel) {

--- a/v3/src/models/tiles/tile-notifications.ts
+++ b/v3/src/models/tiles/tile-notifications.ts
@@ -40,7 +40,7 @@ export function deleteTileNotification(tile?: ITileModel) {
   return tileNotification("delete", values, tile)
 }
 
-export function updateTileNotification(updateType: string, values?: any, tile?: ITileModel) {
+export function updateTileNotification(updateType: string, values: any, tile?: ITileModel) {
   if (!tile) return
 
   return tileNotification(updateType, values, tile)


### PR DESCRIPTION
## Summary

V3 had drifted from V2 in the operation strings and payloads of plugin-visible notifications and user-analytics log events. This PR corrects the drift for the items worth fixing before the v3 release candidate.

@bfinzer Note on review: you should probably also take a look at the follow-up stories to see if there's anything there that strikes you as worth fixing in 3.0.0. For now I put them all into the 3.0.1 sprint as the post-3.0 triage bucket.

## Audit and triage

The starting point was the V2↔V3 event compatibility audit (`v3/doc/v2-v3-compatibility-audit.md`, added by PR #2569) — ~80 findings spanning notification operation strings, log event tokens, and payload shapes. The audit catalogued V3's drift but explicitly deferred the "which of these actually matter" question.

During CODAP-1310 triage we ran a plugin-consumption survey to answer it — reading the source of plugins that filter on these strings: **Story Builder** (cloned from `concord-consortium/story-builder` — the plugin whose breakage originally triggered the audit) and the ~20 data interactives in `codap-data-interactives` (the eepsmedia plugins, the `onboarding-new-*` tutorials, CollectMeasures, NOAA-weather, the API tester, the Sonification prototypes, etc.). For each, we found every notification listener and log-event filter and matched them against the audit's findings.

The result collapsed the ~80 audit items to a short **confirmed-consumer breakage list** — items where a real plugin filters on the affected V2 value. Story Builder turned out to be fully compatible already (its catch-all listener only specifically names five operations, including the `commitEdit` already fixed by PR #2566). The remaining confirmed-consumer items are the new notifications and log changes in this PR.

## Decision rule

**Fix anything with a confirmed consumer in this PR; defer the rest to follow-up stories.** With the v3 release candidate close, the bulk of the audit's findings (notification backfill for areas with no surveyed consumer, large log-token rename batches, behavioral data-model changes) wasn't worth the RC risk; those are filed as CODAP-1351…CODAP-1356.

During execution, V2-baseline re-checks against `master` source kept turning up audit inaccuracies (an evaluation-order claim, a PascalCase-vs-camelCase claim, two "V3-only" log events that V2 also emits, and more). Each task included a brass-tacks V2-vs-V3 verification table before changing anything; several plan items were reworked or dropped as a result — recorded in the CODAP-1310 scope comment.

**Guiding principle, in case of doubt:** V2 compatibility is primary; streamlining V3 is welcome only where it doesn't sacrifice V2 compatibility. The survey covered only a small subset of plugins in the wild, so "no surveyed consumer" was never treated as "no consumer." Every change either renames a V3 string to match V2 or *adds* fields — V3 may add to a payload but must not rename/remove what V2 emits.

## Notification fixes
- **`titleChange`** — mirror the component `type` to the outer envelope (also kept in `values` — additive)
- **Background image** — emit V2's `backgroundImage` / `lockBackgroundImage` / `unlockBackgroundImage`, with an additive `to: "added"|"removed"` discriminator
- **Fuse into bars/histogram** — emit V2's `switch bar and dot` and `toggle between histogram and dots`, with a `to` discriminator
- **Adornment toggles** — rename to V2 operations (`toggle connecting line`, `toggle lock intercept`, `toggle show squares`, `show/hide measure labels`); `isChecked` now reports the resulting state
- **New notifications** (each has a confirmed plugin consumer) — `edit formula`, `togglePlottedMean`/`togglePlottedMedian`, `toggle between histogram and dots`, `toggle table to card`/`toggle card to table`

## Log-event fixes
- **`editValue`** — emit V2's `editValue: { collection, case, attribute, old, new }` event string (payload also in structured args)
- **`attributeCreate`** — standardize V3's create-attribute log on V2's token
- **`Change title 'old' to 'new'`** — match V2's title-change log format
- **`change %@ from %@ to %@`** — match V2's token; unify the arg keys
- **Graph "Hide unselected cases"** — include the count, matching V2 and the V3 map sibling
- **V3-internal cleanups** — "Edited text component" and "Show all cases" log hygiene/bug fixes; "Close component" payload key unified

## Out of scope — follow-up stories

Filed as follow-ups to CODAP-1310 (target CODAP V3.0.1):

| Story | Scope |
|---|---|
| [CODAP-1351](https://concord-consortium.atlassian.net/browse/CODAP-1351) (FU-1) | Graph adornment/plot notification backfill |
| [CODAP-1352](https://concord-consortium.atlassian.net/browse/CODAP-1352) (FU-2) | Map notification backfill |
| [CODAP-1353](https://concord-consortium.atlassian.net/browse/CODAP-1353) (FU-3) | Case-table / calculator / slider / case-card notification backfill |
| [CODAP-1354](https://concord-consortium.atlassian.net/browse/CODAP-1354) (FU-4) | Document undo/redo notifications (HIGH risk) |
| [CODAP-1355](https://concord-consortium.atlassian.net/browse/CODAP-1355) (FU-5) | V2 log-event compatibility (~38 token renames + payloads), incl. the adornment-log family and `toggleShowAs` log value |
| [CODAP-1356](https://concord-consortium.atlassian.net/browse/CODAP-1356) (FU-6) | `dataContextChangeNotice` item-vs-case operations |

A few audit findings were intentionally not fixed — recorded in a comment on the story.

## Testing
`npm run lint`, `npm run build:tsc`, and the full Jest suite (3041 tests) all pass. New/changed behavior is unit-tested where a harness exists.

Story: [CODAP-1310](https://concord-consortium.atlassian.net/browse/CODAP-1310)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CODAP-1351]: https://concord-consortium.atlassian.net/browse/CODAP-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ