### PR TITLE
CODAP-1454: derive swc target from tsconfig instead of defaulting to ES5

### DIFF
--- a/v3/webpack.config.js
+++ b/v3/webpack.config.js
@@ -8,6 +8,27 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const ESLintPlugin = require('eslint-webpack-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+const ts = require('typescript')
+
+// swc-loader doesn't read tsconfig.json, and defaults to ES5 if no target is specified. Our
+// support floor (Chrome 109, Safari/iOS 15.4) handles ES2020 syntax natively, so that default
+// is bloat downloaded by every user and benefiting none of them. Rather than hard-coding a
+// second target that can drift from tsconfig's, derive it from tsconfig.json.
+// `ts.readConfigFile()` is used instead of `require()` because tsconfig.json contains comments.
+function swcTargetFromTsConfig() {
+  const tsconfigPath = path.resolve(__dirname, 'tsconfig.json')
+  const { config, error } = ts.readConfigFile(tsconfigPath, ts.sys.readFile)
+  if (error) {
+    throw new Error(`Unable to read ${tsconfigPath}: ${ts.flattenDiagnosticMessageText(error.messageText, ' ')}`)
+  }
+  // tsconfig targets are case-insensitive; swc targets are lower case
+  const target = String(config?.compilerOptions?.target).toLowerCase()
+  // fail loudly rather than silently falling back to swc's ES5 default
+  if (!/^es(20\d\d|next)$/.test(target)) {
+    throw new Error(`Unsupported tsconfig.json compilerOptions.target for swc-loader: ${target}`)
+  }
+  return target
+}
 
 // DEPLOY_PATH is set by the s3-deploy-action its value will be:
 // `branch/[branch-name]/` or `version/[tag-name]/`
@@ -120,6 +141,7 @@ module.exports = (env, argv) => {
             loader: "swc-loader",
             options: {
               jsc: {
+                target: swcTargetFromTsConfig(),
                 parser: {
                   syntax: "typescript",
                   decorators: true,

--- a/v3/webpack.config.js
+++ b/v3/webpack.config.js
@@ -10,22 +10,29 @@ const ESLintPlugin = require('eslint-webpack-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 const ts = require('typescript')
 
+const TSCONFIG_PATH = path.resolve(__dirname, 'tsconfig.json')
+
 // swc-loader doesn't read tsconfig.json, and defaults to ES5 if no target is specified. Our
 // support floor (Chrome 109, Safari/iOS 15.4) handles ES2020 syntax natively, so that default
 // is bloat downloaded by every user and benefiting none of them. Rather than hard-coding a
-// second target that can drift from tsconfig's, derive it from tsconfig.json.
-// `ts.readConfigFile()` is used instead of `require()` because tsconfig.json contains comments.
+// second target that can drift from tsconfig's, derive it from tsconfig.json. Note that
+// TSCONFIG_PATH is also listed in `cache.buildDependencies` below, so that changing the target
+// invalidates the persistent cache. `ts.readConfigFile()` is used instead of `require()`
+// because tsconfig.json contains comments.
 function swcTargetFromTsConfig() {
-  const tsconfigPath = path.resolve(__dirname, 'tsconfig.json')
-  const { config, error } = ts.readConfigFile(tsconfigPath, ts.sys.readFile)
+  const { config, error } = ts.readConfigFile(TSCONFIG_PATH, ts.sys.readFile)
   if (error) {
-    throw new Error(`Unable to read ${tsconfigPath}: ${ts.flattenDiagnosticMessageText(error.messageText, ' ')}`)
+    throw new Error(`Unable to read ${TSCONFIG_PATH}: ${ts.flattenDiagnosticMessageText(error.messageText, ' ')}`)
+  }
+  // fail loudly rather than silently falling back to swc's ES5 default
+  const tsTarget = config?.compilerOptions?.target
+  if (!tsTarget) {
+    throw new Error(`No compilerOptions.target in ${TSCONFIG_PATH}; swc-loader would fall back to ES5`)
   }
   // tsconfig targets are case-insensitive; swc targets are lower case
-  const target = String(config?.compilerOptions?.target).toLowerCase()
-  // fail loudly rather than silently falling back to swc's ES5 default
+  const target = String(tsTarget).toLowerCase()
   if (!/^es(20\d\d|next)$/.test(target)) {
-    throw new Error(`Unsupported tsconfig.json compilerOptions.target for swc-loader: ${target}`)
+    throw new Error(`Unsupported tsconfig.json compilerOptions.target for swc-loader: ${tsTarget}`)
   }
   return target
 }
@@ -121,7 +128,8 @@ module.exports = (env, argv) => {
     },
     cache: {
       buildDependencies: {
-        config: [__filename],
+        // tsconfig.json is a build dependency because swc-loader's target is derived from it
+        config: [__filename, TSCONFIG_PATH],
       },
       cacheDirectory: path.resolve(__dirname, `${CACHE_DIRECTORY}/webpack`),
       type: 'filesystem',


### PR DESCRIPTION
Fixes CODAP-1454

## Problem

`swc-loader` handles our JS/TS transpilation but — unlike `tsc` — does not read
`tsconfig.json`. With no `jsc.target` set, swc fell back to its ES5 default,
down-leveling `const`→`var`, expanding optional chaining and nullish coalescing,
and so on. Our support floor is Chrome 109 / Safari 15.4 (iOS 15.4), all of which
run ES2020 syntax natively, so this was transpiler bloat downloaded by 100% of
users and benefiting none of them.

## Change

Derive swc's target from `tsconfig.json` rather than hardcoding a second value.
Hardcoding `"es2020"` would fix today's bundle but leave the two targets free to
drift the next time `tsconfig.json` changes, so `webpack.config.js` now reads the
target through the TypeScript compiler API (`ts.readConfigFile`, which tolerates
the comments in that file — plain `require()` would throw).

An unrecognized target throws rather than falling back, because a silent fallback
lands right back on swc's ES5 default — the exact bug being fixed here, and one
that would be invisible in a diff.

This is syntax-only. It adds and removes no polyfills; runtime-API gaps are
tracked separately.

## Impact

Baseline vs. this branch, both `webpack --mode production`, measured locally:

| Metric | Baseline | This PR | Reduction |
|---|---|---|---|
| Total JS (raw) | 8,142,997 B | 7,468,741 B | **−674,256 B (−8.3%)** |
| Total JS (gzip) | 2,204,474 B | 2,106,093 B | **−98,381 B (−4.5%)** |

All savings are in the app chunk; vendor chunks are unaffected, since swc only
processes `src`. Build time is unchanged (36.0s → 37.5s).

## Testing

- Confirmed the resolved `jsc.target` is `es2020` and `eslint webpack.config.js` is clean.
- Confirmed the emitted app chunk retains `??`, `?.`, arrow functions, `class`, and
  `const` — i.e. it is no longer down-leveling.
- Smoke-tested the production build in Chromium: app boots, tool shelf renders, no
  syntax errors in the console. **Not** tested on an actual Chrome-109-class browser.
- Jest is unaffected — it transpiles via `ts-jest`, which already reads `tsconfig.json`.

## Note for the reviewer

The Jira description references `v3/docs/platform-support-matrix.md`. That file does
not exist in the repo or anywhere in its history, so the code comment states the
support floor inline instead. There is also no `browserslist` config in the repo,
which the proposed follow-up story assumes as its input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
