### PR TITLE
CODAP-1434: fix map boundaries missing when data crosses the antimeridian

### DIFF
--- a/v3/src/components/map/hooks/use-map-model.ts
+++ b/v3/src/components/map/hooks/use-map-model.ts
@@ -7,7 +7,7 @@ import { getTileInfo } from "../../../models/document/tile-utils"
 import { useDataDisplayLayout } from "../../data-display/hooks/use-data-display-layout"
 import { kTitleBarHeight } from "../../constants"
 import { kDefaultMapZoomForGeoLocation, kMapBoundsExtensionFactor, kMaxZoomForFitBounds } from "../map-types"
-import { expandLatLngBounds } from "../utilities/map-utils"
+import { expandLatLngBounds, wrapBoundsToCanonicalCenter } from "../utilities/map-utils"
 import { useMapModelContext } from "./use-map-model-context"
 
 export function useMapModel() {
@@ -84,7 +84,7 @@ export function useMapModel() {
       // DataDisplayLayout, but it needs the legends to be rendered to know their height.
       const height = Math.max(0, dimensions.height - kTitleBarHeight)
 
-      const extendedBounds = expandLatLngBounds(bounds, kMapBoundsExtensionFactor)
+      const extendedBounds = wrapBoundsToCanonicalCenter(expandLatLngBounds(bounds, kMapBoundsExtensionFactor))
 
       const div = document.createElement('div')
       div.style.width = `${width}px`

--- a/v3/src/components/map/models/map-content-model.ts
+++ b/v3/src/components/map/models/map-content-model.ts
@@ -21,7 +21,9 @@ import { changeMapCoordinatesNotification } from "../map-notifications"
 import {ILatLngSnapshot, LatLngModel} from "../map-model-types"
 import {BaseMapKey, BaseMapKeys, kMapBoundsExtensionFactor} from "../map-types"
 import { DataSetMapAttributes } from "../utilities/data-set-map-attributes"
-import { collectPolygonVertexLngs, computeBoundsFromCoordinates, expandLatLngBounds } from "../utilities/map-utils"
+import {
+  collectPolygonVertexLngs, computeBoundsFromCoordinates, expandLatLngBounds, wrapBoundsToCanonicalCenter
+} from "../utilities/map-utils"
 import {LeafletMapState} from "./leaflet-map-state"
 import { IMapLayerModel, isMapLayerModel } from "./map-layer-model"
 import { isMapPinLayerModel, MapPinLayerModel } from "./map-pin-layer-model"
@@ -237,8 +239,9 @@ export const MapContentModel = DataDisplayContentModel
     rescale(undoStringKey = "", redoStringKey = "") {
       const bounds = self.latLongBounds
       if (bounds) {
+        const expanded = wrapBoundsToCanonicalCenter(expandLatLngBounds(bounds, kMapBoundsExtensionFactor))
         self.leafletMapState.adjustMapView({
-          fitBounds: expandLatLngBounds(bounds, kMapBoundsExtensionFactor),
+          fitBounds: expanded,
           animate: !!undoStringKey && !!redoStringKey,
           undoStringKey, redoStringKey
         })

--- a/v3/src/components/map/utilities/map-utils.test.ts
+++ b/v3/src/components/map/utilities/map-utils.test.ts
@@ -1,5 +1,6 @@
+import { latLngBounds } from "leaflet"
 import {
-  computeBoundsFromCoordinates, getRationalLongitudeBounds, shiftLongitudeIntoView
+  computeBoundsFromCoordinates, getRationalLongitudeBounds, shiftLongitudeIntoView, wrapBoundsToCanonicalCenter
 } from "./map-utils"
 
 describe("getRationalLongitudeBounds", () => {
@@ -194,5 +195,44 @@ describe("shiftLongitudeIntoView", () => {
     // A point at +700° lands at its nearest world copy of the viewport: 700 - 2×360 = -20
     // (139° from the viewport), which is closer than the next copy at -380 (195° away).
     expect(shiftLongitudeIntoView(700, -185, -159)).toBe(-20)
+  })
+})
+
+describe("wrapBoundsToCanonicalCenter", () => {
+  it("leaves bounds whose center is already canonical unchanged", () => {
+    const bounds = latLngBounds([{lat: 30, lng: -125}, {lat: 50, lng: -67}])
+    const result = wrapBoundsToCanonicalCenter(bounds)
+    expect(result.getWest()).toBe(-125)
+    expect(result.getEast()).toBe(-67)
+    expect(result.getSouth()).toBe(30)
+    expect(result.getNorth()).toBe(50)
+  })
+
+  it("shifts a world-copy-+1 arc back to the canonical world copy (CODAP-1434)", () => {
+    // ~US bounds including Alaska's Aleutians: the compact dateline arc is [172, 293],
+    // centered at 232.5° (one world copy east). Polygons render at canonical longitudes,
+    // so the fit center must come back to -127.5° or the map is blank.
+    const bounds = latLngBounds([{lat: 18.9, lng: 172.5}, {lat: 71.4, lng: 293.1}])
+    const result = wrapBoundsToCanonicalCenter(bounds)
+    expect(result.getWest()).toBeCloseTo(-187.5)
+    expect(result.getEast()).toBeCloseTo(-66.9)
+    // center now canonical
+    expect((result.getWest() + result.getEast()) / 2).toBeCloseTo(-127.2)
+    // latitudes preserved
+    expect(result.getSouth()).toBeCloseTo(18.9)
+    expect(result.getNorth()).toBeCloseTo(71.4)
+  })
+
+  it("preserves the longitude span when shifting", () => {
+    const bounds = latLngBounds([{lat: 0, lng: 172}, {lat: 10, lng: 293}])
+    const result = wrapBoundsToCanonicalCenter(bounds)
+    expect(result.getEast() - result.getWest()).toBeCloseTo(293 - 172)
+  })
+
+  it("wraps a center beyond +180 by exactly one world copy", () => {
+    // center 200° -> -160°
+    const bounds = latLngBounds([{lat: 0, lng: 190}, {lat: 10, lng: 210}])
+    const result = wrapBoundsToCanonicalCenter(bounds)
+    expect((result.getWest() + result.getEast()) / 2).toBeCloseTo(-160)
   })
 })

--- a/v3/src/components/map/utilities/map-utils.ts
+++ b/v3/src/components/map/utilities/map-utils.ts
@@ -150,6 +150,29 @@ export const collectPolygonVertexLngs = (leafletMap: LeafletMap | undefined, lng
   leafletMap?.eachLayer((layer: any) => collectFromLayer(layer))
 }
 
+/**
+ * Shifts a LatLngBounds by whole 360° world copies so its center longitude lands in the
+ * canonical [-180, 180] range. computeBoundsFromCoordinates can return a compact
+ * dateline-crossing arc whose east edge exceeds 180° (e.g. ~[172, 293] for US data that
+ * includes Alaska's Aleutians). Point layers cope with such an arc by shifting each point
+ * into the viewport via shiftLongitudeIntoView, but polygon (boundary) features render once
+ * at their raw canonical coordinates and never shift. Fitting the map to an east>180° box
+ * therefore parks the viewport a world copy east of the polygons, leaving the map blank.
+ * Keeping the fitted center canonical positions the viewport over the world copy where the
+ * polygons are actually drawn. This is a no-op for an already-canonical center, and for
+ * dateline-crossing data it only changes which (geographically identical) world copy the map
+ * centers on, so point rendering is unaffected.
+ */
+export const wrapBoundsToCanonicalCenter = (bounds: LatLngBounds): LatLngBounds => {
+  const west = bounds.getWest(), east = bounds.getEast(), centerLng = (west + east) / 2
+  if (centerLng >= -180 && centerLng <= 180) return bounds
+  const shift = -Math.round(centerLng / 360) * 360
+  return latLngBounds([
+    {lat: bounds.getSouth(), lng: west + shift},
+    {lat: bounds.getNorth(), lng: east + shift}
+  ])
+}
+
 export const expandLatLngBounds = (bounds: LatLngBounds, fraction: number) => {
   const center = bounds.getCenter(),
     latDelta = bounds.getNorth() - bounds.getSouth(),


### PR DESCRIPTION
## Summary

Map boundary (polygon) layers rendered blank whenever the dataset included a region that crosses the antimeridian — most commonly **Alaska**, whose Aleutian Islands span ~172°E to ~−130°W. This was reported against the NASS plugin (boundaries showed in the case table but not the map) and appeared to also affect the Microdata plugin.

## Root cause

The failure is purely in **map viewport fitting**, not in boundary data or formulas — every polygon parses and is added to Leaflet. When the data spans the antimeridian, `computeBoundsFromCoordinates` returns a compact dateline-crossing arc whose center longitude lands in the **+1 world copy** (e.g. ~`[172, 293]`, centered near 232°). The map auto-fit then centers there, but polygon vector features render once at their **raw canonical longitudes** (world copy 0), so the viewport is parked a full world copy east of the polygons → blank map. Point layers avoid this because they already shift each point into the viewport via `shiftLongitudeIntoView`; polygons never shift.

(Datasets without an antimeridian-crossing region — e.g. California alone, or the contiguous states — were unaffected, which matched the original intermittent reports.)

## Fix

- Add `wrapBoundsToCanonicalCenter()` (`map-utils.ts`): shifts fitted bounds by whole 360° world copies so the center longitude lands in `[−180, 180]` — i.e. the world copy where polygons are actually drawn. No-op for already-canonical bounds.
- Apply it at the two map-fit sites: `MapContentModel.rescale()` and the map's initial auto-fit (`use-map-model.ts`).
- Point-layer rendering is untouched.

## Tests

4 unit tests for `wrapBoundsToCanonicalCenter` (canonical no-op, the Alaska `[172, 293]→` canonical case, span preservation, generic >+180° wrap). Full `map-utils` suite passes (30/30); typecheck and lint clean. Manually verified the all-50-states NASS repro now renders.

Fixes CODAP-1434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
