### PR TITLE
CODAP-1432: fix Simmer plugin path to CC-hosted eepsmedia bundle

### DIFF
--- a/v3/src/components/tool-shelf/standard-plugins.json
+++ b/v3/src/components/tool-shelf/standard-plugins.json
@@ -166,7 +166,7 @@
       {
         "title": "Simmer",
         "description": "Create block programmed simulations that generate data.",
-        "path": "https://codap.xyz/plugins/simmer/",
+        "path": "/eepsmedia/plugins/simmer/index.html",
         "icon": "SimmerIcon",
         "width": 800,
         "height": 555,


### PR DESCRIPTION
## Summary

The Simmer plugin was broken in both CODAP V3 and V2. Its tool-shelf entry
pointed at the external `https://codap.xyz/plugins/simmer/` bundle, which loaded
an unpinned Blockly. Blockly v12 removed `Workspace.getAllVariables()`, so
clicking run threw `getAllVariables is not a function`.

This points the Simmer plugin at the CC-hosted `/eepsmedia/plugins/simmer/index.html`
bundle, which pins Blockly to a compatible version — matching how the other
eepsmedia-hosted plugins (Choosy, scrambler, testimate) are referenced.

## Change

- `v3/src/components/tool-shelf/standard-plugins.json`: Simmer `path`
  `https://codap.xyz/plugins/simmer/` → `/eepsmedia/plugins/simmer/index.html`

## Out of Scope

This PR fixes Simmer for CODAP V3 only. The same breakage exists in CODAP V2,
which is not addressed here. Options for V2:

1. **Do a full CODAP V2 build** — picks up the fix the same way V3 does, but is
   the heaviest option.
2. **Manually update the Simmer deploy in the most recent CODAP V2 build** —
   patch the deployed assets without a full rebuild.
3. **Ignore it** — we're no longer actively supporting CODAP V2 except in
   limited circumstances that don't require Simmer.

Fixes CODAP-1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
