### PR TITLE
codap-v3-build: fix tag race, split versioning by release phase

### DIFF
--- a/.claude/skills/codap-v3-build/SKILL.md
+++ b/.claude/skills/codap-v3-build/SKILL.md
@@ -99,6 +99,15 @@ Wait for user confirmation before starting Phase 1.
    is retained because the project may re-enter a pre-release phase for a future major
    version (e.g. a `4.0.0-beta.N` series), at which point it applies again.
 
+   > **Exception — starting a new prerelease series.** Inferring the phase from the newest
+   > tag is reliable *within* a phase but blind to the moment you deliberately switch. When
+   > the next major begins its prerelease series, the newest tag is still production semver
+   > (e.g. `3.1.4`), so the rule above would wrongly say "production, bump the patch"
+   > instead of `4.0.0-beta.N`. A tag can't signal an intent to change phase. So before
+   > applying the rule, **ask the user whether this release starts a new prerelease series
+   > for a new major version.** If yes, switch to the pre-release convention and confirm
+   > the intended prefix (`4.0.0`) and suffix (`-beta`) with them rather than inferring.
+
    **Which component to bump** is a judgment call about the release's contents, not a
    mechanical rule — propose one and confirm it with the user along with the rest of the
    Jira release details (step 8).
@@ -748,10 +757,16 @@ When invoked, introduce the situation:
    >
    > **The steps below are written in `{old-version}` → `{new-version}` terms, which
    > collapses in the production phase** — the two are the same string. Read every
-   > `{new-version}` as `{version}`. One concrete consequence: `release-{version}` is the
-   > branch name the original release already used, so it will still exist locally and on
-   > the remote. Pick a distinct branch name for the respin (e.g. `release-{version}-fix`)
-   > rather than trying to reuse or force-push the original.
+   > `{new-version}` as `{version}`.
+   >
+   > **This creates a branch-name collision in the commands below.** They create and push
+   > `release-{new-version}`, which in the production phase is `release-{version}` — the
+   > branch the original release already used, still present locally and on the remote.
+   > **Choose a distinct respin branch name (e.g. `release-{version}-fix`) and substitute
+   > it for `release-{new-version}` everywhere it appears below.** This note calls that name
+   > `{respin-branch}`; in the pre-release phase `{respin-branch}` is just
+   > `release-{new-version}` (no collision, since the version is new). Do not reuse or
+   > force-push the original release branch.
    >
    > This production-phase path has **not yet been exercised** as of 3.0.5. Confirm the
    > approach with the user before running it rather than assuming these notes are
@@ -804,9 +819,10 @@ Ask the user:
 
 Follow the same working directory rules as Phase 3.
 
-1. **Create release branch:**
+1. **Create release branch** (`{respin-branch}` — see the collision note in Step 1.3; in
+   the pre-release phase this is `release-{new-version}`):
    ```bash
-   git checkout -b release-{new-version}
+   git checkout -b {respin-branch}
    ```
 
 2. **Sync translations:**
@@ -856,13 +872,17 @@ Follow the same process as Phase 4:
    cd /path/to/codap
    git add v3/CHANGELOG.md
    git commit --amend --no-edit
-   git push -u origin release-{new-version}
+   git push -u origin {respin-branch}
    gh pr create \
      --title "Release {new-version}" \
      --body "{release_notes}" \
      --label "v3" \
      --label "run regression"
    ```
+
+   (`{respin-branch}` is the distinct respin branch from Step 1.3; in the pre-release
+   phase it is `release-{new-version}`. The PR **title** still uses `{new-version}`, which
+   equals `{version}` in the production phase.)
 
 4. **Inform user:**
    > **PR created:** {url}
@@ -912,10 +932,22 @@ build number" commit that follows the merge must have landed on `main`.
    the S3 build; the GitHub release for `{new-version}` is published only after the
    revised build reaches production (Step 6 / the deploy phase).
 
-4. **Delete old release branch** (optional cleanup):
+4. **Delete the merged release branch(es)** (optional cleanup):
+
+   **Pre-release phase** — the buggy release's branch:
    ```bash
    git push origin --delete release-{old-version}
    git branch -d release-{old-version}
+   ```
+
+   **Production phase** — `release-{old-version}` is `release-{version}`, the *original*
+   release's branch (already merged for the first attempt), and `{respin-branch}` is the
+   branch this workflow just merged. Both are now merged and can be removed; the respin
+   branch is the one that would otherwise dangle:
+   ```bash
+   git push origin --delete {respin-branch} && git branch -d {respin-branch}
+   # optionally also remove the original release branch if it still exists:
+   git push origin --delete release-{version} 2>/dev/null; git branch -d release-{version} 2>/dev/null || true
    ```
 
 5. **Inform user and wait for S3 deploy:**

--- a/.claude/skills/codap-v3-build/SKILL.md
+++ b/.claude/skills/codap-v3-build/SKILL.md
@@ -127,8 +127,12 @@ Wait for user confirmation before starting Phase 1.
    MCP; it is only the version object itself that is out of reach.
 
    - **Check whether it already exists first** — Jira automation may have created the
-     version (and a `Release {version}` tracking issue) ahead of time. You can see
-     existing versions via the `fixVersions` field on issues (JQL).
+     version (and a `Release {version}` tracking issue) ahead of time. **Ask the user to
+     check Jira → CODAP → Releases**; that is the only reliable check. Querying the
+     `fixVersions` field via JQL is a weak fallback: it can only surface versions already
+     assigned to at least one issue, so a freshly created version with nothing assigned to
+     it — the very case this step is looking for — will not appear. Absence from JQL is
+     **not** evidence the version is missing.
    - If it exists, confirm its release date matches the date agreed in step 8; if it
      doesn't, ask the user to correct it.
    - If it doesn't exist, ask the user to create it with the agreed name, dates, and
@@ -698,7 +702,9 @@ To complete deployment in Claude Code after QA:
 When invoked, introduce the situation:
 
 > A bug was found during staging QA for **{old-version}** and a fix has been merged.
-> This workflow will create a revised release with an updated version number.
+> This workflow will create a revised release. In the pre-release phase that means a new
+> version number; in the production phase the version stays the same and only the build
+> number and tag move (see Step 1.3).
 >
 > I'll walk you through:
 > 1. Determine the new version number and release date
@@ -740,6 +746,13 @@ When invoked, introduce the situation:
    > deploy. Read the steps below with that in mind and skip the version-migration
    > parts; they apply only in the pre-release phase.
    >
+   > **The steps below are written in `{old-version}` → `{new-version}` terms, which
+   > collapses in the production phase** — the two are the same string. Read every
+   > `{new-version}` as `{version}`. One concrete consequence: `release-{version}` is the
+   > branch name the original release already used, so it will still exist locally and on
+   > the remote. Pick a distinct branch name for the respin (e.g. `release-{version}-fix`)
+   > rather than trying to reuse or force-push the original.
+   >
    > This production-phase path has **not yet been exercised** as of 3.0.5. Confirm the
    > approach with the user before running it rather than assuming these notes are
    > complete.
@@ -748,9 +761,22 @@ When invoked, introduce the situation:
    - The original release date (from Phase 1) may no longer be appropriate if QA and the fix took multiple days.
    - Show the original release date and today's date.
    - Ask the user to confirm or update the release date.
-   - This date will be used in CHANGELOG.md, versions.md, and the Jira release.
+   - This date is used in CHANGELOG.md and the Jira release — plus `versions.md` in the
+     pre-release phase, where the row's version string changes. In the production phase
+     the `versions.md` row already carries the right version, so it needs an edit only if
+     the date itself changed.
 
-5. **Confirm with user:**
+5. **Confirm with user** — use the wording for the current phase:
+
+   **Production phase** (version unchanged — do not present this as a version change):
+   > The fix is on main. The version stays **{version}**; the respin changes only the
+   > build number ({old-build} → {new-build}) and moves the `{version}` tag to the new
+   > increment commit.
+   > Release date: **{release-date}**
+   >
+   > Does this look correct?
+
+   **Pre-release phase** (version changes):
    > The fix is on main. New version will be **{new-version}** (old was {old-version}).
    > Release date: **{release-date}**
    >

--- a/.claude/skills/codap-v3-build/SKILL.md
+++ b/.claude/skills/codap-v3-build/SKILL.md
@@ -63,6 +63,9 @@ Wait for user confirmation before starting Phase 1.
    cat v3/build_number.json
    ```
 
+   Needed for the version string only in the pre-release phase (see step 6), but always
+   worth showing as context.
+
 4. **Get previous release tag:**
    ```bash
    git tag --sort=-creatordate | head -5
@@ -73,9 +76,32 @@ Wait for user confirmation before starting Phase 1.
    - Show current build number from `build_number.json`
 
 6. **Determine recommended version string:**
-   - Use build number **+ 1** (build number auto-increments when release PR merges)
-   - Match previous release pattern (e.g., `-beta`, `-pre`)
-   - Example: If build number is `2662`, recommend `3.0.0-beta.2663`
+
+   CODAP v3 has **two versioning conventions**, one per development phase. Identify the
+   current phase from the newest release tag, then apply that phase's rule.
+
+   ```bash
+   git tag --sort=-creatordate | head -3
+   ```
+
+   | Phase | You are here when… | Version format | Rule |
+   |-------|--------------------|----------------|------|
+   | **Production release** | The newest release tag is plain semver with **no** prerelease suffix (`3.0.4`, `3.1.2`) | `MAJOR.MINOR.PATCH` | Increment from the last released version: **patch** for bug fixes, **minor** for new features, **major** for breaking changes. Example: after `3.0.4` → `3.0.5`. |
+   | **Pre-release development** | The newest release tag carries a prerelease suffix (`-beta`, `-rc`, `-pre`) | `{major}.{minor}.{patch}-{suffix}.{buildNumber}` | Use build number **+ 1** (it auto-increments when the release PR merges), carrying over the previous tag's version prefix and suffix. Example: newest tag `3.0.0-beta.2662` with build `2662` → `3.0.0-beta.2663`. |
+
+   **The build number is part of the version string ONLY in the pre-release phase.**
+   In the production phase the build number still exists and still increments, but it is
+   independent of the version — do **not** derive the version from `build_number.json`.
+   (At the 3.0.5 release the build number was 2956, heading to 2957 on merge, while the
+   version was `3.0.5`. The two are unrelated and will never match again.)
+
+   CODAP v3 entered the production phase at `3.0.0` on 2026-06-04. The pre-release rule
+   is retained because the project may re-enter a pre-release phase for a future major
+   version (e.g. a `4.0.0-beta.N` series), at which point it applies again.
+
+   **Which component to bump** is a judgment call about the release's contents, not a
+   mechanical rule — propose one and confirm it with the user along with the rest of the
+   Jira release details (step 8).
 
 7. **Get previous release date from Jira** (for start date default)
 
@@ -83,7 +109,7 @@ Wait for user confirmation before starting Phase 1.
 
    | Field | Default | Options |
    |-------|---------|---------|
-   | Version name | Based on previous release pattern + new build number | Match previous pattern (e.g., `-beta`, `-rc`, or release) |
+   | Version name | The phase-appropriate next version from step 6 | Production phase: patch / minor / major bump. Pre-release phase: previous suffix + new build number |
    | Start date | Previous release date | User can modify |
    | Release date | Today's date | Today / Tomorrow / Custom future date |
    | Description | `Version {version}` | User can modify |
@@ -93,7 +119,23 @@ Wait for user confirmation before starting Phase 1.
    - versions.md entry date
    - Jira release date
 
-9. **Create Jira release version** using Atlassian MCP tools (status: `Unreleased`)
+9. **Ensure the Jira release version exists** (status: `Unreleased`).
+
+   **The Atlassian MCP tools cannot create a version or edit its release date** — they
+   expose no version-management tool. This step is the user's to perform, in the Jira UI
+   (CODAP → Releases). Setting issue Fix Versions (Phase 2, step 9) works fine through
+   MCP; it is only the version object itself that is out of reach.
+
+   - **Check whether it already exists first** — Jira automation may have created the
+     version (and a `Release {version}` tracking issue) ahead of time. You can see
+     existing versions via the `fixVersions` field on issues (JQL).
+   - If it exists, confirm its release date matches the date agreed in step 8; if it
+     doesn't, ask the user to correct it.
+   - If it doesn't exist, ask the user to create it with the agreed name, dates, and
+     description, and to confirm once done.
+
+   The date only has to be correct before the release is marked `Released` in Phase 6, so
+   this need not block the rest of the workflow.
 
 ## Phase 2: Prepare Release Notes
 
@@ -224,7 +266,7 @@ Wait for user confirmation before starting Phase 1.
 
     > Use the Task tool to update Fix Versions for all approved stories. Provide the subagent with:
     > - The list of CODAP-XXX story IDs to update
-    > - The version string to set (e.g., `3.0.0-beta.2664`)
+    > - The version string to set (e.g., `3.0.5`)
     >
     > The subagent should report back ONLY:
     > - Success/failure count (e.g., "Updated 8/10 stories successfully")
@@ -251,7 +293,7 @@ branch must be created before any commits (translations, version files, etc.).
    ```
 
    **Branch naming rules:**
-   - Pattern: `release-{version}` where `{version}` is from Phase 1 (e.g., `release-3.0.0-beta.2664`)
+   - Pattern: `release-{version}` where `{version}` is from Phase 1 (e.g., `release-3.0.5`)
    - Do NOT use `/` in branch names
    - Do NOT invent your own pattern
 
@@ -462,7 +504,8 @@ branch must be created before any commits (translations, version files, etc.).
 > production. The tag still must be pushed now, because the tag push is what
 > triggers the CI build that deploys to S3 (needed for staging).
 
-**Prerequisite:** Release PR must be merged.
+**Prerequisite:** Release PR must be merged, **and** the automatic "Increment the
+build number" commit that follows the merge must have landed on `main` (see step 2).
 
 ### Steps
 
@@ -472,16 +515,48 @@ branch must be created before any commits (translations, version files, etc.).
    git pull
    ```
 
-2. **Create and push annotated tag:**
+2. **Verify the build-number increment commit has landed — do NOT skip this:**
+
+   Merging the release PR triggers an automation that pushes an
+   "Increment the build number" commit to `main`. **That increment commit is the one
+   to tag** — not the `Release {version}` merge commit.
+
+   ```bash
+   git log --oneline -2
+   ```
+
+   The output must show the increment commit sitting on top of the release merge:
+   ```
+   f999f1445 Increment the build number     <- tag THIS one (HEAD)
+   936451ef5 Release {version} (#NNNN)
+   ```
+
+   If `HEAD` is still the `Release {version}` merge commit, the automation has not
+   pushed yet. **Wait, re-run `git pull`, and check again** until the increment
+   commit appears.
+
+   > **Why this matters:** tagging immediately after the merge, before the increment
+   > lands, points the tag at the release merge commit instead. This has happened
+   > before. The resulting build carries the wrong build number, and undoing it means
+   > deleting the tag and its S3 deploy. Every correct release tag (3.0.0 through
+   > 3.0.3) points at an "Increment the build number" commit — use that as your check.
+
+3. **Create and push annotated tag:**
    ```bash
    git tag -a {version} -m "Version {version}"
    git push origin {version}
    ```
 
+   Confirm the tag landed on the increment commit before moving on:
+   ```bash
+   git log -1 --format='%h %s' {version}
+   # expected: <sha> Increment the build number
+   ```
+
    The tag push triggers a CI build that deploys to S3. The GitHub release is
    **not** created until after the production deploy (Phase 6).
 
-3. **Inform user and wait for S3 deploy:**
+4. **Inform user and wait for S3 deploy:**
    > **Tag pushed.** (The GitHub release will be created later, after the production deploy, so external users don't see a release for a version that isn't live yet.)
    >
    > Watch GitHub Actions: https://github.com/concord-consortium/codap/actions
@@ -551,7 +626,7 @@ branch must be created before any commits (translations, version files, etc.).
    ```
 
    **Rules:**
-   - Use the version number from this release (e.g., `3.0.0-beta.2664`)
+   - Use the version number from this release (e.g., `3.0.5`)
    - Include only the sections that have items (Features, Bug Fixes, Under the Hood)
    - Use the same titles and order as in CHANGELOG.md (including emoji prefixes in section headers)
    - Each item on its own line, prefixed with `- **CODAP-XXX:**` — every section, every item, no exceptions
@@ -618,7 +693,7 @@ To complete deployment in Claude Code after QA:
 
 **Trigger:** A show-stopper bug is found during Phase 6 staging QA, and a fix has been merged to `main`.
 
-**Invocation:** `/codap-v3-build fix {old-version}` (e.g., `/codap-v3-build fix 3.0.0-beta.2803`)
+**Invocation:** `/codap-v3-build fix {old-version}` (e.g., `/codap-v3-build fix 3.0.5`)
 
 When invoked, introduce the situation:
 
@@ -649,11 +724,25 @@ When invoked, introduce the situation:
 
    Confirm with the user that the expected fix commit(s) appear in the log.
 
-3. **Determine new version number:**
-   - Current build number is N (from `build_number.json`)
-   - The release PR will increment it once more when merged → version is **N + 1**
-   - Example: If build number is `2804`, new version is `3.0.0-beta.2805`
-   - Match the version pattern of `{old-version}` (same prefix, new build number)
+3. **Determine the new version number — this is phase-dependent** (see Phase 1, step 6,
+   for how to identify the phase):
+
+   | Phase | Revised release version |
+   |-------|-------------------------|
+   | **Production release** | **The version does not change.** `{old-version}` is reused as-is. Only the build number changes (it increments when the revised release PR merges), and the build number is not part of the version. The respin is reflected in the CHANGELOG, not the version string. |
+   | **Pre-release development** | The version **does** change, because the build number is part of it. Current build number is N; the release PR increments it once more on merge → new version is **N + 1**, matching `{old-version}`'s prefix. Example: build `2804` → `3.0.0-beta.2805`. |
+
+   > **The production-phase rule reshapes this whole workflow.** With the version
+   > unchanged there is no "old vs new version" to reconcile: `versions.md` needs no
+   > edit, the Jira release needs no rename, and `npm version` is a no-op. What still
+   > must happen is re-tagging — delete the `{version}` tag and recreate it on the new
+   > increment commit (Step 5) — plus any CHANGELOG corrections and a fresh staging
+   > deploy. Read the steps below with that in mind and skip the version-migration
+   > parts; they apply only in the pre-release phase.
+   >
+   > This production-phase path has **not yet been exercised** as of 3.0.5. Confirm the
+   > approach with the user before running it rather than assuming these notes are
+   > complete.
 
 4. **Confirm release date:**
    - The original release date (from Phase 1) may no longer be appropriate if QA and the fix took multiple days.
@@ -756,13 +845,20 @@ Follow the same process as Phase 4:
 
 ### Step 5: After PR Merge — Clean Up and Re-tag
 
-**Prerequisite:** Release PR must be merged.
+**Prerequisite:** Release PR must be merged, **and** the automatic "Increment the
+build number" commit that follows the merge must have landed on `main`.
 
-1. **Checkout main and pull:**
+1. **Checkout main, pull, and wait for the increment commit:**
    ```bash
    git checkout main
    git pull
+   git log --oneline -2
    ```
+
+   As in Phase 5, the new tag must point at the **"Increment the build number"**
+   commit that the merge automation pushes after the release merge — not at the
+   `Release {new-version}` merge commit itself. If `HEAD` is still the release merge,
+   wait, `git pull` again, and re-check until the increment commit appears.
 
 2. **Delete the old tag:**
    ```bash
@@ -782,6 +878,8 @@ Follow the same process as Phase 4:
    ```bash
    git tag -a {new-version} -m "Version {new-version}"
    git push origin {new-version}
+   git log -1 --format='%h %s' {new-version}
+   # expected: <sha> Increment the build number
    ```
 
    As in Phase 5, do **not** create the GitHub release here. The tag push triggers
@@ -850,7 +948,7 @@ Follow the same process as Phase 4:
 
 | File | Purpose |
 |------|---------|
-| `v3/build_number.json` | Current build number |
+| `v3/build_number.json` | Current build number. Part of the version string **only** in the pre-release phase (Phase 1, step 6). In the production phase it is independent of the version, but its auto-increment commit is always the tag target (Phase 5). |
 | `v3/package.json` | Version field |
 | `v3/versions.md` | Version history table |
 | `v3/CHANGELOG.md` | Release notes |


### PR DESCRIPTION
## Summary

Two fixes to the `codap-v3-build` skill, both found while running the 3.0.5
release, plus a correction to a Jira step that couldn't work as written.

### 1. Phase 5 tagged the wrong commit (race condition)

Phase 5 said `git checkout main && git pull`, then tag. Merging a release PR
triggers automation that pushes an "Increment the build number" commit, and
**that** commit is the tag target. Tagging before it lands points the tag at the
release merge instead, producing a build whose number doesn't match the release.

This actually happened during 3.0.0-beta.2885, when the tag had to be deleted and
recreated. It doesn't fire when a human merges manually, because the increment
lands long before anyone says "PR is merged" — which is why it survived this long.

Phase 5 and the `fix` workflow's re-tag step now wait for the increment commit and
verify the tag landed on it. Verified against history: 3.0.0–3.0.3 all tag an
"Increment the build number" commit. 3.0.5 was tagged with the new procedure and
landed correctly on `b15481e4f` (build 2957).

### 2. Versioning rules assumed the pre-release phase

The rules were written when versions embedded the build number
(`3.0.0-beta.2663`). Since 3.0.0 shipped on 2026-06-04, releases are plain semver
and the build number is independent — at 3.0.5 the build number was 2957. Phase 1
step 6 literally instructed "use build number + 1", which for this release would
have recommended `3.0.0-beta.2957`.

Step 6 now selects a convention based on the newest release tag. The pre-release
rule is retained rather than deleted, since the project may re-enter a pre-release
phase for a future major version (e.g. `4.0.0-beta.N`).

The `fix` workflow's revised-release rule is phase-dependent too: in the
production phase the version does **not** change — only the build number does, and
it isn't part of the version. That path is marked as not yet exercised.

### 3. Update Jira release version instructions

It said to create the Jira release version "using Atlassian MCP tools", but those
tools expose no version-management tool — they can neither create a version nor
set its release date. Both are now the user's to perform in the Jira UI. (Setting
issue Fix Versions via MCP works fine; only the version object is out of reach.)

## Verification

The versioning change was tested with fresh subagents against the real repo,
before and after:

| | Before | After |
|---|---|---|
| Recommended version | 3.0.5, 3.0.5, **3.0.6** | 3.0.5, 3.0.5, 3.0.5 |
| Confidence | medium, medium, medium | **high, high, high** |
| Reported the skill contradicting the repo | **3 of 3** | **0 of 3** |

Baseline agents all reached the right answer *despite* the skill, flagging the
build-number rule as stale and reconstructing the convention from git history. A
pre-release scenario (hypothetical `4.0.0-beta.3210` tag) correctly yields
`4.0.0-beta.3211`, confirming that branch still works.
