### PR TITLE
CODAP-1418: onboarding should not auto-open a case table on touch devices

### DIFF
--- a/v3/src/components/case-table/case-table-tool-shelf-button.test.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.test.tsx
@@ -3,14 +3,14 @@ import { appState } from "../../models/app-state"
 import { setupTestDataset } from "../../test/dataset-test-utils"
 import "../case-card/case-card-registration"
 import "./case-table-registration"
-import { openTableForDatasetWithNotifications } from "./case-table-tool-shelf-button"
+import { openTableOrCardForDatasetWithNotifications } from "./case-table-tool-shelf-button"
 
 // CODAP-1418: opening a case table for an existing dataset from the Tables menu must emit a
 // component `create` notification (type 'table') when it creates a new tile, mirroring V2's
 // `caseTable.open` command (apps/dg/controllers/app_controller.js:122). Plugins such as
 // onboarding detect table creation via this notification; previously the open-existing path
 // emitted only `open case table`, so the onboarding "make a table" task never completed.
-describe("openTableForDatasetWithNotifications", () => {
+describe("openTableOrCardForDatasetWithNotifications", () => {
   // appState.document is a singleton that persists across tests, so use distinct dataset names.
   const content = appState.document.content!
 
@@ -23,7 +23,7 @@ describe("openTableForDatasetWithNotifications", () => {
     const sharedDataSet = addDataset("mammals1418")
     const broadcastSpy = jest.spyOn(content, "broadcastMessage")
 
-    const tile = openTableForDatasetWithNotifications(sharedDataSet)
+    const tile = openTableOrCardForDatasetWithNotifications(sharedDataSet)
     expect(tile).toBeDefined()
 
     const createCall = broadcastSpy.mock.calls.find(([msg]: any[]) =>
@@ -42,11 +42,11 @@ describe("openTableForDatasetWithNotifications", () => {
   it("does not broadcast a second 'create' when re-showing an existing table", () => {
     const sharedDataSet = addDataset("birds1418")
     // First open creates the table.
-    openTableForDatasetWithNotifications(sharedDataSet)
+    openTableOrCardForDatasetWithNotifications(sharedDataSet)
 
     const broadcastSpy = jest.spyOn(content, "broadcastMessage")
     // Second open should re-show the existing tile, not create a new one.
-    openTableForDatasetWithNotifications(sharedDataSet)
+    openTableOrCardForDatasetWithNotifications(sharedDataSet)
 
     const createCall = broadcastSpy.mock.calls.find(([msg]: any[]) =>
       msg?.values?.operation === "create"

--- a/v3/src/components/case-table/case-table-tool-shelf-button.test.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.test.tsx
@@ -1,0 +1,58 @@
+import { getSnapshot } from "mobx-state-tree"
+import { appState } from "../../models/app-state"
+import { setupTestDataset } from "../../test/dataset-test-utils"
+import "../case-card/case-card-registration"
+import "./case-table-registration"
+import { openTableForDatasetWithNotifications } from "./case-table-tool-shelf-button"
+
+// CODAP-1418: opening a case table for an existing dataset from the Tables menu must emit a
+// component `create` notification (type 'table') when it creates a new tile, mirroring V2's
+// `caseTable.open` command (apps/dg/controllers/app_controller.js:122). Plugins such as
+// onboarding detect table creation via this notification; previously the open-existing path
+// emitted only `open case table`, so the onboarding "make a table" task never completed.
+describe("openTableForDatasetWithNotifications", () => {
+  // appState.document is a singleton that persists across tests, so use distinct dataset names.
+  const content = appState.document.content!
+
+  const addDataset = (name: string) => {
+    const { dataset } = setupTestDataset({ datasetName: name })
+    return content.createDataSet(getSnapshot(dataset)).sharedDataSet
+  }
+
+  it("broadcasts a component 'create' notification when it creates a new table", () => {
+    const sharedDataSet = addDataset("mammals1418")
+    const broadcastSpy = jest.spyOn(content, "broadcastMessage")
+
+    const tile = openTableForDatasetWithNotifications(sharedDataSet)
+    expect(tile).toBeDefined()
+
+    const createCall = broadcastSpy.mock.calls.find(([msg]: any[]) =>
+      msg?.values?.operation === "create" && msg?.values?.type === "table"
+    )
+    expect(createCall).toBeDefined()
+    // The V2-compat 'open case table' notification is also emitted.
+    const openCall = broadcastSpy.mock.calls.find(([msg]: any[]) =>
+      msg?.values?.operation === "open case table"
+    )
+    expect(openCall).toBeDefined()
+
+    broadcastSpy.mockRestore()
+  })
+
+  it("does not broadcast a second 'create' when re-showing an existing table", () => {
+    const sharedDataSet = addDataset("birds1418")
+    // First open creates the table.
+    openTableForDatasetWithNotifications(sharedDataSet)
+
+    const broadcastSpy = jest.spyOn(content, "broadcastMessage")
+    // Second open should re-show the existing tile, not create a new one.
+    openTableForDatasetWithNotifications(sharedDataSet)
+
+    const createCall = broadcastSpy.mock.calls.find(([msg]: any[]) =>
+      msg?.values?.operation === "create"
+    )
+    expect(createCall).toBeUndefined()
+
+    broadcastSpy.mockRestore()
+  })
+})

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -13,7 +13,7 @@ import { DataSet } from "../../models/data/data-set"
 import {
   dataContextCountChangedNotification, dataContextDeletedNotification
 } from "../../models/data/data-set-notifications"
-import { kSharedDataSetType, SharedDataSet } from "../../models/shared/shared-data-set"
+import { ISharedDataSet, kSharedDataSetType, SharedDataSet } from "../../models/shared/shared-data-set"
 import { getFormulaManager, getSharedModelManager } from "../../models/tiles/tile-environment"
 import { ITileModel } from "../../models/tiles/tile-model"
 import { createTileNotification } from "../../models/tiles/tile-notifications"
@@ -32,6 +32,35 @@ import TableIcon from "../../assets/icons/icon-table.svg"
 import TrashIcon from "../../assets/icons/icon-trash.svg"
 
 import "../tool-shelf/tool-shelf.scss"
+
+// Open (or re-show) the table/card for an existing dataset, emitting the V2-compatible
+// notifications. A component `create` notification fires only when this actually creates a
+// new tile — mirroring V2's `caseTable.open` command, which emits `create` only when no
+// table view already exists (apps/dg/controllers/app_controller.js:122, guarded by
+// `foundView`). Plugins that detect table creation (e.g. onboarding's "make a table" task)
+// rely on that `create`; the `open case table` notification is additionally emitted for
+// V2-plugin compat (CODAP-1353). Exported for testing. CODAP-1418.
+export function openTableForDatasetWithNotifications(dataset: ISharedDataSet) {
+  const document = appState.document
+  const { content } = document
+  if (!content) return
+  let tile: Maybe<ITileModel>
+  // Capture existing tiles so we can tell whether opening created a new tile or re-showed
+  // an existing one, and only fire `create` for a brand-new tile.
+  const priorTileIds = new Set(content.tileMap.keys())
+  document.applyModelChange(() => {
+    tile = createOrShowTableOrCardForDataset(dataset)
+  }, {
+    notify: [
+      () => (tile && !priorTileIds.has(tile.id) ? createTileNotification(tile) : undefined),
+      () => openCaseTableNotification(tile)
+    ],
+    undoStringKey: "DG.Undo.caseTable.open",
+    redoStringKey: "DG.Redo.caseTable.open",
+    log: "Create caseTable component"
+  })
+  return tile
+}
 
 interface ICaseTableToolShelfMenuListProps {
   setMenuIsOpen: (isOpen: boolean) => void
@@ -122,20 +151,10 @@ const CaseTableToolShelfMenuList = observer(
         {datasets.map((dataset) => {
           // case table title reflects DataSet title
           const tileTitle = dataset.dataSet.displayTitle
-          // Wrap createOrShow in applyModelChange so the V2-compat `open case table`
-          // notification fires for V2 plugins (CODAP-1353). V2's bulk-open path is undoable
-          // (DG.UndoHistory.execute in document_controller.js:1064), so mirror that here.
-          const handleOpenTableForDataset = () => {
-            let tile: Maybe<ITileModel>
-            document.applyModelChange(() => {
-              tile = createOrShowTableOrCardForDataset(dataset)
-            }, {
-              notify: () => openCaseTableNotification(tile),
-              undoStringKey: "DG.Undo.caseTable.open",
-              redoStringKey: "DG.Redo.caseTable.open",
-              log: "Create caseTable component"
-            })
-          }
+          // See openTableForDatasetWithNotifications: opening an existing dataset's table
+          // emits a component `create` notification when it creates a new tile (CODAP-1418),
+          // plus the V2-compat `open case table` notification (CODAP-1353).
+          const handleOpenTableForDataset = () => openTableForDatasetWithNotifications(dataset)
           return (
             <MenuItem key={`${dataset.dataSet.id}`} className="tool-shelf-menu-item table-menu-item"
               onClick={handleOpenTableForDataset} data-testid={`tool-shelf-table-${tileTitle}`}>

--- a/v3/src/components/case-table/case-table-tool-shelf-button.tsx
+++ b/v3/src/components/case-table/case-table-tool-shelf-button.tsx
@@ -40,7 +40,7 @@ import "../tool-shelf/tool-shelf.scss"
 // `foundView`). Plugins that detect table creation (e.g. onboarding's "make a table" task)
 // rely on that `create`; the `open case table` notification is additionally emitted for
 // V2-plugin compat (CODAP-1353). Exported for testing. CODAP-1418.
-export function openTableForDatasetWithNotifications(dataset: ISharedDataSet) {
+export function openTableOrCardForDatasetWithNotifications(dataset: ISharedDataSet) {
   const document = appState.document
   const { content } = document
   if (!content) return
@@ -151,10 +151,10 @@ const CaseTableToolShelfMenuList = observer(
         {datasets.map((dataset) => {
           // case table title reflects DataSet title
           const tileTitle = dataset.dataSet.displayTitle
-          // See openTableForDatasetWithNotifications: opening an existing dataset's table
+          // See openTableOrCardForDatasetWithNotifications: opening an existing dataset's table
           // emits a component `create` notification when it creates a new tile (CODAP-1418),
           // plus the V2-compat `open case table` notification (CODAP-1353).
-          const handleOpenTableForDataset = () => openTableForDatasetWithNotifications(dataset)
+          const handleOpenTableForDataset = () => openTableOrCardForDatasetWithNotifications(dataset)
           return (
             <MenuItem key={`${dataset.dataSet.id}`} className="tool-shelf-menu-item table-menu-item"
               onClick={handleOpenTableForDataset} data-testid={`tool-shelf-table-${tileTitle}`}>

--- a/v3/src/data-interactive/data-interactive-types.ts
+++ b/v3/src/data-interactive/data-interactive-types.ts
@@ -106,6 +106,7 @@ export interface DILogMessage {
 
 export interface DIUrl {
   URL: string
+  title?: string
 }
 export interface DIDataDisplay {
   exportDataUri?: string

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
@@ -1,4 +1,5 @@
 import { appState } from "../../models/app-state"
+import { kCaseTableTileType } from "../../components/case-table/case-table-defs"
 import { gDataBroker } from "../../models/data/data-broker"
 import { getSharedModelManager } from "../../models/tiles/tile-environment"
 import { CsvParseResult, downloadCsvFile } from "../../utilities/csv-import"
@@ -74,6 +75,45 @@ describe("DataInteractive DataContextHandler", () => {
       expect(result.values).toMatchObject({
         name: "https://example.com/"
       })
+    })
+
+    it("imports the dataset without creating a default (case table) tile", async () => {
+      gDataBroker.setSharedModelManager(getSharedModelManager(appState.document)!)
+      const content = appState.document.content!
+      const importSpy = jest.spyOn(content, "importDataSet")
+
+      mockedDownloadCsvFile.mockImplementation((url, onComplete, onError) => {
+        const parseResult: CsvParseResult = {
+            data: [{col1: "value1"}],
+            errors: [],
+            meta: { delimiter: "", linebreak: "", aborted: false, truncated: false, cursor: 0 }
+        }
+        onComplete(parseResult, "")
+      })
+
+      const result = await handler.create!({}, {URL: "https://example.com/mammals.csv"})
+      expect(result.success).toBe(true)
+      expect(importSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ createDefaultTile: false }))
+      // No case table tile should result from the import.
+      expect(content.getTilesOfType(kCaseTableTileType).length).toBe(0)
+      importSpy.mockRestore()
+    })
+
+    it("applies a supplied title to the imported dataset", async () => {
+      gDataBroker.setSharedModelManager(getSharedModelManager(appState.document)!)
+
+      mockedDownloadCsvFile.mockImplementation((url, onComplete, onError) => {
+        const parseResult: CsvParseResult = {
+            data: [{col1: "value1"}],
+            errors: [],
+            meta: { delimiter: "", linebreak: "", aborted: false, truncated: false, cursor: 0 }
+        }
+        onComplete(parseResult, "")
+      })
+
+      const result = await handler.create!({}, {URL: "https://example.com/mammals.csv", title: "Mammals"})
+      expect(result.success).toBe(true)
+      expect(gDataBroker.last?.title).toBe("Mammals")
     })
   })
 })

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.test.ts
@@ -91,11 +91,12 @@ describe("DataInteractive DataContextHandler", () => {
         onComplete(parseResult, "")
       })
 
+      const tablesBefore = content.getTilesOfType(kCaseTableTileType).length
       const result = await handler.create!({}, {URL: "https://example.com/mammals.csv"})
       expect(result.success).toBe(true)
       expect(importSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ createDefaultTile: false }))
-      // No case table tile should result from the import.
-      expect(content.getTilesOfType(kCaseTableTileType).length).toBe(0)
+      // The import should not add a case table tile.
+      expect(content.getTilesOfType(kCaseTableTileType).length).toBe(tablesBefore)
       importSpy.mockRestore()
     })
 

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
@@ -32,7 +32,8 @@ export const diDataContextFromURLHandler: DIAsyncHandler = {
             const filename = getFilenameFromUrl(url)
             const ds = convertParsedCsvToDataSet(results, filename || url)
             if (ds) {
-              appState.document.content?.importDataSet(ds, { createDefaultTile: true })
+              if (values.title) ds.setTitle(values.title)
+              appState.document.content?.importDataSet(ds, { createDefaultTile: false })
               resolve({
                 success: true,
                 values: basicDataSetInfo(ds)

--- a/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
+++ b/v3/src/data-interactive/handlers/data-context-from-url-handler.ts
@@ -32,7 +32,7 @@ export const diDataContextFromURLHandler: DIAsyncHandler = {
             const filename = getFilenameFromUrl(url)
             const ds = convertParsedCsvToDataSet(results, filename || url)
             if (ds) {
-              if (values.title) ds.setTitle(values.title)
+              if (values.title && typeof values.title === "string") ds.setTitle(values.title)
               appState.document.content?.importDataSet(ds, { createDefaultTile: false })
               resolve({
                 success: true,


### PR DESCRIPTION
## Summary

On a touch device (e.g. iPad), opening the "Getting started with CODAP" example
document auto-opened a case table titled "Cases", which (1) blocked the student from
completing the onboarding tasks and (2) was mistitled. This is the **v3 half** of the
fix; the onboarding plugin half is in concord-consortium/codap-data-interactives.

### Changes

1. **No case table on launch** — `dataContextFromURL` no longer auto-creates a
   case-table tile (`createDefaultTile: false`). The onboarding plugin is the only real
   consumer of this request; the desktop drag-import path is separate and unaffected.
   This implements the no-table behavior the v2 handler always intended
   (`importTextFromUrl(url, false /* Don't show case table */)`) but never delivered
   (v2's Importer plugin ignores the flag).

2. **Optional `title` on `dataContextFromURL`** — the request now accepts an optional
   `title`, applied to the imported dataset, so the plugin can title it "Mammals"
   instead of the collection-derived "Cases". Backward compatible (older code ignores
   the extra value).

3. **Opening a table emits a `create` notification** — opening a case table for an
   existing dataset from the Tables menu created the tile but emitted only an
   `open case table` notification, never a component `create`. V2's `caseTable.open`
   command emits `create` (type `table`) for the same action, only when it actually
   creates the table (`apps/dg/controllers/app_controller.js:122`). V3 had regressed;
   plugins (e.g. onboarding's "make a table" task) detect table creation via `create`.
   `openTableForDatasetWithNotifications` now emits `createTileNotification` when a new
   tile is created (guarded so re-showing doesn't), mirroring V2.

### Testing

- `data-context-from-url-handler.test.ts` — no default tile is created; a supplied
  `title` is applied.
- `case-table-tool-shelf-button.test.ts` — a `create` (type `table`) notification fires
  when opening creates a new tile; no duplicate `create` on re-show.

### Out of scope / deferred

- v2 is not modified (final release cycle; the same visible behavior there would require
  changing the shared Importer plugin).
- `dataContextFromURL` is not idempotent — reloading the restored Getting Started doc can
  create a duplicate dataset (pre-existing; deferred).

### Deployment

The companion onboarding plugin change deploys separately to
`s3://codap-resources/plugins/onboarding/` (build-and-manual-copy); merging this PR does
not deploy it. The fix is fully live once this ships **and** the plugin is synced.

Fixes CODAP-1418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
