### PR TITLE
CODAP-1477: eliminate React render-phase update warning from attribute menus

### DIFF
--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
@@ -400,6 +400,33 @@ describe("AxisOrLegendAttributeMenu", () => {
       expect(onChangeAttribute).toHaveBeenCalledWith("bottom", mockDataSet, "attr2")
     })
 
+    it("resets the menu state when an attribute is selected from an open menu", async () => {
+      const user = userEvent.setup()
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+      const svgTarget = document.createElementNS("http://www.w3.org/2000/svg", "g")
+      svg.appendChild(svgTarget)
+      document.body.appendChild(svg)
+
+      try {
+        renderMenu({ place: "bottom", target: svgTarget })
+        const button = screen.getByTestId("axis-legend-attribute-button-bottom")
+        await user.click(button)
+        expect(button).toHaveAttribute("aria-expanded", "true")
+        expect(svgTarget.classList.contains("menu-open")).toBe(true)
+
+        // Selecting an attribute closes the menu via handleCloseMenu, which relies on
+        // Chakra invoking the onClose prop to reset our state.
+        const menuItems = screen.getAllByRole("menuitem", { hidden: true })
+        const weightItem = menuItems.find(item => item.textContent === "Weight")
+        await user.click(weightItem!)
+
+        expect(button).toHaveAttribute("aria-expanded", "false")
+        expect(svgTarget.classList.contains("menu-open")).toBe(false)
+      } finally {
+        svg.remove()
+      }
+    })
+
     it("shows 'No attributes available' when no datasets exist", () => {
       mockGetDataSetsReturn = []
       mockDataConfiguration.attributeID = () => ""

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
@@ -120,6 +120,27 @@ describe("AxisOrLegendAttributeMenu", () => {
     mockUseDndContext.mockReturnValue({ active: null })
   })
 
+  // React warns about render-phase updates only once per rendering component per module
+  // registry, so this must precede any other test in this file that opens the menu.
+  it("opens and closes the menu without triggering a render-phase state update", async () => {
+    const user = userEvent.setup()
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => null)
+    renderMenu()
+    const button = screen.getByTestId("axis-legend-attribute-button-bottom")
+
+    await user.click(button)
+    expect(button).toHaveAttribute("aria-expanded", "true")
+
+    await user.keyboard("{Escape}")
+    expect(button).toHaveAttribute("aria-expanded", "false")
+
+    const renderPhaseWarnings = consoleErrorSpy.mock.calls
+      .filter(args => String(args[0]).includes("Cannot update a component"))
+    expect(renderPhaseWarnings).toEqual([])
+
+    consoleErrorSpy.mockRestore()
+  })
+
   describe("aria-label", () => {
     it("sets aria-label describing the axis when an attribute is assigned", () => {
       renderMenu({ place: "bottom" })

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.test.tsx
@@ -125,20 +125,22 @@ describe("AxisOrLegendAttributeMenu", () => {
   it("opens and closes the menu without triggering a render-phase state update", async () => {
     const user = userEvent.setup()
     const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => null)
-    renderMenu()
-    const button = screen.getByTestId("axis-legend-attribute-button-bottom")
+    try {
+      renderMenu()
+      const button = screen.getByTestId("axis-legend-attribute-button-bottom")
 
-    await user.click(button)
-    expect(button).toHaveAttribute("aria-expanded", "true")
+      await user.click(button)
+      expect(button).toHaveAttribute("aria-expanded", "true")
 
-    await user.keyboard("{Escape}")
-    expect(button).toHaveAttribute("aria-expanded", "false")
+      await user.keyboard("{Escape}")
+      expect(button).toHaveAttribute("aria-expanded", "false")
 
-    const renderPhaseWarnings = consoleErrorSpy.mock.calls
-      .filter(args => String(args[0]).includes("Cannot update a component"))
-    expect(renderPhaseWarnings).toEqual([])
-
-    consoleErrorSpy.mockRestore()
+      const renderPhaseWarnings = consoleErrorSpy.mock.calls
+        .filter(args => String(args[0]).includes("Cannot update a component"))
+      expect(renderPhaseWarnings).toEqual([])
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
   })
 
   describe("aria-label", () => {

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -248,10 +248,16 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
     setIsMenuOpen(true)
   }
 
-  function handleCloseMenu() {
+  // Chakra invokes this from its own event handlers (Escape, item selection, outside click),
+  // so the menu state stays in sync without updating during the Menu's render.
+  function resetMenuState() {
     setOpenCollectionId(null)
-    onCloseMenuRef.current?.()
     setIsMenuOpen(false)
+  }
+
+  function handleCloseMenu() {
+    onCloseMenuRef.current?.()
+    resetMenuState()
   }
 
   // Sync menu-open class with actual menu state, and clean up all visual state classes on close/unmount
@@ -396,11 +402,8 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
 
   return (
     <div className={clsx("axis-legend-attribute-menu", place)} ref={menuRef} title={description + clickLabel}>
-      <Menu placement="auto" onOpen={handleOpenMenu}>
+      <Menu placement="auto" onOpen={handleOpenMenu} onClose={resetMenuState}>
         {({ isOpen, onClose }) => {
-          if (isOpen !== isMenuOpen) {
-            setIsMenuOpen(isOpen)
-          }
           onCloseMenuRef.current = onClose
           return (
             <div className={`attribute-label-menu ${place}`}

--- a/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/v3/src/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -255,9 +255,9 @@ export const AxisOrLegendAttributeMenu = observer(function AxisOrLegendAttribute
     setIsMenuOpen(false)
   }
 
+  // Chakra's onClose prop fires unconditionally, so closing the menu resets our state too.
   function handleCloseMenu() {
     onCloseMenuRef.current?.()
-    resetMenuState()
   }
 
   // Sync menu-open class with actual menu state, and clean up all visual state classes on close/unmount

--- a/v3/src/components/case-tile-common/attribute-header.test.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.test.tsx
@@ -43,19 +43,21 @@ describe("AttributeHeader", () => {
     const user = userEvent.setup()
     const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => null)
 
-    const { attribute } = renderAttributeHeader()
-    const button = screen.getByTestId(`codap-attribute-button ${attribute.name}`)
-    await user.click(button)
-    expect(button).toHaveAttribute("aria-expanded", "true")
+    try {
+      const { attribute } = renderAttributeHeader()
+      const button = screen.getByTestId(`codap-attribute-button ${attribute.name}`)
+      await user.click(button)
+      expect(button).toHaveAttribute("aria-expanded", "true")
 
-    await user.keyboard("{Escape}")
-    expect(button).toHaveAttribute("aria-expanded", "false")
+      await user.keyboard("{Escape}")
+      expect(button).toHaveAttribute("aria-expanded", "false")
 
-    const renderPhaseWarnings = consoleErrorSpy.mock.calls
-      .filter(args => String(args[0]).includes("Cannot update a component"))
-    expect(renderPhaseWarnings).toEqual([])
-
-    consoleErrorSpy.mockRestore()
+      const renderPhaseWarnings = consoleErrorSpy.mock.calls
+        .filter(args => String(args[0]).includes("Cannot update a component"))
+      expect(renderPhaseWarnings).toEqual([])
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
   })
 
   it("notifies the parent when the menu opens and closes", async () => {

--- a/v3/src/components/case-tile-common/attribute-header.test.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.test.tsx
@@ -1,0 +1,80 @@
+import { DndContext } from "@dnd-kit/core"
+import { render, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import React from "react"
+import { DataSetContext } from "../../hooks/use-data-set-context"
+import { ITileSelection, TileSelectionContext } from "../../hooks/use-tile-selection-context"
+import { DataSet, toCanonical } from "../../models/data/data-set"
+import { AttributeHeader } from "./attribute-header"
+
+const tileSelection: ITileSelection = {
+  isTileSelected: () => false,
+  selectTile: () => undefined,
+  addFocusIgnoreFn: () => () => null
+}
+
+function renderAttributeHeader(props: Partial<React.ComponentProps<typeof AttributeHeader>> = {}) {
+  const data = DataSet.create()
+  data.addAttribute({ name: "Species" })
+  data.addCases(toCanonical(data, [{ Species: "Dog" }, { Species: "Cat" }]))
+  const attribute = data.attributes[0]
+
+  return {
+    data,
+    attribute,
+    // dnd-kit's pointer sensor activates a drag on a synthetic click, which closes the menu
+    // before it can open, so these tests exercise the non-draggable header.
+    ...render(
+      <DndContext>
+        <TileSelectionContext.Provider value={tileSelection}>
+          <DataSetContext.Provider value={data}>
+            <AttributeHeader attributeId={attribute.id} draggable={false} {...props} />
+          </DataSetContext.Provider>
+        </TileSelectionContext.Provider>
+      </DndContext>
+    )
+  }
+}
+
+describe("AttributeHeader", () => {
+  // React warns about render-phase updates only once per rendering component per module
+  // registry, so this must precede any other test in this file that opens the menu.
+  it("opens and closes the attribute menu without triggering a render-phase state update", async () => {
+    const user = userEvent.setup()
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => null)
+
+    const { attribute } = renderAttributeHeader()
+    const button = screen.getByTestId(`codap-attribute-button ${attribute.name}`)
+    await user.click(button)
+    expect(button).toHaveAttribute("aria-expanded", "true")
+
+    await user.keyboard("{Escape}")
+    expect(button).toHaveAttribute("aria-expanded", "false")
+
+    const renderPhaseWarnings = consoleErrorSpy.mock.calls
+      .filter(args => String(args[0]).includes("Cannot update a component"))
+    expect(renderPhaseWarnings).toEqual([])
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it("notifies the parent when the menu opens and closes", async () => {
+    const user = userEvent.setup()
+    const onOpenMenu = jest.fn()
+    const onCloseMenu = jest.fn()
+
+    const { attribute } = renderAttributeHeader({ onOpenMenu, onCloseMenu })
+    // no spurious notification on mount
+    expect(onOpenMenu).not.toHaveBeenCalled()
+    expect(onCloseMenu).not.toHaveBeenCalled()
+
+    const button = screen.getByTestId(`codap-attribute-button ${attribute.name}`)
+    await user.click(button)
+    expect(onOpenMenu).toHaveBeenCalledTimes(1)
+    expect(onCloseMenu).not.toHaveBeenCalled()
+
+    await user.keyboard("{Escape}")
+    expect(onCloseMenu).toHaveBeenCalledTimes(1)
+    expect(onOpenMenu).toHaveBeenCalledTimes(1)
+  })
+})

--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -52,7 +52,6 @@ export const AttributeHeader = observer(function AttributeHeader({
   const inputRef = useRef<HTMLInputElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const menuListRef = useRef<HTMLDivElement | null>(null)
-  const isMenuOpen = useRef(false)
   const [isMenuOpenState, setIsMenuOpenState] = useState(false)
   const [editingAttrId, setEditingAttrId] = useState("")
   const [editingAttrName, setEditingAttrName] = useState("")
@@ -73,8 +72,7 @@ export const AttributeHeader = observer(function AttributeHeader({
   const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions)
   const draggableProps = draggable ? { ...attributes, ...listeners } : {}
   // TODO: we really should only enable the outside pointer down listener when the menu is open.
-  // However there doesn't seem to be simple way to do that.
-  // `isMenuOpen` is a ref so we won't be re-rendered when that changes.
+  // Closing an already-closed menu is a no-op, so leaving it enabled is harmless but wasteful.
   useOutsidePointerDown({
     ref: menuListRef,
     handler: () => onCloseMenuRef.current?.(),
@@ -248,6 +246,11 @@ export const AttributeHeader = observer(function AttributeHeader({
     )
   }, [attribute?.description, attribute?.formula, attrName])
 
+  // Chakra calls these from its event handlers, so tracking the menu state here keeps the
+  // update out of the render pass of the `Menu` that owns the disclosure.
+  const handleMenuOpen = useCallback(() => setIsMenuOpenState(true), [])
+  const handleMenuClose = useCallback(() => setIsMenuOpenState(false), [])
+
   // Notify parent of menu open/close as a side effect (not during render).
   // Skip the initial mount (isMenuOpenState starts false) to avoid a spurious onCloseMenu call.
   const didMount = useRef(false)
@@ -266,12 +269,10 @@ export const AttributeHeader = observer(function AttributeHeader({
   const isIndex = attributeId === kIndexColumnKey
   const headerContentClasses = clsx("codap-column-header-content", { "index-column-header": isIndex })
   return (
-    <Menu isLazy>
+    <Menu isLazy onOpen={handleMenuOpen} onClose={handleMenuClose}>
       {({ isOpen, onClose }) => {
         const tooltipDisabled = disableTooltip || dragging || isOpen || modalIsOpen || editingAttrId === attributeId
-        isMenuOpen.current = isOpen
         onCloseMenuRef.current = onClose
-        if (isOpen !== isMenuOpenState) setIsMenuOpenState(isOpen)
         return (
           <Tooltip label={renderTooltipLabel} fontSize="12px" color="white"
               openDelay={1000} placement="bottom" bottom="15px" left="15px" isDisabled={tooltipDisabled}

--- a/v3/src/components/case-tile-common/attribute-header.tsx
+++ b/v3/src/components/case-tile-common/attribute-header.tsx
@@ -71,11 +71,10 @@ export const AttributeHeader = observer(function AttributeHeader({
   }
   const { attributes, listeners, setNodeRef: setDragNodeRef } = useDraggableAttribute(draggableOptions)
   const draggableProps = draggable ? { ...attributes, ...listeners } : {}
-  // TODO: we really should only enable the outside pointer down listener when the menu is open.
-  // Closing an already-closed menu is a no-op, so leaving it enabled is harmless but wasteful.
   useOutsidePointerDown({
     ref: menuListRef,
     handler: () => onCloseMenuRef.current?.(),
+    enabled: isMenuOpenState,
     info: {name: "AttributeHeader menuList", attributeId, attrName}
    })
 


### PR DESCRIPTION
## Summary

On each launch of CODAP, the first click on a case table attribute header that opened the attribute menu logged a React warning to the console:

```
Warning: Cannot update a component (`AttributeHeader`) while rendering a different component (`Menu`).
```

Console-only, with no user-visible symptom, but long-standing noise.

## Cause

`AttributeHeader` synced Chakra's menu open state into its own React state from inside the `<Menu>` children render prop:

```tsx
<Menu isLazy>
  {({ isOpen, onClose }) => {
    if (isOpen !== isMenuOpenState) setIsMenuOpenState(isOpen)
```

`if (next !== prev) setState(next)` during render is legitimate when a component derives state from its *own* props, but this callback runs inside `Menu`'s render — so React sees `AttributeHeader` being updated while a different component renders. The state existed only to feed the effect that calls `onOpenMenu`/`onCloseMenu` on the parent.

## Why only the first click per launch

React dedupes this warning by the name of the **rendering** component (`warnAboutRenderPhaseUpdatesInDEV` in `react-dom.development.js`), so the key was `"Menu"` — one warning per page load, no matter how many menus or clicks.

That dedupe also masked a second, identical occurrence in `AxisOrLegendAttributeMenu`. Fixing only the case table would have left the warning to reappear whenever an axis or legend label was clicked first, so both are fixed here.

## Fix

Drive the state from Chakra's `onOpen`/`onClose` `Menu` props, which `useDisclosure` invokes from event handlers rather than during render. `PluginsButton` already used this pattern, so this brings the two outliers in line with the existing convention.

Parent-notification semantics are unchanged — the dedupe effect that fires `onOpenMenu`/`onCloseMenu` is untouched.

Also gates `useOutsidePointerDown` on the menu being open, which the state change makes possible — removing a permanently-attached document listener per visible attribute. This is what the removed `TODO` was waiting on: the open state had been kept in a ref precisely to avoid re-renders, which is what made gating awkward before.

## Testing

- New `attribute-header.test.tsx`, plus one test added to the existing axis menu suite. Each was confirmed to **fail with its fix stashed**.
- Full Jest suite green (353 suites / 3715 tests); `build:tsc` and `lint` clean.

Two constraints are commented in the tests for future readers:

- They must run before any other menu-opening test in their file, or React's one-shot dedupe makes them pass vacuously.
- In jsdom, dnd-kit's pointer sensor activates a drag on a synthetic click and closes the menu before it opens, so the header tests pass `draggable={false}`.

Not manually verified in a browser; the evidence is the tests reproducing the exact warning text.

Fixes CODAP-1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)
