### PR TITLE
Release 3.1.0-beta.1

### DIFF
--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Version 3.1.0-beta.1 - July 26, 2026
+
+### ✨ Features & Improvements:
+- **CODAP-1404:** Graph connecting lines stay responsive as data streams in
+- **CODAP-1408:** Data streamed from plugins is batched for better responsiveness
+- **CODAP-1454:** Reduce bundle size via build configuration
+- **CODAP-1465:** Map raster layers render faster and animate smoothly
+- **CODAP-1466:** Faster marquee selection in maps and graphs
+
+### 🐞 Bug Fixes:
+- **CODAP-1403:** Graph points now track the expanding axes as data streams in
+- **CODAP-1409:** Fix numeric legend binning when quantiles are degenerate
+- **CODAP-1458:** Fix documents saving much larger than their content warrants
+- **CODAP-1464:** Fix incorrect percentile() results across grouped data
+- **CODAP-1468:** Menus in inspector palettes now close without closing the palette
+
+### 🛠️ Under the Hood:
+- **CODAP-1448:** Add a feature-flag system for gating in-development features
+
+### Asset Sizes
+|      File |          Size | % Change from Previous Release |
+|-----------|---------------|--------------------------------|
+|  main.css |  243735 bytes |                          1.18% |
+|  index.js | 7206477 bytes |                         -8.02% |
+
 ## Version 3.0.5 - July 18, 2026
 
 ### ✨ Features & Improvements:

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codap3",
-  "version": "3.0.5",
+  "version": "3.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codap3",
-      "version": "3.0.5",
+      "version": "3.1.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/v3/package.json
+++ b/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codap3",
-  "version": "3.0.5",
+  "version": "3.1.0-beta.1",
   "description": "Common Online Data Analysis Platform v3",
   "main": "index.js",
   "browser": {

--- a/v3/versions.md
+++ b/v3/versions.md
@@ -6,6 +6,7 @@
 ### Versions
 |      Version    |          Release Date |
 |-----------------|-----------------------|
+| [3.1.0-beta.1](https://codap3.concord.org/version/3.1.0-beta.1/) | July 26, 2026 |
 | [3.0.5](https://codap3.concord.org/version/3.0.5/) | July 18, 2026 |
 | [3.0.4](https://codap3.concord.org/version/3.0.4/) | July 10, 2026 |
 | [3.0.3](https://codap3.concord.org/version/3.0.3/) | June 29, 2026 |


### PR DESCRIPTION
Pre-release build for the QA/testing sessions this week, on the way to
a full 3.1.0 release roughly a week later. This is deliberately a
prerelease rather than 3.1.0 proper: several features intended for
3.1.0 are still in development, and reusing the 3.1.0 version for two
materially different builds would break the immutability of the
/version/3.1.0/ URL.

Features gated behind feature flags (MappingTime legend work, ESTEEM
residual plot) are intentionally omitted from the release notes -- they
are for internal partners at this time and are off by default.

## Version 3.1.0-beta.1 - July 26, 2026

### ✨ Features & Improvements:
- **CODAP-1404:** Graph connecting lines stay responsive as data streams in
- **CODAP-1408:** Data streamed from plugins is batched for better responsiveness
- **CODAP-1454:** Reduce bundle size via build configuration
- **CODAP-1465:** Map raster layers render faster and animate smoothly
- **CODAP-1466:** Faster marquee selection in maps and graphs

### 🐞 Bug Fixes:
- **CODAP-1403:** Graph points now track the expanding axes as data streams in
- **CODAP-1409:** Fix numeric legend binning when quantiles are degenerate
- **CODAP-1458:** Fix documents saving much larger than their content warrants
- **CODAP-1464:** Fix incorrect percentile() results across grouped data
- **CODAP-1468:** Menus in inspector palettes now close without closing the palette

### 🛠️ Under the Hood:
- **CODAP-1448:** Add a feature-flag system for gating in-development features

### Asset Sizes
|      File |          Size | % Change from Previous Release |
|-----------|---------------|--------------------------------|
|  main.css |  243735 bytes |                          1.18% |
|  index.js | 7206477 bytes |                         -8.02% |

The 8% index.js reduction comes from CODAP-1454 (ES2020 target).
