### PR TITLE
CODAP-1421: preserve plugin-set axis bounds across data updates

### DIFF
--- a/v3/src/components/axis/axis-domain-utils.test.ts
+++ b/v3/src/components/axis/axis-domain-utils.test.ts
@@ -1,0 +1,41 @@
+import { setNiceDomain } from "./axis-domain-utils"
+import { NumericAxisModel } from "./models/numeric-axis-models"
+
+describe("setNiceDomain", () => {
+  it("does nothing when given empty values", () => {
+    const axis = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
+    setNiceDomain([], axis)
+    expect(axis.min).toBe(0)
+    expect(axis.max).toBe(10)
+  })
+
+  it("preserves bounds when data fits within them (CODAP-1421)", () => {
+    const axis = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
+    setNiceDomain([1, 5, 9], axis)
+    expect(axis.min).toBe(0)
+    expect(axis.max).toBe(10)
+  })
+
+  it("expands bounds when data extends beyond the current upper bound", () => {
+    const axis = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
+    setNiceDomain([1, 15], axis)
+    expect(axis.min).toBe(0)
+    expect(axis.max).toBeGreaterThanOrEqual(15)
+  })
+
+  it("recomputes bounds when allowRangeToShrink is set (autoScale path)", () => {
+    const axis = NumericAxisModel.create({ place: "bottom", min: 0, max: 100 })
+    axis.setAllowRangeToShrink(true)
+    setNiceDomain([3, 7], axis)
+    // Bounds should have tightened around the data.
+    expect(axis.max).toBeLessThan(100)
+  })
+
+  it("recomputes bounds when clampPosMinAtZero option is set", () => {
+    const axis = NumericAxisModel.create({ place: "bottom", min: 0, max: 100 })
+    setNiceDomain([3, 7], axis, { clampPosMinAtZero: true })
+    // Bounds should have been recomputed (the data-fits early return is skipped for clamping).
+    expect(axis.min).toBe(0)
+    expect(axis.max).toBeLessThan(100)
+  })
+})

--- a/v3/src/components/axis/axis-domain-utils.ts
+++ b/v3/src/components/axis/axis-domain-utils.ts
@@ -61,10 +61,13 @@ export function setNiceDomain(values: number[], axisModel: IBaseNumericAxisModel
     else if (!axisModel.allowRangeToShrink) {
       // Don't widen a bound on a side where the data doesn't exceed it. This lets plugin-set
       // bounds survive subsequent data additions (CODAP-1421) and mirrors V2's setDataMinAndMax,
-      // which leaves bounds alone when current bounds already encompass the data.
-      if (minValue >= axisModel.min) niceMin = axisModel.min
-      if (maxValue <= axisModel.max) niceMax = axisModel.max
-      if (niceMin === axisModel.min && niceMax === axisModel.max) return
+      // which leaves bounds alone when current bounds already encompass the data. We compare
+      // against the current domain (which accounts for any dynamic bounds, e.g. during a drag)
+      // rather than the static min/max, matching the reference used in use-sub-axis and setDomain.
+      const [domainMin, domainMax] = axisModel.domain
+      if (minValue >= domainMin) niceMin = domainMin
+      if (maxValue <= domainMax) niceMax = domainMax
+      if (niceMin === domainMin && niceMax === domainMax) return
     }
     axisModel.setDomain(niceMin, niceMax)
   }

--- a/v3/src/components/axis/axis-domain-utils.ts
+++ b/v3/src/components/axis/axis-domain-utils.ts
@@ -48,8 +48,8 @@ export function setNiceDomain(values: number[], axisModel: IBaseNumericAxisModel
   else if (isAnyNumericAxisModel(axisModel)) {
     const [minValue, maxValue] = extent(values, d => d) as [number, number]
     let {min: niceMin, max: niceMax} = computeNiceNumericBounds(minValue, maxValue)
-    // When clamping, the domain should start at 0 unless there are negative values.
     if (options?.clampPosMinAtZero) {
+      // When clamping, the domain should start at 0 unless there are negative values.
       if (minValue >= 0) {
         niceMin = 0
       }
@@ -57,6 +57,14 @@ export function setNiceDomain(values: number[], axisModel: IBaseNumericAxisModel
         niceMax = 0
       }
       axisModel.setAllowRangeToShrink(true)
+    }
+    else if (!axisModel.allowRangeToShrink) {
+      // Don't widen a bound on a side where the data doesn't exceed it. This lets plugin-set
+      // bounds survive subsequent data additions (CODAP-1421) and mirrors V2's setDataMinAndMax,
+      // which leaves bounds alone when current bounds already encompass the data.
+      if (minValue >= axisModel.min) niceMin = axisModel.min
+      if (maxValue <= axisModel.max) niceMax = axisModel.max
+      if (niceMin === axisModel.min && niceMax === axisModel.max) return
     }
     axisModel.setDomain(niceMin, niceMax)
   }

--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -410,8 +410,15 @@ export const useSubAxis = ({
       const [minValue, maxValue] = extent(numericValues, d => d) as [number, number]
       const niceBounds = computeNiceNumericBounds(minValue, maxValue)
       if (!allowToShrink) {
-        niceBounds.min = Math.min(niceBounds.min, currentAxisDomain[0])
-        niceBounds.max = Math.max(niceBounds.max, currentAxisDomain[1])
+        // Don't widen a bound on a side where the data doesn't exceed it. Matches the
+        // setNiceDomain logic (CODAP-1421) so plugin-set bounds survive data adds without
+        // a brief visual flash of the wider d3 scale.
+        niceBounds.min = minValue >= currentAxisDomain[0]
+                          ? currentAxisDomain[0]
+                          : Math.min(niceBounds.min, currentAxisDomain[0])
+        niceBounds.max = maxValue <= currentAxisDomain[1]
+                          ? currentAxisDomain[1]
+                          : Math.max(niceBounds.max, currentAxisDomain[1])
       }
       if (domainsAreDifferent(currentAxisDomain, [niceBounds.min, niceBounds.max]) ||
         domainsAreDifferent(multiScale?.numericDomain ?? [NaN, NaN], [niceBounds.min, niceBounds.max])) {

--- a/v3/src/components/graph/graph-component-handler.test.ts
+++ b/v3/src/components/graph/graph-component-handler.test.ts
@@ -105,6 +105,30 @@ describe("DataInteractive ComponentHandler Graph", () => {
     handler.delete!({ component: tileModel })
     expect(documentContent.tileMap.size).toBe(0)
 
+    // Create a graph with explicit axis bounds (CODAP-1421 — V2 parity with xLowerBound/etc.
+    // in componentStorage at create time)
+    const boundsCreateResult = create({}, {
+      type: "graph", dataContext: "data", xAttributeName: "a3", yAttributeName: "a4",
+      rightNumericAttributeName: "a3",
+      xLowerBound: -2, xUpperBound: 12, yLowerBound: -10, yUpperBound: 2,
+      y2LowerBound: -1, y2UpperBound: 9
+    })
+    expect(boundsCreateResult.success).toBe(true)
+    const boundsTile = documentContent.tileMap.get(
+      toV3Id(kGraphIdPrefix, (boundsCreateResult.values as DIComponentInfo).id!))!
+    const boundsContent = boundsTile.content as IGraphContentModel
+    const boundsXAxis = boundsContent.getAxis("bottom") as IBaseNumericAxisModel
+    const boundsYAxis = boundsContent.getAxis("left") as IBaseNumericAxisModel
+    const boundsY2Axis = boundsContent.getAxis("rightNumeric") as IBaseNumericAxisModel
+    expect(boundsXAxis.min).toBe(-2)
+    expect(boundsXAxis.max).toBe(12)
+    expect(boundsYAxis.min).toBe(-10)
+    expect(boundsYAxis.max).toBe(2)
+    expect(boundsY2Axis.min).toBe(-1)
+    expect(boundsY2Axis.max).toBe(9)
+    handler.delete!({ component: boundsTile })
+    expect(documentContent.tileMap.size).toBe(0)
+
     // Create a graph with multiple y attributes using ids
     const displayOnlySelectedCases = true
     const filterFormula = "a3 > 1"

--- a/v3/src/components/graph/graph-component-handler.ts
+++ b/v3/src/components/graph/graph-component-handler.ts
@@ -76,7 +76,8 @@ export const graphComponentHandler: DIComponentHandler = {
       backgroundColor, dataContext: _dataContext, displayOnlySelectedCases, enableNumberToggle: showParentToggles,
       filterFormula, hiddenCases: _hiddenCases, numberToggleLastMode: showOnlyLastCase, pointColor,
       pointSize, showMeasuresForSelection, strokeColor, strokeSameAsFill, transparent,
-      yAttributeID, yAttributeIDs, yAttributeName, yAttributeNames, yAttributeType
+      xLowerBound, xUpperBound, yAttributeID, yAttributeIDs, yAttributeName, yAttributeNames, yAttributeType,
+      yLowerBound, yUpperBound, y2LowerBound, y2UpperBound
     } = values as V2Graph
     const attributeInfo = getAttributeInfo(values)
 
@@ -180,6 +181,21 @@ export const graphComponentHandler: DIComponentHandler = {
     const graphModel = GraphContentModel.create(graphContent, { provisionalDataSet, provisionalMetadata })
     graphModel.dataConfiguration.synchronizeFilteredCases()  // kludgy workaround to ensure axis bounds will be correct
     syncModelWithAttributeConfiguration(graphModel, new GraphLayout())
+
+    // Apply plugin-supplied axis bounds at create time, matching V2's behavior of restoring
+    // xLowerBound/xUpperBound/yLowerBound/yUpperBound/y2LowerBound/y2UpperBound from componentStorage
+    // (CODAP-1421).
+    const applyBoundsAtCreate = (place: AxisPlace, lower?: number, upper?: number) => {
+      if (lower == null && upper == null) return
+      const axis = graphModel.getAxis(place)
+      if (isAnyNumericAxisModel(axis)) {
+        if (lower != null) axis.setMinimum(lower)
+        if (upper != null) axis.setMaximum(upper)
+      }
+    }
+    applyBoundsAtCreate("bottom", xLowerBound, xUpperBound)
+    applyBoundsAtCreate("left", yLowerBound, yUpperBound)
+    applyBoundsAtCreate("rightNumeric", y2LowerBound, y2UpperBound)
 
     // Layers will get mangled in the model because it's not in the same tree as the dataset,
     // so we mostly use the constructed layers. However, the primaryRole is determined in the model,


### PR DESCRIPTION
## Summary
- Plugins can now set xLowerBound/xUpperBound/yLowerBound/yUpperBound/y2LowerBound/y2UpperBound on a graph and have those bounds survive subsequent data additions, matching V2.
- These bounds are now also honored at graph create time, not just on update.
- Fixes a visual flash where the d3 scale briefly widened past the user-set bound before settling back.

Fixes CODAP-1421.

## Test plan
- [ ] Create a graph via the api-tester plugin with xLowerBound: 0; verify x-axis lower bound is 0.
- [ ] Update an existing graph with xLowerBound: 0; add cases via plugin; verify lower bound stays at 0 with no flash.
- [ ] Use the inspector's auto-rescale button on a graph with a plugin-set bound; verify rescale still tightens bounds.
- [ ] Regression tests (`run regression`) pass on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
