### PR TITLE
CODAP-1415: replace formula lookbehind regex with linear scanner

### DIFF
--- a/v3/src/models/formula/utils/canonicalization-utils.test.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.test.ts
@@ -60,6 +60,12 @@ describe("makeDisplayNamesSafe", () => {
   it("leaves an unterminated backtick untouched", () => {
     expect(makeDisplayNamesSafe("a + `unterminated")).toEqual("a + `unterminated")
   })
+  it("leaves an empty backtick pair untouched", () => {
+    expect(makeDisplayNamesSafe("a + `` + b")).toEqual("a + `` + b")
+  })
+  it("processes delimited names while leaving a lone escaped backtick untouched", () => {
+    expect(makeDisplayNamesSafe("`My Attr` + \\` + `Other`")).toEqual("My_Attr + \\` + Other")
+  })
   it("treats an escaped backslash followed by a backtick as an opening delimiter", () => {
     // `\\` is an escaped (literal) backslash, so the following backtick DOES open a delimited name.
     // The old one-char lookbehind regex incorrectly treated this backtick as escaped and left it unprocessed.

--- a/v3/src/models/formula/utils/canonicalization-utils.test.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.test.ts
@@ -47,6 +47,24 @@ describe("makeDisplayNamesSafe", () => {
     // \` and \\ treated as one symbol - unescaping is done in safeSymbolNameFromDisplayFormula
     expect(makeDisplayNamesSafe("`Attr\\\\Name` + `Attr\\`Name 2`")).toEqual("Attr_Name + Attr_Name_2")
   })
+  it("handles a backtick-delimited name at the very start of the formula", () => {
+    expect(makeDisplayNamesSafe("`Attribute Name` + 1")).toEqual("Attribute_Name + 1")
+  })
+  it("handles adjacent backtick-delimited names", () => {
+    expect(makeDisplayNamesSafe("`A`+`B`")).toEqual("A+B")
+  })
+  it("ignores an escaped backtick so it does not open a delimited name", () => {
+    // a lone escaped backtick is not a delimiter; the text is left untouched
+    expect(makeDisplayNamesSafe("a + \\` + b")).toEqual("a + \\` + b")
+  })
+  it("leaves an unterminated backtick untouched", () => {
+    expect(makeDisplayNamesSafe("a + `unterminated")).toEqual("a + `unterminated")
+  })
+  it("treats an escaped backslash followed by a backtick as an opening delimiter", () => {
+    // `\\` is an escaped (literal) backslash, so the following backtick DOES open a delimited name.
+    // The old one-char lookbehind regex incorrectly treated this backtick as escaped and left it unprocessed.
+    expect(makeDisplayNamesSafe("\\\\`Name`")).toEqual("\\\\Name")
+  })
 })
 
 describe("customizeDisplayFormula", () => {

--- a/v3/src/models/formula/utils/canonicalization-utils.ts
+++ b/v3/src/models/formula/utils/canonicalization-utils.ts
@@ -18,8 +18,52 @@ export const safeSymbolNameFromDisplayFormula = (name: string) =>
 export const makeDisplayNamesSafe = (formula: string) => {
   // Names between `` are symbols that require special processing, as otherwise they could not be parsed by Mathjs,
   // eg. names with spaces or names that start with a number. Also, it's necessary to ignore escaped backticks.
-  return formula
-    .replace(/(?<!\\)`((?:[^`\\]|\\.)+)`/g, (_, match) => safeSymbolNameFromDisplayFormula(match))
+  //
+  // We scan linearly rather than using a regex with a negative lookbehind (`(?<!\\)`), because JavaScriptCore
+  // (Safari < 16.4, including the system WebKit on iPad Air 2 / mini 4) throws a SyntaxError on lookbehind, which
+  // crashes the formula engine on load. The scanner is also faster (no backtracking) and more correct than the
+  // one-char lookbehind: an escaped backslash (`\\`) followed by a backtick correctly opens a delimited name,
+  // whereas the lookbehind treated that backtick as escaped and left the name unprocessed.
+  let result = ""
+  let i = 0
+  while (i < formula.length) {
+    const char = formula[i]
+    // Outside a delimited name, copy escape pairs (e.g. \\ or \`) untouched so the second char can't open a name.
+    if (char === "\\" && i + 1 < formula.length) {
+      result += char + formula[i + 1]
+      i += 2
+      continue
+    }
+    if (char === "`") {
+      // Scan ahead for the matching unescaped closing backtick, copying escape pairs as part of the name.
+      let inner = ""
+      let j = i + 1
+      let closed = false
+      while (j < formula.length) {
+        const innerChar = formula[j]
+        if (innerChar === "\\" && j + 1 < formula.length) {
+          inner += innerChar + formula[j + 1]
+          j += 2
+          continue
+        }
+        if (innerChar === "`") {
+          closed = true
+          break
+        }
+        inner += innerChar
+        j += 1
+      }
+      // Only replace a non-empty, properly terminated name; otherwise emit the backtick unchanged.
+      if (closed && inner.length > 0) {
+        result += safeSymbolNameFromDisplayFormula(inner)
+        i = j + 1
+        continue
+      }
+    }
+    result += char
+    i += 1
+  }
+  return result
 }
 
 interface IReplacement {


### PR DESCRIPTION
## Summary

Fixes CODAP-1415.

On Safari < 16.4 the formula engine crashes on load. The regex literal in
`makeDisplayNamesSafe` (`canonicalization-utils.ts`) used a negative
lookbehind `(?<!\\)`, which JavaScriptCore did not support until Safari
16.4. The module throws a `SyntaxError` on evaluation — a hard failure,
not a degraded formula. The Safari 15.6 floor includes iPad Air 2 / mini 4
and 2013 iMacs, which are system-WebKit-capped and common in classrooms.

This replaces the regex with a small linear scanner that tracks escape
state. It is not just a compat fix:

- **Fixes the crash** — no lookbehind, so JavaScriptCore no longer rejects
  the module.
- **Faster** — a single linear pass with no regex backtracking.
- **More correct** — an escaped backslash (`\\`) followed by a backtick now
  correctly opens a delimited name; the one-char lookbehind misread that
  backtick as escaped and left the name unprocessed.

This was the only regex lookbehind in `src`, and lookbehind was the only
ES2018+ regex feature Safari 15.6 lacks, so this closes the entire
regex-syntax exposure on the floor.

## Tests

Added cases to the `makeDisplayNamesSafe` suite, pinning: a name at string
start, adjacent names, an ignored escaped backtick, an unterminated
backtick left untouched, and the `\\`+backtick improvement. Full formula
suite (467 tests) passes; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
