### PR TITLE
CODAP-1360: dirty Story Builder moment when text component is edited

### DIFF
--- a/v3/src/components/text/text-notifications.test.ts
+++ b/v3/src/components/text/text-notifications.test.ts
@@ -1,6 +1,6 @@
 import { kV2TextDIType } from "./text-defs"
 import { TextModel } from "./text-model"
-import { commitEditNotification } from "./text-notifications"
+import { commitEditNotification, editTextNotification } from "./text-notifications"
 
 const v2Id = 12345
 const v2Type = kV2TextDIType
@@ -48,5 +48,23 @@ describe("commitEditNotification", () => {
   it("returns undefined when tile is missing", () => {
     const textModel = TextModel.create()
     expect(commitEditNotification(textModel, undefined)).toBeUndefined()
+  })
+})
+
+describe("editTextNotification", () => {
+  it("emits an 'edit text' notification", () => {
+    const tile = { title: "Notes", content: TextModel.create() } as any
+
+    const notification = editTextNotification(tile)
+
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("edit text")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2Type)
+  })
+
+  it("returns undefined when tile is missing", () => {
+    expect(editTextNotification(undefined)).toBeUndefined()
   })
 })

--- a/v3/src/components/text/text-notifications.ts
+++ b/v3/src/components/text/text-notifications.ts
@@ -9,3 +9,8 @@ export function commitEditNotification(textModel: ITextModel, tile?: ITileModel)
     text: JSON.stringify(textModel.value)
   }, tile)
 }
+
+export function editTextNotification(tile?: ITileModel) {
+  if (!tile) return
+  return updateTileNotification("edit text", {}, tile)
+}

--- a/v3/src/components/text/text-tile.tsx
+++ b/v3/src/components/text/text-tile.tsx
@@ -12,7 +12,7 @@ import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { mstReaction } from "../../utilities/mst-reaction"
 import { ITileBaseProps } from "../tiles/tile-base-props"
 import { isTextModel, modelValueToEditorValue } from "./text-model"
-import { commitEditNotification } from "./text-notifications"
+import { commitEditNotification, editTextNotification } from "./text-notifications"
 import { TextTileInspectorContent } from "./text-tile-inspector-content"
 
 import "@concord-consortium/slate-editor/dist/index.css"
@@ -127,6 +127,16 @@ export const TextTile = observer(function TextTile({ tile }: ITileBaseProps) {
 
   function handleChange() {
     textModel?.incEditorChange()
+    // Fire an "edit text" notification on every content-changing edit (matching V2's
+    // `observes('theText')` behavior) so plugins listening for live edits can react immediately.
+    // Selection-only changes also trigger Slate's onChange, so we filter those out.
+    const isContentChange = editor.operations.some(op => op.type !== "set_selection")
+    if (isContentChange) {
+      const notification = editTextNotification(tile)
+      if (notification) {
+        textModel?.tileEnv?.notify?.(notification.message, () => null)
+      }
+    }
   }
 
   function handleBlur() {


### PR DESCRIPTION
## Summary
- Fires an `"edit text"` component notification on every content-changing keystroke in a text tile (matching V2's `observes('theText')` behavior), so plugins like Story Builder can mark their state dirty immediately rather than waiting for blur.
- Selection-only changes (cursor moves) are filtered out via `editor.operations`.
- The existing on-blur `commitEdit` notification is unchanged.

Fixes CODAP-1360.

## Test plan
- [ ] In a new document, add the Story Builder plugin. Moment 1 starts without a yellow background.
- [ ] Type into the text component SB created. Moment 1 turns yellow as soon as editing begins.
- [ ] Clicking inside the text component without typing (cursor moves only) does NOT dirty the moment.
- [ ] On blur, existing plugins that listen for `commitEdit` continue to receive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
