### PR TITLE
CODAP-1376: stabilize flaky case-table-keyboard Escape test

### DIFF
--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -62,7 +62,9 @@ jobs:
       fail-fast: false
       matrix:
         # run multiple copies of the current job in parallel [1, ..., n]
-        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        # TEMP (CODAP-1376): single container while iterating on the Escape-blur flake.
+        # Restore to [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] before merge.
+        containers: [1]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,28 +82,23 @@ jobs:
           wait-on: 'http://localhost:8080'
           # add timeout of 5 minutes to start
           wait-on-timeout: 300
-          # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
-          record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
-          # only do parallel if we have a record key
-          parallel: ${{ !!secrets.CYPRESS_RECORD_KEY }}
+          # TEMP (CODAP-1376): record/parallel off and run only the spec under investigation for
+          # fast iteration. Restore record/parallel to ${{ !!secrets.CYPRESS_RECORD_KEY }}, drop the
+          # spec line, and restore the 'Regression Tests' group before merge.
+          record: false
+          parallel: false
           browser: chrome
-          # TODO: this currently will re-run the smoke test, once we have a dedicated smoke
-          # test that should be excluded
-          # spec: cypress/e2e/**
-          group: 'Regression Tests'
+          spec: 'cypress/e2e/case-table-keyboard.spec.ts'
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # pass GitHub token to allow accurately detecting a build vs a re-run build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # turn on code coverage when running npm start
-          # so far we've been using a webpack coverage-istanbul-loader for this
-          # but there has been work on using the code coverage support in the browser directly,
-          # which should be much faster
-          CODE_COVERAGE: true
+          # TEMP (CODAP-1376): coverage off for faster iteration. Restore both to true before merge.
+          CODE_COVERAGE: false
           # Also turn on the code coverage tasks in cypress itself, these are disabled
           # by default.
-          CYPRESS_coverage: true
+          CYPRESS_coverage: false
           # Have webpack skip eslint checking, that was already done by the build step
           SKIP_ESLINT: true
       - name: Upload coverage to Codecov

--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -62,9 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         # run multiple copies of the current job in parallel [1, ..., n]
-        # TEMP (CODAP-1376): single container while iterating on the Escape-blur flake.
-        # Restore to [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] before merge.
-        containers: [1]
+        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -82,19 +80,24 @@ jobs:
           wait-on: 'http://localhost:8080'
           # add timeout of 5 minutes to start
           wait-on-timeout: 300
-          # TEMP (CODAP-1376): record/parallel off and run only the spec under investigation for
-          # fast iteration. Restore record/parallel to ${{ !!secrets.CYPRESS_RECORD_KEY }}, drop the
-          # spec line, and restore the 'Regression Tests' group before merge.
-          record: false
-          parallel: false
+          # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
+          record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
+          # only do parallel if we have a record key
+          parallel: ${{ !!secrets.CYPRESS_RECORD_KEY }}
           browser: chrome
-          spec: 'cypress/e2e/case-table-keyboard.spec.ts'
+          # TODO: this currently will re-run the smoke test, once we have a dedicated smoke
+          # test that should be excluded
+          # spec: cypress/e2e/**
+          group: 'Regression Tests'
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # pass GitHub token to allow accurately detecting a build vs a re-run build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TEMP (CODAP-1376): coverage back ON to isolate it as the flake trigger (single spec/container).
+          # turn on code coverage when running npm start
+          # so far we've been using a webpack coverage-istanbul-loader for this
+          # but there has been work on using the code coverage support in the browser directly,
+          # which should be much faster
           CODE_COVERAGE: true
           # Also turn on the code coverage tasks in cypress itself, these are disabled
           # by default.

--- a/.github/workflows/v3-regression.yml
+++ b/.github/workflows/v3-regression.yml
@@ -94,11 +94,11 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # pass GitHub token to allow accurately detecting a build vs a re-run build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TEMP (CODAP-1376): coverage off for faster iteration. Restore both to true before merge.
-          CODE_COVERAGE: false
+          # TEMP (CODAP-1376): coverage back ON to isolate it as the flake trigger (single spec/container).
+          CODE_COVERAGE: true
           # Also turn on the code coverage tasks in cypress itself, these are disabled
           # by default.
-          CYPRESS_coverage: false
+          CYPRESS_coverage: true
           # Have webpack skip eslint checking, that was already done by the build step
           SKIP_ESLINT: true
       - name: Upload coverage to Codecov

--- a/v3/cypress/e2e/case-table-keyboard.spec.ts
+++ b/v3/cypress/e2e/case-table-keyboard.spec.ts
@@ -122,47 +122,14 @@ context("Case table keyboard data entry (CODAP-1365)", () => {
     })
 
     it("Escape in SELECT mode blurs the focused cell", () => {
-      // TEMP (CODAP-1376) instrumentation: this test passes locally but fails on CI with
-      // activeElement === DIV after Escape. Capture focus events and the call stack of every
-      // programmatic .focus() so the CI failure message reveals what re-focuses the grid.
-      cy.window().then((win: any) => {
-        win.__focusLog = []
-        const d = (el: any) => el
-          ? `${el.tagName}.${(`${el.className}` || "").split(" ")[0]}` +
-            `[col=${el.getAttribute?.("aria-colindex") || ""}][tid=${el.getAttribute?.("data-testid") || ""}]`
-          : String(el)
-        const origFocus = win.HTMLElement.prototype.focus
-        win.HTMLElement.prototype.focus = function (...args: any[]) {
-          const stack = (new Error().stack || "").split("\n").slice(1, 7).map((s: string) => s.trim()).join("  |  ")
-          win.__focusLog.push(`focus() -> ${d(this)}  @@  ${stack}`)
-          return origFocus.apply(this, args)
-        }
-        win.document.addEventListener("focusin", (e: any) => win.__focusLog.push(`focusin  ${d(e.target)}`), true)
-        win.document.addEventListener("focusout",
-          (e: any) => win.__focusLog.push(`focusout ${d(e.target)} -> ${d(e.relatedTarget)}`), true)
-        win.document.addEventListener("keydown",
-          (e: any) => win.__focusLog.push(`keydown ${e.key} target=${d(e.target)} defPrev=${e.defaultPrevented}`), true)
-      })
-
       // Use realClick (a real DOM click via the native event system) so focus
       // actually lands on the cell. cy.click()'s synthetic events don't always
       // fire focus the way native interaction does.
       table.getGridCell(2, 2).realClick()
       cy.focused().should("have.attr", "aria-colindex", "2")
       cy.realPress("Escape")
-      // Allow any async re-focus to occur, then assert with the captured focus log in the message.
-      cy.wait(300)
-      cy.window().then((win: any) => {
-        const ae = win.document.activeElement
-        const d = (el: any) => el
-          ? `${el.tagName}.${(`${el.className}` || "").split(" ")[0]}` +
-            `[col=${el.getAttribute?.("aria-colindex") || ""}][tid=${el.getAttribute?.("data-testid") || ""}]`
-          : String(el)
-        const escLog = win.__escLog || "(handler never recorded Escape)"
-        const msg = `FINAL activeElement=${d(ae)}\n--- escLog ---\n${escLog}` +
-          `\n--- focusLog ---\n${(win.__focusLog || []).join("\n")}\n---`
-        expect(ae.tagName, msg).to.eq("BODY")
-      })
+      // After Escape, no element inside the grid has focus.
+      cy.document().its("activeElement").its("tagName").should("eq", "BODY")
     })
   })
 

--- a/v3/cypress/e2e/case-table-keyboard.spec.ts
+++ b/v3/cypress/e2e/case-table-keyboard.spec.ts
@@ -122,20 +122,43 @@ context("Case table keyboard data entry (CODAP-1365)", () => {
     })
 
     it("Escape in SELECT mode blurs the focused cell", () => {
+      // TEMP (CODAP-1376) instrumentation: this test passes locally but fails on CI with
+      // activeElement === DIV after Escape. Capture focus events and the call stack of every
+      // programmatic .focus() so the CI failure message reveals what re-focuses the grid.
+      cy.window().then((win: any) => {
+        win.__focusLog = []
+        const d = (el: any) => el
+          ? `${el.tagName}.${(`${el.className}` || "").split(" ")[0]}` +
+            `[col=${el.getAttribute?.("aria-colindex") || ""}][tid=${el.getAttribute?.("data-testid") || ""}]`
+          : String(el)
+        const origFocus = win.HTMLElement.prototype.focus
+        win.HTMLElement.prototype.focus = function (...args: any[]) {
+          const stack = (new Error().stack || "").split("\n").slice(1, 7).map((s: string) => s.trim()).join("  |  ")
+          win.__focusLog.push(`focus() -> ${d(this)}  @@  ${stack}`)
+          return origFocus.apply(this, args)
+        }
+        win.document.addEventListener("focusin", (e: any) => win.__focusLog.push(`focusin  ${d(e.target)}`), true)
+        win.document.addEventListener("focusout",
+          (e: any) => win.__focusLog.push(`focusout ${d(e.target)} -> ${d(e.relatedTarget)}`), true)
+      })
+
       // Use realClick (a real DOM click via the native event system) so focus
       // actually lands on the cell. cy.click()'s synthetic events don't always
       // fire focus the way native interaction does.
       table.getGridCell(2, 2).realClick()
-      // Wait for DOM focus — not just the selection model — to settle on the cell.
-      // RDG's selectCell focuses the cell wrapper asynchronously, so asserting only
-      // aria-selected races ahead of that: realPress("Escape") could then dispatch to
-      // <body> before the cell is focused, and Escape's blur handler only runs when the
-      // keydown reaches the grid. Asserting cy.focused() retries until focus genuinely
-      // lands, which removes the race and makes the post-Escape assertion meaningful.
       cy.focused().should("have.attr", "aria-colindex", "2")
       cy.realPress("Escape")
-      // After Escape, no element inside the grid has focus.
-      cy.document().its("activeElement").its("tagName").should("eq", "BODY")
+      // Allow any async re-focus to occur, then assert with the captured focus log in the message.
+      cy.wait(300)
+      cy.window().then((win: any) => {
+        const ae = win.document.activeElement
+        const d = (el: any) => el
+          ? `${el.tagName}.${(`${el.className}` || "").split(" ")[0]}` +
+            `[col=${el.getAttribute?.("aria-colindex") || ""}][tid=${el.getAttribute?.("data-testid") || ""}]`
+          : String(el)
+        const msg = `FINAL activeElement=${d(ae)}\n--- focusLog ---\n${(win.__focusLog || []).join("\n")}\n---`
+        expect(ae.tagName, msg).to.eq("BODY")
+      })
     })
   })
 

--- a/v3/cypress/e2e/case-table-keyboard.spec.ts
+++ b/v3/cypress/e2e/case-table-keyboard.spec.ts
@@ -140,6 +140,8 @@ context("Case table keyboard data entry (CODAP-1365)", () => {
         win.document.addEventListener("focusin", (e: any) => win.__focusLog.push(`focusin  ${d(e.target)}`), true)
         win.document.addEventListener("focusout",
           (e: any) => win.__focusLog.push(`focusout ${d(e.target)} -> ${d(e.relatedTarget)}`), true)
+        win.document.addEventListener("keydown",
+          (e: any) => win.__focusLog.push(`keydown ${e.key} target=${d(e.target)} defPrev=${e.defaultPrevented}`), true)
       })
 
       // Use realClick (a real DOM click via the native event system) so focus
@@ -156,7 +158,9 @@ context("Case table keyboard data entry (CODAP-1365)", () => {
           ? `${el.tagName}.${(`${el.className}` || "").split(" ")[0]}` +
             `[col=${el.getAttribute?.("aria-colindex") || ""}][tid=${el.getAttribute?.("data-testid") || ""}]`
           : String(el)
-        const msg = `FINAL activeElement=${d(ae)}\n--- focusLog ---\n${(win.__focusLog || []).join("\n")}\n---`
+        const escLog = win.__escLog || "(handler never recorded Escape)"
+        const msg = `FINAL activeElement=${d(ae)}\n--- escLog ---\n${escLog}` +
+          `\n--- focusLog ---\n${(win.__focusLog || []).join("\n")}\n---`
         expect(ae.tagName, msg).to.eq("BODY")
       })
     })

--- a/v3/cypress/e2e/case-table-keyboard.spec.ts
+++ b/v3/cypress/e2e/case-table-keyboard.spec.ts
@@ -126,7 +126,13 @@ context("Case table keyboard data entry (CODAP-1365)", () => {
       // actually lands on the cell. cy.click()'s synthetic events don't always
       // fire focus the way native interaction does.
       table.getGridCell(2, 2).realClick()
-      cy.get(selectedCell).should("have.attr", "aria-colindex", "2")
+      // Wait for DOM focus — not just the selection model — to settle on the cell.
+      // RDG's selectCell focuses the cell wrapper asynchronously, so asserting only
+      // aria-selected races ahead of that: realPress("Escape") could then dispatch to
+      // <body> before the cell is focused, and Escape's blur handler only runs when the
+      // keydown reaches the grid. Asserting cy.focused() retries until focus genuinely
+      // lands, which removes the race and makes the post-Escape assertion meaningful.
+      cy.focused().should("have.attr", "aria-colindex", "2")
       cy.realPress("Escape")
       // After Escape, no element inside the grid has focus.
       cy.document().its("activeElement").its("tagName").should("eq", "BODY")

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -287,8 +287,14 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
     // right after a click while the cell is already focused. The guard would then skip the blur
     // entirely, leaving focus trapped on the cell.
     if (args.mode === "SELECT" && event.key === "Escape") {
-      event.preventGridDefault()
-      if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+      // Only blur when focus is actually inside the grid: keys from portaled UI (e.g. the
+      // index-column menu) can bubble into this handler, and we must not steal their focus
+      // (mirrors the EDIT-mode portal guard below).
+      const activeElement = document.activeElement
+      if (activeElement instanceof HTMLElement && event.currentTarget.contains(activeElement)) {
+        event.preventGridDefault()
+        activeElement.blur()
+      }
       return
     }
     if (args.rowIdx < 0) return

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -275,6 +275,13 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   } = useSelectedCell(gridRef, columns, rows)
 
   const handleCellKeyDown = useCallback((args: TCellKeyDownArgs, event: CellKeyboardEvent) => {
+    // TEMP (CODAP-1376) debug: record entry into the handler for Escape.
+    if (event.key === "Escape" && (window as any).Cypress) {
+      const ae = document.activeElement as any
+      ;(window as any).__escLog = `enter handleCellKeyDown: mode=${args.mode} rowIdx=${args.rowIdx} ` +
+        `active=${!!active} ae=${ae?.tagName}.${(`${ae?.className}` || "").split(" ")[0]}` +
+        `[col=${ae?.getAttribute?.("aria-colindex") || ""}]`
+    }
     // During an active DnDKit drag, suppress RDG's arrow-key cell navigation so DnDKit's
     // document-level sensors handle the keystrokes instead.
     if (active && ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
@@ -327,8 +334,18 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
         return
       } else if (event.key === "Escape") {
         // RDG's default only clears the copied-cell marker; per spec we blur the cell.
+        // TEMP (CODAP-1376) debug: record that we reached the SELECT/Escape blur branch.
+        if ((window as any).Cypress) {
+          const beforeAe = document.activeElement as any
+          ;(window as any).__escLog = `${(window as any).__escLog || ""} | SELECT/Escape branch; ` +
+            `beforeBlur=${beforeAe?.tagName} isHTMLEl=${document.activeElement instanceof HTMLElement}`
+        }
         event.preventGridDefault()
         if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+        if ((window as any).Cypress) {
+          const afterAe = document.activeElement as any
+          ;(window as any).__escLog = `${(window as any).__escLog || ""} -> afterBlur=${afterAe?.tagName}`
+        }
         return
       } else if (event.key === "PageUp" || event.key === "PageDown") {
         // Per spec, scroll only — don't change the selected cell. RDG's default moves

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -275,17 +275,20 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   } = useSelectedCell(gridRef, columns, rows)
 
   const handleCellKeyDown = useCallback((args: TCellKeyDownArgs, event: CellKeyboardEvent) => {
-    // TEMP (CODAP-1376) debug: record entry into the handler for Escape.
-    if (event.key === "Escape" && (window as any).Cypress) {
-      const ae = document.activeElement as any
-      ;(window as any).__escLog = `enter handleCellKeyDown: mode=${args.mode} rowIdx=${args.rowIdx} ` +
-        `active=${!!active} ae=${ae?.tagName}.${(`${ae?.className}` || "").split(" ")[0]}` +
-        `[col=${ae?.getAttribute?.("aria-colindex") || ""}]`
-    }
     // During an active DnDKit drag, suppress RDG's arrow-key cell navigation so DnDKit's
     // document-level sensors handle the keystrokes instead.
     if (active && ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
       event.preventGridDefault()
+      return
+    }
+    // Escape in SELECT mode blurs the focused cell (RDG's default only clears the copied-cell
+    // marker). Handle it BEFORE the `rowIdx < 0` guard below: under heavy load (e.g. code-coverage
+    // instrumentation on CI) RDG can momentarily report the selected position's rowIdx as negative
+    // right after a click while the cell is already focused. The guard would then skip the blur
+    // entirely, leaving focus trapped on the cell.
+    if (args.mode === "SELECT" && event.key === "Escape") {
+      event.preventGridDefault()
+      if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
       return
     }
     if (args.rowIdx < 0) return
@@ -331,21 +334,6 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
         event.preventGridDefault()
         event.preventDefault()
         navigateToNextCell(event.shiftKey, { enterEdit: false })
-        return
-      } else if (event.key === "Escape") {
-        // RDG's default only clears the copied-cell marker; per spec we blur the cell.
-        // TEMP (CODAP-1376) debug: record that we reached the SELECT/Escape blur branch.
-        if ((window as any).Cypress) {
-          const beforeAe = document.activeElement as any
-          ;(window as any).__escLog = `${(window as any).__escLog || ""} | SELECT/Escape branch; ` +
-            `beforeBlur=${beforeAe?.tagName} isHTMLEl=${document.activeElement instanceof HTMLElement}`
-        }
-        event.preventGridDefault()
-        if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
-        if ((window as any).Cypress) {
-          const afterAe = document.activeElement as any
-          ;(window as any).__escLog = `${(window as any).__escLog || ""} -> afterBlur=${afterAe?.tagName}`
-        }
         return
       } else if (event.key === "PageUp" || event.key === "PageDown") {
         // Per spec, scroll only — don't change the selected cell. RDG's default moves


### PR DESCRIPTION
## Summary

Fixes the flaky Cypress test "Escape in SELECT mode blurs the focused cell"
(case-table-keyboard.spec.ts, added with CODAP-1365 / #2608). The flake was a
CI-only failure caused by a real edge-case gap in the production Escape handler,
so this includes a small app fix plus a test-precondition tweak.

## Root cause

The test failed only under code-coverage instrumentation on CI. Under that
slowdown, RDG momentarily reported the selected cell's `args.rowIdx` as a
negative sentinel (-2) right after the click while the cell was already focused.
`handleCellKeyDown` has an early `if (args.rowIdx < 0) return` guard *before* the
SELECT-mode Escape branch, so the blur never ran and focus stayed trapped on the
cell (`activeElement` = the grid cell, never `BODY`). Without coverage the rowIdx
was correct (>=0) and the blur ran — hence it passed locally and only flaked on CI.
(Confirmed via CI-only instrumentation: the Escape keydown reached the handler in
SELECT mode but bailed at the rowIdx guard; no focusout fired — it was not a
re-focus race.)

## Fix

- `collection-table.tsx`: handle SELECT-mode Escape **before** the `rowIdx < 0`
  guard so the blur runs regardless of the transient row index, guarded to only
  blur when focus is within the grid (so keys bubbling from portaled UI like the
  index-column menu aren't disturbed).
- `case-table-keyboard.spec.ts`: assert real DOM focus (`cy.focused()`) before
  pressing Escape instead of the `aria-selected` selection-model assertion.

## Testing

Validated on CI under the exact failing config (coverage on) and in a full
15-container regression attempt. Locally: lint, tsc, and the spec all green.

Fixes CODAP-1376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
