### PR TITLE
CODAP-1365: spreadsheet-style keyboard data entry in case table

### DIFF
--- a/v3/cypress/e2e/case-table-keyboard.spec.ts
+++ b/v3/cypress/e2e/case-table-keyboard.spec.ts
@@ -120,6 +120,17 @@ context("Case table keyboard data entry (CODAP-1365)", () => {
         table.getCell(2, 2).should("have.text", originalText)
       })
     })
+
+    it("Escape in SELECT mode blurs the focused cell", () => {
+      // Use realClick (a real DOM click via the native event system) so focus
+      // actually lands on the cell. cy.click()'s synthetic events don't always
+      // fire focus the way native interaction does.
+      table.getGridCell(2, 2).realClick()
+      cy.get(selectedCell).should("have.attr", "aria-colindex", "2")
+      cy.realPress("Escape")
+      // After Escape, no element inside the grid has focus.
+      cy.document().its("activeElement").its("tagName").should("eq", "BODY")
+    })
   })
 
   describe("Home / End in SELECT mode", () => {

--- a/v3/cypress/e2e/case-table-keyboard.spec.ts
+++ b/v3/cypress/e2e/case-table-keyboard.spec.ts
@@ -1,0 +1,140 @@
+import { TableTileElements as table } from "../support/elements/table-tile"
+
+// Keyboard data-entry behavior in the case table — CODAP-1365.
+// Spec details on the Jira ticket; this spec exercises the navigation behaviors that
+// the user is most likely to hit during data entry and the regressions we fought
+// during implementation (Tab from EDIT mode losing focus, Shift-Tab landing on the
+// resize widget, input-row commit-and-navigate, no-op commit Tab/Shift-Tab).
+
+const queryParams = "?sample=mammals&dashboard&mouseSensor&noEntryModal&suppressUnsavedWarning"
+
+const editor = "[data-testid=cell-text-editor]"
+const selectedCell = '[role="gridcell"][aria-selected="true"]'
+
+function expectSelectedColIndex(idx: number) {
+  cy.get(selectedCell).should("have.attr", "aria-colindex", String(idx))
+}
+
+context("Case table keyboard data entry (CODAP-1365)", () => {
+  beforeEach(() => {
+    const url = `${Cypress.config("index")}${queryParams}`
+    cy.visit(url)
+    cy.get("[data-testid=tool-shelf]").should("be.visible")
+    table.getCaseTableGrid().should("be.visible")
+  })
+
+  describe("Tab / Shift-Tab in EDIT mode", () => {
+    it("Tab advances to next editable cell and keeps the editor open", () => {
+      // Mammals attributes start at colindex 2 (1 = index column).
+      // Edit row 2 (first data row), colindex 2 (Mammal).
+      table.getGridCell(2, 2).dblclick()
+      cy.get(editor).should("be.focused")
+      cy.realPress("Tab")
+      // Editor moves to colindex 3 (Order) on the same row, still in edit mode.
+      cy.get(editor).should("be.focused")
+      expectSelectedColIndex(3)
+    })
+
+    it("Shift-Tab moves backward to the previous editable cell, not the resize widget", () => {
+      // Open editor on colindex 3 (Order).
+      table.getGridCell(2, 3).dblclick()
+      cy.get(editor).should("be.focused")
+      cy.realPress(["Shift", "Tab"])
+      // Editor moves to colindex 2 (Mammal). Focus stays in the grid, not on the
+      // resize widget at the bottom of the case-table tile.
+      cy.get(editor).should("be.focused")
+      expectSelectedColIndex(2)
+    })
+
+    it("Tab from the input row's first column commits a new case and moves to the next cell", () => {
+      // Scroll the input row into view via the index menu.
+      table.openInputRowIndexMenu()
+      // Close the menu — we just wanted to ensure the input row is rendered.
+      cy.realPress("Escape")
+      // Get the input row's first attribute cell. The input row has data-case-id="__input__".
+      cy.get('[data-case-id="__input__"] [aria-colindex="2"]').as("inputA").dblclick()
+      cy.get(editor).should("be.focused").type("test-mammal")
+      cy.realPress("Tab")
+      // After commit + nav: editor is open on the NEW case's colindex 3 (Order).
+      cy.get(editor).should("be.focused")
+      expectSelectedColIndex(3)
+    })
+  })
+
+  describe("Return / Shift-Return in EDIT mode", () => {
+    it("Return commits the edit and moves the editor down one row", () => {
+      table.getGridCell(2, 2).dblclick()
+      cy.get(editor).should("be.focused")
+      cy.realPress("Enter")
+      cy.get(editor).should("be.focused")
+      // Same column, next row (rowindex 3 in DOM coords; header is rowindex 1).
+      cy.get('[aria-rowindex="3"] [aria-colindex="2"]').should("have.attr", "aria-selected", "true")
+    })
+
+    it("Shift-Return moves the editor up one row", () => {
+      table.getGridCell(3, 2).dblclick()
+      cy.get(editor).should("be.focused")
+      cy.realPress(["Shift", "Enter"])
+      cy.get(editor).should("be.focused")
+      cy.get('[aria-rowindex="2"] [aria-colindex="2"]').should("have.attr", "aria-selected", "true")
+    })
+  })
+
+  describe("Entering edit mode from SELECT", () => {
+    it("F2 opens the editor with the existing value selected", () => {
+      // Click a cell with a value to put it in SELECT mode.
+      table.getGridCell(2, 2).click()
+      cy.realPress("F2")
+      cy.get(editor).should("be.focused")
+      // Selected text should equal the cell's content. We don't assert the value
+      // (depends on the sample), but the selection range should cover the whole input.
+      cy.get(editor).then($el => {
+        const input = $el[0] as HTMLInputElement
+        expect(input.selectionStart).to.equal(0)
+        expect(input.selectionEnd).to.equal(input.value.length)
+        expect(input.value.length).to.be.greaterThan(0)
+      })
+    })
+
+    it("Typing a printable character enters edit mode and replaces the existing value", () => {
+      table.getGridCell(2, 2).click()
+      cy.realPress("x")
+      cy.get(editor).should("be.focused").and("have.value", "x")
+    })
+  })
+
+  describe("Escape", () => {
+    it("Escape in EDIT mode cancels the edit and restores the original value", () => {
+      // Capture the original value before editing.
+      table.getCell(2, 2).invoke("text").then(originalText => {
+        table.getGridCell(2, 2).dblclick()
+        cy.get(editor).should("be.focused")
+        // Clear and type a different value, then Escape.
+        cy.get(editor).clear().type("changed-but-cancelled")
+        cy.realPress("Escape")
+        cy.get(editor).should("not.exist")
+        // Cell value reverts to the original.
+        table.getCell(2, 2).should("have.text", originalText)
+      })
+    })
+  })
+
+  describe("Home / End in SELECT mode", () => {
+    it("Home moves selection to the first editable column in the row", () => {
+      // Click a cell partway through the row.
+      table.getGridCell(2, 4).click()
+      expectSelectedColIndex(4)
+      cy.realPress("Home")
+      // First editable column for mammals is colindex 2 (Mammal) — index column is colindex 1.
+      expectSelectedColIndex(2)
+    })
+
+    it("End moves selection to the last editable column in the row", () => {
+      table.getGridCell(2, 2).click()
+      cy.realPress("End")
+      // Last attribute column for the mammals sample. The sample has 9 attributes,
+      // so the last is colindex 10 (1 index + 9 attributes).
+      expectSelectedColIndex(10)
+    })
+  })
+})

--- a/v3/cypress/e2e/case-table-keyboard.spec.ts
+++ b/v3/cypress/e2e/case-table-keyboard.spec.ts
@@ -47,12 +47,15 @@ context("Case table keyboard data entry (CODAP-1365)", () => {
     })
 
     it("Tab from the input row's first column commits a new case and moves to the next cell", () => {
-      // Scroll the input row into view via the index menu.
-      table.openInputRowIndexMenu()
-      // Close the menu — we just wanted to ensure the input row is rendered.
-      cy.realPress("Escape")
-      // Get the input row's first attribute cell. The input row has data-case-id="__input__".
-      cy.get('[data-case-id="__input__"] [aria-colindex="2"]').as("inputA").dblclick()
+      // Use Cmd+End to scroll to the last data row — RDG's row virtualization means
+      // setting scrollTop directly doesn't always render the input row, so we let our
+      // own keyboard handler (which uses collectionTableModel.scrollRowToBottom) do it.
+      table.getGridCell(2, 2).click()
+      cy.realPress(["Meta", "End"])
+      // Input row is just below the last data row — should now be in the DOM.
+      // force: true because the row virtualization may re-render the input row mid-click.
+      cy.get('[data-case-id="__input__"] [aria-colindex="2"]', { timeout: 4000 })
+        .dblclick({ force: true })
       cy.get(editor).should("be.focused").type("test-mammal")
       cy.realPress("Tab")
       // After commit + nav: editor is open on the NEW case's colindex 3 (Order).

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -275,143 +275,103 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   } = useSelectedCell(gridRef, columns, rows)
 
   const handleCellKeyDown = useCallback((args: TCellKeyDownArgs, event: CellKeyboardEvent) => {
-    // During an active DnDKit drag (mouse, pointer, or keyboard), prevent RDG from navigating
-    // cells on arrow keys. DnDKit's sensors handle movement at the document level —
-    // preventGridDefault() stops RDG's navigate() call without affecting the native event,
-    // so DnDKit still fires. This applies to both data cells and, via an RDG patch, header
-    // cells (rowIdx < 0).
+    // During an active DnDKit drag, suppress RDG's arrow-key cell navigation so DnDKit's
+    // document-level sensors handle the keystrokes instead.
     if (active && ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
       event.preventGridDefault()
       return
     }
     if (args.rowIdx < 0) return
 
-    // Open the index column menu via keyboard. RDG keeps focus on the cell div rather than
-    // the MenuButton inside it, so we find and click the MenuButton programmatically.
-    // Only intercept the event when a MenuButton is found — collapsed rows and other index
-    // cells without menus should let the event fall through to their own handlers.
-    if (args.mode === "SELECT" && args.column.key === kIndexColumnKey
-        && ["Enter", " "].includes(event.key)) {
-      const grid = event.currentTarget as HTMLElement
-      const cell = grid.querySelector<HTMLElement>(`.rowId-${args.row.__id__}`)
-      const menuButton = cell?.querySelector<HTMLElement>('button[data-testid="codap-index-content-button"]')
-      if (menuButton) {
+    if (args.mode === "EDIT") {
+      if (["Enter", "Tab", "ArrowUp", "ArrowDown"].includes(event.key)) {
+        // Color-picker popover renders in a portal outside the grid but React still
+        // bubbles its keys through this handler. Let the popover handle them.
+        const activeElement = document.activeElement
+        if (activeElement && !event.currentTarget.contains(activeElement)) return
+        // preventDefault must run BEFORE args.onClose — that call's flushSync unmounts
+        // the editor input, and Chrome then applies the Tab default (focus to the next
+        // tabbable, e.g. the tile's resize widget) before our deferred nav can run.
         event.preventGridDefault()
-        menuButton.click()
+        if (event.key === "Tab") event.preventDefault()
+        // shouldFocusCell=false: prevent RDG's post-commit cell-wrapper focus from
+        // racing with the editor input's autofocus on the navigation target.
+        args.onClose(true, false)
+        // defer:true: the rows update from the commit propagates asynchronously
+        // (debounced syncRowsToRdg in use-rows.ts), so wait for it.
+        if (["Enter", "ArrowUp", "ArrowDown"].includes(event.key)) {
+          const reverse = event.shiftKey || event.key === "ArrowUp"
+          navigateToNextRow(reverse, { defer: true })
+        } else if (event.key === "Tab") {
+          navigateToNextCell(event.shiftKey, { defer: true })
+        }
+      }
+      // Fall through to the ArrowUp/Down case-selection block below (intentional).
+    } else if (args.mode === "SELECT") {
+      // Open the index column menu programmatically — RDG keeps focus on the cell div,
+      // not the MenuButton inside it.
+      if (args.column.key === kIndexColumnKey && ["Enter", " "].includes(event.key)) {
+        const grid = event.currentTarget as HTMLElement
+        const cell = grid.querySelector<HTMLElement>(`.rowId-${args.row.__id__}`)
+        const menuButton = cell?.querySelector<HTMLElement>('button[data-testid="codap-index-content-button"]')
+        if (menuButton) {
+          event.preventGridDefault()
+          menuButton.click()
+          return
+        }
+      } else if (event.key === "Tab") {
+        // RDG's default lets focus escape the grid; route through our nav.
+        event.preventGridDefault()
+        event.preventDefault()
+        navigateToNextCell(event.shiftKey, { enterEdit: false })
+        return
+      } else if (event.key === "Escape") {
+        // RDG's default only clears the copied-cell marker; per spec we blur the cell.
+        event.preventGridDefault()
+        if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+        return
+      } else if (event.key === "PageUp" || event.key === "PageDown") {
+        // Per spec, scroll only — don't change the selected cell. RDG's default moves
+        // selection. Uses CollectionTableModel methods (work with RDG's virtualization).
+        event.preventGridDefault()
+        event.preventDefault()
+        if (collectionTableModel && rows) {
+          const firstVisible = collectionTableModel.firstVisibleRowIndex
+          const lastVisible = collectionTableModel.lastVisibleRowIndex
+          if (event.key === "PageDown") {
+            collectionTableModel.scrollRowToTop(Math.min(rows.length - 1, lastVisible))
+          } else {
+            collectionTableModel.scrollRowToBottom(Math.max(0, firstVisible))
+          }
+        }
+        return
+      } else if (event.key === "Home" || event.key === "End") {
+        // RDG's defaults land on the (non-editable) index column for Home and the
+        // absolute last column for End. With Cmd/Ctrl, extend to the first/last cell
+        // of the collection and follow the cell focus with the case selection.
+        event.preventGridDefault()
+        event.preventDefault()
+        const extendToCollection = event.metaKey || event.ctrlKey
+        const modelRows = collectionTableModel?.rows
+        if (event.key === "Home") {
+          if (extendToCollection) {
+            navigateToFirstEditableCell()
+            const firstRowId = modelRows?.[0]?.__id__
+            if (firstRowId && data) setSelectedCases([firstRowId], data)
+          } else {
+            navigateToFirstEditableInRow(args.rowIdx)
+          }
+        } else {
+          if (extendToCollection) {
+            navigateToLastEditableCell()
+            const lastRowId = modelRows?.[modelRows.length - 1]?.__id__
+            if (lastRowId && data) setSelectedCases([lastRowId], data)
+          } else {
+            navigateToLastEditableInRow(args.rowIdx)
+          }
+        }
         return
       }
-    }
-    // By default in RDG, the enter/return key simply enters/exits edit mode without moving the
-    // selected cell. In CODAP, the enter/return key should accept the edit _and_ advance to the
-    // next row. To achieve this in RDG, we provide this callback, which is called before RDG
-    // handles the event internally. If we get an enter/return key while in edit mode, we handle
-    // it ourselves and call `preventGridDefault()` to prevent RDG from handling the event itself.
-    if (args.mode === "EDIT" && ["Enter", "Tab", "ArrowUp", "ArrowDown"].includes(event.key)) {
-      // React synthetic events bubble through the React component tree, not the DOM tree.
-      // When a color picker popover is open, its portal DOM is outside the grid, but React
-      // still bubbles keydown events up through the component tree to this handler. Skip
-      // cell navigation when focus is inside a popover portal — let the popover handle it.
-      const activeElement = document.activeElement
-      if (activeElement && !event.currentTarget.contains(activeElement)) return
-      // Suppress RDG and browser defaults BEFORE committing. args.onClose below unmounts
-      // the editor input synchronously (via flushSync); if preventDefault runs after that,
-      // Chrome applies the Tab/Shift-Tab default focus move (to the next/previous tabbable
-      // on the page — e.g. the resize widget) before our deferred navigation can take over.
-      // See CODAP-1365.
-      event.preventGridDefault()
-      if (event.key === "Tab") event.preventDefault()
-      // Complete the cell edit. The second argument (shouldFocusCell=false) prevents RDG
-      // from queueing a focus-grab on the cell wrapper after the flushSync commit, which
-      // would race with — and steal focus from — the editor input that our subsequent
-      // navigateToNextCell/Row opens on the target cell.
-      args.onClose(true, false)
-      // Defer the navigation. The post-commit rows update is propagated via a debounced
-      // syncRowsToRdg (use-rows.ts), so it doesn't reach React synchronously inside the
-      // flushSync. navigateToNextCell/Row with { defer: true } stashes pendingNavigation
-      // and bumps navFlushCounter via setTimeout(0), which fires AFTER the debounced
-      // rows update has settled. See CODAP-1365.
-      if (["Enter", "ArrowUp", "ArrowDown"].includes(event.key)) {
-        const reverse = event.shiftKey || event.key === "ArrowUp"
-        navigateToNextRow(reverse, { defer: true })
-      }
-      if (event.key === "Tab") {
-        navigateToNextCell(event.shiftKey, { defer: true })
-      }
-    }
-    // SELECT mode Tab/Shift-Tab: move to the next editable cell, staying in SELECT mode.
-    // Without this branch, RDG's default Tab handling lets focus escape the grid entirely.
-    if (args.mode === "SELECT" && event.key === "Tab") {
-      event.preventGridDefault()
-      event.preventDefault()
-      navigateToNextCell(event.shiftKey, { enterEdit: false })
-      return
-    }
-    // SELECT mode Escape: blur the focused cell so focus exits the grid.
-    // RDG's default for Escape in SELECT mode only clears the copied-cell marker;
-    // it doesn't move focus. See CODAP-1365.
-    if (args.mode === "SELECT" && event.key === "Escape") {
-      event.preventGridDefault()
-      if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur()
-      }
-      return
-    }
-    // SELECT mode PageUp/PageDown: scroll the grid by ~one viewport without changing
-    // the selected cell. RDG's default moves selection by a page; per spec, only the
-    // scroll position changes (focused cell may scroll out of view). Uses the
-    // CollectionTableModel's scrollRowToTop/scrollRowToBottom (which work with RDG's
-    // virtualization) rather than native scrollTop, which doesn't reflect the full
-    // virtual height with row virtualization. See CODAP-1365.
-    if (args.mode === "SELECT" && (event.key === "PageUp" || event.key === "PageDown")) {
-      event.preventGridDefault()
-      event.preventDefault()
-      if (collectionTableModel && rows) {
-        const firstVisible = collectionTableModel.firstVisibleRowIndex
-        const lastVisible = collectionTableModel.lastVisibleRowIndex
-        if (event.key === "PageDown") {
-          // Make the current last-visible row the new top, scrolling forward by one viewport.
-          collectionTableModel.scrollRowToTop(Math.min(rows.length - 1, lastVisible))
-        } else {
-          // Make the current first-visible row the new bottom, scrolling back by one viewport.
-          collectionTableModel.scrollRowToBottom(Math.max(0, firstVisible))
-        }
-      }
-      return
-    }
-    // SELECT mode Home/End: move to first/last editable cell in the row, skipping the
-    // index column and any non-editable attribute columns. With Cmd/Ctrl held, extend
-    // to first/last editable cell of the collection, and also update the case selection
-    // to the target row's case (otherwise the highlighted row stays where it was while
-    // the cell focus moves elsewhere). RDG's defaults land on idx 0 (index column,
-    // non-editable) for Home and the absolute last column for End. See CODAP-1365.
-    if (args.mode === "SELECT" && (event.key === "Home" || event.key === "End")) {
-      event.preventGridDefault()
-      event.preventDefault()
-      const extendToCollection = event.metaKey || event.ctrlKey
-      if (event.key === "Home") {
-        if (extendToCollection) {
-          navigateToFirstEditableCell()
-          const firstRowId = rows?.[0]?.__id__
-          if (firstRowId && firstRowId !== kInputRowKey && data) {
-            setSelectedCases([firstRowId], data)
-          }
-        } else {
-          navigateToFirstEditableInRow(args.rowIdx)
-        }
-      } else {
-        if (extendToCollection) {
-          navigateToLastEditableCell()
-          // Last data row (not the input row).
-          const dataRows = rows?.filter(r => r.__id__ !== kInputRowKey) ?? []
-          const lastDataRowId = dataRows[dataRows.length - 1]?.__id__
-          if (lastDataRowId && data) {
-            setSelectedCases([lastDataRowId], data)
-          }
-        } else {
-          navigateToLastEditableInRow(args.rowIdx)
-        }
-      }
-      return
     }
     if ((event.key === "ArrowDown" || event.key === "ArrowUp")) {
       const caseId = args.row.__id__

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -268,7 +268,11 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
     }
   }, [collectionTableModel?.rows, collectionTableModel?.inputRowIndex, showInputRow])
 
-  const { handleSelectedCellChange, navigateToNextCell, navigateToNextRow } = useSelectedCell(gridRef, columns, rows)
+  const {
+    handleSelectedCellChange, navigateToNextCell, navigateToNextRow,
+    navigateToFirstEditableInRow, navigateToLastEditableInRow,
+    navigateToFirstEditableCell, navigateToLastEditableCell
+  } = useSelectedCell(gridRef, columns, rows)
 
   const handleCellKeyDown = useCallback((args: TCellKeyDownArgs, event: CellKeyboardEvent) => {
     // During an active DnDKit drag (mouse, pointer, or keyboard), prevent RDG from navigating
@@ -309,22 +313,105 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
       // cell navigation when focus is inside a popover portal — let the popover handle it.
       const activeElement = document.activeElement
       if (activeElement && !event.currentTarget.contains(activeElement)) return
-      // complete the cell edit
-      args.onClose(true)
-      // prevent RDG from handling the event
+      // Suppress RDG and browser defaults BEFORE committing. args.onClose below unmounts
+      // the editor input synchronously (via flushSync); if preventDefault runs after that,
+      // Chrome applies the Tab/Shift-Tab default focus move (to the next/previous tabbable
+      // on the page — e.g. the resize widget) before our deferred navigation can take over.
+      // See CODAP-1365.
       event.preventGridDefault()
+      if (event.key === "Tab") event.preventDefault()
+      // Complete the cell edit. The second argument (shouldFocusCell=false) prevents RDG
+      // from queueing a focus-grab on the cell wrapper after the flushSync commit, which
+      // would race with — and steal focus from — the editor input that our subsequent
+      // navigateToNextCell/Row opens on the target cell.
+      args.onClose(true, false)
+      // Defer the navigation. The post-commit rows update is propagated via a debounced
+      // syncRowsToRdg (use-rows.ts), so it doesn't reach React synchronously inside the
+      // flushSync. navigateToNextCell/Row with { defer: true } stashes pendingNavigation
+      // and bumps navFlushCounter via setTimeout(0), which fires AFTER the debounced
+      // rows update has settled. See CODAP-1365.
       if (["Enter", "ArrowUp", "ArrowDown"].includes(event.key)) {
         const reverse = event.shiftKey || event.key === "ArrowUp"
-        navigateToNextRow(reverse)
+        navigateToNextRow(reverse, { defer: true })
       }
       if (event.key === "Tab") {
-        // Prevent the browser's native Tab focus movement, which in Safari can move focus
-        // to other components (e.g. text component) instead of letting our custom navigation
-        // handle it. RDG's navigate() normally calls preventDefault(), but since we called
-        // preventGridDefault() above, RDG's navigate() is skipped entirely.
-        event.preventDefault()
-        navigateToNextCell(event.shiftKey)
+        navigateToNextCell(event.shiftKey, { defer: true })
       }
+    }
+    // SELECT mode Tab/Shift-Tab: move to the next editable cell, staying in SELECT mode.
+    // Without this branch, RDG's default Tab handling lets focus escape the grid entirely.
+    if (args.mode === "SELECT" && event.key === "Tab") {
+      event.preventGridDefault()
+      event.preventDefault()
+      navigateToNextCell(event.shiftKey, { enterEdit: false })
+      return
+    }
+    // SELECT mode Escape: blur the focused cell so focus exits the grid.
+    // RDG's default for Escape in SELECT mode only clears the copied-cell marker;
+    // it doesn't move focus. See CODAP-1365.
+    if (args.mode === "SELECT" && event.key === "Escape") {
+      event.preventGridDefault()
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur()
+      }
+      return
+    }
+    // SELECT mode PageUp/PageDown: scroll the grid by ~one viewport without changing
+    // the selected cell. RDG's default moves selection by a page; per spec, only the
+    // scroll position changes (focused cell may scroll out of view). Uses the
+    // CollectionTableModel's scrollRowToTop/scrollRowToBottom (which work with RDG's
+    // virtualization) rather than native scrollTop, which doesn't reflect the full
+    // virtual height with row virtualization. See CODAP-1365.
+    if (args.mode === "SELECT" && (event.key === "PageUp" || event.key === "PageDown")) {
+      event.preventGridDefault()
+      event.preventDefault()
+      if (collectionTableModel && rows) {
+        const firstVisible = collectionTableModel.firstVisibleRowIndex
+        const lastVisible = collectionTableModel.lastVisibleRowIndex
+        if (event.key === "PageDown") {
+          // Make the current last-visible row the new top, scrolling forward by one viewport.
+          collectionTableModel.scrollRowToTop(Math.min(rows.length - 1, lastVisible))
+        } else {
+          // Make the current first-visible row the new bottom, scrolling back by one viewport.
+          collectionTableModel.scrollRowToBottom(Math.max(0, firstVisible))
+        }
+      }
+      return
+    }
+    // SELECT mode Home/End: move to first/last editable cell in the row, skipping the
+    // index column and any non-editable attribute columns. With Cmd/Ctrl held, extend
+    // to first/last editable cell of the collection, and also update the case selection
+    // to the target row's case (otherwise the highlighted row stays where it was while
+    // the cell focus moves elsewhere). RDG's defaults land on idx 0 (index column,
+    // non-editable) for Home and the absolute last column for End. See CODAP-1365.
+    if (args.mode === "SELECT" && (event.key === "Home" || event.key === "End")) {
+      event.preventGridDefault()
+      event.preventDefault()
+      const extendToCollection = event.metaKey || event.ctrlKey
+      if (event.key === "Home") {
+        if (extendToCollection) {
+          navigateToFirstEditableCell()
+          const firstRowId = rows?.[0]?.__id__
+          if (firstRowId && firstRowId !== kInputRowKey && data) {
+            setSelectedCases([firstRowId], data)
+          }
+        } else {
+          navigateToFirstEditableInRow(args.rowIdx)
+        }
+      } else {
+        if (extendToCollection) {
+          navigateToLastEditableCell()
+          // Last data row (not the input row).
+          const dataRows = rows?.filter(r => r.__id__ !== kInputRowKey) ?? []
+          const lastDataRowId = dataRows[dataRows.length - 1]?.__id__
+          if (lastDataRowId && data) {
+            setSelectedCases([lastDataRowId], data)
+          }
+        } else {
+          navigateToLastEditableInRow(args.rowIdx)
+        }
+      }
+      return
     }
     if ((event.key === "ArrowDown" || event.key === "ArrowUp")) {
       const caseId = args.row.__id__
@@ -371,7 +458,11 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
         }
       }
     }
-  }, [active, collection, collectionId, data, navigateToNextCell, navigateToNextRow, onScrollRowRangeIntoView])
+  }, [active, collection, collectionId, collectionTableModel, data,
+      navigateToNextCell, navigateToNextRow,
+      navigateToFirstEditableInRow, navigateToLastEditableInRow,
+      navigateToFirstEditableCell, navigateToLastEditableCell,
+      onScrollRowRangeIntoView, rows])
 
   const handleClick = (event: React.PointerEvent<HTMLDivElement>) => {
     // See if mouse has moved beyond kMouseMovementThreshold since initial mousedown

--- a/v3/src/components/case-table/use-selected-cell.test.tsx
+++ b/v3/src/components/case-table/use-selected-cell.test.tsx
@@ -136,8 +136,8 @@ describe("useSelectedCell", () => {
     // move selection synchronously for the same reason as navigateToNextRow.
     columns = [
       { name: "Index", key: "__index__" },
-      { name: "Column1", key: "column-1" },
-      { name: "Column2", key: "column-2" }
+      { name: "Column1", key: "column-1", renderEditCell: () => null },
+      { name: "Column2", key: "column-2", renderEditCell: () => null }
     ]
     rows = [{ __id__: "row-0" }, { __id__: "row-1" }]
     const { result } =
@@ -163,10 +163,194 @@ describe("useSelectedCell", () => {
     expect(gridRef.current.selectCell).toHaveBeenCalledTimes(1)
   })
 
+  it("navigateToNextCell with { enterEdit: false } lands the target cell in SELECT mode", () => {
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null },
+      { name: "b", key: "b", renderEditCell: () => null }
+    ]
+    rows = [{ __id__: "row-0" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+    result.current.handleSelectedCellChange({
+      rowIdx: 0, row: rows[0], column: columns[1] as TCalculatedColumn
+    })
+
+    result.current.navigateToNextCell(false, { enterEdit: false })
+
+    expect(gridRef.current.selectCell).toHaveBeenCalledWith({ idx: 2, rowIdx: 0 }, false)
+  })
+
+  it("navigateToNextCell skips non-editable columns when stepping right", () => {
+    // Formula attribute between two editable attributes.
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null },
+      { name: "f", key: "f" },
+      { name: "b", key: "b", renderEditCell: () => null }
+    ]
+    rows = [{ __id__: "row-0" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+    result.current.handleSelectedCellChange({
+      rowIdx: 0, row: rows[0], column: columns[1] as TCalculatedColumn
+    })
+
+    result.current.navigateToNextCell()
+
+    // Should skip "f" (no renderEditCell) and land on "b" at idx 3.
+    expect(gridRef.current.selectCell).toHaveBeenCalledWith({ idx: 3, rowIdx: 0 }, true)
+  })
+
+  it("navigateToNextCell skips non-editable columns when stepping left", () => {
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null },
+      { name: "f", key: "f" },
+      { name: "b", key: "b", renderEditCell: () => null }
+    ]
+    rows = [{ __id__: "row-0" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+    result.current.handleSelectedCellChange({
+      rowIdx: 0, row: rows[0], column: columns[3] as TCalculatedColumn
+    })
+
+    result.current.navigateToNextCell(true)
+
+    // Should skip "f" and land on "a" at idx 1.
+    expect(gridRef.current.selectCell).toHaveBeenCalledWith({ idx: 1, rowIdx: 0 }, true)
+  })
+
+  it("navigateToNextCell wraps Tab at end of row to first editable cell of next row", () => {
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null },
+      { name: "b", key: "b", renderEditCell: () => null }
+    ]
+    rows = [{ __id__: "row-0" }, { __id__: "row-1" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+    result.current.handleSelectedCellChange({
+      rowIdx: 0, row: rows[0], column: columns[2] as TCalculatedColumn
+    })
+
+    result.current.navigateToNextCell()
+
+    // From last column of row 0, Tab wraps to first editable (idx 1) of row 1.
+    expect(gridRef.current.selectCell).toHaveBeenCalledWith({ idx: 1, rowIdx: 1 }, true)
+  })
+
+  it("navigateToNextCell wraps Shift-Tab at start of row to last editable cell of previous row", () => {
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null },
+      { name: "b", key: "b", renderEditCell: () => null }
+    ]
+    rows = [{ __id__: "row-0" }, { __id__: "row-1" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+    result.current.handleSelectedCellChange({
+      rowIdx: 1, row: rows[1], column: columns[1] as TCalculatedColumn
+    })
+
+    result.current.navigateToNextCell(true)
+
+    // From first editable column of row 1, Shift-Tab wraps to last editable (idx 2) of row 0.
+    expect(gridRef.current.selectCell).toHaveBeenCalledWith({ idx: 2, rowIdx: 0 }, true)
+  })
+
+  it("navigateToNextCell does nothing at the top-left editable cell on Shift-Tab", () => {
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null },
+      { name: "b", key: "b", renderEditCell: () => null }
+    ]
+    rows = [{ __id__: "row-0" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+    result.current.handleSelectedCellChange({
+      rowIdx: 0, row: rows[0], column: columns[1] as TCalculatedColumn
+    })
+
+    result.current.navigateToNextCell(true)
+
+    expect(gridRef.current.selectCell).not.toHaveBeenCalled()
+  })
+
+  it("navigateToFirstEditableInRow / navigateToLastEditableInRow target the row's editable extremes", () => {
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null },
+      { name: "f", key: "f" },
+      { name: "b", key: "b", renderEditCell: () => null }
+    ]
+    rows = [{ __id__: "row-0" }, { __id__: "row-1" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+
+    result.current.navigateToFirstEditableInRow(1)
+    expect(gridRef.current.selectCell).toHaveBeenLastCalledWith({ idx: 1, rowIdx: 1 }, false)
+
+    result.current.navigateToLastEditableInRow(1)
+    expect(gridRef.current.selectCell).toHaveBeenLastCalledWith({ idx: 3, rowIdx: 1 }, false)
+  })
+
+  it("navigateToLastEditableCell skips the input row", () => {
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null }
+    ]
+    rows = [
+      { __id__: "row-0" },
+      { __id__: "row-1" },
+      { __id__: "__input__" }
+    ]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+
+    result.current.navigateToLastEditableCell()
+
+    // Two data rows + input row → last data row is rowIdx 1.
+    expect(gridRef.current.selectCell).toHaveBeenLastCalledWith({ idx: 1, rowIdx: 1 }, false)
+  })
+
   it("defers navigation via useEffect when target row doesn't exist yet", () => {
     columns = [
       { name: "Index", key: "__index__" },
-      { name: "Column1", key: "column-1" }
+      { name: "Column1", key: "column-1", renderEditCell: () => null }
     ]
     rows = [
       { __id__: "row-0" },

--- a/v3/src/components/case-table/use-selected-cell.test.tsx
+++ b/v3/src/components/case-table/use-selected-cell.test.tsx
@@ -10,9 +10,11 @@ jest.mock("../../utilities/plugin-utils", () => ({
 }))
 
 const mockScrollRowIntoView = jest.fn()
+const mockModelState: { rows: TRow[] } = { rows: [] }
 jest.mock("./use-collection-table-model", () => ({
   useCollectionTableModel: () => ({
-    scrollRowIntoView: (...args: any[]) => mockScrollRowIntoView(...args)
+    scrollRowIntoView: (...args: any[]) => mockScrollRowIntoView(...args),
+    get rows() { return mockModelState.rows }
   })
 }))
 
@@ -33,6 +35,7 @@ describe("useSelectedCell", () => {
     mockScrollRowIntoView.mockReset()
     columns = []
     rows = []
+    mockModelState.rows = []
   })
 
   afterEach(() => {
@@ -329,6 +332,9 @@ describe("useSelectedCell", () => {
       { name: "Index", key: "__index__" },
       { name: "a", key: "a", renderEditCell: () => null }
     ]
+    // collectionTableModel.rows holds data rows only (no input row); the React
+    // `rows` passed to the hook has the input row appended at the end.
+    mockModelState.rows = [{ __id__: "row-0" }, { __id__: "row-1" }]
     rows = [
       { __id__: "row-0" },
       { __id__: "row-1" },

--- a/v3/src/components/case-table/use-selected-cell.test.tsx
+++ b/v3/src/components/case-table/use-selected-cell.test.tsx
@@ -353,6 +353,88 @@ describe("useSelectedCell", () => {
     expect(gridRef.current.selectCell).toHaveBeenLastCalledWith({ idx: 1, rowIdx: 1 }, false)
   })
 
+  it("first/last editable cell skip the input row when it's been dragged off the end", () => {
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null }
+    ]
+    // Model has 3 data rows; the input row is spliced in the middle of the React `rows`
+    // (e.g. user dragged it via the index menu's "Move Data Entry Row Here").
+    mockModelState.rows = [{ __id__: "row-0" }, { __id__: "row-1" }, { __id__: "row-2" }]
+    rows = [
+      { __id__: "row-0" },
+      { __id__: "__input__" },
+      { __id__: "row-1" },
+      { __id__: "row-2" }
+    ]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+
+    result.current.navigateToFirstEditableCell()
+    // first data row "row-0" is at React rowIdx 0
+    expect(gridRef.current.selectCell).toHaveBeenLastCalledWith({ idx: 1, rowIdx: 0 }, false)
+
+    result.current.navigateToLastEditableCell()
+    // last data row "row-2" is at React rowIdx 3 (after the spliced input row)
+    expect(gridRef.current.selectCell).toHaveBeenLastCalledWith({ idx: 1, rowIdx: 3 }, false)
+  })
+
+  it("first editable cell skips the input row when it's been dragged to the top", () => {
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "a", key: "a", renderEditCell: () => null }
+    ]
+    mockModelState.rows = [{ __id__: "row-0" }, { __id__: "row-1" }]
+    rows = [
+      { __id__: "__input__" },
+      { __id__: "row-0" },
+      { __id__: "row-1" }
+    ]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+
+    result.current.navigateToFirstEditableCell()
+    // first data row "row-0" is at React rowIdx 1 (input row is at 0)
+    expect(gridRef.current.selectCell).toHaveBeenLastCalledWith({ idx: 1, rowIdx: 1 }, false)
+  })
+
+  it("attemptNavigation guards against a stale columnId (deleted attribute)", () => {
+    // Selected cell references a column that's been removed from the columns array.
+    // navigateToNextRow's columns.findIndex returns -1; the guard prevents passing
+    // idx:-1 to RDG's selectCell (where behavior is undefined).
+    columns = [
+      { name: "Index", key: "__index__" },
+      { name: "b", key: "b", renderEditCell: () => null }
+    ]
+    rows = [{ __id__: "row-0" }, { __id__: "row-1" }]
+    const { result } =
+      renderHook(() => useSelectedCell(gridRef, columns, rows), {
+        wrapper: ({ children }) => (
+          <DataSetContext.Provider value={data}>{children}</DataSetContext.Provider>
+        )
+      })
+
+    // Manually seed a stale selectedCell whose columnId is no longer in `columns`.
+    result.current.handleSelectedCellChange({
+      rowIdx: 0,
+      row: rows[0],
+      column: { key: "deleted-column" } as TCalculatedColumn
+    })
+
+    result.current.navigateToNextRow()
+
+    // No selectCell call — the negative idx was guarded.
+    expect(gridRef.current.selectCell).not.toHaveBeenCalled()
+  })
+
   it("defers navigation via useEffect when target row doesn't exist yet", () => {
     columns = [
       { name: "Index", key: "__index__" },

--- a/v3/src/components/case-table/use-selected-cell.ts
+++ b/v3/src/components/case-table/use-selected-cell.ts
@@ -113,6 +113,13 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
   // Skips navigation entirely if a newer navigation has been requested.
   const attemptNavigation = useCallback((nav: IPendingNavigation, currentRows?: TRow[]) => {
     if (pendingNavigation.current !== nav) return false
+    // Guard against a stale selectedCell.columnId whose column has been removed
+    // (e.g. attribute deleted while a cell in that column was selected) — columns.findIndex
+    // returns -1 and propagates here. RDG's behavior on a negative idx is undefined.
+    if (nav.idx < 0) {
+      pendingNavigation.current = null
+      return false
+    }
     const rowCount = currentRows?.length ?? 0
     if (nav.rowIdx < rowCount) {
       pendingNavigation.current = null
@@ -196,18 +203,32 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
   const navigateToFirstEditableCell = useCallback((options: INavigationOptions = {}) => {
     const idx = findFirstEditableIdx(columns)
     if (idx == null) return
-    const nav = { idx, rowIdx: 0, enterEdit: options.enterEdit ?? false }
+    // The React `rows` array splices the input row into the model's data-only rows
+    // at collectionTableModel.inputRowIndex, so React rows[0] isn't necessarily the
+    // first data row. Look up by the data row's __id__ instead.
+    const firstDataRowId = collectionTableModel?.rows?.[0]?.__id__
+    const rowIdx = firstDataRowId != null
+      ? rows?.findIndex(r => r.__id__ === firstDataRowId) ?? -1
+      : -1
+    if (rowIdx < 0) return
+    const nav = { idx, rowIdx, enterEdit: options.enterEdit ?? false }
     pendingNavigation.current = nav
     attemptNavigation(nav, rows)
-  }, [attemptNavigation, columns, rows])
+  }, [attemptNavigation, collectionTableModel, columns, rows])
 
   const navigateToLastEditableCell = useCallback((options: INavigationOptions = {}) => {
     const idx = findLastEditableIdx(columns)
     if (idx == null) return
-    // Last data row, not the input row. collectionTableModel.rows is data-only;
-    // the React `rows` passed into the hook has the input row appended.
-    const dataRowCount = collectionTableModel?.rows?.length ?? 0
-    const rowIdx = Math.max(0, dataRowCount - 1)
+    // Same rationale as navigateToFirstEditableCell: derive React rowIdx from
+    // the data row's __id__ so the input row's drag position can't shift us.
+    const modelRows = collectionTableModel?.rows
+    const lastDataRowId = modelRows && modelRows.length > 0
+      ? modelRows[modelRows.length - 1].__id__
+      : undefined
+    const rowIdx = lastDataRowId != null
+      ? rows?.findIndex(r => r.__id__ === lastDataRowId) ?? -1
+      : -1
+    if (rowIdx < 0) return
     const nav = { idx, rowIdx, enterEdit: options.enterEdit ?? false }
     pendingNavigation.current = nav
     attemptNavigation(nav, rows)

--- a/v3/src/components/case-table/use-selected-cell.ts
+++ b/v3/src/components/case-table/use-selected-cell.ts
@@ -1,12 +1,12 @@
 import { reaction } from "mobx"
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { DataGridHandle } from "react-data-grid"
 import { useDebouncedCallback } from "use-debounce"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useTileModelContext } from "../../hooks/use-tile-model-context"
 import { uiState } from "../../models/ui-state"
 import { blockAPIRequestsWhileEditing } from "../../utilities/plugin-utils"
-import { TCellSelectArgs, TColumn, TRow } from "./case-table-types"
+import { kInputRowKey, TCellSelectArgs, TColumn, TRow } from "./case-table-types"
 import { useCollectionTableModel } from "./use-collection-table-model"
 
 interface ISelectedCell {
@@ -18,6 +18,50 @@ interface ISelectedCell {
 interface IPendingNavigation {
   idx: number
   rowIdx: number
+  // When true, the target cell is opened in edit mode (e.g. Tab from EDIT mode).
+  // When false, the target cell is only selected (e.g. Tab from SELECT mode, Home/End).
+  enterEdit: boolean
+}
+
+export interface INavigationOptions {
+  // Default true to preserve existing call sites (Enter/Tab from EDIT mode).
+  enterEdit?: boolean
+  // When true, only stash pendingNavigation; don't call attemptNavigation synchronously.
+  // Instead, navFlushCounter is bumped via setTimeout(0) so that by the time the useEffect
+  // fires, the debounced post-commit rows update (use-rows.ts resetRowCacheAndSyncRows)
+  // has settled and RDG's `rows` prop is current. Used by the EDIT-mode commit-and-navigate
+  // path where calling selectCell synchronously would set RDG's originalRow to a stale row
+  // identity and the subsequent rows-prop change would trip RDG's guard at bundle.js:2643
+  // and unmount the editor. See CODAP-1365.
+  defer?: boolean
+}
+
+// Editable column predicate: the index column and formula/readonly attribute columns
+// have no renderEditCell, while editable attribute columns set it to a cell editor
+// component. See use-columns.tsx and use-index-column.tsx.
+function isEditableColumn(column: TColumn): boolean {
+  return column.renderEditCell != null
+}
+
+function findNextEditableIdx(columns: TColumn[], fromIdx: number, direction: 1 | -1): number | null {
+  for (let i = fromIdx + direction; i >= 0 && i < columns.length; i += direction) {
+    if (isEditableColumn(columns[i])) return i
+  }
+  return null
+}
+
+function findFirstEditableIdx(columns: TColumn[]): number | null {
+  for (let i = 0; i < columns.length; i++) {
+    if (isEditableColumn(columns[i])) return i
+  }
+  return null
+}
+
+function findLastEditableIdx(columns: TColumn[]): number | null {
+  for (let i = columns.length - 1; i >= 0; i--) {
+    if (isEditableColumn(columns[i])) return i
+  }
+  return null
 }
 
 export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>, columns: TColumn[], rows?: TRow[]) {
@@ -27,6 +71,12 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
   const selectedCell = useRef<Maybe<ISelectedCell>>()
   const pendingNavigation = useRef<IPendingNavigation | null>(null)
   const blockUpdateSelectedCell = useRef(false)
+  // Bumped by navigateToNext{Cell,Row} when called with { defer: true } so that the
+  // retry useEffect below re-runs even when `rows` didn't change. This covers the
+  // case where args.onClose commits a no-op edit and applyCaseValueChanges short-
+  // circuits — without a rows reassignment the useEffect would never fire and
+  // pendingNavigation would be orphaned. See CODAP-1365.
+  const [navFlushCounter, setNavFlushCounter] = useState(0)
   const { tileId } = useTileModelContext()
   const tileIsFocused = tileId === uiState.focusedTile
 
@@ -49,18 +99,24 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
     if (nav.rowIdx < rowCount) {
       pendingNavigation.current = null
       collectionTableModel?.scrollRowIntoView(nav.rowIdx)
-      gridRef.current?.selectCell({ idx: nav.idx, rowIdx: nav.rowIdx }, true)
+      gridRef.current?.selectCell({ idx: nav.idx, rowIdx: nav.rowIdx }, nav.enterEdit)
       return true
     }
     return false
   }, [collectionTableModel, gridRef])
 
-  const navigateToNextRow = useCallback((back = false) => {
+  const navigateToNextRow = useCallback((back = false, options: INavigationOptions = {}) => {
     if (selectedCell.current?.columnId) {
       const idx = columns.findIndex(column => column.key === selectedCell.current?.columnId)
       const rowIdx = Math.max(0, selectedCell.current.rowIdx + (back ? -1 : 1))
-      const nav = { idx, rowIdx }
+      const nav = { idx, rowIdx, enterEdit: options.enterEdit ?? true }
       pendingNavigation.current = nav
+      if (options.defer) {
+        // setTimeout(0) defers the trigger until after any debounced post-commit rows
+        // update has run (use-rows.ts uses useDebouncedCallback which queues setTimeout(0)).
+        setTimeout(() => setNavFlushCounter(c => c + 1), 0)
+        return
+      }
       // Navigate synchronously so a keystroke between the Enter handler and selection
       // move cannot enter edit mode on the old cell. If the target row doesn't exist yet
       // (e.g. input row just created a new case and the grid hasn't re-rendered),
@@ -69,29 +125,78 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
     }
   }, [attemptNavigation, columns, rows])
 
-  const navigateToNextCell = useCallback((back = false) => {
-    if (selectedCell.current?.columnId) {
-      // column index
-      const currentRowIdx = selectedCell.current.rowIdx
-      const currentIdx = columns.findIndex(column => column.key === selectedCell.current?.columnId)
-      const rightmost = currentIdx === columns.length - 1
-      const first = currentIdx === 1
-      if (first && currentRowIdx === 0 && back) {
-        // don't navigate left from the first cell
-        return
+  const navigateToNextCell = useCallback((back = false, options: INavigationOptions = {}) => {
+    if (!selectedCell.current?.columnId) return
+    const currentRowIdx = selectedCell.current.rowIdx
+    const currentIdx = columns.findIndex(column => column.key === selectedCell.current?.columnId)
+    if (currentIdx < 0) return
+
+    const direction: 1 | -1 = back ? -1 : 1
+    // First, try to find the next editable cell in the same row.
+    const nextIdxInRow = findNextEditableIdx(columns, currentIdx, direction)
+    let targetIdx: number | null = nextIdxInRow
+    let targetRowIdx = currentRowIdx
+    if (nextIdxInRow == null) {
+      // No editable cell remaining in this direction within the row — wrap to adjacent row.
+      if (back) {
+        // shift-tab at the start of the first row: do nothing
+        if (currentRowIdx === 0) return
+        targetRowIdx = currentRowIdx - 1
+        targetIdx = findLastEditableIdx(columns)
+      } else {
+        // tab at the end of the row: wrap to the first editable cell of the next row.
+        // If the next row doesn't exist yet (e.g. just committed input row and grid hasn't
+        // re-rendered with the new case), attemptNavigation will queue the nav and the
+        // useEffect retry will complete it once rows updates.
+        targetRowIdx = currentRowIdx + 1
+        targetIdx = findFirstEditableIdx(columns)
       }
-      const idx = back
-        ? first ? Math.max(1, columns.length - 1) : currentIdx - 1
-        : rightmost ? 1 : currentIdx + 1
-      // row index
-      const rowIdx = back
-        ? first ? Math.max(0, currentRowIdx - 1) : currentRowIdx
-        : rightmost ? currentRowIdx + 1 : currentRowIdx
-      const nav = { idx, rowIdx }
-      pendingNavigation.current = nav
-      // Navigate synchronously; see navigateToNextRow for rationale.
-      attemptNavigation(nav, rows)
     }
+    if (targetIdx == null) return
+    const nav = { idx: targetIdx, rowIdx: targetRowIdx, enterEdit: options.enterEdit ?? true }
+    pendingNavigation.current = nav
+    if (options.defer) {
+      // See navigateToNextRow for rationale on setTimeout(0) here.
+      setTimeout(() => setNavFlushCounter(c => c + 1), 0)
+      return
+    }
+    // Navigate synchronously; see navigateToNextRow for rationale.
+    attemptNavigation(nav, rows)
+  }, [attemptNavigation, columns, rows])
+
+  const navigateToFirstEditableInRow = useCallback((rowIdx: number, options: INavigationOptions = {}) => {
+    const idx = findFirstEditableIdx(columns)
+    if (idx == null) return
+    const nav = { idx, rowIdx, enterEdit: options.enterEdit ?? false }
+    pendingNavigation.current = nav
+    attemptNavigation(nav, rows)
+  }, [attemptNavigation, columns, rows])
+
+  const navigateToLastEditableInRow = useCallback((rowIdx: number, options: INavigationOptions = {}) => {
+    const idx = findLastEditableIdx(columns)
+    if (idx == null) return
+    const nav = { idx, rowIdx, enterEdit: options.enterEdit ?? false }
+    pendingNavigation.current = nav
+    attemptNavigation(nav, rows)
+  }, [attemptNavigation, columns, rows])
+
+  const navigateToFirstEditableCell = useCallback((options: INavigationOptions = {}) => {
+    const idx = findFirstEditableIdx(columns)
+    if (idx == null) return
+    const nav = { idx, rowIdx: 0, enterEdit: options.enterEdit ?? false }
+    pendingNavigation.current = nav
+    attemptNavigation(nav, rows)
+  }, [attemptNavigation, columns, rows])
+
+  const navigateToLastEditableCell = useCallback((options: INavigationOptions = {}) => {
+    const idx = findLastEditableIdx(columns)
+    if (idx == null) return
+    // Last data row, not the input row.
+    const dataRowCount = rows?.filter(r => r.__id__ !== kInputRowKey).length ?? 0
+    const rowIdx = Math.max(0, dataRowCount - 1)
+    const nav = { idx, rowIdx, enterEdit: options.enterEdit ?? false }
+    pendingNavigation.current = nav
+    attemptNavigation(nav, rows)
   }, [attemptNavigation, columns, rows])
 
   const refreshSelectedCell = useCallback(() => {
@@ -126,14 +231,24 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
     }
   }, [blockingDataset, refreshSelectedCellDebounced])
 
-  // When sync navigation in navigateToNextRow/Cell finds the target row doesn't yet
-  // exist (e.g. after input row creates a new case and the grid hasn't re-rendered),
-  // this effect retries pending navigation when rows change.
+  // Retries pending navigation when rows change (e.g. after a commit that adds a case
+  // shifts the target row index) or when navFlushCounter bumps from a defer:true call
+  // (a setTimeout(0) deferred trigger that ensures the rows-update debounce in
+  // use-rows.ts has settled before we attempt to navigate). See CODAP-1365.
   useEffect(() => {
     if (pendingNavigation.current && rows) {
       attemptNavigation(pendingNavigation.current, rows)
     }
-  }, [attemptNavigation, rows])
+  }, [attemptNavigation, rows, navFlushCounter])
 
-  return { selectedCell: selectedCell.current, handleSelectedCellChange, navigateToNextCell, navigateToNextRow }
+  return {
+    selectedCell: selectedCell.current,
+    handleSelectedCellChange,
+    navigateToNextCell,
+    navigateToNextRow,
+    navigateToFirstEditableInRow,
+    navigateToLastEditableInRow,
+    navigateToFirstEditableCell,
+    navigateToLastEditableCell
+  }
 }

--- a/v3/src/components/case-table/use-selected-cell.ts
+++ b/v3/src/components/case-table/use-selected-cell.ts
@@ -6,7 +6,7 @@ import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useTileModelContext } from "../../hooks/use-tile-model-context"
 import { uiState } from "../../models/ui-state"
 import { blockAPIRequestsWhileEditing } from "../../utilities/plugin-utils"
-import { kInputRowKey, TCellSelectArgs, TColumn, TRow } from "./case-table-types"
+import { TCellSelectArgs, TColumn, TRow } from "./case-table-types"
 import { useCollectionTableModel } from "./use-collection-table-model"
 
 interface ISelectedCell {
@@ -26,15 +26,17 @@ interface IPendingNavigation {
 export interface INavigationOptions {
   // Default true to preserve existing call sites (Enter/Tab from EDIT mode).
   enterEdit?: boolean
-  // When true, only stash pendingNavigation; don't call attemptNavigation synchronously.
-  // Instead, navFlushCounter is bumped via setTimeout(0) so that by the time the useEffect
-  // fires, the debounced post-commit rows update (use-rows.ts resetRowCacheAndSyncRows)
-  // has settled and RDG's `rows` prop is current. Used by the EDIT-mode commit-and-navigate
-  // path where calling selectCell synchronously would set RDG's originalRow to a stale row
-  // identity and the subsequent rows-prop change would trip RDG's guard at bundle.js:2643
-  // and unmount the editor. See CODAP-1365.
+  // Defer navigation until after the post-commit rows update has propagated.
+  // Used by the EDIT-mode commit-and-navigate path. See CODAP-1365.
   defer?: boolean
 }
+
+// Fallback delay for the no-op commit case (e.g. Tab from an unchanged cell):
+// no MST mutation, no rows change, no mstReaction firing — so we trigger via a
+// timer. 50ms is well past the use-rows.ts debounce (0ms) without being percep-
+// tible. For row-change cases, the mstReaction fires earlier and clears the
+// pending nav; the timer then runs as a no-op.
+const NO_OP_COMMIT_NAV_DELAY_MS = 50
 
 // Editable column predicate: the index column and formula/readonly attribute columns
 // have no renderEditCell, while editable attribute columns set it to a cell editor
@@ -71,12 +73,11 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
   const selectedCell = useRef<Maybe<ISelectedCell>>()
   const pendingNavigation = useRef<IPendingNavigation | null>(null)
   const blockUpdateSelectedCell = useRef(false)
-  // Bumped by navigateToNext{Cell,Row} when called with { defer: true } so that the
-  // retry useEffect below re-runs even when `rows` didn't change. This covers the
-  // case where args.onClose commits a no-op edit and applyCaseValueChanges short-
-  // circuits — without a rows reassignment the useEffect would never fire and
-  // pendingNavigation would be orphaned. See CODAP-1365.
+  // Bumped (by the rows mstReaction below and the no-op-commit fallback timer)
+  // to force the retry useEffect to re-run when pendingNavigation needs to be flushed.
+  // See CODAP-1365.
   const [navFlushCounter, setNavFlushCounter] = useState(0)
+  const deferredNavTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { tileId } = useTileModelContext()
   const tileIsFocused = tileId === uiState.focusedTile
 
@@ -88,6 +89,23 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
                               ? { columnId, rowId, rowIdx: args.rowIdx }
                               : undefined
     }
+  }, [])
+
+  // Fallback for the no-op commit case (deferred nav from EDIT mode where the
+  // commit didn't actually change rows — e.g. Tab from an unchanged cell).
+  // mstReaction below covers the row-change path; this timer covers the case
+  // when no rows update is coming. Cleared in the unmount effect below.
+  const scheduleNoOpCommitFallback = useCallback(() => {
+    if (deferredNavTimer.current != null) clearTimeout(deferredNavTimer.current)
+    deferredNavTimer.current = setTimeout(() => {
+      deferredNavTimer.current = null
+      setNavFlushCounter(c => c + 1)
+    }, NO_OP_COMMIT_NAV_DELAY_MS)
+  }, [])
+
+  // Clear any pending fallback timer on unmount to avoid a setState-on-unmounted warning.
+  useEffect(() => () => {
+    if (deferredNavTimer.current != null) clearTimeout(deferredNavTimer.current)
   }, [])
 
   // Attempts to navigate to the pending position if the target row exists.
@@ -112,18 +130,15 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
       const nav = { idx, rowIdx, enterEdit: options.enterEdit ?? true }
       pendingNavigation.current = nav
       if (options.defer) {
-        // setTimeout(0) defers the trigger until after any debounced post-commit rows
-        // update has run (use-rows.ts uses useDebouncedCallback which queues setTimeout(0)).
-        setTimeout(() => setNavFlushCounter(c => c + 1), 0)
+        scheduleNoOpCommitFallback()
         return
       }
-      // Navigate synchronously so a keystroke between the Enter handler and selection
-      // move cannot enter edit mode on the old cell. If the target row doesn't exist yet
-      // (e.g. input row just created a new case and the grid hasn't re-rendered),
-      // attemptNavigation returns false and the useEffect fallback will handle it.
+      // Sync nav so a keystroke between Enter and the selection move can't enter edit
+      // mode on the old cell. If the target row doesn't exist yet (e.g. just-created
+      // input row), attemptNavigation defers; the rows-dep useEffect retries on update.
       attemptNavigation(nav, rows)
     }
-  }, [attemptNavigation, columns, rows])
+  }, [attemptNavigation, columns, rows, scheduleNoOpCommitFallback])
 
   const navigateToNextCell = useCallback((back = false, options: INavigationOptions = {}) => {
     if (!selectedCell.current?.columnId) return
@@ -156,13 +171,11 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
     const nav = { idx: targetIdx, rowIdx: targetRowIdx, enterEdit: options.enterEdit ?? true }
     pendingNavigation.current = nav
     if (options.defer) {
-      // See navigateToNextRow for rationale on setTimeout(0) here.
-      setTimeout(() => setNavFlushCounter(c => c + 1), 0)
+      scheduleNoOpCommitFallback()
       return
     }
-    // Navigate synchronously; see navigateToNextRow for rationale.
     attemptNavigation(nav, rows)
-  }, [attemptNavigation, columns, rows])
+  }, [attemptNavigation, columns, rows, scheduleNoOpCommitFallback])
 
   const navigateToFirstEditableInRow = useCallback((rowIdx: number, options: INavigationOptions = {}) => {
     const idx = findFirstEditableIdx(columns)
@@ -191,13 +204,14 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
   const navigateToLastEditableCell = useCallback((options: INavigationOptions = {}) => {
     const idx = findLastEditableIdx(columns)
     if (idx == null) return
-    // Last data row, not the input row.
-    const dataRowCount = rows?.filter(r => r.__id__ !== kInputRowKey).length ?? 0
+    // Last data row, not the input row. collectionTableModel.rows is data-only;
+    // the React `rows` passed into the hook has the input row appended.
+    const dataRowCount = collectionTableModel?.rows?.length ?? 0
     const rowIdx = Math.max(0, dataRowCount - 1)
     const nav = { idx, rowIdx, enterEdit: options.enterEdit ?? false }
     pendingNavigation.current = nav
     attemptNavigation(nav, rows)
-  }, [attemptNavigation, columns, rows])
+  }, [attemptNavigation, collectionTableModel, columns, rows])
 
   const refreshSelectedCell = useCallback(() => {
     if (selectedCell.current) {
@@ -231,10 +245,22 @@ export function useSelectedCell(gridRef: React.RefObject<DataGridHandle | null>,
     }
   }, [blockingDataset, refreshSelectedCellDebounced])
 
-  // Retries pending navigation when rows change (e.g. after a commit that adds a case
-  // shifts the target row index) or when navFlushCounter bumps from a defer:true call
-  // (a setTimeout(0) deferred trigger that ensures the rows-update debounce in
-  // use-rows.ts has settled before we attempt to navigate). See CODAP-1365.
+  // When collectionTableModel.rows changes (post-commit syncRowsToRdg → resetRows),
+  // bump the flush counter to re-run the retry effect with the latest React rows.
+  // Watching the MST observable directly is more deterministic than relying on
+  // setTimeout ordering vs. the debounced rows update in use-rows.ts.
+  useEffect(() => {
+    if (!collectionTableModel) return
+    return reaction(
+      () => collectionTableModel.rows,
+      () => { if (pendingNavigation.current) setNavFlushCounter(c => c + 1) },
+      { name: "useSelectedCell.rowsChanged" }
+    )
+  }, [collectionTableModel])
+
+  // Retries pending navigation when rows change (row-change commits) or when
+  // navFlushCounter is bumped (rows-change reaction above, or no-op-commit
+  // fallback timer). See CODAP-1365.
   useEffect(() => {
     if (pendingNavigation.current && rows) {
       attemptNavigation(pendingNavigation.current, rows)


### PR DESCRIPTION
## Summary
- Bring case-table keyboard data entry in line with V2 / standard spreadsheet behavior: Tab/Shift-Tab navigate (skipping the index column and formula columns), Return/Shift-Return commit + move down/up, F2 and typing-to-edit open the editor with the existing value selected, Home/End scope within row, Cmd-Home/Cmd-End scope to the collection (also updating case selection), PageUp/Down scroll without changing selection. Spec captured on the Jira ticket.
- Fix the long-standing focus-loss when Tab is pressed in an edited input-row cell: `args.onClose(true, false)` (suppress RDG's post-commit cell focus-grab), `preventDefault` before `args.onClose` (so Chrome doesn't apply the Tab default once the editor input is unmounted), and defer navigation via a `navFlushCounter` + `setTimeout(0)` so the debounced post-commit rows update has settled before `selectCell` sets RDG's `originalRow`.
- Add Jest tests for the navigation primitives and a Cypress spec covering the regression scenarios.

Fixes [CODAP-1365](https://concord-consortium.atlassian.net/browse/CODAP-1365).

## Known limitation (filed as a separate followup if it bites)
In hierarchical case tables, the first `End` press in a non-leftmost collection sometimes doesn't fully scroll the target into view due to `useSyncScrolling` interaction; a second press works.

## Test plan
- [ ] Tab from an edited cell on the input row commits a new case and opens the editor on the new case's next column (the original bug).
- [ ] Shift-Tab from an edited cell moves backward to the previous editable cell (not the resize widget).
- [ ] Return commits and moves the editor down; Shift-Return moves it up.
- [ ] F2 on a selected cell opens the editor with the existing value selected; typing a printable character also enters edit mode and replaces the value.
- [ ] Escape while editing cancels the edit and restores the original value.
- [ ] Home / End in SELECT mode move to the first / last editable cell in the row.
- [ ] Cmd-Home / Cmd-End move to the first / last editable cell of the collection AND update case selection to the target row.
- [ ] PageUp / PageDown scroll the collection by one viewport without moving the selected cell.
- [ ] Existing case-table tests still pass (Jest + Cypress regression suite via `run regression` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CODAP-1365]: https://concord-consortium.atlassian.net/browse/CODAP-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ