### PR TITLE
CODAP-1409: Numeric legend tweaks — out-of-range → missing, degenerate quantile binning

### DIFF
--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
@@ -189,6 +189,20 @@ describe("choroplethLegend", () => {
     expect(tooltips).toEqual(["1", "2", "3"])
   })
 
+  it("uses the bin index (not color lookup) so duplicate colors map to the right bin", () => {
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
+    // all bins share one color (lowColor === highColor); indexOf(color) would return 0 for every rect
+    const scale = scaleThreshold<number, string>().domain([2, 3]).range(["#x", "#x", "#x"])
+    choroplethLegend(scale, g, {
+      width: 400, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
+      legendMin: 1, legendMax: 3,
+      binDataExtents: [{ min: 1, max: 1 }, { min: 2, max: 2 }, { min: 3, max: 3 }],
+      clickHandler: () => undefined, casesInBinSelectedHandler: () => false
+    })
+    const tooltips = Array.from(g.querySelectorAll("title")).map(t => t.textContent)
+    expect(tooltips).toEqual(["1", "2", "3"]) // not ["1", "1", "1"]
+  })
+
   it("labels a multi-value degenerate bin as a range", () => {
     const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
     // {1}{2,3}{4,5}: thresholds at [2, 4]

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
@@ -192,7 +192,7 @@ describe("choroplethLegend", () => {
   it("uses the bin index (not color lookup) so duplicate colors map to the right bin", () => {
     const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
     // all bins share one color (lowColor === highColor); indexOf(color) would return 0 for every rect
-    const scale = scaleThreshold<number, string>().domain([2, 3]).range(["#x", "#x", "#x"])
+    const scale = scaleThreshold<number, string>().domain([2, 3]).range(["#aaa", "#aaa", "#aaa"])
     choroplethLegend(scale, g, {
       width: 400, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
       legendMin: 1, legendMax: 3,

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
@@ -173,5 +173,34 @@ describe("choroplethLegend", () => {
     expect(narrow.tickMarkCount).toBe(0)
     expect(narrow.hasAxisDomain).toBe(false)
   })
+
+  it("labels degenerate bins from per-bin data extents", () => {
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
+    // three single-value bins {1}{2}{3}: thresholds at the group mins [2, 3]
+    const scale = scaleThreshold<number, string>().domain([2, 3]).range(colors.slice(0, 3))
+    choroplethLegend(scale, g, {
+      width: 400, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
+      legendMin: 1, legendMax: 3,
+      binDataExtents: [{ min: 1, max: 1 }, { min: 2, max: 2 }, { min: 3, max: 3 }],
+      clickHandler: () => undefined, casesInBinSelectedHandler: () => false
+    })
+    const tooltips = Array.from(g.querySelectorAll("title")).map(t => t.textContent)
+    // single-value bins read as a bare value, not a "1 - 1" range
+    expect(tooltips).toEqual(["1", "2", "3"])
+  })
+
+  it("labels a multi-value degenerate bin as a range", () => {
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
+    // {1}{2,3}{4,5}: thresholds at [2, 4]
+    const scale = scaleThreshold<number, string>().domain([2, 4]).range(colors.slice(0, 3))
+    choroplethLegend(scale, g, {
+      width: 400, marginLeft: 6, marginRight: 6, marginTop: 20, ticks: 5,
+      legendMin: 1, legendMax: 5,
+      binDataExtents: [{ min: 1, max: 1 }, { min: 2, max: 3 }, { min: 4, max: 5 }],
+      clickHandler: () => undefined, casesInBinSelectedHandler: () => false
+    })
+    const tooltips = Array.from(g.querySelectorAll("title")).map(t => t.textContent)
+    expect(tooltips).toEqual(["1", "2 - 3", "4 - 5"])
+  })
 })
 /* eslint-enable testing-library/render-result-naming-convention */

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.test.ts
@@ -37,22 +37,19 @@ describe("choroplethLegend", () => {
   })
 
   it("formats bin tooltips with enough precision for a narrow range", () => {
-    // The first and last bins are open-ended ("< t1" / "≥ t_last"): the bins are half-open
-    // [binMin, binMax) and scaleQuantize/scaleQuantile clamp out-of-range values into the ends, so
-    // the first bin covers everything below t1 and the last everything at-or-above t_last, not just
-    // [min, max]. (Matters when the legend range is narrowed; see CODAP-1292.)
+    // Every bin (including the first and last) is shown as a plain [low - high] range. Out-of-range
+    // values are now treated as missing rather than clamped into the end bins (CODAP-1409), so the
+    // end bins cover only [min, t1] and [t_last, max].
     const { tooltips } = renderLegend([100, 110], 400)
     expect(tooltips).toEqual([
-      "< 102", "102 - 104", "104 - 106", "106 - 108", "≥ 108"
+      "100 - 102", "102 - 104", "104 - 106", "106 - 108", "108 - 110"
     ])
   })
 
-  it("always shows the first and last bin tooltips as open-ended", () => {
-    // Even when the legend range equals the data extent, the end bins clamp out-of-range values,
-    // so '<'/'≥' describe their true coverage. The actual min/max remain visible as endpoint labels.
+  it("shows the first and last bin tooltips as plain ranges bounded by the legend min/max", () => {
     const { tooltips } = renderLegend([0, 10], 400)
-    expect(tooltips[0]).toBe("< 2")
-    expect(tooltips[tooltips.length - 1]).toBe("≥ 8")
+    expect(tooltips[0]).toBe("0 - 2")
+    expect(tooltips[tooltips.length - 1]).toBe("8 - 10")
   })
 
   it("renders endpoint labels with an explicit fill so they are visible alongside axis ticks", () => {
@@ -101,7 +98,7 @@ describe("choroplethLegend", () => {
     const { tickLabels, endpointLabels, tooltips } = renderLegend([0, 10000], 500, true)
     expect(tickLabels).toEqual(["2,000", "4,000", "6,000", "8,000"])
     expect(endpointLabels.map(t => t.textContent)).toEqual(["0", "10,000"])
-    expect(tooltips[tooltips.length - 1]).toBe("≥ 8,000") // last bin is open-ended
+    expect(tooltips[tooltips.length - 1]).toBe("8,000 - 10,000") // plain range, grouped
   })
 
   it("suppresses thousands grouping for year-like values when grouping is disabled", () => {
@@ -149,7 +146,7 @@ describe("choroplethLegend", () => {
     expect(endpoints).toEqual(["100", "10000"])
   })
 
-  it("labels the lowest log bin as open-above-zero so missing non-positive values aren't implied", () => {
+  it("shows logarithmic bin tooltips as plain ranges bounded by the log domain", () => {
     const g = document.createElementNS("http://www.w3.org/2000/svg", "g")
     const logMin = 100, logMax = 10000, n = 4
     const thresholds = Array.from({ length: n - 1 }, (_, i) => logMin * Math.pow(logMax / logMin, (i + 1) / n))
@@ -160,10 +157,10 @@ describe("choroplethLegend", () => {
       clickHandler: () => undefined, casesInBinSelectedHandler: () => false
     })
     const tooltips = Array.from(g.querySelectorAll("title")).map(t => t.textContent)
-    // First bin is open above zero (values <= 0 are missing, not in the bin), not "< 300".
-    expect(tooltips[0]).toBe(">0 - 300")
-    // The top bin stays open-ended upward (above-max positives still clamp into it).
-    expect(tooltips[tooltips.length - 1]).toBe("≥ 3000")
+    // Out-of-domain values (including <= 0) are missing, so the end bins are plain ranges bounded by
+    // the positive log domain.
+    expect(tooltips[0]).toBe("100 - 300")
+    expect(tooltips[tooltips.length - 1]).toBe("3000 - 10000")
   })
 
   it("renders interior tick labels without any tick marks (matching the markless narrow case)", () => {

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -39,6 +39,10 @@ export type ChoroplethLegendProps = {
   // override the domain-derived endpoints so the legend matches the range the user set (CODAP-1292).
   legendMin?: number,
   legendMax?: number,
+  // Per-bin data extents (min..max of the values in each bin). Provided only for the degenerate
+  // quantile case, where bins are labeled from the data: a single value when min === max (e.g.
+  // "1"), else a range ("2 - 3"). When absent, bin tooltips use the threshold-derived boundaries.
+  binDataExtents?: Array<{ min: number, max: number }>,
   clickHandler: (bin: number, extend: boolean) => void,
   casesInBinSelectedHandler: (bin: number) => boolean
 }
@@ -74,7 +78,7 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
   const {
       isDate, useGrouping = false, logarithmic = false, transform = '', width = 320,
       marginTop = 0, marginRight = 0, marginLeft = 0,
-      ticks = 5, legendMin, legendMax, clickHandler, casesInBinSelectedHandler
+      ticks = 5, legendMin, legendMax, binDataExtents, clickHandler, casesInBinSelectedHandler
     } = props,
     // Prefer the caller-provided effective range; fall back to the scale domain's extent (a quantile
     // scale's domain is its training samples, so its extent can differ from the user-set range).
@@ -150,6 +154,14 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     .append('title')
     .text((color) => {
       const bin = scale.range().indexOf(color)
+      // Degenerate quantile bins are labeled from their data: a single value when min === max
+      // (e.g. "1"), else a range ("2 - 3").
+      const extent = binDataExtents?.[bin]
+      if (extent) {
+        return extent.min === extent.max
+          ? formatBoundary(extent.min)
+          : `${formatBoundary(extent.min)} - ${formatBoundary(extent.max)}`
+      }
       // Every bin is a plain [low - high] range. Out-of-range values (and <= 0 in logarithmic mode)
       // are treated as missing rather than clamped into the end bins, so the first and last bins are
       // bounded by the legend's min/max like any interior bin.

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -21,11 +21,11 @@ export type ChoroplethLegendProps = {
   // this for year-like attributes (which are typed numeric, not date) so years render as "2024", not
   // "2,024" — matching how CODAP formats numbers elsewhere (see getNumFormatterForAttribute).
   useGrouping?: boolean,
-  // When true, the legend renders a logarithmic (equal-ratio) scale. This (a) formats numeric labels
-  // with a uniform number of significant figures rather than decimal places, since the boundaries
-  // span orders of magnitude (significant figures is the log dual of fixed decimal places); and
-  // (b) labels the lowest bin as open-above-zero (">0 - t₁") rather than "< t₁", because values <= 0
-  // are excluded as missing rather than clamped into the first bin.
+  // When true, the legend renders a logarithmic (equal-ratio) scale, formatting numeric labels with a
+  // uniform number of significant figures rather than decimal places, since the boundaries span
+  // orders of magnitude (significant figures is the log dual of fixed decimal places). Bin tooltips
+  // are plain ranges like the linear/quantile cases; values outside the positive log domain (including
+  // <= 0) are missing rather than clamped into an end bin.
   logarithmic?: boolean,
   width?: number,
   rectHeight?: number,
@@ -150,19 +150,9 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
     .append('title')
     .text((color) => {
       const bin = scale.range().indexOf(color)
-      const lastBin = scale.range().length - 1
-      // Bins are half-open [binMin, binMax) and the scale clamps out-of-range values into the end
-      // bins, so the first bin covers everything below its upper threshold and the last everything
-      // at-or-above its lower threshold. Show those open-ended (rather than the [min, max] domain),
-      // which is only correct once the user can narrow the range (CODAP-1292).
-      // In logarithmic mode values <= 0 are excluded as missing rather than clamped into the first
-      // bin, so label it open-above-zero (">0 - t₁") rather than the unbounded "< t₁".
-      if (lastBin > 0 && bin === 0) {
-        return logarithmic
-          ? `>0 - ${formatBoundary(fullBoundaries[1])}`
-          : `< ${formatBoundary(fullBoundaries[1])}`
-      }
-      if (lastBin > 0 && bin === lastBin) return `≥ ${formatBoundary(fullBoundaries[bin])}`
+      // Every bin is a plain [low - high] range. Out-of-range values (and <= 0 in logarithmic mode)
+      // are treated as missing rather than clamped into the end bins, so the first and last bins are
+      // bounded by the legend's min/max like any interior bin.
       return `${formatBoundary(fullBoundaries[bin])} - ${formatBoundary(fullBoundaries[bin + 1])}`
     })
 

--- a/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
+++ b/v3/src/components/data-display/components/legend/choropleth-legend/choropleth-legend.ts
@@ -133,27 +133,27 @@ export function choroplethLegend(scale: ChoroplethScale, choroplethElt: SVGGElem
         interiorCenters[i - 1] + interiorWidths[i - 1] / 2 + kLegendLabelGap),
     onlyShowMinMax = !(fitBesideEndpoints && interiorLabelsFit)
 
+  // Bind each rect to its bin index (not its color): the index is the unambiguous bin identifier,
+  // whereas looking a color up in scale.range() is O(n) and returns the wrong bin when the ramp
+  // contains duplicate colors (e.g. lowColor === highColor).
+  const colors = scale.range()
   svg.append("g")
     .selectAll("rect")
-    .data(scale.range())
+    .data(colors.map((_, i) => i))
     .join("rect")
     .attr('class', 'choropleth-rect')
-    .classed('legend-rect-selected',
-      (color) => {
-        return casesInBinSelectedHandler(scale.range().indexOf(color))
-      })
+    .classed('legend-rect-selected', bin => casesInBinSelectedHandler(bin))
     .attr('transform', transform)
-    .attr("x", (d, i) => legendScale(i - 1))
+    .attr("x", bin => legendScale(bin - 1))
     .attr("y", marginTop)
-    .attr("width", (d, i) => legendScale(i) - legendScale(i - 1))
+    .attr("width", bin => legendScale(bin) - legendScale(bin - 1))
     .attr("height", kChoroplethHeight /*height - marginTop - marginBottom*/)
-    .attr("fill", (d: string) => d)
-    .on('click', (event, color) => {
-      clickHandler(scale.range().indexOf(color), event.shiftKey)
+    .attr("fill", bin => colors[bin])
+    .on('click', (event, bin) => {
+      clickHandler(bin, event.shiftKey)
     })
     .append('title')
-    .text((color) => {
-      const bin = scale.range().indexOf(color)
+    .text(bin => {
       // Degenerate quantile bins are labeled from their data: a single value when min === max
       // (e.g. "1"), else a range ("2 - 3").
       const extent = binDataExtents?.[bin]

--- a/v3/src/components/data-display/components/legend/numeric-legend.tsx
+++ b/v3/src/components/data-display/components/legend/numeric-legend.tsx
@@ -55,6 +55,7 @@ export const NumericLegend =
           useGrouping: !legendAttr?.isInferredYearType(),
           logarithmic: dataConfiguration.legendIsLogarithmic,
           width: tileWidth, legendMin, legendMax,
+          binDataExtents: dataConfiguration.legendBinDataExtents,
           marginLeft: 6, marginTop: labelHeight + 2 * labelPaddingY, marginRight: 6, ticks: 5,
           clickHandler: (bin: number, extend: boolean) => {
             const dataset = dataConfiguration.dataset

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -21,7 +21,7 @@ import {getChoroplethColors, missingColor, parseColor} from "../../../utilities/
 import { numericSortComparator } from "../../../utilities/data-utils"
 import { stringValuesToDateSeconds } from "../../../utilities/date-utils"
 import {hashStringSets, typedId, uniqueId} from "../../../utilities/js-utils"
-import { isFiniteNumber } from "../../../utilities/math-utils"
+import { equalFrequencyBins, isFiniteNumber } from "../../../utilities/math-utils"
 import { cachedFnWithArgsFactory, onAnyAction } from "../../../utilities/mst-utils"
 import { AxisPlace } from "../../axis/axis-types"
 import {GraphPlace} from "../../axis-graph-shared"
@@ -635,12 +635,7 @@ export const DataConfigurationModel = types
       if (self.legendQuantilesAreLocked && self._legendNumericColorScale) {
         return self._legendNumericColorScale
       }
-      const values = self.numericValuesForAttrRole("legend") ?? []
-
-      const legendAttrId = self.attributeID("legend")
-      const { min: overrideMin, max: overrideMax } =
-        self.metadata?.getAttributeLegendRange(legendAttrId) ?? {}
-      const binningType = self.metadata?.getAttributeBinningType(legendAttrId)
+      const binningType = self.metadata?.getAttributeBinningType(self.attributeID("legend"))
       switch (binningType) {
         case "quantize": {
           // Use the shared effective display range (override ?? data extent, with reversed-range
@@ -666,17 +661,53 @@ export const DataConfigurationModel = types
           return scaleThreshold<number, string>().domain(thresholds).range(colors)
         }
         case "quantile":
-        default: {
-          const filtered = overrideMin == null && overrideMax == null
-            ? values
-            : values.filter(v =>
-                (overrideMin == null || v >= overrideMin) && (overrideMax == null || v <= overrideMax))
-          // If the override range excludes every value (orphaned/stale override, or the data
-          // moved outside the range), train on the full value set rather than producing an
-          // all-first-color scale.
-          return scaleQuantile(filtered.length > 0 ? filtered : values, self.choroplethColors)
-        }
+        default:
+          // d3 quantile scale for non-degenerate data; equal-frequency repair when ties collapse it.
+          return this.legendQuantileScaleAndExtents.scale
       }
+    },
+    // Quantile binning, including the degenerate-tie repair. Computed once and shared by the color
+    // scale (which needs the scale) and the legend (which needs per-bin data extents for labels).
+    // d3's scaleQuantile is used unchanged for non-degenerate data (byte-identical to V2); when
+    // ties collapse the quantile boundaries into empty bins, a scaleThreshold built from the
+    // most-equal partition groups replaces it so distinct values get distinct colors and no bin
+    // is empty.
+    get legendQuantileScaleAndExtents(): {
+      scale: ScaleQuantile<string> | ScaleThreshold<number, string>,
+      extents?: Array<{ min: number, max: number }>
+    } {
+      const legendAttrId = self.attributeID("legend")
+      const values = self.numericValuesForAttrRole("legend") ?? []
+      const { min: overrideMin, max: overrideMax } =
+        self.metadata?.getAttributeLegendRange(legendAttrId) ?? {}
+      const filtered = overrideMin == null && overrideMax == null
+        ? values
+        : values.filter(v =>
+            (overrideMin == null || v >= overrideMin) && (overrideMax == null || v <= overrideMax))
+      // If the override range excludes every value (orphaned/stale override, or the data moved
+      // outside the range), train on the full value set rather than producing an all-first-color scale.
+      const trained = filtered.length > 0 ? filtered : values
+      const scale = scaleQuantile(trained, self.choroplethColors)
+      // Degenerate iff [min, ...quantiles] is not strictly increasing: a duplicate boundary means a
+      // bin has no values. (The last bin always contains the max, so only the lower boundaries matter.)
+      const boundaries = [scale.domain()[0], ...scale.quantiles()]
+      const degenerate = trained.length > 0 &&
+        boundaries.some((b, i) => i > 0 && b <= boundaries[i - 1])
+      if (!degenerate) return { scale }
+      const bins = equalFrequencyBins(trained, self.legendBinCount)
+      const thresholds = bins.slice(1).map(b => b.min)
+      const threshScale = scaleThreshold<number, string>().domain(thresholds).range(self.choroplethColors)
+      return { scale: threshScale, extents: bins.map(b => ({ min: b.min, max: b.max })) }
+    },
+    // Per-bin data extents for labeling the legend, defined only for the degenerate quantile case
+    // (where bins must be labeled from the data, e.g. "1" or "2 - 3"). undefined everywhere else,
+    // so the return value doubles as the "is degenerate" signal the legend keys off. Locked legends
+    // use their frozen threshold labels, so they opt out here.
+    get legendBinDataExtents(): Array<{ min: number, max: number }> | undefined {
+      if (self.legendQuantilesAreLocked) return undefined
+      const binningType = self.metadata?.getAttributeBinningType(self.attributeID("legend"))
+      if (binningType != null && binningType !== "quantile") return undefined
+      return this.legendQuantileScaleAndExtents.extents
     },
   }))
   .views(self => (

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -821,10 +821,13 @@ export const DataConfigurationModel = types
         const thresholds = getScaleThresholds(scale)
         // Out-of-range values are "missing" (not in any bin), so the end bins are bounded by the
         // effective legend range rather than ±Infinity: the first bin starts at the range min and
-        // the last bin ends at the range max, inclusive (the max is a real, plottable value).
+        // the last bin ends at the range max, inclusive (the max is a real, plottable value). In
+        // logarithmic mode with a degenerate domain (no rangeMin) the first bin still starts just
+        // above 0, since non-positive values are missing rather than part of the bin.
         const { min: rangeMin, max: rangeMax } = self.legendDisplayRange
         const isLastBin = bin === thresholds.length
-        const min = bin === 0 ? (rangeMin ?? -Infinity) : thresholds[bin - 1]
+        const firstBinMin = rangeMin ?? (self.legendIsLogarithmic ? Number.MIN_VALUE : -Infinity)
+        const min = bin === 0 ? firstBinMin : thresholds[bin - 1]
         const max = isLastBin ? (rangeMax ?? Infinity) : thresholds[bin]
         return self.getCasesInLegendRange(min, max, isLastBin)
       }

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -696,7 +696,13 @@ export const DataConfigurationModel = types
       if (!degenerate) return { scale }
       const bins = equalFrequencyBins(trained, self.legendBinCount)
       const thresholds = bins.slice(1).map(b => b.min)
-      const threshScale = scaleThreshold<number, string>().domain(thresholds).range(self.choroplethColors)
+      // bins.length can be < legendBinCount when an override leaves fewer distinct values than the
+      // bin-count cap; size the color ramp to the actual bin count so the threshold scale's range
+      // length matches its domain.
+      const colors = bins.length === self.legendBinCount
+        ? self.choroplethColors
+        : getChoroplethColors(self.lowColor, self.highColor, bins.length)
+      const threshScale = scaleThreshold<number, string>().domain(thresholds).range(colors)
       return { scale: threshScale, extents: bins.map(b => ({ min: b.min, max: b.max })) }
     },
     // Per-bin data extents for labeling the legend, defined only for the degenerate quantile case
@@ -718,12 +724,15 @@ export const DataConfigurationModel = types
       },
 
       getLegendColorForNumericValue(value: number): string {
-        // Values outside the effective legend range are "missing" rather than clamped into an end
-        // bin. legendDisplayRange is the same range used for the endpoint labels, so colors and
-        // labels stay in lockstep: the log domain (whose min is positive, so values <= 0 fall
-        // outside) in logarithmic mode, else the user-set/data linear or quantile range.
+        // A log scale is undefined for values <= 0; they are always missing, including when the log
+        // domain is degenerate (<= 1 distinct positive value) and legendDisplayRange is empty.
+        if (self.legendIsLogarithmic && value <= 0) return missingColor
+        // When the effective range is defined, values outside it are "missing" rather than clamped
+        // into an end bin. legendDisplayRange is the same range used for the endpoint labels, so
+        // colors and labels stay in lockstep. A degenerate domain yields no min/max but still
+        // produces a valid single-bin scale, so skip the check there and let the scale color it.
         const { min, max } = self.legendDisplayRange
-        if (min == null || max == null || value < min || value > max) return missingColor
+        if (min != null && max != null && (value < min || value > max)) return missingColor
         return self.legendNumericColorScale(value)
       },
 

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -826,6 +826,7 @@ export const DataConfigurationModel = types
         // above 0, since non-positive values are missing rather than part of the bin.
         const { min: rangeMin, max: rangeMax } = self.legendDisplayRange
         const isLastBin = bin === thresholds.length
+        // Number.MIN_VALUE is the smallest *positive* double, so it floors the first log bin just above 0.
         const firstBinMin = rangeMin ?? (self.legendIsLogarithmic ? Number.MIN_VALUE : -Infinity)
         const min = bin === 0 ? firstBinMin : thresholds[bin - 1]
         const max = isLastBin ? (rangeMax ?? Infinity) : thresholds[bin]

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -687,9 +687,12 @@ export const DataConfigurationModel = types
       },
 
       getLegendColorForNumericValue(value: number): string {
-        // A log scale is undefined for values <= 0; color them as missing rather than letting the
-        // threshold scale place them in the lowest bin.
-        if (self.legendIsLogarithmic && value <= 0) return missingColor
+        // Values outside the effective legend range are "missing" rather than clamped into an end
+        // bin. legendDisplayRange is the same range used for the endpoint labels, so colors and
+        // labels stay in lockstep: the log domain (whose min is positive, so values <= 0 fall
+        // outside) in logarithmic mode, else the user-set/data linear or quantile range.
+        const { min, max } = self.legendDisplayRange
+        if (min == null || max == null || value < min || value > max) return missingColor
         return self.legendNumericColorScale(value)
       },
 
@@ -758,14 +761,14 @@ export const DataConfigurationModel = types
         },
         name: "allCasesForCategoryAreSelected"
       }),
-      getCasesInLegendRange(min: number, max: number) {
+      getCasesInLegendRange(min: number, max: number, inclusiveMax = false) {
         const dataset = self.dataset
         const legendID = self.attributeID('legend')
         const typeIsNumeric = self.attributeType('legend') === 'numeric'
         return legendID
           ? self.getCaseDataArray(0).filter((aCaseData: CaseData) => {
             const value = dataDisplayGetNumericValue(dataset, aCaseData.caseID, legendID, typeIsNumeric)
-            return value != null && value >= min && value < max
+            return value != null && value >= min && (inclusiveMax ? value <= max : value < max)
           }).map((aCaseData: CaseData) => aCaseData.caseID)
           : []
 
@@ -776,14 +779,14 @@ export const DataConfigurationModel = types
       getCasesForLegendBin(bin: number) {
         const scale = self.legendNumericColorScale
         const thresholds = getScaleThresholds(scale)
-        // In logarithmic mode, values <= 0 are "missing" (not in any bin), so the first bin starts
-        // just above 0 rather than at -Infinity; otherwise the first bin captures everything below
-        // its upper threshold, including the non-positive values colored as missing.
-        const min = bin === 0
-          ? (self.legendIsLogarithmic ? Number.MIN_VALUE : -Infinity)
-          : thresholds[bin - 1]
-        const max = bin === thresholds.length ? Infinity : thresholds[bin]
-        return self.getCasesInLegendRange(min, max)
+        // Out-of-range values are "missing" (not in any bin), so the end bins are bounded by the
+        // effective legend range rather than ±Infinity: the first bin starts at the range min and
+        // the last bin ends at the range max, inclusive (the max is a real, plottable value).
+        const { min: rangeMin, max: rangeMax } = self.legendDisplayRange
+        const isLastBin = bin === thresholds.length
+        const min = bin === 0 ? (rangeMin ?? -Infinity) : thresholds[bin - 1]
+        const max = isLastBin ? (rangeMax ?? Infinity) : thresholds[bin]
+        return self.getCasesInLegendRange(min, max, isLastBin)
       }
     }))
   .views(self => (

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -820,6 +820,47 @@ describe("DataConfigurationModel legend range overrides", () => {
     expect(t.config.legendBinDataExtents).toBeUndefined()
   })
 
+  it("handles an override that leaves fewer distinct values than the bin count", () => {
+    // 6 distinct values -> the bin-count cap allows the default 5 bins
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    t.data.addCases(toCanonical(t.data, [
+      { leg: 1 }, { leg: 1 }, { leg: 1 }, { leg: 2 }, { leg: 3 }, { leg: 4 }, { leg: 5 }, { leg: 6 }
+    ]))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "quantile")
+    t.metadata.setAttributeBinCount("legId", 5)
+    // narrow to [1, 2]: trained = [1,1,1,2] has only 2 distinct values (with ties)
+    t.metadata.setAttributeLegendMin("legId", 1)
+    t.metadata.setAttributeLegendMax("legId", 2)
+    // repairs to 2 bins without crashing; the scale has 2 colors, not 5
+    expect(() => t.config.legendNumericColorScale).not.toThrow()
+    expect(t.config.legendNumericColorScale.range().length).toBe(2)
+    expect(t.config.legendBinDataExtents).toEqual([{ min: 1, max: 1 }, { min: 2, max: 2 }])
+    // the two in-range values get distinct colors; an out-of-range value is missing
+    expect(t.config.getLegendColorForNumericValue(1)).not.toBe(t.config.getLegendColorForNumericValue(2))
+    expect(t.config.getLegendColorForNumericValue(5)).toBe(missingColor)
+  })
+
+  it("colors all-equal positive values with the single bin in logarithmic mode", () => {
+    // all values the same positive number -> degenerate log domain ({}), single-bin scale.
+    // The value should get that bin's color, not the missing color (CODAP-1409 review fix).
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    t.data.addCases(toCanonical(t.data, [{ leg: 5 }, { leg: 5 }, { leg: 5 }]))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "logarithmic")
+    expect(t.config.legendLogDomain).toEqual({})
+    expect(t.config.getLegendColorForNumericValue(5)).not.toBe(missingColor)
+    // non-positive values are still missing in logarithmic mode
+    expect(t.config.getLegendColorForNumericValue(-1)).toBe(missingColor)
+    expect(t.config.getLegendColorForNumericValue(0)).toBe(missingColor)
+  })
+
   it("switches between standard and repaired quantile bins as the data changes", () => {
     // start non-degenerate: six distinct values
     const t = TreeModel.create({ data: {}, metadata: {}, config: {} })

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -548,15 +548,43 @@ describe("DataConfigurationModel legend range overrides", () => {
     expect(tree.config.legendNumericColorScale.domain()).toEqual([10, 20])
   })
 
-  it("clamps out-of-range values to the end-bin colors in quantize mode", () => {
+  it("colors out-of-range values as missing in quantize mode", () => {
     tree.metadata.setAttributeLegendMin("legId", 10)
     tree.metadata.setAttributeLegendMax("legId", 20)
-    // a value above the override max gets the same color as the max
-    expect(tree.config.getLegendColorForNumericValue(100))
-      .toBe(tree.config.getLegendColorForNumericValue(20))
-    // a value below the override min gets the same color as the min
-    expect(tree.config.getLegendColorForNumericValue(-100))
-      .toBe(tree.config.getLegendColorForNumericValue(10))
+    // values outside the user-set range are treated as missing rather than clamped into an end bin
+    expect(tree.config.getLegendColorForNumericValue(100)).toBe(missingColor)
+    expect(tree.config.getLegendColorForNumericValue(-100)).toBe(missingColor)
+    // the inclusive endpoints (and an interior value) still get real bin colors
+    expect(tree.config.getLegendColorForNumericValue(10)).not.toBe(missingColor)
+    expect(tree.config.getLegendColorForNumericValue(15)).not.toBe(missingColor)
+    expect(tree.config.getLegendColorForNumericValue(20)).not.toBe(missingColor)
+  })
+
+  it("colors out-of-range values as missing in quantile mode", () => {
+    tree.metadata.setAttributeBinningType("legId", "quantile")
+    tree.metadata.setAttributeLegendMin("legId", 10)
+    tree.metadata.setAttributeLegendMax("legId", 20)
+    // the override excludes 0 and 40, which become missing rather than clamping to an end bin
+    expect(tree.config.getLegendColorForNumericValue(0)).toBe(missingColor)
+    expect(tree.config.getLegendColorForNumericValue(40)).toBe(missingColor)
+    expect(tree.config.getLegendColorForNumericValue(10)).not.toBe(missingColor)
+    expect(tree.config.getLegendColorForNumericValue(20)).not.toBe(missingColor)
+  })
+
+  it("excludes out-of-range cases from the end bins, keeping the inclusive endpoints", () => {
+    // case ids are auto-generated, so assert on the binned values rather than literal ids
+    tree.metadata.setAttributeLegendMin("legId", 10)
+    tree.metadata.setAttributeLegendMax("legId", 20)
+    const binCount = tree.config.legendNumericColorScale.range().length
+    const binnedValues = new Set<number>()
+    for (let bin = 0; bin < binCount; bin++) {
+      tree.config.getCasesForLegendBin(bin).forEach((id: string) => {
+        binnedValues.add(tree.data.getNumeric(id, "legId")!)
+      })
+    }
+    // 0 and 40 are outside [10, 20] and must not be selectable via any bin; the inclusive
+    // endpoints 10 and 20 land in the first and last bins respectively.
+    expect([...binnedValues].sort((a, b) => a - b)).toEqual([10, 20])
   })
 
   it("filters trained values to the override range in quantile mode", () => {
@@ -665,12 +693,18 @@ describe("DataConfigurationModel legend range overrides", () => {
     expect(tree.config.legendDisplayRange).toEqual({ min: 5, max: 30 })
   })
 
-  it("colors non-positive values as missing in logarithmic mode", () => {
+  it("colors non-positive and out-of-range values as missing in logarithmic mode", () => {
     tree.metadata.setAttributeBinningType("legId", "logarithmic")
+    // non-positive values are outside the positive log domain -> missing
     expect(tree.config.getLegendColorForNumericValue(-1)).toBe(missingColor)
     expect(tree.config.getLegendColorForNumericValue(0)).toBe(missingColor)
-    // a positive value gets a real bin color, not the missing color
+    // a positive value within the domain [10, 40] gets a real bin color
     expect(tree.config.getLegendColorForNumericValue(15)).not.toBe(missingColor)
+    // positive values outside the domain are also missing (unified with quantize/quantile)
+    tree.metadata.setAttributeLegendMin("legId", 15)
+    tree.metadata.setAttributeLegendMax("legId", 30)
+    expect(tree.config.getLegendColorForNumericValue(10)).toBe(missingColor)  // below min
+    expect(tree.config.getLegendColorForNumericValue(40)).toBe(missingColor)  // above max
   })
 
   it("falls back to the positive data extent when a logarithmic override range is reversed", () => {

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -744,4 +744,118 @@ describe("DataConfigurationModel legend range overrides", () => {
       expect(v).toBeLessThan(firstThreshold)
     })
   })
+
+  it("leaves non-degenerate quantile binning as a d3 quantile scale", () => {
+    // six distinct values, 3 bins -> standard quantiles, no degeneracy, scale stays a ScaleQuantile
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    t.data.addCases(toCanonical(t.data, [
+      { leg: 1 }, { leg: 2 }, { leg: 3 }, { leg: 4 }, { leg: 5 }, { leg: 6 }
+    ]))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "quantile")
+    t.metadata.setAttributeBinCount("legId", 3)
+    // a ScaleQuantile exposes quantiles(); a repaired ScaleThreshold does not
+    expect("quantiles" in t.config.legendNumericColorScale).toBe(true)
+    expect(t.config.legendBinDataExtents).toBeUndefined()
+  })
+
+  it("repairs degenerate quantile binning so distinct values get distinct colors", () => {
+    // eight 1s, one 2, one 3; 3 bins. d3 collapses all into the last bin/color.
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    const cases = []
+    for (let i = 0; i < 8; i++) cases.push({ leg: 1 })
+    cases.push({ leg: 2 }); cases.push({ leg: 3 })
+    t.data.addCases(toCanonical(t.data, cases))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "quantile")
+    t.metadata.setAttributeBinCount("legId", 3)
+    const c1 = t.config.getLegendColorForNumericValue(1)
+    const c2 = t.config.getLegendColorForNumericValue(2)
+    const c3 = t.config.getLegendColorForNumericValue(3)
+    // three distinct colors, none missing
+    expect(new Set([c1, c2, c3]).size).toBe(3)
+    expect(c1).not.toBe(missingColor)
+    // bins partition the data by value, each non-empty
+    const v0 = t.config.getCasesForLegendBin(0).map((id: string) => t.data.getNumeric(id, "legId"))
+    const v1 = t.config.getCasesForLegendBin(1).map((id: string) => t.data.getNumeric(id, "legId"))
+    const v2 = t.config.getCasesForLegendBin(2).map((id: string) => t.data.getNumeric(id, "legId"))
+    expect(v0).toEqual([1, 1, 1, 1, 1, 1, 1, 1])
+    expect(v1).toEqual([2])
+    expect(v2).toEqual([3])
+  })
+
+  it("exposes per-bin data extents for a degenerate quantile legend", () => {
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    const cases = []
+    for (let i = 0; i < 8; i++) cases.push({ leg: 1 })
+    cases.push({ leg: 2 }); cases.push({ leg: 3 })
+    t.data.addCases(toCanonical(t.data, cases))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "quantile")
+    t.metadata.setAttributeBinCount("legId", 3)
+    expect(t.config.legendBinDataExtents).toEqual([
+      { min: 1, max: 1 }, { min: 2, max: 2 }, { min: 3, max: 3 }
+    ])
+  })
+
+  it("does not expose bin extents for quantize or logarithmic legends", () => {
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    t.data.addCases(toCanonical(t.data, [{ leg: 1 }, { leg: 2 }, { leg: 3 }]))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "quantize")
+    expect(t.config.legendBinDataExtents).toBeUndefined()
+    t.metadata.setAttributeBinningType("legId", "logarithmic")
+    expect(t.config.legendBinDataExtents).toBeUndefined()
+  })
+
+  it("switches between standard and repaired quantile bins as the data changes", () => {
+    // start non-degenerate: six distinct values
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    t.data.addCases(toCanonical(t.data, [
+      { __id__: "c1", leg: 1 }, { __id__: "c2", leg: 2 }, { __id__: "c3", leg: 3 },
+      { __id__: "c4", leg: 4 }, { __id__: "c5", leg: 5 }, { __id__: "c6", leg: 6 }
+    ]))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "quantile")
+    t.metadata.setAttributeBinCount("legId", 3)
+    const caseId = (itemId: string) => t.data.getItemChildCaseId(itemId)!
+    expect("quantiles" in t.config.legendNumericColorScale).toBe(true)   // d3 quantile scale
+    expect(t.config.legendBinDataExtents).toBeUndefined()
+
+    // make it degenerate: four 1s plus 2 and 3
+    t.data.setCaseValues([
+      { __id__: caseId("c4"), legId: 1 },
+      { __id__: caseId("c5"), legId: 1 },
+      { __id__: caseId("c6"), legId: 1 }
+    ])
+    // values are now [1,1,1,1,2,3]
+    expect("quantiles" in t.config.legendNumericColorScale).toBe(false)  // repaired threshold scale
+    expect(t.config.legendBinDataExtents).toEqual([
+      { min: 1, max: 1 }, { min: 2, max: 2 }, { min: 3, max: 3 }
+    ])
+
+    // restore distinct values -> back to a standard quantile scale
+    t.data.setCaseValues([
+      { __id__: caseId("c4"), legId: 4 },
+      { __id__: caseId("c5"), legId: 5 },
+      { __id__: caseId("c6"), legId: 6 }
+    ])
+    expect("quantiles" in t.config.legendNumericColorScale).toBe(true)
+    expect(t.config.legendBinDataExtents).toBeUndefined()
+  })
 })

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -914,4 +914,33 @@ describe("DataConfigurationModel legend range overrides", () => {
     expect("quantiles" in t.config.legendNumericColorScale).toBe(true)
     expect(t.config.legendBinDataExtents).toBeUndefined()
   })
+
+  it("keeps a locked quantile scale when the data later becomes degenerate (no repair)", () => {
+    // start non-degenerate: six distinct values, then lock the quantiles to freeze the scale
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    t.data.addCases(toCanonical(t.data, [
+      { __id__: "c1", leg: 1 }, { __id__: "c2", leg: 2 }, { __id__: "c3", leg: 3 },
+      { __id__: "c4", leg: 4 }, { __id__: "c5", leg: 5 }, { __id__: "c6", leg: 6 }
+    ]))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "quantile")
+    t.metadata.setAttributeBinCount("legId", 3)
+    t.config.setLegendQuantilesAreLocked(true)
+    const frozen = t.config.legendNumericColorScale
+    expect(t.config.legendBinDataExtents).toBeUndefined()
+
+    // make the data degenerate (four 1s plus 2 and 3) — unlocked this would trigger the threshold repair
+    const caseId = (itemId: string) => t.data.getItemChildCaseId(itemId)!
+    t.data.setCaseValues([
+      { __id__: caseId("c4"), legId: 1 },
+      { __id__: caseId("c5"), legId: 1 },
+      { __id__: caseId("c6"), legId: 1 }
+    ])
+    // the frozen scale is still used (same instance) and the repair's bin extents stay opted out
+    expect(t.config.legendNumericColorScale).toBe(frozen)
+    expect(t.config.legendBinDataExtents).toBeUndefined()
+  })
 })

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -844,6 +844,21 @@ describe("DataConfigurationModel legend range overrides", () => {
     expect(t.config.getLegendColorForNumericValue(5)).toBe(missingColor)
   })
 
+  it("excludes non-positive cases from the single bin of a degenerate logarithmic legend", () => {
+    // <= 1 distinct positive value -> degenerate log domain ({}), single-bin scale.
+    const t = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    t.data.addAttribute({ id: "legId", name: "leg" })
+    t.metadata.setData(t.data)
+    t.data.addCases(toCanonical(t.data, [{ leg: 5 }, { leg: 5 }, { leg: -1 }]))
+    t.config.setDataset(t.data, t.metadata)
+    t.config.setAttribute("legend", { attributeID: "legId" })
+    t.metadata.setAttributeBinningType("legId", "logarithmic")
+    expect(t.config.legendLogDomain).toEqual({})
+    // clicking the single bin must not select the non-positive (missing-colored) case
+    const binValues = t.config.getCasesForLegendBin(0).map((id: string) => t.data.getNumeric(id, "legId"))
+    expect(binValues).toEqual([5, 5])
+  })
+
   it("colors all-equal positive values with the single bin in logarithmic mode", () => {
     // all values the same positive number -> degenerate log domain ({}), single-bin scale.
     // The value should get that bin's color, not the missing color (CODAP-1409 review fix).

--- a/v3/src/utilities/math-utils.test.ts
+++ b/v3/src/utilities/math-utils.test.ts
@@ -294,4 +294,46 @@ describe("equalFrequencyBins", () => {
   it("returns an empty array for empty input", () => {
     expect(equalFrequencyBins([], 3)).toEqual([])
   })
+
+  it("matches the brute-force optimal cost on random tie-heavy inputs", () => {
+    // Independent O(nBins * D^2) reference for the minimal sum of squared bin counts.
+    const bruteOptimalCost = (values: number[], nBins: number) => {
+      const sorted = [...values].sort((a, b) => a - b)
+      const counts: number[] = []
+      let prev: number | undefined
+      for (const v of sorted) {
+        if (v === prev) counts[counts.length - 1]++
+        else { counts.push(1); prev = v }
+      }
+      const m = counts.length
+      const n = Math.min(nBins, m)
+      if (n <= 0) return 0
+      const p = [0]
+      for (let k = 0; k < m; k++) p.push(p[k] + counts[k])
+      const dp = Array.from({ length: n + 1 }, () => Array(m + 1).fill(Infinity))
+      dp[0][0] = 0
+      for (let k = 1; k <= n; k++) {
+        for (let i = k; i <= m; i++) {
+          for (let j = k - 1; j < i; j++) {
+            if (dp[k - 1][j] === Infinity) continue
+            const seg = p[i] - p[j]
+            dp[k][i] = Math.min(dp[k][i], dp[k - 1][j] + seg * seg)
+          }
+        }
+      }
+      return dp[n][m]
+    }
+    const costOf = (bins: Array<{ count: number }>) => bins.reduce((sum, b) => sum + b.count * b.count, 0)
+
+    for (let trial = 0; trial < 300; trial++) {
+      const len = 1 + Math.floor(Math.random() * 40)
+      // small value range => lots of ties (the degenerate regime this helper targets)
+      const values = Array.from({ length: len }, () => Math.floor(Math.random() * 8))
+      const nBins = 1 + Math.floor(Math.random() * 6)
+      const bins = equalFrequencyBins(values, nBins)
+      // total count is preserved and the partition is cost-optimal
+      expect(costOf(bins)).toBe(bruteOptimalCost(values, nBins))
+      expect(bins.reduce((sum, b) => sum + b.count, 0)).toBe(values.length)
+    }
+  })
 })

--- a/v3/src/utilities/math-utils.test.ts
+++ b/v3/src/utilities/math-utils.test.ts
@@ -5,6 +5,7 @@ import {
   binBoundarySignificantFigures,
   checkNumber,
   chooseDecimalPlaces,
+  equalFrequencyBins,
   extractNumeric,
   fitGaussianLM,
   isFiniteNumber,
@@ -228,5 +229,56 @@ describe("fitGaussianLM", () => {
 
     expect(result.mu).toBeCloseTo(mu, 6)
     expect(result.sigma).toBeCloseTo(sigma, 6)
+  })
+})
+
+describe("equalFrequencyBins", () => {
+  it("reduces to equal-count quantile groups when there are no ties", () => {
+    const bins = equalFrequencyBins([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 3)
+    expect(bins).toEqual([
+      { min: 1, max: 4, count: 4 },
+      { min: 5, max: 8, count: 4 },
+      { min: 9, max: 12, count: 4 }
+    ])
+  })
+
+  it("keeps a dominant tie in its own bin so distinct values stay distinct", () => {
+    // eight 1s, one 2, one 3 -> {1}{2}{3}, counts (8,1,1)
+    const bins = equalFrequencyBins([1, 1, 1, 1, 1, 1, 1, 1, 2, 3], 3)
+    expect(bins).toEqual([
+      { min: 1, max: 1, count: 8 },
+      { min: 2, max: 2, count: 1 },
+      { min: 3, max: 3, count: 1 }
+    ])
+  })
+
+  it("balances the remainder after a dominant tie anchors the first bin", () => {
+    // eight 1s, then 2,3,4,5 -> {1}{2,3}{4,5}, counts (8,2,2)
+    const bins = equalFrequencyBins([1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 4, 5], 3)
+    expect(bins).toEqual([
+      { min: 1, max: 1, count: 8 },
+      { min: 2, max: 3, count: 2 },
+      { min: 4, max: 5, count: 2 }
+    ])
+  })
+
+  it("balances a top-heavy tie symmetrically (not the lopsided greedy result)", () => {
+    // 1,2,3,4 then eight 5s -> {1,2}{3,4}{5x8}, counts (2,2,8). A bottom-up greedy would
+    // over-merge the early bins to (3,1,8); the most-equal partition keeps it balanced.
+    const bins = equalFrequencyBins([1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5], 3)
+    expect(bins).toEqual([
+      { min: 1, max: 2, count: 2 },
+      { min: 3, max: 4, count: 2 },
+      { min: 5, max: 5, count: 8 }
+    ])
+  })
+
+  it("sorts unsorted input before binning", () => {
+    const bins = equalFrequencyBins([3, 1, 2, 1, 1], 2)
+    // sorted [1,1,1,2,3]; most-equal partition is {1,1,1}{2,3}
+    expect(bins).toEqual([
+      { min: 1, max: 1, count: 3 },
+      { min: 2, max: 3, count: 2 }
+    ])
   })
 })

--- a/v3/src/utilities/math-utils.test.ts
+++ b/v3/src/utilities/math-utils.test.ts
@@ -281,4 +281,17 @@ describe("equalFrequencyBins", () => {
       { min: 2, max: 3, count: 2 }
     ])
   })
+
+  it("returns at most one bin per distinct value when asked for more bins than exist", () => {
+    // [1,1,1,2] has 2 distinct values; asking for 5 bins yields 2 (no crash)
+    const bins = equalFrequencyBins([1, 1, 1, 2], 5)
+    expect(bins).toEqual([
+      { min: 1, max: 1, count: 3 },
+      { min: 2, max: 2, count: 1 }
+    ])
+  })
+
+  it("returns an empty array for empty input", () => {
+    expect(equalFrequencyBins([], 3)).toEqual([])
+  })
 })

--- a/v3/src/utilities/math-utils.test.ts
+++ b/v3/src/utilities/math-utils.test.ts
@@ -348,4 +348,40 @@ describe("equalFrequencyBins", () => {
       expect(bins.reduce((sum, b) => sum + b.count, 0)).toBe(values.length)
     }
   })
+
+  it("stays internally consistent at large distinct-value counts (exercises divide-and-conquer)", () => {
+    // The brute-force test above caps at D <= 8, which never stresses the O(D log D) divide-and-conquer
+    // path. Here D runs into the hundreds; without an independent optimum to compare against we assert
+    // the structural invariants the partition must satisfy: every distinct value lands in exactly one
+    // contiguous, non-empty bin, total count is preserved, and bin count is min(nBins, distinctCount).
+    let state = 987654321
+    const rand = () => {
+      state = (state * 1664525 + 1013904223) % 4294967296
+      return state / 4294967296
+    }
+
+    for (let trial = 0; trial < 50; trial++) {
+      const len = 200 + Math.floor(rand() * 500)
+      // wide range => hundreds of distinct values, with a sprinkling of ties
+      const values = Array.from({ length: len }, () => Math.floor(rand() * 500))
+      const distinct = new Set(values).size
+      const nBins = 1 + Math.floor(rand() * 20)
+      const bins = equalFrequencyBins(values, nBins)
+
+      // exactly min(nBins, distinctCount) bins, each non-empty
+      expect(bins.length).toBe(Math.min(nBins, distinct))
+      bins.forEach(b => expect(b.count).toBeGreaterThan(0))
+      // total count preserved
+      expect(bins.reduce((sum, b) => sum + b.count, 0)).toBe(len)
+      // each bin's own extent is ordered
+      bins.forEach(b => expect(b.min).toBeLessThanOrEqual(b.max))
+      // bins are contiguous & non-overlapping (a distinct value is never split): every bin's max is
+      // strictly below the next bin's min
+      const adjacentGaps = bins.slice(1).map((b, i) => b.min - bins[i].max)
+      adjacentGaps.forEach(gap => expect(gap).toBeGreaterThan(0))
+      // the partition spans the full data range
+      expect(bins[0].min).toBe(Math.min(...values))
+      expect(bins[bins.length - 1].max).toBe(Math.max(...values))
+    }
+  })
 })

--- a/v3/src/utilities/math-utils.test.ts
+++ b/v3/src/utilities/math-utils.test.ts
@@ -302,8 +302,12 @@ describe("equalFrequencyBins", () => {
       const counts: number[] = []
       let prev: number | undefined
       for (const v of sorted) {
-        if (v === prev) counts[counts.length - 1]++
-        else { counts.push(1); prev = v }
+        if (v === prev) {
+          counts[counts.length - 1]++
+        } else {
+          counts.push(1)
+          prev = v
+        }
       }
       const m = counts.length
       const n = Math.min(nBins, m)
@@ -325,11 +329,19 @@ describe("equalFrequencyBins", () => {
     }
     const costOf = (bins: Array<{ count: number }>) => bins.reduce((sum, b) => sum + b.count * b.count, 0)
 
+    // Deterministic LCG (Numerical Recipes constants) so any failure is reproducible. State stays
+    // below 2^32 and state*1664525 stays within Number.MAX_SAFE_INTEGER, so no bitwise ops needed.
+    let state = 123456789
+    const rand = () => {
+      state = (state * 1664525 + 1013904223) % 4294967296
+      return state / 4294967296
+    }
+
     for (let trial = 0; trial < 300; trial++) {
-      const len = 1 + Math.floor(Math.random() * 40)
+      const len = 1 + Math.floor(rand() * 40)
       // small value range => lots of ties (the degenerate regime this helper targets)
-      const values = Array.from({ length: len }, () => Math.floor(Math.random() * 8))
-      const nBins = 1 + Math.floor(Math.random() * 6)
+      const values = Array.from({ length: len }, () => Math.floor(rand() * 8))
+      const nBins = 1 + Math.floor(rand() * 6)
       const bins = equalFrequencyBins(values, nBins)
       // total count is preserved and the partition is cost-optimal
       expect(costOf(bins)).toBe(bruteOptimalCost(values, nBins))

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -171,6 +171,9 @@ export function equalFrequencyBins(values: number[], nBins: number): IEqualFrequ
     }
     dp[k][iMid] = best
     arg[k][iMid] = bestJ
+    // Monotonicity invariant: the optimal boundary is non-decreasing in i, so every i < iMid has its
+    // optimum at j <= bestJ (search [jLo, bestJ]) and every i > iMid at j >= bestJ (search [bestJ, jHi]).
+    // That halving of both the row and the j-range per level is what yields the O(D log D) bound.
     const leftHi = bestJ < 0 ? jHi : bestJ
     const rightLo = bestJ < 0 ? jLo : bestJ
     fillRow(k, iLo, iMid - 1, jLo, leftHi)

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -116,16 +116,17 @@ export interface IEqualFrequencyBin {
 }
 
 /**
- * Partition `values` into `nBins` contiguous, non-empty bins whose case counts are as equal as
- * possible (minimizing the sum of squared bin counts), keeping equal values in the same bin.
- * This is the most-equal contiguous partition: the quantile goal of equal counts, relaxed only
- * as far as indivisible ties force it. It is order-independent (a top-heavy tie is balanced the
- * same as a bottom-heavy one) and reduces to standard equal-count quantile groups when there are
- * no ties. Computed with an O(nBins * D^2) dynamic program over the D distinct values; D is small
- * in the degenerate path (heavy ties => few distinct values), so this is cheap.
+ * Partition `values` into contiguous, non-empty bins whose case counts are as equal as possible
+ * (minimizing the sum of squared bin counts), keeping equal values in the same bin. This is the
+ * most-equal contiguous partition: the quantile goal of equal counts, relaxed only as far as
+ * indivisible ties force it. It is order-independent (a top-heavy tie is balanced the same as a
+ * bottom-heavy one) and reduces to standard equal-count quantile groups when there are no ties.
+ * Computed with an O(nBins * D^2) dynamic program over the D distinct values; D is small in the
+ * degenerate path (heavy ties => few distinct values), so this is cheap.
  *
- * Precondition: `nBins >= 1` and the number of distinct values is `>= nBins` (the legend's
- * bin-count cap guarantees this), so every returned bin is non-empty.
+ * Returns `min(nBins, number of distinct values)` bins (so a value is never split across bins);
+ * an empty input yields no bins. Callers that need exactly `nBins` bins should pass a count no
+ * greater than the number of distinct values.
  */
 export function equalFrequencyBins(values: number[], nBins: number): IEqualFrequencyBin[] {
   const sorted = [...values].sort((a, b) => a - b)
@@ -138,16 +139,20 @@ export function equalFrequencyBins(values: number[], nBins: number): IEqualFrequ
   }
 
   const m = distinct.length
+  // a value can't be split across bins, so never make more bins than there are distinct values
+  const n = Math.min(nBins, m)
+  if (n <= 0) return []
+
   // prefix[k] = number of cases in the first k distinct values
   const prefix = [0]
   for (let k = 0; k < m; k++) prefix.push(prefix[k] + distinct[k].count)
 
   // dp[k][i] = min sum-of-squared-counts to split the first i distinct values into k bins;
   // arg[k][i] = the boundary (count of distinct values before the last bin) achieving it.
-  const dp: number[][] = Array.from({ length: nBins + 1 }, () => Array(m + 1).fill(Infinity))
-  const arg: number[][] = Array.from({ length: nBins + 1 }, () => Array(m + 1).fill(-1))
+  const dp: number[][] = Array.from({ length: n + 1 }, () => Array(m + 1).fill(Infinity))
+  const arg: number[][] = Array.from({ length: n + 1 }, () => Array(m + 1).fill(-1))
   dp[0][0] = 0
-  for (let k = 1; k <= nBins; k++) {
+  for (let k = 1; k <= n; k++) {
     // i >= k so each of the k bins gets at least one distinct value; j >= k-1 likewise for the rest
     for (let i = k; i <= m; i++) {
       for (let j = k - 1; j < i; j++) {
@@ -163,14 +168,14 @@ export function equalFrequencyBins(values: number[], nBins: number): IEqualFrequ
   // reconstruct group boundaries: bounds = [0, b1, ..., m]; group g spans distinct[bounds[g]..bounds[g+1])
   const bounds = [m]
   let cut = m
-  for (let k = nBins; k >= 1; k--) {
+  for (let k = n; k >= 1; k--) {
     const j = arg[k][cut]
     bounds.unshift(j)
     cut = j
   }
 
   const bins: IEqualFrequencyBin[] = []
-  for (let g = 0; g < nBins; g++) {
+  for (let g = 0; g < n; g++) {
     const lo = bounds[g]
     const hi = bounds[g + 1]
     bins.push({ min: distinct[lo].value, max: distinct[hi - 1].value, count: prefix[hi] - prefix[lo] })

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -109,6 +109,75 @@ export function binBoundarySignificantFigures(boundaries: number[], maxSigFigs =
   return sigFigs
 }
 
+export interface IEqualFrequencyBin {
+  min: number
+  max: number
+  count: number
+}
+
+/**
+ * Partition `values` into `nBins` contiguous, non-empty bins whose case counts are as equal as
+ * possible (minimizing the sum of squared bin counts), keeping equal values in the same bin.
+ * This is the most-equal contiguous partition: the quantile goal of equal counts, relaxed only
+ * as far as indivisible ties force it. It is order-independent (a top-heavy tie is balanced the
+ * same as a bottom-heavy one) and reduces to standard equal-count quantile groups when there are
+ * no ties. Computed with an O(nBins * D^2) dynamic program over the D distinct values; D is small
+ * in the degenerate path (heavy ties => few distinct values), so this is cheap.
+ *
+ * Precondition: `nBins >= 1` and the number of distinct values is `>= nBins` (the legend's
+ * bin-count cap guarantees this), so every returned bin is non-empty.
+ */
+export function equalFrequencyBins(values: number[], nBins: number): IEqualFrequencyBin[] {
+  const sorted = [...values].sort((a, b) => a - b)
+  // collapse to distinct values with counts (single pass over the sorted array)
+  const distinct: Array<{ value: number, count: number }> = []
+  for (const v of sorted) {
+    const last = distinct[distinct.length - 1]
+    if (last?.value === v) last.count++
+    else distinct.push({ value: v, count: 1 })
+  }
+
+  const m = distinct.length
+  // prefix[k] = number of cases in the first k distinct values
+  const prefix = [0]
+  for (let k = 0; k < m; k++) prefix.push(prefix[k] + distinct[k].count)
+
+  // dp[k][i] = min sum-of-squared-counts to split the first i distinct values into k bins;
+  // arg[k][i] = the boundary (count of distinct values before the last bin) achieving it.
+  const dp: number[][] = Array.from({ length: nBins + 1 }, () => Array(m + 1).fill(Infinity))
+  const arg: number[][] = Array.from({ length: nBins + 1 }, () => Array(m + 1).fill(-1))
+  dp[0][0] = 0
+  for (let k = 1; k <= nBins; k++) {
+    // i >= k so each of the k bins gets at least one distinct value; j >= k-1 likewise for the rest
+    for (let i = k; i <= m; i++) {
+      for (let j = k - 1; j < i; j++) {
+        const prev = dp[k - 1][j]
+        if (prev === Infinity) continue
+        const segment = prefix[i] - prefix[j]
+        const total = prev + segment * segment
+        if (total < dp[k][i]) { dp[k][i] = total; arg[k][i] = j }
+      }
+    }
+  }
+
+  // reconstruct group boundaries: bounds = [0, b1, ..., m]; group g spans distinct[bounds[g]..bounds[g+1])
+  const bounds = [m]
+  let cut = m
+  for (let k = nBins; k >= 1; k--) {
+    const j = arg[k][cut]
+    bounds.unshift(j)
+    cut = j
+  }
+
+  const bins: IEqualFrequencyBin[] = []
+  for (let g = 0; g < nBins; g++) {
+    const lo = bounds[g]
+    const hi = bounds[g + 1]
+    bins.push({ min: distinct[lo].value, max: distinct[hi - 1].value, count: prefix[hi] - prefix[lo] })
+  }
+  return bins
+}
+
 export function isFiniteNumber(x: any): x is number {
   return x != null && Number.isFinite(x)
 }

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -121,8 +121,10 @@ export interface IEqualFrequencyBin {
  * most-equal contiguous partition: the quantile goal of equal counts, relaxed only as far as
  * indivisible ties force it. It is order-independent (a top-heavy tie is balanced the same as a
  * bottom-heavy one) and reduces to standard equal-count quantile groups when there are no ties.
- * Computed with an O(nBins * D^2) dynamic program over the D distinct values; D is small in the
- * degenerate path (heavy ties => few distinct values), so this is cheap.
+ * Computed with a dynamic program over the D distinct values, accelerated with a divide-and-conquer
+ * optimization (the squared-sum cost is convex, so the optimal boundary is monotonic) to
+ * O(nBins * D log D) — so it stays efficient even when degeneracy coincides with a large number of
+ * distinct values (e.g. one dominant tie plus a long tail of unique values).
  *
  * Returns `min(nBins, number of distinct values)` bins (so a value is never split across bins);
  * an empty input yields no bins. Callers that need exactly `nBins` bins should pass a count no
@@ -149,17 +151,34 @@ export function equalFrequencyBins(values: number[], nBins: number): IEqualFrequ
   const dp: number[][] = Array.from({ length: n + 1 }, () => Array(m + 1).fill(Infinity))
   const arg: number[][] = Array.from({ length: n + 1 }, () => Array(m + 1).fill(-1))
   dp[0][0] = 0
-  for (let k = 1; k <= n; k++) {
-    // i >= k so each of the k bins gets at least one distinct value; j >= k-1 likewise for the rest
-    for (let i = k; i <= m; i++) {
-      for (let j = k - 1; j < i; j++) {
-        const prev = dp[k - 1][j]
-        if (prev === Infinity) continue
-        const segment = prefix[i] - prefix[j]
-        const total = prev + segment * segment
-        if (total < dp[k][i]) { dp[k][i] = total; arg[k][i] = j }
-      }
+  // Fill row k for i in [iLo, iHi] knowing the optimal boundary lies in [jLo, jHi]. The squared-sum
+  // cost is convex, so the optimal boundary is monotonic non-decreasing in i; divide-and-conquer on
+  // that property reduces each row from O(D^2) to O(D log D). Ties pick the smallest boundary (the
+  // ascending scan with a strict `<`), matching a plain left-to-right DP.
+  const fillRow = (k: number, iLo: number, iHi: number, jLo: number, jHi: number) => {
+    if (iLo > iHi) return
+    const iMid = Math.floor((iLo + iHi) / 2)
+    let bestJ = -1
+    let best = Infinity
+    const jStart = Math.max(jLo, k - 1)
+    const jEnd = Math.min(jHi, iMid - 1)
+    for (let j = jStart; j <= jEnd; j++) {
+      const prev = dp[k - 1][j]
+      if (prev === Infinity) continue
+      const segment = prefix[iMid] - prefix[j]
+      const total = prev + segment * segment
+      if (total < best) { best = total; bestJ = j }
     }
+    dp[k][iMid] = best
+    arg[k][iMid] = bestJ
+    const leftHi = bestJ < 0 ? jHi : bestJ
+    const rightLo = bestJ < 0 ? jLo : bestJ
+    fillRow(k, iLo, iMid - 1, jLo, leftHi)
+    fillRow(k, iMid + 1, iHi, rightLo, jHi)
+  }
+  for (let k = 1; k <= n; k++) {
+    // i >= k so each of the k bins gets at least one distinct value; j (the prior boundary) <= m-1
+    fillRow(k, k, m, k - 1, m - 1)
   }
 
   // reconstruct group boundaries: bounds = [0, b1, ..., m]; group g spans distinct[bounds[g]..bounds[g+1])

--- a/v3/src/utilities/math-utils.ts
+++ b/v3/src/utilities/math-utils.ts
@@ -129,14 +129,11 @@ export interface IEqualFrequencyBin {
  * greater than the number of distinct values.
  */
 export function equalFrequencyBins(values: number[], nBins: number): IEqualFrequencyBin[] {
-  const sorted = [...values].sort((a, b) => a - b)
-  // collapse to distinct values with counts (single pass over the sorted array)
-  const distinct: Array<{ value: number, count: number }> = []
-  for (const v of sorted) {
-    const last = distinct[distinct.length - 1]
-    if (last?.value === v) last.count++
-    else distinct.push({ value: v, count: 1 })
-  }
+  // count occurrences in one O(n) pass, then sort only the distinct values (O(n + D log D)) rather
+  // than sorting all n values up front
+  const counts = new Map<number, number>()
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1)
+  const distinct = [...counts.keys()].sort((a, b) => a - b).map(value => ({ value, count: counts.get(value)! }))
 
   const m = distinct.length
   // a value can't be split across bins, so never make more bins than there are distinct values


### PR DESCRIPTION
## Summary

Two related improvements to numeric legends (maps & graphs), funded by Mapping Time.

### 1. Out-of-range values are treated as missing (not clamped)
Previously only the logarithmic legend treated out-of-domain values (≤ 0) as
missing; quantize and quantile clamped values outside the user-set min/max into
the nearest end bin. Now all three modes color any value outside the effective
legend range as missing, gated against `legendDisplayRange` so colors and endpoint
labels stay in lockstep. End-bin case selection is bounded by the effective range
(last bin inclusive of max), and with clamping gone every bin tooltip is a plain
`low – high` range — the special-case `< min` / `≥ max` / `>0 – t₁` labels are removed.

### 2. Degenerate quantile binning degrades usefully
With heavily tied data (e.g. eight 1s, one 2, one 3), d3's `scaleQuantile`
collapsed all cases into the last bin with a single color and left bins empty —
matching V2, but unhelpful. Quantile binning now falls back to the **most-equal
contiguous partition** only when the standard quantile bins degenerate. That
partition is defined by a least-squares criterion: the grouping of the sorted
values that **minimizes the sum of squared bin counts** (equivalently, the
variance of the per-bin case counts), with tied values kept indivisible. It is
computed by a small O(bins · distinct²) dynamic program, is order-independent
(a top-heavy tie is balanced the same as a bottom-heavy one), and reduces to
standard equal-count quantiles when there are no ties. Distinct values get
distinct colors, no bin is empty, and degenerate bins are labeled from their
data (e.g. "1", "2 – 3"). Non-degenerate data is byte-identical to V2.

This is a deliberate, documented improvement over V2, scoped strictly to the
degenerate case.

## Test Plan
- [ ] Unit tests: `equalFrequencyBins` (math-utils), model degeneracy/repair +
      `legendBinDataExtents`, choropleth-legend tooltips, out-of-range → missing
- [ ] Full Cypress regression (via `run regression` label)
- [ ] Manual: map/graph with heavily-tied legend values set to Quantile — confirm
      distinct colors, no empty bins, data-derived tooltips
- [ ] Manual: narrow a legend's Min/Max — confirm excluded values render as missing

Fixes CODAP-1409

🤖 Generated with [Claude Code](https://claude.com/claude-code)