### PR TITLE
CODAP-1399: wrap destination key in backticks in lookupByKey join formula

### DIFF
--- a/v3/src/models/data/join-datasets.test.ts
+++ b/v3/src/models/data/join-datasets.test.ts
@@ -93,6 +93,83 @@ describe("joinSourceToDestCollection", () => {
     expect(dataAttr?.formula?.display).toBe('lookupByKey("Source", "Data", "Key", Key)')
   })
 
+  it("wraps the destination key attribute in backticks when its name needs escaping", () => {
+    const sourceData = createDataSetWithHistory("Source")
+    sourceData.addAttribute({ name: "Key" })
+    sourceData.addAttribute({ name: "value" })
+
+    const destData = createDataSetWithHistory("Destination")
+    // Destination key attribute has a space, so it must be backtick-wrapped in the formula
+    destData.addAttribute({ name: "Attribute Name" })
+
+    const sourceKeyAttr = sourceData.getAttributeByName("Key")
+    const destKeyAttr = destData.getAttributeByName("Attribute Name")
+    const destCollection = destData.getCollectionForAttribute(destKeyAttr!.id)
+
+    joinSourceToDestCollection({
+      sourceDataSet: sourceData,
+      sourceKeyAttributeId: sourceKeyAttr!.id,
+      destDataSet: destData,
+      destCollection: destCollection!,
+      destKeyAttributeId: destKeyAttr!.id
+    })
+
+    const valueAttr = destData.getAttributeByName("value")
+    expect(valueAttr).toBeDefined()
+    expect(valueAttr?.formula?.display)
+      .toBe('lookupByKey("Source", "value", "Key", `Attribute Name`)')
+  })
+
+  it("escapes backticks and backslashes inside a wrapped destination key name", () => {
+    const sourceData = createDataSetWithHistory("Source")
+    sourceData.addAttribute({ name: "Key" })
+    sourceData.addAttribute({ name: "value" })
+
+    const destData = createDataSetWithHistory("Destination")
+    destData.addAttribute({ name: "weird`name\\here" })
+
+    const sourceKeyAttr = sourceData.getAttributeByName("Key")
+    const destKeyAttr = destData.getAttributeByName("weird`name\\here")
+    const destCollection = destData.getCollectionForAttribute(destKeyAttr!.id)
+
+    joinSourceToDestCollection({
+      sourceDataSet: sourceData,
+      sourceKeyAttributeId: sourceKeyAttr!.id,
+      destDataSet: destData,
+      destCollection: destCollection!,
+      destKeyAttributeId: destKeyAttr!.id
+    })
+
+    const valueAttr = destData.getAttributeByName("value")
+    expect(valueAttr?.formula?.display)
+      .toBe('lookupByKey("Source", "value", "Key", `weird\\`name\\\\here`)')
+  })
+
+  it("leaves a safe destination key attribute name unwrapped", () => {
+    const sourceData = createDataSetWithHistory("Source")
+    sourceData.addAttribute({ name: "Key" })
+    sourceData.addAttribute({ name: "value" })
+
+    const destData = createDataSetWithHistory("Destination")
+    destData.addAttribute({ name: "PlainName" })
+
+    const sourceKeyAttr = sourceData.getAttributeByName("Key")
+    const destKeyAttr = destData.getAttributeByName("PlainName")
+    const destCollection = destData.getCollectionForAttribute(destKeyAttr!.id)
+
+    joinSourceToDestCollection({
+      sourceDataSet: sourceData,
+      sourceKeyAttributeId: sourceKeyAttr!.id,
+      destDataSet: destData,
+      destCollection: destCollection!,
+      destKeyAttributeId: destKeyAttr!.id
+    })
+
+    const valueAttr = destData.getAttributeByName("value")
+    expect(valueAttr?.formula?.display)
+      .toBe('lookupByKey("Source", "value", "Key", PlainName)')
+  })
+
   it("returns nothing when source collection has only the key attribute", () => {
     const sourceData = createDataSetWithHistory("Source")
     sourceData.addAttribute({ name: "OnlyKey" })

--- a/v3/src/models/data/join-datasets.ts
+++ b/v3/src/models/data/join-datasets.ts
@@ -1,4 +1,6 @@
 import { joinNotification } from "../../components/case-table/case-table-notifications"
+import { safeSymbolName } from "../formula/utils/name-mapping-utils"
+import { escapeBacktickString } from "../formula/utils/string-utils"
 import { ITileModel } from "../tiles/tile-model"
 import { IAttribute } from "./attribute"
 import { ICollectionModel } from "./collection"
@@ -6,6 +8,13 @@ import { IDataSet } from "./data-set"
 import { createAttributesNotification, dependentCasesNotification } from "./data-set-notifications"
 import { uniqueName } from "../../utilities/js-utils"
 import { t } from "../../utilities/translation/translate"
+
+// Wraps an attribute name in backticks if it contains characters that aren't valid in
+// a bare formula identifier (spaces, leading digit, punctuation, etc.). Any backticks
+// or backslashes in the name are escaped so the wrapped form parses correctly.
+function asFormulaIdentifier(name: string) {
+  return name === safeSymbolName(name) ? name : `\`${escapeBacktickString(name)}\``
+}
 
 export interface IJoinSourceToDestCollectionParams {
   /** The source dataset containing the attributes to join */
@@ -92,8 +101,11 @@ export function joinSourceToDestCollection(params: IJoinSourceToDestCollectionPa
 
         // Create the lookupByKey formula
         // Format: lookupByKey("dataSetName", "attributeName", "keyAttributeName", localKeyAttribute)
+        // The first three arguments are string constants; the fourth is a symbol referencing
+        // a local attribute, so it must be wrapped in backticks when the name contains
+        // characters that aren't valid in a bare formula identifier (e.g. spaces).
         const formula = `lookupByKey("${sourceDataSetName}", "${sourceAttr.name}", ` +
-          `"${sourceKeyAttrName}", ${destKeyAttrName})`
+          `"${sourceKeyAttrName}", ${asFormulaIdentifier(destKeyAttrName)})`
 
         // Add the new attribute to the destination collection
         const newAttr = destDataSet.addAttribute(


### PR DESCRIPTION
## Summary
- When joining datasets by dragging a source key onto a destination
  attribute whose name contains a space (or other character that isn't
  valid in a bare formula identifier), the generated `lookupByKey`
  formula left the destination key bare and the parser rejected it.
- Wrap the destination key in backticks when needed, escaping any
  embedded backticks or backslashes via `escapeBacktickString`.
- Added three unit tests covering the wrap-needed, escape-needed, and
  safe-name paths.

Fixes CODAP-1399.

A follow-up bug — CODAP-1400 — was filed for the related issue that
the first three (string-constant) arguments aren't escaped for embedded
double-quote characters.

## Test plan
- [ ] `npm test -- join-datasets` passes (8/8)
- [ ] In the Demo Join Bug document attached to CODAP-1399, drag `Key`
      from **Source** onto `Attribute Name` in **Destination**; the new
      `value` attribute populates from Source instead of erroring.
- [ ] Drag a key onto a normally-named destination attribute and
      confirm the generated formula is unchanged (no spurious backticks).
