### PR TITLE
Release 3.0.2

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Version 3.0.2 - June 21, 2026
+
+### 🐞 Bug Fixes:
+- **CODAP-1415:** Fix formula engine crash on Safari versions before 16.4
+- **CODAP-1419:** Show the "+" sign when dragging a second attribute to the y-axis
+- **CODAP-1420:** Color the Y2 attribute label to match its points in a scatter plot
+- **CODAP-1422:** Don't show the user entry dialog while a document is loading
+- **CODAP-1424:** Reconnect communication for plugins added by drag/drop or URL import
+
+### 🛠️ Under the Hood:
+- **CODAP-1418:** dataContextFromURL no longer auto-creates a case-table tile
+
+### Asset Sizes
+|      File |          Size | % Change from Previous Release |
+|-----------|---------------|--------------------------------|
+|  main.css |  240888 bytes |                          0.05% |
+|  index.js | 7821976 bytes |                          0.03% |
+
 ## Version 3.0.1 - June 12, 2026
 
 ### 🐞 Bug Fixes:

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browser": {

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -6,6 +6,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.0.2](https://codap3.concord.org/version/3.0.2/) | June 21, 2026 |
 | [3.0.1](https://codap3.concord.org/version/3.0.1/) | June 12, 2026 |
 | [3.0.0](https://codap3.concord.org/version/3.0.0/) | June 7, 2026 |
 | [3.0.0-rc.2921](https://codap3.concord.org/version/3.0.0-rc.2921/) | June 3, 2026 |


### PR DESCRIPTION
## Version 3.0.2 - June 21, 2026

### 🐞 Bug Fixes:
- **CODAP-1415:** Fix formula engine crash on Safari versions before 16.4
- **CODAP-1419:** Show the "+" sign when dragging a second attribute to the y-axis
- **CODAP-1420:** Color the Y2 attribute label to match its points in a scatter plot
- **CODAP-1422:** Don't show the user entry dialog while a document is loading
- **CODAP-1424:** Reconnect communication for plugins added by drag/drop or URL import

### 🛠️ Under the Hood:
- **CODAP-1418:** dataContextFromURL no longer auto-creates a case-table tile
