### PR TITLE
Release 3.0.0-rc.2921

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Version 3.0.0-rc.2921 - June 3, 2026
+
+### 🐞 Bug Fixes:
+- **CODAP-1365:** Case table data entry now matches V2 behavior
+- **CODAP-1367:** Fix map being undraggable in Safari
+- **CODAP-1370:** Restore Case Card view when reopening a closed table
+- **CODAP-1373:** Fix least squares line disappearing when the legend attribute is numeric
+- **CODAP-1375:** Support hiding all attributes in a collection
+
+### Asset Sizes
+|      File |          Size | % Change from Previous Release |
+|-----------|---------------|--------------------------------|
+|  main.css |  240732 bytes |                         -0.02% |
+|  index.js | 7816850 bytes |                          0.05% |
+
 ## Version 3.0.0-rc.2914 - May 26, 2026
 
 ### 🛠️ Under the Hood:

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0-rc.2914",
+  "version": "3.0.0-rc.2921",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0-rc.2914",
+      "version": "3.0.0-rc.2921",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0-rc.2914",
+  "version": "3.0.0-rc.2921",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browser": {

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -6,6 +6,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.0.0-rc.2921](https://codap3.concord.org/version/3.0.0-rc.2921/) | June 3, 2026 |
 | [3.0.0-rc.2914](https://codap3.concord.org/version/3.0.0-rc.2914/) | May 26, 2026 |
 | [3.0.0-rc.2912](https://codap3.concord.org/version/3.0.0-rc.2912/) | May 26, 2026 |
 | [3.0.0-beta.2897](https://codap3.concord.org/version/3.0.0-beta.2897/) | May 21, 2026 |


### PR DESCRIPTION
### 🐞 Bug Fixes:
- **CODAP-1365:** Case table data entry now matches V2 behavior
- **CODAP-1367:** Fix map being undraggable in Safari
- **CODAP-1370:** Restore Case Card view when reopening a closed table
- **CODAP-1373:** Fix least squares line disappearing when the legend attribute is numeric
- **CODAP-1375:** Support hiding all attributes in a collection
