### PR TITLE
fix(build): repair stale v2Type ref in text-notifications test

### DIFF
--- a/v3/src/components/text/text-notifications.test.ts
+++ b/v3/src/components/text/text-notifications.test.ts
@@ -65,7 +65,8 @@ describe("editTextNotification", () => {
     expect(notification?.message.resource).toBe("component")
     expect(notification?.message.values.operation).toBe("edit text")
     expect(notification?.message.values.id).toBe(v2Id)
-    expect(notification?.message.values.type).toBe(v2Type)
+    expect(notification?.message.values.type).toBe(v2SCType)
+    expect(notification?.message.values.diType).toBe(diType)
   })
 
   it("returns undefined when tile is missing", () => {


### PR DESCRIPTION
## Summary
- Repairs a clean-but-broken merge between PR #2596 (CODAP-1353) and PR #2598 (CODAP-1360) that left `main` failing `tsc`.
- PR #2596 renamed the test-local `v2Type` → `v2SCType` and added `diType`; PR #2598 was branched before that rename and appended a new test block still referencing `v2Type`.
- Pure test-only fix; no production code changes.

## Test plan
- [x] `npm run build:tsc` — clean
- [x] `npm test -- text-notifications` — 4/4 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
