### PR TITLE
Release 3.0.1

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Version 3.0.1 - June 12, 2026
+
+### 🐞 Bug Fixes:
+- **CODAP-1385:** Fix numeric legend transparency affecting only one quintile
+- **CODAP-1399:** Fix join failing when destination attribute name contains spaces
+- **CODAP-1401:** Fix Plugins menu not working in older browsers
+- **CODAP-1412:** Fix map connecting lines for points outside the visible area
+
+### 🛠️ Under the Hood:
+- **CODAP-1406:** Eliminate console warnings when closing a graph
+
+### Asset Sizes
+|      File |          Size | % Change from Previous Release |
+|-----------|---------------|--------------------------------|
+|  main.css |  240772 bytes |                          0.02% |
+|  index.js | 7819617 bytes |                         <0.01% |
+
 ## Version 3.0.0 - June 7, 2026
 
 ### 🐞 Bug Fixes:

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browser": {

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -6,6 +6,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.0.1](https://codap3.concord.org/version/3.0.1/) | June 12, 2026 |
 | [3.0.0](https://codap3.concord.org/version/3.0.0/) | June 7, 2026 |
 | [3.0.0-rc.2921](https://codap3.concord.org/version/3.0.0-rc.2921/) | June 3, 2026 |
 | [3.0.0-rc.2914](https://codap3.concord.org/version/3.0.0-rc.2914/) | May 26, 2026 |


### PR DESCRIPTION
## Version 3.0.1 - June 12, 2026

### 🐞 Bug Fixes:
- **CODAP-1385:** Fix numeric legend transparency affecting only one quintile
- **CODAP-1399:** Fix join failing when destination attribute name contains spaces
- **CODAP-1401:** Fix Plugins menu not working in older browsers
- **CODAP-1412:** Fix map connecting lines for points outside the visible area

### 🛠️ Under the Hood:
- **CODAP-1406:** Eliminate console warnings when closing a graph