### PR TITLE
CODAP-1479: allow residual plot with a legend when single line

### DIFF
--- a/v3/src/components/graph/models/graph-content-model.test.ts
+++ b/v3/src/components/graph/models/graph-content-model.test.ts
@@ -370,7 +370,8 @@ describe("GraphContentModel", () => {
   // V2 parity: the Squares of Residuals and Residual Plot booleans must not
   // linger checked-but-disabled. When the possibility of showing squares disappears (no
   // visible line/curve adornment), both flags are cleared; when the Residual Plot's stricter
-  // applicability lapses (e.g. legend attribute added), the Residual Plot flag is cleared.
+  // applicability lapses (e.g. the y attribute becomes non-numeric), the Residual Plot flag is
+  // cleared.
   describe("Squares of Residuals / Residual Plot reactive gates", () => {
     const createScatter = async (datasetName: string, extra: Record<string, any> = {}) => {
       const documentContent = appState.document.content!
@@ -457,9 +458,10 @@ describe("GraphContentModel", () => {
       diComponentHandler.delete!({ component: tile })
     })
 
-    // A legend attribute makes residualPlotIsApplicable false while leaving Movable Line
-    // visible — so the squares gate does not fire, but the residual plot gate should.
-    it("clears showResidualPlot when a legend attribute makes it inapplicable, but keeps Squares", async () => {
+    // CODAP-1479: with a single-line adornment (movable line, plotted function, or LSRL under a
+    // non-categorical legend), adding a legend does not disqualify the residual plot — only one
+    // residual set is being plotted. Squares survive too.
+    it("keeps showResidualPlot when a legend is added and only a movable line is active", async () => {
       (isInquirySpaceMode as jest.Mock).mockReturnValue(false)
       const { tile, content } = await createScatter("residualGateLegend")
       const store = content.adornmentsStore
@@ -468,15 +470,15 @@ describe("GraphContentModel", () => {
       store.setShowSquaresOfResiduals(true)
       store.setShowResidualPlot(true)
 
-      // Assign a legend attribute — residualPlotIsApplicable returns false, but a line
-      // is still visible so the squares possibility survives.
+      // Assign the (numeric) y attribute as the legend. Movable line is a single line regardless
+      // of the legend, so the residual plot's applicability holds.
       const dataConfig = content.graphPointLayerModel.dataConfiguration
       dataConfig.setAttribute("legend", { attributeID: dataConfig.attributeID("y") })
       await new Promise(resolve => setTimeout(resolve, 0))
 
       expect(store.isShowingAdornment(kMovableLineType)).toBe(true)
       expect(store.showSquaresOfResiduals).toBe(true)
-      expect(store.showResidualPlot).toBe(false)
+      expect(store.showResidualPlot).toBe(true)
 
       diComponentHandler.delete!({ component: tile })
     })

--- a/v3/src/components/graph/models/graph-content-model.test.ts
+++ b/v3/src/components/graph/models/graph-content-model.test.ts
@@ -458,7 +458,7 @@ describe("GraphContentModel", () => {
       diComponentHandler.delete!({ component: tile })
     })
 
-    // CODAP-1479: with a single-line adornment (movable line, plotted function, or LSRL under a
+    // With a single-line adornment (movable line, plotted function, or LSRL under a
     // non-categorical legend), adding a legend does not disqualify the residual plot — only one
     // residual set is being plotted. Squares survive too.
     it("keeps showResidualPlot when a legend is added and only a movable line is active", async () => {

--- a/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.test.ts
+++ b/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.test.ts
@@ -110,7 +110,7 @@ describe("residualPlotIsApplicable", () => {
   it("returns false when a rightSplit (right categorical) attribute is present", () => {
     expect(residualPlotIsApplicable(fakeStore({ml: true}), fakeConfig({rightSplit: "attr-right"}))).toBe(false)
   })
-  // CODAP-1479: a legend no longer disables the residual plot outright — only when it would
+  // A legend no longer disables the residual plot outright — only when it would
   // create more than one line's residuals (LSRL + categorical legend).
   it("returns true with movable line + categorical legend (single line regardless of legend)", () => {
     expect(residualPlotIsApplicable(

--- a/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.test.ts
+++ b/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.test.ts
@@ -137,6 +137,19 @@ describe("residualPlotIsApplicable", () => {
       fakeStore({lsrl: true}), fakeConfig({legend: "attr-legend", legendType: "categorical"})
     )).toBe(false)
   })
+  // checkbox and color are treated as categorical by isCategoricalAttributeType (see
+  // attribute-types.ts) — LSRL under either produces multiple LSRLs the same way, so residual
+  // plot must be blocked. Pinning here prevents a regression back to a bare === "categorical" check.
+  it("returns false with LSRL + checkbox legend (checkbox is treated as categorical)", () => {
+    expect(residualPlotIsApplicable(
+      fakeStore({lsrl: true}), fakeConfig({legend: "attr-legend", legendType: "checkbox"})
+    )).toBe(false)
+  })
+  it("returns false with LSRL + color legend (color is treated as categorical)", () => {
+    expect(residualPlotIsApplicable(
+      fakeStore({lsrl: true}), fakeConfig({legend: "attr-legend", legendType: "color"})
+    )).toBe(false)
+  })
   it("returns false when two lines are active (even with all other constraints met)", () => {
     expect(residualPlotIsApplicable(fakeStore({ml: true, lsrl: true}), fakeConfig())).toBe(false)
   })

--- a/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.test.ts
+++ b/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.test.ts
@@ -36,14 +36,20 @@ interface IFakeConfigOptions {
   topSplit?: string
   rightSplit?: string
   legend?: string
+  legendType?: string
 }
 function fakeConfig(opts: IFakeConfigOptions = {}): IGraphDataConfigurationModel {
   const {
     xType = "numeric", yType = "numeric", yAttrCount = 1,
-    rightNumeric = "", topSplit = "", rightSplit = "", legend = ""
+    rightNumeric = "", topSplit = "", rightSplit = "", legend = "", legendType = ""
   } = opts
   return {
-    attributeType: (role: string) => role === "x" ? xType : role === "y" ? yType : "",
+    attributeType: (role: string) => {
+      if (role === "x") return xType
+      if (role === "y") return yType
+      if (role === "legend") return legendType
+      return ""
+    },
     yAttributeIDs: Array.from({length: yAttrCount}, (_, i) => `y${i}`),
     attributeID: (role: string) => {
       if (role === "rightNumeric") return rightNumeric
@@ -104,8 +110,32 @@ describe("residualPlotIsApplicable", () => {
   it("returns false when a rightSplit (right categorical) attribute is present", () => {
     expect(residualPlotIsApplicable(fakeStore({ml: true}), fakeConfig({rightSplit: "attr-right"}))).toBe(false)
   })
-  it("returns false when a legend attribute is present", () => {
-    expect(residualPlotIsApplicable(fakeStore({ml: true}), fakeConfig({legend: "attr-legend"}))).toBe(false)
+  // CODAP-1479: a legend no longer disables the residual plot outright — only when it would
+  // create more than one line's residuals (LSRL + categorical legend).
+  it("returns true with movable line + categorical legend (single line regardless of legend)", () => {
+    expect(residualPlotIsApplicable(
+      fakeStore({ml: true}), fakeConfig({legend: "attr-legend", legendType: "categorical"})
+    )).toBe(true)
+  })
+  it("returns true with plotted function + categorical legend (single line regardless of legend)", () => {
+    expect(residualPlotIsApplicable(
+      fakeStore({pf: true}), fakeConfig({legend: "attr-legend", legendType: "categorical"})
+    )).toBe(true)
+  })
+  it("returns true with LSRL + numeric legend (a continuous legend leaves a single LSRL)", () => {
+    expect(residualPlotIsApplicable(
+      fakeStore({lsrl: true}), fakeConfig({legend: "attr-legend", legendType: "numeric"})
+    )).toBe(true)
+  })
+  it("returns true with LSRL + date legend (a continuous legend leaves a single LSRL)", () => {
+    expect(residualPlotIsApplicable(
+      fakeStore({lsrl: true}), fakeConfig({legend: "attr-legend", legendType: "date"})
+    )).toBe(true)
+  })
+  it("returns false with LSRL + categorical legend (one LSRL per category = multiple residual sets)", () => {
+    expect(residualPlotIsApplicable(
+      fakeStore({lsrl: true}), fakeConfig({legend: "attr-legend", legendType: "categorical"})
+    )).toBe(false)
   })
   it("returns false when two lines are active (even with all other constraints met)", () => {
     expect(residualPlotIsApplicable(fakeStore({ml: true, lsrl: true}), fakeConfig())).toBe(false)

--- a/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.ts
+++ b/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.ts
@@ -8,6 +8,7 @@ import { kPlottedFunctionType } from "../../adornments/plotted-function/plotted-
 import { leastSquaresLinearRegression } from "../../utilities/graph-utils"
 import { dataDisplayGetNumericValue } from "../../../data-display/data-display-value-utils"
 import { Point } from "../../../data-display/data-display-types"
+import { isCategoricalAttributeType } from "../../../../models/data/attribute-types"
 import { isFiniteNumber } from "../../../../utilities/math-utils"
 import {
   defaultSelectedColor, defaultSelectedStroke, defaultSelectedStrokeOpacity, defaultSelectedStrokeWidth,
@@ -35,7 +36,10 @@ export function getActiveLineKind(store: IAdornmentsBaseStore): ActiveLineKind |
 //   - Exactly one of {movable line, LSRL, plotted function} visible
 //   - Legend is allowed when exactly one line's residuals are being plotted: movable line and
 //     plotted function are always a single line; LSRL is single only when the legend isn't
-//     categorical (a categorical legend produces one LSRL per category).
+//     categorical (a categorical legend produces one LSRL per category). "Categorical" here uses
+//     isCategoricalAttributeType, which treats checkbox and color legends as categorical too —
+//     matching the rest of the graph code and preventing LSRL + checkbox/color from slipping
+//     through and producing multiple residual sets.
 export function residualPlotIsApplicable(
   store: IAdornmentsBaseStore, dataConfig?: IGraphDataConfigurationModel
 ): boolean {
@@ -49,7 +53,7 @@ export function residualPlotIsApplicable(
   if (dataConfig.attributeID("topSplit")) return false
   if (dataConfig.attributeID("rightSplit")) return false
   if (dataConfig.attributeID("legend") && kind === "lsrl" &&
-      dataConfig.attributeType("legend") === "categorical") return false
+      isCategoricalAttributeType(dataConfig.attributeType("legend"))) return false
   return true
 }
 

--- a/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.ts
+++ b/v3/src/components/graph/plots/scatter-plot/residual-plot-utils.ts
@@ -32,12 +32,15 @@ export function getActiveLineKind(store: IAdornmentsBaseStore): ActiveLineKind |
 //   - Numeric attribute on left y-axis, exactly one y attribute (no y+)
 //   - No attribute on the right numeric (Y2) axis
 //   - No attribute on the top or right split axes (categorical splitters)
-//   - No legend attribute
 //   - Exactly one of {movable line, LSRL, plotted function} visible
+//   - Legend is allowed when exactly one line's residuals are being plotted: movable line and
+//     plotted function are always a single line; LSRL is single only when the legend isn't
+//     categorical (a categorical legend produces one LSRL per category).
 export function residualPlotIsApplicable(
   store: IAdornmentsBaseStore, dataConfig?: IGraphDataConfigurationModel
 ): boolean {
-  if (getActiveLineKind(store) === null) return false
+  const kind = getActiveLineKind(store)
+  if (kind === null) return false
   if (!dataConfig) return false
   if (dataConfig.attributeType("x") !== "numeric") return false
   if (dataConfig.attributeType("y") !== "numeric") return false
@@ -45,7 +48,8 @@ export function residualPlotIsApplicable(
   if (dataConfig.attributeID("rightNumeric")) return false
   if (dataConfig.attributeID("topSplit")) return false
   if (dataConfig.attributeID("rightSplit")) return false
-  if (dataConfig.attributeID("legend")) return false
+  if (dataConfig.attributeID("legend") && kind === "lsrl" &&
+      dataConfig.attributeType("legend") === "categorical") return false
   return true
 }
 


### PR DESCRIPTION
## Summary
- Previously the residual plot disappeared whenever a legend was added.
- `residualPlotIsApplicable` now only disqualifies the legend case that would create multiple residual sets: LSRL + categorical legend (one LSRL per category).
- Movable line and plotted function are always a single line regardless of legend.
- LSRL under a numeric or date legend is a single line — leaning on the CODAP-1480 fix.
- Residual points get colored by the legend (that path already existed but was gated).

Fixes CODAP-1479.

## Depends on
- #2681 (CODAP-1480). Base branch is `CODAP-1480-numeric-legend-lsrl`; retarget to `main` after #2681 merges.

## Test plan
- [ ] Movable line + legend: residual plot stays visible, points colored by legend.
- [ ] Plotted function + legend: same.
- [ ] LSRL + numeric legend: residual plot stays with one line, points colored.
- [ ] LSRL + categorical legend: residual plot hides.
- [ ] `npm test -- residual-plot-utils graph-content-model` passes.
