### PR TITLE
CODAP-1370: restore last-shown case card/table view on re-open

### DIFF
--- a/v3/src/components/case-tile-common/case-tile-utils.test.ts
+++ b/v3/src/components/case-tile-common/case-tile-utils.test.ts
@@ -1,7 +1,8 @@
 import { getSnapshot } from "mobx-state-tree"
 import { appState } from "../../models/app-state"
 import { IFreeTileLayout, isFreeTileLayout } from "../../models/document/free-tile-row"
-import { getMetadataFromDataSet, getSharedDataSets } from "../../models/shared/shared-data-utils"
+import { ISharedDataSet } from "../../models/shared/shared-data-set"
+import { getMetadataFromDataSet } from "../../models/shared/shared-data-utils"
 import { uiState } from "../../models/ui-state"
 import { setupTestDataset } from "../../test/dataset-test-utils"
 import { kCaseCardTileType } from "../case-card/case-card-defs"
@@ -12,14 +13,17 @@ import { applyCaseValueChanges, createOrShowTableOrCardForDataset, toggleCardTab
 
 describe("createOrShowTableOrCardForDataset", () => {
   const documentContent = appState.document.content!
+  // appState.document is a singleton that persists across tests, so datasets created here accumulate.
+  // Capture the dataset created for *this* test (a pristine one with no tiles yet) instead of reaching
+  // for getSharedDataSets(...)[0], which would target the first dataset created in the whole file.
+  let sharedDataSet: ISharedDataSet
 
   beforeEach(() => {
     const { dataset } = setupTestDataset()
-    documentContent.createDataSet(getSnapshot(dataset))
+    sharedDataSet = documentContent.createDataSet(getSnapshot(dataset)).sharedDataSet
   })
 
   it("does not hide an already-visible table when called again", () => {
-    const sharedDataSet = getSharedDataSets(documentContent)[0]
     const tile = createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)!
     expect(tile).toBeDefined()
     expect(documentContent.isTileHidden(tile.id)).toBe(false)
@@ -32,7 +36,6 @@ describe("createOrShowTableOrCardForDataset", () => {
   })
 
   it("finds existing table via caseTableTileId when lastShownTableOrCardTileId is not set", () => {
-    const sharedDataSet = getSharedDataSets(documentContent)[0]
     const tile = createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)!
     expect(tile).toBeDefined()
 
@@ -48,7 +51,6 @@ describe("createOrShowTableOrCardForDataset", () => {
   })
 
   it("unminimizes a minimized table when selected from the menu", () => {
-    const sharedDataSet = getSharedDataSets(documentContent)[0]
     const tile = createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)!
     expect(tile).toBeDefined()
 
@@ -65,7 +67,6 @@ describe("createOrShowTableOrCardForDataset", () => {
   })
 
   it("re-opens the last-shown card view when called with no tileType (CODAP-1370)", () => {
-    const sharedDataSet = getSharedDataSets(documentContent)[0]
     const table = createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)!
     // Toggle to case card view: hides the table, shows/creates the card, lastShown = card
     const card = toggleCardTable(documentContent, table.id)!
@@ -86,7 +87,6 @@ describe("createOrShowTableOrCardForDataset", () => {
   })
 
   it("shows the explicitly requested type, ignoring the last-shown view (plugin path)", () => {
-    const sharedDataSet = getSharedDataSets(documentContent)[0]
     const table = createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)!
     // Toggle to card view so lastShownTableOrCardTileId points at the card
     const card = toggleCardTable(documentContent, table.id)!

--- a/v3/src/components/case-tile-common/case-tile-utils.test.ts
+++ b/v3/src/components/case-tile-common/case-tile-utils.test.ts
@@ -4,9 +4,11 @@ import { IFreeTileLayout, isFreeTileLayout } from "../../models/document/free-ti
 import { getMetadataFromDataSet, getSharedDataSets } from "../../models/shared/shared-data-utils"
 import { uiState } from "../../models/ui-state"
 import { setupTestDataset } from "../../test/dataset-test-utils"
+import { kCaseCardTileType } from "../case-card/case-card-defs"
+import "../case-card/case-card-registration"
 import { kCaseTableTileType } from "../case-table/case-table-defs"
 import "../case-table/case-table-registration"
-import { applyCaseValueChanges, createOrShowTableOrCardForDataset } from "./case-tile-utils"
+import { applyCaseValueChanges, createOrShowTableOrCardForDataset, toggleCardTable } from "./case-tile-utils"
 
 describe("createOrShowTableOrCardForDataset", () => {
   const documentContent = appState.document.content!
@@ -60,6 +62,41 @@ describe("createOrShowTableOrCardForDataset", () => {
     createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)
     expect((tileLayout as IFreeTileLayout).isMinimized).toBeFalsy()
     expect(uiState.focusedTile).toBe(tile.id)
+  })
+
+  it("re-opens the last-shown card view when called with no tileType (CODAP-1370)", () => {
+    const sharedDataSet = getSharedDataSets(documentContent)[0]
+    const table = createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)!
+    // Toggle to case card view: hides the table, shows/creates the card, lastShown = card
+    const card = toggleCardTable(documentContent, table.id)!
+    expect(card.content.type).toBe(kCaseCardTileType)
+    expect(documentContent.isTileHidden(table.id)).toBe(true)
+
+    // Close (hide) the card, as the title-bar close button does (non-destructive)
+    documentContent.toggleNonDestroyableTileVisibility(card.id)
+    expect(documentContent.isTileHidden(card.id)).toBe(true)
+
+    // Re-open from the tool-shelf menu (no explicit tileType): should restore the CARD, not the table
+    const reopened = createOrShowTableOrCardForDataset(sharedDataSet)!
+    expect(reopened.id).toBe(card.id)
+    expect(reopened.content.type).toBe(kCaseCardTileType)
+    expect(documentContent.isTileHidden(card.id)).toBe(false)
+    expect(documentContent.isTileHidden(table.id)).toBe(true)
+    expect(uiState.focusedTile).toBe(card.id)
+  })
+
+  it("shows the explicitly requested type, ignoring the last-shown view (plugin path)", () => {
+    const sharedDataSet = getSharedDataSets(documentContent)[0]
+    const table = createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)!
+    // Toggle to card view so lastShownTableOrCardTileId points at the card
+    const card = toggleCardTable(documentContent, table.id)!
+    expect(card.content.type).toBe(kCaseCardTileType)
+
+    // A plugin that explicitly requests a case table should get the table, not the last-shown card
+    const result = createOrShowTableOrCardForDataset(sharedDataSet, kCaseTableTileType)!
+    expect(result.id).toBe(table.id)
+    expect(result.content.type).toBe(kCaseTableTileType)
+    expect(documentContent.isTileHidden(table.id)).toBe(false)
   })
 })
 

--- a/v3/src/components/case-tile-common/case-tile-utils.ts
+++ b/v3/src/components/case-tile-common/case-tile-utils.ts
@@ -95,34 +95,53 @@ export function createTableOrCardForDataset (
   return tile
 }
 
+// Makes an existing (possibly hidden/minimized) tile visible and focused. Returns the tile.
+function showExistingTile(content: IDocumentContentModel, tileId: string) {
+  if (content.isTileHidden(tileId)) {
+    content.toggleNonDestroyableTileVisibility(tileId)
+  }
+  const tileLayout = content.getTileLayoutById(tileId)
+  if (isFreeTileLayout(tileLayout) && tileLayout.isMinimized) {
+    tileLayout.setMinimized(false)
+  }
+  uiState.setFocusedTile(tileId)
+  return content.tileMap.get(tileId)
+}
+
+// Shows the case table or card for a dataset, creating it if necessary.
+// When `tileType` is omitted (e.g. the tool-shelf "Tables" menu), the last-shown table/card view is
+// restored as-is — fixing CODAP-1370, where re-opening a closed card incorrectly reverted to the table.
+// When `tileType` is provided (e.g. a plugin creating a specific component), a tile of exactly that
+// type is shown/created, regardless of which view was shown last.
 export function createOrShowTableOrCardForDataset (
-  sharedDataSet: ISharedDataSet, tileType: kCardOrTableTileType = kCaseTableTileType, options?: INewTileOptions
+  sharedDataSet: ISharedDataSet, tileType?: kCardOrTableTileType, options?: INewTileOptions
 ) {
   const document = appState.document
   const { content } = document
   const metadata = getMetadataFromDataSet(sharedDataSet.dataSet)
-  if (!sharedDataSet || !metadata) return
+  if (!sharedDataSet || !metadata || !content) return
 
-  const existingTileId = metadata.lastShownTableOrCardTileId
-    || (tileType === kCaseTableTileType ? metadata.caseTableTileId : metadata.caseCardTileId)
-  if (existingTileId) { // We already have a case card/table so make sure it's visible and has focus
-    const existingTile = content?.getTile(existingTileId)
-    if (existingTile?.content.type === tileType) {
-      if (content?.isTileHidden(existingTileId)) {
-        content?.toggleNonDestroyableTileVisibility(existingTileId)
-      }
-      const tileLayout = content?.getTileLayoutById(existingTileId)
-      if (isFreeTileLayout(tileLayout) && tileLayout.isMinimized) {
-        tileLayout.setMinimized(false)
-      }
-      uiState.setFocusedTile(existingTileId)
-      return content?.tileMap.get(existingTileId)
-    } else if (content) {
-      return toggleCardTable(content, existingTileId, options)
+  if (tileType == null) {
+    // Restore mode: re-show whatever table/card was last visible for this dataset.
+    const lastShownId = metadata.lastShownTableOrCardTileId
+      || metadata.caseTableTileId || metadata.caseCardTileId
+    if (lastShownId && content.getTile(lastShownId)) {
+      return showExistingTile(content, lastShownId)
     }
-  } else {  // We don't already have a card/table for this dataset
-    return createTableOrCardForDataset(sharedDataSet, metadata, tileType, options)
+    return createTableOrCardForDataset(sharedDataSet, metadata, kCaseTableTileType, options)
   }
+
+  // Ensure-type mode: show/create a tile of exactly the requested type.
+  const sameTypeId = tileType === kCaseTableTileType ? metadata.caseTableTileId : metadata.caseCardTileId
+  if (sameTypeId && content.getTile(sameTypeId)) {
+    return showExistingTile(content, sameTypeId)
+  }
+  // The requested type doesn't exist yet; if the other type does, toggle to the requested type.
+  const otherTypeId = tileType === kCaseTableTileType ? metadata.caseCardTileId : metadata.caseTableTileId
+  if (otherTypeId && content.getTile(otherTypeId)) {
+    return toggleCardTable(content, otherTypeId, options)
+  }
+  return createTableOrCardForDataset(sharedDataSet, metadata, tileType, options)
 }
 
 // TileID is that of a case table or case card tile. Toggle its visibility and create and/or show the other.

--- a/v3/src/components/case-tile-common/case-tile-utils.ts
+++ b/v3/src/components/case-tile-common/case-tile-utils.ts
@@ -95,17 +95,21 @@ export function createTableOrCardForDataset (
   return tile
 }
 
-// Makes an existing (possibly hidden/minimized) tile visible and focused. Returns the tile.
+// Makes an existing (possibly hidden/minimized) tile visible and focused. Returns the tile, or
+// undefined if no tile with the given id exists. Resolves the tile once (via getTile, which also
+// accepts v2 numeric ids) and uses its canonical id for the subsequent layout/visibility calls.
 function showExistingTile(content: IDocumentContentModel, tileId: string) {
-  if (content.isTileHidden(tileId)) {
-    content.toggleNonDestroyableTileVisibility(tileId)
+  const tile = content.getTile(tileId)
+  if (!tile) return undefined
+  if (content.isTileHidden(tile.id)) {
+    content.toggleNonDestroyableTileVisibility(tile.id)
   }
-  const tileLayout = content.getTileLayoutById(tileId)
+  const tileLayout = content.getTileLayoutById(tile.id)
   if (isFreeTileLayout(tileLayout) && tileLayout.isMinimized) {
     tileLayout.setMinimized(false)
   }
-  uiState.setFocusedTile(tileId)
-  return content.tileMap.get(tileId)
+  uiState.setFocusedTile(tile.id)
+  return tile
 }
 
 // Shows the case table or card for a dataset, creating it if necessary.
@@ -125,17 +129,15 @@ export function createOrShowTableOrCardForDataset (
     // Restore mode: re-show whatever table/card was last visible for this dataset.
     const lastShownId = metadata.lastShownTableOrCardTileId
       || metadata.caseTableTileId || metadata.caseCardTileId
-    if (lastShownId && content.getTile(lastShownId)) {
-      return showExistingTile(content, lastShownId)
-    }
+    const restored = lastShownId ? showExistingTile(content, lastShownId) : undefined
+    if (restored) return restored
     return createTableOrCardForDataset(sharedDataSet, metadata, kCaseTableTileType, options)
   }
 
   // Ensure-type mode: show/create a tile of exactly the requested type.
   const sameTypeId = tileType === kCaseTableTileType ? metadata.caseTableTileId : metadata.caseCardTileId
-  if (sameTypeId && content.getTile(sameTypeId)) {
-    return showExistingTile(content, sameTypeId)
-  }
+  const shown = sameTypeId ? showExistingTile(content, sameTypeId) : undefined
+  if (shown) return shown
   // The requested type doesn't exist yet; if the other type does, toggle to the requested type.
   const otherTypeId = tileType === kCaseTableTileType ? metadata.caseCardTileId : metadata.caseTableTileId
   if (otherTypeId && content.getTile(otherTypeId)) {


### PR DESCRIPTION
## Summary

Fixes CODAP-1370. When a case table was switched to **case card view**, then
closed, re-opening it from the tool-shelf "Tables" dropdown reverted to **table
view** instead of restoring the card view.

## Root cause

`createOrShowTableOrCardForDataset` resolved the tile to show from
`lastShownTableOrCardTileId` (correctly the card), but then compared that tile's
type against the `tileType` argument — which the tool-shelf menu leaves at its
default of `kCaseTableTileType`. The type mismatch (card ≠ table) routed
execution into `toggleCardTable`, which deliberately hides the card and shows
the table. The defect has existed since the function was introduced (#1294,
2024-06-20); it is not a recent regression. (Document save/restore is a separate
path that serializes tile visibility directly and was unaffected.)

## Fix

`createOrShowTableOrCardForDataset` now distinguishes two intents via an optional
`tileType`:

- **omitted** (tool-shelf "Tables" menu): restore whatever table/card view was
  last shown, as-is.
- **explicit** (plugin component creation): show/create a tile of exactly the
  requested type, no longer relying on `lastShownTableOrCardTileId`.

## Testing

- New unit test reproducing the close → re-open-in-card-view scenario (red before
  the fix, green after).
- New guard test confirming an explicit `tileType` request honors that type
  regardless of the last-shown view.
- Full `case-tile-utils`, `component-handler`, and `case-tile` suites pass; lint
  and `build:tsc` clean.

Fixes CODAP-1370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
