### PR TITLE
CODAP-1401: Replace URL.canParse with browser-compatible helper

### DIFF
--- a/v3/eslint.config.mjs
+++ b/v3/eslint.config.mjs
@@ -110,6 +110,14 @@ export default [
       "no-constant-binary-expression": "error",
       "no-debugger": "off",
       "no-duplicate-imports": "error",
+      "no-restricted-properties": ["error",
+        // URL.canParse/URL.parse aren't supported in browsers we still target (e.g. Chrome <120,
+        // Safari <17). See CODAP-1401. Use the helpers in utilities/urls instead.
+        { object: "URL", property: "canParse",
+          message: "URL.canParse() is unsupported in older browsers; use canParseUrl() from utilities/urls." },
+        { object: "URL", property: "parse",
+          message: "URL.parse() is unsupported in older browsers; use safeParseUrl() from utilities/urls." }
+      ],
       "no-sequences": "error",
       "no-shadow": "off", // superseded by @typescript-eslint/no-shadow
       "no-unneeded-ternary": "error",

--- a/v3/src/components/tool-shelf/plugins-button.tsx
+++ b/v3/src/components/tool-shelf/plugins-button.tsx
@@ -11,6 +11,7 @@ import { useRemotePluginsConfig } from "../../hooks/use-remote-plugins-config"
 import { DEBUG_PLUGINS } from "../../lib/debug"
 import { logMessageWithReplacement } from "../../lib/log-message"
 import { persistentState } from "../../models/persistent-state"
+import { canParseUrl } from "../../utilities/urls"
 import { getSpecialLangFontClassName, t } from "../../utilities/translation/translate"
 import { kWebViewTileType } from "../web-view/web-view-defs"
 import { isWebViewModel } from "../web-view/web-view-model"
@@ -67,7 +68,7 @@ function PluginItem({ onClose, pluginData }: IPluginItemProps) {
     if (!pluginData) return
     documentContent?.applyModelChange(
       () => {
-        const url = URL.canParse(pluginData.path) ? pluginData.path : processWebViewUrl(`${kRootPluginsUrl}${path}`)
+        const url = canParseUrl(pluginData.path) ? pluginData.path : processWebViewUrl(`${kRootPluginsUrl}${path}`)
         const options = { height, width }
         const tile = documentContent?.createOrShowTile?.(kWebViewTileType, options)
         if (isWebViewModel(tile?.content)) {

--- a/v3/src/utilities/urls.test.ts
+++ b/v3/src/utilities/urls.test.ts
@@ -1,6 +1,20 @@
-import { getExtensionFromUrl, safeParseUrl } from "./urls"
+import { canParseUrl, getExtensionFromUrl, safeParseUrl } from "./urls"
 
 describe("urls", () => {
+  describe("canParseUrl", () => {
+    it("returns true for absolute URLs", () => {
+      expect(canParseUrl("https://example.com/plugins/Sampler/")).toBe(true)
+      expect(canParseUrl("http://localhost:8080/foo")).toBe(true)
+      expect(canParseUrl("data:image/png;base64,abc123")).toBe(true)
+    })
+
+    it("returns false for relative paths (no base provided)", () => {
+      expect(canParseUrl("Sampler/")).toBe(false)
+      expect(canParseUrl("/codap-resources/plugins/Foo/index.html")).toBe(false)
+      expect(canParseUrl("")).toBe(false)
+    })
+  })
+
   describe("safeParseUrl", () => {
     it("parses absolute URLs", () => {
       const url = safeParseUrl("https://example.com/path/file.html")

--- a/v3/src/utilities/urls.ts
+++ b/v3/src/utilities/urls.ts
@@ -13,14 +13,13 @@ export function safeParseUrl(url: string): URL | undefined {
 }
 
 /**
- * Replacement for URL.canParse(), which isn't available in older browsers (e.g. Chrome < 120,
- * the last version supported on macOS Mojave). Returns true if the string can be parsed as an
- * absolute URL. Like URL.canParse() with no base, relative paths return false.
+ * Replacement for URL.canParse(), which isn't supported in some browsers we still target
+ * (added in Chrome 120 / Safari 17). Returns true if the string can be parsed as an absolute
+ * URL; like URL.canParse() with no base, relative paths return false.
  */
 export function canParseUrl(url: string): boolean {
   try {
-    // eslint-disable-next-line no-new
-    new URL(url)
+    void new URL(url)
     return true
   } catch {
     return false

--- a/v3/src/utilities/urls.ts
+++ b/v3/src/utilities/urls.ts
@@ -12,6 +12,21 @@ export function safeParseUrl(url: string): URL | undefined {
   }
 }
 
+/**
+ * Replacement for URL.canParse(), which isn't available in older browsers (e.g. Chrome < 120,
+ * the last version supported on macOS Mojave). Returns true if the string can be parsed as an
+ * absolute URL. Like URL.canParse() with no base, relative paths return false.
+ */
+export function canParseUrl(url: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function getExtensionFromUrl(url: string): string | undefined {
   const pathParts = safeParseUrl(url)?.pathname.toLowerCase().split(".") ?? []
   return pathParts.length > 1 ? pathParts[pathParts.length - 1] : undefined


### PR DESCRIPTION
## Summary

Users on older browsers were hitting `Uncaught TypeError: URL.canParse is not a function`
when opening a plugin (e.g. Sampler) from the tool shelf. `URL.canParse()` is only available
in Chrome 120+ / Firefox 115+ / Safari 17+. The affected users are on 2013 iMacs running macOS
Mojave, where Chrome 116 is the last supported version — so they cannot update past the gap.

This wasn't caught at compile time: TypeScript's DOM lib ships with the installed TS version
and is not constrained by the `es2020` target, so `URL.canParse` type-checks regardless of the
browsers we actually support.

## Changes

- Add `canParseUrl()` to `src/utilities/urls.ts` — a `try { new URL() }` helper matching
  `URL.canParse`'s no-base semantics (relative paths return `false`).
- Use `canParseUrl()` in place of `URL.canParse()` in `plugins-button.tsx`.
- Add unit tests for `canParseUrl()`.

Fixes CODAP-1401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
