### PR TITLE
CODAP-1478: animate residual plot points

### DIFF
--- a/v3/src/components/axis/hooks/use-sub-axis.ts
+++ b/v3/src/components/axis/hooks/use-sub-axis.ts
@@ -79,6 +79,14 @@ export const useSubAxis = ({
 
     renderSubAxis = useCallback(() => {
       const axisModel = axisProvider.getAxis?.(axisPlace)
+      // Silent skip when no axis is registered at this place — expected during the render
+      // window that follows removing an axis (e.g., a residual-plot toggle-off, or an undo of
+      // a residual-plot-show action): observable reads in reactions above still fire before
+      // React unmounts the SubAxis, and they call renderSubAxis with no axis to render.
+      // Warn only when we do have an axis reference that has gone defunct — that's a genuinely
+      // suspect condition worth surfacing. Matches the undefined/defunct split in
+      // installDomainSync below.
+      if (!axisModel) return
       if (!isAliveSafe(axisModel)) {
         console.warn("useSubAxis.renderSubAxis skipping rendering of defunct axis model:", axisPlace)
         return
@@ -86,7 +94,7 @@ export const useSubAxis = ({
       const multiScale = layout.getAxisMultiScale(axisPlace)
       if (!multiScale) return // no scale, no axis (But this shouldn't happen)
 
-      axisModel && axisProvider.getAxisHelper(axisModel.place, subAxisIndex)?.render()
+      axisProvider.getAxisHelper(axisModel.place, subAxisIndex)?.render()
     }, [axisPlace, axisProvider, layout, subAxisIndex]),
 
     onDragStart = useCallback((event: any) => {

--- a/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
+++ b/v3/src/components/graph/adornments/movable-line/movable-line-adornment-component.tsx
@@ -13,6 +13,7 @@ import { useAdornmentCells } from "../../hooks/use-adornment-cells"
 import { useGraphContentModelContext } from "../../hooks/use-graph-content-model-context"
 import {useGraphDataConfigurationContext} from "../../hooks/use-graph-data-configuration-context"
 import { useGraphLayoutContext } from "../../hooks/use-graph-layout-context"
+import { useDataDisplayAnimation } from "../../../data-display/hooks/use-data-display-animation"
 import { isDateAxisModel } from "../../../axis/models/numeric-axis-models"
 import {
   calculateSumOfSquares, computeSlopeAndIntercept, equationString, IAxisIntercepts, lineToAxisIntercepts
@@ -58,6 +59,7 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
   const { tile } = useTileModelContext()
   const instanceId = useInstanceIdContext()
   const adornmentsStore = graphModel.adornmentsStore
+  const { stopAnimation } = useDataDisplayAnimation()
   const { xAttrId, xAttrName, yAttrId, yAttrName, xScale, yScale } = useAdornmentAttributes()
   const { classFromKey, instanceKey } = useAdornmentCells(model, cellKey)
   const { xSubAxesCount, ySubAxesCount } = useAdornmentCategories()
@@ -400,14 +402,21 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
 
   // Add the behaviors to the line segments
   useEffect(function addBehaviors() {
+    // Dragging the line ends any animation in progress, matching the point drag, dot-plot drag, and
+    // axis drag. Anything that tracks the line — the Residual Plot's points, most visibly — has to
+    // follow the cursor in real time, so a drag that began inside an earlier change's animation
+    // window must not leave those followers easing toward a position the line has already left.
     const behaviors: { [index: string]: any } = {
       lower: drag()
+        .on("start", stopAnimation)
         .on("drag", (e) => handleRotation(e, "lower"))
         .on("end", (e) => handleRotation(e, "lower", true)),
       middle: drag()
+        .on("start", stopAnimation)
         .on("drag", (e) => handleTranslate(e))
         .on("end", (e) => handleTranslate(e, true)),
       upper: drag()
+        .on("start", stopAnimation)
         .on("drag", (e) => handleRotation(e, "upper"))
         .on("end", (e) => handleRotation(e, "upper", true)),
       equation: drag()
@@ -425,7 +434,8 @@ export const MovableLineAdornment = observer(function MovableLineAdornment(props
     !interceptLocked && lineObject.middle?.call(behaviors.middle)
     lineObject.upper?.call(behaviors.upper)
     lineObject.equation?.call(behaviors.equation)
-  }, [lineObject, handleTranslate, handleRotation, handleMoveEquation, interceptLocked, model.lines, instanceKey])
+  }, [lineObject, handleTranslate, handleRotation, handleMoveEquation, interceptLocked, model.lines, instanceKey,
+      stopAnimation])
 
   // Build the line and its cover segments and handles just once
   useEffect(function createElements() {

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -398,9 +398,12 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
     // don't establish MobX deps, so our mstAutorun doesn't re-fire). usePlotResponders wires an
     // onAnyAction listener that calls refreshPointPositions on every setCaseValues, so this path
     // fires per drag frame and reads current cached values via renderResidualsIfActive.
-    renderResidualsIfActive()
-  }, [adornmentsStore, refreshConnectingLines, refreshSquares,
-      refreshPointPositionsPerfMode, refreshAllPointPositions, renderResidualsIfActive, showSquares])
+    // Pass isAnimating() so debounced refreshes fired during the main plot's animation window
+    // (attribute change) animate the residual points along; drag/other refreshes see false and
+    // snap. The syncResidualPlot autorun independently animates the attribute-change case.
+    renderResidualsIfActive(isAnimating())
+  }, [adornmentsStore, refreshConnectingLines, refreshSquares, refreshPointPositionsPerfMode,
+      refreshAllPointPositions, renderResidualsIfActive, showSquares, isAnimating])
 
   // Call refreshSquares when Squares of Residuals option is switched on and when a
   // Movable Line adornment is being dragged.

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -76,7 +76,7 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
   const functionSquaresRef = useRef<SVGGElement>(null)
 
   const { residualPointsRef, renderResidualsIfActive, restyleResidualSelection } = useResidualPlot({
-    graphModel, dataConfiguration, dataset, layout, legendAttrID
+    graphModel, dataConfiguration, dataset, layout, legendAttrID, isAnimating
   })
 
   const marqueeState = useMarqueeStateContext()

--- a/v3/src/components/graph/plots/scatter-plot/use-residual-plot.ts
+++ b/v3/src/components/graph/plots/scatter-plot/use-residual-plot.ts
@@ -22,19 +22,42 @@ interface IUseResidualPlot {
   dataset?: IDataSet
   layout: GraphLayout
   legendAttrID?: string
+  isAnimating: () => boolean
+}
+
+// A residual point plus the screen position it should occupy. Carried on the joined datum so the
+// enter and update selections read the coordinates without recomputing them.
+type IPositionedResidualPoint = IResidualPoint & { cx: number, cy: number }
+
+// True when every point would land exactly where the previous paint put it. Compares by case ID
+// rather than by index so a reordered case array doesn't read as a move. A NaN coordinate always
+// compares unequal, which errs toward repainting.
+function samePositions(prev: Map<string, IPositionedResidualPoint> | null, next: IPositionedResidualPoint[]) {
+  if (prev?.size !== next.length) return false
+  return next.every(d => {
+    const prevPoint = prev.get(d.caseID)
+    return prevPoint?.cx === d.cx && prevPoint?.cy === d.cy
+  })
 }
 
 // Owns the Residual Plot's SVG rendering, split-layout sync, and selection-halo restyle. The
 // ScatterPlot consumes the returned refs/callbacks: refreshPointPositions calls renderResidualsIfActive
 // (drag caching) and refreshPointSelection calls restyleResidualSelection (selection halo).
 export function useResidualPlot(props: IUseResidualPlot) {
-  const { graphModel, dataConfiguration, dataset, layout, legendAttrID } = props
+  const { graphModel, dataConfiguration, dataset, layout, legendAttrID, isAnimating } = props
   const adornmentsStore = graphModel.adornmentsStore
   const residualPointsRef = useRef<SVGGElement>(null)
-  // Attribute IDs at the last active render. Used by the syncResidualPlot autorun to detect an x/y
-  // attribute change since its previous fire so renderResidualPoints can transition cx/cy instead
-  // of snapping. Reset to null on teardown so re-activation doesn't trigger a spurious animation.
-  const prevRenderedAttrIDsRef = useRef<{ x?: string, y?: string } | null>(null)
+  // Target positions of the last paint, keyed by case ID. renderResidualPoints consults this before
+  // touching cx/cy at all: a repaint that would land every point exactly where it is already headed
+  // must leave an in-flight transition alone rather than interrupting or restarting it.
+  //
+  // This matters because one logical change produces several repaints. Changing an attribute fires
+  // the syncResidualPlot autorun below three times: it writes the axis and MultiScale domains that
+  // it also reads, so MobX re-schedules it, and the graph's layout then reflows (a taller y range
+  // widens the left axis labels, which shifts the bottom axis and every point's cx). Only the first
+  // of those repaints knows what caused it, and the later ones can carry genuinely different
+  // coordinates — so "did anything actually move" is the only reliable question to ask here.
+  const lastRenderedPositionsRef = useRef<Map<string, IPositionedResidualPoint> | null>(null)
 
   // Hover tooltip for residual points. Matches the "graph-d3-tip" styling used by other adornment
   // hovers so the tip visually reads like the main plot's data tips. The `no-svg-export` class
@@ -119,15 +142,20 @@ export function useResidualPlot(props: IUseResidualPlot) {
   // this) does not subscribe to the selection set — otherwise every selection change would re-fire
   // the autorun and recompute the predictor/residuals purely to update halos.
   //
-  // animateCxCy is set by callers who know the context. The autorun sets it iff an x/y attribute
-  // just changed; the piggyback from scatter-plot passes isAnimating() so refreshes during the
-  // main plot's animation window animate along. All other paths (drag, movable-line drag,
-  // mount-after-commit, etc.) leave it false and get an immediate snap. Snap uses
-  // .interrupt("cxcy") so a previous cx/cy transition (e.g., an attribute change still in flight
-  // when the user starts dragging a line) is killed rather than continuing to fight the snap on
-  // every tick. The name is scoped so the enter-circle "radius" fade-in survives — otherwise the
-  // debounced piggyback that follows a case-add would cancel the r=0→full transition and cause a
-  // visible flash of the new point at full radius.
+  // animateCxCy tracks the main plot: callers pass isAnimating(), the same signal the upper plot's
+  // points use, so the residual points ease in step with the points they mirror and snap the rest
+  // of the time. Everything that needs immediate positions — dragging a point, dragging the line,
+  // dragging an axis — ends the animation at drag start, so isAnimating() is already false by the
+  // first drag frame and residuals track the cursor in real time.
+  //
+  // Snap uses .interrupt("cxcy") so a slide still in flight when a drag begins is killed rather
+  // than fighting the snap on every tick. The name is scoped so the enter-circle "radius" fade-in
+  // survives — otherwise the debounced piggyback that follows a case-add would cancel the r=0→full
+  // transition and flash the new point at full radius.
+  //
+  // Both paths are guarded on positions having actually changed (see lastRenderedPositionsRef): a
+  // repaint that moves nothing has nothing to snap to and nothing to animate toward, and acting on
+  // it would cancel or restart a slide already going where it belongs.
   const renderResidualPoints = useCallback((residuals: IResidualPoint[], animateCxCy = false) => {
     const g = residualPointsRef.current
     if (!g) return
@@ -135,6 +163,7 @@ export function useResidualPlot(props: IUseResidualPlot) {
     const lowerScale = layout.getAxisScale("leftLower") as ScaleLinear<number, number> | undefined
     if (!lowerScale) {
       select(g).selectAll("circle").remove()
+      lastRenderedPositionsRef.current = null
       return
     }
     const plotHeight = layout.plotHeight
@@ -154,17 +183,27 @@ export function useResidualPlot(props: IUseResidualPlot) {
     const residualTip = residualDataTipRef.current
     // Install the tip on the parent SVG so absolute positioning works.
     select(g).call(residualTip)
-    const selection = select(g).selectAll<SVGCircleElement, IResidualPoint>("circle")
-      .data(residuals, d => d.caseID)
+    const positioned: IPositionedResidualPoint[] = residuals.map(d => ({
+      ...d, cx: getXCoord(d.caseID), cy: plotHeight + lowerScale(d.residual)
+    }))
+    const positionsChanged = !samePositions(lastRenderedPositionsRef.current, positioned)
+    lastRenderedPositionsRef.current = new Map(positioned.map(d => [d.caseID, d]))
+    const selection = select(g).selectAll<SVGCircleElement, IPositionedResidualPoint>("circle")
+      .data(positioned, d => d.caseID)
     selection.exit().remove()
     // Enter: new circles at their final cx/cy with r=0. applyResidualStyles below transitions r up
     // to the assigned radius (see currentR===0 branch there), so newly-appeared residual points
     // fade in from a dot the way newly-appeared main-plot points do.
-    selection.enter().append("circle")
+    const enterSelection = selection.enter().append("circle")
       .attr("data-testid", d => `residual-point-${d.caseID}`)
-      .attr("cx", d => getXCoord(d.caseID))
-      .attr("cy", d => plotHeight + lowerScale(d.residual))
+      .attr("cx", d => d.cx)
+      .attr("cy", d => d.cy)
       .attr("r", 0)
+    // Cursor and handlers are bound on enter+update every paint. tipTextFor closes over the x
+    // attribute's ID and name as of this paint, and the join is keyed by case ID, so circles survive
+    // an attribute change — handlers left in place from an earlier paint would report the previous x
+    // attribute's name and value.
+    enterSelection.merge(selection)
       .style("cursor", "pointer")
       .on("mouseover", function(event, d) { residualTip.show(tipTextFor(d), this) })
       .on("mouseout", () => residualTip.hide())
@@ -175,17 +214,21 @@ export function useResidualPlot(props: IUseResidualPlot) {
         event.stopPropagation()
         if (dataset) handleClickOnCase(event, d.caseID, dataset)
       })
-    // Update-only cx/cy: animate when the caller asks for it; snap otherwise. New circles already
-    // have their final positions from the enter block, so excluding them here avoids a spurious
+    // Update-only cx/cy: animate when the caller asks for it, snap otherwise — and do neither when
+    // every point is already headed where it belongs, so a repaint that moves nothing leaves an
+    // in-flight slide running instead of interrupting or restarting it. New circles already have
+    // their final positions from the enter block, so excluding them here avoids a spurious
     // transition-from-undefined.
-    if (animateCxCy) {
-      selection.transition("cxcy").duration(transitionDuration)
-        .attr("cx", d => getXCoord(d.caseID))
-        .attr("cy", d => plotHeight + lowerScale(d.residual))
-    } else {
-      selection.interrupt("cxcy")
-        .attr("cx", d => getXCoord(d.caseID))
-        .attr("cy", d => plotHeight + lowerScale(d.residual))
+    if (positionsChanged) {
+      if (animateCxCy) {
+        selection.transition("cxcy").duration(transitionDuration)
+          .attr("cx", d => d.cx)
+          .attr("cy", d => d.cy)
+      } else {
+        selection.interrupt("cxcy")
+          .attr("cx", d => d.cx)
+          .attr("cy", d => d.cy)
+      }
     }
     // Apply current selection styling to enter+update circles without subscribing to selection.
     // Enter circles (r=0) get their r transitioned up here.
@@ -225,9 +268,9 @@ export function useResidualPlot(props: IUseResidualPlot) {
         if (layout.showLowerPlot) layout.setShowLowerPlot(false)
         if (graphModel.getAxis("leftLower")) graphModel.removeAxis("leftLower")
         if (residualPointsRef.current) select(residualPointsRef.current).selectAll("circle").remove()
-        // Forget the last-rendered attribute IDs so re-activation doesn't wrongly detect an
-        // attribute change and start an animation with no old points to animate from.
-        prevRenderedAttrIDsRef.current = null
+        // Forget the last-rendered positions so the first paint after re-activation isn't mistaken
+        // for a no-op and skipped.
+        lastRenderedPositionsRef.current = null
       }
       const isActive = adornmentsStore.showResidualPlot && residualPlotIsApplicable(adornmentsStore, dataConfiguration)
       if (!isActive) {
@@ -271,20 +314,13 @@ export function useResidualPlot(props: IUseResidualPlot) {
       if (curMin !== minY || curMax !== maxY) {
         multiScale.setNumericDomain([minY, maxY])
       }
-      // Compare x/y attribute IDs against the last fire; when they've changed, ask
-      // renderResidualPoints to transition cx/cy so the residual points slide to their new
-      // positions alongside the main plot's animation. Any other trigger for this autorun
-      // (movable-line drag, LSRL change, category-set change, etc.) leaves attrsChanged false,
-      // giving an immediate snap — critical so a movable-line drag started within the main plot's
-      // 2s animation window doesn't get its residuals lagging 1s behind the line.
-      const xAttrID = dataConfiguration.attributeID("x")
-      const yAttrID = dataConfiguration.attributeID("y")
-      const prevAttrIDs = prevRenderedAttrIDsRef.current
-      const attrsChanged = !!prevAttrIDs && (prevAttrIDs.x !== xAttrID || prevAttrIDs.y !== yAttrID)
-      prevRenderedAttrIDsRef.current = { x: xAttrID, y: yAttrID }
-      renderResidualPoints(residuals, attrsChanged)
+      // Animate whenever the main plot is animating, so the residual points ease alongside the
+      // points they mirror. renderResidualPoints ignores the request when nothing has moved, which
+      // is what keeps this fire and the two that follow it — the re-fire provoked by the domain
+      // writes above, and the one that follows the layout reflow — from restarting the same slide.
+      renderResidualPoints(residuals, isAnimating())
     }, { name: "ScatterPlot.syncResidualPlot" }, graphModel)
-  }, [adornmentsStore, dataConfiguration, graphModel, layout, renderResidualPoints])
+  }, [adornmentsStore, dataConfiguration, graphModel, isAnimating, layout, renderResidualPoints])
 
   // Post-mount effect: the residual points <g> is conditionally mounted on layout.showLowerPlot,
   // so its ref is null the first time the autorun runs (state flips and JSX re-renders in the same

--- a/v3/src/components/graph/plots/scatter-plot/use-residual-plot.ts
+++ b/v3/src/components/graph/plots/scatter-plot/use-residual-plot.ts
@@ -1,10 +1,11 @@
-import { format, ScaleLinear, select } from "d3"
+import { active, format, ScaleLinear, select } from "d3"
 import { tip as d3tip } from "d3-v6-tip"
 import { untracked } from "mobx"
 import { useCallback, useEffect, useRef } from "react"
 import { IDataSet } from "../../../../models/data/data-set"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
 import { t } from "../../../../utilities/translation/translate"
+import { transitionDuration } from "../../../data-display/data-display-types"
 import { handleClickOnCase } from "../../../data-display/data-display-utils"
 import { isNumericAxisModel, NumericAxisModel } from "../../../axis/models/numeric-axis-models"
 import { IGraphContentModel } from "../../models/graph-content-model"
@@ -30,6 +31,10 @@ export function useResidualPlot(props: IUseResidualPlot) {
   const { graphModel, dataConfiguration, dataset, layout, legendAttrID } = props
   const adornmentsStore = graphModel.adornmentsStore
   const residualPointsRef = useRef<SVGGElement>(null)
+  // Attribute IDs at the last active render. Used by the syncResidualPlot autorun to detect an x/y
+  // attribute change since its previous fire so renderResidualPoints can transition cx/cy instead
+  // of snapping. Reset to null on teardown so re-activation doesn't trigger a spurious animation.
+  const prevRenderedAttrIDsRef = useRef<{ x?: string, y?: string } | null>(null)
 
   // Hover tooltip for residual points. Matches the "graph-d3-tip" styling used by other adornment
   // hovers so the tip visually reads like the main plot's data tips. The `no-svg-export` class
@@ -69,12 +74,32 @@ export function useResidualPlot(props: IUseResidualPlot) {
   // join, no residual/predictor recompute — a selection change (via refreshPointSelection) updates
   // styling without re-running the residual pipeline.
   // Compute the style once per circle (styleFor does selection/legend lookups) rather than per attr.
+  //
+  // Radius handling: circles that come in at r=0 (enter selection in renderResidualPoints, marking
+  // "newly-appeared point") animate up to their assigned radius via a named "radius" transition
+  // that survives the "cxcy" interrupt in the snap path of renderResidualPoints. Existing circles
+  // snap. If a "radius" transition is in flight (typical when a debounced piggyback re-runs
+  // applyResidualStyles right after the enter, or when the user drags a point within ~1s of
+  // showing the residual plot), leave r alone — snapping via .attr would flash the point at its
+  // full radius before the fade-in resumes. We can't redirect the transition target either;
+  // once the transition is past its "starting" phase, .attr on it throws "too late; already
+  // running", and the point-radius-changed-mid-fade case (which the redirect would handle) is
+  // rare enough that finishing at the old target is acceptable — the next applyResidualStyles
+  // after the fade-in completes will snap to the current radius.
   const applyResidualStyles = useCallback((g: SVGGElement) => {
     select(g).selectAll<SVGCircleElement, IResidualPoint>("circle")
       .each(function (d) {
         const style = styleFor(d.caseID)
-        select(this)
-          .attr("r", style.radius)
+        const sel = select(this)
+        if (!active(this, "radius")) {
+          const currentR = +sel.attr("r")
+          if (currentR === 0 && style.radius > 0) {
+            sel.transition("radius").duration(transitionDuration).attr("r", style.radius)
+          } else {
+            sel.attr("r", style.radius)
+          }
+        }
+        sel
           .attr("fill", style.fill)
           .attr("stroke", style.stroke)
           .attr("stroke-width", style.strokeWidth)
@@ -93,7 +118,17 @@ export function useResidualPlot(props: IUseResidualPlot) {
   // styling is applied at the end under untracked so that the syncResidualPlot autorun (which calls
   // this) does not subscribe to the selection set — otherwise every selection change would re-fire
   // the autorun and recompute the predictor/residuals purely to update halos.
-  const renderResidualPoints = useCallback((residuals: IResidualPoint[]) => {
+  //
+  // animateCxCy is set by callers who know the context. The autorun sets it iff an x/y attribute
+  // just changed; the piggyback from scatter-plot passes isAnimating() so refreshes during the
+  // main plot's animation window animate along. All other paths (drag, movable-line drag,
+  // mount-after-commit, etc.) leave it false and get an immediate snap. Snap uses
+  // .interrupt("cxcy") so a previous cx/cy transition (e.g., an attribute change still in flight
+  // when the user starts dragging a line) is killed rather than continuing to fight the snap on
+  // every tick. The name is scoped so the enter-circle "radius" fade-in survives — otherwise the
+  // debounced piggyback that follows a case-add would cancel the r=0→full transition and cause a
+  // visible flash of the new point at full radius.
+  const renderResidualPoints = useCallback((residuals: IResidualPoint[], animateCxCy = false) => {
     const g = residualPointsRef.current
     if (!g) return
     const { getXCoord } = scatterPlotFuncs(layout, dataConfiguration)
@@ -119,12 +154,17 @@ export function useResidualPlot(props: IUseResidualPlot) {
     const residualTip = residualDataTipRef.current
     // Install the tip on the parent SVG so absolute positioning works.
     select(g).call(residualTip)
-    select(g).selectAll<SVGCircleElement, IResidualPoint>("circle")
+    const selection = select(g).selectAll<SVGCircleElement, IResidualPoint>("circle")
       .data(residuals, d => d.caseID)
-      .join("circle")
+    selection.exit().remove()
+    // Enter: new circles at their final cx/cy with r=0. applyResidualStyles below transitions r up
+    // to the assigned radius (see currentR===0 branch there), so newly-appeared residual points
+    // fade in from a dot the way newly-appeared main-plot points do.
+    selection.enter().append("circle")
       .attr("data-testid", d => `residual-point-${d.caseID}`)
       .attr("cx", d => getXCoord(d.caseID))
       .attr("cy", d => plotHeight + lowerScale(d.residual))
+      .attr("r", 0)
       .style("cursor", "pointer")
       .on("mouseover", function(event, d) { residualTip.show(tipTextFor(d), this) })
       .on("mouseout", () => residualTip.hide())
@@ -135,21 +175,34 @@ export function useResidualPlot(props: IUseResidualPlot) {
         event.stopPropagation()
         if (dataset) handleClickOnCase(event, d.caseID, dataset)
       })
-    // Apply current selection styling to the (possibly new) circles without subscribing to selection.
+    // Update-only cx/cy: animate when the caller asks for it; snap otherwise. New circles already
+    // have their final positions from the enter block, so excluding them here avoids a spurious
+    // transition-from-undefined.
+    if (animateCxCy) {
+      selection.transition("cxcy").duration(transitionDuration)
+        .attr("cx", d => getXCoord(d.caseID))
+        .attr("cy", d => plotHeight + lowerScale(d.residual))
+    } else {
+      selection.interrupt("cxcy")
+        .attr("cx", d => getXCoord(d.caseID))
+        .attr("cy", d => plotHeight + lowerScale(d.residual))
+    }
+    // Apply current selection styling to enter+update circles without subscribing to selection.
+    // Enter circles (r=0) get their r transitioned up here.
     untracked(() => applyResidualStyles(g))
   }, [layout, dataConfiguration, dataset, applyResidualStyles])
 
   // Recompute and repaint the residual points if the Residual Plot is active and all applicability
-  // constraints hold. Single entry-point used by every code path that needs to refresh the residual
-  // rendering — the sync autorun, the post-mount effect, the upper-plot's refreshPointPositions
-  // (drag caching), and refreshPointSelection (selection halo sync). No-op when inactive.
-  const renderResidualsIfActive = useCallback(() => {
+  // constraints hold. Used by the post-mount effect and by scatter-plot's refreshPointPositions
+  // piggyback (drag frames + attribute-change refreshes). Callers pass animateCxCy=true to have
+  // cx/cy transition; the default snaps. No-op when inactive.
+  const renderResidualsIfActive = useCallback((animateCxCy = false) => {
     if (!adornmentsStore.showResidualPlot) return
     if (!residualPlotIsApplicable(adornmentsStore, dataConfiguration)) return
     if (!dataConfiguration) return
     const predictor = getPredictor(adornmentsStore, dataConfiguration)
     if (!predictor) return
-    renderResidualPoints(computeResiduals(dataConfiguration, predictor))
+    renderResidualPoints(computeResiduals(dataConfiguration, predictor), animateCxCy)
   }, [adornmentsStore, dataConfiguration, renderResidualPoints])
 
   // Sync the split-plot layout, lower y-axis registration, and residual point rendering with the
@@ -172,6 +225,9 @@ export function useResidualPlot(props: IUseResidualPlot) {
         if (layout.showLowerPlot) layout.setShowLowerPlot(false)
         if (graphModel.getAxis("leftLower")) graphModel.removeAxis("leftLower")
         if (residualPointsRef.current) select(residualPointsRef.current).selectAll("circle").remove()
+        // Forget the last-rendered attribute IDs so re-activation doesn't wrongly detect an
+        // attribute change and start an animation with no old points to animate from.
+        prevRenderedAttrIDsRef.current = null
       }
       const isActive = adornmentsStore.showResidualPlot && residualPlotIsApplicable(adornmentsStore, dataConfiguration)
       if (!isActive) {
@@ -215,7 +271,18 @@ export function useResidualPlot(props: IUseResidualPlot) {
       if (curMin !== minY || curMax !== maxY) {
         multiScale.setNumericDomain([minY, maxY])
       }
-      renderResidualPoints(residuals)
+      // Compare x/y attribute IDs against the last fire; when they've changed, ask
+      // renderResidualPoints to transition cx/cy so the residual points slide to their new
+      // positions alongside the main plot's animation. Any other trigger for this autorun
+      // (movable-line drag, LSRL change, category-set change, etc.) leaves attrsChanged false,
+      // giving an immediate snap — critical so a movable-line drag started within the main plot's
+      // 2s animation window doesn't get its residuals lagging 1s behind the line.
+      const xAttrID = dataConfiguration.attributeID("x")
+      const yAttrID = dataConfiguration.attributeID("y")
+      const prevAttrIDs = prevRenderedAttrIDsRef.current
+      const attrsChanged = !!prevAttrIDs && (prevAttrIDs.x !== xAttrID || prevAttrIDs.y !== yAttrID)
+      prevRenderedAttrIDsRef.current = { x: xAttrID, y: yAttrID }
+      renderResidualPoints(residuals, attrsChanged)
     }, { name: "ScatterPlot.syncResidualPlot" }, graphModel)
   }, [adornmentsStore, dataConfiguration, graphModel, layout, renderResidualPoints])
 


### PR DESCRIPTION
## Summary
- Residual-plot points now transition smoothly to their new positions when the x or y attribute changes, matching the main plot's animation.
- Newly-appearing residual points (residual plot toggle-on, case add) fade in from radius 0.
- Fixes a misleading "defunct axis model" warning that `useSubAxis.renderSubAxis` printed when no axis was registered at the given place; it now silent-skips (as `installDomainSync` already does) and only warns for truly defunct axis references.

## Test plan
- [ ] Scatterplot with movable line / LSRL / plotted function + residual plot: change the X attribute → residual points slide smoothly
- [ ] Same but change the Y attribute → residual points slide smoothly
- [ ] Toggle residual plot on → points fade in from radius 0
- [ ] Add a new case → residual point fades in from radius 0 (no full-radius flash)
- [ ] Change attribute, then within 2s drag the movable line → residuals snap to follow the line in real time
- [ ] Drag a data point → residuals update in real time (no lag)
- [ ] Toggle residual plot off, then undo the toggle → no console warnings

Fixes CODAP-1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
