### PR TITLE
CODAP-1384: fix Rescale to include all points across the antimeridian

### DIFF
--- a/v3/src/components/map/components/map-pin-layer.tsx
+++ b/v3/src/components/map/components/map-pin-layer.tsx
@@ -15,6 +15,7 @@ import PlacedLocationMarker from "../assets/placed-location-marker.svg"
 import { useMapModelContext } from "../hooks/use-map-model-context"
 import { kPinColors, kPinCursors } from "../map-types"
 import { IMapPinLayerModel } from "../models/map-pin-layer-model"
+import { shiftLongitudeIntoView } from "../utilities/map-utils"
 import { PinControls } from "./pin-controls"
 
 import "./map-pin-layer.scss"
@@ -147,6 +148,9 @@ export const MapPinLayer = observer(function MapPinLayer({ mapLayerModel }: IMap
   const style = mapLayerModel.addMode ? { cursor: `url(${kPinCursors[colorIndex]}) 15 37, pointer` } : undefined
 
   const renderPins = mapLayerModel.isVisible && mapLayerModel.pinsAreVisible
+  const mapBounds = map.getBounds()
+  const west = mapBounds.getWest()
+  const east = mapBounds.getEast()
   return (
     <div className="map-pin-layer">
       <div
@@ -162,7 +166,8 @@ export const MapPinLayer = observer(function MapPinLayer({ mapLayerModel }: IMap
         const long = dataset.getNumeric(__id__, pinLongId)
         if (lat == null || long == null || !isFinite(lat) || !isFinite(long)) return null
 
-        const { x, y } = map.latLngToContainerPoint([lat, long])
+        const shiftedLong = shiftLongitudeIntoView(long, west, east)
+        const { x, y } = map.latLngToContainerPoint([lat, shiftedLong])
         const pinX = x - mapPinWidth / 2
         const pinY = y - mapPinHeight
 

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -58,13 +58,10 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
 
   const { wrapClickHandler } = useMapClickWithDoubleClickZoom(leafletMap)
 
-  const connectingLine = useCallback((caseID: string) => {
+  const connectingLine = useCallback((caseID: string, west: number, east: number) => {
     const {latId, longId} = mapLayerModel.pointAttributes || {}
     if (!dataset || !latId || !longId) return
 
-    const mapBounds = leafletMap.getBounds()
-    const west = mapBounds.getWest()
-    const east = mapBounds.getEast()
     const getCoords = (anID: string) => {
       const long = dataset.getNumeric(anID, longId) || 0,
         lat = dataset?.getNumeric(anID, latId) || 0
@@ -92,12 +89,16 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
 
   const connectingLinesForCases = useCallback(() => {
     const lineDescriptions: IConnectingLineDescription[] = []
+    // Compute the viewport bounds once per refresh; they're constant across all cases.
+    const mapBounds = leafletMap.getBounds()
+    const west = mapBounds.getWest()
+    const east = mapBounds.getEast()
     dataConfiguration?.getCaseDataArray(0).forEach(c => {
-        const cLine = connectingLine(c.caseID)
+        const cLine = connectingLine(c.caseID, west, east)
         cLine && lineDescriptions.push(cLine)
     })
     return lineDescriptions
-  }, [connectingLine, dataConfiguration])
+  }, [connectingLine, dataConfiguration, leafletMap])
 
   const handleConnectingLinesClick = useCallback(() => {
     // temporarily ignore leaflet clicks to prevent the map click handler

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -25,6 +25,7 @@ import { IPoint, IPointMetadata, PixiPointRenderer, useLayerRenderer } from "../
 import {useMapClickWithDoubleClickZoom} from "../hooks/use-map-click-with-double-click-zoom"
 import {useMapModelContext} from "../hooks/use-map-model-context"
 import {IMapPointLayerModel} from "../models/map-point-layer-model"
+import {shiftLongitudeIntoView} from "../utilities/map-utils"
 import {MapPointGrid} from "./map-point-grid"
 import { useInstanceIdContext } from "../../../hooks/use-instance-id-context"
 import { useConnectingLines } from "../../data-display/hooks/use-connecting-lines"
@@ -61,10 +62,14 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
     const {latId, longId} = mapLayerModel.pointAttributes || {}
     if (!dataset || !latId || !longId) return
 
+    const mapBounds = leafletMap.getBounds()
+    const west = mapBounds.getWest()
+    const east = mapBounds.getEast()
     const getCoords = (anID: string) => {
       const long = dataset.getNumeric(anID, longId) || 0,
         lat = dataset?.getNumeric(anID, latId) || 0
-      return leafletMap.latLngToContainerPoint([lat, long])
+      const shiftedLong = shiftLongitudeIntoView(long, west, east)
+      return leafletMap.latLngToContainerPoint([lat, shiftedLong])
     },
     getScreenX = (anID: string) => {
       const coords = getCoords(anID)
@@ -195,13 +200,17 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
       // Add the data to the heatmap
       const { latId, longId } = mapLayerModel.pointAttributes || {}
       if (!latId || !longId) return
+      const mapBounds = leafletMap.getBounds()
+      const west = mapBounds.getWest()
+      const east = mapBounds.getEast()
       dataConfiguration.joinedCaseDataArrays.forEach(c => {
         const { caseID } = c
         const value = dataset.getNumeric(caseID, legendAttributeId) || minValue
         const normalizedValue = (value - minValue) / (maxValue - minValue)
         const long = dataset.getNumeric(caseID, longId) || 0
         const lat = dataset.getNumeric(caseID, latId) || 0
-        const point = leafletMap.latLngToContainerPoint([lat, long])
+        const shiftedLong = shiftLongitudeIntoView(long, west, east)
+        const point = leafletMap.latLngToContainerPoint([lat, shiftedLong])
         simpleheatRef.current?.add([point.x * scaleX, point.y * scaleY, normalizedValue])
       })
     }
@@ -291,11 +300,15 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
 
   const displayPoints = displayType === "points" && pointsAreVisible && layerIsVisible
   const refreshPoints = useDebouncedCallback(async (selectedOnly: boolean) => {
+    const mapBounds = leafletMap.getBounds()
+    const west = mapBounds.getWest()
+    const east = mapBounds.getEast()
     const {pointSizeMultiplier, pointStrokeColor} = pointDescription,
       getCoords = (anID: string) => {
         const long = longId ? dataset?.getNumeric(anID, longId) || 0 : 0,
           lat = latId ? dataset?.getNumeric(anID, latId) || 0 : 0
-        return leafletMap.latLngToContainerPoint([lat, long])
+        const shiftedLong = shiftLongitudeIntoView(long, west, east)
+        return leafletMap.latLngToContainerPoint([lat, shiftedLong])
       },
       getScreenX = (anID: string) => {
         const coords = getCoords(anID)

--- a/v3/src/components/map/utilities/map-utils.test.ts
+++ b/v3/src/components/map/utilities/map-utils.test.ts
@@ -170,7 +170,7 @@ describe("shiftLongitudeIntoView", () => {
   it("applies multiple rotations when a single 360° shift is not enough", () => {
     // A point at -500° is two full rotations west of the viewport.
     expect(shiftLongitudeIntoView(-500, 175, 201)).toBe(220)
-    // And a point at +700° is two rotations east.
+    // And a point at +700° is three rotations east (700 - 3×360 = -380).
     expect(shiftLongitudeIntoView(700, -185, -159)).toBe(-380)
   })
 })

--- a/v3/src/components/map/utilities/map-utils.test.ts
+++ b/v3/src/components/map/utilities/map-utils.test.ts
@@ -1,25 +1,12 @@
-import { computeBoundsFromCoordinates, getRationalLongitudeBounds } from "./map-utils"
+import {
+  computeBoundsFromCoordinates, getRationalLongitudeBounds, shiftLongitudeIntoView
+} from "./map-utils"
 
 describe("getRationalLongitudeBounds", () => {
-  it("returns the original min/max when span <= 180", () => {
+  it("returns canonical min/max when all values fit within 180° of canonical range", () => {
     const result = getRationalLongitudeBounds([-100, -90, -80, -70])
     expect(result.min).toBe(-100)
     expect(result.max).toBe(-70)
-  })
-
-  it("handles Alaska-like data crossing the date line", () => {
-    // Alaska spans from about 172°E to 130°W (-130°)
-    // Naive span: -130 to 172 = 302°, but actual span crossing date line is ~58°
-    const result = getRationalLongitudeBounds([172, 175, 178, -178, -175, -170, -160, -140, -130])
-    expect(result.max - result.min).toBeLessThanOrEqual(180)
-    expect(result.max - result.min).toBeCloseTo(58, 0)
-  })
-
-  it("handles Pacific-centered data near the date line", () => {
-    // Points clustered on both sides of the date line
-    const result = getRationalLongitudeBounds([170, 175, 179, -179, -175, -170])
-    expect(result.max - result.min).toBeLessThanOrEqual(180)
-    expect(result.max - result.min).toBeCloseTo(20, 0)
   })
 
   it("handles all-positive longitudes", () => {
@@ -34,10 +21,77 @@ describe("getRationalLongitudeBounds", () => {
     expect(result.max).toBe(-80)
   })
 
+  it("returns canonical bounds when the wrap-around gap is the largest", () => {
+    // Evenly spaced points spanning 200°: every inter-point gap is 20°, and the
+    // wrap gap is 160° — the canonical arc is the smallest enclosing one.
+    const longs = [-100, -80, -60, -40, -20, 0, 20, 40, 60, 80, 100]
+    const result = getRationalLongitudeBounds([...longs])
+    expect(result.min).toBe(-100)
+    expect(result.max).toBe(100)
+  })
+
+  it("handles Alaska-like data crossing the date line", () => {
+    // Cluster from 172°E through the dateline to 130°W: the 302° gap dominates
+    // so the compact arc goes east from 172° to -130° (expressed as +230°).
+    const result = getRationalLongitudeBounds([172, 175, 178, -178, -175, -170, -160, -140, -130])
+    expect(result.min).toBe(172)
+    expect(result.max).toBe(230)
+    expect(result.max - result.min).toBe(58)
+  })
+
+  it("handles data tightly clustered across the date line", () => {
+    // Hawaii (-159, -158) and Russia (175, 176, 176.25) clusters: the 333° gap
+    // between the clusters is larger than the 24.75° wrap gap, so we get a
+    // 27° dateline-crossing arc.
+    const result = getRationalLongitudeBounds([-159, -158, 175, 176, 176.25])
+    expect(result.min).toBe(175)
+    expect(result.max).toBe(202)
+    expect(result.max - result.min).toBeLessThanOrEqual(180)
+  })
+
+  it("picks the dateline-crossing arc when an inter-point gap exceeds the wrap gap (CODAP-1384)", () => {
+    // Subset of the CODAP-1384 longitudes: the gap between -123.1 and -77.3 is
+    // 45.8°, larger than the 24.29° wrap gap, so the shortest enclosing arc
+    // crosses the date line. Renderers must use shiftLongitudeIntoView so points
+    // at canonical -159.46 etc. land inside this non-canonical viewport.
+    const longs = [-159.46, -123.1, -77.3, -43.1, -9.2, 4.5, 8.5, 39.6, 72.8, 114.2, 153.0, 176.25]
+    const result = getRationalLongitudeBounds([...longs])
+    expect(result.min).toBe(-77.3)
+    expect(result.max).toBeCloseTo(236.9, 10)
+  })
+
+  it("canonicalizes input values outside the [-180, 180] range", () => {
+    // 200° = canonical -160°; -200° = canonical 160°. With three points at
+    // canonical -160, 0, 160, every inter-point gap is 160° and wrap is 40°,
+    // so the dateline-crossing arc wins.
+    const result = getRationalLongitudeBounds([200, -200, 0])
+    expect(result.min).toBe(0)
+    expect(result.max).toBe(200)
+  })
+
+  it("ignores non-finite values", () => {
+    const result = getRationalLongitudeBounds([NaN, -100, Infinity, 0, -Infinity, 50])
+    expect(result.min).toBe(-100)
+    expect(result.max).toBe(50)
+  })
+
+  it("returns NaN bounds when no finite values are provided", () => {
+    const result = getRationalLongitudeBounds([NaN, Infinity, -Infinity])
+    expect(result.min).toBeNaN()
+    expect(result.max).toBeNaN()
+  })
+
+  it("handles a single value", () => {
+    const result = getRationalLongitudeBounds([42])
+    expect(result.min).toBe(42)
+    expect(result.max).toBe(42)
+  })
+
   it("handles exactly 2 values crossing the date line", () => {
     const result = getRationalLongitudeBounds([-170, 170])
-    expect(result.max - result.min).toBeLessThanOrEqual(180)
-    expect(result.max - result.min).toBeCloseTo(20, 0)
+    expect(result.min).toBe(170)
+    expect(result.max).toBe(190)
+    expect(result.max - result.min).toBe(20)
   })
 })
 
@@ -56,7 +110,7 @@ describe("computeBoundsFromCoordinates", () => {
     expect(bounds.getEast()).toBe(-80)
   })
 
-  it("computes correct bounds when longitudes cross the date line", () => {
+  it("returns a compact dateline-crossing arc for clustered antimeridian data", () => {
     const bounds = computeBoundsFromCoordinates(
       [50, 55, 60, 65, 52, 58],
       [172, 175, 178, -178, -160, -130]
@@ -73,5 +127,50 @@ describe("computeBoundsFromCoordinates", () => {
     expect(bounds.getNorth()).toBe(45)
     expect(bounds.getWest()).toBe(-122)
     expect(bounds.getEast()).toBe(-122)
+  })
+
+  it("canonicalizes out-of-range longitudes", () => {
+    const bounds = computeBoundsFromCoordinates([10, 20], [200, -200])!
+    // 200° canonicalizes to -160°, -200° to 160°. The 40° wrap gap is smaller
+    // than the 320° inter-point gap, so we get the compact 40° dateline arc.
+    expect(bounds.getWest()).toBe(160)
+    expect(bounds.getEast()).toBe(200)
+  })
+})
+
+describe("shiftLongitudeIntoView", () => {
+  it("returns the longitude unchanged when already in the viewport", () => {
+    expect(shiftLongitudeIntoView(100, -180, 180)).toBe(100)
+    expect(shiftLongitudeIntoView(-50, -180, 180)).toBe(-50)
+  })
+
+  it("shifts a negative-canonical longitude into a dateline-crossing viewport", () => {
+    // Viewport showing the Russia + Hawaii cluster crossing the dateline.
+    // Canonical -159° belongs in the next world copy of this viewport.
+    expect(shiftLongitudeIntoView(-159, 175, 201)).toBe(201)
+  })
+
+  it("shifts a positive-canonical longitude into a viewport that starts below -180", () => {
+    expect(shiftLongitudeIntoView(176, -185, -159)).toBe(-184)
+  })
+
+  it("leaves longitudes within a dateline-crossing viewport unchanged", () => {
+    expect(shiftLongitudeIntoView(178, 175, 201)).toBe(178)
+    expect(shiftLongitudeIntoView(200, 175, 201)).toBe(200)
+  })
+
+  it("does not pull a point inside a viewport it cannot reach", () => {
+    // A 26° viewport near the dateline can't contain a Greenwich point.
+    // The shift still attempts a single rotation, but the result remains
+    // outside the viewport so the point renders off-screen.
+    const result = shiftLongitudeIntoView(0, 175, 201)
+    expect(result < 175 || result > 201).toBe(true)
+  })
+
+  it("applies multiple rotations when a single 360° shift is not enough", () => {
+    // A point at -500° is two full rotations west of the viewport.
+    expect(shiftLongitudeIntoView(-500, 175, 201)).toBe(220)
+    // And a point at +700° is two rotations east.
+    expect(shiftLongitudeIntoView(700, -185, -159)).toBe(-380)
   })
 })

--- a/v3/src/components/map/utilities/map-utils.ts
+++ b/v3/src/components/map/utilities/map-utils.ts
@@ -13,65 +13,81 @@ export const isBoundaryAttribute = (attribute: IAttribute) => {
           kPolygonNames.includes(attribute.title.toLowerCase())
 }
 
+// Normalize a longitude to the canonical [-180, 180] range so that inputs like
+// 200° (= -160°) are treated identically to their canonical equivalents.
+// In-range values are returned as-is to avoid floating-point drift from the
+// modulo arithmetic. Callers must pre-filter non-finite inputs: ±Infinity falls
+// into the modulo branch and produces NaN.
+const canonicalizeLongitude = (lng: number) => {
+  if (lng >= -180 && lng <= 180) return lng
+  return ((lng + 180) % 360 + 360) % 360 - 180
+}
+
 /**
- * Finds the smallest contiguous longitude range by adjusting for
- * date line crossing. Sorts and mutates the input array.
+ * Finds the smallest contiguous longitude arc that contains every input value,
+ * accounting for the international date line and inputs outside [-180, 180].
+ *
+ * The arc is the complement of the largest cyclic gap between consecutive
+ * (sorted, canonicalized) longitudes. When the largest gap straddles the date
+ * line, the returned arc is the simple sorted min/max; otherwise the returned
+ * `max` exceeds 180° to represent an arc that wraps east across the date line.
+ *
+ * Callers that render data on top of a Leaflet map should use
+ * `shiftLongitudeIntoView` when projecting point coordinates so that points
+ * in the canonical world copy still render inside a dateline-crossing view.
  */
 export const getRationalLongitudeBounds = (longs: number[]) => {
-  longs.sort((v1: number, v2: number) => (v1 - v2))
-  let tLength = longs.length,
-    tMin = longs[0],
-    tMax = longs[tLength - 1],
-    tMedian
-  while (tMax - tMin > 180) {
-    tMin = Math.min(tMin, longs[0])
-    tMax = Math.max(tMax, longs[tLength - 1])
-    tMedian = longs[Math.floor(tLength / 2)]
-    if (tMax - tMedian > tMedian - tMin) {
-      tMax -= 360
-      if (tMax < longs[tLength - 2]) {
-        tMin = Math.min(tMin, tMax)
-        tMax = longs[tLength - 2]
-        longs.pop()
-      }
-    } else {
-      tMin += 360
-      if (tMin > longs[1]) {
-        tMax = Math.max(tMax, tMin)
-        tMin = longs[1]
-        longs.shift()
-      }
-    }
-    tLength = longs.length
-    if (tMax < tMin) {
-      const tTemp = tMax
-      tMax = tMin
-      tMin = tTemp
+  const sorted: number[] = []
+  for (const lng of longs) {
+    if (isFiniteNumber(lng)) sorted.push(canonicalizeLongitude(lng))
+  }
+  sorted.sort((a, b) => a - b)
+  const n = sorted.length
+  if (n === 0) return {min: NaN, max: NaN}
+  if (n === 1) return {min: sorted[0], max: sorted[0]}
+  let maxGap = -Infinity, maxGapIdx = 0
+  for (let i = 0; i < n - 1; i++) {
+    const gap = sorted[i + 1] - sorted[i]
+    if (gap > maxGap) {
+      maxGap = gap
+      maxGapIdx = i
     }
   }
-  return {min: tMin, max: tMax}
+  // Gap from the easternmost point east across the date line back to the westernmost.
+  const wrapGap = (sorted[0] + 360) - sorted[n - 1]
+  if (wrapGap >= maxGap) {
+    return {min: sorted[0], max: sorted[n - 1]}
+  }
+  return {min: sorted[maxGapIdx + 1], max: sorted[maxGapIdx] + 360}
+}
+
+/**
+ * Shifts a longitude into the [west, east] viewport by adding or subtracting
+ * whole rotations of 360°, mirroring CODAP V2's behavior. This lets a point at
+ * a canonical longitude render inside a dateline-crossing map view (where the
+ * viewport's east bound may exceed 180°).
+ */
+export const shiftLongitudeIntoView = (lng: number, west: number, east: number) => {
+  if (lng < west) return lng + Math.ceil((west - lng) / 360) * 360
+  if (lng > east) return lng - Math.ceil((lng - east) / 360) * 360
+  return lng
 }
 
 /**
  * Computes LatLngBounds from arrays of latitude and longitude values,
- * handling the international date line when longitude values span > 180°.
+ * handling the international date line and longitude values outside [-180, 180].
  */
 export const computeBoundsFromCoordinates = (lats: number[], lngs: number[]): LatLngBounds | undefined => {
   if (lats.length === 0 || lngs.length === 0) {
     return undefined
   }
   // Use a for loop instead of Math.min/max(...array) to avoid call stack overflow with large arrays
-  let latMin = Infinity, latMax = -Infinity, lngMin = Infinity, lngMax = -Infinity
+  let latMin = Infinity, latMax = -Infinity
   for (const lat of lats) { if (lat < latMin) latMin = lat; if (lat > latMax) latMax = lat }
-  for (const lng of lngs) { if (lng < lngMin) lngMin = lng; if (lng > lngMax) lngMax = lng }
-  if (lngMax - lngMin > 180) {
-    const rationalLngs = getRationalLongitudeBounds([...lngs])
-    if (isFiniteNumber(rationalLngs.min) && isFiniteNumber(rationalLngs.max)) {
-      lngMin = rationalLngs.min
-      lngMax = rationalLngs.max
-    }
-  }
-  return latLngBounds([{lat: latMin, lng: lngMin}, {lat: latMax, lng: lngMax}])
+  if (!isFiniteNumber(latMin) || !isFiniteNumber(latMax)) return undefined
+  const lngBounds = getRationalLongitudeBounds(lngs)
+  if (!isFiniteNumber(lngBounds.min) || !isFiniteNumber(lngBounds.max)) return undefined
+  return latLngBounds([{lat: latMin, lng: lngBounds.min}, {lat: latMax, lng: lngBounds.max}])
 }
 
 /**
@@ -116,7 +132,9 @@ export const expandLatLngBounds = (bounds: LatLngBounds, fraction: number) => {
     latDelta = bounds.getNorth() - bounds.getSouth(),
     lngDelta = bounds.getEast() - bounds.getWest(),
     newLatDelta = latDelta * fraction,
-    newLngDelta = lngDelta * fraction,
+    // Once the longitude arc spans the full globe, further expansion would
+    // wrap past the original bounds and confuse Leaflet's fitBounds.
+    newLngDelta = Math.min(lngDelta * fraction, 360),
     southWest = {lat: center.lat - newLatDelta / 2, lng: center.lng - newLngDelta / 2},
     northEast = {lat: center.lat + newLatDelta / 2, lng: center.lng + newLngDelta / 2}
   return latLngBounds([southWest, northEast])

--- a/v3/src/components/map/utilities/map-utils.ts
+++ b/v3/src/components/map/utilities/map-utils.ts
@@ -38,13 +38,24 @@ const canonicalizeLongitude = (lng: number) => {
  */
 export const getRationalLongitudeBounds = (longs: number[]) => {
   const sorted: number[] = []
+  let canonMin = Infinity, canonMax = -Infinity
   for (const lng of longs) {
-    if (isFiniteNumber(lng)) sorted.push(canonicalizeLongitude(lng))
+    if (isFiniteNumber(lng)) {
+      const canon = canonicalizeLongitude(lng)
+      sorted.push(canon)
+      if (canon < canonMin) canonMin = canon
+      if (canon > canonMax) canonMax = canon
+    }
   }
-  sorted.sort((a, b) => a - b)
   const n = sorted.length
   if (n === 0) return {min: NaN, max: NaN}
   if (n === 1) return {min: sorted[0], max: sorted[0]}
+  // Fast path: when the canonical span is within 180°, the wrap gap (360 - span)
+  // necessarily exceeds every interior gap, so the smallest enclosing arc is just
+  // the canonical min/max. Skip the O(n log n) sort entirely. This also mirrors
+  // V2, which only invoked the date-line algorithm when the span exceeded 180°.
+  if (canonMax - canonMin <= 180) return {min: canonMin, max: canonMax}
+  sorted.sort((a, b) => a - b)
   let maxGap = -Infinity, maxGapIdx = 0
   for (let i = 0; i < n - 1; i++) {
     const gap = sorted[i + 1] - sorted[i]


### PR DESCRIPTION
## Summary
- Rewrite `getRationalLongitudeBounds` as a gap-based algorithm (largest cyclic gap → complement arc) so Rescale no longer drops points across the date line. Inputs outside [-180, 180] are canonicalized; a compact dateline-crossing arc is returned with `max > 180` when appropriate.
- Mirror CODAP V2's per-point shift: introduce `shiftLongitudeIntoView` and apply it at every (lat, long) → container-point projection in the point and pin layers, so canonical-longitude points render inside a viewport whose east bound exceeds 180°.
- Cap longitude expansion in `expandLatLngBounds` at 360° to keep `fitBounds` well-defined for near-global views.

Fixes CODAP-1384.

## Known follow-up
- Polygon layers still position via Leaflet's `L.Polygon` at canonical longitudes; for a polygon dataset clustered across the date line, polygons in the canonical world copy could render off-screen in a dateline-crossing view. CODAP-1384's repro has no polygons; worth a separate ticket.
- `getRationalLongitudeBounds` no longer mutates the input array. The only in-tree caller already passed a copy.

## Test plan
- [x] `npm test -- src/components/map` — 101 tests pass, including new coverage of the CODAP-1384 dataset shape, tight Hawaii↔Russia clusters, out-of-range input canonicalization, multi-rotation shifts, and the "viewport too narrow to reach" edge case.
- [x] `npm run lint`
- [x] `npm run build:tsc`
- [x] Manual: opened `Map rescale problem.codap`. Initial map and Rescale fit every point.
- [x] Manual: pared-down dataset with only the dateline-clustered points — Rescale produces a compact Hawaii↔Russia viewport with all points rendered correctly.
