### PR TITLE
CODAP-1475: accept repeated url parameters without crashing

### DIFF
--- a/v3/src/models/feature-flags/feature-flag-manager.test.ts
+++ b/v3/src/models/feature-flags/feature-flag-manager.test.ts
@@ -160,6 +160,19 @@ describe("FeatureFlagManager", () => {
       expect(manager.isFeatureEnabled("legendLogarithmic")).toBe(false)
     })
 
+    // an occurrence with no value parses as null rather than a string
+    it("ignores an occurrence that carries no value", () => {
+      setUrlParams("?features&features=residualPlot")
+      const manager = new FeatureFlagManager()
+      expect(manager.isFeatureEnabled("residualPlot")).toBe(true)
+    })
+
+    it("enables nothing when no occurrence carries a value", () => {
+      setUrlParams("?features&features")
+      const manager = new FeatureFlagManager()
+      expect(manager.urlEnabledFlags).toEqual([])
+    })
+
     it("records the flags of every occurrence for document persistence", () => {
       setUrlParams("?features=residualPlot&features=legendRange")
       const manager = new FeatureFlagManager()

--- a/v3/src/models/feature-flags/feature-flag-manager.test.ts
+++ b/v3/src/models/feature-flags/feature-flag-manager.test.ts
@@ -142,6 +142,31 @@ describe("FeatureFlagManager", () => {
     })
   })
 
+  // query-string yields an array rather than a string when a url parameter
+  // appears more than once, a form users reach for as readily as the
+  // comma-separated one
+  describe("repeated features parameter", () => {
+    it("combines the tokens of every occurrence", () => {
+      setUrlParams("?features=MappingTime&features=ESTEEM")
+      const manager = new FeatureFlagManager()
+      expect(manager.isFeatureEnabled("legendRange")).toBe(true)
+      expect(manager.isFeatureEnabled("residualPlot")).toBe(true)
+    })
+
+    it("applies a - prefix appearing in a later occurrence", () => {
+      setUrlParams("?features=MappingTime&features=-legendLogarithmic")
+      const manager = new FeatureFlagManager()
+      expect(manager.isFeatureEnabled("legendRange")).toBe(true)
+      expect(manager.isFeatureEnabled("legendLogarithmic")).toBe(false)
+    })
+
+    it("records the flags of every occurrence for document persistence", () => {
+      setUrlParams("?features=residualPlot&features=legendRange")
+      const manager = new FeatureFlagManager()
+      expect([...manager.urlEnabledFlags].sort()).toEqual(["legendRange", "residualPlot"])
+    })
+  })
+
   describe("urlEnabledFlags", () => {
     it("reports flags this session enabled via the url", () => {
       setUrlParams(`?features=${kFlag}`)

--- a/v3/src/models/feature-flags/feature-flag-manager.ts
+++ b/v3/src/models/feature-flags/feature-flag-manager.ts
@@ -19,9 +19,10 @@ export class FeatureFlagManager {
     // query-string yields an array rather than a string when `features` appears
     // more than once in the url. The repeated and comma-separated forms mean the
     // same thing, so flatten to a single token list; tokens stay in url order,
-    // which is what lets a later one override an earlier one.
+    // which is what lets a later one override an earlier one. An occurrence
+    // written without a value parses as null and names no flag, so it drops out.
     const occurrences = urlParams.features == null ? [] : [urlParams.features].flat()
-    occurrences.flatMap(occurrence => occurrence.split(",")).forEach(entry => {
+    occurrences.flatMap(occurrence => occurrence?.split(",") ?? []).forEach(entry => {
       const trimmed = entry.trim()
       if (!trimmed) return
       const enabled = !trimmed.startsWith("-")

--- a/v3/src/models/feature-flags/feature-flag-manager.ts
+++ b/v3/src/models/feature-flags/feature-flag-manager.ts
@@ -16,8 +16,12 @@ export class FeatureFlagManager {
 
   private get urlFlags(): ReadonlyMap<FeatureFlagName, boolean> {
     const flags = new Map<FeatureFlagName, boolean>()
-    const source = urlParams.features ?? ""
-    source.split(",").forEach(entry => {
+    // query-string yields an array rather than a string when `features` appears
+    // more than once in the url. The repeated and comma-separated forms mean the
+    // same thing, so flatten to a single token list; tokens stay in url order,
+    // which is what lets a later one override an earlier one.
+    const occurrences = urlParams.features == null ? [] : [urlParams.features].flat()
+    occurrences.flatMap(occurrence => occurrence.split(",")).forEach(entry => {
       const trimmed = entry.trim()
       if (!trimmed) return
       const enabled = !trimmed.startsWith("-")

--- a/v3/src/utilities/url-params.test.ts
+++ b/v3/src/utilities/url-params.test.ts
@@ -60,6 +60,18 @@ describe("urlParams", () => {
     expect(booleanParam("unexpected")).toBe(true)
   })
 
+  // query-string yields an array rather than a string when a parameter appears
+  // more than once; a repeated param must not throw, because these are read
+  // during startup where a throw keeps the document from displaying at all
+  it("booleanParam takes the last occurrence of a repeated param", () => {
+    const { booleanParam } = require("./url-params")
+
+    expect(booleanParam(["true", "false"])).toBe(false)
+    expect(booleanParam(["false", "true"])).toBe(true)
+    expect(booleanParam(["true"])).toBe(true)
+    expect(booleanParam([])).toBe(false)      // no occurrence carries a value
+  })
+
   it("removeDevUrlParams strips appropriate dev-only params", () => {
     // In Jest 30+ with jsdom 25+, we can only change the path/search, not the origin
     setLocation("http://localhost/?sample=mammals&dashboard")

--- a/v3/src/utilities/url-params.test.ts
+++ b/v3/src/utilities/url-params.test.ts
@@ -70,6 +70,10 @@ describe("urlParams", () => {
     expect(booleanParam(["false", "true"])).toBe(true)
     expect(booleanParam(["true"])).toBe(true)
     expect(booleanParam([])).toBe(false)      // no occurrence carries a value
+    // an occurrence written without a value parses as null, which reads as true
+    // for the same reason a lone "?inbounds" does
+    expect(booleanParam(["false", null])).toBe(true)
+    expect(booleanParam([null, "false"])).toBe(false)
   })
 
   it("removeDevUrlParams strips appropriate dev-only params", () => {

--- a/v3/src/utilities/url-params.ts
+++ b/v3/src/utilities/url-params.ts
@@ -88,9 +88,11 @@ export interface UrlParams {
    * lives in the URL and nowhere else. Names are matched against the feature-flag
    * registry (src/models/feature-flags/) and ignored if unrecognized.
    * value: comma-separated flag names, each optionally prefixed with "-" to disable,
-   *   e.g. "residualPlot,-someOtherFeature"
+   *   e.g. "residualPlot,-someOtherFeature". The parameter may also be repeated,
+   *   e.g. "?features=residualPlot&features=-someOtherFeature", in which case
+   *   query-string parses it as an array of the individual occurrences.
    */
-  features?: string | null
+  features?: string | string[] | null
   /*
    * [V2] When present enables the gaussian fit feature of the normal curve adornment.
    * value: ignored

--- a/v3/src/utilities/url-params.ts
+++ b/v3/src/utilities/url-params.ts
@@ -90,9 +90,10 @@ export interface UrlParams {
    * value: comma-separated flag names, each optionally prefixed with "-" to disable,
    *   e.g. "residualPlot,-someOtherFeature". The parameter may also be repeated,
    *   e.g. "?features=residualPlot&features=-someOtherFeature", in which case
-   *   query-string parses it as an array of the individual occurrences.
+   *   query-string parses it as an array of the individual occurrences. An
+   *   occurrence written without a value is null, so the entries are nullable.
    */
-  features?: string | string[] | null
+  features?: string | (string | null)[] | null
   /*
    * [V2] When present enables the gaussian fit feature of the normal curve adornment.
    * value: ignored
@@ -271,7 +272,7 @@ export let urlParams: UrlParams = queryString.parse(getSearchParams())
 
 export const setUrlParams = (search: string) => urlParams = queryString.parse(search)
 
-export function booleanParam(param?: string | string[] | null): boolean {
+export function booleanParam(param?: string | (string | null)[] | null): boolean {
   // undefined => param is absent, which is treated as false
   if (param === undefined) return false
   // query-string yields an array when the param appears more than once; the last

--- a/v3/src/utilities/url-params.ts
+++ b/v3/src/utilities/url-params.ts
@@ -271,9 +271,12 @@ export let urlParams: UrlParams = queryString.parse(getSearchParams())
 
 export const setUrlParams = (search: string) => urlParams = queryString.parse(search)
 
-export function booleanParam(param?: string | null): boolean {
+export function booleanParam(param?: string | string[] | null): boolean {
   // undefined => param is absent, which is treated as false
   if (param === undefined) return false
+  // query-string yields an array when the param appears more than once; the last
+  // occurrence wins, so that appending to a url overrides what it already said
+  if (Array.isArray(param)) return param.length > 0 && booleanParam(param[param.length - 1])
   // null => param is present without argument, which is treated as true
   if (param === null) return true
   // treat "false", "no", and "0" as false, everything else as true


### PR DESCRIPTION
Fixes CODAP-1475

A url that repeats a query parameter, such as
`?features=MappingTime&features=ESTEEM`, prevented CODAP from displaying
the document at all. Reported by @wfinzer against the staging build.

## Cause

`query-string` parses a repeated key into an **array**, not a string:

| URL | Parsed value |
|---|---|
| `?features=MappingTime&features=ESTEEM` | `["MappingTime","ESTEEM"]` |
| `?features=MappingTime,ESTEEM` | `"MappingTime,ESTEEM"` |

Every entry in the `UrlParams` interface is declared `string | null` and
`queryString.parse()`'s result is cast to it, so TypeScript cannot catch
the array case. Two live call sites assumed the string form:

- `FeatureFlagManager.urlFlags` called `.split(",")`. It is read during
  render, so the `TypeError` escaped to the error boundary and took down
  the whole document rather than merely disabling the flags.
- `booleanParam()` called `.toLowerCase()`. It is reachable from ~10
  `ui-state.ts` call sites (`inbounds`, `componentMode`, `embeddedMode`,
  `standalone`, `hideSplashScreen`, …) and read at startup, where a throw
  is equally unrecoverable.

## Changes

- `features` flattens all occurrences into one token list in url order, so
  the repeated and comma-separated forms are equivalent and a later token
  still overrides an earlier one — across occurrences as well as within one.
- `booleanParam()` takes the last occurrence; an empty array reads as absent.
- `UrlParams.features` now admits the array form.

## Not included

The other ~30 `UrlParams` entries remain typed `string | null`. Only the two
paths that actually crash were hardened; making the whole interface honest
would ripple into every consumer and seemed better as its own change.

## Testing

Both fixes were written test-first, each test confirmed failing with the
real error before implementing. tsc and lint clean; full Jest suite
3648 passed / 15 skipped / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
