### PR TITLE
CODAP-1422: suppress user entry dialog while a document loads

### DIFF
--- a/v3/src/components/app.test.tsx
+++ b/v3/src/components/app.test.tsx
@@ -105,6 +105,8 @@ describe.skip("App component", () => {
 describe("App user entry modal visibility", () => {
   afterEach(() => {
     setUrlParams("")
+    // Reset the flag flipped below so it doesn't leak into other tests in this file.
+    ;(uiState as any)._hideUserEntryModal = false
     spySetMenuBarInfo?.mockRestore()
     spySetMenuBarInfo = undefined
     cfm = undefined

--- a/v3/src/components/app.test.tsx
+++ b/v3/src/components/app.test.tsx
@@ -2,6 +2,7 @@ import { CloudFileManager, CloudFileManagerClientEvent } from "@concord-consorti
 import { act, render, screen } from "@testing-library/react"
 import { ReactNode } from "react"
 import { Root } from "react-dom/client"
+import { uiState } from "../models/ui-state"
 import { prf } from "../utilities/profiler"
 import { setUrlParams } from "../utilities/url-params"
 import { App } from "./app"
@@ -50,6 +51,13 @@ jest.mock("./tool-shelf/tool-shelf", () => ({
   ToolShelf: () => null
 }))
 
+// Mock the `UserEntryModal` to avoid Chakra Modal/focus-lock act() warnings. The overlay
+// element whose visibility we assert is rendered by `App` itself (gated by `showUserEntry`),
+// not by the modal, so this preserves the behavior under test. The modal has its own test.
+jest.mock("./menu-bar/user-entry-modal", () => ({
+  UserEntryModal: () => <div data-testid="mock-user-entry-modal" />
+}))
+
 describe.skip("App component", () => {
 
   afterEach(() => {
@@ -92,4 +100,26 @@ describe.skip("App component", () => {
     expect(screen.getByTestId("codap-app")).toBeInTheDocument()
   })
 
+})
+
+describe("App user entry modal visibility", () => {
+  afterEach(() => {
+    setUrlParams("")
+    spySetMenuBarInfo?.mockRestore()
+    spySetMenuBarInfo = undefined
+    cfm = undefined
+  })
+
+  it("hides the user entry modal reactively when uiState.hideUserEntryModal becomes true", () => {
+    setUrlParams("")
+    render(<App/>)
+    // With no auto-open params, the user entry modal is shown initially
+    expect(screen.getByTestId("mock-user-entry-modal")).toBeInTheDocument()
+    // When a document starts loading (e.g. CFM willOpenFile sets this flag), the modal
+    // should disappear immediately, before the document finishes loading.
+    act(() => {
+      uiState.setHideUserEntryModal()
+    })
+    expect(screen.queryByTestId("mock-user-entry-modal")).not.toBeInTheDocument()
+  })
 })

--- a/v3/src/components/app.test.tsx
+++ b/v3/src/components/app.test.tsx
@@ -106,7 +106,7 @@ describe("App user entry modal visibility", () => {
   afterEach(() => {
     setUrlParams("")
     // Reset the flag flipped below so it doesn't leak into other tests in this file.
-    ;(uiState as any)._hideUserEntryModal = false
+    uiState.setHideUserEntryModal(false)
     spySetMenuBarInfo?.mockRestore()
     spySetMenuBarInfo = undefined
     cfm = undefined

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -1,4 +1,3 @@
-import { useDisclosure } from "@chakra-ui/react"
 import { CloudFileManager } from "@concord-consortium/cloud-file-manager"
 import { clsx } from "clsx"
 import { autorun, reaction } from "mobx"
@@ -75,13 +74,13 @@ export const App = observer(function App() {
   // default behavior is to show the user entry modal when CODAP is loaded
   // We close the modal if user imports, drags a document, opens a document
   // or plugin using url params
-  const {isOpen: isOpenUserEntry, onOpen: onOpenUserEntry, onClose: onCloseUserEntry}
-    = useDisclosure({defaultIsOpen: true})
-  // The disclosure tracks user-initiated open/close, but `uiState.hideUserEntryModal`
+  const [userDismissedEntry, setUserDismissedEntry] = useState(false)
+  const onCloseUserEntry = useCallback(() => setUserDismissedEntry(true), [])
+  // `userDismissedEntry` tracks the user dismissing the modal, while `uiState.hideUserEntryModal`
   // overrides it whenever a document is auto-opening at startup (e.g. a shared document
   // loaded via the CFM or the `url` param). Reading it here (App is an observer) keeps the
   // modal hidden reactively for the entire load, rather than only after `openedFile`.
-  const showUserEntry = isOpenUserEntry && !uiState.hideUserEntryModal
+  const showUserEntry = !userDismissedEntry && !uiState.hideUserEntryModal
   const [isDragOver, setIsDragOver] = useState(false)
   const userEntryOverlayRef = useRef<HTMLDivElement>(null)
   const cfmRef = useRef<CloudFileManager | null>(null)
@@ -218,7 +217,7 @@ export const App = observer(function App() {
     }
 
     initialize()
-  }, [cfm, cfmReadyPromise, onCloseUserEntry, onOpenUserEntry])
+  }, [cfm, cfmReadyPromise])
 
   const { fallbackRender } = useUncaughtErrorHandler(cfm)
 

--- a/v3/src/components/app.tsx
+++ b/v3/src/components/app.tsx
@@ -77,6 +77,11 @@ export const App = observer(function App() {
   // or plugin using url params
   const {isOpen: isOpenUserEntry, onOpen: onOpenUserEntry, onClose: onCloseUserEntry}
     = useDisclosure({defaultIsOpen: true})
+  // The disclosure tracks user-initiated open/close, but `uiState.hideUserEntryModal`
+  // overrides it whenever a document is auto-opening at startup (e.g. a shared document
+  // loaded via the CFM or the `url` param). Reading it here (App is an observer) keeps the
+  // modal hidden reactively for the entire load, rather than only after `openedFile`.
+  const showUserEntry = isOpenUserEntry && !uiState.hideUserEntryModal
   const [isDragOver, setIsDragOver] = useState(false)
   const userEntryOverlayRef = useRef<HTMLDivElement>(null)
   const cfmRef = useRef<CloudFileManager | null>(null)
@@ -137,7 +142,7 @@ export const App = observer(function App() {
   cfmRef.current = cfm
 
   useDropHandler({
-    selector: isOpenUserEntry ? `#${kUserEntryDropOverlay}` : `#${kCodapAppElementId}`,
+    selector: showUserEntry ? `#${kUserEntryDropOverlay}` : `#${kCodapAppElementId}`,
     onDrop: handleDrop,
     onSetIsDragOver: setIsDragOver
   })
@@ -200,10 +205,6 @@ export const App = observer(function App() {
             if (isWebViewModel(plugin?.content)) plugin.content.setUrl(di)
           })
         })
-      }
-
-      if (uiState.hideUserEntryModal) {
-        onCloseUserEntry()
       }
 
       appState.enableDocumentMonitoring()
@@ -269,12 +270,12 @@ export const App = observer(function App() {
                 </If>
               </div>
             </SectionNavigationProvider>
-            <If condition={isOpenUserEntry}>
+            <If condition={showUserEntry}>
               <div id={`${kUserEntryDropOverlay}`} ref={userEntryOverlayRef}
-                className={clsx({ "show-highlight": isOpenUserEntry && isDragOver })}
+                className={clsx({ "show-highlight": showUserEntry && isDragOver })}
               >
                 <UserEntryModal
-                  isOpen={isOpenUserEntry}
+                  isOpen={showUserEntry}
                   onClose={onCloseUserEntry}
                   containerRef={userEntryOverlayRef}
                 />

--- a/v3/src/lib/cfm/handle-cfm-event.test.ts
+++ b/v3/src/lib/cfm/handle-cfm-event.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@concord-consortium/cloud-file-manager"
 import { getSnapshot } from "mobx-state-tree"
 import { appState } from "../../models/app-state"
+import { uiState } from "../../models/ui-state"
 import { createCodapDocument, isCodapDocument } from "../../models/codap/create-codap-document"
 import { ICodapV2DocumentJson } from "../../v2/codap-v2-types"
 import * as ImportV2Document from "../../v2/import-v2-document"
@@ -121,10 +122,15 @@ describe("handleCFMEvent", () => {
       callback: jest.fn()
     }
     const spy = jest.spyOn(urlParamsModule, "removeDevUrlParams")
+    // Opening any file should suppress the user entry modal so it doesn't linger
+    // in front of a still-loading document (e.g. a CFM `#shared=` shared document).
+    const hideModalSpy = jest.spyOn(uiState, "setHideUserEntryModal")
     const mockCfmEventArg = mockCfmEvent as unknown as CloudFileManagerClientEvent
     await handleCFMEvent(mockCfmClient, mockCfmEventArg)
     expect(spy).toHaveBeenCalledTimes(1)
+    expect(hideModalSpy).toHaveBeenCalledTimes(1)
     spy.mockRestore()
+    hideModalSpy.mockRestore()
   })
 
   it("handles the `openedFile` message with a v2 document", async () => {

--- a/v3/src/lib/cfm/handle-cfm-event.test.ts
+++ b/v3/src/lib/cfm/handle-cfm-event.test.ts
@@ -124,7 +124,9 @@ describe("handleCFMEvent", () => {
     const spy = jest.spyOn(urlParamsModule, "removeDevUrlParams")
     // Opening any file should suppress the user entry modal so it doesn't linger
     // in front of a still-loading document (e.g. a CFM `#shared=` shared document).
-    const hideModalSpy = jest.spyOn(uiState, "setHideUserEntryModal")
+    // Mock the implementation so the spy asserts the call without mutating the
+    // global `uiState` singleton.
+    const hideModalSpy = jest.spyOn(uiState, "setHideUserEntryModal").mockImplementation(() => {})
     const mockCfmEventArg = mockCfmEvent as unknown as CloudFileManagerClientEvent
     await handleCFMEvent(mockCfmClient, mockCfmEventArg)
     expect(spy).toHaveBeenCalledTimes(1)

--- a/v3/src/lib/cfm/handle-cfm-event.ts
+++ b/v3/src/lib/cfm/handle-cfm-event.ts
@@ -67,6 +67,10 @@ export async function handleCFMEvent(cfmClient: CloudFileManagerClient, event: C
       break
     }
     case "willOpenFile":
+      // Hide the user entry modal as soon as a file open begins, so it doesn't linger in
+      // front of a still-loading document (e.g. a CFM `#shared=` shared document, which is
+      // fetched over the network). This fires before the load completes, unlike `openedFile`.
+      uiState.setHideUserEntryModal()
       removeDevUrlParams()
       break
     // case "newedFile":

--- a/v3/src/models/ui-state.test.ts
+++ b/v3/src/models/ui-state.test.ts
@@ -449,5 +449,29 @@ describe("UIState", () => {
       const uiState = new UIState()
       expect(uiState.hideUserEntryModal).toBe(true)
     })
+
+    it("should be true when a document url is specified", () => {
+      setUrlParams("?url=https://example.com/shared.codap")
+      const uiState = new UIState()
+      expect(uiState.hideUserEntryModal).toBe(true)
+    })
+
+    it("should be true when interactiveApi is present (Activity Player context)", () => {
+      setUrlParams("?interactiveApi")
+      const uiState = new UIState()
+      expect(uiState.hideUserEntryModal).toBe(true)
+    })
+
+    it("should be true when launchFromLara has a value", () => {
+      setUrlParams("?launchFromLara=abc123")
+      const uiState = new UIState()
+      expect(uiState.hideUserEntryModal).toBe(true)
+    })
+
+    it("should be true when lara has a value", () => {
+      setUrlParams("?lara=true")
+      const uiState = new UIState()
+      expect(uiState.hideUserEntryModal).toBe(true)
+    })
   })
 })

--- a/v3/src/models/ui-state.ts
+++ b/v3/src/models/ui-state.ts
@@ -90,10 +90,16 @@ export class UIState {
   constructor() {
     const {
       componentMode, dashboard, di, embeddedMode, embeddedServer, hideSplashScreen,
-      hideUndoRedoInComponent, inbounds, noEntryModal, sample, standalone, suppressUnsavedWarning
+      hideUndoRedoInComponent, inbounds, noEntryModal, sample, standalone, suppressUnsavedWarning, url
     } = urlParams
     this._hideSplashScreen = booleanParam(hideSplashScreen)
-    this._hideUserEntryModal = !!sample || booleanParam(dashboard) || !!di || booleanParam(noEntryModal)
+    // Suppress the user entry modal whenever a document is known to be auto-opening at
+    // startup, so it never appears in front of a still-loading document. `url` covers the
+    // `?url=` document parameter; `hasInteractiveApiContext()` covers Activity Player / LARA
+    // launches. CFM-initiated opens (e.g. `#shared=` links) are handled separately by hiding
+    // the modal on the CFM `willOpenFile` event.
+    this._hideUserEntryModal = !!sample || booleanParam(dashboard) || !!di ||
+      booleanParam(noEntryModal) || !!url || hasInteractiveApiContext()
 
     // Initialize standalone mode
     this._standaloneMode = booleanParam(standalone)

--- a/v3/src/models/ui-state.ts
+++ b/v3/src/models/ui-state.ts
@@ -236,8 +236,8 @@ export class UIState {
   }
 
   @action
-  setHideUserEntryModal() {
-    this._hideUserEntryModal = true
+  setHideUserEntryModal(hidden = true) {
+    this._hideUserEntryModal = hidden
   }
 
   get focusedTile() {


### PR DESCRIPTION
## Summary
The user entry dialog ("What would you like to do?" — open-existing vs. create-new) defaulted to open and was only closed after the CFM `openedFile` event, so it lingered in front of a shared document while it loaded over the network. This was most visible for CFM-loaded shared documents (e.g. `#shared=…` links), and also affected the `?url=…` document parameter.

Now the dialog is suppressed for the entire load whenever CODAP is auto-opening a document at startup. It appears only when CODAP starts with no document to open.

## Changes
- **`ui-state.ts`** — the `UIState` constructor suppresses the modal up-front for the `url` param and for Activity Player / LARA context (`hasInteractiveApiContext()`), so there's no flash for those paths.
- **`handle-cfm-event.ts`** — the CFM `willOpenFile` event now calls `uiState.setHideUserEntryModal()`. This is the catch-all for CFM-initiated opens (shared-hash links), and it fires at the *start* of the load rather than after `openedFile`.
- **`app.tsx`** — visibility is derived as `showUserEntry = isOpenUserEntry && !uiState.hideUserEntryModal` and observed reactively, so the hide takes effect mid-session; the now-redundant one-shot close in `initialize()` is removed.

On load failure the dialog stays suppressed (the CFM shows its own error dialog), consistent with existing `sample`/`di`/`dashboard` behavior.

## Testing
- `ui-state.test.ts`: `hideUserEntryModal` is true for `url`, `interactiveApi`, `launchFromLara`, and `lara`.
- `handle-cfm-event.test.ts`: `willOpenFile` calls `setHideUserEntryModal()`.
- `app.test.tsx`: the modal disappears reactively when `uiState.hideUserEntryModal` becomes true.
- `npm run lint` and `npm run build:tsc` pass.

Fixes CODAP-1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
