### PR TITLE
Release 3.0.0-rc.2914

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Version 3.0.0-rc.2914 - May 26, 2026
+
+### 🛠️ Under the Hood:
+- **CODAP-1326:** Route codap2to3.concord.org traffic to the production log server; log launch URL at startup
+
+### Asset Sizes
+|      File |          Size | % Change from Previous Release |
+|-----------|---------------|--------------------------------|
+|  main.css |  240772 bytes |                          0.00% |
+|  index.js | 7812720 bytes |                         <0.01% |
+
 ## Version 3.0.0-rc.2912 - May 26, 2026
 
 ### ✨ Features & Improvements:

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-rc.2912",
+  "version": "3.0.0-rc.2914",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-rc.2912",
+      "version": "3.0.0-rc.2914",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-rc.2912",
+  "version": "3.0.0-rc.2914",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browser": {

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -6,6 +6,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.0.0-rc.2914](https://codap3.concord.org/version/3.0.0-rc.2914/) | May 26, 2026 |
 | [3.0.0-rc.2912](https://codap3.concord.org/version/3.0.0-rc.2912/) | May 26, 2026 |
 | [3.0.0-beta.2897](https://codap3.concord.org/version/3.0.0-beta.2897/) | May 21, 2026 |
 | [3.0.0-beta.2885](https://codap3.concord.org/version/3.0.0-beta.2885/) | May 15, 2026 |


### PR DESCRIPTION
## Version 3.0.0-rc.2914 - May 26, 2026

### 🛠️ Under the Hood:
- **CODAP-1326:** Route codap2to3.concord.org traffic to the production log server; log launch URL at startup

### Asset Sizes
|      File |          Size | % Change from Previous Release |
|-----------|---------------|--------------------------------|
|  main.css |  240772 bytes |                          0.00% |
|  index.js | 7812720 bytes |                         <0.01% |