### PR TITLE
Re-cut Release 3.0.0 to include CODAP-1388

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🐞 Bug Fixes:
 - **CODAP-1381:** Fix numeric legend label rendering
 - **CODAP-1384:** Fix map rescale to include all points, including across the date line
+- **CODAP-1388:** Fix dragging dot plot points corrupting date values
 
 ### Asset Sizes
 |      File |          Size | % Change from Previous Release |


### PR DESCRIPTION
Re-cut of the 3.0.0 release to include CODAP-1388 (#2620), which merged to
main after the original 3.0.0 tag was created. The only change vs the
original 3.0.0 cut is the added CODAP-1388 bug-fix line in the CHANGELOG;
the version number, versions.md, and asset sizes are unchanged.

After this merges, the existing 3.0.0 tag + GitHub release (staging-only,
never deployed to production/beta) will be deleted and re-created at the
new main HEAD so /version/3.0.0/ includes the fix.

## Version 3.0.0 - June 7, 2026

### 🐞 Bug Fixes:
- **CODAP-1381:** Fix numeric legend label rendering
- **CODAP-1384:** Fix map rescale to include all points, including across the date line
- **CODAP-1388:** Fix dragging dot plot points corrupting date values
