### PR TITLE
CODAP-1438: WebView URL-scheme validation — edit-modal + drop guards, docs, tests

### DIFF
--- a/v3/src/components/web-view/web-view-url-modal.test.tsx
+++ b/v3/src/components/web-view/web-view-url-modal.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { WebViewUrlModal } from "./web-view-url-modal"
+
+function renderModal(overrides: Partial<Parameters<typeof WebViewUrlModal>[0]> = {}) {
+  const onAccept = jest.fn()
+  const onClose = jest.fn()
+  const onRemoveEmptyWebView = jest.fn()
+  render(
+    <WebViewUrlModal
+      currentValue=""
+      isOpen={true}
+      onAccept={onAccept}
+      onClose={onClose}
+      onRemoveEmptyWebView={onRemoveEmptyWebView}
+      {...overrides}
+    />
+  )
+  return { onAccept, onClose, onRemoveEmptyWebView }
+}
+
+function typeUrl(value: string) {
+  const input = screen.getByTestId("web-view-url-input")
+  fireEvent.change(input, { target: { value } })
+}
+
+describe("WebViewUrlModal URL validation", () => {
+  it("accepts an https URL", () => {
+    const { onAccept } = renderModal()
+    typeUrl("https://example.com")
+    expect(screen.queryByTestId("web-view-url-error")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId("OK-button"))
+    expect(onAccept).toHaveBeenCalledWith("https://example.com")
+  })
+
+  it("accepts a scheme-less domain (https:// is added downstream)", () => {
+    const { onAccept } = renderModal()
+    typeUrl("codap.concord.org")
+    expect(screen.queryByTestId("web-view-url-error")).not.toBeInTheDocument()
+    const okButton = screen.getByTestId("OK-button")
+    expect(okButton).not.toBeDisabled()
+    fireEvent.click(okButton)
+    expect(onAccept).toHaveBeenCalledWith("codap.concord.org")
+  })
+
+  it("rejects a javascript: URL: shows an error, disables OK, and does not accept", () => {
+    const { onAccept } = renderModal()
+    typeUrl("javascript:alert(1)")
+    expect(screen.getByTestId("web-view-url-error")).toBeInTheDocument()
+    expect(screen.getByTestId("OK-button")).toBeDisabled()
+    fireEvent.click(screen.getByTestId("OK-button"))
+    expect(onAccept).not.toHaveBeenCalled()
+  })
+
+  it("does not accept a javascript: URL submitted via the Enter key", () => {
+    const { onAccept } = renderModal()
+    typeUrl("javascript:alert(1)")
+    fireEvent.keyUp(screen.getByTestId("web-view-url-input"), { key: "Enter" })
+    expect(onAccept).not.toHaveBeenCalled()
+  })
+})

--- a/v3/src/components/web-view/web-view-url-modal.test.tsx
+++ b/v3/src/components/web-view/web-view-url-modal.test.tsx
@@ -57,4 +57,20 @@ describe("WebViewUrlModal URL validation", () => {
     fireEvent.keyUp(screen.getByTestId("web-view-url-input"), { key: "Enter" })
     expect(onAccept).not.toHaveBeenCalled()
   })
+
+  it("treats whitespace-only input as empty: OK disabled, no error, not accepted", () => {
+    const { onAccept } = renderModal()
+    typeUrl("   ")
+    expect(screen.queryByTestId("web-view-url-error")).not.toBeInTheDocument()
+    expect(screen.getByTestId("OK-button")).toBeDisabled()
+    fireEvent.click(screen.getByTestId("OK-button"))
+    expect(onAccept).not.toHaveBeenCalled()
+  })
+
+  it("trims surrounding whitespace before accepting", () => {
+    const { onAccept } = renderModal()
+    typeUrl("  https://example.com  ")
+    fireEvent.click(screen.getByTestId("OK-button"))
+    expect(onAccept).toHaveBeenCalledWith("https://example.com")
+  })
 })

--- a/v3/src/components/web-view/web-view-url-modal.tsx
+++ b/v3/src/components/web-view/web-view-url-modal.tsx
@@ -1,9 +1,10 @@
 import {
-  Button, FormControl, FormLabel, Input, ModalBody, ModalFooter, ModalHeader, Tooltip
+  Button, FormControl, FormErrorMessage, FormLabel, Input, ModalBody, ModalFooter, ModalHeader, Tooltip
 } from "@chakra-ui/react"
 import React, { useRef, useState } from "react"
 import { CodapModal } from "../codap-modal"
 import { t } from "../../utilities/translation/translate"
+import { isSafeWebViewUrl } from "./web-view-utils"
 import MediaToolIcon from "../../assets/icons/icon-media-tool.svg"
 
 interface IProps {
@@ -24,8 +25,13 @@ export const WebViewUrlModal = ({
   const inputRef = useRef<HTMLInputElement | null>(null)
   const [value, setValue] = useState(currentValue)
 
+  // Reject URLs with an unsafe scheme (e.g. javascript:) to prevent XSS.
+  // Scheme-less input (e.g. "codap.concord.org") is allowed; it is prefixed with https:// downstream.
+  const isUrlSafe = isSafeWebViewUrl(value)
+
   const applyValue = () => {
     if (value !== "") {
+      if (!isUrlSafe) return // keep the modal open so the user can see/fix the error
       onAccept(value)
     }
 
@@ -59,7 +65,7 @@ export const WebViewUrlModal = ({
     tooltip: t("DG.DocumentController.enterViewWebPageOKTip"),
     onClick: applyValue,
     default: true,
-    disabled: !value
+    disabled: !value || !isUrlSafe
   }]
 
   return (
@@ -83,7 +89,8 @@ export const WebViewUrlModal = ({
         <div className="codap-header-title"/>
       </ModalHeader>
       <ModalBody>
-        <FormControl display="flex" flexDirection="column" data-testid="web-view-url-form">
+        <FormControl display="flex" flexDirection="column" data-testid="web-view-url-form"
+          isInvalid={value !== "" && !isUrlSafe}>
           <FormLabel className="web-view-url-prompt">
             {t("DG.DocumentController.enterURLPrompt")}
             <Input
@@ -96,6 +103,9 @@ export const WebViewUrlModal = ({
               value={value}
             />
           </FormLabel>
+          <FormErrorMessage data-testid="web-view-url-error">
+            {t("V3.WebView.Modal.invalidUrl")}
+          </FormErrorMessage>
         </FormControl>
       </ModalBody>
       <ModalFooter mt="-5">

--- a/v3/src/components/web-view/web-view-url-modal.tsx
+++ b/v3/src/components/web-view/web-view-url-modal.tsx
@@ -27,19 +27,21 @@ export const WebViewUrlModal = ({
 
   // Reject URLs with an unsafe scheme (e.g. javascript:) to prevent XSS.
   // Scheme-less input (e.g. "codap.concord.org") is allowed; it is prefixed with https:// downstream.
-  const isUrlSafe = isSafeWebViewUrl(value)
+  // Trim first so whitespace-only input is treated as empty (never accepted as a broken "https://").
+  const trimmedValue = value.trim()
+  const isUrlSafe = isSafeWebViewUrl(trimmedValue)
 
   const applyValue = () => {
-    if (value !== "") {
+    if (trimmedValue !== "") {
       if (!isUrlSafe) return // keep the modal open so the user can see/fix the error
-      onAccept(value)
+      onAccept(trimmedValue)
     }
 
     closeModal()
   }
 
   const closeModal = () => {
-    if (value === "" && currentValue === "") {
+    if (trimmedValue === "" && currentValue === "") {
       onRemoveEmptyWebView()
     }
 
@@ -65,7 +67,7 @@ export const WebViewUrlModal = ({
     tooltip: t("DG.DocumentController.enterViewWebPageOKTip"),
     onClick: applyValue,
     default: true,
-    disabled: !value || !isUrlSafe
+    disabled: !trimmedValue || !isUrlSafe
   }]
 
   return (
@@ -90,7 +92,7 @@ export const WebViewUrlModal = ({
       </ModalHeader>
       <ModalBody>
         <FormControl display="flex" flexDirection="column" data-testid="web-view-url-form"
-          isInvalid={value !== "" && !isUrlSafe}>
+          isInvalid={trimmedValue !== "" && !isUrlSafe}>
           <FormLabel className="web-view-url-prompt">
             {t("DG.DocumentController.enterURLPrompt")}
             <Input

--- a/v3/src/components/web-view/web-view-utils.test.ts
+++ b/v3/src/components/web-view/web-view-utils.test.ts
@@ -247,38 +247,43 @@ describe("appendLocaleParam", () => {
   })
 })
 
-describe("isSafeWebViewUrl", () => {
-  it("allows allowlisted schemes (http, https, data, blob, about)", () => {
+describe("isSafeWebViewUrl (XSS guard)", () => {
+  it("allows http and https URLs", () => {
     expect(isSafeWebViewUrl("https://example.com/plugin/index.html")).toBe(true)
     expect(isSafeWebViewUrl("http://example.com")).toBe(true)
+  })
+  it("allows data:, blob:, and about: URLs", () => {
     expect(isSafeWebViewUrl("data:text/html,<p>hi</p>")).toBe(true)
     expect(isSafeWebViewUrl("blob:https://example.com/1234")).toBe(true)
     expect(isSafeWebViewUrl("about:blank")).toBe(true)
   })
-  it("allows empty and scheme-less (relative) URLs", () => {
+  it("treats empty and scheme-less (relative) URLs as safe", () => {
     expect(isSafeWebViewUrl("")).toBe(true)
     expect(isSafeWebViewUrl("../plugin/index.html")).toBe(true)
     expect(isSafeWebViewUrl("example.com/path")).toBe(true)
     expect(isSafeWebViewUrl("//example.com/path")).toBe(true)
   })
-  it("rejects URLs whose scheme is not in the allowlist", () => {
+  it("rejects javascript: URLs", () => {
     expect(isSafeWebViewUrl("javascript:alert(1)")).toBe(false)
-    expect(isSafeWebViewUrl("vbscript:msgbox(1)")).toBe(false)
-    expect(isSafeWebViewUrl("file:///etc/passwd")).toBe(false)
   })
-  it("extracts the scheme the way browsers do, ignoring case", () => {
+  it("rejects javascript: URLs regardless of case", () => {
     expect(isSafeWebViewUrl("JavaScript:alert(1)")).toBe(false)
     expect(isSafeWebViewUrl("JAVASCRIPT:alert(1)")).toBe(false)
   })
-  it("ignores leading whitespace and control characters when reading the scheme", () => {
+  it("rejects javascript: URLs with leading whitespace or control characters", () => {
     expect(isSafeWebViewUrl("   javascript:alert(1)")).toBe(false)
     expect(isSafeWebViewUrl("\x01javascript:alert(1)")).toBe(false)
     expect(isSafeWebViewUrl("\t javascript:alert(1)")).toBe(false)
   })
-  it("strips embedded tab/newline/CR before reading the scheme", () => {
+  it("rejects javascript: URLs with embedded tab/newline/CR in the scheme", () => {
+    // Browsers strip tab/LF/CR from anywhere in a URL, so these are still executable.
     expect(isSafeWebViewUrl("java\tscript:alert(1)")).toBe(false)
     expect(isSafeWebViewUrl("java\nscript:alert(1)")).toBe(false)
     expect(isSafeWebViewUrl("java\rscript:alert(1)")).toBe(false)
     expect(isSafeWebViewUrl("javascript\n:alert(1)")).toBe(false)
+  })
+  it("rejects vbscript: and other non-allowlisted schemes", () => {
+    expect(isSafeWebViewUrl("vbscript:msgbox(1)")).toBe(false)
+    expect(isSafeWebViewUrl("file:///etc/passwd")).toBe(false)
   })
 })

--- a/v3/src/components/web-view/web-view-utils.test.ts
+++ b/v3/src/components/web-view/web-view-utils.test.ts
@@ -1,7 +1,7 @@
 import { kCodapResourcesUrl, kRootDataGamesPluginUrl, kRootGuideUrl, kRootPluginsUrl } from "../../constants"
 import {
-  appendLangParam, appendLocaleParam, getNameFromURL, kRelativeGuideRoot, kRelativePluginRoot, kRelativeURLRoot,
-  normalizeUrlScheme, processWebViewUrl
+  appendLangParam, appendLocaleParam, getNameFromURL, isSafeWebViewUrl, kRelativeGuideRoot, kRelativePluginRoot,
+  kRelativeURLRoot, normalizeUrlScheme, processWebViewUrl
 } from "./web-view-utils"
 
 const kTestUrls: Array<{ original: string, processed: string }> = [
@@ -244,5 +244,41 @@ describe("appendLocaleParam", () => {
   it("collapses duplicate param entries to a single value (matches URLSearchParams.set)", () => {
     expect(appendLocaleParam("../plugin/index.html?locale=en-US&locale=fr", "es"))
       .toBe("../plugin/index.html?locale=es")
+  })
+})
+
+describe("isSafeWebViewUrl", () => {
+  it("allows allowlisted schemes (http, https, data, blob, about)", () => {
+    expect(isSafeWebViewUrl("https://example.com/plugin/index.html")).toBe(true)
+    expect(isSafeWebViewUrl("http://example.com")).toBe(true)
+    expect(isSafeWebViewUrl("data:text/html,<p>hi</p>")).toBe(true)
+    expect(isSafeWebViewUrl("blob:https://example.com/1234")).toBe(true)
+    expect(isSafeWebViewUrl("about:blank")).toBe(true)
+  })
+  it("allows empty and scheme-less (relative) URLs", () => {
+    expect(isSafeWebViewUrl("")).toBe(true)
+    expect(isSafeWebViewUrl("../plugin/index.html")).toBe(true)
+    expect(isSafeWebViewUrl("example.com/path")).toBe(true)
+    expect(isSafeWebViewUrl("//example.com/path")).toBe(true)
+  })
+  it("rejects URLs whose scheme is not in the allowlist", () => {
+    expect(isSafeWebViewUrl("javascript:alert(1)")).toBe(false)
+    expect(isSafeWebViewUrl("vbscript:msgbox(1)")).toBe(false)
+    expect(isSafeWebViewUrl("file:///etc/passwd")).toBe(false)
+  })
+  it("extracts the scheme the way browsers do, ignoring case", () => {
+    expect(isSafeWebViewUrl("JavaScript:alert(1)")).toBe(false)
+    expect(isSafeWebViewUrl("JAVASCRIPT:alert(1)")).toBe(false)
+  })
+  it("ignores leading whitespace and control characters when reading the scheme", () => {
+    expect(isSafeWebViewUrl("   javascript:alert(1)")).toBe(false)
+    expect(isSafeWebViewUrl("\x01javascript:alert(1)")).toBe(false)
+    expect(isSafeWebViewUrl("\t javascript:alert(1)")).toBe(false)
+  })
+  it("strips embedded tab/newline/CR before reading the scheme", () => {
+    expect(isSafeWebViewUrl("java\tscript:alert(1)")).toBe(false)
+    expect(isSafeWebViewUrl("java\nscript:alert(1)")).toBe(false)
+    expect(isSafeWebViewUrl("java\rscript:alert(1)")).toBe(false)
+    expect(isSafeWebViewUrl("javascript\n:alert(1)")).toBe(false)
   })
 })

--- a/v3/src/components/web-view/web-view-utils.test.ts
+++ b/v3/src/components/web-view/web-view-utils.test.ts
@@ -257,7 +257,7 @@ describe("isSafeWebViewUrl (XSS guard)", () => {
     expect(isSafeWebViewUrl("blob:https://example.com/1234")).toBe(true)
     expect(isSafeWebViewUrl("about:blank")).toBe(true)
   })
-  it("treats empty and scheme-less (relative) URLs as safe", () => {
+  it("treats empty, relative, and scheme-relative URLs as safe", () => {
     expect(isSafeWebViewUrl("")).toBe(true)
     expect(isSafeWebViewUrl("../plugin/index.html")).toBe(true)
     expect(isSafeWebViewUrl("example.com/path")).toBe(true)

--- a/v3/src/components/web-view/web-view-utils.ts
+++ b/v3/src/components/web-view/web-view-utils.ts
@@ -138,19 +138,20 @@ export function appendLocaleParam(url: string, locale: string): string {
   return setUrlQueryParam(url, "locale", locale)
 }
 
-// URL schemes supported as a WebView <iframe> src. A URL that carries an explicit scheme is
-// loaded only if that scheme is in this allowlist; empty and scheme-less (relative) URLs are
-// treated as supported. http/https are the normal cases; data/blob support locally-generated
-// content; about covers about:blank.
+// URL schemes that are safe to load into the WebView <iframe> src. Anything with an explicit
+// scheme outside this allowlist is rejected — notably `javascript:` and `vbscript:`, which
+// execute in the parent document's origin and enable DOM-based XSS / page takeover.
+// `http`/`https` are the normal cases; `data`/`blob` support locally-generated content and load
+// in their creator's origin (not CODAP's, for typed or plugin-supplied URLs) so cannot reach the
+// parent DOM; `about` covers about:blank.
 const kSafeWebViewUrlSchemes = new Set(["http", "https", "data", "blob", "about"])
 
 /**
- * Returns true if the URL can be loaded as a WebView <iframe> src.
- * Empty and scheme-less (relative) URLs are allowed; a URL with an explicit scheme is allowed
- * only if that scheme is in the allowlist. The scheme is extracted the way browsers parse it:
- * tab/LF/CR are stripped from anywhere in the URL and leading C0 control characters and spaces
- * are ignored, so variants like " http:", "HTTP:", and "ht\ttp:" are normalized before the
- * scheme is read.
+ * Returns true if the URL is safe to assign to a WebView <iframe> src.
+ * Empty and scheme-less (relative) URLs are safe; a URL with an explicit scheme is safe only if
+ * that scheme is in the allowlist. The scheme is extracted the way browsers parse it: tab/LF/CR
+ * are stripped from anywhere in the URL and leading C0 control characters and spaces are ignored,
+ * so obfuscations like " javascript:", "JavaScript:", and "java\tscript:" are all detected.
  */
 export function isSafeWebViewUrl(url: string): boolean {
   if (!url) return true

--- a/v3/src/components/web-view/web-view-utils.ts
+++ b/v3/src/components/web-view/web-view-utils.ts
@@ -138,6 +138,31 @@ export function appendLocaleParam(url: string, locale: string): string {
   return setUrlQueryParam(url, "locale", locale)
 }
 
+// URL schemes supported as a WebView <iframe> src. A URL that carries an explicit scheme is
+// loaded only if that scheme is in this allowlist; empty and scheme-less (relative) URLs are
+// treated as supported. http/https are the normal cases; data/blob support locally-generated
+// content; about covers about:blank.
+const kSafeWebViewUrlSchemes = new Set(["http", "https", "data", "blob", "about"])
+
+/**
+ * Returns true if the URL can be loaded as a WebView <iframe> src.
+ * Empty and scheme-less (relative) URLs are allowed; a URL with an explicit scheme is allowed
+ * only if that scheme is in the allowlist. The scheme is extracted the way browsers parse it:
+ * tab/LF/CR are stripped from anywhere in the URL and leading C0 control characters and spaces
+ * are ignored, so variants like " http:", "HTTP:", and "ht\ttp:" are normalized before the
+ * scheme is read.
+ */
+export function isSafeWebViewUrl(url: string): boolean {
+  if (!url) return true
+  // Browsers remove all tab/LF/CR characters from anywhere in a URL and ignore leading C0
+  // control characters and spaces, so mirror that before extracting the scheme.
+  // eslint-disable-next-line no-control-regex
+  const sanitized = url.replace(/[\t\n\r]/g, "").replace(/^[\x00-\x20]+/, "")
+  const match = /^([a-z][a-z0-9+.-]*):/i.exec(sanitized)
+  if (!match) return true // no explicit scheme → relative URL, resolved against our own origin
+  return kSafeWebViewUrlSchemes.has(match[1].toLowerCase())
+}
+
 export function normalizeUrlScheme(url: string): string {
   url = url.trim()
   if (url.startsWith("//")) {

--- a/v3/src/components/web-view/web-view-utils.ts
+++ b/v3/src/components/web-view/web-view-utils.ts
@@ -141,9 +141,9 @@ export function appendLocaleParam(url: string, locale: string): string {
 // URL schemes that are safe to load into the WebView <iframe> src. Anything with an explicit
 // scheme outside this allowlist is rejected — notably `javascript:` and `vbscript:`, which
 // execute in the parent document's origin and enable DOM-based XSS / page takeover.
-// `http`/`https` are the normal cases; `data`/`blob` support locally-generated content and load
-// in their creator's origin (not CODAP's, for typed or plugin-supplied URLs) so cannot reach the
-// parent DOM; `about` covers about:blank.
+// `http`/`https` are the normal cases. `data:` loads in an opaque origin and `blob:` in the origin
+// of whatever created the blob — for user-typed or plugin-supplied URLs, neither is CODAP's origin,
+// so the iframe cannot reach the parent DOM. `about` covers about:blank.
 const kSafeWebViewUrlSchemes = new Set(["http", "https", "data", "blob", "about"])
 
 /**
@@ -160,7 +160,9 @@ export function isSafeWebViewUrl(url: string): boolean {
   // eslint-disable-next-line no-control-regex
   const sanitized = url.replace(/[\t\n\r]/g, "").replace(/^[\x00-\x20]+/, "")
   const match = /^([a-z][a-z0-9+.-]*):/i.exec(sanitized)
-  if (!match) return true // no explicit scheme → relative URL, resolved against our own origin
+  // No explicit scheme (a relative or scheme-relative URL) → allowed: it loads as ordinary content,
+  // not as script in CODAP's origin.
+  if (!match) return true
   return kSafeWebViewUrlSchemes.has(match[1].toLowerCase())
 }
 

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -172,10 +172,12 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
     }
   }, [])
 
-  // Announce loading state when iframe src changes
+  // Announce loading state when iframe src changes. Key off iframeSrc (not webViewModel.url):
+  // when the security backstop blanks an unsafe URL, iframeSrc is "" and the iframe never loads,
+  // so clear the status instead of leaving screen readers stuck announcing "loading".
   useEffect(() => {
-    if (isWebViewModel(webViewModel) && !webViewModel.isImage && webViewModel.url) {
-      setLoadingStatus(t("V3.WebView.loading"))
+    if (isWebViewModel(webViewModel) && !webViewModel.isImage) {
+      setLoadingStatus(iframeSrc ? t("V3.WebView.loading") : "")
     }
   }, [iframeSrc, webViewModel])
 

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -10,7 +10,7 @@ import { useDataInteractiveController } from "./use-data-interactive-controller"
 import { kWebViewBodyClass } from "./web-view-defs"
 import { WebViewDropOverlay } from "./web-view-drop-overlay"
 import { isWebViewModel } from "./web-view-model"
-import { appendLangParam, appendLocaleParam } from "./web-view-utils"
+import { appendLangParam, appendLocaleParam, isSafeWebViewUrl } from "./web-view-utils"
 
 import "./web-view.scss"
 
@@ -157,9 +157,11 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
   // `lang` is the 2-letter base language to match V2 behavior; some plugins (e.g. Simmer)
   // crash if given a region-qualified locale they don't have strings for. Plugins that need
   // region or script information (e.g. zh-Hans vs zh-TW) can read `locale` instead.
-  const iframeSrc = isWebViewModel(webViewModel) && webViewModel.needsLocaleReload
+  const rawIframeSrc = isWebViewModel(webViewModel) && webViewModel.needsLocaleReload
     ? appendLocaleParam(appendLangParam(webViewModel.url, gLocale.currentBaseLanguage), gLocale.current)
     : isWebViewModel(webViewModel) ? webViewModel.url : ""
+  // Load the url only when its scheme is supported; otherwise fall back to an empty src.
+  const iframeSrc = isSafeWebViewUrl(rawIframeSrc) ? rawIframeSrc : ""
 
   useEffect(() => {
     return () => {

--- a/v3/src/components/web-view/web-view.tsx
+++ b/v3/src/components/web-view/web-view.tsx
@@ -160,7 +160,8 @@ export const WebViewComponent = observer(function WebViewComponent({ tile }: ITi
   const rawIframeSrc = isWebViewModel(webViewModel) && webViewModel.needsLocaleReload
     ? appendLocaleParam(appendLangParam(webViewModel.url, gLocale.currentBaseLanguage), gLocale.current)
     : isWebViewModel(webViewModel) ? webViewModel.url : ""
-  // Load the url only when its scheme is supported; otherwise fall back to an empty src.
+  // Security backstop: never load an unsafe-scheme URL (e.g. javascript:) into the iframe,
+  // regardless of how it was set (inspector input, plugin API, launch param, saved doc).
   const iframeSrc = isSafeWebViewUrl(rawIframeSrc) ? rawIframeSrc : ""
 
   useEffect(() => {

--- a/v3/src/hooks/use-import-helpers.test.ts
+++ b/v3/src/hooks/use-import-helpers.test.ts
@@ -1,4 +1,7 @@
-import { getDropPriority } from "./use-import-helpers"
+import { renderHook } from "@testing-library/react"
+import { kWebViewTileType } from "../components/web-view/web-view-defs"
+import { appState } from "../models/app-state"
+import { getDropPriority, useImportHelpers } from "./use-import-helpers"
 
 // Helper to create a mock DataTransferItemList from an array of {kind, type} objects
 function mockItems(items: Array<{ kind: string, type: string }>): DataTransferItemList {
@@ -75,5 +78,40 @@ describe("getDropPriority", () => {
   it("returns 'none' for an empty items list", () => {
     const items = mockItems([])
     expect(getDropPriority(items)).toBe("none")
+  })
+})
+
+describe("useImportHelpers loadWebView URL scheme guard", () => {
+  const renderImportHelpers = () =>
+    renderHook(() => useImportHelpers({ cfmRef: { current: null }, onCloseUserEntry: () => undefined }))
+
+  it("alerts and does not create a web view for an unsafe-scheme dropped URL", () => {
+    const alertSpy = jest.spyOn(appState, "alert").mockImplementation(() => undefined)
+    const createSpy = jest.spyOn(appState.document.content!, "createOrShowTile")
+      .mockImplementation(() => undefined)
+    const { result } = renderImportHelpers()
+
+    result.current.handleUrlImported("javascript:alert(1)")
+
+    expect(alertSpy).toHaveBeenCalled()
+    expect(createSpy).not.toHaveBeenCalled()
+
+    createSpy.mockRestore()
+    alertSpy.mockRestore()
+  })
+
+  it("creates a web view for a supported-scheme dropped URL", () => {
+    const alertSpy = jest.spyOn(appState, "alert").mockImplementation(() => undefined)
+    const createSpy = jest.spyOn(appState.document.content!, "createOrShowTile")
+      .mockImplementation(() => undefined)
+    const { result } = renderImportHelpers()
+
+    result.current.handleUrlImported("https://example.com/plugin/index")
+
+    expect(createSpy).toHaveBeenCalledWith(kWebViewTileType, undefined)
+    expect(alertSpy).not.toHaveBeenCalled()
+
+    createSpy.mockRestore()
+    alertSpy.mockRestore()
   })
 })

--- a/v3/src/hooks/use-import-helpers.ts
+++ b/v3/src/hooks/use-import-helpers.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react"
 import { kTitleBarHeight } from "../components/constants"
 import { kWebViewTileType, WebViewSubType } from "../components/web-view/web-view-defs"
 import { isWebViewModel } from "../components/web-view/web-view-model"
+import { isSafeWebViewUrl } from "../components/web-view/web-view-utils"
 import { IImportedFile } from "../lib/cfm/use-cloud-file-manager"
 import { logStringifiedObjectMessage } from "../lib/log-message"
 import { appState } from "../models/app-state"
@@ -21,6 +22,7 @@ import {
   getImportableFileTypeFromDataTransferFile, getImportableFileTypeFromFile, getImportableFileTypeFromUrl,
   ImportableFileType, stripExtensionFromFilename
 } from "../utilities/importable-files"
+import { t } from "../utilities/translation/translate"
 
 const USE_IMPORTER_PLUGIN_FOR_CSV_FILE = true
 
@@ -50,6 +52,12 @@ interface IProps {
 
 export function useImportHelpers({ cfmRef, onCloseUserEntry }: IProps) {
   const loadWebView = useCallback((url: string, subType?: WebViewSubType, tileOptions?: INewTileOptions) => {
+    // Don't create a web view for a URL whose scheme isn't supported (e.g. javascript:); tell the
+    // user instead of silently producing a blank tile. (The iframe src is also guarded at render time.)
+    if (!isSafeWebViewUrl(url)) {
+      appState.alert(t("V3.WebView.Modal.invalidUrl"), t("V3.WebView.iframeTitle.webPage"))
+      return
+    }
     const tile = appState.document.content?.createOrShowTile(kWebViewTileType, tileOptions)
     if (isWebViewModel(tile?.content)) {
       subType && tile.content.setSubType(subType)

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -1534,6 +1534,7 @@
     "V3.WebView.Inspector.URL": "URL",
     "V3.WebView.Modal.PlaceholderText": "URL",
     "V3.WebView.Modal.okBtnTitle": "OK",
+    "V3.WebView.Modal.invalidUrl": "That web address can’t be loaded. Try an address like https://codap.concord.org.",
     "V3.Undo.webView.show": "Undo adding web page component",
     "V3.Redo.webView.show": "Redo adding web page component",
     "V3.Undo.webView.changeUrl": "Undo changing web page url",


### PR DESCRIPTION
Brings the CODAP-1438 WebView URL-scheme fix to `main`, plus the user-facing
follow-up deferred from the 3.0.4 security hot-fix.

## Context
The core fix (allowlist scheme validation on the iframe `src`) shipped in **3.0.4**
as a security hot-fix off the 3.0.3 tag (advisory GHSA-pgwc-mw3r-6vpc). `main` did
not receive it and the user-facing pieces were intentionally deferred; this PR lands
both on `main`.

## Changes
- **Fix (already in 3.0.4):** `isSafeWebViewUrl()` allowlist (`http`/`https`/`data`/
  `blob`/`about`; empty + relative allowed) applied at the iframe `src` sink —
  covers inspector input, plugin API, launch params, and saved documents.
  Browser-accurate scheme parsing catches case/whitespace/tab/newline obfuscation.
- **New (for 3.0.5):** URL edit modal shows an inline error and disables OK for
  unsafe-scheme input; drag/drop (`loadWebView`) alerts instead of silently creating
  a blank tile; new `V3.WebView.Modal.invalidUrl` string; expanded tests and
  documented code comments.

## Notes
- Advisory: GHSA-pgwc-mw3r-6vpc
- Security *logic* is byte-identical to 3.0.4 (verified); this PR adds only
  comments/framing plus the user-facing modal/drop pieces.
- Fix Version: 3.0.4 (quiet fix) + 3.0.5 (user-facing parts).
- The new `invalidUrl` string syncs to POEditor as part of the 3.0.5 release.
