### PR TITLE
CODAP-1420: color Y2 axis attribute label to match its points

### DIFF
--- a/v3/src/components/graph/components/graph-attribute-label-color.test.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label-color.test.tsx
@@ -23,7 +23,11 @@ jest.mock("../../data-display/components/attribute-label", () => {
       props: { place: string, refreshLabel: () => void },
       ref: React.ForwardedRef<SVGGElement>
     ) {
-      ReactModule.useEffect(() => autorun(() => props.refreshLabel()), [props])
+      const { refreshLabel } = props
+      ReactModule.useEffect(() => {
+        const disposer = autorun(() => refreshLabel())
+        return disposer
+      }, [refreshLabel])
       return <g ref={ref} data-testid={`attribute-label-${props.place}`} />
     })
   }
@@ -79,9 +83,14 @@ describe("GraphAttributeLabel Y2 (rightNumeric) color", () => {
   const labelFill = (container: HTMLElement, place: string) =>
     container.querySelector(`[data-testid='attribute-label-${place}'] text`)?.getAttribute("style") ?? ""
 
+  // jsdom doesn't implement getBBox, which renderLabelBackground (called by refreshAxisTitle) needs.
+  // Save and restore the original so we don't pollute other test files sharing this Jest worker.
+  const originalGetBBox = (SVGElement.prototype as any).getBBox
   beforeAll(() => {
-    // jsdom doesn't implement getBBox, which renderLabelBackground (called by refreshAxisTitle) needs.
     ;(SVGElement.prototype as any).getBBox = () => ({ x: 0, y: 0, width: 0, height: 0 })
+  })
+  afterAll(() => {
+    ;(SVGElement.prototype as any).getBBox = originalGetBBox
   })
 
   beforeEach(() => {

--- a/v3/src/components/graph/components/graph-attribute-label-color.test.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label-color.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable testing-library/no-node-access, testing-library/no-container */
+/* eslint-disable testing-library/no-node-access */
 import { act, render } from "@testing-library/react"
 import React from "react"
 import { DataSet } from "../../../models/data/data-set"
@@ -143,4 +143,4 @@ describe("GraphAttributeLabel Y2 (rightNumeric) color", () => {
     expect(style).not.toContain("fill:")
   })
 })
-/* eslint-enable testing-library/no-node-access, testing-library/no-container */
+/* eslint-enable testing-library/no-node-access */

--- a/v3/src/components/graph/components/graph-attribute-label-color.test.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label-color.test.tsx
@@ -134,13 +134,34 @@ describe("GraphAttributeLabel Y2 (rightNumeric) color", () => {
     expect(labelFill(container, "rightNumeric")).toContain("fill: #abcdef")
   })
 
-  it("does not set an inline fill on a primary (non-rightNumeric) label", () => {
+  it("does not set an inline fill on the left label when no Y2 attribute is present", () => {
     const { container } = renderLabel("left")
     // The label text is rendered (non-empty inline style) but carries no fill, so it falls back
     // to its CSS class color rather than a point color.
     const style = labelFill(container, "left")
     expect(style).not.toBe("")
     expect(style).not.toContain("fill:")
+  })
+
+  it("colors the single-Y left label to match its points when a Y2 attribute is present", () => {
+    // With one primary Y attribute, the Y attribute's plot index is 0.
+    pointDescription.setPointColor("#abc123", 0)
+    dataConfiguration.setAttribute("rightNumeric", { attributeID: "y2Id" })
+
+    const { container } = renderLabel("left")
+    expect(pointDescription.pointColorAtIndex(0)).toBe("#abc123")
+    expect(labelFill(container, "left")).toContain(`fill: ${pointDescription.pointColorAtIndex(0)}`)
+  })
+
+  it("updates the single-Y left label color when the Y point color changes", () => {
+    pointDescription.setPointColor("#abc123", 0)
+    dataConfiguration.setAttribute("rightNumeric", { attributeID: "y2Id" })
+
+    const { container } = renderLabel("left")
+    expect(labelFill(container, "left")).toContain("fill: #abc123")
+
+    act(() => pointDescription.setPointColor("#fedcba", 0))
+    expect(labelFill(container, "left")).toContain("fill: #fedcba")
   })
 })
 /* eslint-enable testing-library/no-node-access */

--- a/v3/src/components/graph/components/graph-attribute-label-color.test.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label-color.test.tsx
@@ -1,0 +1,137 @@
+/* eslint-disable testing-library/no-node-access, testing-library/no-container */
+import { act, render } from "@testing-library/react"
+import React from "react"
+import { DataSet } from "../../../models/data/data-set"
+import { DataSetMetadata } from "../../../models/shared/data-set-metadata"
+import { GraphContentModelContext } from "../hooks/use-graph-content-model-context"
+import { GraphDataConfigurationContext } from "../hooks/use-graph-data-configuration-context"
+import { GraphLayoutContext } from "../hooks/use-graph-layout-context"
+import { TileSelectionContext } from "../../../hooks/use-tile-selection-context"
+import { GraphAttributeLabel } from "./graph-attribute-label"
+import { GraphDataConfigurationModel } from "../models/graph-data-configuration-model"
+import { GraphLayout } from "../models/graph-layout"
+import { DisplayItemDescriptionModel } from "../../data-display/models/display-item-description-model"
+
+// Unlike graph-attribute-label.test.tsx, which mocks AttributeLabel as an inert <g> to avoid
+// portal setup, this mock drives refreshLabel inside a MobX autorun so the real refreshAxisTitle
+// runs (and re-runs reactively). That lets us assert the SVG text fill the label actually renders.
+jest.mock("../../data-display/components/attribute-label", () => {
+  const ReactModule = require("react")
+  const { autorun } = require("mobx")
+  return {
+    AttributeLabel: ReactModule.forwardRef(function MockAttributeLabel(
+      props: { place: string, refreshLabel: () => void },
+      ref: React.ForwardedRef<SVGGElement>
+    ) {
+      ReactModule.useEffect(() => autorun(() => props.refreshLabel()), [props])
+      return <g ref={ref} data-testid={`attribute-label-${props.place}`} />
+    })
+  }
+})
+
+describe("GraphAttributeLabel Y2 (rightNumeric) color", () => {
+  let dataSet: typeof DataSet.Type
+  let metadata: typeof DataSetMetadata.Type
+  let dataConfiguration: typeof GraphDataConfigurationModel.Type
+  let layout: GraphLayout
+  let pointDescription: typeof DisplayItemDescriptionModel.Type
+
+  const createMockGraphModel = () => ({
+    type: "Graph",
+    plotType: "scatterPlot",
+    pointDescription,
+    pointsFusedIntoBars: false,
+    plot: {
+      type: "scatterPlot",
+      hasCountPercentFormulaAxis: false,
+      countPercentFormulaAxisLabel: "",
+      axisLabelClickHandler: () => undefined
+    }
+  })
+
+  const mockTileSelectionContext = {
+    isTileSelected: () => false,
+    selectTile: () => undefined,
+    addFocusIgnoreFn: () => () => undefined
+  }
+
+  const renderLabel = (place: "left" | "rightNumeric") => {
+    return render(
+      <TileSelectionContext.Provider value={mockTileSelectionContext}>
+        <GraphContentModelContext.Provider value={createMockGraphModel() as any}>
+          <GraphDataConfigurationContext.Provider value={dataConfiguration}>
+            <GraphLayoutContext.Provider value={layout}>
+              <svg>
+                <GraphAttributeLabel
+                  place={place}
+                  onChangeAttribute={jest.fn()}
+                  onRemoveAttribute={jest.fn()}
+                  onTreatAttributeAs={jest.fn()}
+                />
+              </svg>
+            </GraphLayoutContext.Provider>
+          </GraphDataConfigurationContext.Provider>
+        </GraphContentModelContext.Provider>
+      </TileSelectionContext.Provider>
+    )
+  }
+
+  const labelFill = (container: HTMLElement, place: string) =>
+    container.querySelector(`[data-testid='attribute-label-${place}'] text`)?.getAttribute("style") ?? ""
+
+  beforeAll(() => {
+    // jsdom doesn't implement getBBox, which renderLabelBackground (called by refreshAxisTitle) needs.
+    ;(SVGElement.prototype as any).getBBox = () => ({ x: 0, y: 0, width: 0, height: 0 })
+  })
+
+  beforeEach(() => {
+    dataSet = DataSet.create({ name: "Test Data" })
+    dataSet.addAttribute({ id: "xId", name: "X" })
+    dataSet.addAttribute({ id: "y1Id", name: "Height" })
+    dataSet.addAttribute({ id: "y2Id", name: "Weight" })
+
+    metadata = DataSetMetadata.create()
+    metadata.setData(dataSet)
+
+    dataConfiguration = GraphDataConfigurationModel.create()
+    dataConfiguration.setDataset(dataSet, metadata)
+    dataConfiguration.setAttribute("x", { attributeID: "xId" })
+    dataConfiguration.setAttribute("y", { attributeID: "y1Id" })
+
+    layout = new GraphLayout()
+    layout.setTileExtent(400, 300)
+
+    pointDescription = DisplayItemDescriptionModel.create()
+  })
+
+  it("colors the rightNumeric label to match its points when a Y2 attribute is present", () => {
+    // With one primary Y attribute, the Y2 attribute's plot index is 1.
+    pointDescription.setPointColor("#123456", 1)
+    dataConfiguration.setAttribute("rightNumeric", { attributeID: "y2Id" })
+
+    const { container } = renderLabel("rightNumeric")
+    expect(pointDescription.pointColorAtIndex(1)).toBe("#123456")
+    expect(labelFill(container, "rightNumeric")).toContain(`fill: ${pointDescription.pointColorAtIndex(1)}`)
+  })
+
+  it("updates the rightNumeric label color when the Y2 point color changes", () => {
+    pointDescription.setPointColor("#123456", 1)
+    dataConfiguration.setAttribute("rightNumeric", { attributeID: "y2Id" })
+
+    const { container } = renderLabel("rightNumeric")
+    expect(labelFill(container, "rightNumeric")).toContain("fill: #123456")
+
+    act(() => pointDescription.setPointColor("#abcdef", 1))
+    expect(labelFill(container, "rightNumeric")).toContain("fill: #abcdef")
+  })
+
+  it("does not set an inline fill on a primary (non-rightNumeric) label", () => {
+    const { container } = renderLabel("left")
+    // The label text is rendered (non-empty inline style) but carries no fill, so it falls back
+    // to its CSS class color rather than a point color.
+    const style = labelFill(container, "left")
+    expect(style).not.toBe("")
+    expect(style).not.toContain("fill:")
+  })
+})
+/* eslint-enable testing-library/no-node-access, testing-library/no-container */

--- a/v3/src/components/graph/components/graph-attribute-label.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label.tsx
@@ -200,12 +200,19 @@ export const GraphAttributeLabel =
           .attr('data-testid', className)
           .attr("transform", labelTransform + tRotation)
           .style('visibility', visibility)
+          .style('fill', labelColor)
           .attr('x', tX)
           .attr('y', tY)
           .text(label)
       }
 
-      const {labelFont, className, unusedClassName, visibility} = getClickHereCue(),
+      const {labelFont, className, unusedClassName, useClickHereCue, visibility} = getClickHereCue(),
+        // Y2 (rightNumeric) label takes the color of its points, matching V2 behavior.
+        // Its plot index sits after all primary Y attributes.
+        labelColor = place === 'rightNumeric' && !useClickHereCue
+          ? graphModel.pointDescription.pointColorAtIndex(
+              dataConfiguration?.yAttributeDescriptionsExcludingY2.length ?? 0)
+          : null,
         bounds = layout.getComputedBounds(place),
         layoutIsVertical = isVertical(place),
         halfRange = layoutIsVertical ? bounds.height / 2 : bounds.width / 2,
@@ -253,7 +260,8 @@ export const GraphAttributeLabel =
         gSelection, textSelector: `text.${className}`,
         transform: labelTransform + tRotation, visibility
       })
-    }, [getClickHereCue, getLabel, isTileSelected, layout, place])
+    }, [dataConfiguration?.yAttributeDescriptionsExcludingY2.length, getClickHereCue, getLabel,
+        graphModel.pointDescription, isTileSelected, layout, place])
 
     const plotDefinedAxisClickHandler = graphModel.plot.axisLabelClickHandler(graphPlaceToAttrRole[place])
 

--- a/v3/src/components/graph/components/graph-attribute-label.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label.tsx
@@ -207,12 +207,18 @@ export const GraphAttributeLabel =
       }
 
       const {labelFont, className, unusedClassName, visibility} = getClickHereCue(),
-        // Y2 (rightNumeric) label takes the color of its points, matching V2 behavior.
-        // Its plot index sits after all primary Y attributes.
-        labelColor = place === 'rightNumeric' && dataConfiguration?.hasY2Attribute
-          ? graphModel.pointDescription.pointColorAtIndex(
-              dataConfiguration.yAttributeDescriptionsExcludingY2.length)
-          : null,
+        // When a Y2 (rightNumeric) attribute is present, both labels take their points' color
+        // (matching V2). The Y2 label's plot index sits after all primary Y attributes; with a
+        // single Y, the left label uses index 0. The multi-Y case is handled by
+        // SingleYAttributeLabel, which renders each label with its own color.
+        labelColor = !dataConfiguration?.hasY2Attribute
+          ? null
+          : place === 'rightNumeric'
+            ? graphModel.pointDescription.pointColorAtIndex(
+                dataConfiguration.yAttributeDescriptionsExcludingY2.length)
+            : place === 'left' && dataConfiguration.yAttributeDescriptionsExcludingY2.length === 1
+              ? graphModel.pointDescription.pointColorAtIndex(0)
+              : null,
         bounds = layout.getComputedBounds(place),
         layoutIsVertical = isVertical(place),
         halfRange = layoutIsVertical ? bounds.height / 2 : bounds.width / 2,

--- a/v3/src/components/graph/components/graph-attribute-label.tsx
+++ b/v3/src/components/graph/components/graph-attribute-label.tsx
@@ -206,12 +206,12 @@ export const GraphAttributeLabel =
           .text(label)
       }
 
-      const {labelFont, className, unusedClassName, useClickHereCue, visibility} = getClickHereCue(),
+      const {labelFont, className, unusedClassName, visibility} = getClickHereCue(),
         // Y2 (rightNumeric) label takes the color of its points, matching V2 behavior.
         // Its plot index sits after all primary Y attributes.
-        labelColor = place === 'rightNumeric' && !useClickHereCue
+        labelColor = place === 'rightNumeric' && dataConfiguration?.hasY2Attribute
           ? graphModel.pointDescription.pointColorAtIndex(
-              dataConfiguration?.yAttributeDescriptionsExcludingY2.length ?? 0)
+              dataConfiguration.yAttributeDescriptionsExcludingY2.length)
           : null,
         bounds = layout.getComputedBounds(place),
         layoutIsVertical = isVertical(place),
@@ -260,8 +260,7 @@ export const GraphAttributeLabel =
         gSelection, textSelector: `text.${className}`,
         transform: labelTransform + tRotation, visibility
       })
-    }, [dataConfiguration?.yAttributeDescriptionsExcludingY2.length, getClickHereCue, getLabel,
-        graphModel.pointDescription, isTileSelected, layout, place])
+    }, [dataConfiguration, getClickHereCue, getLabel, graphModel, isTileSelected, layout, place])
 
     const plotDefinedAxisClickHandler = graphModel.plot.axisLabelClickHandler(graphPlaceToAttrRole[place])
 


### PR DESCRIPTION
## Summary
- On a scatter plot, when a Y2 (rightNumeric) attribute is present, the axis
  attribute labels now render in the same color as their points, matching V2
  behavior. Previously they were always black.
  - The **Y2 (rightNumeric)** label takes the Y2 points' color.
  - The **single primary-Y (left)** label takes its points' color (index 0).
  - The multi-Y case is unchanged — each left label is colored individually by
    `SingleYAttributeLabel`.
- Implemented in `GraphAttributeLabel.refreshAxisTitle`: when
  `dataConfiguration.hasY2Attribute` is true, the label fill is set from
  `graphModel.pointDescription.pointColorAtIndex(...)` — the same source used by
  the multi-Y label code path. With no Y2 attribute the fill is cleared, so labels
  fall back to their CSS color.

Fixes CODAP-1420

## Test plan
- [ ] Open Roller Coasters, plot Top_Speed (x) × Max_Height (y), drop Length on the
  y2 axis — both the "Max_Height" (left) and "Length" (Y2) labels should be colored
  to match their respective points.
- [ ] Change the Y2 point color in the inspector — the Y2 label color tracks.
- [ ] Change the primary-Y point color — the left label color tracks.
- [ ] Remove the Y2 attribute — the right axis goes away and the left "Max_Height"
  label reverts to its default (black) color.
- [ ] Confirm X, top, and legend labels render unchanged.
