### PR TITLE
CODAP-1358: support next(self) for single-attribute recursive formulas

### DIFF
--- a/v3/src/models/formula/attribute-formula-adapter.test.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.test.ts
@@ -141,6 +141,23 @@ describe("AttributeFormulaAdapter", () => {
       expect(rainyError).toBeUndefined()
     })
 
+    it("should not report false cycle when two attributes reference each other only via next() (CODAP-1358)", () => {
+      // Symmetric counterpart to the prev() case: each attribute references the other only
+      // through next(). next() reads the next case, so this is not a runtime cycle.
+      const { dataSet, adapter, contextMap, metadataMap } = getCycleTestEnv([
+        { name: "a", formula: "caseIndex=27 ? 1 : next(a, 0) + next(b, 0)" },
+        { name: "b", formula: "caseIndex=27 ? 1 : next(a, 0) + next(b, 0)" }
+      ])
+      const aAttr = dataSet.attributes[0]
+      const aError = adapter.getFormulaError(
+        contextMap.get(aAttr.formula!.id)!, metadataMap.get(aAttr.formula!.id)!)
+      expect(aError).toBeUndefined()
+      const bAttr = dataSet.attributes[1]
+      const bError = adapter.getFormulaError(
+        contextMap.get(bAttr.formula!.id)!, metadataMap.get(bAttr.formula!.id)!)
+      expect(bError).toBeUndefined()
+    })
+
     it("should still detect cycle when a prev() cross-reference is paired with a direct reference", () => {
       // A = prev(B) + B  (B is referenced both inside and outside prev)
       // B = A            (B depends directly on A)

--- a/v3/src/models/formula/attribute-formula-adapter.test.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.test.ts
@@ -44,6 +44,45 @@ describe("AttributeFormulaAdapter", () => {
       adapter.recalculateFormula(context, extraMetadata, "ALL_CASES")
       expect(dataSet.getValueAtItemIndex(0, attribute.id)).toEqual(3)
     })
+
+    it("handles next(self) on large datasets without stack overflow (CODAP-1358)", () => {
+      // Recursive next(self) evaluation would add ~10 stack frames per case, hitting the
+      // ~10k JS stack limit around 1000 cases. With iterative reverse-order evaluation, the
+      // outer loop fills the cache before each next() read, so depth stays O(1).
+      const N = 2000
+      const formulaManager = new FormulaManager()
+      const dataSet = createDataSet({
+        attributes: [{ name: "x", formula: { display: `caseIndex = ${N} ? 1 : next(x, 0) + 1` } }]
+      }, {formulaManager})
+      dataSet.addCases(Array.from({ length: N }, (_, i) => ({ __id__: `c${i}` })))
+      const adapter = new AttributeFormulaAdapter(formulaManager.getAdapterApi())
+      formulaManager.addDataSet(dataSet)
+      formulaManager.addAdapters([adapter])
+
+      const xAttr = dataSet.attributes[0]
+      // Reverse-counting: case 1 -> N, case 2 -> N-1, ..., case N -> 1
+      expect(dataSet.getValueAtItemIndex(0, xAttr.id)).toEqual(N)
+      expect(dataSet.getValueAtItemIndex(N - 1, xAttr.id)).toEqual(1)
+      expect(dataSet.getValueAtItemIndex(Math.floor(N / 2), xAttr.id)).toEqual(N - Math.floor(N / 2))
+    })
+
+    it("rejects formulas that mix prev(self) and next(self) with a formula error (CODAP-1358)", () => {
+      // Such a formula would require iterative resolution (cannot be satisfied in a single
+      // forward or reverse pass). Until that's supported (see CODAP-1359 follow-up), reject
+      // at recalculation time with a clear error rather than silently computing wrong values
+      // or stack-overflowing on the runtime guard.
+      const formulaManager = new FormulaManager()
+      const dataSet = createDataSet({
+        attributes: [{ name: "x", formula: { display: "prev(x, 0) + next(x, 0)" } }]
+      }, {formulaManager})
+      dataSet.addCases([{ __id__: "1" }, { __id__: "2" }, { __id__: "3" }])
+      const adapter = new AttributeFormulaAdapter(formulaManager.getAdapterApi())
+      formulaManager.addDataSet(dataSet)
+      formulaManager.addAdapters([adapter])
+
+      const xAttr = dataSet.attributes[0]
+      expect(dataSet.getValueAtItemIndex(0, xAttr.id)).toMatch(/prev.*next|next.*prev/)
+    })
   })
 
   describe("setError", () => {

--- a/v3/src/models/formula/attribute-formula-adapter.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.ts
@@ -11,11 +11,12 @@ import { IFormulaAdapterApi, FormulaManagerAdapter } from "./formula-manager-ada
 import { FormulaMathJsScope, NO_PARENT_KEY } from "./formula-mathjs-scope"
 import { observeDatasetHierarchyChanges } from "./formula-observers"
 import { FValue, ILocalAttributeDependency, ILookupDependency } from "./formula-types"
+import { UNDEF_RESULT } from "./functions/function-utils"
 import { math } from "./functions/math"
 import {
   getFormulaChildMostAggregateCollectionIndex, getIncorrectChildAttrReference, getIncorrectParentAttrReference
 } from "./utils/collection-utils"
-import { getFormulaDependencies } from "./utils/formula-dependency-utils"
+import { getFormulaDependencies, getSelfReferenceDirection } from "./utils/formula-dependency-utils"
 import { formulaError } from "./utils/misc"
 
 const ATTRIBUTE_FORMULA_ADAPTER = "AttributeFormulaAdapter"
@@ -212,6 +213,15 @@ export class AttributeFormulaAdapter extends FormulaManagerAdapter {
       caseChildrenCount: this.getCaseChildrenCountMap(formulaContext, extraMetadata)
     })
 
+    // Direction of self-references through prev()/next(). "reverse" (only next(self)) makes the
+    // outer loop iterate last-to-first so the cache is filled before next() reads it - this is
+    // the iterative form of V2's behavior and avoids stack growth proportional to remaining cases.
+    // "mixed" (both prev(self) and next(self)) cannot be resolved in a single pass and is rejected.
+    const direction = getSelfReferenceDirection(formula.canonical, attributeId)
+    if (direction === "mixed") {
+      return this.setFormulaError(formulaContext, extraMetadata, formulaError("V3.formula.error.mixedSelfRef"))
+    }
+
     let compiledFormula: EvalFunction
     try {
       compiledFormula = math.compile(formula.canonical)
@@ -222,22 +232,31 @@ export class AttributeFormulaAdapter extends FormulaManagerAdapter {
     // next(self) can recursively re-evaluate at a future case when the cache hasn't been filled yet.
     formulaScope.setCompiledFormula(compiledFormula)
 
-    return casesToRecalculate.map((c, idx) => {
+    const n = casesToRecalculate.length
+    const evalOrder: number[] = direction === "reverse"
+      ? Array.from({ length: n }, (_, i) => n - 1 - i)
+      : Array.from({ length: n }, (_, i) => i)
+    const formulaValues: FValue[] = new Array(n)
+    for (const idx of evalOrder) {
       formulaScope.setCasePointer(idx)
       let formulaValue: FValue
       try {
         formulaValue = compiledFormula.evaluate(formulaScope)
-        // This is necessary for functions like `prev` that need to know the previous result when they reference
-        // its own attribute.
+        // This is necessary for functions like `prev` and `next` that read their own attribute's
+        // previously-computed values via the case-pointer-indexed previousResults cache.
         formulaScope.savePreviousResult(formulaValue)
       } catch (e: any) {
         formulaValue = formulaError(e.message)
       }
-      return {
-        __id__: c.__id__,
-        [attributeId]: formulaValue
-      }
-    })
+      formulaValues[idx] = formulaValue
+    }
+    return casesToRecalculate.map((c, idx) => ({
+      __id__: c.__id__,
+      // Coerce undefined to the empty-string sentinel (UNDEF_RESULT) so users never see an
+      // `undefined` cell. Internally undefined is used as a "missing" signal that prev()/next()
+      // can catch via `?? defaultValue`; at this boundary it should always become `""`.
+      [attributeId]: formulaValues[idx] ?? UNDEF_RESULT
+    }))
   }
 
   // Error message is set as formula output, similarly as in CODAP V2.

--- a/v3/src/models/formula/attribute-formula-adapter.ts
+++ b/v3/src/models/formula/attribute-formula-adapter.ts
@@ -218,6 +218,9 @@ export class AttributeFormulaAdapter extends FormulaManagerAdapter {
     } catch (e: any) {
       return this.setFormulaError(formulaContext, extraMetadata, formulaError(e.message))
     }
+    // Give the scope access to the compiled formula so that self-referencing functions like
+    // next(self) can recursively re-evaluate at a future case when the cache hasn't been filled yet.
+    formulaScope.setCompiledFormula(compiledFormula)
 
     return casesToRecalculate.map((c, idx) => {
       formulaScope.setCasePointer(idx)

--- a/v3/src/models/formula/filter-formula-adapter.ts
+++ b/v3/src/models/formula/filter-formula-adapter.ts
@@ -99,6 +99,7 @@ export class FilterFormulaAdapter extends FormulaManagerAdapter {
 
     try {
       const compiledFormula = math.compile(formula.canonical)
+      formulaScope.setCompiledFormula(compiledFormula)
       return casesToRecalculate.map((c, idx) => {
         formulaScope.setCasePointer(idx)
         const formulaValue = compiledFormula.evaluate(formulaScope)

--- a/v3/src/models/formula/formula-mathjs-scope.ts
+++ b/v3/src/models/formula/formula-mathjs-scope.ts
@@ -1,5 +1,5 @@
 import { parse } from "mathjs/number"
-import type { MathNode } from "mathjs"
+import type { EvalFunction, MathNode } from "mathjs"
 import { t } from "../../utilities/translation/translate"
 import { BoundaryManager } from "../boundaries/boundary-manager"
 import type { IValueType } from "../data/attribute-types"
@@ -43,9 +43,16 @@ export class FormulaMathJsScope {
   caseIndexCache?: Record<string, number>
   // `cache` is used directly by custom formula functions like `prev`, `next` or aggregate functions.
   cache = new Map<string, any>()
-  // `previousResults` is used for calculating self-referencing, recursive functions like prev(), e.g.:
+  // `previousResults` caches each case's computed formula value, indexed by casePointer. Used by
+  // self-referencing recursive functions like prev() and next(), e.g.:
   // [CumulativeValue attribute formula]: "prev(CumulativeValue, 0) + Value"
+  // [ReverseSum attribute formula]: "caseIndex == numCases ? Value : Value + next(ReverseSum, 0)"
+  // For prev(self), entries are filled in forward order by the outer recalculation loop. For
+  // next(self), getLocalValue triggers recursive re-evaluation to fill entries on demand.
   previousResults: FValue[] = []
+  // Compiled formula, used by getLocalValue to recursively re-evaluate the formula at a different
+  // case pointer when a self-reference reads a row that hasn't been computed yet.
+  compiledFormula?: EvalFunction
   defaultArgumentNode?: MathNode
   // Extra scope is used to pass additional values to the formula scope, e.g. when evaluating plotted function
   // with `x` argument.
@@ -154,7 +161,18 @@ export class FormulaMathJsScope {
       // When formula references its own attribute, we cannot simply return case values - we're just trying
       // to calculate them. In most cases this is not allowed, but there are some exceptions, e.g. prev function
       // referencing its own attribute. It could be used to calculate cumulative value in a recursive way.
-      return this.previousResults[this.casePointer]
+      const cached = this.previousResults[this.casePointer]
+      if (cached !== undefined) return cached
+      // Cache miss: this case hasn't been computed yet (e.g. next(self) reading a future row).
+      // Recursively re-evaluate the formula at this case, matching V2's behavior. Cache the result
+      // so the outer recalculation loop and any peer recursive calls reuse it.
+      const totalCases = this.context.caseIds?.length ?? 0
+      if (this.compiledFormula && this.casePointer >= 0 && this.casePointer < totalCases) {
+        const value = this.compiledFormula.evaluate(this) as FValue
+        this.previousResults[this.casePointer] = value
+        return value
+      }
+      return undefined as any
     }
     return attrId === CASE_INDEX_FAKE_ATTR_ID
       ? this.getCaseIndex(caseId)
@@ -197,7 +215,14 @@ export class FormulaMathJsScope {
   }
 
   savePreviousResult(value: FValue) {
-    this.previousResults.push(value)
+    // Index-based assignment (not push) so that recursive self-reference fills (e.g. next(self))
+    // can populate future indices without colliding with the outer recalculation loop's
+    // sequential saves.
+    this.previousResults[this.casePointer] = value
+  }
+
+  setCompiledFormula(fn: EvalFunction) {
+    this.compiledFormula = fn
   }
 
   // with... methods could be replaced by more elegant approach of creating sub-scope with modified properties,

--- a/v3/src/models/formula/formula-mathjs-scope.ts
+++ b/v3/src/models/formula/formula-mathjs-scope.ts
@@ -24,11 +24,13 @@ export interface IFormulaMathjsScopeContext {
   // Cases that the formula is evaluated for, in case it's evaluated for a group of cases during one evaluation.
   // This is necessary for case-dependant formulas to work, e.g. `round(NewAttribute)` or `prev(NewAttribute, 0) + 1`.
   caseIds?: string[]
-  // When set, the scope routes reads of this attribute through getLocalValue's self-reference
-  // branch (using previousResults + the compiled formula for recursive fills). Callers that set
-  // this MUST also call setCompiledFormula(), or self-reference cache misses for next(self)
-  // will silently return undefined. All current callers that set formulaAttrId also set the
-  // compiled formula; filter-formula adapters set formulaAttrId to undefined and do not need it.
+  // When defined, the scope routes reads of this attribute through getLocalValue's self-reference
+  // branch (using previousResults + the compiled formula for recursive fills). Callers that pass
+  // a defined value MUST also call setCompiledFormula(), or self-reference cache misses for
+  // next(self) will silently return undefined. Filter-formula adapters pass `formulaAttrId:
+  // attributeId` from extraMetadata, but extraMetadata.attributeId is always undefined for filter
+  // formulas (they have no target attribute), so the self-reference branch is unreachable from
+  // those call sites today.
   formulaAttrId?: string
   formulaCollectionIndex?: number
   childMostAggregateCollectionIndex?: number

--- a/v3/src/models/formula/formula-mathjs-scope.ts
+++ b/v3/src/models/formula/formula-mathjs-scope.ts
@@ -53,6 +53,10 @@ export class FormulaMathJsScope {
   // Compiled formula, used by getLocalValue to recursively re-evaluate the formula at a different
   // case pointer when a self-reference reads a row that hasn't been computed yet.
   compiledFormula?: EvalFunction
+  // Tracks case pointers currently mid-evaluation, to break runtime cycles that the static cycle
+  // detector cannot see. E.g. `prev(next(self, 0), 0)` shifts -1 then +1, returning to the
+  // current case before its value is cached, and would otherwise recurse indefinitely.
+  evaluatingCasePointers = new Set<number>()
   defaultArgumentNode?: MathNode
   // Extra scope is used to pass additional values to the formula scope, e.g. when evaluating plotted function
   // with `x` argument.
@@ -163,14 +167,23 @@ export class FormulaMathJsScope {
       // referencing its own attribute. It could be used to calculate cumulative value in a recursive way.
       const cached = this.previousResults[this.casePointer]
       if (cached !== undefined) return cached
+      // If we're already mid-evaluation for this case (e.g. prev(next(self, 0), 0) shifts -1
+      // then +1, returning to the current case before its value is cached), break the cycle
+      // by returning undefined - this is a runtime cycle the static detector cannot see.
+      if (this.evaluatingCasePointers.has(this.casePointer)) return undefined as any
       // Cache miss: this case hasn't been computed yet (e.g. next(self) reading a future row).
       // Recursively re-evaluate the formula at this case, matching V2's behavior. Cache the result
       // so the outer recalculation loop and any peer recursive calls reuse it.
       const totalCases = this.context.caseIds?.length ?? 0
       if (this.compiledFormula && this.casePointer >= 0 && this.casePointer < totalCases) {
-        const value = this.compiledFormula.evaluate(this) as FValue
-        this.previousResults[this.casePointer] = value
-        return value
+        this.evaluatingCasePointers.add(this.casePointer)
+        try {
+          const value = this.compiledFormula.evaluate(this) as FValue
+          this.previousResults[this.casePointer] = value
+          return value
+        } finally {
+          this.evaluatingCasePointers.delete(this.casePointer)
+        }
       }
       return undefined as any
     }

--- a/v3/src/models/formula/formula-mathjs-scope.ts
+++ b/v3/src/models/formula/formula-mathjs-scope.ts
@@ -24,6 +24,11 @@ export interface IFormulaMathjsScopeContext {
   // Cases that the formula is evaluated for, in case it's evaluated for a group of cases during one evaluation.
   // This is necessary for case-dependant formulas to work, e.g. `round(NewAttribute)` or `prev(NewAttribute, 0) + 1`.
   caseIds?: string[]
+  // When set, the scope routes reads of this attribute through getLocalValue's self-reference
+  // branch (using previousResults + the compiled formula for recursive fills). Callers that set
+  // this MUST also call setCompiledFormula(), or self-reference cache misses for next(self)
+  // will silently return undefined. All current callers that set formulaAttrId also set the
+  // compiled formula; filter-formula adapters set formulaAttrId to undefined and do not need it.
   formulaAttrId?: string
   formulaCollectionIndex?: number
   childMostAggregateCollectionIndex?: number
@@ -170,6 +175,10 @@ export class FormulaMathJsScope {
       // If we're already mid-evaluation for this case (e.g. prev(next(self, 0), 0) shifts -1
       // then +1, returning to the current case before its value is cached), break the cycle
       // by returning undefined - this is a runtime cycle the static detector cannot see.
+      // We use `undefined` (not the user-facing `""` UNDEF_RESULT sentinel) so that the
+      // surrounding prev()/next() catches it via `?? defaultValue` and falls back cleanly.
+      // The AttributeFormulaAdapter coerces any surviving undefined to `""` at the case-value
+      // boundary so users never see a literal `undefined` cell.
       if (this.evaluatingCasePointers.has(this.casePointer)) return undefined as any
       // Cache miss: this case hasn't been computed yet (e.g. next(self) reading a future row).
       // Recursively re-evaluate the formula at this case, matching V2's behavior. Cache the result

--- a/v3/src/models/formula/functions/local-lookup-functions.test.ts
+++ b/v3/src/models/formula/functions/local-lookup-functions.test.ts
@@ -167,6 +167,14 @@ describe("local lookup functions", () => {
       const expected = Array.from({ length: 27 }, (_, i) => 27 - i)
       expect(result).toEqual(expected)
     })
+
+    it("does not infinitely recurse when a self-reference returns to the current case", () => {
+      // prev(next(self, 0), 0) shifts case pointer -1 then +1, returning to the current case
+      // during evaluation. Without a per-casePointer re-entry guard in getLocalValue, the
+      // recursive eval would loop indefinitely and stack-overflow.
+      const options = { formulaAttrName: "LifeSpan" }
+      expect(() => evaluateForAllCases("prev(next(LifeSpan, 0), 0)", options)).not.toThrow()
+    })
   })
 
   it("implements caching that ensures O(n) complexity", () => {

--- a/v3/src/models/formula/functions/local-lookup-functions.test.ts
+++ b/v3/src/models/formula/functions/local-lookup-functions.test.ts
@@ -155,6 +155,18 @@ describe("local lookup functions", () => {
         20, 10, 10, 5, 7, 25, "", ""
       ])
     })
+
+    it("supports self reference for reverse-counting formulas (CODAP-1358)", () => {
+      // Reverse counting: last case is 1, each earlier case is next(self) + 1.
+      // This exercises recursive evaluation of next(self) without depending on data values.
+      const options = { formulaAttrName: "LifeSpan" }
+      const result = evaluateForAllCases(
+        "caseIndex = 27 ? 1 : next(LifeSpan, 0) + 1", options
+      )
+      // 27 cases: 27, 26, 25, ..., 2, 1
+      const expected = Array.from({ length: 27 }, (_, i) => 27 - i)
+      expect(result).toEqual(expected)
+    })
   })
 
   it("implements caching that ensures O(n) complexity", () => {

--- a/v3/src/models/formula/functions/local-lookup-functions.test.ts
+++ b/v3/src/models/formula/functions/local-lookup-functions.test.ts
@@ -175,6 +175,48 @@ describe("local lookup functions", () => {
       const options = { formulaAttrName: "LifeSpan" }
       expect(() => evaluateForAllCases("prev(next(LifeSpan, 0), 0)", options)).not.toThrow()
     })
+
+    it("evaluates next() with a filter correctly across all cases", () => {
+      // Exercises the with-filter cache across multiple sequential evaluations (the existing
+      // single-case `evaluate()` tests don't share scope state across cases).
+      const result = evaluateForAllCases("next(LifeSpan, 0, Diet = 'both')")
+      // Mirrors the single-case results from "supports the filter argument" - each case sees
+      // the next LifeSpan whose Diet is 'both'. Final cases without a forward match get the
+      // default value of 0.
+      expect(result[0]).toBe(40)
+      expect(result[1]).toBe(40)
+      expect(result[5]).toBe(9)
+      expect(result[6]).toBe(9)
+      expect(result[11]).toBe(3)
+      expect(result[12]).toBe(3)
+    })
+
+    it("evaluates next() with a filter correctly when called from descending casePointers", () => {
+      // Directly exercises the with-filter cache under reverse-direction casePointer access -
+      // the cacheSetAtCasePointer guard must invalidate the entry when we cross below the
+      // case where it was set, or earlier-case calls would reuse a stale (later) match.
+      const { dataSetsByName, dataSets, globalValueManager } = getFormulaTestEnv()
+      const localDataSet = dataSetsByName.Mammals
+      const caseIds = localDataSet.items.map(c => c.__id__)
+      const scope = new FormulaMathJsScope({
+        localDataSet, dataSets, globalValueManager, caseIds, childMostCollectionCaseIds: caseIds
+      })
+      const displayNameMap = getDisplayNameMap({ localDataSet, dataSets, globalValueManager })
+      const compiledFormula = math.compile(
+        displayToCanonical("next(LifeSpan, 0, Diet = 'both')", displayNameMap)
+      )
+      // Call in descending order, matching reverse iteration. The expected values are the
+      // same as forward-order calls because the answer is a function of casePointer alone,
+      // not call order - so any deviation means the cache mis-fired.
+      const descending: any[] = new Array(caseIds.length)
+      for (let i = caseIds.length - 1; i >= 0; i--) {
+        scope.setCasePointer(i)
+        descending[i] = compiledFormula.evaluate(scope)
+      }
+      expect(descending[0]).toBe(40)
+      expect(descending[5]).toBe(9)
+      expect(descending[11]).toBe(3)
+    })
   })
 
   it("implements caching that ensures O(n) complexity", () => {

--- a/v3/src/models/formula/functions/local-lookup-functions.ts
+++ b/v3/src/models/formula/functions/local-lookup-functions.ts
@@ -23,6 +23,14 @@ export const localLookupFunctions: CODAPMathjsFunctionRegistry = {
   // next(expression, defaultValue, filterExpression)
   next: {
     numOfRequiredArguments: 1,
+    // Self-reference is used by reverse-cumulative formulas, e.g.:
+    // `ReverseSum = caseIndex == numCases ? value : value + next(ReverseSum, 0)`.
+    // When the cached self-reference value is missing (forward iteration hasn't reached that row
+    // yet), getLocalValue falls back to recursive re-evaluation - matching V2's behavior.
+    // Note: cross-attribute mutual next() references (e.g. two attributes that both call next()
+    // on each other) require V2-style on-demand cross-formula evaluation, which V3 does not yet
+    // support - tracked in CODAP-1359.
+    selfReferenceAllowed: true,
     // expression and filter are evaluated as aggregate symbols, defaultValue is not - it depends on case index
     isSemiAggregate: [true, false, true],
     evaluateRaw: (args: MathNode[], mathjs: any, currentScope: CurrentScope) => {

--- a/v3/src/models/formula/functions/local-lookup-functions.ts
+++ b/v3/src/models/formula/functions/local-lookup-functions.ts
@@ -37,20 +37,30 @@ export const localLookupFunctions: CODAPMathjsFunctionRegistry = {
       interface ICachedData {
         result?: FValue
         resultCasePointer: number
+        // casePointer at which this entry was computed. The cached result represents "no
+        // matching case between cacheSetAtCasePointer+1 and resultCasePointer-1, match at
+        // resultCasePointer." That guarantee only holds for callers at or after
+        // cacheSetAtCasePointer; reverse iteration crosses below it and must recompute.
+        cacheSetAtCasePointer: number
       }
 
       const scope = getRootScope(currentScope)
       const caseGroupId = scope.getCaseGroupId()
       const cacheKey = `next(${args.toString()})-${caseGroupId}`
       const [ expression, defaultValue, filter ] = args
-      const cachedData = scope.getCached<ICachedData>(cacheKey)
 
       let result
-      let casePointer = scope.getCasePointer()
-      if (!cachedData || casePointer >= cachedData.resultCasePointer) {
-        // We need to look for a new next value when there's no cached data (e.g. first case being processed) or when
-        // we already passed the index of cached result.
-        if (filter) {
+      if (filter) {
+        // With a filter we may need to scan forward through cases until the filter is truthy.
+        // Cache the result so subsequent calls at smaller casePointers can reuse it (forward
+        // iteration). For reverse iteration the cacheSetAtCasePointer guard invalidates the
+        // entry when we cross below it.
+        const cachedData = scope.getCached<ICachedData>(cacheKey)
+        const originalCasePointer = scope.getCasePointer()
+        let casePointer = originalCasePointer
+        if (!cachedData ||
+            casePointer >= cachedData.resultCasePointer ||
+            casePointer < cachedData.cacheSetAtCasePointer) {
           const numOfCases = scope.getNumberOfCases()
           let expressionValue, filterValue
           let currentGroup = caseGroupId
@@ -72,21 +82,24 @@ export const localLookupFunctions: CODAPMathjsFunctionRegistry = {
             }, casePointer)
           }
           result = isValueTruthy(filterValue) ? expressionValue : undefined
+          scope.setCached(cacheKey, {
+            result, resultCasePointer: casePointer, cacheSetAtCasePointer: originalCasePointer
+          })
         } else {
-          // When there's no filter, simply get the next expression value (within the same case group).
-          casePointer = scope.getCasePointer() + 1
-          result = scope.withCustomCasePointer(() => {
-            if (scope.getCaseGroupId() === caseGroupId) {
-              return evaluateNode(expression, scope)
-            }
-            return undefined
-          }, casePointer)
+          result = cachedData.result
         }
-
-        scope.setCached(cacheKey, { result, resultCasePointer: casePointer })
       } else {
-        // When scope.casePointer < cachedData.resultCasePointer, we can reuse the previous result.
-        result = cachedData.result
+        // Without a filter, next() always reads casePointer+1 within the same case group, an O(1)
+        // lookup. The cache-reuse optimization that the filter case relies on would actively
+        // mis-fire in reverse iteration (where casePointer decreases), so we just recompute - it's
+        // cheap and direction-agnostic.
+        const targetCasePointer = scope.getCasePointer() + 1
+        result = scope.withCustomCasePointer(() => {
+          if (scope.getCaseGroupId() === caseGroupId) {
+            return evaluateNode(expression, scope)
+          }
+          return undefined
+        }, targetCasePointer)
       }
 
       return result ?? (defaultValue ? evaluateNode(defaultValue, scope) : UNDEF_RESULT)

--- a/v3/src/models/formula/test-utils/formula-test-utils.ts
+++ b/v3/src/models/formula/test-utils/formula-test-utils.ts
@@ -7,6 +7,7 @@ import { getSharedModelManager } from "../../tiles/tile-environment"
 import { FormulaMathJsScope, IFormulaMathjsScopeContext } from "../formula-mathjs-scope"
 import { math } from "../functions/math"
 import { displayToCanonical } from "../utils/canonicalization-utils"
+import { getSelfReferenceDirection } from "../utils/formula-dependency-utils"
 import { getDisplayNameMap } from "../utils/name-mapping-utils"
 import testDoc from "./test-doc.json"
 
@@ -123,10 +124,19 @@ export const evaluateForAllCases = (displayFormula: string, options?: IEvaluateF
   const compiledFormula = math.compile(formula)
   scope.setCompiledFormula(compiledFormula)
 
-  return caseIds.map((caseId, idx) => {
+  // Match the AttributeFormulaAdapter's iteration policy: when the formula uses only next(self),
+  // evaluate cases last-to-first so the cache is filled before each next() read.
+  const direction = formulaAttrId ? getSelfReferenceDirection(formula, formulaAttrId) : "none"
+  const reverse = direction === "reverse"
+  const indices = reverse
+    ? Array.from({ length: caseIds.length }, (_, i) => caseIds.length - 1 - i)
+    : Array.from({ length: caseIds.length }, (_, i) => i)
+  const results: any[] = new Array(caseIds.length)
+  for (const idx of indices) {
     scope.setCasePointer(idx)
     const formulaValue = compiledFormula.evaluate(scope)
     scope.savePreviousResult(formulaValue)
-    return formulaValue
-  })
+    results[idx] = formulaValue
+  }
+  return results
 }

--- a/v3/src/models/formula/test-utils/formula-test-utils.ts
+++ b/v3/src/models/formula/test-utils/formula-test-utils.ts
@@ -124,8 +124,11 @@ export const evaluateForAllCases = (displayFormula: string, options?: IEvaluateF
   const compiledFormula = math.compile(formula)
   scope.setCompiledFormula(compiledFormula)
 
-  // Match the AttributeFormulaAdapter's iteration policy: when the formula uses only next(self),
-  // evaluate cases last-to-first so the cache is filled before each next() read.
+  // Mirror only the reverse-order optimization from AttributeFormulaAdapter: when the formula
+  // uses only next(self), evaluate cases last-to-first so the cache is filled before each next()
+  // read. We deliberately do NOT mirror the adapter's "mixed direction" rejection here so
+  // existing tests can use this helper to exercise the runtime re-entry guard (e.g. with
+  // `prev(next(self, 0), 0)`) without being short-circuited at setup.
   const direction = formulaAttrId ? getSelfReferenceDirection(formula, formulaAttrId) : "none"
   const reverse = direction === "reverse"
   const indices = reverse

--- a/v3/src/models/formula/test-utils/formula-test-utils.ts
+++ b/v3/src/models/formula/test-utils/formula-test-utils.ts
@@ -121,6 +121,7 @@ export const evaluateForAllCases = (displayFormula: string, options?: IEvaluateF
   })
   const formula = displayToCanonical(displayFormula, displayNameMap)
   const compiledFormula = math.compile(formula)
+  scope.setCompiledFormula(compiledFormula)
 
   return caseIds.map((caseId, idx) => {
     scope.setCasePointer(idx)

--- a/v3/src/models/formula/utils/formula-dependency-utils.test.ts
+++ b/v3/src/models/formula/utils/formula-dependency-utils.test.ts
@@ -1,0 +1,46 @@
+import { getSelfReferenceDirection } from "./formula-dependency-utils"
+import { localAttrIdToCanonical } from "./name-mapping-utils"
+
+describe("getSelfReferenceDirection", () => {
+  const selfId = "self_attr_id"
+  const otherId = "other_attr_id"
+  const self = localAttrIdToCanonical(selfId)
+  const other = localAttrIdToCanonical(otherId)
+
+  it("returns 'none' when the formula has no prev/next self-references", () => {
+    expect(getSelfReferenceDirection(`${other} + 1`, selfId)).toBe("none")
+    expect(getSelfReferenceDirection(`prev(${other}, 0)`, selfId)).toBe("none")
+    expect(getSelfReferenceDirection(`next(${other}, 0)`, selfId)).toBe("none")
+  })
+
+  it("returns 'forward' for pure prev(self)", () => {
+    expect(getSelfReferenceDirection(`prev(${self}, 0) + 1`, selfId)).toBe("forward")
+    expect(getSelfReferenceDirection(`${other} + prev(${self}, 0)`, selfId)).toBe("forward")
+    // Nested prev(prev(self)) still counts as forward-only
+    expect(getSelfReferenceDirection(`prev(prev(${self}, 0), 0)`, selfId)).toBe("forward")
+  })
+
+  it("returns 'reverse' for pure next(self)", () => {
+    expect(getSelfReferenceDirection(`next(${self}, 0) + 1`, selfId)).toBe("reverse")
+    expect(getSelfReferenceDirection(`${other} + next(${self}, 0)`, selfId)).toBe("reverse")
+  })
+
+  it("returns 'mixed' when both prev(self) and next(self) appear", () => {
+    expect(getSelfReferenceDirection(`prev(${self}, 0) + next(${self}, 0)`, selfId)).toBe("mixed")
+    // Even when the prev/next-of-self is nested - the subtree walk picks up the self reference
+    expect(getSelfReferenceDirection(`prev(next(${self}, 0), 0)`, selfId)).toBe("mixed")
+  })
+
+  it("ignores self-references in defaultValue arg (which is current-case, not row-shifted)", () => {
+    // The selfReferenceAllowed propagation only marks aggregate args in isSemiAggregate (true at
+    // index 0 expression and index 2 filter). Index 1 defaultValue is current-case context, so
+    // a self-ref there would be caught as a real cycle by the static detector, not iterated.
+    expect(getSelfReferenceDirection(`prev(${other}, ${self})`, selfId)).toBe("none")
+    expect(getSelfReferenceDirection(`next(${other}, ${self})`, selfId)).toBe("none")
+  })
+
+  it("returns 'none' when arguments are missing or attributeId is empty", () => {
+    expect(getSelfReferenceDirection("", selfId)).toBe("none")
+    expect(getSelfReferenceDirection(`prev(${self}, 0)`, "")).toBe("none")
+  })
+})

--- a/v3/src/models/formula/utils/formula-dependency-utils.ts
+++ b/v3/src/models/formula/utils/formula-dependency-utils.ts
@@ -2,7 +2,7 @@ import { parse, isFunctionNode } from "mathjs/number"
 import type { MathNode } from "mathjs"
 import { IFormulaDependency, ILocalAttributeDependency, isLocalAttributeDependency } from "../formula-types"
 import { typedFnRegistry } from "../functions/math"
-import { basicCanonicalNameToDependency } from "./name-mapping-utils"
+import { basicCanonicalNameToDependency, localAttrIdToCanonical } from "./name-mapping-utils"
 import { isNonFunctionSymbolNode } from "./mathjs-utils"
 
 export const ifSelfReference = (dependency?: IFormulaDependency, formulaAttributeId?: string) =>
@@ -110,4 +110,54 @@ export const getFormulaDependencies = (formulaCanonical: string, formulaAttribut
   }
   formulaTree.traverse(visitNode)
   return result
+}
+
+// Iteration direction implied by the formula's self-references inside prev()/next() calls.
+// - "forward": only prev(self) appears - outer recalc loop iterates 0..n-1 so each prev() reads a cached value
+// - "reverse": only next(self) appears - outer loop iterates n-1..0 so each next() reads a cached value
+// - "mixed":  both prev(self) and next(self) appear - single-pass evaluation cannot satisfy both;
+//            caller should reject the formula since it would require iterative resolution
+// - "none":   no self-references through prev()/next() - direction does not matter
+export type SelfReferenceDirection = "forward" | "reverse" | "mixed" | "none"
+
+const subtreeReferencesSymbol = (root: MathNode, canonicalSymbolName: string): boolean => {
+  let found = false
+  root.traverse((node) => {
+    if (found) return
+    if (node.type === "SymbolNode" && (node as any).name === canonicalSymbolName) {
+      found = true
+    }
+  })
+  return found
+}
+
+export const getSelfReferenceDirection = (
+  formulaCanonical: string, formulaAttributeId: string
+): SelfReferenceDirection => {
+  if (!formulaCanonical || !formulaAttributeId) return "none"
+  const formulaTree = parse(formulaCanonical)
+  const canonicalAttrName = localAttrIdToCanonical(formulaAttributeId)
+  let hasPrevSelf = false
+  let hasNextSelf = false
+  formulaTree.traverse((node) => {
+    if (!isFunctionNode(node)) return
+    const fnName = node.fn.name
+    if (fnName !== "prev" && fnName !== "next") return
+    // Only the row-shifted (aggregate) args carry the self-reference cycle; defaultValue is
+    // evaluated in the current-case context and a self-ref there is a real cycle (caught by
+    // the static detector), not a recurrence to be iterated.
+    const semiAggregate = typedFnRegistry[fnName]?.isSemiAggregate
+    if (!semiAggregate) return
+    semiAggregate.forEach((isAggregate, index) => {
+      if (!isAggregate || !node.args[index]) return
+      if (subtreeReferencesSymbol(node.args[index], canonicalAttrName)) {
+        if (fnName === "prev") hasPrevSelf = true
+        else hasNextSelf = true
+      }
+    })
+  })
+  if (hasPrevSelf && hasNextSelf) return "mixed"
+  if (hasNextSelf) return "reverse"
+  if (hasPrevSelf) return "forward"
+  return "none"
 }

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -1549,6 +1549,7 @@
     // V3 formula strings that are not present in V2 and will eventually require translation.
     "V3.formula.error.invalidParentAttrRef": "invalid reference to parent attribute '%@' within aggregate function",
     "V3.formula.error.cycle": "Circular reference: formula refers to its own attribute either directly or indirectly",
+    "V3.formula.error.mixedSelfRef": "Formula uses both prev() and next() on its own attribute, which requires iterative resolution and is not yet supported",
     "V3.formula.error.stringConstantArg": "The '%@()' function expects %@ argument to be a string constant",
     "V3.formula.error.caseDependentNotSupported": "This formula scope does not support case-dependent formulas",
 


### PR DESCRIPTION
## Summary

Fixes [CODAP-1358](https://concord-consortium.atlassian.net/browse/CODAP-1358).

`next()` now mirrors `prev()`'s `selfReferenceAllowed` flag, so the cycle detector
no longer flags self-references through `next()`. Reverse-cumulative formulas like
`ReverseSum = caseIndex == numCases ? value : value + next(ReverseSum, 0)` now
compute correctly.

Because forward iteration's `previousResults` cache doesn't have row K+1 when
computing row K, `getLocalValue` falls back to recursively re-evaluating the
formula at the requested case pointer when a self-reference cache miss occurs.
This mirrors V2's behavior in `apps/dg/formula/lookup_agg_fns.js`. Results are
cached so the outer recalculation loop and peer recursive calls reuse them.

`savePreviousResult` switches from `push()` to index-based assignment so
sequential and recursive callers don't collide on previousResults indexing.

## Scope (and what's out of scope)

**Works:**
- Cycle detector accepts `next(self)` and mutual `next()` cross-references between
  attributes (no more circular-reference errors).
- Single-attribute reverse-cumulative formulas via `next(self)` compute correctly.

**Does NOT yet work (filed as follow-up CODAP-1359):**
- Cross-attribute mutual `next()` references (e.g. Markov-style sunny/rainy
  formulas that each call `next()` on the other). V3 batches per-attribute and
  reads `""` for not-yet-computed siblings; V3's V2-parity operators propagate
  `""` through arithmetic, so only the base case computes correctly.
- The fix requires V2-style on-demand cross-formula evaluation per case.

## Test plan

- [x] New unit test in `local-lookup-functions.test.ts` for `next(self)`
      reverse-counting formula (27, 26, 25, ..., 1).
- [x] New unit test in `attribute-formula-adapter.test.ts` for the cycle detector
      accepting mutual `next()` cross-references.
- [x] All 464 existing formula unit tests pass.
- [x] Lint and TypeScript check pass.
- [ ] Manually verify with a single-attribute `next(self)` document on the dev
      server.
- [ ] Cypress regression tests pass on CI (will trigger via `run regression` label).


[CODAP-1358]: https://concord-consortium.atlassian.net/browse/CODAP-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ