### PR TITLE
CODAP-1469: make residual-plot points marquee-selectable

### DIFF
--- a/v3/cypress/e2e/bivariate-adornments.spec.ts
+++ b/v3/cypress/e2e/bivariate-adornments.spec.ts
@@ -454,4 +454,47 @@ context("Graph adornments", () => {
     cy.get('*[data-testid^=residual-point-][fill="#4682b4"]').should("have.length.at.least", 1)
     cy.get("*[data-testid^=residual-points-]").find("circle").should("have.length.at.least", 1)
   })
+
+  it("adds to the existing selection when the residual marquee is shift-dragged", () => {
+    c.selectTile("graph", 0)
+    cy.dragAttributeToTarget("table", "Sleep", "bottom")
+    cy.dragAttributeToTarget("table", "Speed", "left")
+    graph.getDisplayValuesButton().click()
+    cy.get("[data-testid=adornment-checkbox-movable-line]").click()
+    cy.get("[data-testid=adornment-checkbox-residual-plot]").click()
+    cy.get("*[data-testid^=residual-points-]").find("circle").should("have.length.at.least", 1)
+
+    // Drags a marquee over a horizontal slice of the residual strip, expressed as fractions of its
+    // width. pointermove/pointerup go to the document so they reach the marquee's window listeners.
+    const dragSlice = (fromFraction: number, toFraction: number, shiftKey: boolean) => {
+      cy.get("[data-testid^=residual-plot-background-]").first().then($rect => {
+        const r = $rect[0].getBoundingClientRect()
+        const x = (fraction: number) => r.left + (r.right - r.left) * fraction
+        const [x1, y1, x2, y2] = [x(fromFraction), r.top + 4, x(toFraction), r.bottom - 4]
+        cy.wrap($rect).trigger("pointerdown", { clientX: x1, clientY: y1, shiftKey, force: true })
+        cy.document().trigger("pointermove", { clientX: (x1 + x2) / 2, clientY: (y1 + y2) / 2, shiftKey })
+        cy.document().trigger("pointermove", { clientX: x2, clientY: y2, shiftKey })
+        cy.document().trigger("pointerup", { clientX: x2, clientY: y2, shiftKey })
+      })
+    }
+    const selectedPoints = () => cy.get('*[data-testid^=residual-point-][fill="#4682b4"]')
+
+    // Establish a selection by marqueeing the left half of the strip.
+    dragSlice(0.01, 0.5, false)
+    selectedPoints().should("have.length.at.least", 1)
+    selectedPoints().then($selected => {
+      const leftCount = $selected.length
+      const leftIds = [...$selected].map(el => el.getAttribute("data-testid"))
+
+      // Shift-dragging the right half adds to that selection rather than replacing it: every
+      // left-half point stays selected and the total grows.
+      dragSlice(0.51, 0.99, true)
+      selectedPoints().should("have.length.greaterThan", leftCount)
+      leftIds.forEach(id => cy.get(`*[data-testid="${id}"]`).should("have.attr", "fill", "#4682b4"))
+
+      // Without Shift the same drag replaces the selection, so the left-half points are dropped.
+      dragSlice(0.51, 0.99, false)
+      leftIds.forEach(id => cy.get(`*[data-testid="${id}"]`).should("not.have.attr", "fill", "#4682b4"))
+    })
+  })
 })

--- a/v3/cypress/e2e/bivariate-adornments.spec.ts
+++ b/v3/cypress/e2e/bivariate-adornments.spec.ts
@@ -422,4 +422,36 @@ context("Graph adornments", () => {
     cy.get("[data-testid^=residual-plot-background-]").click("topLeft", { force: true })
     cy.get("*[data-testid^=residual-point-]").first().should("not.have.attr", "fill", "#4682b4")
   })
+
+  it("marquee-selects residual points with a drag over the residual strip", () => {
+    c.selectTile("graph", 0)
+    cy.dragAttributeToTarget("table", "Sleep", "bottom")
+    cy.dragAttributeToTarget("table", "Speed", "left")
+    graph.getDisplayValuesButton().click()
+    cy.get("[data-testid=adornment-checkbox-movable-line]").click()
+    cy.get("[data-testid=adornment-checkbox-residual-plot]").click()
+    cy.get("*[data-testid^=residual-points-]").find("circle").should("have.length.at.least", 1)
+
+    // No residual point carries the solid selection fill before the drag.
+    cy.get('*[data-testid^=residual-point-][fill="#4682b4"]').should("not.exist")
+
+    // Drag a marquee across the whole residual strip. pointermove/pointerup are dispatched on the
+    // document so they reach the window-level listeners the marquee attaches on pointerdown.
+    cy.get("[data-testid^=residual-plot-background-]").first().then($rect => {
+      const r = $rect[0].getBoundingClientRect()
+      const x1 = r.left + 4
+      const y1 = r.top + 4
+      const x2 = r.right - 4
+      const y2 = r.bottom - 4
+      cy.wrap($rect).trigger("pointerdown", { clientX: x1, clientY: y1, force: true })
+      cy.document().trigger("pointermove", { clientX: (x1 + x2) / 2, clientY: (y1 + y2) / 2 })
+      cy.document().trigger("pointermove", { clientX: x2, clientY: y2 })
+      cy.document().trigger("pointerup", { clientX: x2, clientY: y2 })
+    })
+
+    // The marquee covered the strip, so at least one residual point is now selected (selection fill),
+    // and the residual plot is not torn down.
+    cy.get('*[data-testid^=residual-point-][fill="#4682b4"]').should("have.length.at.least", 1)
+    cy.get("*[data-testid^=residual-points-]").find("circle").should("have.length.at.least", 1)
+  })
 })

--- a/v3/src/components/data-display/components/background.tsx
+++ b/v3/src/components/data-display/components/background.tsx
@@ -15,7 +15,7 @@ import { useGraphLayoutContext } from "../../graph/hooks/use-graph-layout-contex
 import { kZoomInFactor, kZoomOutFactor, zoomAxis } from "../../axis/axis-utils"
 import { isAnyNumericAxisModel } from "../../axis/models/numeric-axis-models"
 import {rTreeRect} from "../data-display-types"
-import {rectangleSubtract, rectNormalize} from "../data-display-utils"
+import {CaseObject, getCasesForDelta, rectNormalize, RTree} from "../data-display-utils"
 import {useDataDisplayLayout} from "../hooks/use-data-display-layout"
 import {useDataDisplayModelContext} from "../hooks/use-data-display-model"
 import {useRendererPointerDownDeselect} from "../hooks/use-renderer-pointer-down-deselect"
@@ -25,13 +25,6 @@ import { BackgroundPassThroughEvent, PointRendererArray } from "../renderer"
 interface IProps {
   marqueeState: MarqueeState
   rendererArray: PointRendererArray
-}
-
-type RTree = ReturnType<typeof RTreeLib>
-
-interface caseObject {
-  datasetID: string
-  caseID: string
 }
 
 interface SelectionSpec {
@@ -59,18 +52,6 @@ const prepareTree = (rendererArray: PointRendererArray): RTree => {
     })
   })
   return selectionTree
-}
-
-const getCasesForDelta = (tree: RTree | null, newRect: rTreeRect, prevRect: rTreeRect) => {
-  if (!tree) return []
-
-  const diffRects = rectangleSubtract(newRect, prevRect)
-  let caseObjects: caseObject[] = []
-  diffRects.forEach(aRect => {
-    const newlyFoundCaseObjects = tree.search(aRect)
-    caseObjects = caseObjects.concat(newlyFoundCaseObjects)
-  })
-  return caseObjects
 }
 
 export const Background = forwardRef<SVGGElement | HTMLDivElement, IProps>((props, ref) => {
@@ -165,10 +146,10 @@ export const Background = forwardRef<SVGGElement | HTMLDivElement, IProps>((prop
     const newSelection = getCasesForDelta(selectionTree.current, currentRect, previousMarqueeRect.current)
     const newDeselection = getCasesForDelta(selectionTree.current, previousMarqueeRect.current, currentRect)
     // Stash the caseIDs to select and deselect for each dataset
-    newSelection.forEach((caseObject: caseObject) => {
+    newSelection.forEach((caseObject: CaseObject) => {
       datasetsMap[caseObject.datasetID].caseIDsToSelect.push(caseObject.caseID)
     })
-    newDeselection.forEach((caseObject: caseObject) => {
+    newDeselection.forEach((caseObject: CaseObject) => {
       datasetsMap[caseObject.datasetID].caseIDsToDeselect.push(caseObject.caseID)
     })
     // Apply the selections and de-selections for each dataset. selectAndDeselectCases uses a

--- a/v3/src/components/data-display/data-display-utils.test.ts
+++ b/v3/src/components/data-display/data-display-utils.test.ts
@@ -5,9 +5,10 @@ import {
   defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeOpacity, defaultSelectedStrokeWidth,
   defaultStrokeOpacity, defaultStrokeWidth
 } from "../../utilities/color-utils"
+import RTreeLib from "rtree"
 import { GraphDataConfigurationModel } from "../graph/models/graph-data-configuration-model"
 import { IPointStyle, PointRendererBase } from "./renderer"
-import { setPointSelection } from "./data-display-utils"
+import { getCasesForDelta, setPointSelection } from "./data-display-utils"
 
 const TreeModel = types.model("Tree", {
   data: DataSet,
@@ -281,5 +282,21 @@ describe("setPointSelection", () => {
     expect(mockRenderer.forEachPoint).toHaveBeenCalled()
     expect(mockRenderer.getPointForCaseData).not.toHaveBeenCalled()
     expect(styleUpdates.size).toBe(3)
+  })
+})
+
+describe("getCasesForDelta", () => {
+  it("returns only cases inside the newly-entered region", () => {
+    const tree = RTreeLib(10)
+    tree.insert({ x: 5, y: 5, w: 1, h: 1 }, { datasetID: "d", caseID: "a" })
+    tree.insert({ x: 50, y: 50, w: 1, h: 1 }, { datasetID: "d", caseID: "b" })
+    const prev = { x: 0, y: 0, w: 10, h: 10 }   // contains "a" only
+    const next = { x: 0, y: 0, w: 100, h: 100 } // contains "a" and "b"
+    const entered = getCasesForDelta(tree, next, prev)
+    expect(entered.map(c => c.caseID)).toEqual(["b"])
+  })
+
+  it("returns [] when the tree is null", () => {
+    expect(getCasesForDelta(null, { x: 0, y: 0, w: 1, h: 1 }, { x: 0, y: 0, w: 1, h: 1 })).toEqual([])
   })
 })

--- a/v3/src/components/data-display/data-display-utils.test.ts
+++ b/v3/src/components/data-display/data-display-utils.test.ts
@@ -1,11 +1,11 @@
 import { Instance, types } from "mobx-state-tree"
+import RTreeLib from "rtree"
 import { DataSet, toCanonical } from "../../models/data/data-set"
 import { DataSetMetadata } from "../../models/shared/data-set-metadata"
 import {
   defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeOpacity, defaultSelectedStrokeWidth,
   defaultStrokeOpacity, defaultStrokeWidth
 } from "../../utilities/color-utils"
-import RTreeLib from "rtree"
 import { GraphDataConfigurationModel } from "../graph/models/graph-data-configuration-model"
 import { IPointStyle, PointRendererBase } from "./renderer"
 import { getCasesForDelta, setPointSelection } from "./data-display-utils"

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -1,4 +1,3 @@
-import RTreeLib from "rtree"
 import {measureText} from "../../hooks/use-measure-text"
 import {IDataSet} from "../../models/data/data-set"
 import { selectCases, setOrExtendSelection } from "../../models/data/data-set-utils"
@@ -242,11 +241,16 @@ export function rectangleSubtract(iA: rTreeRect, iB: rTreeRect) {
   return result
 }
 
-export type RTree = ReturnType<typeof RTreeLib>
-
 export interface CaseObject {
   datasetID: string
   caseID: string
+}
+
+// Minimal structural view of the rtree instance needed for marquee delta hit-testing. Declaring it
+// here (rather than `ReturnType<typeof RTreeLib>`) keeps the runtime `rtree` import out of this
+// widely-imported module; the tree is constructed by callers that already depend on rtree.
+export interface RTree {
+  search(rect: rTreeRect): CaseObject[]
 }
 
 // Delta hit-test: the caseObjects that fall in newRect but not prevRect, found by searching only the

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -1,3 +1,4 @@
+import RTreeLib from "rtree"
 import {measureText} from "../../hooks/use-measure-text"
 import {IDataSet} from "../../models/data/data-set"
 import { selectCases, setOrExtendSelection } from "../../models/data/data-set-utils"
@@ -239,6 +240,26 @@ export function rectangleSubtract(iA: rTreeRect, iB: rTreeRect) {
   }
 
   return result
+}
+
+export type RTree = ReturnType<typeof RTreeLib>
+
+export interface CaseObject {
+  datasetID: string
+  caseID: string
+}
+
+// Delta hit-test: the caseObjects that fall in newRect but not prevRect, found by searching only the
+// difference region(s). Proportional to what changed, not to the total point count. Shared by the
+// graph/map background marquee and the residual-plot marquee.
+export const getCasesForDelta = (tree: RTree | null, newRect: rTreeRect, prevRect: rTreeRect): CaseObject[] => {
+  if (!tree) return []
+  const diffRects = rectangleSubtract(newRect, prevRect)
+  let caseObjects: CaseObject[] = []
+  diffRects.forEach(aRect => {
+    caseObjects = caseObjects.concat(tree.search(aRect))
+  })
+  return caseObjects
 }
 
 export function rectToTreeRect(rect: Rect) {

--- a/v3/src/components/data-display/hooks/use-marquee-state.ts
+++ b/v3/src/components/data-display/hooks/use-marquee-state.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from "react"
+import { MarqueeState } from "../models/marquee-state"
+
+// Shares the display's MarqueeState with descendants (e.g. a plot that renders its own marquee)
+// without threading it through props. Provided by the graph alongside the Background/Marquee it
+// already passes the same state to.
+export const MarqueeStateContext = createContext<MarqueeState | undefined>(undefined)
+
+export const useMarqueeStateContext = () => useContext(MarqueeStateContext)

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -506,73 +506,73 @@ export const Graph = observer(function Graph({
   return (
     <GraphDataConfigurationContext.Provider value={graphModel.dataConfiguration}>
       <MarqueeStateContext.Provider value={marqueeState}>
-      <div className={clsx(kGraphClass, kPortalClass)} ref={mySetGraphRef} data-testid="graph">
-        {graphModel.showParentToggles && <ParentToggles/>}
-        <svg className='graph-svg' ref={svgRef}>
-          <Background
-            ref={backgroundSvgRef}
-            marqueeState={marqueeState}
-            rendererArray={rendererArray}
-          />
+        <div className={clsx(kGraphClass, kPortalClass)} ref={mySetGraphRef} data-testid="graph">
+          {graphModel.showParentToggles && <ParentToggles/>}
+          <svg className='graph-svg' ref={svgRef}>
+            <Background
+              ref={backgroundSvgRef}
+              marqueeState={marqueeState}
+              rendererArray={rendererArray}
+            />
 
-          {renderGraphAxes()}
-          {/*
-            Note that this division into plotArea1 and plotArea2 SVG group elements, along with the separate handling of
-            the Pixi container, is due to a Safari-specific bug. Apparently, Safari renders the position of foreign
-            element content incorrectly if it or its parent is translated. The only workaround, as of January 2024, is
-            to use the X and Y attributes of the foreignElement tag itself. See:
-            - https://www.pivotaltracker.com/story/show/186784214
-            - https://bugs.webkit.org/show_bug.cgi?id=219978
-            - https://github.com/bkrem/react-d3-tree/issues/284
-          */}
-          <g className="below-points-group" ref={belowPointsGroupRef}>
-            {/* Components rendered below the dots/points should be added to this group. */}
-            {renderDisplayOnlySelectedWarning()}
-            {renderPlotComponent()}
-          </g>
-        </svg>
-        {/* HTML host for Pixi canvas to avoid Safari foreignObject issues */}
-        <div ref={pixiContainerRef} className="pixi-points-host" />
-        {/* Renderer type indicator (developer only - enable with localStorage debug="renderers") */}
-        <If condition={DEBUG_RENDERERS && !!rendererType && rendererType !== "null"}>
-          <div
-            className="renderer-type-indicator"
-            style={{ bottom: layout.getComputedBounds("legend").height + 4 }}
-            title={rendererType === "webgl"
-              ? "WebGL renderer (click to switch)"
-              : "Canvas 2D renderer (click to switch)"}
-            onClick={onToggleRendererType}
-          >
-            {rendererType === "webgl" ? "GL" : "2D"}
-          </div>
-        </If>
-        <svg className="overlay-svg">
-          <g className="above-points-group" ref={abovePointsGroupRef}>
-            {/* Components rendered on top of the dots/points should be added to this group. */}
-            <Marquee marqueeState={marqueeState}/>
-          </g>
+            {renderGraphAxes()}
+            {/*
+              Note that this division into plotArea1 and plotArea2 SVG group elements, along with the separate handling
+              of the Pixi container, is due to a Safari-specific bug. Apparently, Safari renders the position of foreign
+              element content incorrectly if it or its parent is translated. The only workaround, as of January 2024, is
+              to use the X and Y attributes of the foreignElement tag itself. See:
+              - https://www.pivotaltracker.com/story/show/186784214
+              - https://bugs.webkit.org/show_bug.cgi?id=219978
+              - https://github.com/bkrem/react-d3-tree/issues/284
+            */}
+            <g className="below-points-group" ref={belowPointsGroupRef}>
+              {/* Components rendered below the dots/points should be added to this group. */}
+              {renderDisplayOnlySelectedWarning()}
+              {renderPlotComponent()}
+            </g>
+          </svg>
+          {/* HTML host for Pixi canvas to avoid Safari foreignObject issues */}
+          <div ref={pixiContainerRef} className="pixi-points-host" />
+          {/* Renderer type indicator (developer only - enable with localStorage debug="renderers") */}
+          <If condition={DEBUG_RENDERERS && !!rendererType && rendererType !== "null"}>
+            <div
+              className="renderer-type-indicator"
+              style={{ bottom: layout.getComputedBounds("legend").height + 4 }}
+              title={rendererType === "webgl"
+                ? "WebGL renderer (click to switch)"
+                : "Canvas 2D renderer (click to switch)"}
+              onClick={onToggleRendererType}
+            >
+              {rendererType === "webgl" ? "GL" : "2D"}
+            </div>
+          </If>
+          <svg className="overlay-svg">
+            <g className="above-points-group" ref={abovePointsGroupRef}>
+              {/* Components rendered on top of the dots/points should be added to this group. */}
+              <Marquee marqueeState={marqueeState}/>
+            </g>
 
-          <DroppablePlot
-            graphElt={graphRef.current}
-            plotElt={backgroundSvgRef.current}
-            insets={plotDropInsets}
+            <DroppablePlot
+              graphElt={graphRef.current}
+              plotElt={backgroundSvgRef.current}
+              insets={plotDropInsets}
+              onDropAttribute={handleChangeAttribute}
+            />
+          </svg>
+          <MultiLegend
+            divElt={graphRef.current}
             onDropAttribute={handleChangeAttribute}
           />
-        </svg>
-        <MultiLegend
-          divElt={graphRef.current}
-          onDropAttribute={handleChangeAttribute}
-        />
-        <Adornments/>
-        {renderDroppableAddAttributes()}
-        <DataTip
-          dataConfiguration={graphModel.dataConfiguration}
-          dataset={dataset}
-          getTipAttrs={getTipAttrs}
-          renderer={renderer}
-          getTipText={graphModel.getTipText}
-        />
-      </div>
+          <Adornments/>
+          {renderDroppableAddAttributes()}
+          <DataTip
+            dataConfiguration={graphModel.dataConfiguration}
+            dataset={dataset}
+            getTipAttrs={getTipAttrs}
+            renderer={renderer}
+            getTipText={graphModel.getTipText}
+          />
+        </div>
       </MarqueeStateContext.Provider>
     </GraphDataConfigurationContext.Provider>
   )

--- a/v3/src/components/graph/components/graph.tsx
+++ b/v3/src/components/graph/components/graph.tsx
@@ -33,6 +33,7 @@ import {GraphAttrRole, graphPlaceToAttrRole, kPortalClass} from "../../data-disp
 import {useDataDisplayAnimation} from "../../data-display/hooks/use-data-display-animation"
 import {isSetAttributeIDAction} from "../../data-display/models/display-model-actions"
 import {MarqueeState} from "../../data-display/models/marquee-state"
+import {MarqueeStateContext} from "../../data-display/hooks/use-marquee-state"
 import { setNumberOfCategoriesLimit } from "../../axis/axis-utils"
 import {Adornments} from "../adornments/components/adornments"
 import {IPlotProps, kDropZoneGap, kDropZoneSize, kGraphClass, PlotType} from "../graphing-types"
@@ -504,6 +505,7 @@ export const Graph = observer(function Graph({
 
   return (
     <GraphDataConfigurationContext.Provider value={graphModel.dataConfiguration}>
+      <MarqueeStateContext.Provider value={marqueeState}>
       <div className={clsx(kGraphClass, kPortalClass)} ref={mySetGraphRef} data-testid="graph">
         {graphModel.showParentToggles && <ParentToggles/>}
         <svg className='graph-svg' ref={svgRef}>
@@ -571,6 +573,7 @@ export const Graph = observer(function Graph({
           getTipText={graphModel.getTipText}
         />
       </div>
+      </MarqueeStateContext.Provider>
     </GraphDataConfigurationContext.Provider>
   )
 })

--- a/v3/src/components/graph/plots/scatter-plot/residual-marquee-utils.test.ts
+++ b/v3/src/components/graph/plots/scatter-plot/residual-marquee-utils.test.ts
@@ -1,0 +1,34 @@
+import { buildResidualPositions, clampRectToLowerRegion } from "./residual-marquee-utils"
+
+describe("buildResidualPositions", () => {
+  it("maps each residual to screen coords y = plotHeight + lowerScale(residual)", () => {
+    const residuals = [{ caseID: "a", x: 1, residual: 2 }, { caseID: "b", x: 3, residual: -1 }]
+    const getXCoord = (id: string) => (id === "a" ? 10 : 30)
+    const lowerScale = (r: number) => r * 5 // stand-in linear scale
+    const positions = buildResidualPositions(residuals, getXCoord, 100, lowerScale)
+    expect(positions).toEqual([
+      { caseID: "a", x: 10, y: 110 },
+      { caseID: "b", x: 30, y: 95 }
+    ])
+  })
+
+  it("drops points with non-finite coordinates", () => {
+    const residuals = [{ caseID: "a", x: NaN, residual: 2 }]
+    const positions = buildResidualPositions(residuals, () => NaN, 100, (r) => r)
+    expect(positions).toEqual([])
+  })
+})
+
+describe("clampRectToLowerRegion", () => {
+  const region = { top: 100, bottom: 160, right: 200 }
+
+  it("clamps a rect that overflows the region to the region bounds", () => {
+    const clamped = clampRectToLowerRegion({ x: -20, y: 40, w: 300, h: 200 }, region)
+    expect(clamped).toEqual({ x: 0, y: 100, w: 200, h: 60 })
+  })
+
+  it("leaves an already-contained rect unchanged", () => {
+    const clamped = clampRectToLowerRegion({ x: 10, y: 110, w: 50, h: 20 }, region)
+    expect(clamped).toEqual({ x: 10, y: 110, w: 50, h: 20 })
+  })
+})

--- a/v3/src/components/graph/plots/scatter-plot/residual-marquee-utils.ts
+++ b/v3/src/components/graph/plots/scatter-plot/residual-marquee-utils.ts
@@ -1,0 +1,40 @@
+import { rTreeRect } from "../../../data-display/data-display-types"
+import { IResidualPoint } from "./residual-plot-utils"
+
+export interface IResidualPosition {
+  caseID: string
+  x: number
+  y: number
+}
+
+// Screen position of each residual point, in the graph-SVG coordinate frame: x from the shared
+// getXCoord, y on the lower axis (plotHeight is the top of the residual region). Mirrors the cx/cy
+// used to draw the residual circles, so the hit-test index and the drawn points agree by construction.
+export function buildResidualPositions(
+  residuals: IResidualPoint[], getXCoord: (caseID: string) => number,
+  plotHeight: number, lowerScale: (residual: number) => number
+): IResidualPosition[] {
+  const positions: IResidualPosition[] = []
+  residuals.forEach(r => {
+    const x = getXCoord(r.caseID)
+    const y = plotHeight + lowerScale(r.residual)
+    if (isFinite(x) && isFinite(y)) positions.push({ caseID: r.caseID, x, y })
+  })
+  return positions
+}
+
+export interface ILowerRegion {
+  top: number
+  bottom: number
+  right: number
+}
+
+// Clamp a normalized rect to the residual region so the marquee can neither extend into the upper
+// plot nor past the plot edges. Keeps the visible rect and the hit-test rect identical.
+export function clampRectToLowerRegion(rect: rTreeRect, region: ILowerRegion): rTreeRect {
+  const left = Math.max(0, rect.x)
+  const top = Math.max(region.top, rect.y)
+  const right = Math.min(region.right, rect.x + rect.w)
+  const bottom = Math.min(region.bottom, rect.y + rect.h)
+  return { x: left, y: top, w: Math.max(0, right - left), h: Math.max(0, bottom - top) }
+}

--- a/v3/src/components/graph/plots/scatter-plot/residual-marquee-utils.ts
+++ b/v3/src/components/graph/plots/scatter-plot/residual-marquee-utils.ts
@@ -23,6 +23,8 @@ export function buildResidualPositions(
   return positions
 }
 
+// The region's left edge is always 0, so it isn't carried here: the residual hit rect is drawn at
+// x=0 in the same group as the residual points, which puts the frame's origin at the plot's left edge.
 export interface ILowerRegion {
   top: number
   bottom: number

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -1,4 +1,4 @@
-import {format, ScaleLinear, select} from "d3"
+import {ScaleLinear, select} from "d3"
 import { tip as d3tip } from "d3-v6-tip"
 import { untracked } from "mobx"
 import { observer } from "mobx-react-lite"
@@ -38,11 +38,8 @@ import {useGraphDataConfigurationContext} from "../../hooks/use-graph-data-confi
 import {useGraphLayoutContext} from "../../hooks/use-graph-layout-context"
 import {useRendererDragHandlers, usePlotResponders} from "../../hooks/use-plot"
 import { setPointCoordinates } from "../../utilities/graph-utils"
-import { isNumericAxisModel, NumericAxisModel } from "../../../axis/models/numeric-axis-models"
-import {
-  computeResiduals, getPredictor, IResidualPoint, residualDomain, residualPlotIsApplicable, residualPointStyle
-} from "./residual-plot-utils"
 import { connectingLinesSignature, scatterPlotFuncs } from "./scatter-plot-utils"
+import { useResidualPlot } from "./use-residual-plot"
 
 export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProps) {
   const graphModel = useGraphContentModelContext(),
@@ -75,7 +72,10 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
   const movableLineSquaresRef = useRef<SVGGElement>(null)
   const lsrlSquaresRef = useRef<SVGGElement>(null)
   const functionSquaresRef = useRef<SVGGElement>(null)
-  const residualPointsRef = useRef<SVGGElement>(null)
+
+  const { residualPointsRef, renderResidualsIfActive, restyleResidualSelection } = useResidualPlot({
+    graphModel, dataConfiguration, dataset, layout, legendAttrID
+  })
 
   const connectingLinesRef = useRef<SVGGElement>(null)
   const connectingLinesActivatedRef = useRef(false)
@@ -207,127 +207,6 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
   }, [dataConfiguration, dataset, dragID, startAnimation])
 
   useRendererDragHandlers(renderer, {start: onDragStart, drag: onDrag, end: onDragEnd})
-
-  // Hover tooltip for residual points. Matches the "graph-d3-tip" styling used by other adornment
-  // hovers so the tip visually reads like the main plot's data tips. The `no-svg-export` class
-  // keeps it out of image exports. Disposed on unmount so the DOM node d3-tip attaches to
-  // document.body doesn't leak across scatter-plot mounts.
-  const residualDataTipRef = useRef(
-    d3tip().attr("class", "graph-d3-tip no-svg-export")
-      .attr("data-testid", "residual-data-tip")
-      .html((d: string) => `<p>${d}</p>`)
-  )
-  useEffect(() => {
-    const tip = residualDataTipRef.current
-    return () => { tip.destroy?.() }
-  }, [])
-
-  // Selection-dependent styling for one residual point. Reads the dataset selection (observable),
-  // so callers in a reactive context must apply it via untracked (see renderResidualPoints) to avoid
-  // subscribing to selection. Delegates the pure decision to residualPointStyle (unit-tested).
-  const styleFor = useCallback((caseID: string) => {
-    const isSelected = !!dataset?.isCaseSelected(caseID)
-    // The legend handling here is intentionally retained even though residualPlotIsApplicable
-    // currently excludes legends (so legendAttrID is always undefined in this path today). Coloring
-    // each residual point by its legend category is structurally/mathematically well-defined — each
-    // point's residual is taken against its own category's line, and the adornments already store a
-    // line per cell — so this is kept ready for a future legend-supporting version rather than
-    // removed as dead code. (Enabling it also means dropping the legend exclusion and making the
-    // predictor cell-aware; see getPredictor/computeResiduals in residual-plot-utils.)
-    const legendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase(caseID) : undefined
-    const { pointColor, pointStrokeColor } = graphModel.pointDescription
-    return residualPointStyle({
-      isSelected, hasLegend: !!legendAttrID, legendColor, pointColor, pointStrokeColor,
-      pointRadius: graphModel.getPointRadius(), selectedRadius: graphModel.getPointRadius('select')
-    })
-  }, [dataset, legendAttrID, dataConfiguration, graphModel])
-
-  // Selection-only restyle: re-set the selection-dependent attrs on the existing circles. No data
-  // join, no residual/predictor recompute — a selection change (via refreshPointSelection) updates
-  // styling without re-running the residual pipeline.
-  // Compute the style once per circle (styleFor does selection/legend lookups) rather than per attr.
-  const applyResidualStyles = useCallback((g: SVGGElement) => {
-    select(g).selectAll<SVGCircleElement, IResidualPoint>("circle")
-      .each(function (d) {
-        const style = styleFor(d.caseID)
-        select(this)
-          .attr("r", style.radius)
-          .attr("fill", style.fill)
-          .attr("stroke", style.stroke)
-          .attr("stroke-width", style.strokeWidth)
-          .attr("stroke-opacity", style.strokeOpacity)
-      })
-  }, [styleFor])
-
-  // Restyle residual points to track the current selection. Called by refreshPointSelection on every
-  // selection change. Cheap (attrs only) and does not touch the split layout or the leftLower axis.
-  const restyleResidualSelection = useCallback(() => {
-    const g = residualPointsRef.current
-    if (g) applyResidualStyles(g)
-  }, [applyResidualStyles])
-
-  // Geometry + structure paint: the data join, positions, hover tip, and click handling. Selection
-  // styling is applied at the end under untracked so that the syncResidualPlot autorun (which calls
-  // this) does not subscribe to the selection set — otherwise every selection change would re-fire
-  // the autorun and recompute the predictor/residuals purely to update halos.
-  const renderResidualPoints = useCallback((residuals: IResidualPoint[]) => {
-    const g = residualPointsRef.current
-    if (!g) return
-    const { getXCoord } = scatterPlotFuncs(layout, dataConfiguration)
-    const lowerScale = layout.getAxisScale("leftLower") as ScaleLinear<number, number> | undefined
-    if (!lowerScale) {
-      select(g).selectAll("circle").remove()
-      return
-    }
-    const plotHeight = layout.plotHeight
-    // Hover tip: "<xAttrName>: <xValue><br/>Residual: <value>". Numeric formatting mirrors the
-    // main plot's data tip (three significant figures via d3.format('.3~f')).
-    const xAttrID = dataConfiguration?.attributeID("x") ?? ""
-    const xAttr = dataset?.getAttribute(xAttrID)
-    const xAttrName = xAttr?.name ?? ""
-    const float = format(".3~f")
-    const tipTextFor = (d: IResidualPoint) => {
-      const xValue = dataset?.getValue(d.caseID, xAttrID)
-      const xValueStr = typeof xValue === "number" && isFinite(xValue)
-        ? float(xValue) : (xValue != null ? String(xValue) : "")
-      const residualStr = isFinite(d.residual) ? float(d.residual) : String(d.residual)
-      return `${xAttrName}: ${xValueStr}<br/>${t("V3.ResidualPlot.dataTip.residual")}: ${residualStr}`
-    }
-    const residualTip = residualDataTipRef.current
-    // Install the tip on the parent SVG so absolute positioning works.
-    select(g).call(residualTip)
-    select(g).selectAll<SVGCircleElement, IResidualPoint>("circle")
-      .data(residuals, d => d.caseID)
-      .join("circle")
-      .attr("data-testid", d => `residual-point-${d.caseID}`)
-      .attr("cx", d => getXCoord(d.caseID))
-      .attr("cy", d => plotHeight + lowerScale(d.residual))
-      .style("cursor", "pointer")
-      .on("mouseover", function(event, d) { residualTip.show(tipTextFor(d), this) })
-      .on("mouseout", () => residualTip.hide())
-      .on("click", (event, d) => {
-        // handleClickOnCase honors shift/meta/ctrl for extend selection, matching the upper plot.
-        // stopPropagation prevents the click from bubbling to the residual-plot-background rect,
-        // whose handler would immediately deselect everything the click just selected.
-        event.stopPropagation()
-        if (dataset) handleClickOnCase(event, d.caseID, dataset)
-      })
-    // Apply current selection styling to the (possibly new) circles without subscribing to selection.
-    untracked(() => applyResidualStyles(g))
-  }, [layout, dataConfiguration, dataset, applyResidualStyles])
-
-  // Recompute and repaint the residual points if the Residual Plot is active and all applicability
-  // constraints hold. Single entry-point used by every code path that needs to refresh the residual
-  // rendering — the sync autorun, the post-mount effect, the upper-plot's refreshPointPositions
-  // (drag caching), and refreshPointSelection (selection halo sync). No-op when inactive.
-  const renderResidualsIfActive = useCallback(() => {
-    if (!adornmentsStore.showResidualPlot) return
-    if (!residualPlotIsApplicable(adornmentsStore, dataConfiguration)) return
-    if (!dataConfiguration) return
-    const predictor = getPredictor(adornmentsStore, dataConfiguration)
-    if (!predictor) return
-    renderResidualPoints(computeResiduals(dataConfiguration, predictor))
-  }, [adornmentsStore, dataConfiguration, renderResidualPoints])
 
   // When caseIds is provided, only those cases' points are restyled (delta path used during a
   // marquee drag); otherwise every point is restyled.
@@ -537,80 +416,6 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
   useEffect(function drawSquaresAfterMount() {
     if (showSquares) refreshSquares()
   }, [showSquares, movableLine?.isVisible, lsrl?.isVisible, plottedFunctionModel?.isVisible, refreshSquares])
-
-  // Sync the split-plot layout, lower y-axis registration, and residual point rendering with the
-  // Residual Plot store boolean and applicability. When active, activate the split layout, ensure a
-  // NumericAxisModel at "leftLower" with the auto-scaled residual domain, and paint the residual
-  // points. When inactive, tear the split down and clear the points. The store boolean persists as
-  // user intent (mirroring Squares of Residuals); this reaction owns the derived state.
-  //
-  // Load-bearing pattern: every mutation below is preceded by a read-and-compare guard
-  // (`if (!layout.showLowerPlot)`, `if (axis.min !== minY || ...)`, etc.). MobX would otherwise
-  // re-fire this autorun on its own mutations because it reads the same observables it writes
-  // (layout.showLowerPlot, axis.min/max, etc.). The guards make each mutation idempotent so a
-  // re-fire converges immediately. Do NOT remove any guard without adding equivalent protection —
-  // an unguarded write here creates an infinite reaction loop.
-  useEffect(function syncResidualPlot() {
-    return mstAutorun(() => {
-      // Tear the split down: collapse the lower region, drop the leftLower axis, clear the points.
-      // Idempotent (each mutation is guarded), so calling it when already inactive is a no-op.
-      const teardown = () => {
-        if (layout.showLowerPlot) layout.setShowLowerPlot(false)
-        if (graphModel.getAxis("leftLower")) graphModel.removeAxis("leftLower")
-        if (residualPointsRef.current) select(residualPointsRef.current).selectAll("circle").remove()
-      }
-      const isActive = adornmentsStore.showResidualPlot && residualPlotIsApplicable(adornmentsStore, dataConfiguration)
-      if (!isActive) {
-        teardown()
-        return
-      }
-      // Applicability doesn't guarantee the line is computable (e.g. an LSRL with < 2 finite points,
-      // or a plotted function not yet populated). If there's no predictor, tear down rather than
-      // leaving stale residual UI on screen.
-      const predictor = getPredictor(adornmentsStore, dataConfiguration)
-      if (!predictor || !dataConfiguration) {
-        teardown()
-        return
-      }
-      const residuals = computeResiduals(dataConfiguration, predictor)
-      const [minY, maxY] = residualDomain(residuals)
-      if (!layout.showLowerPlot) layout.setShowLowerPlot(true)
-      let axis = graphModel.getAxis("leftLower")
-      if (!axis || !isNumericAxisModel(axis)) {
-        graphModel.setAxis("leftLower", NumericAxisModel.create({ place: "leftLower", min: minY, max: maxY }))
-        axis = graphModel.getAxis("leftLower")
-      }
-      if (axis && isNumericAxisModel(axis)) {
-        if (axis.min !== minY || axis.max !== maxY) {
-          // setDomain is grow-only by default; the Residual Plot's domain must be able to shrink as
-          // the line moves closer to fit. Allow shrinking for this one call (the flag auto-resets).
-          axis.setAllowRangeToShrink(true)
-          axis.setDomain(minY, maxY)
-        }
-      }
-      // The graph-controller's installAxisReaction only watches "left" and "bottom"; changes to the
-      // "leftLower" axis model do not automatically push through to the MultiScale that owns the D3
-      // scale used for pixel mapping. Sync explicitly — guarded like the mutations above so a re-fire
-      // with an unchanged scale type / domain is a no-op (setNumericDomain would otherwise write a
-      // fresh array every run and churn the domain observable during e.g. movable-line drag). Guard
-      // on the MultiScale's own domain, not the axis model's: on first activation the model already
-      // carries [minY, maxY], so an axis-based guard would wrongly skip the initial MultiScale sync.
-      const multiScale = layout.getAxisMultiScale("leftLower")
-      if (multiScale.scaleType !== "linear") layout.setAxisScaleType("leftLower", "linear")
-      const [curMin, curMax] = multiScale.numericDomain
-      if (curMin !== minY || curMax !== maxY) {
-        multiScale.setNumericDomain([minY, maxY])
-      }
-      renderResidualPoints(residuals)
-    }, { name: "ScatterPlot.syncResidualPlot" }, graphModel)
-  }, [adornmentsStore, dataConfiguration, graphModel, layout, renderResidualPoints])
-
-  // Post-mount effect: the residual points <g> is conditionally mounted on layout.showLowerPlot,
-  // so its ref is null the first time the autorun runs (state flips and JSX re-renders in the same
-  // tick). This redraws once the group is committed.
-  useEffect(function drawResidualPointsAfterMount() {
-    renderResidualsIfActive()
-  }, [layout.showLowerPlot, adornmentsStore.showResidualPlot, renderResidualsIfActive])
 
   // Show/hide toggle: full render (with fade). Observe only showConnectingLines — adding a case must
   // not rebuild lines from here (that caused ~4x O(N) rebuilds per streamed case); per-add updates

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -9,7 +9,7 @@ import {useInstanceIdContext} from "../../../../hooks/use-instance-id-context"
 import {appState} from "../../../../models/app-state"
 import {ICase} from "../../../../models/data/data-set-types"
 import {
-  firstVisibleParentAttribute, idOfChildmostCollectionForAttributes, selectAllCases, selectCases, setSelectedCases
+  firstVisibleParentAttribute, idOfChildmostCollectionForAttributes, selectCases, setSelectedCases
 } from "../../../../models/data/data-set-utils"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
 import { t } from "../../../../utilities/translation/translate"
@@ -24,6 +24,7 @@ import {
   ConnectingLines, IConnectingLinesRenderInput
 } from "../../../data-display/models/connecting-lines"
 import {useDataDisplayAnimation} from "../../../data-display/hooks/use-data-display-animation"
+import {useMarqueeStateContext} from "../../../data-display/hooks/use-marquee-state"
 import { IPoint, IPointMetadata } from "../../../data-display/renderer"
 import { ILSRLAdornmentModel } from "../../adornments/lsrl/lsrl-adornment-model"
 import { IMovableLineAdornmentModel } from "../../adornments/movable-line/movable-line-adornment-model"
@@ -40,6 +41,7 @@ import {useRendererDragHandlers, usePlotResponders} from "../../hooks/use-plot"
 import { setPointCoordinates } from "../../utilities/graph-utils"
 import { connectingLinesSignature, scatterPlotFuncs } from "./scatter-plot-utils"
 import { useResidualPlot } from "./use-residual-plot"
+import { useResidualMarquee } from "./use-residual-marquee"
 
 export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProps) {
   const graphModel = useGraphContentModelContext(),
@@ -75,6 +77,11 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
 
   const { residualPointsRef, renderResidualsIfActive, restyleResidualSelection } = useResidualPlot({
     graphModel, dataConfiguration, dataset, layout, legendAttrID
+  })
+
+  const marqueeState = useMarqueeStateContext()
+  const residualMarquee = useResidualMarquee({
+    layout, dataConfiguration, dataset, adornmentsStore, marqueeState
   })
 
   const connectingLinesRef = useRef<SVGGElement>(null)
@@ -486,9 +493,9 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
         />
       }
       <If condition={layout.showLowerPlot}>
-        {/* Transparent background rect for the lower plot region. Captures clicks in the residual
-            plot's white space and deselects all cases (unless a modifier key is held), mirroring
-            the upper plot's background behavior wired via useRendererPointerDownDeselect. */}
+        {/* Transparent hit rect for the lower plot region. A drag marquee-selects the residual points
+            (useResidualMarquee); a click in the white space deselects all cases unless a modifier key
+            is held, mirroring the upper plot's background behavior. */}
         <rect
           data-testid={`residual-plot-background-${instanceId}`}
           className="residual-plot-background"
@@ -497,11 +504,8 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
           width={layout.getLowerPlotBounds().width}
           height={layout.getLowerPlotBounds().height}
           fill="transparent"
-          onClick={(event) => {
-            if (!event.shiftKey && !event.metaKey && !event.ctrlKey && dataset) {
-              selectAllCases(dataset, false)
-            }
-          }}
+          onPointerDown={residualMarquee.onPointerDown}
+          onClick={residualMarquee.onClick}
         />
         <g
           data-testid={`residual-points-${instanceId}`}

--- a/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
+++ b/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
@@ -99,6 +99,9 @@ export function useResidualMarquee(props: IUseResidualMarquee) {
     const onUp = () => {
       window.removeEventListener("pointermove", onMove)
       window.removeEventListener("pointerup", onUp)
+      // pointercancel (touch/gesture cancellation) also ends the drag, so the listeners and marquee
+      // rect don't leak until a later pointerup that may never come.
+      window.removeEventListener("pointercancel", onUp)
       marqueeState.setMarqueeRect({ x: 0, y: 0, width: 0, height: 0 })
       treeRef.current = null
       if (draggingRef.current) {
@@ -110,6 +113,7 @@ export function useResidualMarquee(props: IUseResidualMarquee) {
 
     window.addEventListener("pointermove", onMove)
     window.addEventListener("pointerup", onUp)
+    window.addEventListener("pointercancel", onUp)
   }, [adornmentsStore, dataConfiguration, dataset, layout, marqueeState])
 
   const onClick = useCallback((event: React.MouseEvent<SVGRectElement>) => {

--- a/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
+++ b/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
@@ -32,7 +32,6 @@ export function useResidualMarquee(props: IUseResidualMarquee) {
   const { layout, dataConfiguration, dataset, adornmentsStore, marqueeState } = props
   const treeRef = useRef<ReturnType<typeof RTreeLib> | null>(null)
   const startRef = useRef({ x: 0, y: 0 })
-  const sizeRef = useRef({ w: 0, h: 0 })
   const prevRectRef = useRef<rTreeRect | undefined>(undefined)
   const needsClearRef = useRef(false)
   const draggingRef = useRef(false)
@@ -61,7 +60,6 @@ export function useResidualMarquee(props: IUseResidualMarquee) {
       x: event.clientX - rectBounds.left,
       y: event.clientY - rectBounds.top + layout.plotHeight
     }
-    sizeRef.current = { w: 0, h: 0 }
     prevRectRef.current = undefined
     needsClearRef.current = !event.shiftKey
     draggingRef.current = false
@@ -72,15 +70,14 @@ export function useResidualMarquee(props: IUseResidualMarquee) {
     const lowerBounds = layout.getLowerPlotBounds()
     const region = { top: layout.plotHeight, bottom: layout.plotHeight + lowerBounds.height, right: lowerBounds.width }
 
-    const prev = { x: event.clientX, y: event.clientY }
+    const startClientX = event.clientX
+    const startClientY = event.clientY
     const onMove = (moveEvent: PointerEvent) => {
-      sizeRef.current.w += moveEvent.clientX - prev.x
-      sizeRef.current.h += moveEvent.clientY - prev.y
-      prev.x = moveEvent.clientX
-      prev.y = moveEvent.clientY
-      if (!draggingRef.current &&
-          Math.abs(sizeRef.current.w) < kMarqueeDragThreshold &&
-          Math.abs(sizeRef.current.h) < kMarqueeDragThreshold) {
+      // Net displacement from pointerdown. The rect is anchored at the pointerdown point
+      // (startRef), so this displacement is its signed width/height.
+      const w = moveEvent.clientX - startClientX
+      const h = moveEvent.clientY - startClientY
+      if (!draggingRef.current && Math.abs(w) < kMarqueeDragThreshold && Math.abs(h) < kMarqueeDragThreshold) {
         return // below threshold: still a click, not a drag
       }
       draggingRef.current = true
@@ -88,8 +85,7 @@ export function useResidualMarquee(props: IUseResidualMarquee) {
         if (dataset.selection.size > 0) selectAllCases(dataset, false)
         needsClearRef.current = false
       }
-      const rawRect = rectNormalize(
-        { x: startRef.current.x, y: startRef.current.y, w: sizeRef.current.w, h: sizeRef.current.h })
+      const rawRect = rectNormalize({ x: startRef.current.x, y: startRef.current.y, w, h })
       const rect = clampRectToLowerRegion(rawRect, region)
       marqueeState.setMarqueeRect({ x: rect.x, y: rect.y, width: rect.w, height: rect.h })
       const prevRect = prevRectRef.current ?? { x: rect.x, y: rect.y, w: 0, h: 0 }

--- a/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
+++ b/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
@@ -1,0 +1,121 @@
+import { ScaleLinear } from "d3"
+import { useCallback, useRef } from "react"
+import RTreeLib from "rtree"
+import { Logger } from "../../../../lib/logger"
+import { IDataSet } from "../../../../models/data/data-set"
+import { selectAllCases, selectAndDeselectCases } from "../../../../models/data/data-set-utils"
+import { rTreeRect } from "../../../data-display/data-display-types"
+import { getCasesForDelta, rectNormalize } from "../../../data-display/data-display-utils"
+import { MarqueeState } from "../../../data-display/models/marquee-state"
+import { IAdornmentsBaseStore } from "../../adornments/store/adornments-base-store"
+import { GraphLayout } from "../../models/graph-layout"
+import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
+import { computeResiduals, getPredictor } from "./residual-plot-utils"
+import { buildResidualPositions, clampRectToLowerRegion } from "./residual-marquee-utils"
+import { scatterPlotFuncs } from "./scatter-plot-utils"
+
+interface IUseResidualMarquee {
+  layout: GraphLayout
+  dataConfiguration?: IGraphDataConfigurationModel
+  dataset?: IDataSet
+  adornmentsStore: IAdornmentsBaseStore
+  marqueeState?: MarqueeState
+}
+
+const kMarqueeDragThreshold = 3 // px of pointer travel before a press becomes a marquee drag
+
+// Marquee (drag-rectangle) selection confined to the residual strip. Independent of the upper-plot
+// marquee (which the shared Background owns): residual points are SVG circles the renderer doesn't
+// know about, so this builds its own R-tree from the residual positions on pointerdown and selects
+// via the same delta hit-testing. Dynamic while dragging; Shift adds to the current selection.
+export function useResidualMarquee(props: IUseResidualMarquee) {
+  const { layout, dataConfiguration, dataset, adornmentsStore, marqueeState } = props
+  const treeRef = useRef<ReturnType<typeof RTreeLib> | null>(null)
+  const startRef = useRef({ x: 0, y: 0 })
+  const sizeRef = useRef({ w: 0, h: 0 })
+  const prevRectRef = useRef<rTreeRect | undefined>(undefined)
+  const needsClearRef = useRef(false)
+  const draggingRef = useRef(false)
+  const suppressClickRef = useRef(false)
+
+  const onPointerDown = useCallback((event: React.PointerEvent<SVGRectElement>) => {
+    if (!marqueeState || !adornmentsStore.showResidualPlot || !dataConfiguration || !dataset) return
+    const lowerScale = layout.getAxisScale("leftLower") as ScaleLinear<number, number> | undefined
+    if (!lowerScale) return
+    const predictor = getPredictor(adornmentsStore, dataConfiguration)
+    if (!predictor) return
+
+    const { getXCoord } = scatterPlotFuncs(layout, dataConfiguration)
+    const positions = buildResidualPositions(
+      computeResiduals(dataConfiguration, predictor), getXCoord, layout.plotHeight, lowerScale)
+    const tree = RTreeLib(10)
+    positions.forEach(p => tree.insert({ x: p.x, y: p.y, w: 1, h: 1 }, { datasetID: dataset.id, caseID: p.caseID }))
+    treeRef.current = tree
+
+    // Window coords → graph-SVG frame (the frame the residual points are drawn in and the marquee
+    // rect is rendered in). ownerSVGElement is the .graph-svg that hosts the residual points.
+    const svgRect = event.currentTarget.ownerSVGElement?.getBoundingClientRect()
+    startRef.current = { x: event.clientX - (svgRect?.left ?? 0), y: event.clientY - (svgRect?.top ?? 0) }
+    sizeRef.current = { w: 0, h: 0 }
+    prevRectRef.current = undefined
+    needsClearRef.current = !event.shiftKey
+    draggingRef.current = false
+
+    const lowerBounds = layout.getLowerPlotBounds()
+    const region = { top: layout.plotHeight, bottom: layout.plotHeight + lowerBounds.height, right: lowerBounds.width }
+
+    const prev = { x: event.clientX, y: event.clientY }
+    const onMove = (moveEvent: PointerEvent) => {
+      sizeRef.current.w += moveEvent.clientX - prev.x
+      sizeRef.current.h += moveEvent.clientY - prev.y
+      prev.x = moveEvent.clientX
+      prev.y = moveEvent.clientY
+      if (!draggingRef.current &&
+          Math.abs(sizeRef.current.w) < kMarqueeDragThreshold &&
+          Math.abs(sizeRef.current.h) < kMarqueeDragThreshold) {
+        return // below threshold: still a click, not a drag
+      }
+      draggingRef.current = true
+      if (needsClearRef.current) {
+        if (dataset.selection.size > 0) selectAllCases(dataset, false)
+        needsClearRef.current = false
+      }
+      const rawRect = rectNormalize(
+        { x: startRef.current.x, y: startRef.current.y, w: sizeRef.current.w, h: sizeRef.current.h })
+      const rect = clampRectToLowerRegion(rawRect, region)
+      marqueeState.setMarqueeRect({ x: rect.x, y: rect.y, width: rect.w, height: rect.h })
+      const prevRect = prevRectRef.current ?? { x: rect.x, y: rect.y, w: 0, h: 0 }
+      const entered = getCasesForDelta(treeRef.current, rect, prevRect)
+      const exited = getCasesForDelta(treeRef.current, prevRect, rect)
+      selectAndDeselectCases(entered.map(c => c.caseID), exited.map(c => c.caseID), dataset)
+      prevRectRef.current = rect
+    }
+
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove)
+      window.removeEventListener("pointerup", onUp)
+      marqueeState.setMarqueeRect({ x: 0, y: 0, width: 0, height: 0 })
+      treeRef.current = null
+      if (draggingRef.current) {
+        suppressClickRef.current = true // the trailing click must not deselect what the drag selected
+        const numCases = dataset.selection.size
+        if (numCases > 0) Logger.log(`marqueeSelection: ${numCases}`, { numCases }, "plot")
+      }
+    }
+
+    window.addEventListener("pointermove", onMove)
+    window.addEventListener("pointerup", onUp)
+  }, [adornmentsStore, dataConfiguration, dataset, layout, marqueeState])
+
+  const onClick = useCallback((event: React.MouseEvent<SVGRectElement>) => {
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false
+      return
+    }
+    if (!event.shiftKey && !event.metaKey && !event.ctrlKey && dataset) {
+      selectAllCases(dataset, false)
+    }
+  }, [dataset])
+
+  return { onPointerDown, onClick }
+}

--- a/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
+++ b/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
@@ -65,6 +65,9 @@ export function useResidualMarquee(props: IUseResidualMarquee) {
     prevRectRef.current = undefined
     needsClearRef.current = !event.shiftKey
     draggingRef.current = false
+    // Clear any stale suppression from a prior drag that ended without a trailing click (e.g. pointerup
+    // off the rect), so suppression only ever applies to the click immediately following a drag.
+    suppressClickRef.current = false
 
     const lowerBounds = layout.getLowerPlotBounds()
     const region = { top: layout.plotHeight, bottom: layout.plotHeight + lowerBounds.height, right: lowerBounds.width }

--- a/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
+++ b/v3/src/components/graph/plots/scatter-plot/use-residual-marquee.ts
@@ -52,10 +52,15 @@ export function useResidualMarquee(props: IUseResidualMarquee) {
     positions.forEach(p => tree.insert({ x: p.x, y: p.y, w: 1, h: 1 }, { datasetID: dataset.id, caseID: p.caseID }))
     treeRef.current = tree
 
-    // Window coords → graph-SVG frame (the frame the residual points are drawn in and the marquee
-    // rect is rendered in). ownerSVGElement is the .graph-svg that hosts the residual points.
-    const svgRect = event.currentTarget.ownerSVGElement?.getBoundingClientRect()
-    startRef.current = { x: event.clientX - (svgRect?.left ?? 0), y: event.clientY - (svgRect?.top ?? 0) }
+    // Window coords → plot-area frame (the frame the residual points are drawn in and the marquee
+    // rect is rendered in — origin at the plot's left edge, inside the axes). Anchor to this hit
+    // rect's own box: it is drawn at frame (0, plotHeight) in the same group as the residual points,
+    // so its screen top-left maps to frame (0, plotHeight) regardless of the axis margins.
+    const rectBounds = event.currentTarget.getBoundingClientRect()
+    startRef.current = {
+      x: event.clientX - rectBounds.left,
+      y: event.clientY - rectBounds.top + layout.plotHeight
+    }
     sizeRef.current = { w: 0, h: 0 }
     prevRectRef.current = undefined
     needsClearRef.current = !event.shiftKey

--- a/v3/src/components/graph/plots/scatter-plot/use-residual-plot.ts
+++ b/v3/src/components/graph/plots/scatter-plot/use-residual-plot.ts
@@ -1,0 +1,230 @@
+import { format, ScaleLinear, select } from "d3"
+import { tip as d3tip } from "d3-v6-tip"
+import { untracked } from "mobx"
+import { useCallback, useEffect, useRef } from "react"
+import { IDataSet } from "../../../../models/data/data-set"
+import { mstAutorun } from "../../../../utilities/mst-autorun"
+import { t } from "../../../../utilities/translation/translate"
+import { handleClickOnCase } from "../../../data-display/data-display-utils"
+import { isNumericAxisModel, NumericAxisModel } from "../../../axis/models/numeric-axis-models"
+import { IGraphContentModel } from "../../models/graph-content-model"
+import { IGraphDataConfigurationModel } from "../../models/graph-data-configuration-model"
+import { GraphLayout } from "../../models/graph-layout"
+import {
+  computeResiduals, getPredictor, IResidualPoint, residualDomain, residualPlotIsApplicable, residualPointStyle
+} from "./residual-plot-utils"
+import { scatterPlotFuncs } from "./scatter-plot-utils"
+
+interface IUseResidualPlot {
+  graphModel: IGraphContentModel
+  dataConfiguration?: IGraphDataConfigurationModel
+  dataset?: IDataSet
+  layout: GraphLayout
+  legendAttrID?: string
+}
+
+// Owns the Residual Plot's SVG rendering, split-layout sync, and selection-halo restyle. The
+// ScatterPlot consumes the returned refs/callbacks: refreshPointPositions calls renderResidualsIfActive
+// (drag caching) and refreshPointSelection calls restyleResidualSelection (selection halo).
+export function useResidualPlot(props: IUseResidualPlot) {
+  const { graphModel, dataConfiguration, dataset, layout, legendAttrID } = props
+  const adornmentsStore = graphModel.adornmentsStore
+  const residualPointsRef = useRef<SVGGElement>(null)
+
+  // Hover tooltip for residual points. Matches the "graph-d3-tip" styling used by other adornment
+  // hovers so the tip visually reads like the main plot's data tips. The `no-svg-export` class
+  // keeps it out of image exports. Disposed on unmount so the DOM node d3-tip attaches to
+  // document.body doesn't leak across scatter-plot mounts.
+  const residualDataTipRef = useRef(
+    d3tip().attr("class", "graph-d3-tip no-svg-export")
+      .attr("data-testid", "residual-data-tip")
+      .html((d: string) => `<p>${d}</p>`)
+  )
+  useEffect(() => {
+    const tip = residualDataTipRef.current
+    return () => { tip.destroy?.() }
+  }, [])
+
+  // Selection-dependent styling for one residual point. Reads the dataset selection (observable),
+  // so callers in a reactive context must apply it via untracked (see renderResidualPoints) to avoid
+  // subscribing to selection. Delegates the pure decision to residualPointStyle (unit-tested).
+  const styleFor = useCallback((caseID: string) => {
+    const isSelected = !!dataset?.isCaseSelected(caseID)
+    // The legend handling here is intentionally retained even though residualPlotIsApplicable
+    // currently excludes legends (so legendAttrID is always undefined in this path today). Coloring
+    // each residual point by its legend category is structurally/mathematically well-defined — each
+    // point's residual is taken against its own category's line, and the adornments already store a
+    // line per cell — so this is kept ready for a future legend-supporting version rather than
+    // removed as dead code. (Enabling it also means dropping the legend exclusion and making the
+    // predictor cell-aware; see getPredictor/computeResiduals in residual-plot-utils.)
+    const legendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase(caseID) : undefined
+    const { pointColor, pointStrokeColor } = graphModel.pointDescription
+    return residualPointStyle({
+      isSelected, hasLegend: !!legendAttrID, legendColor, pointColor, pointStrokeColor,
+      pointRadius: graphModel.getPointRadius(), selectedRadius: graphModel.getPointRadius('select')
+    })
+  }, [dataset, legendAttrID, dataConfiguration, graphModel])
+
+  // Selection-only restyle: re-set the selection-dependent attrs on the existing circles. No data
+  // join, no residual/predictor recompute — a selection change (via refreshPointSelection) updates
+  // styling without re-running the residual pipeline.
+  // Compute the style once per circle (styleFor does selection/legend lookups) rather than per attr.
+  const applyResidualStyles = useCallback((g: SVGGElement) => {
+    select(g).selectAll<SVGCircleElement, IResidualPoint>("circle")
+      .each(function (d) {
+        const style = styleFor(d.caseID)
+        select(this)
+          .attr("r", style.radius)
+          .attr("fill", style.fill)
+          .attr("stroke", style.stroke)
+          .attr("stroke-width", style.strokeWidth)
+          .attr("stroke-opacity", style.strokeOpacity)
+      })
+  }, [styleFor])
+
+  // Restyle residual points to track the current selection. Called by refreshPointSelection on every
+  // selection change. Cheap (attrs only) and does not touch the split layout or the leftLower axis.
+  const restyleResidualSelection = useCallback(() => {
+    const g = residualPointsRef.current
+    if (g) applyResidualStyles(g)
+  }, [applyResidualStyles])
+
+  // Geometry + structure paint: the data join, positions, hover tip, and click handling. Selection
+  // styling is applied at the end under untracked so that the syncResidualPlot autorun (which calls
+  // this) does not subscribe to the selection set — otherwise every selection change would re-fire
+  // the autorun and recompute the predictor/residuals purely to update halos.
+  const renderResidualPoints = useCallback((residuals: IResidualPoint[]) => {
+    const g = residualPointsRef.current
+    if (!g) return
+    const { getXCoord } = scatterPlotFuncs(layout, dataConfiguration)
+    const lowerScale = layout.getAxisScale("leftLower") as ScaleLinear<number, number> | undefined
+    if (!lowerScale) {
+      select(g).selectAll("circle").remove()
+      return
+    }
+    const plotHeight = layout.plotHeight
+    // Hover tip: "<xAttrName>: <xValue><br/>Residual: <value>". Numeric formatting mirrors the
+    // main plot's data tip (three significant figures via d3.format('.3~f')).
+    const xAttrID = dataConfiguration?.attributeID("x") ?? ""
+    const xAttr = dataset?.getAttribute(xAttrID)
+    const xAttrName = xAttr?.name ?? ""
+    const float = format(".3~f")
+    const tipTextFor = (d: IResidualPoint) => {
+      const xValue = dataset?.getValue(d.caseID, xAttrID)
+      const xValueStr = typeof xValue === "number" && isFinite(xValue)
+        ? float(xValue) : (xValue != null ? String(xValue) : "")
+      const residualStr = isFinite(d.residual) ? float(d.residual) : String(d.residual)
+      return `${xAttrName}: ${xValueStr}<br/>${t("V3.ResidualPlot.dataTip.residual")}: ${residualStr}`
+    }
+    const residualTip = residualDataTipRef.current
+    // Install the tip on the parent SVG so absolute positioning works.
+    select(g).call(residualTip)
+    select(g).selectAll<SVGCircleElement, IResidualPoint>("circle")
+      .data(residuals, d => d.caseID)
+      .join("circle")
+      .attr("data-testid", d => `residual-point-${d.caseID}`)
+      .attr("cx", d => getXCoord(d.caseID))
+      .attr("cy", d => plotHeight + lowerScale(d.residual))
+      .style("cursor", "pointer")
+      .on("mouseover", function(event, d) { residualTip.show(tipTextFor(d), this) })
+      .on("mouseout", () => residualTip.hide())
+      .on("click", (event, d) => {
+        // handleClickOnCase honors shift/meta/ctrl for extend selection, matching the upper plot.
+        // stopPropagation prevents the click from bubbling to the residual-plot-background rect,
+        // whose handler would immediately deselect everything the click just selected.
+        event.stopPropagation()
+        if (dataset) handleClickOnCase(event, d.caseID, dataset)
+      })
+    // Apply current selection styling to the (possibly new) circles without subscribing to selection.
+    untracked(() => applyResidualStyles(g))
+  }, [layout, dataConfiguration, dataset, applyResidualStyles])
+
+  // Recompute and repaint the residual points if the Residual Plot is active and all applicability
+  // constraints hold. Single entry-point used by every code path that needs to refresh the residual
+  // rendering — the sync autorun, the post-mount effect, the upper-plot's refreshPointPositions
+  // (drag caching), and refreshPointSelection (selection halo sync). No-op when inactive.
+  const renderResidualsIfActive = useCallback(() => {
+    if (!adornmentsStore.showResidualPlot) return
+    if (!residualPlotIsApplicable(adornmentsStore, dataConfiguration)) return
+    if (!dataConfiguration) return
+    const predictor = getPredictor(adornmentsStore, dataConfiguration)
+    if (!predictor) return
+    renderResidualPoints(computeResiduals(dataConfiguration, predictor))
+  }, [adornmentsStore, dataConfiguration, renderResidualPoints])
+
+  // Sync the split-plot layout, lower y-axis registration, and residual point rendering with the
+  // Residual Plot store boolean and applicability. When active, activate the split layout, ensure a
+  // NumericAxisModel at "leftLower" with the auto-scaled residual domain, and paint the residual
+  // points. When inactive, tear the split down and clear the points. The store boolean persists as
+  // user intent (mirroring Squares of Residuals); this reaction owns the derived state.
+  //
+  // Load-bearing pattern: every mutation below is preceded by a read-and-compare guard
+  // (`if (!layout.showLowerPlot)`, `if (axis.min !== minY || ...)`, etc.). MobX would otherwise
+  // re-fire this autorun on its own mutations because it reads the same observables it writes
+  // (layout.showLowerPlot, axis.min/max, etc.). The guards make each mutation idempotent so a
+  // re-fire converges immediately. Do NOT remove any guard without adding equivalent protection —
+  // an unguarded write here creates an infinite reaction loop.
+  useEffect(function syncResidualPlot() {
+    return mstAutorun(() => {
+      // Tear the split down: collapse the lower region, drop the leftLower axis, clear the points.
+      // Idempotent (each mutation is guarded), so calling it when already inactive is a no-op.
+      const teardown = () => {
+        if (layout.showLowerPlot) layout.setShowLowerPlot(false)
+        if (graphModel.getAxis("leftLower")) graphModel.removeAxis("leftLower")
+        if (residualPointsRef.current) select(residualPointsRef.current).selectAll("circle").remove()
+      }
+      const isActive = adornmentsStore.showResidualPlot && residualPlotIsApplicable(adornmentsStore, dataConfiguration)
+      if (!isActive) {
+        teardown()
+        return
+      }
+      // Applicability doesn't guarantee the line is computable (e.g. an LSRL with < 2 finite points,
+      // or a plotted function not yet populated). If there's no predictor, tear down rather than
+      // leaving stale residual UI on screen.
+      const predictor = getPredictor(adornmentsStore, dataConfiguration)
+      if (!predictor || !dataConfiguration) {
+        teardown()
+        return
+      }
+      const residuals = computeResiduals(dataConfiguration, predictor)
+      const [minY, maxY] = residualDomain(residuals)
+      if (!layout.showLowerPlot) layout.setShowLowerPlot(true)
+      let axis = graphModel.getAxis("leftLower")
+      if (!axis || !isNumericAxisModel(axis)) {
+        graphModel.setAxis("leftLower", NumericAxisModel.create({ place: "leftLower", min: minY, max: maxY }))
+        axis = graphModel.getAxis("leftLower")
+      }
+      if (axis && isNumericAxisModel(axis)) {
+        if (axis.min !== minY || axis.max !== maxY) {
+          // setDomain is grow-only by default; the Residual Plot's domain must be able to shrink as
+          // the line moves closer to fit. Allow shrinking for this one call (the flag auto-resets).
+          axis.setAllowRangeToShrink(true)
+          axis.setDomain(minY, maxY)
+        }
+      }
+      // The graph-controller's installAxisReaction only watches "left" and "bottom"; changes to the
+      // "leftLower" axis model do not automatically push through to the MultiScale that owns the D3
+      // scale used for pixel mapping. Sync explicitly — guarded like the mutations above so a re-fire
+      // with an unchanged scale type / domain is a no-op (setNumericDomain would otherwise write a
+      // fresh array every run and churn the domain observable during e.g. movable-line drag). Guard
+      // on the MultiScale's own domain, not the axis model's: on first activation the model already
+      // carries [minY, maxY], so an axis-based guard would wrongly skip the initial MultiScale sync.
+      const multiScale = layout.getAxisMultiScale("leftLower")
+      if (multiScale.scaleType !== "linear") layout.setAxisScaleType("leftLower", "linear")
+      const [curMin, curMax] = multiScale.numericDomain
+      if (curMin !== minY || curMax !== maxY) {
+        multiScale.setNumericDomain([minY, maxY])
+      }
+      renderResidualPoints(residuals)
+    }, { name: "ScatterPlot.syncResidualPlot" }, graphModel)
+  }, [adornmentsStore, dataConfiguration, graphModel, layout, renderResidualPoints])
+
+  // Post-mount effect: the residual points <g> is conditionally mounted on layout.showLowerPlot,
+  // so its ref is null the first time the autorun runs (state flips and JSX re-renders in the same
+  // tick). This redraws once the group is committed.
+  useEffect(function drawResidualPointsAfterMount() {
+    renderResidualsIfActive()
+  }, [layout.showLowerPlot, adornmentsStore.showResidualPlot, renderResidualsIfActive])
+
+  return { residualPointsRef, renderResidualsIfActive, restyleResidualSelection }
+}


### PR DESCRIPTION
## Summary

Adds marquee (drag-rectangle) selection to the residual plot, alongside the
existing click selection. Fixes CODAP-1469.

- Dragging on the residual strip selects the residual points inside the rectangle;
  selection updates dynamically while dragging, and Shift adds to the current
  selection.
- Selection is confined to the residual strip (separate zone) — the upper-plot
  marquee and the map marquee are unchanged. A rectangle spanning both the main
  Y-axis space and the residual space has no coherent meaning, so the two zones
  stay independent.
- A click (no drag) still deselects all cases, as before.

## Implementation notes

- Residual points are hand-drawn SVG circles that the point renderer doesn't
  track, so the shared `Background` marquee (which hit-tests the renderer's
  R-tree) can't see them. The new `useResidualMarquee` hook builds its own
  R-tree from the residual positions on pointerdown and selects via the same
  delta hit-testing — the R-tree is built up front to stay efficient with large
  datasets (one residual point per case).
- Refactor: the residual rendering/sync code was extracted out of
  `scatter-plot.tsx` into a `useResidualPlot` hook, and `Background`'s
  `getCasesForDelta` was moved into `data-display-utils.ts` so both marquees
  share it.

## Reviewer notes

This PR is a mix of new logic and mechanical moves — the commit history is
structured so each is reviewable on its own.

**New code (warrants closer review):**
- `use-residual-marquee.ts` — the new drag-select behavior: R-tree build,
  delta hit-testing, dynamic/Shift selection, the pointer→plot-area coordinate
  conversion, and the click-vs-drag threshold that preserves click-to-deselect.
- `residual-marquee-utils.ts` — new pure helpers (`buildResidualPositions`,
  `clampRectToLowerRegion`) + their unit tests.
- `scatter-plot.tsx` — the *new* bits only: the `useResidualMarquee` call and
  the residual hit-rect's `onPointerDown`/`onClick` wiring (the rest of the diff
  in this file is the extraction below).
- `use-marquee-state.ts` + the `MarqueeStateContext` provider in `graph.tsx` —
  new, but trivial context plumbing.
- `bivariate-adornments.spec.ts` — new Cypress test.
- the `getCasesForDelta` unit test in `data-display-utils.test.ts`.

**Moved / mechanical (lighter review):**
- `use-residual-plot.ts` — a behavior-preserving extraction of the residual
  rendering/sync code out of `scatter-plot.tsx` (no logic changes; the guards
  and `untracked` wrapping were moved verbatim). Most of the `scatter-plot.tsx`
  deletions are the other side of this move.
- `getCasesForDelta` moved from `background.tsx` into `data-display-utils.ts`;
  `background.tsx` just imports it now.
- the `graph.tsx` reindent commit is whitespace only (JSX nested under the new
  provider).

## Testing

- Unit tests for the extracted `getCasesForDelta` and the pure residual-marquee
  geometry helpers.
- Cypress e2e: drag-selecting residual points on the strip (plus the existing
  click select/deselect coverage).
