### PR TITLE
CODAP-1351: V2 plugin-event compatibility — graph adornments/plots

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -2,12 +2,14 @@ import { MutableRefObject, useCallback, useEffect, useMemo, useRef } from "react
 import { BaseType, drag, extent, select, Selection } from "d3"
 import { comparer, reaction } from "mobx"
 import { logMessageWithReplacement } from "../../../lib/log-message"
+import { getTileModel } from "../../../models/tiles/tile-model"
 import { mstAutorun } from "../../../utilities/mst-autorun"
 import { mstReaction } from "../../../utilities/mst-reaction"
 import { isAliveSafe } from "../../../utilities/mst-utils"
 import { translate } from "../../../utilities/translation/translate"
 import { isVertical } from "../../axis-graph-shared"
 import { axisPlaceToAttrRole, kOther } from "../../data-display/data-display-types"
+import { swapCategoriesNotification } from "../../graph/graph-notifications"
 import { useDataDisplayAnimation } from "../../data-display/hooks/use-data-display-animation"
 import { useDataDisplayModelContextMaybe } from "../../data-display/hooks/use-data-display-model"
 import { kDefaultFontHeight } from "../axis-constants"
@@ -147,6 +149,8 @@ export const useSubAxis = ({
         displayModel?.applyModelChange(() => {
           categorySet?.move(dI.catName, dI.currentDragPositionCatName)
         }, {
+          notify: () => swapCategoriesNotification(
+                          displayModel ? getTileModel(displayModel) : undefined, axisPlace),
           undoStringKey: "DG.Undo.graph.swapCategories",
           redoStringKey: "DG.Redo.graph.swapCategories",
           log: logMessageWithReplacement(

--- a/v3/src/components/data-display/components/legend/categorical-legend-model.ts
+++ b/v3/src/components/data-display/components/legend/categorical-legend-model.ts
@@ -1,6 +1,7 @@
 import { makeAutoObservable } from "mobx"
 import { measureText } from "../../../../hooks/use-measure-text"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
+import { INotify } from "../../../../models/history/history-service"
 import { missingColor } from "../../../../utilities/color-utils"
 import { axisGap, labelPaddingY } from "../../../axis/axis-types"
 import { getStringBounds } from "../../../axis/axis-utils"
@@ -181,7 +182,8 @@ export class CategoricalLegendModel {
   }
 
   onDragEnd(
-    dataConfiguration: IDataConfigurationModel | undefined, d: Key
+    dataConfiguration: IDataConfigurationModel | undefined, d: Key,
+    options?: { notify?: INotify }
   ) {
     const categories = dataConfiguration?.categoryArrayForAttrRole('legend') || []
     const dI = this.dragInfo
@@ -212,6 +214,7 @@ export class CategoricalLegendModel {
         categorySet?.move(dI.category, beforeCategory)
         dI.category = ""
       }, {
+        notify: options?.notify,
         undoStringKey: 'DG.Undo.graph.swapCategories',
         redoStringKey: 'DG.Redo.graph.swapCategories',
         log: logMessageWithReplacement(

--- a/v3/src/components/data-display/components/legend/categorical-legend.tsx
+++ b/v3/src/components/data-display/components/legend/categorical-legend.tsx
@@ -3,9 +3,12 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {mstReaction} from "../../../../utilities/mst-reaction"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
 import { setSelectedCases, selectCases } from "../../../../models/data/data-set-utils"
+import { getTileModel } from "../../../../models/tiles/tile-model"
 import {axisGap} from "../../../axis/axis-types"
+import { swapCategoriesNotification } from "../../../graph/graph-notifications"
 import { transitionDuration } from "../../data-display-types"
 import {useDataConfigurationContext} from "../../hooks/use-data-configuration-context"
+import { useDataDisplayModelContextMaybe } from "../../hooks/use-data-display-model"
 import {useDataDisplayLayout} from "../../hooks/use-data-display-layout"
 import { IBaseLegendProps } from "./legend-common"
 import { CategoricalLegendModel, keySize, padding, labelHeight, Key } from "./categorical-legend-model"
@@ -18,6 +21,7 @@ export const CategoricalLegend =
   function CategoricalLegend({layerIndex, setDesiredExtent}: IBaseLegendProps) {
 
     const dataConfiguration = useDataConfigurationContext()
+    const displayModel = useDataDisplayModelContextMaybe()
     const dataDisplayLayout = useDataDisplayLayout()
     const duration = useRef(0)
     const keysElt = useRef(null)
@@ -83,14 +87,17 @@ export const CategoricalLegend =
 
       const onDragEnd = (event: any, d: Key) => {
         duration.current = transitionDuration
-        legendModel.onDragEnd(dataConfiguration, d)
+        const tile = displayModel ? getTileModel(displayModel) : undefined
+        legendModel.onDragEnd(dataConfiguration, d, {
+          notify: () => swapCategoriesNotification(tile, "legend")
+        })
       }
 
       return drag<SVGGElement, Key>()
         .on("start", onDragStart)
         .on("drag", onDrag)
         .on("end", onDragEnd)
-    }, [dataConfiguration, legendModel])
+    }, [dataConfiguration, displayModel, legendModel])
 
     useEffect(() => { return mstAutorun(function d3Render() {
       if (!keysElt.current) return

--- a/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/count/count-adornment-registration.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react"
 import { Radio, RadioGroup } from "react-aria-components"
 import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
+import { updateTileNotification } from "../../../../models/tiles/tile-notifications"
 import { t } from "../../../../utilities/translation/translate"
 import { PaletteCheckbox } from "../../../palette-checkbox"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
@@ -19,6 +21,7 @@ import { kCountClass, kCountLabelKey, kCountPrefix, kCountType, kPercentLabelKey
 const Controls = () => {
   const graphModel = useGraphContentModelContext()
   const dataConfig = useGraphDataConfigurationContext()
+  const { tile } = useTileModelContext()
   const adornmentsStore = graphModel.adornmentsStore
   const existingAdornment = adornmentsStore.findAdornmentOfType<ICountAdornmentModel>(kCountType)
   const leftBottomCategoricalAttrCount = dataConfig?.leftBottomCategoricalAttrCount ?? 0
@@ -39,36 +42,41 @@ const Controls = () => {
     const existingCountAdornment = adornmentsStore.findAdornmentOfType<ICountAdornmentModel>(kCountType)
     const componentContentInfo = getAdornmentContentInfo(kCountType)
     const adornment = existingCountAdornment ?? componentContentInfo.modelClass.create() as ICountAdornmentModel
-    const undoAddKey = checkBoxType === "count" ? "DG.Undo.graph.showCount" : "DG.Undo.graph.showPercent"
-    const redoAddKey = checkBoxType === "count" ? "DG.Redo.graph.showCount" : "DG.Redo.graph.showPercent"
-    const undoRemoveKey = checkBoxType === "count" ? "DG.Undo.graph.hideCount" : "DG.Undo.graph.hidePercent"
-    const redoRemoveKey = checkBoxType === "count" ? "DG.Redo.graph.hideCount" : "DG.Redo.graph.hidePercent"
+    const isCount = checkBoxType === "count"
+    const undoAddKey = isCount ? "DG.Undo.graph.showCount" : "DG.Undo.graph.showPercent"
+    const redoAddKey = isCount ? "DG.Redo.graph.showCount" : "DG.Redo.graph.showPercent"
+    const undoRemoveKey = isCount ? "DG.Undo.graph.hideCount" : "DG.Undo.graph.hidePercent"
+    const redoRemoveKey = isCount ? "DG.Redo.graph.hideCount" : "DG.Redo.graph.hidePercent"
 
-    const setShowAdornment = checkBoxType === "count"
+    const setShowAdornment = isCount
       ? () => adornment.setShowCount(checked)
       : () => handleShowPercent(adornment, checked)
 
+    // V2 emits `toggle plotted Count` / `toggle plotted Percent` from
+    // apps/dg/components/graph/plots/plot_model.js (togglePlottedCount(iWhat) ~:465).
+    // Op string is `'toggle plotted ' + iWhat` where iWhat is `'Count'` or `'Percent'`.
+    const notificationOp = isCount ? "toggle plotted Count" : "toggle plotted Percent"
+    const notify = tile
+      ? () => updateTileNotification(notificationOp, { isChecked: checked }, tile)
+      : undefined
+
     if (checked) {
-      graphModel.applyModelChange(
-        () => {
-          adornmentsStore.addAdornment(adornment, graphModel.getUpdateCategoriesOptions())
-          setShowAdornment()
-        },
-        {
-          undoStringKey: undoAddKey,
-          redoStringKey: redoAddKey,
-          log: logMessageWithReplacement("Show %@", {adornmentType: checkBoxType === "count" ? "count" : "percent"})
-        }
-      )
+      graphModel.applyModelChange(() => {
+        adornmentsStore.addAdornment(adornment, graphModel.getUpdateCategoriesOptions())
+        setShowAdornment()
+      }, {
+        notify,
+        undoStringKey: undoAddKey,
+        redoStringKey: redoAddKey,
+        log: logMessageWithReplacement("Show %@", {adornmentType: isCount ? "count" : "percent"})
+      })
     } else {
-      graphModel.applyModelChange(
-        () => adornmentsStore.updateAdornment(setShowAdornment),
-        {
-          undoStringKey: undoRemoveKey,
-          redoStringKey: redoRemoveKey,
-          log: logMessageWithReplacement("Hide %@", {adornmentType: checkBoxType === "count" ? "count" : "percent"})
-        }
-      )
+      graphModel.applyModelChange(() => adornmentsStore.updateAdornment(setShowAdornment), {
+        notify,
+        undoStringKey: undoRemoveKey,
+        redoStringKey: redoRemoveKey,
+        log: logMessageWithReplacement("Hide %@", {adornmentType: isCount ? "count" : "percent"})
+      })
     }
   }
 

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
@@ -1,12 +1,14 @@
 import { drag, select, Selection } from "d3"
 import { observer } from "mobx-react-lite"
 import React, { useCallback, useEffect, useRef } from "react"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { LogMessageFn, logModelChangeFn } from "../../../../lib/log-message"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
 import { mstReaction } from "../../../../utilities/mst-reaction"
 import { safeGetSnapshot } from "../../../../utilities/mst-utils"
 import { t } from "../../../../utilities/translation/translate"
 import { kMain } from "../../../data-display/data-display-types"
+import { repositionEquationNotification } from "../../graph-notifications"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
 import { useAdornmentCategories } from "../../hooks/use-adornment-categories"
 import { useAdornmentCells } from "../../hooks/use-adornment-cells"
@@ -50,6 +52,7 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
   const graphModel = useGraphContentModelContext()
   const dataConfig = useGraphDataConfigurationContext()
   const layout = useGraphLayoutContext()
+  const { tile } = useTileModelContext()
   const adornmentsStore = graphModel?.adornmentsStore
   const showSumSquares = graphModel?.adornmentsStore.showSquaresOfResiduals
   const { xAttrId, yAttrId, xAttrName, yAttrName, xScale, yScale } = useAdornmentAttributes()
@@ -130,18 +133,16 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
           // compute proportional position of center of label within container
           const x = (left + equationBounds.width / 2) / containerBounds.width
           const y = (top + equationBounds.height / 2) / containerBounds.height
-          graphModel.applyModelChange(
-            () => model.setLabelEquationCoords(cellKey, category, { x, y}),
-            {
-              undoStringKey: "DG.Undo.graph.repositionEquation",
-              redoStringKey: "DG.Redo.graph.repositionEquation",
-              log: logFn.current
-            }
-          )
+          graphModel.applyModelChange(() => model.setLabelEquationCoords(cellKey, category, { x, y }), {
+            notify: () => repositionEquationNotification(tile, "lsrl"),
+            undoStringKey: "DG.Undo.graph.repositionEquation",
+            redoStringKey: "DG.Redo.graph.repositionEquation",
+            log: logFn.current
+          })
         }
       }
     }
-  }, [cellKey, equationContainerSelector, graphModel, model])
+  }, [cellKey, equationContainerSelector, graphModel, model, tile])
 
   const updateEquations = useCallback(() => {
     const lines = getLines()

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-registration.tsx
@@ -1,6 +1,8 @@
 import { observer } from "mobx-react-lite"
 import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
+import { updateTileNotification } from "../../../../models/tiles/tile-notifications"
 import { t } from "../../../../utilities/translation/translate"
 import { PaletteCheckbox } from "../../../palette-checkbox"
 import { If } from "../../../common/if"
@@ -21,6 +23,7 @@ function logLSRLToggle(action: "hide" | "show") {
 
 const Controls = observer(function Controls() {
   const graphModel = useGraphContentModelContext()
+  const { tile } = useTileModelContext()
   const adornmentsStore = graphModel.adornmentsStore
   const existingAdornment = adornmentsStore.findAdornmentOfType<ILSRLAdornmentModel>(kLSRLType)
   const interceptLocked = adornmentsStore?.interceptLocked
@@ -36,10 +39,16 @@ const Controls = observer(function Controls() {
       redoRemove: componentContentInfo.undoRedoKeys?.redoRemove
     }
 
+    // V2 emits `toggle LSRL` from apps/dg/components/graph/plots/scatter_plot_model.js
+    // (toggleLSRLLine ~:336). Match the adornment-checkbox convention with `{ isChecked }`.
+    const notify = tile
+      ? () => updateTileNotification("toggle LSRL", { isChecked: checked }, tile)
+      : undefined
+
     if (checked) {
       graphModel.applyModelChange(
-        () => adornmentsStore.addAdornment(adornment, graphModel.getUpdateCategoriesOptions()),
-        {
+        () => adornmentsStore.addAdornment(adornment, graphModel.getUpdateCategoriesOptions()), {
+          notify,
           undoStringKey: undoRedoKeys.undoAdd || "",
           redoStringKey: undoRedoKeys.redoAdd || "",
           log: logLSRLToggle("show")
@@ -47,8 +56,8 @@ const Controls = observer(function Controls() {
       )
     } else {
       graphModel.applyModelChange(
-        () => adornmentsStore.hideAdornment(adornment.type),
-        {
+        () => adornmentsStore.hideAdornment(adornment.type), {
+          notify,
           undoStringKey: undoRedoKeys.undoRemove || "",
           redoStringKey: undoRedoKeys.redoRemove || "",
           log: logLSRLToggle("hide")

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
@@ -2,9 +2,11 @@ import React, {useCallback, useEffect, useRef, useState} from "react"
 import { observer } from "mobx-react-lite"
 import {drag, select, Selection} from "d3"
 import {useInstanceIdContext} from "../../../../hooks/use-instance-id-context"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { LogMessageFn, logMessageWithReplacement, logModelChangeFn } from "../../../../lib/log-message"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
 import { safeGetSnapshot } from "../../../../utilities/mst-utils"
+import { dragMovableLineNotification, repositionEquationNotification } from "../../graph-notifications"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
 import { useAdornmentCategories } from "../../hooks/use-adornment-categories"
 import { useAdornmentCells } from "../../hooks/use-adornment-cells"
@@ -53,6 +55,7 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
   const graphModel = useGraphContentModelContext()
   const dataConfig = useGraphDataConfigurationContext()
   const layout = useGraphLayoutContext()
+  const { tile } = useTileModelContext()
   const instanceId = useInstanceIdContext()
   const adornmentsStore = graphModel.adornmentsStore
   const { xAttrId, xAttrName, yAttrId, yAttrName, xScale, yScale } = useAdornmentAttributes()
@@ -229,6 +232,7 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
         const equationCoords = lineParams?.equationCoords
         model.setLine({slope, intercept: newIntercept, equationCoords}, instanceKey)
       }, {
+        notify: () => dragMovableLineNotification(tile),
         log: logMessageWithReplacement("dragMovableLine: '%@'", {equation}, "plot"),
         undoStringKey: "V3.Undo.graph.adjustMovableLine",
         redoStringKey: "V3.Redo.graph.adjustMovableLine"
@@ -236,7 +240,7 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
     } else {
       model.setVolatileLine({intercept: newIntercept, slope}, instanceKey)
     }
-  }, [getEquationString, instanceKey, interceptLocked, model, updateLine, xAxis, yAxis])
+  }, [getEquationString, instanceKey, interceptLocked, model, tile, updateLine, xAxis, yAxis])
 
   const newSlopeAndIntercept = useCallback((
     pivot: Point, mousePosition: Point, lineSection: string, isVertical: boolean
@@ -325,6 +329,7 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
             equationCoords,
           }, instanceKey)
         }, {
+          notify: () => dragMovableLineNotification(tile),
           log: logMessageWithReplacement("dragMovableLine: '%@'", {equation}, "plot"),
           undoStringKey: "V3.Undo.graph.adjustMovableLine",
           redoStringKey: "V3.Redo.graph.adjustMovableLine"
@@ -335,7 +340,7 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
       }
     }
   }, [getEquationString, instanceKey, interceptLocked, lineObject.lower, lineObject.upper, model,
-      newSlopeAndIntercept, updateLine, xAxis, yAxis])
+      newSlopeAndIntercept, tile, updateLine, xAxis, yAxis])
 
   const handleMoveEquation = useCallback((
     event: { x: number, y: number, dx: number, dy: number },
@@ -359,18 +364,16 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
           // compute proportional position of center of label within container
           const x = (left + equationBounds.width / 2) / containerBounds.width
           const y = (top + equationBounds.height / 2) / containerBounds.height
-          model.applyModelChange(
-            () => lineInstance?.setEquationCoords({ x, y }),
-            {
-              undoStringKey: "DG.Undo.graph.repositionEquation",
-              redoStringKey: "DG.Redo.graph.repositionEquation",
-              log: logFn.current
-            }
-          )
+          model.applyModelChange(() => lineInstance?.setEquationCoords({ x, y }), {
+            notify: () => repositionEquationNotification(tile, "movableLine"),
+            undoStringKey: "DG.Undo.graph.repositionEquation",
+            redoStringKey: "DG.Redo.graph.repositionEquation",
+            log: logFn.current
+          })
         }
       }
     }
-  }, [equationContainerSelector, instanceKey, model])
+  }, [equationContainerSelector, instanceKey, model, tile])
 
   // Refresh the line
   useEffect(function refresh() {

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.test.ts
@@ -16,4 +16,9 @@ describe("Movable line registration", () => {
     expect(movableLineComponentInfo?.Component).toBeDefined()
     expect(movableLineComponentInfo?.type).toBe(kMovableLineType)
   })
+
+  it("registers notificationOperation for 'toggle movable line'", () => {
+    const movableLineContentInfo = getAdornmentContentInfo(kMovableLineType)
+    expect(movableLineContentInfo?.notificationOperation).toBe("toggle movable line")
+  })
 })

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-registration.tsx
@@ -26,6 +26,9 @@ registerAdornmentContentInfo({
   plots: ['scatterPlot'],
   prefix: kMovableLinePrefix,
   modelClass: MovableLineAdornmentModel,
+  // V2 emits `toggle movable line` from apps/dg/components/graph/plots/scatter_plot_model.js
+  // (toggleMovableLine ~:277). AdornmentCheckbox forwards with `{ isChecked }`.
+  notificationOperation: "toggle movable line",
   undoRedoKeys: {
     undoAdd: kMovableLineUndoAddKey,
     redoAdd: kMovableLineRedoAddKey,

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-component.tsx
@@ -3,8 +3,10 @@ import {drag, select, Selection} from "d3"
 import {tip as d3tip} from "d3-v6-tip"
 import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import { IAdornmentComponentProps } from "../adornment-component-info"
+import { dragMovablePointNotification } from "../../graph-notifications"
 import { IMovablePointAdornmentModel } from "./movable-point-adornment-model"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
@@ -28,6 +30,7 @@ export const MovablePointAdornment = observer(function MovablePointAdornment(pro
   const {plotHeight, plotWidth, cellKey = {}, xAxis, yAxis} = props
   const model = props.model as IMovablePointAdornmentModel
   const graphModel = useGraphContentModelContext()
+  const { tile } = useTileModelContext()
   const { xAttrId, yAttrId, xAttrName, yAttrName, xScale, yScale } = useAdornmentAttributes()
   const { classFromKey, instanceKey } = useAdornmentCells(model, cellKey)
   const { xSubAxesCount, ySubAxesCount } = useAdornmentCategories()
@@ -91,18 +94,16 @@ export const MovablePointAdornment = observer(function MovablePointAdornment(pro
     const xValue = Math.round(xScale.invert(xPoint * xSubAxesCount) * 10) / 10
     const yValue = Math.round(yScale.invert(yPoint * ySubAxesCount) * 10) / 10
 
-    graphModel.applyModelChange(
-      () => model.setPoint({x: xValue, y: yValue}, instanceKey),
-      {
-        undoStringKey: "DG.Undo.graph.moveMovablePoint",
-        redoStringKey: "DG.Redo.graph.moveMovablePoint",
-        log: logMessageWithReplacement(
-              "Move point from (%@, %@) to (%@, %@)",
-              { xInitial: dragStartPoint.current.x, yInitial: dragStartPoint.current.y, x: xValue, y: yValue})
-      }
-    )
+    graphModel.applyModelChange(() => model.setPoint({x: xValue, y: yValue}, instanceKey), {
+      notify: () => dragMovablePointNotification(tile),
+      undoStringKey: "DG.Undo.graph.moveMovablePoint",
+      redoStringKey: "DG.Redo.graph.moveMovablePoint",
+      log: logMessageWithReplacement(
+            "Move point from (%@, %@) to (%@, %@)",
+            { xInitial: dragStartPoint.current.x, yInitial: dragStartPoint.current.y, x: xValue, y: yValue})
+    })
 
-  }, [graphModel, instanceKey, model, xScale, xSubAxesCount, yScale, ySubAxesCount])
+  }, [graphModel, instanceKey, model, tile, xScale, xSubAxesCount, yScale, ySubAxesCount])
 
   useEffect(function repositionPoint() {
     return autorun(() => {

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.test.ts
@@ -16,4 +16,9 @@ describe("Movable point registration", () => {
     expect(movablePointComponentInfo?.Component).toBeDefined()
     expect(movablePointComponentInfo?.type).toBe(kMovablePointType)
   })
+
+  it("registers notificationOperation for 'toggle movable point'", () => {
+    const movablePointContentInfo = getAdornmentContentInfo(kMovablePointType)
+    expect(movablePointContentInfo?.notificationOperation).toBe("toggle movable point")
+  })
 })

--- a/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-point/movable-point-adornment-registration.tsx
@@ -25,6 +25,9 @@ registerAdornmentContentInfo({
   plots: ['scatterPlot'],
   prefix: kMovablePointPrefix,
   modelClass: MovablePointAdornmentModel,
+  // V2 emits `toggle movable point` from apps/dg/components/graph/plots/scatter_plot_model.js
+  // (toggleMovablePoint ~:232). AdornmentCheckbox forwards with `{ isChecked }`.
+  notificationOperation: "toggle movable point",
   undoRedoKeys: {
     undoAdd: kMovablePointUndoAddKey,
     redoAdd: kMovablePointRedoAddKey,

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-component.tsx
@@ -2,10 +2,12 @@ import {drag, select, Selection} from "d3"
 import {autorun} from "mobx"
 import { observer } from "mobx-react-lite"
 import {useCallback, useEffect, useRef} from "react"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { isNumericAttributeType } from "../../../../models/data/attribute-types"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import {useAxisLayoutContext} from "../../../axis/models/axis-layout-context"
 import { IDateAxisModel, isDateAxisModel } from "../../../axis/models/numeric-axis-models"
+import { dragMovableValueNotification } from "../../graph-notifications"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
 import { useAdornmentCells } from "../../hooks/use-adornment-cells"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
@@ -29,6 +31,7 @@ export const MovableValueAdornment = observer(function MovableValueAdornment(pro
   const layout = useAxisLayoutContext()
   const graphModel = useGraphContentModelContext()
   const dataConfig = useGraphDataConfigurationContext()
+  const { tile } = useTileModelContext()
   const { xAttrType, xScale, yScale } = useAdornmentAttributes()
   const { cellCounts, classFromKey, instanceKey } = useAdornmentCells(model, cellKey)
   const [left, right] = xScale?.range() || [0, 1]
@@ -145,15 +148,14 @@ export const MovableValueAdornment = observer(function MovableValueAdornment(pro
                                 ? Math.round(model.values.get(instanceKey)![dragIndex] * 10) / 10
                                 : 'undefined'
       const logToValue = Math.round(dragValue *10)/10
-      graphModel.applyModelChange(
-        () => model.endDrag(dragValue, instanceKey, dragIndex),
-        { undoStringKey: "DG.Undo.graph.moveMovableValue",
-          redoStringKey: "DG.Redo.graph.moveMovableValue",
-          log: logMessageWithReplacement("Moved value from %@ to %@", {from: logFromValue, to: logToValue})
-        }
-      )
+      graphModel.applyModelChange(() => model.endDrag(dragValue, instanceKey, dragIndex), {
+        notify: () => dragMovableValueNotification(tile),
+        undoStringKey: "DG.Undo.graph.moveMovableValue",
+        redoStringKey: "DG.Redo.graph.moveMovableValue",
+        log: logMessageWithReplacement("Moved value from %@ to %@", {from: logFromValue, to: logToValue})
+      })
     }
-  }, [graphModel, instanceKey, model])
+  }, [graphModel, instanceKey, model, tile])
 
   // Add drag behaviors to the line cover
   const addDragHandlers = useCallback(() => {

--- a/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/movable-value/movable-value-adornment-registration.tsx
@@ -1,8 +1,10 @@
 import { registerAdornmentHandler } from "../../../../data-interactive/handlers/adornment-handler"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { isFiniteNumber } from "../../../../utilities/math-utils"
 import { stringToCellKey } from "../../utilities/cell-key-utils"
 import { t } from "../../../../utilities/translation/translate"
 import { ICodapV2MovableValueAdornmentInstance } from "../../../../v2/codap-v2-types"
+import { addMovableValueNotification, removeMovableValueNotification } from "../../graph-notifications"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import { registerAdornmentComponentInfo } from "../adornment-component-info"
 import { exportAdornmentBase, getAdornmentContentInfo, registerAdornmentContentInfo } from "../adornment-content-info"
@@ -19,6 +21,7 @@ import {
 
 const Controls = () => {
   const graphModel = useGraphContentModelContext()
+  const { tile } = useTileModelContext()
   const adornmentsStore = graphModel.adornmentsStore
 
   const handleAddMovableValue = () => {
@@ -27,30 +30,26 @@ const Controls = () => {
     const adornment = existingAdornment ?? componentContentInfo.modelClass.create() as IMovableValueAdornmentModel
     const options: IUpdateCategoriesOptions = { ...graphModel.getUpdateCategoriesOptions(), addMovableValue: true }
 
-    graphModel.applyModelChange(
-      () => adornmentsStore.addAdornment(adornment, options),
-      {
-        undoStringKey: kMovableValueUndoAddKey,
-        redoStringKey: kMovableValueRedoAddKey,
-        log: `Added movable value`
-      }
-    )
+    graphModel.applyModelChange(() => adornmentsStore.addAdornment(adornment, options), {
+      notify: () => addMovableValueNotification(tile),
+      undoStringKey: kMovableValueUndoAddKey,
+      redoStringKey: kMovableValueRedoAddKey,
+      log: `Added movable value`
+    })
   }
 
   const handleRemoveMovableValue = () => {
     const adornment = adornmentsStore.findAdornmentOfType<IMovableValueAdornmentModel>(kMovableValueType)
 
-    graphModel.applyModelChange(
-      () => {
-          adornmentsStore.updateAdornment(() => { adornment?.deleteValue() })
-          if (!adornment?.hasValues) adornment?.setVisibility(false)
-      },
-      {
-        undoStringKey: kMovableValueUndoRemoveKey,
-        redoStringKey: kMovableValueRedoRemoveKey,
-        log: `Removed movable value`
-      }
-    )
+    graphModel.applyModelChange(() => {
+      adornmentsStore.updateAdornment(() => { adornment?.deleteValue() })
+      if (!adornment?.hasValues) adornment?.setVisibility(false)
+    }, {
+      notify: () => removeMovableValueNotification(tile),
+      undoStringKey: kMovableValueUndoRemoveKey,
+      redoStringKey: kMovableValueRedoRemoveKey,
+      log: `Removed movable value`
+    })
   }
 
   return (

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react"
 import { observer } from "mobx-react-lite"
 import { Button, useDisclosure } from "@chakra-ui/react"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { t } from "../../../../utilities/translation/translate"
 import { logStringifiedObjectMessage } from "../../../../lib/log-message"
 import { EditFormulaModal } from "../../../common/edit-formula-modal"
+import { editPlotFormulaNotification } from "../../graph-notifications"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import { IAdornmentBannerComponentProps } from "../adornment-component-info"
 import { IPlottedFunctionAdornmentModel } from "./plotted-function-adornment-model"
@@ -15,6 +17,7 @@ export const PlottedFunctionAdornmentBanner = observer(function PlottedFunctionA
 ) {
   const model = props.model as IPlottedFunctionAdornmentModel
   const graphModel = useGraphContentModelContext()
+  const { tile } = useTileModelContext()
   const dataset = graphModel.dataset
   const yAttrID = graphModel.dataConfiguration.attributeID('y')
   const yAttrName = dataset?.getAttribute(yAttrID)?.name ?? t("DG.PlottedFunction.formulaPrompt")
@@ -38,14 +41,12 @@ export const PlottedFunctionAdornmentBanner = observer(function PlottedFunctionA
 
   const handleEditExpressionClose = (newExpression: string) => {
     handleCloseModal()
-    graphModel.applyModelChange(
-      () => model.setExpression(newExpression),
-      {
-        undoStringKey: "DG.Undo.graph.changePlotFunction",
-        redoStringKey: "DG.Redo.graph.changePlotFunction",
-        log: logStringifiedObjectMessage("Change plotted function: %@", {from: expression, to: newExpression})
-      }
-    )
+    graphModel.applyModelChange(() => model.setExpression(newExpression), {
+      notify: () => editPlotFormulaNotification(tile, "plottedFunction", expression, newExpression),
+      undoStringKey: "DG.Undo.graph.changePlotFunction",
+      redoStringKey: "DG.Redo.graph.changePlotFunction",
+      log: logStringifiedObjectMessage("Change plotted function: %@", {from: expression, to: newExpression})
+    })
   }
 
   return (

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.test.ts
@@ -17,4 +17,9 @@ describe("PlottedFunctionRegistration", () => {
     expect(plottedFunctionComponentInfo?.BannerComponent).toBeDefined()
     expect(plottedFunctionComponentInfo?.type).toBe(kPlottedFunctionType)
   })
+
+  it("registers notificationOperation for 'toggle plot function'", () => {
+    const plottedFunctionContentInfo = getAdornmentContentInfo(kPlottedFunctionType)
+    expect(plottedFunctionContentInfo?.notificationOperation).toBe("toggle plot function")
+  })
 })

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-registration.tsx
@@ -29,6 +29,9 @@ registerAdornmentContentInfo({
   plots: ["scatterPlot"],
   prefix: kPlottedFunctionPrefix,
   modelClass: PlottedFunctionAdornmentModel,
+  // V2 emits `toggle plot function` from apps/dg/components/graph/plots/scatter_plot_model.js
+  // (togglePlotFunction ~:461). AdornmentCheckbox forwards with `{ isChecked }`.
+  notificationOperation: "toggle plot function",
   undoRedoKeys: {
     undoAdd: kPlottedFunctionUndoAddKey,
     redoAdd: kPlottedFunctionRedoAddKey,

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
@@ -1,9 +1,14 @@
 import { observer } from "mobx-react-lite"
 import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { useTileModelContext } from "../../../../../hooks/use-tile-model-context"
 import { logMessageWithReplacement } from "../../../../../lib/log-message"
+import { updateTileNotification } from "../../../../../models/tiles/tile-notifications"
 import { getDocumentContentPropertyFromNode } from "../../../../../utilities/mst-utils"
 import { t } from "../../../../../utilities/translation/translate"
 import { PaletteCheckbox } from "../../../../palette-checkbox"
+import {
+  toggleShowICINotification, toggleShowOutliersNotification
+} from "../../../graph-notifications"
 import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
 import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { getAdornmentContentInfo, registerAdornmentContentInfo } from "../../adornment-content-info"
@@ -18,6 +23,7 @@ import {
 
 const Controls = observer(function Controls() {
   const graphModel = useGraphContentModelContext()
+  const { tile } = useTileModelContext()
   const adornmentsStore = graphModel.adornmentsStore
   const existingAdornment = adornmentsStore.findAdornmentOfType<IBoxPlotAdornmentModel>(kBoxPlotType)
   const showICIOption = getDocumentContentPropertyFromNode(graphModel, "iciEnabled") || existingAdornment?.showICI
@@ -32,11 +38,15 @@ const Controls = observer(function Controls() {
       undoRemove: componentContentInfo.undoRedoKeys?.undoRemove,
       redoRemove: componentContentInfo.undoRedoKeys?.redoRemove
     }
+    // V2 op: `togglePlottedBoxPlot` (univariate_adornment_base_model.js toggleAverage ~:321).
+    const notify = tile
+      ? () => updateTileNotification("togglePlottedBoxPlot", { isChecked: checked }, tile)
+      : undefined
 
     if (checked) {
       graphModel.applyModelChange(
-        () => adornmentsStore.addAdornment(adornment, graphModel.getUpdateCategoriesOptions()),
-        {
+        () => adornmentsStore.addAdornment(adornment, graphModel.getUpdateCategoriesOptions()), {
+          notify,
           undoStringKey: undoRedoKeys.undoAdd || "",
           redoStringKey: undoRedoKeys.redoAdd || "",
           log: logMessageWithReplacement("Added %@", {adornmentType: adornment.type})
@@ -44,8 +54,8 @@ const Controls = observer(function Controls() {
       )
     } else {
       graphModel.applyModelChange(
-        () => adornmentsStore.hideAdornment(adornment.type),
-        {
+        () => adornmentsStore.hideAdornment(adornment.type), {
+          notify,
           undoStringKey: undoRedoKeys.undoRemove || "",
           redoStringKey: undoRedoKeys.redoRemove || "",
           log: logMessageWithReplacement("Removed %@", {adornmentType: adornment.type})
@@ -55,11 +65,25 @@ const Controls = observer(function Controls() {
   }
 
   const handleShowOutliersSetting = (checked: boolean) => {
-    existingAdornment?.setShowOutliers(checked)
+    // V3 pre-existing bug: this previously bypassed applyModelChange (no undo/redo/log).
+    // Wrap now so the toggle is undoable AND so V2 plugins see `toggle show outliers`.
+    graphModel.applyModelChange(() => existingAdornment?.setShowOutliers(checked), {
+      notify: () => toggleShowOutliersNotification(tile, checked),
+      undoStringKey: checked ? "DG.Undo.graph.showOutliers" : "DG.Undo.graph.hideOutliers",
+      redoStringKey: checked ? "DG.Redo.graph.showOutliers" : "DG.Redo.graph.hideOutliers",
+      log: logMessageWithReplacement("%@ outliers", {action: checked ? "Show" : "Hide"})
+    })
   }
 
   const handleShowIciSetting = (checked: boolean) => {
-    existingAdornment?.setShowICI(checked)
+    // V3 pre-existing bug: this previously bypassed applyModelChange. Wrap and emit the V3-clarified
+    // op `toggle show ICI` (V2 emits the wrong `toggle show outliers` op here — audit §3.5 bug).
+    graphModel.applyModelChange(() => existingAdornment?.setShowICI(checked), {
+      notify: () => toggleShowICINotification(tile, checked),
+      undoStringKey: checked ? "V3.Undo.graph.showICI" : "V3.Undo.graph.hideICI",
+      redoStringKey: checked ? "V3.Redo.graph.showICI" : "V3.Redo.graph.hideICI",
+      log: logMessageWithReplacement("%@ ICI", {action: checked ? "Show" : "Hide"})
+    })
   }
 
   const renderShowOutliers = () => {

--- a/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/box-plot/box-plot-adornment-registration.tsx
@@ -80,8 +80,8 @@ const Controls = observer(function Controls() {
     // op `toggle show ICI` (V2 emits the wrong `toggle show outliers` op here — audit §3.5 bug).
     graphModel.applyModelChange(() => existingAdornment?.setShowICI(checked), {
       notify: () => toggleShowICINotification(tile, checked),
-      undoStringKey: checked ? "V3.Undo.graph.showICI" : "V3.Undo.graph.hideICI",
-      redoStringKey: checked ? "V3.Redo.graph.showICI" : "V3.Redo.graph.hideICI",
+      undoStringKey: checked ? "DG.Undo.graph.showICI" : "DG.Undo.graph.hideICI",
+      redoStringKey: checked ? "DG.Redo.graph.showICI" : "DG.Redo.graph.hideICI",
       log: logMessageWithReplacement("%@ ICI", {action: checked ? "Show" : "Hide"})
     })
   }

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-registration.test.ts
@@ -17,4 +17,9 @@ describe("MeanAbsoluteDeviationRegistration", () => {
     expect(standardDeviationComponentInfo?.Component).toBeDefined()
     expect(standardDeviationComponentInfo?.type).toBe(kMeanAbsoluteDeviationType)
   })
+
+  it("registers notificationOperation for 'togglePlottedMad'", () => {
+    const info = getAdornmentContentInfo(kMeanAbsoluteDeviationType)
+    expect(info?.notificationOperation).toBe("togglePlottedMad")
+  })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/mean-absolute-deviation/mean-absolute-deviation-adornment-registration.tsx
@@ -28,6 +28,8 @@ registerAdornmentContentInfo({
   plots: ["dotPlot"],
   prefix: kMeanAbsoluteDeviationPrefix,
   modelClass: MeanAbsoluteDeviationAdornmentModel,
+  // V2 op string (univariate_adornment_base_model.js togglePlottedMad ~:411/321).
+  notificationOperation: "togglePlottedMad",
   exporter: (model, options) => {
     const adornment = isMeanAbsoluteDeviationAdornment(model) ? model : undefined
     return adornment

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-component.tsx
@@ -5,8 +5,10 @@ import { clsx } from "clsx"
 import { t } from "../../../../../utilities/translation/translate"
 import { getDocumentContentPropertyFromNode } from "../../../../../utilities/mst-utils"
 import { measureText } from "../../../../../hooks/use-measure-text"
+import { useTileModelContext } from "../../../../../hooks/use-tile-model-context"
 import { fitGaussianLM, normal, sqrtTwoPi } from "../../../../../utilities/math-utils"
 import { getDomainExtentForPixelWidth } from "../../../../axis/axis-utils"
+import { repositionEquationNotification } from "../../../graph-notifications"
 import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
 import { isBinnedPlotModel } from "../../../plots/histogram/histogram-model"
 import { curveBasis } from "../../../utilities/graph-utils"
@@ -40,6 +42,7 @@ export const NormalCurveAdornmentComponent = observer(
       xAxis, yAxis, spannerRef
     } = props
     const graphModel = useGraphContentModelContext()
+    const { tile } = useTileModelContext()
     const model = props.model as INormalCurveAdornmentModel
     const {
       dataConfig, layout, adornmentsStore,
@@ -140,7 +143,14 @@ export const NormalCurveAdornmentComponent = observer(
       labelObj.label.call(
         drag<HTMLDivElement, unknown>()
           .on("drag", (e) => helper.handleMoveLabel(e, labelId))
-          .on("end", (e) => helper.handleEndMoveLabel(e, labelId))
+          .on("end", (e) => {
+            graphModel.applyModelChange(() => helper.handleEndMoveLabel(e, labelId), {
+              notify: () => repositionEquationNotification(tile, model.type),
+              undoStringKey: "DG.Undo.graph.repositionEquation",
+              redoStringKey: "DG.Redo.graph.repositionEquation",
+              log: "Moved equation label"
+            })
+          })
       )
 
       labelObj.label.on("mouseover", () => highlightCovers(true))
@@ -149,8 +159,8 @@ export const NormalCurveAdornmentComponent = observer(
       selectionsObj.normalCurveHoverCover?.on("mouseover", () => highlightLabel(labelId, true))
         .on("mouseout", () => highlightLabel(labelId, false))
 
-    }, [containerId, dataConfig, defaultLabelTopOffset, helper, highlightCovers, highlightLabel,
-        isVerticalRef, labelRef, model, numericAttrId])
+    }, [containerId, dataConfig, defaultLabelTopOffset, graphModel, helper, highlightCovers,
+        highlightLabel, isVerticalRef, labelRef, model, numericAttrId, tile])
 
     const addTextTip = useCallback((plotValue: number, textContent: string, valueObj: INormalCurveSelections) => {
       const measure = model?.measures.get(helper.instanceKey)

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-registration.test.ts
@@ -17,4 +17,9 @@ describe("NormalCurveRegistration", () => {
     expect(standardErrorComponentInfo?.Component).toBeDefined()
     expect(standardErrorComponentInfo?.type).toBe(kNormalCurveType)
   })
+
+  it("registers notificationOperation for 'togglePlottedNormal'", () => {
+    const info = getAdornmentContentInfo(kNormalCurveType)
+    expect(info?.notificationOperation).toBe("togglePlottedNormal")
+  })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/normal-curve/normal-curve-adornment-registration.tsx
@@ -31,6 +31,8 @@ registerAdornmentContentInfo({
   plots: ["dotPlot"],
   prefix: kNormalCurvePrefix,
   modelClass: NormalCurveAdornmentModel,
+  // V2 op string (univariate_adornment_base_model.js togglePlottedNormal ~:425/321).
+  notificationOperation: "togglePlottedNormal",
   undoRedoKeys: {
     undoAdd: kNormalCurveUndoAddKey,
     redoAdd: kNormalCurveRedoAddKey,

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-banner.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-banner.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react"
 import { observer } from "mobx-react-lite"
 import { Button, useDisclosure } from "@chakra-ui/react"
+import { useTileModelContext } from "../../../../../hooks/use-tile-model-context"
 import { logMessageWithReplacement } from "../../../../../lib/log-message"
 import { t } from "../../../../../utilities/translation/translate"
 import { EditFormulaModal } from "../../../../common/edit-formula-modal"
+import { editPlotFormulaNotification } from "../../../graph-notifications"
 import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
 import { IAdornmentBannerComponentProps } from "../../adornment-component-info"
 import { IPlottedValueAdornmentModel } from "./plotted-value-adornment-model"
@@ -15,6 +17,7 @@ export const PlottedValueAdornmentBanner = observer(function PlottedValueAdornme
 ) {
   const model = props.model as IPlottedValueAdornmentModel
   const graphModel = useGraphContentModelContext()
+  const { tile } = useTileModelContext()
   const { expression, error } = model
   const { isOpen, onClose, onOpen } = useDisclosure()
   const [modalIsOpen, setModalIsOpen] = useState(false)
@@ -35,15 +38,13 @@ export const PlottedValueAdornmentBanner = observer(function PlottedValueAdornme
 
   const handleEditExpressionClose = (newExpression: string) => {
     handleCloseModal()
-    graphModel.applyModelChange(
-      () => model.setExpression(newExpression),
-      {
-        undoStringKey: "DG.Undo.graph.changePlotValue",
-        redoStringKey: "DG.Redo.graph.changePlotValue",
-        log: logMessageWithReplacement("Change plotted value from %@ to %@",
-                {expression, newExpression})
-      }
-    )
+    graphModel.applyModelChange(() => model.setExpression(newExpression), {
+      notify: () => editPlotFormulaNotification(tile, "plottedValue", expression, newExpression),
+      undoStringKey: "DG.Undo.graph.changePlotValue",
+      redoStringKey: "DG.Redo.graph.changePlotValue",
+      log: logMessageWithReplacement("Change plotted value from %@ to %@",
+              {expression, newExpression})
+    })
   }
 
   return (

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.test.ts
@@ -17,4 +17,9 @@ describe("PlottedValueRegistration", () => {
     expect(plottedValueComponentInfo?.BannerComponent).toBeDefined()
     expect(plottedValueComponentInfo?.type).toBe(kPlottedValueType)
   })
+
+  it("registers notificationOperation for 'toggle plotted value'", () => {
+    const plottedValueContentInfo = getAdornmentContentInfo(kPlottedValueType)
+    expect(plottedValueContentInfo?.notificationOperation).toBe("toggle plotted value")
+  })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-registration.tsx
@@ -31,6 +31,10 @@ registerAdornmentContentInfo({
   plots: ["dotPlot", "scatterPlot"],
   prefix: kPlottedValuePrefix,
   modelClass: PlottedValueAdornmentModel,
+  // V2 emits `toggle plotted value` from apps/dg/components/graph/plots/plot_model.js
+  // (togglePlottedValue ~:421). AdornmentCheckbox forwards this as the V2 op string,
+  // with `{ isChecked }` carrying the resulting state.
+  notificationOperation: "toggle plotted value",
   undoRedoKeys: {
     undoAdd: kPlottedValueUndoAddKey,
     redoAdd: kPlottedValueRedoAddKey,

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-registration.test.ts
@@ -17,4 +17,9 @@ describe("StandardDeviationRegistration", () => {
     expect(standardDeviationComponentInfo?.Component).toBeDefined()
     expect(standardDeviationComponentInfo?.type).toBe(kStandardDeviationType)
   })
+
+  it("registers notificationOperation for 'togglePlottedStDev'", () => {
+    const info = getAdornmentContentInfo(kStandardDeviationType)
+    expect(info?.notificationOperation).toBe("togglePlottedStDev")
+  })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-deviation/standard-deviation-adornment-registration.tsx
@@ -28,6 +28,8 @@ registerAdornmentContentInfo({
   plots: ["dotPlot"],
   prefix: kStandardDeviationPrefix,
   modelClass: StandardDeviationAdornmentModel,
+  // V2 op string (univariate_adornment_base_model.js togglePlottedStDev ~:397/321).
+  notificationOperation: "togglePlottedStDev",
   undoRedoKeys: {
     undoAdd: kStandardDeviationUndoAddKey,
     redoAdd: kStandardDeviationRedoAddKey,

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-component.tsx
@@ -4,10 +4,13 @@ import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { t } from "../../../../../utilities/translation/translate"
 import { measureText } from "../../../../../hooks/use-measure-text"
+import { useTileModelContext } from "../../../../../hooks/use-tile-model-context"
 import { IAdornmentComponentProps } from "../../adornment-component-info"
 import { UnivariateMeasureAdornmentHelper } from "../univariate-measure-adornment-helper"
+import { repositionEquationNotification } from "../../../graph-notifications"
 import { useAdornmentAttributes } from "../../../hooks/use-adornment-attributes"
 import { useAdornmentCells } from "../../../hooks/use-adornment-cells"
+import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
 import { ILabel } from "../univariate-measure-adornment-types"
 import { IStandardErrorAdornmentModel } from "./standard-error-adornment-model"
 import { IMeasureInstance } from "../univariate-measure-adornment-model"
@@ -29,6 +32,8 @@ export const StandardErrorAdornmentComponent = observer(
   function StandardErrorAdornmentComponent(props: IAdornmentComponentProps) {
     const {cellKey = {}, cellCoords, containerId, plotWidth, xAxis, yAxis, spannerRef} = props
     const model = props.model as IStandardErrorAdornmentModel
+    const graphModel = useGraphContentModelContext()
+    const { tile } = useTileModelContext()
     const {
       dataConfig, layout, adornmentsStore,
       numericAttrId, showLabel, isVerticalRef, valueRef,
@@ -102,7 +107,14 @@ export const StandardErrorAdornmentComponent = observer(
       labelObj.label.call(
         drag<HTMLDivElement, unknown>()
           .on("drag", (e) => helper.handleMoveLabel(e, labelId))
-          .on("end", (e) => helper.handleEndMoveLabel(e, labelId))
+          .on("end", (e) => {
+            graphModel.applyModelChange(() => helper.handleEndMoveLabel(e, labelId), {
+              notify: () => repositionEquationNotification(tile, model.type),
+              undoStringKey: "DG.Undo.graph.repositionEquation",
+              redoStringKey: "DG.Redo.graph.repositionEquation",
+              log: "Moved equation label"
+            })
+          })
       )
 
       labelObj.label.on("mouseover", () => highlightCovers(true))
@@ -111,8 +123,8 @@ export const StandardErrorAdornmentComponent = observer(
       selectionsObj.errorBarHoverCover?.on("mouseover", () => highlightLabel(labelId, true))
         .on("mouseout", () => highlightLabel(labelId, false))
 
-    }, [containerId, dataConfig, defaultLabelTopOffset, helper, highlightCovers, highlightLabel,
-        isVerticalRef, labelRef, model, numericAttrId])
+    }, [containerId, dataConfig, defaultLabelTopOffset, graphModel, helper, highlightCovers,
+        highlightLabel, isVerticalRef, labelRef, model, numericAttrId, tile])
 
     const addTextTip = useCallback((plotValue: number, textContent: string, valueObj: IStandardErrorSelections) => {
       const measure = model?.measures.get(helper.instanceKey)

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.test.ts
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.test.ts
@@ -17,4 +17,9 @@ describe("StandardErrorRegistration", () => {
     expect(standardErrorComponentInfo?.Component).toBeDefined()
     expect(standardErrorComponentInfo?.type).toBe(kStandardErrorType)
   })
+
+  it("registers notificationOperation for 'togglePlottedStErr'", () => {
+    const info = getAdornmentContentInfo(kStandardErrorType)
+    expect(info?.notificationOperation).toBe("togglePlottedStErr")
+  })
 })

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.tsx
@@ -30,19 +30,20 @@ const Controls = () => {
 
   const handleBlur = useCallback(() => {
     if (existingAdornment) {
+      const numStErrs = existingAdornment.numStErrs  // Can be NaN if user cleared value
+      const isValid = isFinite(numStErrs)
       graphModel.applyModelChange(() => {
-        const numStErrs = existingAdornment.numStErrs  // Can be NaN if user cleared value
-        if (isFinite(numStErrs)) {
+        if (isValid) {
           existingAdornment.setNumStErrs(numStErrs)
         }
         else {
-          existingAdornment?.setDynamicNumStErrs(undefined)
+          existingAdornment.setDynamicNumStErrs(undefined)
         }
       }, {
-        notify: () => setNumStdErrsNotification(tile, existingAdornment.numStErrs),
+        notify: isValid ? () => setNumStdErrsNotification(tile, numStErrs) : undefined,
         undoStringKey: 'DG.Undo.graph.setNumStErrs',
-        redoStringKey: 'DG.Undo.graph.setNumStErrs',
-        log: logMessageWithReplacement("Set standard error to %@", {numStErrs: existingAdornment.numStErrs})
+        redoStringKey: 'DG.Redo.graph.setNumStErrs',
+        log: logMessageWithReplacement("Set standard error to %@", {numStErrs})
       })
     }
   }, [existingAdornment, graphModel, tile])

--- a/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/standard-error/standard-error-adornment-registration.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback, useEffect } from "react"
 import { Button, Group, Input, NumberField } from "react-aria-components"
 import { registerAdornmentHandler } from "../../../../../data-interactive/handlers/adornment-handler"
+import { useTileModelContext } from "../../../../../hooks/use-tile-model-context"
 import { logMessageWithReplacement } from "../../../../../lib/log-message"
 import { translate } from "../../../../../utilities/translation/translate"
+import { setNumStdErrsNotification } from "../../../graph-notifications"
 import { useGraphContentModelContext } from "../../../hooks/use-graph-content-model-context"
 import { registerAdornmentComponentInfo } from "../../adornment-component-info"
 import { registerAdornmentContentInfo } from "../../adornment-content-info"
@@ -21,30 +23,29 @@ import {
 
 const Controls = () => {
   const graphModel = useGraphContentModelContext()
+  const { tile } = useTileModelContext()
   const adornmentsStore = graphModel.adornmentsStore
   const existingAdornment =
     adornmentsStore.findAdornmentOfType<IStandardErrorAdornmentModel>(kStandardErrorType)
 
   const handleBlur = useCallback(() => {
     if (existingAdornment) {
-      graphModel.applyModelChange(
-        () => {
-          const numStErrs = existingAdornment.numStErrs  // Can be NaN if user cleared value
-          if (isFinite(numStErrs)) {
-            existingAdornment.setNumStErrs(numStErrs)
-          }
-          else {
-            existingAdornment?.setDynamicNumStErrs(undefined)
-          }
-        },
-        {
-          undoStringKey: 'DG.Undo.graph.setNumStErrs',
-          redoStringKey: 'DG.Undo.graph.setNumStErrs',
-          log: logMessageWithReplacement("Set standard error to %@", {numStErrs: existingAdornment.numStErrs})
+      graphModel.applyModelChange(() => {
+        const numStErrs = existingAdornment.numStErrs  // Can be NaN if user cleared value
+        if (isFinite(numStErrs)) {
+          existingAdornment.setNumStErrs(numStErrs)
         }
-      )
+        else {
+          existingAdornment?.setDynamicNumStErrs(undefined)
+        }
+      }, {
+        notify: () => setNumStdErrsNotification(tile, existingAdornment.numStErrs),
+        undoStringKey: 'DG.Undo.graph.setNumStErrs',
+        redoStringKey: 'DG.Undo.graph.setNumStErrs',
+        log: logMessageWithReplacement("Set standard error to %@", {numStErrs: existingAdornment.numStErrs})
+      })
     }
-  }, [existingAdornment, graphModel])
+  }, [existingAdornment, graphModel, tile])
 
   useEffect(() => {
     // Return a cleanup function that will be called when the component is unmounted
@@ -103,6 +104,8 @@ registerAdornmentContentInfo({
   plots: ["dotPlot"],
   prefix: kStandardErrorPrefix,
   modelClass: StandardErrorAdornmentModel,
+  // V2 op string (univariate_adornment_base_model.js togglePlottedStErr ~:404/321).
+  notificationOperation: "togglePlottedStErr",
   undoRedoKeys: {
     undoAdd: kStandardErrorUndoAddKey,
     redoAdd: kStandardErrorRedoAddKey,

--- a/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/univariate-measure-adornment-simple-component.tsx
@@ -4,20 +4,25 @@ import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { t } from "../../../../utilities/translation/translate"
 import { isFiniteNumber } from "../../../../utilities/math-utils"
+import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { IMeasureInstance, IUnivariateMeasureAdornmentModel } from "./univariate-measure-adornment-model"
 import { measureText } from "../../../../hooks/use-measure-text"
 import { IAdornmentComponentProps } from "../adornment-component-info"
 import { IValue } from "./univariate-measure-adornment-types"
 import { UnivariateMeasureAdornmentHelper } from "./univariate-measure-adornment-helper"
 import { UnivariateMeasureAdornmentBaseComponent } from "./univariate-measure-adornment-base-component"
+import { repositionEquationNotification } from "../../graph-notifications"
 import { useAdornmentAttributes } from "../../hooks/use-adornment-attributes"
 import { useAdornmentCells } from "../../hooks/use-adornment-cells"
+import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 
 export const UnivariateMeasureAdornmentSimpleComponent = observer(
   function UnivariateMeasureAdornmentSimpleComponent (props: IAdornmentComponentProps) {
     const {cellKey={}, containerId,
       xAxis, yAxis, spannerRef, labelsDivRef} = props
     const model = props.model as IUnivariateMeasureAdornmentModel
+    const graphModel = useGraphContentModelContext()
+    const { tile } = useTileModelContext()
     const {
       dataConfig, layout, adornmentsStore,
       numericAttrId, showLabel, isVerticalRef, valueRef,
@@ -83,7 +88,17 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
       valueObj.label.call(
         drag<HTMLDivElement, unknown>()
           .on("drag", (e) => helper.handleMoveLabel(e, labelId))
-          .on("end", (e) => helper.handleEndMoveLabel(e, labelId))
+          .on("end", (e) => {
+            // V2 wraps equation-label drag-end in a Command with undo/redo/log/notify;
+            // V3 historically did not, leaving the move non-undoable. Wrap here so the
+            // user can undo the label move and so V2 plugins see `reposition equation`.
+            graphModel.applyModelChange(() => helper.handleEndMoveLabel(e, labelId), {
+              notify: () => repositionEquationNotification(tile, model.type),
+              undoStringKey: "DG.Undo.graph.repositionEquation",
+              redoStringKey: "DG.Redo.graph.repositionEquation",
+              log: "Moved equation label"
+            })
+          })
       )
 
       valueObj.label.on("mouseover", () => highlightCovers(true))
@@ -100,7 +115,8 @@ export const UnivariateMeasureAdornmentSimpleComponent = observer(
         .on("mouseout", () => highlightLabel(labelId, false))
 
     },
-      [containerId, dataConfig, helper, highlightCovers, highlightLabel, labelsDivRef])
+      [containerId, dataConfig, graphModel, helper, highlightCovers, highlightLabel,
+       labelsDivRef, model.type, tile])
 
     const addTextTip = useCallback((plotValue: number, textContent: string, valueObj: IValue, range?: number) => {
       if (!spannerRef?.current) return

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -40,6 +40,7 @@ import {useGraphContentModelContext} from "../hooks/use-graph-content-model-cont
 import {GraphDataConfigurationContext} from "../hooks/use-graph-data-configuration-context"
 import {useGraphLayoutContext} from "../hooks/use-graph-layout-context"
 import {useGraphModel} from "../hooks/use-graph-model"
+import { add2ndAxisAttributeNotification, addAxisAttributeNotification } from "../graph-notifications"
 import {GraphController} from "../models/graph-controller"
 import { attrChangeNotificationValues, IAttrChangeValues } from "../models/graph-notification-utils"
 import { BarChart } from "../plots/bar-chart/bar-chart"
@@ -256,8 +257,18 @@ export const Graph = observer(function Graph({
     const attribute = dataSet.getAttribute(attrId || attrIdToRemove)
     const attrName = attribute?.name
     const tile = getTileModel(graphModel)
-    const notificationType = place === "legend" ? "legendAttributeChange" : "attributeChange"
     let notificationValues: IAttrChangeValues | undefined = undefined
+
+    // V2 routes drops on the y-axis multi-target (`yPlus`) and Y2 axis (`rightNumeric`) to
+    // op-specific notifications via `multiTargetDidAcceptDrop` / `y2AxisDidAcceptDrop`
+    // (graph_controller.js ~:619 / :688); other drops fall through to the generic
+    // `attributeChange` (or `legendAttributeChange` for legend drops).
+    const notify = () => {
+      if (place === "yPlus") return addAxisAttributeNotification(tile, notificationValues)
+      if (place === "rightNumeric") return add2ndAxisAttributeNotification(tile, notificationValues)
+      const notificationType = place === "legend" ? "legendAttributeChange" : "attributeChange"
+      return updateTileNotification(notificationType, notificationValues, tile)
+    }
 
     graphModel.applyModelChange(
       () => {
@@ -268,7 +279,7 @@ export const Graph = observer(function Graph({
         notificationValues = attrChangeNotificationValues(place, attrId, attrName, attrIdToRemove, tile)
       },
       {
-        notify: () => updateTileNotification(notificationType, notificationValues, tile),
+        notify,
         undoStringKey: "DG.Undo.axisAttributeChange",
         redoStringKey: "DG.Redo.axisAttributeChange",
         log: logStringifiedObjectMessage(

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -7,6 +7,9 @@ import { isGraphContentModel } from "../../models/graph-content-model"
 import { t } from "../../../../utilities/translation/translate"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import { updateTileNotification } from "../../../../models/tiles/tile-notifications"
+import {
+  toggleMeasuresForSelectionNotification, toggleNumberToggleNotification
+} from "../../graph-notifications"
 import { EditFormulaModal } from "../../../common/edit-formula-modal"
 import { DataSetContext } from "../../../../hooks/use-data-set-context"
 import { useInspectorFormulaString } from "../../../../hooks/use-inspector-formula-string"
@@ -98,28 +101,28 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
   }
 
   const handleParentTogglesChange = () => {
-    const [undoStringKey, redoStringKey] = graphModel?.showParentToggles
+    const wasEnabled = !!graphModel?.showParentToggles
+    const [undoStringKey, redoStringKey] = wasEnabled
       ? ["DG.Undo.disableNumberToggle", "DG.Redo.disableNumberToggle"]
       : ["DG.Undo.enableNumberToggle", "DG.Redo.enableNumberToggle"]
 
-    dataConfig?.applyModelChange(
-      () => graphModel?.setShowParentToggles(!graphModel?.showParentToggles),
-      { undoStringKey, redoStringKey,
-        log: graphModel?.showParentToggles ? "Disable Number Toggle" : "Enable Number Toggle"
-      }
-    )
+    dataConfig?.applyModelChange(() => graphModel?.setShowParentToggles(!wasEnabled), {
+      notify: () => toggleNumberToggleNotification(tile, !wasEnabled),
+      undoStringKey, redoStringKey,
+      log: wasEnabled ? "Disable Number Toggle" : "Enable Number Toggle"
+    })
   }
 
   const handleMeasuresForSelectionChange = () => {
-    const [undoStringKey, redoStringKey] = dataConfig?.showMeasuresForSelection
+    const wasEnabled = !!dataConfig?.showMeasuresForSelection
+    const [undoStringKey, redoStringKey] = wasEnabled
       ? ["DG.Undo.disableMeasuresForSelection", "DG.Redo.disableMeasuresForSelection"]
       : ["DG.Undo.enableMeasuresForSelection", "DG.Redo.enableMeasuresForSelection"]
-    dataConfig?.applyModelChange(
-      () => dataConfig?.setShowMeasuresForSelection(!dataConfig?.showMeasuresForSelection),
-      { undoStringKey, redoStringKey,
-        log: dataConfig?.showMeasuresForSelection ? "Disable Measures For Selection" : "Enable Measures For Selection"
-      }
-    )
+    dataConfig?.applyModelChange(() => dataConfig?.setShowMeasuresForSelection(!wasEnabled), {
+      notify: () => toggleMeasuresForSelectionNotification(tile, !wasEnabled),
+      undoStringKey, redoStringKey,
+      log: wasEnabled ? "Disable Measures For Selection" : "Enable Measures For Selection"
+    })
   }
 
   const numSelected = dataConfig?.selection.length ?? 0,

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -8,6 +8,7 @@ import { t } from "../../../../utilities/translation/translate"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import { updateTileNotification } from "../../../../models/tiles/tile-notifications"
 import {
+  displayOnlySelectedNotification, showAllCasesNotification,
   toggleMeasuresForSelectionNotification, toggleNumberToggleNotification
 } from "../../graph-notifications"
 import { EditFormulaModal } from "../../../common/edit-formula-modal"
@@ -59,25 +60,21 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
   }
 
   const displayOnlySelectedCases = () => {
-    dataConfig?.applyModelChange(
-      () => graphModel?.displayOnlySelectedCases(),
-      {
-        undoStringKey: "DG.Undo.displayOnlySelected",
-        redoStringKey: "DG.Redo.displayOnlySelected",
-        log: "Display only selected cases"
-      }
-    )
+    dataConfig?.applyModelChange(() => graphModel?.displayOnlySelectedCases(), {
+      notify: () => displayOnlySelectedNotification(tile),
+      undoStringKey: "DG.Undo.displayOnlySelected",
+      redoStringKey: "DG.Redo.displayOnlySelected",
+      log: "Display only selected cases"
+    })
   }
 
   const showAllCases = () => {
-    dataConfig?.applyModelChange(
-      () => graphModel?.showAllCases(),
-      {
-        undoStringKey: "DG.Undo.showAllCases",
-        redoStringKey: "DG.Redo.showAllCases",
-        log: {message: "Show all cases", args: {}, category: "data"}
-      }
-    )
+    dataConfig?.applyModelChange(() => graphModel?.showAllCases(), {
+      notify: () => showAllCasesNotification(tile),
+      undoStringKey: "DG.Undo.showAllCases",
+      redoStringKey: "DG.Redo.showAllCases",
+      log: {message: "Show all cases", args: {}, category: "data"}
+    })
   }
 
   const applyFilterFormula = (formula: string) => {

--- a/v3/src/components/graph/components/inspector-panel/point-format-palette.tsx
+++ b/v3/src/components/graph/components/inspector-panel/point-format-palette.tsx
@@ -2,7 +2,9 @@ import {observer} from "mobx-react-lite"
 import { t } from "../../../../utilities/translation/translate"
 import { ITileModel } from "../../../../models/tiles/tile-model"
 import {isGraphContentModel} from "../../models/graph-content-model"
-import { changeBackgroundColorNotification } from "../../graph-notifications"
+import {
+  changeBackgroundColorNotification, toggleBackgroundTransparencyNotification
+} from "../../graph-notifications"
 import {InspectorPalette} from "../../../inspector-panel"
 import FormatIcon from "../../../../assets/icons/inspector-panel/format-icon.svg"
 import {DisplayItemFormatControl} from "../../../data-display/inspector/display-item-format-control"
@@ -24,6 +26,7 @@ export const PointFormatPalette = observer(function PointFormatPalette({id, tile
   const handleBackgroundTransparencyChange = (isTransparent: boolean) => {
     graphModel.applyModelChange(() => graphModel.setIsTransparent(isTransparent),
     {
+      notify: () => toggleBackgroundTransparencyNotification(tile, isTransparent),
       undoStringKey: "DG.Undo.graph.toggleTransparent",
       redoStringKey: "DG.Redo.graph.toggleTransparent",
       log: `Made plot background ${isTransparent ? "transparent" : "opaque"}`

--- a/v3/src/components/graph/components/inspector-panel/point-format-palette.tsx
+++ b/v3/src/components/graph/components/inspector-panel/point-format-palette.tsx
@@ -2,6 +2,7 @@ import {observer} from "mobx-react-lite"
 import { t } from "../../../../utilities/translation/translate"
 import { ITileModel } from "../../../../models/tiles/tile-model"
 import {isGraphContentModel} from "../../models/graph-content-model"
+import { changeBackgroundColorNotification } from "../../graph-notifications"
 import {InspectorPalette} from "../../../inspector-panel"
 import FormatIcon from "../../../../assets/icons/inspector-panel/format-icon.svg"
 import {DisplayItemFormatControl} from "../../../data-display/inspector/display-item-format-control"
@@ -32,6 +33,7 @@ export const PointFormatPalette = observer(function PointFormatPalette({id, tile
   const handleBackgroundColorChange = (color: string) => {
     graphModel.applyModelChange(() => graphModel.setPlotBackgroundColor(color),
     {
+      notify: () => changeBackgroundColorNotification(tile, color),
       undoStringKey: "DG.Undo.graph.changeBackgroundColor",
       redoStringKey: "DG.Redo.graph.changeBackgroundColor",
       log: "Changed background color"

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,0 +1,43 @@
+import { changeBackgroundColorNotification } from "./graph-notifications"
+
+const v2Id = 77001
+// V2 component-resource notifications carry the SC class name (`DG.GraphView`) in
+// `values.type`; V3 adds the DI-convention name as `values.diType`.
+const v2SCType = "DG.GraphView"
+const diType = "graph"
+
+jest.mock("../../models/tiles/tile-notifications", () => ({
+  updateTileNotification: jest.fn((updateType: string, values: any, tileModel: any) => {
+    if (!tileModel) return undefined
+    return {
+      message: {
+        action: "notify",
+        resource: "component",
+        values: { operation: updateType, ...values, id: v2Id, type: v2SCType, diType }
+      }
+    }
+  })
+}))
+
+describe("changeBackgroundColorNotification", () => {
+  it("emits 'change background color' with the resulting color", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = changeBackgroundColorNotification(tile, "#ff8800")
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("change background color")
+    expect(notification?.message.values.to).toBe("#ff8800")
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-graph tiles (e.g. calculator)", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(changeBackgroundColorNotification(calcTile, "#ff8800")).toBeUndefined()
+  })
+
+  it("returns undefined when the graph tile is missing", () => {
+    expect(changeBackgroundColorNotification(undefined, "#ff8800")).toBeUndefined()
+  })
+})

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,4 +1,6 @@
-import { changeBackgroundColorNotification } from "./graph-notifications"
+import {
+  changeBackgroundColorNotification, toggleBackgroundTransparencyNotification
+} from "./graph-notifications"
 
 const v2Id = 77001
 // V2 component-resource notifications carry the SC class name (`DG.GraphView`) in
@@ -39,5 +41,28 @@ describe("changeBackgroundColorNotification", () => {
 
   it("returns undefined when the graph tile is missing", () => {
     expect(changeBackgroundColorNotification(undefined, "#ff8800")).toBeUndefined()
+  })
+})
+
+describe("toggleBackgroundTransparencyNotification", () => {
+  it("emits 'toggle background transparency' with the resulting state", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = toggleBackgroundTransparencyNotification(tile, true)
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("toggle background transparency")
+    expect(notification?.message.values.to).toBe(true)
+    expect(notification?.message.values.id).toBe(v2Id)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(toggleBackgroundTransparencyNotification(calcTile, true)).toBeUndefined()
+  })
+
+  it("returns undefined when the graph tile is missing", () => {
+    expect(toggleBackgroundTransparencyNotification(undefined, false)).toBeUndefined()
   })
 })

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,6 +1,8 @@
 import {
   add2ndAxisAttributeNotification, addAxisAttributeNotification,
-  changeBackgroundColorNotification, swapCategoriesNotification, toggleBackgroundTransparencyNotification
+  changeBackgroundColorNotification, swapCategoriesNotification,
+  toggleBackgroundTransparencyNotification, toggleMeasuresForSelectionNotification,
+  toggleNumberToggleNotification
 } from "./graph-notifications"
 
 const v2Id = 77001
@@ -100,6 +102,46 @@ describe("add2ndAxisAttributeNotification", () => {
 
   it("returns undefined when the graph tile is missing", () => {
     expect(add2ndAxisAttributeNotification(undefined, sampleValues)).toBeUndefined()
+  })
+})
+
+describe("toggleNumberToggleNotification", () => {
+  it("emits 'toggle NumberToggle' with the resulting enabled state", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = toggleNumberToggleNotification(tile, true)
+    expect(notification?.message.values.operation).toBe("toggle NumberToggle")
+    expect(notification?.message.values.to).toBe(true)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(toggleNumberToggleNotification(calcTile, true)).toBeUndefined()
+  })
+
+  it("returns undefined when the tile is missing", () => {
+    expect(toggleNumberToggleNotification(undefined, false)).toBeUndefined()
+  })
+})
+
+describe("toggleMeasuresForSelectionNotification", () => {
+  it("emits 'toggle MeasuresForSelection' with the resulting enabled state", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = toggleMeasuresForSelectionNotification(tile, false)
+    expect(notification?.message.values.operation).toBe("toggle MeasuresForSelection")
+    expect(notification?.message.values.to).toBe(false)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(toggleMeasuresForSelectionNotification(calcTile, true)).toBeUndefined()
+  })
+
+  it("returns undefined when the tile is missing", () => {
+    expect(toggleMeasuresForSelectionNotification(undefined, true)).toBeUndefined()
   })
 })
 

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,10 +1,11 @@
 import {
   add2ndAxisAttributeNotification, addAxisAttributeNotification, addMovableValueNotification,
   changeBackgroundColorNotification, dragBinBoundaryNotification, dragMovableLineNotification,
-  dragMovablePointNotification, dragMovableValueNotification, removeMovableValueNotification,
-  repositionEquationNotification, setNumStdErrsNotification, swapCategoriesNotification,
-  toggleBackgroundTransparencyNotification, toggleMeasuresForSelectionNotification,
-  toggleNumberToggleNotification, toggleShowICINotification, toggleShowOutliersNotification
+  dragMovablePointNotification, dragMovableValueNotification, editPlotFormulaNotification,
+  removeMovableValueNotification, repositionEquationNotification, setNumStdErrsNotification,
+  swapCategoriesNotification, toggleBackgroundTransparencyNotification,
+  toggleMeasuresForSelectionNotification, toggleNumberToggleNotification,
+  toggleShowICINotification, toggleShowOutliersNotification
 } from "./graph-notifications"
 
 const v2Id = 77001
@@ -187,6 +188,22 @@ describe("dragMovableLineNotification", () => {
   it("returns undefined for non-graph tiles", () => {
     const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
     expect(dragMovableLineNotification(calcTile)).toBeUndefined()
+  })
+})
+
+describe("editPlotFormulaNotification", () => {
+  it("emits 'edit plot formula' with adornment + from + to", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = editPlotFormulaNotification(tile, "plottedValue", "mean(x)", "median(x)")
+    expect(notification?.message.values.operation).toBe("edit plot formula")
+    expect(notification?.message.values.adornment).toBe("plottedValue")
+    expect(notification?.message.values.from).toBe("mean(x)")
+    expect(notification?.message.values.to).toBe("median(x)")
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(editPlotFormulaNotification(calcTile, "plottedFunction", "", "x")).toBeUndefined()
   })
 })
 

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -2,8 +2,9 @@ import {
   add2ndAxisAttributeNotification, addAxisAttributeNotification, addMovableValueNotification,
   changeBackgroundColorNotification, dragBinBoundaryNotification, dragMovableLineNotification,
   dragMovablePointNotification, dragMovableValueNotification, removeMovableValueNotification,
-  repositionEquationNotification, swapCategoriesNotification, toggleBackgroundTransparencyNotification,
-  toggleMeasuresForSelectionNotification, toggleNumberToggleNotification
+  repositionEquationNotification, setNumStdErrsNotification, swapCategoriesNotification,
+  toggleBackgroundTransparencyNotification, toggleMeasuresForSelectionNotification,
+  toggleNumberToggleNotification, toggleShowICINotification, toggleShowOutliersNotification
 } from "./graph-notifications"
 
 const v2Id = 77001
@@ -186,6 +187,49 @@ describe("dragMovableLineNotification", () => {
   it("returns undefined for non-graph tiles", () => {
     const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
     expect(dragMovableLineNotification(calcTile)).toBeUndefined()
+  })
+})
+
+describe("setNumStdErrsNotification", () => {
+  it("emits 'setNumStdErrs' with the new value in `to`", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = setNumStdErrsNotification(tile, 2.5)
+    expect(notification?.message.values.operation).toBe("setNumStdErrs")
+    expect(notification?.message.values.to).toBe(2.5)
+    expect(notification?.message.values.type).toBe(v2SCType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(setNumStdErrsNotification(calcTile, 1)).toBeUndefined()
+  })
+})
+
+describe("toggleShowOutliersNotification", () => {
+  it("emits 'toggle show outliers' with isChecked", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = toggleShowOutliersNotification(tile, true)
+    expect(notification?.message.values.operation).toBe("toggle show outliers")
+    expect(notification?.message.values.isChecked).toBe(true)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(toggleShowOutliersNotification(calcTile, true)).toBeUndefined()
+  })
+})
+
+describe("toggleShowICINotification", () => {
+  it("emits the V3-only `toggle show ICI` op (not V2's wrong-op `toggle show outliers`)", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = toggleShowICINotification(tile, true)
+    expect(notification?.message.values.operation).toBe("toggle show ICI")
+    expect(notification?.message.values.isChecked).toBe(true)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(toggleShowICINotification(calcTile, true)).toBeUndefined()
   })
 })
 

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,6 +1,7 @@
 import {
   add2ndAxisAttributeNotification, addAxisAttributeNotification,
-  changeBackgroundColorNotification, swapCategoriesNotification,
+  changeBackgroundColorNotification, dragMovableLineNotification, dragMovablePointNotification,
+  dragMovableValueNotification, repositionEquationNotification, swapCategoriesNotification,
   toggleBackgroundTransparencyNotification, toggleMeasuresForSelectionNotification,
   toggleNumberToggleNotification
 } from "./graph-notifications"
@@ -142,6 +143,64 @@ describe("toggleMeasuresForSelectionNotification", () => {
 
   it("returns undefined when the tile is missing", () => {
     expect(toggleMeasuresForSelectionNotification(undefined, true)).toBeUndefined()
+  })
+})
+
+describe("dragMovablePointNotification", () => {
+  it("emits 'drag movable point' on the graph component resource", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = dragMovablePointNotification(tile)
+    expect(notification?.message.values.operation).toBe("drag movable point")
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(dragMovablePointNotification(calcTile)).toBeUndefined()
+  })
+})
+
+describe("dragMovableValueNotification", () => {
+  it("emits the V3-clarified 'drag movable value' op (not V2's confusingly-named 'drag movable line')", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = dragMovableValueNotification(tile)
+    expect(notification?.message.values.operation).toBe("drag movable value")
+    expect(notification?.message.values.type).toBe(v2SCType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(dragMovableValueNotification(calcTile)).toBeUndefined()
+  })
+})
+
+describe("dragMovableLineNotification", () => {
+  it("emits 'drag movable line' for scatterplot movable-line drag (fills V2 gap)", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = dragMovableLineNotification(tile)
+    expect(notification?.message.values.operation).toBe("drag movable line")
+    expect(notification?.message.values.type).toBe(v2SCType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(dragMovableLineNotification(calcTile)).toBeUndefined()
+  })
+})
+
+describe("repositionEquationNotification", () => {
+  it("emits 'reposition equation' with the adornment type", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = repositionEquationNotification(tile, "movableLine")
+    expect(notification?.message.values.operation).toBe("reposition equation")
+    expect(notification?.message.values.adornment).toBe("movableLine")
+    expect(notification?.message.values.type).toBe(v2SCType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(repositionEquationNotification(calcTile, "lsrl")).toBeUndefined()
   })
 })
 

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,6 +1,6 @@
 import {
   add2ndAxisAttributeNotification, addAxisAttributeNotification,
-  changeBackgroundColorNotification, toggleBackgroundTransparencyNotification
+  changeBackgroundColorNotification, swapCategoriesNotification, toggleBackgroundTransparencyNotification
 } from "./graph-notifications"
 
 const v2Id = 77001
@@ -100,6 +100,35 @@ describe("add2ndAxisAttributeNotification", () => {
 
   it("returns undefined when the graph tile is missing", () => {
     expect(add2ndAxisAttributeNotification(undefined, sampleValues)).toBeUndefined()
+  })
+})
+
+describe("swapCategoriesNotification", () => {
+  it("emits 'swap categories' with the originating place (axis variant)", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = swapCategoriesNotification(tile, "bottom")
+    expect(notification?.message.action).toBe("notify")
+    expect(notification?.message.resource).toBe("component")
+    expect(notification?.message.values.operation).toBe("swap categories")
+    expect(notification?.message.values.place).toBe("bottom")
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("emits 'swap categories' with place='legend' for the legend variant", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = swapCategoriesNotification(tile, "legend")
+    expect(notification?.message.values.operation).toBe("swap categories")
+    expect(notification?.message.values.place).toBe("legend")
+  })
+
+  it("returns undefined for non-graph tiles (so the shared sub-axis hook and legend are safe for maps)", () => {
+    const mapTile = { id: "MAP1", content: { type: "Map" } } as any
+    expect(swapCategoriesNotification(mapTile, "legend")).toBeUndefined()
+  })
+
+  it("returns undefined when the tile is missing", () => {
+    expect(swapCategoriesNotification(undefined, "left")).toBeUndefined()
   })
 })
 

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,4 +1,5 @@
 import {
+  add2ndAxisAttributeNotification, addAxisAttributeNotification,
   changeBackgroundColorNotification, toggleBackgroundTransparencyNotification
 } from "./graph-notifications"
 
@@ -41,6 +42,64 @@ describe("changeBackgroundColorNotification", () => {
 
   it("returns undefined when the graph tile is missing", () => {
     expect(changeBackgroundColorNotification(undefined, "#ff8800")).toBeUndefined()
+  })
+})
+
+describe("addAxisAttributeNotification", () => {
+  const sampleValues: any = {
+    attributeId: 4242, attributeName: "MPG", plotType: "scatterPlot",
+    primaryAxis: "x", axisOrientation: "vertical"
+  }
+
+  it("emits 'add axis attribute' with the given attribute-change values", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = addAxisAttributeNotification(tile, sampleValues)
+    expect(notification?.message.values.operation).toBe("add axis attribute")
+    expect(notification?.message.values.attributeId).toBe(4242)
+    expect(notification?.message.values.attributeName).toBe("MPG")
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("falls back to an empty payload when values are undefined", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = addAxisAttributeNotification(tile, undefined)
+    expect(notification?.message.values.operation).toBe("add axis attribute")
+    expect(notification?.message.values.attributeId).toBeUndefined()
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(addAxisAttributeNotification(calcTile, sampleValues)).toBeUndefined()
+  })
+
+  it("returns undefined when the graph tile is missing", () => {
+    expect(addAxisAttributeNotification(undefined, sampleValues)).toBeUndefined()
+  })
+})
+
+describe("add2ndAxisAttributeNotification", () => {
+  const sampleValues: any = {
+    attributeId: 5151, attributeName: "Horsepower", plotType: "scatterPlot",
+    primaryAxis: "x", axisOrientation: "vertical"
+  }
+
+  it("emits 'add 2nd axis attribute' with the given attribute-change values", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = add2ndAxisAttributeNotification(tile, sampleValues)
+    expect(notification?.message.values.operation).toBe("add 2nd axis attribute")
+    expect(notification?.message.values.attributeId).toBe(5151)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(add2ndAxisAttributeNotification(calcTile, sampleValues)).toBeUndefined()
+  })
+
+  it("returns undefined when the graph tile is missing", () => {
+    expect(add2ndAxisAttributeNotification(undefined, sampleValues)).toBeUndefined()
   })
 })
 

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,9 +1,9 @@
 import {
   add2ndAxisAttributeNotification, addAxisAttributeNotification,
-  changeBackgroundColorNotification, dragMovableLineNotification, dragMovablePointNotification,
-  dragMovableValueNotification, repositionEquationNotification, swapCategoriesNotification,
-  toggleBackgroundTransparencyNotification, toggleMeasuresForSelectionNotification,
-  toggleNumberToggleNotification
+  changeBackgroundColorNotification, dragBinBoundaryNotification, dragMovableLineNotification,
+  dragMovablePointNotification, dragMovableValueNotification, repositionEquationNotification,
+  swapCategoriesNotification, toggleBackgroundTransparencyNotification,
+  toggleMeasuresForSelectionNotification, toggleNumberToggleNotification
 } from "./graph-notifications"
 
 const v2Id = 77001
@@ -186,6 +186,29 @@ describe("dragMovableLineNotification", () => {
   it("returns undefined for non-graph tiles", () => {
     const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
     expect(dragMovableLineNotification(calcTile)).toBeUndefined()
+  })
+})
+
+describe("dragBinBoundaryNotification", () => {
+  it("emits 'drag bin boundary' with the resulting alignment and width", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = dragBinBoundaryNotification(tile, { alignment: 2.5, width: 7 })
+    expect(notification?.message.values.operation).toBe("drag bin boundary")
+    expect(notification?.message.values.alignment).toBe(2.5)
+    expect(notification?.message.values.width).toBe(7)
+    expect(notification?.message.values.type).toBe(v2SCType)
+  })
+
+  it("omits alignment/width when undefined", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = dragBinBoundaryNotification(tile, {})
+    expect(notification?.message.values.alignment).toBeUndefined()
+    expect(notification?.message.values.width).toBeUndefined()
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(dragBinBoundaryNotification(calcTile, { alignment: 1, width: 1 })).toBeUndefined()
   })
 })
 

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,8 +1,8 @@
 import {
-  add2ndAxisAttributeNotification, addAxisAttributeNotification,
+  add2ndAxisAttributeNotification, addAxisAttributeNotification, addMovableValueNotification,
   changeBackgroundColorNotification, dragBinBoundaryNotification, dragMovableLineNotification,
-  dragMovablePointNotification, dragMovableValueNotification, repositionEquationNotification,
-  swapCategoriesNotification, toggleBackgroundTransparencyNotification,
+  dragMovablePointNotification, dragMovableValueNotification, removeMovableValueNotification,
+  repositionEquationNotification, swapCategoriesNotification, toggleBackgroundTransparencyNotification,
   toggleMeasuresForSelectionNotification, toggleNumberToggleNotification
 } from "./graph-notifications"
 
@@ -186,6 +186,35 @@ describe("dragMovableLineNotification", () => {
   it("returns undefined for non-graph tiles", () => {
     const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
     expect(dragMovableLineNotification(calcTile)).toBeUndefined()
+  })
+})
+
+describe("addMovableValueNotification", () => {
+  it("emits 'add movable value' on the graph component resource", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = addMovableValueNotification(tile)
+    expect(notification?.message.values.operation).toBe("add movable value")
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(addMovableValueNotification(calcTile)).toBeUndefined()
+  })
+})
+
+describe("removeMovableValueNotification", () => {
+  it("emits 'remove movable value' on the graph component resource", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = removeMovableValueNotification(tile)
+    expect(notification?.message.values.operation).toBe("remove movable value")
+    expect(notification?.message.values.type).toBe(v2SCType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
+    expect(removeMovableValueNotification(calcTile)).toBeUndefined()
   })
 })
 

--- a/v3/src/components/graph/graph-notifications.test.ts
+++ b/v3/src/components/graph/graph-notifications.test.ts
@@ -1,11 +1,11 @@
 import {
   add2ndAxisAttributeNotification, addAxisAttributeNotification, addMovableValueNotification,
-  changeBackgroundColorNotification, dragBinBoundaryNotification, dragMovableLineNotification,
-  dragMovablePointNotification, dragMovableValueNotification, editPlotFormulaNotification,
-  removeMovableValueNotification, repositionEquationNotification, setNumStdErrsNotification,
-  swapCategoriesNotification, toggleBackgroundTransparencyNotification,
-  toggleMeasuresForSelectionNotification, toggleNumberToggleNotification,
-  toggleShowICINotification, toggleShowOutliersNotification
+  changeBackgroundColorNotification, displayOnlySelectedNotification, dragBinBoundaryNotification,
+  dragMovableLineNotification, dragMovablePointNotification, dragMovableValueNotification,
+  editPlotFormulaNotification, removeMovableValueNotification, repositionEquationNotification,
+  setNumStdErrsNotification, showAllCasesNotification, swapCategoriesNotification,
+  toggleBackgroundTransparencyNotification, toggleMeasuresForSelectionNotification,
+  toggleNumberToggleNotification, toggleShowICINotification, toggleShowOutliersNotification
 } from "./graph-notifications"
 
 const v2Id = 77001
@@ -188,6 +188,34 @@ describe("dragMovableLineNotification", () => {
   it("returns undefined for non-graph tiles", () => {
     const calcTile = { id: "CALC1", content: { type: "Calculator" } } as any
     expect(dragMovableLineNotification(calcTile)).toBeUndefined()
+  })
+})
+
+describe("showAllCasesNotification", () => {
+  it("emits 'showAllCases' on the graph component resource", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = showAllCasesNotification(tile)
+    expect(notification?.message.values.operation).toBe("showAllCases")
+    expect(notification?.message.values.type).toBe(v2SCType)
+  })
+
+  it("returns undefined for non-graph tiles (map gets its own helper in CODAP-1352)", () => {
+    const mapTile = { id: "MAP1", content: { type: "Map" } } as any
+    expect(showAllCasesNotification(mapTile)).toBeUndefined()
+  })
+})
+
+describe("displayOnlySelectedNotification", () => {
+  it("emits 'displayOnlySelected' on the graph component resource", () => {
+    const tile = { id: "GRAPH1", content: { type: "Graph" } } as any
+    const notification = displayOnlySelectedNotification(tile)
+    expect(notification?.message.values.operation).toBe("displayOnlySelected")
+    expect(notification?.message.values.type).toBe(v2SCType)
+  })
+
+  it("returns undefined for non-graph tiles", () => {
+    const mapTile = { id: "MAP1", content: { type: "Map" } } as any
+    expect(displayOnlySelectedNotification(mapTile)).toBeUndefined()
   })
 })
 

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -62,6 +62,44 @@ export function toggleMeasuresForSelectionNotification(graphTile: ITileModel | u
   return updateTileNotification("toggle MeasuresForSelection", { to }, graphTile)
 }
 
+// V2 emits `drag movable point` from apps/dg/components/graph/adornments/movable_point_adornment.js
+// (endDrag ~:128) when a user finishes dragging the scatterplot movable point. Bare payload.
+// No-ops for non-graph tiles.
+export function dragMovablePointNotification(graphTile: ITileModel | undefined) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("drag movable point", {}, graphTile)
+}
+
+// V2's `endTranslate` in apps/dg/components/graph/adornments/movable_value_adornment.js (~:166)
+// emits a notification with op string `'drag movable line'` for movable-VALUE drag — a confusingly
+// named V2 op (the actual movable LINE has no V2 notification; see dragMovableLineNotification).
+// V3 renames the value-drag emission to `drag movable value` for clarity. This is a deliberate
+// V2 deviation: the V2 op name was misleading enough that no plugin would have intentionally
+// matched on it for value-drag events. Bare payload. No-ops for non-graph tiles.
+export function dragMovableValueNotification(graphTile: ITileModel | undefined) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("drag movable value", {}, graphTile)
+}
+
+// V2 does NOT emit a notification when the scatterplot movable LINE is dragged
+// (apps/dg/components/graph/adornments/movable_line_adornment.js has a `dragMovableLine` log
+// but no `executeNotification`) — a V2 gap. V3 fills it by emitting `drag movable line` here.
+// Now that V3's value drag uses `drag movable value`, the op string is unambiguously the line.
+// Bare payload. No-ops for non-graph tiles.
+export function dragMovableLineNotification(graphTile: ITileModel | undefined) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("drag movable line", {}, graphTile)
+}
+
+// V2 emits `reposition equation` from two sites — plotted_average_adornment.js (~:529, equation
+// labels for plotted averages/measures) and twoD_line_adornment.js (~:285, equation labels for
+// movable line / LSRL). Bare V2 payload. V3 adds `adornment: <type>` so plugins know which
+// adornment's equation moved. No-ops for non-graph tiles.
+export function repositionEquationNotification(graphTile: ITileModel | undefined, adornment: string) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("reposition equation", { adornment }, graphTile)
+}
+
 // V2 emits `swap categories` from apps/dg/components/graph/axes/cell_axis_view.js (endDrag
 // ~:198) when a user finishes dragging a category label on a graph's categorical axis to a
 // new position. V2's analogous LEGEND swap command at apps/dg/components/graph_map_common/

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -47,6 +47,21 @@ export function add2ndAxisAttributeNotification(
   return updateTileNotification("add 2nd axis attribute", values ?? {}, graphTile)
 }
 
+// V2 emits `toggle NumberToggle` and `toggle MeasuresForSelection` from
+// apps/dg/components/graph/graph_model.js (`toggleCapability` closure ~:511), reached via
+// the inspector hide/show menu items. The op string is interpolated from the capability
+// name (`'toggle ' + iCapability`); V2's payload is bare. V3 additionally carries
+// `to: <boolean>` for the resulting enabled state. No-ops for non-graph tiles.
+export function toggleNumberToggleNotification(graphTile: ITileModel | undefined, to: boolean) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("toggle NumberToggle", { to }, graphTile)
+}
+
+export function toggleMeasuresForSelectionNotification(graphTile: ITileModel | undefined, to: boolean) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("toggle MeasuresForSelection", { to }, graphTile)
+}
+
 // V2 emits `swap categories` from apps/dg/components/graph/axes/cell_axis_view.js (endDrag
 // ~:198) when a user finishes dragging a category label on a graph's categorical axis to a
 // new position. V2's analogous LEGEND swap command at apps/dg/components/graph_map_common/

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -1,6 +1,7 @@
 import { ITileModel } from "../../models/tiles/tile-model"
 import { updateTileNotification } from "../../models/tiles/tile-notifications"
 import { kGraphTileType } from "./graph-defs"
+import { IAttrChangeValues } from "./models/graph-notification-utils"
 
 // V2 emits { action:'notify', resource:'component', values:{ operation:'change background color',
 // type:'DG.GraphView' } } from apps/dg/components/graph/graph_controller.js (createSetColorAndAlphaCommand,
@@ -19,4 +20,28 @@ export function changeBackgroundColorNotification(graphTile: ITileModel | undefi
 export function toggleBackgroundTransparencyNotification(graphTile: ITileModel | undefined, to: boolean) {
   if (graphTile?.content.type !== kGraphTileType) return
   return updateTileNotification("toggle background transparency", { to }, graphTile)
+}
+
+// V2 emits `add axis attribute` from apps/dg/components/graph/graph_controller.js
+// (multiTargetDidAcceptDrop ~:619) when an attribute is dropped on the y-axis multi-target —
+// the "+" drop zone that adds another y-axis attribute (or splits horizontally for nominal
+// attributes). V3 routes drops on the `yPlus` place to this op; the richer `IAttrChangeValues`
+// payload (attributeId/Name, plotType, primaryAxis, axisOrientation) is additive over V2's bare
+// emission. No-ops for non-graph tiles.
+export function addAxisAttributeNotification(
+  graphTile: ITileModel | undefined, values: IAttrChangeValues | undefined
+) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("add axis attribute", values ?? {}, graphTile)
+}
+
+// V2 emits `add 2nd axis attribute` from apps/dg/components/graph/graph_controller.js
+// (y2AxisDidAcceptDrop ~:688) when an attribute is dropped on the Y2 (rightNumeric) axis,
+// creating a second scatterplot axis. V3 routes drops on the `rightNumeric` place to this op
+// with the richer `IAttrChangeValues` payload. No-ops for non-graph tiles.
+export function add2ndAxisAttributeNotification(
+  graphTile: ITileModel | undefined, values: IAttrChangeValues | undefined
+) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("add 2nd axis attribute", values ?? {}, graphTile)
 }

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -111,6 +111,24 @@ export function removeMovableValueNotification(graphTile: ITileModel | undefined
   return updateTileNotification("remove movable value", {}, graphTile)
 }
 
+// V2 emits `showAllCases` from apps/dg/components/graph_map_common/data_layer_model.js (~:680)
+// when the user clicks "Show All" in the inspector hide/show menu. V2 emits with `type: ''`
+// (empty string — likely accidental, since the shared graph_map_common file doesn't know the SC
+// class name at that point). V3 emits with the correct `'DG.GraphView'` type via tileNotification —
+// an implicit V2 wart-fix. Bare payload. No-ops for non-graph tiles (map is CODAP-1352).
+export function showAllCasesNotification(graphTile: ITileModel | undefined) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("showAllCases", {}, graphTile)
+}
+
+// V2 emits `displayOnlySelected` from apps/dg/components/graph_map_common/data_layer_model.js
+// (~:705) when the user picks "Display Only Selected Cases". Same `type: ''` V2 wart as
+// showAllCases; V3 emits with the correct type. Bare payload. No-ops for non-graph tiles.
+export function displayOnlySelectedNotification(graphTile: ITileModel | undefined) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("displayOnlySelected", {}, graphTile)
+}
+
 // V2 emits `edit plot formula` from apps/dg/components/graph/adornments/plotted_formula_edit_context.js
 // (createEditCommand ~:102) when the user applies a new formula via the plotted-value or plotted-function
 // edit dialog. V2's payload is bare. V3 additionally carries `{ adornment, from, to }` so plugins can

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -91,6 +91,26 @@ export function dragMovableLineNotification(graphTile: ITileModel | undefined) {
   return updateTileNotification("drag movable line", {}, graphTile)
 }
 
+// V2 emits `add movable value` from apps/dg/components/graph/plots/univariate_adornment_base_model.js
+// (addMovableValue ~:195) when the user clicks the "Add" button in the movable-value adornment
+// Controls. Bare payload. No-ops for non-graph tiles.
+//
+// NOTE: V2's `toggle movable value` (~:107) is NOT replicated here. V2's only emission of that op
+// is a copy-paste bug in V2's `togglePlottedCount` override — it fires `'toggle movable value'`
+// instead of the correct `'toggle plotted Count|Percent'` (audit §3.5). V3 has no
+// add-all/remove-all UI, so no semantic place to emit the toggle op from anyway.
+export function addMovableValueNotification(graphTile: ITileModel | undefined) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("add movable value", {}, graphTile)
+}
+
+// V2 emits `remove movable value` from apps/dg/components/graph/plots/univariate_adornment_base_model.js
+// (removeMovableValue ~:272) when the user clicks "Remove". Bare payload. No-ops for non-graph tiles.
+export function removeMovableValueNotification(graphTile: ITileModel | undefined) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("remove movable value", {}, graphTile)
+}
+
 // V2 emits `drag bin boundary` from both apps/dg/components/graph/plots/binned_plot_view.js
 // (~:210) and histogram_view.js (~:261) via identical `markBinParamsChange` functions, fired on
 // drag-end after a user adjusts a histogram/binned-dot-plot bin boundary. V2's payload is bare

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -111,6 +111,36 @@ export function removeMovableValueNotification(graphTile: ITileModel | undefined
   return updateTileNotification("remove movable value", {}, graphTile)
 }
 
+// V2 emits `setNumStdErrs` from apps/dg/components/graph/plots/univariate_adornment_base_model.js
+// (~:357) when the user changes the number of standard errors in the std-err adornment's number
+// input. V2's payload is bare (the new value lives only in the log). V3 carries the new value
+// in `to` so plugins can react without re-querying. No-ops for non-graph tiles.
+export function setNumStdErrsNotification(graphTile: ITileModel | undefined, to: number) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("setNumStdErrs", { to }, graphTile)
+}
+
+// V2 emits `toggle show outliers` from apps/dg/components/graph/plots/univariate_adornment_base_model.js
+// (~:462) when the user toggles the box-plot "Show Outliers" sub-option. V3 also carries
+// `{ isChecked }` matching the adornment-checkbox convention.
+// V2 ALSO emits `'toggle show outliers'` from `toggleShowICI` (~:511) — a wrong-op bug
+// (audit §3.5). V3 does NOT replicate that; the ICI toggle uses `toggleShowICINotification`.
+// No-ops for non-graph tiles.
+export function toggleShowOutliersNotification(graphTile: ITileModel | undefined, isChecked: boolean) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("toggle show outliers", { isChecked }, graphTile)
+}
+
+// V3-only op. V2 incorrectly emits `'toggle show outliers'` for the ICI sub-option toggle
+// (audit §3.5 bug at univariate_adornment_base_model.js:~511); V3 uses the clarifying op
+// `'toggle show ICI'` so plugins can distinguish outliers vs ICI events. ICI is a research/
+// developer-only feature gated by the `iciEnabled` document flag, so the V2-compat audience
+// is narrow. No-ops for non-graph tiles.
+export function toggleShowICINotification(graphTile: ITileModel | undefined, isChecked: boolean) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("toggle show ICI", { isChecked }, graphTile)
+}
+
 // V2 emits `drag bin boundary` from both apps/dg/components/graph/plots/binned_plot_view.js
 // (~:210) and histogram_view.js (~:261) via identical `markBinParamsChange` functions, fired on
 // drag-end after a user adjusts a histogram/binned-dot-plot bin boundary. V2's payload is bare

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -1,0 +1,13 @@
+import { ITileModel } from "../../models/tiles/tile-model"
+import { updateTileNotification } from "../../models/tiles/tile-notifications"
+import { kGraphTileType } from "./graph-defs"
+
+// V2 emits { action:'notify', resource:'component', values:{ operation:'change background color',
+// type:'DG.GraphView' } } from apps/dg/components/graph/graph_controller.js (createSetColorAndAlphaCommand,
+// ~line 772) when the user picks a color in the inspector palette. V3 additionally carries `to: <color>`
+// so V3-aware plugins can see the resulting color without re-querying.
+// No-ops for non-graph tiles so it's safe to call from generic notify callbacks.
+export function changeBackgroundColorNotification(graphTile: ITileModel | undefined, to: string) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("change background color", { to }, graphTile)
+}

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -111,6 +111,17 @@ export function removeMovableValueNotification(graphTile: ITileModel | undefined
   return updateTileNotification("remove movable value", {}, graphTile)
 }
 
+// V2 emits `edit plot formula` from apps/dg/components/graph/adornments/plotted_formula_edit_context.js
+// (createEditCommand ~:102) when the user applies a new formula via the plotted-value or plotted-function
+// edit dialog. V2's payload is bare. V3 additionally carries `{ adornment, from, to }` so plugins can
+// tell which adornment's formula was edited and see the old/new expressions. No-ops for non-graph tiles.
+export function editPlotFormulaNotification(
+  graphTile: ITileModel | undefined, adornment: string, from: string, to: string
+) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("edit plot formula", { adornment, from, to }, graphTile)
+}
+
 // V2 emits `setNumStdErrs` from apps/dg/components/graph/plots/univariate_adornment_base_model.js
 // (~:357) when the user changes the number of standard errors in the std-err adornment's number
 // input. V2's payload is bare (the new value lives only in the log). V3 carries the new value

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -1,5 +1,6 @@
 import { ITileModel } from "../../models/tiles/tile-model"
 import { updateTileNotification } from "../../models/tiles/tile-notifications"
+import { GraphPlace } from "../axis-graph-shared"
 import { kGraphTileType } from "./graph-defs"
 import { IAttrChangeValues } from "./models/graph-notification-utils"
 
@@ -44,4 +45,17 @@ export function add2ndAxisAttributeNotification(
 ) {
   if (graphTile?.content.type !== kGraphTileType) return
   return updateTileNotification("add 2nd axis attribute", values ?? {}, graphTile)
+}
+
+// V2 emits `swap categories` from apps/dg/components/graph/axes/cell_axis_view.js (endDrag
+// ~:198) when a user finishes dragging a category label on a graph's categorical axis to a
+// new position. V2's analogous LEGEND swap command at apps/dg/components/graph_map_common/
+// legend/categories_view.js ~:120 has no `executeNotification` block — a V2 oversight (the
+// undo/redo strings line up; only the notification is missing). V3 fires the same op from
+// both code paths, additionally carrying `place` so plugins can distinguish axis vs legend
+// (and which axis). No-ops for non-graph tiles — the axis hook and legend component are
+// shared with the map tile, which V2 also did not emit for.
+export function swapCategoriesNotification(graphTile: ITileModel | undefined, place: GraphPlace) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("swap categories", { place }, graphTile)
 }

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -11,3 +11,12 @@ export function changeBackgroundColorNotification(graphTile: ITileModel | undefi
   if (graphTile?.content.type !== kGraphTileType) return
   return updateTileNotification("change background color", { to }, graphTile)
 }
+
+// V2 emits { action:'notify', resource:'component', values:{ operation:'toggle background transparency',
+// type:'DG.GraphView' } } from apps/dg/components/graph/graph_controller.js (transparency-checkbox
+// valueDidChange ~line 837). V3 additionally carries `to: <boolean>` for the resulting state.
+// No-ops for non-graph tiles so it's safe to call from generic notify callbacks.
+export function toggleBackgroundTransparencyNotification(graphTile: ITileModel | undefined, to: boolean) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  return updateTileNotification("toggle background transparency", { to }, graphTile)
+}

--- a/v3/src/components/graph/graph-notifications.ts
+++ b/v3/src/components/graph/graph-notifications.ts
@@ -91,6 +91,21 @@ export function dragMovableLineNotification(graphTile: ITileModel | undefined) {
   return updateTileNotification("drag movable line", {}, graphTile)
 }
 
+// V2 emits `drag bin boundary` from both apps/dg/components/graph/plots/binned_plot_view.js
+// (~:210) and histogram_view.js (~:261) via identical `markBinParamsChange` functions, fired on
+// drag-end after a user adjusts a histogram/binned-dot-plot bin boundary. V2's payload is bare
+// (the new alignment/width are only in the log). V3 carries them in the notification too so
+// plugins can react without re-querying. No-ops for non-graph tiles.
+export function dragBinBoundaryNotification(
+  graphTile: ITileModel | undefined, params: { alignment?: number, width?: number }
+) {
+  if (graphTile?.content.type !== kGraphTileType) return
+  const values: Record<string, number> = {}
+  if (params.alignment != null) values.alignment = params.alignment
+  if (params.width != null) values.width = params.width
+  return updateTileNotification("drag bin boundary", values, graphTile)
+}
+
 // V2 emits `reposition equation` from two sites — plotted_average_adornment.js (~:529, equation
 // labels for plotted averages/measures) and twoD_line_adornment.js (~:285, equation labels for
 // movable line / LSRL). Bare V2 payload. V3 adds `adornment: <type>` so plugins know which

--- a/v3/src/components/graph/hooks/use-bin-boundary-drag.ts
+++ b/v3/src/components/graph/hooks/use-bin-boundary-drag.ts
@@ -3,11 +3,13 @@ import { comparer } from "mobx"
 import { useCallback, useEffect, useRef } from "react"
 import { clsx } from "clsx"
 import { LogMessageFn, logModelChangeFn } from "../../../lib/log-message"
+import { getTileModel } from "../../../models/tiles/tile-model"
 import { isFiniteNumber, roundToPrecision } from "../../../utilities/math-utils"
 import { mstReaction } from "../../../utilities/mst-reaction"
 import { t } from "../../../utilities/translation/translate"
 import { AxisPlace } from "../../axis/axis-types"
 import { getDomainExtentForPixelWidth } from "../../axis/axis-utils"
+import { dragBinBoundaryNotification } from "../graph-notifications"
 import { IGraphDataConfigurationModel } from "../models/graph-data-configuration-model"
 import { IGraphContentModel } from "../models/graph-content-model"
 import { GraphLayout } from "../models/graph-layout"
@@ -148,25 +150,27 @@ export function useBinBoundaryDrag({
       drawBinBoundaries()
       addBinBoundaryDragHandlers()
     }
-    binnedPlot.applyModelChange(
-      () => {
-        if (binnedPlot.binAlignment != null && binnedPlot.binWidth != null) {
-          binnedPlot.endBinBoundaryDrag(binnedPlot.binAlignment, binnedPlot.binWidth)
-          // Update axis domain as part of the same undo entry (skipped during drag)
-          const { totalNumberOfBins, minBinEdge } = binnedPlot.binDetails()
-          if (isFiniteNumber(minBinEdge) && isFiniteNumber(totalNumberOfBins)) {
-            const axisModel = graphModel.getNumericAxis(primaryPlace)
-            axisModel?.setAllowRangeToShrink(true)
-            axisModel?.setDomain(minBinEdge, minBinEdge + binnedPlot.binWidth * totalNumberOfBins)
-          }
+    binnedPlot.applyModelChange(() => {
+      if (binnedPlot.binAlignment != null && binnedPlot.binWidth != null) {
+        binnedPlot.endBinBoundaryDrag(binnedPlot.binAlignment, binnedPlot.binWidth)
+        // Update axis domain as part of the same undo entry (skipped during drag)
+        const { totalNumberOfBins, minBinEdge } = binnedPlot.binDetails()
+        if (isFiniteNumber(minBinEdge) && isFiniteNumber(totalNumberOfBins)) {
+          const axisModel = graphModel.getNumericAxis(primaryPlace)
+          axisModel?.setAllowRangeToShrink(true)
+          axisModel?.setDomain(minBinEdge, minBinEdge + binnedPlot.binWidth * totalNumberOfBins)
         }
-        lowerBoundaryRef.current = 0
-      }, {
-        undoStringKey: "DG.Undo.graph.dragBinBoundary",
-        redoStringKey: "DG.Redo.graph.dragBinBoundary",
-        log: logFn.current
       }
-    )
+      lowerBoundaryRef.current = 0
+    }, {
+      notify: () => dragBinBoundaryNotification(getTileModel(graphModel), {
+        alignment: binnedPlot.binAlignment,
+        width: binnedPlot.binWidth
+      }),
+      undoStringKey: "DG.Undo.graph.dragBinBoundary",
+      redoStringKey: "DG.Redo.graph.dragBinBoundary",
+      log: logFn.current
+    })
   }, [addBinBoundaryDragHandlers, binnedPlot, drawBinBoundaries, graphModel, primaryPlace])
 
   // If the pixel width of binWidth would be less than kMinBinScreenWidth, set it to kMinBinScreenWidth.


### PR DESCRIPTION
## Summary
Backfills V2-compatible plugin notifications for graph adornments, plots,
and the inspector hide/show menu per audit §3.3 graph portion. Builds on
the `tileNotification` infrastructure from #2596 (CODAP-1353).

Fixes CODAP-1351.

**Stacked on #2596** (`CODAP-1353-tile-notification-backfill`). Will rebase
onto `main` once that PR lands.

## What's covered

Each commit is one logical V2 op (or a small cluster sharing a code path):

- Background color + transparency toggles (graph_controller.js)
- Add axis attribute / add 2nd axis attribute (y-multi-target + Y2 drops)
- Swap categories (axis + legend, both code paths)
- Toggle NumberToggle / MeasuresForSelection (capability toggles)
- Toggle plotted value + Count + Percent
- Scatter-plot toggles (movable point/line, LSRL, plot function)
- Drag-end notifications: movable point, movable value, movable line,
  reposition equation (movable line + LSRL + univariate measures)
- Drag bin boundary (histogram + binned dot plot)
- Add / remove movable value
- togglePlotted family (StDev, StErr, MAD, Normal, BoxPlot) +
  setNumStdErrs + outliers + ICI
- Edit plot formula (plotted-value + plotted-function)
- Show all cases / display only selected

## Notable V2 deviations (documented per commit)

- **`drag movable value`** — RENAMED from V2's misleading `drag movable line`
  (V2 fires that op for movable-VALUE drag from
  `movable_value_adornment.js`; the actual movable LINE drag has no V2
  notification at all). V3 uses the clearer name.
- **`drag movable line`** — now emitted for the actual scatterplot movable
  LINE drag (V2 gap).
- **`toggle movable value`** — intentionally NOT emitted (V2's only emission
  was a §3.5 copy-paste bug in `togglePlottedCount`; V3 has no toggle-all UI).
- **`togglePlottedIQR`** — intentionally NOT emitted (V3 has no separate IQR
  adornment; IQR is internal to box-plot).
- **`toggle show ICI`** — new V3-only op. V2 emits the wrong-op
  `'toggle show outliers'` for ICI (§3.5 bug); V3 disambiguates.
- **`swap categories`** — emitted from both axis AND legend code paths.
  V2 only had the axis emission (legend command lacked `executeNotification`).
- **`type: ''`** — V2's `showAllCases` / `displayOnlySelected` emit empty
  string for `type`. V3 emits the correct `'DG.GraphView'` via
  `tileNotification`.

## V3 regressions fixed along the way

- Univariate measure equation-label drag (`handleEndMoveLabel`) bypassed
  `applyModelChange`, making label moves non-undoable. Now wrapped at each
  consumer (simple, standard-error, normal-curve components).
- Box-plot `handleShowOutliersSetting` and `handleShowIciSetting` likewise
  bypassed `applyModelChange`. Both now wrapped.

## Test plan
- [ ] CI passes (lint, tsc, jest, Cypress)
- [ ] Verify movable-line drag fires `drag movable line`
- [ ] Verify movable-value drag fires `drag movable value` (not `drag movable line`)
- [ ] Verify category swap fires `swap categories` from BOTH axis and legend
- [ ] Verify univariate measure equation-label drag is now undoable
- [ ] Verify box-plot outliers / ICI checkboxes are now undoable
- [ ] Spot-check V2 plugins still receive expected ops on each backfilled action

🤖 Generated with [Claude Code](https://claude.com/claude-code)
