### PR TITLE
CODAP-1406: eliminate MST use-after-free warnings on closing graph

### DIFF
--- a/v3/src/components/codap-component.tsx
+++ b/v3/src/components/codap-component.tsx
@@ -87,8 +87,12 @@ export const CodapComponent = observer(function CodapComponent(props: IProps) {
     onTabTrapReady?.(handleTabTrap)
   }, [handleTabTrap, onTabTrapReady])
 
-  // Clean up last-focused tracking when tile unmounts
-  useEffect(() => () => clearLastFocusedForTile(tile.id), [tile.id])
+  // Clean up last-focused tracking when tile unmounts. Capture the id while the tile is still
+  // alive so the cleanup doesn't read it off an already-destroyed MST node (which would warn).
+  useEffect(() => {
+    const tileId = tile.id
+    return () => clearLastFocusedForTile(tileId)
+  }, [tile.id])
 
   const focused = uiState.isFocusedTile(tile.id) || uiState.isHoveredTile(tile.id)
 

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -315,7 +315,10 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
         refreshSquares()
       }
     }, { name: "ScatterDots.updateSquares" }, graphModel)
-  }, [adornmentsStore.showSquaresOfResiduals, graphModel, refreshSquares])
+    // showSquaresOfResiduals is observed inside the autorun, so it's intentionally not an effect
+    // dependency — keeping it here would recreate the mstAutorun on every toggle, accumulating
+    // no-op addDisposer entries on graphModel until it's destroyed.
+  }, [adornmentsStore, graphModel, refreshSquares])
 
   // Call refreshConnectingLines when Connecting Lines option is switched on and when all
   // points are selected.

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -1,5 +1,4 @@
 import {ScaleLinear, select} from "d3"
-import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
 import {useCallback, useEffect, useRef, useState} from "react"
 import {useDataSetContext} from "../../../../hooks/use-data-set-context"
@@ -9,6 +8,7 @@ import {ICase} from "../../../../models/data/data-set-types"
 import {
   firstVisibleParentAttribute, idOfChildmostCollectionForAttributes
 } from "../../../../models/data/data-set-utils"
+import { mstAutorun } from "../../../../utilities/mst-autorun"
 import {ScaleNumericBaseType} from "../../../axis/axis-types"
 import { getDomainExtentForPixelWidth } from "../../../axis/axis-utils"
 import { CaseData } from "../../../data-display/d3-types"
@@ -310,12 +310,12 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
   // Call refreshSquares when Squares of Residuals option is switched on and when a
   // Movable Line adornment is being dragged.
   useEffect(function updateSquares() {
-    return autorun(() => {
+    return mstAutorun(() => {
       if (adornmentsStore.showSquaresOfResiduals) {
         refreshSquares()
       }
-    }, { name: "ScatterDots.updateSquares" })
-  }, [adornmentsStore.showSquaresOfResiduals, refreshSquares])
+    }, { name: "ScatterDots.updateSquares" }, graphModel)
+  }, [adornmentsStore.showSquaresOfResiduals, graphModel, refreshSquares])
 
   // Call refreshConnectingLines when Connecting Lines option is switched on and when all
   // points are selected.
@@ -323,12 +323,16 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
   // we always get the current value, rather than relying on closures which can become stale
   // during rapid state changes (e.g., during undo when renderer is also changing).
   useEffect(function updateConnectingLines() {
-    return autorun(() => {
+    return mstAutorun(() => {
       // Read showConnectingLines directly from store inside autorun to create a reactive dependency
       const currentShowConnectingLines = adornmentsStore.showConnectingLines
+      // Observe selection inside the autorun (rather than via the effect dependencies) so the lines
+      // restyle on selection change without tearing down and reinstalling the autorun each time.
+      // (drawConnectingLines styles selected lines, so the lines genuinely depend on selection.)
+      dataConfiguration?.selection // eslint-disable-line @typescript-eslint/no-unused-expressions
       refreshConnectingLines(currentShowConnectingLines)
-    }, { name: "ScatterDots.updateConnectingLines" })
-  }, [adornmentsStore, dataConfiguration?.selection, refreshConnectingLines])
+    }, { name: "ScatterDots.updateConnectingLines" }, graphModel)
+  }, [adornmentsStore, dataConfiguration, graphModel, refreshConnectingLines])
 
   usePlotResponders({renderer, refreshPointPositions, refreshPointSelection})
 

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -332,8 +332,8 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
       // Observe selection inside the autorun (rather than via the effect dependencies) so the lines
       // restyle on selection change without tearing down and reinstalling the autorun each time.
       // (drawConnectingLines styles selected lines, so the lines genuinely depend on selection.)
-      // Only observe it when lines are shown: when hidden, refreshConnectingLines is a no-op, so
-      // tracking selection would just cause wasted reruns (incl. the O(N) selection computation).
+      // Only observe it when lines are shown: when hidden, selection has no effect on rendering, so
+      // tracking it would just cause wasted reruns (incl. the O(N) selection computation).
       if (currentShowConnectingLines) {
         dataConfiguration?.selection // eslint-disable-line @typescript-eslint/no-unused-expressions
       }

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -332,7 +332,11 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
       // Observe selection inside the autorun (rather than via the effect dependencies) so the lines
       // restyle on selection change without tearing down and reinstalling the autorun each time.
       // (drawConnectingLines styles selected lines, so the lines genuinely depend on selection.)
-      dataConfiguration?.selection // eslint-disable-line @typescript-eslint/no-unused-expressions
+      // Only observe it when lines are shown: when hidden, refreshConnectingLines is a no-op, so
+      // tracking selection would just cause wasted reruns (incl. the O(N) selection computation).
+      if (currentShowConnectingLines) {
+        dataConfiguration?.selection // eslint-disable-line @typescript-eslint/no-unused-expressions
+      }
       refreshConnectingLines(currentShowConnectingLines)
     }, { name: "ScatterDots.updateConnectingLines" }, graphModel)
   }, [adornmentsStore, dataConfiguration, graphModel, refreshConnectingLines])


### PR DESCRIPTION
## Summary

Fixes CODAP-1406.

The filed bug — a *closed* graph keeps reacting to data changes — **did not reproduce**: closing a graph cleanly unmounts and disposes its responders (`usePlotResponders` reactions dispose on unmount; the model's `mstReaction`/`mstAutorun` auto-dispose via `addDisposer`). The original "same counts when closed" was a profiler artifact (counts left from the prior open run).

Reproducing it (with instrumentation) surfaced a real, related issue that matches the ticket title: closing a scatterplot logged a number of MST `object is no longer part of a state tree` warnings.

## Root cause

The close handler removes the shared dataset and destroys the tile inside a single `applyModelChange` action; MobX defers reactions to the end of that action. Two raw `autorun()`s in `scatter-plot.tsx` (`updateSquares`, `updateConnectingLines`) were only disposed on React unmount (after the action), so they fired at `endBatch` reading already-dead nodes. Separately, `CodapComponent`'s unmount cleanup read `tile.id` off the destroyed tile.

## Fix

- **`scatter-plot.tsx`**: `autorun` → `mstAutorun(…, graphModel)`, so `addDisposer` disposes them during the destroy (before `endBatch`). Also observe `selection` inside the connecting-lines autorun (it styles selected lines) and depend on `dataConfiguration` rather than `dataConfiguration.selection`, so selection changes restyle the lines without tearing down/reinstalling the autorun each time.
- **`codap-component.tsx`**: capture `tile.id` while the tile is alive so the unmount cleanup doesn't read a destroyed node.

## Testing

- Verified by reproduction: closing a scatterplot (connecting lines on) while streaming cases → **zero** MST warnings; selection still restyles connecting lines.
- `npm run build:tsc` clean; lint clean; `jest src/components/graph` (603 passed) + `codap-component` tests pass.

No automated test added: the only graph-component render harness is `describe.skip`'d/non-functional, and standing up a full mount-and-destroy harness just to assert "no console warning" would be large and brittle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
