### PR TITLE
CODAP-1375: render collections with all attributes hidden (V2-style)

### DIFF
--- a/v3/src/components/case-table/case-table-hidden-attributes.test.tsx
+++ b/v3/src/components/case-table/case-table-hidden-attributes.test.tsx
@@ -1,0 +1,81 @@
+import { DndContext } from "@dnd-kit/core"
+import { render, screen } from "@testing-library/react"
+import { getSnapshot } from "mobx-state-tree"
+import { CaseTableComponent } from "./case-table-component"
+import { CaseTableModel } from "./case-table-model"
+import { DataSetContext } from "../../hooks/use-data-set-context"
+import { ITileSelection, TileSelectionContext } from "../../hooks/use-tile-selection-context"
+import { createCodapDocument } from "../../models/codap/create-codap-document"
+import { DataBroker } from "../../models/data/data-broker"
+import { DataSet, IDataSet, toCanonical } from "../../models/data/data-set"
+import { getSharedModelManager } from "../../models/tiles/tile-environment"
+import { ITileModel, TileModel } from "../../models/tiles/tile-model"
+import { t } from "../../utilities/translation/translate"
+import "./case-table-registration"
+
+jest.mock("./case-table-shared.scss", () => ({
+  headerRowHeight: "30"
+}))
+
+const tileSelection: ITileSelection = {
+  isTileSelected() { return false },
+  selectTile() {},
+  addFocusIgnoreFn() { return () => null }
+}
+
+describe("Case Table with all attributes hidden in a collection", () => {
+  let broker: DataBroker
+  let tile: ITileModel
+
+  beforeEach(() => {
+    // a document provides the shared model manager that links a DataSet to its metadata,
+    // which is the path useVisibleAttributes uses to determine which attributes are hidden
+    const document = createCodapDocument()
+    broker = new DataBroker({ sharedModelManager: getSharedModelManager(document) })
+    tile = TileModel.create({ content: getSnapshot(CaseTableModel.create()) })
+  })
+
+  const renderTable = (data: IDataSet) =>
+    render(
+      <TileSelectionContext.Provider value={tileSelection}>
+        <DndContext>
+          <DataSetContext.Provider value={data}>
+            <CaseTableComponent tile={tile}/>
+          </DataSetContext.Provider>
+        </DndContext>
+      </TileSelectionContext.Provider>
+    )
+
+  // the grid's accessible name is "{collection name} data table" (V3.CaseTable.gridAriaLabel)
+  const groupsGridName = t("V3.CaseTable.gridAriaLabel", { vars: ["groups"] })
+
+  it("renders the parent collection's grid with only the index column when all its attributes are hidden", () => {
+    // no custom env: the DataSet inherits the document's environment when the broker adds it.
+    // The collections array includes the childmost collection, so attributes added without a
+    // collection (here "value") land there, leaving "groups" as the parent collection.
+    const data = DataSet.create({ name: "data", collections: [{ name: "groups" }, { name: "cases" }] })
+    const groups = data.collections[0]
+    const groupAttr = data.addAttribute({ name: "group" }, { collection: groups.id })
+    data.addAttribute({ name: "value" }) // lands in the childmost collection
+    data.addCases(toCanonical(data, [
+      { group: "a", value: 1 }, { group: "a", value: 2 }, { group: "b", value: 3 }
+    ]))
+    data.validateCases()
+    const { sharedMetadata } = broker.addDataSet(data)
+
+    // with both collections fully visible, the parent grid has the index column + "group" column
+    const { unmount } = renderTable(data)
+    expect(screen.getAllByTestId("collection-table-grid")).toHaveLength(2)
+    expect(screen.getByRole("grid", { name: groupsGridName })).toHaveAttribute("aria-colcount", "2")
+    unmount()
+
+    // hide the only attribute in the parent collection
+    sharedMetadata.setIsHidden(groupAttr.id, true)
+
+    renderTable(data)
+    // both collections still render a grid (V2-style: the parent keeps its index column)
+    expect(screen.getAllByTestId("collection-table-grid")).toHaveLength(2)
+    // the parent grid is now index-only (the "group" attribute column is gone)
+    expect(screen.getByRole("grid", { name: groupsGridName })).toHaveAttribute("aria-colcount", "1")
+  })
+})

--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -6,7 +6,6 @@ import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useDataSetMetadata } from "../../hooks/use-data-set-metadata"
 import { getDragAttributeInfo, useTileDroppable } from "../../hooks/use-drag-drop"
 import { measureText } from "../../hooks/use-measure-text"
-import { useVisibleAttributes } from "../../hooks/use-visible-attributes"
 import { useTileModelContext } from "../../hooks/use-tile-model-context"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { IDataSet } from "../../models/data/data-set"
@@ -54,7 +53,6 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
   const parentCollectionId = useParentCollectionContext()
   const parentCollection = parentCollectionId ? data?.getCollection(parentCollectionId) : undefined
   const parentTableModel = useCollectionTableModel(parentCollectionId)
-  const visibleParentAttributes = useVisibleAttributes(parentCollectionId)
   const parentScrollTop = parentTableModel?.scrollTop ?? 0
   const announce = useCaseTableAnnounce()
   const childCollectionId = useCollectionContext()
@@ -201,7 +199,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
 
   return (
     <div className={classes} ref={handleRef} onClick={handleBackgroundClick}>
-      {parentCollectionId && parentTableModel && childTableModel && visibleParentAttributes.length > 0 &&
+      {parentCollectionId && parentTableModel && childTableModel &&
         <>
           <div className="spacer-top">
             {<ExpandCollapseButton isCollapsed={everyCaseIsCollapsed || false} onClick={handleExpandCollapseAllClick}

--- a/v3/src/components/case-table/collection-table-spacer.tsx
+++ b/v3/src/components/case-table/collection-table-spacer.tsx
@@ -6,6 +6,7 @@ import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useDataSetMetadata } from "../../hooks/use-data-set-metadata"
 import { getDragAttributeInfo, useTileDroppable } from "../../hooks/use-drag-drop"
 import { measureText } from "../../hooks/use-measure-text"
+import { useVisibleAttributes } from "../../hooks/use-visible-attributes"
 import { useTileModelContext } from "../../hooks/use-tile-model-context"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { IDataSet } from "../../models/data/data-set"
@@ -18,6 +19,7 @@ import { kInputRowKey } from "./case-table-types"
 import { CurvedSplineFill } from "./curved-spline-fill"
 import { CurvedSplineStroke } from "./curved-spline-stroke"
 import { useCaseTableAnnounce } from "./use-case-table-announce"
+import { useCaseTableModel } from "./use-case-table-model"
 import { useCollectionTableModel } from "./use-collection-table-model"
 
 const kRelationDefaultFillColor = "#ffffff" // white
@@ -58,6 +60,16 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
   const childCollectionId = useCollectionContext()
   const childTableModel = useCollectionTableModel()
   const parentMost = !parentCollection
+  // The relationship lines connect parent grid cells to child grid cells, so only draw them when
+  // both adjacent collections actually render a grid. A collection renders a grid when it has at
+  // least one column — the index column (shown unless hidden for the whole table) or a visible
+  // attribute. (A collection with the index hidden and all attributes hidden renders no grid.)
+  const caseTableModel = useCaseTableModel()
+  const isIndexHidden = caseTableModel?.isIndexHidden ?? false
+  const visibleParentAttributes = useVisibleAttributes(parentCollectionId)
+  const visibleChildAttributes = useVisibleAttributes(childCollectionId)
+  const parentHasGrid = !isIndexHidden || visibleParentAttributes.length > 0
+  const childHasGrid = !isIndexHidden || visibleChildAttributes.length > 0
   const preventCollectionDrop = preventCollectionReorg(data, childCollectionId)
   const { active, isOver, setNodeRef } = useTileDroppable(`new-collection-${childCollectionId}`, _active => {
     if (!preventCollectionDrop) {
@@ -199,7 +211,7 @@ export const CollectionTableSpacer = observer(function CollectionTableSpacer({
 
   return (
     <div className={classes} ref={handleRef} onClick={handleBackgroundClick}>
-      {parentCollectionId && parentTableModel && childTableModel &&
+      {parentCollectionId && parentTableModel && childTableModel && parentHasGrid && childHasGrid &&
         <>
           <div className="spacer-top">
             {<ExpandCollapseButton isCollapsed={everyCaseIsCollapsed || false} onClick={handleExpandCollapseAllClick}

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -89,6 +89,28 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
     }
   }, [collectionId, collectionTableModel, gridRef.current?.element, onMount])
 
+  useEffect(() => {
+    return registerCanAutoScrollCallback((element) => {
+      // prevent auto-scroll on grid since there's nothing droppable in the grid
+      return element !== gridRef.current?.element
+    })
+  }, [])
+
+  // Mark non-editable cells with aria-readonly (RDG doesn't support this natively)
+  useEffect(() => {
+    gridRef.current?.element?.querySelectorAll('[role="gridcell"]').forEach(cell => {
+      if (cell.classList.contains("readonly-cell")) {
+        cell.setAttribute("aria-readonly", "true")
+      } else {
+        cell.removeAttribute("aria-readonly")
+      }
+    })
+  })
+
+  // columns
+  const indexColumn = useIndexColumn()
+  const columns = useColumns({ data, indexColumn: caseTableModel?.isIndexHidden ? undefined : indexColumn })
+
   // RDG assigns tabindex="0" to the first header cell for Tab entry into the grid.
   // Since that cell is the inert index column header, the grid has no focusable entry point.
   // Make the grid element a Tab entry point that uses RDG's selectCell API to focus the first
@@ -112,9 +134,13 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
     // the attribute header cell → second focusin (target=descendant) sets grid.tabIndex = -1.
     const handleFocusIn = (e: FocusEvent) => {
       if (e.target === grid) {
-        // Tab entered on the grid element itself → forward to the first attribute header.
+        // Tab entered on the grid element itself → forward to the first attribute header, but
+        // only when one exists (an index-only grid with all attributes hidden has no attribute
+        // column, so firstAttrIdx would be out of range).
         const firstAttrIdx = isIndexHidden ? 0 : 1
-        gridRef.current?.selectCell({ idx: firstAttrIdx, rowIdx: -1 })
+        if (firstAttrIdx < columns.length) {
+          gridRef.current?.selectCell({ idx: firstAttrIdx, rowIdx: -1 })
+        }
       } else {
         // A descendant of the grid received focus → disable the grid's tab stop so
         // Shift+Tab from within skips the grid element.
@@ -135,29 +161,7 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
       grid.removeEventListener("focusin", handleFocusIn)
       grid.removeEventListener("focusout", handleFocusOut)
     }
-  }, [gridRef.current?.element, isIndexHidden])
-
-  useEffect(() => {
-    return registerCanAutoScrollCallback((element) => {
-      // prevent auto-scroll on grid since there's nothing droppable in the grid
-      return element !== gridRef.current?.element
-    })
-  }, [])
-
-  // Mark non-editable cells with aria-readonly (RDG doesn't support this natively)
-  useEffect(() => {
-    gridRef.current?.element?.querySelectorAll('[role="gridcell"]').forEach(cell => {
-      if (cell.classList.contains("readonly-cell")) {
-        cell.setAttribute("aria-readonly", "true")
-      } else {
-        cell.removeAttribute("aria-readonly")
-      }
-    })
-  })
-
-  // columns
-  const indexColumn = useIndexColumn()
-  const columns = useColumns({ data, indexColumn: caseTableModel?.isIndexHidden ? undefined : indexColumn })
+  }, [gridRef.current?.element, isIndexHidden, columns.length])
 
   // rows
   const { handleRowsChange } = useRows(gridRef.current?.element ?? null)

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -8,7 +8,6 @@ import { useCollectionContext } from "../../hooks/use-collection-context"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
 import { useTileDroppable } from "../../hooks/use-drag-drop"
 import { useTileSelectionContext } from "../../hooks/use-tile-selection-context"
-import { useVisibleAttributes } from "../../hooks/use-visible-attributes"
 import { registerCanAutoScrollCallback } from "../../lib/dnd-kit/dnd-can-auto-scroll"
 import { logStringifiedObjectMessage } from "../../lib/log-message"
 import { IAttribute } from "../../models/data/attribute"
@@ -74,7 +73,6 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   const caseTableModel = useCaseTableModel()
   const collectionTableModel = useCollectionTableModel()
   const gridRef = useRef<DataGridHandle>(null)
-  const visibleAttributes = useVisibleAttributes(collectionId)
   const { selectedRows, setSelectedRows, handleCellClick } =
     useSelectedRows({ gridRef, onScrollClosestRowIntoView, onScrollRowRangeIntoView })
   const { isTileSelected } = useTileSelectionContext()
@@ -484,9 +482,8 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
 
   if (!data || !rows) return null
 
-  const hasVisibleAttributes = visibleAttributes.length > 0
   const dragId = String(active?.id)
-  const showDragOverlay = hasVisibleAttributes && dragId.includes(kInputRowKey) && dragId.includes(collectionId)
+  const showDragOverlay = dragId.includes(kInputRowKey) && dragId.includes(collectionId)
   const gridAriaLabel = t("V3.CaseTable.gridAriaLabel", { vars: [collection?.name ?? ""] })
   const gridInstructionsId = `sr-grid-instructions-${collectionId}`
   return (

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -490,13 +490,16 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
   const gridAriaLabel = t("V3.CaseTable.gridAriaLabel", { vars: [collection?.name ?? ""] })
   const gridInstructionsId = `sr-grid-instructions-${collectionId}`
   return (
-    <div className={clsx("collection-table", `collection-${collectionId}`, { "no-attributes": !hasVisibleAttributes })}>
+    <div className={clsx("collection-table", `collection-${collectionId}`, { "no-attributes": columns.length === 0 })}>
       <CollectionTableSpacer gridElt={gridRef.current?.element}
         onWhiteSpaceClick={onWhiteSpaceClick} onDrop={handleNewCollectionDrop} />
       <div className="collection-table-and-title" ref={setNodeRef} onClick={handleClick}
             onPointerDown={handlePointerDown} onPointerMove={handlePointerMove} onPointerUp={handlePointerUp}>
         <CollectionTitle onAddNewAttribute={handleAddNewAttribute} showCount={true} collectionIndex={collectionIndex}/>
-        <If condition={hasVisibleAttributes}>
+        {/* A collection with all attributes hidden still renders its grid showing just the index
+            column (matching V2), so the parent/child relationship lines have cells to connect to.
+            Guard against the rare case of no columns at all (e.g. index column also hidden). */}
+        <If condition={columns.length > 0}>
           <VisuallyHidden id={gridInstructionsId}>
             {t("V3.CaseTable.gridEditInstructions")}
           </VisuallyHidden>

--- a/v3/src/models/shared/data-set-metadata.test.ts
+++ b/v3/src/models/shared/data-set-metadata.test.ts
@@ -152,7 +152,8 @@ describe("DataSetMetadata", () => {
     expect(tree.metadata.isHidden("aId")).toBe(false)
     expect(tree.metadata.attributes.get("aId")?.hidden).toBeUndefined()
 
-    // hiding the last attribute in a collection shows all attributes
+    // hiding every attribute in a collection leaves them all hidden (CODAP-1375): the case
+    // table renders such a collection as a header-only box rather than auto-showing them.
     tree.metadata.setIsHidden("aId", true)
     tree.metadata.setIsHidden("bId", true)
     expect(tree.metadata.isHidden("aId")).toBe(true)
@@ -160,6 +161,12 @@ describe("DataSetMetadata", () => {
     expect(tree.metadata.isHidden("cId")).toBe(false)
 
     tree.metadata.setIsHidden("cId", true)
+    expect(tree.metadata.isHidden("aId")).toBe(true)
+    expect(tree.metadata.isHidden("bId")).toBe(true)
+    expect(tree.metadata.isHidden("cId")).toBe(true)
+
+    // showAllAttributes() remains the way to recover them
+    tree.metadata.showAllAttributes()
     expect(tree.metadata.isHidden("aId")).toBe(false)
     expect(tree.metadata.isHidden("bId")).toBe(false)
     expect(tree.metadata.isHidden("cId")).toBe(false)

--- a/v3/src/models/shared/data-set-metadata.test.ts
+++ b/v3/src/models/shared/data-set-metadata.test.ts
@@ -153,7 +153,7 @@ describe("DataSetMetadata", () => {
     expect(tree.metadata.attributes.get("aId")?.hidden).toBeUndefined()
 
     // hiding every attribute in a collection leaves them all hidden (CODAP-1375): the case
-    // table renders such a collection as a header-only box rather than auto-showing them.
+    // table renders such a collection's grid with only the index column rather than auto-showing them.
     tree.metadata.setIsHidden("aId", true)
     tree.metadata.setIsHidden("bId", true)
     expect(tree.metadata.isHidden("aId")).toBe(true)

--- a/v3/src/models/shared/data-set-metadata.ts
+++ b/v3/src/models/shared/data-set-metadata.ts
@@ -1,4 +1,4 @@
-import { comparer, observable, reaction, when } from "mobx"
+import { observable, when } from "mobx"
 import {
   addDisposer, applySnapshot, getEnv, getSnapshot, getType, hasEnv, IAnyStateTreeNode, Instance,
   ISerializedActionCall, resolveIdentifier, SnapshotIn, types
@@ -567,30 +567,6 @@ export const DataSetMetadata = SharedModel
         )
       }
       return categorySet
-    }
-  }))
-  .actions(self => ({
-    afterCreate() {
-      // if all attributes in a collection are hidden, show the remaining attributes
-      addDisposer(self, reaction(
-        () => self.data?.collections.map(collection => {
-          return collection.attributes.map(attr => ({
-            attrId: attr?.id,
-            isHidden: attr?.id ? self.isHidden(attr.id) : false
-          }))
-        }) ?? [],
-        (collections) => {
-          collections.forEach(collection => {
-            if (collection.length > 0 && collection.every(({ isHidden }) => isHidden)) {
-              collection.forEach(({ attrId }) => attrId && self.setIsHidden(attrId, false))
-            }
-          })
-        }, {
-          name: "DataSetMetadata.afterCreate.reaction [show remaining hidden attributes in a collection]",
-          fireImmediately: true,
-          equals: comparer.structural
-        }
-      ))
     }
   }))
   .actions(applyModelChange)


### PR DESCRIPTION
## Summary

When every attribute in a collection is hidden, CODAP v3 previously auto-showed all of
that collection's attributes via a MobX reaction in `DataSetMetadata`. The reaction
existed because the case table didn't render a collection with no visible attributes —
it collapsed to nothing.

This PR removes that reaction and, matching CODAP v2, renders such a collection's grid
showing just the **index column**, so the parent/child relationship lines still have
cells to connect to on both sides.

~~This is a companion change to CODAP-1375 (Bill is working on a separate aspect of the
Choosy hide-all behavior).~~

> Note: an earlier revision of this PR took a different approach (a header-only box with an
> "All attributes hidden" message and suppressed gutters). It was reworked to match v2's
> index-only rendering, which keeps the parent/child relationship lines intact. Some resolved
> Copilot review threads reference that earlier approach.

## Changes
- Remove the auto-show reaction from `data-set-metadata.ts` (attributes now stay hidden)
- `CollectionTable`: render the grid whenever it has at least the index column, so an
  all-hidden collection shows an index-only grid
- `CollectionTableSpacer`: draw the relationship gutter whenever adjacent collections have
  grids (no longer gated on the parent having visible attributes)
- Tests: update the metadata test for the new "all hidden stays hidden" behavior; add an
  integration test for index-only rendering

## Testing
- `npm run build:tsc` clean; lint clean
- Jest: data-set-metadata, case-table, and case-tile-common suites pass
- Verified in the running app: a middle collection with all attributes hidden renders as an
  index-only column with connecting lines drawn on both sides

Relates to CODAP-1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
