### PR TITLE
CODAP-1353: tile-notification backfill for case-table/calculator/slider/case-card

### DIFF
--- a/v3/src/components/axis/models/axis-notifications.test.ts
+++ b/v3/src/components/axis/models/axis-notifications.test.ts
@@ -2,13 +2,16 @@ import { updateAxisNotification } from "./axis-notifications"
 
 const v3Id = "TILE12345"
 const v2Id = 12345
-const v3Type = "Graph"
-const v2Type = "graph"
+const v3TileType = "Graph"
+// V2 component-resource notifications carry the SC class name (`DG.GraphView`) in
+// `values.type`; V3 adds the DI-convention name as `values.diType`.
+const v2SCType = "DG.GraphView"
+const diType = "graph"
 
 jest.mock("../../../models/tiles/tile-model", () => ({
   getTileModel: jest.fn(() => ({
     id: v3Id,
-    type: v3Type
+    type: v3TileType
   }))
 }))
 
@@ -21,7 +24,8 @@ jest.mock("../../../models/tiles/tile-notifications", () => ({
         operation: updateType,
         ...values,
         id: v2Id,
-        type: v2Type
+        type: v2SCType,
+        diType
       }
     }
   }))
@@ -33,7 +37,7 @@ describe("updateAxisNotification", () => {
     const domain = [0, 10]
     const tileModel = {
       content: {
-        type: v3Type
+        type: v3TileType
       }
     } as any
 
@@ -45,7 +49,8 @@ describe("updateAxisNotification", () => {
     expect(notification?.message.values.operation).toBe(updateType)
     expect(notification?.message.values.newBounds.lower).toBe(domain[0])
     expect(notification?.message.values.newBounds.upper).toBe(domain[1])
-    expect(notification?.message.values.type).toBe(v2Type)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
     expect(notification?.message.values.id).toBe(v2Id)
   })
 })

--- a/v3/src/components/calculator/calculator-notifications.test.ts
+++ b/v3/src/components/calculator/calculator-notifications.test.ts
@@ -31,6 +31,11 @@ describe("calculateNotification", () => {
     expect(notification?.message.values.diType).toBe(diType)
   })
 
+  it("returns undefined for non-calculator tiles (e.g. graph)", () => {
+    const graphTile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    expect(calculateNotification(graphTile)).toBeUndefined()
+  })
+
   it("returns undefined when the calculator tile is missing", () => {
     expect(calculateNotification(undefined)).toBeUndefined()
   })

--- a/v3/src/components/calculator/calculator-notifications.test.ts
+++ b/v3/src/components/calculator/calculator-notifications.test.ts
@@ -1,0 +1,37 @@
+import { calculateNotification } from "./calculator-notifications"
+
+const v2Id = 77001
+// V2 component-resource notifications carry the SC class name (`DG.Calculator`) in
+// `values.type`; V3 adds the DI-convention name as `values.diType`.
+const v2SCType = "DG.Calculator"
+const diType = "calculator"
+
+jest.mock("../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
+    if (!tileModel) return undefined
+    return {
+      message: {
+        action: "notify",
+        resource: "component",
+        values: { operation: updateType, ...values, id: v2Id, type: v2SCType, diType }
+      }
+    }
+  })
+}))
+
+describe("calculateNotification", () => {
+  it("emits a 'calculate' notification on the component resource", () => {
+    const tile = { id: "CALC1", content: { type: "Calculator" } } as any
+    const notification = calculateNotification(tile)
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("calculate")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined when the calculator tile is missing", () => {
+    expect(calculateNotification(undefined)).toBeUndefined()
+  })
+})

--- a/v3/src/components/calculator/calculator-notifications.ts
+++ b/v3/src/components/calculator/calculator-notifications.ts
@@ -1,0 +1,9 @@
+import { ITileModel } from "../../models/tiles/tile-model"
+import { updateTileNotification } from "../../models/tiles/tile-notifications"
+
+// V2 emits { action:'notify', resource:'component', values:{ operation:'calculate', type:'DG.Calculator' } }
+// from apps/dg/components/calculator/calculator.js on both clearValue (~:94) and evaluate (~:156).
+export function calculateNotification(calculatorTile?: ITileModel) {
+  if (!calculatorTile) return
+  return updateTileNotification("calculate", {}, calculatorTile)
+}

--- a/v3/src/components/calculator/calculator-notifications.ts
+++ b/v3/src/components/calculator/calculator-notifications.ts
@@ -1,9 +1,11 @@
 import { ITileModel } from "../../models/tiles/tile-model"
 import { updateTileNotification } from "../../models/tiles/tile-notifications"
+import { kCalculatorTileType } from "./calculator-defs"
 
 // V2 emits { action:'notify', resource:'component', values:{ operation:'calculate', type:'DG.Calculator' } }
 // from apps/dg/components/calculator/calculator.js on both clearValue (~:94) and evaluate (~:156).
+// No-ops for non-calculator tiles so it's safe to call from generic notify callbacks.
 export function calculateNotification(calculatorTile?: ITileModel) {
-  if (!calculatorTile) return
+  if (calculatorTile?.content.type !== kCalculatorTileType) return
   return updateTileNotification("calculate", {}, calculatorTile)
 }

--- a/v3/src/components/calculator/calculator-title-bar.tsx
+++ b/v3/src/components/calculator/calculator-title-bar.tsx
@@ -5,6 +5,7 @@ import { useDocumentContent } from "../../hooks/use-document-content"
 import { ITileTitleBarProps } from "../tiles/tile-base-props"
 import { kCalculatorTileType } from "./calculator-defs"
 import { logStringifiedObjectMessage } from "../../lib/log-message"
+import { componentShowHideNotification } from "../../models/tiles/tile-notifications"
 
 export const CalculatorTitleBar =
   observer(function CalculatorTitleBar({ tile, onCloseTile, ...others }: ITileTitleBarProps) {
@@ -13,11 +14,12 @@ export const CalculatorTitleBar =
       documentContent?.applyModelChange(() => {
         documentContent?.toggleSingletonTileVisibility(kCalculatorTileType)
       }, {
+        notify: () => componentShowHideNotification(tile, "hide"),
         undoStringKey: "DG.Undo.toggleComponent.delete.calcView",
         redoStringKey: "DG.Redo.toggleComponent.delete.calcView",
         log: logStringifiedObjectMessage("Close calculator", { type: kCalculatorTileType}, "component")
       })
-    }, [documentContent])
+    }, [documentContent, tile])
     return (
       <ComponentTitleBar tile={tile} onCloseTile={closeCalculator} {...others} />
     )

--- a/v3/src/components/calculator/calculator-title-bar.tsx
+++ b/v3/src/components/calculator/calculator-title-bar.tsx
@@ -5,16 +5,24 @@ import { useDocumentContent } from "../../hooks/use-document-content"
 import { ITileTitleBarProps } from "../tiles/tile-base-props"
 import { kCalculatorTileType } from "./calculator-defs"
 import { logStringifiedObjectMessage } from "../../lib/log-message"
+import { isFreeTileLayout } from "../../models/document/free-tile-row"
 import { componentShowHideNotification } from "../../models/tiles/tile-notifications"
 
 export const CalculatorTitleBar =
   observer(function CalculatorTitleBar({ tile, onCloseTile, ...others }: ITileTitleBarProps) {
     const documentContent = useDocumentContent()
     const closeCalculator = useCallback(() => {
+      // `toggleSingletonTileVisibility` only actually hides the tile when its layout is
+      // a FreeTileLayout (per document-content.ts:225). In non-free layouts the click is
+      // a no-op visually, so suppress the V2 `hide` notification — emitting it would be
+      // a lie. Other code paths (e.g. tool-shelf re-click) handle this with a fall-through;
+      // here we just skip the notification.
+      const tileLayout = tile && documentContent?.getTileLayoutById(tile.id)
+      const willActuallyHide = isFreeTileLayout(tileLayout)
       documentContent?.applyModelChange(() => {
         documentContent?.toggleSingletonTileVisibility(kCalculatorTileType)
       }, {
-        notify: () => componentShowHideNotification(tile, "hide"),
+        notify: () => willActuallyHide ? componentShowHideNotification(tile, "hide") : undefined,
         undoStringKey: "DG.Undo.toggleComponent.delete.calcView",
         redoStringKey: "DG.Redo.toggleComponent.delete.calcView",
         log: logStringifiedObjectMessage("Close calculator", { type: kCalculatorTileType}, "component")

--- a/v3/src/components/calculator/calculator.tsx
+++ b/v3/src/components/calculator/calculator.tsx
@@ -5,6 +5,7 @@ import { math } from "../../models/formula/functions/math"
 import { preprocessDisplayFormula } from "../../models/formula/utils/canonicalization-utils"
 import { mstAutorun } from "../../utilities/mst-autorun"
 import { ITileBaseProps } from "../tiles/tile-base-props"
+import { calculateNotification } from "./calculator-notifications"
 import { isCalculatorModel } from "./calculator-model"
 
 import "./calculator.scss"
@@ -44,6 +45,7 @@ export const CalculatorComponent = ({ tile }: ITileBaseProps) => {
       calculatorModel?.applyModelChange(() => {
         calculatorModel.setValue()
       }, {
+        notify: () => calculateNotification(tile),
         undoStringKey: "V3.Undo.calculator.clear",
         redoStringKey: "V3.Redo.calculator.clear",
         log: {message: "Calculator value cleared", args: {}, category: "calculator"}
@@ -51,7 +53,7 @@ export const CalculatorComponent = ({ tile }: ITileBaseProps) => {
     }
     // Focus the input after clearing
     inputRef.current?.focus()
-  }, [calculatorModel, isValidModel])
+  }, [calculatorModel, isValidModel, tile])
 
   const insert = useCallback((strToInsert: string) => {
     if (justEvaled) {
@@ -103,6 +105,7 @@ export const CalculatorComponent = ({ tile }: ITileBaseProps) => {
         calculatorModel?.applyModelChange(() => {
           calculatorModel.setValue(solutionStr)
         }, {
+          notify: () => calculateNotification(tile),
           undoStringKey: "V3.Undo.calculator.calculate",
           redoStringKey: "V3.Redo.calculator.calculate",
           log: logMessageWithReplacement("Calculation done: %@ = %@", {calcValue, solution: solutionStr}, "calculator")
@@ -115,6 +118,7 @@ export const CalculatorComponent = ({ tile }: ITileBaseProps) => {
         calculatorModel?.applyModelChange(() => {
           calculatorModel.setValue(errorMessage)
         }, {
+          notify: () => calculateNotification(tile),
           undoStringKey: "V3.Undo.calculator.calculate",
           redoStringKey: "V3.Redo.calculator.calculate",
           log: logMessageWithReplacement("Calculation error: %@ = %@", {calcValue, error: errorMessage}, "calculator")
@@ -122,7 +126,7 @@ export const CalculatorComponent = ({ tile }: ITileBaseProps) => {
       }
     }
     setJustEvaled(true)
-  }, [justEvaled, calcValue, calculatorModel, isValidModel])
+  }, [justEvaled, calcValue, calculatorModel, isValidModel, tile])
 
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     if (justEvaled) {

--- a/v3/src/components/case-card/case-card-notifications.test.ts
+++ b/v3/src/components/case-card/case-card-notifications.test.ts
@@ -31,6 +31,11 @@ describe("changeColumnWidthNotification", () => {
     expect(notification?.message.values.diType).toBe(diType)
   })
 
+  it("returns undefined for non-case-card tiles (e.g. case table)", () => {
+    const tableTile = { id: "TABLE1", content: { type: "CaseTable" } } as any
+    expect(changeColumnWidthNotification(tableTile)).toBeUndefined()
+  })
+
   it("returns undefined when the case-card tile is missing", () => {
     expect(changeColumnWidthNotification(undefined)).toBeUndefined()
   })

--- a/v3/src/components/case-card/case-card-notifications.test.ts
+++ b/v3/src/components/case-card/case-card-notifications.test.ts
@@ -1,0 +1,37 @@
+import { changeColumnWidthNotification } from "./case-card-notifications"
+
+const v2Id = 88001
+// V2 component-resource notifications carry the SC class name (`DG.CaseCard`) in
+// `values.type`; V3 adds the DI-convention name as `values.diType`.
+const v2SCType = "DG.CaseCard"
+const diType = "caseCard"
+
+jest.mock("../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
+    if (!tileModel) return undefined
+    return {
+      message: {
+        action: "notify",
+        resource: "component",
+        values: { operation: updateType, ...values, id: v2Id, type: v2SCType, diType }
+      }
+    }
+  })
+}))
+
+describe("changeColumnWidthNotification", () => {
+  it("emits a 'change column width' notification on the component resource", () => {
+    const tile = { id: "CARD1", content: { type: "CaseCard" } } as any
+    const notification = changeColumnWidthNotification(tile)
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("change column width")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined when the case-card tile is missing", () => {
+    expect(changeColumnWidthNotification(undefined)).toBeUndefined()
+  })
+})

--- a/v3/src/components/case-card/case-card-notifications.ts
+++ b/v3/src/components/case-card/case-card-notifications.ts
@@ -1,10 +1,12 @@
 import { ITileModel } from "../../models/tiles/tile-model"
 import { updateTileNotification } from "../../models/tiles/tile-notifications"
+import { kCaseCardTileType } from "./case-card-defs"
 
 // V2 emits { action:'notify', resource:'component', values:{ operation:'change column width',
 // type:'DG.CaseCard' } } from apps/dg/components/case_card/case_card_view.js (~:119) on
 // completed column-width drag. Payload carries no width/collection — bare operation only.
+// No-ops for non-case-card tiles so it's safe to call from generic notify callbacks.
 export function changeColumnWidthNotification(caseCardTile?: ITileModel) {
-  if (!caseCardTile) return
+  if (caseCardTile?.content.type !== kCaseCardTileType) return
   return updateTileNotification("change column width", {}, caseCardTile)
 }

--- a/v3/src/components/case-card/case-card-notifications.ts
+++ b/v3/src/components/case-card/case-card-notifications.ts
@@ -1,0 +1,10 @@
+import { ITileModel } from "../../models/tiles/tile-model"
+import { updateTileNotification } from "../../models/tiles/tile-notifications"
+
+// V2 emits { action:'notify', resource:'component', values:{ operation:'change column width',
+// type:'DG.CaseCard' } } from apps/dg/components/case_card/case_card_view.js (~:119) on
+// completed column-width drag. Payload carries no width/collection — bare operation only.
+export function changeColumnWidthNotification(caseCardTile?: ITileModel) {
+  if (!caseCardTile) return
+  return updateTileNotification("change column width", {}, caseCardTile)
+}

--- a/v3/src/components/case-card/case-card.tsx
+++ b/v3/src/components/case-card/case-card.tsx
@@ -13,7 +13,9 @@ import { ICoreNotification } from "../../data-interactive/notification-core-type
 import { IDataSet } from "../../models/data/data-set"
 import { ICollectionModel } from "../../models/data/collection"
 import { createCollectionNotification, deleteCollectionNotification } from "../../models/data/data-set-notifications"
+import { getTileModel } from "../../models/tiles/tile-model"
 import { logMessageWithReplacement } from "../../lib/log-message"
+import { changeColumnWidthNotification } from "./case-card-notifications"
 
 import "./case-card.scss"
 
@@ -63,6 +65,7 @@ export const CaseCard = observer(function CaseCard({ setNodeRef }: IProps) {
       data.applyModelChange(() => {
         cardModel.setAttributeColumnWidth(collectionId, widthPct)
       }, {
+        notify: () => changeColumnWidthNotification(getTileModel(cardModel)),
         undoStringKey: "DG.Undo.caseCard.columnWidthChange",
         redoStringKey: "DG.Redo.caseCard.columnWidthChange",
         log: logMessageWithReplacement(

--- a/v3/src/components/case-table/case-table-notifications.test.ts
+++ b/v3/src/components/case-table/case-table-notifications.test.ts
@@ -1,0 +1,42 @@
+import { openCaseTableNotification } from "./case-table-notifications"
+
+const v2Id = 77501
+// V2 component-resource notifications carry the SC class name (`DG.CaseTable`) in
+// `values.type`; V3 adds the DI-convention name as `values.diType`.
+const v2SCType = "DG.CaseTable"
+const diType = "caseTable"
+
+jest.mock("../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
+    if (!tileModel) return undefined
+    return {
+      message: {
+        action: "notify",
+        resource: "component",
+        values: { operation: updateType, ...values, id: v2Id, type: v2SCType, diType }
+      }
+    }
+  })
+}))
+
+describe("openCaseTableNotification", () => {
+  it("emits an 'open case table' notification for case-table tiles", () => {
+    const tile = { id: "TABLE1", content: { type: "CaseTable" } } as any
+    const notification = openCaseTableNotification(tile)
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("open case table")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-case-table tiles (e.g. case card)", () => {
+    const cardTile = { id: "CARD1", content: { type: "CaseCard" } } as any
+    expect(openCaseTableNotification(cardTile)).toBeUndefined()
+  })
+
+  it("returns undefined when no tile is provided", () => {
+    expect(openCaseTableNotification(undefined)).toBeUndefined()
+  })
+})

--- a/v3/src/components/case-table/case-table-notifications.test.ts
+++ b/v3/src/components/case-table/case-table-notifications.test.ts
@@ -1,5 +1,5 @@
 import {
-  openCaseTableNotification, resizeColumnNotification, resizeColumnsNotification
+  expandCollapseAllNotification, openCaseTableNotification, resizeColumnNotification, resizeColumnsNotification
 } from "./case-table-notifications"
 
 const v2Id = 77501
@@ -84,5 +84,41 @@ describe("resizeColumnsNotification", () => {
 
   it("returns undefined when no tile is provided", () => {
     expect(resizeColumnsNotification(undefined)).toBeUndefined()
+  })
+})
+
+describe("expandCollapseAllNotification", () => {
+  it("emits an 'expand/collapse all' notification with `to: expanded` for case-table tiles", () => {
+    const tile = { id: "TABLE1", content: { type: "CaseTable" } } as any
+    const notification = expandCollapseAllNotification(tile, "expanded")
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("expand/collapse all")
+    expect(notification?.message.values.to).toBe("expanded")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("emits `to: collapsed` for the collapse direction", () => {
+    const tile = { id: "TABLE1", content: { type: "CaseTable" } } as any
+    const notification = expandCollapseAllNotification(tile, "collapsed")
+    expect(notification?.message.values.to).toBe("collapsed")
+  })
+
+  it("omits `to` when no direction is provided", () => {
+    const tile = { id: "TABLE1", content: { type: "CaseTable" } } as any
+    const notification = expandCollapseAllNotification(tile)
+    expect(notification?.message.values.operation).toBe("expand/collapse all")
+    expect(notification?.message.values.to).toBeUndefined()
+  })
+
+  it("returns undefined for non-case-table tiles (e.g. case card)", () => {
+    const cardTile = { id: "CARD1", content: { type: "CaseCard" } } as any
+    expect(expandCollapseAllNotification(cardTile, "expanded")).toBeUndefined()
+  })
+
+  it("returns undefined when no tile is provided", () => {
+    expect(expandCollapseAllNotification(undefined, "expanded")).toBeUndefined()
   })
 })

--- a/v3/src/components/case-table/case-table-notifications.test.ts
+++ b/v3/src/components/case-table/case-table-notifications.test.ts
@@ -1,5 +1,6 @@
 import {
-  expandCollapseAllNotification, openCaseTableNotification, resizeColumnNotification, resizeColumnsNotification
+  expandCollapseAllNotification, joinNotification, openCaseTableNotification, resizeColumnNotification,
+  resizeColumnsNotification
 } from "./case-table-notifications"
 
 const v2Id = 77501
@@ -120,5 +121,27 @@ describe("expandCollapseAllNotification", () => {
 
   it("returns undefined when no tile is provided", () => {
     expect(expandCollapseAllNotification(undefined, "expanded")).toBeUndefined()
+  })
+})
+
+describe("joinNotification", () => {
+  it("emits a 'join' notification on the destination case-table tile", () => {
+    const destTile = { id: "TABLE1", content: { type: "CaseTable" } } as any
+    const notification = joinNotification(destTile)
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("join")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-case-table tiles (e.g. case card)", () => {
+    const cardTile = { id: "CARD1", content: { type: "CaseCard" } } as any
+    expect(joinNotification(cardTile)).toBeUndefined()
+  })
+
+  it("returns undefined when no tile is provided", () => {
+    expect(joinNotification(undefined)).toBeUndefined()
   })
 })

--- a/v3/src/components/case-table/case-table-notifications.test.ts
+++ b/v3/src/components/case-table/case-table-notifications.test.ts
@@ -1,4 +1,6 @@
-import { openCaseTableNotification } from "./case-table-notifications"
+import {
+  openCaseTableNotification, resizeColumnNotification, resizeColumnsNotification
+} from "./case-table-notifications"
 
 const v2Id = 77501
 // V2 component-resource notifications carry the SC class name (`DG.CaseTable`) in
@@ -38,5 +40,49 @@ describe("openCaseTableNotification", () => {
 
   it("returns undefined when no tile is provided", () => {
     expect(openCaseTableNotification(undefined)).toBeUndefined()
+  })
+})
+
+describe("resizeColumnNotification", () => {
+  it("emits a 'resize column' notification for case-table tiles", () => {
+    const tile = { id: "TABLE1", content: { type: "CaseTable" } } as any
+    const notification = resizeColumnNotification(tile)
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("resize column")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-case-table tiles (e.g. case card)", () => {
+    const cardTile = { id: "CARD1", content: { type: "CaseCard" } } as any
+    expect(resizeColumnNotification(cardTile)).toBeUndefined()
+  })
+
+  it("returns undefined when no tile is provided", () => {
+    expect(resizeColumnNotification(undefined)).toBeUndefined()
+  })
+})
+
+describe("resizeColumnsNotification", () => {
+  it("emits a 'resize columns' (plural) notification for case-table tiles", () => {
+    const tile = { id: "TABLE1", content: { type: "CaseTable" } } as any
+    const notification = resizeColumnsNotification(tile)
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("resize columns")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-case-table tiles (e.g. case card)", () => {
+    const cardTile = { id: "CARD1", content: { type: "CaseCard" } } as any
+    expect(resizeColumnsNotification(cardTile)).toBeUndefined()
+  })
+
+  it("returns undefined when no tile is provided", () => {
+    expect(resizeColumnsNotification(undefined)).toBeUndefined()
   })
 })

--- a/v3/src/components/case-table/case-table-notifications.ts
+++ b/v3/src/components/case-table/case-table-notifications.ts
@@ -32,3 +32,16 @@ export function resizeColumnsNotification(tile?: ITileModel) {
   if (tile?.content.type !== kCaseTableTileType) return
   return updateTileNotification("resize columns", {}, tile)
 }
+
+// V2 emits `expand/collapse all` (with the literal `/` in the op name) from
+// apps/dg/components/case_table/case_table_view.js (~:2172) on the table-spacer
+// expand-all-or-collapse-all button. A single op covers both directions, and V2's
+// payload carries no expand/collapse discriminator. V3 adds an additive `to` field —
+// the resulting state ("expanded" or "collapsed") — following the discriminator pattern
+// established in PR #2592 (e.g. background image `to: "added"|"removed"`). V2 plugins
+// ignore the extra field; V3-aware plugins can branch on it without inferring state.
+// Payload: { operation:'expand/collapse all', type:'DG.CaseTable', to:'expanded'|'collapsed' }.
+export function expandCollapseAllNotification(tile?: ITileModel, to?: "expanded" | "collapsed") {
+  if (tile?.content.type !== kCaseTableTileType) return
+  return updateTileNotification("expand/collapse all", to ? { to } : {}, tile)
+}

--- a/v3/src/components/case-table/case-table-notifications.ts
+++ b/v3/src/components/case-table/case-table-notifications.ts
@@ -1,0 +1,15 @@
+import { ITileModel } from "../../models/tiles/tile-model"
+import { updateTileNotification } from "../../models/tiles/tile-notifications"
+import { kCaseTableTileType } from "./case-table-defs"
+
+// V2 emits { action:'notify', resource:'component', values:{ operation:'open case table',
+// type:'DG.CaseTable' } } from apps/dg/controllers/document_controller.js (~:1069) in
+// `openCaseTablesForEachContext` — the bulk-open path invoked by Ctrl+Alt+T or by creating
+// a new case-table component via menu. V3 has no bulk-open path; the user-visible analogues
+// are per-dataset open/create actions (tool-shelf, plugin API). Emit here for V2-plugin
+// compat. No-ops for non-case-table tiles so it can be called unconditionally from generic
+// notify callbacks.
+export function openCaseTableNotification(tile?: ITileModel) {
+  if (tile?.content.type !== kCaseTableTileType) return
+  return updateTileNotification("open case table", {}, tile)
+}

--- a/v3/src/components/case-table/case-table-notifications.ts
+++ b/v3/src/components/case-table/case-table-notifications.ts
@@ -13,3 +13,22 @@ export function openCaseTableNotification(tile?: ITileModel) {
   if (tile?.content.type !== kCaseTableTileType) return
   return updateTileNotification("open case table", {}, tile)
 }
+
+// V2 emits `resize column` (singular) from two sites:
+//   - apps/dg/components/case_table/case_table_controller.js (~:906) on the "Fit Width"
+//     attribute-menu item (single-column auto-fit)
+//   - apps/dg/components/case_table/case_table_view.js (~:1926) on user drag-resize
+// Both carry only { operation:'resize column', type:'DG.CaseTable' } — no width/attr info.
+export function resizeColumnNotification(tile?: ITileModel) {
+  if (tile?.content.type !== kCaseTableTileType) return
+  return updateTileNotification("resize column", {}, tile)
+}
+
+// V2 emits `resize columns` (plural) from apps/dg/components/case_table/case_table_controller.js
+// (~:1136) on the "Fit All Columns" inspector button. Payload: { operation:'resize columns',
+// type:'DG.CaseTable' }. Audit §3.5: V2's log at that site has a `%` typo (missing `@`) —
+// V3 must NOT replicate.
+export function resizeColumnsNotification(tile?: ITileModel) {
+  if (tile?.content.type !== kCaseTableTileType) return
+  return updateTileNotification("resize columns", {}, tile)
+}

--- a/v3/src/components/case-table/case-table-notifications.ts
+++ b/v3/src/components/case-table/case-table-notifications.ts
@@ -45,3 +45,15 @@ export function expandCollapseAllNotification(tile?: ITileModel, to?: "expanded"
   if (tile?.content.type !== kCaseTableTileType) return
   return updateTileNotification("expand/collapse all", to ? { to } : {}, tile)
 }
+
+// V2 emits `join` on the component resource from apps/dg/utilities/data_context_utilities.js
+// (~:924) when a user joins attributes from another dataset into a destination case table
+// (drag-drop on an attribute header). V2's payload has a documented bug: `type: DG.CaseTable`
+// is the SC class OBJECT, not the string — what plugins actually receive is malformed (audit
+// §3.5). V3 emits the well-formed string via `updateTileNotification`, which the lifecycle/
+// operational logic in `tileNotification` routes as an operational op (so `type` becomes
+// `'DG.CaseTable'`). No-ops for non-case-table tiles.
+export function joinNotification(destCaseTableTile?: ITileModel) {
+  if (destCaseTableTile?.content.type !== kCaseTableTileType) return
+  return updateTileNotification("join", {}, destCaseTableTile)
+}

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -137,7 +137,6 @@ const CaseTableToolShelfMenuList = observer(
             })
           }
           return (
-            // FIXME: this will create multiple undo entries
             <MenuItem key={`${dataset.dataSet.id}`} className="tool-shelf-menu-item table-menu-item"
               onClick={handleOpenTableForDataset} data-testid={`tool-shelf-table-${tileTitle}`}>
               <TableIcon className="menu-icon case-table-icon"/>

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -25,6 +25,7 @@ import { createOrShowTableOrCardForDataset, createTableOrCardForDataset } from "
 import { CodapModal } from "../codap-modal"
 import { ToolShelfButtonTag } from "../tool-shelf/tool-shelf-button"
 import { kCaseTableTileType } from "./case-table-defs"
+import { openCaseTableNotification } from "./case-table-notifications"
 
 import AlertIcon from "../../assets/icons/icon-alert.svg"
 import TableIcon from "../../assets/icons/icon-table.svg"
@@ -84,7 +85,11 @@ const CaseTableToolShelfMenuList = observer(
       const actualTileId = sharedMetadata.caseTableTileId
       tile = actualTileId ? content.tileMap.get(actualTileId) : undefined
     }, {
-      notify: [ dataContextCountChangedNotification, () => createTileNotification(tile) ],
+      notify: [
+        dataContextCountChangedNotification,
+        () => createTileNotification(tile),
+        () => openCaseTableNotification(tile)
+      ],
       undoStringKey: "V3.Undo.caseTable.create",
       redoStringKey: "V3.Redo.caseTable.create",
       log: {message: "Create New Empty DataSet", args: {}, category: "document"}
@@ -117,10 +122,24 @@ const CaseTableToolShelfMenuList = observer(
         {datasets.map((dataset) => {
           // case table title reflects DataSet title
           const tileTitle = dataset.dataSet.displayTitle
+          // Wrap createOrShow in applyModelChange so the V2-compat `open case table`
+          // notification fires for V2 plugins (CODAP-1353). V2's bulk-open path is undoable
+          // (DG.UndoHistory.execute in document_controller.js:1064), so mirror that here.
+          const handleOpenTableForDataset = () => {
+            let tile: Maybe<ITileModel>
+            document.applyModelChange(() => {
+              tile = createOrShowTableOrCardForDataset(dataset)
+            }, {
+              notify: () => openCaseTableNotification(tile),
+              undoStringKey: "DG.Undo.caseTable.open",
+              redoStringKey: "DG.Redo.caseTable.open",
+              log: "Create caseTable component"
+            })
+          }
           return (
             // FIXME: this will create multiple undo entries
             <MenuItem key={`${dataset.dataSet.id}`} className="tool-shelf-menu-item table-menu-item"
-              onClick={()=>createOrShowTableOrCardForDataset(dataset)} data-testid={`tool-shelf-table-${tileTitle}`}>
+              onClick={handleOpenTableForDataset} data-testid={`tool-shelf-table-${tileTitle}`}>
               <TableIcon className="menu-icon case-table-icon"/>
               {tileTitle}
               <span className="menu-list-button tool-shelf-menu-trash" role="button" tabIndex={0}

--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -7,12 +7,14 @@ import { useDataSetMetadata } from "../../hooks/use-data-set-metadata"
 import { getDragAttributeInfo, useTileDroppable } from "../../hooks/use-drag-drop"
 import { measureText } from "../../hooks/use-measure-text"
 import { useVisibleAttributes } from "../../hooks/use-visible-attributes"
+import { useTileModelContext } from "../../hooks/use-tile-model-context"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { IDataSet } from "../../models/data/data-set"
 import { isAnyChildSelected } from "../../models/data/data-set-utils"
 import { getStringCssVariable } from "../../utilities/css-utils"
 import { preventAttributeMove, preventCollectionReorg } from "../../utilities/plugin-utils"
 import { t } from "../../utilities/translation/translate"
+import { expandCollapseAllNotification } from "./case-table-notifications"
 import { kInputRowKey } from "./case-table-types"
 import { CurvedSplineFill } from "./curved-spline-fill"
 import { CurvedSplineStroke } from "./curved-spline-stroke"
@@ -48,6 +50,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
 }: IProps) {
   const data = useDataSetContext()
   const metadata = useDataSetMetadata()
+  const { tile } = useTileModelContext()
   const parentCollectionId = useParentCollectionContext()
   const parentCollection = parentCollectionId ? data?.getCollection(parentCollectionId) : undefined
   const parentTableModel = useCollectionTableModel(parentCollectionId)
@@ -153,9 +156,12 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
   // }
 
   function handleExpandCollapseAllClick() {
+    // Resulting state — click toggles from current `everyCaseIsCollapsed`.
+    const toState = everyCaseIsCollapsed ? "expanded" : "collapsed"
     metadata?.applyModelChange(() => {
       parentCases?.forEach((value) => metadata?.setIsCollapsed(value.__id__, !everyCaseIsCollapsed))
     }, {
+      notify: () => expandCollapseAllNotification(tile, toState),
       log: logMessageWithReplacement("%@ all",
               { state: everyCaseIsCollapsed ? "Expand" : "Collapse" }, "table"),
       undoStringKey: "DG.Undo.caseTable.groupToggleExpandCollapseAll",

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -14,6 +14,8 @@ import { logStringifiedObjectMessage } from "../../lib/log-message"
 import { IAttribute } from "../../models/data/attribute"
 import { IDataSet } from "../../models/data/data-set"
 import { createAttributesNotification } from "../../models/data/data-set-notifications"
+import { getTileModel } from "../../models/tiles/tile-model"
+import { resizeColumnNotification } from "./case-table-notifications"
 import {
   collectionCaseIdFromIndex, collectionCaseIndexFromId, isAnyChildSelected, selectCases, setSelectedCases
 } from "../../models/data/data-set-utils"
@@ -223,6 +225,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
         caseTableModel?.applyModelChange(() => {
           caseTableModel?.columnWidths.set(attrId, newWidth)
         }, {
+          notify: () => resizeColumnNotification(caseTableModel ? getTileModel(caseTableModel) : undefined),
           log: {message: "Resize one case table column", args:{}, category: "table"},
           undoStringKey: "DG.Undo.caseTable.resizeOneColumn",
           redoStringKey: "DG.Redo.caseTable.resizeOneColumn"

--- a/v3/src/components/case-tile-common/attribute-header-join-target.tsx
+++ b/v3/src/components/case-tile-common/attribute-header-join-target.tsx
@@ -6,6 +6,7 @@ import { flip, offset, shift, useFloating } from "@floating-ui/react"
 import { useCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { getDragAttributeInfo, useTileDroppable } from "../../hooks/use-drag-drop"
+import { useTileModelContext } from "../../hooks/use-tile-model-context"
 import { getJoinTip, joinSourceToDestCollection } from "../../models/data/join-datasets"
 import { kJoinTargetDropZoneBaseId } from "../case-table/case-table-drag-drop"
 import { If } from "../common/if"
@@ -32,6 +33,7 @@ function AttributeHeaderJoinTarget_({
 }: IAttributeHeaderJoinTargetProps) {
   const collectionId = useCollectionContext()
   const destDataSet = useDataSetContext()
+  const { tile: destTile } = useTileModelContext()
   const containerRef = useContext(AttributeHeaderDividerContext)
   const containerElt = containerRef.current
   const { active } = useDndContext()
@@ -72,7 +74,8 @@ function AttributeHeaderJoinTarget_({
       sourceKeyAttributeId: dropSourceAttributeId,
       destDataSet,
       destCollection,
-      destKeyAttributeId: attributeId
+      destKeyAttributeId: attributeId,
+      destTile
     })
   })
 

--- a/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
+++ b/v3/src/components/case-tile-common/attribute-menu/attribute-menu-list.tsx
@@ -10,11 +10,13 @@ import {
 } from "../../../models/data/data-set-notifications"
 import { IAttributeChangeResult } from "../../../models/data/data-set-types"
 import { sortItemsWithCustomUndoRedo } from "../../../models/data/data-set-undo"
+import { getTileModel } from "../../../models/tiles/tile-model"
 import { uiState } from "../../../models/ui-state"
 import {
   allowAttributeDeletion, preventCollectionReorg, preventTopLevelReorg
 } from "../../../utilities/plugin-utils"
 import { t } from "../../../utilities/translation/translate"
+import { resizeColumnNotification } from "../../case-table/case-table-notifications"
 import { kCellPadding } from "../../case-table/case-table-types"
 import { useCaseTableModel } from "../../case-table/use-case-table-model"
 import { findLongestContentWidth } from "../attribute-format-utils"
@@ -88,6 +90,7 @@ const AttributeMenuListComponent = forwardRef<HTMLDivElement, IProps>(
             tableModel?.setColumnWidth(attributeId, longestContentWidth)
           }
         }, {
+          notify: () => resizeColumnNotification(tableModel ? getTileModel(tableModel) : undefined),
           undoStringKey: "DG.Undo.caseTable.resizeColumn",
           redoStringKey: "DG.Redo.caseTable.resizeColumn",
           log: logStringifiedObjectMessage("Fit column width: %@",

--- a/v3/src/components/case-tile-common/case-tile-notifications.test.ts
+++ b/v3/src/components/case-tile-common/case-tile-notifications.test.ts
@@ -1,17 +1,21 @@
 import { toggleCardTableNotification } from "./case-tile-notifications"
 
 const v2Id = 99001
+// V2 component-resource notifications carry the SC class name (`DG.CaseTable` / `DG.CaseCard`)
+// in `values.type`; V3 adds the DI-convention name as `values.diType`.
 
 jest.mock("../../models/tiles/tile-notifications", () => ({
   updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
     if (!tileModel) return undefined
+    const isCaseTable = tileModel.content.type === "CaseTable"
     return {
       message: {
         action: "notify",
         resource: "component",
         values: {
           operation: updateType, ...values, id: v2Id,
-          type: tileModel.content.type === "CaseTable" ? "DG.CaseTable" : "DG.CaseCard"
+          type: isCaseTable ? "DG.CaseTable" : "DG.CaseCard",
+          diType: isCaseTable ? "caseTable" : "caseCard"
         }
       }
     }
@@ -25,6 +29,7 @@ describe("toggleCardTableNotification", () => {
     expect(notification?.message.resource).toBe("component")
     expect(notification?.message.values.operation).toBe("toggle table to card")
     expect(notification?.message.values.type).toBe("DG.CaseTable")
+    expect(notification?.message.values.diType).toBe("caseTable")
   })
 
   it("emits 'toggle card to table' when toggling from a case card", () => {
@@ -32,6 +37,7 @@ describe("toggleCardTableNotification", () => {
     const notification = toggleCardTableNotification(tile)
     expect(notification?.message.values.operation).toBe("toggle card to table")
     expect(notification?.message.values.type).toBe("DG.CaseCard")
+    expect(notification?.message.values.diType).toBe("caseCard")
   })
 
   it("returns undefined when the tile is missing", () => {

--- a/v3/src/components/case-tile-common/inspector-panel/case-tile-inspector.tsx
+++ b/v3/src/components/case-tile-common/inspector-panel/case-tile-inspector.tsx
@@ -4,6 +4,7 @@ import { DataSetContext } from "../../../hooks/use-data-set-context"
 import { DataSetMetadataContext } from "../../../hooks/use-data-set-metadata"
 import { t } from "../../../utilities/translation/translate"
 import { ICaseTableModel, isCaseTableModel } from "../../case-table/case-table-model"
+import { resizeColumnsNotification } from "../../case-table/case-table-notifications"
 import { resizeAllColumns } from "../../case-table/case-table-utils"
 import { InspectorButton, InspectorMenu, InspectorPanel } from "../../inspector-panel"
 import { ITileInspectorPanelProps } from "../../tiles/tile-base-props"
@@ -46,6 +47,7 @@ export const CaseTileInspector = ({ tile, show, showResizeColumnsButton }: IProp
     tableModel.applyModelChange(() => {
       resizeAllColumns(tableModel)
     }, {
+      notify: () => resizeColumnsNotification(tile),
       log: {message: "Resize all columns", args:{}, category: "table"},
       undoStringKey: "DG.Undo.caseTable.resizeColumns",
       redoStringKey: "DG.Redo.caseTable.resizeColumns"

--- a/v3/src/components/common/edit-formula-notifications.test.ts
+++ b/v3/src/components/common/edit-formula-notifications.test.ts
@@ -1,7 +1,10 @@
 import { editFormulaNotification } from "./edit-formula-notifications"
 
 const v2Id = 54321
-const v2Type = "DG.CaseTable"
+// V2 component-resource notifications carry the SC class name (`DG.CaseTable`) in
+// `values.type`; V3 adds the DI-convention name as `values.diType`.
+const v2SCType = "DG.CaseTable"
+const diType = "caseTable"
 
 jest.mock("../../models/tiles/tile-notifications", () => ({
   updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
@@ -10,7 +13,7 @@ jest.mock("../../models/tiles/tile-notifications", () => ({
       message: {
         action: "notify",
         resource: "component",
-        values: { operation: updateType, ...values, id: v2Id, type: v2Type }
+        values: { operation: updateType, ...values, id: v2Id, type: v2SCType, diType }
       }
     }
   })
@@ -24,7 +27,8 @@ describe("editFormulaNotification", () => {
     expect(notification?.message.resource).toBe("component")
     expect(notification?.message.values.operation).toBe("edit formula")
     expect(notification?.message.values.id).toBe(v2Id)
-    expect(notification?.message.values.type).toBe(v2Type)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
   })
 
   it("returns undefined when the case-table tile is missing", () => {

--- a/v3/src/components/slider/editable-slider-value.tsx
+++ b/v3/src/components/slider/editable-slider-value.tsx
@@ -2,11 +2,13 @@ import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
 import { isAlive } from "mobx-state-tree"
 import React, { useState, useEffect } from "react"
+import { useTileModelContext } from "../../hooks/use-tile-model-context"
 import { convertToDate } from "../../utilities/date-utils"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { t } from "../../utilities/translation/translate"
 import { MultiScale } from "../axis/models/multi-scale"
 import { ISliderModel } from "./slider-model"
+import { changeSliderValueNotification } from "./slider-notifications"
 import { valueChangeNotification } from "./slider-utils"
 import { useSliderAxisAnimation } from "./use-slider-axis-animation"
 
@@ -21,6 +23,7 @@ interface IProps {
 export const EditableSliderValue = observer(function EditableSliderValue({sliderModel, multiScale,
     onStatusMessage}: IProps) {
   const [candidate, setCandidate] = useState("")
+  const { tile } = useTileModelContext()
   const { animateAxisToEncompass } = useSliderAxisAnimation(sliderModel)
 
   useEffect(() => {
@@ -62,7 +65,10 @@ export const EditableSliderValue = observer(function EditableSliderValue({slider
     const inputValue = parseValue(e.target.value)
     if (isFinite(inputValue)) {
       animateAxisToEncompass(inputValue, {
-        notify: () => valueChangeNotification(sliderModel.value, sliderModel.name),
+        notify: [
+          () => valueChangeNotification(sliderModel.value, sliderModel.name),
+          () => changeSliderValueNotification(tile, sliderModel.value)
+        ],
         undoStringKey: "DG.Undo.slider.change",
         redoStringKey: "DG.Redo.slider.change",
         log: logMessageWithReplacement("sliderEdit: { expression: %@ = %@ }",

--- a/v3/src/components/slider/slider-component.tsx
+++ b/v3/src/components/slider/slider-component.tsx
@@ -21,6 +21,7 @@ import { ITileBaseProps } from "../tiles/tile-base-props"
 import { EditableSliderValue } from "./editable-slider-value"
 import { SliderAxisLayout } from "./slider-layout"
 import { isSliderModel } from "./slider-model"
+import { changeSliderValueNotification } from "./slider-notifications"
 import { CodapSliderThumb } from "./slider-thumb"
 import { kSliderClass } from "./slider-types"
 import { valueChangeNotification } from "./slider-utils"
@@ -78,13 +79,18 @@ export const SliderComponent = observer(function SliderComponent({ tile } : ITil
     sliderModel.applyModelChange(
       () => sliderModel.setValue(values[0]),
       {
+        // V2 emits `change slider value` on mouseUp after drag (slider_view.js:330).
+        // Mirror that here. The during-drag handleChange above continues to fire the
+        // `global[<name>]` notification per tick, which V2 also does via the model
+        // observer; the component-resource notification fires only on drag completion.
+        notify: () => changeSliderValueNotification(tile, values[0]),
         undoStringKey: "DG.Undo.slider.change",
         redoStringKey: "DG.Redo.slider.change",
         log: logMessageWithReplacement("sliderThumbDrag: { name: %@ = value: %@ }",
               { name: sliderModel.name, value: values[0] }, "slider")
       }
     )
-  }, [sliderModel])
+  }, [sliderModel, tile])
 
   const numberFormatter = useMemo(() => new Intl.NumberFormat(), [])
 

--- a/v3/src/components/slider/slider-notifications.test.ts
+++ b/v3/src/components/slider/slider-notifications.test.ts
@@ -1,0 +1,56 @@
+import { changeSliderValueNotification } from "./slider-notifications"
+
+const v2Id = 66001
+// V2 component-resource notifications carry the SC class name (`DG.SliderView`) in
+// `values.type`; V3 adds the DI-convention name as `values.diType`.
+const v2SCType = "DG.SliderView"
+const diType = "slider"
+
+jest.mock("../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
+    if (!tileModel) return undefined
+    return {
+      message: {
+        action: "notify",
+        resource: "component",
+        values: { operation: updateType, ...values, id: v2Id, type: v2SCType, diType }
+      }
+    }
+  })
+}))
+
+describe("changeSliderValueNotification", () => {
+  it("emits a 'change slider value' notification with `to: value` for slider tiles", () => {
+    const tile = { id: "SLIDER1", content: { type: "CodapSlider" } } as any
+    const notification = changeSliderValueNotification(tile, 3.14)
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("change slider value")
+    expect(notification?.message.values.to).toBe(3.14)
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("includes `to: 0` (not omitted) when value is zero", () => {
+    const tile = { id: "SLIDER1", content: { type: "CodapSlider" } } as any
+    const notification = changeSliderValueNotification(tile, 0)
+    expect(notification?.message.values.to).toBe(0)
+  })
+
+  it("omits `to` when no value is provided", () => {
+    const tile = { id: "SLIDER1", content: { type: "CodapSlider" } } as any
+    const notification = changeSliderValueNotification(tile)
+    expect(notification?.message.values.operation).toBe("change slider value")
+    expect(notification?.message.values.to).toBeUndefined()
+  })
+
+  it("returns undefined for non-slider tiles (e.g. graph)", () => {
+    const graphTile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    expect(changeSliderValueNotification(graphTile, 3.14)).toBeUndefined()
+  })
+
+  it("returns undefined when no tile is provided", () => {
+    expect(changeSliderValueNotification(undefined, 3.14)).toBeUndefined()
+  })
+})

--- a/v3/src/components/slider/slider-notifications.ts
+++ b/v3/src/components/slider/slider-notifications.ts
@@ -1,0 +1,18 @@
+import { ITileModel } from "../../models/tiles/tile-model"
+import { updateTileNotification } from "../../models/tiles/tile-notifications"
+import { kSliderTileType } from "./slider-defs"
+
+// V2 emits `change slider value` on the component resource from two sites:
+//   - apps/dg/components/slider/slider_controller.js (~:225) when the editable value is set
+//   - apps/dg/components/slider/slider_view.js (~:330) on `mouseUp` after thumb drag
+// V2's payload is bare ({ operation, type:'DG.SliderView' }) — no value, no name. V3 adds
+// the new value as an additive `to` field (same discriminator pattern as `expand/collapse
+// all` and PR #2592's background-image notifications), so V3-aware plugins don't have to
+// make a separate API request just to read the resulting value. V2 plugins ignore the
+// extra field. V2 also emits the global `global[<name>]` notification from the model
+// observer; V3 already mirrors that via `valueChangeNotification` in slider-utils.ts.
+// No-ops for non-slider tiles so it's safe to call from generic notify callbacks.
+export function changeSliderValueNotification(sliderTile?: ITileModel, value?: number) {
+  if (sliderTile?.content.type !== kSliderTileType) return
+  return updateTileNotification("change slider value", value != null ? { to: value } : {}, sliderTile)
+}

--- a/v3/src/components/text/text-notifications.test.ts
+++ b/v3/src/components/text/text-notifications.test.ts
@@ -1,9 +1,11 @@
-import { kV2TextDIType } from "./text-defs"
 import { TextModel } from "./text-model"
 import { commitEditNotification } from "./text-notifications"
 
 const v2Id = 12345
-const v2Type = kV2TextDIType
+// V2 component-resource notifications carry the SC class name (`DG.TextView`) in
+// `values.type`; V3 adds the DI-convention name as `values.diType`.
+const v2SCType = "DG.TextView"
+const diType = "text"
 
 jest.mock("../../models/tiles/tile-notifications", () => ({
   updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
@@ -16,7 +18,8 @@ jest.mock("../../models/tiles/tile-notifications", () => ({
           operation: updateType,
           ...values,
           id: v2Id,
-          type: v2Type
+          type: v2SCType,
+          diType
         }
       }
     }
@@ -36,7 +39,8 @@ describe("commitEditNotification", () => {
     expect(notification?.message.values.operation).toBe("commitEdit")
     expect(notification?.message.values.title).toBe("Notes")
     expect(notification?.message.values.id).toBe(v2Id)
-    expect(notification?.message.values.type).toBe(v2Type)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
     // V2 contract: text is JSON.stringify of the slate exchange value, not plain text
     const text = notification?.message.values.text
     expect(typeof text).toBe("string")

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -15,8 +15,10 @@ import GuideIcon from "../../assets/icons/icon-guide.svg"
 import { DEBUG_UNDO } from "../../lib/debug"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { IDocumentModel } from "../../models/document/document"
+import { isFreeTileLayout } from "../../models/document/free-tile-row"
+import { getTileContentInfo } from "../../models/tiles/tile-content-info"
 import { ITileModel } from "../../models/tiles/tile-model"
-import { createTileNotification } from "../../models/tiles/tile-notifications"
+import { componentShowHideNotification, createTileNotification } from "../../models/tiles/tile-notifications"
 import { persistentState } from "../../models/persistent-state"
 import { uiState } from "../../models/ui-state"
 import { t } from "../../utilities/translation/translate"
@@ -133,13 +135,24 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
 
   function handleTileButtonClick(tileType: string) {
     const tileInfo = getTileComponentInfo(tileType)
+    const isSingleton = !!getTileContentInfo(tileType)?.isSingleton
     const { undoStringKey = "", redoStringKey = "" } = tileInfo?.shelf || {}
     let tile: Maybe<ITileModel>
+    // For singletons, V2 emits `hide`/`show` rather than `create` (the operation reflects
+    // the resulting visible state, not whether the tile was newly created). For
+    // non-singletons V2 emits `create`. We mirror that per-op convention (CODAP-1353).
+    let resultingShowHide: "show" | "hide" | undefined
     document?.content?.applyModelChange(() => {
       tile = document?.content?.createOrShowTile?.(tileType, { animateCreation: true })
       if (tile) tileInfo?.shelf?.afterCreate?.(tile.content)
+      if (isSingleton && tile) {
+        const layout = document?.content?.getTileLayoutById(tile.id)
+        resultingShowHide = isFreeTileLayout(layout) && layout.isHidden ? "hide" : "show"
+      }
     }, {
-      notify: () => createTileNotification(tile),
+      notify: () => isSingleton
+        ? componentShowHideNotification(tile, resultingShowHide ?? "show")
+        : createTileNotification(tile),
       undoStringKey,
       redoStringKey,
       log: logMessageWithReplacement("Create component: %@", {tileType}, "component")

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -139,19 +139,28 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
   function handleTileButtonClick(tileType: string) {
     const tileInfo = getTileComponentInfo(tileType)
     const isSingleton = !!getTileContentInfo(tileType)?.isSingleton
+    const diType = kComponentTypeV3ToV2Map[tileType]
+    // Only take the V2-compat singleton path when the tile is both a singleton AND has
+    // a V2 type mapping. Singletons without a V2 mapping (e.g. test-only tile types or
+    // future tile types not yet registered with V2) fall back to the generic
+    // create-notification path so we don't generate broken
+    // `DG.Undo.toggleComponent.{add,delete}.<V3-name>` translation keys or emit
+    // notifications with undefined `type`/`diType`.
+    const useSingletonV2Path = isSingleton && !!diType
+
     let undoStringKey = tileInfo?.shelf?.undoStringKey ?? ""
     let redoStringKey = tileInfo?.shelf?.redoStringKey ?? ""
     let log: ReturnType<typeof logMessageWithReplacement> | string =
       logMessageWithReplacement("Create component: %@", {tileType}, "component")
 
-    // For singletons, V2 emits `hide`/`show` rather than `create` (the op reflects the
-    // resulting visible state, not whether the tile was newly created). Compute the
-    // resulting state ahead of time so we can pick V2's matching add/delete undo strings
-    // and log message — `DG.{Undo,Redo}.toggleComponent.{add,delete}.{lifecycleName}` per
-    // document_controller.js:1644-1666. lifecycleName comes from the V2 lifecycle-name
-    // override (calculator → 'calcView') with DI-name fallback.
+    // For singletons with a V2 mapping, V2 emits `hide`/`show` rather than `create` (the
+    // op reflects the resulting visible state). Compute the resulting state ahead of time
+    // so we can pick V2's matching add/delete undo strings — `DG.{Undo,Redo}.
+    // toggleComponent.{add,delete}.{lifecycleName}` per document_controller.js:1644-1666.
+    // lifecycleName comes from the V2 lifecycle-name override (calculator → 'calcView')
+    // with DI-name fallback.
     let resultingShowHide: "show" | "hide" | undefined
-    if (isSingleton) {
+    if (useSingletonV2Path) {
       const existingTiles = document?.content?.getTilesOfType(tileType) ?? []
       if (existingTiles.length > 0) {
         const existingLayout = document?.content?.getTileLayoutById(existingTiles[0].id)
@@ -159,8 +168,8 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
       } else {
         resultingShowHide = "show"
       }
-      const diType = kComponentTypeV3ToV2Map[tileType]
-      const lifecycleName = (diType && kV2DITypeToLifecycleNameMap[diType]) ?? diType ?? tileType
+      // diType is guaranteed truthy here (gated by useSingletonV2Path).
+      const lifecycleName = kV2DITypeToLifecycleNameMap[diType!] ?? diType!
       const action = resultingShowHide === "hide" ? "delete" : "add"
       undoStringKey = `DG.Undo.toggleComponent.${action}.${lifecycleName}`
       redoStringKey = `DG.Redo.toggleComponent.${action}.${lifecycleName}`
@@ -174,7 +183,7 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
       tile = document?.content?.createOrShowTile?.(tileType, { animateCreation: true })
       if (tile) tileInfo?.shelf?.afterCreate?.(tile.content)
     }, {
-      notify: () => isSingleton
+      notify: () => useSingletonV2Path
         ? componentShowHideNotification(tile, resultingShowHide ?? "show")
         : createTileNotification(tile),
       undoStringKey,

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -14,6 +14,9 @@ import TileListIcon from "../../assets/icons/icon-tile-list.svg"
 import GuideIcon from "../../assets/icons/icon-guide.svg"
 import { DEBUG_UNDO } from "../../lib/debug"
 import { logMessageWithReplacement } from "../../lib/log-message"
+import {
+  kComponentTypeV3ToV2Map, kV2DITypeToLifecycleNameMap
+} from "../../data-interactive/data-interactive-component-types"
 import { IDocumentModel } from "../../models/document/document"
 import { isFreeTileLayout } from "../../models/document/free-tile-row"
 import { getTileContentInfo } from "../../models/tiles/tile-content-info"
@@ -136,26 +139,47 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
   function handleTileButtonClick(tileType: string) {
     const tileInfo = getTileComponentInfo(tileType)
     const isSingleton = !!getTileContentInfo(tileType)?.isSingleton
-    const { undoStringKey = "", redoStringKey = "" } = tileInfo?.shelf || {}
-    let tile: Maybe<ITileModel>
-    // For singletons, V2 emits `hide`/`show` rather than `create` (the operation reflects
-    // the resulting visible state, not whether the tile was newly created). For
-    // non-singletons V2 emits `create`. We mirror that per-op convention (CODAP-1353).
+    let undoStringKey = tileInfo?.shelf?.undoStringKey ?? ""
+    let redoStringKey = tileInfo?.shelf?.redoStringKey ?? ""
+    let log: ReturnType<typeof logMessageWithReplacement> | string =
+      logMessageWithReplacement("Create component: %@", {tileType}, "component")
+
+    // For singletons, V2 emits `hide`/`show` rather than `create` (the op reflects the
+    // resulting visible state, not whether the tile was newly created). Compute the
+    // resulting state ahead of time so we can pick V2's matching add/delete undo strings
+    // and log message — `DG.{Undo,Redo}.toggleComponent.{add,delete}.{lifecycleName}` per
+    // document_controller.js:1644-1666. lifecycleName comes from the V2 lifecycle-name
+    // override (calculator → 'calcView') with DI-name fallback.
     let resultingShowHide: "show" | "hide" | undefined
+    if (isSingleton) {
+      const existingTiles = document?.content?.getTilesOfType(tileType) ?? []
+      if (existingTiles.length > 0) {
+        const existingLayout = document?.content?.getTileLayoutById(existingTiles[0].id)
+        resultingShowHide = isFreeTileLayout(existingLayout) && existingLayout.isHidden ? "show" : "hide"
+      } else {
+        resultingShowHide = "show"
+      }
+      const diType = kComponentTypeV3ToV2Map[tileType]
+      const lifecycleName = (diType && kV2DITypeToLifecycleNameMap[diType]) ?? diType ?? tileType
+      const action = resultingShowHide === "hide" ? "delete" : "add"
+      undoStringKey = `DG.Undo.toggleComponent.${action}.${lifecycleName}`
+      redoStringKey = `DG.Redo.toggleComponent.${action}.${lifecycleName}`
+      log = action === "add"
+        ? `Add toggle component: ${lifecycleName}`
+        : `Remove toggle component: ${lifecycleName}`
+    }
+
+    let tile: Maybe<ITileModel>
     document?.content?.applyModelChange(() => {
       tile = document?.content?.createOrShowTile?.(tileType, { animateCreation: true })
       if (tile) tileInfo?.shelf?.afterCreate?.(tile.content)
-      if (isSingleton && tile) {
-        const layout = document?.content?.getTileLayoutById(tile.id)
-        resultingShowHide = isFreeTileLayout(layout) && layout.isHidden ? "hide" : "show"
-      }
     }, {
       notify: () => isSingleton
         ? componentShowHideNotification(tile, resultingShowHide ?? "show")
         : createTileNotification(tile),
       undoStringKey,
       redoStringKey,
-      log: logMessageWithReplacement("Create component: %@", {tileType}, "component")
+      log
     })
   }
 

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -169,7 +169,7 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
         resultingShowHide = "show"
       }
       // diType is guaranteed truthy here (gated by useSingletonV2Path).
-      const lifecycleName = kV2DITypeToLifecycleNameMap[diType!] ?? diType!
+      const lifecycleName = kV2DITypeToLifecycleNameMap[diType] ?? diType
       const action = resultingShowHide === "hide" ? "delete" : "add"
       undoStringKey = `DG.Undo.toggleComponent.${action}.${lifecycleName}`
       redoStringKey = `DG.Redo.toggleComponent.${action}.${lifecycleName}`

--- a/v3/src/components/tool-shelf/tool-shelf.tsx
+++ b/v3/src/components/tool-shelf/tool-shelf.tsx
@@ -140,35 +140,46 @@ export const ToolShelf = observer(function ToolShelf({ document }: IProps) {
     const tileInfo = getTileComponentInfo(tileType)
     const isSingleton = !!getTileContentInfo(tileType)?.isSingleton
     const diType = kComponentTypeV3ToV2Map[tileType]
-    // Only take the V2-compat singleton path when the tile is both a singleton AND has
-    // a V2 type mapping. Singletons without a V2 mapping (e.g. test-only tile types or
-    // future tile types not yet registered with V2) fall back to the generic
-    // create-notification path so we don't generate broken
-    // `DG.Undo.toggleComponent.{add,delete}.<V3-name>` translation keys or emit
-    // notifications with undefined `type`/`diType`.
-    const useSingletonV2Path = isSingleton && !!diType
+
+    // Compute the V2-compat singleton path's preconditions and resulting state up front.
+    // We take the singleton path only when ALL of these hold:
+    //   - tile is a singleton (`isSingleton`)
+    //   - there's a V2 type mapping (`diType`) — otherwise undo keys + notification
+    //     `type`/`diType` would be undefined
+    //   - the toggle will actually change visibility — `toggleSingletonTileVisibility`
+    //     gates `setHidden` on `isFreeTileLayout` (document-content.ts:225), so in
+    //     mosaic/legacy layouts the click is a no-op visually. Emitting V2 hide/show in
+    //     that case would lie about what happened.
+    // When any precondition fails we fall back to the generic create-notification path.
+    let useSingletonV2Path = isSingleton && !!diType
+    let resultingShowHide: "show" | "hide" | undefined
+    if (useSingletonV2Path) {
+      const existingTiles = document?.content?.getTilesOfType(tileType) ?? []
+      if (existingTiles.length > 0) {
+        const existingLayout = document?.content?.getTileLayoutById(existingTiles[0].id)
+        if (isFreeTileLayout(existingLayout)) {
+          resultingShowHide = existingLayout.isHidden ? "show" : "hide"
+        } else {
+          // Non-free layout — toggleSingletonTileVisibility won't toggle visibility.
+          useSingletonV2Path = false
+        }
+      } else {
+        // No existing tile — `createTile` runs and the singleton appears.
+        resultingShowHide = "show"
+      }
+    }
 
     let undoStringKey = tileInfo?.shelf?.undoStringKey ?? ""
     let redoStringKey = tileInfo?.shelf?.redoStringKey ?? ""
     let log: ReturnType<typeof logMessageWithReplacement> | string =
       logMessageWithReplacement("Create component: %@", {tileType}, "component")
 
-    // For singletons with a V2 mapping, V2 emits `hide`/`show` rather than `create` (the
-    // op reflects the resulting visible state). Compute the resulting state ahead of time
-    // so we can pick V2's matching add/delete undo strings — `DG.{Undo,Redo}.
-    // toggleComponent.{add,delete}.{lifecycleName}` per document_controller.js:1644-1666.
-    // lifecycleName comes from the V2 lifecycle-name override (calculator → 'calcView')
-    // with DI-name fallback.
-    let resultingShowHide: "show" | "hide" | undefined
+    // For singletons with a V2 mapping in a hideable layout, V2 emits `hide`/`show`
+    // rather than `create` (the op reflects the resulting visible state). Use V2's
+    // matching add/delete undo strings — `DG.{Undo,Redo}.toggleComponent.{add,delete}.
+    // {lifecycleName}` per document_controller.js:1644-1666. lifecycleName comes from
+    // the V2 lifecycle-name override (calculator → 'calcView') with DI-name fallback.
     if (useSingletonV2Path) {
-      const existingTiles = document?.content?.getTilesOfType(tileType) ?? []
-      if (existingTiles.length > 0) {
-        const existingLayout = document?.content?.getTileLayoutById(existingTiles[0].id)
-        resultingShowHide = isFreeTileLayout(existingLayout) && existingLayout.isHidden ? "show" : "hide"
-      } else {
-        resultingShowHide = "show"
-      }
-      // diType is guaranteed truthy here (gated by useSingletonV2Path).
       const lifecycleName = kV2DITypeToLifecycleNameMap[diType] ?? diType
       const action = resultingShowHide === "hide" ? "delete" : "add"
       undoStringKey = `DG.Undo.toggleComponent.${action}.${lifecycleName}`

--- a/v3/src/components/web-view/web-view-registration.ts
+++ b/v3/src/components/web-view/web-view-registration.ts
@@ -21,6 +21,7 @@ import {
   kWebViewTileType, WebViewSubType
 } from "./web-view-defs"
 import { isWebViewModel, IWebViewSnapshot, WebViewModel } from "./web-view-model"
+import { kSubTypeToV2TypeMap, webViewV2Type } from "./web-view-types"
 import { WebViewComponent } from "./web-view"
 import { WebViewInspector } from "./web-view-inspector"
 import { WebViewTitleBar } from "./web-view-title-bar"
@@ -53,7 +54,7 @@ registerTileContentInfo({
   defaultContent: () => ({ type: kWebViewTileType }),
   defaultName: () => t("DG.WebView.defaultTitle"),
   getTitle: (tile) => tile.title || t("DG.WebView.defaultTitle"),
-  getV2Type: (content) => isWebViewModel(content) && content.isPlugin ? kV2GameType : kV2WebViewType
+  getV2Type: webViewV2Type
 })
 
 registerTileComponentInfo({
@@ -290,12 +291,7 @@ const webViewComponentHandler: DIComponentHandler = {
 
   get(content) {
     if (isWebViewModel(content)) {
-      const subTypeToV2TypeMap: Record<WebViewSubType, string> = {
-        guide: kV2GuideViewType,
-        image: kV2ImageComponentViewType,
-        plugin: kV2GameType
-      }
-      const type = (content.subType && subTypeToV2TypeMap[content.subType]) ?? kV2WebViewType
+      const type = (content.subType && kSubTypeToV2TypeMap[content.subType]) ?? kV2WebViewType
 
       // Return guide-specific properties
       if (content.isGuide) {

--- a/v3/src/components/web-view/web-view-types.ts
+++ b/v3/src/components/web-view/web-view-types.ts
@@ -1,0 +1,20 @@
+import { ITileContentModel } from "../../models/tiles/tile-content"
+import {
+  kV2GameType, kV2GuideViewType, kV2ImageComponentViewType, kV2WebViewType, WebViewSubType
+} from "./web-view-defs"
+import { isWebViewModel } from "./web-view-model"
+
+// V3 collapses V2's GameView / GuideView / ImageComponentView / WebView into a single
+// CodapWebView tile type, then routes the V2 type per content.subType. Shared by the
+// WebView DI handler's `get` path and by `getV2Type` so notifications and API responses
+// agree on the V2 type for the same content (CODAP-1353).
+export const kSubTypeToV2TypeMap: Record<WebViewSubType, string> = {
+  guide: kV2GuideViewType,
+  image: kV2ImageComponentViewType,
+  plugin: kV2GameType
+}
+
+export function webViewV2Type(content: ITileContentModel) {
+  if (!isWebViewModel(content)) return kV2WebViewType
+  return (content.subType && kSubTypeToV2TypeMap[content.subType]) ?? kV2WebViewType
+}

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -24,6 +24,29 @@ export const kComponentTypeV3ToV2Map: Record<string, string> = {
   [kWebViewTileType]: kV2WebViewType
 }
 
+// For V2-plugin compatibility. V2 is internally inconsistent: it sends the lowercase
+// DI-convention name (`"calculator"`) in `get component/<id>` API responses — translated by
+// `data_interactive_phone_handler.js:1718` — but the SC class name (`"DG.Calculator"`) in
+// the `type` field of component-resource notification payloads (e.g.
+// apps/dg/components/calculator/calculator.js:99 emits `type: 'DG.Calculator'`). Each V2
+// `executeNotification` block hard-codes the SC name with no translation. Arguably the V2
+// notification path should have used the same translation table the API path does, but
+// that's water under the bridge; V2 plugins in the wild filter notifications on the SC name.
+// V3's `tileNotification` therefore emits the SC name as `values.type` (for V2-plugin
+// matching) and the DI-convention name as `values.diType` (additive). V3 collapses
+// WebView/Game/Guide/Image into a single tile type; this mapping uses the generic
+// `DG.WebView` for all of them.
+export const kComponentTypeV3ToV2SCNameMap: Record<string, string> = {
+  [kCalculatorTileType]: "DG.Calculator",
+  [kCaseTableTileType]: "DG.CaseTable",
+  [kCaseCardTileType]: "DG.CaseCard",
+  [kGraphTileType]: "DG.GraphView",
+  [kMapTileType]: "DG.MapView",
+  [kSliderTileType]: "DG.SliderView",
+  [kTextTileType]: "DG.TextView",
+  [kWebViewTileType]: "DG.WebView"
+}
+
 export const kComponentTypeV2ToV3Map: Record<string, string> = {
   [kV2GameType]: kWebViewTileType,
   [kV2GuideViewType]: kWebViewTileType,

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -45,7 +45,7 @@ export const kComponentTypeV3ToV2Map: Record<string, string> = {
 // resolves the DI type at runtime via `getTileContentInfo(type)?.getV2Type?.(content)`
 // (e.g. WebView returns `'game'` when `isPlugin`), so the SC mapping needs to follow the
 // runtime-resolved DI type, not the static V3 tile type. This map covers all DI types
-// V3 may emit, including the WebView subtypes (game / guideView / imageComponent).
+// V3 may emit, including the WebView subtypes (game / guideView / imageComponentView).
 export const kV2DITypeToSCNameMap: Record<string, string> = {
   calculator: "DG.Calculator",
   caseTable: "DG.CaseTable",
@@ -57,19 +57,22 @@ export const kV2DITypeToSCNameMap: Record<string, string> = {
   webView: "DG.WebView",
   game: "DG.GameView",
   guideView: "DG.GuideView",
-  imageComponent: "DG.ImageComponentView"
+  imageComponentView: "DG.ImageComponentView"
 }
 
 // V2's lifecycle `type` strings sometimes differ from its DI-API names. Verified V2
-// sources: app_controller.js:122 (`'table'` for case-table create/delete) and
-// document_controller.js:587, 1649 (`'calcView'` for calculator hide/show). Everything
-// else lines up with the DI name — graph, map, slider, text, webView, etc.
+// sources: app_controller.js:122 (`'table'` for case-table create/delete);
+// document_controller.js:587, 1649 (`'calcView'` for calculator hide/show); and
+// document_controller.js (`'imageComponent'` for image-component create/delete via
+// `makeComponentNotification('create', 'imageComponent')`). Everything else lines up
+// with the DI name — graph, map, slider, text, webView, etc.
 //
 // Keys are V2 DI types; values are V2's lifecycle-notification `type` strings. Anything
 // not listed uses its DI name verbatim for lifecycle ops.
 export const kV2DITypeToLifecycleNameMap: Record<string, string> = {
   caseTable: "table",
-  calculator: "calcView"
+  calculator: "calcView",
+  imageComponentView: "imageComponent"
 }
 
 export const kComponentTypeV2ToV3Map: Record<string, string> = {

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -24,18 +24,25 @@ export const kComponentTypeV3ToV2Map: Record<string, string> = {
   [kWebViewTileType]: kV2WebViewType
 }
 
-// For V2-plugin compatibility. V2 is internally inconsistent: it sends the lowercase
-// DI-convention name (`"calculator"`) in `get component/<id>` API responses — translated by
-// `data_interactive_phone_handler.js:1718` — but the SC class name (`"DG.Calculator"`) in
-// the `type` field of component-resource notification payloads (e.g.
-// apps/dg/components/calculator/calculator.js:99 emits `type: 'DG.Calculator'`). Each V2
-// `executeNotification` block hard-codes the SC name with no translation. Arguably the V2
-// notification path should have used the same translation table the API path does, but
-// that's water under the bridge; V2 plugins in the wild filter notifications on the SC name.
-// V3's `tileNotification` therefore emits the SC name as `values.type` (for V2-plugin
-// matching) and the DI-convention name as `values.diType` (additive). V3 collapses
-// WebView/Game/Guide/Image into a single tile type; this mapping uses the generic
-// `DG.WebView` for all of them.
+// For V2-plugin compatibility. V2 uses two `type` conventions in component-resource
+// notification payloads depending on the operation kind:
+//   - OPERATIONAL ops (titleChange, calculate, edit formula, attributeChange, change
+//     column width, resize column, etc.) — emitted via inline `executeNotification`
+//     blocks — carry the SC class name (e.g. `"DG.Calculator"`,
+//     apps/dg/components/calculator/calculator.js:99 emits `type: 'DG.Calculator'`).
+//   - LIFECYCLE ops (create, delete, hide, show) — emitted via the
+//     `DG.UndoHistory.makeComponentNotification(op, type)` helper — carry the lowercase
+//     DI-convention name (e.g. `"calculator"`).
+// V2's `get component/<id>` API responses use the lowercase DI name too (translated by
+// data_interactive_phone_handler.js:1718). Arguably V2's notification path should have
+// used the same translation table the API path does for all ops, but that's water under
+// the bridge — V2 plugins in the wild filter on whichever string V2 actually sent.
+// V3's `tileNotification` mirrors V2's per-op convention so V2 plugins match, and always
+// adds the DI name as the additive `values.diType` so V3-aware plugins don't have to
+// know V2's two conventions. This map provides the SC name for operational ops; the
+// existing kComponentTypeV3ToV2Map provides the DI name (used for both API responses and
+// for the lifecycle-op `type` value). V3 collapses WebView/Game/Guide/Image into a single
+// tile type; this mapping uses the generic `DG.WebView` for all of them.
 export const kComponentTypeV3ToV2SCNameMap: Record<string, string> = {
   [kCalculatorTileType]: "DG.Calculator",
   [kCaseTableTileType]: "DG.CaseTable",

--- a/v3/src/data-interactive/data-interactive-component-types.ts
+++ b/v3/src/data-interactive/data-interactive-component-types.ts
@@ -32,26 +32,44 @@ export const kComponentTypeV3ToV2Map: Record<string, string> = {
 //     apps/dg/components/calculator/calculator.js:99 emits `type: 'DG.Calculator'`).
 //   - LIFECYCLE ops (create, delete, hide, show) — emitted via the
 //     `DG.UndoHistory.makeComponentNotification(op, type)` helper — carry the lowercase
-//     DI-convention name (e.g. `"calculator"`).
-// V2's `get component/<id>` API responses use the lowercase DI name too (translated by
-// data_interactive_phone_handler.js:1718). Arguably V2's notification path should have
-// used the same translation table the API path does for all ops, but that's water under
-// the bridge — V2 plugins in the wild filter on whichever string V2 actually sent.
-// V3's `tileNotification` mirrors V2's per-op convention so V2 plugins match, and always
-// adds the DI name as the additive `values.diType` so V3-aware plugins don't have to
-// know V2's two conventions. This map provides the SC name for operational ops; the
-// existing kComponentTypeV3ToV2Map provides the DI name (used for both API responses and
-// for the lifecycle-op `type` value). V3 collapses WebView/Game/Guide/Image into a single
-// tile type; this mapping uses the generic `DG.WebView` for all of them.
-export const kComponentTypeV3ToV2SCNameMap: Record<string, string> = {
-  [kCalculatorTileType]: "DG.Calculator",
-  [kCaseTableTileType]: "DG.CaseTable",
-  [kCaseCardTileType]: "DG.CaseCard",
-  [kGraphTileType]: "DG.GraphView",
-  [kMapTileType]: "DG.MapView",
-  [kSliderTileType]: "DG.SliderView",
-  [kTextTileType]: "DG.TextView",
-  [kWebViewTileType]: "DG.WebView"
+//     DI-convention name in MOST cases, but V2 sometimes uses a *different* lowercase
+//     name than what its DI-API responses use (see kV2DITypeToLifecycleNameMap).
+// V2's `get component/<id>` API responses use the lowercase DI name. Arguably V2's
+// notification path should have used the same translation table the API path does, but
+// that's water under the bridge — V2 plugins in the wild filter on whichever string V2
+// actually sent. V3's `tileNotification` mirrors V2's per-op convention so V2 plugins
+// match, and always adds the DI name as the additive `values.diType` so V3-aware plugins
+// don't have to know V2's two conventions.
+//
+// `kV2DITypeToSCNameMap` is keyed by DI type rather than V3 tile type. V3 sometimes
+// resolves the DI type at runtime via `getTileContentInfo(type)?.getV2Type?.(content)`
+// (e.g. WebView returns `'game'` when `isPlugin`), so the SC mapping needs to follow the
+// runtime-resolved DI type, not the static V3 tile type. This map covers all DI types
+// V3 may emit, including the WebView subtypes (game / guideView / imageComponent).
+export const kV2DITypeToSCNameMap: Record<string, string> = {
+  calculator: "DG.Calculator",
+  caseTable: "DG.CaseTable",
+  caseCard: "DG.CaseCard",
+  graph: "DG.GraphView",
+  map: "DG.MapView",
+  slider: "DG.SliderView",
+  text: "DG.TextView",
+  webView: "DG.WebView",
+  game: "DG.GameView",
+  guideView: "DG.GuideView",
+  imageComponent: "DG.ImageComponentView"
+}
+
+// V2's lifecycle `type` strings sometimes differ from its DI-API names. Verified V2
+// sources: app_controller.js:122 (`'table'` for case-table create/delete) and
+// document_controller.js:587, 1649 (`'calcView'` for calculator hide/show). Everything
+// else lines up with the DI name — graph, map, slider, text, webView, etc.
+//
+// Keys are V2 DI types; values are V2's lifecycle-notification `type` strings. Anything
+// not listed uses its DI name verbatim for lifecycle ops.
+export const kV2DITypeToLifecycleNameMap: Record<string, string> = {
+  caseTable: "table",
+  calculator: "calcView"
 }
 
 export const kComponentTypeV2ToV3Map: Record<string, string> = {

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -1,5 +1,7 @@
 import { isCaseTableModel } from "../../components/case-table/case-table-model"
-import { openCaseTableNotification } from "../../components/case-table/case-table-notifications"
+import {
+  openCaseTableNotification, resizeColumnsNotification
+} from "../../components/case-table/case-table-notifications"
 import { resizeAllColumns } from "../../components/case-table/case-table-utils"
 import { isGraphContentModel } from "../../components/graph/models/graph-content-model"
 import { isMapContentModel } from "../../components/map/models/map-content-model"
@@ -172,7 +174,18 @@ export const diComponentHandler: DIHandler = {
         } else if (isMapContentModel(content)) {
           content.rescale()
         } else if (isCaseTableModel(content)) {
-          resizeAllColumns(content)
+          // V2's resize-all path (case_table_controller.js:1136) is undoable and emits
+          // `resize columns`. Mirror that here so plugin-initiated rescales are also
+          // undoable and visible to V2 plugins (CODAP-1353). Graph/Map rescales above are
+          // not yet wrapped — deferred to CODAP-1351 / CODAP-1352.
+          content.applyModelChange(() => {
+            resizeAllColumns(content)
+          }, {
+            notify: () => resizeColumnsNotification(component),
+            log: {message: "Resize all columns", args:{}, category: "table"},
+            undoStringKey: "DG.Undo.caseTable.resizeColumns",
+            redoStringKey: "DG.Redo.caseTable.resizeColumns"
+          })
         } else {
           return errorResult(t("V3.DI.Error.componentDoesNotSupportRescale"))
         }

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -1,4 +1,5 @@
 import { isCaseTableModel } from "../../components/case-table/case-table-model"
+import { openCaseTableNotification } from "../../components/case-table/case-table-notifications"
 import { resizeAllColumns } from "../../components/case-table/case-table-utils"
 import { isGraphContentModel } from "../../components/graph/models/graph-content-model"
 import { isMapContentModel } from "../../components/map/models/map-content-model"
@@ -90,10 +91,12 @@ export const diComponentHandler: DIHandler = {
           }
         }
       }, {
-        // Wrap in a function so it runs AFTER applyModelChange's actionFn assigns `tile`.
-        // Evaluating createTileNotification(tile) inline would call it with tile=undefined,
-        // producing no notification (createTileNotification returns undefined for falsy tile).
-        notify: () => createTileNotification(tile),
+        // Wrap each helper in a function so it runs AFTER applyModelChange's actionFn assigns
+        // `tile`. Evaluating notifications inline would call them with tile=undefined,
+        // producing no notification (the helpers return undefined for falsy tile).
+        // openCaseTableNotification no-ops for non-case-table tiles, so it's safe to call
+        // unconditionally here (V2-plugin compat for the case-table create path, CODAP-1353).
+        notify: [() => createTileNotification(tile), () => openCaseTableNotification(tile)],
         // Don't echo the create back to the requesting plugin — Story Builder otherwise treats
         // notifications about its own DI-API actions as document edits and marks the current
         // moment as unsaved (CODAP-1307).

--- a/v3/src/data-interactive/handlers/component-handler.ts
+++ b/v3/src/data-interactive/handlers/component-handler.ts
@@ -178,10 +178,16 @@ export const diComponentHandler: DIHandler = {
           // `resize columns`. Mirror that here so plugin-initiated rescales are also
           // undoable and visible to V2 plugins (CODAP-1353). Graph/Map rescales above are
           // not yet wrapped — deferred to CODAP-1351 / CODAP-1352.
+          //
+          // Don't echo the notification back to the requesting plugin — Story Builder
+          // otherwise treats notifications about its own DI-API actions as document edits
+          // and marks the current moment as unsaved (CODAP-1307), matching the pattern
+          // used by the create/update/delete handlers in this file.
           content.applyModelChange(() => {
             resizeAllColumns(content)
           }, {
             notify: () => resizeColumnsNotification(component),
+            excludeTileId: resources.interactiveFrame?.id,
             log: {message: "Resize all columns", args:{}, category: "table"},
             undoStringKey: "DG.Undo.caseTable.resizeColumns",
             redoStringKey: "DG.Redo.caseTable.resizeColumns"

--- a/v3/src/models/data/join-datasets.ts
+++ b/v3/src/models/data/join-datasets.ts
@@ -1,3 +1,5 @@
+import { joinNotification } from "../../components/case-table/case-table-notifications"
+import { ITileModel } from "../tiles/tile-model"
 import { IAttribute } from "./attribute"
 import { ICollectionModel } from "./collection"
 import { IDataSet } from "./data-set"
@@ -16,6 +18,12 @@ export interface IJoinSourceToDestCollectionParams {
   destCollection: ICollectionModel
   /** The attribute ID in the destination that serves as the join key */
   destKeyAttributeId: string
+  /**
+   * The destination case-table tile this join was initiated from, if any. When provided,
+   * a `join` notification is emitted on its component resource for V2-plugin compatibility
+   * (CODAP-1353). No-ops for non-case-table tiles.
+   */
+  destTile?: ITileModel
 }
 
 /**
@@ -37,7 +45,8 @@ export function joinSourceToDestCollection(params: IJoinSourceToDestCollectionPa
     sourceKeyAttributeId,
     destDataSet,
     destCollection,
-    destKeyAttributeId
+    destKeyAttributeId,
+    destTile
   } = params
 
   // Get the source collection containing the key attribute
@@ -106,9 +115,12 @@ export function joinSourceToDestCollection(params: IJoinSourceToDestCollectionPa
     {
       undoStringKey: t("DG.Undo.DataContext.join", { vars: [sourceDataSetName, destDataSetName] }),
       redoStringKey: t("DG.Redo.DataContext.join", { vars: [sourceDataSetName, destDataSetName] }),
-      notify: () => [
-        createAttributesNotification(createdAttributes, destDataSet),
-        dependentCasesNotification(destDataSet)
+      notify: [
+        // `joinNotification` no-ops for non-case-table tiles, so it's safe to include
+        // here even when the join was initiated outside a case-table context.
+        () => createAttributesNotification(createdAttributes, destDataSet),
+        () => dependentCasesNotification(destDataSet),
+        () => joinNotification(destTile)
       ],
       log: `Joined ${sourceCollection.name} to ${destCollection.name}`
     }

--- a/v3/src/models/tiles/tile-notifications.test.ts
+++ b/v3/src/models/tiles/tile-notifications.test.ts
@@ -1,10 +1,22 @@
 import { ITileModel } from "./tile-model"
-import { createTileNotification, deleteTileNotification, updateTileNotification } from "./tile-notifications"
+import {
+  componentShowHideNotification, createTileNotification, deleteTileNotification, updateTileNotification
+} from "./tile-notifications"
+
+jest.mock("./tile-content-info", () => ({
+  getTileContentInfo: jest.fn((type: string) => {
+    // The calculator is V3's only singleton today; Graph and other types are non-singleton.
+    if (type === "Calculator") return { isSingleton: true }
+    return { isSingleton: false }
+  })
+}))
 
 const v3TileType = "Graph"
-// V2 component-resource notifications carry the SC class name (`DG.GraphView` for graph)
-// in `values.type`; V3 mirrors this for V2-plugin compatibility and adds the
-// DI-convention name as `values.diType`.
+// V2 uses two `type` conventions depending on the operation: lifecycle ops
+// (create/delete/hide/show) carry the lowercase DI-convention name (`graph`);
+// operational ops (titleChange, attributeChange, etc.) carry the SC class name
+// (`DG.GraphView`). V3 mirrors this per-op and always emits the DI name as the
+// additive `diType` field.
 const v2SCType = "DG.GraphView"
 const diType = "graph"
 const v3Id = "TILE12345"
@@ -22,7 +34,8 @@ describe("createTileNotification", () => {
     expect(notification?.message.resource).toBe("component")
     expect(notification?.message.values.operation).toBe("create")
     expect(notification?.message.values.id).toBe(v2Id)
-    expect(notification?.message.values.type).toBe(v2SCType)
+    // `create` is a lifecycle op — V2 emits the lowercase name here.
+    expect(notification?.message.values.type).toBe(diType)
     expect(notification?.message.values.diType).toBe(diType)
   })
 
@@ -51,7 +64,8 @@ describe("deleteTileNotification", () => {
     expect(notification?.message.values.id).toBe(v2Id)
     expect(notification?.message.values.name).toBe(tileTitle)
     expect(notification?.message.values.title).toBe(tileTitle)
-    expect(notification?.message.values.type).toBe(v2SCType)
+    // `delete` is a lifecycle op — V2 emits the lowercase name here.
+    expect(notification?.message.values.type).toBe(diType)
     expect(notification?.message.values.diType).toBe(diType)
   })
 })
@@ -105,5 +119,34 @@ describe("titleChange notification envelope", () => {
     expect((notification?.message as any).type).toBeUndefined()
     expect(notification?.message.values.type).toBe(v2SCType)
     expect(notification?.message.values.diType).toBe(diType)
+  })
+})
+
+describe("componentShowHideNotification (singleton lifecycle)", () => {
+  it("emits `show` with the lowercase DI name as `type` for a singleton tile", () => {
+    // Calculator is V3's only singleton; v2Id constant is shared across this file.
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as ITileModel
+    const notification = componentShowHideNotification(calcTile, "show")
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("show")
+    expect(notification?.message.values.type).toBe("calculator")  // lifecycle ops use DI name
+    expect(notification?.message.values.diType).toBe("calculator")
+  })
+
+  it("emits `hide` for a singleton tile", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as ITileModel
+    const notification = componentShowHideNotification(calcTile, "hide")
+    expect(notification?.message.values.operation).toBe("hide")
+    expect(notification?.message.values.type).toBe("calculator")
+  })
+
+  it("returns undefined for non-singleton tiles (e.g. Graph)", () => {
+    const graphTile = { id: v3Id, content: { type: v3TileType } } as ITileModel
+    expect(componentShowHideNotification(graphTile, "hide")).toBeUndefined()
+  })
+
+  it("returns undefined when no tile is provided", () => {
+    expect(componentShowHideNotification(undefined, "show")).toBeUndefined()
   })
 })

--- a/v3/src/models/tiles/tile-notifications.test.ts
+++ b/v3/src/models/tiles/tile-notifications.test.ts
@@ -1,15 +1,19 @@
 import { ITileModel } from "./tile-model"
 import { createTileNotification, deleteTileNotification, updateTileNotification } from "./tile-notifications"
 
-const v3Type = "Graph"
-const v2Type = "graph"
+const v3TileType = "Graph"
+// V2 component-resource notifications carry the SC class name (`DG.GraphView` for graph)
+// in `values.type`; V3 mirrors this for V2-plugin compatibility and adds the
+// DI-convention name as `values.diType`.
+const v2SCType = "DG.GraphView"
+const diType = "graph"
 const v3Id = "TILE12345"
 const v2Id = 12345
 const tileTitle = "Test Graph"
 
 describe("createTileNotification", () => {
   it("should create a notification with the correct operation and result", () => {
-    const tileMock = { id: v3Id, content: { type: v3Type } } as ITileModel
+    const tileMock = { id: v3Id, content: { type: v3TileType } } as ITileModel
 
     const notification = createTileNotification(tileMock)
 
@@ -18,7 +22,8 @@ describe("createTileNotification", () => {
     expect(notification?.message.resource).toBe("component")
     expect(notification?.message.values.operation).toBe("create")
     expect(notification?.message.values.id).toBe(v2Id)
-    expect(notification?.message.values.type).toBe(v2Type)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
   })
 
   it("should return undefined if no tile is provided", () => {
@@ -32,7 +37,7 @@ describe("deleteTileNotification", () => {
   it("should create a notification with the correct operation and result", () => {
     const tileMock = {
       id: v3Id,
-      content: { type: v3Type },
+      content: { type: v3TileType },
       name: tileTitle,
       title: tileTitle
     } as ITileModel
@@ -46,14 +51,15 @@ describe("deleteTileNotification", () => {
     expect(notification?.message.values.id).toBe(v2Id)
     expect(notification?.message.values.name).toBe(tileTitle)
     expect(notification?.message.values.title).toBe(tileTitle)
-    expect(notification?.message.values.type).toBe(v2Type)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
   })
 })
 
 describe("updateTileNotification", () => {
   it("should create a notification with the correct operation and result", () => {
     const updateType = "attributeChange"
-    const tileMock = { id: v3Id, content: { type: v3Type } } as ITileModel
+    const tileMock = { id: v3Id, content: { type: v3TileType } } as ITileModel
     const values = {
       attributeId: "ATTR123",
       attributeName: "Test Attribute",
@@ -67,34 +73,37 @@ describe("updateTileNotification", () => {
     expect(notification?.message.resource).toBe("component")
     expect(notification?.message.values.operation).toBe(updateType)
     expect(notification?.message.values.id).toBe(v2Id)
-    expect(notification?.message.values.type).toBe(v2Type)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
   })
 })
 
 describe("titleChange notification envelope", () => {
-  it("adds type to the outer envelope for the titleChange operation", () => {
-    const tileMock = { id: v3Id, content: { type: v3Type } } as ITileModel
+  it("adds type (SC name) to the outer envelope for the titleChange operation", () => {
+    const tileMock = { id: v3Id, content: { type: v3TileType } } as ITileModel
     const values = { from: "Old Title", to: "New Title" }
 
     const notification = updateTileNotification("titleChange", values, tileMock)
 
     expect(notification?.message.action).toBe("notify")
     expect(notification?.message.resource).toBe(`component[${v2Id}]`)
-    // type is mirrored to the outer envelope AND kept in values
-    expect((notification?.message as any).type).toBe(v2Type)
+    // Outer envelope mirrors V2's `model.type` (the SC name).
+    expect((notification?.message as any).type).toBe(v2SCType)
     expect(notification?.message.values.operation).toBe("titleChange")
     expect(notification?.message.values.id).toBe(v2Id)
     expect(notification?.message.values.from).toBe("Old Title")
     expect(notification?.message.values.to).toBe("New Title")
-    expect(notification?.message.values.type).toBe(v2Type)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
   })
 
   it("keeps type inside values for non-titleChange operations", () => {
-    const tileMock = { id: v3Id, content: { type: v3Type } } as ITileModel
+    const tileMock = { id: v3Id, content: { type: v3TileType } } as ITileModel
 
     const notification = updateTileNotification("attributeChange", {}, tileMock)
 
     expect((notification?.message as any).type).toBeUndefined()
-    expect(notification?.message.values.type).toBe(v2Type)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
   })
 })

--- a/v3/src/models/tiles/tile-notifications.test.ts
+++ b/v3/src/models/tiles/tile-notifications.test.ts
@@ -6,7 +6,15 @@ import {
 jest.mock("./tile-content-info", () => ({
   getTileContentInfo: jest.fn((type: string) => {
     // The calculator is V3's only singleton today; Graph and other types are non-singleton.
+    // WebView exposes a content-dependent `getV2Type` (returns 'game' when content.isPlugin)
+    // so the helper can route plugin webviews to the DG.GameView SC name automatically.
     if (type === "Calculator") return { isSingleton: true }
+    if (type === "CodapWebView") {
+      return {
+        isSingleton: false,
+        getV2Type: (content: any) => content?.isPlugin ? "game" : "webView"
+      }
+    }
     return { isSingleton: false }
   })
 }))
@@ -123,22 +131,24 @@ describe("titleChange notification envelope", () => {
 })
 
 describe("componentShowHideNotification (singleton lifecycle)", () => {
-  it("emits `show` with the lowercase DI name as `type` for a singleton tile", () => {
-    // Calculator is V3's only singleton; v2Id constant is shared across this file.
+  it("emits `show` with V2's lifecycle name as `type` (calcView, not calculator)", () => {
+    // V2 emits `type: 'calcView'` for calculator hide/show (document_controller.js:587).
+    // V3 mirrors this via kV2DITypeToLifecycleNameMap. `diType` stays the DI name.
     const calcTile = { id: "CALC1", content: { type: "Calculator" } } as ITileModel
     const notification = componentShowHideNotification(calcTile, "show")
     expect(notification?.message.action).toBe("notify")
     expect(notification?.message.resource).toBe("component")
     expect(notification?.message.values.operation).toBe("show")
-    expect(notification?.message.values.type).toBe("calculator")  // lifecycle ops use DI name
+    expect(notification?.message.values.type).toBe("calcView")
     expect(notification?.message.values.diType).toBe("calculator")
   })
 
-  it("emits `hide` for a singleton tile", () => {
+  it("emits `hide` for a singleton tile with the calcView lifecycle name", () => {
     const calcTile = { id: "CALC1", content: { type: "Calculator" } } as ITileModel
     const notification = componentShowHideNotification(calcTile, "hide")
     expect(notification?.message.values.operation).toBe("hide")
-    expect(notification?.message.values.type).toBe("calculator")
+    expect(notification?.message.values.type).toBe("calcView")
+    expect(notification?.message.values.diType).toBe("calculator")
   })
 
   it("returns undefined for non-singleton tiles (e.g. Graph)", () => {
@@ -148,5 +158,60 @@ describe("componentShowHideNotification (singleton lifecycle)", () => {
 
   it("returns undefined when no tile is provided", () => {
     expect(componentShowHideNotification(undefined, "show")).toBeUndefined()
+  })
+})
+
+describe("V2 lifecycle-name overrides via kV2DITypeToLifecycleNameMap", () => {
+  it("emits `type: 'table'` (not 'caseTable') on case-table create", () => {
+    // V2: app_controller.js:122 emits makeComponentNotification('create', 'table').
+    const tableTile = {
+      id: "TABLE1", content: { type: "CaseTable" }, name: "Mammals", title: "Mammals"
+    } as ITileModel
+    const notification = createTileNotification(tableTile)
+    expect(notification?.message.values.operation).toBe("create")
+    expect(notification?.message.values.type).toBe("table")
+    expect(notification?.message.values.diType).toBe("caseTable")
+  })
+
+  it("emits `type: 'table'` on case-table delete (same override)", () => {
+    const tableTile = {
+      id: "TABLE1", content: { type: "CaseTable" }, name: "Mammals", title: "Mammals"
+    } as ITileModel
+    const notification = deleteTileNotification(tableTile)
+    expect(notification?.message.values.operation).toBe("delete")
+    expect(notification?.message.values.type).toBe("table")
+    expect(notification?.message.values.diType).toBe("caseTable")
+  })
+
+  it("uses the DI name verbatim for tile types with no override (e.g. graph)", () => {
+    const graphTile = { id: v3Id, content: { type: v3TileType } } as ITileModel
+    const notification = createTileNotification(graphTile)
+    // No override → lifecycle type === DI type.
+    expect(notification?.message.values.type).toBe("graph")
+    expect(notification?.message.values.diType).toBe("graph")
+  })
+})
+
+describe("getV2Type integration (content-dependent DI type)", () => {
+  it("resolves the DI type via getV2Type — WebView with isPlugin yields `game`", () => {
+    // V3 collapses Game / Guide / Image / WebView into a single tile type; the V2 DI type
+    // depends on content. WebView's getV2Type returns 'game' when content.isPlugin, mirrored
+    // by the API responses in component-handler / component-list-handler / data-display-handler.
+    const pluginTile = {
+      id: "PLUGIN1", content: { type: "CodapWebView", isPlugin: true }
+    } as any
+    const notification = updateTileNotification("attributeChange", {}, pluginTile)
+    // diType follows getV2Type's result; SC name follows the DI type via kV2DITypeToSCNameMap.
+    expect(notification?.message.values.diType).toBe("game")
+    expect(notification?.message.values.type).toBe("DG.GameView")
+  })
+
+  it("falls back to the static map when getV2Type returns the non-plugin name", () => {
+    const webTile = {
+      id: "WEB1", content: { type: "CodapWebView", isPlugin: false }
+    } as any
+    const notification = updateTileNotification("attributeChange", {}, webTile)
+    expect(notification?.message.values.diType).toBe("webView")
+    expect(notification?.message.values.type).toBe("DG.WebView")
   })
 })

--- a/v3/src/models/tiles/tile-notifications.ts
+++ b/v3/src/models/tiles/tile-notifications.ts
@@ -1,5 +1,5 @@
 import {
-  kComponentTypeV3ToV2Map, kComponentTypeV3ToV2SCNameMap
+  kComponentTypeV3ToV2Map, kV2DITypeToLifecycleNameMap, kV2DITypeToSCNameMap
 } from "../../data-interactive/data-interactive-component-types"
 import { notification } from "../../data-interactive/notification-utils"
 import { toV2Id } from "../../utilities/codap-utils"
@@ -9,13 +9,13 @@ import { ITileModel } from "./tile-model"
 // For V2-plugin compatibility, V2 emits the `type` field with one of two conventions
 // depending on the operation:
 //   - LIFECYCLE ops (create, delete, hide, show) — emitted via V2's
-//     DG.UndoHistory.makeComponentNotification(op, type) helper — use the lowercase
-//     DI-convention name (e.g. 'calculator', 'graph', 'table').
+//     `DG.UndoHistory.makeComponentNotification(op, type)` helper — carry the lowercase
+//     DI-convention name in MOST cases, but V2 sometimes uses a different lowercase name
+//     for the lifecycle path (see kV2DITypeToLifecycleNameMap).
 //   - OPERATIONAL ops (titleChange, calculate, edit formula, attributeChange, change
 //     column width, resize column, etc.) — emitted via inline `executeNotification`
-//     blocks — use the SC class name (e.g. 'DG.Calculator', 'DG.GraphView',
-//     'DG.CaseTable').
-// V3 mirrors this per-op convention so V2 plugins filtering on either form match. The
+//     blocks — carry the SC class name (e.g. 'DG.Calculator', 'DG.GraphView').
+// V3 mirrors V2's per-op convention so V2 plugins filtering on either form match. The
 // additive `diType` field always carries the DI name regardless, so V3-aware plugins
 // don't need to know V2's two conventions.
 const kLifecycleOps = new Set(["create", "delete", "hide", "show"])
@@ -25,9 +25,17 @@ export const tileNotification = (
 ) => {
   const isTitleChange = operation === "titleChange"
   const resource = isTitleChange ? `component[${toV2Id(tile.id)}]` : "component"
-  const v2SCType = kComponentTypeV3ToV2SCNameMap[tile.content.type]
-  const diType = kComponentTypeV3ToV2Map[tile.content.type]
-  const v2Type = kLifecycleOps.has(operation) ? diType : v2SCType
+  // Source of truth for the DI type is `getV2Type(content)` when available — matches the
+  // pattern used by component-handler / component-list-handler / data-display-handler for
+  // API responses, so notifications and API responses stay consistent (e.g. a WebView
+  // plugin tile resolves to `'game'` in both places).
+  const diType = getTileContentInfo(tile.content.type)?.getV2Type?.(tile.content)
+    ?? kComponentTypeV3ToV2Map[tile.content.type]
+  const v2SCType = kV2DITypeToSCNameMap[diType]
+  // V2 sometimes uses a different lifecycle-notification `type` than its DI-API type
+  // (case-table → 'table'; calculator → 'calcView'). Default to the DI name.
+  const v2LifecycleType = kV2DITypeToLifecycleNameMap[diType] ?? diType
+  const v2Type = kLifecycleOps.has(operation) ? v2LifecycleType : v2SCType
 
   values.operation = operation
   values.id = toV2Id(tile.id)

--- a/v3/src/models/tiles/tile-notifications.ts
+++ b/v3/src/models/tiles/tile-notifications.ts
@@ -3,25 +3,35 @@ import {
 } from "../../data-interactive/data-interactive-component-types"
 import { notification } from "../../data-interactive/notification-utils"
 import { toV2Id } from "../../utilities/codap-utils"
+import { getTileContentInfo } from "./tile-content-info"
 import { ITileModel } from "./tile-model"
+
+// For V2-plugin compatibility, V2 emits the `type` field with one of two conventions
+// depending on the operation:
+//   - LIFECYCLE ops (create, delete, hide, show) — emitted via V2's
+//     DG.UndoHistory.makeComponentNotification(op, type) helper — use the lowercase
+//     DI-convention name (e.g. 'calculator', 'graph', 'table').
+//   - OPERATIONAL ops (titleChange, calculate, edit formula, attributeChange, change
+//     column width, resize column, etc.) — emitted via inline `executeNotification`
+//     blocks — use the SC class name (e.g. 'DG.Calculator', 'DG.GraphView',
+//     'DG.CaseTable').
+// V3 mirrors this per-op convention so V2 plugins filtering on either form match. The
+// additive `diType` field always carries the DI name regardless, so V3-aware plugins
+// don't need to know V2's two conventions.
+const kLifecycleOps = new Set(["create", "delete", "hide", "show"])
 
 export const tileNotification = (
   operation: string, values: any, tile: ITileModel, callback?: (result: any) => void
 ) => {
   const isTitleChange = operation === "titleChange"
   const resource = isTitleChange ? `component[${toV2Id(tile.id)}]` : "component"
-  // For V2-plugin compatibility: V2 inconsistently uses SC class names (`DG.Calculator`)
-  // in notification payloads but lowercase DI-convention names (`calculator`) in API
-  // responses — see the note on kComponentTypeV3ToV2SCNameMap. V3 emits the SC name as
-  // `type` (so V2 plugins filtering on `values.type === 'DG.X'` match) plus an additive
-  // `diType` with the DI-convention name (so consumers don't have to learn V2's two
-  // conventions).
   const v2SCType = kComponentTypeV3ToV2SCNameMap[tile.content.type]
   const diType = kComponentTypeV3ToV2Map[tile.content.type]
+  const v2Type = kLifecycleOps.has(operation) ? diType : v2SCType
 
   values.operation = operation
   values.id = toV2Id(tile.id)
-  values.type = v2SCType
+  values.type = v2Type
   values.diType = diType
 
   const result = notification(resource, values, callback)
@@ -54,4 +64,17 @@ export function updateTileNotification(updateType: string, values: any, tile?: I
   if (!tile) return
 
   return tileNotification(updateType, values, tile)
+}
+
+// V2 emits `hide` / `show` on the component resource for singleton-component toggle
+// (apps/dg/controllers/document_controller.js:1644-1666) via the
+// `DG.UndoHistory.makeComponentNotification(op, type)` helper — `type` is the lowercase
+// DI-convention name (e.g. `'calculator'`). The op reflects the resulting visible state:
+// hiding/deleting the singleton emits `hide`; making it visible (whether newly created
+// or unhidden) emits `show`. Non-singleton tiles use `create`/`delete` instead — this
+// helper no-ops for them so it's safe to call from generic notify callbacks.
+export function componentShowHideNotification(tile: ITileModel | undefined, op: "show" | "hide") {
+  if (!tile) return
+  if (!getTileContentInfo(tile.content.type)?.isSingleton) return
+  return tileNotification(op, {}, tile)
 }

--- a/v3/src/models/tiles/tile-notifications.ts
+++ b/v3/src/models/tiles/tile-notifications.ts
@@ -1,4 +1,6 @@
-import { kComponentTypeV3ToV2Map } from "../../data-interactive/data-interactive-component-types"
+import {
+  kComponentTypeV3ToV2Map, kComponentTypeV3ToV2SCNameMap
+} from "../../data-interactive/data-interactive-component-types"
 import { notification } from "../../data-interactive/notification-utils"
 import { toV2Id } from "../../utilities/codap-utils"
 import { ITileModel } from "./tile-model"
@@ -8,17 +10,25 @@ export const tileNotification = (
 ) => {
   const isTitleChange = operation === "titleChange"
   const resource = isTitleChange ? `component[${toV2Id(tile.id)}]` : "component"
-  const v2Type = kComponentTypeV3ToV2Map[tile.content.type]
+  // For V2-plugin compatibility: V2 inconsistently uses SC class names (`DG.Calculator`)
+  // in notification payloads but lowercase DI-convention names (`calculator`) in API
+  // responses — see the note on kComponentTypeV3ToV2SCNameMap. V3 emits the SC name as
+  // `type` (so V2 plugins filtering on `values.type === 'DG.X'` match) plus an additive
+  // `diType` with the DI-convention name (so consumers don't have to learn V2's two
+  // conventions).
+  const v2SCType = kComponentTypeV3ToV2SCNameMap[tile.content.type]
+  const diType = kComponentTypeV3ToV2Map[tile.content.type]
 
   values.operation = operation
   values.id = toV2Id(tile.id)
-  values.type = v2Type
+  values.type = v2SCType
+  values.diType = diType
 
   const result = notification(resource, values, callback)
-  // V2 (apps/dg/views/component_view.js) places `type` at the outer envelope level for
-  // titleChange, a peer of `action`/`resource`. Mirror it there for V2 plugins while
-  // keeping `type` in `values` for consistency with every other operation.
-  if (isTitleChange) (result.message as any).type = v2Type
+  // V2 (apps/dg/views/component_view.js:284) places `type` at the outer envelope level for
+  // titleChange — its value is `model.type` (the SC class name), peer of `action`/`resource`.
+  // Mirror it there for V2 plugins while keeping `type` and `diType` in `values`.
+  if (isTitleChange) (result.message as any).type = v2SCType
 
   return result
 }

--- a/v3/src/models/tiles/tile-notifications.ts
+++ b/v3/src/models/tiles/tile-notifications.ts
@@ -76,8 +76,10 @@ export function updateTileNotification(updateType: string, values: any, tile?: I
 
 // V2 emits `hide` / `show` on the component resource for singleton-component toggle
 // (apps/dg/controllers/document_controller.js:1644-1666) via the
-// `DG.UndoHistory.makeComponentNotification(op, type)` helper — `type` is the lowercase
-// DI-convention name (e.g. `'calculator'`). The op reflects the resulting visible state:
+// `DG.UndoHistory.makeComponentNotification(op, type)` helper. The `type` value defaults
+// to the lowercase DI-convention name but is subject to V2's lifecycle-name overrides
+// (e.g. calculator → `'calcView'`) — see `kV2DITypeToLifecycleNameMap`. `tileNotification`
+// applies the override automatically. The op reflects the resulting visible state:
 // hiding/deleting the singleton emits `hide`; making it visible (whether newly created
 // or unhidden) emits `show`. Non-singleton tiles use `create`/`delete` instead — this
 // helper no-ops for them so it's safe to call from generic notify callbacks.


### PR DESCRIPTION
## Summary

Follow-up to CODAP-1310 (PR #2592) covering the deferred case-table, calculator,
slider, and case-card notification backfill from the V2↔V3 audit §3.3.
Story Builder's catch-all dirty-tracking depends on these notifications;
without them, user actions silently fail to mark moments as changed.

Fixes CODAP-1353.

### Infrastructure changes (worth a careful review)

**V2 is genuinely inconsistent in its `values.type` field across notification
paths.** This PR mirrors V2 faithfully — including the inconsistencies — so
V2 plugins receive what they expect, while adding a new `values.diType` field
that consistently carries V3's DI-convention name for plugins that prefer a
stable contract.

V2's three sources of `type` inconsistency, all now reflected in V3:

1. **Operational vs lifecycle ops use different conventions.** Operational
   ops (titleChange, calculate, attributeChange, edit formula, etc.) are
   emitted via inline `executeNotification` blocks and carry the SC class
   name (`'DG.Calculator'`, `'DG.GraphView'`). Lifecycle ops (create, delete,
   hide, show) are emitted via `DG.UndoHistory.makeComponentNotification` and
   carry the lowercase DI-style name. V3 picks the right convention per-op
   via a `kLifecycleOps` set.
2. **V2's lifecycle `type` names sometimes differ from V2's own DI-API names.**
   Three known overrides: case-table create/delete emits `'table'` (not
   `'caseTable'`); calculator hide/show emits `'calcView'` (not
   `'calculator'`); image-component create/delete emits `'imageComponent'`
   (not `'imageComponentView'`). Captured by a small
   `kV2DITypeToLifecycleNameMap` of overrides.
3. **Some V3 tile types have content-dependent V2 types.** WebView returns
   `'game'` (SC class `DG.GameView`) when `isPlugin`, `'webView'` (SC class
   `DG.WebView`) otherwise. `tileNotification` now sources the DI type via
   `getTileContentInfo(type)?.getV2Type?.(content)` — matching the pattern
   already used by component-list-handler / data-display-handler /
   component-handler for API responses — so notifications stay consistent
   with API responses for the same content.

**V3 attempts to mirror V2 in `values.type` so V2-plugin filters match.**
V2-plugin compatibility is the primary goal of CODAP-1353; silently sending
the wrong `type` would defeat the whole point of backfilling these
notifications.

**V3 adds an additive `values.diType`** on every component-resource
notification, always carrying the DI-convention name regardless of op kind
or content. V3-aware plugins can use it and ignore V2's three conventions.

Other notable behavior changes:

- **Singleton tool-shelf clicks now emit `show`/`hide` instead of `create`,**
  matching V2's `_addCalcComponent` / `_deleteComponent` flow. (V3 used to
  emit `create` for calculator toggles, which was incompatible with V2.)
  Undo-menu labels and logs branch per-action too, using V2's
  `DG.{Undo,Redo}.toggleComponent.{add,delete}.{lifecycleName}` translation
  keys — so "undo showing the calculator" reads correctly instead of
  "undo create component."

### New notifications (each maps to a V2 emission site)

| Tile | Op | V2 source | V3 site(s) |
|---|---|---|---|
| Calculator | `calculate` | `calculator.js:99,161` | `calculator.tsx` clear/evaluate/error |
| Case Card | `change column width` | `case_card_view.js:119` | `case-card.tsx handleResizeColumn` |
| Case Table | `open case table` | `document_controller.js:1069` | `tool-shelf-button` + plugin API |
| Case Table | `resize column` | `case_table_controller.js:906`, `case_table_view.js:1926` | `collection-table.tsx` drag, attr-menu Fit Width |
| Case Table | `resize columns` | `case_table_controller.js:1136` | inspector Resize All, plugin-API autoScale |
| Case Table | `expand/collapse all` | `case_table_view.js:2172` | `collection-table-spacer.tsx` (+ additive `to: "expanded"\|"collapsed"`) |
| Slider | `change slider value` | `slider_controller.js:225`, `slider_view.js:330` | `editable-slider-value.tsx`, `handleChangeEnd` (+ additive `to: value`) |
| Singleton | `hide` / `show` | `document_controller.js:1644-1666` | `tool-shelf.tsx`, `calculator-title-bar.tsx` close |
| Data context | `join` | `data_context_utilities.js:924` | `join-datasets.ts` via `useTileModelContext` |

### Out of scope (deferred per Jira)

- Graph adornment/plot notifications → CODAP-1351
- Map notifications → CODAP-1352
- Document undo/redo notifications → CODAP-1354
- Log-event compatibility → CODAP-1355
- `dataContextChangeNotice` item-vs-case ops → CODAP-1356

### Two V2 bugs intentionally not replicated (audit §3.5)

- Data-context `join`: V2 emits `type: DG.CaseTable` (SC class **object**, not the string). V3 emits the string.
- Case Table `resizeColumns` log has a `%` typo (missing `@`). V3 does not replicate.

### Testing

`npm run lint`, `npm run build:tsc`, and the full Jest suite (3085 tests)
all pass. Each new notification has a focused unit test verifying the V2
op string, the per-op `type` convention, and the additive `diType` field;
the helper itself has tests covering the lifecycle-name overrides and the
content-dependent `getV2Type` path.
