### PR TITLE
CODAP-1464: fix percentile() cross-group cache collision

### DIFF
--- a/v3/src/models/formula/functions/percentile-hierarchical-cache.test.ts
+++ b/v3/src/models/formula/functions/percentile-hierarchical-cache.test.ts
@@ -8,11 +8,11 @@ import { FormulaManager } from "../formula-manager"
 // so the first group's sorted values leaked into the others and every group reported the first group's percentile.
 
 // Builds a two-level hierarchy: a parent "group" collection over a child collection holding `value`. Each entry in
-// `groups` becomes one parent case whose children all share that group's value. The parent-level formula attributes
+// `groups` becomes one parent case whose children hold that group's `values`. The parent-level formula attributes
 // reference the child `value` attribute, so they are evaluated once per parent group.
 const buildHierarchy = (
   formulaAttrs: Array<{ name: string, display: string }>,
-  groups: Array<{ name: string, value: number, count: number }>
+  groups: Array<{ name: string, values: number[] }>
 ) => {
   const formulaManager = new FormulaManager()
   const dataSet = createDataSet({
@@ -24,8 +24,8 @@ const buildHierarchy = (
   }, { formulaManager })
 
   // Cases must use canonical (attribute-ID-keyed) format; here the ids match the attribute names.
-  const cases = groups.flatMap(({ name, value, count }) =>
-    Array.from({ length: count }, (_, i) => ({ __id__: `${name}${i}`, group: name, value }))
+  const cases = groups.flatMap(({ name, values }) =>
+    values.map((value, i) => ({ __id__: `${name}${i}`, group: name, value }))
   )
   dataSet.addCases(cases)
 
@@ -54,8 +54,8 @@ describe("percentile() in a hierarchical (parent-child) context", () => {
         { name: "ptileV", display: "percentile(value, 0.5)" }
       ],
       [
-        { name: "A", value: 10, count: 16 },
-        { name: "B", value: -10, count: 24 }
+        { name: "A", values: Array(16).fill(10) },
+        { name: "B", values: Array(24).fill(-10) }
       ]
     )
     const medV = dataSet.attrIDFromName("medV")!
@@ -71,20 +71,22 @@ describe("percentile() in a hierarchical (parent-child) context", () => {
   })
 
   it("computes distinct percentiles across three groups with differing spreads", () => {
-    // Three groups with distinct value ranges confirm each group caches its own sorted values, independent of
-    // evaluation order. Each group's 25th percentile falls a quarter of the way through its own sorted values.
+    // Each group holds a different spread of values, so its 25th percentile is a genuine position within its own
+    // sorted distribution (interpolated when the index falls between two values). Distinct per-group results confirm
+    // each group caches its own sorted values, independent of evaluation order.
     const dataSet = buildHierarchy(
       [{ name: "q1", display: "percentile(value, 0.25)" }],
       [
-        { name: "A", value: 100, count: 5 },  // all 100 -> q1 = 100
-        { name: "B", value: 200, count: 5 },  // all 200 -> q1 = 200
-        { name: "C", value: 300, count: 5 }   // all 300 -> q1 = 300
+        // q1 index = (n - 1) * 0.25
+        { name: "A", values: [0, 4, 8, 12] },            // index 0.75 -> 0.75*4 + 0.25*0 = 3
+        { name: "B", values: [100, 200, 300, 400, 500] }, // index 1.0  -> exactly 200
+        { name: "C", values: [20, 40, 60] }              // index 0.5  -> 0.5*40 + 0.5*20 = 30
       ]
     )
     const q1 = dataSet.attrIDFromName("q1")!
 
-    expect(dataSet.getValueAtItemIndex(0, q1)).toEqual(100)   // group A
-    expect(dataSet.getValueAtItemIndex(5, q1)).toEqual(200)   // group B
-    expect(dataSet.getValueAtItemIndex(10, q1)).toEqual(300)  // group C
+    expect(dataSet.getValueAtItemIndex(0, q1)).toEqual(3)    // group A (items 0-3)
+    expect(dataSet.getValueAtItemIndex(4, q1)).toEqual(200)  // group B (items 4-8)
+    expect(dataSet.getValueAtItemIndex(9, q1)).toEqual(30)   // group C (items 9-11)
   })
 })

--- a/v3/src/models/formula/functions/percentile-hierarchical-cache.test.ts
+++ b/v3/src/models/formula/functions/percentile-hierarchical-cache.test.ts
@@ -1,0 +1,90 @@
+import { createDataSet } from "../../data/data-set-conversion"
+import { AttributeFormulaAdapter } from "../attribute-formula-adapter"
+import { FormulaManager } from "../formula-manager"
+
+// Regression test for percentile() evaluated in a parent collection while referencing a child-collection attribute.
+// percentile() caches its sorted per-group values; the cache key must distinguish parent case groups. Keying on the
+// same-level group id (rather than the aggregate group id) collapsed every top-level parent group to a single key,
+// so the first group's sorted values leaked into the others and every group reported the first group's percentile.
+
+// Builds a two-level hierarchy: a parent "group" collection over a child collection holding `value`. Each entry in
+// `groups` becomes one parent case whose children all share that group's value. The parent-level formula attributes
+// reference the child `value` attribute, so they are evaluated once per parent group.
+const buildHierarchy = (
+  formulaAttrs: Array<{ name: string, display: string }>,
+  groups: Array<{ name: string, value: number, count: number }>
+) => {
+  const formulaManager = new FormulaManager()
+  const dataSet = createDataSet({
+    attributes: [
+      { id: "group", name: "group" },
+      { id: "value", name: "value" },
+      ...formulaAttrs.map(({ name, display }) => ({ id: name, name, formula: { display } }))
+    ]
+  }, { formulaManager })
+
+  // Cases must use canonical (attribute-ID-keyed) format; here the ids match the attribute names.
+  const cases = groups.flatMap(({ name, value, count }) =>
+    Array.from({ length: count }, (_, i) => ({ __id__: `${name}${i}`, group: name, value }))
+  )
+  dataSet.addCases(cases)
+
+  const adapter = new AttributeFormulaAdapter(formulaManager.getAdapterApi())
+  formulaManager.addDataSet(dataSet)
+  formulaManager.addAdapters([adapter])
+
+  // Move `group` and the formula attributes into a parent collection, leaving `value` in the child collection.
+  const parentCollection = dataSet.moveAttributeToNewCollection(dataSet.attrIDFromName("group")!)!
+  formulaAttrs.forEach(({ name }) => {
+    dataSet.moveAttribute(dataSet.attrIDFromName(name)!, { collection: parentCollection.id })
+  })
+
+  // Recalculate now that the hierarchy is in place, so each parent group evaluates its own child cases.
+  formulaManager.recalculateActiveFormulas()
+
+  return dataSet
+}
+
+describe("percentile() in a hierarchical (parent-child) context", () => {
+  it("computes per-group results without cache collisions (CODAP-1464)", () => {
+    // Group A: 16 cases of value 10; group B: 24 cases of value -10. Item 0 is in group A, item 16 in group B.
+    const dataSet = buildHierarchy(
+      [
+        { name: "medV", display: "median(value)" },
+        { name: "ptileV", display: "percentile(value, 0.5)" }
+      ],
+      [
+        { name: "A", value: 10, count: 16 },
+        { name: "B", value: -10, count: 24 }
+      ]
+    )
+    const medV = dataSet.attrIDFromName("medV")!
+    const ptileV = dataSet.attrIDFromName("ptileV")!
+
+    // median (unaffected by the bug) establishes the expected per-group values.
+    expect(dataSet.getValueAtItemIndex(0, medV)).toEqual(10)
+    expect(dataSet.getValueAtItemIndex(16, medV)).toEqual(-10)
+
+    // percentile must match median for p = 0.5; group B previously leaked group A's cached value (10).
+    expect(dataSet.getValueAtItemIndex(0, ptileV)).toEqual(10)
+    expect(dataSet.getValueAtItemIndex(16, ptileV)).toEqual(-10)
+  })
+
+  it("computes distinct percentiles across three groups with differing spreads", () => {
+    // Three groups with distinct value ranges confirm each group caches its own sorted values, independent of
+    // evaluation order. Each group's 25th percentile falls a quarter of the way through its own sorted values.
+    const dataSet = buildHierarchy(
+      [{ name: "q1", display: "percentile(value, 0.25)" }],
+      [
+        { name: "A", value: 100, count: 5 },  // all 100 -> q1 = 100
+        { name: "B", value: 200, count: 5 },  // all 200 -> q1 = 200
+        { name: "C", value: 300, count: 5 }   // all 300 -> q1 = 300
+      ]
+    )
+    const q1 = dataSet.attrIDFromName("q1")!
+
+    expect(dataSet.getValueAtItemIndex(0, q1)).toEqual(100)   // group A
+    expect(dataSet.getValueAtItemIndex(5, q1)).toEqual(200)   // group B
+    expect(dataSet.getValueAtItemIndex(10, q1)).toEqual(300)  // group C
+  })
+})

--- a/v3/src/models/formula/functions/univariate-stats-functions.ts
+++ b/v3/src/models/formula/functions/univariate-stats-functions.ts
@@ -111,7 +111,10 @@ export const univariateStatsFunctions: Record<string, IFormulaMathjsFunction> = 
       const scope = getRootScope(currentScope)
       const [expressionArg, percentileArg, filterArg] = args
 
-      const caseGroupId = scope.getCaseGroupId()
+      // Use the aggregate group id so each parent case caches its own sorted values. When the formula lives in a
+      // parent collection and references a child attribute, the same-level group id collapses every top-level parent
+      // group to a single key, which would cause one group's values to be reused for the others.
+      const caseGroupId = scope.getCaseAggregateGroupId()
       const cacheKey = `percentile(${args.toString()})-${caseGroupId}`
       let cached = scope.getCached<IPercentileFunctionCache>(cacheKey)
 


### PR DESCRIPTION
## Summary

`percentile()` disagreed with `median()` for a parent collection that groups
child cases: for the reported document (16 cases of `value=10`, 24 cases of
`value=-10`), the −10 group reported `10` — the first group's value.

**Root cause:** `percentile()` cached its sorted per-group values under a key
built from `scope.getCaseGroupId()`, whereas every standard aggregate
(`median`, `mean`, …) uses `scope.getCaseAggregateGroupId()`. The two diverge
only when the formula lives in a **parent** collection and references a
**child** attribute: the same-level group id collapses every top-level parent
group to `NO_PARENT_KEY`, so the first group evaluated poisoned the shared
cache entry and the rest read back its value.

**Fix:** key the cache on `getCaseAggregateGroupId()`, matching the standard
aggregates, so each parent case caches its own values.

`rollingMean()` and the `linRegr*` bivariate functions share the same
`getCaseGroupId()` cache pattern, but the collision is unreachable for them:
as true per-case semi-aggregates they only produce values when the formula is
in the same collection as the referenced series, where the two group-id
functions already agree. They were left unchanged.

## Testing

- New `percentile-hierarchical-cache.test.ts` builds a two-level hierarchy and
  verifies per-group percentiles; confirmed failing before the fix and passing
  after.
- Full `src/models/formula` suite (474 tests) passes.

Fixes CODAP-1464
