### PR TITLE
CODAP-1234: fix hierarchical selection scroll and MST use-after-free on load

### DIFF
--- a/v3/src/components/case-table/collection-table-model.test.ts
+++ b/v3/src/components/case-table/collection-table-model.test.ts
@@ -41,4 +41,21 @@ describe("CollectionTableModel", () => {
 
     disposer()
   })
+
+  it("modulates scroll behavior by distance: smooth within one page, instant beyond", () => {
+    const m = new CollectionTableModel("id")
+    const page = m.gridBodyHeight // one visible page (default height; current scrollTop is 0)
+    expect(page).toBeGreaterThan(0)
+
+    // scrolls within one page animate smoothly
+    expect(m.scrollBehaviorForTarget(page / 2)).toBe("smooth")
+    expect(m.scrollBehaviorForTarget(page)).toBe("smooth")
+    // scrolls farther than one page jump instantly to avoid a long, laggy animation
+    expect(m.scrollBehaviorForTarget(page + 1)).toBe("auto")
+    expect(m.scrollBehaviorForTarget(page * 10)).toBe("auto")
+
+    // an explicitly requested behavior always wins
+    expect(m.scrollBehaviorForTarget(page * 10, { scrollBehavior: "smooth" })).toBe("smooth")
+    expect(m.scrollBehaviorForTarget(0, { scrollBehavior: "auto" })).toBe("auto")
+  })
 })

--- a/v3/src/components/case-table/collection-table-model.ts
+++ b/v3/src/components/case-table/collection-table-model.ts
@@ -256,9 +256,20 @@ export class CollectionTableModel {
     }
   }
 
+  // Chooses the scroll animation behavior for a target position. A caller-supplied behavior always
+  // wins; otherwise we modulate by distance: short scrolls (within one visible page) animate
+  // smoothly (a nicer experience, e.g. for arrow-key navigation to a neighboring row), while longer
+  // scrolls jump instantly to avoid a slow, distracting animation across many rows (e.g. selecting a
+  // distant case in a graph). See CODAP-1234.
+  scrollBehaviorForTarget(scrollTop: number, options?: IScrollOptions): "auto" | "smooth" {
+    if (options?.scrollBehavior) return options.scrollBehavior
+    return Math.abs(scrollTop - this.scrollTop) > this.gridBodyHeight ? "auto" : "smooth"
+  }
+
   @action setTargetScrollTop(scrollTop: number, options?: IScrollOptions) {
     this.targetScrollTop = scrollTop
-    this.setElementScrollTop(scrollTop, options)
+    const scrollBehavior = this.scrollBehaviorForTarget(scrollTop, options)
+    this.setElementScrollTop(scrollTop, { ...options, scrollBehavior })
   }
 
   syncScrollTopToElement() {

--- a/v3/src/components/case-table/collection-table.tsx
+++ b/v3/src/components/case-table/collection-table.tsx
@@ -404,38 +404,19 @@ export const CollectionTable = observer(function CollectionTable(props: IProps) 
               selectCases([nextCaseId], data)
             }
           } else {
-            let caseIds = [nextCaseId]
+            // The onAnyAction selection reaction (useSelectedRows) cascades the scroll to
+            // descendant collections for this single setSelectedCases selection, so we don't
+            // repeat that here. See CODAP-1234.
             setSelectedCases([nextCaseId], data)
-            // loop through collections and scroll newly selected child cases into view
-            for (let childCollection = collection?.child; childCollection; childCollection = childCollection?.child) {
-              const childCaseIds: string[] = []
-              const childIndices: number[] = []
-              caseIds.forEach(id => {
-                const caseInfo = data?.caseInfoMap.get(id)
-                caseInfo?.childCaseIds?.forEach(childCaseId => {
-                  childCaseIds.push(childCaseId)
-                  const caseIndex = collectionCaseIndexFromId(childCaseId, data, childCollection.id)
-                  if (caseIndex != null) {
-                    childIndices.push(caseIndex)
-                  }
-                })
-              })
-              // scroll to newly selected child cases (if any)
-              if (childIndices.length) {
-                onScrollRowRangeIntoView(childCollection.id, childIndices, { disableScrollSync: true })
-              }
-              // advance to child cases in next collection
-              caseIds = childCaseIds
-            }
           }
         }
       }
     }
-  }, [active, collection, collectionId, collectionTableModel, data,
+  }, [active, collectionId, collectionTableModel, data,
       navigateToNextCell, navigateToNextRow,
       navigateToFirstEditableInRow, navigateToLastEditableInRow,
       navigateToFirstEditableCell, navigateToLastEditableCell,
-      onScrollRowRangeIntoView, rows])
+      rows])
 
   const handleClick = (event: React.PointerEvent<HTMLDivElement>) => {
     // See if mouse has moved beyond kMouseMovementThreshold since initial mousedown

--- a/v3/src/components/case-table/sync-selection-scroll.test.ts
+++ b/v3/src/components/case-table/sync-selection-scroll.test.ts
@@ -39,10 +39,10 @@ describe("scrollChildCollectionsToSelectedCases", () => {
     expect(calls[0].rowIndices).toEqual([0, 1, 2])
     // a=1 has 9 c-grandchildren at leaf-collection rows 0..8
     expect(calls[1].rowIndices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8])
-    // disables scroll sync to avoid feedback loops, and uses "auto" (not smooth) so the child
-    // tables jump straight to the selection instead of animating across thousands of rows
-    expect(calls[0].options).toEqual({ disableScrollSync: true, scrollBehavior: "auto" })
-    expect(calls[1].options).toEqual({ disableScrollSync: true, scrollBehavior: "auto" })
+    // disables scroll sync to avoid feedback loops; the scroll model chooses smooth vs instant by
+    // distance, so the helper no longer forces a scroll behavior
+    expect(calls[0].options).toEqual({ disableScrollSync: true })
+    expect(calls[1].options).toEqual({ disableScrollSync: true })
   })
 
   it("scrolls to the descendants of a non-first parent (mid-data selection)", () => {

--- a/v3/src/components/case-table/sync-selection-scroll.test.ts
+++ b/v3/src/components/case-table/sync-selection-scroll.test.ts
@@ -1,0 +1,76 @@
+import { DataSet } from "../../models/data/data-set"
+import { scrollChildCollectionsToSelectedCases } from "./sync-selection-scroll"
+
+// builds a 3-level hierarchy (a > b > c) from 3x3x3 = 27 items
+function createHierarchicalDataSet() {
+  const data = DataSet.create()
+  data.addAttribute({ id: "aId", name: "a" })
+  data.addAttribute({ id: "bId", name: "b" })
+  data.addAttribute({ id: "cId", name: "c" })
+  for (let a = 1; a <= 3; ++a) {
+    for (let b = 1; b <= 3; ++b) {
+      for (let c = 1; c <= 3; ++c) {
+        data.addCases([{ __id__: `${a}-${b}-${c}`, aId: `${a}`, bId: `${b}`, cId: `${c}` }])
+      }
+    }
+  }
+  const topCollection = data.addCollection({ attributes: ["aId"] })
+  const midCollection = data.addCollection({ attributes: ["bId"] })
+  const leafCollection = data.childCollection
+  data.validateCases()
+  return { data, topCollection, midCollection, leafCollection }
+}
+
+describe("scrollChildCollectionsToSelectedCases", () => {
+  it("scrolls each descendant collection to the selected parent's descendant cases", () => {
+    const { data, topCollection, midCollection, leafCollection } = createHierarchicalDataSet()
+    // select the first top-level case (a=1)
+    const topCase = data.getCasesForCollection(topCollection.id)[0]
+
+    const calls: Array<{ collectionId: string, rowIndices: number[], options?: any }> = []
+    const onScrollRowRangeIntoView = (collectionId: string, rowIndices: number[], options?: any) =>
+      calls.push({ collectionId, rowIndices, options })
+
+    scrollChildCollectionsToSelectedCases(data, topCollection.id, [topCase.__id__], onScrollRowRangeIntoView)
+
+    // scrolls the two descendant collections (mid + leaf), not the selected/top collection itself
+    expect(calls.map(c => c.collectionId)).toEqual([midCollection.id, leafCollection.id])
+    // a=1 has 3 b-children at mid-collection rows 0,1,2
+    expect(calls[0].rowIndices).toEqual([0, 1, 2])
+    // a=1 has 9 c-grandchildren at leaf-collection rows 0..8
+    expect(calls[1].rowIndices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8])
+    // disables scroll sync to avoid feedback loops, and uses "auto" (not smooth) so the child
+    // tables jump straight to the selection instead of animating across thousands of rows
+    expect(calls[0].options).toEqual({ disableScrollSync: true, scrollBehavior: "auto" })
+    expect(calls[1].options).toEqual({ disableScrollSync: true, scrollBehavior: "auto" })
+  })
+
+  it("scrolls to the descendants of a non-first parent (mid-data selection)", () => {
+    const { data, topCollection, midCollection, leafCollection } = createHierarchicalDataSet()
+    // select the third top-level case (a=3)
+    const topCase = data.getCasesForCollection(topCollection.id)[2]
+
+    const calls: Array<{ collectionId: string, rowIndices: number[], options?: any }> = []
+    const onScrollRowRangeIntoView = (collectionId: string, rowIndices: number[], options?: any) =>
+      calls.push({ collectionId, rowIndices, options })
+
+    scrollChildCollectionsToSelectedCases(data, topCollection.id, [topCase.__id__], onScrollRowRangeIntoView)
+
+    expect(calls.map(c => c.collectionId)).toEqual([midCollection.id, leafCollection.id])
+    // a=3 has 3 b-children at mid-collection rows 6,7,8
+    expect(calls[0].rowIndices).toEqual([6, 7, 8])
+    // a=3 has 9 c-grandchildren at leaf-collection rows 18..26
+    expect(calls[1].rowIndices).toEqual([18, 19, 20, 21, 22, 23, 24, 25, 26])
+  })
+
+  it("does nothing when the selected case has no descendants (leaf collection)", () => {
+    const { data, leafCollection } = createHierarchicalDataSet()
+    const leafCase = data.getCasesForCollection(leafCollection.id)[0]
+
+    const calls: string[] = []
+    scrollChildCollectionsToSelectedCases(data, leafCollection.id, [leafCase.__id__],
+      collectionId => calls.push(collectionId))
+
+    expect(calls).toEqual([])
+  })
+})

--- a/v3/src/components/case-table/sync-selection-scroll.ts
+++ b/v3/src/components/case-table/sync-selection-scroll.ts
@@ -1,0 +1,45 @@
+import { IDataSet } from "../../models/data/data-set"
+import { collectionCaseIndexFromId } from "../../models/data/data-set-utils"
+import { OnScrollRowsIntoViewFn } from "./case-table-types"
+
+/**
+ * Scrolls each descendant collection's table to bring the selected parent cases' descendants
+ * into view. Starting from the given (selected) cases in `parentCollectionId`, it walks down
+ * the collection hierarchy, gathering each level's child cases and scrolling that collection's
+ * table to their row range. `disableScrollSync` is passed so these programmatic scrolls don't
+ * feed back into the scroll-synchronization logic.
+ *
+ * This is the cascade that keeps hierarchical selection visible across collections. It is
+ * invoked for any selection source (graph, plugin, programmatic, or a table cell click).
+ */
+export function scrollChildCollectionsToSelectedCases(
+  data: IDataSet | undefined,
+  parentCollectionId: string,
+  selectedCaseIds: string[],
+  onScrollRowRangeIntoView: OnScrollRowsIntoViewFn
+) {
+  const collection = data?.getCollection(parentCollectionId)
+  let caseIds = selectedCaseIds
+  for (let childCollection = collection?.child; childCollection; childCollection = childCollection?.child) {
+    const childCaseIds: string[] = []
+    const childIndices: number[] = []
+    caseIds.forEach(id => {
+      const caseInfo = data?.caseInfoMap.get(id)
+      caseInfo?.childCaseIds?.forEach(childCaseId => {
+        childCaseIds.push(childCaseId)
+        const caseIndex = collectionCaseIndexFromId(childCaseId, data, childCollection.id)
+        if (caseIndex != null) {
+          childIndices.push(caseIndex)
+        }
+      })
+    })
+    // scroll to newly selected child cases (if any). `scrollBehavior: "auto"` makes the table
+    // jump directly to the target instead of smooth-scrolling across the entire dataset (which
+    // is both slow and distracting for deep selections); `disableScrollSync` avoids feedback.
+    if (childIndices.length) {
+      onScrollRowRangeIntoView(childCollection.id, childIndices, { disableScrollSync: true, scrollBehavior: "auto" })
+    }
+    // advance to child cases in next collection
+    caseIds = childCaseIds
+  }
+}

--- a/v3/src/components/case-table/sync-selection-scroll.ts
+++ b/v3/src/components/case-table/sync-selection-scroll.ts
@@ -33,11 +33,11 @@ export function scrollChildCollectionsToSelectedCases(
         }
       })
     })
-    // scroll to newly selected child cases (if any). `scrollBehavior: "auto"` makes the table
-    // jump directly to the target instead of smooth-scrolling across the entire dataset (which
-    // is both slow and distracting for deep selections); `disableScrollSync` avoids feedback.
+    // scroll to newly selected child cases (if any). `disableScrollSync` avoids feedback; the
+    // scroll model picks the behavior by distance (instant for far selections — avoiding a slow
+    // animation across the dataset — smooth for nearby ones), so we don't force it here.
     if (childIndices.length) {
-      onScrollRowRangeIntoView(childCollection.id, childIndices, { disableScrollSync: true, scrollBehavior: "auto" })
+      onScrollRowRangeIntoView(childCollection.id, childIndices, { disableScrollSync: true })
     }
     // advance to child cases in next collection
     caseIds = childCaseIds

--- a/v3/src/components/case-table/use-selected-rows.ts
+++ b/v3/src/components/case-table/use-selected-rows.ts
@@ -122,7 +122,9 @@ export const useSelectedRows = (props: UseSelectedRows) => {
             const caseIds = action.args[0]
             const caseIndices = caseIds.map(id => collectionCaseIndexFromId(id, data, collectionId))
                                        .filter(index => index != null)
-            const isSelecting = ((action.name === "selectCases") && action.args[1]) || true
+            // `selectCases` carries an explicit select/deselect flag (default true); deselection
+            // should not scroll. Other selection actions (setSelectedCases, etc.) are always selecting.
+            const isSelecting = action.name === "selectCases" ? (action.args[1] ?? true) : true
             isSelecting && caseIndices.length && onScrollClosestRowIntoView(collectionId, caseIndices)
 
             // For a single, non-extending selection, cascade the scroll to descendant collections

--- a/v3/src/components/case-table/use-selected-rows.ts
+++ b/v3/src/components/case-table/use-selected-rows.ts
@@ -12,6 +12,7 @@ import { onAnyAction } from "../../utilities/mst-utils"
 import { prf } from "../../utilities/profiler"
 import { kIndexColumnKey } from "../case-tile-common/case-tile-types"
 import { kInputRowKey, OnScrollRowsIntoViewFn, TCellClickArgs } from "./case-table-types"
+import { scrollChildCollectionsToSelectedCases } from "./sync-selection-scroll"
 import { useCollectionTableModel } from "./use-collection-table-model"
 
 interface UseSelectedRows {
@@ -123,12 +124,22 @@ export const useSelectedRows = (props: UseSelectedRows) => {
                                        .filter(index => index != null)
             const isSelecting = ((action.name === "selectCases") && action.args[1]) || true
             isSelecting && caseIndices.length && onScrollClosestRowIntoView(collectionId, caseIndices)
+
+            // For a single, non-extending selection, cascade the scroll to descendant collections
+            // so they also scroll to show the selection's descendants. This handles selection from
+            // any source (graph, plugin, programmatic), mirroring the case-table cell-click path
+            // which previously had its own copy of this cascade. See CODAP-1234.
+            if (action.name === "setSelectedCases" && caseIndices.length === 1) {
+              const myCaseIds = caseIds.filter((id: string) =>
+                collectionCaseIndexFromId(id, data, collectionId) != null)
+              scrollChildCollectionsToSelectedCases(data, collectionId, myCaseIds, onScrollRowRangeIntoView)
+            }
           }
         }
       })
     })
     return () => disposer?.()
-  }, [collectionId, collectionTableModel, data, onScrollClosestRowIntoView,
+  }, [collectionId, collectionTableModel, data, onScrollClosestRowIntoView, onScrollRowRangeIntoView,
       syncRowSelectionToDom, syncRowSelectionToRdg])
 
   // anchor row for shift-selection
@@ -174,34 +185,13 @@ export const useSelectedRows = (props: UseSelectedRows) => {
     // In this case, we match the v2 behavior in that clicking on a single row when multiple rows
     // are selected deselects other rows.
     else {
-      let caseIds = [caseId]
-      setSelectedCases(caseIds, data)
+      // Selecting a single case. The onAnyAction selection reaction (above) cascades the scroll
+      // to descendant collections via scrollChildCollectionsToSelectedCases, so we don't repeat
+      // that here. See CODAP-1234.
+      setSelectedCases([caseId], data)
       anchorCase.current = caseId
-
-      // loop through collections and scroll newly selected child cases into view
-      const collection = data?.getCollection(collectionId)
-      for (let childCollection = collection?.child; childCollection; childCollection = childCollection?.child) {
-        const childCaseIds: string[] = []
-        const childIndices: number[] = []
-        caseIds.forEach(id => {
-          const caseInfo = data?.caseInfoMap.get(id)
-          caseInfo?.childCaseIds?.forEach(childCaseId => {
-            childCaseIds.push(childCaseId)
-            const caseIndex = collectionCaseIndexFromId(childCaseId, data, childCollection.id)
-            if (caseIndex != null) {
-              childIndices.push(caseIndex)
-            }
-          })
-        })
-        // scroll to newly selected child cases (if any)
-        if (childIndices.length) {
-          onScrollRowRangeIntoView(childCollection.id, childIndices, { disableScrollSync: true })
-        }
-        // advance to child cases in next collection
-        caseIds = childCaseIds
-      }
     }
-  }, [collectionId, data, onScrollRowRangeIntoView])
+  }, [collectionId, data])
 
   return { selectedRows, setSelectedRows, handleCellClick }
 }

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -1,5 +1,6 @@
-import { applySnapshot, getSnapshot, types } from "mobx-state-tree"
+import { applySnapshot, destroy, getSnapshot, types } from "mobx-state-tree"
 import { kellyColors } from "../../utilities/color-utils"
+import { jestSpyConsole } from "../../test/jest-spy-console"
 import { Attribute, IAttribute } from "./attribute"
 import { CategorySet, ICategorySet, createProvisionalCategorySet, getProvisionalDataSet } from "./category-set"
 import { DataSet } from "./data-set"
@@ -61,6 +62,23 @@ describe("CategorySet", () => {
     const c = Attribute.create({ id: "cId", name: "c" }, undefined)
     expect(getProvisionalDataSet(c)).toBeUndefined()
     expect(getProvisionalDataSet(null)).toBeUndefined()
+  })
+
+  it("disposes its attribute-change reaction when its provisional DataSet is destroyed", async () => {
+    const data = DataSet.create()
+    data.addAttribute({ id: "aId", name: "aFree" })
+    const categories = createProvisionalCategorySet(data, "aId")
+    // accessing the attribute establishes the reaction's dependency on the (live) DataSet
+    expect(categories.attribute.name).toBe("aFree")
+
+    // Destroying the DataSet (as happens when a document is replaced on load) must dispose the
+    // CategorySet's invalidate-on-change reaction. Otherwise the orphaned reaction fires during
+    // teardown and resolves `attribute` through the now-dead DataSet, logging an MST
+    // "no longer part of a state tree" use-after-free warning via console.warn.
+    await jestSpyConsole("warn", spy => {
+      destroy(data)
+      expect(spy).not.toHaveBeenCalled()
+    })
   })
 
   it("constructs categories, allows them to be moved, and responds to changes", () => {

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -248,15 +248,19 @@ export const CategorySet = types.model("CategorySet", {
     // don't change at that moment, and any subsequent recomputation goes through setComputedValues
     // which will bump changeCount and trigger this reaction.
     // The accessor guards against an invalid attribute reference (which can occur briefly while
-    // the attribute is being destroyed); the reaction is auto-disposed when this CategorySet
-    // is destroyed via the onInvalidated → removeCategorySet chain.
+    // the attribute is being destroyed). The reaction is disposed when this CategorySet is
+    // destroyed; for a provisional CategorySet (a standalone node held in a volatile map, which
+    // is never itself destroyed) we also dispose it when its provisional DataSet is destroyed.
+    // Otherwise the orphaned reaction would fire during teardown and resolve `attribute` through
+    // the now-dead DataSet, logging an MST use-after-free warning (CODAP-1234).
+    const provisionalDataSet = getProvisionalDataSet(self)
     mstReaction(
       () => isValidReference(() => self.attribute) ? self.attribute.changeCount : undefined,
       changeCount => {
         if (changeCount != null) self.invalidate()
       },
       { name: "CategorySet.invalidateOnAttributeChangeCount" },
-      self
+      provisionalDataSet ? [self, provisionalDataSet] : self
     )
   },
   move(value: string, beforeValue?: string) {


### PR DESCRIPTION
## Summary

Part 1 of 2 for CODAP-1234. The bar-chart selection-visibility symptom is handled
in a separate PR (different, visual/Cypress testing requirements). This PR fixes
issues surfaced by the story's document:

### 1. Case table doesn't scroll to hierarchical child selection
When a parent case is selected via the graph, a plugin, or programmatically, the
child collection tables now scroll to show the selection's descendants. Previously
only table cell-clicks cascaded the scroll; selections routed through the
`onAnyAction` reaction fell back to the generic visible-range alignment, which
aligned child tables to the parent at the top of the viewport rather than the
selected parent. The descendant-scroll cascade is now a shared, tested helper
(`scrollChildCollectionsToSelectedCases`) invoked from the selection reaction, so
every selection source — graph, plugin, programmatic, table cell-click, and
keyboard arrow navigation — behaves the same. (The previously-duplicated inline
cascades in `handleCellClick` and the keyboard handler were removed.)

Scroll behavior is modulated by distance in `CollectionTableModel` — smooth within
one visible page, instant beyond — so selecting a distant case jumps instantly (no
slow animation across the dataset) while arrow-key navigation to a neighboring row
scrolls smoothly.

### 2. MST use-after-free warnings on document load
Loading a document logged two `[mobx-state-tree] … no longer part of a state tree`
warnings. Provisional CategorySets are standalone MST nodes held in a volatile map
and are never destroyed; their attribute-change reaction outlived the DataSet and
fired during teardown, reading the dead DataSet. The reaction is now also disposed
when its provisional DataSet is destroyed.

### 3. Don't auto-scroll the table on deselection
A pre-existing bug (from #436): `isSelecting` was always `true` due to a trailing
`|| true`, so the table scrolled to cases even when deselecting. It now reads the
`selectCases` select flag (defaulting to true when omitted).

## Test plan
- New/updated unit tests: `sync-selection-scroll.test.ts` (descendant cascade);
  `collection-table-model.test.ts` (distance-based `scrollBehaviorForTarget`);
  `category-set.test.ts` (reproduces then verifies the two warnings are gone).
- `npm run build:tsc`, `npm run lint`, and the case-table + data-model Jest suites pass.
- Manual: selecting a parent case (graph, table click, or arrow keys) scrolls child
  collections to the selection — instantly when far, smoothly when adjacent — with
  no double-scroll; loading the document produces no MST warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
