### PR TITLE
[Do Not Merge] CODAP-1429: fix stale CategorySet for formula attributes in loaded documents

### DIFF
--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -1,3 +1,4 @@
+import { runInAction } from "mobx"
 import { applySnapshot, getSnapshot, types } from "mobx-state-tree"
 import { kellyColors } from "../../utilities/color-utils"
 import { Attribute, IAttribute } from "./attribute"
@@ -183,6 +184,36 @@ describe("CategorySet", () => {
     // simulate a formula recomputing the values
     a.setComputedValues([0, 1, 2, 3], ["x", "y", "x", "y"])
     expect(categories.valuesArray).toEqual(["x", "y"])
+  })
+
+  // CODAP-1429 regression: when CategorySet construction, the initial empty refresh,
+  // and the value-mutating setComputedValues all happen inside the SAME outermost
+  // mobx batch (which is what happens in the running app: the case-table renderer
+  // creates a provisional CategorySet for an attribute whose formula adapter hasn't
+  // run yet, reads `.valuesArray` (caching empty `_values`), and then the deferred
+  // formula adapter recomputes and bumps `changeCount`), mobx defers the reaction's
+  // initial accessor invocation until the outermost batch ends. Without
+  // `fireImmediately`, that deferred first invocation captures the post-mutation
+  // changeCount as its baseline — so the effect never fires for the change we needed
+  // to react to, and the empty cached categories stick around.
+  it("invalidates when creation, initial refresh, and setComputedValues happen in same batch", () => {
+    const a = Attribute.create({ name: "a", values: ["", "", "", ""] })
+    let categories: ICategorySet | undefined
+    runInAction(() => {
+      const tree = Tree.create({
+        attribute: a,
+        categories: { attribute: a.id }
+      })
+      categories = tree.categories
+      // Trigger the initial refresh while strValues is still empty (the case-table
+      // renderer does this during document load).
+      expect(categories.valuesArray).toEqual([])
+      // Now the deferred formula adapter populates the values.
+      a.setComputedValues([0, 1, 2, 3], ["A", "B", "A", "B"])
+    })
+
+    expect(a.strValues).toEqual(["A", "B", "A", "B"])
+    expect(categories?.valuesArray).toEqual(["A", "B"])
   })
 
   it("handles volatile category drags", () => {

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -243,19 +243,24 @@ export const CategorySet = types.model("CategorySet", {
     // Invalidate the cached categories whenever the attribute's values change.
     // Reacting to changeCount (the canonical "values changed" signal) covers all value-mutation
     // paths, including the volatile setComputedValues path used by formula evaluation, which
-    // doesn't fire its own MST action. Note: clearFormula/setDisplayExpression don't bump
-    // changeCount, but they don't need to invalidate the cache either — the values themselves
-    // don't change at that moment, and any subsequent recomputation goes through setComputedValues
-    // which will bump changeCount and trigger this reaction.
+    // doesn't fire its own MST action.
     // The accessor guards against an invalid attribute reference (which can occur briefly while
     // the attribute is being destroyed); the reaction is auto-disposed when this CategorySet
     // is destroyed via the onInvalidated → removeCategorySet chain.
+    // fireImmediately is required: CategorySets are typically created inside an MST action
+    // (afterCreate runs as one), so mobx defers the reaction's initial accessor invocation
+    // until after the surrounding action(s) complete. If formula recomputation runs in that
+    // window — which it does for a provisional CategorySet created while a doc is still
+    // loading and the formula adapter setTimeout hasn't fired yet (CODAP-1429) — the deferred
+    // accessor call captures the post-recompute changeCount as its baseline, so the effect
+    // never fires for the very change we needed to react to. fireImmediately makes the effect
+    // run on the first invocation regardless, so the (already-stale) cache is invalidated.
     mstReaction(
       () => isValidReference(() => self.attribute) ? self.attribute.changeCount : undefined,
       changeCount => {
         if (changeCount != null) self.invalidate()
       },
-      { name: "CategorySet.invalidateOnAttributeChangeCount" },
+      { name: "CategorySet.invalidateOnAttributeChangeCount", fireImmediately: true },
       self
     )
   },


### PR DESCRIPTION
This PR is a temporary stop-gap. #2650 is the proper fix.

## Summary

Fixes CODAP-1429. In a copied or saved document, dragging a formula-driven
attribute (e.g. `randomPick("A","B")`) to a graph axis produced points
bunched at the upper-left corner instead of a proper categorical dot chart.

## Root cause

`CategorySet`'s `mstReaction` on `attribute.changeCount` is installed inside
`afterCreate` — an MST action. MobX defers a reaction's *initial* accessor
invocation until the outermost batch ends. When CategorySet creation, the
initial empty `refresh()`, and the formula adapter's `setComputedValues`
all land in the same outer batch (which is the natural pattern during
document load), the deferred first invocation captures the post-mutation
`changeCount` as its baseline. No "change" is detected, the effect never
fires, and the empty pre-formula cache sticks around — producing NaN
positions and the bunched-at-origin symptom.

A fresh document dodges this because the user adds the formula and creates
the graph in separate actions; the CategorySet is constructed only after
the formula's batch has drained, so its first `refresh()` sees populated
`strValues` directly.

This has the same fingerprint as the bug fixed in CODAP-1280, which was
a different way of reaching the same stale-categories state.

## Fix

`fireImmediately: true` makes the effect run on the first accessor
invocation regardless of whether mobx detects a "change" — so the
(potentially stale) cache is invalidated on the first chance, and the
next read recomputes from current `strValues`.

A follow-up cleanup PR will replace the manual cache + reaction with a
pure computed view, which eliminates the race-prone pattern entirely.

## Test plan

- [x] New regression test (`category-set.test.ts`) wraps CategorySet
      creation, initial refresh, and `setComputedValues` in a single
      `runInAction` — fails without the fix, passes with it
- [x] Existing CategorySet tests still pass (8/8)
- [x] Full jest suite passes (3276/3276)
- [x] Lint clean
- [x] tsc clean
- [ ] Manual verification in browser of the original bug repro