### PR TITLE
CODAP-1326: flip V3 release switches for production

### DIFF
--- a/v3/docs/plans/2026-05-25-codap-1326-release-switches-design.md
+++ b/v3/docs/plans/2026-05-25-codap-1326-release-switches-design.md
@@ -1,0 +1,186 @@
+# CODAP-1326: Flip V3 release switches for production — Design
+
+**Status:** Approved
+**Jira:** [CODAP-1326](https://concord-consortium.atlassian.net/browse/CODAP-1326)
+**Branch:** `CODAP-1326-release-switches`
+
+## Goal
+
+Flip three V3-internal switches in the release build so the production cutover behaves correctly:
+
+1. Log destination → production server (host- and path-aware).
+2. Default save extension → `.codap` (drop the beta-era `.codap3` precaution).
+3. V2-document open behavior → treat V2 docs like any other doc (drop the beta-era auto-save disabling).
+
+Per the V3 Release Plan (CODAP-1322): the V3 file format is now standardized, V3 owns the `.codap` extension, and we are confident V3 won't break V2 documents. The three switches reflect that.
+
+## Switch 1: Log destination
+
+### Current state
+
+`v3/src/lib/logger.ts`:
+
+- Line 13–16: `logManagerUrl` already defines both URLs (`dev` = `logger.concordqa.org`, `production` = `logger.concord.org`).
+- Line 227: `sendToLoggingService()` unconditionally selects `logManagerUrl.dev`.
+- Lines 225–226: stale commented-out conditional referencing `user.portal` / `productionPortal` — symbols that don't exist anywhere in v3.
+
+V2 master (`apps/dg/core.js:209+498`) unconditionally uses the production URL. The "always production" V2 behavior is simpler than what we want here.
+
+### Requirement
+
+The production log server persists every log message to a permanent database. We want logs from real users only — not from dev, QA, branch deploys, or beta/staging channels.
+
+### Solution
+
+Replace the hardcoded `logManagerUrl.dev` with a host- and path-aware production check.
+
+```typescript
+function isProductionLogHost() {
+  if (typeof window === "undefined") return false
+  const host = window.location.hostname.toLowerCase()
+  if (host !== "codap.concord.org" && host !== "codap3.concord.org") return false
+  const firstSegment = window.location.pathname.split("/").filter(Boolean)[0]
+  return firstSegment !== "beta" && firstSegment !== "staging" && firstSegment !== "branch"
+}
+```
+
+Wire into `sendToLoggingService()`:
+
+```typescript
+const url = logManagerUrl[isProductionLogHost() ? "production" : "dev"]
+```
+
+Delete the stale commented-out lines 225–226.
+
+### Behavior matrix
+
+| URL | Production logs? | Why |
+|---|---|---|
+| `codap.concord.org/` | ✓ | Post-cutover production host |
+| `codap.concord.org/anything` | ✓ | Same host, non-blacklisted path |
+| `codap3.concord.org/` | ✓ | Current production host (real beta users) |
+| `codap3.concord.org/beta/` | ✗ | Beta channel |
+| `codap3.concord.org/staging/` | ✗ | Staging channel |
+| `codap3.concord.org/branch/<name>/` | ✗ | Per-branch deploy |
+| `localhost`, `127.0.0.1` | ✗ | Local dev (also fails `Logger.isLoggingEnabled`) |
+| Other hostnames | ✗ | Not a known production host |
+
+### Notes
+
+- `Logger.isLoggingEnabled` (line 76–78) already gates all logging to `.concord.org` hostnames + `DEBUG_LOGGER`. The new check sits inside that gate.
+- The first-segment matching mirrors the codebase's `isBeta()` pattern (in `version-utils.ts`), which checks `pathSegments.includes("beta")`. We use first-segment instead of `includes` so a branch named "beta" doesn't accidentally route to dev when accessed via `/branch/beta/` (which it shouldn't anyway, since `/branch/` itself is excluded).
+
+## Switch 2: Default save extension
+
+### Current state
+
+- `v3/src/lib/cfm/use-cloud-file-manager.ts:355`: `extension: CONFIG_SAVE_AS_V2 ? "codap" : "codap3"`.
+- `v3/src/lib/config.ts:6`: `CONFIG_SAVE_AS_V2 = DEBUG_SAVE_AS_V2 || isBeta()` — so any user on a `/beta/` deploy gets V2-format saves with `.codap` extension.
+- `CONFIG_SAVE_AS_V2` is consulted in `serialize-document.ts:45` (chooses V2 vs V3 export) and `use-cloud-file-manager.ts:355` (extension).
+
+### Solution
+
+Two coupled changes:
+
+**`v3/src/lib/cfm/use-cloud-file-manager.ts:355`** — extension becomes unconditional:
+
+```diff
+- extension: CONFIG_SAVE_AS_V2 ? "codap" : "codap3",
++ extension: "codap",
+```
+
+**`v3/src/lib/config.ts:6`** — drop the `isBeta()` trigger, keep the debug escape hatch:
+
+```diff
+- export const CONFIG_SAVE_AS_V2 = DEBUG_SAVE_AS_V2 || isBeta()
++ export const CONFIG_SAVE_AS_V2 = DEBUG_SAVE_AS_V2
+```
+
+### Behavior matrix
+
+| Context | `CONFIG_SAVE_AS_V2` (before → after) | Save format (before → after) | Extension (before → after) |
+|---|---|---|---|
+| Production root path | `false` → `false` | V3 → V3 | `.codap3` → `.codap` |
+| `/beta/` deploy | `true` → `false` | V2 → V3 | `.codap` → `.codap` |
+| `?debug=saveAsV2` | `true` → `true` | V2 → V2 | `.codap` → `.codap` |
+| Other | `false` → `false` | V3 → V3 | `.codap3` → `.codap` |
+
+The behavior change for `/beta/` users is deliberate: post-cutover, every user saves V3 format.
+
+### Notes
+
+- `readableExtensions` continues to accept both `.codap` and `.codap3` on open — no change to existing test fixtures or user files.
+- We are not retiring `CONFIG_SAVE_AS_V2` or `DEBUG_SAVE_AS_V2` in this story. That belongs in a follow-up cleanup.
+
+## Switch 3: V2-document open behavior
+
+### Current state
+
+`v3/src/lib/cfm/handle-cfm-event.ts:107–138` disables CFM auto-save when V3 opens a V2 document outside a LARA/embedded context. The block was a beta-era precaution; its own comment says it "might be temporary until we are confident that CODAPv3 won't break v2 documents."
+
+### Solution
+
+Delete the entire `if (isCodapV2Document(resolvedDocument))` block and the `shouldAutoSaveDocument` flag. After the deletion, the surrounding code becomes:
+
+```typescript
+const resolvedDocument = await resolveDocument(content, metadata)
+await appState.setDocument(resolvedDocument, metadata)
+cfmClient.autoSave(kCFMAutoSaveInterval)
+```
+
+Clean-up:
+
+- Remove the `isCodapV2Document` import if unused elsewhere in the file.
+- Remove the `kCFMAutoSaveDisabledInterval` import if unused elsewhere in the file.
+- Remove or simplify the now-stale comments about the V2 precaution.
+
+### Behavior change
+
+| Context | Before | After |
+|---|---|---|
+| LARA / embedded (V2 doc) | Auto-save on | Auto-save on (no change) |
+| Non-LARA (V2 doc saved by V3) | Auto-save on | Auto-save on (no change) |
+| Non-LARA (true V2 doc) | Auto-save off | Auto-save on |
+
+Combined with Switch 2: any auto-save of a previously-V2 document writes V3 `.codap` content to the same location. No user message. The position: "This is CODAP V3; it saves files in V3 format."
+
+### Out of scope
+
+- In-app messaging notifying users that their V2 doc has been opened in V3. Explicitly omitted per the design decision.
+- Storage-backend-aware behavior (Drive vs LARA vs local). The existing `hasInteractiveApiContext()` distinction is no longer needed once auto-save is uniformly enabled.
+
+## Verification
+
+### Switch 1
+
+- Unit tests: mock `window.location` with each matrix row above; assert `isProductionLogHost()` returns the expected boolean.
+- Manual: build → deploy to a branch path → confirm dev server receives traffic (network tab to `logger.concordqa.org`). Hit `codap.concord.org` root → confirm production traffic.
+
+### Switch 2
+
+- Manual: load app, create a new document, save → filename ends in `.codap`. Open an existing `.codap3` fixture → still loads.
+- Existing serialize-document tests already cover format selection; verify they pass under the new default (`CONFIG_SAVE_AS_V2 = DEBUG_SAVE_AS_V2 = false`).
+
+### Switch 3
+
+- Manual: open a true V2 doc (e.g., `v3/src/test/v2/mammals.codap`) without LARA params, edit, wait 5 s → confirm auto-save fires and the resulting file is V3 format. With LARA params: same behavior, was-already-the-case.
+- Existing CFM event tests: ensure none rely on the V2 auto-save-disable code path; update or remove as needed.
+
+## Sequencing
+
+All three switches bundled into a single PR. Final RC deadline: 2026-05-25 (extended from 2026-05-22). Release cutover: 2026-06-07.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Real users on `codap3.concord.org` outside `/` (e.g., bookmarked `/beta/`) lose their V2-format save behavior | Deliberate; beta-format saves are no longer a goal. |
+| A `.codap` file the user thinks is V2 is silently overwritten with V3 content after edit | Position: V3 owns the `.codap` extension going forward; V2 retirement is announced. No code-level safeguard. |
+| Branch deploys send no logs to production | Intentional; branches are dev/QA traffic. |
+| New host added (e.g., `codap2.concord.org`) is forgotten in the allowlist | Allowlist is short and grep-able; future hosts must be added explicitly. |
+
+## Follow-ups (not in this story)
+
+- Retire `CONFIG_SAVE_AS_V2` / `DEBUG_SAVE_AS_V2` once the debug pathway is no longer needed.
+- Add (or revisit) an In-app message about V2→V3 conversion if user feedback warrants it.
+- Consider deleting the staging URL from `logManagerUrl` once branch/beta deploys move to a dedicated dev log target.

--- a/v3/src/lib/cfm/handle-cfm-event.test.ts
+++ b/v3/src/lib/cfm/handle-cfm-event.test.ts
@@ -151,8 +151,10 @@ describe("handleCFMEvent", () => {
     expect(ImportV2Document.importV2Document).toHaveBeenCalledTimes(1)
     // No error and no shared data
     expect(cfmEvent.callback).toHaveBeenCalledWith(null, {})
-    // autoSave should be disabled for v2 documents with an appVersion other than 3.x
-    expect(mockCfmClient.autoSave).toHaveBeenCalledWith(-1)
+    // V3 owns the .codap extension; v2 docs get auto-saved like any other doc, which on
+    // the next save converts them to v3 format in place (see CODAP-1326).
+    expect(mockCfmClient.autoSave).not.toHaveBeenCalledWith(-1)
+    expect(mockCfmClient.autoSave).toHaveBeenCalledWith(kCFMAutoSaveInterval)
     spy.mockRestore()
   })
 
@@ -234,76 +236,6 @@ describe("handleCFMEvent", () => {
     // No error and the sharing info is returned
     expect(cfmEvent.callback).toHaveBeenCalledWith(null, mockSharingInfo)
     spy.mockRestore()
-  })
-
-  describe("openedFile + embedded LARA context", () => {
-    let savedUrlParams: any
-
-    beforeEach(() => {
-      // Snapshot the *current* params, then actively clear the three we care about so
-      // leftover state from a prior test elsewhere can't make our negative assertions
-      // pass for the wrong reason.
-      savedUrlParams = { ...urlParamsModule.urlParams }
-      delete urlParamsModule.urlParams.interactiveApi
-      delete urlParamsModule.urlParams.launchFromLara
-      delete urlParamsModule.urlParams.lara
-    })
-
-    afterEach(() => {
-      // Restore each param we may have touched
-      delete urlParamsModule.urlParams.interactiveApi
-      delete urlParamsModule.urlParams.launchFromLara
-      delete urlParamsModule.urlParams.lara
-      Object.assign(urlParamsModule.urlParams, savedUrlParams)
-    })
-
-    const v2Doc = {
-      appName: "DG",
-      appVersion: "2.0.0",
-      appBuildNum: "555",
-      components: [],
-      contexts: []
-    } as unknown as ICodapV2DocumentJson
-
-    const makeEvent = () => ({
-      type: "openedFile",
-      data: { content: v2Doc, metadata: { filename: "file.codap" } },
-      callback: jest.fn() as ClientEventCallback
-    } as CloudFileManagerClientEvent)
-
-    // Each test verifies BOTH paths of the autoSave gate:
-    //   1. The "disable" branch (autoSave(-1)) is NOT called
-    //   2. The "enable" branch (autoSave(kCFMAutoSaveInterval)) IS called
-    // This matches the assertion style used by "handles the openedFile message with
-    // a v2 document saved by v3" at the top of this test file and catches both
-    // "called with wrong interval" and "never called" regressions.
-
-    it("keeps autoSave enabled for v2 doc when interactiveApi is present", async () => {
-      urlParamsModule.urlParams.interactiveApi = null  // present without value
-      const mockCfmClient =
-        { closeFile: jest.fn(), autoSave: jest.fn() } as unknown as CloudFileManagerClient
-      await handleCFMEvent(mockCfmClient, makeEvent())
-      expect(mockCfmClient.autoSave).not.toHaveBeenCalledWith(-1)
-      expect(mockCfmClient.autoSave).toHaveBeenCalledWith(kCFMAutoSaveInterval)
-    })
-
-    it("keeps autoSave enabled for v2 doc when launchFromLara is present with a value", async () => {
-      urlParamsModule.urlParams.launchFromLara = "base64payload"
-      const mockCfmClient =
-        { closeFile: jest.fn(), autoSave: jest.fn() } as unknown as CloudFileManagerClient
-      await handleCFMEvent(mockCfmClient, makeEvent())
-      expect(mockCfmClient.autoSave).not.toHaveBeenCalledWith(-1)
-      expect(mockCfmClient.autoSave).toHaveBeenCalledWith(kCFMAutoSaveInterval)
-    })
-
-    it("keeps autoSave enabled for v2 doc when lara is present with a value", async () => {
-      urlParamsModule.urlParams.lara = "1"
-      const mockCfmClient =
-        { closeFile: jest.fn(), autoSave: jest.fn() } as unknown as CloudFileManagerClient
-      await handleCFMEvent(mockCfmClient, makeEvent())
-      expect(mockCfmClient.autoSave).not.toHaveBeenCalledWith(-1)
-      expect(mockCfmClient.autoSave).toHaveBeenCalledWith(kCFMAutoSaveInterval)
-    })
   })
 
   describe("`openedFile` message with invalid documents", () => {

--- a/v3/src/lib/cfm/handle-cfm-event.ts
+++ b/v3/src/lib/cfm/handle-cfm-event.ts
@@ -5,9 +5,8 @@ import pkg from "../../../package.json"
 import { appState } from "../../models/app-state"
 import { uiState } from "../../models/ui-state"
 import { t } from "../../utilities/translation/translate"
-import { hasInteractiveApiContext, removeDevUrlParams, urlParams } from "../../utilities/url-params"
+import { removeDevUrlParams, urlParams } from "../../utilities/url-params"
 import { displayVersion } from "../../utilities/version-utils"
-import { isCodapV2Document } from "../../v2/codap-v2-types"
 import { DEBUG_CFM_EVENTS, DEBUG_CFM_NO_AUTO_SAVE } from "../debug"
 import { Logger } from "../logger"
 import { wrapCfmCallback } from "./cfm-utils"
@@ -103,48 +102,12 @@ export async function handleCFMEvent(cfmClient: CloudFileManagerClient, event: C
         const clonedCfmSharedMetadata = cloneDeep(cfmSharedMetadata)
 
         const resolvedDocument = await resolveDocument(content, metadata)
-
-        let shouldAutoSaveDocument = true
-        if (isCodapV2Document(resolvedDocument)) {
-          // Disable autoSave for v2 documents that were not saved by CODAP v3
-          // This disabling of autoSave might be temporary until we are confident that
-          // CODAPv3 won't break v2 documents. If this disabling becomes permanent we
-          // should use a more advanced mechanism to determine which application saved
-          // the document. In the meantime we just look at the appVersion. If it isn't
-          // a v3 appVersion, then we assume this is a v2 document.
-          // If CFM file menu is hidden because the app is launched in embedded-LARA context
-          // (interactiveApi, launchFromLara, or lara URL params; see hasInteractiveApiContext)
-          // then we keep autoSave enabled.
-          // Note: if auto save is disabled by the debug flag DEBUG_CFM_NO_AUTO_SAVE,
-          // that will override this, and is handled by the value of kCFMAutoSaveInterval
-          // computed above.
-          // Note: in some v2 documents the appVersion is not set
-          const loadedDocumentWasSavedByV3 = !!resolvedDocument.appVersion?.startsWith("3.")
-          shouldAutoSaveDocument = loadedDocumentWasSavedByV3 || hasInteractiveApiContext()
-          if (!shouldAutoSaveDocument) {
-            // eslint-disable-next-line no-console
-            console.log("Disabling autoSave for v2 document that was saved by CODAPv2",
-              { appVersion: resolvedDocument.appVersion })
-            // NOTE: Whether the document is saved automatically depends on more factors.
-            // For example the CFM provider has to support autoSave.
-            cfmClient.autoSave(kCFMAutoSaveDisabledInterval)
-          }
-          // If shouldAutoSaveDocument is true, we do not enable autoSave yet.
-          // At this point the appState.document will still be the original document
-          // not the new one we are trying to open. The new document gets set by
-          // setDocument below. If autoSave is enabled before this, the CFM might decide
-          // to save the original document before the new document is set. The original
-          // document might be one that we don't want to autoSave.
-        }
         await appState.setDocument(resolvedDocument, metadata)
 
-        // Now that the new document is set as the appState.document, it is
-        // safe to enable autoSave.
-        // Note: appState.document.version will always start with '3." here because
-        // the conversion from v2 to v3 documents does not migrate the appVersion.
-        if (shouldAutoSaveDocument) {
-          cfmClient.autoSave(kCFMAutoSaveInterval)
-        }
+        // Enable autoSave only after the new document is set as appState.document.
+        // Otherwise the CFM might save the previous document while the new one is
+        // still loading.
+        cfmClient.autoSave(kCFMAutoSaveInterval)
 
         // acknowledge a successful open and return shared metadata
         event.callback(null, clonedCfmSharedMetadata)

--- a/v3/src/lib/cfm/use-cloud-file-manager.ts
+++ b/v3/src/lib/cfm/use-cloud-file-manager.ts
@@ -10,7 +10,6 @@ import { persistentState } from "../../models/persistent-state"
 import { gLocale } from "../../utilities/translation/locale"
 import { t } from "../../utilities/translation/translate"
 import { hasInteractiveApiContext, removeDevUrlParams } from "../../utilities/url-params"
-import { CONFIG_SAVE_AS_V2 } from "../config"
 import { DEBUG_CFM_LOCAL_STORAGE } from "../debug"
 import { Logger } from "../logger"
 import { handleLogLaraData } from "./cfm-log-utils"
@@ -352,7 +351,7 @@ export function useCloudFileManager(optionsArg: CFMAppOptions, hookOptions?: IUs
       mimeType: 'application/json',
       localFileMimeType: 'application/octet-stream',
       readableMimeTypes: ['application/x-codap-document'],
-      extension: CONFIG_SAVE_AS_V2 ? "codap" : "codap3",
+      extension: "codap",
       readableExtensions: ["json", "", "codap", "codap3"],
       enableLaraSharing: true,
       log(_event: string, _eventData: any) {

--- a/v3/src/lib/config.ts
+++ b/v3/src/lib/config.ts
@@ -1,6 +1,3 @@
-import { isBeta } from "../utilities/version-utils"
 import { DEBUG_SAVE_AS_V2 } from "./debug"
 
-// For now, this is determined by DEBUG flag, but it may be configured by url parameter
-// or some other means eventually.
-export const CONFIG_SAVE_AS_V2 = DEBUG_SAVE_AS_V2 || isBeta()
+export const CONFIG_SAVE_AS_V2 = DEBUG_SAVE_AS_V2

--- a/v3/src/lib/logger.test.ts
+++ b/v3/src/lib/logger.test.ts
@@ -1,6 +1,32 @@
 import mockXhr from "xhr-mock"
-import { Logger, LogMessage } from "./logger"
+import { isProductionLogHost, Logger, LogMessage } from "./logger"
 import { IDocumentModel } from "../models/document/document"
+
+describe("isProductionLogHost", () => {
+  it("routes the production hosts at the root path to production", () => {
+    expect(isProductionLogHost("codap.concord.org", "/")).toBe(true)
+    expect(isProductionLogHost("codap.concord.org", "")).toBe(true)
+    expect(isProductionLogHost("codap.concord.org", "/some/spa/route")).toBe(true)
+    expect(isProductionLogHost("codap3.concord.org", "/")).toBe(true)
+    expect(isProductionLogHost("CODAP.CONCORD.ORG", "/")).toBe(true)
+  })
+
+  it("excludes beta, staging, and branch deploy paths", () => {
+    expect(isProductionLogHost("codap.concord.org", "/beta/")).toBe(false)
+    expect(isProductionLogHost("codap.concord.org", "/beta/index.html")).toBe(false)
+    expect(isProductionLogHost("codap3.concord.org", "/staging/")).toBe(false)
+    expect(isProductionLogHost("codap3.concord.org", "/branch/main/")).toBe(false)
+    expect(isProductionLogHost("codap3.concord.org", "/branch/feature-x/index.html")).toBe(false)
+  })
+
+  it("excludes non-production hosts", () => {
+    expect(isProductionLogHost("localhost", "/")).toBe(false)
+    expect(isProductionLogHost("127.0.0.1", "/")).toBe(false)
+    expect(isProductionLogHost("learn.concord.org", "/")).toBe(false)
+    expect(isProductionLogHost("staging.concord.org", "/")).toBe(false)
+    expect(isProductionLogHost("", "/")).toBe(false)
+  })
+})
 
 describe("Logger", () => {
   beforeEach(() => {

--- a/v3/src/lib/logger.ts
+++ b/v3/src/lib/logger.ts
@@ -239,9 +239,11 @@ function sendToLoggingService(data: LogMessage) {
     isProductionLogHost(window.location.hostname, window.location.pathname)
   const url = logManagerUrl[isProduction ? "production" : "dev"]
 
-  if (!Logger.isLoggingEnabled || !DEBUG_LOG_TO_SERVER) return
-
+  // Trace before the early-exit so DEBUG_LOGGER can see the destination URL.
+  // DEBUG_LOGGER on => DEBUG_LOG_TO_SERVER off => we return below without sending.
   debugLog(DEBUG_LOGGER, "Logger#sendToLoggingService sending", data, "to", url)
+
+  if (!Logger.isLoggingEnabled || !DEBUG_LOG_TO_SERVER) return
 
   const request = new XMLHttpRequest()
 

--- a/v3/src/lib/logger.ts
+++ b/v3/src/lib/logger.ts
@@ -15,6 +15,19 @@ const logManagerUrl: Record<LoggerEnvironment, string> = {
   production: "https://logger.concord.org/logs"
 }
 
+const kProductionHostNames = ["codap.concord.org", "codap3.concord.org"]
+const kNonProductionPathSegments = ["beta", "staging", "branch"]
+
+// Hostname allowlist + path blacklist that route log traffic to the production
+// log server. Real user traffic on these hosts is durable; everything else
+// (branch deploys, beta/staging channels, localhost) goes to the dev server.
+export function isProductionLogHost(hostname: string, pathname: string): boolean {
+  const host = hostname.toLowerCase()
+  if (!kProductionHostNames.includes(host)) return false
+  const firstSegment = pathname.split("/").filter(Boolean)[0]
+  return !kNonProductionPathSegments.includes(firstSegment)
+}
+
 export interface LogMessage {
   // these top-level properties are treated specially by the log-ingester:
   // https://github.com/concord-consortium/log-ingester/blob/a8b16fdb02f4cef1f06965a55c5ec6c1f5d3ae1b/canonicalize.js#L3
@@ -222,9 +235,9 @@ export class Logger {
 }
 
 function sendToLoggingService(data: LogMessage) {
-  // const isProduction = user.portal === productionPortal || data.parameters?.portal === productionPortal
-  // const url = logManagerUrl[isProduction ? "production" : "dev"]
-  const url = logManagerUrl.dev
+  const isProduction = typeof window !== "undefined" &&
+    isProductionLogHost(window.location.hostname, window.location.pathname)
+  const url = logManagerUrl[isProduction ? "production" : "dev"]
 
   if (!Logger.isLoggingEnabled || !DEBUG_LOG_TO_SERVER) return
 


### PR DESCRIPTION
## Summary

Three V3-internal release switches for the production cutover, bundled per the story:

- **Log destination:** new host- and path-aware check (`isProductionLogHost`). Real user traffic on `codap.concord.org` and `codap3.concord.org` (excluding `/beta/`, `/staging/`, `/branch/`) routes to the production log server; everything else stays on dev. Adds unit tests covering the host/path matrix.
- **Default save extension:** drop the `.codap3` precaution. `extension: "codap"` unconditionally; existing `.codap3` files still open via `readableExtensions`.
- **V2-doc open behavior:** remove the beta-era auto-save-disable block in `handle-cfm-event`. V2 documents now auto-save like any other doc; combined with the extension change, the next save converts the file to V3 `.codap` in place. No user message.
- **CONFIG_SAVE_AS_V2:** drop the `isBeta()` trigger so `/beta/` deploys no longer save V2 format. The `?debug=saveAsV2` flag still works for dev testing.
- **Drive-by:** move a previously-unreachable `debugLog` above the `DEBUG_LOG_TO_SERVER` early-exit so developers using `DEBUG_LOGGER` actually see which URL a log message would have gone to.

Design doc: `v3/docs/plans/2026-05-25-codap-1326-release-switches-design.md`

Fixes CODAP-1326.

## Test plan

- [ ] CI passes (lint, build, limited Cypress)
- [ ] Manual: confirm a new document saves as `.codap` (V3 format)
- [ ] Manual: open a `.codap3` file → still loads
- [ ] Manual: open a true V2 doc (e.g. `v3/src/test/v2/mammals.codap`), edit, wait 5s → auto-save fires and writes V3 format
- [ ] Manual: in DevTools, confirm logs target `logger.concordqa.org` on localhost / branch deploys and `logger.concord.org` on `codap.concord.org` / `codap3.concord.org` roots
- [ ] Full Cypress regression (after \`run regression\` label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)