### PR TITLE
Tweaks from rc.2912 review: codap2to3 log routing + launch URL

### DIFF
--- a/v3/src/index.tsx
+++ b/v3/src/index.tsx
@@ -9,6 +9,10 @@ import { theme } from "./theme"
 
 import "./index.scss"
 
+// Log the launch URL so testers can confirm where CODAP landed after any redirects.
+// eslint-disable-next-line no-console
+console.log(`CODAP launched at ${window.location.hostname}${window.location.pathname}${window.location.search}`)
+
 // https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
 const container = document.getElementById(kCodapAppElementId)
 const root = createRoot(container!)

--- a/v3/src/lib/logger.test.ts
+++ b/v3/src/lib/logger.test.ts
@@ -7,6 +7,7 @@ describe("isProductionLogHost", () => {
     expect(isProductionLogHost("codap.concord.org", "/")).toBe(true)
     expect(isProductionLogHost("codap.concord.org", "")).toBe(true)
     expect(isProductionLogHost("codap.concord.org", "/some/spa/route")).toBe(true)
+    expect(isProductionLogHost("codap2to3.concord.org", "/")).toBe(true)
     expect(isProductionLogHost("codap3.concord.org", "/")).toBe(true)
     expect(isProductionLogHost("CODAP.CONCORD.ORG", "/")).toBe(true)
   })
@@ -14,6 +15,7 @@ describe("isProductionLogHost", () => {
   it("excludes beta, staging, and branch deploy paths", () => {
     expect(isProductionLogHost("codap.concord.org", "/beta/")).toBe(false)
     expect(isProductionLogHost("codap.concord.org", "/beta/index.html")).toBe(false)
+    expect(isProductionLogHost("codap2to3.concord.org", "/beta/")).toBe(false)
     expect(isProductionLogHost("codap3.concord.org", "/staging/")).toBe(false)
     expect(isProductionLogHost("codap3.concord.org", "/branch/main/")).toBe(false)
     expect(isProductionLogHost("codap3.concord.org", "/branch/feature-x/index.html")).toBe(false)

--- a/v3/src/lib/logger.ts
+++ b/v3/src/lib/logger.ts
@@ -15,7 +15,7 @@ const logManagerUrl: Record<LoggerEnvironment, string> = {
   production: "https://logger.concord.org/logs"
 }
 
-const kProductionHostNames = ["codap.concord.org", "codap3.concord.org"]
+const kProductionHostNames = ["codap.concord.org", "codap2to3.concord.org", "codap3.concord.org"]
 const kNonProductionPathSegments = ["beta", "staging", "branch"]
 
 // Hostname allowlist + path blacklist that route log traffic to the production


### PR DESCRIPTION
## Summary
Two small follow-ups from the recent release-candidate review:

- Add `codap2to3.concord.org` to the production-log-server hostname allowlist
  (`src/lib/logger.ts`). Beta/staging/branch paths on that host still route to dev.
- Log `CODAP launched at <hostname><pathname><search>` to the console at startup
  (`src/index.tsx`) so testers can see where CODAP landed after any redirects.

## Test plan
- [ ] Logger unit tests pass (`npm test -- src/lib/logger.test.ts`)
- [ ] Visit `codap2to3.concord.org` and confirm logs go to the production server
- [ ] Visit `codap2to3.concord.org/beta/...` and confirm logs still go to the dev server
- [ ] Open CODAP in a browser and confirm the launch URL appears in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)