### PR TITLE
CODAP-1445: add split-plot layout infrastructure

### DIFF
--- a/v3/src/components/axis-graph-shared.ts
+++ b/v3/src/components/axis-graph-shared.ts
@@ -4,5 +4,5 @@ export const GraphPlaces = [...AxisPlaces, "yPlus", "plot", "legend"] as const
 export type GraphPlace = typeof GraphPlaces[number]
 
 export function isVertical(place: GraphPlace) {
-  return ["left", "rightCat", "rightNumeric", "yPlus"].includes(place)
+  return ["left", "leftLower", "rightCat", "rightNumeric", "yPlus"].includes(place)
 }

--- a/v3/src/components/axis/axis-types.ts
+++ b/v3/src/components/axis/axis-types.ts
@@ -6,8 +6,9 @@ export const labelMargin = 13   // whitespace outside the label background rect 
 export const labelPaddingX = 8  // horizontal padding inside the label background rect (between rect edge and text)
 export const labelPaddingY = 4  // vertical padding inside the label background rect (between rect edge and text)
 
-// "rightCat" and "top" can only be categorical axes. "rightNumeric" can only be numeric
-export const AxisPlaces = ["bottom", "left", "rightCat", "top", "rightNumeric"] as const
+// "rightCat" and "top" can only be categorical axes. "rightNumeric" and "leftLower" can only be numeric.
+// "leftLower" is the numeric y-axis for the optional split-plot lower region (see GraphLayout.showLowerPlot).
+export const AxisPlaces = ["bottom", "left", "leftLower", "rightCat", "top", "rightNumeric"] as const
 export type AxisPlace = typeof AxisPlaces[number]
 
 export function isAxisPlace(place: string): place is AxisPlace {
@@ -27,6 +28,7 @@ export const axisPlaceToAxisFn = (place: AxisPlace) => {
   return {
     bottom: axisBottom,
     left: axisLeft,
+    leftLower: axisLeft,
     rightCat: axisRight,
     rightNumeric: axisRight,
     top: axisTop

--- a/v3/src/components/axis/models/axis-model.ts
+++ b/v3/src/components/axis/models/axis-model.ts
@@ -21,7 +21,7 @@ export const AxisModel = types.model("AxisModel", {
   }))
   .views(self => ({
     get orientation(): AxisOrientation {
-      return ['left', 'rightCat', 'rightNumeric'].includes(self.place)
+      return ['left', 'leftLower', 'rightCat', 'rightNumeric'].includes(self.place)
         ? "vertical" : "horizontal"
     },
     get isUpdatingDynamically() {

--- a/v3/src/components/data-display/data-display-types.ts
+++ b/v3/src/components/data-display/data-display-types.ts
@@ -85,6 +85,9 @@ export const attrRoleToGraphPlace: Partial<Record<GraphAttrRole, GraphPlace>> = 
 export const axisPlaceToAttrRole: Record<AxisPlace, GraphAttrRole> = {
   bottom: "x",
   left: "y",
+  // The "leftLower" axis has no owning attribute — it is driven by an adornment (e.g. Residual Plot).
+  // Map it to "y" so that any residual code paths that read the role for it see a sensible fallback.
+  leftLower: "y",
   top: "topSplit",
   rightCat: "rightSplit",
   rightNumeric: "rightNumeric"

--- a/v3/src/components/data-display/models/data-display-layout.ts
+++ b/v3/src/components/data-display/models/data-display-layout.ts
@@ -8,7 +8,7 @@ export interface ITileSize {
   tileHeight: number
 }
 
-export type GraphExtentsPlace = GraphPlace | "banners"
+export type GraphExtentsPlace = GraphPlace | "banners" | "lowerPlot"
 
 export interface Bounds {
   left: number
@@ -63,9 +63,11 @@ export class DataDisplayLayout {
       legendHeight = desiredExtents.get('legend') ?? 0
     return {
       left: {left: 0, top: 0, width: 0, height: tileHeight - legendHeight},
+      leftLower: {left: 0, top: 0, width: 0, height: 0},
       banners: {left: 0, top: 0, width: tileWidth, height: 0},
       top: {left: 0, top: 0, width: tileWidth, height: 0},
       plot: {left: 0, top: 0, width: tileWidth, height: tileHeight - legendHeight},  // So map can use this
+      lowerPlot: {left: 0, top: 0, width: 0, height: 0},
       bottom: {left: 0, top: tileHeight - legendHeight, width: tileWidth, height: 0},
       legend: {left: 6, top: tileHeight - legendHeight, width: tileWidth - 6, height: legendHeight},
       rightNumeric: {left: tileWidth, top: 0, width: 0, height: tileWidth},

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -151,11 +151,15 @@ export const Graph = observer(function Graph({
       // - https://github.com/bkrem/react-d3-tree/issues/284
       select(belowPointsGroupRef.current).attr("transform", translate)
       select(abovePointsGroupRef.current).attr("transform", translate)
-      // Position the HTML host (absolute) to overlay the plot area
+      // Position the HTML host (absolute) to overlay the plot area. When the split plot is
+      // active, the host spans both the upper and lower regions so a residual adornment can
+      // render into either. When inactive, lowerPlot.height is 0 so this collapses to the
+      // original upper-region-only sizing.
       const host = pixiContainerRef.current
       if (host) {
+        const lowerHeight = layout.getLowerPlotBounds().height
         const w = Math.max(0, layout.plotWidth)
-        const h = Math.max(0, layout.plotHeight)
+        const h = Math.max(0, layout.plotHeight + lowerHeight)
         host.style.position = "absolute"
         host.style.left = `${x}px`
         host.style.top = `${y}px`
@@ -166,7 +170,8 @@ export const Graph = observer(function Graph({
 
       updateCellMasks({ dataConfig: graphModel.dataConfiguration, layout, renderer })
     }
-  }, [dataset, graphModel.dataConfiguration, layout, layout.plotHeight, layout.plotWidth, renderer, xScale])
+  }, [dataset, graphModel.dataConfiguration, layout, layout.plotHeight, layout.plotWidth,
+      layout.showLowerPlot, renderer, xScale])
 
   useEffect(function handleSubPlotsUpdate() {
     return mstReaction(

--- a/v3/src/components/graph/hooks/use-init-graph-layout.ts
+++ b/v3/src/components/graph/hooks/use-init-graph-layout.ts
@@ -1,13 +1,18 @@
 import { comparer } from "mobx"
 import { useEffect } from "react"
 import { useMemo } from "use-memo-one"
+import { DEBUG_LOWER_PLOT } from "../../../lib/debug"
 import { mstReaction } from "../../../utilities/mst-reaction"
 import { AxisPlace } from "../../axis/axis-types"
 import {IGraphContentModel} from "../models/graph-content-model"
 import { GraphLayout } from "../models/graph-layout"
 
 export function useInitGraphLayout(model?: IGraphContentModel) {
-  const layout = useMemo(() => new GraphLayout(), [])
+  const layout = useMemo(() => {
+    const l = new GraphLayout()
+    if (DEBUG_LOWER_PLOT) l.setShowLowerPlot(true)
+    return l
+  }, [])
 
   useEffect(() => {
     // synchronize the number of repetitions from the DataConfiguration to the layout's MultiScales

--- a/v3/src/components/graph/models/graph-controller.test.ts
+++ b/v3/src/components/graph/models/graph-controller.test.ts
@@ -4,8 +4,8 @@ import { createDataSet } from "../../../models/data/data-set-conversion"
 import { DataSetMetadata } from "../../../models/shared/data-set-metadata"
 import { isEmptyAxisModel } from "../../axis/models/axis-model"
 import { isCategoricalAxisModel } from "../../axis/models/categorical-axis-models"
-import { isNumericAxisModel } from "../../axis/models/numeric-axis-models"
-import { AxisPlace } from "../../axis/axis-types"
+import { isNumericAxisModel, NumericAxisModel } from "../../axis/models/numeric-axis-models"
+import { AxisPlace, AxisPlaces } from "../../axis/axis-types"
 import { attrRoleToGraphPlace, GraphAttrRole } from "../../data-display/data-display-types"
 import { GraphContentModel } from "./graph-content-model"
 import { GraphController } from "./graph-controller"
@@ -308,6 +308,43 @@ describe("GraphController", () => {
     setAttributeId("y", "cId")
     expect(model.dataConfiguration.attributeID("rightNumeric")).toBe("")
     expect(model.axes.get("rightNumeric")).toBeUndefined()
+  })
+
+  // CODAP-1445 split-plot infrastructure. Simulates what the future Residual Plot adornment
+  // will do: flip the layout's showLowerPlot flag and register a NumericAxisModel at leftLower.
+  // The existing axis rendering pipeline should pick it up without any further wiring.
+  it("supports a numeric axis at leftLower for split-plot rendering", () => {
+    ;({ tree, model, controller, data } = setup())
+    controller.layout.setTileExtent(400, 300)
+    setAttributeId("x", "xId")
+    setAttributeId("y", "yId")
+    expect(model.plotType).toBe("scatterPlot")
+
+    // Activate the split and register the lower axis. syncAxisScalesWithModel is what a
+    // controller would call after any axis-model change.
+    controller.layout.setShowLowerPlot(true)
+    model.setAxis("leftLower", NumericAxisModel.create({ place: "leftLower", min: -50, max: 50 }))
+    controller.syncAxisScalesWithModel()
+
+    // Scale plumbing for leftLower is linear, sized to the lower region, with the expected domain.
+    const leftLowerScale = controller.layout.getAxisMultiScale("leftLower")
+    expect(leftLowerScale.scaleType).toBe("linear")
+    expect(leftLowerScale.length).toBe(controller.layout.getLowerPlotBounds().height)
+    expect(controller.layout.getNumericScale("leftLower")?.domain()).toEqual([-50, 50])
+
+    // renderGraphAxes in graph.tsx filters AxisPlaces by getAxis(place) — leftLower is now included.
+    const renderablePlaces = AxisPlaces.filter(place => !!model.getAxis(place))
+    expect(renderablePlaces).toContain("leftLower")
+
+    // Coordinate helper maps values into the lower region using absolute tile-y.
+    const bounds = controller.layout.computedBounds
+    expect(controller.layout.getLowerYCoord(0))
+      .toBeCloseTo(bounds.lowerPlot.top + bounds.lowerPlot.height / 2, 5)
+
+    // Toggling off collapses the lower region to zero size; the upper 'left' scale restores.
+    controller.layout.setShowLowerPlot(false)
+    expect(controller.layout.getLowerPlotBounds().height).toBe(0)
+    expect(controller.layout.getAxisMultiScale("left").length).toBe(controller.layout.plotHeight)
   })
 
   it("preserves rightNumeric when setAttributeType is called directly", () => {

--- a/v3/src/components/graph/models/graph-layout.test.ts
+++ b/v3/src/components/graph/models/graph-layout.test.ts
@@ -26,10 +26,15 @@ describe("GraphLayout", () => {
 
     it("should initialize axis scales for all axis places", () => {
       expect(layout.getAxisMultiScale("left")).toBeDefined()
+      expect(layout.getAxisMultiScale("leftLower")).toBeDefined()
       expect(layout.getAxisMultiScale("bottom")).toBeDefined()
       expect(layout.getAxisMultiScale("top")).toBeDefined()
       expect(layout.getAxisMultiScale("rightCat")).toBeDefined()
       expect(layout.getAxisMultiScale("rightNumeric")).toBeDefined()
+    })
+
+    it("should default showLowerPlot to false", () => {
+      expect(layout.showLowerPlot).toBe(false)
     })
   })
 
@@ -321,7 +326,113 @@ describe("GraphLayout", () => {
     it("should return arrays of category values from all scales", () => {
       const arrays = layout.categorySetArrays
       expect(Array.isArray(arrays)).toBe(true)
-      expect(arrays.length).toBe(5) // one for each axis place
+      expect(arrays.length).toBe(6) // one for each axis place
+    })
+  })
+
+  describe("split-plot layout (showLowerPlot)", () => {
+    beforeEach(() => {
+      layout.setTileExtent(400, 300)
+    })
+
+    it("does not affect computedBounds when off", () => {
+      // Capture bounds with flag off
+      const off = layout.computedBounds
+      // Toggle on and off — bounds should match the original
+      layout.setShowLowerPlot(true)
+      layout.setShowLowerPlot(false)
+      const restored = layout.computedBounds
+      expect(restored.plot).toEqual(off.plot)
+      expect(restored.left).toEqual(off.left)
+      expect(restored.bottom).toEqual(off.bottom)
+    })
+
+    it("reports zero-sized leftLower/lowerPlot bounds when off", () => {
+      const bounds = layout.computedBounds
+      expect(bounds.lowerPlot.width).toBe(0)
+      expect(bounds.lowerPlot.height).toBe(0)
+      expect(bounds.leftLower.width).toBe(0)
+      expect(bounds.leftLower.height).toBe(0)
+    })
+
+    it("splits the plot area 2:1 when on", () => {
+      // With defaults (left=20, bottom=20), full plot height = 300 - 20 = 280.
+      // Lower = round(280 * 1/3) = 93, upper = 280 - 93 = 187.
+      layout.setShowLowerPlot(true)
+      const bounds = layout.computedBounds
+      expect(bounds.plot.height).toBe(187)
+      expect(bounds.lowerPlot.height).toBe(93)
+      expect(bounds.plot.top + bounds.plot.height).toBe(bounds.lowerPlot.top)
+      // Upper + lower still fills the full plot height
+      expect(bounds.plot.height + bounds.lowerPlot.height).toBe(280)
+    })
+
+    it("places the bottom axis below the lower region when on", () => {
+      layout.setShowLowerPlot(true)
+      const bounds = layout.computedBounds
+      expect(bounds.bottom.top).toBe(bounds.lowerPlot.top + bounds.lowerPlot.height)
+    })
+
+    it("positions leftLower directly below left with matching width", () => {
+      layout.setDesiredExtent("left", 50)
+      layout.setShowLowerPlot(true)
+      const bounds = layout.computedBounds
+      expect(bounds.leftLower.width).toBe(50)
+      expect(bounds.leftLower.left).toBe(0)
+      expect(bounds.leftLower.top).toBe(bounds.left.top + bounds.left.height)
+      expect(bounds.leftLower.height).toBe(bounds.lowerPlot.height)
+    })
+
+    it("shrinks the left axis scale to the upper region when toggled on", () => {
+      // Full plot height = 280
+      layout.setAxisScaleType("left", "linear")
+      layout.setAxisScaleType("leftLower", "linear")
+      expect(layout.getAxisMultiScale("left").length).toBe(280)
+      expect(layout.getAxisMultiScale("leftLower").length).toBe(0)
+      layout.setShowLowerPlot(true)
+      expect(layout.getAxisMultiScale("left").length).toBe(187)
+      expect(layout.getAxisMultiScale("leftLower").length).toBe(93)
+    })
+
+    it("restores the left axis scale length when toggled off", () => {
+      layout.setAxisScaleType("left", "linear")
+      layout.setShowLowerPlot(true)
+      layout.setShowLowerPlot(false)
+      expect(layout.getAxisMultiScale("left").length).toBe(280)
+      expect(layout.getAxisMultiScale("leftLower").length).toBe(0)
+    })
+
+    it("getAxisLength returns the lower region height for leftLower", () => {
+      layout.setShowLowerPlot(true)
+      expect(layout.getAxisLength("leftLower")).toBe(93)
+      expect(layout.getAxisLength("left")).toBe(187)
+    })
+
+    it("getLowerYCoord returns undefined until a numeric domain is set", () => {
+      layout.setShowLowerPlot(true)
+      // Scale defaults to ordinal; numericScale is undefined
+      expect(layout.getLowerYCoord(0)).toBeUndefined()
+    })
+
+    it("getLowerYCoord maps values into the lower region using absolute tile y", () => {
+      layout.setShowLowerPlot(true)
+      layout.setAxisScaleType("leftLower", "linear")
+      const scale = layout.getAxisMultiScale("leftLower")
+      scale.setNumericDomain([-50, 50])
+      const bounds = layout.computedBounds
+      // Value at top of domain (50) should map to lowerPlot.top; bottom of domain (-50) to bottom edge.
+      expect(layout.getLowerYCoord(50)).toBeCloseTo(bounds.lowerPlot.top, 5)
+      expect(layout.getLowerYCoord(-50)).toBeCloseTo(bounds.lowerPlot.top + bounds.lowerPlot.height, 5)
+      // Zero maps to the middle
+      expect(layout.getLowerYCoord(0)).toBeCloseTo(bounds.lowerPlot.top + bounds.lowerPlot.height / 2, 5)
+    })
+
+    it("setShowLowerPlot is idempotent", () => {
+      layout.setShowLowerPlot(true)
+      const bounds1 = layout.computedBounds
+      layout.setShowLowerPlot(true)
+      const bounds2 = layout.computedBounds
+      expect(bounds1).toEqual(bounds2)
     })
   })
 

--- a/v3/src/components/graph/models/graph-layout.ts
+++ b/v3/src/components/graph/models/graph-layout.ts
@@ -12,6 +12,10 @@ interface BannerRegistration {
   order: number
 }
 
+// When showLowerPlot is on, the plot area splits with the upper region getting (1 - kLowerPlotFraction)
+// of the height and the lower region getting kLowerPlotFraction. Hardcoded per CODAP-1445 spec.
+export const kLowerPlotFraction = 1 / 3
+
 export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
   // actual measured sizes of axis elements
   @observable axisBounds: Map<AxisPlace, AxisBounds> = new Map()
@@ -19,6 +23,9 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
   desiredExtentsFromComponents: Map<GraphExtentsPlace, number> = new Map() // not necessarily the extent they get
   // Dynamic banner registration - allows any client to register a banner with a height and order
   @observable bannerHeights: Map<string, BannerRegistration> = new Map()
+  // When true, splits the plot area into an upper (2/3) and lower (1/3) region — infrastructure
+  // for the future Residual Plot adornment. See CODAP-1445. Default off preserves all existing behavior.
+  @observable showLowerPlot = false
   private disposer?: () => void
 
   constructor() {
@@ -70,7 +77,23 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
   }
 
   getAxisLength(place: AxisPlace) {
+    if (place === 'leftLower') return this.getLowerPlotBounds().height
     return isVertical(place) ? this.plotHeight : this.plotWidth
+  }
+
+  getLowerPlotBounds(): Bounds {
+    return this.getComputedBounds('lowerPlot')
+  }
+
+  /**
+   * Map a numeric value to a y-pixel in the lower plot region, in the tile's outer coordinate space
+   * (i.e. add this to nothing — it's already an absolute y within the tile). Returns undefined if
+   * the lower scale isn't numeric or has no domain yet.
+   */
+  getLowerYCoord(value: number): number | undefined {
+    const scale = this.getNumericScale('leftLower')
+    if (!scale) return undefined
+    return this.getLowerPlotBounds().top + scale(value)
   }
 
   getAxisBounds(place: AxisPlace) {
@@ -104,8 +127,16 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
 
   @action setAxisScaleType(place: AxisPlace, scale: IScaleType) {
     this.getAxisMultiScale(place)?.setScaleType(scale)
-    const length = isVertical(place) ? this.plotHeight : this.plotWidth
-    this.getAxisMultiScale(place)?.setLength(length)
+    this.getAxisMultiScale(place)?.setLength(this.getAxisLength(place))
+  }
+
+  @action setShowLowerPlot(show: boolean) {
+    if (this.showLowerPlot === show) return
+    this.showLowerPlot = show
+    // computedBounds reacts automatically via @observable, but the axis scale ranges are pull-updated
+    // via updateScaleRanges — trigger it so the upper 'left' scale shrinks (or restores) and
+    // 'leftLower' picks up its non-zero range.
+    this.updateScaleRanges(this.plotWidth, this.plotHeight)
   }
 
   @action resetAxisScale(place: AxisPlace) {
@@ -156,6 +187,7 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
     const labelHeight = measureTextExtent('Xy', vars.labelFont).height
     switch (place) {
       case 'left':
+      case 'leftLower':
       case 'rightNumeric':
       case 'rightCat': {
         extent = Math.max(minimumExtent, Math.min(extent, labelHeight + 2 * this.tileWidth / 5))
@@ -172,8 +204,11 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
   }
 
   updateScaleRanges(plotWidth: number, plotHeight: number) {
+    const lowerHeight = this.getLowerPlotBounds().height
     AxisPlaces.forEach(place => {
-      const length = isVertical(place) ? plotHeight : plotWidth
+      const length = place === 'leftLower'
+        ? lowerHeight
+        : isVertical(place) ? plotHeight : plotWidth
       this.getAxisMultiScale(place)?.setLength(length)
     })
   }
@@ -191,7 +226,7 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
    * We set the computedBounds only once at the end so there should be only one notification to respond to.
    */
   @override get computedBounds() {
-    const {desiredExtents, tileWidth, tileHeight} = this,
+    const {desiredExtents, tileWidth, tileHeight, showLowerPlot} = this,
       topAxisHeight = desiredExtents.get('top') ?? 0,
       bannersHeight = this.totalBannersHeight,
       leftAxisWidth = desiredExtents.get('left') ?? 20,
@@ -200,13 +235,24 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
       v2AxisWidth = desiredExtents.get('rightNumeric') ?? 0,
       rightAxisWidth = desiredExtents.get('rightCat') ?? 0,
       plotWidth = tileWidth - leftAxisWidth - v2AxisWidth - rightAxisWidth,
-      plotHeight = tileHeight - bannersHeight - topAxisHeight - bottomAxisHeight - legendHeight,
+      fullPlotHeight = tileHeight - bannersHeight - topAxisHeight - bottomAxisHeight - legendHeight,
+      lowerPlotHeight = showLowerPlot ? Math.round(fullPlotHeight * kLowerPlotFraction) : 0,
+      plotHeight = fullPlotHeight - lowerPlotHeight,
+      plotTop = bannersHeight + topAxisHeight,
+      lowerPlotTop = plotTop + plotHeight,
       newBounds: Record<GraphExtentsPlace, Bounds> = {
         left: {
           left: 0,
-          top: bannersHeight + topAxisHeight,
+          top: plotTop,
           width: leftAxisWidth,
           height: plotHeight
+        },
+        leftLower: {
+          left: 0,
+          top: lowerPlotTop,
+          // Zero width when inactive so no code path can accidentally size against it.
+          width: showLowerPlot ? leftAxisWidth : 0,
+          height: lowerPlotHeight
         },
         banners: {
           left: leftAxisWidth,
@@ -222,13 +268,19 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
         },
         plot: {
           left: leftAxisWidth,
-          top: bannersHeight + topAxisHeight,
+          top: plotTop,
           width: plotWidth,
           height: plotHeight
         },
+        lowerPlot: {
+          left: leftAxisWidth,
+          top: lowerPlotTop,
+          width: showLowerPlot ? plotWidth : 0,
+          height: lowerPlotHeight
+        },
         bottom: {
           left: leftAxisWidth,
-          top: bannersHeight + topAxisHeight + plotHeight,
+          top: lowerPlotTop + lowerPlotHeight,
           width: plotWidth,
           height: bottomAxisHeight
         },
@@ -240,19 +292,19 @@ export class GraphLayout extends DataDisplayLayout implements IAxisLayout {
         },
         rightNumeric: {
           left: leftAxisWidth + plotWidth,
-          top: bannersHeight + topAxisHeight,
+          top: plotTop,
           width: v2AxisWidth,
           height: plotHeight
         },
         rightCat: {
           left: leftAxisWidth + plotWidth,
-          top: bannersHeight + topAxisHeight,
+          top: plotTop,
           width: rightAxisWidth,
           height: plotHeight
         },
         yPlus: {
           left: 0,
-          top: bannersHeight + topAxisHeight,
+          top: plotTop,
           width: leftAxisWidth,
           height: plotHeight
         } // This value is not used

--- a/v3/src/components/graph/models/graph-model-utils.ts
+++ b/v3/src/components/graph/models/graph-model-utils.ts
@@ -72,6 +72,10 @@ export function setupAxes(graphModel: IGraphContentModel, layout: GraphLayout) {
 
   const setupAxis = (place: AxisPlace) => {
     if (!graphModel) return
+    // The lower plot's y-axis has no owning attribute — it is created and managed by an adornment
+    // (see CODAP-1445 / Residual Plot). Auto-configuring it from y-attribute state would corrupt
+    // the axis (create a categorical model that then flips the y attribute type back to categorical).
+    if (place === 'leftLower') return
     const dataConfig = graphModel.dataConfiguration
     const isPrimaryPlace = place === graphModel.primaryPlace
     const isSecondaryPlace = place === graphModel.secondaryPlace

--- a/v3/src/components/graph/models/graph-notification-utils.ts
+++ b/v3/src/components/graph/models/graph-notification-utils.ts
@@ -10,6 +10,7 @@ const axisPlaceToOrientationMap: Record<OrientableGraphPlace, AxisOrientation> =
   "bottom": "horizontal",
   "top": "horizontal",
   "left": "vertical",
+  "leftLower": "vertical",
   "rightCat": "vertical",
   "rightNumeric": "vertical",
   "yPlus": "vertical"

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -11,6 +11,7 @@ import {
 import { mstAutorun } from "../../../../utilities/mst-autorun"
 import {ScaleNumericBaseType} from "../../../axis/axis-types"
 import { getDomainExtentForPixelWidth } from "../../../axis/axis-utils"
+import { If } from "../../../common/if"
 import { CaseData } from "../../../data-display/d3-types"
 import { handleClickOnCase, setPointSelection } from "../../../data-display/data-display-utils"
 import { dataDisplayGetNumericValue } from "../../../data-display/data-display-value-utils"
@@ -360,6 +361,11 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
         <clipPath id={`plot-clip-${instanceId}`}>
           <rect width={layout.plotWidth} height={layout.plotHeight} />
         </clipPath>
+        <If condition={layout.showLowerPlot}>
+          <clipPath id={`plot-clip-lower-${instanceId}`}>
+            <rect width={layout.getLowerPlotBounds().width} height={layout.getLowerPlotBounds().height} />
+          </clipPath>
+        </If>
       </defs>
       <g
         className="connecting-lines"

--- a/v3/src/lib/debug.ts
+++ b/v3/src/lib/debug.ts
@@ -30,6 +30,9 @@ export const DEBUG_EVENT_MODIFICATION = debugContains("eventModification")
 export const DEBUG_FORMULAS = debugContains("formulas")
 export const DEBUG_HISTORY = debugContains("history")
 export const DEBUG_LOGGER = debugContains("logger")
+// Split-plot infrastructure smoke test (CODAP-1445): flips GraphLayout.showLowerPlot on for every
+// graph on mount so the 2:1 upper/lower geometry is visible without a residual adornment.
+export const DEBUG_LOWER_PLOT = debugContains("lowerPlot")
 export const DEBUG_MAP = debugContains("map")
 export const DEBUG_PIXI_POINTS = debugContains("pixiPoints")
 export const DEBUG_PLUGINS = debugContains("plugins")


### PR DESCRIPTION
## Summary
Fixes CODAP-1445.

Foundational plumbing for a future Residual Plot adornment. Extends `GraphLayout` to support an optional 2/3 upper + 1/3 lower plot split (each region with its own y-scale, y-axis, clip region, and coordinate mapping) behind a `showLowerPlot` flag that defaults **off**. No user-visible feature; no residual computation.

- **New `leftLower` `AxisPlace`** — threaded through the exhaustive `Record<AxisPlace, ...>` and `Record<GraphExtentsPlace, ...>` maps and every `isVertical` / `orientation` predicate. The existing `GraphAxis` / `Axis` / `SubAxis` machinery renders it out of the box once a `NumericAxisModel` is registered there.
- **`GraphLayout` APIs:** `showLowerPlot` observable + setter, `getLowerPlotBounds()`, `getLowerYCoord(value)`, and a `kLowerPlotFraction = 1/3` constant. `computedBounds` returns `lowerPlot` + `leftLower` entries; `getAxisLength` / `updateScaleRanges` special-case `leftLower` to the lower region's height.
- **Zero-diff when off** is the acceptance bar. All new bounds/scale entries collapse to zero-size when the flag is off; existing scatter plots render/resize/rescale identically. A test in `graph-layout.test.ts` captures bounds off → toggles on/off → asserts identical restoration.
- **Second SVG clipPath** `plot-clip-lower-${instanceId}` in `scatter-plot.tsx` gated on the flag. Pixi host in `graph.tsx`'s `setupPlotArea` spans both regions when on.
- **Debug hook** — set localStorage `debug: "lowerPlot"` (via the existing debug-flag registry) to flip `showLowerPlot` on for every graph mount so the geometry is eyeball-verifiable. No document mutation.

### One non-obvious change worth reviewing carefully

In `graph-model-utils.ts::setupAxis` I added an early return for `place === 'leftLower'`. Without it, `AxisPlaces.forEach(setupAxis)` visits `leftLower`, sees `axisPlaceToAttrRole["leftLower"] = "y"` (a placeholder to satisfy the exhaustive `Record<AxisPlace, GraphAttrRole>`), doesn't match primary/secondary/rightNumeric, and falls into `categoricalOrColorAxisModel(...)` which creates a **categorical** axis for `leftLower` because the y attribute is numeric. `syncAttributeTypeWithAxis` then reads that back and overrides the y attribute's type to `"categorical"`, dropping any scatterplot to `dotPlot`. Caught by `graph-controller.test.ts`. The early return is correct semantically: `leftLower` is adornment-driven, not attribute-driven.

## Test plan
- [x] `npm run build:tsc` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 3345 pass, 0 fail (10 new unit tests in `graph-layout.test.ts`, 1 integration test in `graph-controller.test.ts`)
- [ ] CI: lint + build + limited Cypress on this draft PR
- [ ] Full Cypress via `run regression` label — should be **clean** on all scatterplot / graph specs, since the flag is off by default
- [ ] Eyeball the debug hook: set localStorage `debug: "lowerPlot"`, reload, open a scatterplot; upper region ≈ 2/3 of previous height, bottom axis pushed down ≈ 1/3, lower region visibly empty, no console errors. Clear `debug` → back to pristine.
- [ ] Eyeball zero-diff: with `debug` unset (or set to a value not containing `"lowerPlot"`), open a scatterplot / dot plot / histogram — should be pixel-identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
