### PR TITLE
CODAP-1277: suppress phantom undo entry from no-op cell commits

### DIFF
--- a/v3/src/components/case-tile-common/case-tile-utils.test.ts
+++ b/v3/src/components/case-tile-common/case-tile-utils.test.ts
@@ -6,7 +6,7 @@ import { uiState } from "../../models/ui-state"
 import { setupTestDataset } from "../../test/dataset-test-utils"
 import { kCaseTableTileType } from "../case-table/case-table-defs"
 import "../case-table/case-table-registration"
-import { createOrShowTableOrCardForDataset } from "./case-tile-utils"
+import { applyCaseValueChanges, createOrShowTableOrCardForDataset } from "./case-tile-utils"
 
 describe("createOrShowTableOrCardForDataset", () => {
   const documentContent = appState.document.content!
@@ -60,5 +60,58 @@ describe("createOrShowTableOrCardForDataset", () => {
     createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)
     expect((tileLayout as IFreeTileLayout).isMinimized).toBeFalsy()
     expect(uiState.focusedTile).toBe(tile.id)
+  })
+})
+
+describe("applyCaseValueChanges", () => {
+  it("creates an undo entry and updates the value when a value changes", () => {
+    const { dataset, a3 } = setupTestDataset()
+    const itemId = dataset.getItemAtIndex(0)!.__id__
+    const spy = jest.spyOn(dataset, "applyModelChange")
+
+    applyCaseValueChanges(dataset, [{ __id__: itemId, [a3.id]: 99 }], undefined, [a3.id])
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(dataset.getStrValue(itemId, a3.id)).toBe("99")
+  })
+
+  it("skips no-op changes when values match current (the CODAP-1277 regression)", () => {
+    const { dataset, a3 } = setupTestDataset()
+    const itemId = dataset.getItemAtIndex(0)!.__id__
+    const currentValue = dataset.getStrValue(itemId, a3.id)
+    const spy = jest.spyOn(dataset, "applyModelChange")
+
+    applyCaseValueChanges(dataset, [{ __id__: itemId, [a3.id]: currentValue }], undefined, [a3.id])
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("only checks attributes listed in affectedAttributes", () => {
+    const { dataset, a3, a4 } = setupTestDataset()
+    const itemId = dataset.getItemAtIndex(0)!.__id__
+    const a3Current = dataset.getStrValue(itemId, a3.id)
+    const spy = jest.spyOn(dataset, "applyModelChange")
+
+    // a4 carries a different value, but affectedAttributes restricts the check to a3 (matches),
+    // so the call is treated as a no-op and skipped.
+    applyCaseValueChanges(
+      dataset,
+      [{ __id__: itemId, [a3.id]: a3Current, [a4.id]: 999 }],
+      undefined,
+      [a3.id]
+    )
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("checks all attributes in the case when affectedAttributes is omitted", () => {
+    const { dataset, a4 } = setupTestDataset()
+    const itemId = dataset.getItemAtIndex(0)!.__id__
+    const spy = jest.spyOn(dataset, "applyModelChange")
+
+    applyCaseValueChanges(dataset, [{ __id__: itemId, [a4.id]: 999 }])
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(dataset.getStrValue(itemId, a4.id)).toBe("999")
   })
 })

--- a/v3/src/components/case-tile-common/case-tile-utils.ts
+++ b/v3/src/components/case-tile-common/case-tile-utils.ts
@@ -181,7 +181,9 @@ export function applyCaseValueChanges(
       const newValue = aCase[attrId]
       if (newValue === undefined) return false
       const newStr = newValue === null ? "" : String(newValue)
-      const currentStr = data.getStrValue(aCase.__id__, attrId)
+      // Coalesce to "" because getStrValue can return undefined in caching mode
+      // (DataSet.getStrValueAtItemIndex returns cachedItem[attributeID]?.toString()).
+      const currentStr = data.getStrValue(aCase.__id__, attrId) ?? ""
       return newStr !== currentStr
     })
   })

--- a/v3/src/components/case-tile-common/case-tile-utils.ts
+++ b/v3/src/components/case-tile-common/case-tile-utils.ts
@@ -169,6 +169,23 @@ export function toggleCardTable(documentContent: IDocumentContentModel, tileID: 
 export function applyCaseValueChanges(
   data: IDataSet, cases: ICase[], log?: ILogMessage | LogMessageFn, affectedAttributes?: string[]
 ) {
+  // Skip no-op changes: when an editor commits a row whose values haven't actually
+  // been edited (e.g. the auto-advanced cell editor on Enter being closed by a blur),
+  // RDG still routes the close through onRowsChange. Without this guard, every such
+  // commit creates a phantom undo entry that the user has to skip past.
+  const hasChanges = cases.some(aCase => {
+    const attrIds = affectedAttributes?.length
+      ? affectedAttributes
+      : Object.keys(aCase).filter(k => k !== "__id__")
+    return attrIds.some(attrId => {
+      const newValue = aCase[attrId]
+      if (newValue === undefined) return false
+      const newStr = newValue === null ? "" : String(newValue)
+      const currentStr = data.getStrValue(aCase.__id__, attrId)
+      return newStr !== currentStr
+    })
+  })
+  if (!hasChanges) return
   const updatedCaseIds = cases.map(aCase => aCase.__id__)
   const newCaseIds: string[] = []
   data.applyModelChange(() => {


### PR DESCRIPTION
## Summary

Fixes CODAP-1277. Editing a case table cell and then pressing Enter (or clicking
outside) created a phantom undo entry, so the user had to press Undo twice to
revert a single edit. The first Undo silently reverted a no-op commit; the
second finally reverted the actual edit.

**Root cause:** When RDG's commit-on-blur fires for an editor whose value
hasn't changed, it still routes through `onRowsChange` → `applyCaseValueChanges`,
which unconditionally created an undoable model change. RDG's own
reference-equality short-circuit (`if (row === rows[rowIdx]) return`) doesn't
catch it because our row cache is rebuilt during the previous commit's reactive
cascade, so the row reference no longer matches even when the values are
identical.

**Fix:** Guard `applyCaseValueChanges` so it compares incoming attribute values
against the dataset's current values (restricted to `affectedAttributes` when
provided) and bails out before `applyModelChange` if nothing actually changed.

## Beyond the reported scenario

Because the guard sits in the shared `applyCaseValueChanges` layer, it also
fixes the same pattern in:
- Case card cell commits
- Checkbox cells set to their current state
- Edits that are typed-then-reverted before committing (zero entries instead
  of one trivial one)

## Test plan

- [ ] Case table: edit a cell, press Enter, click Undo → reverts in one click
- [ ] Case table: edit a cell, click outside the table → one Undo reverts
- [ ] Case table: edit a cell to a real new value → entry created, undo/redo works normally
- [ ] Case card: same scenarios behave correctly
- [ ] Checkbox cells still toggle correctly

## Tests

Added `describe("applyCaseValueChanges")` with 4 unit tests in
`case-tile-utils.test.ts`: real change applies, no-op skipped (regression),
`affectedAttributes` hint respected, omitted hint checks all attrs.
