### PR TITLE
CODAP-1357: allow cross-attribute prev() references without cycle error

### DIFF
--- a/v3/src/models/formula/attribute-formula-adapter.test.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.test.ts
@@ -123,6 +123,37 @@ describe("AttributeFormulaAdapter", () => {
       const error = adapter.getFormulaError(context, extraMetadata)
       expect(error).toBeUndefined()
     })
+
+    it("should not report false cycle when two attributes reference each other only via prev() (CODAP-1357)", () => {
+      // Markov-style mutual recurrence: each attribute references the other only through prev().
+      // prev() reads the previous case, so this is not a runtime cycle.
+      const { dataSet, adapter, contextMap, metadataMap } = getCycleTestEnv([
+        { name: "sunny", formula: "caseIndex=1 ? 3600 : 5/6 * prev(sunny) + 4/6 * prev(rainy)" },
+        { name: "rainy", formula: "caseIndex=1 ? 0 : 1/6 * prev(sunny) + 2/6 * prev(rainy)" }
+      ])
+      const sunnyAttr = dataSet.attributes[0]
+      const sunnyError = adapter.getFormulaError(
+        contextMap.get(sunnyAttr.formula!.id)!, metadataMap.get(sunnyAttr.formula!.id)!)
+      expect(sunnyError).toBeUndefined()
+      const rainyAttr = dataSet.attributes[1]
+      const rainyError = adapter.getFormulaError(
+        contextMap.get(rainyAttr.formula!.id)!, metadataMap.get(rainyAttr.formula!.id)!)
+      expect(rainyError).toBeUndefined()
+    })
+
+    it("should still detect cycle when a prev() cross-reference is paired with a direct reference", () => {
+      // A = prev(B) + B  (B is referenced both inside and outside prev)
+      // B = A            (B depends directly on A)
+      // This is a real cycle: B[N] needs A[N], A[N] needs B[N].
+      const { dataSet, adapter, contextMap, metadataMap } = getCycleTestEnv([
+        { name: "A", formula: "prev(B) + B" },
+        { name: "B", formula: "A" }
+      ])
+      const aAttr = dataSet.attributes[0]
+      const error = adapter.getFormulaError(
+        contextMap.get(aAttr.formula!.id)!, metadataMap.get(aAttr.formula!.id)!)
+      expect(error).toMatch(/Circular reference/)
+    })
   })
 
   describe("setupFormulaObservers", () => {

--- a/v3/src/models/formula/attribute-formula-adapter.test.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.test.ts
@@ -154,6 +154,20 @@ describe("AttributeFormulaAdapter", () => {
         contextMap.get(aAttr.formula!.id)!, metadataMap.get(aAttr.formula!.id)!)
       expect(error).toMatch(/Circular reference/)
     })
+
+    it("should detect cycle when a prev() defaultValue arg references an attr that closes the cycle", () => {
+      // A = prev(B, B): B in the expression arg is row-shifted, but B in the defaultValue arg
+      // is evaluated in the current-case context (see prev() in local-lookup-functions.ts),
+      // so it is NOT cycle-safe. With B = A, this is a real cycle on case 1.
+      const { dataSet, adapter, contextMap, metadataMap } = getCycleTestEnv([
+        { name: "A", formula: "prev(B, B)" },
+        { name: "B", formula: "A" }
+      ])
+      const aAttr = dataSet.attributes[0]
+      const error = adapter.getFormulaError(
+        contextMap.get(aAttr.formula!.id)!, metadataMap.get(aAttr.formula!.id)!)
+      expect(error).toMatch(/Circular reference/)
+    })
   })
 
   describe("setupFormulaObservers", () => {

--- a/v3/src/models/formula/attribute-formula-adapter.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.ts
@@ -284,8 +284,11 @@ export class AttributeFormulaAdapter extends FormulaManagerAdapter {
       const { attributeId } = this.api.getFormulaExtraMetadata(currentFormula)
       const formulaDependencies = getFormulaDependencies(formula.canonical, attributeId)
 
-      const localDatasetAttributeDependencies: ILocalAttributeDependency[] =
-        formulaDependencies.filter(d => d.type === "localAttribute")
+      // Skip dependencies wrapped only in prev() (or any selfReferenceAllowed function) - prev()
+      // breaks the row-level cycle by reading the previous case's value, so cross-attribute
+      // references through prev() (e.g. attrA = prev(attrB), attrB = prev(attrA)) are not real cycles.
+      const localDatasetAttributeDependencies: ILocalAttributeDependency[] = formulaDependencies
+        .filter((d): d is ILocalAttributeDependency => d.type === "localAttribute" && !d.selfReferenceAllowed)
       for (const dependency of localDatasetAttributeDependencies) {
         const dependencyAttribute = dataSet.attrFromID(dependency.attrId)
         if (isValidFormulaAttr(dependencyAttribute)) {

--- a/v3/src/models/formula/formula-manager.test.ts
+++ b/v3/src/models/formula/formula-manager.test.ts
@@ -113,6 +113,38 @@ describe("FormulaManager", () => {
     })
   })
 
+  describe("when two formulas reference each other only through prev() (CODAP-1357)", () => {
+    it("recalculates without infinite recursion in the downstream cascade", () => {
+      // Pre-PR, cycle detection rejected mutual prev() references. With CODAP-1357 they pass
+      // validation, but recalculateDownstreamFormulas still walks the cycle-safe edges, so
+      // without a re-entry guard the cascade recurses sunny -> rainy -> sunny -> ... and
+      // stack-overflows (RangeError, caught by MobX and logged to console.error).
+      const consoleErrSpy = jest.spyOn(console, "error").mockImplementation(() => undefined)
+      try {
+        const formulaManager = new FormulaManager()
+        const dataSet = createDataSet({
+          attributes: [
+            { name: "sunny", formula: { display: "prev(rainy)" } },
+            { name: "rainy", formula: { display: "prev(sunny)" } }
+          ]
+        }, {formulaManager})
+        dataSet.addCases([{ __id__: "1" }])
+        const adapter = new AttributeFormulaAdapter(formulaManager.getAdapterApi())
+        formulaManager.addDataSet(dataSet)
+        formulaManager.addAdapters([adapter])
+
+        // No errors should have been reported by MobX (a stack overflow would be).
+        expect(consoleErrSpy).not.toHaveBeenCalled()
+        const sunnyValue = dataSet.getValueAtItemIndex(0, dataSet.attrFromName("sunny")?.id || "")
+        const rainyValue = dataSet.getValueAtItemIndex(0, dataSet.attrFromName("rainy")?.id || "")
+        expect(typeof sunnyValue === "string" ? sunnyValue : "").not.toMatch(/Circular reference/)
+        expect(typeof rainyValue === "string" ? rainyValue : "").not.toMatch(/Circular reference/)
+      } finally {
+        consoleErrSpy.mockRestore()
+      }
+    })
+  })
+
   describe("when formula becomes inactive or it's removed", () => {
     it("un-registers formula", () => {
       const { manager, adapter, formula } = getManagerWithFakeAdapter()

--- a/v3/src/models/formula/formula-manager.ts
+++ b/v3/src/models/formula/formula-manager.ts
@@ -30,6 +30,11 @@ export class FormulaManager implements IFormulaManager {
 
   adapters: IFormulaManagerAdapter[] = []
 
+  // Tracks formulas currently being recalculated, to prevent infinite recursion through
+  // cycle-safe (selfReferenceAllowed) edges where recalculateDownstreamFormulas could
+  // otherwise propagate back into a formula that is already higher in the call stack.
+  recalculatingFormulas = new Set<string>()
+
   @observable
   areAdaptersInitialized = false
 
@@ -118,20 +123,30 @@ export class FormulaManager implements IFormulaManager {
   }
 
   recalculateFormula(formulaId: string, casesToRecalculate?: ICase[] | "ALL_CASES") {
+    // Skip re-entry for a formula already mid-recalculation in the current call stack.
+    // Mutual prev() references (e.g. sunny = prev(rainy), rainy = prev(sunny)) now pass
+    // cycle detection but their dependency edges are still walked by the downstream cascade,
+    // which would otherwise recurse indefinitely.
+    if (this.recalculatingFormulas.has(formulaId)) return
     const formulaContext = this.getFormulaContext(formulaId)
     const { adapter, isInitialized } = formulaContext
     if (!isInitialized) {
       return
     }
-    const extraMetadata = this.getExtraMetadata(formulaId)
-    adapter.recalculateFormula(formulaContext, extraMetadata, casesToRecalculate)
+    this.recalculatingFormulas.add(formulaId)
+    try {
+      const extraMetadata = this.getExtraMetadata(formulaId)
+      adapter.recalculateFormula(formulaContext, extraMetadata, casesToRecalculate)
 
-    // After evaluating, recalculate any downstream formulas that depend on this formula's
-    // output attribute. This replaces the reactive onAnyAction cascade for formula-to-formula
-    // dependencies, using the static dependency graph instead of MST action dispatch.
-    const { attributeId, dataSetId } = extraMetadata
-    if (attributeId) {
-      this.recalculateDownstreamFormulas(dataSetId, attributeId)
+      // After evaluating, recalculate any downstream formulas that depend on this formula's
+      // output attribute. This replaces the reactive onAnyAction cascade for formula-to-formula
+      // dependencies, using the static dependency graph instead of MST action dispatch.
+      const { attributeId, dataSetId } = extraMetadata
+      if (attributeId) {
+        this.recalculateDownstreamFormulas(dataSetId, attributeId)
+      }
+    } finally {
+      this.recalculatingFormulas.delete(formulaId)
     }
   }
 

--- a/v3/src/models/formula/formula-types.ts
+++ b/v3/src/models/formula/formula-types.ts
@@ -18,6 +18,10 @@ export interface ILocalAttributeDependency {
   type: "localAttribute"
   attrId: string
   aggregate?: boolean
+  // True when every reference to this attribute in the formula is inside a function with
+  // `selfReferenceAllowed` (currently only `prev()`). Such edges are ignored by cycle detection
+  // because `prev()` reads the previous case's value and breaks any row-level cycle.
+  selfReferenceAllowed?: boolean
 }
 export function isLocalAttributeDependency(dep?: IFormulaDependency): dep is ILocalAttributeDependency {
   return dep?.type === "localAttribute"

--- a/v3/src/models/formula/utils/formula-dependency-utils.ts
+++ b/v3/src/models/formula/utils/formula-dependency-utils.ts
@@ -1,6 +1,6 @@
 import { parse, isFunctionNode } from "mathjs/number"
 import type { MathNode } from "mathjs"
-import { IFormulaDependency, isLocalAttributeDependency } from "../formula-types"
+import { IFormulaDependency, ILocalAttributeDependency, isLocalAttributeDependency } from "../formula-types"
 import { typedFnRegistry } from "../functions/math"
 import { basicCanonicalNameToDependency } from "./name-mapping-utils"
 import { isNonFunctionSymbolNode } from "./mathjs-utils"
@@ -45,15 +45,30 @@ export const getFormulaDependencies = (formulaCanonical: string, formulaAttribut
         dependency.aggregate = true
       }
       const isSelfReference = ifSelfReference(dependency, formulaAttributeId)
-      // Note that when self reference is allowed, we should NOT add the attribute to the dependency list.
-      // This would create cycle in observers and trigger an error even earlier, when we check for this scenario.
-      const isPresent = result.some((dep) => {
-        return isLocalAttributeDependency(dep) &&
-                isLocalAttributeDependency(dependency) &&
-                dep.attrId === dependency.attrId
-      })
-      if (dependency && (!isSelfReference || !isSelfReferenceAllowed) && !isPresent) {
-        result.push(dependency)
+      // Direct self-reference inside prev() (e.g. CumulativeValue = Value + prev(CumulativeValue, 0))
+      // is dropped from the dependency list - prev() breaks the row-level cycle, and adding the
+      // attribute would create an observer cycle that recalculates the formula from its own output.
+      const skipDirectSelfRef = isSelfReference && isSelfReferenceAllowed
+      if (dependency && !skipDirectSelfRef) {
+        const existing = isLocalAttributeDependency(dependency)
+          ? result.find((dep): dep is ILocalAttributeDependency =>
+              isLocalAttributeDependency(dep) && dep.attrId === dependency.attrId)
+          : undefined
+        if (existing) {
+          // If the same attribute is referenced outside a selfReferenceAllowed function anywhere
+          // in the formula, the dependency cannot be treated as cycle-safe.
+          if (!isSelfReferenceAllowed) {
+            existing.selfReferenceAllowed = false
+          }
+        } else {
+          if (isLocalAttributeDependency(dependency) && isSelfReferenceAllowed) {
+            // Cross-attribute reference inside prev() (e.g. sunny = prev(rainy), rainy = prev(sunny)).
+            // Keep the dependency so observers fire when the referenced attribute changes, but mark
+            // it so the cycle detector ignores it - prev() breaks the row-level cycle.
+            dependency.selfReferenceAllowed = true
+          }
+          result.push(dependency)
+        }
       }
     }
 

--- a/v3/src/models/formula/utils/formula-dependency-utils.ts
+++ b/v3/src/models/formula/utils/formula-dependency-utils.ts
@@ -34,7 +34,22 @@ export const getFormulaDependencies = (formulaCanonical: string, formulaAttribut
         }
       })
     }
-    if (isFunctionNode(node) && typedFnRegistry[node.fn.name]?.selfReferenceAllowed || parent?.isSelfReferenceAllowed) {
+    if (isFunctionNode(node) && typedFnRegistry[node.fn.name]?.selfReferenceAllowed) {
+      const semiAggregate = typedFnRegistry[node.fn.name].isSemiAggregate
+      if (semiAggregate) {
+        // Only the row-shifted args (marked aggregate in isSemiAggregate) are cycle-safe.
+        // E.g. prev()'s defaultValue is evaluated in the current-case context and is NOT
+        // row-shifted, so deps appearing only there should not be treated as cycle-safe.
+        semiAggregate.forEach((isAggregateArgument, index) => {
+          if (node.args[index] && isAggregateArgument) {
+            (node.args[index] as IExtendedMathNode).isSelfReferenceAllowed = true
+          }
+        })
+      } else {
+        (node as IExtendedMathNode).isSelfReferenceAllowed = true
+      }
+    }
+    if (parent?.isSelfReferenceAllowed) {
       node.isSelfReferenceAllowed = true
     }
     const isDescendantOfAggregateFunc = !!node.isDescendantOfAggregateFunc
@@ -55,6 +70,10 @@ export const getFormulaDependencies = (formulaCanonical: string, formulaAttribut
               isLocalAttributeDependency(dep) && dep.attrId === dependency.attrId)
           : undefined
         if (existing) {
+          // Merge aggregate flag - if any reference is in an aggregate context, the dep is aggregate.
+          if (isLocalAttributeDependency(dependency) && dependency.aggregate) {
+            existing.aggregate = true
+          }
           // If the same attribute is referenced outside a selfReferenceAllowed function anywhere
           // in the formula, the dependency cannot be treated as cycle-safe.
           if (!isSelfReferenceAllowed) {


### PR DESCRIPTION
## Summary

Fixes [CODAP-1357](https://concord-consortium.atlassian.net/browse/CODAP-1357).

Two attributes that reference each other only through `prev()` (e.g. the Markov-style
sunny/rainy formulas in the linked story) were incorrectly flagged as a circular
reference. `prev()` reads the previous case's value, so there's no actual row-level
cycle - V2 handles this without error.

The dependency extractor (`formula-dependency-utils.ts`) already filtered out direct
self-references inside `prev()`, but cross-references between two attributes still
landed in the dependency graph as a mutual cycle. This change marks such dependencies
with `selfReferenceAllowed: true` on the `ILocalAttributeDependency` record and skips
them in the cycle detector, while still keeping them in the dependency list so
observers fire when the referenced attribute changes. The flag is cleared if the same
attribute is also referenced outside a `prev()` call elsewhere in the formula, so
genuine cycles paired with a `prev()` reference are still caught.

A follow-up issue (CODAP-1358) was filed for extending the same fix to `next()`,
which has the same row-shifted semantics but a different runtime path that needs
separate verification.

## Test plan

- [x] New unit tests in `attribute-formula-adapter.test.ts` cover the CODAP-1357 sunny/rainy case and an edge case where a `prev()` cross-reference is paired with a direct reference (real cycle should still be detected).
- [x] All 462 existing formula unit tests pass.
- [x] Lint and TypeScript check pass.
- [ ] Manually verified the attached `markovWeatherTest.codap` document now opens without circular-reference errors in V3.
- [ ] Cypress regression tests pass on CI (will trigger via `run regression` label once draft CI is green).


[CODAP-1357]: https://concord-consortium.atlassian.net/browse/CODAP-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ