### PR TITLE
CODAP-1403: Graph points respond appropriately to streamed data

### DIFF
--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -83,12 +83,13 @@ export interface IMatchCirclesProps {
   pointDisplayType?: PointDisplayType
   pointStrokeColor: string
   startAnimation: () => void
+  stopAnimation?: () => void
   instanceId: string | undefined
   renderer: PointRendererBase
 }
 
 export function matchCirclesToData(props: IMatchCirclesProps) {
-  const { dataConfiguration, renderer, startAnimation, pointRadius, pointColor, pointStrokeColor,
+  const { dataConfiguration, renderer, startAnimation, stopAnimation, pointRadius, pointColor, pointStrokeColor,
           pointDisplayType = "points" } = props
   // TODO: eliminate dependence on GraphDataConfigurationModel
   const allCaseData: CaseDataWithSubPlot[] = isGraphDataConfigurationModel(dataConfiguration)
@@ -98,6 +99,10 @@ export function matchCirclesToData(props: IMatchCirclesProps) {
   // Skip animation when filter formula results were just recalculated (e.g., slider value changed),
   // so points/bars update instantly instead of animating in/out.
   if (dataConfiguration.suppressAnimation) {
+    // Actively stop any in-flight animation (its 2s timer may have been armed earlier, e.g. during
+    // initial plot setup, and outlive a fast streaming burst). Skipping startAnimation alone leaves
+    // that timer running, so point refreshes still get duration>0 transitions and freeze.
+    stopAnimation?.()
     dataConfiguration.setSuppressAnimation(false)
   } else {
     startAnimation()

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -83,7 +83,7 @@ export interface IMatchCirclesProps {
   pointDisplayType?: PointDisplayType
   pointStrokeColor: string
   startAnimation: () => void
-  stopAnimation?: () => void
+  stopAnimation: () => void
   instanceId: string | undefined
   renderer: PointRendererBase
 }
@@ -102,7 +102,7 @@ export function matchCirclesToData(props: IMatchCirclesProps) {
     // Actively stop any in-flight animation (its 2s timer may have been armed earlier, e.g. during
     // initial plot setup, and outlive a fast streaming burst). Skipping startAnimation alone leaves
     // that timer running, so point refreshes still get duration>0 transitions and freeze.
-    stopAnimation?.()
+    stopAnimation()
     dataConfiguration.setSuppressAnimation(false)
   } else {
     startAnimation()

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -881,8 +881,9 @@ export const DataConfigurationModel = types
         // rather than animating. This is essential while data streams in (e.g. one case at a
         // time via a plugin): otherwise each added case restarts a fresh transition every frame,
         // and because the transition clock resets each time, existing points never advance toward
-        // their new positions until streaming stops. matchCirclesToData consumes this flag to skip
-        // startAnimation. (See updateFilterFormulaResults for the analogous slider/filter case.)
+        // their new positions until streaming stops. matchCirclesToData consumes this flag to stop
+        // any in-flight animation and skip startAnimation. (See updateFilterFormulaResults for the
+        // analogous slider/filter case.)
         self.suppressAnimation = true
         this.invalidateCases()
       }

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -877,6 +877,13 @@ export const DataConfigurationModel = types
       // addCases and removeCases don't currently self-invalidate, so we have to do it here.
       const cacheClearingActions = ["addCases", "removeCases"]
       if (cacheClearingActions.includes(actionCall.name)) {
+        // Suppress animation when cases are added or removed so points/bars update instantly
+        // rather than animating. This is essential while data streams in (e.g. one case at a
+        // time via a plugin): otherwise each added case restarts a fresh transition every frame,
+        // and because the transition clock resets each time, existing points never advance toward
+        // their new positions until streaming stops. matchCirclesToData consumes this flag to skip
+        // startAnimation. (See updateFilterFormulaResults for the analogous slider/filter case.)
+        self.suppressAnimation = true
         this.invalidateCases()
       }
       // forward all actions from dataset except "setCaseValues" which requires intervention

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -103,6 +103,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
   const { refreshPointPositions, refreshPointSelection, renderer} = props,
     graphModel = useGraphContentModelContext(),
     startAnimation = graphModel.startAnimation,
+    stopAnimation = graphModel.stopAnimation,
     layout = useGraphLayoutContext(),
     dataConfiguration = graphModel.dataConfiguration,
     legendAttrID = dataConfiguration?.attributeID("legend"),
@@ -145,10 +146,10 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
         pointDisplayType: graphModel.plot.displayType,
         pointStrokeColor: graphModel.pointDescription.pointStrokeColor,
         renderer,
-        startAnimation, instanceId
+        startAnimation, stopAnimation, instanceId
       })
     }
-  }, [dataConfiguration, graphModel, instanceId, renderer, startAnimation])
+  }, [dataConfiguration, graphModel, instanceId, renderer, startAnimation, stopAnimation])
 
   // Track the previous renderer to detect actual renderer changes
   const prevRendererRef = useRef<typeof renderer>(undefined)

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -74,10 +74,11 @@ export class GraphController {
         {pointColor, pointStrokeColor} = graphModel.pointDescription,
         pointRadius = graphModel.getPointRadius(),
         pointDisplayType = graphModel.plot.displayType,
-        startAnimation = graphModel.startAnimation
+        startAnimation = graphModel.startAnimation,
+        stopAnimation = graphModel.stopAnimation
       dataConfiguration && matchCirclesToData({
         dataConfiguration, renderer, pointDisplayType,
-        pointRadius, startAnimation, instanceId, pointColor, pointStrokeColor
+        pointRadius, startAnimation, stopAnimation, instanceId, pointColor, pointStrokeColor
       })
     }
   }

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -3,6 +3,7 @@ import {applyPatch, Instance, types} from "mobx-state-tree"
 import { DataSet, toCanonical } from "../../../models/data/data-set"
 import {DataSetMetadata} from "../../../models/shared/data-set-metadata"
 import { kMain } from "../../data-display/data-display-types"
+import { matchCirclesToData } from "../../data-display/data-display-utils"
 import {GraphDataConfigurationModel, isGraphDataConfigurationModel} from "./graph-data-configuration-model"
 
 const TreeModel = types.model("Tree", {
@@ -263,6 +264,55 @@ describe("DataConfigurationModel", () => {
       { __id__: caseIdFromItemId("c3")!, xId: 3.3 }
     ])
     expect(handleAction).toHaveBeenCalled()
+  })
+
+  it("suppresses animation when cases are added or removed", () => {
+    // Streaming cases in (e.g. via a plugin) must not animate existing points: each added case
+    // would otherwise restart a transition every frame, freezing points until streaming stops.
+    // matchCirclesToData consumes this flag to skip startAnimation so points snap to position.
+    const config = tree.config
+    config.setDataset(tree.data, tree.metadata)
+    config.setAttribute("x", { attributeID: "xId" })
+
+    expect(config.suppressAnimation).toBe(false)
+
+    tree.data.addCases(toCanonical(tree.data, [{ __id__: "c4", n: "n1", x: 4, y: 4 }]))
+    expect(config.suppressAnimation).toBe(true)
+
+    config.setSuppressAnimation(false)
+    tree.data.removeCases(["c4"])
+    expect(config.suppressAnimation).toBe(true)
+  })
+
+  it("matchCirclesToData stops in-flight animation (not just skips starting) when suppressed", () => {
+    // When cases stream in, an animation timer armed earlier (e.g. during initial plot setup) can
+    // still be running. Merely skipping startAnimation isn't enough — the points would keep getting
+    // duration>0 transitions and freeze. Suppression must actively stop the in-flight animation so
+    // the ensuing point refresh snaps (duration 0).
+    const config = tree.config
+    config.setDataset(tree.data, tree.metadata)
+    const startAnimation = jest.fn()
+    const stopAnimation = jest.fn()
+    const renderer = { matchPointsToData: jest.fn() } as any
+
+    // Not suppressed: starts animation, does not stop it.
+    matchCirclesToData({
+      dataConfiguration: config, renderer, pointRadius: 5,
+      pointColor: "#000", pointStrokeColor: "#000", startAnimation, stopAnimation, instanceId: "test"
+    })
+    expect(startAnimation).toHaveBeenCalledTimes(1)
+    expect(stopAnimation).not.toHaveBeenCalled()
+
+    // Suppressed: stops the in-flight animation and does NOT start a new one; flag is consumed.
+    startAnimation.mockClear()
+    config.setSuppressAnimation(true)
+    matchCirclesToData({
+      dataConfiguration: config, renderer, pointRadius: 5,
+      pointColor: "#000", pointStrokeColor: "#000", startAnimation, stopAnimation, instanceId: "test"
+    })
+    expect(startAnimation).not.toHaveBeenCalled()
+    expect(stopAnimation).toHaveBeenCalledTimes(1)
+    expect(config.suppressAnimation).toBe(false)
   })
 
   it("only allows x and y as primary place", () => {

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -283,8 +283,8 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
         renderer,
         pointRadius: mapLayerModel.getPointRadius(),
         instanceId: dataConfiguration.id,
-        pointColor: pointDescription?.pointColor,
-        pointStrokeColor: pointDescription?.pointStrokeColor,
+        pointColor: pointDescription.pointColor,
+        pointStrokeColor: pointDescription.pointStrokeColor,
         startAnimation: mapModel.startAnimation,
         stopAnimation: mapModel.stopAnimation
       })

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -285,10 +285,12 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
         instanceId: dataConfiguration.id,
         pointColor: pointDescription?.pointColor,
         pointStrokeColor: pointDescription?.pointStrokeColor,
-        startAnimation: mapModel.startAnimation
+        startAnimation: mapModel.startAnimation,
+        stopAnimation: mapModel.stopAnimation
       })
     }
-  }, [dataConfiguration, layout, mapLayerModel, mapModel.startAnimation, pointDescription, renderer])
+  }, [dataConfiguration, layout, mapLayerModel, mapModel.startAnimation, mapModel.stopAnimation,
+      pointDescription, renderer])
 
   const refreshPointSelection = useCallback(() => {
     const {pointColor, pointStrokeColor} = pointDescription,


### PR DESCRIPTION
## Summary

Fixes CODAP-1403.

When data is added incrementally to a scatter plot (e.g. one case at a time from a plugin such as Simmer), previously rendered points failed to track the expanding axis — they piled up near the right edge and only animated to their correct positions once streaming stopped. Connecting lines tracked correctly throughout (separate render path).

## Root cause

During a streaming burst the display's animation timer (`animationTimerId`, ~2s) is armed during initial plot setup and, because the whole burst completes within that window, never expires. `setPointCoordinates` therefore reads `isAnimating() === true` and gives every per-frame point refresh a 1000ms transition. Because a fresh transition is constructed each frame (its clock resetting to 0), the points never advance toward their targets until streaming stops.

## Fix

Treat "suppress animation" as "stop the in-flight animation," not merely "don't start one":

- `handleDataSetAction` sets `suppressAnimation` on `addCases`/`removeCases` (the existing slider/filter mechanism).
- `matchCirclesToData`, when suppressed, now calls `stopAnimation()` to clear the lingering timer, so streamed point refreshes use `duration: 0` and track the scale in real time.
- `stopAnimation` threaded through the graph (`use-plot`, `graph-controller`) and map (`map-point-layer`) callers.

## Testing

- 2 new TDD unit tests (suppress-on-add/remove; `matchCirclesToData` stops the in-flight animation when suppressed).
- 1054 data-display/graph/map Jest tests pass; tsc + lint clean.
- Verified in-app with a streaming plugin (per-refresh transition duration flips 1000 → 0; points track the axis live, no end-of-stream snap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
