### PR TITLE
CODAP-1458: prune unused group key mappings from serialized collections

### DIFF
--- a/v3/src/models/data/collection.test.ts
+++ b/v3/src/models/data/collection.test.ts
@@ -435,6 +435,67 @@ describe("CollectionModel", () => {
     expect(c1.groupKeyCaseIds.get(makeGroupKey(["c", "d"]))).toBe("case6")
   })
 
+  it("prepareSnapshot only serializes group key mappings for cases that still exist", () => {
+    const c1 = CollectionModel.create({ name: "c1" })
+    let items = ["i0", "i1", "i2"]
+    const hiddenItems = new Set<string>(["i2"])
+    const itemData: IItemData = {
+      itemIds: () => items,
+      isHidden: (itemId: string) => hiddenItems.has(itemId),
+      getValue: (itemId: string) => itemId,
+      addItemInfo: () => null,
+      invalidate: () => null
+    }
+    syncCollectionLinks([c1], itemData)
+
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+    const caseIdForItem = new Map(items.map(itemId => [itemId, c1.groupKeyCaseIds.get(itemId)!]))
+    expect(c1.groupKeyCaseIds.size).toBe(3)
+
+    // remove the first item and regroup
+    items = ["i1", "i2"]
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+    // the volatile map deliberately retains the mapping for the removed item
+    expect(c1.groupKeyCaseIds.size).toBe(3)
+
+    // ...but the removed item's mapping isn't serialized, while the hidden case's mapping is
+    c1.prepareSnapshot()
+    expect(c1._groupKeyCaseIds).toEqual([
+      ["i1", caseIdForItem.get("i1")],
+      ["i2", caseIdForItem.get("i2")]
+    ])
+  })
+
+  it("prepareSnapshot leaves the volatile map intact so re-added items keep their case ids", () => {
+    const c1 = CollectionModel.create({ name: "c1" })
+    let items = ["i0", "i1"]
+    const itemData: IItemData = {
+      itemIds: () => items,
+      isHidden: () => false,
+      getValue: (itemId: string) => itemId,
+      addItemInfo: () => null,
+      invalidate: () => null
+    }
+    syncCollectionLinks([c1], itemData)
+
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+    const origCaseIdForItem0 = c1.groupKeyCaseIds.get("i0")!
+
+    // remove an item, serialize (which prunes the serialized copy), then add the item back
+    items = ["i1"]
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+    c1.prepareSnapshot()
+    items = ["i0", "i1"]
+    c1.updateCaseGroups()
+    c1.completeCaseGroups(undefined)
+
+    expect(c1.groupKeyCaseIds.get("i0")).toBe(origCaseIdForItem0)
+  })
+
   it("invalidateCaseGroups followed by invalidateCaseGroupsForNewCases still results in full rebuild", () => {
     const c1 = CollectionModel.create({ name: "c1" })
     const itemData: IItemData = {

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -695,12 +695,12 @@ export const CollectionModel = V2Model
     // cases are grouped like any other (with isHidden set), so their mappings are retained.
     // We iterate the (live) caseGroupMap rather than filtering the (historical) groupKeyCaseIds
     // so that the work is proportional to the number of current groups rather than to the full
-    // history. Every caseGroupMap key is guaranteed to have a mapping, because updateCaseGroups
-    // calls groupKeyCaseId() -- which creates the mapping -- before adding the caseGroupMap entry.
+    // history. The case id comes from the case group rather than from groupKeyCaseIds because
+    // the group's own id is what a reloaded document needs to reproduce; the two are always in
+    // sync (groupKeyCaseIds is only written where the corresponding groupedCase.__id__ is set).
     const groupKeyCaseIds: Array<[string, string]> = []
     self.caseGroupMap.forEach((caseGroup, groupKey) => {
-      const caseId = self.groupKeyCaseIds.get(groupKey)
-      if (caseId) groupKeyCaseIds.push([groupKey, caseId])
+      groupKeyCaseIds.push([groupKey, caseGroup.groupedCase.__id__])
     })
     self._groupKeyCaseIds = groupKeyCaseIds
   },

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -693,9 +693,14 @@ export const CollectionModel = V2Model
     // DataSet.prepareSnapshot() calls validateCases() before delegating to its collections, and
     // validateCases() regroups every collection, not just the childmost one. Hidden/set-aside
     // cases are grouped like any other (with isHidden set), so their mappings are retained.
+    // We iterate the (live) caseGroupMap rather than filtering the (historical) groupKeyCaseIds
+    // so that the work is proportional to the number of current groups rather than to the full
+    // history. Every caseGroupMap key is guaranteed to have a mapping, because updateCaseGroups
+    // calls groupKeyCaseId() -- which creates the mapping -- before adding the caseGroupMap entry.
     const groupKeyCaseIds: Array<[string, string]> = []
-    self.groupKeyCaseIds.forEach((caseId, groupKey) => {
-      if (self.caseGroupMap.has(groupKey)) groupKeyCaseIds.push([groupKey, caseId])
+    self.caseGroupMap.forEach((caseGroup, groupKey) => {
+      const caseId = self.groupKeyCaseIds.get(groupKey)
+      if (caseId) groupKeyCaseIds.push([groupKey, caseId])
     })
     self._groupKeyCaseIds = groupKeyCaseIds
   },

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -681,7 +681,23 @@ export const CollectionModel = V2Model
     ))
   },
   prepareSnapshot() {
-    self._groupKeyCaseIds = Array.from(self.groupKeyCaseIds.entries())
+    // Only the mappings for the current groupings are serialized. The volatile map is
+    // deliberately _not_ pruned here -- retaining the full history of mappings is what allows
+    // case ids to survive hierarchy changes within a session (see the reaction in afterCreate).
+    // Serializing that history, however, can dominate the size of a saved document for datasets
+    // that churn through large numbers of items (e.g. the Sampler plugin, which can accumulate
+    // tens of thousands of dead mappings in a document with no remaining data). The cost of
+    // pruning the serialized copy is that a hierarchy change which straddles a save/load will
+    // generate new case ids rather than restoring the previous ones.
+    // caseGroupMap is keyed by group key and is up to date whenever this runs, because
+    // DataSet.prepareSnapshot() calls validateCases() before delegating to its collections, and
+    // validateCases() regroups every collection, not just the childmost one. Hidden/set-aside
+    // cases are grouped like any other (with isHidden set), so their mappings are retained.
+    const groupKeyCaseIds: Array<[string, string]> = []
+    self.groupKeyCaseIds.forEach((caseId, groupKey) => {
+      if (self.caseGroupMap.has(groupKey)) groupKeyCaseIds.push([groupKey, caseId])
+    })
+    self._groupKeyCaseIds = groupKeyCaseIds
   },
   completeSnapshot() {
   },

--- a/v3/src/models/data/data-set-collections.test.ts
+++ b/v3/src/models/data/data-set-collections.test.ts
@@ -1,5 +1,5 @@
 import { reaction } from "mobx"
-import { types } from "mobx-state-tree"
+import { getSnapshot, types } from "mobx-state-tree"
 import { ICollectionModel } from "./collection"
 import { DataSet, IDataSet } from "./data-set"
 
@@ -349,6 +349,32 @@ describe("DataSet collections", () => {
     const parentCollection = data.collections[0]
     expect(parentCollection.caseGroups.length).toBe(3) // 3 unique values of "a"
     expect(data.childCollection.caseGroups.length).toBe(27)
+  })
+
+  it("serializes group key mappings for surviving cases but not for removed ones", () => {
+    data.moveAttributeToNewCollection("aId")
+    data.validateCases()
+    const [parentCollection] = data.collections
+    const origParentCaseIds = [...parentCollection.caseIds]
+    expect(origParentCaseIds.length).toBe(3)
+
+    // remove the nine items whose "a" value is 3
+    const removedItemIds = data.itemIds.filter(itemId => itemId.startsWith("3-"))
+    expect(removedItemIds.length).toBe(9)
+    data.removeCases(removedItemIds)
+
+    data.prepareSnapshot()
+    const snapshot = getSnapshot(data)
+    data.completeSnapshot()
+
+    // the removed parent case and its items are no longer serialized
+    expect(snapshot.collections[0]._groupKeyCaseIds?.length).toBe(2)
+    expect(snapshot.collections[1]._groupKeyCaseIds?.length).toBe(18)
+
+    // ...and the surviving cases keep their ids when the document is reloaded
+    const reloaded = DataSet.create(snapshot)
+    reloaded.validateCases()
+    expect(reloaded.collections[0].caseIds).toEqual(origParentCaseIds.slice(0, 2))
   })
 
   it("getCasesForCollection implicitly validates after hierarchical change", () => {


### PR DESCRIPTION
## Summary

A Sampler document with no remaining data could still serialize to ~2.5 MB.
The bulk of it was `_groupKeyCaseIds`: `CollectionModel.prepareSnapshot()`
serialized the entire volatile `groupKeyCaseIds` map, including mappings for
cases that no longer exist. Sampler documents repeatedly generate and discard
thousands of items, so these dead mappings accumulate without bound — the
reported document had 53,066 entries in its leaf collection.

`prepareSnapshot()` now walks the live `caseGroupMap` and serializes one
mapping per current group, taking each case id from the case group itself.

## What is deliberately unchanged

The volatile map is *not* pruned. Retaining the full history of mappings is
what allows case ids to survive hierarchy changes within a session (removing
an attribute from a collection and adding it back restores the original case
ids), and that behavior was an intentional decision. Pruning only the
serialized copy leaves it fully intact.

The tradeoff being accepted here is narrower: a hierarchy change that
straddles a save/load will now generate new case ids rather than restoring
the previous ones.

## Why `caseGroupMap` is a safe source

- `DataSet.prepareSnapshot()` calls `validateCases()` before delegating to its
  collections, and `validateCases()` regroups *every* collection, not just the
  childmost — so `caseGroupMap` is current and complete at every level.
- Hidden and set-aside cases are still grouped (with `isHidden` set), so their
  mappings are retained.
- The case id is taken from `caseGroup.groupedCase.__id__` rather than looked
  up, because that is the id a reloaded document needs to reproduce. The two
  are always in sync: `groupKeyCaseIds` is only written where the corresponding
  `groupedCase.__id__` is set (`:219`/`:362` and `:428`/`:437`).
- The volatile `groupKeyCaseIds` map is read only from `updateCaseGroups` —
  directly at `:323` and via `groupKeyCaseId()` at `:216` — and
  `_groupKeyCaseIds` has a single reader, `initializeVolatileState()`.
  `prepareSnapshot()` no longer reads the volatile map at all, so no other code
  can observe a pruned entry.

## Tests

- `collection.test.ts`: mappings for removed cases are not serialized, while a
  hidden case's mapping is.
- `collection.test.ts`: the volatile map is left intact, so re-added items keep
  their case ids.
- `data-set-collections.test.ts`: at the `DataSet` level, removing 9 of 27 items
  from a two-level hierarchy drops the dead mappings *and* the surviving cases
  keep their ids after a serialize/reload round trip.

Full Jest suite, lint, and `build:tsc` pass locally. No Cypress run.

## Verified against the reported document

Re-saving the Sampler document from CODAP-1458 produces an 8.9 KB file,
down from ~2.5 MB.

Fixes CODAP-1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)
