### PR TITLE
CODAP-1461: don't show an LSRL equation when no line can be fit

### DIFF
--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -331,4 +331,64 @@ describe("LSRLAdornmentModel", () => {
       expect(updatedLinesInCell?.has("cat3")).toBe(false)
     })
   })
+
+  describe("computeValues", () => {
+    const xAttrId = "xId"
+    const yAttrId = "yId"
+
+    // dataConfig backed by a minimal fake dataset so the case values can be specified directly
+    function createMockDataConfigForPoints(points: { x: number, y: number }[]) {
+      const caseIds = points.map((_, index) => `c${index}`)
+      const getNum = (caseId: string, attrId: string) => {
+        const point = points[caseIds.indexOf(caseId)]
+        return attrId === xAttrId ? point.x : point.y
+      }
+      const dataset = {
+        getAttribute: () => ({ type: "numeric" }),
+        getNumeric: (caseId: string, attrId: string) => getNum(caseId, attrId),
+        getStrValue: (caseId: string, attrId: string) => String(getNum(caseId, attrId))
+      }
+      return {
+        dataset,
+        attributeID: () => undefined,
+        subPlotCases: () => caseIds,
+        filterCasesForDisplay: (ids: string[]) => ids
+      } as unknown as IGraphDataConfigurationModel
+    }
+
+    it("computes the line fitting the cases in the plot", () => {
+      const lSRL = LSRLAdornmentModel.create()
+      const dataConfig = createMockDataConfigForPoints([{ x: 1, y: 2 }, { x: 2, y: 4 }, { x: 3, y: 6 }])
+      const { intercept, slope } = lSRL.computeValues(xAttrId, yAttrId, {}, dataConfig, false, kMain)
+      expect(slope).toBeCloseTo(2)
+      expect(intercept).toBeCloseTo(0)
+    })
+
+    // With identical (or vertically aligned) points no line can be fit, so the line's values must be
+    // left undefined rather than NaN, which rendered as a bogus "x = (not a number)" equation.
+    it("returns no line values when the cases all have the same coordinates", () => {
+      const lSRL = LSRLAdornmentModel.create()
+      const dataConfig = createMockDataConfigForPoints([{ x: 5, y: 10 }, { x: 5, y: 10 }])
+      const { intercept, rSquared, sdResiduals, slope } =
+        lSRL.computeValues(xAttrId, yAttrId, {}, dataConfig, false, kMain)
+      expect(slope).toBeUndefined()
+      expect(intercept).toBeUndefined()
+      expect(rSquared).toBeUndefined()
+      expect(sdResiduals).toBeUndefined()
+    })
+
+    it("stores an invalid line when no line can be fit", () => {
+      const lSRL = LSRLAdornmentModel.create()
+      const dataConfig = createMockDataConfigForPoints([{ x: 5, y: 10 }, { x: 5, y: 10 }])
+      const instanceKey = lSRL.instanceKey({})
+      const { intercept, rSquared, sdResiduals, slope } =
+        lSRL.computeValues(xAttrId, yAttrId, {}, dataConfig, false, kMain)
+      lSRL.updateLines({ category: kMain, intercept, rSquared, sdResiduals, slope }, instanceKey)
+
+      const line = lSRL.lines.get(instanceKey)?.get(kMain)
+      expect(line?.slope).toBeUndefined()
+      expect(line?.intercept).toBeUndefined()
+      expect(line?.isValid).toBe(false)
+    })
+  })
 })

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -1,8 +1,8 @@
 import {ptInRect} from "../../data-display/data-display-utils"
 import { GraphLayout } from "../models/graph-layout"
 import {
-  dateTimeSlopeUnit, equationString, formatDateDuration, formatValue, kMinus, lineToAxisIntercepts,
-  lsrlEquationString, valueLabelString
+  dateTimeSlopeUnit, equationString, formatDateDuration, formatValue, kMinus, leastSquaresLinearRegression,
+  lineToAxisIntercepts, lsrlEquationString, valueLabelString
 } from "./graph-utils"
 
 describe("formatValue", () => {
@@ -166,6 +166,59 @@ describe("formatDateDuration", () => {
     // 0.99998 rounds to "1" for display, so the unit should be singular too.
     expect(formatDateDuration(0.99998, 60)).toBe("1 second")
     expect(formatDateDuration(1.001, 60)).toBe("1 second")
+  })
+})
+
+describe("leastSquaresLinearRegression", () => {
+  it("computes slope, intercept and rSquared for a set of points", () => {
+    const result = leastSquaresLinearRegression([{x: 1, y: 2}, {x: 2, y: 4}, {x: 3, y: 6}], false)
+    expect(result.slope).toBeCloseTo(2)
+    expect(result.intercept).toBeCloseTo(0)
+    expect(result.rSquared).toBeCloseTo(1)
+  })
+
+  it("returns no line when there are fewer than two points", () => {
+    const result = leastSquaresLinearRegression([{x: 1, y: 2}], false)
+    expect(result.slope).toBeUndefined()
+    expect(result.intercept).toBeUndefined()
+  })
+
+  // No least squares line can be fit when the x values don't vary, since the slope would be
+  // 0/0. Leaving slope and intercept undefined keeps NaNs out of the line and its equation.
+  it("returns no line when all of the points have the same coordinates", () => {
+    const result = leastSquaresLinearRegression([{x: 5, y: 10}, {x: 5, y: 10}], false)
+    expect(result.slope).toBeUndefined()
+    expect(result.intercept).toBeUndefined()
+    expect(result.rSquared).toBeUndefined()
+    expect(result.sdResiduals).toBeUndefined()
+  })
+
+  it("returns no line when the points are vertically aligned", () => {
+    const result = leastSquaresLinearRegression([{x: 5, y: 10}, {x: 5, y: 20}, {x: 5, y: 30}], false)
+    expect(result.slope).toBeUndefined()
+    expect(result.intercept).toBeUndefined()
+    expect(result.rSquared).toBeUndefined()
+    expect(result.sdResiduals).toBeUndefined()
+  })
+
+  it("returns a horizontal line when the points are horizontally aligned", () => {
+    const result = leastSquaresLinearRegression([{x: 1, y: 10}, {x: 2, y: 10}, {x: 3, y: 10}], false)
+    expect(result.slope).toBeCloseTo(0)
+    expect(result.intercept).toBeCloseTo(10)
+  })
+
+  describe("with the intercept locked", () => {
+    it("computes a slope through the origin", () => {
+      const result = leastSquaresLinearRegression([{x: 5, y: 10}, {x: 5, y: 10}], true)
+      expect(result.slope).toBeCloseTo(2)
+      expect(result.intercept).toEqual(0)
+    })
+
+    it("returns no line when all of the points are at the origin", () => {
+      const result = leastSquaresLinearRegression([{x: 0, y: 0}, {x: 0, y: 0}], true)
+      expect(result.slope).toBeUndefined()
+      expect(result.intercept).toBeUndefined()
+    })
   })
 })
 

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -738,17 +738,25 @@ export const leastSquaresLinearRegression = (iValues: Point[], iInterceptLocked:
   const tRegression: IRegression = {}
   const tBiStats = computeBivariateStats(iValues)
   if (tBiStats.count > 1) {
+    // No least squares line can be fit when the slope works out to 0/0, e.g. when the points are
+    // identical or vertically aligned (or, with the intercept locked, all at the origin). The slope and
+    // intercept are left undefined in that case so clients neither draw a line nor show an equation.
     if (iInterceptLocked) {
-      tRegression.slope = (tBiStats.sumOfProductDiffs + tBiStats.xMean * tBiStats.ySum) /
+      const tSlope = (tBiStats.sumOfProductDiffs + tBiStats.xMean * tBiStats.ySum) /
           (tBiStats.xSumSquaredDeviations + tBiStats.xMean * tBiStats.xSum)
+      if (!isFiniteNumber(tSlope)) return tRegression
+      tRegression.slope = tSlope
       tRegression.intercept = 0
     } else {
       tRegression.count = tBiStats.count
       tRegression.xMean = tBiStats.xMean
       tRegression.yMean = tBiStats.yMean
       tRegression.xSumSquaredDeviations = tBiStats.xSumSquaredDeviations
-      tRegression.slope = tBiStats.sumOfProductDiffs / tBiStats.xSumSquaredDeviations
-      tRegression.intercept = tBiStats.yMean - tRegression.slope * tBiStats.xMean
+      const tSlope = tBiStats.sumOfProductDiffs / tBiStats.xSumSquaredDeviations
+      const tIntercept = tBiStats.yMean - tSlope * tBiStats.xMean
+      if (!isFiniteNumber(tSlope) || !isFiniteNumber(tIntercept)) return tRegression
+      tRegression.slope = tSlope
+      tRegression.intercept = tIntercept
       tRegression.rSquared = (tBiStats.sumOfProductDiffs * tBiStats.sumOfProductDiffs) /
           (tBiStats.xSumSquaredDeviations * tBiStats.ySumSquaredDeviations)
 


### PR DESCRIPTION
Fixes CODAP-1461

## Problem

With a scatter plot whose points are all identical (or vertically aligned) and
the Least Squares Line enabled, the graph showed a bogus equation
`x = (not a number)` with no line drawn.

## Root cause

`leastSquaresLinearRegression` computes `slope = sumOfProductDiffs /
xSumSquaredDeviations`. When the x values don't vary that is `0/0`, so slope,
intercept and r² all come back `NaN`. The LSRL adornment stores those NaNs, and
its guards test `!= null` — which `NaN` passes — so the equation string fell into
its vertical-line branch and rendered `x = (not a number)`. The line itself never
appeared because the endpoint code does check for finite values.

## Fix

Compute the slope and intercept into locals and return no slope/intercept when
either isn't finite. The existing null checks downstream then correctly treat the
regression as "no line": no line and no equation. The intercept-locked branch
gets the same guard for its own degenerate case (all points at the origin).

## Testing

- New unit tests for `leastSquaresLinearRegression` covering normal data, fewer
  than two points, identical points, vertically aligned points, horizontally
  aligned points, and both intercept-locked cases.
- New `LSRLAdornmentModel.computeValues` tests confirming that a degenerate fit
  yields undefined line values and an invalid stored line.
- Verified in the browser: before the fix, two identical points reproduce
  `x = (not a number)`; after, no line and no equation. Non-degenerate data still
  renders its line and equation correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
