### PR TITLE
CODAP-1299: White space on right side of table should allow unselect

### DIFF
--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -24,6 +24,7 @@ import { CollectionTable } from "./collection-table"
 import { CaseTableAnnounceContext } from "./use-case-table-announce"
 import { useCaseTableModel } from "./use-case-table-model"
 import { useSyncScrolling } from "./use-sync-scrolling"
+import { useWhiteSpaceClick } from "./use-white-space-click"
 
 import "./case-table.scss"
 
@@ -34,6 +35,7 @@ export const CaseTable = observer(function CaseTable() {
   const data = useDataSetContext()
   const tableModel = useCaseTableModel()
   const tileSelection = useTileSelectionContext()
+  const { handleWhiteSpaceClick } = useWhiteSpaceClick()
   const contentRef = useRef<HTMLDivElement>(null)
   const lastNewCollectionDrop = useRef<{ newCollectionId: string, beforeCollectionId: string } | undefined>()
   const [statusMessage, setStatusMessage] = useState("")
@@ -191,7 +193,8 @@ export const CaseTable = observer(function CaseTable() {
                       <CollectionTable collectionIndex={i} onMount={handleCollectionTableMount}
                         onNewCollectionDrop={handleNewCollectionDrop} onTableScroll={handleTableScroll}
                         onScrollClosestRowIntoView={handleScrollClosestRowIntoView}
-                        onScrollRowRangeIntoView={handleScrollRowRangeIntoView} />
+                        onScrollRowRangeIntoView={handleScrollRowRangeIntoView}
+                        onWhiteSpaceClick={handleWhiteSpaceClick} />
                     </CollectionContext.Provider>
                   </ParentCollectionContext.Provider>
                 )

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -174,6 +174,11 @@ export const CaseTable = observer(function CaseTable() {
     if (!tableModel || !data) return null
 
     const collections = data.collections
+    const handleContentClick = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target === contentRef.current) {
+        handleWhiteSpaceClick()
+      }
+    }
     const handleHorizontalScroll: React.UIEventHandler<HTMLDivElement> = () => {
       tableModel.setHorizontalScrollOffset(contentRef.current?.scrollLeft ?? 0)
     }
@@ -182,7 +187,8 @@ export const CaseTable = observer(function CaseTable() {
       <div ref={handleTableRef} className="case-table" data-testid="case-table">
         <CaseTableAnnounceContext.Provider value={announce}>
           {data.hasFilterFormula && <FilterFormulaBar />}
-          <div className="case-table-content" ref={contentRef} onScroll={handleHorizontalScroll}>
+          <div className="case-table-content" ref={contentRef}
+               onScroll={handleHorizontalScroll} onClick={handleContentClick}>
             <AttributeHeaderDividerContext.Provider value={contentRef}>
               {collections.map((collection, i) => {
                 const key = collection.id

--- a/v3/src/components/case-table/case-table.tsx
+++ b/v3/src/components/case-table/case-table.tsx
@@ -175,7 +175,7 @@ export const CaseTable = observer(function CaseTable() {
 
     const collections = data.collections
     const handleContentClick = (event: React.MouseEvent<HTMLDivElement>) => {
-      if (event.target === contentRef.current) {
+      if (tileSelection.isTileSelected() && event.target === contentRef.current) {
         handleWhiteSpaceClick()
       }
     }

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -41,8 +41,6 @@ import { useMarqueeSelection } from "./use-marquee-selection"
 import { useRows } from "./use-rows"
 import { useSelectedCell } from "./use-selected-cell"
 import { useSelectedRows } from "./use-selected-rows"
-import { useWhiteSpaceClick } from "./use-white-space-click"
-
 import "react-data-grid/lib/styles.css"
 import styles from "./case-table-shared.scss"
 
@@ -60,10 +58,12 @@ interface IProps {
   onTableScroll: OnTableScrollFn
   onScrollClosestRowIntoView: OnScrollRowsIntoViewFn
   onScrollRowRangeIntoView: OnScrollRowsIntoViewFn
+  onWhiteSpaceClick: () => void
 }
 export const CollectionTable = observer(function CollectionTable(props: IProps) {
   const {
-    collectionIndex, onMount, onNewCollectionDrop, onScrollClosestRowIntoView, onScrollRowRangeIntoView, onTableScroll
+    collectionIndex, onMount, onNewCollectionDrop, onScrollClosestRowIntoView, onScrollRowRangeIntoView,
+    onTableScroll, onWhiteSpaceClick
   } = props
   const data = useDataSetContext()
   const collectionId = useCollectionContext()
@@ -74,7 +74,6 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   const visibleAttributes = useVisibleAttributes(collectionId)
   const { selectedRows, setSelectedRows, handleCellClick } =
     useSelectedRows({ gridRef, onScrollClosestRowIntoView, onScrollRowRangeIntoView })
-  const { handleWhiteSpaceClick } = useWhiteSpaceClick({ gridRef })
   const { isTileSelected } = useTileSelectionContext()
   const initialPointerDownPosition = useRef({ x: 0, y: 0 })
   const kPointerMovementThreshold = 3
@@ -384,7 +383,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
 
     // the grid element is the target when clicking outside the cells (otherwise, the cell is the target)
     if (isTileSelected() && event.target === gridRef.current?.element) {
-      handleWhiteSpaceClick()
+      onWhiteSpaceClick()
       initialPointerDownPosition.current = { x: 0, y: 0 }
     }
   }
@@ -427,7 +426,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   return (
     <div className={clsx("collection-table", `collection-${collectionId}`, { "no-attributes": !hasVisibleAttributes })}>
       <CollectionTableSpacer gridElt={gridRef.current?.element}
-        onWhiteSpaceClick={handleWhiteSpaceClick} onDrop={handleNewCollectionDrop} />
+        onWhiteSpaceClick={onWhiteSpaceClick} onDrop={handleNewCollectionDrop} />
       <div className="collection-table-and-title" ref={setNodeRef} onClick={handleClick}
             onPointerDown={handlePointerDown} onPointerMove={handlePointerMove} onPointerUp={handlePointerUp}>
         <CollectionTitle onAddNewAttribute={handleAddNewAttribute} showCount={true} collectionIndex={collectionIndex}/>

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -41,6 +41,7 @@ import { useMarqueeSelection } from "./use-marquee-selection"
 import { useRows } from "./use-rows"
 import { useSelectedCell } from "./use-selected-cell"
 import { useSelectedRows } from "./use-selected-rows"
+
 import "react-data-grid/lib/styles.css"
 import styles from "./case-table-shared.scss"
 

--- a/v3/src/components/case-table/use-white-space-click.ts
+++ b/v3/src/components/case-table/use-white-space-click.ts
@@ -1,15 +1,10 @@
 import { useCallback, useEffect, useRef } from "react"
-import { DataGridHandle } from "react-data-grid"
 import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
 import { selectAllCases } from "../../models/data/data-set-utils"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useCodapComponentContext } from "../../hooks/use-codap-component-context"
 
-interface IProps {
-  gridRef: React.RefObject<DataGridHandle>
-}
-
-export function useWhiteSpaceClick({ gridRef }: IProps) {
+export function useWhiteSpaceClick() {
   const data = useDataSetContext()
   const componentRef = useCodapComponentContext()
   // Whitespace should only clear selection if the table is already focused.


### PR DESCRIPTION
## Summary
- Lifts `useWhiteSpaceClick` from `collection-table.tsx` up to `case-table.tsx` so a single per-tile hook instance owns the focus-state tracking, then threads `handleWhiteSpaceClick` down to each `<CollectionTable>` as a new `onWhiteSpaceClick` prop. Pure refactor — drops the unused `gridRef` prop from the hook signature in the process.
- Adds an `onClick` handler on `.case-table-content` (guarded by `event.target === contentRef.current` plus `isTileSelected()`) so clicks landing on the bare flex-container area to the right of the rightmost collection clear the case selection, matching the existing left-spacer and below-rows behavior.
- The `isTileSelected()` guard keeps the new path symmetric with the in-grid background-click handler in `collection-table.tsx`. Also restores a blank line between import groups in `collection-table.tsx` that was lost when the local `useWhiteSpaceClick` import was removed in the refactor commit.

Fixes CODAP-1299

## Test plan
- [x] \`npm run build:tsc\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm test -- case-table\` — 21 passed, 1 pre-existing skip
- [x] Browser: small 5-row dataset in a wide tile, click right whitespace with a case selected → cases deselect
- [x] Browser: regression sweep — left-spacer, below-rows-in-grid, cell click (no spurious deselect), first-click-focuses-without-deselecting, second-click-deselects — all behave correctly
- [ ] CI to confirm lint/build/limited Cypress
- [ ] After CI passes, apply \`run regression\` label for full Cypress suite