### PR TITLE
CODAP-1430: replace CategorySet manual cache + reaction with computed views

### DIFF
--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -88,8 +88,8 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
         : []
       const primCatsCount = primCatsArray.length
       const legendCats = dataConfig.categorySetForAttrRole("legend")?.values ?? []
-      // sortLegendCategories returns a sorted copy: `legendCats` is the CategorySet's shared
-      // observable array, so sorting it in place would corrupt its canonical ordering and index map.
+      // sortLegendCategories returns a sorted copy so we don't mutate the categories array
+      // returned by the CategorySet (which is a readonly memoized computed value).
       const sortedLegendCats = sortLegendCategories(legendCats, dataConfig.attributeType("legend"))
       Object.entries(catMap).forEach(([primeCat, secCats]) => {
         Object.entries(secCats).forEach(([secCat, primSplitCats]) => {

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -1,3 +1,4 @@
+import { runInAction } from "mobx"
 import { applySnapshot, destroy, getSnapshot, types } from "mobx-state-tree"
 import { kellyColors } from "../../utilities/color-utils"
 import { jestSpyConsole } from "../../test/jest-spy-console"
@@ -200,6 +201,36 @@ describe("CategorySet", () => {
     // simulate a formula recomputing the values
     a.setComputedValues([0, 1, 2, 3], ["x", "y", "x", "y"])
     expect(categories.valuesArray).toEqual(["x", "y"])
+  })
+
+  // CODAP-1429 regression: the originating bug occurred when CategorySet construction, the
+  // initial empty read, and the value-mutating setComputedValues all happened inside the SAME
+  // outermost mobx batch (the document-load pattern: the case-table renderer creates a
+  // provisional CategorySet for a formula attribute whose adapter hasn't run yet, reads its
+  // categories while strValues is still empty, and then the deferred formula adapter recomputes
+  // and bumps changeCount). The previous manual cache + mstReaction implementation failed here
+  // because mobx defers a reaction's initial accessor invocation to the end of the batch, so the
+  // deferred baseline captured the post-mutation changeCount and the invalidation never fired,
+  // leaving the empty categories cached. The computed `values` view has no such batch-timing
+  // window — it establishes its dependencies on whatever state is current at read time — so it
+  // re-derives correctly even when everything happens in one batch.
+  it("re-derives when creation, initial read, and setComputedValues happen in the same batch", () => {
+    const a = Attribute.create({ name: "a", values: ["", "", "", ""] })
+    let categories: ICategorySet | undefined
+    runInAction(() => {
+      const tree = Tree.create({
+        attribute: a,
+        categories: { attribute: a.id }
+      })
+      categories = tree.categories
+      // initial read while strValues is still empty (the case-table renderer does this during load)
+      expect(categories.valuesArray).toEqual([])
+      // the deferred formula adapter populates the values within the same batch
+      a.setComputedValues([0, 1, 2, 3], ["A", "B", "A", "B"])
+    })
+
+    expect(a.strValues).toEqual(["A", "B", "A", "B"])
+    expect(categories?.valuesArray).toEqual(["A", "B"])
   })
 
   it("handles volatile category drags", () => {

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -1,4 +1,4 @@
-import { runInAction } from "mobx"
+import { autorun, runInAction } from "mobx"
 import { applySnapshot, destroy, getSnapshot, types } from "mobx-state-tree"
 import { kellyColors } from "../../utilities/color-utils"
 import { jestSpyConsole } from "../../test/jest-spy-console"
@@ -231,6 +231,57 @@ describe("CategorySet", () => {
 
     expect(a.strValues).toEqual(["A", "B", "A", "B"])
     expect(categories?.valuesArray).toEqual(["A", "B"])
+  })
+
+  // The categories list is a MobX computed (an MST view). A computed only memoizes — and only
+  // matters reactively — while it's observed; accessed imperatively it simply recomputes on every
+  // read, so imperative `expect(categories.values)` assertions would pass even if the view weren't
+  // reactive at all. This test observes `values` from an autorun and asserts the autorun re-runs
+  // for each kind of dependency change, which is the actual guarantee the refactor relies on (and
+  // the one that, if broken — e.g. by dropping the deliberate `attribute.changeCount` read — would
+  // reintroduce the CODAP-1429 / CODAP-1280 class of stale-categories bugs).
+  it("notifies observers when the derived categories change", () => {
+    const a = Attribute.create({ name: "a", values: ["b", "a"] })
+    const tree = Tree.create({
+      attribute: a,
+      categories: { attribute: a.id }
+    })
+    const categories = tree.categories
+
+    const observed: string[][] = []
+    const dispose = autorun(() => observed.push(Array.from(categories.values)))
+    expect(observed).toEqual([["a", "b"]])
+
+    // adding a value bumps changeCount and re-derives
+    a.addValue("c")
+    expect(observed).toHaveLength(2)
+    expect(observed[1]).toEqual(["a", "b", "c"])
+
+    // a formula recompute via the volatile setComputedValues (bumps changeCount) re-derives
+    a.setComputedValues([0, 1, 2], ["x", "y", "z"])
+    expect(observed).toHaveLength(3)
+    expect(observed[2]).toEqual(["x", "y", "z"])
+
+    // a user re-ordering re-derives
+    categories.move("z", "x") // move z before x
+    expect(observed).toHaveLength(4)
+    expect(observed[3]).toEqual(["z", "x", "y"])
+
+    // an in-flight drag re-derives
+    categories.setDragCategory("y", 0)
+    expect(observed).toHaveLength(5)
+    expect(observed[4]).toEqual(["y", "z", "x"])
+
+    dispose()
+  })
+
+  it("excludes blank values from the derived categories", () => {
+    const a = Attribute.create({ name: "a", values: ["a", "", "b", "", "a"] })
+    const tree = Tree.create({
+      attribute: a,
+      categories: { attribute: a.id }
+    })
+    expect(tree.categories.valuesArray).toEqual(["a", "b"])
   })
 
   it("handles volatile category drags", () => {

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -184,6 +184,28 @@ describe("CategorySet", () => {
     expect(categories.lastMove?.fromIndex).toBe(originalFromIndex)
   })
 
+  // Documents move-to-end behavior. `move()` initializes the destination index to
+  // `values.length - 1` only when no (or a non-existent) `beforeValue` is given, and the
+  // `fromIndex < toIndex` decrement is in a mutually-exclusive `else if` branch — so the
+  // end case is never decremented and a category reliably lands at the true end.
+  it("moves a category to the end for an omitted or non-existent beforeValue", () => {
+    // omitted beforeValue -> move to end
+    const a = Attribute.create({ name: "a", values: ["a", "b", "c", "d"] })
+    const treeA = Tree.create({ attribute: a, categories: { attribute: a.id } })
+    expect(treeA.categories.valuesArray).toEqual(["a", "b", "c", "d"])
+    treeA.categories.move("b") // no beforeValue
+    expect(treeA.categories.valuesArray).toEqual(["a", "c", "d", "b"])
+    expect(treeA.categories.lastMove)
+      .toEqual({ value: "b", fromIndex: 1, toIndex: 3, length: 4, after: "d", before: undefined })
+
+    // non-existent beforeValue -> also move to end
+    const b = Attribute.create({ name: "b", values: ["a", "b", "c", "d"] })
+    const treeB = Tree.create({ attribute: b, categories: { attribute: b.id } })
+    treeB.categories.move("a", "bogus")
+    expect(treeB.categories.valuesArray).toEqual(["b", "c", "d", "a"])
+    expect(treeB.categories.lastMove?.toIndex).toBe(3)
+  })
+
   // Regression test (CODAP-1280): formula-computed values are written via
   // Attribute.setComputedValues, which is a volatile method that doesn't fire its own MST
   // action — it bumps changeCount. The CategorySet's `values` view depends on changeCount,

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -32,11 +32,10 @@ describe("CategorySet", () => {
     // attribute reference resolves to the free attribute
     expect(categories.attribute.name).toBe("aFree")
 
-    // attribute value changes trigger invalidation for provisional category sets
-    const provisionalSpy = jest.spyOn(categories, "invalidate")
+    // attribute value changes are picked up by provisional category sets
+    expect(categories.valuesArray).toEqual([])
     data.attributes[0].addValue("a")
-    expect(provisionalSpy).toHaveBeenCalledTimes(1)
-    provisionalSpy.mockRestore()
+    expect(categories.valuesArray).toEqual(["a"])
 
     const tree = Tree.create({
       attribute: Attribute.create({ id: "aId", name: "aTree" }),
@@ -47,11 +46,10 @@ describe("CategorySet", () => {
     // attribute reference resolves to attribute in tree
     expect(tree.categories.attribute.name).toBe("aTree")
 
-    // attribute value changes trigger invalidation for attached category sets
-    const attachedSpy = jest.spyOn(tree.categories, "invalidate")
+    // attribute value changes are picked up by attached category sets
+    expect(tree.categories.valuesArray).toEqual([])
     tree.attribute.addValue("a")
-    expect(attachedSpy).toHaveBeenCalledTimes(1)
-    attachedSpy.mockRestore()
+    expect(tree.categories.valuesArray).toEqual(["a"])
 
     // assigning a new attribute sets the attribute id
     tree.setAttribute(Attribute.create({ id: "bId", name: "bTree" }))
@@ -185,11 +183,12 @@ describe("CategorySet", () => {
     expect(categories.lastMove?.fromIndex).toBe(originalFromIndex)
   })
 
-  // Regression test: formula-computed values are written via Attribute.setComputedValues, which
-  // is a volatile method that doesn't fire its own MST action. The CategorySet must still invalidate
-  // and pick up the new categories — otherwise categorical scales backed by formula attributes are
-  // empty, points get NaN positions, and graphs render blank.
-  it("invalidates when formula-computed values are written via setComputedValues", () => {
+  // Regression test (CODAP-1280): formula-computed values are written via
+  // Attribute.setComputedValues, which is a volatile method that doesn't fire its own MST
+  // action — it bumps changeCount. The CategorySet's `values` view depends on changeCount,
+  // so it must pick up the new categories. Otherwise categorical scales backed by formula
+  // attributes are empty, points get NaN positions, and graphs render blank.
+  it("re-derives when formula-computed values are written via setComputedValues", () => {
     const a = Attribute.create({ name: "a", values: ["a", "a", "a", "a"] })
     const tree = Tree.create({
       attribute: a,

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -1,12 +1,9 @@
 import { uniq } from "lodash"
-import { observable, runInAction } from "mobx"
 import {
-  addDisposer, getEnv, hasEnv, IAnyStateTreeNode, Instance, isValidReference,
-  onPatch, resolveIdentifier, SnapshotIn, types
+  getEnv, hasEnv, IAnyStateTreeNode, Instance, resolveIdentifier, SnapshotIn, types
 } from "mobx-state-tree"
 import { kellyColors } from "../../utilities/color-utils"
 import { compareValues } from "../../utilities/data-utils"
-import { mstReaction } from "../../utilities/mst-reaction"
 import { gLocale } from "../../utilities/translation/locale"
 import { Attribute, IAttribute } from "./attribute"
 import { IDataSet } from "./data-set"
@@ -39,6 +36,90 @@ export function createProvisionalCategorySet(data: IDataSet | undefined, attrId:
   return CategorySet.create({ attribute: attrId }, { provisionalDataSet: data })
 }
 
+// Apply the user-recorded category moves to a freshly-sorted values array. Each move records
+// neighbor categories (`after`/`before`) so a re-derivation can place the moved category back
+// into approximately its user-chosen slot, even after other categories have come or gone.
+function applyMoves(values: string[], moves: readonly ICategoryMove[]): string[] {
+  if (moves.length === 0) return values
+
+  const result = values.slice()
+  const indexMap = new Map<string, number>()
+  function rebuildIndexMap() {
+    indexMap.clear()
+    result.forEach((v, i) => indexMap.set(v, i))
+  }
+  function moveValueToIndex(value: string, dstIndex: number) {
+    const valueIndex = indexMap.get(value)
+    if (valueIndex != null && valueIndex !== dstIndex) {
+      result.splice(valueIndex, 1)
+      result.splice(dstIndex, 0, value)
+      rebuildIndexMap()
+    }
+  }
+  // if the source index is after the destination index, adjust the destination index
+  const afterDstIndex = (srcIndex: number, afterIndex: number) =>
+    srcIndex > afterIndex ? afterIndex + 1 : afterIndex
+  // if the source index is before the destination index, adjust the destination index
+  const beforeDstIndex = (srcIndex: number, beforeIndex: number) =>
+    srcIndex < beforeIndex ? beforeIndex - 1 : beforeIndex
+
+  rebuildIndexMap()
+  moves.forEach(move => {
+    const valueIndex = indexMap.get(move.value)
+    // the value associated with this category move is no longer one of the categories
+    if (valueIndex == null) return
+
+    const afterIndex = move.after ? indexMap.get(move.after) : undefined
+    const beforeIndex = move.before ? indexMap.get(move.before) : undefined
+    // both neighboring categories still exist?
+    if ((afterIndex != null) && (beforeIndex != null)) {
+      // category is already (at least approximately) where it should be
+      if ((valueIndex >= afterIndex) && (valueIndex <= beforeIndex)) return
+
+      // move it next to the category closest to its original position
+      const moveRatio = move.toIndex / move.length
+      const afterRatio = afterIndex / result.length
+      const beforeRatio = beforeIndex / result.length
+      const afterDistance = Math.abs(moveRatio - afterRatio)
+      const beforeDistance = Math.abs(moveRatio - beforeRatio)
+      const dstIndex = afterDistance < beforeDistance
+        ? afterDstIndex(valueIndex, afterIndex)
+        : beforeDstIndex(valueIndex, beforeIndex)
+      moveValueToIndex(move.value, dstIndex)
+    }
+    else if (afterIndex != null) {
+      moveValueToIndex(move.value, afterDstIndex(valueIndex, afterIndex))
+    }
+    else if (beforeIndex != null) {
+      moveValueToIndex(move.value, beforeDstIndex(valueIndex, beforeIndex))
+    }
+    else {
+      // neither category neighbor still exists
+      const moveRatio = move.toIndex / move.length
+      // if it was moved near the beginning, put it at the beginning
+      if (moveRatio <= 0.2) {
+        moveValueToIndex(move.value, 0)
+      }
+      // if it was moved near the end, put it at the end
+      else if (moveRatio >= 0.8) {
+        moveValueToIndex(move.value, result.length - 1)
+      }
+      // else just punt for now
+    }
+  })
+  return result
+}
+
+// While a category drag is in progress, slot the dragged category into its in-flight position.
+function applyDrag(values: string[], dragCategory: string, dragCategoryIndex: number): string[] {
+  const fromIndex = values.indexOf(dragCategory)
+  if (fromIndex < 0 || fromIndex === dragCategoryIndex) return values
+  const result = values.slice()
+  result.splice(fromIndex, 1)
+  result.splice(dragCategoryIndex, 0, dragCategory)
+  return result
+}
+
 export const CategorySet = types.model("CategorySet", {
   // Customize the reference lookup so that provisional category sets are looked up directly in the DataSet.
   // Otherwise, references can only be resolved once the CategorySet has been added to the document, which
@@ -66,139 +147,55 @@ export const CategorySet = types.model("CategorySet", {
   dragCategory: undefined as Maybe<string>,
   dragCategoryIndex: -1
 }))
-.actions(self => ({
-  onAttributeInvalidated(handler: (attrId: string) => void) {
-    self.handleAttributeInvalidated = handler
+.views(self => ({
+  // Categories are derived directly from the attribute's values plus user moves and the in-flight
+  // drag state. MST views are MobX computeds, so the result is cached and re-derived only when one
+  // of the tracked dependencies changes. The deliberate read of `attribute.changeCount` establishes
+  // a dependency on element mutations in `strValues` (which is a volatile array — element-level
+  // mutations like setComputedValues bump changeCount but don't fire on the array reference).
+  // This is the simpler successor to a manual cache + reaction that previously lived here; that
+  // pattern was fragile because mobx defers a reaction's initial accessor invocation past mutations
+  // landing in the same outer batch (CODAP-1429).
+  get values(): readonly string[] {
+    const attr = self.attribute
+    // DO NOT REMOVE: this read tracks element-level mutations in attr.strValues (a volatile
+    // array whose mutations bump changeCount but don't fire on the array reference). Without
+    // it, formula recomputes via setComputedValues would not re-derive the categories.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    attr.changeCount
+    const sorted = uniq(attr.strValues.filter(v => v != null && v !== ""))
+                    .sort((a, b) => compareValues(a, b, gLocale.compareStrings))
+    const reordered = applyMoves(sorted, self.moves)
+    return self.dragCategory != null
+      ? applyDrag(reordered, self.dragCategory, self.dragCategoryIndex)
+      : reordered
   }
 }))
-.extend(self => {
-  // map from category value to index
-  const _indexMap = new Map<string, number>()
-  const observableValues = observable.array<string>()
-  let _values: string[] = []
-  const _isValid = observable.box(false)
-
-  function rebuildIndexMap() {
-    _indexMap.clear()
-    _values.forEach((value, index) => {
-      _indexMap.set(value, index)
-    })
+.views(self => ({
+  get indexMap(): ReadonlyMap<string, number> {
+    const map = new Map<string, number>()
+    self.values.forEach((v, i) => map.set(v, i))
+    return map
   }
-
-  function moveValueToIndex(value: string, dstIndex: number) {
-    const valueIndex = _indexMap.get(value)
-    if (valueIndex != null && valueIndex !== dstIndex) {
-      // remove value from current position
-      _values.splice(valueIndex, 1)
-      // insert value in new position
-      _values.splice(dstIndex, 0, value)
-      // update the index map
-      rebuildIndexMap()
-    }
+}))
+.views(self => ({
+  index(value: string): number | undefined {
+    return self.indexMap.get(value)
+  },
+  get valuesArray(): string[] {
+    return Array.from(self.values)
+  },
+  // list of actions that indicate deliberate action by the user
+  // used to determine when to move provisional category sets into the document
+  get userActionNames() {
+    return ["move", "setColorForCategory", "storeCurrentColorForCategory"]
+  },
+  get lastMove() {
+    return self.moves.length > 0
+            ? self.moves[self.moves.length - 1]
+            : undefined
   }
-
-  function afterDstIndex(srcIndex: number, afterIndex: number) {
-    // if the source index is after the destination index, we need to adjust the destination index
-    return srcIndex > afterIndex ? afterIndex + 1 : afterIndex
-  }
-
-  function beforeDstIndex(srcIndex: number, beforeIndex: number) {
-    // if the source index is before the destination index, we need to adjust the destination index
-    return srcIndex < beforeIndex ? beforeIndex - 1 : beforeIndex
-  }
-
-  function refresh() {
-    if (!_isValid.get()) {
-      // build default category set order (sorted alphanumerically)
-      _values = uniq(self.attribute.strValues.filter(value => value != null && value !== ""))
-      _values.sort((a, b) => compareValues(a, b, gLocale.compareStrings))
-      rebuildIndexMap()
-
-      // apply category moves
-      self.moves.forEach(move => {
-        const valueIndex = _indexMap.get(move.value)
-        // the value associated with this category move is no longer one of the categories
-        if (valueIndex == null) return
-
-        const afterIndex = move.after ? _indexMap.get(move.after) : undefined
-        const beforeIndex = move.before ? _indexMap.get(move.before) : undefined
-        // both neighboring categories still exist?
-        if ((afterIndex != null) && (beforeIndex != null)) {
-          // category is already (at least approximately) where it should be
-          if ((valueIndex >= afterIndex) && (valueIndex <= beforeIndex)) return
-
-          // move it next to the category closest to its original position
-          const moveRatio = move.toIndex / move.length
-          const afterRatio = afterIndex / _values.length
-          const beforeRatio = beforeIndex / _values.length
-          const afterDistance = Math.abs(moveRatio - afterRatio)
-          const beforeDistance = Math.abs(moveRatio - beforeRatio)
-          const dstIndex = afterDistance < beforeDistance
-                            ? afterDstIndex(valueIndex, afterIndex)
-                            : beforeDstIndex(valueIndex, beforeIndex)
-          moveValueToIndex(move.value, dstIndex)
-        }
-        else if (afterIndex != null) {
-          moveValueToIndex(move.value, afterDstIndex(valueIndex, afterIndex))
-        }
-        else if (beforeIndex != null) {
-          moveValueToIndex(move.value, beforeDstIndex(valueIndex, beforeIndex))
-        }
-        else {
-          // neither category neighbor still exists
-          const moveRatio = move.toIndex / move.length
-          // if it was moved near the beginning, put it at the beginning
-          if (moveRatio <= 0.2) {
-            moveValueToIndex(move.value, 0)
-          }
-          // if it was moved near the end, put it at the end
-          else if (moveRatio >= 0.8) {
-            moveValueToIndex(move.value, move.length - 1)
-          }
-          else {
-            // just punt for now
-          }
-        }
-      })
-
-      // move the currently dragged category into position
-      if (self.dragCategory) {
-        const dragCategoryIndex = _indexMap.get(self.dragCategory)
-        if (dragCategoryIndex != null && self.dragCategoryIndex !== dragCategoryIndex) {
-          moveValueToIndex(self.dragCategory, self.dragCategoryIndex)
-        }
-      }
-
-      runInAction(() => {
-        observableValues.replace(_values)
-        _isValid.set(true)
-      })
-    }
-  }
-
-  return {
-    views: {
-      get values() {
-        refresh()
-        return observableValues
-      },
-      index(value: string) {
-        refresh()
-        return _indexMap.get(value)
-      }
-    },
-    actions: {
-      invalidate() {
-        _isValid.set(false)
-      },
-      setDragCategory(category?: string, index = -1) {
-        self.dragCategory = category
-        self.dragCategoryIndex = index
-        _isValid.set(false)
-      }
-    }
-  }
-})
+}))
 .views(self => ({
   get colorMap() {
     const colorForCategory = (category: string, index: number) => {
@@ -214,54 +211,17 @@ export const CategorySet = types.model("CategorySet", {
   }
 }))
 .views(self => ({
-  get valuesArray() {
-    return Array.from(self.values)
-  },
-  get userActionNames() {
-    // list of actions that indicate deliberate action by the user
-    // used to determine when to move provisional category sets into the document
-    return ["move", "setColorForCategory", "storeCurrentColorForCategory"]
-  },
-  get lastMove() {
-    return self.moves.length > 0
-            ? self.moves[self.moves.length - 1]
-            : undefined
-  },
   colorForCategory(category: string) {
     return self.colorMap[category]
   }
 }))
 .actions(self => ({
-  afterCreate() {
-    addDisposer(self, onPatch(self, patch => {
-      // invalidate the categories when the moves are changed
-      if (patch.path.includes("/moves")) {
-        self.invalidate()
-      }
-    }))
-
-    // Invalidate the cached categories whenever the attribute's values change.
-    // Reacting to changeCount (the canonical "values changed" signal) covers all value-mutation
-    // paths, including the volatile setComputedValues path used by formula evaluation, which
-    // doesn't fire its own MST action. Note: clearFormula/setDisplayExpression don't bump
-    // changeCount, but they don't need to invalidate the cache either — the values themselves
-    // don't change at that moment, and any subsequent recomputation goes through setComputedValues
-    // which will bump changeCount and trigger this reaction.
-    // The accessor guards against an invalid attribute reference (which can occur briefly while
-    // the attribute is being destroyed). The reaction is disposed when this CategorySet is
-    // destroyed; for a provisional CategorySet (a standalone node held in a volatile map, which
-    // is never itself destroyed) we also dispose it when its provisional DataSet is destroyed.
-    // Otherwise the orphaned reaction would fire during teardown and resolve `attribute` through
-    // the now-dead DataSet, logging an MST use-after-free warning (CODAP-1234).
-    const provisionalDataSet = getProvisionalDataSet(self)
-    mstReaction(
-      () => isValidReference(() => self.attribute) ? self.attribute.changeCount : undefined,
-      changeCount => {
-        if (changeCount != null) self.invalidate()
-      },
-      { name: "CategorySet.invalidateOnAttributeChangeCount" },
-      provisionalDataSet ? [self, provisionalDataSet] : self
-    )
+  onAttributeInvalidated(handler: (attrId: string) => void) {
+    self.handleAttributeInvalidated = handler
+  },
+  setDragCategory(category?: string, index = -1) {
+    self.dragCategory = category
+    self.dragCategoryIndex = index
   },
   move(value: string, beforeValue?: string) {
     const fromIndex = self.index(value)


### PR DESCRIPTION
## Summary

Follow-up cleanup from CODAP-1429.

`CategorySet` maintained a manual `_values`/`_indexMap`/`observableValues`/`_isValid` cache invalidated by an `mstReaction` on `attribute.changeCount` and an `onPatch` listener on `/moves`. This pattern was fragile — CODAP-1429 was caused by mobx deferring the reaction's initial accessor invocation past the very mutation it was supposed to detect, leaving the cache stale and the graph blank.

This PR replaces the cache + reaction with a pure computed `values` view that derives categories directly from the attribute's `strValues`, user `moves`, and the in-flight drag state. MST views are MobX computeds, so the result is cached and re-derived only when a tracked dependency changes. No reaction needed, no race possible.

Fixes CODAP-1430.

## What changed

- Deleted: `_values`, `_indexMap`, `observableValues`, `_isValid`, `refresh()`, `invalidate()`, the `onPatch` listener for moves, the `mstReaction` on `changeCount`
- Added: `get values()` computed view that derives the full category list each time a tracked dependency changes (memoized by MobX/MST)
- Added: `get indexMap()` and `index()` views as derivations
- Extracted: `applyMoves()` and `applyDrag()` as pure top-level helpers
- Updated: `setDragCategory()` no longer needs to manually invalidate — setting the volatile prop auto-invalidates the computed
- The dependency on `attribute.changeCount` is preserved (read inside the view) to track element-level mutations on the volatile `strValues` array
- Updated an outdated comment in `bar-chart.tsx` that referred to the CategorySet's "shared observable array"

## Why this is race-free

MobX establishes dependencies the first time something *reads* `values`, not at construction time. There's no separate "install the reaction" / "the reaction must be invoked at the right moment" coordination — the read itself sets up tracking with whatever state is current, and subsequent reads either hit the computed cache or recompute if any dep changed.

## Test plan

- [x] All existing CategorySet tests pass (7/7)
- [x] CODAP-1280 regression test (formula `setComputedValues` triggers re-derivation) still passes
- [x] Full jest suite passes (3275/3275)
- [x] Lint clean
- [x] tsc clean
- [ ] Manual verification in browser: original CODAP-1429 repro (set formula on attribute in a copied document, drag to graph) still works
- [ ] Manual verification in browser: existing category drag/move/color flows in graphs/legends still work

## Relation to CODAP-1429

This is the deeper fix that CODAP-1429's PR (#2649) deferred to a separate cleanup. After both PRs land, the `fireImmediately: true` introduced in CODAP-1429 will no longer be present (the reaction it modified has been removed entirely). The CODAP-1429 regression test, which exercises the bug behavior, continues to pass with this refactor.
