### PR TITLE
CODAP-1412: Fix map connecting lines for off-screen points

### DIFF
--- a/v3/src/components/map/utilities/map-utils.test.ts
+++ b/v3/src/components/map/utilities/map-utils.test.ts
@@ -144,6 +144,20 @@ describe("shiftLongitudeIntoView", () => {
     expect(shiftLongitudeIntoView(-50, -180, 180)).toBe(-50)
   })
 
+  it("leaves a point just outside a normal viewport at its nearest world copy (CODAP-1412)", () => {
+    // Regression: a point a fraction of a degree outside a narrow, non-dateline viewport must NOT be
+    // flung a whole 360° away (which projected it to ~±infinity pixels and broke connecting lines).
+    expect(shiftLongitudeIntoView(14.97, 13, 14.8)).toBeCloseTo(14.97)   // just east of east bound
+    expect(shiftLongitudeIntoView(12.5, 13, 14.8)).toBeCloseTo(12.5)     // just west of west bound
+  })
+
+  it("keeps a point far outside a normal viewport at its true longitude (CODAP-1412)", () => {
+    // The point stays in the same world copy as the viewport, so a connecting line to it heads off
+    // in the correct direction (off the near edge) rather than being clamped or wrapped to the far side.
+    expect(shiftLongitudeIntoView(30, 13, 14.8)).toBe(30)     // far east — line should exit the east edge
+    expect(shiftLongitudeIntoView(-10, 13, 14.8)).toBe(-10)   // far west — line should exit the west edge
+  })
+
   it("shifts a negative-canonical longitude into a dateline-crossing viewport", () => {
     // Viewport showing the Russia + Hawaii cluster crossing the dateline.
     // Canonical -159° belongs in the next world copy of this viewport.
@@ -170,7 +184,8 @@ describe("shiftLongitudeIntoView", () => {
   it("applies multiple rotations when a single 360° shift is not enough", () => {
     // A point at -500° is two full rotations west of the viewport.
     expect(shiftLongitudeIntoView(-500, 175, 201)).toBe(220)
-    // And a point at +700° is three rotations east (700 - 3×360 = -380).
-    expect(shiftLongitudeIntoView(700, -185, -159)).toBe(-380)
+    // A point at +700° lands at its nearest world copy of the viewport: 700 - 2×360 = -20
+    // (139° from the viewport), which is closer than the next copy at -380 (195° away).
+    expect(shiftLongitudeIntoView(700, -185, -159)).toBe(-20)
   })
 })

--- a/v3/src/components/map/utilities/map-utils.test.ts
+++ b/v3/src/components/map/utilities/map-utils.test.ts
@@ -144,6 +144,13 @@ describe("shiftLongitudeIntoView", () => {
     expect(shiftLongitudeIntoView(-50, -180, 180)).toBe(-50)
   })
 
+  it("leaves the antimeridian endpoints unshifted in a whole-world view (no dateline split)", () => {
+    // [-180, 180] spans exactly 360°: rounding (center - lng)/360 would tie at lng = -180 and shift
+    // it to 180, jumping a dateline-crossing connecting line across the whole map. Endpoints stay put.
+    expect(shiftLongitudeIntoView(-180, -180, 180)).toBe(-180)
+    expect(shiftLongitudeIntoView(180, -180, 180)).toBe(180)
+  })
+
   it("leaves a point just outside a normal viewport at its nearest world copy (CODAP-1412)", () => {
     // Regression: a point a fraction of a degree outside a narrow, non-dateline viewport must NOT be
     // flung a whole 360° away (which projected it to ~±infinity pixels and broke connecting lines).

--- a/v3/src/components/map/utilities/map-utils.ts
+++ b/v3/src/components/map/utilities/map-utils.ts
@@ -88,6 +88,10 @@ export const getRationalLongitudeBounds = (longs: number[]) => {
  * from the raw, unshifted longitude.
  */
 export const shiftLongitudeIntoView = (lng: number, west: number, east: number) => {
+  // A longitude already in view never needs shifting. This also avoids a tie at the
+  // antimeridian: in a whole-world view [-180, 180] the rounding below would otherwise
+  // map -180 to 180 (Math.round(0.5) === 1) and split lines crossing the dateline.
+  if (lng >= west && lng <= east) return lng
   const center = (west + east) / 2
   return lng + Math.round((center - lng) / 360) * 360
 }

--- a/v3/src/components/map/utilities/map-utils.ts
+++ b/v3/src/components/map/utilities/map-utils.ts
@@ -73,15 +73,23 @@ export const getRationalLongitudeBounds = (longs: number[]) => {
 }
 
 /**
- * Shifts a longitude into the [west, east] viewport by adding or subtracting
- * whole rotations of 360°, mirroring CODAP V2's behavior. This lets a point at
- * a canonical longitude render inside a dateline-crossing map view (where the
- * viewport's east bound may exceed 180°).
+ * Shifts a longitude to the 360° world copy nearest the [west, east] viewport.
+ * This lets a point at a canonical longitude render inside a dateline-crossing
+ * map view (where the viewport's east bound may exceed 180°): the nearest copy is
+ * the one inside the viewport when the point is reachable, otherwise the closest
+ * copy, so the point renders just off-screen rather than a full turn away.
+ *
+ * Must pick the *nearest* copy, not the first copy inside the bounds. CODAP-1384
+ * introduced a Math.ceil version (modeled on V2's point projection) and applied it
+ * to connecting-line coordinates too — but a point a fraction of a degree outside a
+ * normal viewport was flung a whole 360° away, projecting to ~±infinity pixels and
+ * mangling the lines (CODAP-1412). V2 itself avoided this: it shifted only point
+ * circles (where an off-screen point is invisible anyway) and drew connecting lines
+ * from the raw, unshifted longitude.
  */
 export const shiftLongitudeIntoView = (lng: number, west: number, east: number) => {
-  if (lng < west) return lng + Math.ceil((west - lng) / 360) * 360
-  if (lng > east) return lng - Math.ceil((lng - east) / 360) * 360
-  return lng
+  const center = (west + east) / 2
+  return lng + Math.round((center - lng) / 360) * 360
 }
 
 /**


### PR DESCRIPTION
## Summary

Map connecting lines rendered as garbage — shooting off toward ±infinity — when a point was panned or zoomed out of the visible map area ([reported by Dan Damelin](https://concord-consortium.atlassian.net/browse/CODAP-1412); repro: the sea-turtle track document).

Root cause is a regression from #2618 (CODAP-1384). That PR introduced `shiftLongitudeIntoView` and, mirroring V2's *point* projection, applied a `Math.ceil` longitude shift — but it also applied it to **connecting-line** coordinates, which V2 never did. `Math.ceil` rounds the number of 360° rotations *up to a whole turn*, so a point only slightly outside the viewport — which needs essentially no shift — was instead moved a full 360° to the **opposite** side of the world (raw `long 14.97` → `shiftedLong −345` → container pixel `x = −169087`). The connecting line then ran clear across the map and exited the wrong edge.

## Fix

Shift to the **nearest** 360° world copy of the viewport instead of forcing the point inside it:

```ts
const center = (west + east) / 2
return lng + Math.round((center - lng) / 360) * 360
```

This is a no-op for a normal viewport (`k = 0`, raw longitude) and still brings reachable points into a date-line-crossing view.

## V2 vs V3 behavior

The author's "consistent with V2" assumption was understandable — V2 never *showed* the bug — but it only held for points. This matrix shows why:

| Scenario | V2 (master) | V3 before #2618 | V3 after #2618 | V3 with this fix |
|---|---|---|---|---|
| **Point** off-screen, normal view | ✅ flung to far copy, but off-screen = invisible | ✅ raw longitude, off-screen = invisible | ✅ flung, off-screen = invisible | ✅ true longitude, off-screen = invisible |
| **Point** across the date line | ✅ `ceil` shift brings it into view | ❌ raw longitude → misplaced (Rescale dropped it; the bug #2618 fixed) | ✅ `ceil` shift brings it into view | ✅ nearest-copy shift brings it into view |
| **Connecting line** to off-screen point, normal view | ✅ raw longitude → exits correct edge | ✅ raw longitude → exits correct edge | ❌ **endpoint flung 360° → line shoots to wrong side (CODAP-1412)** | ✅ `k=0` (raw) → exits correct edge |
| **Connecting line** across the date line | ❌ raw longitude → line shoots ~360° off (latent V2 bug) | ❌ raw longitude → line shoots ~360° off | ✅ shift brings endpoint to nearest copy | ✅ nearest-copy shift |

Net: the fix makes V3 connecting lines correct on **both** the normal-viewport and date-line axes — the date-line line case being the one V2 itself got wrong.

## Test plan

- [x] `npm test -- src/components/map` — 102 pass (25 in `map-utils`), incl. new regression + far-point tests; updated the one existing test that had encoded the old overshoot.
- [x] `npm run lint`, `npm run build:tsc` clean
- [x] Manual: sea-turtle doc — connecting lines now clip cleanly to the map edge when points are panned/zoomed out of view (verified via projection logging that `shiftedLong` stays sane)
- [ ] CI green
- [ ] Cypress regression (`run regression`)

Fixes CODAP-1412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

