### PR TITLE
CODAP-1471: omit LSRL statistics that aren't estimable

### DIFF
--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-component.tsx
@@ -213,16 +213,16 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
     const tPixelMin = xScale(xMin)
     const tPixelMax = xScale(xMax)
     const kPixelGap = 1
-    let upperPath = ""
-    let lowerPath = ""
     const { upperPoints, lowerPoints } = model.confidenceBandsPoints(
       tPixelMin, tPixelMax, cellCounts.x, cellCounts.y, kPixelGap, caseValues, xScale, yScale, cellKey, category
     )
-    if (upperPoints.length > 0) {
-      // Accomplish spline interpolation
-      upperPath = `M${upperPoints[0].x}, ${upperPoints[0].y}${curveBasis(upperPoints)}`
-      lowerPath = `M${lowerPoints[0].x}, ${lowerPoints[0].y}${curveBasis(lowerPoints)}`
-    }
+    // There are no points when the bands can't be estimated, e.g. when the fit has no degrees of
+    // freedom. Returning null paths clears the band elements rather than assigning them empty paths.
+    if (upperPoints.length === 0) return { upperPath: null, lowerPath: null, combinedPath: null }
+
+    // Accomplish spline interpolation
+    const upperPath = `M${upperPoints[0].x}, ${upperPoints[0].y}${curveBasis(upperPoints)}`
+    const lowerPath = `M${lowerPoints[0].x}, ${lowerPoints[0].y}${curveBasis(lowerPoints)}`
     const combinedPath = `${upperPath}${lowerPath.replace("M", "L")}Z`
 
     return { upperPath, lowerPath, combinedPath }
@@ -243,9 +243,10 @@ export const LSRLAdornment = observer(function LSRLAdornment(props: IAdornmentCo
 
     const caseValues = model.getCaseValues(xAttrId, yAttrId, cellKey, dataConfig, line.category)
     const { upperPath, lowerPath, combinedPath } = confidenceBandPaths(caseValues, line.category)
-    lineObj?.confidenceBandCurve?.attr("d", `${upperPath}${lowerPath}`)
+    const curvePath = upperPath != null && lowerPath != null ? `${upperPath}${lowerPath}` : null
+    lineObj?.confidenceBandCurve?.attr("d", curvePath)
       .style("stroke-dasharray", "4,3")
-    lineObj?.confidenceBandCover?.attr("d", `${upperPath}${lowerPath}`)
+    lineObj?.confidenceBandCover?.attr("d", curvePath)
     lineObj?.confidenceBandShading?.attr("d", combinedPath)
 
     lineObj?.confidenceBandShading?.on("mouseover", (e) => toggleConfidenceBandTip(e, true))

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -435,5 +435,21 @@ describe("LSRLAdornmentModel", () => {
       expect(upperPoints).toHaveLength(0)
       expect(lowerPoints).toHaveLength(0)
     })
+
+    // The guard reads `line?.intercept` before `line.slope`; the leading `||` operand short-circuits
+    // so the unchained accesses are never evaluated when there is no line for the category.
+    it("returns no bounds without throwing when there is no line for the category", () => {
+      const points = [{ x: 1, y: 2 }, { x: 2, y: 4.5 }, { x: 3, y: 5.5 }, { x: 4, y: 8 }]
+      const lSRL = LSRLAdornmentModel.create()
+      expect(() => lSRL.confidenceValues(2.5, points, {}, kMain)).not.toThrow()
+      expect(lSRL.confidenceValues(2.5, points, {}, kMain)).toBeUndefined()
+    })
+
+    it("returns no bounds without throwing when the category has no line of its own", () => {
+      const points = [{ x: 1, y: 2 }, { x: 2, y: 4.5 }, { x: 3, y: 5.5 }, { x: 4, y: 8 }]
+      const lSRL = createLSRLWithLine(points)
+      expect(() => lSRL.confidenceValues(2.5, points, {}, "someOtherCategory")).not.toThrow()
+      expect(lSRL.confidenceValues(2.5, points, {}, "someOtherCategory")).toBeUndefined()
+    })
   })
 })

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -391,4 +391,49 @@ describe("LSRLAdornmentModel", () => {
       expect(line?.isValid).toBe(false)
     })
   })
+
+  describe("confidenceValues", () => {
+    function createLSRLWithLine(points: { x: number, y: number }[]) {
+      const lSRL = LSRLAdornmentModel.create()
+      const { intercept, rSquared, sdResiduals, slope } = (() => {
+        // compute directly from the points, bypassing dataConfig
+        const n = points.length
+        const xMean = points.reduce((s, p) => s + p.x, 0) / n
+        const yMean = points.reduce((s, p) => s + p.y, 0) / n
+        const sxy = points.reduce((s, p) => s + (p.x - xMean) * (p.y - yMean), 0)
+        const sxx = points.reduce((s, p) => s + (p.x - xMean) ** 2, 0)
+        const m = sxy / sxx
+        return { intercept: yMean - m * xMean, rSquared: 1, sdResiduals: 0, slope: m }
+      })()
+      lSRL.updateLines({ category: kMain, intercept, rSquared, sdResiduals, slope }, lSRL.instanceKey({}))
+      return lSRL
+    }
+
+    it("computes confidence bounds when there are enough degrees of freedom", () => {
+      const points = [{ x: 1, y: 2 }, { x: 2, y: 4.5 }, { x: 3, y: 5.5 }, { x: 4, y: 8 }]
+      const lSRL = createLSRLWithLine(points)
+      const bounds = lSRL.confidenceValues(2.5, points, {}, kMain)
+      expect(bounds).toBeDefined()
+      expect(Number.isFinite(bounds?.lower)).toBe(true)
+      expect(Number.isFinite(bounds?.upper)).toBe(true)
+    })
+
+    // With two points the fit has zero degrees of freedom, so mse is 0/0. Returning bounds at all
+    // would push NaN into the confidence band path coordinates.
+    it("returns no bounds when there are only two points", () => {
+      const points = [{ x: 1, y: 2 }, { x: 3, y: 7 }]
+      const lSRL = createLSRLWithLine(points)
+      expect(lSRL.confidenceValues(2, points, {}, kMain)).toBeUndefined()
+    })
+
+    it("returns no confidence band points when there are only two points", () => {
+      const points = [{ x: 1, y: 2 }, { x: 3, y: 7 }]
+      const lSRL = createLSRLWithLine(points)
+      const scale = Object.assign((v: number) => v, { invert: (v: number) => v }) as any
+      const { upperPoints, lowerPoints } =
+        lSRL.confidenceBandsPoints(0, 10, 1, 1, 1, points, scale, scale, {}, kMain)
+      expect(upperPoints).toHaveLength(0)
+      expect(lowerPoints).toHaveLength(0)
+    })
+  })
 })

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -179,9 +179,11 @@ export const LSRLAdornmentModel = AdornmentModel
   ) {
     const line = self.lines.get(self.instanceKey(cellKey))?.get(legendCat)
     const { count, mse, xSumSquaredDeviations, xMean } = leastSquaresLinearRegression(caseValues, isInterceptLocked)
+    // Finiteness rather than nullness: with only two points the fit has no degrees of freedom, so
+    // mse is 0/0, and returning bounds anyway would push NaN into the confidence band coordinates.
     if (
-      line?.intercept == null || line.slope == null || count == null || mse == null || xMean == null ||
-      xSumSquaredDeviations == null
+      !isFiniteNumber(line?.intercept) || !isFiniteNumber(line.slope) || !isFiniteNumber(count) ||
+      !isFiniteNumber(mse) || !isFiniteNumber(xMean) || !isFiniteNumber(xSumSquaredDeviations)
     ) return
     const tAt0975ForD = tAt0975ForDf(count - 2)
     const tYHat = line.intercept + line.slope * iX

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -292,6 +292,39 @@ describe("lsrlEquationString", () => {
     expect(result).not.toContain("r<sup>2</sup>")
   })
 
+  // Undefined statistics are omitted rather than displayed. rSquared is 0/0 when the y values
+  // don't vary, so the line itself is valid while the correlation is not.
+  describe("undefined statistics", () => {
+    it("should omit r and r² when rSquared is not a number", () => {
+      const result = lsrlEquationString({
+        caseValues: [], slope: 0, intercept: 5, rSquared: NaN, attrNames, units, layout,
+        showR: true, showRSquared: true
+      })
+      expect(result).toBe('<em>Speed</em> = 5')
+      expect(result).not.toContain("r =")
+      expect(result).not.toContain("r<sup>2</sup>")
+      expect(result).not.toContain("not a number")
+    })
+
+    it("should omit σslope and σintercept when they are not numbers", () => {
+      const result = lsrlEquationString({
+        caseValues: [], slope: 2.5, intercept: -0.5, rSquared: 1, attrNames, units, layout,
+        showConfidenceBands: true, seSlope: NaN, seIntercept: NaN
+      })
+      expect(result).not.toContain("σ")
+      expect(result).not.toContain("not a number")
+    })
+
+    it("should still show σslope and σintercept when they are finite", () => {
+      const result = lsrlEquationString({
+        caseValues: [], slope: 2.5, intercept: -0.5, rSquared: 1, attrNames, units, layout,
+        showConfidenceBands: true, seSlope: 0.15, seIntercept: 0.5
+      })
+      expect(result).toContain("σ<sub>slope</sub> = 0.15")
+      expect(result).toContain("σ<sub>intercept</sub> = 0.5")
+    })
+  })
+
   describe("date-time x-axis", () => {
     const oneDay = 86400
     it("uses slope-only form and still appends r² and sum-of-squares", () => {

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -453,9 +453,9 @@ export const lsrlEquationString = (props: ILsrlEquationString) => {
   const formattedIntercept = formatEquationValue(intercept, neededFractionDigits.interceptDigits, interceptUnits)
   const formattedSlope = formatEquationValue(slope, neededFractionDigits.slopeDigits, slopeUnits, true)
   const formattedSumOfSquares = formatEquationValue(sumOfSquares || 0, sumOfSquares && sumOfSquares > 100 ? 0 : 3)
-  const formattedRSquared = formatEquationValue(rSquared || 0, 3)
-  const formattedSeSlope = seSlope != null ? formatEquationValue(seSlope, 3) : ""
-  const formattedSeIntercept = seIntercept != null ? formatEquationValue(seIntercept, 3) : ""
+  const formattedRSquared = isFiniteNumber(rSquared) ? formatEquationValue(rSquared, 3) : ""
+  const formattedSeSlope = isFiniteNumber(seSlope) ? formatEquationValue(seSlope, 3) : ""
+  const formattedSeIntercept = isFiniteNumber(seIntercept) ? formatEquationValue(seIntercept, 3) : ""
   const xAttrString = attrNames.x.length > 1 ? `(<em>${attrNames.x}</em>)` : `<em>${attrNames.x}</em>`
   const interceptDisplaysAsZero = formatValue(intercept, neededFractionDigits.interceptDigits) === "0"
   const interceptString = !interceptDisplaysAsZero ? ` ${intercept > 0 ? "+" : ""} ${formattedIntercept}` : ""
@@ -465,16 +465,21 @@ export const lsrlEquationString = (props: ILsrlEquationString) => {
     : slopeIsFinite
       ? `<em>${attrNames.y}</em> = ${formattedSlope} ${xAttrString}${interceptString}`
       : `<em>${slope === 0 ? attrNames.y : attrNames.x}</em> = ${formattedIntercept}`
-  const rValue = rSquared != null && slope != null ? Math.sign(slope) * Math.sqrt(rSquared) : undefined
-  const formattedR = rValue != null ? formatEquationValue(rValue, 4) : ""
-  const rPart = showR && !interceptLocked && rValue != null ? `<br />r = ${formattedR}` : ""
-  const seSlopePart = showConfidenceBands && !interceptLocked ? `<br />σ<sub>slope</sub> = ${formattedSeSlope}` : ""
-  const seInterceptPart = showConfidenceBands && !interceptLocked
+  // Statistics that aren't estimable are omitted rather than displayed. rSquared is 0/0 when the
+  // y values don't vary, and the standard errors are 0/0 when the fit has no degrees of freedom.
+  const rValue = isFiniteNumber(rSquared) && isFiniteNumber(slope)
+                  ? Math.sign(slope) * Math.sqrt(rSquared)
+                  : undefined
+  const formattedR = isFiniteNumber(rValue) ? formatEquationValue(rValue, 4) : ""
+  const rPart = showR && !interceptLocked && isFiniteNumber(rValue) ? `<br />r = ${formattedR}` : ""
+  const seSlopePart = showConfidenceBands && !interceptLocked && isFiniteNumber(seSlope)
+    ? `<br />σ<sub>slope</sub> = ${formattedSeSlope}` : ""
+  const seInterceptPart = showConfidenceBands && !interceptLocked && isFiniteNumber(seIntercept)
     ? `<br />σ<sub>intercept</sub> = ${formattedSeIntercept}` : ""
   const squaresPart = isFiniteNumber(sumOfSquares)
     ? `<br />${t("DG.ScatterPlotModel.sumSquares")} = ${formattedSumOfSquares}`
     : ""
-  const rSquaredPart = showRSquared && !interceptLocked && rSquared != null
+  const rSquaredPart = showRSquared && !interceptLocked && isFiniteNumber(rSquared)
     ? `<br />r<sup>2</sup> = ${formattedRSquared}` : ""
 
   return `${equationPart}${rPart}${rSquaredPart}${seSlopePart}${seInterceptPart}${squaresPart}`

--- a/v3/src/utilities/stats-utils.test.ts
+++ b/v3/src/utilities/stats-utils.test.ts
@@ -27,9 +27,11 @@ describe("stats-utils", () => {
     expect(rSquared(values)).toBe(1)
     expect(linRegrIntercept(values)).toBe(0)
     expect(linRegrSlope(values)).toBe(1)
+    // The standard errors are not estimable with two points: the fit has zero degrees of freedom,
+    // so they are undefined rather than zero. V2 returns NaN here as well.
     const { stdErrSlope, stdErrIntercept } = linRegrStdErrSlopeAndIntercept(values)
-    expect(stdErrIntercept).toBe(0)
-    expect(stdErrSlope).toBe(0)
+    expect(stdErrIntercept).toBeNaN()
+    expect(stdErrSlope).toBeNaN()
   })
 
   it("matches results from NIST Norris data set", () => {

--- a/v3/src/utilities/stats-utils.ts
+++ b/v3/src/utilities/stats-utils.ts
@@ -204,8 +204,8 @@ export function linRegrStdErrSlopeAndIntercept(xyValues: XYValues): StdErrLSRRes
   const result = { stdErrSlope: NaN, stdErrIntercept: NaN }
   const { count, sumSquaredErrors, xMean, xSumSquaredDeviations } = leastSquaresLinearRegression(xyValues)
   if (!count || xMean == null || xSumSquaredDeviations == null) return result
-  // no error if only two points
-  if (count === 2) return { stdErrSlope: 0, stdErrIntercept: 0 }
+  // With two points the fit has zero degrees of freedom, so the standard errors aren't estimable
+  // and are left NaN rather than reported as zero.
   if (count > 2) {
     result.stdErrSlope = Math.sqrt((sumSquaredErrors / (count - 2)) / xSumSquaredDeviations)
     result.stdErrIntercept = Math.sqrt(sumSquaredErrors / (count - 2)) *


### PR DESCRIPTION
Fixes CODAP-1471

⚠️ **Stacked on #2674** (CODAP-1461). Targets that branch, not `main` — retarget
once #2674 merges. Review only the latest commit; the rest is #2674's diff.

## Problem

Three cases where a statistic that can't be estimated still reached the LSRL's output:

| Data | Before | After |
|---|---|---|
| Horizontally aligned + Show r/r² | `y = 5`, `r = (not a number)`, `r² = 0` | `y = 5` |
| Two points + Confidence Bands | `σslope = 0`, `σintercept = 0`, NaN band paths, 3 console errors | equation only, paths cleared, no errors |
| Normal data | r, r², σ, bands | unchanged |

## Root causes

- `rSquared` is `(sumOfProductDiffs)² / (xSumSquaredDeviations * ySumSquaredDeviations)`,
  which is `0/0` when the y values don't vary. The r branch formatted that NaN directly
  while the r² branch passed it through `rSquared || 0` — hence the two disagreeing.
- `linRegrStdErrSlopeAndIntercept` special-cased `count === 2` to return `{0, 0}`. With
  zero degrees of freedom the standard errors aren't estimable, so 0 asserts something
  we can't know.
- `mse = sumSquaredErrors / (count - 2)` is `0/0` with two points, and `confidenceValues`
  guarded with `== null`, which NaN passes. NaN reached the band path `d` attribute, so
  the browser rejected the paths and logged `<path> attribute d: Expected number`.

## Fix

Per the rule agreed with Bill: **anything undefined is omitted** — geometry that can't be
drawn isn't drawn, numbers that can't be computed get no row.

- `lsrlEquationString` omits the r, r², σslope and σintercept rows unless the value is
  finite, and no longer launders NaN through `|| 0`.
- `linRegrStdErrSlopeAndIntercept` drops the `count === 2` special case.
- `confidenceValues` guards on finiteness rather than nullness, and the component clears
  the band paths instead of assigning empty/NaN ones.

## V2 compatibility

I ran v2's own math in the live v2 app (build 0745). v2 produces the same NaNs for every
one of these cases and has **no** `count === 2 → 0` special case — it returns NaN for
seSlope/seIntercept with two points. So removing that special case *restores* v2 behavior
rather than diverging from it. On 5-point data v3 now yields σslope = 0.15 and
σintercept = 0.497, matching v2's 0.15000000000000005 / 0.49749371855331026.

## Testing

- New `lsrlEquationString` tests: r/r² omitted when rSquared is NaN, σ rows omitted when
  the standard errors are NaN, plus a positive control that finite values still render.
- New `confidenceValues` / `confidenceBandsPoints` tests: no bounds and no band points
  with two points; finite bounds with four.
- Updated the two-point `linRegrStdErrSlopeAndIntercept` expectation from 0 to NaN.
- Verified in the browser for all three rows of the table above, including that the
  console errors are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
