### PR TITLE
CODAP-1482: enable the residual plot by removing its feature gate

### DIFF
--- a/v3/cypress/e2e/bivariate-adornments.spec.ts
+++ b/v3/cypress/e2e/bivariate-adornments.spec.ts
@@ -4,9 +4,7 @@ import { ToolbarElements as toolbar } from "../support/elements/toolbar-elements
 
 context("Graph adornments", () => {
   beforeEach(function () {
-    // The Residual Plot menu item is gated behind the residualPlot feature flag; enable it via the
-    // URL pilot channel so the residual-plot tests below can reach the affordance.
-    const queryParams = "?sample=mammals&dashboard&mouseSensor&suppressUnsavedWarning&features=residualPlot"
+    const queryParams = "?sample=mammals&dashboard&mouseSensor&suppressUnsavedWarning"
     const url = `${Cypress.config("index")}${queryParams}`
     cy.visit(url)
     cy.wait(2500)

--- a/v3/src/components/graph/adornments/store/adornments-store-utils.test.ts
+++ b/v3/src/components/graph/adornments/store/adornments-store-utils.test.ts
@@ -1,5 +1,4 @@
 import { getAdornmentsMenuItemsFromTheStore, IMeasureMenuItem } from "./adornments-store-utils"
-import { featureFlagManager } from "../../../../models/feature-flags/feature-flag-manager"
 import { updateTileNotification } from "../../../../models/tiles/tile-notifications"
 
 jest.mock("../../../../models/tiles/tile-notifications", () => ({
@@ -62,7 +61,7 @@ describe("adornment notification operation names match V2", () => {
   })
 })
 
-describe("residual plot menu item is gated behind the residualPlot feature flag", () => {
+describe("residual plot menu item", () => {
   const tile = { id: "TILE1", content: { type: "Graph" } } as any
 
   function buildStore() {
@@ -78,16 +77,8 @@ describe("residual plot menu item is gated behind the residualPlot feature flag"
     } as any
   }
 
-  afterEach(() => featureFlagManager.setServerConfig({}))
-
-  it("omits the Residual Plot item when the flag is disabled", () => {
-    featureFlagManager.setServerConfig({})
-    const items = getAdornmentsMenuItemsFromTheStore(buildStore(), tile, "scatterPlot", false)
-    expect(findItem(items, "V3.Inspector.graphResidualPlot")).toBeUndefined()
-  })
-
-  it("includes the Residual Plot item when the flag is enabled", () => {
-    featureFlagManager.setServerConfig({ residualPlot: "on" })
+  // The item is always present; applicability is reflected by `disabled`, not by omission.
+  it("is included with no feature flag enabled", () => {
     const items = getAdornmentsMenuItemsFromTheStore(buildStore(), tile, "scatterPlot", false)
     expect(findItem(items, "V3.Inspector.graphResidualPlot")).toBeDefined()
   })

--- a/v3/src/components/graph/adornments/store/adornments-store-utils.ts
+++ b/v3/src/components/graph/adornments/store/adornments-store-utils.ts
@@ -1,5 +1,4 @@
 import { logMessageWithReplacement } from "../../../../lib/log-message"
-import { isFeatureEnabled } from "../../../../models/feature-flags/feature-flag-manager"
 import { ITileModel } from "../../../../models/tiles/tile-model"
 import { updateTileNotification } from "../../../../models/tiles/tile-notifications"
 import { PlotType } from "../../graphing-types"
@@ -205,20 +204,18 @@ export function getAdornmentsMenuItemsFromTheStore(theStore: IAdornmentsBaseStor
         })
       }
     })
-    // Residual Plot follows the Squares of Residuals pattern. The menu item appears only when the
-    // residualPlot feature flag is enabled; the render path in ScatterPlot keys off the persisted
-    // showResidualPlot state rather than the flag, so a document that already has the residual plot
-    // on still opens and renders when the flag is off. Enabled only when the full applicability
-    // check passes: numeric x/y axes, exactly one y attribute, no right numeric / top-split /
-    // right-split / legend attributes, and exactly one of movable line, LSRL, or plotted function
-    // is visible. Delegates to residualPlotIsApplicable so the menu-item gating and the render-path
-    // gating (in ScatterPlot) share one predicate.
+    // Residual Plot follows the Squares of Residuals pattern. The menu item is always present, and
+    // is enabled only when the full applicability check passes: numeric x/y axes, exactly one y
+    // attribute, no right numeric / top-split / right-split attributes, exactly one of movable line,
+    // LSRL, or plotted function visible, and — for an LSRL — no categorical legend, which would fit
+    // a separate line per category. Delegates to residualPlotIsApplicable so the menu-item gating
+    // and the render-path gating (in ScatterPlot) share one predicate.
     const tileContent = tile?.content
     const dataConfig = tileContent && "dataConfiguration" in tileContent
       ? (tileContent as { dataConfiguration?: IGraphDataConfigurationModel }).dataConfiguration
       : undefined
     const residualPlotApplicable = residualPlotIsApplicable(theStore, dataConfig)
-    addItemIfCondition(isFeatureEnabled("residualPlot"), {
+    addItemIfCondition(true, {
       checked: theStore.showResidualPlot,
       disabled: !residualPlotApplicable,
       title: "V3.Inspector.graphResidualPlot",

--- a/v3/src/models/feature-flags/feature-flag-registry.ts
+++ b/v3/src/models/feature-flags/feature-flag-registry.ts
@@ -44,8 +44,14 @@ export const kFeatureFlags = {
     added: "2026-07-24",
     expires: "2027-07-31"
   },
+  /*
+   * DEPRECATED — gates nothing. The residual plot shipped enabled, and its gate was removed
+   * rather than switched on by server config, so that the feature cannot silently fail off
+   * when the config fetch fails. The entry is retained only because the feature-flag tests
+   * use this name as their sample flag; delete it once they are repointed at a live flag.
+   */
   residualPlot: {
-    description: "Residual plots on the graph",
+    description: "Residual plots on the graph (deprecated — no longer gates anything)",
     owner: "ESTEEM",
     added: "2026-07-22",
     expires: "2027-07-31"


### PR DESCRIPTION
Enables the residual plot for all users by removing its feature gate.

## Why code removal rather than server config

`fetchFeatureFlagConfig` fails open to an empty config, so a flag that is "on"
only by server directive resolves to off whenever the fetch fails — offline, an
S3 hiccup, a restrictive embedding context, or simply slower than the 5s
timeout. That bias is right for a pilot but wrong for a feature named in release
notes, where the failure is silent and the user has no way to diagnose it.

Trade-off: this gives up the ability to disable the residual plot via
`?features=-residualPlot` or a server kill switch. Reverting requires a release.

## Why the flag is deprecated rather than deleted

Deleting the registry entry would force churn through four feature-flag
infrastructure test files that use `residualPlot` as their sample flag name.
Keeping the entry, clearly marked, holds this change to the gate itself — a
smaller blast radius immediately before the 3.1.0 release. Deleting it, and
repointing those tests at a live flag, is left as follow-up.

## Also

The applicability comment still said legend attributes disqualify the residual
plot. CODAP-1479 narrowed that to categorical legends on an LSRL; corrected here
since it sits on the line being changed.

## Testing

- `npm run build:tsc` clean
- 58 suites / 304 tests pass across `graph/adornments` and `graph/plots/scatter-plot`
- eslint clean on all changed files
- The Cypress spec no longer needs `?features=residualPlot` to reach the affordance

Fixes CODAP-1482
