### PR TITLE
CODAP-1294: logarithmic option for numeric legend scale

### DIFF
--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable testing-library/render-result-naming-convention */
-import { scaleQuantile, scaleQuantize } from "d3"
+import { scaleQuantile, scaleQuantize, scaleThreshold } from "d3"
 import { choroplethLegend } from "./choropleth-legend"
 
 // jest-canvas-mock's measureText returns 0-width, which defeats the label-collision logic; mock the
@@ -126,6 +126,27 @@ describe("choroplethLegend", () => {
     const endpoints = Array.from(g.querySelectorAll<SVGTextElement>(".legend-axis-label text"))
       .map(t => parseFloat(t.textContent ?? ""))
     expect(endpoints).toEqual([101, 108])
+  })
+
+  it("formats logarithmic legend labels with uniform significant figures", () => {
+    // A scaleThreshold with log-spaced (equal-ratio) boundaries is the logarithmic legend's scale.
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
+    // range [100, 10000], 4 bins -> 3 equal-ratio thresholds (~316, 1000, ~3162)
+    const logMin = 100, logMax = 10000, n = 4
+    const thresholds = Array.from({ length: n - 1 }, (_, i) => logMin * Math.pow(logMax / logMin, (i + 1) / n))
+    const scale = scaleThreshold<number, string>().domain(thresholds).range(colors.slice(0, n))
+    choroplethLegend(scale, g, {
+      width: 600, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
+      legendMin: logMin, legendMax: logMax, useSignificantFigures: true,
+      clickHandler: () => undefined, casesInBinSelectedHandler: () => false
+    })
+    const tickLabels = Array.from(g.querySelectorAll(".legend-axis .tick text")).map(t => t.textContent)
+    const endpoints = Array.from(g.querySelectorAll<SVGTextElement>(".legend-axis-label text"))
+      .map(t => t.textContent)
+    // 1 sig fig already distinguishes every boundary; labels round to uniform significant figures
+    // ("300", "3000") rather than the decimal-place rounding a linear legend would use ("316", "3162").
+    expect(tickLabels).toEqual(["300", "1000", "3000"])
+    expect(endpoints).toEqual(["100", "10000"])
   })
 
   it("renders interior tick labels without any tick marks (matching the markless narrow case)", () => {

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
@@ -137,7 +137,7 @@ describe("choroplethLegend", () => {
     const scale = scaleThreshold<number, string>().domain(thresholds).range(colors.slice(0, n))
     choroplethLegend(scale, g, {
       width: 600, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
-      legendMin: logMin, legendMax: logMax, useSignificantFigures: true,
+      legendMin: logMin, legendMax: logMax, logarithmic: true,
       clickHandler: () => undefined, casesInBinSelectedHandler: () => false
     })
     const tickLabels = Array.from(g.querySelectorAll(".legend-axis .tick text")).map(t => t.textContent)
@@ -147,6 +147,23 @@ describe("choroplethLegend", () => {
     // ("300", "3000") rather than the decimal-place rounding a linear legend would use ("316", "3162").
     expect(tickLabels).toEqual(["300", "1000", "3000"])
     expect(endpoints).toEqual(["100", "10000"])
+  })
+
+  it("labels the lowest log bin as open-above-zero so missing non-positive values aren't implied", () => {
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
+    const logMin = 100, logMax = 10000, n = 4
+    const thresholds = Array.from({ length: n - 1 }, (_, i) => logMin * Math.pow(logMax / logMin, (i + 1) / n))
+    const scale = scaleThreshold<number, string>().domain(thresholds).range(colors.slice(0, n))
+    choroplethLegend(scale, g, {
+      width: 600, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
+      legendMin: logMin, legendMax: logMax, logarithmic: true,
+      clickHandler: () => undefined, casesInBinSelectedHandler: () => false
+    })
+    const tooltips = Array.from(g.querySelectorAll("title")).map(t => t.textContent)
+    // First bin is open above zero (values <= 0 are missing, not in the bin), not "< 300".
+    expect(tooltips[0]).toBe(">0 - 300")
+    // The top bin stays open-ended upward (above-max positives still clamp into it).
+    expect(tooltips[tooltips.length - 1]).toBe("≥ 3000")
   })
 
   it("renders interior tick labels without any tick marks (matching the markless narrow case)", () => {

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -4,7 +4,7 @@ import { measureTextExtent } from "../../../../../hooks/use-measure-text"
 import {
   determineLevels, formatDate, kDatePrecisionNone, mapLevelToPrecision
 } from "../../../../../utilities/date-utils"
-import { binBoundaryDecimalPlaces } from "../../../../../utilities/math-utils"
+import { binBoundaryDecimalPlaces, binBoundarySignificantFigures } from "../../../../../utilities/math-utils"
 import { kChoroplethHeight, kDataDisplayFont } from "../../../data-display-types"
 
 // Gap (px) below the color bar before the label text. Used both as the axis tickPadding for the
@@ -21,6 +21,10 @@ export type ChoroplethLegendProps = {
   // this for year-like attributes (which are typed numeric, not date) so years render as "2024", not
   // "2,024" — matching how CODAP formats numbers elsewhere (see getNumFormatterForAttribute).
   useGrouping?: boolean,
+  // When true, format numeric labels with a uniform number of significant figures rather than a
+  // uniform number of decimal places. Used for logarithmic (equal-ratio) bins, whose boundaries span
+  // orders of magnitude; significant figures is the log-scale dual of fixed decimal places.
+  useSignificantFigures?: boolean,
   width?: number,
   rectHeight?: number,
   transform?: string,
@@ -48,6 +52,8 @@ function isScaleQuantize(scale: ChoroplethScale): scale is ScaleQuantize<string>
 }
 
 export function getScaleThresholds(scale: ChoroplethScale) {
+  // The remaining case is ScaleThreshold, whose domain() IS its array of cut points (used by the
+  // logarithmic legend).
   return isScaleQuantile(scale) ? scale.quantiles()
     : isScaleQuantize(scale) ? scale.thresholds()
       : scale.domain()
@@ -64,7 +70,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
   }
 
   const {
-      isDate, useGrouping = false, transform = '', width = 320,
+      isDate, useGrouping = false, useSignificantFigures = false, transform = '', width = 320,
       marginTop = 0, marginRight = 0, marginLeft = 0,
       ticks = 5, legendMin, legendMax, clickHandler, casesInBinSelectedHandler
     } = props,
@@ -89,9 +95,14 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     // rather than "0, 0.5, 1.00") and stops a narrow range like 100–110 from collapsing to
     // "100, 100, 110" the way a fixed 2-significant-figure format did.
     decimalPlaces = binBoundaryDecimalPlaces(fullBoundaries),
+    // Logarithmic (equal-ratio) boundaries span orders of magnitude, so format them with a uniform
+    // number of significant figures (the log-scale dual of the linear case's uniform decimal places).
+    sigFigs = binBoundarySignificantFigures(fullBoundaries),
     formatBoundary = isDate
       ? (value: number) => formatDate(value * 1000, datePrecision) ?? ''
-      : format(`${useGrouping ? ',' : ''}.${decimalPlaces}f`)
+      : useSignificantFigures
+        ? format(`${useGrouping ? ',' : ''}.${sigFigs}r`)
+        : format(`${useGrouping ? ',' : ''}.${decimalPlaces}f`)
 
   const legendScale = scaleLinear()
       .domain([-1, scale.range().length - 1])

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -21,10 +21,12 @@ export type ChoroplethLegendProps = {
   // this for year-like attributes (which are typed numeric, not date) so years render as "2024", not
   // "2,024" — matching how CODAP formats numbers elsewhere (see getNumFormatterForAttribute).
   useGrouping?: boolean,
-  // When true, format numeric labels with a uniform number of significant figures rather than a
-  // uniform number of decimal places. Used for logarithmic (equal-ratio) bins, whose boundaries span
-  // orders of magnitude; significant figures is the log-scale dual of fixed decimal places.
-  useSignificantFigures?: boolean,
+  // When true, the legend renders a logarithmic (equal-ratio) scale. This (a) formats numeric labels
+  // with a uniform number of significant figures rather than decimal places, since the boundaries
+  // span orders of magnitude (significant figures is the log dual of fixed decimal places); and
+  // (b) labels the lowest bin as open-above-zero (">0 - t₁") rather than "< t₁", because values <= 0
+  // are excluded as missing rather than clamped into the first bin.
+  logarithmic?: boolean,
   width?: number,
   rectHeight?: number,
   transform?: string,
@@ -70,7 +72,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
   }
 
   const {
-      isDate, useGrouping = false, useSignificantFigures = false, transform = '', width = 320,
+      isDate, useGrouping = false, logarithmic = false, transform = '', width = 320,
       marginTop = 0, marginRight = 0, marginLeft = 0,
       ticks = 5, legendMin, legendMax, clickHandler, casesInBinSelectedHandler
     } = props,
@@ -100,7 +102,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     sigFigs = binBoundarySignificantFigures(fullBoundaries),
     formatBoundary = isDate
       ? (value: number) => formatDate(value * 1000, datePrecision) ?? ''
-      : useSignificantFigures
+      : logarithmic
         ? format(`${useGrouping ? ',' : ''}.${sigFigs}r`)
         : format(`${useGrouping ? ',' : ''}.${decimalPlaces}f`)
 
@@ -153,7 +155,13 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
       // bins, so the first bin covers everything below its upper threshold and the last everything
       // at-or-above its lower threshold. Show those open-ended (rather than the [min, max] domain),
       // which is only correct once the user can narrow the range (CODAP-1292).
-      if (lastBin > 0 && bin === 0) return `< ${formatBoundary(fullBoundaries[1])}`
+      // In logarithmic mode values <= 0 are excluded as missing rather than clamped into the first
+      // bin, so label it open-above-zero (">0 - t₁") rather than the unbounded "< t₁".
+      if (lastBin > 0 && bin === 0) {
+        return logarithmic
+          ? `>0 - ${formatBoundary(fullBoundaries[1])}`
+          : `< ${formatBoundary(fullBoundaries[1])}`
+      }
       if (lastBin > 0 && bin === lastBin) return `≥ ${formatBoundary(fullBoundaries[bin])}`
       return `${formatBoundary(fullBoundaries[bin])} - ${formatBoundary(fullBoundaries[bin + 1])}`
     })

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -44,14 +44,16 @@ export const NumericLegend =
       // attributes — years are typed numeric (not date), so isDate won't catch them. This mirrors
       // getNumFormatterForAttribute, which suppresses grouping for inferred year types.
       const legendAttr = dataConfiguration.dataset?.attrFromID(legendAttrID)
-      // Display the effective legend range (override ?? data extent) as the endpoint labels so the
-      // legend matches the user-set Min/Max even in quantile mode (whose trained domain is the data
-      // quantiles, not the override range).
-      const { min: legendMin, max: legendMax } = dataConfiguration.legendNumericRange
+      // Display the effective legend range as the endpoint labels so the legend matches the user-set
+      // Min/Max even in quantile mode (whose trained domain is the data quantiles, not the override
+      // range); in logarithmic mode this is the positive log domain (floored to the smallest positive
+      // value), not the raw override/data extent.
+      const { min: legendMin, max: legendMax } = dataConfiguration.legendDisplayRange
       choroplethLegend(dataConfiguration.legendNumericColorScale, choroplethElt,
         {
           isDate: dataConfiguration.attributeType('legend') === 'date',
           useGrouping: !legendAttr?.isInferredYearType(),
+          useSignificantFigures: dataConfiguration.legendIsLogarithmic,
           width: tileWidth, legendMin, legendMax,
           marginLeft: 6, marginTop: labelHeight + 2 * labelPaddingY, marginRight: 6, ticks: 5,
           clickHandler: (bin: number, extend: boolean) => {

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -53,7 +53,7 @@ export const NumericLegend =
         {
           isDate: dataConfiguration.attributeType('legend') === 'date',
           useGrouping: !legendAttr?.isInferredYearType(),
-          useSignificantFigures: dataConfiguration.legendIsLogarithmic,
+          logarithmic: dataConfiguration.legendIsLogarithmic,
           width: tileWidth, legendMin, legendMax,
           marginLeft: 6, marginTop: labelHeight + 2 * labelPaddingY, marginRight: 6, ticks: 5,
           clickHandler: (bin: number, extend: boolean) => {

--- a/v3/src/components/data-display/inspector/legend-color-controls.test.tsx
+++ b/v3/src/components/data-display/inspector/legend-color-controls.test.tsx
@@ -211,6 +211,18 @@ describe("LegendBinsSelect", () => {
 
     expect(screen.getByRole("button", { name: /V3.Inspector.graph.legendBins/i })).toBeDisabled()
   })
+
+  it("offers a Logarithmic option that commits the binning type", async () => {
+    const user = userEvent.setup()
+    const config = createMockDataConfig()
+    render(<LegendBinsSelect dataConfiguration={config as any} />)
+
+    // open the dropdown and choose Logarithmic (translation is mocked to return the key)
+    await user.click(screen.getByRole("button", { name: /V3.Inspector.graph.legendBins/i }))
+    await user.click(screen.getByRole("option", { name: "V3.Inspector.graph.legendBins.logarithmic" }))
+
+    expect(config.metadata.setAttributeBinningType).toHaveBeenCalledWith("attr-1", "logarithmic")
+  })
 })
 
 describe("LegendRangeInputs", () => {

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -567,33 +567,37 @@ export const DataConfigurationModel = types
       }
       return { min, max }
     },
-    // The positive log domain for a logarithmic legend: upper bound = Max override (if positive) else
-    // data max; lower bound = a positive Min override, else the smallest positive value within the
-    // range (a Min override <= 0 is invalid for a log scale and ignored). Returns {} when no positive
-    // range exists (degenerate -> single bin).
+    // The positive log domain for a logarithmic legend: upper bound = a positive Max override else the
+    // positive data max; lower bound = a positive Min override else the smallest positive value within
+    // the range (an override <= 0 is invalid for a log scale and ignored). An invalid/reversed override
+    // (min >= max) falls back to the positive data extent rather than blanking the legend (mirroring
+    // legendNumericRange); only a data set with no usable positive range (<= 1 distinct positive value)
+    // returns {} (degenerate -> single bin / blank legend).
     get legendLogDomain(): { min?: number, max?: number } {
       const values = self.numericValuesForAttrRole("legend") ?? []
       const legendAttrId = self.attributeID("legend")
       const { min: overrideMin, max: overrideMax } =
         self.metadata?.getAttributeLegendRange(legendAttrId) ?? {}
       const [, dataMax] = extent(values)
-      const max = overrideMax != null ? overrideMax : dataMax
-      if (max == null || max <= 0) return {}
-      let min: number | undefined
-      if (overrideMin != null && overrideMin > 0) {
-        min = overrideMin
-      } else {
-        // Find the smallest positive value in range with a single pass; a spread (Math.min(...values))
-        // would expand the whole array into call arguments and can overflow for large datasets.
-        let smallestPositive: number | undefined
+      // Smallest positive value <= cap, found in a single pass; a spread (Math.min(...values)) would
+      // expand the whole array into call arguments and can overflow for large datasets.
+      const smallestPositiveUpTo = (cap: number) => {
+        let smallest: number | undefined
         for (const v of values) {
-          if (v > 0 && v <= max && (smallestPositive == null || v < smallestPositive)) {
-            smallestPositive = v
-          }
+          if (v > 0 && v <= cap && (smallest == null || v < smallest)) smallest = v
         }
-        min = smallestPositive
+        return smallest
       }
-      if (min == null || min >= max) return {}
+      let max = overrideMax != null && overrideMax > 0 ? overrideMax : dataMax
+      let min = overrideMin != null && overrideMin > 0
+        ? overrideMin
+        : max != null ? smallestPositiveUpTo(max) : undefined
+      // A reversed/invalid override range falls back to the positive data extent rather than blanking.
+      if (min == null || max == null || max <= 0 || min >= max) {
+        max = dataMax
+        min = max != null && max > 0 ? smallestPositiveUpTo(max) : undefined
+      }
+      if (min == null || max == null || max <= 0 || min >= max) return {}
       return { min, max }
     },
     get legendIsLogarithmic(): boolean {

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -765,7 +765,12 @@ export const DataConfigurationModel = types
       getCasesForLegendBin(bin: number) {
         const scale = self.legendNumericColorScale
         const thresholds = getScaleThresholds(scale)
-        const min = bin === 0 ? -Infinity : thresholds[bin - 1]
+        // In logarithmic mode, values <= 0 are "missing" (not in any bin), so the first bin starts
+        // just above 0 rather than at -Infinity; otherwise the first bin captures everything below
+        // its upper threshold, including the non-positive values colored as missing.
+        const min = bin === 0
+          ? (self.legendIsLogarithmic ? Number.MIN_VALUE : -Infinity)
+          : thresholds[bin - 1]
         const max = bin === thresholds.length ? Infinity : thresholds[bin]
         return self.getCasesInLegendRange(min, max)
       }

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -567,6 +567,35 @@ export const DataConfigurationModel = types
       }
       return { min, max }
     },
+    // The positive log domain for a logarithmic legend: upper bound = Max override (if positive) else
+    // data max; lower bound = a positive Min override, else the smallest positive value within the
+    // range (a Min override <= 0 is invalid for a log scale and ignored). Returns {} when no positive
+    // range exists (degenerate -> single bin).
+    get legendLogDomain(): { min?: number, max?: number } {
+      const values = self.numericValuesForAttrRole("legend") ?? []
+      const legendAttrId = self.attributeID("legend")
+      const { min: overrideMin, max: overrideMax } =
+        self.metadata?.getAttributeLegendRange(legendAttrId) ?? {}
+      const [, dataMax] = extent(values)
+      const max = overrideMax != null ? overrideMax : dataMax
+      if (max == null || max <= 0) return {}
+      let min: number | undefined
+      if (overrideMin != null && overrideMin > 0) {
+        min = overrideMin
+      } else {
+        const positives = values.filter(v => v > 0 && v <= max)
+        min = positives.length ? Math.min(...positives) : undefined
+      }
+      if (min == null || min >= max) return {}
+      return { min, max }
+    },
+    get legendIsLogarithmic(): boolean {
+      return self.metadata?.getAttributeBinningType(self.attributeID("legend")) === "logarithmic"
+    },
+    // Endpoint labels to display: the log domain in logarithmic mode, else the linear/quantile range.
+    get legendDisplayRange(): { min?: number, max?: number } {
+      return this.legendIsLogarithmic ? this.legendLogDomain : this.legendNumericRange
+    },
     get legendNumericColorScale() {
       // TODO: Handle the displayOnlySelectedCases better. What we would like to do is
       // to basically ignore displayOnlySelectedCases when computing the legend bins.
@@ -612,6 +641,19 @@ export const DataConfigurationModel = types
           // scaleQuantize maps out-of-domain values to the nearest range extreme automatically
           return scaleQuantize([effectiveMin, effectiveMax], self.choroplethColors)
         }
+        case "logarithmic": {
+          const { min: logMin, max: logMax } = this.legendLogDomain
+          const colors = self.choroplethColors
+          // Degenerate range -> single bin (threshold scale with no cut points, one color).
+          if (logMin == null || logMax == null) {
+            return scaleThreshold<number, string>().domain([]).range([colors[0]])
+          }
+          const n = colors.length // == legendBinCount
+          const ratio = logMax / logMin
+          // n-1 equal-ratio cut points: t_i = logMin * ratio^(i/n)
+          const thresholds = Array.from({ length: n - 1 }, (_, i) => logMin * Math.pow(ratio, (i + 1) / n))
+          return scaleThreshold<number, string>().domain(thresholds).range(colors)
+        }
         case "quantile":
         default: {
           const filtered = overrideMin == null && overrideMax == null
@@ -634,6 +676,9 @@ export const DataConfigurationModel = types
       },
 
       getLegendColorForNumericValue(value: number): string {
+        // A log scale is undefined for values <= 0; color them as missing rather than letting the
+        // threshold scale place them in the lowest bin.
+        if (self.legendIsLogarithmic && value <= 0) return missingColor
         return self.legendNumericColorScale(value)
       },
 

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -583,8 +583,15 @@ export const DataConfigurationModel = types
       if (overrideMin != null && overrideMin > 0) {
         min = overrideMin
       } else {
-        const positives = values.filter(v => v > 0 && v <= max)
-        min = positives.length ? Math.min(...positives) : undefined
+        // Find the smallest positive value in range with a single pass; a spread (Math.min(...values))
+        // would expand the whole array into call arguments and can overflow for large datasets.
+        let smallestPositive: number | undefined
+        for (const v of values) {
+          if (v > 0 && v <= max && (smallestPositive == null || v < smallestPositive)) {
+            smallestPositive = v
+          }
+        }
+        min = smallestPositive
       }
       if (min == null || min >= max) return {}
       return { min, max }

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -2,6 +2,7 @@ import { reaction } from "mobx"
 import {applyPatch, Instance, types} from "mobx-state-tree"
 import { DataSet, toCanonical } from "../../../models/data/data-set"
 import {DataSetMetadata} from "../../../models/shared/data-set-metadata"
+import { missingColor } from "../../../utilities/color-utils"
 import { kMain } from "../../data-display/data-display-types"
 import {GraphDataConfigurationModel, isGraphDataConfigurationModel} from "./graph-data-configuration-model"
 
@@ -637,5 +638,46 @@ describe("DataConfigurationModel legend range overrides", () => {
     // the reported count is an integer, matching the rendered color-ramp length
     expect(tree.config.legendBinCount).toBe(3)
     expect(tree.config.legendNumericColorScale.range().length).toBe(3)
+  })
+
+  it("builds a scaleThreshold with equal-ratio cut points in logarithmic mode", () => {
+    // legend values 0,10,20,40 from beforeEach; smallest positive is 10, max is 40
+    tree.metadata.setAttributeBinningType("legId", "logarithmic")
+    tree.metadata.setAttributeBinCount("legId", 2)
+    // 2 bins -> 1 threshold at the geometric midpoint of [10, 40] = 20
+    const thresholds = tree.config.legendNumericColorScale.domain()
+    expect(thresholds).toHaveLength(1)
+    expect(thresholds[0]).toBeCloseTo(20, 6)
+  })
+
+  it("floors the log domain to the smallest positive value (ignoring non-positive data)", () => {
+    tree.metadata.setAttributeBinningType("legId", "logarithmic")
+    // smallest positive value (10), not the data min (0), is the low endpoint
+    expect(tree.config.legendDisplayRange).toEqual({ min: 10, max: 40 })
+  })
+
+  it("ignores a Min override <= 0 in logarithmic mode but honors a positive Min and the Max", () => {
+    tree.metadata.setAttributeBinningType("legId", "logarithmic")
+    tree.metadata.setAttributeLegendMin("legId", -5)   // invalid for log -> ignored
+    expect(tree.config.legendDisplayRange.min).toBe(10) // falls back to smallest positive
+    tree.metadata.setAttributeLegendMin("legId", 5)     // positive override honored
+    tree.metadata.setAttributeLegendMax("legId", 30)
+    expect(tree.config.legendDisplayRange).toEqual({ min: 5, max: 30 })
+  })
+
+  it("colors non-positive values as missing in logarithmic mode", () => {
+    tree.metadata.setAttributeBinningType("legId", "logarithmic")
+    expect(tree.config.getLegendColorForNumericValue(-1)).toBe(missingColor)
+    expect(tree.config.getLegendColorForNumericValue(0)).toBe(missingColor)
+    // a positive value gets a real bin color, not the missing color
+    expect(tree.config.getLegendColorForNumericValue(15)).not.toBe(missingColor)
+  })
+
+  it("degenerates to a single bin when there are no positive values in range", () => {
+    tree.data.addCases(toCanonical(tree.data, [{ __id__: "c5", leg: -3 }]))
+    tree.metadata.setAttributeBinningType("legId", "logarithmic")
+    // override the max below the smallest positive so no positive value remains in range
+    tree.metadata.setAttributeLegendMax("legId", -1)
+    expect(tree.config.legendNumericColorScale.domain()).toHaveLength(0)
   })
 })

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -673,12 +673,26 @@ describe("DataConfigurationModel legend range overrides", () => {
     expect(tree.config.getLegendColorForNumericValue(15)).not.toBe(missingColor)
   })
 
-  it("degenerates to a single bin when there are no positive values in range", () => {
-    tree.data.addCases(toCanonical(tree.data, [{ __id__: "c5", leg: -3 }]))
+  it("falls back to the positive data extent when a logarithmic override range is reversed", () => {
     tree.metadata.setAttributeBinningType("legId", "logarithmic")
-    // override the max below the smallest positive so no positive value remains in range
-    tree.metadata.setAttributeLegendMax("legId", -1)
-    expect(tree.config.legendNumericColorScale.domain()).toHaveLength(0)
+    tree.metadata.setAttributeLegendMin("legId", 100)
+    tree.metadata.setAttributeLegendMax("legId", 40) // reversed (min >= max)
+    // rather than blanking the legend, fall back to the positive data extent [smallest positive, max]
+    expect(tree.config.legendDisplayRange).toEqual({ min: 10, max: 40 })
+  })
+
+  it("degenerates to a single bin when the data has no positive values", () => {
+    // build a dataset with only non-positive legend values (the honest degenerate condition)
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    t.data.addCases(toCanonical(t.data, [
+      { __id__: "n1", leg: 0 }, { __id__: "n2", leg: -3 }, { __id__: "n3", leg: -10 }
+    ]))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "logarithmic")
+    expect(t.config.legendNumericColorScale.domain()).toHaveLength(0)
   })
 
   it("excludes non-positive cases from the first bin when logarithmic", () => {

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -680,4 +680,20 @@ describe("DataConfigurationModel legend range overrides", () => {
     tree.metadata.setAttributeLegendMax("legId", -1)
     expect(tree.config.legendNumericColorScale.domain()).toHaveLength(0)
   })
+
+  it("excludes non-positive cases from the first bin when logarithmic", () => {
+    // a negative case (case ids are auto-generated, so assert on values rather than a literal id)
+    tree.data.addCases(toCanonical(tree.data, [{ leg: -7 }]))
+    tree.metadata.setAttributeBinningType("legId", "logarithmic")
+    const firstThreshold = tree.config.legendNumericColorScale.domain()[0]
+    const bin0Cases = tree.config.getCasesForLegendBin(0)
+    // every case in the first bin must be a positive value below the first threshold; the
+    // non-positive case (and the zero from beforeEach) must be excluded as "missing".
+    expect(bin0Cases.length).toBeGreaterThan(0)
+    bin0Cases.forEach(id => {
+      const v = tree.data.getNumeric(id, "legId")!
+      expect(v).toBeGreaterThan(0)
+      expect(v).toBeLessThan(firstThreshold)
+    })
+  })
 })

--- a/v3/src/models/shared/data-set-metadata.test.ts
+++ b/v3/src/models/shared/data-set-metadata.test.ts
@@ -218,6 +218,13 @@ describe("DataSetMetadata", () => {
     expect(tree.metadata.attributes.get("aId")?.deletedFormula).toBe("foo")
   })
 
+  it("round-trips a logarithmic binning type through the scale block", () => {
+    tree.metadata.setAttributeBinningType("aId", "logarithmic")
+    expect(tree.metadata.getAttributeBinningType("aId")).toBe("logarithmic")
+    const restored = DataSetMetadata.create(cloneDeep(getSnapshot(tree.metadata)))
+    expect(restored.getAttributeBinningType("aId")).toBe("logarithmic")
+  })
+
   it("stores legend range overrides per attribute", () => {
     // no override by default
     expect(tree.metadata.getAttributeLegendMin("aId")).toBeUndefined()

--- a/v3/src/models/shared/data-set-metadata.ts
+++ b/v3/src/models/shared/data-set-metadata.ts
@@ -95,7 +95,7 @@ const ColorRangeModel = types.model("ColorRangeModel", {
   }
 }))
 
-export const AttributeBinningTypes = ["quantize", "quantile"] as const
+export const AttributeBinningTypes = ["quantize", "quantile", "logarithmic"] as const
 export type AttributeBinningType = typeof AttributeBinningTypes[number]
 
 // This is an object so it can be expanded in the future to store

--- a/v3/src/utilities/math-utils.test.ts
+++ b/v3/src/utilities/math-utils.test.ts
@@ -2,6 +2,7 @@ import {FormatLocaleDefinition, format, formatLocale} from "d3-format"
 import {
   between,
   binBoundaryDecimalPlaces,
+  binBoundarySignificantFigures,
   checkNumber,
   chooseDecimalPlaces,
   extractNumeric,
@@ -188,6 +189,23 @@ describe("math-utils", () => {
 
     it("respects the maxDecimals cap", () => {
       expect(binBoundaryDecimalPlaces([0, 1e-30], 6)).toBe(6)
+    })
+  })
+
+  describe("binBoundarySignificantFigures", () => {
+    it("returns the minimum uniform significant figures that keep adjacent boundaries distinct", () => {
+      // ratio 10: 1 sig fig already distinguishes ("1", "1e+1", "1e+2")
+      expect(binBoundarySignificantFigures([1, 10, 100])).toBe(1)
+      // ratio 1.1: need 2 sig figs ("100","110","120") — 1 sig fig collapses all to "1e+2"
+      expect(binBoundarySignificantFigures([100, 110, 121])).toBe(2)
+    })
+
+    it("ignores genuinely-equal adjacent boundaries", () => {
+      expect(binBoundarySignificantFigures([5, 5, 10])).toBe(1)
+    })
+
+    it("respects the maxSigFigs cap", () => {
+      expect(binBoundarySignificantFigures([1, 1.0000000001], 4)).toBe(4)
     })
   })
 })

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -89,6 +89,26 @@ export function binBoundaryDecimalPlaces(boundaries: number[], maxDecimals = 12)
   return decimals
 }
 
+/**
+ * The significant-figures dual of `binBoundaryDecimalPlaces`. Log-spaced bin boundaries differ from
+ * their neighbor by a constant *ratio*, so a single uniform significant-figure count distinguishes
+ * every adjacent pair (just as a single decimal-place count does for the constant-*difference* linear
+ * case). Returns the minimum such count, ignoring genuinely-equal adjacent boundaries (no precision
+ * can separate them); `maxSigFigs` is a final safety bound. `toPrecision` requires at least 1
+ * significant figure, so the search starts at 1.
+ */
+export function binBoundarySignificantFigures(boundaries: number[], maxSigFigs = 12) {
+  const adjacentBoundariesDistinct = (sig: number) =>
+    boundaries.every((value, i) =>
+      i === 0 || value === boundaries[i - 1] ||
+        value.toPrecision(sig) !== boundaries[i - 1].toPrecision(sig))
+  let sigFigs = 1
+  while (sigFigs < maxSigFigs && !adjacentBoundariesDistinct(sigFigs)) {
+    sigFigs++
+  }
+  return sigFigs
+}
+
 export function isFiniteNumber(x: any): x is number {
   return x != null && Number.isFinite(x)
 }

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -1368,6 +1368,7 @@
     "V3.Inspector.graph.legendBins": "Legend Bins",
     "V3.Inspector.graph.legendBins.quantize": "Linear",
     "V3.Inspector.graph.legendBins.quantile": "Quantile",
+    "V3.Inspector.graph.legendBins.logarithmic": "Logarithmic",
     "V3.Inspector.graph.legendBinCount": "Number of Bins",
     "V3.Inspector.graph.legendRange": "Legend Range",
     "V3.Inspector.graph.legendRange.min": "Min",


### PR DESCRIPTION
## Summary

Adds **Logarithmic** as a third numeric-legend binning method, alongside the
existing **Linear** (`quantize`) and **Quantile** (`quantile`) methods, in both
the graph Format menu and the map Layers menu.

A logarithmic legend divides the legend range into **N equal-ratio bins** (equal
width in log space), where N is the existing **Number of Bins** control. The
choice persists per-attribute in legend metadata, so it saves with the document.

## Details

- **Equal-ratio bins**, not fixed decade boundaries: the data's range is divided
  into N equal-ratio bins via a d3 `scaleThreshold` with log-spaced cut points.
  (Fixed decade boundaries would make the Number of Bins control meaningless.)
- **Non-positive values** (≤ 0, undefined for a log scale) are colored as
  **missing** rather than clamped into the lowest bin, and excluded from the
  first bin's legend-click selection. The lowest bin's tooltip reads `>0 - t₁`
  rather than the misleading `< t₁`.
- **Log domain floor** is the smallest positive value in range. A Legend Range
  **Min override ≤ 0 is ignored** (falls back to the smallest positive); a
  positive Min and the Max override are honored.
- **Labels use uniform significant figures** (`binBoundarySignificantFigures`),
  the log-scale dual of the linear case's uniform decimal places — log boundaries
  differ by a constant ratio, so one sig-fig count distinguishes every adjacent
  pair.

V3-only: V2 export has no representation for a logarithmic binning type, so it is
dropped on a V2 save (consistent with the Legend Range / Bin Count features).

Fixes CODAP-1294

## Testing

- `binBoundarySignificantFigures` unit tests
- log color-scale construction, log-domain/override handling, non-positive →
  missing, and degenerate single-bin tests (data-configuration model)
- significant-figure label formatting + open-above-zero lowest-bin tooltip
  (choropleth legend)
- Logarithmic dropdown option commit (legend color controls)
- lint, tsc, and the full affected Jest suites pass (145 tests)
