### PR TITLE
CODAP-1424: re-establish plugin connection for interactives added by drag/drop or URL import

### DIFF
--- a/v3/src/components/web-view/use-data-interactive-controller.test.ts
+++ b/v3/src/components/web-view/use-data-interactive-controller.test.ts
@@ -1,4 +1,28 @@
-import { extractOrigin } from "./use-data-interactive-controller"
+import { act, renderHook } from "@testing-library/react"
+import iframePhone from "iframe-phone"
+import { DIComponentInfo } from "../../data-interactive/data-interactive-types"
+import { diComponentHandler } from "../../data-interactive/handlers/component-handler"
+import { appState } from "../../models/app-state"
+import { toV3Id } from "../../utilities/codap-utils"
+import { extractOrigin, useDataInteractiveController } from "./use-data-interactive-controller"
+import { IWebViewModel } from "./web-view-model"
+import { kWebViewIdPrefix } from "./web-view-registration"
+
+// Replace iframe-phone with lightweight mocks so the hook doesn't attempt real postMessage
+// handshakes; we only care about how many times a connection (ParentEndpoint) is established.
+jest.mock("iframe-phone", () => ({
+  __esModule: true,
+  default: {
+    ParentEndpoint: jest.fn(() => ({ disconnect: jest.fn() })),
+    IframePhoneRpcEndpoint: jest.fn(() => ({ call: jest.fn(), disconnect: jest.fn() }))
+  }
+}))
+
+jest.mock("../../hooks/use-cfm-context", () => ({ useCfmContext: () => undefined }))
+
+jest.mock("../../data-interactive/data-interactive-request-processor", () => ({
+  setupRequestQueueProcessor: jest.fn(() => jest.fn())
+}))
 
 describe("extractOrigin", () => {
   it("extracts origin from absolute https URLs", () => {
@@ -33,5 +57,41 @@ describe("extractOrigin", () => {
   it("handles data: URLs", () => {
     expect(extractOrigin("data:image/png;base64,abc123"))
       .toBe("null")
+  })
+})
+
+describe("useDataInteractiveController", () => {
+  // CODAP-1424: An interactive added by drag/drop or URL import starts as a generic web view.
+  // When its plugin handshake succeeds, CODAP promotes it to a plugin (setSubType("plugin")),
+  // which flips `needsLocaleReload` to true and forces the iframe to reload with locale params
+  // WITHOUT changing the model url. The connection effect must re-run on that flip so that the
+  // reloaded iframe is re-sent `codap-present`; otherwise the surviving load never learns it is
+  // embedded in CODAP and the plugin's "send data to CODAP" UI stays hidden.
+  it("re-establishes the connection when a generic web view is promoted to a plugin", () => {
+    const documentContent = appState.document.content!
+    const result = diComponentHandler.create!(
+      {}, { type: "webView", URL: "https://lab.concord.org/embeddable.html#interactives/sample.json" })
+    const id = (result.values as DIComponentInfo).id!
+    const tile = documentContent.tileMap.get(toV3Id(kWebViewIdPrefix, id))!
+    const webViewModel = tile.content as IWebViewModel
+    const ParentEndpoint = iframePhone.ParentEndpoint as unknown as jest.Mock
+
+    // Precondition: a dropped/imported URL is a generic web view that does not reload for locale.
+    expect(webViewModel.needsLocaleReload).toBe(false)
+
+    const iframeRef = { current: document.createElement("iframe") }
+    const { rerender } = renderHook(() => useDataInteractiveController(iframeRef, tile))
+    const connectionsAfterMount = ParentEndpoint.mock.calls.length
+    expect(connectionsAfterMount).toBeGreaterThanOrEqual(1)
+
+    // Simulate the plugin handshake promoting the generic web view to a plugin.
+    act(() => { webViewModel.setPluginIsCommunicating() })
+    expect(webViewModel.needsLocaleReload).toBe(true)
+    // The model url is unchanged — only the computed iframe src (with locale params) changes,
+    // so without `needsLocaleReload` in the effect deps the connection would NOT re-establish.
+    expect(webViewModel.url).toBe("https://lab.concord.org/embeddable.html#interactives/sample.json")
+
+    rerender()
+    expect(ParentEndpoint.mock.calls.length).toBeGreaterThan(connectionsAfterMount)
   })
 })

--- a/v3/src/components/web-view/use-data-interactive-controller.ts
+++ b/v3/src/components/web-view/use-data-interactive-controller.ts
@@ -23,6 +23,14 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
   const tileContentModel = tile?.content
   const webViewModel = isWebViewModel(tileContentModel) ? tileContentModel : undefined
   const url = webViewModel?.url
+  // The iframe loads `iframeSrc` (see web-view.tsx), which appends locale params when
+  // `needsLocaleReload` is true. That flag can flip from false to true at runtime when a
+  // generic web view (e.g. an interactive added by drag/drop or URL import) is promoted to a
+  // plugin after its handshake — which mutates the iframe src and forces a reload WITHOUT
+  // changing `url`. Tracking it here re-runs the effect below so the connection is
+  // re-established and `codap-present` is re-sent to the reloaded iframe; otherwise the
+  // reloaded plugin never learns it is embedded in CODAP. (CODAP-1424)
+  const needsLocaleReload = webViewModel?.needsLocaleReload
   const cfm = useCfmContext()
 
   // Counter incremented when a localized plugin needs to reload due to a locale change.
@@ -97,5 +105,5 @@ export function useDataInteractiveController(iframeRef: React.RefObject<HTMLIFra
         phone.disconnect()
       }
     }
-  }, [cfm, iframeRef, localeVersion, tile, url, webViewModel])
+  }, [cfm, iframeRef, localeVersion, needsLocaleReload, tile, url, webViewModel])
 }


### PR DESCRIPTION
## Summary

Fixes an interactive added to CODAP by **drag/drop or URL import** (e.g. a Lab
interactive from lab.concord.org) failing to detect it's embedded in CODAP, so
it never showed its "send data to CODAP" controls. The same interactive worked
via share link, Google Drive reload, or "make a copy".

## Root cause

A dropped/imported URL is created as a *generic* web view (`subType` undefined,
`isPluginCandidate` false), so `needsLocaleReload` is false and the iframe first
loads the raw URL. When the iframe-phone handshake succeeds,
`setPluginIsCommunicating()` promotes the tile to a plugin
(`setSubType("plugin")`), flipping `needsLocaleReload` to true. That makes
`web-view.tsx` recompute the iframe `src` to append `?lang=…&locale=…`, forcing
a second iframe load. Because the model `url` (a dependency of the connection
effect) is unchanged, the effect did not re-run, so CODAP never re-sent
`codap-present` to the reloaded iframe — the surviving load never learned it was
in CODAP.

Paths that classify as a plugin before first render don't hit this: the Plugins
menu sets `setPluginCandidate(true)`, and saved docs / "make a copy" carry
`subType: "plugin"` in the snapshot, so they load exactly once.

## Fix

Add `needsLocaleReload` to the connection effect's dependency array in
`use-data-interactive-controller.ts`, so the iframe-phone connection is
re-established (and `codap-present` re-sent) when the runtime plugin-promotion
flips it and reloads the iframe. This reuses the re-establish mechanism the
locale-change path already relies on.

## Why fix the reload path instead of forcing a single load?

The obvious alternative is to mark dropped/imported URLs as a plugin candidate up
front (as the Plugins menu does via `setPluginCandidate(true)`), so
`needsLocaleReload` is true from the first render and the iframe loads once with
locale params — no second load. We deliberately did **not** do this:

- Drag/drop and URL import are also how plain **web pages** (and images) are
  added, and there's no way to know at drop time whether a URL is a plugin or an
  ordinary web page.
- Treating every dropped URL as a plugin candidate would append `?lang=…&locale=…`
  to arbitrary web pages. Some sites interpret those params (changing language or
  behavior), it would force those pages to reload on every CODAP locale change
  (losing scroll/form state), and it extends a plugin-only feature to non-plugins
  — diverging from the existing design (and from v2).

Keeping locale params plugin-only and making the already-intended reload robust
is the lower-risk, more faithful fix. (The cost is one extra iframe load for a
dropped interactive at the moment it's recognized as a plugin — the same reload
the locale feature already performs — with no impact on web pages.)

## Testing

- New regression test in `use-data-interactive-controller.test.ts` (verified it
  fails without the added dependency).
- Manually reproduced and verified in the running app with `debug=plugins`: after
  promotion, a second connection + `codap-present` reaches the reloaded iframe and
  the interactive's controls appear.
- `npm run build:tsc`, lint, and the full web-view jest suite pass.

Fixes CODAP-1424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
