### PR TITLE
CODAP-1419: restore "+" on y-axis drop zone and fix Safari drag flicker

### DIFF
--- a/v3/src/components/graph/components/droppable-add-attribute.tsx
+++ b/v3/src/components/graph/components/droppable-add-attribute.tsx
@@ -16,10 +16,11 @@ interface IAddAttributeProps {
   place: GraphPlace
   plotType: PlotType
   hasRightDropZone?: boolean
+  hasTopAxis?: boolean
   onDrop: (dataSet: IDataSet, attributeId: string) => void
 }
 
-export const DroppableAddAttribute = ({place, hasRightDropZone, onDrop}: IAddAttributeProps) => {
+export const DroppableAddAttribute = ({place, hasRightDropZone, hasTopAxis, onDrop}: IAddAttributeProps) => {
   const layout = useGraphLayoutContext()
   const graphID = useInstanceIdContext(),
     dataConfiguration = useGraphDataConfigurationContext(),
@@ -57,21 +58,43 @@ export const DroppableAddAttribute = ({place, hasRightDropZone, onDrop}: IAddAtt
     if (placeKey === "right") {
       return { height: Math.max(0, plotBounds.height - kDropZoneGap), top: plotBounds.top + kDropZoneGap }
     }
-    if (placeKey === "top" || placeKey === "yPlus") {
-      // Only inset by the portion of the right-edge drop zone that would actually overlap the
-      // top drop zone.
-      const rightAxisExtent =
-        layout.getDesiredExtent('rightNumeric') + layout.getDesiredExtent('rightCat')
-      const rightInset = hasRightDropZone
-        ? Math.max(0, kDropZoneSize + kDropZoneGap - rightAxisExtent)
-        : 0
+    // Only inset by the portion of the right-edge drop zone that would actually overlap.
+    const rightAxisExtent =
+      layout.getDesiredExtent('rightNumeric') + layout.getDesiredExtent('rightCat')
+    const rightInset = hasRightDropZone
+      ? Math.max(0, kDropZoneSize + kDropZoneGap - rightAxisExtent)
+      : 0
+    if (placeKey === "yPlus" && hasTopAxis) {
+      // A top axis already occupies the wide strip across the top of the plot, so narrow
+      // the yPlus drop zone to just the y-axis column. Makes it clear the drop will add
+      // another y attribute rather than a top-axis category.
+      return { width: Math.max(0, plotBounds.left - kDropZoneGap), left: 0 }
+    }
+    if (placeKey === "yPlus") {
+      // Span the entire top of the graph including the y-axis column, matching v2's
+      // full-width strip and giving the "+" a place to sit over the y-axis.
+      return { width: Math.max(0, plotBounds.left + plotBounds.width - kDropZoneGap - rightInset), left: 0 }
+    }
+    if (placeKey === "top") {
+      // Plot-split (categorical) is bounded by the plot area only.
       return { width: Math.max(0, plotBounds.width - kDropZoneGap - rightInset), left: plotBounds.left + kDropZoneGap }
     }
   })()
 
+  // "+" only on yPlus (multi-y numeric on scatterplot).
+  const showPlusIcon = place === 'yPlus'
+  // Half the drop-zone height. Set inline to override `.graph-plot svg { width/height: 100% }`.
+  const kPlusSize = kDropZoneSize / 2
+  const plusStyle: CSSProperties = { width: kPlusSize, height: kPlusSize }
+
   return isActive ? (
     <div ref={setNodeRef} id={droppableId} className={className} style={style}
       data-testid={`add-attribute-drop-${place}`}>
+      {showPlusIcon && (
+        <svg className="add-attribute-plus" style={plusStyle} viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M12 3v18M3 12h18" stroke="currentColor" strokeWidth="6"/>
+        </svg>
+      )}
       <DropHint hintText={hintString} isVisible={isOver}/>
     </div>
   ) : null

--- a/v3/src/components/graph/components/droppable-axis.tsx
+++ b/v3/src/components/graph/components/droppable-axis.tsx
@@ -14,17 +14,23 @@ interface IProps {
   dropId: string
   hintString?: string
   onIsActive?: (active: Active) => boolean
+  // shrinks the rect from the top so it doesn't overlap an adjacent add-attribute drop zone
+  topInset?: number
 }
 export const DroppableAxis = observer(function DroppableAxis(
-  { place, portal, target, dropId, hintString, onIsActive }: IProps) {
+  { place, portal, target, dropId, hintString, onIsActive, topInset = 0 }: IProps) {
   const layout = useGraphLayoutContext(),
     axisBounds = layout?.getComputedBounds(place)
 
   const { active, isOver, setNodeRef } = useDroppable({ id: dropId })
   const isActive = active && onIsActive?.(active)
 
-  // calculate the position of the overlay
+  // calculate the position of the overlay, applying topInset to avoid overlap
   const style: CSSProperties = { ...axisBounds }
+  if (topInset > 0 && axisBounds) {
+    style.top = (axisBounds.top ?? 0) + topInset
+    style.height = Math.max(0, (axisBounds.height ?? 0) - topInset)
+  }
   const classes =
     clsx("droppable-axis", "droppable-svg", place, { active: isActive, over: isActive && isOver })
 

--- a/v3/src/components/graph/components/graph-axis.tsx
+++ b/v3/src/components/graph/components/graph-axis.tsx
@@ -25,12 +25,14 @@ interface IProps {
   onDropAttribute?: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void
   onRemoveAttribute?: (place: GraphPlace, attrId: string) => void
   onTreatAttributeAs?: (place: GraphPlace, attrId: string, treatAs: AttributeType) => void
+  // forwarded to DroppableAxis to avoid overlap with adjacent add-attribute drop zones
+  topInset?: number
 }
 
 const trueFn = () => true
 
 export const GraphAxis = observer(function GraphAxis(
-  {place, onDropAttribute, onRemoveAttribute, onTreatAttributeAs}: IProps) {
+  {place, onDropAttribute, onRemoveAttribute, onTreatAttributeAs, topInset}: IProps) {
   const dataConfig = useGraphDataConfigurationContext(),
     isDropAllowed = dataConfig?.placeCanAcceptAttributeIDDrop ?? trueFn,
     graphModel = useGraphContentModelContext(),
@@ -114,6 +116,7 @@ export const GraphAxis = observer(function GraphAxis(
             portal={parentEltRef.current}
             target={wrapperElt}
             onIsActive={handleIsActive}
+            topInset={topInset}
         />}
     </g>
   )

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -127,8 +127,7 @@
   top: 50%;
   left: 6px;
   transform: translateY(-50%);
-  // saturated yellow-gold so the "+" stands out against the translucent yellow drop highlight
-  color: #e6b800;
+  color: vars.$drop-zone-plus-color;
   pointer-events: none;
 }
 

--- a/v3/src/components/graph/components/graph.scss
+++ b/v3/src/components/graph/components/graph.scss
@@ -122,6 +122,16 @@
   @include vars.drop-zone-states;
 }
 
+.add-attribute-plus {
+  position: absolute;
+  top: 50%;
+  left: 6px;
+  transform: translateY(-50%);
+  // saturated yellow-gold so the "+" stands out against the translucent yellow drop highlight
+  color: #e6b800;
+  pointer-events: none;
+}
+
 .above-points-group {
   outline: none;
 }

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -407,6 +407,44 @@ export const Graph = observer(function Graph({
     }
   }
 
+  // Drop-zone flags and insets. Drive both the axis rendering and the add-attribute zones.
+  // Only apply insets when the drop zones would actually accept the currently dragged attribute.
+  const { active } = useDndContext()
+  const { dataSet: dragDataSet, attributeId: dragAttrId } = getDragAttributeInfo(active) || {}
+  const isDropAllowed = graphModel.dataConfiguration.placeCanAcceptAttributeIDDrop
+  const hasTopAxis = !!graphModel.getAxis("top")
+  const hasTopDropZone = plotType !== "casePlot"
+    && !hasTopAxis
+    && !!dragAttrId
+    && isDropAllowed("top", dragDataSet, dragAttrId)
+  const hasYPlusDropZone = plotType === "scatterPlot"
+    && !!dragAttrId
+    && isDropAllowed("yPlus", dragDataSet, dragAttrId)
+  const hasRightDropZone = plotType !== "casePlot" && (
+    (!graphModel.getAxis("rightCat")
+      && !!dragAttrId
+      && isDropAllowed("rightCat", dragDataSet, dragAttrId)) ||
+    (plotType === "scatterPlot" && !graphModel.getAxis("rightNumeric")
+      && !!dragAttrId
+      && isDropAllowed("rightNumeric", dragDataSet, dragAttrId))
+  )
+  // Vertical overlap between the top yPlus/top strip (y=0..kDropZoneSize) and the plot.
+  // Plot.top and left-axis.top are always equal (both = bannersHeight + topAxisHeight), so a
+  // single overlap value drives both the plot-drop-zone inset and the left-axis inset. When
+  // a top axis pushes that boundary below the strip, the overlap is 0 and nothing shrinks.
+  const topStripOverlap = Math.max(0, kDropZoneSize + kDropZoneGap - layout.getComputedBounds("plot").top)
+  const leftAxisTopInset = hasYPlusDropZone ? topStripOverlap : 0
+  // Only inset by the portion of the right-edge drop zone that would actually overlap.
+  const rightAxisExtent =
+    layout.getDesiredExtent('rightNumeric') + layout.getDesiredExtent('rightCat')
+  const rightDropZoneInset = hasRightDropZone
+    ? Math.max(0, kDropZoneSize + kDropZoneGap - rightAxisExtent)
+    : 0
+  const plotDropInsets: IDropInsets = {
+    ...((hasTopDropZone || hasYPlusDropZone) && topStripOverlap > 0 ? { top: topStripOverlap } : {}),
+    ...(rightDropZoneInset > 0 ? { right: rightDropZoneInset } : {})
+  }
+
   const renderGraphAxes = () => {
     // Render horizontal axes first so vertical axes (and their labels) appear on top
     // of the full-width horizontal axis backgrounds
@@ -421,37 +459,9 @@ export const Graph = observer(function Graph({
                         onDropAttribute={handleChangeAttribute}
                         onRemoveAttribute={handleRemoveAttribute}
                         onTreatAttributeAs={handleTreatAttrAs}
+                        topInset={place === 'left' ? leftAxisTopInset : undefined}
       />
     })
-  }
-
-  // Compute insets for the plot drop zone so it doesn't overlap adjacent add-attribute drop zones.
-  // Only apply insets when the drop zones would actually accept the currently dragged attribute.
-  const { active } = useDndContext()
-  const { dataSet: dragDataSet, attributeId: dragAttrId } = getDragAttributeInfo(active) || {}
-  const isDropAllowed = graphModel.dataConfiguration.placeCanAcceptAttributeIDDrop
-  const hasTopDropZone = plotType !== "casePlot"
-    && !graphModel.getAxis("top")
-    && !!dragAttrId
-    && isDropAllowed("top", dragDataSet, dragAttrId)
-  const hasRightDropZone = plotType !== "casePlot" && (
-    (!graphModel.getAxis("rightCat")
-      && !!dragAttrId
-      && isDropAllowed("rightCat", dragDataSet, dragAttrId)) ||
-    (plotType === "scatterPlot" && !graphModel.getAxis("rightNumeric")
-      && !!dragAttrId
-      && isDropAllowed("rightNumeric", dragDataSet, dragAttrId))
-  )
-  // Only inset by the portion of the right-edge drop zone that would actually overlap the
-  // plot drop zone.
-  const rightAxisExtent =
-    layout.getDesiredExtent('rightNumeric') + layout.getDesiredExtent('rightCat')
-  const rightDropZoneInset = hasRightDropZone
-    ? Math.max(0, kDropZoneSize + kDropZoneGap - rightAxisExtent)
-    : 0
-  const plotDropInsets: IDropInsets = {
-    ...(hasTopDropZone ? { top: kDropZoneSize + kDropZoneGap } : {}),
-    ...(rightDropZoneInset > 0 ? { right: rightDropZoneInset } : {})
   }
 
   const renderDroppableAddAttributes = () => {
@@ -468,6 +478,7 @@ export const Graph = observer(function Graph({
               place={place}
               plotType={plotType}
               hasRightDropZone={hasRightDropZone}
+              hasTopAxis={hasTopAxis}
               onDrop={handleChangeAttribute.bind(null, place)}
             />
           )

--- a/v3/src/components/vars.scss
+++ b/v3/src/components/vars.scss
@@ -54,6 +54,8 @@ $tile-border-color: #0081a9;
 $focus-border-color: #1c9fc7;
 $focus-outline-color: #0957d0;
 $drop-highlight-color: rgba(255, 229, 0, 0.55);
+// saturated yellow-gold "+" indicator that stands out against the translucent yellow drop highlight
+$drop-zone-plus-color: #e6b800;
 
 @mixin focus-outline($offset: -2px, $radius: 2px) {
   border-radius: $radius;

--- a/v3/src/lib/dnd-kit/dnd-detect-collision.ts
+++ b/v3/src/lib/dnd-kit/dnd-detect-collision.ts
@@ -37,10 +37,38 @@ export const dndDetectCollision: CollisionDetection = (args) => {
 
   // check for registered tile-specific collision handlers
   if (sortedCollisions.length > 0) {
-    // find the prefix for the first tile collision
-    const prefix = `${sortedCollisions[0].id}`.match(prefixRegex)?.[0]
-    if (prefix) {
-      // find all collisions for the first tile
+    // data-tile-z-index doesn't always reflect actual visual stacking (overlapping tiles
+    // can be in separate CSS stacking contexts), so when tiles overlap in screen space we
+    // use elementFromPoint to find the visually-topmost tile and try its prefix first.
+    // Without this, dragging from one tile (e.g., the case table) into an overlapping tile
+    // (e.g., a graph) can let the source tile's droppables win at positions the user sees
+    // as inside the destination tile.
+    //
+    // We can't extract the prefix from the tile root <div>'s id, because tile DOM ids are
+    // ULIDs (GRAPH_xxxx) while droppable prefixes use a separate instance-id convention
+    // ("graph-1"). Instead we walk sortedCollisions (already sorted by z-index) and pick the
+    // first whose droppable's DOM node contains the topmost element under the cursor.
+    const candidatePrefixes: string[] = []
+    if (args.pointerCoordinates) {
+      const { x, y } = args.pointerCoordinates
+      const topEl = document.elementFromPoint(x, y)
+      if (topEl) {
+        for (const collision of sortedCollisions) {
+          const node = collision.data?.droppableContainer.node.current
+          if (node?.contains(topEl)) {
+            const prefix = `${collision.id}`.match(prefixRegex)?.[0]
+            if (prefix) {
+              candidatePrefixes.push(prefix)
+              break
+            }
+          }
+        }
+      }
+    }
+    const firstPrefix = `${sortedCollisions[0].id}`.match(prefixRegex)?.[0]
+    if (firstPrefix && !candidatePrefixes.includes(firstPrefix)) candidatePrefixes.push(firstPrefix)
+
+    for (const prefix of candidatePrefixes) {
       const tileCollisions = sortedCollisions.filter(c => `${c.id}`.startsWith(prefix))
       for (const collision of tileCollisions) {
         const { id: collisionId } = collision

--- a/v3/src/lib/dnd-kit/dnd-detect-collision.ts
+++ b/v3/src/lib/dnd-kit/dnd-detect-collision.ts
@@ -37,12 +37,15 @@ export const dndDetectCollision: CollisionDetection = (args) => {
 
   // check for registered tile-specific collision handlers
   if (sortedCollisions.length > 0) {
-    // data-tile-z-index doesn't always reflect actual visual stacking (overlapping tiles
-    // can be in separate CSS stacking contexts), so when tiles overlap in screen space we
-    // use elementFromPoint to find the visually-topmost tile and try its prefix first.
-    // Without this, dragging from one tile (e.g., the case table) into an overlapping tile
-    // (e.g., a graph) can let the source tile's droppables win at positions the user sees
-    // as inside the destination tile.
+    // pointerWithin returns droppables whose measured *rects* contain the cursor, and sorting by
+    // data-tile-z-index orders the tiles correctly by paint order. The problem isn't the ordering:
+    // the drag source tile (e.g., a case table) is raised to the top z-index when it's focused at
+    // drag start, so it legitimately sorts above the destination tile (e.g., a graph) it's dragged
+    // onto. At cursor positions where the source tile's droppable rect extends past its painted
+    // area into the destination tile, the source's droppables still win even though the user sees
+    // the destination under the cursor -- causing the drop highlight to flicker. z-index can't
+    // disambiguate this (the ordering is already correct), so we use elementFromPoint to find the
+    // actually-painted topmost tile and try its prefix first.
     //
     // We can't extract the prefix from the tile root <div>'s id, because tile DOM ids are
     // ULIDs (GRAPH_xxxx) while droppable prefixes use a separate instance-id convention


### PR DESCRIPTION
## Summary
- Restores the v2 "+" indicator inside the y-axis multi-attribute (yPlus) drop zone so users can see that dragging a numeric attribute to the top of a scatterplot adds a second y attribute.
- Reshapes the yPlus drop zone — full-width across the top normally, narrowed to the y-axis column when a top axis (categorical split) is already in place — and trims the left-axis drop zone so it doesn't overlap the strip.
- Fixes a cross-tile drop-zone flicker that was most visible in Safari: when dragging from one tile (e.g., a case table) over a graph, case-table droppables would intermittently "win" collision detection at certain cursor positions, causing the yellow drop highlight to flash off. `dndDetectCollision` now uses `document.elementFromPoint` to identify the visually-topmost tile and prefer its prefix.

Fixes CODAP-1419

## Test plan
- [ ] Open Roller Coasters; put Top_Speed on x and Max_Height on y. Drag Drop to the top of the plot — a yellow strip appears with a small yellow "+" over the y-axis column.
- [ ] Same plot, in Safari: drag slowly across the strip — yellow highlight stays steady.
- [ ] Split the plot by adding Type to the top axis. Drag Drop to the top — the yPlus zone is now narrowed to just the y-axis column; the top-axis zone stays plot-bounded.
- [ ] Drag a numeric attribute to the left axis — replace works; left-axis drop zone extends the full plot height when there's a top axis.
- [ ] Sanity-check drag-and-drop interactions in case table and other tiles for any cross-tile regressions from the dndDetectCollision change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)