### PR TITLE
CODAP-1470: update formula editor UI to match latest design spec

### DIFF
--- a/v3/cypress/e2e/formula/formula-component.spec.ts
+++ b/v3/cypress/e2e/formula/formula-component.spec.ts
@@ -301,10 +301,16 @@ context("Formula Engine", () => {
         cy.get("[data-testid=formula-insert-function-button]").should("have.focus")
         // Tab to Cancel button
         cy.realPress("Tab")
-        cy.focused().should("contain.text", "Cancel")
+        cy.get("[data-testid=Cancel-button]").should("have.focus")
+        // Tab to Clear button
+        cy.realPress("Tab")
+        cy.get("[data-testid=Clear-button]").should("have.focus")
         // Tab to Apply button
         cy.realPress("Tab")
-        cy.focused().should("contain.text", "Apply")
+        cy.get("[data-testid=Apply-button]").should("have.focus")
+        // Tab wraps to the close button in the header
+        cy.realPress("Tab")
+        cy.get("[data-testid=formula-modal-close-button]").should("have.focus")
         // Tab to attribute name input
         cy.realPress("Tab")
         cy.get("[data-testid=attr-name-input]").should("have.focus")
@@ -318,12 +324,18 @@ context("Formula Engine", () => {
         // Shift+Tab to attribute name input
         cy.realPress(["Shift", "Tab"])
         cy.get("[data-testid=attr-name-input]").should("have.focus")
-        // Shift+Tab to Apply button
+        // Shift+Tab to the close button in the header
         cy.realPress(["Shift", "Tab"])
-        cy.focused().should("contain.text", "Apply")
+        cy.get("[data-testid=formula-modal-close-button]").should("have.focus")
+        // Shift+Tab wraps to the Apply button
+        cy.realPress(["Shift", "Tab"])
+        cy.get("[data-testid=Apply-button]").should("have.focus")
+        // Shift+Tab to Clear button
+        cy.realPress(["Shift", "Tab"])
+        cy.get("[data-testid=Clear-button]").should("have.focus")
         // Shift+Tab to Cancel button
         cy.realPress(["Shift", "Tab"])
-        cy.focused().should("contain.text", "Cancel")
+        cy.get("[data-testid=Cancel-button]").should("have.focus")
         // Shift+Tab to Insert Function menu button
         cy.realPress(["Shift", "Tab"])
         cy.get("[data-testid=formula-insert-function-button]").should("have.focus")

--- a/v3/src/components/case-tile-common/filter-formula-bar.tsx
+++ b/v3/src/components/case-tile-common/filter-formula-bar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { useDisclosure } from "@chakra-ui/react"
 import { t } from "../../utilities/translation/translate"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { useInspectorFormulaTitle } from "../../hooks/use-inspector-formula-string"
 import { EditFormulaModal } from "../common/edit-formula-modal"
 
 import "./filter-formula-bar.scss"
@@ -30,6 +31,9 @@ export const FilterFormulaBar = () => {
     onClose()
   }
 
+  // computed before the early return so the hook is called unconditionally
+  const modalTitle = useInspectorFormulaTitle(data?.filterFormula?.display)
+
   if (!data) return null
   const filterFormula = data.filterFormula?.display
 
@@ -47,6 +51,7 @@ export const FilterFormulaBar = () => {
         <EditFormulaModal
           applyFormula={handleSubmitEditFormula}
           isOpen={isOpen}
+          modalTitle={modalTitle}
           onClose={handleCloseModal}
           titleLabel={t("V3.hideShowMenu.filterFormulaPrompt")}
           value={filterFormula}

--- a/v3/src/components/case-tile-common/filter-formula-bar.tsx
+++ b/v3/src/components/case-tile-common/filter-formula-bar.tsx
@@ -31,7 +31,6 @@ export const FilterFormulaBar = () => {
     onClose()
   }
 
-  // computed before the early return so the hook is called unconditionally
   const modalTitle = useInspectorFormulaTitle(data?.filterFormula?.display)
 
   if (!data) return null

--- a/v3/src/components/case-tile-common/hide-show-menu-list.tsx
+++ b/v3/src/components/case-tile-common/hide-show-menu-list.tsx
@@ -4,6 +4,7 @@ import { isAlive } from "mobx-state-tree"
 import { useMemo } from "react"
 import { useDataSetMetadata } from "../../hooks/use-data-set-metadata"
 import { useDataSetContext } from "../../hooks/use-data-set-context"
+import { useInspectorFormulaTitle } from "../../hooks/use-inspector-formula-string"
 import { hideAttributeNotification } from "../../models/data/data-set-notifications"
 import { addSetAsideCases, restoreSetAsideCases } from "../../models/data/data-set-utils"
 import { t } from "../../utilities/translation/translate"
@@ -90,6 +91,8 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
     }
   ], [data, hiddenAttributeCount, hiddenAttributes, itemCount, metadata, onOpen, selectionCount, setAsideCount])
 
+  const modalTitle = useInspectorFormulaTitle(data?.filterFormula?.display)
+
   if (data && !isAlive(data)) return null
 
   return (
@@ -100,6 +103,7 @@ export const HideShowMenuList = observer(function HideShowMenuList() {
         <EditFormulaModal
           applyFormula={data.setFilterFormula}
           isOpen={isOpen}
+          modalTitle={modalTitle}
           onClose={onClose}
           titleLabel={t("V3.hideShowMenu.filterFormulaPrompt")}
           value={data.filterFormula?.display}

--- a/v3/src/components/common/edit-attribute-formula-modal.tsx
+++ b/v3/src/components/common/edit-attribute-formula-modal.tsx
@@ -9,6 +9,7 @@ import { getMetadataFromDataSet, getSharedDataSets } from "../../models/shared/s
 import { uiState } from "../../models/ui-state"
 import { t } from "../../utilities/translation/translate"
 import { editFormulaNotification } from "./edit-formula-notifications"
+import { stripTrailingEllipsis } from "../../utilities/translation/label-utils"
 import { EditFormulaModal } from "./edit-formula-modal"
 
 export const EditAttributeFormulaModal = observer(function EditAttributeFormulaModal() {
@@ -62,6 +63,7 @@ export const EditAttributeFormulaModal = observer(function EditAttributeFormulaM
         finalFocusRef={finalFocusRef}
         formulaPrompt={t("DG.AttrFormView.formulaPrompt")}
         isOpen={!!uiState.editFormulaAttributeId}
+        modalTitle={stripTrailingEllipsis(t("DG.TableController.headerMenuItems.editFormula"))}
         onClose={() => uiState.setEditFormulaAttributeId()}
         titleInput={attribute?.name}
         titleLabel={t("DG.AttrFormView.attrNamePrompt")}

--- a/v3/src/components/common/edit-formula-modal.scss
+++ b/v3/src/components/common/edit-formula-modal.scss
@@ -5,7 +5,6 @@ $edit-formula-modal-min-height: 280;
 // same, for callers that edit only a formula and so get no name row
 $edit-formula-modal-filter-min-height: 218;
 $edit-formula-modal-min-width: 450;
-$edit-formula-modal-min-width-px: #{$edit-formula-modal-min-width}px;
 
 // https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 :export {
@@ -14,19 +13,21 @@ $edit-formula-modal-min-width-px: #{$edit-formula-modal-min-width}px;
   editFormulaModalMinWidth: $edit-formula-modal-min-width;
 }
 
-$formula-header-face: #a5e3f6;
+// Named for what they are used for, and valued from the shared palette so they follow it.
+$formula-header-face: vars.$accent-light-2;
 // button faces, matching the Chakra `v3*` variants these buttons replaced
-$formula-button-face: #d3f4ff;
-$formula-button-face-hover: #bbefff;
-$formula-button-face-active: #a5e3f6;
-$formula-button-default-face: #bbefff;
-$formula-button-default-hover: #93d5e4;
-$formula-button-default-active: #72bfca;
+$formula-button-face: vars.$icon-fill-light;
+$formula-button-face-hover: vars.$accent-light-3;
+$formula-button-face-active: vars.$accent-light-2;
+$formula-button-default-face: vars.$accent-light-3;
+$formula-button-default-hover: vars.$teal-light3;
+$formula-button-default-active: vars.$codap-teal-light;
 
 $formula-control-height: 30px;
 $formula-side-padding: 15px;
-$formula-label-color: #222; // the `labelText` color the Chakra button variants used
-// 4.02:1 against the #f0f0f0 modal body, so control boundaries meet WCAG 1.4.11's 3:1
+$formula-label-color: vars.$default-font-color;
+// No palette equivalent: chosen for contrast, 4.02:1 against the #f0f0f0 modal body, so that
+// control boundaries meet WCAG 1.4.11's 3:1.
 $formula-control-border: #767676;
 
 @mixin formula-button {

--- a/v3/src/components/common/edit-formula-modal.scss
+++ b/v3/src/components/common/edit-formula-modal.scss
@@ -1,125 +1,277 @@
 @use "../vars";
-$edit-formula-modal-min-height: 180;
-$edit-formula-modal-min-height-px: #{$edit-formula-modal-min-height}px;
-$edit-formula-modal-min-width: 400;
+// How small the user may drag the modal. The size it opens at comes from its content, not from
+// these: the formula field's two-row minimum sets that.
+$edit-formula-modal-min-height: 280;
+// same, for callers that edit only a formula and so get no name row
+$edit-formula-modal-filter-min-height: 218;
+$edit-formula-modal-min-width: 450;
 $edit-formula-modal-min-width-px: #{$edit-formula-modal-min-width}px;
 
 // https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 :export {
   editFormulaModalMinHeight: $edit-formula-modal-min-height;
+  editFormulaModalFilterMinHeight: $edit-formula-modal-filter-min-height;
   editFormulaModalMinWidth: $edit-formula-modal-min-width;
 }
 
-.formula-modal-body {
-  cursor: default;
+$formula-header-face: #a5e3f6;
+// button faces, matching the Chakra `v3*` variants these buttons replaced
+$formula-button-face: #d3f4ff;
+$formula-button-face-hover: #bbefff;
+$formula-button-face-active: #a5e3f6;
+$formula-button-default-face: #bbefff;
+$formula-button-default-hover: #93d5e4;
+$formula-button-default-active: #72bfca;
+
+$formula-control-height: 30px;
+$formula-side-padding: 15px;
+$formula-label-color: #222; // the `labelText` color the Chakra button variants used
+
+@mixin formula-button {
+  align-items: center;
+  border: 1px solid lightgray;
+  border-radius: 4px;
+  color: $formula-label-color;
+  cursor: pointer;
   display: flex;
-  flex-direction: column;
-  height: inherit;
-  margin-bottom: 10px;
-  min-height: 72px;
-  min-width: $edit-formula-modal-min-width-px;
+  flex-shrink: 0;
+  font-size: 14px;
+  font-weight: 500;
+  height: $formula-control-height;
+  justify-content: center;
+  white-space: nowrap;
 
-  .formula-form-control {
-    display: flex;
-    flex-grow: 1;
-    align-items: flex-start;
-
-    .attr-name-form-label {
-      align-items: center;
-      width: 100%;
-    }
-    // The label sizes to its text and the input absorbs the remainder, so that a long
-    // translation widens the label instead of wrapping onto a second line. A wrapped label
-    // grows the form control and pushes the insert buttons out of the modal body.
-    .title-label {
-      flex: 0 0 auto;
-      margin-right: 5px;
-      white-space: nowrap;
-    }
-    .attr-name-input {
-      border: 1px solid vars.$charcoal-light-2;
-      flex: 1 1 auto;
-      min-width: 0;
-      margin-right: 3px;
-      margin-left: 0;
-      padding-left: 5px;
-
-      &:focus-visible {
-        @include vars.focus-outline;
-      }
-    }
-    .formula-editor-container {
-      display: flex;
-      height: 100%;
-      width: 100%;
-
-      .formula-editor-input {
-        width: calc(100% - 50px); //50px is to account for modal margins and paddings
-
-        .cm-editor {
-          border: 1px solid vars.$charcoal-light-2;
-          height: 100%;
-          width: 100%;
-
-          &.cm-focused {
-            @include vars.focus-outline;
-          }
-        }
-      }
-    }
-
-  }
-
-  .formula-insert-buttons-container {
-    position: relative;
-    bottom: 0;
-    // never give up height or width to the formula editor above; the buttons are the
-    // first thing clipped when the body overflows
-    flex-shrink: 0;
-
-    .formula-editor-button {
-      flex-shrink: 0;
-      padding: 0 10px;
-      &:hover {
-        background: vars.$codap-teal-lighter;
-      }
-      &:active, &.menu-open {
-        background: vars.$codap-teal-dark;
-        color: white;
-      }
-      &:focus-visible {
-        @include vars.focus-outline;
-      }
-      &.insert-value {
-        margin-left: 0;
-      }
-    }
-  }
-}
-
-.formula-modal-footer {
-  cursor: default;
-  border-radius: 6px;
-  position: relative;
-  bottom: 0;
-  right: 0;
-
-  button:focus-visible {
+  &:focus-visible {
     @include vars.focus-outline;
   }
 }
 
-.codap-modal-corner {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  height: 24px;
-  width: 24px;
-  cursor: se-resize;
+// two classes, to override Chakra's single-class ModalHeader defaults
+.chakra-modal__header.formula-modal-header {
+  align-items: center;
+  background-color: $formula-header-face;
+  box-shadow: none;
+  display: flex;
+  flex-direction: row;
+  flex-shrink: 0;
+  font-size: 14px;
+  font-weight: 500;
+  height: 34px;
+  justify-content: space-between;
+  // min-height as well as height: the modal content is a flex column, and without this the
+  // header gives up space whenever the content wants more than the modal's current height
+  min-height: 34px;
+  padding: 0;
+
+  .formula-modal-title {
+    padding-left: $formula-side-padding;
+  }
+
+  .formula-modal-close-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    line-height: 1;
+    margin-right: 5px;
+    padding: 0 5px;
+
+    &:focus-visible {
+      @include vars.focus-outline;
+    }
+  }
 }
-.component-resize-handle {
-  fill: #d3d3d3;
-  &:hover {
-    fill: white;
+
+// three classes, to beat codap-modal.scss's `.chakra-modal__content .chakra-modal__body`
+// as well as Chakra's own single-class defaults
+.codap-modal-content .chakra-modal__body.formula-modal-body {
+  cursor: default;
+  display: flex;
+  flex-direction: column;
+  // min-height:0 lets this flex child shrink below its content size, so the editor inside
+  // absorbs the overflow rather than pushing the insert buttons past the bottom edge
+  min-height: 0;
+  flex: 1 1 auto;
+  padding: 10px $formula-side-padding 0;
+
+  .formula-form-control {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+
+    // Labels sit above their fields, so a long translation lengthens the label's own line
+    // instead of competing with the field for width.
+    .formula-field-label {
+      color: $formula-label-color;
+      flex: 0 0 auto;
+      font-size: 14px;
+      font-weight: 500;
+      margin-bottom: 5px;
+    }
+
+    .attr-name-form-label {
+      display: flex;
+      flex-direction: column;
+      flex: 0 0 auto;
+      margin-bottom: 10px;
+      width: 100%;
+
+      .attr-name-input-row {
+        align-items: center;
+        display: flex;
+        flex-direction: row;
+        width: 100%;
+      }
+      .attr-name-input {
+        border: 1px solid vars.$charcoal-light-2;
+        border-radius: 2px;
+        flex: 1 1 auto;
+        // the ModalBody theme sets a "medium" weight that the input would otherwise inherit
+        font-size: 14px;
+        font-weight: normal;
+        height: $formula-control-height;
+        min-width: 0;
+        padding-left: 5px;
+
+        &:focus-visible {
+          @include vars.focus-outline;
+        }
+      }
+      .attr-name-equals {
+        flex: 0 0 auto;
+        margin-left: 8px;
+      }
+    }
+
+    .formula-editor-container {
+      display: flex;
+      flex: 1 1 auto;
+      flex-direction: column;
+      min-height: 0;
+      width: 100%;
+
+      .formula-editor-frame {
+        display: flex;
+        flex: 1 1 auto;
+        // two rows of the monospace formula text. With the modal's height left to the content,
+        // this is what establishes the default size; once the user resizes, the modal has an
+        // explicit height and the field flexes to fill it, never dropping below two rows.
+        min-height: 48px;
+        position: relative;
+        width: 100%;
+
+        .formula-editor-input {
+          flex: 1 1 auto;
+          min-height: 0;
+          min-width: 0;
+
+          .cm-editor {
+            border: 1px solid vars.$charcoal-light-2;
+            border-radius: 2px;
+            height: 100%;
+            width: 100%;
+
+            &.cm-focused {
+              @include vars.focus-outline;
+            }
+          }
+        }
+
+        // Sizing the formula field sizes the modal, so this is the modal's only resize grip.
+        .formula-editor-resize-corner {
+          align-items: center;
+          bottom: 1px;
+          color: vars.$charcoal-light-1;
+          cursor: se-resize;
+          display: flex;
+          height: 14px;
+          justify-content: center;
+          position: absolute;
+          right: 1px;
+          width: 14px;
+
+          svg {
+            height: 12px;
+            width: 12px;
+          }
+          &:hover {
+            color: vars.$charcoal-dark-1;
+          }
+        }
+      }
+    }
+  }
+
+  .formula-insert-buttons-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: 20px;
+    margin-top: 10px;
+    // never give up height to the formula editor above; the buttons are the
+    // first thing clipped when the body overflows
+    flex-shrink: 0;
+
+    .formula-insert-button-wrapper {
+      position: relative;
+    }
+
+    .formula-editor-button {
+      @include formula-button;
+      background: $formula-button-face;
+      padding: 0;
+
+      .formula-editor-button-label {
+        padding: 0 8px 0 10px;
+      }
+      // the caret sits in its own segment, per the spec's select-style control
+      .formula-editor-button-caret {
+        align-items: center;
+        border-left: 1px solid lightgray;
+        display: flex;
+        font-size: 10px;
+        height: 100%;
+        justify-content: center;
+        width: 24px;
+      }
+
+      &:hover {
+        background: $formula-button-face-hover;
+      }
+      &:active, &.menu-open {
+        background: $formula-button-face-active;
+      }
+    }
+  }
+}
+
+.codap-modal-content .chakra-modal__footer.formula-modal-footer {
+  cursor: default;
+  gap: 10px;
+  padding: 10px $formula-side-padding 15px;
+
+  .formula-modal-footer-button {
+    @include formula-button;
+    background: white;
+    padding: 0 12px;
+
+    &:hover {
+      background: $formula-button-face-hover;
+    }
+    &:active {
+      background: $formula-button-face-active;
+    }
+
+    &.apply-button {
+      background: $formula-button-default-face;
+
+      &:hover {
+        background: $formula-button-default-hover;
+      }
+      &:active {
+        background: $formula-button-default-active;
+      }
+    }
   }
 }

--- a/v3/src/components/common/edit-formula-modal.scss
+++ b/v3/src/components/common/edit-formula-modal.scss
@@ -26,10 +26,12 @@ $formula-button-default-active: #72bfca;
 $formula-control-height: 30px;
 $formula-side-padding: 15px;
 $formula-label-color: #222; // the `labelText` color the Chakra button variants used
+// 4.02:1 against the #f0f0f0 modal body, so control boundaries meet WCAG 1.4.11's 3:1
+$formula-control-border: #767676;
 
 @mixin formula-button {
   align-items: center;
-  border: 1px solid lightgray;
+  border: 1px solid $formula-control-border;
   border-radius: 4px;
   color: $formula-label-color;
   cursor: pointer;
@@ -43,6 +45,35 @@ $formula-label-color: #222; // the `labelText` color the Chakra button variants 
 
   &:focus-visible {
     @include vars.focus-outline;
+  }
+}
+
+.formula-modal-header-wrapper {
+  flex-shrink: 0;
+  position: relative;
+
+  // Positioned over the header rather than inside it: the header is the dialog's
+  // aria-labelledby target, and anything within it becomes part of the dialog's name.
+  .formula-modal-close-button {
+    align-items: center;
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    font-size: 20px;
+    // 24px of target around a 20px glyph, per WCAG 2.2 target size
+    height: 24px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    width: 24px;
+
+    &:focus-visible {
+      @include vars.focus-outline;
+    }
   }
 }
 
@@ -64,21 +95,11 @@ $formula-label-color: #222; // the `labelText` color the Chakra button variants 
   padding: 0;
 
   .formula-modal-title {
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    margin: 0;
     padding-left: $formula-side-padding;
-  }
-
-  .formula-modal-close-button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-size: 20px;
-    line-height: 1;
-    margin-right: 5px;
-    padding: 0 5px;
-
-    &:focus-visible {
-      @include vars.focus-outline;
-    }
   }
 }
 
@@ -124,7 +145,7 @@ $formula-label-color: #222; // the `labelText` color the Chakra button variants 
         width: 100%;
       }
       .attr-name-input {
-        border: 1px solid vars.$charcoal-light-2;
+        border: 1px solid $formula-control-border;
         border-radius: 2px;
         flex: 1 1 auto;
         // the ModalBody theme sets a "medium" weight that the input would otherwise inherit
@@ -167,7 +188,7 @@ $formula-label-color: #222; // the `labelText` color the Chakra button variants 
           min-width: 0;
 
           .cm-editor {
-            border: 1px solid vars.$charcoal-light-2;
+            border: 1px solid $formula-control-border;
             border-radius: 2px;
             height: 100%;
             width: 100%;
@@ -179,17 +200,20 @@ $formula-label-color: #222; // the `labelText` color the Chakra button variants 
         }
 
         // Sizing the formula field sizes the modal, so this is the modal's only resize grip.
+        // 24px of target around a 12px icon, per WCAG 2.2 target size. The box is transparent and
+        // the icon stays pinned to the corner, so only the hit area grows.
         .formula-editor-resize-corner {
-          align-items: center;
-          bottom: 1px;
-          color: vars.$charcoal-light-1;
+          align-items: flex-end;
+          bottom: 0;
+          color: $formula-control-border;
           cursor: se-resize;
           display: flex;
-          height: 14px;
-          justify-content: center;
+          height: 24px;
+          justify-content: flex-end;
+          padding: 0 1px 1px 0;
           position: absolute;
-          right: 1px;
-          width: 14px;
+          right: 0;
+          width: 24px;
 
           svg {
             height: 12px;
@@ -228,7 +252,7 @@ $formula-label-color: #222; // the `labelText` color the Chakra button variants 
       // the caret sits in its own segment, per the spec's select-style control
       .formula-editor-button-caret {
         align-items: center;
-        border-left: 1px solid lightgray;
+        border-left: 1px solid $formula-control-border;
         display: flex;
         font-size: 10px;
         height: 100%;

--- a/v3/src/components/common/edit-formula-modal.scss
+++ b/v3/src/components/common/edit-formula-modal.scss
@@ -24,12 +24,22 @@ $edit-formula-modal-min-width-px: #{$edit-formula-modal-min-width}px;
     flex-grow: 1;
     align-items: flex-start;
 
+    .attr-name-form-label {
+      align-items: center;
+      width: 100%;
+    }
+    // The label sizes to its text and the input absorbs the remainder, so that a long
+    // translation widens the label instead of wrapping onto a second line. A wrapped label
+    // grows the form control and pushes the insert buttons out of the modal body.
     .title-label {
-      width: 97px;
+      flex: 0 0 auto;
+      margin-right: 5px;
+      white-space: nowrap;
     }
     .attr-name-input {
       border: 1px solid vars.$charcoal-light-2;
-      width: 270px;
+      flex: 1 1 auto;
+      min-width: 0;
       margin-right: 3px;
       margin-left: 0;
       padding-left: 5px;
@@ -63,8 +73,12 @@ $edit-formula-modal-min-width-px: #{$edit-formula-modal-min-width}px;
   .formula-insert-buttons-container {
     position: relative;
     bottom: 0;
+    // never give up height or width to the formula editor above; the buttons are the
+    // first thing clipped when the body overflows
+    flex-shrink: 0;
 
     .formula-editor-button {
+      flex-shrink: 0;
       padding: 0 10px;
       &:hover {
         background: vars.$codap-teal-lighter;

--- a/v3/src/components/common/edit-formula-modal.scss.d.ts
+++ b/v3/src/components/common/edit-formula-modal.scss.d.ts
@@ -1,6 +1,7 @@
 // https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
 export interface IEditFormulaModalShared {
   editFormulaModalMinHeight: number
+  editFormulaModalFilterMinHeight: number
   editFormulaModalMinWidth: number
 }
 

--- a/v3/src/components/common/edit-formula-modal.test.tsx
+++ b/v3/src/components/common/edit-formula-modal.test.tsx
@@ -20,6 +20,7 @@ jest.mock("./formula-editor", () => ({
 type ModalProps = ComponentProps<typeof EditFormulaModal>
 
 const baseProps: Omit<ModalProps, "applyFormula"> = {
+  modalTitle: "Edit Formula",
   titleLabel: "Attribute name",
   onClose: () => {},
   value: "",
@@ -101,9 +102,71 @@ describe("EditFormulaModal", () => {
     expect(screen.getByTestId("attr-name-input")).not.toBeDisabled()
   })
 
-  it("disables the title input when no titleInput prop is provided (e.g. filter formula)", () => {
+  it("omits the title row entirely when no titleInput prop is provided (e.g. filter formula)", () => {
     setup({ titleInput: undefined, titleLabel: "Filter formula" })
-    expect(screen.getByTestId("attr-name-input")).toBeDisabled()
+    expect(screen.queryByTestId("attr-name-input")).not.toBeInTheDocument()
+  })
+
+  it("adds the title row when titleInput arrives after the first render", () => {
+    // Callers derive titleInput from a model that may still be resolving, so the first render
+    // can legitimately have no title. Anything derived from its presence — including the modal's
+    // default height — has to follow when it shows up.
+    const { props, rerender } = setup({ titleInput: undefined })
+    expect(screen.queryByTestId("attr-name-input")).not.toBeInTheDocument()
+
+    rerender(<EditFormulaModal {...props} applyFormula={jest.fn()} titleInput="Design" />)
+    expect(screen.getByTestId("attr-name-input")).toHaveValue("Design")
+  })
+
+  it("marks the resize grip so CodapModal does not also drag the modal", () => {
+    // CodapModal's drag handler skips pointers inside `.component-resize-handle`. Without the
+    // class the modal drags while it resizes, moving the corner at twice the pointer's speed.
+    setup()
+    expect(screen.getByTestId("formula-editor-resize-corner")).toHaveClass("component-resize-handle")
+  })
+
+  it("strips the trailing colon from field labels", () => {
+    setup({ titleLabel: "Attribute Name:", formulaPrompt: "Formula:" })
+    expect(screen.getByText("Attribute Name")).toBeInTheDocument()
+    expect(screen.getByText("Formula")).toBeInTheDocument()
+  })
+
+  it("shows the modal title in the header", () => {
+    setup({ modalTitle: "Add Filter Formula" })
+    expect(screen.getByTestId("formula-modal-header")).toHaveTextContent("Add Filter Formula")
+  })
+
+  it("empties the formula when Clear is pressed", async () => {
+    const { user, applyFormula } = setup({ value: "Height * 2" })
+
+    await user.click(screen.getByRole("button", { name: "Clear" }))
+    await user.click(screen.getByRole("button", { name: "Apply" }))
+
+    expect(applyFormula).toHaveBeenLastCalledWith("", "A")
+  })
+
+  it("does not close the modal or apply the formula when Clear is pressed", async () => {
+    const onClose = jest.fn()
+    const { user, applyFormula } = setup({ value: "Height * 2", onClose })
+
+    await user.click(screen.getByRole("button", { name: "Clear" }))
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(applyFormula).not.toHaveBeenCalled()
+  })
+
+  it("leaves the title untouched when Clear is pressed", async () => {
+    const { user, applyFormula } = setup({ value: "Height * 2" })
+
+    const input = await screen.findByDisplayValue("A")
+    await user.clear(input)
+    await user.type(input, "renamed")
+
+    await user.click(screen.getByRole("button", { name: "Clear" }))
+    await user.click(screen.getByRole("button", { name: "Apply" }))
+
+    // Clear applies to the formula only; an in-session name edit survives it
+    expect(applyFormula).toHaveBeenLastCalledWith("", "renamed")
   })
 
   it("passes the in-session edited attribute name (trimmed) to applyFormula", async () => {

--- a/v3/src/components/common/edit-formula-modal.test.tsx
+++ b/v3/src/components/common/edit-formula-modal.test.tsx
@@ -136,6 +136,23 @@ describe("EditFormulaModal", () => {
     expect(screen.getByTestId("formula-modal-header")).toHaveTextContent("Add Filter Formula")
   })
 
+  it("names the dialog with the title alone", () => {
+    // Chakra points aria-labelledby at the header, and the accessible name is computed from that
+    // element's whole subtree, so the close button must stay outside it.
+    setup({ modalTitle: "Add Filter Formula" })
+    const header = screen.getByTestId("formula-modal-header")
+    expect(header).toHaveTextContent("Add Filter Formula")
+    expect(header).not.toContainElement(screen.getByTestId("formula-modal-close-button"))
+    expect(screen.getByRole("dialog", { name: "Add Filter Formula" })).toBeInTheDocument()
+  })
+
+  it("gives the attribute input a single accessible name, from its label", () => {
+    setup({ titleLabel: "Attribute Name:" })
+    expect(screen.getByRole("textbox", { name: "Attribute Name" })).toHaveAttribute(
+      "data-testid", "attr-name-input"
+    )
+  })
+
   it("empties the formula when Clear is pressed", async () => {
     const { user, applyFormula } = setup({ value: "Height * 2" })
 

--- a/v3/src/components/common/edit-formula-modal.test.tsx
+++ b/v3/src/components/common/edit-formula-modal.test.tsx
@@ -125,6 +125,39 @@ describe("EditFormulaModal", () => {
     expect(screen.getByTestId("formula-editor-resize-corner")).toHaveClass("component-resize-handle")
   })
 
+  it("closes the Insert Value menu when its button is clicked again", async () => {
+    const { user } = setup()
+    const button = screen.getByTestId("formula-insert-value-button")
+
+    await user.click(button)
+    expect(screen.getByTestId("formula-value-list")).toBeInTheDocument()
+
+    await user.click(button)
+    expect(screen.queryByTestId("formula-value-list")).not.toBeInTheDocument()
+  })
+
+  it("closes the Insert Function menu when its button is clicked again", async () => {
+    const { user } = setup()
+    const button = screen.getByTestId("formula-insert-function-button")
+
+    await user.click(button)
+    expect(screen.getByTestId("formula-function-category-list")).toBeInTheDocument()
+
+    await user.click(button)
+    expect(screen.queryByTestId("formula-function-category-list")).not.toBeInTheDocument()
+  })
+
+  it("swaps menus when the other insert button is clicked", async () => {
+    const { user } = setup()
+
+    await user.click(screen.getByTestId("formula-insert-value-button"))
+    expect(screen.getByTestId("formula-value-list")).toBeInTheDocument()
+
+    await user.click(screen.getByTestId("formula-insert-function-button"))
+    expect(screen.queryByTestId("formula-value-list")).not.toBeInTheDocument()
+    expect(screen.getByTestId("formula-function-category-list")).toBeInTheDocument()
+  })
+
   it("strips the trailing colon from field labels", () => {
     setup({ titleLabel: "Attribute Name:", formulaPrompt: "Formula:" })
     expect(screen.getByText("Attribute Name")).toBeInTheDocument()

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -181,8 +181,6 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     const startHeight = modalRect?.height ?? dimensions.height
     const startPosition = {x: e.pageX, y: e.pageY}
 
-    let resizingWidth = startWidth, resizingHeight = startHeight
-
     // Before the first resize the modal is still sized by its content, so that first drag is the
     // opportunity to record the content height.
     if (contentHeightRef.current == null && !userSize) {
@@ -194,9 +192,9 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     const onPointerMove = (pointerMoveEvent: { pageX: number; pageY: number }) => {
       const xDelta = pointerMoveEvent.pageX - startPosition.x
       const yDelta = pointerMoveEvent.pageY - startPosition.y
-      resizingWidth = Math.max(startWidth + xDelta, widthFloor)
-      resizingHeight = Math.max(startHeight + yDelta, heightFloor)
-      setUserSize({width: Math.round(resizingWidth), height: Math.round(resizingHeight)})
+      const width = Math.max(startWidth + xDelta, widthFloor)
+      const height = Math.max(startHeight + yDelta, heightFloor)
+      setUserSize({width: Math.round(width), height: Math.round(height)})
     }
     const onPointerUp = () => {
       document.body.removeEventListener("pointermove", onPointerMove, { capture: true })

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -1,10 +1,9 @@
-import {
-  Box, Button, Flex, FormControl, FormLabel, ModalBody, ModalFooter, Tooltip
-} from "@chakra-ui/react"
+import { ModalBody, ModalFooter, ModalHeader } from "@chakra-ui/react"
 import React, { useCallback, useRef, useState } from "react"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { isCommandKeyDown } from "../../utilities/platform-utils"
+import { stripTrailingColon } from "../../utilities/translation/label-utils"
 import { stripLabelDecoration } from "../../utilities/translation/strip-label-decoration"
 import { t } from "../../utilities/translation/translate"
 import { FormulaEditor } from "./formula-editor"
@@ -12,7 +11,6 @@ import { FormulaEditorContext, useFormulaEditorState } from "./formula-editor-co
 import { CodapModal } from "../codap-modal"
 import { InsertFunctionMenu } from "./formula-insert-function-menu"
 import { InsertValuesMenu } from "./formula-insert-values-menu"
-import ResizeHandle from "../../assets/icons/icon-corner-resize-handle.svg"
 
 import styles from './edit-formula-modal.scss'
 
@@ -24,6 +22,8 @@ interface IProps {
   finalFocusRef?: React.RefObject<HTMLElement>
   formulaPrompt?: string
   isOpen: boolean
+  // Text shown in the modal's header bar, e.g. "Edit Formula" or "Add Filter Formula".
+  modalTitle: string
   onClose?: () => void
   returnFocusOnClose?: boolean
   titleInput?: string
@@ -33,16 +33,16 @@ interface IProps {
 }
 
 export const EditFormulaModal = observer(function EditFormulaModal({
-  applyFormula, finalFocusRef, formulaPrompt, isOpen, onClose, returnFocusOnClose, titleInput, titleLabel,
+  applyFormula, finalFocusRef, formulaPrompt, isOpen, modalTitle, onClose, returnFocusOnClose, titleInput, titleLabel,
   titlePlaceholder, value
 }: IProps) {
   const minWidth = +styles.editFormulaModalMinWidth
-  const minHeight = +styles.editFormulaModalMinHeight
-  const headerHeight = 36
-  const footerHeight = 56
-  const insertButtonsHeight = 35
+  // without a name row the modal is shorter by that row's height
+  const minHeight = titleInput != null
+                      ? +styles.editFormulaModalMinHeight
+                      : +styles.editFormulaModalFilterMinHeight
 
-  const modalContentRef = React.useRef<HTMLDivElement>(null)
+  const modalContentRef = React.useRef<HTMLElement>(null)
   const formulaEditorContainerRef = useRef<HTMLLabelElement>(null)
   const insertValueButtonRef = useRef<HTMLButtonElement>(null)
   const insertFunctionButtonRef = useRef<HTMLButtonElement>(null)
@@ -50,8 +50,11 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   const [showFunctionMenu, setShowFunctionMenu] = useState(false)
   const formulaEditorState = useFormulaEditorState(value ?? "")
   const { formula, setFormula } = formulaEditorState
-  const [dimensions, setDimensions] = useState({ width: minWidth, height: minHeight })
-  const editorHeight = dimensions.height - headerHeight - footerHeight - insertButtonsHeight
+  // Set once the user drags the formula field's resize grip. Until then the modal takes its
+  // default size, which depends on whether a name row is present — and that is not known on the
+  // first render, since callers derive titleInput from a model that may still be resolving.
+  const [userSize, setUserSize] = useState<{ width: number, height: number }>()
+  const dimensions = userSize ?? { width: minWidth, height: minHeight }
   const [title, setTitle] = useState(titleInput ?? "")
   const isAutoCompleteMenuOpen = useRef(false)
   // Sync formula and title state from props using React's recommended
@@ -82,7 +85,14 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     setPrevTitleInput(titleInput)
     isAutoCompleteMenuOpen.current = false
     onClose?.()
-    setDimensions({ width: minWidth, height: minHeight })
+    setUserSize(undefined)
+  }
+
+  // Empties the formula without applying it or dismissing the modal, so the user can start over.
+  const clearFormula = () => {
+    setShowValuesMenu(false)
+    setShowFunctionMenu(false)
+    setFormula("")
   }
 
   const handleModalWhitespaceClick = () => {
@@ -112,13 +122,23 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     insertFunctionButtonRef.current?.focus()
   }
 
+  // Apply must remain last: cmMoveFocus() in formula-editor.tsx targets
+  // `.formula-modal-footer button:last-of-type` when shift-tabbing out of the editor.
   const footerButtons = [{
-    variant: "v3Clear",
+    className: "cancel-button",
+    testId: "Cancel-button",
     label: t("DG.AttrFormView.cancelBtnTitle"),
     tooltip: t("DG.AttrFormView.cancelBtnTooltip"),
     onClick: closeModal
   }, {
-    variant: "v3Default",
+    className: "clear-button",
+    testId: "Clear-button",
+    label: t("V3.AttrFormView.clearBtnTitle"),
+    tooltip: t("V3.AttrFormView.clearBtnTooltip"),
+    onClick: clearFormula
+  }, {
+    className: "apply-button",
+    testId: "Apply-button",
     label: t("DG.AttrFormView.applyBtnTitle"),
     onClick: applyAndClose
   }]
@@ -153,12 +173,17 @@ export const EditFormulaModal = observer(function EditFormulaModal({
 
     let resizingWidth = startWidth, resizingHeight = startHeight
 
+    // Before the first resize the modal is sized by its content, which can be shorter than the
+    // nominal minimum; clamping to the measured size keeps the first drag from jumping.
+    const widthFloor = Math.min(minWidth, startWidth)
+    const heightFloor = Math.min(minHeight, startHeight)
+
     const onPointerMove = (pointerMoveEvent: { pageX: number; pageY: number }) => {
       const xDelta = pointerMoveEvent.pageX - startPosition.x
       const yDelta = pointerMoveEvent.pageY - startPosition.y
-      resizingWidth = Math.max(startWidth + xDelta, minWidth)
-      resizingHeight = Math.max(startHeight + yDelta, minHeight)
-      setDimensions({width: Math.round(resizingWidth), height: Math.round(resizingHeight)})
+      resizingWidth = Math.max(startWidth + xDelta, widthFloor)
+      resizingHeight = Math.max(startHeight + yDelta, heightFloor)
+      setUserSize({width: Math.round(resizingWidth), height: Math.round(resizingHeight)})
     }
     const onPointerUp = () => {
       document.body.removeEventListener("pointermove", onPointerMove, { capture: true })
@@ -171,6 +196,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   return (
     <FormulaEditorContext.Provider value={formulaEditorState}>
       <CodapModal
+        ref={modalContentRef}
         finalFocusRef={finalFocusRef}
         initialRef={formulaEditorContainerRef}
         isOpen={isOpen}
@@ -178,84 +204,116 @@ export const EditFormulaModal = observer(function EditFormulaModal({
         closeOnOverlayClick={false}
         onClose={closeModal}
         modalWidth={`${dimensions.width}px`}
-        modalHeight={`${dimensions.height}px`}
+        // Until the user resizes, the content decides the height: the formula field's two-row
+        // minimum sets the default, rather than a hard-coded total that has to be kept in sync
+        // with the heights of everything around it.
+        modalHeight={userSize ? `${userSize.height}px` : "auto"}
         onClick={handleModalWhitespaceClick}
       >
+        {/* ModalHeader wires the dialog's aria-labelledby to the title. */}
+        <ModalHeader className="formula-modal-header" data-testid="formula-modal-header">
+          <span className="formula-modal-title">{modalTitle}</span>
+          <button type="button" className="formula-modal-close-button" onClick={closeModal}
+                  aria-label={t("V3.AttrFormView.closeBtnLabel")} data-testid="formula-modal-close-button">
+            ×
+          </button>
+        </ModalHeader>
         <ModalBody className="formula-modal-body" onKeyDown={handleKeyDown}>
-          <FormControl display="flex" flexDirection="column" className="formula-form-control">
+          {/*
+            TODO: rename the `attr-name-form-label` and `attr-name-input` className/data-testid
+            to a generic `title-form-label` / `title-input`. The title is not always an
+            attribute name (this modal is shared across multiple callers). Touches the SCSS,
+            the focus selector in formula-editor.tsx (`input.attr-name-input:not(:disabled)`),
+            and several Cypress selectors — keep `edit-attribute-properties-modal.tsx`'s
+            independent `attr-name-input` testid as-is.
+          */}
+          <div className="formula-form-control">
             {/*
-              TODO: rename the `attr-name-form-label` and `attr-name-input` className/data-testid
-              to a generic `title-form-label` / `title-input`. The title is not always an
-              attribute name (this modal is shared across multiple callers). Touches the SCSS,
-              the focus selector in formula-editor.tsx (`input.attr-name-input:not(:disabled)`),
-              and several Cypress selectors — keep `edit-attribute-properties-modal.tsx`'s
-              independent `attr-name-input` testid as-is.
+              Callers that edit only a formula (e.g. a filter formula) pass no titleInput and get
+              no name row at all. `titleInput === ""` still gets one, since Attribute.setName()
+              can trim a name to "" and the user needs a way to fix it.
             */}
-            <FormLabel display="flex" flexDirection="row"
-                      className="attr-name-form-label">
-              <span className="title-label">{titleLabel}</span>
-              <input
-                className="attr-name-input"
-                value={title}
-                onChange={e => setTitle(e.target.value)}
-                data-testid="attr-name-input"
-                aria-label={titleLabel}
-                // Disable only when there's no title prop at all (most callers).
-                // Allow editing when titleInput is "", since Attribute.setName()
-                // can trim a name to "" and the user needs a way to fix it.
-                disabled={titleInput == null}
-              />
-              <span>=</span>
-            </FormLabel>
-            <FormLabel ref={formulaEditorContainerRef} className="formula-editor-container" tabIndex={-1}>
-              {formulaPrompt ?? t("DG.AttrFormView.formulaPrompt")}
-              <FormulaEditor editorHeight={editorHeight} isAutoCompleteMenuOpen={isAutoCompleteMenuOpen}/>
-            </FormLabel>
-          </FormControl>
-          <Flex className="formula-insert-buttons-container" flexDirection="row" justifyContent="flex-start">
-            <Box position="relative">
-              <Button ref={insertValueButtonRef} variant="v3"
+            {titleInput != null &&
+              <label className="attr-name-form-label">
+                <span className="formula-field-label">{stripTrailingColon(titleLabel)}</span>
+                <span className="attr-name-input-row">
+                  <input
+                    className="attr-name-input"
+                    value={title}
+                    onChange={e => setTitle(e.target.value)}
+                    placeholder={titlePlaceholder}
+                    data-testid="attr-name-input"
+                    aria-label={stripTrailingColon(titleLabel)}
+                  />
+                  <span className="attr-name-equals">=</span>
+                </span>
+              </label>
+            }
+            <label ref={formulaEditorContainerRef} className="formula-editor-container" tabIndex={-1}>
+              <span className="formula-field-label">
+                {stripTrailingColon(formulaPrompt ?? t("DG.AttrFormView.formulaPrompt"))}
+              </span>
+              <span className="formula-editor-frame">
+                <FormulaEditor isAutoCompleteMenuOpen={isAutoCompleteMenuOpen}/>
+                {/*
+                  Sizing the formula field resizes the modal that sizes it. The
+                  `component-resize-handle` class is what CodapModal's drag handler looks for to
+                  leave the pointer alone; without it a drag runs alongside the resize and the
+                  corner tracks the mouse at twice its speed.
+                */}
+                <span className="formula-editor-resize-corner component-resize-handle"
+                      onPointerDown={handleResizeModal} data-testid="formula-editor-resize-corner">
+                  <svg viewBox="0 0 12 12" aria-hidden="true" focusable="false">
+                    <path d="M11 4 4 11M11 8 8 11" stroke="currentColor" strokeWidth="1.25" fill="none"/>
+                  </svg>
+                </span>
+              </span>
+            </label>
+          </div>
+          <div className="formula-insert-buttons-container">
+            <div className="formula-insert-button-wrapper">
+              <button ref={insertValueButtonRef} type="button"
                 className={clsx("formula-editor-button", "insert-value", {"menu-open": showValuesMenu})}
-                size="xs" ml="5" onClick={handleInsertValuesOpen} data-testid="formula-insert-value-button"
+                onClick={handleInsertValuesOpen} data-testid="formula-insert-value-button"
                 aria-expanded={showValuesMenu} aria-haspopup="menu"
               >
-                {stripLabelDecoration(t("DG.AttrFormView.operandMenuTitle"))}
-              </Button>
+                <span className="formula-editor-button-label">
+                  {stripLabelDecoration(t("DG.AttrFormView.operandMenuTitle"))}
+                </span>
+                <span className="formula-editor-button-caret" aria-hidden="true">▾</span>
+              </button>
               {showValuesMenu &&
                 <InsertValuesMenu buttonRef={insertValueButtonRef} onClose={handleInsertValuesClose} />
               }
-            </Box>
-            <Box position="relative">
-              <Button ref={insertFunctionButtonRef} variant="v3"
+            </div>
+            <div className="formula-insert-button-wrapper">
+              <button ref={insertFunctionButtonRef} type="button"
                 className={clsx("formula-editor-button", "insert-function", {"menu-open": showFunctionMenu})}
-                size="xs" ml="5" onClick={handleInsertFunctionsOpen} data-testid="formula-insert-function-button"
+                onClick={handleInsertFunctionsOpen} data-testid="formula-insert-function-button"
                 aria-expanded={showFunctionMenu} aria-haspopup="menu"
               >
-                {stripLabelDecoration(t("DG.AttrFormView.functionMenuTitle"))}
-              </Button>
+                <span className="formula-editor-button-label">
+                  {stripLabelDecoration(t("DG.AttrFormView.functionMenuTitle"))}
+                </span>
+                <span className="formula-editor-button-caret" aria-hidden="true">▾</span>
+              </button>
               {showFunctionMenu &&
                 <InsertFunctionMenu buttonRef={insertFunctionButtonRef} onClose={handleInsertFunctionsClose} />
               }
-            </Box>
-          </Flex>
+            </div>
+          </div>
         </ModalBody>
-        <ModalFooter mt="-5" className="formula-modal-footer">
+        <ModalFooter className="formula-modal-footer">
           { footerButtons.map((b) => {
               return (
-                <Tooltip key={b.label} label={b.tooltip} h="20px" fontSize="12px" color="white" openDelay={1000}
-                  placement="bottom" bottom="15px" left="15px" data-testid="modal-tooltip"
-                >
-                  <Button size="xs" variant={b.variant} ml="5" onClick={b.onClick}
-                        data-testid={`${b.label}-button`}>
-                    {b.label}
-                  </Button>
-                </Tooltip>
+                <button key={b.testId} type="button" title={b.tooltip}
+                      className={clsx("formula-modal-footer-button", b.className)}
+                      onClick={b.onClick} data-testid={b.testId}>
+                  {b.label}
+                </button>
               )
             })
           }
-          <div className="codap-modal-corner bottom-right" onPointerDown={handleResizeModal}>
-            <ResizeHandle className="component-resize-handle"/>
-          </div>
         </ModalFooter>
       </CodapModal>
     </FormulaEditorContext.Provider>

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useRef, useState } from "react"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { isCommandKeyDown } from "../../utilities/platform-utils"
+import { stripLabelDecoration } from "../../utilities/translation/strip-label-decoration"
 import { t } from "../../utilities/translation/translate"
 import { FormulaEditor } from "./formula-editor"
 import { FormulaEditorContext, useFormulaEditorState } from "./formula-editor-context"
@@ -218,7 +219,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
                 size="xs" ml="5" onClick={handleInsertValuesOpen} data-testid="formula-insert-value-button"
                 aria-expanded={showValuesMenu} aria-haspopup="menu"
               >
-                {t("DG.AttrFormView.operandMenuTitle")}
+                {stripLabelDecoration(t("DG.AttrFormView.operandMenuTitle"))}
               </Button>
               {showValuesMenu &&
                 <InsertValuesMenu buttonRef={insertValueButtonRef} onClose={handleInsertValuesClose} />
@@ -230,7 +231,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
                 size="xs" ml="5" onClick={handleInsertFunctionsOpen} data-testid="formula-insert-function-button"
                 aria-expanded={showFunctionMenu} aria-haspopup="menu"
               >
-                {t("DG.AttrFormView.functionMenuTitle")}
+                {stripLabelDecoration(t("DG.AttrFormView.functionMenuTitle"))}
               </Button>
               {showFunctionMenu &&
                 <InsertFunctionMenu buttonRef={insertFunctionButtonRef} onClose={handleInsertFunctionsClose} />

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -37,7 +37,8 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   titlePlaceholder, value
 }: IProps) {
   const minWidth = +styles.editFormulaModalMinWidth
-  // without a name row the modal is shorter by that row's height
+  // Fallback floor for resizing, used only when the content height cannot be measured. A modal
+  // with no name row is shorter by that row's height.
   const minHeight = titleInput != null
                       ? +styles.editFormulaModalMinHeight
                       : +styles.editFormulaModalFilterMinHeight
@@ -51,11 +52,14 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   const formulaEditorState = useFormulaEditorState(value ?? "")
   const { editorApi, formula, setFormula } = formulaEditorState
   const formulaLabelId = useId()
-  // Set once the user drags the formula field's resize grip. Until then the modal takes its
-  // default size, which depends on whether a name row is present — and that is not known on the
-  // first render, since callers derive titleInput from a model that may still be resolving.
+  // Set once the user drags the formula field's resize grip; until then the modal is sized by
+  // its content.
   const [userSize, setUserSize] = useState<{ width: number, height: number }>()
   const dimensions = userSize ?? { width: minWidth, height: minHeight }
+  // The height the modal takes from its content, measured when a resize first begins. Dragging
+  // shorter than this would leave the formula field — which has a two-row minimum — overflowing
+  // its container and covering the controls beneath it.
+  const contentHeightRef = useRef<number>()
   const [title, setTitle] = useState(titleInput ?? "")
   const isAutoCompleteMenuOpen = useRef(false)
   // Sync formula and title state from props using React's recommended
@@ -87,6 +91,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     isAutoCompleteMenuOpen.current = false
     onClose?.()
     setUserSize(undefined)
+    contentHeightRef.current = undefined
   }
 
   // Empties the formula without applying it or dismissing the modal, so the user can start over.
@@ -176,10 +181,13 @@ export const EditFormulaModal = observer(function EditFormulaModal({
 
     let resizingWidth = startWidth, resizingHeight = startHeight
 
-    // Before the first resize the modal is sized by its content, which can be shorter than the
-    // nominal minimum; clamping to the measured size keeps the first drag from jumping.
+    // Before the first resize the modal is still sized by its content, so that first drag is the
+    // opportunity to record the content height.
+    if (contentHeightRef.current == null && !userSize) {
+      contentHeightRef.current = startHeight
+    }
     const widthFloor = Math.min(minWidth, startWidth)
-    const heightFloor = Math.min(minHeight, startHeight)
+    const heightFloor = contentHeightRef.current ?? Math.min(minHeight, startHeight)
 
     const onPointerMove = (pointerMoveEvent: { pageX: number; pageY: number }) => {
       const xDelta = pointerMoveEvent.pageX - startPosition.x
@@ -194,7 +202,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     }
     document.body.addEventListener("pointermove", onPointerMove, { capture: true })
     document.body.addEventListener("pointerup", onPointerUp, { capture: true })
-  }, [dimensions.height, dimensions.width, minHeight, minWidth])
+  }, [dimensions.height, dimensions.width, minHeight, minWidth, userSize])
 
   return (
     <FormulaEditorContext.Provider value={formulaEditorState}>

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -108,9 +108,11 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     setShowFunctionMenu(false)
   }
 
-  const handleInsertValuesOpen = (e: React.MouseEvent) => {
+  // Clicks on the button are kept from the modal's own click handler, so the button itself has to
+  // close the menu it opened.
+  const handleInsertValuesToggle = (e: React.MouseEvent) => {
     e.stopPropagation()
-    setShowValuesMenu(true)
+    setShowValuesMenu(current => !current)
     setShowFunctionMenu(false)
   }
 
@@ -119,9 +121,9 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     insertValueButtonRef.current?.focus()
   }
 
-  const handleInsertFunctionsOpen = (e: React.MouseEvent) => {
+  const handleInsertFunctionsToggle = (e: React.MouseEvent) => {
     e.stopPropagation()
-    setShowFunctionMenu(true)
+    setShowFunctionMenu(current => !current)
     setShowValuesMenu(false)
   }
 
@@ -295,7 +297,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
             <div className="formula-insert-button-wrapper">
               <button ref={insertValueButtonRef} type="button"
                 className={clsx("formula-editor-button", "insert-value", {"menu-open": showValuesMenu})}
-                onClick={handleInsertValuesOpen} data-testid="formula-insert-value-button"
+                onClick={handleInsertValuesToggle} data-testid="formula-insert-value-button"
                 aria-expanded={showValuesMenu} aria-haspopup="menu"
               >
                 <span className="formula-editor-button-label">
@@ -310,7 +312,7 @@ export const EditFormulaModal = observer(function EditFormulaModal({
             <div className="formula-insert-button-wrapper">
               <button ref={insertFunctionButtonRef} type="button"
                 className={clsx("formula-editor-button", "insert-function", {"menu-open": showFunctionMenu})}
-                onClick={handleInsertFunctionsOpen} data-testid="formula-insert-function-button"
+                onClick={handleInsertFunctionsToggle} data-testid="formula-insert-function-button"
                 aria-expanded={showFunctionMenu} aria-haspopup="menu"
               >
                 <span className="formula-editor-button-label">

--- a/v3/src/components/common/edit-formula-modal.tsx
+++ b/v3/src/components/common/edit-formula-modal.tsx
@@ -1,5 +1,5 @@
 import { ModalBody, ModalFooter, ModalHeader } from "@chakra-ui/react"
-import React, { useCallback, useRef, useState } from "react"
+import React, { useCallback, useId, useRef, useState } from "react"
 import { observer } from "mobx-react-lite"
 import { clsx } from "clsx"
 import { isCommandKeyDown } from "../../utilities/platform-utils"
@@ -49,7 +49,8 @@ export const EditFormulaModal = observer(function EditFormulaModal({
   const [showValuesMenu, setShowValuesMenu] = useState(false)
   const [showFunctionMenu, setShowFunctionMenu] = useState(false)
   const formulaEditorState = useFormulaEditorState(value ?? "")
-  const { formula, setFormula } = formulaEditorState
+  const { editorApi, formula, setFormula } = formulaEditorState
+  const formulaLabelId = useId()
   // Set once the user drags the formula field's resize grip. Until then the modal takes its
   // default size, which depends on whether a name row is present — and that is not known on the
   // first render, since callers derive titleInput from a model that may still be resolving.
@@ -93,6 +94,8 @@ export const EditFormulaModal = observer(function EditFormulaModal({
     setShowValuesMenu(false)
     setShowFunctionMenu(false)
     setFormula("")
+    // Return to the now-empty field, so the effect of the button is evident without sight of it.
+    editorApi?.focus()
   }
 
   const handleModalWhitespaceClick = () => {
@@ -210,14 +213,20 @@ export const EditFormulaModal = observer(function EditFormulaModal({
         modalHeight={userSize ? `${userSize.height}px` : "auto"}
         onClick={handleModalWhitespaceClick}
       >
-        {/* ModalHeader wires the dialog's aria-labelledby to the title. */}
-        <ModalHeader className="formula-modal-header" data-testid="formula-modal-header">
-          <span className="formula-modal-title">{modalTitle}</span>
+        {/*
+          Chakra points the dialog's aria-labelledby at ModalHeader, and the accessible name is
+          computed from its whole subtree — so the close button sits outside it, or the dialog
+          announces as "Edit Formula Close".
+        */}
+        <div className="formula-modal-header-wrapper">
+          <ModalHeader className="formula-modal-header" data-testid="formula-modal-header">
+            <h2 className="formula-modal-title">{modalTitle}</h2>
+          </ModalHeader>
           <button type="button" className="formula-modal-close-button" onClick={closeModal}
                   aria-label={t("V3.AttrFormView.closeBtnLabel")} data-testid="formula-modal-close-button">
-            ×
+            <span aria-hidden="true">×</span>
           </button>
-        </ModalHeader>
+        </div>
         <ModalBody className="formula-modal-body" onKeyDown={handleKeyDown}>
           {/*
             TODO: rename the `attr-name-form-label` and `attr-name-input` className/data-testid
@@ -243,18 +252,22 @@ export const EditFormulaModal = observer(function EditFormulaModal({
                     onChange={e => setTitle(e.target.value)}
                     placeholder={titlePlaceholder}
                     data-testid="attr-name-input"
-                    aria-label={stripTrailingColon(titleLabel)}
                   />
-                  <span className="attr-name-equals">=</span>
+                  {/* decorative: the label wraps the input, so this would otherwise land in its name */}
+                  <span className="attr-name-equals" aria-hidden="true">=</span>
                 </span>
               </label>
             }
             <label ref={formulaEditorContainerRef} className="formula-editor-container" tabIndex={-1}>
-              <span className="formula-field-label">
+              {/*
+                A <label> only names labelable elements, and the editor's editable region is a
+                contenteditable div, so the label is wired to it by id instead.
+              */}
+              <span className="formula-field-label" id={formulaLabelId}>
                 {stripTrailingColon(formulaPrompt ?? t("DG.AttrFormView.formulaPrompt"))}
               </span>
               <span className="formula-editor-frame">
-                <FormulaEditor isAutoCompleteMenuOpen={isAutoCompleteMenuOpen}/>
+                <FormulaEditor labelId={formulaLabelId} isAutoCompleteMenuOpen={isAutoCompleteMenuOpen}/>
                 {/*
                   Sizing the formula field resizes the modal that sizes it. The
                   `component-resize-handle` class is what CodapModal's drag handler looks for to

--- a/v3/src/components/common/formula-editor.tsx
+++ b/v3/src/components/common/formula-editor.tsx
@@ -20,8 +20,6 @@ import { getSharedModelManager } from "../../models/tiles/tile-environment"
 import { getGlobalValueManager } from "../../models/global/global-value-manager"
 import { FormulaEditorApi, useFormulaEditorContext } from "./formula-editor-context"
 
-import styles from './edit-formula-modal.scss'
-
 interface ICompletionOptions {
   attributes: boolean
   boundaries: boolean
@@ -38,7 +36,6 @@ const kAllOptions: ICompletionOptions = {
 interface IProps {
   // options default to true if not specified
   options?: Partial<ICompletionOptions>
-  editorHeight?: number
   isAutoCompleteMenuOpen: React.MutableRefObject<boolean>
 }
 
@@ -273,9 +270,7 @@ function cmExtensionsSetup() {
   return extensions.filter(Boolean)
 }
 
-export function FormulaEditor({
-  options: _options, editorHeight = +styles.editFormulaModalMinHeight, isAutoCompleteMenuOpen
-}: IProps) {
+export function FormulaEditor({ options: _options, isAutoCompleteMenuOpen }: IProps) {
   const dataSet = useDataSetContext()
   const jsonOptions = JSON.stringify(_options ?? {})
   const options = useMemo(() => JSON.parse(jsonOptions), [jsonOptions])
@@ -335,8 +330,10 @@ export function FormulaEditor({
 
   // .input-element indicates to CodapModal not to drag the modal from within the element
   const classes = "formula-editor-input input-element"
-  return <CodeMirror ref={cmRef} className={classes} data-testid="formula-editor-input" height="70px"
-                     basicSetup={false} extensions={extensions} style={{height: editorHeight}}
+  // The editor fills the space the modal's flex layout gives it, so that a taller header or a
+  // wrapped label cannot push it — or the controls below it — outside the modal body.
+  return <CodeMirror ref={cmRef} className={classes} data-testid="formula-editor-input" height="100%"
+                     basicSetup={false} extensions={extensions}
                      onCreateEditor={handleCreateEditor}
                      value={formula} onChange={handleFormulaChange} />
 }

--- a/v3/src/components/common/formula-editor.tsx
+++ b/v3/src/components/common/formula-editor.tsx
@@ -37,6 +37,9 @@ interface IProps {
   // options default to true if not specified
   options?: Partial<ICompletionOptions>
   isAutoCompleteMenuOpen: React.MutableRefObject<boolean>
+  // id of the element naming the editor. CodeMirror's editable region is a contenteditable div,
+  // which a wrapping <label> cannot name, so the association is made here instead.
+  labelId?: string
 }
 
 /*
@@ -239,12 +242,13 @@ function cmMoveFocus(view: EditorView, forward: boolean): boolean {
 /*
  * editor configuration
  */
-function cmExtensionsSetup() {
+function cmExtensionsSetup(labelId?: string) {
   let keymaps: KeyBinding[] = []
   keymaps = keymaps.concat(closeBracketsKeymap)
   keymaps = keymaps.concat(defaultKeymap)
   keymaps = keymaps.concat(completionKeymap)
   const extensions: Extension[] = [
+    ...(labelId ? [EditorView.contentAttributes.of({ "aria-labelledby": labelId })] : []),
     cmDataSetState,
     cmOptionsState,
     drawSelection(),
@@ -270,12 +274,12 @@ function cmExtensionsSetup() {
   return extensions.filter(Boolean)
 }
 
-export function FormulaEditor({ options: _options, isAutoCompleteMenuOpen }: IProps) {
+export function FormulaEditor({ options: _options, isAutoCompleteMenuOpen, labelId }: IProps) {
   const dataSet = useDataSetContext()
   const jsonOptions = JSON.stringify(_options ?? {})
   const options = useMemo(() => JSON.parse(jsonOptions), [jsonOptions])
   const cmRef = useRef<ReactCodeMirrorRef>(null)
-  const extensions = useMemo(() => cmExtensionsSetup(), [])
+  const extensions = useMemo(() => cmExtensionsSetup(labelId), [labelId])
   const { formula, setFormula, setEditorApi } = useFormulaEditorContext()
 
   useEffect(() => {

--- a/v3/src/components/common/formula-insert-function-menu.tsx
+++ b/v3/src/components/common/formula-insert-function-menu.tsx
@@ -3,10 +3,10 @@ import { Menu, MenuItem } from "react-aria-components"
 
 import { functionCategoryInfoArray, FunctionInfo } from "../../lib/functions"
 import { useFormulaEditorContext } from "./formula-editor-context"
+import { useFormulaMenuPlacement } from "./use-formula-menu-placement"
 
 import "./formula-insert-menus.scss"
 
-const kMenuGap = 3
 const kMaxMenuHeight = 380  // matches max-height in formula-insert-menus.scss
 
 // Focus a menu item by data-name, or fall back to the first menu item
@@ -27,31 +27,12 @@ export const InsertFunctionMenu = ({ buttonRef, onClose }: IProps) => {
   const [functionMenuView, setFunctionMenuView] = useState<"category" | "list" | "info">("category")
   const [selectedCategory, setSelectedCategory] = useState("")
   const [selectedFunction, setSelectedFunction] = useState("")
-  const [menuPosition, setMenuPosition] = useState<React.CSSProperties>({})
   const containerRef = useRef<HTMLDivElement>(null)
   // Track last-focused keys for restoring focus on back navigation
   const lastFocusedCategoryRef = useRef("")
   const lastFocusedFunctionRef = useRef("")
 
-  const getFunctionMenuPosition = useCallback((): React.CSSProperties => {
-    const buttonEl = buttonRef.current
-
-    if (buttonEl) {
-      const buttonRect = buttonEl.getBoundingClientRect()
-      // Calculate available space above and below the button to determine where to position the menu
-      const spaceBelow = window.innerHeight - buttonRect.bottom
-      const spaceAbove = buttonRect.top
-      if (spaceBelow < kMaxMenuHeight && spaceAbove >= kMaxMenuHeight) {
-        return { bottom: buttonRect.height + kMenuGap }
-      }
-      return { top: buttonRect.height + kMenuGap }
-    }
-    return {}
-  }, [buttonRef])
-
-  useEffect(() => {
-    setMenuPosition(getFunctionMenuPosition())
-  }, [getFunctionMenuPosition])
+  const menuPosition = useFormulaMenuPlacement(buttonRef, containerRef, kMaxMenuHeight)
 
   // Focus management when views change
   useEffect(() => {

--- a/v3/src/components/common/formula-insert-menu-position.test.ts
+++ b/v3/src/components/common/formula-insert-menu-position.test.ts
@@ -1,0 +1,69 @@
+import { getMenuPlacement, isSamePlacement } from "./formula-insert-menu-position"
+
+const kMaxHeight = 470
+// a button in the middle of a tall window, with room on both sides
+const midButton = { top: 500, bottom: 530, height: 30 }
+
+describe("getMenuPlacement", () => {
+  it("places a menu below the button when it fits there", () => {
+    const placement = getMenuPlacement(midButton, 200, kMaxHeight, 1000)
+    expect(placement.top).toBe(30)
+    expect(placement.bottom).toBeUndefined()
+  })
+
+  it("flips above when the menu does not fit below but does fit above", () => {
+    // the reported case: a modal dragged near the bottom of a tall window
+    const button = { top: 1239, bottom: 1269, height: 30 }
+    const placement = getMenuPlacement(button, 98, kMaxHeight, 1353)
+    expect(placement.bottom).toBe(30)
+    expect(placement.top).toBeUndefined()
+  })
+
+  it("never returns a maxHeight larger than the space on the chosen side", () => {
+    // 1353 - 1269 - 8 = 76 below, so a menu placed below may be no taller than that
+    const button = { top: 1239, bottom: 1269, height: 30 }
+    const tallWindowPlacement = getMenuPlacement(button, 98, kMaxHeight, 1353)
+    expect(tallWindowPlacement.maxHeight).toBeLessThanOrEqual(1239 - 8)
+
+    // a button with little room on either side still may not overflow
+    const cramped = getMenuPlacement({ top: 60, bottom: 90, height: 30 }, 400, kMaxHeight, 150)
+    expect(cramped.maxHeight).toBeLessThanOrEqual(Math.max(150 - 90 - 8, 60 - 8))
+  })
+
+  it("takes the roomier side when the menu fits neither", () => {
+    // 300 below, 192 above: below wins even though the menu is cut off either way
+    const placement = getMenuPlacement({ top: 200, bottom: 230, height: 30 }, 900, kMaxHeight, 538)
+    expect(placement.top).toBe(30)
+    expect(placement.maxHeight).toBe(538 - 230 - 8)
+
+    // and the other way round
+    const flipped = getMenuPlacement({ top: 400, bottom: 430, height: 30 }, 900, kMaxHeight, 530)
+    expect(flipped.bottom).toBe(30)
+    expect(flipped.maxHeight).toBe(400 - 8)
+  })
+
+  it("caps maxHeight at the menu's own maximum when there is ample room", () => {
+    const placement = getMenuPlacement(midButton, 2000, kMaxHeight, 5000)
+    expect(placement.maxHeight).toBe(kMaxHeight)
+  })
+
+  it("does not return a negative maxHeight when the button is off-screen", () => {
+    const placement = getMenuPlacement({ top: -100, bottom: -70, height: 30 }, 200, kMaxHeight, 800)
+    expect(placement.maxHeight).toBeGreaterThanOrEqual(0)
+  })
+
+  it("measures against the cap, so content taller than the cap still fits a large space", () => {
+    // content is 2000 but the menu will only ever be 470, and 600 of room is enough for that
+    const placement = getMenuPlacement({ top: 700, bottom: 730, height: 30 }, 2000, kMaxHeight, 1338)
+    expect(placement.top).toBe(30)
+  })
+})
+
+describe("isSamePlacement", () => {
+  it("compares side and height", () => {
+    expect(isSamePlacement({ top: 30, maxHeight: 100 }, { top: 30, maxHeight: 100 })).toBe(true)
+    expect(isSamePlacement({ top: 30, maxHeight: 100 }, { top: 30, maxHeight: 200 })).toBe(false)
+    expect(isSamePlacement({ top: 30, maxHeight: 100 }, { bottom: 30, maxHeight: 100 })).toBe(false)
+    expect(isSamePlacement(undefined, { top: 30, maxHeight: 100 })).toBe(false)
+  })
+})

--- a/v3/src/components/common/formula-insert-menu-position.ts
+++ b/v3/src/components/common/formula-insert-menu-position.ts
@@ -1,0 +1,45 @@
+// keeps a menu clear of the window edge it is placed against
+const kWindowMargin = 8
+
+export interface IButtonMetrics {
+  top: number
+  bottom: number
+  height: number
+}
+
+export interface IMenuPlacement {
+  top?: number
+  bottom?: number
+  maxHeight: number
+}
+
+/**
+ * Places a dropdown against the button that opens it, flush with the button's edge.
+ *
+ * Below the button by preference, above it when the menu does not fit below but does fit above,
+ * and on the roomier side when it fits neither. The returned maxHeight never exceeds the space on
+ * the chosen side, so the menu scrolls rather than running past the edge of the window.
+ *
+ * Shared by the insert values and insert function menus so the two cannot drift apart.
+ */
+export function getMenuPlacement(
+  button: IButtonMetrics, contentHeight: number, maxHeight: number, windowHeight: number
+): IMenuPlacement {
+  const spaceBelow = windowHeight - button.bottom - kWindowMargin
+  const spaceAbove = button.top - kWindowMargin
+  // the menu is never drawn taller than its cap, so that is the height that has to fit
+  const height = Math.min(contentHeight, maxHeight)
+  const fitsBelow = height <= spaceBelow
+  const fitsAbove = height <= spaceAbove
+  const placeBelow = fitsBelow || (!fitsAbove && spaceBelow >= spaceAbove)
+  const available = Math.max(placeBelow ? spaceBelow : spaceAbove, 0)
+
+  return {
+    [placeBelow ? "top" : "bottom"]: button.height,
+    maxHeight: Math.min(maxHeight, available)
+  }
+}
+
+export function isSamePlacement(a: IMenuPlacement | undefined, b: IMenuPlacement) {
+  return a?.top === b.top && a?.bottom === b.bottom && a?.maxHeight === b.maxHeight
+}

--- a/v3/src/components/common/formula-insert-menus.scss
+++ b/v3/src/components/common/formula-insert-menus.scss
@@ -1,7 +1,6 @@
 @use "../vars";
 
 .formula-function-menu-container {
-  margin: 3px 0;
   border: 1px solid #000;
   font-size: 12px;
   z-index: 1005;
@@ -11,7 +10,9 @@
   overflow-y: auto;
   position: absolute;
   max-height: 380px;
-  left: 20px;
+  // aligned with the button, and spaced from it by the same gap the values menu uses, which
+  // both menus set as `top` when they measure the button
+  left: 0;
   cursor: pointer;
 
   .formula-function-list[role="menu"] {
@@ -189,6 +190,10 @@
     display: flex;
     flex-direction: column;
     outline: none;
+    // shrink within the container's measured max-height, so a long list scrolls
+    // instead of running past the window
+    flex: 1 1 auto;
+    min-height: 0;
 
     .list-divider {
       border: 0.5px solid #d6d6d6;

--- a/v3/src/components/common/formula-insert-menus.scss
+++ b/v3/src/components/common/formula-insert-menus.scss
@@ -10,8 +10,8 @@
   overflow-y: auto;
   position: absolute;
   max-height: 380px;
-  // aligned with the button, and spaced from it by the same gap the values menu uses, which
-  // both menus set as `top` when they measure the button
+  // aligned with the button's left edge; the placement hook sets top or bottom so the menu sits
+  // flush against the button, as the values menu does
   left: 0;
   cursor: pointer;
 

--- a/v3/src/components/common/formula-insert-values-menu.tsx
+++ b/v3/src/components/common/formula-insert-values-menu.tsx
@@ -95,10 +95,14 @@ export const InsertValuesMenu = ({ buttonRef, onClose }: IProps) => {
     }
   }, [])
 
-  const isScrollable = scrollableContainerRef.current && scrollableContainerRef.current.scrollHeight > kMaxHeight
-  const canScrollUp = scrollableContainerRef.current && scrollableContainerRef.current.scrollTop > 0
-  const canScrollDown = scrollableContainerRef.current &&
-          (scrollableContainerRef.current.scrollHeight - scrollableContainerRef.current.scrollTop + 20 > kMaxHeight)
+  // Measured against the list's own box rather than the nominal maximum, since the placement hook
+  // caps the menu to the space available, which is often less. These read refs during render, so
+  // they depend on something else re-rendering: the placement hook settling, or a scroll.
+  const scrollEl = scrollableContainerRef.current
+  const isScrollable = !!scrollEl && scrollEl.scrollHeight > scrollEl.clientHeight
+  const canScrollUp = !!scrollEl && scrollEl.scrollTop > 0
+  // the -1 absorbs the fractional pixel a scrolled-to-bottom list can report
+  const canScrollDown = !!scrollEl && scrollEl.scrollTop + scrollEl.clientHeight < scrollEl.scrollHeight - 1
 
   return (
     <div ref={containerRef} className="formula-operand-list-container" data-testid="formula-value-list"

--- a/v3/src/components/common/formula-insert-values-menu.tsx
+++ b/v3/src/components/common/formula-insert-values-menu.tsx
@@ -6,10 +6,10 @@ import { boundaryManager } from "../../models/boundaries/boundary-manager"
 import { getSharedModelManager } from "../../models/tiles/tile-environment"
 import { getGlobalValueManager } from "../../models/global/global-value-manager"
 import { useFormulaEditorContext } from "./formula-editor-context"
+import { useFormulaMenuPlacement } from "./use-formula-menu-placement"
 
 import "./formula-insert-menus.scss"
 
-const kMenuGap = 3
 const kMaxHeight = 470
 
 interface IProps {
@@ -31,12 +31,12 @@ export const InsertValuesMenu = ({ buttonRef, onClose }: IProps) => {
       .map(attr => attr?.name)
       .filter(name => name !== undefined)
   )
-  const attributeNames = dataSet?.attributes.map(attr => attr.name)
   const globalsNames = getGlobalsNames(dataSet)
   const constants = ["e", "false", "true", "π"]
   const containerRef = useRef<HTMLDivElement>(null)
   const scrollableContainerRef = useRef<HTMLDivElement>(null)
   const [, setScrollPosition] = useState(0)
+  const menuStyle = useFormulaMenuPlacement(buttonRef, containerRef, kMaxHeight, scrollableContainerRef)
 
   const insertValueToFormula = (value: string) => {
     // if the name begins with a digit or has any non-alphanumeric chars, wrap it in backticks
@@ -49,33 +49,6 @@ export const InsertValuesMenu = ({ buttonRef, onClose }: IProps) => {
     // strip the category prefix (e.g. "attr:", "const:") to get the actual value
     const value = String(key).replace(/^[^:]+:/, "")
     insertValueToFormula(value)
-  }
-
-  function getListContainerStyle() {
-    // calculate the top of the list container based on the height of the list. The list should be
-    // nearly centered on the button that opens it.
-    // The list should not extend beyond the top or bottom of the window.
-    const listEl = containerRef.current
-    const button = buttonRef.current
-
-    const allNames = [...(attributeNames ?? []), ...boundaryManager.boundaryKeys, ...globalsNames]
-    const maxItemLength = allNames.length > 0 ? Math.max(...allNames.map(n => n.length)) : 0
-
-    let top = 0
-    if (button && listEl) {
-      const buttonRect = button.getBoundingClientRect()
-      const buttonBottom = buttonRect.bottom || 0
-      const listHeight = listEl.offsetHeight || 0
-      const spaceBelow = window.innerHeight - buttonBottom
-
-      if (spaceBelow >= listHeight) {
-        top = buttonRect.height + kMenuGap
-      } else {
-        top = spaceBelow - listHeight
-      }
-      return { top, height: kMaxHeight, width: 40 + 10 * maxItemLength }
-    }
-    return {}
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -129,7 +102,7 @@ export const InsertValuesMenu = ({ buttonRef, onClose }: IProps) => {
 
   return (
     <div ref={containerRef} className="formula-operand-list-container" data-testid="formula-value-list"
-        style={getListContainerStyle()} onKeyDown={handleKeyDown}>
+        style={menuStyle} onKeyDown={handleKeyDown}>
       { isScrollable && canScrollUp &&
         <div className="scroll-arrow" aria-hidden="true" onPointerOver={() => handleScroll("up")}>
           <span>▲</span>

--- a/v3/src/components/common/use-formula-menu-placement.ts
+++ b/v3/src/components/common/use-formula-menu-placement.ts
@@ -41,7 +41,13 @@ export function useFormulaMenuPlacement(
     const observer = new ResizeObserver(place)
     observer.observe(menuEl)
     if (scrollRef?.current) observer.observe(scrollRef.current)
-    return () => observer.disconnect()
+    // Resizing the window changes the space available without resizing either observed element,
+    // so the window height the placement was computed against would otherwise go stale.
+    window.addEventListener("resize", place)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener("resize", place)
+    }
   }, [buttonRef, menuRef, maxHeight, scrollRef])
 
   return placement

--- a/v3/src/components/common/use-formula-menu-placement.ts
+++ b/v3/src/components/common/use-formula-menu-placement.ts
@@ -1,0 +1,48 @@
+import React, { useLayoutEffect, useState } from "react"
+import { getMenuPlacement, IMenuPlacement, isSamePlacement } from "./formula-insert-menu-position"
+
+/**
+ * Positions a formula editor dropdown against the button that opens it, and keeps it on screen.
+ *
+ * Returns a style to apply to the menu element, or undefined before the first measurement.
+ */
+export function useFormulaMenuPlacement(
+  buttonRef: React.RefObject<HTMLElement | null>,
+  menuRef: React.RefObject<HTMLElement | null>,
+  maxHeight: number,
+  // The element that scrolls, when it is not the menu itself. A menu that clips inside a child
+  // never overflows, so its own scrollHeight collapses to whatever maxHeight was last applied —
+  // which would then always look like a fit, and the menu could never flip.
+  scrollRef?: React.RefObject<HTMLElement | null>
+): IMenuPlacement | undefined {
+  const [placement, setPlacement] = useState<IMenuPlacement>()
+
+  useLayoutEffect(() => {
+    const menuEl = menuRef.current
+    const button = buttonRef.current
+    if (!menuEl || !button) return
+
+    const contentHeight = () => {
+      const scrollEl = scrollRef?.current
+      if (!scrollEl) return menuEl.scrollHeight
+      // the scrolling child holds the true content height; add the chrome around it
+      return scrollEl.scrollHeight + Math.max(menuEl.clientHeight - scrollEl.clientHeight, 0)
+    }
+
+    const place = () => {
+      const next = getMenuPlacement(button.getBoundingClientRect(), contentHeight(),
+                                    maxHeight, window.innerHeight)
+      setPlacement(current => isSamePlacement(current, next) ? current : next)
+    }
+    place()
+    // react-aria builds a menu's items in a later pass, so the first measurement can be of a list
+    // whose contents have yet to appear — which would read as fitting anywhere. Measure again
+    // once it has its real size.
+    const observer = new ResizeObserver(place)
+    observer.observe(menuEl)
+    if (scrollRef?.current) observer.observe(scrollRef.current)
+    return () => observer.disconnect()
+  }, [buttonRef, menuRef, maxHeight, scrollRef])
+
+  return placement
+}

--- a/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
+++ b/v3/src/components/graph/adornments/plotted-function/plotted-function-adornment-banner.tsx
@@ -75,6 +75,7 @@ export const PlottedFunctionAdornmentBanner = observer(function PlottedFunctionA
           applyFormula={handleEditExpressionClose}
           formulaPrompt={`${yAttrName} =`}
           isOpen={isOpen}
+          modalTitle={t("DG.PlottedFunction.namePrompt")}
           onClose={handleCloseModal}
           titleLabel={t("DG.PlottedFunction.namePrompt")}
           value={expression}

--- a/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-banner.tsx
+++ b/v3/src/components/graph/adornments/univariate-measures/plotted-value/plotted-value-adornment-banner.tsx
@@ -70,6 +70,7 @@ export const PlottedValueAdornmentBanner = observer(function PlottedValueAdornme
           applyFormula={handleEditExpressionClose}
           formulaPrompt={t("DG.PlottedValue.formulaPrompt")}
           isOpen={isOpen}
+          modalTitle={t("DG.PlottedValue.namePrompt")}
           onClose={handleCloseModal}
           titleLabel={t("DG.PlottedValue.namePrompt")}
           value={expression}

--- a/v3/src/components/graph/components/inspector-panel/display-config-palette.test.tsx
+++ b/v3/src/components/graph/components/inspector-panel/display-config-palette.test.tsx
@@ -209,7 +209,7 @@ describe("DisplayConfigPalette", () => {
       )
 
       const binWidthInput =
-        within(screen.getByTestId("graph-bin-width-setting")).getByRole("textbox") as HTMLInputElement
+        within(screen.getByTestId("graph-bin-width-setting")).getByRole<HTMLInputElement>("textbox")
       // On mount the palette focuses this field and selects its text, two animation frames later.
       // Typing before that lands lets the select() swallow what was typed, leaving only the last
       // character. Wait for the selection, then type over it instead of clearing first.

--- a/v3/src/components/graph/components/inspector-panel/display-config-palette.test.tsx
+++ b/v3/src/components/graph/components/inspector-panel/display-config-palette.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen, within } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { tileNotification } from "../../../../models/tiles/tile-notifications"
 import { DisplayConfigPalette } from "./display-config-palette"
@@ -208,9 +208,21 @@ describe("DisplayConfigPalette", () => {
         <DisplayConfigPalette tile={tile} setShowPalette={mockSetShowPalette} />
       )
 
-      const binWidthInput = within(screen.getByTestId("graph-bin-width-setting")).getByRole("textbox")
-      await user.clear(binWidthInput)
-      await user.type(binWidthInput, "20{Enter}")
+      const binWidthInput =
+        within(screen.getByTestId("graph-bin-width-setting")).getByRole("textbox") as HTMLInputElement
+      // On mount the palette focuses this field and selects its text, two animation frames later.
+      // Typing before that lands lets the select() swallow what was typed, leaving only the last
+      // character. Wait for the selection, then type over it instead of clearing first.
+      await waitFor(() => {
+        expect(binWidthInput).toHaveFocus()
+        expect(binWidthInput.selectionStart).toBe(0)
+        expect(binWidthInput.selectionEnd).toBe(binWidthInput.value.length)
+      })
+      // type() clicks first, which collapses that selection, so state the replacement explicitly
+      await user.type(binWidthInput, "20{Enter}", {
+        initialSelectionStart: 0,
+        initialSelectionEnd: binWidthInput.value.length
+      })
 
       expect(mockLogMessageWithReplacement).toHaveBeenCalledWith(
         "change %@ from %@ to %@",

--- a/v3/src/components/graph/components/inspector-panel/display-config-palette.tsx
+++ b/v3/src/components/graph/components/inspector-panel/display-config-palette.tsx
@@ -267,7 +267,13 @@ export const DisplayConfigPalette = observer(function DisplayConfigPanel(props: 
   useEffect(() => {
     if (plotIsBinned) {
       // Use requestAnimationFrame to wait for the bin settings to render,
-      // then a second frame to ensure focus doesn't reset the selection
+      // then a second frame to ensure focus doesn't reset the selection.
+      //
+      // This races anything typed before the second frame lands: select() then covers those
+      // characters and the next keystroke replaces them, so the field keeps only what was typed
+      // last. Someone who clicks into the field and types immediately can lose input this way,
+      // and a test must wait for the selection before typing. Deriving the selection from a
+      // rendered/ready signal rather than a frame count would remove the race.
       requestAnimationFrame(() => {
         binWidthInputRef.current?.focus()
         requestAnimationFrame(() => {

--- a/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/graph/components/inspector-panel/hide-show-menu-list.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../graph-notifications"
 import { EditFormulaModal } from "../../../common/edit-formula-modal"
 import { DataSetContext } from "../../../../hooks/use-data-set-context"
-import { useInspectorFormulaString } from "../../../../hooks/use-inspector-formula-string"
+import { useInspectorFormulaString, useInspectorFormulaTitle } from "../../../../hooks/use-inspector-formula-string"
 import { InspectorMenuContent, useInspectorMenuOpen } from "../../../inspector-panel"
 
 interface IProps {
@@ -143,6 +143,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
       : t("DG.DataDisplayMenu.enableMeasuresForSelection"),
     displayOnlySelectedIsDisabled = dataConfig?.displayOnlySelectedCases
     const addOrEditFormulaString = useInspectorFormulaString(dataConfig?.filterFormula?.display)
+    const modalTitle = useInspectorFormulaTitle(dataConfig?.filterFormula?.display)
 
   return (
     <>
@@ -177,6 +178,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
           <EditFormulaModal
             applyFormula={applyFilterFormula}
             isOpen={isOpen}
+            modalTitle={modalTitle}
             onClose={handleEditFormulaClose}
             titleLabel={t("V3.hideShowMenu.filterFormulaPrompt")}
             value={dataConfig.filterFormula?.display} />

--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -242,6 +242,7 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
             applyFormula={handleEditExpressionClose}
             formulaPrompt={t("DG.BarChartFunction.formulaPrompt")}
             isOpen={barChartModel.formulaEditorIsOpen}
+            modalTitle={t("DG.BarChartFunction.namePrompt")}
             onClose={handleCloseModal}
             titleLabel={t("DG.BarChartFunction.namePrompt")}
             value={barChartModel.formula?.display}

--- a/v3/src/components/map/components/inspector-panel/hide-show-menu-list.tsx
+++ b/v3/src/components/map/components/inspector-panel/hide-show-menu-list.tsx
@@ -3,7 +3,7 @@ import {observer} from "mobx-react-lite"
 import {isAlive} from "mobx-state-tree"
 import { MenuItem } from "react-aria-components"
 import { DataSetContext } from "../../../../hooks/use-data-set-context"
-import { useInspectorFormulaString } from "../../../../hooks/use-inspector-formula-string"
+import { useInspectorFormulaString, useInspectorFormulaTitle } from "../../../../hooks/use-inspector-formula-string"
 import { logMessageWithReplacement } from "../../../../lib/log-message"
 import {ITileContentModel} from "../../../../models/tiles/tile-content"
 import {ITileModel} from "../../../../models/tiles/tile-model"
@@ -45,6 +45,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
                               ? t("DG.DataDisplayMenu.hideUnselectedSing")
                               : t("DG.DataDisplayMenu.hideUnselectedPlural")
   const addOrEditFormulaString = useInspectorFormulaString(dataConfig?.filterFormula?.display)
+  const modalTitle = useInspectorFormulaTitle(dataConfig?.filterFormula?.display)
 
   const hideSelectedCases = () => {
     mapModel?.applyModelChange(
@@ -116,6 +117,7 @@ export const HideShowMenuList = observer(function HideShowMenuList({tile}: IProp
           <EditFormulaModal
             applyFormula={applyFilterFormula}
             isOpen={isOpen}
+            modalTitle={modalTitle}
             onClose={onClose}
             titleLabel={t("V3.hideShowMenu.filterFormulaPrompt")}
             value={dataConfig.filterFormula?.display} />

--- a/v3/src/hooks/use-inspector-formula-string.ts
+++ b/v3/src/hooks/use-inspector-formula-string.ts
@@ -1,7 +1,14 @@
+import { stripTrailingEllipsis } from "../utilities/translation/label-utils"
 import { t } from "../utilities/translation/translate"
 
 export function useInspectorFormulaString(display: string | undefined): string {
   const addOrEditFormulaString = display ? t("V3.hideShowMenu.editFilterFormula")
                                           : t("V3.hideShowMenu.addFilterFormula")
   return addOrEditFormulaString
+}
+
+// The formula editor's header shows the same Add/Edit wording as the menu item that opened it,
+// minus the ellipsis that marks the menu item as opening a dialog.
+export function useInspectorFormulaTitle(display: string | undefined): string {
+  return stripTrailingEllipsis(useInspectorFormulaString(display))
 }

--- a/v3/src/models/formula/lezer/formula-highlight.scss
+++ b/v3/src/models/formula/lezer/formula-highlight.scss
@@ -1,4 +1,6 @@
 .cm-editor {
+  font-family: 'Noto Sans Mono', monospace;
+
   .cm-line {
 
     .cm-comment {

--- a/v3/src/utilities/translation/label-utils.test.ts
+++ b/v3/src/utilities/translation/label-utils.test.ts
@@ -32,7 +32,23 @@ describe("stripTrailingEllipsis", () => {
   })
 
   it("removes a single-character ellipsis", () => {
+    // e.g. the Japanese translation
     expect(stripTrailingEllipsis("Edit Formula…")).toBe("Edit Formula")
+    expect(stripTrailingEllipsis("式を編集する…")).toBe("式を編集する")
+  })
+
+  it("removes a two-dot ellipsis", () => {
+    // e.g. the Hebrew translation
+    expect(stripTrailingEllipsis("ערוך נוסחה..")).toBe("ערוך נוסחה")
+  })
+
+  it("removes an ellipsis followed by whitespace", () => {
+    // e.g. the Thai translation
+    expect(stripTrailingEllipsis("แก้ไขสูตร... ")).toBe("แก้ไขสูตร")
+  })
+
+  it("leaves a single trailing period alone", () => {
+    expect(stripTrailingEllipsis("Edit Formula.")).toBe("Edit Formula.")
   })
 
   it("removes trailing whitespace after the ellipsis", () => {

--- a/v3/src/utilities/translation/label-utils.test.ts
+++ b/v3/src/utilities/translation/label-utils.test.ts
@@ -1,0 +1,51 @@
+import { stripTrailingColon, stripTrailingEllipsis } from "./label-utils"
+
+describe("stripTrailingColon", () => {
+  it("removes a trailing colon", () => {
+    expect(stripTrailingColon("Attribute Name:")).toBe("Attribute Name")
+    expect(stripTrailingColon("Formula:")).toBe("Formula")
+    expect(stripTrailingColon("Name des Merkmals:")).toBe("Name des Merkmals")
+  })
+
+  it("removes a full-width colon and surrounding whitespace", () => {
+    // e.g. the Japanese and Chinese translations
+    expect(stripTrailingColon("属性名：")).toBe("属性名")
+    expect(stripTrailingColon("Formula : ")).toBe("Formula")
+  })
+
+  it("leaves a label without a trailing colon untouched", () => {
+    expect(stripTrailingColon("Formula")).toBe("Formula")
+    expect(stripTrailingColon("")).toBe("")
+    // adornment banners pass a prompt ending in "="
+    expect(stripTrailingColon("LifeSpan =")).toBe("LifeSpan =")
+  })
+
+  it("leaves interior colons alone", () => {
+    expect(stripTrailingColon("Ratio a:b")).toBe("Ratio a:b")
+  })
+})
+
+describe("stripTrailingEllipsis", () => {
+  it("removes a three-dot ellipsis", () => {
+    expect(stripTrailingEllipsis("Edit Formula...")).toBe("Edit Formula")
+    expect(stripTrailingEllipsis("Add Filter Formula...")).toBe("Add Filter Formula")
+  })
+
+  it("removes a single-character ellipsis", () => {
+    expect(stripTrailingEllipsis("Edit Formula…")).toBe("Edit Formula")
+  })
+
+  it("removes trailing whitespace after the ellipsis", () => {
+    expect(stripTrailingEllipsis("Edit Formula... ")).toBe("Edit Formula")
+  })
+
+  it("leaves a label without an ellipsis untouched", () => {
+    expect(stripTrailingEllipsis("Plotted Value")).toBe("Plotted Value")
+    expect(stripTrailingEllipsis("")).toBe("")
+  })
+
+  it("leaves interior dots alone", () => {
+    expect(stripTrailingEllipsis("N.B. Edit Formula")).toBe("N.B. Edit Formula")
+    expect(stripTrailingEllipsis("A...B")).toBe("A...B")
+  })
+})

--- a/v3/src/utilities/translation/label-utils.ts
+++ b/v3/src/utilities/translation/label-utils.ts
@@ -12,9 +12,9 @@ export function stripTrailingEllipsis(label: string) {
 /**
  * Removes a trailing colon from a label.
  *
- * Field prompts are stored with a colon ("Attribute Name:") because they were rendered inline with
- * their field. The formula editor stacks the label above its field, where the colon is not wanted.
- * Deriving it from the existing string keeps the translations.
+ * Field prompts are stored with a colon ("Attribute Name:"), which suits the callers that render
+ * them inline with their field. The formula editor stacks the label above its field, where the
+ * colon is unwanted. Deriving it from the existing string keeps the translations.
  */
 export function stripTrailingColon(label: string) {
   return label.replace(/\s*[:：]\s*$/, "")

--- a/v3/src/utilities/translation/label-utils.ts
+++ b/v3/src/utilities/translation/label-utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Removes a trailing ellipsis from a label.
+ *
+ * Menu items that open a dialog end with an ellipsis by convention ("Edit Formula..."), but the
+ * dialog's own title bar shows the same text without it. Deriving the title from the menu string
+ * keeps the two in sync and reuses the existing translation.
+ */
+export function stripTrailingEllipsis(label: string) {
+  return label.replace(/(\.\.\.|…)\s*$/, "")
+}
+
+/**
+ * Removes a trailing colon from a label.
+ *
+ * Field prompts are stored with a colon ("Attribute Name:") because they were rendered inline with
+ * their field. The formula editor stacks the label above its field, where the colon is not wanted.
+ * Deriving it from the existing string keeps the translations.
+ */
+export function stripTrailingColon(label: string) {
+  return label.replace(/\s*[:：]\s*$/, "")
+}

--- a/v3/src/utilities/translation/label-utils.ts
+++ b/v3/src/utilities/translation/label-utils.ts
@@ -4,9 +4,12 @@
  * Menu items that open a dialog end with an ellipsis by convention ("Edit Formula..."), but the
  * dialog's own title bar shows the same text without it. Deriving the title from the menu string
  * keeps the two in sync and reuses the existing translation.
+ *
+ * Any run of two or more dots counts, since the translations are not consistent about it: Hebrew
+ * uses two, Japanese uses the single ellipsis character, and Thai adds a trailing space.
  */
 export function stripTrailingEllipsis(label: string) {
-  return label.replace(/(\.\.\.|…)\s*$/, "")
+  return label.replace(/\s*(\.{2,}|…)\s*$/, "")
 }
 
 /**

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -1500,6 +1500,9 @@
     "V3.Undo.hideShowMenu.changeFilterFormula": "Undo changing filter formula",
     "V3.Redo.hideShowMenu.changeFilterFormula": "Redo changing filter formula",
     "V3.AttrFormView.attrPlaceholder": "attribute",
+    "V3.AttrFormView.closeBtnLabel": "Close",
+    "V3.AttrFormView.clearBtnTitle": "Clear",
+    "V3.AttrFormView.clearBtnTooltip": "Clear the formula without closing the dialog",
 
     "V3.Inspector.rescale.noRescale.toolTip": "All the data are already visible",
     "V3.Inspector.rescale.casePlot.toolTip": "Move the points to new random positions",

--- a/v3/src/utilities/translation/lang/en-US.json5
+++ b/v3/src/utilities/translation/lang/en-US.json5
@@ -737,8 +737,8 @@
     // DG.AttributeFormulaView
     "DG.AttrFormView.attrNamePrompt": "Attribute Name:",
     "DG.AttrFormView.formulaPrompt": "Formula:",
-    "DG.AttrFormView.operandMenuTitle": "--- Insert Value ---",
-    "DG.AttrFormView.functionMenuTitle": "--- Insert Function ---",
+    "DG.AttrFormView.operandMenuTitle": "Insert Value",
+    "DG.AttrFormView.functionMenuTitle": "Insert Function",
     "DG.AttrFormView.applyBtnTitle": "Apply",
     "DG.AttrFormView.cancelBtnTitle": "Cancel",
     "DG.AttrFormView.cancelBtnTooltip": "Dismiss the dialog without making any changes",

--- a/v3/src/utilities/translation/strip-label-decoration.test.ts
+++ b/v3/src/utilities/translation/strip-label-decoration.test.ts
@@ -1,0 +1,34 @@
+import { stripLabelDecoration } from "./strip-label-decoration"
+
+describe("stripLabelDecoration", () => {
+  it("removes surrounding dashes and the whitespace around them", () => {
+    expect(stripLabelDecoration("--- Insert Value ---")).toBe("Insert Value")
+    expect(stripLabelDecoration("--- Wert einfügen ---")).toBe("Wert einfügen")
+    expect(stripLabelDecoration("--- Εισαγωγή Τιμής ---")).toBe("Εισαγωγή Τιμής")
+  })
+
+  it("handles dashes with no adjacent whitespace", () => {
+    // e.g. the Japanese and Chinese translations
+    expect(stripLabelDecoration("---値の挿入---")).toBe("値の挿入")
+    expect(stripLabelDecoration("---插入数值---")).toBe("插入数值")
+  })
+
+  it("handles a differing number of dashes", () => {
+    // e.g. the Hebrew translation, which uses two
+    expect(stripLabelDecoration("-- הכנס ערך --")).toBe("הכנס ערך")
+  })
+
+  it("leaves an undecorated label untouched", () => {
+    expect(stripLabelDecoration("Insert Value")).toBe("Insert Value")
+    expect(stripLabelDecoration("Insertar Valor")).toBe("Insertar Valor")
+  })
+
+  it("preserves hyphens inside the label", () => {
+    expect(stripLabelDecoration("--- Insert Sub-Value ---")).toBe("Insert Sub-Value")
+    expect(stripLabelDecoration("Insert Sub-Value")).toBe("Insert Sub-Value")
+  })
+
+  it("handles an empty string", () => {
+    expect(stripLabelDecoration("")).toBe("")
+  })
+})

--- a/v3/src/utilities/translation/strip-label-decoration.ts
+++ b/v3/src/utilities/translation/strip-label-decoration.ts
@@ -1,0 +1,12 @@
+/**
+ * Removes the decorative dashes that wrap some menu-button labels, e.g. "--- Insert Value ---".
+ *
+ * The English strings carry no dashes, but the translations are owned by POEditor and still supply
+ * them, so they are stripped at render time to keep the label consistent across locales. Once every
+ * translation has been updated, this helper and its call sites can be removed.
+ *
+ * Only leading and trailing dash runs are removed; hyphens within the label are preserved.
+ */
+export function stripLabelDecoration(label: string) {
+  return label.replace(/^\s*-+\s*/, "").replace(/\s*-+\s*$/, "")
+}


### PR DESCRIPTION
Re-skins the formula editor modal to the published design spec, and fixes two long-standing bugs in it.

Fixes CODAP-1470
Fixes CODAP-1207

## What changed

**Modal shell.** A header bar with the dialog title and a close button; the title tracks "Add Filter Formula" → "Edit Filter Formula", derived from the same strings the menu item uses. A Clear button between Cancel and Apply that empties the formula without applying it or dismissing the dialog. Field labels stacked above their fields without their trailing colons. Select-style insert buttons with a caret segment. Noto Sans Mono for the formula text. Callers that edit only a formula no longer get a disabled attribute-name row.

**Chakra reduced (not eliminated).** `Box`, `Flex`, `FormControl`, `FormLabel`, `Tooltip` and `Button` are replaced with plain markup and SCSS that reproduces the `v3`/`v3Clear`/`v3Default` button faces from `theme.ts`. Only the shell composition (`CodapModal`, `ModalHeader`/`Body`/`Footer`) is still Chakra, to be migrated separately for all ten of its consumers.

**Sizing is driven by content, not arithmetic.** The editor's height came from subtracting fixed header, footer and button-row heights from the modal height, which a taller header or a wrapped label could invalidate. The formula field now carries a two-row minimum and the modal takes its height from its content until resized. The corner resize handle moves onto the formula field, where sizing the field sizes the modal that sizes it.

**Insert menus.** Re-clicking an open menu's button now closes it. Both menus share one placement rule — flush below the button, above it when it doesn't fit below, capped to the space available so neither runs off-screen.

## Bugs fixed along the way

- **CODAP-1207** — the attribute-name label had a fixed 97px width, so longer translations wrapped and pushed the insert buttons out of the modal body, where the footer clipped them. Because the editor height was computed by subtraction, resizing fed every extra pixel to the formula field and never uncovered them. Verified in German and Greek.
- The modal froze a default size derived from a prop that callers resolve asynchronously, so the editor could collapse on first open.
- A timing-fragile bin-width test that races the display config palette's auto-select. Unrelated to this story, but this branch's added tests tipped it over.

## Accessibility

An audit confirmed all six keyboard behaviours from CODAP-1136 survive, including the two couplings most at risk: `cmMoveFocus`'s `button.insert-value` selector, and `.formula-modal-footer button:last-of-type` still resolving to Apply with Clear inserted before it.

Fixed: the dialog announced as "Edit Formula Close" (the close button sat inside the `aria-labelledby` target); the formula field had no accessible name at all (a `<label>` can't name a `contenteditable` div — now wired via `EditorView.contentAttributes`); control borders were ~1.3:1 against the modal body, now `#767676` at 4.02:1; 24×24 targets for the close button and resize grip, with the icons unchanged in size.

## Out of scope

- The Insert Function dropdown's cascading-flyout restructure is **CODAP-1473**.
- Syntax-highlight colours are unresolved and deliberately untouched: the spec's legend specifies magenta for values, which is 3.14:1 on white and fails AA. Needs a designer decision.
- The resize grip remains pointer-only (WCAG 2.1.1), pre-existing.

## Testing

Full suite green at 3679. New tests cover the Clear button, the menu toggle, the dialog's accessible name, and the placement rule (8 unit tests, including the near-the-bottom flip and the never-overflow guarantee).

**CODAP-1205** ([Safari] Cancel/Apply buttons not tabbable) was verified on Safari and closed as a browser setting rather than a defect — see the issue for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

