### PR TITLE
CODAP-1367: fix Safari map background drag crash

### DIFF
--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -6,6 +6,7 @@ import { PixiTransition, TransitionPropMap, TransitionProp } from "../pixi/pixi-
 import { PointerState } from "../models/pointer-state"
 import {
   circleAnchor,
+  getRendererForEvent,
   hBarAnchor,
   PointRendererBase
 } from "./point-renderer-base"
@@ -550,16 +551,24 @@ export class PixiPointRenderer extends PointRendererBase {
 
     this.background.eventMode = "static"
 
+    // Skip federated events whose native event we dispatched, to avoid infinite recursion
+    // in Safari (CODAP-1367), where synthetic events re-enter PIXI's EventSystem.
+    const isOwnDispatchedEvent = (event: PIXI.FederatedPointerEvent) =>
+      !!event.nativeEvent && !!getRendererForEvent(event.nativeEvent as Event)
+
     this.background.on("click", (event: PIXI.FederatedPointerEvent) => {
+      if (isOwnDispatchedEvent(event)) return
       this.dispatchEvent(getElementUnderCanvas(event), new MouseEvent("click", event), event)
     })
 
     this.background.on("pointerdown", (event: PIXI.FederatedPointerEvent) => {
+      if (isOwnDispatchedEvent(event)) return
       this.dispatchEvent(getElementUnderCanvas(event), new PointerEvent("pointerdown", event), event)
     })
 
     let mouseoverElement: Element | null = null
     this.background.on("mousemove", (event: PIXI.FederatedPointerEvent) => {
+      if (isOwnDispatchedEvent(event)) return
       const elementUnderneath = getElementUnderCanvas(event)
 
       // Dispatch mousemove on every move to enable cursor updates (e.g., for zoom mode)
@@ -585,6 +594,7 @@ export class PixiPointRenderer extends PointRendererBase {
     })
 
     this.background.on("mouseout", (event: PIXI.FederatedPointerEvent) => {
+      if (isOwnDispatchedEvent(event)) return
       this.dispatchEvent(mouseoverElement, new MouseEvent("mouseout", event), event)
       mouseoverElement = null
     })


### PR DESCRIPTION
## Summary

Fixes CODAP-1367.

In Safari, clicking and dragging on the map background triggered a
"Maximum call stack size exceeded" RangeError. The PIXI background event
handlers in `pixi-point-renderer.ts` forward synthetic Pointer/MouseEvents
to the element underneath the canvas via `dispatchEvent`. In Safari, those
synthetic events re-enter PIXI's `EventSystem._onPointerDown`, which
re-fires `mapPointerDown` on the background sprite, which dispatches
again — recursing without bound.

The recursion guard infrastructure was already in place
(`registerDispatchedEvent` / `getRendererForEvent` in
`point-renderer-base.ts`) and is used correctly by
`canvas-point-renderer.ts`. The PIXI sibling registered events without
ever checking the map on re-entry. This PR adds an `isOwnDispatchedEvent`
check at the top of all four background handlers (click, pointerdown,
mousemove, mouseout) to match the canvas renderer's pattern.

## Test plan

- [ ] In Safari, open Lee's document from the Jira story and verify
      clicking and dragging on the map background works without the
      RangeError.
- [ ] In Safari and Chrome, verify map point hover, click, and drag still
      work as before.
- [ ] In Safari and Chrome, verify graph point hover, click, and drag
      still work (same renderer is used for graphs).
- [ ] CI: lint, type check, unit tests pass.
- [ ] CI: Cypress (`run regression` label) passes.
