### PR TITLE
V2 build guidance for the extracted eepsmedia plugins (CODAP-1423)

### DIFF
--- a/.claude/skills/codap-v2-build/SKILL.md
+++ b/.claude/skills/codap-v2-build/SKILL.md
@@ -542,7 +542,7 @@ Explain to the user:
 
    Copy the whole `eepsmedia` tree from the previous release:
    ```bash
-   ssh codap-server.concord.org "sudo cp -r /var/www/html/releases/build_PPPP/extn/plugins/eepsmedia /var/www/html/releases/build_XXXX/extn/plugins/eepsmedia"
+   ssh codap-server.concord.org "sudo rsync -a --delete /var/www/html/releases/build_PPPP/extn/plugins/eepsmedia/ /var/www/html/releases/build_XXXX/extn/plugins/eepsmedia/"
    ```
 
    If no previous release has it (first build after the extraction), pull from S3 instead — the
@@ -550,8 +550,14 @@ Explain to the user:
    ```bash
    aws s3 sync s3://codap-resources/plugins/eepsmedia/ ./eepsmedia/
    scp -r ./eepsmedia codap-server.concord.org:
-   ssh codap-server.concord.org "sudo mv ~/eepsmedia /var/www/html/releases/build_XXXX/extn/plugins/eepsmedia"
+   ssh codap-server.concord.org "sudo rsync -a --delete ~/eepsmedia/ /var/www/html/releases/build_XXXX/extn/plugins/eepsmedia/ && rm -rf ~/eepsmedia"
    ```
+
+   **Mind the trailing slashes** — they make `rsync` copy the *contents* of the source into the
+   destination. `rsync` is used here rather than `cp -r` or `mv` because those nest the source
+   inside the destination when it already exists, producing
+   `extn/plugins/eepsmedia/eepsmedia/...` if this step is re-run after a partial copy. With the
+   trailing slashes and `--delete`, the step is idempotent and safe to run as many times as needed.
 
    Verify the result — note the capital C in `Choosy`, which is case-sensitive on Linux:
    ```bash

--- a/.claude/skills/codap-v2-build/SKILL.md
+++ b/.claude/skills/codap-v2-build/SKILL.md
@@ -152,7 +152,7 @@ Wait for user confirmation before starting Phase 1.
    Check that `node_modules` exists in repositories that need it:
    - `codap`
    - `cloud-file-manager`
-   - `codap-data-interactives` (and subdirectories: `DrawTool`, `eepsmedia/plugins/scrambler`, `Importer`, `Sonify`, `TP-Sampler`)
+   - `codap-data-interactives` (and subdirectories: `DrawTool`, `Importer`, `Sonify`, `TP-Sampler`)
    - `codap-transformers`
    - `noaa-codap-plugin`
    - `story-builder`
@@ -299,9 +299,12 @@ Wait for user confirmation before starting Phase 1.
    **4b. Propagate to plugins:**
 
    Explain to the user:
-   > Some CODAP plugins (Importer, TP-Sampler, Scrambler, Story Builder) also have
+   > Some CODAP plugins (Importer, TP-Sampler, Story Builder) also have
    > translatable strings in the same POEditor project. We pull the plugin-specific
    > strings to their respective repositories.
+   >
+   > Scrambler and Testimate used to be pulled here too. They moved to the
+   > eepsmedia repo (CODAP-1423) and are now translated from there.
 
    Read the API token from `~/.porc` and pass to the script:
    ```bash
@@ -470,6 +473,10 @@ Explain to the user:
 
    Monitor output for errors. In particular, check for plugin build failures — the `bin/build` script in `codap-data-interactives` reports failed plugins to stderr (e.g., `ERROR - Failed to build ../noaa-codap-plugin`) but continues building the remaining plugins. If any plugin builds failed, stop and investigate before proceeding.
 
+   `bin/build` also ends with a large `WARNING: THE eepsmedia PLUGINS WERE NOT BUILT` banner on
+   stderr. **This is not a build failure** and does not need investigating — it is an expected
+   reminder that those four plugins must be copied in by hand at Step 9.
+
    After completion, verify the zip file exists:
    ```bash
    ls -lh codap_build_XXXX.zip
@@ -502,13 +509,15 @@ Explain to the user:
 
    Explain to the user:
    > The `makeExtn` step builds four plugins from sibling repositories (`onboarding`, `codap-transformers`, `story-builder`, `noaa-codap-plugin`). These builds can fail silently because the build script does not use `set -e`. We verify that all expected plugin folders exist in the deployed build.
+   >
+   > We also check `eepsmedia`, which is a different case: it is not built at all any more (see the next step), so it is *expected* to be missing until we copy it in.
 
    Check that all expected plugin folders are present:
    ```bash
-   ssh codap-server.concord.org "for d in onboarding codap-transformers story-builder noaa-codap-plugin; do [ -d /var/www/html/releases/build_XXXX/extn/plugins/\$d ] && echo \"\$d: OK\" || echo \"\$d: MISSING\"; done"
+   ssh codap-server.concord.org "for d in onboarding codap-transformers story-builder noaa-codap-plugin eepsmedia; do [ -d /var/www/html/releases/build_XXXX/extn/plugins/\$d ] && echo \"\$d: OK\" || echo \"\$d: MISSING\"; done"
    ```
 
-   If any are missing, the plugin build failed silently during `makeExtn`. Investigate by checking the build output for errors. Common causes:
+   `eepsmedia: MISSING` is expected on a fresh build — handle it in Step 9. For the other four, missing means the plugin build failed silently during `makeExtn`. Investigate by checking the build output for errors. Common causes:
    - **noaa-codap-plugin:** Missing peer dependencies (`@emotion/react`, `@emotion/styled`). Fix: use `npm ci` instead of `npm install` in `codap-data-interactives/bin/build` (already fixed as of 2026-02-13).
    - **General:** Stale `node_modules` in a sibling repo. Fix: `rm -rf node_modules && npm ci` in the affected repo, then rebuild.
 
@@ -517,7 +526,50 @@ Explain to the user:
    ssh codap-server.concord.org "sudo cp -r /var/www/html/releases/build_PPPP/extn/plugins/<plugin-name> /var/www/html/releases/build_XXXX/extn/plugins/<plugin-name>"
    ```
 
-9. **Verify deployment:**
+9. **Copy in the eepsmedia plugins (REQUIRED — they are not built):**
+
+   Explain to the user:
+   > Choosy, Scrambler, Simmer and Testimate moved to the
+   > [eepsmedia repo](https://github.com/concord-consortium/eepsmedia) on 2026-07-31 (CODAP-1423)
+   > and deploy themselves to S3 for CODAP V3. The V2 build no longer produces them, but they are
+   > still listed in `published-plugins.json` — deliberately, because that file describes what a V2
+   > build *should* contain, and delisting them would silently drop them from the plugin menu.
+   >
+   > The consequence is that every V2 build needs these four folders copied in by hand. Nothing
+   > fails loudly if this is skipped: the build works, but those four plugins 404 from CODAP's
+   > plugin menu. `codap-data-interactives/bin/build` prints a warning banner at the end of its run
+   > as a reminder.
+
+   Copy the whole `eepsmedia` tree from the previous release:
+   ```bash
+   ssh codap-server.concord.org "sudo cp -r /var/www/html/releases/build_PPPP/extn/plugins/eepsmedia /var/www/html/releases/build_XXXX/extn/plugins/eepsmedia"
+   ```
+
+   If no previous release has it (first build after the extraction), pull from S3 instead — the
+   bucket layout mirrors the eepsmedia repo root:
+   ```bash
+   aws s3 sync s3://codap-resources/plugins/eepsmedia/ ./eepsmedia/
+   scp -r ./eepsmedia codap-server.concord.org:
+   ssh codap-server.concord.org "sudo mv ~/eepsmedia /var/www/html/releases/build_XXXX/extn/plugins/eepsmedia"
+   ```
+
+   Verify the result — note the capital C in `Choosy`, which is case-sensitive on Linux:
+   ```bash
+   ssh codap-server.concord.org "ls /var/www/html/releases/build_XXXX/extn/plugins/eepsmedia/ && for d in Choosy scrambler simmer testimate; do [ -d /var/www/html/releases/build_XXXX/extn/plugins/eepsmedia/plugins/\$d ] && echo \"\$d: OK\" || echo \"\$d: MISSING\"; done"
+   ```
+
+   Expected layout:
+   ```
+   extn/plugins/eepsmedia/common/
+   extn/plugins/eepsmedia/plugins/{Choosy,scrambler,simmer,testimate}/
+   ```
+
+   **Do not fix this by editing `published-plugins.json` or `data_interactive_map.json`** in
+   `codap-data-interactives`. Removing the entries makes the warning go away but silently drops the
+   plugins from the V2 plugin menu, which is the failure this step exists to prevent. See
+   `eepsmedia/README.md` in that repo.
+
+10. **Verify deployment:**
 
    Ask the user to open the build and verify that it looks correct:
    > The build is now live at `https://codap.concord.org/releases/build_XXXX/`
@@ -526,13 +578,17 @@ Explain to the user:
 
    **Wait for the user to confirm the build looks good before proceeding.** Do not move on to the summary or Phase 4 until the user has acknowledged that the build works.
 
-10. **Summary:**
+   Include the eepsmedia plugins in the spot check — Choosy is `"visible": "false"` so it will not
+   appear in the plugin menu, but Scrambler, Simmer and Testimate should all open.
+
+11. **Summary:**
 
    > **Build and deployment complete.**
    >
    > - Build number: XXXX
    > - Zip file: codap_build_XXXX.zip
    > - Deployed to: codap-server.concord.org
+   > - eepsmedia plugins: copied in [from build_PPPP / from S3]
    > - URL: https://codap.concord.org/releases/build_XXXX/
    >
    > Ready for Phase 4: Post-Build. Run `/codap-v2-build post` or say "continue" to proceed.
@@ -585,7 +641,7 @@ Explain to the user:
 | `codap` | `master` | Main CODAP v2 application |
 | `cloud-file-manager` | `v1.9.x` | File storage integration (CFM) |
 | `codap-data` | `master` | Example documents and boundary files |
-| `codap-data-interactives` | `master` | Standard plugins |
+| `codap-data-interactives` | `master` | Standard plugins (no longer includes the eepsmedia plugins — see Phase 3, Step 9) |
 | `codap-transformers` | `main` | Transformer plugin |
 | `noaa-codap-plugin` | `main` | NOAA weather plugin |
 | `story-builder` | `master` | Story Builder plugin |

--- a/bin/strings-pull-plugins
+++ b/bin/strings-pull-plugins
@@ -4,11 +4,14 @@
 #
 # This invokes each plugin repo's own strings:pull script, which downloads
 # translations from POEditor project #125447 and filters for the plugin's
-# string prefix (e.g. DG.plugin.Scrambler, DG.plugin.StoryBuilder).
+# string prefix (e.g. DG.plugin.Importer, DG.plugin.StoryBuilder).
 #
 # Affected repos:
-#   codap-data-interactives — Importer, TP-Sampler, Scrambler
+#   codap-data-interactives — Importer, TP-Sampler
 #   story-builder           — Story Builder
+#
+# Scrambler and Testimate moved to the eepsmedia repo (CODAP-1423) and are no
+# longer covered here; they are translated from that repo.
 #
 # Usage: ./bin/strings-pull-plugins --APIToken=XXXX
 #   (all arguments are passed through to each repo's strings:pull script)


### PR DESCRIPTION
Companion to [codap-data-interactives#162](https://github.com/concord-consortium/codap-data-interactives/pull/162), which deletes the eepsmedia plugin code now that it lives in [concord-consortium/eepsmedia](https://github.com/concord-consortium/eepsmedia). Part of CODAP-1423.

Docs and skill content only — no application code changes.

## The problem this addresses

Choosy, Scrambler, Simmer and Testimate are no longer produced by `codap-data-interactives/bin/build`. They remain listed in `published-plugins.json` on purpose: that file describes what a V2 build *should* contain, and delisting them would silently drop them from CODAP's plugin menu.

So a V2 build now needs those four folders copied in by hand — and **nothing fails loudly if that is skipped.** The build succeeds, the zip is produced, the deploy works, and the four plugins simply 404 from the plugin menu. That is exactly the kind of thing that gets rediscovered painfully a year from now, so it gets an explicit step.

## Changes to the `codap-v2-build` skill

**New — Phase 3, Step 9: copy in the eepsmedia plugins.** Copies the tree from the previous release on the server, with an S3 fallback for the first build after the extraction, then verifies the layout. Notes that `Choosy` has a capital C and is case-sensitive on Linux.

The copy is done **server-side after deploy**, reusing the same fallback the skill already applies at Step 8 to any plugin that fails to build. The alternative — copying locally — has to land between `makeExtn` finishing and the zip being sealed, because `makeExtn` rsyncs into `extn/plugins` with `--delete` and `bin/build` does `rm -rf` on its own working directory, so neither earlier destination survives. The server-side copy has no such hazard.

The step also says explicitly **not** to silence the warning by editing `published-plugins.json` or `data_interactive_map.json`. That is the one "fix" that makes the symptom disappear while causing the exact failure the step exists to prevent — and it is what the CODAP-1423 ticket description tells you to do.

**Supporting changes:**

- **Phase 3, Step 8** — `eepsmedia` added to the deployed-folder check, flagged as expected-missing, so a skipped copy fails loudly rather than silently.
- **Phase 3, Step 5** — notes the new `WARNING: THE eepsmedia PLUGINS WERE NOT BUILT` banner from `bin/build` is *not* a build failure, so it is not mistaken for one alongside the real plugin-build errors this step already watches for.
- **Phase 3, Steps 10/11** — renumbered; spot-check the plugins during verification; report the copy in the summary.

**Stale references corrected:**

- **Phase 1, Step 6** — dropped `eepsmedia/plugins/scrambler` from the `node_modules` checks. That path no longer exists, so the step would report MISSING and offer a pointless `npm ci`.
- **Phase 2, Step 4b** — Scrambler and Testimate are no longer translated from `codap-data-interactives`.
- **Repository Map** — notes `codap-data-interactives` no longer includes the eepsmedia plugins.

## `bin/strings-pull-plugins`

Comment-only fix to the affected-repos list for the same reason. No behavior change — the script iterates `PLUGIN_PATHS`, which is unaffected.

## Verification

- `sh -n bin/strings-pull-plugins` passes
- Phase 3 step numbering is contiguous 1–11 after the insertion
- all three `Step 9` cross-references resolve to the new step

Two caveats, since neither is empirically tested: the S3 fallback assumes `aws s3 sync` credentials are available to whoever runs the build, and the timing rule was derived from reading `makeExtn`/`makeCodapZip` rather than from running a V2 build. Worth confirming on the next real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
