### PR TITLE
CODAP-1480: single LSRL for continuous legends

### DIFF
--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -143,13 +143,15 @@ describe("LSRLAdornmentModel", () => {
     function createMockDataConfig(options: {
       cellKeys: Record<string, string>[],
       legendCategories: string[],
+      legendType?: "categorical" | "numeric" | "date",
       xAttrId?: string,
       yAttrId?: string
     }) {
-      const { cellKeys, legendCategories, xAttrId = "xAttr", yAttrId = "yAttr" } = options
+      const { cellKeys, legendCategories, legendType, xAttrId = "xAttr", yAttrId = "yAttr" } = options
       return {
         getAllCellKeys: () => cellKeys,
         categoryArrayForAttrRole: (role: string) => role === "legend" ? legendCategories : [],
+        attributeType: (role: string) => role === "legend" ? legendType : undefined,
         getCategoriesOptions: () => ({
           xAttrId,
           yAttrId,
@@ -299,6 +301,28 @@ describe("LSRLAdornmentModel", () => {
 
       expect(cat1Values).toEqual([{ x: 10, y: 100 }, { x: 30, y: 300 }])
       expect(cat2Values).toEqual([{ x: 20, y: 200 }, { x: 40, y: 400 }])
+    })
+
+    // CODAP-1480: dragging a numeric attribute into the middle of a scatterplot creates a
+    // continuous (color-gradient) legend. categoryArrayForAttrRole then returns one entry per
+    // unique numeric value, so without the fix the adornment would create one LSRL per case.
+    it("produces a single LSRL keyed by kMain when the legend is numeric", () => {
+      const lSRL = LSRLAdornmentModel.create()
+      const cellKey = { xAttr: "A" }
+      const instanceKey = lSRL.instanceKey(cellKey)
+
+      // Pretend the numeric legend has many unique values — the fix must ignore them.
+      const mockDataConfig = createMockDataConfig({
+        cellKeys: [cellKey],
+        legendCategories: ["1.1", "2.2", "3.3", "4.4", "5.5"],
+        legendType: "numeric"
+      })
+
+      lSRL.updateCategories({ dataConfig: mockDataConfig })
+
+      const linesInCell = lSRL.lines.get(instanceKey)
+      expect(linesInCell?.size).toEqual(1)
+      expect(linesInCell?.has(kMain)).toBe(true)
     })
 
     it("removes stale legend categories within a cell", () => {

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.test.ts
@@ -265,7 +265,7 @@ describe("LSRLAdornmentModel", () => {
     })
 
     it("filters cases by category when the legend attribute is numeric (used as categorical)", () => {
-      // CODAP-1373: a numeric attribute used as a categorical legend stores its values as numbers,
+      // A numeric attribute used as a categorical legend stores its values as numbers,
       // but `categoryArrayForAttrRole` returns string category labels (via getStrValue). The
       // `getCaseValues` comparison must normalize both sides to strings or no cases match.
       const xAttrId = "xId"
@@ -303,7 +303,7 @@ describe("LSRLAdornmentModel", () => {
       expect(cat2Values).toEqual([{ x: 20, y: 200 }, { x: 40, y: 400 }])
     })
 
-    // CODAP-1480: dragging a numeric attribute into the middle of a scatterplot creates a
+    // Dragging a numeric attribute into the middle of a scatterplot creates a
     // continuous (color-gradient) legend. categoryArrayForAttrRole then returns one entry per
     // unique numeric value, so without the fix the adornment would create one LSRL per case.
     it("produces a single LSRL keyed by kMain when the legend is numeric", () => {

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -158,6 +158,10 @@ export const LSRLAdornmentModel = AdornmentModel
     return caseValues
   },
   getLegendCategories(dataConfig: IGraphDataConfigurationModel) {
+    // A continuous (numeric or date) legend must produce a single LSRL over all cases; otherwise
+    // categoryArrayForAttrRole returns one entry per unique legend value, yielding one LSRL per case.
+    const legendType = dataConfig.attributeType("legend")
+    if (legendType && legendType !== "categorical") return [kMain]
     return dataConfig.categoryArrayForAttrRole("legend")
   },
   get lineDescriptions() {

--- a/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
+++ b/v3/src/components/graph/adornments/lsrl/lsrl-adornment-model.ts
@@ -161,7 +161,7 @@ export const LSRLAdornmentModel = AdornmentModel
     // A continuous (numeric or date) legend must produce a single LSRL over all cases; otherwise
     // categoryArrayForAttrRole returns one entry per unique legend value, yielding one LSRL per case.
     const legendType = dataConfig.attributeType("legend")
-    if (legendType && legendType !== "categorical") return [kMain]
+    if (legendType && legendType !== "categorical" && legendType !== "checkbox") return [kMain]
     return dataConfig.categoryArrayForAttrRole("legend")
   },
   get lineDescriptions() {


### PR DESCRIPTION
## Summary
- Numeric/date legends caused the LSRL adornment to create one line per unique legend value (i.e. often one per case), which was very slow and produced many spurious lines.
- `getLegendCategories` now returns `[kMain]` when the legend attribute isn't categorical, matching the pattern already used in `scatter-plot-utils.ts`.
- Added a unit test that pins the behavior with a numeric legend.

Fixes CODAP-1480.

## Test plan
- [ ] Roller Coasters: plot `Max_Height` vs `Top_Speed`, add LSRL, drag `Drop` to create a numeric legend. Verify: fast, exactly one LSRL, values match the no-legend LSRL.
- [ ] Repeat with a categorical legend to confirm per-category LSRLs still render.
- [ ] `npm test -- lsrl` passes locally.
