### PR TITLE
CODAP-1381: fix numeric legend label rendering

### DIFF
--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable testing-library/render-result-naming-convention */
+import { scaleQuantize } from "d3"
+import { choroplethLegend } from "./choropleth-legend"
+
+// jest-canvas-mock's measureText returns 0-width, which defeats the label-collision logic; mock the
+// text measurer with a simple proportional width (~7px/char) so the layout decisions are testable.
+jest.mock("../../../../../hooks/use-measure-text", () => ({
+  measureTextExtent: (text: string) => ({ width: text.length * 7, height: 12 })
+}))
+
+const colors = ["#a", "#b", "#c", "#d", "#e"]
+
+function renderLegend(domain: [number, number], width: number) {
+  const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
+  document.body.appendChild(g)
+  choroplethLegend(scaleQuantize(domain, colors), g, {
+    width, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
+    clickHandler: () => undefined, casesInBinSelectedHandler: () => false
+  })
+  const texts = (selector: string) =>
+    Array.from(g.querySelectorAll(selector)).map(t => t.textContent)
+  return {
+    tickLabels: texts(".legend-axis .tick text"),
+    endpointLabels: Array.from(g.querySelectorAll<SVGTextElement>(".legend-axis-label text")),
+    tooltips: Array.from(g.querySelectorAll("title")).map(t => t.textContent),
+    tickMarkCount: g.querySelectorAll(".legend-axis .tick line").length,
+    hasAxisDomain: !!g.querySelector(".legend-axis .domain")
+  }
+}
+
+describe("choroplethLegend", () => {
+  it("formats threshold tick labels with enough precision for a narrow range", () => {
+    // wide enough that interior ticks render
+    const { tickLabels } = renderLegend([100, 110], 400)
+    expect(tickLabels).toEqual(["102", "104", "106", "108"])
+  })
+
+  it("formats bin tooltips with enough precision for a narrow range", () => {
+    const { tooltips } = renderLegend([100, 110], 400)
+    expect(tooltips).toEqual([
+      "100 - 102", "102 - 104", "104 - 106", "106 - 108", "108 - 110"
+    ])
+  })
+
+  it("renders endpoint labels with an explicit fill so they are visible alongside axis ticks", () => {
+    const { endpointLabels } = renderLegend([100, 110], 400)
+    expect(endpointLabels.map(t => t.textContent)).toEqual(["100", "110"])
+    endpointLabels.forEach(t => expect(t.getAttribute("fill")).toBe("currentColor"))
+  })
+
+  it("justifies endpoint labels to the bar edges so they stay within the legend bounds", () => {
+    // marginLeft and marginRight are both 6 in renderLegend
+    const { endpointLabels } = renderLegend([100, 110], 400)
+    const [minLabel, maxLabel] = endpointLabels
+    expect(minLabel.getAttribute("x")).toBe("6")                          // marginLeft
+    expect(minLabel.style.getPropertyValue("text-anchor")).toBe("start")
+    expect(maxLabel.getAttribute("x")).toBe("394")                        // width - marginRight
+    expect(maxLabel.style.getPropertyValue("text-anchor")).toBe("end")
+  })
+
+  it("uses a uniform number of decimal places across all labels", () => {
+    const { tickLabels, endpointLabels } = renderLegend([0, 1], 400)
+    expect(tickLabels).toEqual(["0.2", "0.4", "0.6", "0.8"])
+    expect(endpointLabels.map(t => t.textContent)).toEqual(["0.0", "1.0"])
+  })
+
+  it("still shows endpoint labels when the legend is too narrow for interior ticks", () => {
+    const { tickLabels, endpointLabels } = renderLegend([100, 110], 60)
+    expect(tickLabels).toEqual([])
+    expect(endpointLabels.map(t => t.textContent)).toEqual(["100", "110"])
+  })
+
+  it("hides interior labels when they would collide with the justified endpoint labels", () => {
+    // A tiny min ("1") and a wide max ("110"): at this width the interior labels fit on their own,
+    // but the right-justified max endpoint would overlap the last interior label, so show endpoints
+    // only. (The old heuristic gated on the min-label width and showed interior labels here.)
+    const { tickLabels, endpointLabels } = renderLegend([1, 110], 150)
+    expect(tickLabels).toEqual([])
+    expect(endpointLabels.map(t => t.textContent)).toEqual(["1", "110"])
+  })
+
+  it("shows interior labels once there is room beside the endpoints", () => {
+    const { tickLabels } = renderLegend([1, 110], 500)
+    expect(tickLabels.length).toBe(4)
+  })
+
+  it("renders interior tick labels without any tick marks (matching the markless narrow case)", () => {
+    const wide = renderLegend([100, 110], 400)
+    expect(wide.tickLabels).toEqual(["102", "104", "106", "108"]) // interior labels kept
+    expect(wide.tickMarkCount).toBe(0)                            // no tick-line marks
+    expect(wide.hasAxisDomain).toBe(false)                        // no domain path / endpoint end-caps
+
+    const narrow = renderLegend([100, 110], 60)
+    expect(narrow.tickMarkCount).toBe(0)
+    expect(narrow.hasAxisDomain).toBe(false)
+  })
+})
+/* eslint-enable testing-library/render-result-naming-convention */

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
@@ -10,12 +10,12 @@ jest.mock("../../../../../hooks/use-measure-text", () => ({
 
 const colors = ["#a", "#b", "#c", "#d", "#e"]
 
-function renderLegend(domain: [number, number], width: number) {
+function renderLegend(domain: [number, number], width: number, useGrouping = false) {
   // The <g> stays detached: d3 renders into it and we read it via querySelectorAll, neither of which
   // needs it in the document (measureTextExtent is mocked), so nothing leaks into document.body.
   const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
   choroplethLegend(scaleQuantize(domain, colors), g, {
-    width, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
+    width, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5, useGrouping,
     clickHandler: () => undefined, casesInBinSelectedHandler: () => false
   })
   const texts = (selector: string) =>
@@ -83,6 +83,21 @@ describe("choroplethLegend", () => {
   it("shows interior labels once there is room beside the endpoints", () => {
     const { tickLabels } = renderLegend([1, 110], 500)
     expect(tickLabels.length).toBe(4)
+  })
+
+  it("groups thousands in all labels when grouping is enabled (e.g. large quantities)", () => {
+    const { tickLabels, endpointLabels, tooltips } = renderLegend([0, 10000], 500, true)
+    expect(tickLabels).toEqual(["2,000", "4,000", "6,000", "8,000"])
+    expect(endpointLabels.map(t => t.textContent)).toEqual(["0", "10,000"])
+    expect(tooltips[tooltips.length - 1]).toBe("8,000 - 10,000")
+  })
+
+  it("suppresses thousands grouping for year-like values when grouping is disabled", () => {
+    // Years are typed numeric (not date), so isDate is false; the caller disables grouping via the
+    // attribute's year-type inference so "1996" does not render as "1,996".
+    const { tickLabels, endpointLabels } = renderLegend([1990, 2020], 500, false)
+    expect(tickLabels).toEqual(["1996", "2002", "2008", "2014"])
+    expect(endpointLabels.map(t => t.textContent)).toEqual(["1990", "2020"])
   })
 
   it("renders interior tick labels without any tick marks (matching the markless narrow case)", () => {

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
@@ -11,8 +11,9 @@ jest.mock("../../../../../hooks/use-measure-text", () => ({
 const colors = ["#a", "#b", "#c", "#d", "#e"]
 
 function renderLegend(domain: [number, number], width: number) {
+  // The <g> stays detached: d3 renders into it and we read it via querySelectorAll, neither of which
+  // needs it in the document (measureTextExtent is mocked), so nothing leaks into document.body.
   const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
-  document.body.appendChild(g)
   choroplethLegend(scaleQuantize(domain, colors), g, {
     width, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
     clickHandler: () => undefined, casesInBinSelectedHandler: () => false

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -17,6 +17,10 @@ const kLegendLabelGap = 4
 
 export type ChoroplethLegendProps = {
   isDate?: boolean,
+  // When true, format numeric labels with thousands separators (e.g. "10,000"). The caller disables
+  // this for year-like attributes (which are typed numeric, not date) so years render as "2024", not
+  // "2,024" — matching how CODAP formats numbers elsewhere (see getNumFormatterForAttribute).
+  useGrouping?: boolean,
   width?: number,
   rectHeight?: number,
   transform?: string,
@@ -55,7 +59,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
   }
 
   const {
-      isDate, transform = '', width = 320,
+      isDate, useGrouping = false, transform = '', width = 320,
       marginTop = 0, marginRight = 0, marginLeft = 0,
       ticks = 5, clickHandler, casesInBinSelectedHandler
     } = props,
@@ -80,7 +84,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     decimalPlaces = binBoundaryDecimalPlaces(fullBoundaries),
     formatBoundary = isDate
       ? (value: number) => formatDate(value * 1000, datePrecision) ?? ''
-      : format(`.${decimalPlaces}f`)
+      : format(`${useGrouping ? ',' : ''}.${decimalPlaces}f`)
 
   const legendScale = scaleLinear()
       .domain([-1, scale.range().length - 1])

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -4,12 +4,19 @@ import { measureTextExtent } from "../../../../../hooks/use-measure-text"
 import {
   determineLevels, formatDate, kDatePrecisionNone, mapLevelToPrecision
 } from "../../../../../utilities/date-utils"
-import { neededSigDigitsArrayForBinBoundaries } from "../../../../../utilities/math-utils"
+import { binBoundaryDecimalPlaces } from "../../../../../utilities/math-utils"
 import { kChoroplethHeight, kDataDisplayFont } from "../../../data-display-types"
+
+// Gap (px) below the color bar before the label text. Used both as the axis tickPadding for the
+// interior tick labels and as the `y` of the min/max endpoint labels; the endpoint labels also copy
+// d3's `dy` of "0.71em", so endpoint and interior labels share an identical baseline.
+const kLegendLabelPadding = 6
+const kLegendLabelBaselineDy = "0.71em"
+// Minimum horizontal gap (px) required between adjacent legend labels before interior labels show.
+const kLegendLabelGap = 4
 
 export type ChoroplethLegendProps = {
   isDate?: boolean,
-  tickSize?: number,
   width?: number,
   rectHeight?: number,
   transform?: string,
@@ -48,14 +55,12 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
   }
 
   const {
-      isDate, tickSize = 6, transform = '', width = 320,
+      isDate, transform = '', width = 320,
       marginTop = 0, marginRight = 0, marginLeft = 0,
       ticks = 5, clickHandler, casesInBinSelectedHandler
     } = props,
     minValue = min(scale.domain()) ?? 0,
     maxValue = max(scale.domain()) ?? 0
-
-  const tickFormatSpec = '.2r'
 
   select(choroplethElt).selectAll("*").remove()
   const svg = select(choroplethElt).append("svg")
@@ -66,23 +71,39 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
 
   const thresholds = getScaleThresholds(scale),
     fullBoundaries = [minValue, ...thresholds, maxValue],
-    domainValues = scale.domain(),
-    significantDigits = neededSigDigitsArrayForBinBoundaries(fullBoundaries, domainValues),
     dateLevels = isDate ? determineLevels(minValue, maxValue) : {increment: 1, outerLevel: 0, innerLevel: 0},
-    datePrecision = isDate ? mapLevelToPrecision(dateLevels.innerLevel + 1) : kDatePrecisionNone
-
-  const thresholdFormat = isDate ? (date: number) => formatDate(date * 1000, datePrecision) ?? ''
-    : format(tickFormatSpec)
+    datePrecision = isDate ? mapLevelToPrecision(dateLevels.innerLevel + 1) : kDatePrecisionNone,
+    // Format every boundary (tick labels, tooltips, and the min/max endpoint labels) with a single,
+    // shared number of decimal places. This keeps labels visually consistent (e.g. "0.0, 0.5, 1.0"
+    // rather than "0, 0.5, 1.00") and stops a narrow range like 100–110 from collapsing to
+    // "100, 100, 110" the way a fixed 2-significant-figure format did.
+    decimalPlaces = binBoundaryDecimalPlaces(fullBoundaries),
+    formatBoundary = isDate
+      ? (value: number) => formatDate(value * 1000, datePrecision) ?? ''
+      : format(`.${decimalPlaces}f`)
 
   const legendScale = scaleLinear()
       .domain([-1, scale.range().length - 1])
       .rangeRound([marginLeft, width - marginRight]),
     tickValues = range(thresholds.length),
-    tickFormat = (i: NumberValue) => thresholdFormat(thresholds[Number(i)]),
-    minMaxFormat = isDate ? thresholdFormat
-      : (d: number, i: number) => format(`.${significantDigits[i === 0 ? 0 : 5]}r`)(d),
-    minStringWidth = measureTextExtent(minMaxFormat(minValue, 0), kDataDisplayFont).width,
-    onlyShowMinMax = minStringWidth > 3 * width / 20 - 10
+    tickFormat = (i: NumberValue) => formatBoundary(thresholds[Number(i)])
+
+  // Show the interior threshold labels only if they fit without colliding with each other or with
+  // the left/right-justified min/max endpoint labels; otherwise show just the endpoints. (The
+  // endpoints are always shown, justified to the bar edges; interior labels are centered on their
+  // boundaries.)
+  const labelWidth = (value: number) => measureTextExtent(formatBoundary(value), kDataDisplayFont).width,
+    interiorCenters = tickValues.map(i => legendScale(i)),
+    interiorWidths = thresholds.map(labelWidth),
+    lastIndex = interiorCenters.length - 1,
+    fitBesideEndpoints = interiorCenters.length === 0 || (
+      interiorCenters[0] - interiorWidths[0] / 2 >= marginLeft + labelWidth(minValue) + kLegendLabelGap &&
+      interiorCenters[lastIndex] + interiorWidths[lastIndex] / 2 <=
+        (width - marginRight) - labelWidth(maxValue) - kLegendLabelGap),
+    interiorLabelsFit = interiorCenters.every((center, i) =>
+      i === 0 || center - interiorWidths[i] / 2 >=
+        interiorCenters[i - 1] + interiorWidths[i - 1] / 2 + kLegendLabelGap),
+    onlyShowMinMax = !(fitBesideEndpoints && interiorLabelsFit)
 
   svg.append("g")
     .selectAll("rect")
@@ -105,7 +126,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     .append('title')
     .text((color) => {
       const bin = scale.range().indexOf(color)
-      return `${thresholdFormat(fullBoundaries[bin])} - ${thresholdFormat(fullBoundaries[bin + 1])}`
+      return `${formatBoundary(fullBoundaries[bin])} - ${formatBoundary(fullBoundaries[bin + 1])}`
     })
 
 
@@ -116,8 +137,15 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     legendAxis.call(axisBottom(legendScale)
       .ticks(ticks)
       .tickFormat(tickFormat)
-      .tickSize(tickSize)
+      // tickSize 0 removes the tick-line allowance from the label offset; tickPadding then sets the
+      // gap below the bar (we strip the now-zero-length lines and domain below anyway).
+      .tickSize(0)
+      .tickPadding(kLegendLabelPadding)
       .tickValues(tickValues))
+    // Show only the interior threshold labels: strip the tick lines and the domain path so no tick
+    // marks render, matching the markless narrow (endpoints-only) case.
+    legendAxis.selectAll('.tick line').remove()
+    legendAxis.select('.domain').remove()
   }
 
   svg.select('.legend-axis')
@@ -128,10 +156,17 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     .join(
       (enter) =>
         enter.append('text')
-          .attr('y', kChoroplethHeight)
+          // The min/max labels live inside the .legend-axis group. When interior ticks render, d3's
+          // axisBottom sets fill:none on that group (overriding it only on its own tick texts), so
+          // without an explicit fill these endpoint labels would inherit fill:none and disappear.
+          .attr('fill', 'currentColor')
+          .attr('y', kLegendLabelPadding)
+          .attr('dy', kLegendLabelBaselineDy)
+          // Justify min to the bar's left edge and max to its right edge so both stay within the
+          // legend bounds (rather than the SVG edges, which sit marginLeft/marginRight outside the bar).
           .style('text-anchor', (d, i) => i ? 'end' : 'start')
-          .attr('x', (d, i) => i * width)
-          .text(minMaxFormat)
+          .attr('x', (d, i) => i ? width - marginRight : marginLeft)
+          .text(formatBoundary)
     )
 
   return svg.node()

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -40,9 +40,14 @@ export const NumericLegend =
       if (!choroplethElt || !dataConfiguration) return
 
       setDesiredExtent(layerIndex, computeDesiredExtent())
+      // Group thousands (e.g. "10,000") for ordinary numeric legends, but not for year-like
+      // attributes — years are typed numeric (not date), so isDate won't catch them. This mirrors
+      // getNumFormatterForAttribute, which suppresses grouping for inferred year types.
+      const legendAttr = dataConfiguration.dataset?.attrFromID(legendAttrID)
       choroplethLegend(dataConfiguration.legendNumericColorScale, choroplethElt,
         {
           isDate: dataConfiguration.attributeType('legend') === 'date',
+          useGrouping: !legendAttr?.isInferredYearType(),
           width: tileWidth,
           marginLeft: 6, marginTop: labelHeight + 2 * labelPaddingY, marginRight: 6, ticks: 5,
           clickHandler: (bin: number, extend: boolean) => {
@@ -62,7 +67,7 @@ export const NumericLegend =
     },
     [dataConfiguration]
   ),
-  [choroplethElt, dataConfiguration, getLabelHeight, setDesiredExtent, tileWidth, layerIndex])
+  [choroplethElt, dataConfiguration, getLabelHeight, layerIndex, legendAttrID, setDesiredExtent, tileWidth])
 
   // Reactions to check
   // - changing attribute by menu

--- a/v3/src/utilities/math-utils.test.ts
+++ b/v3/src/utilities/math-utils.test.ts
@@ -1,6 +1,7 @@
 import {FormatLocaleDefinition, format, formatLocale} from "d3-format"
 import {
   between,
+  binBoundaryDecimalPlaces,
   checkNumber,
   chooseDecimalPlaces,
   extractNumeric,
@@ -167,6 +168,27 @@ describe("math-utils", () => {
       expect(chooseDecimalPlaces(0.91234, 0, 1)).toBe("0.912")
     })
 
+  })
+
+  describe("binBoundaryDecimalPlaces", () => {
+    it("uses 0 decimals when integer boundaries are already distinct", () => {
+      // the narrow-range legend case: boundaries 100..110 by 2 are distinct as integers
+      expect(binBoundaryDecimalPlaces([100, 102, 104, 106, 108, 110])).toBe(0)
+      expect(binBoundaryDecimalPlaces([0, 25, 50, 75, 100])).toBe(0)
+    })
+
+    it("adds just enough decimals to keep closely-spaced boundaries distinct", () => {
+      expect(binBoundaryDecimalPlaces([0, 0.3, 0.6])).toBe(1)
+      expect(binBoundaryDecimalPlaces([0, 0.01, 0.02])).toBe(2)
+    })
+
+    it("does not hang on duplicate adjacent boundaries", () => {
+      expect(binBoundaryDecimalPlaces([100, 100, 110])).toBe(0)
+    })
+
+    it("respects the maxDecimals cap", () => {
+      expect(binBoundaryDecimalPlaces([0, 1e-30], 6)).toBe(6)
+    })
   })
 })
 

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -1,10 +1,4 @@
-import {FormatLocaleDefinition, formatLocale} from "d3-format"
-
 export const sqrtTwoPi = Math.sqrt(2 * Math.PI)
-
-// locale which uses ASCII minus sign and ignores grouping and currency
-const asciiLocale = formatLocale({ minus: "-" } as FormatLocaleDefinition)
-const asciiFormat = asciiLocale.format
 
 export function between(num: number, min: number, max: number) {
   return min < max ? (min <= num && num <= max) : (max <= num && num <= min)
@@ -39,24 +33,6 @@ export function roundToPrecision(num: number, precision: number) {
     // For 1000: mantissa "1" (0 decimals), exponent 3 → 0 - 3 = -3 ✓
     return mantissaDecimals - exponent
   }
-
-/* Given two numbers, determine the least number of significant figures needed for their display to distinguish
-* between them. */
-export function neededSignificantDigits(num1: number, num2: number) {
-  let significantDigits = 0,
-    f: ReturnType<typeof asciiFormat>,
-    done = false
-  while (!done) {
-    f = asciiFormat(`.${significantDigits}r`)
-    const num1str = f(num1),
-      num2str = f(num2)
-    done = num1str !== num2str
-    if (!done) {
-      significantDigits++
-    }
-  }
-  return significantDigits
-}
 
 /* Given a n1 < n < n2, return a string representation of n with an appropriate precision. */
 export function chooseDecimalPlaces(n: number, lower: number, upper: number) {
@@ -94,79 +70,23 @@ export function chooseDecimalPlaces(n: number, lower: number, upper: number) {
 }
 
 /**
- * Given an array of numbers, return a new array of significant digits needed for each number in the array to
- * distinguish it from the numbers on either side of it. For the first and last numbers, the number of significant
- * digits needed only need consider the second and second to last numbers, respectively. Use
- * `neededSignificantDigits` to determine the number of significant digits needed for each pair of numbers.
+ * Given a sorted array of bin-boundary values, return the single number of decimal places to use
+ * when formatting ALL of them so that adjacent boundaries remain distinct. Applying one decimal-place
+ * count to every label keeps them visually consistent (e.g. "0.0, 0.5, 1.0" rather than a ragged mix
+ * like "0, 0.5, 1.00"), while using no more precision than the closest pair of boundaries requires.
+ * Genuinely-equal adjacent boundaries are ignored (no number of decimals can separate them), so the
+ * result stays minimal and the loop always terminates; `maxDecimals` is a final safety bound.
  */
-export function neededSignificantDigitsArray(numbers: number[]) {
-  return numbers.map((num, index) => {
-    if (index === 0) {
-      return neededSignificantDigits(numbers[1], num)
-    } else if (index === numbers.length - 1) {
-      return neededSignificantDigits(numbers[numbers.length - 2], num)
-    } else {
-      return Math.max(neededSignificantDigits(numbers[index - 1], num),
-        neededSignificantDigits(numbers[index + 1], num))
-    }
-  })
-}
-
-/**
- * Given an array of bin boundary values and an array of numbers, return a new array of significant digits
- * needed for each bin boundary value to distinguish it from the numbers on either side of it in the array.
- * Both the array of bin boundary values and the array of numbers is assumed to be sorted.
- */
-export function neededSigDigitsArrayForBinBoundaries(binBoundaries: number[], values: number[]) {
-
-  const sigDigits = (n1: number, n2: number, operator: '<' | '>' | '<=' | '>=') => {
-    let significantDigits = 0,
-      f: ReturnType<typeof asciiFormat>,
-      done = false
-    while (!done) {
-      f = asciiFormat(`.${significantDigits}r`)
-      const n1String = f(n1),
-        n1AfterFormatting = Number(n1String)
-      switch (operator) {
-        case '<':
-          done = n1AfterFormatting < n2
-          break
-        case ">":
-          done = n1AfterFormatting > n2
-          break
-        case "<=":
-          done = n1AfterFormatting <= n2
-          break
-        case ">=":
-          done = n1AfterFormatting >= n2
-      }
-      if (!done) {
-        significantDigits++
-      }
-    }
-    return significantDigits
-
+export function binBoundaryDecimalPlaces(boundaries: number[], maxDecimals = 12) {
+  const adjacentBoundariesDistinct = (places: number) =>
+    boundaries.every((value, i) =>
+      i === 0 || value === boundaries[i - 1] ||
+        value.toFixed(places) !== boundaries[i - 1].toFixed(places))
+  let decimals = 0
+  while (decimals < maxDecimals && !adjacentBoundariesDistinct(decimals)) {
+    decimals++
   }
-
-  const lastBinBoundaryIndex = binBoundaries.length - 1,
-    lastValuesIndex = values.length - 1
-  return binBoundaries.map((boundaryValue, index) => {
-    const
-      leftValue = index === 0 ? boundaryValue
-        : values.find((value, i) => {
-          return i < lastValuesIndex && value < boundaryValue && values[i + 1] >= boundaryValue
-        }),
-      rightValue = index === lastBinBoundaryIndex ? boundaryValue
-        : values.find((value, i) => {
-          return i > 0 && value > boundaryValue && values[i - 1] <= boundaryValue
-        })
-    const
-      leftDigits = leftValue !== undefined ? sigDigits(leftValue, boundaryValue,
-        index === 0 ? '<=' : '<') : 0,
-      rightDigits = rightValue !== undefined ? sigDigits(rightValue, boundaryValue,
-        index === lastBinBoundaryIndex ? '>=' : '>') : 0
-    return Math.max(leftDigits, rightDigits)
-  })
+  return decimals
 }
 
 export function isFiniteNumber(x: any): x is number {


### PR DESCRIPTION
Note: these issues came to light while working on `CODAP-1292: Change the range of a numeric legend` for mapping time. I separated out these issues into a PR on main because they fix bugs that are potential candidates for fixing in 3.0.0.

## Summary
Fixes several pre-existing display issues in the choropleth (numeric) legend's
bin-boundary labels. Surfaced while testing CODAP-1292 but independent of it.

1. **Precision.** Threshold tick labels and bin tooltips used a fixed 2
   significant figures (`'.2r'`), so over a narrow range (e.g. 100–110) the
   boundaries collapsed to identical labels ("100, 100, 110, 110") with
   degenerate tooltips (`[100,100)`). All labels (ticks, tooltips, and the
   min/max endpoints) now share a single number of decimal places — the minimum
   needed to keep adjacent boundaries distinct — so they are correct and
   visually consistent ("0.0, 0.5, 1.0" rather than "0, 0.5, 1.00").
2. **Invisible endpoints.** The min/max labels are children of the
   `.legend-axis` group; d3's `axisBottom` sets `fill: none` on that group
   (re-applying `fill: currentColor` only to its own tick texts), so the
   endpoint labels disappeared whenever interior ticks were shown (wider
   legends). They now set an explicit `fill: currentColor`.
3. **Tick marks.** Marks appeared only in the wide layout (interior tick lines
   plus the axis domain path's endpoint end-caps) and never when narrow. Marks
   are now removed in both layouts, leaving the labels only (closer to V2, which
   shows only endpoint values plus hover tooltips).
4. **Spacing/alignment.** With marks gone, the labels are nudged closer to the
   color bar, and the endpoint labels copy d3's tick-text baseline (`y` + `dy`)
   so they align exactly with the interior labels.
5. **Justification.** Endpoint labels are justified to the bar edges (min left,
   max right) rather than the SVG edges, so they stay within the legend bounds
   (and the max value sits a bit further from the resize handle).
6. **Interior-label visibility.** Interior labels now show only when they fit
   without colliding with the justified endpoints or each other (measured with
   real text widths), replacing a heuristic that gated on the min-label width
   and could let a wide max endpoint overlap the last interior label.
7. **Thousands grouping.** Numeric labels were never grouped ("10000"),
   unlike V2 ("10,000"). Grouping is restored for ordinary numeric legends
   and applied uniformly to ticks, endpoints, and tooltips. Year-like
   attributes are typed numeric (not date), so `isDate` doesn't catch them;
   grouping is suppressed for inferred year types (integers 1000–2999) via
   `isInferredYearType()` — mirroring `getNumFormatterForAttribute` — so years
   render as "2024" not "2,024". This replaces V2's arbitrary `< 2500`
   no-grouping cutoff and also correctly handles years 2500–2999.

Adds `binBoundaryDecimalPlaces()` to math-utils and removes the now-unused
significant-digit helpers (`neededSignificantDigits`,
`neededSignificantDigitsArray`, `neededSigDigitsArrayForBinBoundaries`) the old
per-value formatting relied on.

## V2 / V3 comparison
V2 renders the numeric (choropleth) legend in `choropleth_view.js`. How this
PR's V3 behavior lines up:

| Aspect | V2 | V3 (this PR) |
|--------|----|--------------|
| Interior threshold labels | None — only the two endpoints plus per-bin hover tooltips | Shown when they fit without colliding with the endpoints or each other; endpoints-only otherwise |
| Label precision | Endpoints 0–2 decimals, trailing zeros dropped; tooltips rounded to 2 decimals | One uniform decimal-place count — the minimum to keep adjacent boundaries distinct, capped at 12 — across ticks, endpoints, and tooltips |
| Very narrow ranges | Hard 2-decimal cap, so endpoints can still collapse (e.g. 1.001–1.002 → "1"/"1") | Adds as many decimals as needed to stay distinct |
| Thousands grouping | On for values ≥ 2500, off below (an indirect way to avoid grouping years) | On for ordinary numeric; suppressed for inferred year types (1000–2999), which is more precise and also covers 2500–2999 |
| Tick marks | None | None (now matches) |

Intentional V3 divergences: uniform fixed decimals (vs V2's variable,
trailing-zero-dropping format) and showing interior labels when they fit (V2
never does). One pre-existing, unrelated divergence not touched here: negative
values use d3's Unicode minus ("−") in V3 vs an ASCII hyphen in V2.

Fixes CODAP-1381. A sibling graph/tile **layout** bug — the resize handle
obscuring the rightmost bottom-edge label (legend max value, x-axis max tick) —
is filed separately as CODAP-1382 and is out of scope here.

## Test plan
- [x] Jest: math-utils + choropleth-legend suites (36 tests)
- [x] `build:tsc` clean, `lint` clean
- [x] Manual QA: narrow/wide numeric legend, narrow value range (100–110), 0–1 range, large values (grouping), year legend (no grouping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
