### PR TITLE
CODAP-1388: preserve original string value when dragging dot plot points

### DIFF
--- a/v3/src/components/graph/hooks/use-dot-plot-drag-drop.test.ts
+++ b/v3/src/components/graph/hooks/use-dot-plot-drag-drop.test.ts
@@ -68,6 +68,23 @@ describe("useDotPlotDragDrop", () => {
     expect(dataset.getStrValue("c1", "wId")).toBe("2020-01-01")
   })
 
+  it("restores every selected case when multiple points are dragged", () => {
+    const dataset = DataSet.create({})
+    dataset.addAttribute({ id: "wId", name: "when" })
+    dataset.addCases(toCanonical(dataset, [
+      { __id__: "c1", when: "2020-01-01" },
+      { __id__: "c2", when: "2021-06-15" },
+      { __id__: "c3", when: "2022-12-31" }
+    ]))
+
+    dragRoundTrip(dataset, "wId", ["c1", "c2", "c3"], "c1")
+
+    expect(dataset.getAttribute("wId")!.type).toBe("date")
+    expect(dataset.getStrValue("c1", "wId")).toBe("2020-01-01")
+    expect(dataset.getStrValue("c2", "wId")).toBe("2021-06-15")
+    expect(dataset.getStrValue("c3", "wId")).toBe("2022-12-31")
+  })
+
   it("restores a numeric attribute's value unchanged after a drag round-trip", () => {
     const dataset = DataSet.create({})
     dataset.addAttribute({ id: "xId", name: "x" })

--- a/v3/src/components/graph/hooks/use-dot-plot-drag-drop.test.ts
+++ b/v3/src/components/graph/hooks/use-dot-plot-drag-drop.test.ts
@@ -1,0 +1,86 @@
+import { scaleLinear } from "d3"
+import { act, renderHook } from "@testing-library/react"
+import { DataSet, IDataSet, toCanonical } from "../../../models/data/data-set"
+import { IPoint, IPointMetadata } from "../../data-display/renderer"
+import { useDataSetContext } from "../../../hooks/use-data-set-context"
+import { useDataDisplayAnimation } from "../../data-display/hooks/use-data-display-animation"
+import { useGraphDataConfigurationContext } from "./use-graph-data-configuration-context"
+import { useGraphLayoutContext } from "./use-graph-layout-context"
+import { useDotPlotDragDrop } from "./use-dot-plot-drag-drop"
+
+jest.mock("../../../hooks/use-data-set-context")
+jest.mock("../../data-display/hooks/use-data-display-animation")
+jest.mock("./use-graph-data-configuration-context")
+jest.mock("./use-graph-layout-context")
+// Selection is supplied through the mocked data configuration, so stub the click handler
+// to avoid the renderer registry it would otherwise consult.
+jest.mock("../../data-display/data-display-utils", () => ({
+  handleClickOnCase: jest.fn()
+}))
+
+const mockUseDataSetContext = useDataSetContext as jest.Mock
+const mockUseDataDisplayAnimation = useDataDisplayAnimation as jest.Mock
+const mockUseGraphDataConfig = useGraphDataConfigurationContext as jest.Mock
+const mockUseGraphLayout = useGraphLayoutContext as jest.Mock
+
+// A pointer event only needs the fields the hook reads.
+const pointerEvent = (clientX: number) =>
+  ({ clientX, clientY: 0, shiftKey: false }) as unknown as PointerEvent
+
+// Simulate a full start -> drag -> end gesture on the primary (x) axis.
+function dragRoundTrip(dataset: IDataSet, attrID: string, selection: string[], dragCaseID: string) {
+  mockUseDataSetContext.mockReturnValue(dataset)
+  mockUseDataDisplayAnimation.mockReturnValue({ startAnimation: jest.fn(), stopAnimation: jest.fn() })
+  mockUseGraphDataConfig.mockReturnValue({
+    primaryRole: "x",
+    attributeID: () => attrID,
+    numRepetitionsForPlace: () => 1,
+    selection
+  })
+  mockUseGraphLayout.mockReturnValue({
+    getAxisScale: () => scaleLinear().domain([0, 100]).range([0, 200])
+  })
+
+  const { result } = renderHook(() => useDotPlotDragDrop())
+  const point = {} as IPoint
+  const metadata = { caseID: dragCaseID } as IPointMetadata
+  act(() => result.current.onDragStart(pointerEvent(50), point, metadata))
+  act(() => result.current.onDrag(pointerEvent(120)))
+  act(() => result.current.onDragEnd(pointerEvent(120), point, metadata))
+}
+
+describe("useDotPlotDragDrop", () => {
+  it("preserves a date attribute's inferred type and value after a drag round-trip (CODAP-1388)", () => {
+    const dataset = DataSet.create({})
+    dataset.addAttribute({ id: "wId", name: "when" })
+    dataset.addCases(toCanonical(dataset, [
+      { __id__: "c1", when: "2020-01-01" },
+      { __id__: "c2", when: "2021-06-15" },
+      { __id__: "c3", when: "2022-12-31" }
+    ]))
+    expect(dataset.getAttribute("wId")!.type).toBe("date")
+
+    dragRoundTrip(dataset, "wId", ["c1"], "c1")
+
+    // Restoring the original *string* keeps the attribute a date (a numeric restore
+    // would serialize epoch-seconds and flip the inferred type to categorical).
+    expect(dataset.getAttribute("wId")!.type).toBe("date")
+    expect(dataset.getStrValue("c1", "wId")).toBe("2020-01-01")
+  })
+
+  it("restores a numeric attribute's value unchanged after a drag round-trip", () => {
+    const dataset = DataSet.create({})
+    dataset.addAttribute({ id: "xId", name: "x" })
+    dataset.addCases(toCanonical(dataset, [
+      { __id__: "c1", x: 10 },
+      { __id__: "c2", x: 20 },
+      { __id__: "c3", x: 30 }
+    ]))
+    expect(dataset.getAttribute("xId")!.type).toBe("numeric")
+
+    dragRoundTrip(dataset, "xId", ["c1"], "c1")
+
+    expect(dataset.getAttribute("xId")!.type).toBe("numeric")
+    expect(dataset.getStrValue("c1", "xId")).toBe("10")
+  })
+})

--- a/v3/src/components/graph/hooks/use-dot-plot-drag-drop.ts
+++ b/v3/src/components/graph/hooks/use-dot-plot-drag-drop.ts
@@ -44,7 +44,10 @@ export const useDotPlotDragDrop = () => {
     setDragID(() => tItsID)
     currPos.current = primaryIsBottom ? event.clientX : event.clientY
     handleClickOnCase(event, tItsID, dataset)
-    // Record the current values, so we can change them during the drag and restore them when done
+    // Record the current values, so we can change them during the drag and restore them when done.
+    // Reset first so the map only holds values for the current selection (no stale entries from
+    // a prior drag, which could otherwise be restored if the selection changes).
+    selectedDataObjects.current = {}
     const {selection} = dataConfig || {}
     selection?.forEach((anID: string) => {
       const itsValue = dataset?.getStrValue(anID, primaryAttrID)

--- a/v3/src/components/graph/hooks/use-dot-plot-drag-drop.ts
+++ b/v3/src/components/graph/hooks/use-dot-plot-drag-drop.ts
@@ -3,7 +3,6 @@ import { useRef, useState } from "react"
 import { useDataSetContext } from "../../../hooks/use-data-set-context"
 import { appState } from "../../../models/app-state"
 import { ICase } from "../../../models/data/data-set-types"
-import { toNonEmptyValue } from "../../../utilities/math-utils"
 import { getDomainExtentForPixelWidth } from "../../axis/axis-utils"
 import { handleClickOnCase } from "../../data-display/data-display-utils"
 import { dataDisplayGetNumericValue } from "../../data-display/data-display-value-utils"
@@ -22,7 +21,9 @@ export const useDotPlotDragDrop = () => {
   const primaryPlace = primaryIsBottom ? "bottom" : "left"
   const primaryAxisScale = layout.getAxisScale(primaryPlace) as ScaleLinear<number, number>
   const primaryAttrID = dataConfig?.attributeID(primaryAttrRole) ?? ""
-  const selectedDataObjects = useRef<Record<string, number>>({})
+  // Store original string values; restoring a date attribute with numeric epoch-seconds
+  // would flip its inferred type away from date (CODAP-1388).
+  const selectedDataObjects = useRef<Record<string, string>>({})
   const [dragID, setDragID] = useState('')
   const currPos = useRef(0)
   const didDrag = useRef(false)
@@ -46,7 +47,7 @@ export const useDotPlotDragDrop = () => {
     // Record the current values, so we can change them during the drag and restore them when done
     const {selection} = dataConfig || {}
     selection?.forEach((anID: string) => {
-      const itsValue = toNonEmptyValue(dataDisplayGetNumericValue(dataset, anID, primaryAttrID))
+      const itsValue = dataset?.getStrValue(anID, primaryAttrID)
       if (itsValue != null) {
         selectedDataObjects.current[anID] = itsValue
       }


### PR DESCRIPTION
## Summary
- Fixes CODAP-1388. Dragging a point in a dot plot whose x-axis is a date
  attribute no longer corrupts the dragged point's value or flips the axis
  type to categorical on release.
- Root cause: `useDotPlotDragDrop` stored each selected case's value as a
  number (epoch-seconds for dates) at drag start and restored that number
  at drag end. For date attributes, `Attribute.setValue` serialized the
  number as a plain numeric string, which broke `isInferredDateType` and
  caused the attribute to be inferred as categorical.
- Fix: store and restore the original *string* value via
  `dataset.getStrValue`. The intermediate `onDrag` math is unchanged.
- Affects both `dot-line-plot` and `binned-dot-plot`, which share the hook.

## Test plan
- [ ] Open Four Seals, dot plot of `date`, drag a point, release —
      point animates back to its original position; axis remains a date axis.
- [ ] Same with a numeric attribute — drag/release behavior unchanged.
- [ ] Same with multiple selected points — all restore correctly.
- [ ] Binned dot plot of a date — drag/release behavior matches dot plot.
