### PR TITLE
CODAP-1385: numeric legend transparency interpolates across quintiles

### DIFF
--- a/v3/src/components/map/components/map-polygon-layer.tsx
+++ b/v3/src/components/map/components/map-polygon-layer.tsx
@@ -246,6 +246,18 @@ export const MapPolygonLayer = function MapPolygonLayer(props: {
     )
   }, [refreshPolygonStyles, mapLayerModel])
 
+  // The numeric-legend gradient (low/high colors set via the Layers palette) is observed by the
+  // legend itself but not by the polygon fills, so dragging the color/transparency slider would
+  // update the legend bar without refilling the polygons until a pan/zoom/resize forced a redraw.
+  useEffect(function respondToLegendColorRangeChange() {
+    return mstReaction(
+      () => dataConfiguration.choroplethColors,
+      () => refreshPolygonStyles(),
+      {name: "MapPolygonLayer.respondToLegendColorRangeChange", equals: comparer.structural},
+      dataConfiguration
+    )
+  }, [dataConfiguration, refreshPolygonStyles])
+
   // Clean up Leaflet features when model is destroyed or component unmounts
   useEffect(function cleanupOnUnmount() {
     const cleanup = () => {

--- a/v3/src/utilities/color-utils.test.ts
+++ b/v3/src/utilities/color-utils.test.ts
@@ -1,4 +1,4 @@
-import { parseColor, parseColorToHex } from "./color-utils"
+import { getChoroplethColors, interpolateColors, parseColor, parseColorToHex } from "./color-utils"
 
 describe("Color utilities", () => {
   it("parseColor works as expected without color names", () => {
@@ -117,5 +117,36 @@ describe("Color utilities", () => {
     expect(parseColorToHex("hsl(100, 50%, 50%, 0.5)", { colorNames: true })).toBe("#6abf4080")
     // projects out-of-range hue to valid range
     expect(parseColorToHex("hsl(460, 50%, 50%)", { colorNames: true })).toBe("#6abf40")
+  })
+
+  it("interpolateColors interpolates RGB and alpha", () => {
+    // RGB interpolation between two opaque colors
+    expect(interpolateColors("#000000", "#ffffff", 0)).toBe("#000000")
+    expect(interpolateColors("#000000", "#ffffff", 1)).toBe("#ffffff")
+    expect(interpolateColors("#000000", "#ffffff", 0.5)).toBe("#808080")
+
+    // Opaque endpoints stay opaque (no 8-digit hex suffix introduced)
+    expect(interpolateColors("#ff0000", "#0000ff", 0.5)).toBe("#800080")
+
+    // Alpha interpolates linearly alongside RGB (CODAP-1385)
+    // fully opaque -> fully transparent at midpoint = 50% alpha
+    expect(interpolateColors("#ff0000ff", "#ff000000", 0.5)).toBe("#ff000080")
+    // both endpoints transparent: midpoint alpha lies between them
+    expect(interpolateColors("#ff000000", "#ff0000ff", 0.25)).toBe("#ff000040")
+    // alpha-only difference is preserved at the endpoints
+    expect(interpolateColors("#ff0000ff", "#ff000000", 0)).toBe("#ff0000")
+    expect(interpolateColors("#ff0000ff", "#ff000000", 1)).toBe("#ff000000")
+  })
+
+  it("getChoroplethColors propagates alpha across all five stops", () => {
+    // With opaque endpoints, every stop is opaque (6-digit hex)
+    const opaque = getChoroplethColors("#000000", "#ffffff")
+    expect(opaque).toHaveLength(5)
+    opaque.forEach(c => expect(c).toMatch(/^#[0-9a-f]{6}$/))
+
+    // CODAP-1385: when an endpoint has transparency, alpha must interpolate across stops
+    // rather than only changing the endpoint quintile.
+    const fading = getChoroplethColors("#ff0000ff", "#ff000000")
+    expect(fading).toEqual(["#ff0000ff", "#ff0000bf", "#ff000080", "#ff000040", "#ff000000"])
   })
 })

--- a/v3/src/utilities/color-utils.ts
+++ b/v3/src/utilities/color-utils.ts
@@ -132,17 +132,16 @@ export function tinycolor(color: string) {
   return new TinyColor(color)
 }
 
-// Returns a color that is between color1 and color2
+// Returns a color that is between color1 and color2. Alpha is interpolated alongside RGB so
+// numeric legend gradients fade smoothly when an endpoint has transparency (CODAP-1385).
 export function interpolateColors(color1: string, color2: string, percentage: number) {
   const rgb1 = colord(color1).toRgb()
   const rgb2 = colord(color2).toRgb()
-  const rRange = rgb2.r - rgb1.r
-  const gRange = rgb2.g - rgb1.g
-  const bRange = rgb2.b - rgb1.b
-  const r = rgb1.r + percentage * rRange
-  const g = rgb1.g + percentage * gRange
-  const b = rgb1.b + percentage * bRange
-  return colord({ r, g, b }).toHex()
+  const r = rgb1.r + percentage * (rgb2.r - rgb1.r)
+  const g = rgb1.g + percentage * (rgb2.g - rgb1.g)
+  const b = rgb1.b + percentage * (rgb2.b - rgb1.b)
+  const a = rgb1.a + percentage * (rgb2.a - rgb1.a)
+  return colord({ r, g, b, a }).toHex()
 }
 
 // Create a very light, low-saturation version of a base color. The defaults are used for default color ranges.


### PR DESCRIPTION
## Summary
- `interpolateColors` now carries the alpha channel through, so the five-stop gradient used by numeric legends (graph and map) fades transparency smoothly between the low and high colors instead of clamping every interior stop to fully opaque. Closes the original repro from CODAP-1385.
- `MapPolygonLayer` now observes `dataConfiguration.choroplethColors` and refreshes polygon styles when the gradient changes, so polygons refill live while the user drags the color/transparency sliders (previously only the legend bar updated; polygons lagged until a pan/zoom/resize).
- Added unit tests for `interpolateColors` and `getChoroplethColors` covering both the opaque and alpha-fading cases.

Fixes CODAP-1385.

## Test plan
- [ ] Open `Problem controlling numeric legend transparency.codap` (attached to CODAP-1385).
- [ ] Map → Layers → click rightmost States legend color → More → drag the transparency slider. All five legend quintiles should fade together, and the map polygons should refill in sync.
- [ ] Repeat on the graph's numeric legend — the gradient should fade smoothly across all five stops.
- [ ] Verify the existing point/heatmap dynamic update and the graph's dynamic legend update still work.