### PR TITLE
fix: Calculated attributes don't always update on graphs (CODAP-1439)

### DIFF
--- a/v3/src/components/axis/axis-domain-utils.test.ts
+++ b/v3/src/components/axis/axis-domain-utils.test.ts
@@ -38,4 +38,19 @@ describe("setNiceDomain", () => {
     expect(axis.min).toBe(0)
     expect(axis.max).toBeLessThan(100)
   })
+
+  it("does not shrink a clamped axis when growOnly is set and the data already fits", () => {
+    const axis = NumericAxisModel.create({ place: "bottom", min: 0, max: 100 })
+    setNiceDomain([3, 7], axis, { clampPosMinAtZero: true, growOnly: true })
+    // Grow-only: a larger user/plugin-set bound survives rather than being refit tightly.
+    expect(axis.min).toBe(0)
+    expect(axis.max).toBe(100)
+  })
+
+  it("still grows a clamped axis when growOnly is set and the data exceeds the current max", () => {
+    const axis = NumericAxisModel.create({ place: "bottom", min: 0, max: 10 })
+    setNiceDomain([3, 50], axis, { clampPosMinAtZero: true, growOnly: true })
+    expect(axis.min).toBe(0)
+    expect(axis.max).toBeGreaterThanOrEqual(50)
+  })
 })

--- a/v3/src/components/axis/axis-domain-utils.ts
+++ b/v3/src/components/axis/axis-domain-utils.ts
@@ -56,7 +56,12 @@ export function setNiceDomain(values: number[], axisModel: IBaseNumericAxisModel
       else if (maxValue <= 0) {
         niceMax = 0
       }
-      axisModel.setAllowRangeToShrink(true)
+      // Allowing the range to shrink refits the axis tightly to the data. Grow-only callers must
+      // not do this, or a larger user/plugin-set bound would be silently discarded on a data change;
+      // leaving allowRangeToShrink false lets setDomain's grow-only clamp preserve that bound.
+      if (!options.growOnly) {
+        axisModel.setAllowRangeToShrink(true)
+      }
     }
     else if (!axisModel.allowRangeToShrink) {
       // Don't widen a bound on a side where the data doesn't exceed it. This lets plugin-set

--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -46,6 +46,10 @@ export interface AxisBounds {
 
 export interface IAxisDomainOptions {
   clampPosMinAtZero?: boolean
+  // When set, the domain is only ever grown to fit the data, never shrunk. This preserves a
+  // larger user/plugin-set bound even for clamped (count/percent) axes, which otherwise refit
+  // tightly to the data on every change.
+  growOnly?: boolean
 }
 
 export type TickFormatter = (value: number) => string

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -413,7 +413,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
           // formula recalculations on unrelated attributes.
           if (isSetComputedCaseValuesAction(action)) {
             const affectedAttrs = action.args[1]
-            const plottedAttrs = dataConfiguration?.uniqueAttributes
+            const plottedAttrs = dataConfiguration?.plottedAttributeIDs
             if (affectedAttrs && plottedAttrs &&
                 !affectedAttrs.some(attrId => plottedAttrs.includes(attrId))) {
               return

--- a/v3/src/components/graph/models/graph-content-model.test.ts
+++ b/v3/src/components/graph/models/graph-content-model.test.ts
@@ -241,4 +241,81 @@ describe("GraphContentModel", () => {
       diComponentHandler.delete!({ component: tile })
     })
   })
+
+  // These tests write values via setComputedCaseValues (the attribute-formula path) and rely on the
+  // casesChangeCount reaction to rescale — they don't call rescaleNumericAxesForValueChange directly.
+  describe("rescale on value change", () => {
+    // Builds a scatter graph over testCases (a3 on x, a4 on first y) plus an extra numeric attribute
+    // "yr" (values 11..16) that callers can assign to a role via extraValues (e.g. y2AttributeName).
+    const createGraph = async (datasetName: string, extraValues: Record<string, any> = {}) => {
+      const documentContent = appState.document.content!
+      const { dataset: _dataset } = setupTestDataset({ datasetName })
+      const dataset = documentContent.createDataSet(getSnapshot(_dataset)).sharedDataSet.dataSet
+      dataset.addAttribute({ name: "yr" })
+      dataset.addCases(testCases.map((c, i) => ({ ...c, yr: 11 + i })), { canonicalize: true })
+      dataset.validateCases()
+      const result = diComponentHandler.create!(
+        {}, { type: "graph", dataContext: datasetName, xAttributeName: "a3", yAttributeName: "a4", ...extraValues }
+      )
+      const tile = documentContent.tileMap.get(
+        toV3Id(kGraphIdPrefix, (result.values as DIComponentInfo).id!)
+      )!
+      const content = tile.content as IGraphContentModel
+      // Let afterAttachToDocument's awaits resolve so axes are set up.
+      await new Promise(resolve => setTimeout(resolve, 0))
+      const firstCaseId = content.graphPointLayerModel.dataConfiguration.getCaseDataArray(0)[0].caseID
+      return { dataset, tile, content, firstCaseId }
+    }
+
+    it("grows the left y axis to fit a first-y value that moved outside the current domain", async () => {
+      (isInquirySpaceMode as jest.Mock).mockReturnValue(false)
+      const { dataset, tile, content, firstCaseId } = await createGraph("rescaleLeftData")
+      const yAxis = content.getAxis("left") as IBaseNumericAxisModel
+      const initialMax = yAxis.max
+      const a4 = dataset.getAttributeByName("a4")!
+      dataset.setComputedCaseValues([{ __id__: firstCaseId, [a4.id]: 100 }], [a4.id])
+
+      expect(yAxis.max).toBeGreaterThan(initialMax)
+      expect(yAxis.max).toBeGreaterThanOrEqual(100)
+
+      diComponentHandler.delete!({ component: tile })
+    })
+
+    it("is grow-only: leaves the domain unchanged when values stay within it", async () => {
+      (isInquirySpaceMode as jest.Mock).mockReturnValue(false)
+      const { dataset, tile, content, firstCaseId } = await createGraph("rescaleGrowOnlyData")
+      const yAxis = content.getAxis("left") as IBaseNumericAxisModel
+      const initialMin = yAxis.min
+      const initialMax = yAxis.max
+      const a4 = dataset.getAttributeByName("a4")!
+      // a4 values are -1..-6; set one to -3, still well within the existing domain
+      dataset.setComputedCaseValues([{ __id__: firstCaseId, [a4.id]: -3 }], [a4.id])
+
+      expect(yAxis.min).toBe(initialMin)
+      expect(yAxis.max).toBe(initialMax)
+
+      diComponentHandler.delete!({ component: tile })
+    })
+
+    // A numeric attribute assigned only to the y2/rightNumeric axis (not to x or first-y).
+    it("grows the right (y2) axis when a y2-only attribute's values move outside the domain", async () => {
+      (isInquirySpaceMode as jest.Mock).mockReturnValue(false)
+      const { dataset, tile, content, firstCaseId } = await createGraph("rescaleY2Data", { y2AttributeName: "yr" })
+      const y2Axis = content.getAxis("rightNumeric") as IBaseNumericAxisModel
+      expect(y2Axis).toBeDefined()
+      const initialMax = y2Axis.max
+      expect(initialMax).toBeLessThan(100)
+      // Read the values first, as the live app does while rendering, so the cache holds pre-change
+      // values that the rescale must see invalidated in order to grow.
+      const dataConfig = content.graphPointLayerModel.dataConfiguration
+      expect(dataConfig.numericValuesForAttrRole("rightNumeric")).not.toContain(100)
+      const yr = dataset.getAttributeByName("yr")!
+      dataset.setComputedCaseValues([{ __id__: firstCaseId, [yr.id]: 100 }], [yr.id])
+
+      expect(y2Axis.max).toBeGreaterThan(initialMax)
+      expect(y2Axis.max).toBeGreaterThanOrEqual(100)
+
+      diComponentHandler.delete!({ component: tile })
+    })
+  })
 })

--- a/v3/src/components/graph/models/graph-content-model.test.ts
+++ b/v3/src/components/graph/models/graph-content-model.test.ts
@@ -317,5 +317,49 @@ describe("GraphContentModel", () => {
 
       diComponentHandler.delete!({ component: tile })
     })
+
+    // A bar chart's count axis is a clamped (clampPosMinAtZero) axis, which refits tightly to the
+    // data. The value-change rescale must still be grow-only for it, or a user/plugin-set count-axis
+    // max would be silently discarded whenever a plotted value changes (e.g. a formula recalculates).
+    it("does not shrink a bar chart's count axis (grow-only) when a value changes", async () => {
+      (isInquirySpaceMode as jest.Mock).mockReturnValue(false)
+      const documentContent = appState.document.content!
+      const { dataset: _dataset } = setupTestDataset({ datasetName: "barChartCountData" })
+      const dataset = documentContent.createDataSet(getSnapshot(_dataset)).sharedDataSet.dataSet
+      dataset.addCases(testCases, { canonicalize: true })
+      dataset.validateCases()
+      const result = diComponentHandler.create!(
+        {}, { type: "graph", dataContext: "barChartCountData", xAttributeName: "a1" }
+      )
+      const tile = documentContent.tileMap.get(
+        toV3Id(kGraphIdPrefix, (result.values as DIComponentInfo).id!)
+      )!
+      const content = tile.content as IGraphContentModel
+      await new Promise(resolve => setTimeout(resolve, 0))
+      // Fuse points into bars to make a bar chart; this establishes a count axis on the secondary
+      // (left) place.
+      content.fusePointsIntoBars(true)
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(content.plotType).toBe("barChart")
+
+      // The tallest bar is 3 cases, so the count axis auto-fits to a small max. Simulate the user
+      // dragging it well above that.
+      const countAxis = content.getAxis("left") as IBaseNumericAxisModel
+      expect(countAxis.type).toBe("count")
+      expect(countAxis.max).toBeLessThan(20)
+      countAxis.setDomain(0, 20)
+      expect(countAxis.max).toBe(20)
+
+      // Change a value to bump casesChangeCount and fire the rescale reaction.
+      const firstCaseId = content.graphPointLayerModel.dataConfiguration.getCaseDataArray(0)[0].caseID
+      const a3 = dataset.getAttributeByName("a3")!
+      dataset.setComputedCaseValues([{ __id__: firstCaseId, [a3.id]: 2 }], [a3.id])
+
+      // Grow-only: the user's larger max survives; it is not snapped back to fit the bars.
+      expect(countAxis.min).toBe(0)
+      expect(countAxis.max).toBe(20)
+
+      diComponentHandler.delete!({ component: tile })
+    })
   })
 })

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -193,6 +193,21 @@ export const GraphContentModel = DataDisplayContentModel
         self.axes.set(place, axis)
       }
     },
+    // Grow-only (setNiceDomain never shrinks without setAllowRangeToShrink): fits data that has grown
+    // past an axis while leaving user/plugin-set bounds and already-fitting axes untouched.
+    growNumericAxesToFit() {
+      AxisPlaces.forEach((axisPlace: AxisPlace) => {
+        const axis = self.getAxis(axisPlace),
+          role = axisPlaceToAttrRole[axisPlace]
+        if (isAnyNumericAxisModel(axis)) {
+          // A binned plot's primary axis owns [minBinEdge, maxBinEdge] and resyncs itself; niceing it
+          // here would extend it past the bins.
+          if (self.plot.hasBinnedNumericAxis && axisPlace === self.primaryPlace) return
+          const numericValues = self.plot.numericValuesForRole(role)
+          setNiceDomain(numericValues, axis, self.plot.axisDomainOptions)
+        }
+      })
+    },
     async afterAttachToDocument() {
       if (!self.tileEnv?.sharedModelManager?.isReady) {
         await when(() => !!self.tileEnv?.sharedModelManager?.isReady)
@@ -220,11 +235,8 @@ export const GraphContentModel = DataDisplayContentModel
       // Expand numeric axis domains when new cases are added (e.g., via plugin API)
       addDisposer(self, self.dataConfiguration.onAction((actionCall) => {
         if (actionCall.name === "addCases") {
-          // Binned plots own [minBinEdge, maxBinEdge] on the primary axis; running
-          // setNiceDomain on it would re-nice the domain past the bins and produce
-          // the half-bin sliver at top/bottom (CODAP-1281). Let the plot resync
-          // its own domain (and grow bins to fit new data), then skip the binned
-          // primary axis below.
+          // Binned plots own [minBinEdge, maxBinEdge] on the primary axis; let the plot resync its own
+          // domain (and grow bins to fit new data). growNumericAxesToFit then skips the binned primary.
           if (self.plot.hasBinnedNumericAxis) {
             // The captured self doesn't satisfy IAxisProviderBase here because
             // setAxisHelper is defined in the same .actions block as this callback,
@@ -236,17 +248,18 @@ export const GraphContentModel = DataDisplayContentModel
               secondaryPlace: self.secondaryPlace
             })
           }
-          AxisPlaces.forEach((axisPlace: AxisPlace) => {
-            const axis = self.getAxis(axisPlace),
-              role = axisPlaceToAttrRole[axisPlace]
-            if (isAnyNumericAxisModel(axis)) {
-              if (self.plot.hasBinnedNumericAxis && axisPlace === self.primaryPlace) return
-              const numericValues = self.plot.numericValuesForRole(role)
-              setNiceDomain(numericValues, axis, self.plot.axisDomainOptions)
-            }
-          })
+          this.growNumericAxesToFit()
         }
       }))
+
+      // Grow-fit numeric axes when case values change. Driven by casesChangeCount, which
+      // clearCasesCache bumps after invalidating the numeric-values cache, so the rescale reads
+      // current values rather than the stale cache a synchronous action response would see.
+      addDisposer(self, mstReaction(
+        () => self.dataConfiguration.casesChangeCount,
+        () => this.growNumericAxesToFit(),
+        {name: "GraphContentModel.afterAttachToDocument.rescaleOnValueChange"}, self.dataConfiguration
+      ))
 
       // When showMeasuresForSelection is true, update adornments when selection changes. Only observe
       // the (O(N)) selection while the flag is on, so an ordinary marquee selection doesn't recompute

--- a/v3/src/components/graph/models/graph-content-model.ts
+++ b/v3/src/components/graph/models/graph-content-model.ts
@@ -193,8 +193,9 @@ export const GraphContentModel = DataDisplayContentModel
         self.axes.set(place, axis)
       }
     },
-    // Grow-only (setNiceDomain never shrinks without setAllowRangeToShrink): fits data that has grown
-    // past an axis while leaving user/plugin-set bounds and already-fitting axes untouched.
+    // Grows numeric axes to fit data that has moved past them, while leaving user/plugin-set bounds
+    // and already-fitting axes untouched. Passes growOnly so that clamped (count/percent) axes, which
+    // otherwise refit tightly to the data, are also only grown and never shrunk.
     growNumericAxesToFit() {
       AxisPlaces.forEach((axisPlace: AxisPlace) => {
         const axis = self.getAxis(axisPlace),
@@ -204,7 +205,7 @@ export const GraphContentModel = DataDisplayContentModel
           // here would extend it past the bins.
           if (self.plot.hasBinnedNumericAxis && axisPlace === self.primaryPlace) return
           const numericValues = self.plot.numericValuesForRole(role)
-          setNiceDomain(numericValues, axis, self.plot.axisDomainOptions)
+          setNiceDomain(numericValues, axis, { ...self.plot.axisDomainOptions, growOnly: true })
         }
       })
     },
@@ -232,29 +233,27 @@ export const GraphContentModel = DataDisplayContentModel
         self.adornmentsStore.updateAdornments(updateCategoriesOptions)
       }, {name: "GraphContentModel.afterAttachToDocument.updateAdornments"}, self.dataConfiguration))
 
-      // Expand numeric axis domains when new cases are added (e.g., via plugin API)
+      // Binned plots own [minBinEdge, maxBinEdge] on the primary axis; when cases are added, let the
+      // plot resync its own domain (and grow bins to fit new data) before the casesChangeCount reaction
+      // below grows the remaining numeric axes (which skips the binned primary).
       addDisposer(self, self.dataConfiguration.onAction((actionCall) => {
-        if (actionCall.name === "addCases") {
-          // Binned plots own [minBinEdge, maxBinEdge] on the primary axis; let the plot resync its own
-          // domain (and grow bins to fit new data). growNumericAxesToFit then skips the binned primary.
-          if (self.plot.hasBinnedNumericAxis) {
-            // The captured self doesn't satisfy IAxisProviderBase here because
-            // setAxisHelper is defined in the same .actions block as this callback,
-            // so it isn't visible on self yet. The cast through unknown is required;
-            // at runtime self does provide every method on the interface.
-            self.plot.respondToPlotChange({
-              axisProvider: self as unknown as IAxisProviderBase,
-              primaryPlace: self.primaryPlace,
-              secondaryPlace: self.secondaryPlace
-            })
-          }
-          this.growNumericAxesToFit()
+        if (actionCall.name === "addCases" && self.plot.hasBinnedNumericAxis) {
+          // The captured self doesn't satisfy IAxisProviderBase here because
+          // setAxisHelper is defined in the same .actions block as this callback,
+          // so it isn't visible on self yet. The cast through unknown is required;
+          // at runtime self does provide every method on the interface.
+          self.plot.respondToPlotChange({
+            axisProvider: self as unknown as IAxisProviderBase,
+            primaryPlace: self.primaryPlace,
+            secondaryPlace: self.secondaryPlace
+          })
         }
       }))
 
-      // Grow-fit numeric axes when case values change. Driven by casesChangeCount, which
-      // clearCasesCache bumps after invalidating the numeric-values cache, so the rescale reads
-      // current values rather than the stale cache a synchronous action response would see.
+      // Grow-fit numeric axes when cases are added/removed or their values change. Driven by
+      // casesChangeCount, which clearCasesCache bumps after invalidating the numeric-values cache, so
+      // the rescale reads current values rather than the stale cache a synchronous action response
+      // would see. addCases bumps casesChangeCount too, so this also covers the case-addition path.
       addDisposer(self, mstReaction(
         () => self.dataConfiguration.casesChangeCount,
         () => this.growNumericAxesToFit(),

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -120,6 +120,28 @@ describe("DataConfigurationModel", () => {
     ])
   })
 
+  it("plottedAttributeIDs includes 2nd-y and y2 attributes that uniqueAttributes omits", () => {
+    const config = tree.config
+    config.setDataset(tree.data, tree.metadata)
+    tree.data.addAttribute({ id: "y2Id", name: "y2" })
+    tree.data.addAttribute({ id: "yRightId", name: "yRight" })
+    config.setAttribute("x", { attributeID: "xId" })
+    config.setAttribute("y", { attributeID: "yId" })
+    config.addYAttribute({ attributeID: "y2Id" })          // 2nd attribute on the left y axis
+    config.setY2Attribute({ attributeID: "yRightId" })     // right (y2) vertical axis attribute
+
+    // uniqueAttributes omits the 2nd left-y attribute and the rightNumeric (y2) attribute
+    expect(config.uniqueAttributes).not.toContain("y2Id")
+    expect(config.uniqueAttributes).not.toContain("yRightId")
+
+    // plottedAttributeIDs includes x, first-y, 2nd-y, and y2, with no duplicates
+    expect(config.plottedAttributeIDs).toContain("xId")
+    expect(config.plottedAttributeIDs).toContain("yId")
+    expect(config.plottedAttributeIDs).toContain("y2Id")
+    expect(config.plottedAttributeIDs).toContain("yRightId")
+    expect(config.plottedAttributeIDs.length).toBe(new Set(config.plottedAttributeIDs).size)
+  })
+
   it("behaves as expected with scatter plot and explicit caption attribute", () => {
     const config = tree.config
     config.setDataset(tree.data, tree.metadata)

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -1,6 +1,6 @@
 import {comparer, reaction} from "mobx"
 import {addDisposer, getSnapshot, Instance, SnapshotIn, types} from "mobx-state-tree"
-import { AttributeType, isCategoricalAttributeType } from "../../../models/data/attribute-types"
+import { AttributeType, isCategoricalAttributeType, isNumericAttributeType } from "../../../models/data/attribute-types"
 import {IDataSet} from "../../../models/data/data-set"
 import {typedId} from "../../../utilities/js-utils"
 import { isFiniteNumber } from "../../../utilities/math-utils"
@@ -63,6 +63,11 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     // Includes rightNumeric if present
     get yAttributeIDs() {
       return this.yAttributeDescriptions.map((d: IAttributeDescriptionSnapshot) => d.attributeID)
+    },
+    // Every plotted attribute ID. Unlike `uniqueAttributes`, includes the additional left-y and the
+    // y2/rightNumeric attributes, which the `attributeDescriptions` override below omits.
+    get plottedAttributeIDs() {
+      return Array.from(new Set<string>([...self.uniqueAttributes, ...this.yAttributeIDs]))
     },
     /**
      * No attribute descriptions beyond the first for y are returned.
@@ -305,9 +310,18 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     },
     get numericAttrs(): Array<{ role: AttrRole, attrId: string }> {
       const roles: Array<Maybe<AttrRole>> = [self.primaryRole, self.secondaryRole, "topSplit", "rightSplit"]
-      return roles.filter(role => !!role).filter(role => {
+      const entries = roles.filter((role): role is AttrRole => !!role).filter(role => {
         return self.attributeType(role) === "numeric"
       }).map(role => ({ role, attrId: self.attributeID(role) }))
+      // The 'y' role above captures only the first y attribute; add the remaining left-y attributes
+      // and the y2/rightNumeric attribute so their value changes are observed and invalidate caches.
+      self.yAttributeIDs.forEach(attrId => {
+        const attr = attrId ? self.dataset?.getAttribute(attrId) : undefined
+        if (attrId && isNumericAttributeType(attr?.type) && !entries.some(e => e.attrId === attrId)) {
+          entries.push({ role: "y", attrId })
+        }
+      })
+      return entries
     },
     get numberOfHorizontalRegions() {
       return self.primaryRole === 'x'

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -311,7 +311,7 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     get numericAttrs(): Array<{ role: AttrRole, attrId: string }> {
       const roles: Array<Maybe<AttrRole>> = [self.primaryRole, self.secondaryRole, "topSplit", "rightSplit"]
       const entries = roles.filter((role): role is AttrRole => !!role).filter(role => {
-        return self.attributeType(role) === "numeric"
+        return isNumericAttributeType(self.attributeType(role))
       }).map(role => ({ role, attrId: self.attributeID(role) }))
       // The 'y' role above captures only the first y attribute; add the remaining left-y attributes
       // and the y2/rightNumeric attribute so their value changes are observed and invalidate caches.


### PR DESCRIPTION
Fixes [CODAP-1439](https://concord-consortium.atlassian.net/browse/CODAP-1439). When a calculated (formula) attribute was plotted on a graph, changing its formula didn't reliably update the graph:

- **No update at all** when the attribute was a 2nd attribute on the left axis or on the right (y2) axis — the dots only moved after a manual resize forced a full refresh.
- **Position updated but no rescale** when the attribute was on x or the first y axis — dots moved but the axis didn't refit, so recalculated values could land outside the viewport.

Both symptoms are fixed: the dots move immediately, and the numeric axes grow to fit values that move outside the current view.

These changes also fix [CODAP-1444: Graph with computed values as second y attribute doesn't update when slider is dragged](https://concord-consortium.atlassian.net/browse/CODAP-1444)

## Root causes

1. **Dots not moving (2nd-y / y2).** The value-change responder in `use-plot.ts` skips refreshing when a formula recalc affects no plotted attribute, checked against `uniqueAttributes`. But the graph's `attributeDescriptions` override omits the additional left-y and the y2/`rightNumeric` attributes, so `uniqueAttributes` never contained them and their recalcs were filtered out.

2. **No rescale on value change.** Nothing refit axis domains when values changed — only `addCases` did. Compounding this, `numericValuesForRole` reads a manually-invalidated cache (`numericValuesForAttribute`) that is only cleared by `clearCasesCache`, which fires from a reaction keyed on `numericAttrs` — and `numericAttrs` excluded the 2nd-y/y2 attributes, so their value changes never invalidated the cache. A naïve synchronous rescale also reads this cache before the invalidation reaction runs.

## Changes

- **`plottedAttributeIDs`** (new view) — union of `uniqueAttributes` and `yAttributeIDs`; the value-change responder now filters against it so 2nd-y/y2 recalcs move the dots.
- **`numericAttrs`** now includes the additional left-y and y2 numeric attributes, so their value changes invalidate the cases cache (fixing cache coherence for the rescale and other consumers such as adornments).
- **`growNumericAxesToFit()`** (new grow-only action) grows numeric axes to fit current data without shrinking, so user/plugin-set bounds are preserved and a binned plot's primary axis is left to its own bin sync. It's driven by a reaction on `casesChangeCount`, which `clearCasesCache` bumps *after* invalidating the cache — guaranteeing the rescale reads post-change values. The `addCases` handler now shares this helper.

Rescale is grow-only (never shrinks) — consistent with the existing `addCases` behavior — so it fits outliers without discarding manually adjusted bounds.

## Testing

- Unit tests for `plottedAttributeIDs` (includes 2nd-y/y2 that `uniqueAttributes` omits).
- Reaction-driven rescale tests using the real `setComputedCaseValues` formula path: left-y grows, grow-only leaves in-range domains unchanged, and a y2-only attribute grows its axis (with the cache pre-populated, reproducing the reported scenario).
- Full graph suite passes (612 tests); typecheck and lint clean.

## Manual verification

Confirmed against the shared document from the story: editing the "calculated values" formula now updates and rescales all graphs without a manual resize.


[CODAP-1439]: https://concord-consortium.atlassian.net/browse/CODAP-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ