### PR TITLE
CODAP-1234: render fused bars as coalesced solid segments

### DIFF
--- a/v3/src/components/data-display/renderer/bar-coalescing.test.ts
+++ b/v3/src/components/data-display/renderer/bar-coalescing.test.ts
@@ -30,6 +30,33 @@ describe("coalesceBarRuns", () => {
     ])
   })
 
+  it("splits a same-fill run where a selected case carries a distinct selection stroke (legend mode)", () => {
+    // With a legend, selection is encoded only in the stroke (the fill stays the legend color). A
+    // selected case between unselected same-fill cases must remain its own run so its selection
+    // stroke survives — grouping by fill alone would drop it, hiding the selection. See CODAP-1234.
+    const runs = coalesceBarRuns([
+      piece(0, "#e6805b"),
+      piece(1, "#e6805b", { stroke: "#ff0000", strokeWidth: 2, strokeOpacity: 1 }),
+      piece(2, "#e6805b")
+    ], anchor)
+    expect(runs).toEqual([
+      { left: 10, top: 0, width: 4, height: 1, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 },
+      { left: 10, top: 1, width: 4, height: 1, fill: "#e6805b", stroke: "#ff0000", strokeWidth: 2, strokeOpacity: 1 },
+      { left: 10, top: 2, width: 4, height: 1, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ])
+  })
+
+  it("still merges contiguous cases that share both fill and stroke (selection coalesces too)", () => {
+    const selected = { stroke: "#ff0000", strokeWidth: 2, strokeOpacity: 1 }
+    const runs = coalesceBarRuns([
+      piece(0, "#e6805b", selected), piece(1, "#e6805b", selected), piece(2, "#e6805b")
+    ], anchor)
+    expect(runs).toEqual([
+      { left: 10, top: 0, width: 4, height: 2, fill: "#e6805b", stroke: "#ff0000", strokeWidth: 2, strokeOpacity: 1 },
+      { left: 10, top: 2, width: 4, height: 1, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ])
+  })
+
   it("produces one run per interleaved single-case run", () => {
     const runs = coalesceBarRuns([piece(0, "#4682b4"), piece(1, "#e6805b"), piece(2, "#4682b4")], anchor)
     expect(runs.map(r => r.fill)).toEqual(["#4682b4", "#e6805b", "#4682b4"])
@@ -102,6 +129,19 @@ describe("coalesceBarRuns with stackAxis='x' (horizontal bars)", () => {
     const runs = coalesceBarRuns([hpiece(0, "#4682b4"), hpiece(1, "#4682b4"), hpiece(2, "#e6805b")], anchor, "x")
     expect(runs).toEqual([
       { left: 0, top: 10, width: 2, height: 4, fill: "#4682b4", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 },
+      { left: 2, top: 10, width: 1, height: 4, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ])
+  })
+
+  it("splits a same-fill run where a selected case carries a distinct selection stroke (legend mode)", () => {
+    const runs = coalesceBarRuns([
+      hpiece(0, "#e6805b"),
+      hpiece(1, "#e6805b", { stroke: "#ff0000", strokeWidth: 2, strokeOpacity: 1 }),
+      hpiece(2, "#e6805b")
+    ], anchor, "x")
+    expect(runs).toEqual([
+      { left: 0, top: 10, width: 1, height: 4, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 },
+      { left: 1, top: 10, width: 1, height: 4, fill: "#e6805b", stroke: "#ff0000", strokeWidth: 2, strokeOpacity: 1 },
       { left: 2, top: 10, width: 1, height: 4, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
     ])
   })

--- a/v3/src/components/data-display/renderer/bar-coalescing.test.ts
+++ b/v3/src/components/data-display/renderer/bar-coalescing.test.ts
@@ -79,3 +79,57 @@ describe("coalesceBars", () => {
     expect(coalesceBars([], anchor)).toEqual([])
   })
 })
+
+// horizontal bars (primaryIsBottom === false): cases in a bar share y and stack along x
+function hpiece(x: number, fill: string, overrides: Partial<IBarPiece> = {}): IBarPiece {
+  return {
+    x, y: 10, scale: 1, width: 1, height: 4,
+    fill, stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4,
+    ...overrides
+  }
+}
+
+describe("coalesceBarRuns with stackAxis='x' (horizontal bars)", () => {
+  it("merges a uniform-fill bar into a single run extending along x", () => {
+    const runs = coalesceBarRuns([hpiece(0, "#e6805b"), hpiece(1, "#e6805b"), hpiece(2, "#e6805b")], anchor, "x")
+    // anchor {0,0}: left = x, top = y; run extends in x from 0 to 3, cross-axis height stays 4
+    expect(runs).toEqual([
+      { left: 0, top: 10, width: 3, height: 4, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ])
+  })
+
+  it("splits into runs at fill boundaries, expanding along x", () => {
+    const runs = coalesceBarRuns([hpiece(0, "#4682b4"), hpiece(1, "#4682b4"), hpiece(2, "#e6805b")], anchor, "x")
+    expect(runs).toEqual([
+      { left: 0, top: 10, width: 2, height: 4, fill: "#4682b4", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 },
+      { left: 2, top: 10, width: 1, height: 4, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ])
+  })
+
+  it("sorts pieces by x before merging", () => {
+    const runs = coalesceBarRuns([hpiece(2, "#e6805b"), hpiece(0, "#4682b4"), hpiece(1, "#4682b4")], anchor, "x")
+    expect(runs.map(r => [r.fill, r.left, r.width])).toEqual([
+      ["#4682b4", 0, 2],
+      ["#e6805b", 2, 1]
+    ])
+  })
+})
+
+describe("coalesceBars with stackAxis='x' (horizontal bars)", () => {
+  it("groups pieces into bars by y, coalescing each along x", () => {
+    // bar at y=10 (two #e6805b) and bar at y=50 (two #4682b4), interleaved in input order;
+    // both bars start at the same baseline x — must NOT be merged across the two rows
+    const pieces: IBarPiece[] = [
+      hpiece(0, "#e6805b", { y: 10 }),
+      hpiece(0, "#4682b4", { y: 50 }),
+      hpiece(1, "#e6805b", { y: 10 }),
+      hpiece(1, "#4682b4", { y: 50 })
+    ]
+    const runs = coalesceBars(pieces, anchor, "x")
+    expect(runs).toHaveLength(2)
+    expect(runs).toEqual(expect.arrayContaining([
+      { left: 0, top: 10, width: 2, height: 4, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 },
+      { left: 0, top: 50, width: 2, height: 4, fill: "#4682b4", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ]))
+  })
+})

--- a/v3/src/components/data-display/renderer/bar-coalescing.test.ts
+++ b/v3/src/components/data-display/renderer/bar-coalescing.test.ts
@@ -1,0 +1,81 @@
+import { coalesceBarRuns, coalesceBars, IBarPiece } from "./bar-coalescing"
+
+const anchor = { x: 0, y: 0 } // top-left anchored → top = y, bottom = y + height*scale
+function piece(y: number, fill: string, overrides: Partial<IBarPiece> = {}): IBarPiece {
+  return {
+    x: 10, y, scale: 1, width: 4, height: 1,
+    fill, stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4,
+    ...overrides
+  }
+}
+
+describe("coalesceBarRuns", () => {
+  it("merges a uniform-fill bar into a single run carrying its stroke style", () => {
+    const runs = coalesceBarRuns([piece(0, "#e6805b"), piece(1, "#e6805b"), piece(2, "#e6805b")], anchor)
+    expect(runs).toEqual([
+      { left: 10, top: 0, width: 4, height: 3, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ])
+  })
+
+  it("splits into runs at fill boundaries, each with its own stroke style", () => {
+    // two selected (#4682b4, red stroke) on top of three unselected (#e6805b, white stroke)
+    const runs = coalesceBarRuns([
+      piece(0, "#4682b4", { stroke: "#ff0000", strokeWidth: 2, strokeOpacity: 1 }),
+      piece(1, "#4682b4", { stroke: "#ff0000", strokeWidth: 2, strokeOpacity: 1 }),
+      piece(2, "#e6805b"), piece(3, "#e6805b"), piece(4, "#e6805b")
+    ], anchor)
+    expect(runs).toEqual([
+      { left: 10, top: 0, width: 4, height: 2, fill: "#4682b4", stroke: "#ff0000", strokeWidth: 2, strokeOpacity: 1 },
+      { left: 10, top: 2, width: 4, height: 3, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ])
+  })
+
+  it("produces one run per interleaved single-case run", () => {
+    const runs = coalesceBarRuns([piece(0, "#4682b4"), piece(1, "#e6805b"), piece(2, "#4682b4")], anchor)
+    expect(runs.map(r => r.fill)).toEqual(["#4682b4", "#e6805b", "#4682b4"])
+    expect(runs.map(r => r.height)).toEqual([1, 1, 1])
+  })
+
+  it("applies anchor and scale to geometry", () => {
+    // anchor bottom-center, scale 2: left = x - 0.5*width*scale; top = y - 1*height*scale
+    const runs = coalesceBarRuns(
+      [{ x: 10, y: 20, scale: 2, width: 4, height: 0.5, fill: "#4682b4",
+         stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }],
+      { x: 0.5, y: 1 }
+    )
+    expect(runs).toEqual([
+      { left: 10 - 0.5 * 4 * 2, top: 20 - 1 * 0.5 * 2, width: 8, height: 1, fill: "#4682b4",
+        stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ])
+  })
+
+  it("sorts pieces by y before merging (input order independent)", () => {
+    const runs = coalesceBarRuns([piece(2, "#e6805b"), piece(0, "#4682b4"), piece(1, "#4682b4")], anchor)
+    expect(runs.map(r => [r.fill, r.top, r.height])).toEqual([
+      ["#4682b4", 0, 2],
+      ["#e6805b", 2, 1]
+    ])
+  })
+})
+
+describe("coalesceBars", () => {
+  it("groups pieces into bars by x, coalescing each bar independently", () => {
+    // bar at x=10 (two #e6805b) and bar at x=50 (two #4682b4), interleaved in input order
+    const pieces: IBarPiece[] = [
+      piece(0, "#e6805b", { x: 10 }),
+      piece(0, "#4682b4", { x: 50 }),
+      piece(1, "#e6805b", { x: 10 }),
+      piece(1, "#4682b4", { x: 50 })
+    ]
+    const runs = coalesceBars(pieces, anchor)
+    expect(runs).toHaveLength(2)
+    expect(runs).toEqual(expect.arrayContaining([
+      { left: 10, top: 0, width: 4, height: 2, fill: "#e6805b", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 },
+      { left: 50, top: 0, width: 4, height: 2, fill: "#4682b4", stroke: "#ffffff", strokeWidth: 1, strokeOpacity: 0.4 }
+    ]))
+  })
+
+  it("returns an empty array for no pieces", () => {
+    expect(coalesceBars([], anchor)).toEqual([])
+  })
+})

--- a/v3/src/components/data-display/renderer/bar-coalescing.ts
+++ b/v3/src/components/data-display/renderer/bar-coalescing.ts
@@ -1,3 +1,5 @@
+import { IPointState } from "./point-renderer-types"
+
 export interface IBarPiece {
   x: number
   y: number
@@ -22,42 +24,83 @@ export interface IBarRun {
 }
 
 /**
- * Merge a single bar's per-case rectangles ("pieces") into one rectangle per contiguous same-fill
- * run. Bars are drawn as a stack of per-case rects so selected cases can be shown distinctly, but
- * drawing each case as its own rect produces undesirable per-case separator lines and, when the
- * rects are sub-pixel-thin, washes the fill out (abutting sub-pixel opaque rects composite to
- * <100% opacity under coverage-based anti-aliasing). Coalescing same-fill runs yields solid
- * segments with strokes only at meaningful boundaries (selection changes and the bar outline).
+ * Maps a renderer point state to a bar piece, or undefined when the point is not a drawable bar
+ * (hidden, or missing width/height). Shared by the Canvas and Pixi renderers so the visibility
+ * guard and the `strokeOpacity` default stay in one place.
+ */
+export function pointStateToBarPiece(p: IPointState): IBarPiece | undefined {
+  const { style } = p
+  if (!p.isVisible || style.width == null || style.height == null) return undefined
+  return {
+    x: p.x, y: p.y, scale: p.scale,
+    width: style.width, height: style.height,
+    fill: style.fill, stroke: style.stroke,
+    strokeWidth: style.strokeWidth, strokeOpacity: style.strokeOpacity ?? 0.4
+  }
+}
+
+/**
+ * Top-left corner and scaled size of an anchored bar rectangle. `anchor` is the fraction of the
+ * scaled width/height sitting left of / above (x, y): {0,0} = top-left anchored, {0.5,0.5} =
+ * centered. Shared by bar rendering (coalesceBarRuns) and bar hit-testing (canvas-hit-tester) so
+ * the drawn rect and its hit region use the same geometry. See CODAP-1234.
+ */
+export function anchoredBarRect(
+  x: number, y: number, width: number, height: number, scale: number, anchor: { x: number; y: number }
+): { left: number; top: number; width: number; height: number } {
+  const w = width * scale
+  const h = height * scale
+  return { left: x - anchor.x * w, top: y - anchor.y * h, width: w, height: h }
+}
+
+/**
+ * Two pieces coalesce only when they render identically: same fill AND same stroke style. Without a
+ * legend, selection is encoded in the fill (selected cases get a distinct fill); with a legend the
+ * fill stays the legend color and selection is encoded only in the stroke. Grouping by fill alone
+ * would therefore merge a selected case into an adjacent unselected same-color case and drop its
+ * selection stroke, making the selection invisible. See CODAP-1234.
+ */
+function sameRunStyle(a: IBarPiece, b: IBarPiece): boolean {
+  return a.fill === b.fill && a.stroke === b.stroke &&
+    a.strokeWidth === b.strokeWidth && a.strokeOpacity === b.strokeOpacity
+}
+
+/**
+ * Merge a single bar's per-case rectangles ("pieces") into one rectangle per contiguous same-style
+ * run (same fill and stroke; see `sameRunStyle`). Bars are drawn as a stack of per-case rects so
+ * selected cases can be shown distinctly, but drawing each case as its own rect produces undesirable
+ * per-case separator lines and, when the rects are sub-pixel-thin, washes the fill out (abutting
+ * sub-pixel opaque rects composite to <100% opacity under coverage-based anti-aliasing). Coalescing
+ * same-style runs yields solid segments with strokes only at meaningful boundaries (selection
+ * changes and the bar outline).
  *
  * Pieces must all belong to the same bar. `stackAxis` is the axis along which the cases stack:
  * "y" for vertical bars (primary/categorical axis on the bottom) and "x" for horizontal bars
- * (primary axis on the left). Pieces are sorted along the stack axis and each run is extended
- * along it, keeping the cross-axis position/size constant. Each run carries the stroke style of
- * its first piece (uniform within a run, since the fill encodes selection/legend state).
- * See CODAP-1234.
+ * (primary axis on the left). Pieces are sorted along the stack axis (in place — callers pass a
+ * throwaway per-bar array) and each run is extended along it, keeping the cross-axis position/size
+ * constant. Each run carries the stroke style of its first piece (uniform within a run, since the
+ * run only spans same-style pieces). See CODAP-1234.
  */
 export function coalesceBarRuns(
   barPieces: IBarPiece[], anchor: { x: number; y: number }, stackAxis: "x" | "y" = "y"
 ): IBarRun[] {
-  const sorted = [...barPieces].sort((a, b) => a[stackAxis] - b[stackAxis])
+  const sorted = barPieces.sort((a, b) => a[stackAxis] - b[stackAxis])
   const runs: IBarRun[] = []
   let i = 0
   while (i < sorted.length) {
     const p0 = sorted[i]
     const { fill, stroke, strokeWidth, strokeOpacity } = p0
-    const w0 = p0.width * p0.scale
-    const h0 = p0.height * p0.scale
-    const left0 = p0.x - anchor.x * w0
-    const top0 = p0.y - anchor.y * h0
+    const { left: left0, top: top0, width: w0, height: h0 } =
+      anchoredBarRect(p0.x, p0.y, p0.width, p0.height, p0.scale, anchor)
     // the run grows along the stack axis (start..end); the cross axis stays as p0's
     let start = stackAxis === "y" ? top0 : left0
     let end = start + (stackAxis === "y" ? h0 : w0)
     let j = i + 1
-    while (j < sorted.length && sorted[j].fill === fill) {
+    while (j < sorted.length && sameRunStyle(sorted[j], p0)) {
       const pj = sorted[j]
-      const wj = pj.width * pj.scale
-      const hj = pj.height * pj.scale
-      const startj = stackAxis === "y" ? pj.y - anchor.y * hj : pj.x - anchor.x * wj
+      const { left: leftj, top: topj, width: wj, height: hj } =
+        anchoredBarRect(pj.x, pj.y, pj.width, pj.height, pj.scale, anchor)
+      const startj = stackAxis === "y" ? topj : leftj
       start = Math.min(start, startj)
       end = Math.max(end, startj + (stackAxis === "y" ? hj : wj))
       j++
@@ -71,7 +114,7 @@ export function coalesceBarRuns(
 }
 
 /**
- * Groups a flat list of bar pieces into bars and coalesces each bar's same-fill runs, returning
+ * Groups a flat list of bar pieces into bars and coalesces each bar's same-style runs, returning
  * all runs across all bars. Shared by the Canvas and Pixi renderers; each renderer maps its own
  * point state into `IBarPiece`s and draws the returned runs.
  *
@@ -79,6 +122,12 @@ export function coalesceBarRuns(
  * are keyed by the cross axis (the primary/categorical coordinate). The exact coordinate is used
  * as the key — all cases in one fused bar share an identical computed value — which avoids merging
  * distinct, sub-pixel-spaced bars that rounding to an integer key would collapse together.
+ *
+ * This relies on every case in a bar computing a bit-identical cross-axis coordinate (they do: it
+ * comes from one scale call on the shared category value). If that ever stopped holding, the bar
+ * would split into adjacent runs (a hairline seam, the per-case washout this module fixes) — but do
+ * NOT add a tolerance to the key to paper over it: a tolerance would instead merge genuinely
+ * distinct, sub-pixel-spaced bars. Tag pieces with a per-bar identity key instead.
  */
 export function coalesceBars(
   barPieces: IBarPiece[], anchor: { x: number; y: number }, stackAxis: "x" | "y" = "y"

--- a/v3/src/components/data-display/renderer/bar-coalescing.ts
+++ b/v3/src/components/data-display/renderer/bar-coalescing.ts
@@ -25,55 +25,73 @@ export interface IBarRun {
  * Merge a single bar's per-case rectangles ("pieces") into one rectangle per contiguous same-fill
  * run. Bars are drawn as a stack of per-case rects so selected cases can be shown distinctly, but
  * drawing each case as its own rect produces undesirable per-case separator lines and, when the
- * rects are sub-pixel-tall, washes the fill out (abutting sub-pixel opaque rects composite to
+ * rects are sub-pixel-thin, washes the fill out (abutting sub-pixel opaque rects composite to
  * <100% opacity under coverage-based anti-aliasing). Coalescing same-fill runs yields solid
  * segments with strokes only at meaningful boundaries (selection changes and the bar outline).
  *
- * Pieces must all belong to the same bar (shared primary coord); they are sorted by ascending y
- * (top→bottom). Each run carries the stroke style of its first piece (uniform within a run, since
- * the fill encodes selection/legend state). See CODAP-1234.
+ * Pieces must all belong to the same bar. `stackAxis` is the axis along which the cases stack:
+ * "y" for vertical bars (primary/categorical axis on the bottom) and "x" for horizontal bars
+ * (primary axis on the left). Pieces are sorted along the stack axis and each run is extended
+ * along it, keeping the cross-axis position/size constant. Each run carries the stroke style of
+ * its first piece (uniform within a run, since the fill encodes selection/legend state).
+ * See CODAP-1234.
  */
-export function coalesceBarRuns(barPieces: IBarPiece[], anchor: { x: number; y: number }): IBarRun[] {
-  const sorted = [...barPieces].sort((a, b) => a.y - b.y)
+export function coalesceBarRuns(
+  barPieces: IBarPiece[], anchor: { x: number; y: number }, stackAxis: "x" | "y" = "y"
+): IBarRun[] {
+  const sorted = [...barPieces].sort((a, b) => a[stackAxis] - b[stackAxis])
   const runs: IBarRun[] = []
   let i = 0
   while (i < sorted.length) {
     const p0 = sorted[i]
     const { fill, stroke, strokeWidth, strokeOpacity } = p0
-    const width = p0.width * p0.scale
-    const left = p0.x - anchor.x * width
-    let top = p0.y - anchor.y * p0.height * p0.scale
-    let bottom = top + p0.height * p0.scale
+    const w0 = p0.width * p0.scale
+    const h0 = p0.height * p0.scale
+    const left0 = p0.x - anchor.x * w0
+    const top0 = p0.y - anchor.y * h0
+    // the run grows along the stack axis (start..end); the cross axis stays as p0's
+    let start = stackAxis === "y" ? top0 : left0
+    let end = start + (stackAxis === "y" ? h0 : w0)
     let j = i + 1
     while (j < sorted.length && sorted[j].fill === fill) {
       const pj = sorted[j]
-      const t = pj.y - anchor.y * pj.height * pj.scale
-      top = Math.min(top, t)
-      bottom = Math.max(bottom, t + pj.height * pj.scale)
+      const wj = pj.width * pj.scale
+      const hj = pj.height * pj.scale
+      const startj = stackAxis === "y" ? pj.y - anchor.y * hj : pj.x - anchor.x * wj
+      start = Math.min(start, startj)
+      end = Math.max(end, startj + (stackAxis === "y" ? hj : wj))
       j++
     }
-    runs.push({ left, top, width, height: bottom - top, fill, stroke, strokeWidth, strokeOpacity })
+    runs.push(stackAxis === "y"
+      ? { left: left0, top: start, width: w0, height: end - start, fill, stroke, strokeWidth, strokeOpacity }
+      : { left: start, top: top0, width: end - start, height: h0, fill, stroke, strokeWidth, strokeOpacity })
     i = j
   }
   return runs
 }
 
 /**
- * Groups a flat list of bar pieces into bars by their shared primary (x) coordinate and coalesces
- * each bar's same-fill runs, returning all runs across all bars. Shared by the Canvas and Pixi
- * renderers; each renderer maps its own point state into `IBarPiece`s and draws the returned runs.
+ * Groups a flat list of bar pieces into bars and coalesces each bar's same-fill runs, returning
+ * all runs across all bars. Shared by the Canvas and Pixi renderers; each renderer maps its own
+ * point state into `IBarPiece`s and draws the returned runs.
+ *
+ * `stackAxis` is the axis the cases stack along ("y" for vertical bars, "x" for horizontal); bars
+ * are keyed by the cross axis (the primary/categorical coordinate). The exact coordinate is used
+ * as the key — all cases in one fused bar share an identical computed value — which avoids merging
+ * distinct, sub-pixel-spaced bars that rounding to an integer key would collapse together.
  */
-export function coalesceBars(barPieces: IBarPiece[], anchor: { x: number; y: number }): IBarRun[] {
-  // Group by the exact primary (x) coordinate: all cases in one fused bar share an identical
-  // computed x, and using the exact value avoids merging distinct, sub-pixel-spaced bars (which
-  // rounding to an integer key would collapse together).
+export function coalesceBars(
+  barPieces: IBarPiece[], anchor: { x: number; y: number }, stackAxis: "x" | "y" = "y"
+): IBarRun[] {
+  const keyAxis = stackAxis === "y" ? "x" : "y"
   const piecesByBar = new Map<number, IBarPiece[]>()
   for (const piece of barPieces) {
-    const bar = piecesByBar.get(piece.x) ?? []
+    const key = piece[keyAxis]
+    const bar = piecesByBar.get(key) ?? []
     bar.push(piece)
-    piecesByBar.set(piece.x, bar)
+    piecesByBar.set(key, bar)
   }
   const runs: IBarRun[] = []
-  piecesByBar.forEach(bar => runs.push(...coalesceBarRuns(bar, anchor)))
+  piecesByBar.forEach(bar => runs.push(...coalesceBarRuns(bar, anchor, stackAxis)))
   return runs
 }

--- a/v3/src/components/data-display/renderer/bar-coalescing.ts
+++ b/v3/src/components/data-display/renderer/bar-coalescing.ts
@@ -64,12 +64,14 @@ export function coalesceBarRuns(barPieces: IBarPiece[], anchor: { x: number; y: 
  * renderers; each renderer maps its own point state into `IBarPiece`s and draws the returned runs.
  */
 export function coalesceBars(barPieces: IBarPiece[], anchor: { x: number; y: number }): IBarRun[] {
+  // Group by the exact primary (x) coordinate: all cases in one fused bar share an identical
+  // computed x, and using the exact value avoids merging distinct, sub-pixel-spaced bars (which
+  // rounding to an integer key would collapse together).
   const piecesByBar = new Map<number, IBarPiece[]>()
   for (const piece of barPieces) {
-    const key = Math.round(piece.x)
-    const bar = piecesByBar.get(key) ?? []
+    const bar = piecesByBar.get(piece.x) ?? []
     bar.push(piece)
-    piecesByBar.set(key, bar)
+    piecesByBar.set(piece.x, bar)
   }
   const runs: IBarRun[] = []
   piecesByBar.forEach(bar => runs.push(...coalesceBarRuns(bar, anchor)))

--- a/v3/src/components/data-display/renderer/bar-coalescing.ts
+++ b/v3/src/components/data-display/renderer/bar-coalescing.ts
@@ -1,0 +1,77 @@
+export interface IBarPiece {
+  x: number
+  y: number
+  scale: number
+  width: number
+  height: number
+  fill: string
+  stroke: string
+  strokeWidth: number
+  strokeOpacity: number
+}
+
+export interface IBarRun {
+  left: number
+  top: number
+  width: number
+  height: number
+  fill: string
+  stroke: string
+  strokeWidth: number
+  strokeOpacity: number
+}
+
+/**
+ * Merge a single bar's per-case rectangles ("pieces") into one rectangle per contiguous same-fill
+ * run. Bars are drawn as a stack of per-case rects so selected cases can be shown distinctly, but
+ * drawing each case as its own rect produces undesirable per-case separator lines and, when the
+ * rects are sub-pixel-tall, washes the fill out (abutting sub-pixel opaque rects composite to
+ * <100% opacity under coverage-based anti-aliasing). Coalescing same-fill runs yields solid
+ * segments with strokes only at meaningful boundaries (selection changes and the bar outline).
+ *
+ * Pieces must all belong to the same bar (shared primary coord); they are sorted by ascending y
+ * (top→bottom). Each run carries the stroke style of its first piece (uniform within a run, since
+ * the fill encodes selection/legend state). See CODAP-1234.
+ */
+export function coalesceBarRuns(barPieces: IBarPiece[], anchor: { x: number; y: number }): IBarRun[] {
+  const sorted = [...barPieces].sort((a, b) => a.y - b.y)
+  const runs: IBarRun[] = []
+  let i = 0
+  while (i < sorted.length) {
+    const p0 = sorted[i]
+    const { fill, stroke, strokeWidth, strokeOpacity } = p0
+    const width = p0.width * p0.scale
+    const left = p0.x - anchor.x * width
+    let top = p0.y - anchor.y * p0.height * p0.scale
+    let bottom = top + p0.height * p0.scale
+    let j = i + 1
+    while (j < sorted.length && sorted[j].fill === fill) {
+      const pj = sorted[j]
+      const t = pj.y - anchor.y * pj.height * pj.scale
+      top = Math.min(top, t)
+      bottom = Math.max(bottom, t + pj.height * pj.scale)
+      j++
+    }
+    runs.push({ left, top, width, height: bottom - top, fill, stroke, strokeWidth, strokeOpacity })
+    i = j
+  }
+  return runs
+}
+
+/**
+ * Groups a flat list of bar pieces into bars by their shared primary (x) coordinate and coalesces
+ * each bar's same-fill runs, returning all runs across all bars. Shared by the Canvas and Pixi
+ * renderers; each renderer maps its own point state into `IBarPiece`s and draws the returned runs.
+ */
+export function coalesceBars(barPieces: IBarPiece[], anchor: { x: number; y: number }): IBarRun[] {
+  const piecesByBar = new Map<number, IBarPiece[]>()
+  for (const piece of barPieces) {
+    const key = Math.round(piece.x)
+    const bar = piecesByBar.get(key) ?? []
+    bar.push(piece)
+    piecesByBar.set(key, bar)
+  }
+  const runs: IBarRun[] = []
+  piecesByBar.forEach(bar => runs.push(...coalesceBarRuns(bar, anchor)))
+  return runs
+}

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.ts
@@ -488,8 +488,9 @@ export class CanvasPointRenderer extends PointRendererBase {
       // Draw each point. Bars whose cases are fused into shared stacked bars (bar chart/histogram)
       // are drawn by coalescing contiguous same-fill cases into one solid segment rect each (see
       // drawBars), rather than one rect per case. Non-fused bars (each case its own bar) fall
-      // through to per-case drawing.
-      if (this._displayType === "bars" && this._pointsFusedIntoBars) {
+      // through to per-case drawing, as do bars mid-transition: coalescing assumes stable geometry,
+      // so during a transition (e.g. the points<->bars fuse) we draw per case so the animation plays.
+      if (this._displayType === "bars" && this._pointsFusedIntoBars && !this.anyTransitionActive) {
         this.drawBars(points)
       } else {
         for (const pointState of points) {

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.ts
@@ -524,7 +524,7 @@ export class CanvasPointRenderer extends PointRendererBase {
         strokeWidth: p.style.strokeWidth, strokeOpacity: p.style.strokeOpacity ?? 0.4
       })
     }
-    for (const run of coalesceBars(pieces, this._anchor)) {
+    for (const run of coalesceBars(pieces, this._anchor, this._barStackAxis)) {
       ctx.fillStyle = run.fill
       ctx.fillRect(run.left, run.top, run.width, run.height)
       if (run.strokeWidth > 0) {

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.ts
@@ -12,7 +12,7 @@
 
 import { CaseDataWithSubPlot } from "../d3-types"
 import { PointDisplayType, transitionDuration } from "../data-display-types"
-import { coalesceBars, IBarPiece } from "./bar-coalescing"
+import { coalesceBars, IBarPiece, pointStateToBarPiece } from "./bar-coalescing"
 import { CanvasHitTester, CanvasTransitionManager } from "./canvas"
 import {
   circleAnchor,
@@ -486,11 +486,10 @@ export class CanvasPointRenderer extends PointRendererBase {
       }
 
       // Draw each point. Bars whose cases are fused into shared stacked bars (bar chart/histogram)
-      // are drawn by coalescing contiguous same-fill cases into one solid segment rect each (see
+      // are drawn by coalescing contiguous same-style cases into one solid segment rect each (see
       // drawBars), rather than one rect per case. Non-fused bars (each case its own bar) fall
-      // through to per-case drawing, as do bars mid-transition: coalescing assumes stable geometry,
-      // so during a transition (e.g. the points<->bars fuse) we draw per case so the animation plays.
-      if (this._displayType === "bars" && this._pointsFusedIntoBars && !this.anyTransitionActive) {
+      // through to per-case drawing, as do bars mid-transition (see shouldCoalesceBars).
+      if (this.shouldCoalesceBars) {
         this.drawBars(points)
       } else {
         for (const pointState of points) {
@@ -517,13 +516,8 @@ export class CanvasPointRenderer extends PointRendererBase {
     if (!ctx) return
     const pieces: IBarPiece[] = []
     for (const p of points) {
-      if (!p.isVisible || p.style.width == null || p.style.height == null) continue
-      pieces.push({
-        x: p.x, y: p.y, scale: p.scale,
-        width: p.style.width, height: p.style.height,
-        fill: p.style.fill, stroke: p.style.stroke,
-        strokeWidth: p.style.strokeWidth, strokeOpacity: p.style.strokeOpacity ?? 0.4
-      })
+      const piece = pointStateToBarPiece(p)
+      if (piece) pieces.push(piece)
     }
     for (const run of coalesceBars(pieces, this._anchor, this._barStackAxis)) {
       ctx.fillStyle = run.fill

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.ts
@@ -485,9 +485,11 @@ export class CanvasPointRenderer extends PointRendererBase {
         this.ctx.clip()
       }
 
-      // Draw each point. Bars are drawn by coalescing contiguous same-fill cases into one solid
-      // segment rect each (see drawBars), rather than one rect per case.
-      if (this._displayType === "bars") {
+      // Draw each point. Bars whose cases are fused into shared stacked bars (bar chart/histogram)
+      // are drawn by coalescing contiguous same-fill cases into one solid segment rect each (see
+      // drawBars), rather than one rect per case. Non-fused bars (each case its own bar) fall
+      // through to per-case drawing.
+      if (this._displayType === "bars" && this._pointsFusedIntoBars) {
         this.drawBars(points)
       } else {
         for (const pointState of points) {

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.ts
@@ -506,7 +506,7 @@ export class CanvasPointRenderer extends PointRendererBase {
     this.hitTester?.updateFromPoints(sortedPoints, this._displayType, this._anchor)
   }
 
-  // Draws bars by coalescing each bar's contiguous same-fill cases into a single solid segment
+  // Draws bars by coalescing each bar's contiguous same-style cases into a single solid segment
   // rectangle (with that segment's stroke), instead of one rect per case. This avoids the
   // undesirable per-case separator lines and the sub-pixel fill washout that occur when hundreds
   // of cases stack into one bar. Per-case hit-testing is unaffected (it uses the point positions).

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.ts
@@ -12,6 +12,7 @@
 
 import { CaseDataWithSubPlot } from "../d3-types"
 import { PointDisplayType, transitionDuration } from "../data-display-types"
+import { coalesceBars, IBarPiece } from "./bar-coalescing"
 import { CanvasHitTester, CanvasTransitionManager } from "./canvas"
 import {
   circleAnchor,
@@ -484,10 +485,15 @@ export class CanvasPointRenderer extends PointRendererBase {
         this.ctx.clip()
       }
 
-      // Draw each point
-      for (const pointState of points) {
-        if (pointState.isVisible) {
-          this.drawPoint(pointState)
+      // Draw each point. Bars are drawn by coalescing contiguous same-fill cases into one solid
+      // segment rect each (see drawBars), rather than one rect per case.
+      if (this._displayType === "bars") {
+        this.drawBars(points)
+      } else {
+        for (const pointState of points) {
+          if (pointState.isVisible) {
+            this.drawPoint(pointState)
+          }
         }
       }
 
@@ -496,6 +502,37 @@ export class CanvasPointRenderer extends PointRendererBase {
 
     // Update hit tester with current positions
     this.hitTester?.updateFromPoints(sortedPoints, this._displayType, this._anchor)
+  }
+
+  // Draws bars by coalescing each bar's contiguous same-fill cases into a single solid segment
+  // rectangle (with that segment's stroke), instead of one rect per case. This avoids the
+  // undesirable per-case separator lines and the sub-pixel fill washout that occur when hundreds
+  // of cases stack into one bar. Per-case hit-testing is unaffected (it uses the point positions).
+  // See CODAP-1234.
+  private drawBars(points: IPointState[]): void {
+    const ctx = this.ctx
+    if (!ctx) return
+    const pieces: IBarPiece[] = []
+    for (const p of points) {
+      if (!p.isVisible || p.style.width == null || p.style.height == null) continue
+      pieces.push({
+        x: p.x, y: p.y, scale: p.scale,
+        width: p.style.width, height: p.style.height,
+        fill: p.style.fill, stroke: p.style.stroke,
+        strokeWidth: p.style.strokeWidth, strokeOpacity: p.style.strokeOpacity ?? 0.4
+      })
+    }
+    for (const run of coalesceBars(pieces, this._anchor)) {
+      ctx.fillStyle = run.fill
+      ctx.fillRect(run.left, run.top, run.width, run.height)
+      if (run.strokeWidth > 0) {
+        ctx.strokeStyle = run.stroke
+        ctx.lineWidth = run.strokeWidth
+        ctx.globalAlpha = run.strokeOpacity
+        ctx.strokeRect(run.left, run.top, run.width, run.height)
+        ctx.globalAlpha = 1
+      }
+    }
   }
 
   private drawPoint(point: IPointState): void {

--- a/v3/src/components/data-display/renderer/canvas/canvas-hit-tester.ts
+++ b/v3/src/components/data-display/renderer/canvas/canvas-hit-tester.ts
@@ -6,6 +6,7 @@
  */
 
 import { PointDisplayType } from "../../data-display-types"
+import { anchoredBarRect } from "../bar-coalescing"
 import { IPointState } from "../point-renderer-types"
 
 /**
@@ -172,14 +173,8 @@ export class CanvasHitTester {
 
     if (displayType === "bars" && style.width !== undefined && style.height !== undefined) {
       // Bar/rectangle
-      const w = style.width * scale
-      const h = style.height * scale
-      return {
-        x: x - anchor.x * w,
-        y: y - anchor.y * h,
-        width: w,
-        height: h
-      }
+      const { left, top, width, height } = anchoredBarRect(x, y, style.width, style.height, scale, anchor)
+      return { x: left, y: top, width, height }
     } else {
       // Circle/point
       const r = style.radius * scale

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -11,7 +11,7 @@ import {
   PointRendererBase
 } from "./point-renderer-base"
 import { PointsState } from "./points-state"
-import { coalesceBars, IBarPiece } from "./bar-coalescing"
+import { coalesceBars, IBarPiece, pointStateToBarPiece } from "./bar-coalescing"
 import {
   IBackgroundEventDistributionOptions,
   IPoint,
@@ -282,12 +282,10 @@ export class PixiPointRenderer extends PointRendererBase {
     this.sprites.forEach(sprite => {
       sprite.mask = null
     })
-    // Defer destruction of old masks
+    // Defer destruction of old masks (see deferDestroy)
     const oldMasks = this.subPlotMasks
     this.subPlotMasks = []
-    requestAnimationFrame(() => {
-      oldMasks.forEach(mask => mask.destroy())
-    })
+    this.deferDestroy(oldMasks)
 
     // Create new masks
     for (let top = 0; top < topCats; ++top) {
@@ -321,17 +319,22 @@ export class PixiPointRenderer extends PointRendererBase {
   // plots coalesce and clip per cell. eventMode "none" keeps the layer from swallowing pointer
   // events (empty-space clicks should reach the background to deselect; bar clicks are handled by
   // the SVG bar covers). pointsContainer has no transform, so the stage shares its coordinate space.
+  // Destroy PIXI objects on the next animation frame rather than synchronously: an in-flight render
+  // this frame may still reference them, and rendering a destroyed object throws (null GPU context).
+  // Used when swapping out subplot masks and the per-subplot bar layers. See CODAP-1234.
+  private deferDestroy(objects: Array<{ destroy(): void }>): void {
+    requestAnimationFrame(() => objects.forEach(obj => obj.destroy()))
+  }
+
   private rebuildBarsGraphics(): void {
     // Remove the old layers from the stage and clear their masks now (so they are no longer
-    // collected for rendering), but defer destroy() to the next frame: an in-flight render this
-    // frame may still reference them, and rendering a destroyed Graphics throws (null GPU context).
-    // This mirrors the deferred destruction of the subplot masks in doResize. See CODAP-1234.
+    // collected for rendering), but defer destroy() to the next frame (see deferDestroy).
     const oldGraphics = this.barsGraphicsBySubplot
     oldGraphics.forEach(graphics => {
       graphics.mask = null
       this.stage.removeChild(graphics)
     })
-    requestAnimationFrame(() => oldGraphics.forEach(graphics => graphics.destroy()))
+    this.deferDestroy(oldGraphics)
 
     this.barsGraphicsBySubplot = this.subPlotMasks.map(mask => {
       const graphics = new PIXI.Graphics()
@@ -550,12 +553,10 @@ export class PixiPointRenderer extends PointRendererBase {
     this.barsGraphicsBySubplot.forEach(graphics => {
       graphics.mask = null
     })
-    // Defer destruction of old masks
+    // Defer destruction of old masks (see deferDestroy)
     const oldMasks = this.subPlotMasks
     this.subPlotMasks = []
-    requestAnimationFrame(() => {
-      oldMasks.forEach(mask => mask.destroy())
-    })
+    this.deferDestroy(oldMasks)
     // Trigger a render to show sprites without masks
     this.doStartRendering()
   }
@@ -677,12 +678,9 @@ export class PixiPointRenderer extends PointRendererBase {
   // are handled by the SVG bar covers, so hiding the sprites doesn't affect selection. See
   // CODAP-1234.
   private updateBarsLayer(): void {
-    // Only coalesce when cases are fused into shared stacked bars (bar chart/histogram), and not
-    // during any transition. Coalescing assumes stable geometry, so while a transition is running
-    // (the points<->bars fuse, or position/axis animations) we keep per-case sprite rendering so
-    // the animation plays. Non-fused "bars" (each case its own bar) also stay per-case.
-    const useCoalesced = this._displayType === "bars" && this._pointsFusedIntoBars &&
-      !this.anyTransitionActive
+    // Coalesce only fused bars and not mid-transition (see shouldCoalesceBars); otherwise keep
+    // per-case sprite rendering so transitions animate and non-fused "bars" draw per case.
+    const useCoalesced = this.shouldCoalesceBars
     if (!useCoalesced) {
       if (this.barsLayerActive) {
         this.barsGraphicsBySubplot.forEach(graphics => graphics.clear())
@@ -697,16 +695,11 @@ export class PixiPointRenderer extends PointRendererBase {
     // masked to its cell). Each subplot's runs are drawn into its own masked Graphics.
     const piecesBySubplot = new Map<number, IBarPiece[]>()
     this.state.forEach(pointState => {
-      const { style } = pointState
-      if (!pointState.isVisible || style.width == null || style.height == null) return
+      const piece = pointStateToBarPiece(pointState)
+      if (!piece) return
       const subplot = pointState.subPlotNum ?? 0
       const pieces = piecesBySubplot.get(subplot) ?? []
-      pieces.push({
-        x: pointState.x, y: pointState.y, scale: pointState.scale,
-        width: style.width, height: style.height,
-        fill: style.fill, stroke: style.stroke,
-        strokeWidth: style.strokeWidth, strokeOpacity: style.strokeOpacity ?? 0.4
-      })
+      pieces.push(piece)
       piecesBySubplot.set(subplot, pieces)
     })
 

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -209,6 +209,10 @@ export class PixiPointRenderer extends PointRendererBase {
     // pointsContainer has no transform, so the stage shares its coordinate space. eventMode "none"
     // keeps this layer from swallowing pointer events (e.g. empty-space clicks that should reach
     // the background to deselect); bar clicks are handled by the SVG bar covers above the canvas.
+    // NOTE: unlike the per-case sprites (masked per subplot via subPlotMasks), this single layer is
+    // not subplot-clipped. Coalesced bars are sized by the secondary axis to fit their cell, so
+    // they don't bleed into adjacent split-plot cells in practice; per-subplot masking is a
+    // deferred robustness follow-up.
     this.barsGraphics.eventMode = "none"
     this.stage.addChild(this.barsGraphics)
 
@@ -639,7 +643,10 @@ export class PixiPointRenderer extends PointRendererBase {
   // are handled by the SVG bar covers, so hiding the sprites doesn't affect selection. See
   // CODAP-1234.
   private updateBarsLayer(): void {
-    const useCoalesced = this._displayType === "bars" && !this.displayTypeTransitionState.isActive
+    // Only coalesce when cases are fused into shared stacked bars (bar chart/histogram), and not
+    // mid-transition. Non-fused "bars" (each case its own bar) keep per-case sprite rendering.
+    const useCoalesced = this._displayType === "bars" && this._pointsFusedIntoBars &&
+      !this.displayTypeTransitionState.isActive
     if (!useCoalesced) {
       if (this.barsLayerActive) {
         this.barsGraphics.clear()

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -11,6 +11,7 @@ import {
   PointRendererBase
 } from "./point-renderer-base"
 import { PointsState } from "./points-state"
+import { coalesceBars, IBarPiece } from "./bar-coalescing"
 import {
   IBackgroundEventDistributionOptions,
   IPoint,
@@ -67,6 +68,14 @@ export class PixiPointRenderer extends PointRendererBase {
   // Sprite management
   private sprites = new Map<string, PIXI.Sprite>()
   private textures = new Map<string, PIXI.Texture>()
+
+  // Bars are drawn by coalescing contiguous same-fill cases into one solid segment rect each
+  // (see updateBarsLayer / bar-coalescing) rather than one sprite per case. The per-case sprites
+  // are hidden (renderable = false) while this layer is active; they remain in the scene only
+  // because points mode and the points<->bars fuse transition still use them. Bar clicks are
+  // handled separately by the SVG bar covers (see renderBarCovers), not these sprites.
+  private barsGraphics = new PIXI.Graphics()
+  private barsLayerActive = false
 
   // Transition state
   private displayTypeTransitionState: IDisplayTypeTransitionState = { isActive: false }
@@ -196,6 +205,12 @@ export class PixiPointRenderer extends PointRendererBase {
     this.stage.addChild(this.background)
     this.stage.addChild(this.pointsContainer)
     this.pointsContainer.sortableChildren = true
+    // Coalesced-bars layer: drawn on top of the (hidden) per-case sprites when in bars mode.
+    // pointsContainer has no transform, so the stage shares its coordinate space. eventMode "none"
+    // keeps this layer from swallowing pointer events (e.g. empty-space clicks that should reach
+    // the background to deselect); bar clicks are handled by the SVG bar covers above the canvas.
+    this.barsGraphics.eventMode = "none"
+    this.stage.addChild(this.barsGraphics)
 
     if (options?.backgroundEventDistribution) {
       this.doSetupBackgroundEventDistribution(options.backgroundEventDistribution)
@@ -613,7 +628,48 @@ export class PixiPointRenderer extends PointRendererBase {
       this.ticker.stop()
       this.cleanupUnusedTextures()
     }
+    this.updateBarsLayer()
     this.renderer.render(this.stage)
+  }
+
+  // Rebuilds the coalesced-bars layer from the current point state. When fully in bars mode, each
+  // bar's contiguous same-fill cases are merged into one solid segment rect (with its stroke), and
+  // the per-case sprites are hidden from rendering (renderable = false). In points mode or during
+  // the points<->bars transition, the layer is cleared and the sprites render normally. Bar clicks
+  // are handled by the SVG bar covers, so hiding the sprites doesn't affect selection. See
+  // CODAP-1234.
+  private updateBarsLayer(): void {
+    const useCoalesced = this._displayType === "bars" && !this.displayTypeTransitionState.isActive
+    if (!useCoalesced) {
+      if (this.barsLayerActive) {
+        this.barsGraphics.clear()
+        this.sprites.forEach(sprite => { sprite.renderable = true })
+        this.barsLayerActive = false
+      }
+      return
+    }
+
+    const pieces: IBarPiece[] = []
+    this.state.forEach(pointState => {
+      const { style } = pointState
+      if (!pointState.isVisible || style.width == null || style.height == null) return
+      pieces.push({
+        x: pointState.x, y: pointState.y, scale: pointState.scale,
+        width: style.width, height: style.height,
+        fill: style.fill, stroke: style.stroke,
+        strokeWidth: style.strokeWidth, strokeOpacity: style.strokeOpacity ?? 0.4
+      })
+    })
+
+    this.barsGraphics.clear()
+    for (const run of coalesceBars(pieces, this._anchor)) {
+      this.barsGraphics.rect(run.left, run.top, run.width, run.height).fill(run.fill)
+      if (run.strokeWidth > 0) {
+        this.barsGraphics.stroke({ color: run.stroke, width: run.strokeWidth, alpha: run.strokeOpacity })
+      }
+    }
+    this.sprites.forEach(sprite => { sprite.renderable = false })
+    this.barsLayerActive = true
   }
 
   private syncFromState(): void {

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -322,7 +322,17 @@ export class PixiPointRenderer extends PointRendererBase {
   // events (empty-space clicks should reach the background to deselect; bar clicks are handled by
   // the SVG bar covers). pointsContainer has no transform, so the stage shares its coordinate space.
   private rebuildBarsGraphics(): void {
-    this.barsGraphicsBySubplot.forEach(graphics => graphics.destroy())
+    // Remove the old layers from the stage and clear their masks now (so they are no longer
+    // collected for rendering), but defer destroy() to the next frame: an in-flight render this
+    // frame may still reference them, and rendering a destroyed Graphics throws (null GPU context).
+    // This mirrors the deferred destruction of the subplot masks in doResize. See CODAP-1234.
+    const oldGraphics = this.barsGraphicsBySubplot
+    oldGraphics.forEach(graphics => {
+      graphics.mask = null
+      this.stage.removeChild(graphics)
+    })
+    requestAnimationFrame(() => oldGraphics.forEach(graphics => graphics.destroy()))
+
     this.barsGraphicsBySubplot = this.subPlotMasks.map(mask => {
       const graphics = new PIXI.Graphics()
       graphics.eventMode = "none"
@@ -532,9 +542,13 @@ export class PixiPointRenderer extends PointRendererBase {
   }
 
   protected doRemoveMasks(): void {
-    // Clear sprite mask references
+    // Clear sprite and coalesced-bars-layer mask references before the masks are destroyed, so
+    // nothing renders a destroyed mask (which throws on a null GPU context).
     this.sprites.forEach(sprite => {
       sprite.mask = null
+    })
+    this.barsGraphicsBySubplot.forEach(graphics => {
+      graphics.mask = null
     })
     // Defer destruction of old masks
     const oldMasks = this.subPlotMasks

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -660,9 +660,11 @@ export class PixiPointRenderer extends PointRendererBase {
   // CODAP-1234.
   private updateBarsLayer(): void {
     // Only coalesce when cases are fused into shared stacked bars (bar chart/histogram), and not
-    // mid-transition. Non-fused "bars" (each case its own bar) keep per-case sprite rendering.
+    // during any transition. Coalescing assumes stable geometry, so while a transition is running
+    // (the points<->bars fuse, or position/axis animations) we keep per-case sprite rendering so
+    // the animation plays. Non-fused "bars" (each case its own bar) also stay per-case.
     const useCoalesced = this._displayType === "bars" && this._pointsFusedIntoBars &&
-      !this.displayTypeTransitionState.isActive
+      !this.anyTransitionActive
     if (!useCoalesced) {
       if (this.barsLayerActive) {
         this.barsGraphicsBySubplot.forEach(graphics => graphics.clear())

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -70,11 +70,13 @@ export class PixiPointRenderer extends PointRendererBase {
   private textures = new Map<string, PIXI.Texture>()
 
   // Bars are drawn by coalescing contiguous same-fill cases into one solid segment rect each
-  // (see updateBarsLayer / bar-coalescing) rather than one sprite per case. The per-case sprites
-  // are hidden (renderable = false) while this layer is active; they remain in the scene only
-  // because points mode and the points<->bars fuse transition still use them. Bar clicks are
-  // handled separately by the SVG bar covers (see renderBarCovers), not these sprites.
-  private barsGraphics = new PIXI.Graphics()
+  // (see updateBarsLayer / bar-coalescing) rather than one sprite per case. There is one Graphics
+  // per subplot cell (created in doResize, masked to its cell) so split-plot cells coalesce and
+  // clip independently. The per-case sprites are hidden (renderable = false) while this layer is
+  // active; they remain in the scene only because points mode and the points<->bars fuse
+  // transition still use them. Bar clicks are handled separately by the SVG bar covers (see
+  // renderBarCovers), not these sprites.
+  private barsGraphicsBySubplot: PIXI.Graphics[] = []
   private barsLayerActive = false
 
   // Transition state
@@ -205,16 +207,8 @@ export class PixiPointRenderer extends PointRendererBase {
     this.stage.addChild(this.background)
     this.stage.addChild(this.pointsContainer)
     this.pointsContainer.sortableChildren = true
-    // Coalesced-bars layer: drawn on top of the (hidden) per-case sprites when in bars mode.
-    // pointsContainer has no transform, so the stage shares its coordinate space. eventMode "none"
-    // keeps this layer from swallowing pointer events (e.g. empty-space clicks that should reach
-    // the background to deselect); bar clicks are handled by the SVG bar covers above the canvas.
-    // NOTE: unlike the per-case sprites (masked per subplot via subPlotMasks), this single layer is
-    // not subplot-clipped. Coalesced bars are sized by the secondary axis to fit their cell, so
-    // they don't bleed into adjacent split-plot cells in practice; per-subplot masking is a
-    // deferred robustness follow-up.
-    this.barsGraphics.eventMode = "none"
-    this.stage.addChild(this.barsGraphics)
+    // The coalesced-bars layers (one per subplot cell, masked to that cell) are created in
+    // doResize once the subplot masks exist.
 
     if (options?.backgroundEventDistribution) {
       this.doSetupBackgroundEventDistribution(options.backgroundEventDistribution)
@@ -250,9 +244,11 @@ export class PixiPointRenderer extends PointRendererBase {
     this.ticker.destroy()
     this.renderer?.destroy()
     this.renderer = undefined
-    // Destroy masks before stage
+    // Destroy masks and the per-subplot bar layers before stage
     this.subPlotMasks.forEach(mask => mask.destroy())
     this.subPlotMasks = []
+    this.barsGraphicsBySubplot.forEach(graphics => graphics.destroy())
+    this.barsGraphicsBySubplot = []
     this.stage.destroy()
     this.textures.forEach(texture => texture.destroy())
     this.textures.clear()
@@ -311,8 +307,28 @@ export class PixiPointRenderer extends PointRendererBase {
 
     // Re-apply masks to existing sprites based on their subPlotNum in state
     this.reapplyMasksFromState()
+    // Rebuild the per-subplot coalesced-bars layers to match the new masks
+    this.rebuildBarsGraphics()
     // Trigger a render after masks are reapplied
     this.doStartRendering()
+  }
+
+  // (Re)creates one coalesced-bars Graphics per subplot cell, each masked to that cell, so split
+  // plots coalesce and clip per cell. eventMode "none" keeps the layer from swallowing pointer
+  // events (empty-space clicks should reach the background to deselect; bar clicks are handled by
+  // the SVG bar covers). pointsContainer has no transform, so the stage shares its coordinate space.
+  private rebuildBarsGraphics(): void {
+    this.barsGraphicsBySubplot.forEach(graphics => graphics.destroy())
+    this.barsGraphicsBySubplot = this.subPlotMasks.map(mask => {
+      const graphics = new PIXI.Graphics()
+      graphics.eventMode = "none"
+      graphics.mask = mask
+      this.stage.addChild(graphics)
+      return graphics
+    })
+    // sprites render normally until the next updateBarsLayer decides to hide them
+    this.sprites.forEach(sprite => { sprite.renderable = true })
+    this.barsLayerActive = false
   }
 
   /**
@@ -649,32 +665,42 @@ export class PixiPointRenderer extends PointRendererBase {
       !this.displayTypeTransitionState.isActive
     if (!useCoalesced) {
       if (this.barsLayerActive) {
-        this.barsGraphics.clear()
+        this.barsGraphicsBySubplot.forEach(graphics => graphics.clear())
         this.sprites.forEach(sprite => { sprite.renderable = true })
         this.barsLayerActive = false
       }
       return
     }
 
-    const pieces: IBarPiece[] = []
+    // Group pieces by subplot so each cell coalesces independently: bars in different split-plot
+    // cells must not be merged even when they share a primary coordinate (and each cell's layer is
+    // masked to its cell). Each subplot's runs are drawn into its own masked Graphics.
+    const piecesBySubplot = new Map<number, IBarPiece[]>()
     this.state.forEach(pointState => {
       const { style } = pointState
       if (!pointState.isVisible || style.width == null || style.height == null) return
+      const subplot = pointState.subPlotNum ?? 0
+      const pieces = piecesBySubplot.get(subplot) ?? []
       pieces.push({
         x: pointState.x, y: pointState.y, scale: pointState.scale,
         width: style.width, height: style.height,
         fill: style.fill, stroke: style.stroke,
         strokeWidth: style.strokeWidth, strokeOpacity: style.strokeOpacity ?? 0.4
       })
+      piecesBySubplot.set(subplot, pieces)
     })
 
-    this.barsGraphics.clear()
-    for (const run of coalesceBars(pieces, this._anchor, this._barStackAxis)) {
-      this.barsGraphics.rect(run.left, run.top, run.width, run.height).fill(run.fill)
-      if (run.strokeWidth > 0) {
-        this.barsGraphics.stroke({ color: run.stroke, width: run.strokeWidth, alpha: run.strokeOpacity })
+    this.barsGraphicsBySubplot.forEach((graphics, subplot) => {
+      graphics.clear()
+      const pieces = piecesBySubplot.get(subplot)
+      if (!pieces) return
+      for (const run of coalesceBars(pieces, this._anchor, this._barStackAxis)) {
+        graphics.rect(run.left, run.top, run.width, run.height).fill(run.fill)
+        if (run.strokeWidth > 0) {
+          graphics.stroke({ color: run.stroke, width: run.strokeWidth, alpha: run.strokeOpacity })
+        }
       }
-    }
+    })
     this.sprites.forEach(sprite => { sprite.renderable = false })
     this.barsLayerActive = true
   }

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -669,7 +669,7 @@ export class PixiPointRenderer extends PointRendererBase {
     })
 
     this.barsGraphics.clear()
-    for (const run of coalesceBars(pieces, this._anchor)) {
+    for (const run of coalesceBars(pieces, this._anchor, this._barStackAxis)) {
       this.barsGraphics.rect(run.left, run.top, run.width, run.height).fill(run.fill)
       if (run.strokeWidth > 0) {
         this.barsGraphics.stroke({ color: run.stroke, width: run.strokeWidth, alpha: run.strokeOpacity })

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -697,9 +697,13 @@ export class PixiPointRenderer extends PointRendererBase {
       const pieces = piecesBySubplot.get(subplot)
       if (!pieces) return
       for (const run of coalesceBars(pieces, this._anchor, this._barStackAxis)) {
-        graphics.rect(run.left, run.top, run.width, run.height).fill(run.fill)
+        // chain fill/stroke onto the same rect() command, matching getRectTexture's usage
         if (run.strokeWidth > 0) {
-          graphics.stroke({ color: run.stroke, width: run.strokeWidth, alpha: run.strokeOpacity })
+          graphics.rect(run.left, run.top, run.width, run.height)
+            .fill(run.fill)
+            .stroke({ color: run.stroke, width: run.strokeWidth, alpha: run.strokeOpacity })
+        } else {
+          graphics.rect(run.left, run.top, run.width, run.height).fill(run.fill)
         }
       }
     })

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -69,7 +69,7 @@ export class PixiPointRenderer extends PointRendererBase {
   private sprites = new Map<string, PIXI.Sprite>()
   private textures = new Map<string, PIXI.Texture>()
 
-  // Bars are drawn by coalescing contiguous same-fill cases into one solid segment rect each
+  // Bars are drawn by coalescing contiguous same-style cases into one solid segment rect each
   // (see updateBarsLayer / bar-coalescing) rather than one sprite per case. There is one Graphics
   // per subplot cell (created in doResize, masked to its cell) so split-plot cells coalesce and
   // clip independently. The per-case sprites are hidden (renderable = false) while this layer is
@@ -672,7 +672,7 @@ export class PixiPointRenderer extends PointRendererBase {
   }
 
   // Rebuilds the coalesced-bars layer from the current point state. When fully in bars mode, each
-  // bar's contiguous same-fill cases are merged into one solid segment rect (with its stroke), and
+  // bar's contiguous same-style cases are merged into one solid segment rect (with its stroke), and
   // the per-case sprites are hidden from rendering (renderable = false). In points mode or during
   // the points<->bars transition, the layer is cleared and the sprites render normally. Bar clicks
   // are handled by the SVG bar covers, so hiding the sprites doesn't affect selection. See

--- a/v3/src/components/data-display/renderer/pixi-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/pixi-point-renderer.ts
@@ -244,11 +244,15 @@ export class PixiPointRenderer extends PointRendererBase {
     this.ticker.destroy()
     this.renderer?.destroy()
     this.renderer = undefined
-    // Destroy masks and the per-subplot bar layers before stage
+    // Destroy the per-subplot bar layers (clearing their mask refs) before the masks they use,
+    // then the masks, then the stage.
+    this.barsGraphicsBySubplot.forEach(graphics => {
+      graphics.mask = null
+      graphics.destroy()
+    })
+    this.barsGraphicsBySubplot = []
     this.subPlotMasks.forEach(mask => mask.destroy())
     this.subPlotMasks = []
-    this.barsGraphicsBySubplot.forEach(graphics => graphics.destroy())
-    this.barsGraphicsBySubplot = []
     this.stage.destroy()
     this.textures.forEach(texture => texture.destroy())
     this.textures.clear()

--- a/v3/src/components/data-display/renderer/point-renderer-base.ts
+++ b/v3/src/components/data-display/renderer/point-renderer-base.ts
@@ -257,6 +257,16 @@ export abstract class PointRendererBase {
     this._anchor = value
   }
 
+  /**
+   * Whether the renderer should draw fused bars as coalesced same-style segments rather than
+   * per-case rects/sprites: only for bar charts/histograms whose cases are fused into shared
+   * stacked bars, and not mid-transition (coalescing assumes stable geometry, so during a
+   * transition we keep per-case rendering so the animation plays). Shared by both renderers.
+   */
+  protected get shouldCoalesceBars(): boolean {
+    return this._displayType === "bars" && this._pointsFusedIntoBars && !this.anyTransitionActive
+  }
+
   // ===== Template methods (shared logic + delegation) =====
 
   /**
@@ -333,6 +343,13 @@ export abstract class PointRendererBase {
     // (e.g., PixiPointRenderer's display type transition), so defer the assignment.
     this.doMatchPointsToData(datasetID, caseData, displayType, style)
     this._displayType = displayType
+    // The bar-only state is set imperatively by the bar-chart/histogram plot components and is
+    // never otherwise reset; clear it whenever we leave bars mode so a reused renderer can't carry
+    // a stale fuse flag / stack axis into a non-bars plot. See CODAP-1234.
+    if (displayType !== "bars") {
+      this._pointsFusedIntoBars = false
+      this._barStackAxis = "y"
+    }
   }
 
   /**

--- a/v3/src/components/data-display/renderer/point-renderer-base.ts
+++ b/v3/src/components/data-display/renderer/point-renderer-base.ts
@@ -49,6 +49,9 @@ export abstract class PointRendererBase {
   protected _isVisible = true
   protected _displayType: PointDisplayType = "points"
   protected _pointsFusedIntoBars = false
+  // axis along which fused-bar cases stack: "y" for vertical bars (primary axis on bottom),
+  // "x" for horizontal bars (primary axis on left). Used by bar coalescing.
+  protected _barStackAxis: "x" | "y" = "y"
   protected _anchor = circleAnchor
   protected animationFrames = new Map<AnimationFrameRequestId, number>()
 
@@ -236,6 +239,14 @@ export abstract class PointRendererBase {
 
   set pointsFusedIntoBars(value: boolean) {
     this._pointsFusedIntoBars = value
+  }
+
+  get barStackAxis(): "x" | "y" {
+    return this._barStackAxis
+  }
+
+  set barStackAxis(value: "x" | "y") {
+    this._barStackAxis = value
   }
 
   get anchor(): { x: number; y: number } {

--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -170,6 +170,9 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
       renderBarCovers({ barCovers, barCoversRef, graphModel, primaryAttrRole })
     }
 
+    // tell the renderer which axis bar cases stack along, so bar coalescing groups bars correctly
+    // for both vertical (primary axis on bottom) and horizontal (primary axis on left) orientations
+    if (renderer) renderer.barStackAxis = primaryIsBottom ? "y" : "x"
     const anchor = circleAnchor
     setPointCoordinates({
       anchor, dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),

--- a/v3/src/components/graph/plots/dot-plot/dot-line-plot.tsx
+++ b/v3/src/components/graph/plots/dot-plot/dot-line-plot.tsx
@@ -161,6 +161,12 @@ export const DotLinePlot = observer(function DotLinePlot({ renderer }: IPlotProp
         ? primaryIsBottom ? hBarAnchor : vBarAnchor
         : circleAnchor
 
+      // Dot/line plots are never fused bars ("bar for each point" draws each case as its own bar),
+      // so clear the fuse flag explicitly. A reused renderer can switch here from a fused histogram
+      // without leaving bars mode (displayType stays "bars"), and bar coalescing must not apply.
+      // See CODAP-1234.
+      if (renderer) renderer.pointsFusedIntoBars = false
+
       setPointCoordinates({
         pointRadius: graphModel.getPointRadius(),
         selectedPointRadius: graphModel.getPointRadius('select'),

--- a/v3/src/components/graph/plots/histogram/histogram.tsx
+++ b/v3/src/components/graph/plots/histogram/histogram.tsx
@@ -186,6 +186,9 @@ export const Histogram = observer(function Histogram({ abovePointsGroupRef, rend
       addHistogramBinDragHandlers()
     }
 
+    // tell the renderer which axis bar cases stack along, so bar coalescing groups bars correctly
+    // for both vertical (primary axis on bottom) and horizontal (primary axis on left) orientations
+    if (renderer) renderer.barStackAxis = primaryIsBottom ? "y" : "x"
     setPointCoordinates({
       anchor: circleAnchor,
       pointRadius: graphModel.getPointRadius(),


### PR DESCRIPTION
## Summary

Part 2 of 2 for CODAP-1234 (the case-table scroll + MST fixes are in #2647).

In a bar chart or histogram, each fused bar is a stack of one rectangle per case so selected cases can be shown distinctly within the bar. When a bar holds hundreds of cases, each rectangle is sub-pixel-thin, and abutting sub-pixel opaque rectangles composite to less than full opacity under the browser's coverage-based anti-aliasing (Canvas and WebGL alike). The selection color (and the per-case separator lines) wash out to a faint tint instead of the solid color seen when zoomed in. V2 (SVG) doesn't exhibit this.

This renders each fused bar as **coalesced same-style segments**: contiguous cases that render identically (same fill *and* same stroke) are merged into one solid rectangle drawn with that segment's stroke. Selection renders solid at any case count, and strokes appear only at meaningful boundaries (selection changes and the bar outline) rather than as inconsistent per-case lines.

Coalescing by full style (not fill alone) is what makes selection visible **with a legend**: without a legend, selection changes a case's fill; with a legend the fill stays the legend color and selection is carried only by the stroke, so merging by fill alone would drop a selected case's stroke and hide the selection.

### Scope (all handled)
- **Vertical and horizontal** bars (cases stack along y or x).
- **Bar charts and histograms** (categorical and numeric-binned).
- **With and without a categorical legend** (selection by fill vs. by stroke).
- **Split plots** — bars coalesce and clip per subplot cell, so cells don't merge or bleed.
- **Bar-for-each-point** (non-fused "bars") and **transitions** (the points↔bars fuse, category reorder, axis/resize animations) stay on the per-case path — coalescing assumes stable, fused geometry.

### Implementation
- `bar-coalescing.ts` — shared, unit-tested helpers: `coalesceBars`/`coalesceBarRuns` (group by bar, sort along the stack axis, merge contiguous same-style runs), `pointStateToBarPiece`, `anchoredBarRect` (anchored-rect geometry, also used by hit-testing), `sameRunStyle` (the fill+stroke run boundary).
- `PointRendererBase` — `shouldCoalesceBars` gate (fused bars, not mid-transition) and a shared `barStackAxis`; `matchPointsToData` clears the bar-only state on leaving bars mode so a reused renderer can't carry stale fuse/stack state into a non-bars plot.
- **Canvas** — `drawBars` maps point state → pieces → `coalesceBars`, then fills/strokes each segment, clipped per subplot.
- **Pixi/WebGL** — one masked `Graphics` per subplot cell, rebuilt from the coalesced runs each render and clipped to its cell; per-case sprites are hidden (`renderable = false`) while in bars mode (kept for points mode and the fuse transition). Mask/layer teardown is ordered and deferred a frame to avoid rendering a destroyed object. Bar selection is handled by the existing SVG bar covers, so hiding sprites doesn't affect interaction.

## Test plan

### Automated
- `bar-coalescing.test.ts` — 14 unit tests: uniform / fill-boundary / interleaved runs; same-fill-but-different-stroke split (legend selection) for both vertical and horizontal bars; anchor+scale geometry; per-bar grouping; per-segment stroke.
- `npm run build:tsc`, `npm run lint`, and the data-display renderer suite (271 tests) pass.

### Manual
Use a dataset where at least one bar holds many cases (≈200+) so washout would be obvious. Run on the default WebGL/Pixi renderer; repeat the ★ cases on the Canvas renderer (the no-WebGL fallback). In each case, verify bars are solid (no washout, no spurious per-case lines) and selection is clearly visible.

**Rendering & selection**
- [ ] ★ Vertical fused bar chart, **no legend** — select cases (click a bar; select rows in a linked table) → selected cases solid-colored.
- [ ] ★ Vertical fused bar chart, **categorical legend** — select some-but-not-all cases within one colored segment → selected cases show their selection outline (stroke); unselected don't.
- [ ] Horizontal fused bar chart (primary attribute on the **left** axis), no legend and with legend — same checks; bars extend horizontally.
- [ ] ★ Histogram (numeric bins), no legend and with legend — bins render solid; legend selection shows the stroke.

**Split plots**
- [ ] ★ Split bar chart (categorical on x **and** y, or an x + top/right split) — each cell's bars coalesce and clip independently; selecting in one cell highlights only that cell; **bars never bleed outside their cell**.
- [ ] Split histogram with a legend — same independence; selection visible per cell.

**Must-not-coalesce / stale state**
- [ ] **Bar for each point** (univariate numeric → "Bars" display, not fused) — each case is its own distinct bar; bars are **not** merged.
- [ ] Switch a fused bar chart → a points plot (scatter/dot) → back — points render as points (no leftover/blank bars); bars return correctly.

**Transitions** (should animate, not clip or blank out)
- [ ] Toggle "Fuse Dots into Bars" on/off — the points↔bars animation plays and ends in the correct coalesced (on) / per-case (off) rendering.
- [ ] Reorder categories on a categorical/split bar chart — bars slide to new positions, the animation isn't clipped to the old cells, and bars settle correctly clipped.
- [ ] Add / remove a split category — cells rebuild; bars appear in the new layout and clip correctly once settled; no stale or blank bars.
- [ ] Resize the graph / drag an axis — bars rescale and stay clipped; selection persists.

**Interaction**
- [ ] Click a bar selects its cases; click empty plot space deselects; selection round-trips with a linked case table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
