### PR TITLE
docs(codap-resources): add direct-to-S3 deploy path

### DIFF
--- a/.claude/skills/codap-resources/SKILL.md
+++ b/.claude/skills/codap-resources/SKILL.md
@@ -75,11 +75,11 @@ After updating cached assets (plugins, documents, boundaries), invalidate the Cl
 
 **There are three distributions, and the one you invalidate depends on how the asset is consumed:**
 
-| Distribution | Serves | Invalidation path |
-|--------------|--------|-------------------|
-| `E1RS9TZVZBEEEC` | `codap-resources.concord.org` (direct bucket access) | `/<folder>/*` |
-| `E7WVRGISCR2VR` | `codap3.concord.org` | `/codap-resources/<folder>/*` |
-| `E26XOJN7T3CJO` | `codap.concord.org`, `codap2to3.concord.org` | `/codap-resources/<folder>/*` |
+| Distribution | Serves | Viewer path | **Invalidation path** |
+|--------------|--------|-------------|------------------------|
+| `E1RS9TZVZBEEEC` | `codap-resources.concord.org` (direct bucket access) | `/<folder>/...` | `/<folder>/*` |
+| `E7WVRGISCR2VR` | `codap3.concord.org` | `/codap-resources/<folder>/...` | `/<folder>/*` |
+| `E26XOJN7T3CJO` | `codap.concord.org`, `codap2to3.concord.org` | `/codap-resources/<folder>/...` | `/<folder>/*` |
 
 > ⚠️ **Production V3 does NOT load assets from `codap-resources.concord.org`.** It loads them
 > from a **relative** `/codap-resources/...` path (see `kCodapResourcesUrl` in
@@ -89,17 +89,31 @@ After updating cached assets (plugins, documents, boundaries), invalidate the Cl
 > leaves production users on stale files.** Anything production V3 loads (plugins,
 > example-document guides, boundaries) needs the app distributions invalidated too.
 
+> 🛑 **On the app distributions, invalidate the STRIPPED path (`/<folder>/*`), NOT
+> `/codap-resources/<folder>/*`.** The `/codap-resources/*` behavior has a viewer-request
+> CloudFront function (`StripCodapResourcesPrefix`) that rewrites the URI
+> `/codap-resources/...` → `/...` **before** the cache key is computed. Objects are therefore
+> cached under the stripped key (e.g. `/plugins/onboarding/strings.json`). An invalidation for
+> `/codap-resources/plugins/onboarding/*` matches nothing — it reports `Completed` while
+> purging zero objects, and stale content keeps being served. Always invalidate the
+> post-rewrite path: `/plugins/onboarding/*`.
+
 ```bash
-# codap-resources.concord.org (direct bucket access)
+# codap-resources.concord.org (direct bucket access — no prefix function)
 aws cloudfront create-invalidation --distribution-id E1RS9TZVZBEEEC \
   --paths "/<folder>/*"
 
-# production app hosts (what V3 users actually hit) — repeat for both
+# production app hosts (what V3 users actually hit) — use the STRIPPED path, repeat for both
 aws cloudfront create-invalidation --distribution-id E7WVRGISCR2VR \
-  --paths "/codap-resources/<folder>/*"
+  --paths "/<folder>/*"
 aws cloudfront create-invalidation --distribution-id E26XOJN7T3CJO \
-  --paths "/codap-resources/<folder>/*"
+  --paths "/<folder>/*"
 ```
+
+To confirm an invalidation actually took effect (not just `Completed`), re-request the asset
+and check the response: `x-cache: Miss from cloudfront` on the first hit plus the expected
+`last-modified`/content means the edge refetched. A `Hit` with stale `last-modified` after a
+`Completed` invalidation is the tell-tale sign you invalidated the wrong (pre-rewrite) path.
 
 ### List contents of a folder
 
@@ -225,10 +239,11 @@ Read `~/.codap-build.rc` to get `CODAP_SERVER` (defaults to `codap-server.concor
    ```bash
    aws cloudfront create-invalidation --distribution-id E1RS9TZVZBEEEC \
      --paths "/plugins/TP-Sampler/*"
+   # app distributions: STRIPPED path (the StripCodapResourcesPrefix function), NOT /codap-resources/...
    aws cloudfront create-invalidation --distribution-id E7WVRGISCR2VR \
-     --paths "/codap-resources/plugins/TP-Sampler/*"
+     --paths "/plugins/TP-Sampler/*"
    aws cloudfront create-invalidation --distribution-id E26XOJN7T3CJO \
-     --paths "/codap-resources/plugins/TP-Sampler/*"
+     --paths "/plugins/TP-Sampler/*"
    ```
 
 7. **Clean up the temp directory:**

--- a/.claude/skills/codap-resources/SKILL.md
+++ b/.claude/skills/codap-resources/SKILL.md
@@ -163,10 +163,87 @@ leave users on a **half-updated plugin** — e.g. a new `onboarding.js` that ref
 keys a stale `strings.json` doesn't have yet, so lookups return raw keys like
 `~onboarding1.mammals.table.title` instead of the translated text.
 
-## Syncing from V2 Build
+## Deploying Plugins and Example Documents
 
-During the V2-to-V3 transition, the V2 build on `codap-server.concord.org` is the source of truth for plugins and example documents. CODAP V3 accesses these assets from S3 rather than bundling them in the build. After a V2 build is deployed, the relevant assets can be synced from the server to S3.
+CODAP V3 loads these assets from S3 (`s3://codap-resources/`) rather than bundling
+them in the build. There are two ways assets get there:
 
+- **Direct-to-S3 (current, preferred)** — copy a plugin's files straight from its
+  source repo to S3. This is the normal path going forward.
+- **Syncing from a V2 build (historical / bulk)** — described further below, kept
+  for context and for the occasional bulk re-sync of many plugins at once.
+
+Before the release of V3, certain static/built-in plugins were deployed as part of
+the V2 build on `codap-server.concord.org`, then manually copied to S3 for
+compatibility with V3. With the release of V3 we are no longer performing regular
+V2 builds, so the direct-to-S3 path below is required for routine plugin updates.
+
+### Direct-to-S3 deploy (no V2 build)
+
+Use this for a targeted update to a single plugin from its source repo (sibling
+repos under `codap-build/`, e.g. `codap-data-interactives`).
+
+Many static plugins are served as **raw source with no build step** — e.g. Simmer
+at `eepsmedia/plugins/simmer/`, whose `index.html` loads `src/*.js` directly via
+script tags. For these the source folder *is* the deployable artifact: copy the
+changed file(s) straight to S3, no build required.
+
+1. **Identify the S3 location.** Plugins live under
+   `s3://codap-resources/plugins/<path>/`, mirroring the build's layout. The path
+   can be nested — e.g. eepsmedia plugins are at
+   `s3://codap-resources/plugins/eepsmedia/plugins/<name>/`. Confirm with
+   `aws s3 ls`, and diff the deployed file against your local copy first so you
+   know exactly what will change.
+
+2. **Copy the changed file(s).** For mutable entry files (`index.html`, top-level
+   `*.js` / `strings.json`) add `--cache-control "no-cache"` (see
+   [When to Use No-Cache](#when-to-use-no-cache)):
+
+   ```bash
+   aws s3 cp eepsmedia/plugins/simmer/index.html \
+     s3://codap-resources/plugins/eepsmedia/plugins/simmer/index.html \
+     --acl public-read --cache-control "no-cache"
+   ```
+
+   For a whole-folder update use `aws s3 sync ... --size-only` (see
+   [Sync a folder](#sync-a-folder-plugins-examples-etc)); for webpack-built plugins
+   remember to `cp` `index.html` explicitly afterward (hashed chunks).
+
+3. **Invalidate CloudFront** on all three distributions at the STRIPPED path — see
+   [CloudFront Invalidation](#cloudfront-invalidation):
+
+   ```bash
+   aws cloudfront create-invalidation --distribution-id E1RS9TZVZBEEEC \
+     --paths "/plugins/eepsmedia/plugins/simmer/*"
+   aws cloudfront create-invalidation --distribution-id E7WVRGISCR2VR \
+     --paths "/plugins/eepsmedia/plugins/simmer/*"
+   aws cloudfront create-invalidation --distribution-id E26XOJN7T3CJO \
+     --paths "/plugins/eepsmedia/plugins/simmer/*"
+   ```
+
+4. **Verify** the edge refetched (required — a `Completed` status alone proves
+   nothing):
+
+   ```bash
+   for host in codap.concord.org codap3.concord.org; do
+     echo "--- $host ---"
+     curl -sI "https://$host/codap-resources/plugins/eepsmedia/plugins/simmer/index.html" \
+       | grep -iE "x-cache|last-modified"
+   done
+   ```
+
+   Expect `x-cache: Miss from cloudfront` plus the new `last-modified` on the first
+   request after the invalidation.
+
+### Syncing from a V2 build (historical / bulk)
+
+> **Note:** This path predates regular V3 releases and is retained for context and
+> for bulk re-syncing many plugins from a known build at once. For a routine
+> single-plugin update, use [Direct-to-S3 deploy](#direct-to-s3-deploy-no-v2-build)
+> above instead.
+
+When a V2 build was the source of truth for plugins and example documents, the
+relevant assets were synced from `codap-server.concord.org` to S3 after each build.
 The V2 build stores these assets under `extn/` in the release directory:
 
 | Server path | S3 destination |

--- a/.claude/skills/codap-resources/SKILL.md
+++ b/.claude/skills/codap-resources/SKILL.md
@@ -141,9 +141,26 @@ aws s3 cp onboarding.js s3://codap-resources/plugins/onboarding/onboarding.js \
   --acl public-read --cache-control "no-cache"
 ```
 
-Without this, different entry files age out of cache at different times and a deploy can leave
-users on a **half-updated plugin** — e.g. a new `onboarding.js` that references string keys a
-stale `strings.json` doesn't have yet, so lookups return raw keys like
+**`no-cache` does NOT mean "don't cache" — it means "cache, but revalidate before reusing."**
+It does not force a full download on every load:
+- **First load:** the browser downloads the file and stores it along with its `ETag` (the
+  content fingerprint S3 returns).
+- **Later loads:** the browser sends a conditional request (`If-None-Match: <etag>`). If the
+  file is unchanged, the server returns **`304 Not Modified`** with an **empty body** and the
+  browser reuses its cached copy — a tiny header-only round-trip, no payload. Only when the
+  content actually changed does the server return `200` with the new body.
+
+So the cost is one lightweight revalidation per load (a `304` when nothing changed), and the
+benefit is that a deploy is picked up on the **next** load. Contrast:
+- `no-store` — never cache; full download every time (heavier than needed here).
+- `max-age=N` / immutable — no revalidation round-trip at all; correct only for
+  **content-hashed** files (the chunk's filename changes when its content does).
+- *(no `Cache-Control`)* — browsers fall back to **heuristic** freshness (~10% of age since
+  `Last-Modified`); a year-old `Last-Modified` ⇒ ~weeks of staleness. This is the bug to avoid.
+
+Without `no-cache`, different entry files age out of cache at different times and a deploy can
+leave users on a **half-updated plugin** — e.g. a new `onboarding.js` that references string
+keys a stale `strings.json` doesn't have yet, so lookups return raw keys like
 `~onboarding1.mammals.table.title` instead of the translated text.
 
 ## Syncing from V2 Build

--- a/.claude/skills/codap-resources/SKILL.md
+++ b/.claude/skills/codap-resources/SKILL.md
@@ -246,7 +246,31 @@ Read `~/.codap-build.rc` to get `CODAP_SERVER` (defaults to `codap-server.concor
      --paths "/plugins/TP-Sampler/*"
    ```
 
-7. **Clean up the temp directory:**
+7. **Verify the invalidation actually purged (required — do NOT skip):**
+
+   A `Completed` status does **not** mean anything was purged — CloudFront reports no
+   match/purge count, so a wrong-path (no-op) invalidation looks identical to a real one.
+   The only reliable check is to re-request the asset on each app host and confirm the edge
+   refetched. Request an entry file that changed (e.g. a plugin's `index.html` or, for the
+   onboarding plugin, `strings.json`):
+
+   ```bash
+   for host in codap.concord.org codap3.concord.org; do
+     echo "--- $host ---"
+     curl -sI "https://$host/codap-resources/plugins/TP-Sampler/index.html" \
+       | grep -iE "x-cache|last-modified"
+   done
+   ```
+
+   **Expect:** `x-cache: Miss from cloudfront` on the first request after the invalidation,
+   plus the **new** `last-modified` (or the new content). ✅
+
+   **Red flag:** `x-cache: Hit from cloudfront` with a **stale** `last-modified` after a
+   `Completed` invalidation means you invalidated the wrong path (most often the pre-rewrite
+   `/codap-resources/...` instead of the stripped `/...` — see the CloudFront Invalidation
+   section). Re-invalidate with the correct path and re-verify.
+
+8. **Clean up the temp directory:**
    ```bash
    rm -rf /tmp/codap-sync/
    ```

--- a/.claude/skills/codap-resources/SKILL.md
+++ b/.claude/skills/codap-resources/SKILL.md
@@ -73,9 +73,32 @@ Add `--delete` to remove S3 files that no longer exist locally. Omit it to prese
 
 After updating cached assets (plugins, documents, boundaries), invalidate the CloudFront cache so changes are served immediately. Not needed for `notifications/` since those use no-cache headers.
 
+**There are three distributions, and the one you invalidate depends on how the asset is consumed:**
+
+| Distribution | Serves | Invalidation path |
+|--------------|--------|-------------------|
+| `E1RS9TZVZBEEEC` | `codap-resources.concord.org` (direct bucket access) | `/<folder>/*` |
+| `E7WVRGISCR2VR` | `codap3.concord.org` | `/codap-resources/<folder>/*` |
+| `E26XOJN7T3CJO` | `codap.concord.org`, `codap2to3.concord.org` | `/codap-resources/<folder>/*` |
+
+> ⚠️ **Production V3 does NOT load assets from `codap-resources.concord.org`.** It loads them
+> from a **relative** `/codap-resources/...` path (see `kCodapResourcesUrl` in
+> `v3/src/constants.ts`, which resolves to `"/codap-resources"` when not in local dev). That
+> path is served by the **app** distributions — `E7WVRGISCR2VR` (codap3) and `E26XOJN7T3CJO`
+> (codap / codap2to3) — each with its own edge cache. **Invalidating only `E1RS9TZVZBEEEC`
+> leaves production users on stale files.** Anything production V3 loads (plugins,
+> example-document guides, boundaries) needs the app distributions invalidated too.
+
 ```bash
+# codap-resources.concord.org (direct bucket access)
 aws cloudfront create-invalidation --distribution-id E1RS9TZVZBEEEC \
   --paths "/<folder>/*"
+
+# production app hosts (what V3 users actually hit) — repeat for both
+aws cloudfront create-invalidation --distribution-id E7WVRGISCR2VR \
+  --paths "/codap-resources/<folder>/*"
+aws cloudfront create-invalidation --distribution-id E26XOJN7T3CJO \
+  --paths "/codap-resources/<folder>/*"
 ```
 
 ### List contents of a folder
@@ -90,7 +113,24 @@ Use `--cache-control "no-cache, no-store, must-revalidate"` for any asset that:
 - May be updated frequently
 - Must take effect immediately after changes (e.g., banners, feature flags, notifications)
 
-Static assets (plugins, documents, boundaries) can use default caching.
+Immutable, content-hashed files (webpack chunks with a hash in the filename) can use default
+caching — their name changes when the content changes.
+
+**But mutable, unversioned plugin entry files** — `index.html`, and any top-level
+same-named-across-deploys files like `onboarding.js`, `strings.json`, `init_*.js`,
+`task_descriptions*.js` — should be uploaded with `--cache-control "no-cache"` so browsers
+revalidate via ETag and pick up changes immediately instead of waiting out CloudFront's (and
+the browser's heuristic) default TTL:
+
+```bash
+aws s3 cp onboarding.js s3://codap-resources/plugins/onboarding/onboarding.js \
+  --acl public-read --cache-control "no-cache"
+```
+
+Without this, different entry files age out of cache at different times and a deploy can leave
+users on a **half-updated plugin** — e.g. a new `onboarding.js` that references string keys a
+stale `strings.json` doesn't have yet, so lookups return raw keys like
+`~onboarding1.mammals.table.title` instead of the translated text.
 
 ## Syncing from V2 Build
 
@@ -103,6 +143,16 @@ The V2 build stores these assets under `extn/` in the release directory:
 | `extn/plugins/` | `s3://codap-resources/plugins/` |
 | `extn/example-documents/` | `s3://codap-resources/example-documents/` |
 | `extn/boundaries/` | `s3://codap-resources/boundaries/` |
+
+### Plugins to exclude from sync
+
+The V2 build still ships some plugin folders that are no longer used. **Skip these** when syncing `plugins/` — they're dead weight and uploading them just wastes bandwidth and pollutes S3.
+
+| Folder | Why it's dead | Use instead |
+|--------|---------------|-------------|
+| `NOAA-weather/` | Renamed; V2's plugin map points to `noaa-codap-plugin/`. V3 has an explicit URL rewriter at `v3/src/components/web-view/web-view-utils.ts:28` that translates `/plugins/NOAA-weather/...` → `/plugins/noaa-codap-plugin/...` so old saved documents still load. | `noaa-codap-plugin/` |
+
+When using `aws s3 sync ... s3://codap-resources/plugins/`, pass `--exclude "NOAA-weather/*"` (repeat `--exclude` for any others added in future).
 
 ### Sync workflow
 
@@ -169,10 +219,16 @@ Read `~/.codap-build.rc` to get `CODAP_SERVER` (defaults to `codap-server.concor
    This step is not needed for example documents or boundaries since they don't
    have entry-point files with hashed references.
 
-6. **Invalidate CloudFront cache:**
+6. **Invalidate CloudFront cache** on every distribution that serves the asset — see the
+   [CloudFront Invalidation](#cloudfront-invalidation) section. For a plugin, that means the
+   direct distribution **and** the two app distributions production V3 actually loads from:
    ```bash
    aws cloudfront create-invalidation --distribution-id E1RS9TZVZBEEEC \
      --paths "/plugins/TP-Sampler/*"
+   aws cloudfront create-invalidation --distribution-id E7WVRGISCR2VR \
+     --paths "/codap-resources/plugins/TP-Sampler/*"
+   aws cloudfront create-invalidation --distribution-id E26XOJN7T3CJO \
+     --paths "/codap-resources/plugins/TP-Sampler/*"
    ```
 
 7. **Clean up the temp directory:**

--- a/.claude/skills/codap-v3-build/SKILL.md
+++ b/.claude/skills/codap-v3-build/SKILL.md
@@ -17,8 +17,8 @@ Interactive workflow for CODAP v3 releases. Guides you through Jira setup, relea
 | 2 | `/codap-v3-build notes` | Prepare release notes (interactive) |
 | 3 | `/codap-v3-build files` | Update version files |
 | 4 | `/codap-v3-build pr` | Create release PR |
-| 5 | `/codap-v3-build tag` | Tag and create GitHub release |
-| 6 | `/codap-v3-build deploy [version]` | Deploy to staging/production |
+| 5 | `/codap-v3-build tag` | Tag the release (triggers S3 build) |
+| 6 | `/codap-v3-build deploy [version]` | Deploy to staging/production, publish GitHub release |
 | fix | `/codap-v3-build fix {old-version}` | Revise release after staging QA failure |
 
 ## Getting Started
@@ -31,8 +31,8 @@ When invoked, introduce the skill:
 > 2. **Prepare Release Notes** - Interactive walkthrough to create CHANGELOG entry
 > 3. **Update Version Files** - Update package.json, versions.md, CHANGELOG.md
 > 4. **Create Release PR** - Build, capture asset sizes, create PR
-> 5. **Tag and Release** - After PR merge, create git tag and GitHub release
-> 6. **Deploy** - Stage, QA, deploy to production
+> 5. **Tag** - After PR merge, create git tag (triggers the S3 build)
+> 6. **Deploy** - Stage, QA, deploy to production, then publish the GitHub release
 >
 > Are you ready to proceed?
 
@@ -451,9 +451,16 @@ branch must be created before any commits (translations, version files, etc.).
    >
    > After CI passes and PR is reviewed/merged, run `/codap-v3-build tag` to continue.
 
-## Phase 5: Tag and Release
+## Phase 5: Tag
 
-**Goal:** After PR merge, create git tag and GitHub release.
+**Goal:** After PR merge, create the git tag that triggers the S3 build.
+
+> **Do NOT create the GitHub release here.** Publishing the GitHub release at tag
+> time confused external users: they saw a published release for a version that
+> was not yet available in production (staging QA can take 1+ days). The GitHub
+> release is created later, in Phase 6, only **after** the build is live in
+> production. The tag still must be pushed now, because the tag push is what
+> triggers the CI build that deploys to S3 (needed for staging).
 
 **Prerequisite:** Release PR must be merged.
 
@@ -471,15 +478,11 @@ branch must be created before any commits (translations, version files, etc.).
    git push origin {version}
    ```
 
-3. **Create GitHub release:**
-   ```bash
-   gh release create {version} \
-     --title "Version {version}" \
-     --notes "{release_notes_from_phase_2}"
-   ```
+   The tag push triggers a CI build that deploys to S3. The GitHub release is
+   **not** created until after the production deploy (Phase 6).
 
-4. **Inform user and wait for S3 deploy:**
-   > **Tag pushed and GitHub release created.**
+3. **Inform user and wait for S3 deploy:**
+   > **Tag pushed.** (The GitHub release will be created later, after the production deploy, so external users don't see a release for a version that isn't live yet.)
    >
    > Watch GitHub Actions: https://github.com/concord-consortium/codap/actions
    >
@@ -492,7 +495,7 @@ branch must be created before any commits (translations, version files, etc.).
 
 ## Phase 6: Deploy
 
-**Goal:** Stage, test, deploy to production and beta, finalize Jira.
+**Goal:** Stage, test, deploy to production and beta, publish the GitHub release, finalize Jira.
 
 ### Steps
 
@@ -566,7 +569,11 @@ branch must be created before any commits (translations, version files, etc.).
    >
    > If you'd prefer to complete deployment separately, see manual instructions below.
 
-4. **After QA approval, deploy to production and beta, then finalize Jira.**
+4. **After QA approval:** deploy to production and beta, **then publish the GitHub
+   release** (now that the build is live in production), and finalize Jira. See the
+   Manual Completion Instructions below for the exact commands, and run them in that
+   order — the GitHub release should not be published until the production deploy
+   has succeeded.
 
 ### Manual Completion Instructions
 
@@ -583,6 +590,16 @@ Or use GitHub UI: https://github.com/concord-consortium/codap/actions/workflows/
 gh workflow run release-v3-beta.yml -f version={version}
 ```
 Or use GitHub UI: https://github.com/concord-consortium/codap/actions/workflows/release-v3-beta.yml
+
+**Publish the GitHub release** (only after the production deploy has succeeded):
+```bash
+gh release create {version} \
+  --title "Version {version}" \
+  --notes "{release_notes_from_phase_2}"
+```
+Creating the GitHub release now — rather than at tag time (Phase 5) — ensures
+external users only see a published release once the version is actually available
+in production.
 
 **Finalize Jira release:**
 1. Go to CODAPv3 project in Jira
@@ -747,26 +764,29 @@ Follow the same process as Phase 4:
    git pull
    ```
 
-2. **Delete old GitHub release and tag:**
+2. **Delete the old tag:**
    ```bash
-   gh release delete {old-version} --yes
    git push origin --delete {old-version}
    git tag -d {old-version}
    ```
 
-   These are safe to delete because:
-   - The release was never deployed to production or beta
-   - The tag points to a known-buggy build
-   - No external consumers depend on it
+   The tag is safe to delete because it points to a known-buggy build that was
+   never deployed to production or beta and that no external consumer depends on.
 
-3. **Create new tag and GitHub release:**
+   **No GitHub release to delete:** under the current flow the GitHub release is
+   only created after a production deploy (Phase 6). Since `{old-version}` failed
+   staging QA, it never reached production and never had a release published. (If
+   one somehow exists, remove it with `gh release delete {old-version} --yes`.)
+
+3. **Create the new tag:**
    ```bash
    git tag -a {new-version} -m "Version {new-version}"
    git push origin {new-version}
-   gh release create {new-version} \
-     --title "Version {new-version}" \
-     --notes "{release_notes}"
    ```
+
+   As in Phase 5, do **not** create the GitHub release here. The tag push triggers
+   the S3 build; the GitHub release for `{new-version}` is published only after the
+   revised build reaches production (Step 6 / the deploy phase).
 
 4. **Delete old release branch** (optional cleanup):
    ```bash
@@ -775,7 +795,7 @@ Follow the same process as Phase 4:
    ```
 
 5. **Inform user and wait for S3 deploy:**
-   > **Old release cleaned up. New tag and GitHub release created.**
+   > **Old tag cleaned up. New tag created.** (The GitHub release will be created later, after the revised build reaches production.)
    >
    > Watch GitHub Actions: https://github.com/concord-consortium/codap/actions
    >

--- a/.claude/skills/codap-v3-build/SKILL.md
+++ b/.claude/skills/codap-v3-build/SKILL.md
@@ -316,10 +316,15 @@ branch must be created before any commits (translations, version files, etc.).
      `sync_terms=0`, but worth noting)
    - Unexpected value changes to existing keys
 
-   Ask the user to approve the push before proceeding. If the diff is empty
-   (no changes), note that and ask whether to skip the push.
+   **Decide whether to push — based solely on whether English strings changed:**
+   - **No value changes AND no new keys** (English strings unchanged): **skip the
+     push entirely — do not ask.** There is nothing to upload, so the push (2b)
+     would be a no-op. Note that English is unchanged and go straight to the
+     mandatory pull (2c).
+   - **There ARE English string changes** (new keys or changed values): show the
+     diff and ask the user to approve the push before proceeding to 2b.
 
-   **2b. Push English strings to POEditor:**
+   **2b. Push English strings to POEditor** (only when 2a found English changes):
    ```bash
    ./scripts/strings-push-project.sh
    ```
@@ -334,6 +339,11 @@ branch must be created before any commits (translations, version files, etc.).
    ```
    This pulls translated strings for all supported languages. Report results to the
    user (the streaming output may be collapsed in the UI).
+
+   **Always run the pull — never skip it and never ask whether to pull.** Every
+   build must pull from POEditor, because translators may have added or updated
+   non-English strings since the last release even when the English strings are
+   unchanged. (The push in 2b is conditional; this pull is not.)
 
    **2d. Verify and commit pulled translations:**
 
@@ -667,9 +677,13 @@ Follow the same working directory rules as Phase 3.
    git checkout -b release-{new-version}
    ```
 
-2. **Sync translations (only if needed):**
-   - Only perform the translation sync (Phase 3, step 2) if the bug fix introduced new or changed translatable strings.
-   - For most bug fixes, this can be skipped. Ask the user if unsure.
+2. **Sync translations:**
+   - **Always pull** translations from POEditor (Phase 3, step 2c) — every build
+     must pull, since translators may have added or updated non-English strings
+     even when the English strings are unchanged. Do not skip this.
+   - **Only push** English strings (Phase 3, steps 2a–2b) if the bug fix introduced
+     new or changed translatable strings. For most bug fixes there are none, so the
+     push is skipped — but the pull still runs.
 
 3. **Update package.json:**
    ```bash


### PR DESCRIPTION
## Summary

Updates the `codap-resources` skill to document a **direct-to-S3 deploy path** for plugins, now that regular V2 builds have ended following the V3 release.

## Changes

- Reframes the former "Syncing from V2 Build" section as historical context (the V2 build was the source of truth before V3) and keeps it for the occasional bulk re-sync.
- Adds a **Direct-to-S3 deploy (no V2 build)** subsection: identify the S3 location, copy the changed file(s) with `no-cache` on mutable entry files, invalidate all three CloudFront distributions at the stripped path, and verify the edge refetched.

## Background

Derived from a real deploy: Simmer broke when its unpinned Blockly script tag began resolving to v12/v13 (which removed `Workspace.getAllVariables()`). The fix (pin to `blockly@11`) was shipped by copying the raw-source plugin straight to `s3://codap-resources/plugins/eepsmedia/plugins/simmer/` — no V2 build involved. This skill update captures that path for next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
