### PR TITLE
CODAP-1485: support incremental case append for hierarchical collections

### DIFF
--- a/v3/src/data-interactive/handlers/item-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-handler.test.ts
@@ -159,6 +159,22 @@ describe("createItemsInSegments", () => {
     expect(results[1].caseIDs?.length).toBe(1)
   })
 
+  it("reports the cases a re-sent item id creates when its grouping values are new", () => {
+    const { dataset } = setupTestDataset()
+    const existingItemId = dataset.items[0].__id__
+    const before = dataset.collections.map(collection => new Set(collection.caseIds))
+
+    // re-sending an id moves that item to a new group, forming cases that really are new
+    const results = createItemsInSegments(dataset, [[
+      { id: toV2Id(existingItemId), values: { a1: "brandNewA1", a2: "brandNewA2", a3: 42 } }
+    ]]) as DISuccessResult[]
+
+    const created = dataset.collections.flatMap((collection, index) =>
+      collection.caseIds.filter(caseId => !before[index].has(caseId)))
+    expect(created.length).toBeGreaterThan(0)
+    created.forEach(caseId => expect(results[0].caseIDs).toContain(toV2Id(caseId)))
+  })
+
   it("does not report pre-existing cases when an item id is re-sent", () => {
     const { dataset } = setupTestDataset()
     const existingItemId = dataset.items[0].__id__

--- a/v3/src/data-interactive/handlers/item-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-handler.test.ts
@@ -159,6 +159,45 @@ describe("createItemsInSegments", () => {
     expect(results[1].caseIDs?.length).toBe(1)
   })
 
+  it("does not report a new case that is hidden", () => {
+    const { dataset } = setupTestDataset()
+    const itemId = dataset.items[0].__id__
+
+    // Setting an item aside and then removing it leaves its id set aside, so an item
+    // re-created under that id is hidden as soon as its case is formed.
+    dataset.hideCasesOrItems([itemId])
+    dataset.validateCases()
+    dataset.removeCases([itemId])
+    dataset.validateCases()
+
+    const results = createItemsInSegments(dataset, [[
+      { __id__: itemId, a1: "hidden", a2: "hidden", a3: 99 }
+    ]]) as DISuccessResult[]
+
+    expect(dataset.isItemHidden(itemId)).toBe(true)
+    expect(results[0].caseIDs).toEqual([])
+  })
+
+  it("reports new case ids in collection order rather than the order the items arrived", () => {
+    const { dataset, c2 } = setupTestDataset()
+    const c2Before = new Set(c2.caseIds)
+
+    // The first item joins the later parent "b" and the second the earlier parent "a", so
+    // the case the second item forms precedes the case the first item forms.
+    const results = createItemsInSegments(dataset, [[
+      { a1: "b", a2: "later", a3: 7 },
+      { a1: "a", a2: "earlier", a3: 8 }
+    ]]) as DISuccessResult[]
+
+    const newC2CaseIds = c2.caseIds.filter(caseId => !c2Before.has(caseId))
+    expect(newC2CaseIds.length).toBe(2)
+
+    const reported = results[0].caseIDs ?? []
+    const positions = newC2CaseIds.map(caseId => reported.indexOf(toV2Id(caseId)))
+    expect(positions.every(position => position >= 0)).toBe(true)
+    expect(positions).toEqual([...positions].sort((a, b) => a - b))
+  })
+
   it("attributes a shared case to the earliest contributing segment when that is not segment 0", () => {
     const { dataset, c1 } = setupTestDataset()
     const c1Before = new Set(c1.caseIds)

--- a/v3/src/data-interactive/handlers/item-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-handler.test.ts
@@ -159,6 +159,44 @@ describe("createItemsInSegments", () => {
     expect(results[1].caseIDs?.length).toBe(1)
   })
 
+  it("does not report pre-existing cases when an item id is re-sent", () => {
+    const { dataset } = setupTestDataset()
+    const existingItemId = dataset.items[0].__id__
+
+    // The Collaborative plugin supplies its own ids; a replayed or duplicated sync message
+    // re-sends one CODAP already holds. No case is created, so none should be reported.
+    const results = createItemsInSegments(dataset, [[
+      { id: toV2Id(existingItemId), values: { a1: "a", a2: "x", a3: 42 } }
+    ]]) as DISuccessResult[]
+
+    expect(results[0].caseIDs).toEqual([])
+  })
+
+  it("reports each new case for its own collection when an item id repeats in one request", () => {
+    const { dataset } = setupTestDataset()
+    const c1Before = new Set(dataset.collections[0].caseIds)
+    const c2Before = new Set(dataset.collections[1].caseIds)
+    const c3Before = new Set(dataset.collections[2].caseIds)
+
+    const results = createItemsInSegments(dataset, [[
+      { __id__: "dup", a1: "new", a2: "n1", a3: 1 },
+      { __id__: "dup", a1: "new", a2: "n2", a3: 2 }
+    ]]) as DISuccessResult[]
+
+    const reported = new Set(results[0].caseIDs ?? [])
+    const newIn = (collection: { caseIds: string[] }, before: Set<string>) =>
+      collection.caseIds.filter(caseId => !before.has(caseId))
+
+    // every case this request created is reported, in whichever collection it belongs to
+    const created = [
+      ...newIn(dataset.collections[0], c1Before),
+      ...newIn(dataset.collections[1], c2Before),
+      ...newIn(dataset.collections[2], c3Before)
+    ]
+    expect(created.length).toBeGreaterThan(0)
+    created.forEach(caseId => expect(reported.has(toV2Id(caseId))).toBe(true))
+  })
+
   it("does not report a new case that is hidden", () => {
     const { dataset } = setupTestDataset()
     const itemId = dataset.items[0].__id__

--- a/v3/src/data-interactive/handlers/item-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-handler.test.ts
@@ -1,5 +1,6 @@
 import { isAddCasesAction } from "../../models/data/data-set-actions"
 import { IAddCasesOptions } from "../../models/data/data-set-types"
+import { IDataSet } from "../../models/data/data-set"
 import { setupTestDataset } from "../../test/dataset-test-utils"
 import { toV2Id } from "../../utilities/codap-utils"
 import { onAnyAction } from "../../utilities/mst-utils"
@@ -119,6 +120,82 @@ describe("DataInteractive ItemHandler", () => {
 })
 
 describe("createItemsInSegments", () => {
+  // Ground truth, independent of how the handler works it out: a case belongs to a request
+  // exactly when every item in it came from that request. Deriving the expectation from the
+  // dataset's own caseIds would share whatever staleness the implementation has.
+  function casesCreatedBy(dataset: IDataSet, itemIds: string[]) {
+    dataset.validateCases()
+    const added = new Set(itemIds)
+    const created: string[] = []
+    dataset.caseInfoMap.forEach((caseInfo, caseId) => {
+      const items = [...caseInfo.childItemIds, ...caseInfo.hiddenChildItemIds]
+      if (items.length === 0 || !items.every(itemId => added.has(itemId))) return
+      // a case with no visible items has no index and is deliberately not reported
+      if (caseInfo.childItemIds.length === 0) return
+      created.push(caseId)
+    })
+    return created
+  }
+
+  it("reports every case created after the group's items were deleted", () => {
+    const { dataset } = setupTestDataset()
+    // a plugin deletes a whole group, then re-creates it; deleting doesn't revalidate
+    dataset.items.filter((_, index) => index % 2 === 1)
+      .forEach(item => diItemHandler.delete?.({ dataContext: dataset, item }))
+    expect(dataset.isValidCases).toBe(false)   // the path under test
+
+    const results = createItemsInSegments(dataset, [[
+      { a1: "b", a2: "y", a3: 100 }
+    ]]) as DISuccessResult[]
+
+    const newItemId = dataset.items[dataset.items.length - 1].__id__
+    const created = casesCreatedBy(dataset, [newItemId])
+    expect(created.length).toBe(3)
+    expect(results[0].caseIDs).toHaveLength(created.length)
+    created.forEach(caseId => expect(results[0].caseIDs).toContain(toV2Id(caseId)))
+  })
+
+  it("doesn't report a surviving parent case when an append joins it", () => {
+    const { dataset } = setupTestDataset()
+    // delete one item of the a1="b" group, leaving that parent case alive, and don't
+    // revalidate -- so the append below runs the same newly-taken path as the tests around it
+    diItemHandler.delete?.({ dataContext: dataset, item: dataset.items[1] })
+    expect(dataset.isValidCases).toBe(false)
+
+    const results = createItemsInSegments(dataset, [[
+      { a1: "b", a2: "y", a3: 100 }
+    ]]) as DISuccessResult[]
+
+    const newItemId = dataset.items[dataset.items.length - 1].__id__
+    const created = casesCreatedBy(dataset, [newItemId])
+    // the a1="b" parent and the (b,y) middle case both survive, so only the leaf is new
+    expect(created.length).toBe(1)
+    expect(results[0].caseIDs).toHaveLength(1)
+    created.forEach(caseId => expect(results[0].caseIDs).toContain(toV2Id(caseId)))
+  })
+
+  it("reports only the new cases when a snapshot has just replaced the dataset", () => {
+    const { dataset, a1 } = setupTestDataset()
+    // prepareSnapshot first, as serializing a document does; without it afterApplySnapshot
+    // rebuilds the volatile values from an already-cleared frozen array and blanks them all,
+    // so the test would run against an empty dataset rather than a restored one
+    dataset.prepareSnapshot()
+    dataset.afterApplySnapshot()
+    dataset.completeSnapshot()
+    expect(a1.strValues).toEqual(["a", "b", "a", "b", "a", "b"])
+    expect(dataset.isValidCases).toBe(false)
+
+    const results = createItemsInSegments(dataset, [[
+      { a1: "zz", a2: "zz", a3: 200 }
+    ]]) as DISuccessResult[]
+
+    const newItemId = dataset.items[dataset.items.length - 1].__id__
+    const created = casesCreatedBy(dataset, [newItemId])
+    expect(created.length).toBe(3)
+    expect(results[0].caseIDs).toHaveLength(created.length)
+    created.forEach(caseId => expect(results[0].caseIDs).toContain(toV2Id(caseId)))
+  })
+
   it("slices itemIDs positionally per segment", () => {
     const { dataset } = setupTestDataset()
     const segments: DIItemValues[][] = [
@@ -159,6 +236,76 @@ describe("createItemsInSegments", () => {
     expect(results[1].caseIDs?.length).toBe(1)
   })
 
+  // The fast path can't always say what it created. When it can't, the answer has to be
+  // worked out rather than assumed to be "nothing" — the cases exist either way, and a
+  // plugin told otherwise silently diverges from CODAP.
+  it("reports created cases when the data context is invalid on arrival", () => {
+    const { dataset } = setupTestDataset()
+    // deleteItem/deleteCaseBy/itemSearch.delete all removeCases without revalidating, so a
+    // plugin that deletes and then creates arrives here with grouping invalid
+    dataset.removeCases([dataset.items[0].__id__])
+    const before = dataset.collections.map(collection => new Set(collection.caseIds))
+
+    const results = createItemsInSegments(dataset, [[
+      { a1: "qq", a2: "qq", a3: 300 }
+    ]]) as DISuccessResult[]
+
+    const created = dataset.collections.flatMap((collection, index) =>
+      collection.caseIds.filter(caseId => !before[index].has(caseId)))
+    expect(created.length).toBeGreaterThan(0)
+    created.forEach(caseId => expect(results[0].caseIDs).toContain(toV2Id(caseId)))
+    // and nothing beyond them: reporting a case the request didn't produce sends the plugin
+    // a createCases notification for a case it already has
+    expect(results[0].caseIDs).toHaveLength(created.length)
+  })
+
+  it("reports created cases when an appended item un-hides a case", () => {
+    const { dataset } = setupTestDataset()
+    const bItemIds = dataset.items.filter((_, index) => index % 2 === 1).map(item => item.__id__)
+    dataset.hideCasesOrItems(bItemIds)
+    dataset.validateCases()
+    const before = dataset.collections.map(collection => new Set(collection.caseIds))
+
+    // the first item un-hides the "b" branch; the second forms an unrelated new branch
+    const results = createItemsInSegments(dataset, [[
+      { a1: "b", a2: "y", a3: 100 },
+      { a1: "zz", a2: "zz", a3: 200 }
+    ]]) as DISuccessResult[]
+
+    const created = dataset.collections.flatMap((collection, index) =>
+      collection.caseIds.filter(caseId => !before[index].has(caseId)))
+    expect(created.length).toBeGreaterThan(0)
+    created.forEach(caseId => expect(results[0].caseIDs).toContain(toV2Id(caseId)))
+    // and nothing beyond them: reporting a case the request didn't produce sends the plugin
+    // a createCases notification for a case it already has
+    expect(results[0].caseIDs).toHaveLength(created.length)
+  })
+
+  // The un-hidden case can turn up in a collection whose ancestors have already been grouped
+  // and already gained cases of their own, so recovering what they started from means
+  // discounting those.
+  it("reports created cases when an un-hidden case follows a new case in an outer collection", () => {
+    const { dataset } = setupTestDataset()
+    // item 2 is the only (a, z) item, so hiding it hides that middle case while its parent
+    // case "a" stays visible through items 0 and 4
+    dataset.hideCasesOrItems([dataset.items[2].__id__])
+    dataset.validateCases()
+    const before = dataset.collections.map(collection => new Set(collection.caseIds))
+
+    const results = createItemsInSegments(dataset, [[
+      { a1: "NEW", a2: "n", a3: 1 },   // forms a new case in the outermost collection
+      { a1: "a", a2: "z", a3: 9 }      // un-hides the middle case, in a later collection
+    ]]) as DISuccessResult[]
+
+    const created = dataset.collections.flatMap((collection, index) =>
+      collection.caseIds.filter(caseId => !before[index].has(caseId)))
+    expect(created.length).toBeGreaterThan(0)
+    created.forEach(caseId => expect(results[0].caseIDs).toContain(toV2Id(caseId)))
+    // and nothing beyond them: reporting a case the request didn't produce sends the plugin
+    // a createCases notification for a case it already has
+    expect(results[0].caseIDs).toHaveLength(created.length)
+  })
+
   it("reports the cases a re-sent item id creates when its grouping values are new", () => {
     const { dataset } = setupTestDataset()
     const existingItemId = dataset.items[0].__id__
@@ -173,6 +320,9 @@ describe("createItemsInSegments", () => {
       collection.caseIds.filter(caseId => !before[index].has(caseId)))
     expect(created.length).toBeGreaterThan(0)
     created.forEach(caseId => expect(results[0].caseIDs).toContain(toV2Id(caseId)))
+    // and nothing beyond them: reporting a case the request didn't produce sends the plugin
+    // a createCases notification for a case it already has
+    expect(results[0].caseIDs).toHaveLength(created.length)
   })
 
   it("does not report pre-existing cases when an item id is re-sent", () => {

--- a/v3/src/data-interactive/handlers/item-handler.test.ts
+++ b/v3/src/data-interactive/handlers/item-handler.test.ts
@@ -158,7 +158,7 @@ describe("createItemsInSegments", () => {
   it("doesn't report a surviving parent case when an append joins it", () => {
     const { dataset } = setupTestDataset()
     // delete one item of the a1="b" group, leaving that parent case alive, and don't
-    // revalidate -- so the append below runs the same newly-taken path as the tests around it
+    // revalidate — so the append below runs the same newly-taken path as the tests around it
     diItemHandler.delete?.({ dataContext: dataset, item: dataset.items[1] })
     expect(dataset.isValidCases).toBe(false)
 

--- a/v3/src/data-interactive/handlers/item-handler.ts
+++ b/v3/src/data-interactive/handlers/item-handler.ts
@@ -46,12 +46,6 @@ export function createItemsInSegments(dataContext: IDataSet, segments: DIItemVal
   const newCaseIds: Record<string, string[]> = {}
   let itemIDs: string[] = []
   dataContext.applyModelChange(() => {
-    // Get case ids from before new items are added
-    const oldCaseIds: Record<string, Set<string>> = {}
-    dataContext.collections.forEach(collection => {
-      oldCaseIds[collection.id] = new Set(collection.caseIds)
-    })
-
     // Add items and update cases. A multi-segment batch is a coalesced run of streamed
     // create requests, so observers (e.g. graphs) should snap rather than animate; a
     // single create request — even one with many items — animates as an ordinary add.
@@ -59,12 +53,28 @@ export function createItemsInSegments(dataContext: IDataSet, segments: DIItemVal
     itemIDs = dataContext.addCases(items, { canonicalize: true, suppressAnimation })
     dataContext.validateCases()
 
-    // Find newly added cases by comparing current cases to previous cases
-    dataContext.collections.forEach(collection => {
-      newCaseIds[collection.id] = []
-      collection.caseIds.forEach(caseId => {
-        if (!oldCaseIds[collection.id].has(caseId)) newCaseIds[collection.id].push(caseId)
+    // Find the cases this request created. Only cases containing one of the new items can
+    // be new, and such a case is new precisely when the first item in it is one of them --
+    // a case that already existed keeps whichever item it already held at the front. That
+    // makes this proportional to the number of items added rather than to the size of the
+    // dataset, which matters for plugins that stream items into a large data context.
+    const addedItemIds = new Set(itemIDs)
+    dataContext.collections.forEach((collection, collectionIndex) => {
+      const caseIds = new Set<string>()
+      itemIDs.forEach(itemId => {
+        const caseId = dataContext.getItemCaseIds(itemId)[collectionIndex]
+        if (caseId == null || caseIds.has(caseId)) return
+        const caseInfo = dataContext.caseInfoMap.get(caseId)
+        const firstItemId = caseInfo?.childItemIds[0] ?? caseInfo?.hiddenChildItemIds[0]
+        if (firstItemId != null && addedItemIds.has(firstItemId)) caseIds.add(caseId)
       })
+      // Report them in the collection's case order, as a scan of its case ids would. Cases
+      // with no index of their own (hidden ones) aren't in that list and aren't reported.
+      newCaseIds[collection.id] = Array.from(caseIds)
+        .map(caseId => ({ caseId, index: collection.getCaseIndex(caseId) ?? -1 }))
+        .filter(({ index }) => index >= 0)
+        .sort((a, b) => a.index - b.index)
+        .map(({ caseId }) => caseId)
     })
   }, {
     notify: () => {

--- a/v3/src/data-interactive/handlers/item-handler.ts
+++ b/v3/src/data-interactive/handlers/item-handler.ts
@@ -52,7 +52,7 @@ export function createItemsInSegments(dataContext: IDataSet, segments: DIItemVal
     // knows only the end state, and the request would report nothing while cases existed.
     // Ordinary plugin traffic arrives here invalid: deleteItem, deleteCaseBy and
     // itemSearch.delete all removeCases without revalidating.
-    if (!dataContext.isValidCases) dataContext.validateCases()
+    dataContext.validateCases()
 
     // Add items and update cases. A multi-segment batch is a coalesced run of streamed
     // create requests, so observers (e.g. graphs) should snap rather than animate; a

--- a/v3/src/data-interactive/handlers/item-handler.ts
+++ b/v3/src/data-interactive/handlers/item-handler.ts
@@ -45,14 +45,6 @@ export function createItemsInSegments(dataContext: IDataSet, segments: DIItemVal
 
   const newCaseIds: Record<string, string[]> = {}
   let itemIDs: string[] = []
-  // Ids the request supplied for items the data context already holds. A plugin that manages
-  // its own ids (the Collaborative plugin) can re-send one, e.g. on a replayed sync message;
-  // the cases around such an item already exist, so they are not created by this request.
-  const resentItemIds = new Set(
-    items
-      .map(item => item.__id__)
-      .filter((itemId): itemId is string => typeof itemId === "string" && dataContext.hasItem(itemId))
-  )
 
   dataContext.applyModelChange(() => {
     // Add items and update cases. A multi-segment batch is a coalesced run of streamed
@@ -62,31 +54,15 @@ export function createItemsInSegments(dataContext: IDataSet, segments: DIItemVal
     itemIDs = dataContext.addCases(items, { canonicalize: true, suppressAnimation })
     dataContext.validateCases()
 
-    // Find the cases this request created. Only a case holding one of the new items can be
-    // new, and such a case is new precisely when the first item in it is one of them -- a
-    // case that already existed keeps whichever item it already held at the front. That makes
-    // this proportional to the number of items added rather than to the size of the dataset,
-    // which matters for plugins that stream items into a large data context.
-    const creatingItemIds = new Set(itemIDs.filter(itemId => !resentItemIds.has(itemId)))
-    const caseIdsByCollection = new Map<string, Set<string>>()
-    itemIDs.forEach(itemId => {
-      // An item's case ids are collected per collection as it is grouped, so read the
-      // collection from the case itself rather than assuming a position in this list.
-      dataContext.getItemCaseIds(itemId).forEach(caseId => {
-        const caseInfo = dataContext.caseInfoMap.get(caseId)
-        if (!caseInfo) return
-        const firstItemId = caseInfo.childItemIds[0] ?? caseInfo.hiddenChildItemIds[0]
-        if (firstItemId == null || !creatingItemIds.has(firstItemId)) return
-        const caseIds = caseIdsByCollection.get(caseInfo.collectionId)
-        if (caseIds) caseIds.add(caseId)
-        else caseIdsByCollection.set(caseInfo.collectionId, new Set([caseId]))
-      })
-    })
-
+    // The cases this request created, as reported by the add itself -- which knows exactly
+    // which case ids it minted, and costs nothing proportional to the size of the dataset.
+    // It reports nothing when grouping had to start over, in which case there is no cheap
+    // answer to be had.
+    const created = dataContext.newCaseIdsForLastAppend ?? {}
     dataContext.collections.forEach(collection => {
       // Report them in the collection's case order, as a scan of its case ids would. Cases
       // with no index of their own (hidden ones) aren't in that list and aren't reported.
-      newCaseIds[collection.id] = Array.from(caseIdsByCollection.get(collection.id) ?? [])
+      newCaseIds[collection.id] = (created[collection.id] ?? [])
         .map(caseId => ({ caseId, index: collection.getCaseIndex(caseId) ?? -1 }))
         .filter(({ index }) => index >= 0)
         .sort((a, b) => a.index - b.index)

--- a/v3/src/data-interactive/handlers/item-handler.ts
+++ b/v3/src/data-interactive/handlers/item-handler.ts
@@ -47,6 +47,13 @@ export function createItemsInSegments(dataContext: IDataSet, segments: DIItemVal
   let itemIDs: string[] = []
 
   dataContext.applyModelChange(() => {
+    // Bring grouping up to date before adding, so the add can group the new items additively
+    // and say which cases it created. Left invalid, it would defer to a full rebuild that
+    // knows only the end state, and the request would report nothing while cases existed.
+    // Ordinary plugin traffic arrives here invalid: deleteItem, deleteCaseBy and
+    // itemSearch.delete all removeCases without revalidating.
+    if (!dataContext.isValidCases) dataContext.validateCases()
+
     // Add items and update cases. A multi-segment batch is a coalesced run of streamed
     // create requests, so observers (e.g. graphs) should snap rather than animate; a
     // single create request — even one with many items — animates as an ordinary add.
@@ -54,11 +61,9 @@ export function createItemsInSegments(dataContext: IDataSet, segments: DIItemVal
     itemIDs = dataContext.addCases(items, { canonicalize: true, suppressAnimation })
     dataContext.validateCases()
 
-    // The cases this request created, as reported by the add itself -- which knows exactly
-    // which case ids it minted, and costs nothing proportional to the size of the dataset.
-    // It reports nothing when grouping had to start over, in which case there is no cheap
-    // answer to be had.
-    const created = dataContext.newCaseIdsForLastAppend ?? {}
+    // The cases this request created, as reported by the add itself. The additive path knows
+    // exactly which case ids it minted; the paths that regroup work it out by comparison.
+    const created = dataContext.takeCaseIdsCreatedByLastAppend() ?? {}
     dataContext.collections.forEach(collection => {
       // Report them in the collection's case order, as a scan of its case ids would. Cases
       // with no index of their own (hidden ones) aren't in that list and aren't reported.

--- a/v3/src/data-interactive/handlers/item-handler.ts
+++ b/v3/src/data-interactive/handlers/item-handler.ts
@@ -45,6 +45,15 @@ export function createItemsInSegments(dataContext: IDataSet, segments: DIItemVal
 
   const newCaseIds: Record<string, string[]> = {}
   let itemIDs: string[] = []
+  // Ids the request supplied for items the data context already holds. A plugin that manages
+  // its own ids (the Collaborative plugin) can re-send one, e.g. on a replayed sync message;
+  // the cases around such an item already exist, so they are not created by this request.
+  const resentItemIds = new Set(
+    items
+      .map(item => item.__id__)
+      .filter((itemId): itemId is string => typeof itemId === "string" && dataContext.hasItem(itemId))
+  )
+
   dataContext.applyModelChange(() => {
     // Add items and update cases. A multi-segment batch is a coalesced run of streamed
     // create requests, so observers (e.g. graphs) should snap rather than animate; a
@@ -53,24 +62,31 @@ export function createItemsInSegments(dataContext: IDataSet, segments: DIItemVal
     itemIDs = dataContext.addCases(items, { canonicalize: true, suppressAnimation })
     dataContext.validateCases()
 
-    // Find the cases this request created. Only cases containing one of the new items can
-    // be new, and such a case is new precisely when the first item in it is one of them --
-    // a case that already existed keeps whichever item it already held at the front. That
-    // makes this proportional to the number of items added rather than to the size of the
-    // dataset, which matters for plugins that stream items into a large data context.
-    const addedItemIds = new Set(itemIDs)
-    dataContext.collections.forEach((collection, collectionIndex) => {
-      const caseIds = new Set<string>()
-      itemIDs.forEach(itemId => {
-        const caseId = dataContext.getItemCaseIds(itemId)[collectionIndex]
-        if (caseId == null || caseIds.has(caseId)) return
+    // Find the cases this request created. Only a case holding one of the new items can be
+    // new, and such a case is new precisely when the first item in it is one of them -- a
+    // case that already existed keeps whichever item it already held at the front. That makes
+    // this proportional to the number of items added rather than to the size of the dataset,
+    // which matters for plugins that stream items into a large data context.
+    const creatingItemIds = new Set(itemIDs.filter(itemId => !resentItemIds.has(itemId)))
+    const caseIdsByCollection = new Map<string, Set<string>>()
+    itemIDs.forEach(itemId => {
+      // An item's case ids are collected per collection as it is grouped, so read the
+      // collection from the case itself rather than assuming a position in this list.
+      dataContext.getItemCaseIds(itemId).forEach(caseId => {
         const caseInfo = dataContext.caseInfoMap.get(caseId)
-        const firstItemId = caseInfo?.childItemIds[0] ?? caseInfo?.hiddenChildItemIds[0]
-        if (firstItemId != null && addedItemIds.has(firstItemId)) caseIds.add(caseId)
+        if (!caseInfo) return
+        const firstItemId = caseInfo.childItemIds[0] ?? caseInfo.hiddenChildItemIds[0]
+        if (firstItemId == null || !creatingItemIds.has(firstItemId)) return
+        const caseIds = caseIdsByCollection.get(caseInfo.collectionId)
+        if (caseIds) caseIds.add(caseId)
+        else caseIdsByCollection.set(caseInfo.collectionId, new Set([caseId]))
       })
+    })
+
+    dataContext.collections.forEach(collection => {
       // Report them in the collection's case order, as a scan of its case ids would. Cases
       // with no index of their own (hidden ones) aren't in that list and aren't reported.
-      newCaseIds[collection.id] = Array.from(caseIds)
+      newCaseIds[collection.id] = Array.from(caseIdsByCollection.get(collection.id) ?? [])
         .map(caseId => ({ caseId, index: collection.getCaseIndex(caseId) ?? -1 }))
         .filter(({ index }) => index >= 0)
         .sort((a, b) => a.index - b.index)

--- a/v3/src/models/data/attribute.test.ts
+++ b/v3/src/models/data/attribute.test.ts
@@ -418,6 +418,22 @@ describe("Attribute", () => {
     a.completeSnapshot()
   })
 
+  it("notifies observers when setLength grows the attribute", () => {
+    const a = Attribute.create({ name: "a", values: ["1"] })
+    const observed: number[] = []
+    const dispose = reaction(() => a.length, length => observed.push(length), { fireImmediately: true })
+    expect(observed).toEqual([1])
+
+    a.setLength(3)
+    expect(a.strValues).toEqual(["1", "", ""])
+    expect(observed).toEqual([1, 3])
+
+    // no growth, so nothing to report
+    a.setLength(3)
+    expect(observed).toEqual([1, 3])
+    dispose()
+  })
+
   describe("string hashing for serialization", () => {
     const shortValue = "a".repeat(kHashMapSizeThreshold - 1) // 63 chars, below threshold
     const longValue = "b".repeat(kHashMapSizeThreshold) // 64 chars, at threshold

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -505,16 +505,16 @@ export const Attribute = V2Model.named("Attribute").props({
       }
       self.incChangeCount()
     },
+    // Grows in place rather than building a replacement array. Appending items calls this for
+    // every attribute, so reallocating would make each append cost the full attribute length.
+    // Growing in place also keeps `strValues` and `values` the same array in production, where
+    // they're shared (in development `values` is frozen and cleared during initialization).
     setLength(length: number) {
-      if (self.strValues.length < length) {
-        self.strValues = self.strValues.concat(new Array(length - self.strValues.length).fill(""))
-        if (isProduction()) {
-          // in production mode, `strValues` shares the `values` array since it isn't frozen
-          self.values = self.strValues
-        }
+      for (let i = self.strValues.length; i < length; ++i) {
+        self.strValues.push("")
       }
-      if (self.numValues.length < length) {
-        self.numValues = self.numValues.concat(new Array(length - self.numValues.length).fill(NaN))
+      for (let i = self.numValues.length; i < length; ++i) {
+        self.numValues.push(NaN)
       }
     },
     removeValues(index: number, count = 1) {

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -509,13 +509,17 @@ export const Attribute = V2Model.named("Attribute").props({
     // every attribute, so reallocating would make each append cost the full attribute length.
     // Growing in place also keeps `strValues` and `values` the same array in production, where
     // they're shared (in development `values` is frozen and cleared during initialization).
+    // Because the arrays are volatile, mutating their contents is not itself observable — only
+    // changeCount is — so growing them has to report the change explicitly.
     setLength(length: number) {
+      const didGrow = self.strValues.length < length || self.numValues.length < length
       for (let i = self.strValues.length; i < length; ++i) {
         self.strValues.push("")
       }
       for (let i = self.numValues.length; i < length; ++i) {
         self.numValues.push(NaN)
       }
+      if (didGrow) self.incChangeCount()
     },
     removeValues(index: number, count = 1) {
       if ((index != null) && (index < self.strValues.length) && (count > 0)) {

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -513,7 +513,9 @@ export const Attribute = V2Model.named("Attribute").props({
     // Growing in place also keeps `strValues` and `values` the same array in production, where
     // they're shared (in development `values` is frozen and cleared during initialization).
     // Because the arrays are volatile, mutating their contents is not itself observable — only
-    // changeCount is — so growing them has to report the change explicitly.
+    // changeCount is — so growing them has to report the change explicitly. Note that growth is
+    // therefore visible only to views that read changeCount, as `length`, `type` and `isNumeric`
+    // do; the per-index accessors don't, and so don't react to it.
     setLength(length: number) {
       const didGrow = self.strValues.length < length || self.numValues.length < length
       for (let i = self.strValues.length; i < length; ++i) {

--- a/v3/src/models/data/attribute.ts
+++ b/v3/src/models/data/attribute.ts
@@ -149,6 +149,9 @@ export const Attribute = V2Model.named("Attribute").props({
       return importValueToString(value)
     },
     get isNumeric() {
+      // Values live in a volatile array whose contents aren't observable, so like `length` and
+      // `type` this depends on changeCount to know when they've changed.
+      void self.changeCount
       // An attribute is considered numeric if any of its values is a number.
       return self.numValues.some(value => !isNaN(value))
     },

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -594,6 +594,14 @@ export const CollectionModel = V2Model
               .filter((group): group is CaseInfo => !!group)
           : undefined
 
+        // A collection that had no case added to it is left exactly as it was — same cases,
+        // same order, same indices, with only the contents of existing case groups mutated in
+        // place, which the version bump at the end reports. A parent collection can reuse its
+        // caches on that basis, since its nonEmptyCases simply mirror its cases. The childmost
+        // collection cannot: emptiness there is derived from item values, and re-sending an
+        // item id writes new values into a case that already exists.
+        const mustRecompute = _needsFullRebuild || newCaseIds?.length !== 0 || !self.child
+
         // Hidden-only groups are excluded so this matches REBUILD's walk of self.caseIds
         // (which already excludes them), which means the result can be empty even when
         // newCaseIds isn't (e.g. when re-adding previously deleted items whose group key
@@ -614,7 +622,7 @@ export const CollectionModel = V2Model
               : undefined
           : newCaseGroups
 
-        if (parentCases) {
+        if (parentCases && mustRecompute) {
           if (appendedCaseGroups) {
             // The appended cases occupy the tail of their parent's childCaseIds, so their
             // index within the parent counts back from the end of that list. Every other case
@@ -674,7 +682,7 @@ export const CollectionModel = V2Model
           _nonEmptyCases = [..._nonEmptyCases, ...newNonEmptyCases]
         }
         // REBUILD path: full recompute from volatile state
-        else {
+        else if (mustRecompute) {
           _caseGroups = self.caseIds
                           .map(caseId => self.getCaseGroup(caseId))
                           .filter(group => !!group)

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -322,6 +322,8 @@ export const CollectionModel = V2Model
     }
 
     const newCaseIds: string[] = []
+    // cases that already existed but became visible during this pass
+    const unhiddenCaseIds: string[] = []
     // key is child caseId
     const parentChildIdMap = new Map<string, { parentCaseId: string, isHidden: boolean }>()
     const itemInfo: Array<{itemId: string, caseId: string}> = []
@@ -377,7 +379,19 @@ export const CollectionModel = V2Model
             const parentChildInfo = parentChildIdMap.get(caseId)
             self.caseIds.push(caseId)
             self.caseIdToIndexMap.set(caseId, newCaseIndex)
-            parentChildInfo && (parentChildInfo.isHidden = false)
+            if (parentChildInfo) {
+              parentChildInfo.isHidden = false
+            }
+            else {
+              // The case was grouped in an earlier pass, so it has no entry here and its parent
+              // has never been told about it — it was hidden the last time the parent collected
+              // its children. Register it so it is added to the parent below.
+              const parentCaseId = self.parent?.groupKeyCaseId(self.parentGroupKey(itemId))
+              if (parentCaseId) {
+                parentChildIdMap.set(caseId, { parentCaseId, isHidden: false })
+              }
+            }
+            unhiddenCaseIds.push(caseId)
             caseGroup.groupedCase[symIndex] = newCaseIndex
             caseGroup.isHidden = false
           }
@@ -448,7 +462,7 @@ export const CollectionModel = V2Model
     })
     self.clearPrevCases()
 
-    return { newCaseIds }
+    return { newCaseIds, unhiddenCaseIds }
   }
 }))
 .views(self => ({
@@ -529,8 +543,16 @@ export const CollectionModel = V2Model
       const parentCaseId = group.groupedCase[symParent]
       return parentCaseId != null ? self.parent?.getCaseIndex(parentCaseId) : undefined
     }
+    // Where the existing cases end. If the last one's parent can't be located there is no
+    // baseline to compare against, so fall back to re-sorting rather than assume the append
+    // belongs at the end.
+    let parentIndex = -1
     const lastCompleted = _caseGroups[_caseGroups.length - 1]
-    let parentIndex = lastCompleted ? parentIndexOf(lastCompleted) ?? -1 : -1
+    if (lastCompleted) {
+      const lastParentIndex = parentIndexOf(lastCompleted)
+      if (lastParentIndex == null) return false
+      parentIndex = lastParentIndex
+    }
     return groups.every(group => {
       const groupParentIndex = parentIndexOf(group)
       if (groupParentIndex == null || groupParentIndex < parentIndex) return false

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -512,6 +512,27 @@ export const CollectionModel = V2Model
   let _needsFullRebuild = true   // starts true: no valid data yet
   let _pendingNewCaseIds: string[] | undefined
 
+  // Cases in a child collection are ordered by parent case, then by position within the
+  // parent. New cases are always pushed onto the end of their parent's childCaseIds, so an
+  // append extends the existing order — rather than inserting into the middle of it — only
+  // when each new case's parent is at or after the parent of the case that currently sits
+  // last. Streamed appends (a plugin adding samples to the newest experiment) satisfy this;
+  // adding to an older parent doesn't, and has to fall back to re-sorting the collection.
+  const appendExtendsOrder = (groups: CaseInfo[]) => {
+    const parentIndexOf = (group: CaseInfo) => {
+      const parentCaseId = group.groupedCase[symParent]
+      return parentCaseId != null ? self.parent?.getCaseIndex(parentCaseId) : undefined
+    }
+    const lastCompleted = _caseGroups[_caseGroups.length - 1]
+    let parentIndex = lastCompleted ? parentIndexOf(lastCompleted) ?? -1 : -1
+    return groups.every(group => {
+      const groupParentIndex = parentIndexOf(group)
+      if (groupParentIndex == null || groupParentIndex < parentIndex) return false
+      parentIndex = groupParentIndex
+      return true
+    })
+  }
+
   return {
     views: {
       get caseGroups() {
@@ -536,49 +557,82 @@ export const CollectionModel = V2Model
         return _caseIdsOrderedHash
       },
       completeCaseGroups(parentCases: Maybe<CaseInfo[]>) {
-        if (parentCases) {
-          self.caseIds.splice(0, self.caseIds.length)
-          // sort cases by parent cases
-          parentCases.forEach(parentCase => {
-            const childCaseIds = parentCase.childCaseIds ?? []
-            // update indices
-            childCaseIds.forEach((childCaseId, index) => {
-              const caseGroup = self.getCaseGroup(childCaseId)
-              caseGroup && (caseGroup.groupedCase[symIndex] = index)
-            })
-            // append case ids in grouped order
-            self.caseIds.push(...childCaseIds)
-          })
-          // rebuild the case id to index map, since the order of child cases may have changed
-          self.caseIdToIndexMap.clear()
-          self.caseIds.forEach((caseId, index) => {
-            self.caseIdToIndexMap.set(caseId, index)
-          })
-        }
-
         const newCaseIds = _pendingNewCaseIds
         _pendingNewCaseIds = undefined
 
-        // APPEND path: top-level collection with only new cases added
-        // Uses concatenation (not mutation) so consumers holding old references see a new array.
-        // Note: newCaseIds can be an empty array (e.g., when re-adding previously deleted items
-        // whose group key mappings still exist), so check length to fall through to REBUILD.
-        if (!parentCases && !_needsFullRebuild && newCaseIds?.length) {
-          // Exclude hidden-only case groups so this branch matches REBUILD's walk of
-          // self.caseIds (which already excludes them).
-          const newCaseGroups = newCaseIds
-                                  .map(caseId => self.getCaseGroup(caseId))
-                                  .filter((group): group is CaseInfo => !!group && !group.isHidden)
-          _caseGroups = [..._caseGroups, ...newCaseGroups]
+        // The case groups for the newly added cases. Hidden-only groups are excluded so this
+        // matches REBUILD's walk of self.caseIds (which already excludes them), which means
+        // the result can be empty even when newCaseIds isn't (e.g. when re-adding previously
+        // deleted items whose group key mappings still exist).
+        const newCaseGroups = !_needsFullRebuild && newCaseIds?.length
+          ? newCaseIds
+              .map(caseId => self.getCaseGroup(caseId))
+              .filter((group): group is CaseInfo => !!group && !group.isHidden)
+          : undefined
 
-          const newCases = newCaseGroups.map(group => group.groupedCase)
+        // The groups to complete additively, or undefined to rebuild the caches from scratch.
+        // A child collection appends only when its own case list grew and the new cases sort
+        // to the end; a top-level collection completes additively regardless, since an append
+        // that contributed no visible cases leaves its existing completion correct as-is.
+        const appendedCaseGroups = parentCases
+          ? newCaseGroups?.length && appendExtendsOrder(newCaseGroups) ? newCaseGroups : undefined
+          : newCaseGroups
+
+        if (parentCases) {
+          if (appendedCaseGroups) {
+            // The appended cases occupy the tail of their parent's childCaseIds, so their
+            // index within the parent counts back from the end of that list. Every other case
+            // in the collection keeps the position it already had.
+            const groupsByParent = new Map<string, CaseInfo[]>()
+            appendedCaseGroups.forEach(group => {
+              const parentCaseId = group.groupedCase[symParent]
+              if (parentCaseId == null) return
+              const groups = groupsByParent.get(parentCaseId)
+              if (groups) groups.push(group)
+              else groupsByParent.set(parentCaseId, [group])
+            })
+            groupsByParent.forEach((groups, parentCaseId) => {
+              const childCaseIds = self.parent?.getCaseGroup(parentCaseId)?.childCaseIds ?? []
+              const firstNewIndex = childCaseIds.length - groups.length
+              groups.forEach((group, index) => {
+                group.groupedCase[symIndex] = firstNewIndex + index
+              })
+            })
+          }
+          else {
+            self.caseIds.splice(0, self.caseIds.length)
+            // sort cases by parent cases
+            parentCases.forEach(parentCase => {
+              const childCaseIds = parentCase.childCaseIds ?? []
+              // update indices
+              childCaseIds.forEach((childCaseId, index) => {
+                const caseGroup = self.getCaseGroup(childCaseId)
+                caseGroup && (caseGroup.groupedCase[symIndex] = index)
+              })
+              // append case ids in grouped order
+              self.caseIds.push(...childCaseIds)
+            })
+            // rebuild the case id to index map, since the order of child cases may have changed
+            self.caseIdToIndexMap.clear()
+            self.caseIds.forEach((caseId, index) => {
+              self.caseIdToIndexMap.set(caseId, index)
+            })
+          }
+        }
+
+        // APPEND path: only new cases were added
+        // Uses concatenation (not mutation) so consumers holding old references see a new array.
+        if (appendedCaseGroups) {
+          _caseGroups = [..._caseGroups, ...appendedCaseGroups]
+
+          const newCases = appendedCaseGroups.map(group => group.groupedCase)
           _cases = [..._cases, ...newCases]
 
           // Parent collections: every case is non-empty by definition (isNonEmptyCaseGroup
           // short-circuits to true), so reuse newCases rather than running the filter.
           const newNonEmptyCases = self.child
             ? newCases
-            : newCaseGroups
+            : appendedCaseGroups
                 .filter(group => self.isNonEmptyCaseGroup(group))
                 .map(group => group.groupedCase)
           _nonEmptyCases = [..._nonEmptyCases, ...newNonEmptyCases]

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -302,10 +302,18 @@ export const CollectionModel = V2Model
   }
 }))
 .views(self => ({
-  updateCaseGroups(itemIds?: string[], isAppending?: boolean) {
-    // For now, we treat appending items as a special case for which we don't need to start
-    // from scratch. Eventually, we may be able to handle inserting items efficiently as well.
-    const isAppendingItems = !!itemIds && !!isAppending
+  // Passing itemIds regroups just those items instead of starting from scratch, which is how
+  // appended items are handled; omitting them rebuilds the collection from all of its items.
+  // Insertions currently take the rebuild path. Handling them incrementally is the opportunity
+  // still open here, and it would want the insert position rather than a flag, since which
+  // existing cases have to shift depends on where the items landed.
+  //
+  // Note that appending items does not imply appending cases: a child collection orders its
+  // cases by parent case and then by position within the parent, so items added at the end of
+  // the item list still belong in the middle of that order whenever they join an older parent.
+  // completeCaseGroups works that out from the parents' case indices; no caller of this method
+  // is in a position to tell it in advance.
+  updateCaseGroups(itemIds?: string[]) {
     // newCaseIds semantics differ between rebuild and additive paths — see the push site.
     const isFullRebuild = !itemIds
     if (!itemIds) {
@@ -438,11 +446,9 @@ export const CollectionModel = V2Model
         }
       }
     })
-    if (!isAppendingItems) {
-      self.clearPrevCases()
-    }
+    self.clearPrevCases()
 
-    return { isAppendingItems, newCaseIds }
+    return { newCaseIds }
   }
 }))
 .views(self => ({

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -634,11 +634,11 @@ export const CollectionModel = V2Model
             })
             groupsByParent.forEach((groups, parentCaseId) => {
               const childCaseIds = self.parent?.getCaseGroup(parentCaseId)?.childCaseIds
-              // Without the parent's children there is no way to say where these cases sit
-              // among their siblings, and counting back from an empty list would give them
-              // negative indices. Leave the indices updateCaseGroups assigned and report it,
-              // as addChildCase already does for the same condition.
-              if (!childCaseIds) {
+              // Without the parent's children — or with fewer of them than we are placing —
+              // there is no way to say where these cases sit among their siblings, and counting
+              // back would give them negative indices. Leave the indices updateCaseGroups
+              // assigned and report it, as addChildCase already does for the same condition.
+              if (!childCaseIds || childCaseIds.length < groups.length) {
                 console.warn("CollectionModel.completeCaseGroups -- missing parent case:", parentCaseId)
                 return
               }

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -596,7 +596,8 @@ export const CollectionModel = V2Model
         // caches on that basis, since its nonEmptyCases simply mirror its cases. The childmost
         // collection cannot: emptiness there is derived from item values, and re-sending an
         // item id writes new values into a case that already exists.
-        const mustRecompute = _needsFullRebuild || newCaseIds?.length !== 0 || !self.child
+        const mustRecompute =
+          _needsFullRebuild || newCaseIds == null || newCaseIds.length > 0 || !self.child
 
         // Hidden-only groups are excluded so this matches REBUILD's walk of self.caseIds
         // (which already excludes them), which means the result can be empty even when
@@ -632,7 +633,15 @@ export const CollectionModel = V2Model
               else groupsByParent.set(parentCaseId, [group])
             })
             groupsByParent.forEach((groups, parentCaseId) => {
-              const childCaseIds = self.parent?.getCaseGroup(parentCaseId)?.childCaseIds ?? []
+              const childCaseIds = self.parent?.getCaseGroup(parentCaseId)?.childCaseIds
+              // Without the parent's children there is no way to say where these cases sit
+              // among their siblings, and counting back from an empty list would give them
+              // negative indices. Leave the indices updateCaseGroups assigned and report it,
+              // as addChildCase already does for the same condition.
+              if (!childCaseIds) {
+                console.warn("CollectionModel.completeCaseGroups -- missing parent case:", parentCaseId)
+                return
+              }
               const firstNewIndex = childCaseIds.length - groups.length
               groups.forEach((group, index) => {
                 group.groupedCase[symIndex] = firstNewIndex + index

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -304,9 +304,7 @@ export const CollectionModel = V2Model
 .views(self => ({
   // Passing itemIds regroups just those items instead of starting from scratch, which is how
   // appended items are handled; omitting them rebuilds the collection from all of its items.
-  // Insertions currently take the rebuild path. Handling them incrementally is the opportunity
-  // still open here, and it would want the insert position rather than a flag, since which
-  // existing cases have to shift depends on where the items landed.
+  // Insertions take the rebuild path.
   //
   // Note that appending items does not imply appending cases: a child collection orders its
   // cases by parent case and then by position within the parent, so items added at the end of
@@ -385,13 +383,11 @@ export const CollectionModel = V2Model
             else {
               // The case was grouped in an earlier pass, so it has no entry here and its parent
               // has never been told about it — it was hidden the last time the parent collected
-              // its children. Register it so it is added to the parent below.
-              const parentCaseId = self.parent?.groupKeyCaseId(self.parentGroupKey(itemId))
-              if (parentCaseId) {
-                parentChildIdMap.set(caseId, { parentCaseId, isHidden: false })
-              }
+              // its children. Where it belongs among its siblings follows from item order,
+              // which only a regroup from scratch can work out, so report it and let the caller
+              // start over rather than appending it to the end of its parent's children.
+              unhiddenCaseIds.push(caseId)
             }
-            unhiddenCaseIds.push(caseId)
             caseGroup.groupedCase[symIndex] = newCaseIndex
             caseGroup.isHidden = false
           }
@@ -702,6 +698,16 @@ export const CollectionModel = V2Model
                 .filter(aCase => !!aCase)
 
           _needsFullRebuild = false
+        }
+        // UNCHANGED: no case was added here, so the cached contents still hold. The case
+        // groups themselves may have been mutated in place, though — a descendant collection
+        // adds to their childCaseIds — so hand out fresh arrays, because the rebuild path
+        // treats a new array identity as the signal that something changed and consumers
+        // identity-compare on that basis.
+        else {
+          _caseGroups = [..._caseGroups]
+          _cases = [..._cases]
+          _nonEmptyCases = [..._nonEmptyCases]
         }
 
         _caseIdsHash = hashStringSet(self.caseIds)

--- a/v3/src/models/data/collection.ts
+++ b/v3/src/models/data/collection.ts
@@ -560,22 +560,30 @@ export const CollectionModel = V2Model
         const newCaseIds = _pendingNewCaseIds
         _pendingNewCaseIds = undefined
 
-        // The case groups for the newly added cases. Hidden-only groups are excluded so this
-        // matches REBUILD's walk of self.caseIds (which already excludes them), which means
-        // the result can be empty even when newCaseIds isn't (e.g. when re-adding previously
-        // deleted items whose group key mappings still exist).
-        const newCaseGroups = !_needsFullRebuild && newCaseIds?.length
+        const newGroups = !_needsFullRebuild && newCaseIds?.length
           ? newCaseIds
               .map(caseId => self.getCaseGroup(caseId))
-              .filter((group): group is CaseInfo => !!group && !group.isHidden)
+              .filter((group): group is CaseInfo => !!group)
           : undefined
+
+        // Hidden-only groups are excluded so this matches REBUILD's walk of self.caseIds
+        // (which already excludes them), which means the result can be empty even when
+        // newCaseIds isn't (e.g. when re-adding previously deleted items whose group key
+        // mappings still exist).
+        const newCaseGroups = newGroups?.filter(group => !group.isHidden)
 
         // The groups to complete additively, or undefined to rebuild the caches from scratch.
         // A child collection appends only when its own case list grew and the new cases sort
         // to the end; a top-level collection completes additively regardless, since an append
         // that contributed no visible cases leaves its existing completion correct as-is.
+        // A child collection also rebuilds when any of the new cases is hidden: its REBUILD
+        // repopulates caseIdToIndexMap from caseIds and so drops the placeholder index a
+        // hidden case is given, and appending has no equivalent step.
         const appendedCaseGroups = parentCases
-          ? newCaseGroups?.length && appendExtendsOrder(newCaseGroups) ? newCaseGroups : undefined
+          ? newCaseGroups?.length && newCaseGroups.length === newGroups?.length &&
+              appendExtendsOrder(newCaseGroups)
+              ? newCaseGroups
+              : undefined
           : newCaseGroups
 
         if (parentCases) {

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -76,6 +76,47 @@ describe("DataSet hierarchical append", () => {
     expect(appended).toEqual(regroupFromScratch(data))
   })
 
+  it("excludes an appended case with no values from nonEmptyCases", () => {
+    const data = makeSamplerDataSet()
+    addSample(data, 0)
+
+    // no value for the childmost collection's attribute, so this forms an empty case
+    data.addCases([{ __id__: "e1-s1-empty", expId: "1", sampId: "1", outId: "" }])
+    data.validateCases()
+
+    expect(data.childCollection.cases.length).toBe(4)
+    expect(data.childCollection.nonEmptyCases.length).toBe(3)
+
+    const appended = groupingOf(data)
+    expect(appended).toEqual(regroupFromScratch(data))
+  })
+
+  it("excludes an appended case that is hidden", () => {
+    const data = makeSamplerDataSet()
+    addSample(data, 0)
+
+    // Setting an item aside and then removing it leaves its id set aside, so an item later
+    // re-added under that id is already hidden by the time its case group is created.
+    data.hideCasesOrItems(["e1-s0-i0"])
+    data.validateCases()
+    data.removeCases(["e1-s0-i0"])
+    data.validateCases()
+
+    data.addCases([
+      { __id__: "e1-s0-i0", expId: "1", sampId: "1", outId: "0" },
+      { __id__: "e1-s1-i1", expId: "1", sampId: "1", outId: "1" }
+    ])
+    data.validateCases()
+
+    expect(data.isItemHidden("e1-s0-i0")).toBe(true)
+    expect(data.childCollection.caseIds).not.toContain(
+      data.getItemChildCaseId("e1-s0-i0")
+    )
+
+    const appended = groupingOf(data)
+    expect(appended).toEqual(regroupFromScratch(data))
+  })
+
   it("orders appended cases correctly when they join an existing, earlier parent", () => {
     const data = makeSamplerDataSet()
     addSample(data, 0, { experiment: "1" })

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -73,9 +73,10 @@ describe("DataSet hierarchical append", () => {
 
     expect(writes.clears).toBe(0)
     expect(writes.sets).toEqual([])
-    // its cached arrays are reused rather than rebuilt, so identity-comparing reactions
-    // on them don't fire for an append that didn't touch this collection
-    expect(data.collections[1].caseGroups).toBe(caseGroupsBefore)
+    // its cases are reused rather than re-derived, but the array is still handed out fresh:
+    // a descendant added children to those case groups, and consumers identity-compare
+    expect(data.collections[1].caseGroups).not.toBe(caseGroupsBefore)
+    expect(data.collections[1].caseGroups).toEqual(caseGroupsBefore)
 
     const appended = groupingOf(data)
     expect(appended).toEqual(regroupFromScratch(data))
@@ -292,6 +293,31 @@ describe("DataSet hierarchical append", () => {
 
     const middle = data.collections[1]
     expect(middle.cases.length).toBe(middle.caseIds.length)
+
+    const appended = groupingOf(data)
+    expect(appended).toEqual(regroupFromScratch(data))
+  })
+
+  // The un-hidden case belongs at its item-order position among its siblings, which is before
+  // a sibling that already existed -- not appended after it.
+  it("orders a case that an appended item un-hides by item order, not by when it reappeared", () => {
+    const data = DataSet.create()
+    data.addAttribute({ id: "gId", name: "g" })
+    data.addAttribute({ id: "mId", name: "m" })
+    data.addAttribute({ id: "vId", name: "v" })
+    data.addCollection({ attributes: ["gId"] })
+    data.addCollection({ attributes: ["mId"] })
+
+    data.addCases([
+      { __id__: "i1", gId: "1", mId: "1", vId: "a" },
+      { __id__: "i2", gId: "1", mId: "2", vId: "b" }
+    ])
+    data.validateCases()
+    data.hideCasesOrItems(["i1"])   // hides the m=1 case, the FIRST of the two
+    data.validateCases()
+
+    data.addCases([{ __id__: "i3", gId: "1", mId: "1", vId: "c" }])
+    data.validateCases()
 
     const appended = groupingOf(data)
     expect(appended).toEqual(regroupFromScratch(data))

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -83,6 +83,27 @@ describe("DataSet hierarchical append", () => {
     expect(appended).toEqual(lookupMapsOf(data))
   })
 
+  // A case whose only item is hidden has no visible item to be keyed by, so the child case
+  // map has to fall back to the hidden one. Setting an item aside and removing it leaves the
+  // id set aside, so an item re-added under it is hidden as soon as its case is created.
+  it("keys an appended case that is hidden by its hidden item", () => {
+    const data = makeSamplerDataSet()
+    addSample(data, 0)
+    data.hideCasesOrItems(["e1-s0-i0"])
+    data.validateCases()
+    data.removeCases(["e1-s0-i0"])
+    data.validateCases()
+
+    data.addCases([{ __id__: "e1-s0-i0", expId: "1", sampId: "9", outId: "0" }])
+    data.validateCases()
+    expect(data.isItemHidden("e1-s0-i0")).toBe(true)
+
+    const appended = lookupMapsOf(data)
+    data.invalidateCases()
+    data.validateCases()
+    expect(appended).toEqual(lookupMapsOf(data))
+  })
+
   it("maps only the new items to their child cases when appending", () => {
     const data = makeSamplerDataSet()
     for (let sample = 0; sample < 5; ++sample) addSample(data, sample)

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -1,0 +1,90 @@
+import { DataSet, IDataSet } from "./data-set"
+import { symIndex, symParent } from "./data-set-types"
+
+// A Sampler-shaped dataset: experiment -> sample -> item.
+function makeSamplerDataSet() {
+  const data = DataSet.create()
+  data.addAttribute({ id: "expId", name: "experiment" })
+  data.addAttribute({ id: "sampId", name: "sample" })
+  data.addAttribute({ id: "outId", name: "output" })
+  data.addCollection({ attributes: ["expId"] })
+  data.addCollection({ attributes: ["sampId"] })
+  return data
+}
+
+function addSample(data: IDataSet, sample: number, { experiment = "1", size = 3 } = {}) {
+  data.addCases(Array.from({ length: size }, (_, i) => ({
+    __id__: `e${experiment}-s${sample}-i${i}`, expId: experiment, sampId: `${sample}`, outId: `${i}`
+  })))
+  data.validateCases()
+}
+
+// Records which items had their values read. Regrouping a collection reads the values of
+// every item it touches, so this reports how much of the dataset a given operation walked.
+function trackValueReads(data: IDataSet) {
+  const readItemIds: string[] = []
+  const { getValue } = data.itemData
+  data.itemData.getValue = (itemId: string, attrId: string) => {
+    readItemIds.push(itemId)
+    return getValue(itemId, attrId)
+  }
+  return readItemIds
+}
+
+describe("DataSet hierarchical append", () => {
+  it("doesn't read values for existing items when appending a new sample", () => {
+    const data = makeSamplerDataSet()
+    for (let sample = 0; sample < 5; ++sample) addSample(data, sample)
+
+    const readItemIds = trackValueReads(data)
+    addSample(data, 5)
+
+    expect([...new Set(readItemIds)].sort()).toEqual(["e1-s5-i0", "e1-s5-i1", "e1-s5-i2"])
+  })
+
+  // Everything about a collection that case grouping is responsible for producing. A full
+  // regroup from scratch is the ground truth for all of it, so comparing this before and
+  // after one is how these tests check that an incremental append got the same answer.
+  function groupingOf(data: IDataSet) {
+    return data.collections.map(collection => ({
+      id: collection.id,
+      caseIds: [...collection.caseIds],
+      indices: collection.caseGroups.map(group => group.groupedCase[symIndex]),
+      parents: collection.caseGroups.map(group => group.groupedCase[symParent]),
+      caseIdToIndex: [...collection.caseIdToIndexMap.entries()],
+      nonEmptyCaseIds: collection.nonEmptyCases.map(aCase => aCase.__id__)
+    }))
+  }
+
+  function regroupFromScratch(data: IDataSet) {
+    data.invalidateCases()
+    data.validateCases()
+    return groupingOf(data)
+  }
+
+  it("indexes appended cases within their parent, not across the collection", () => {
+    const data = makeSamplerDataSet()
+    addSample(data, 0)
+    addSample(data, 1)
+    addSample(data, 2)
+
+    // each sample's items are indexed 0..2 within that sample, not 0..8 across the collection
+    expect(data.childCollection.caseGroups.map(group => group.groupedCase[symIndex]))
+      .toEqual([0, 1, 2, 0, 1, 2, 0, 1, 2])
+
+    const appended = groupingOf(data)
+    expect(appended).toEqual(regroupFromScratch(data))
+  })
+
+  it("orders appended cases correctly when they join an existing, earlier parent", () => {
+    const data = makeSamplerDataSet()
+    addSample(data, 0, { experiment: "1" })
+    addSample(data, 0, { experiment: "2" })
+
+    // a new sample under experiment 1, which is no longer the last experiment
+    addSample(data, 1, { experiment: "1" })
+
+    const appended = groupingOf(data)
+    expect(appended).toEqual(regroupFromScratch(data))
+  })
+})

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -289,6 +289,12 @@ describe("DataSet hierarchical append", () => {
       { __id__: "i3", gId: "1", mId: "2", outId: "c" },
       { __id__: "i4", gId: "1", mId: "3", outId: "d" }
     ])
+    // the append leaves the dataset grouped rather than handing back one that is invalid and
+    // holding case ids its cached case arrays don't know about — asserted before validating
+    expect(data.isValidCases).toBe(true)
+    data.collections.forEach(collection =>
+      expect(collection.cases.length).toBe(collection.caseIds.length))
+
     data.validateCases()
 
     const middle = data.collections[1]

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -156,6 +156,67 @@ describe("DataSet hierarchical append", () => {
     expect(appended).toEqual(regroupFromScratch(data))
   })
 
+  // Appending an item to a case whose items were all hidden makes that case visible again.
+  // The case already exists, so it isn't among the new cases the additive path is told about,
+  // and its parent has never been told about it either -- it was hidden when the parent last
+  // collected its children. Both collections have to end up as a full regroup would.
+  it("restores a case that an appended item un-hides, in a middle collection", () => {
+    const data = DataSet.create()
+    data.addAttribute({ id: "gId", name: "g" })
+    data.addAttribute({ id: "mId", name: "m" })
+    data.addAttribute({ id: "outId", name: "out" })
+    data.addCollection({ attributes: ["gId"] })
+    data.addCollection({ attributes: ["mId"] })
+
+    data.addCases([
+      { __id__: "i1", gId: "1", mId: "1", outId: "a" },
+      { __id__: "i2", gId: "1", mId: "2", outId: "b" }
+    ])
+    data.validateCases()
+    data.hideCasesOrItems(["i2"])
+    data.validateCases()
+
+    // i3 un-hides the m=2 case; i4 creates a new m=3 case
+    data.addCases([
+      { __id__: "i3", gId: "1", mId: "2", outId: "c" },
+      { __id__: "i4", gId: "1", mId: "3", outId: "d" }
+    ])
+    data.validateCases()
+
+    const middle = data.collections[1]
+    expect(middle.cases.length).toBe(middle.caseIds.length)
+
+    const appended = groupingOf(data)
+    expect(appended).toEqual(regroupFromScratch(data))
+  })
+
+  it("restores a case that an appended item un-hides, in a top-level collection", () => {
+    const data = DataSet.create()
+    data.addAttribute({ id: "expId", name: "experiment" })
+    data.addAttribute({ id: "outId", name: "output" })
+    data.addCollection({ attributes: ["expId"] })
+
+    data.addCases([
+      { __id__: "i1", expId: "1", outId: "a" },
+      { __id__: "i2", expId: "2", outId: "b" }
+    ])
+    data.validateCases()
+    data.hideCasesOrItems(["i2"])
+    data.validateCases()
+
+    data.addCases([
+      { __id__: "i3", expId: "2", outId: "c" },
+      { __id__: "i4", expId: "3", outId: "d" }
+    ])
+    data.validateCases()
+
+    const parent = data.collections[0]
+    expect(parent.cases.length).toBe(parent.caseIds.length)
+
+    const appended = groupingOf(data)
+    expect(appended).toEqual(regroupFromScratch(data))
+  })
+
   it("orders appended cases correctly when they join an existing, earlier parent", () => {
     const data = makeSamplerDataSet()
     addSample(data, 0, { experiment: "1" })

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -59,6 +59,43 @@ describe("DataSet hierarchical append", () => {
     expect([...new Set(readItemIds)].sort()).toEqual(["e1-s5-i0", "e1-s5-i1", "e1-s5-i2"])
   })
 
+  // Streaming into an existing sample of an existing experiment adds no case to either
+  // parent collection, so nothing about them changes and re-sorting them is wasted work --
+  // work proportional to how many cases they already hold.
+  it("doesn't re-sort a parent collection when an append adds no case to it", () => {
+    const data = makeSamplerDataSet()
+    for (let sample = 0; sample < 5; ++sample) addSample(data, sample)
+
+    const caseGroupsBefore = data.collections[1].caseGroups
+    const writes = trackWrites(data.collections[1].caseIdToIndexMap)
+    data.addCases([{ __id__: "extra-0", expId: "1", sampId: "4", outId: "9" }])
+    data.validateCases()
+
+    expect(writes.clears).toBe(0)
+    expect(writes.sets).toEqual([])
+    // its cached arrays are reused rather than rebuilt, so identity-comparing reactions
+    // on them don't fire for an append that didn't touch this collection
+    expect(data.collections[1].caseGroups).toBe(caseGroupsBefore)
+
+    const appended = groupingOf(data)
+    expect(appended).toEqual(regroupFromScratch(data))
+  })
+
+  // The childmost collection can't take that shortcut: its cases are non-empty or not
+  // according to their item's values, and re-sending an item id writes new values into a
+  // case that already exists — so nothing new is added, but emptiness still changes.
+  it("recomputes emptiness when a re-sent item id fills in a previously empty case", () => {
+    const data = makeSamplerDataSet()
+    data.addCases([{ __id__: "i0", expId: "1", sampId: "0", outId: "" }])
+    data.validateCases()
+    expect(data.childCollection.nonEmptyCases.length).toBe(0)
+
+    data.addCases([{ __id__: "i0", expId: "1", sampId: "0", outId: "5" }])
+    data.validateCases()
+
+    expect(data.childCollection.nonEmptyCases.length).toBe(1)
+  })
+
   it("registers only the new cases in the case info map when appending", () => {
     const data = makeSamplerDataSet()
     for (let sample = 0; sample < 5; ++sample) addSample(data, sample)

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -240,8 +240,8 @@ describe("DataSet hierarchical append", () => {
     expect(appended).toEqual(regroupFromScratch(data))
   })
 
-  // One request that adds items for two samples at once -- the shape the Sampler produces
-  // when a batch is coalesced -- is the only way the childmost collection sees new cases
+  // One request that adds items for two samples at once — the shape the Sampler produces
+  // when a batch is coalesced — is the only way the childmost collection sees new cases
   // under more than one parent in a single pass, which is what the per-parent index
   // arithmetic exists for.
   it("indexes appended cases per parent when one batch spans two parents", () => {
@@ -266,7 +266,7 @@ describe("DataSet hierarchical append", () => {
 
   // Appending an item to a case whose items were all hidden makes that case visible again.
   // The case already exists, so it isn't among the new cases the additive path is told about,
-  // and its parent has never been told about it either -- it was hidden when the parent last
+  // and its parent has never been told about it either — it was hidden when the parent last
   // collected its children. Both collections have to end up as a full regroup would.
   it("restores a case that an appended item un-hides, in a middle collection", () => {
     const data = DataSet.create()
@@ -299,7 +299,7 @@ describe("DataSet hierarchical append", () => {
   })
 
   // The un-hidden case belongs at its item-order position among its siblings, which is before
-  // a sibling that already existed -- not appended after it.
+  // a sibling that already existed — not appended after it.
   it("orders a case that an appended item un-hides by item order, not by when it reappeared", () => {
     const data = DataSet.create()
     data.addAttribute({ id: "gId", name: "g" })

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -70,6 +70,19 @@ describe("DataSet hierarchical append", () => {
     expect(writes.sets.length).toBe(4)
   })
 
+  it("leaves the case lookup maps as a full regroup would after appending", () => {
+    const data = makeSamplerDataSet()
+    for (let sample = 0; sample < 3; ++sample) addSample(data, sample)
+    // a second experiment, so the maps span more than one branch of the hierarchy
+    addSample(data, 0, { experiment: "2" })
+
+    const appended = lookupMapsOf(data)
+    data.invalidateCases()
+    data.validateCases()
+
+    expect(appended).toEqual(lookupMapsOf(data))
+  })
+
   it("maps only the new items to their child cases when appending", () => {
     const data = makeSamplerDataSet()
     for (let sample = 0; sample < 5; ++sample) addSample(data, sample)
@@ -93,6 +106,18 @@ describe("DataSet hierarchical append", () => {
       caseIdToIndex: [...collection.caseIdToIndexMap.entries()],
       nonEmptyCaseIds: collection.nonEmptyCases.map(aCase => aCase.__id__)
     }))
+  }
+
+  // The dataset-level lookup maps every selection, notification and plugin request goes
+  // through. Compared by content rather than by identity, since a regroup builds fresh
+  // CaseInfo objects for the same cases.
+  function lookupMapsOf(data: IDataSet) {
+    return {
+      caseInfo: [...data.caseInfoMap.entries()]
+        .map(([caseId, info]) => `${caseId} -> ${info.collectionId}/${info.groupedCase.__id__}`).sort(),
+      itemIdChildCase: [...data.itemIdChildCaseMap.entries()]
+        .map(([itemId, info]) => `${itemId} -> ${info.groupedCase.__id__}`).sort()
+    }
   }
 
   function regroupFromScratch(data: IDataSet) {
@@ -151,6 +176,30 @@ describe("DataSet hierarchical append", () => {
     expect(data.childCollection.caseIds).not.toContain(
       data.getItemChildCaseId("e1-s0-i0")
     )
+
+    const appended = groupingOf(data)
+    expect(appended).toEqual(regroupFromScratch(data))
+  })
+
+  // One request that adds items for two samples at once -- the shape the Sampler produces
+  // when a batch is coalesced -- is the only way the childmost collection sees new cases
+  // under more than one parent in a single pass, which is what the per-parent index
+  // arithmetic exists for.
+  it("indexes appended cases per parent when one batch spans two parents", () => {
+    const data = makeSamplerDataSet()
+    addSample(data, 0)
+
+    data.addCases([
+      { __id__: "e1-s1-i0", expId: "1", sampId: "1", outId: "0" },
+      { __id__: "e1-s1-i1", expId: "1", sampId: "1", outId: "1" },
+      { __id__: "e1-s2-i0", expId: "1", sampId: "2", outId: "0" },
+      { __id__: "e1-s2-i1", expId: "1", sampId: "2", outId: "1" }
+    ])
+    data.validateCases()
+
+    // sample 0 has three items, samples 1 and 2 have two each; each is indexed from 0
+    expect(data.childCollection.caseGroups.map(group => group.groupedCase[symIndex]))
+      .toEqual([0, 1, 2, 0, 1, 0, 1])
 
     const appended = groupingOf(data)
     expect(appended).toEqual(regroupFromScratch(data))

--- a/v3/src/models/data/data-set-hierarchical-append.test.ts
+++ b/v3/src/models/data/data-set-hierarchical-append.test.ts
@@ -31,6 +31,23 @@ function trackValueReads(data: IDataSet) {
   return readItemIds
 }
 
+// Records the keys written to a map, so a test can report how much of it an operation
+// rewrote rather than just whether the end state is right.
+function trackWrites<V>(map: Map<string, V>) {
+  const record = { sets: [] as string[], clears: 0 }
+  const set = map.set.bind(map)
+  const clear = map.clear.bind(map)
+  map.set = (key: string, value: V) => {
+    record.sets.push(key)
+    return set(key, value)
+  }
+  map.clear = () => {
+    ++record.clears
+    clear()
+  }
+  return record
+}
+
 describe("DataSet hierarchical append", () => {
   it("doesn't read values for existing items when appending a new sample", () => {
     const data = makeSamplerDataSet()
@@ -40,6 +57,28 @@ describe("DataSet hierarchical append", () => {
     addSample(data, 5)
 
     expect([...new Set(readItemIds)].sort()).toEqual(["e1-s5-i0", "e1-s5-i1", "e1-s5-i2"])
+  })
+
+  it("registers only the new cases in the case info map when appending", () => {
+    const data = makeSamplerDataSet()
+    for (let sample = 0; sample < 5; ++sample) addSample(data, sample)
+
+    const writes = trackWrites(data.caseInfoMap)
+    addSample(data, 5)
+
+    // one new sample case and three new item cases; the experiment case already exists
+    expect(writes.sets.length).toBe(4)
+  })
+
+  it("maps only the new items to their child cases when appending", () => {
+    const data = makeSamplerDataSet()
+    for (let sample = 0; sample < 5; ++sample) addSample(data, sample)
+
+    const writes = trackWrites(data.itemIdChildCaseMap)
+    addSample(data, 5)
+
+    expect(writes.clears).toBe(0)
+    expect(writes.sets).toEqual(["e1-s5-i0", "e1-s5-i1", "e1-s5-i2"])
   })
 
   // Everything about a collection that case grouping is responsible for producing. A full

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1413,3 +1413,16 @@ describe("caseIdsCreatedByLastAppend", () => {
     expect(data.takeCaseIdsCreatedByLastAppend()).toBeUndefined()
   })
 })
+
+test("addCases inserts after a case whose last item is the first item", () => {
+  const data = DataSet.create()
+  data.addAttribute({ id: "pId", name: "p" })
+  data.addCases([{ __id__: "i0", pId: "a" }, { __id__: "i1", pId: "b" }], { canonicalize: false })
+  data.validateCases()
+
+  // index 0 is a valid position to insert after, so it must not be mistaken for "no position"
+  const firstCaseId = data.getItemChildCaseId("i0")!
+  data.addCases([{ __id__: "iX", pId: "c" }], { canonicalize: false, after: firstCaseId })
+
+  expect(data.itemIds).toEqual(["i0", "iX", "i1"])
+})

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1337,3 +1337,79 @@ test("appended items that make an attribute numeric notify isNumeric observers",
   expect(observed).toEqual([false, true])
   dispose()
 })
+
+describe("caseIdsCreatedByLastAppend", () => {
+  function makeGrouped() {
+    const data = DataSet.create()
+    data.addAttribute({ id: "pId", name: "p" })
+    data.addAttribute({ id: "vId", name: "v" })
+    data.addCollection({ attributes: ["pId"] })
+    data.addCases([{ __id__: "i0", pId: "a", vId: "1" }], { canonicalize: false })
+    data.validateCases()
+    return data
+  }
+
+
+  // Both of the ways it can answer have to go stale together: the ids either would report
+  // can name cases that no longer exist once anything else changes the dataset.
+  it("stops reporting once something other than an append changes the dataset", () => {
+    const data = makeGrouped()
+    data.addCases([{ __id__: "i1", pId: "b", vId: "2" }], { canonicalize: false })
+    data.validateCases()
+
+    // don't read before the change: reading consumes the answer, which would make this pass
+    // whether or not the change discarded it
+    data.removeCases(["i0"])
+    expect(data.takeCaseIdsCreatedByLastAppend()).toBeUndefined()
+  })
+
+  // addCases leaves grouping alone, so a caller that appends while the dataset is invalid
+  // gets no report -- not an empty one. (Whether those items are grouped at all in this
+  // state is CODAP-1486; callers that need an answer, like the item handler, validate first.)
+  it("declines to answer when it appended without grouping the items", () => {
+    const data = makeGrouped()
+    data.invalidateCases(false)
+    data.addCases([{ __id__: "i1", pId: "b", vId: "2" }], { canonicalize: false })
+    data.validateCases()
+
+    expect(data.takeCaseIdsCreatedByLastAppend()).toBeUndefined()
+  })
+
+  it("reports every collection's new case, not just the childmost", () => {
+    const data = makeGrouped()
+    data.addCases([{ __id__: "i1", pId: "b", vId: "2" }], { canonicalize: false })
+    data.validateCases()
+
+    // a new parent value forms one case in each of the two collections
+    const reported = Object.values(data.takeCaseIdsCreatedByLastAppend() ?? {}).flat()
+    expect(reported).toHaveLength(2)
+  })
+
+  it("answers only once, so a later reader can't be handed a stale answer", () => {
+    const data = makeGrouped()
+    data.addCases([{ __id__: "i1", pId: "b", vId: "2" }], { canonicalize: false })
+
+    expect(data.takeCaseIdsCreatedByLastAppend()).toBeDefined()
+    expect(data.takeCaseIdsCreatedByLastAppend()).toBeUndefined()
+  })
+
+  it("stops reporting once a snapshot replaces the dataset", () => {
+    const data = makeGrouped()
+    data.addCases([{ __id__: "i1", pId: "b", vId: "2" }], { canonicalize: false })
+
+    // the ids would name cases from the replaced dataset
+    data.afterApplySnapshot()
+    expect(data.takeCaseIdsCreatedByLastAppend()).toBeUndefined()
+  })
+
+  // Inserting regroups from scratch, so it can't name what it produced. It has to say so
+  // rather than answer emptily -- a caller told "nothing was created" acts on that.
+  it("declines to answer after an insert rather than reporting nothing", () => {
+    const data = makeGrouped()
+    data.addCases([{ __id__: "i1", pId: "b", vId: "2" }], { canonicalize: false, before: "i0" })
+    data.validateCases()
+
+    expect(data.getItemCaseIds("i1").length).toBeGreaterThan(0)   // cases really were made
+    expect(data.takeCaseIdsCreatedByLastAppend()).toBeUndefined()
+  })
+})

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1,5 +1,5 @@
 import { isEqual, isEqualWith } from "lodash"
-import { autorun } from "mobx"
+import { autorun, reaction } from "mobx"
 import { applyAction, clone, destroy, getSnapshot, onAction, onSnapshot } from "mobx-state-tree"
 import { uniqueName } from "../../utilities/js-utils"
 import { onAnyAction } from "../../utilities/mst-utils"
@@ -1315,4 +1315,25 @@ test("removeAttribute invalidates cases", () => {
   // re-validate and verify validationCount incremented
   data.validateCases()
   expect(data.validationCount).toBe(validationCountBefore + 1)
+})
+
+test("appended items that make an attribute numeric notify isNumeric observers", () => {
+  const data = DataSet.create()
+  data.addAttribute({ id: "nId", name: "n" })
+  data.addCases([{ __id__: "i0", nId: "" }])
+  data.validateCases()
+  const attr = data.getAttribute("nId")!
+
+  const observed: boolean[] = []
+  const dispose = reaction(() => attr.isNumeric, isNumeric => observed.push(isNumeric),
+    { fireImmediately: true })
+  expect(observed).toEqual([false])
+
+  // addCases grows every attribute and then writes the values supplied, in one action
+  data.addCases([{ __id__: "i1", nId: 5 }])
+  data.validateCases()
+
+  expect(attr.isNumeric).toBe(true)
+  expect(observed).toEqual([false, true])
+  dispose()
 })

--- a/v3/src/models/data/data-set.test.ts
+++ b/v3/src/models/data/data-set.test.ts
@@ -1338,7 +1338,7 @@ test("appended items that make an attribute numeric notify isNumeric observers",
   dispose()
 })
 
-describe("caseIdsCreatedByLastAppend", () => {
+describe("takeCaseIdsCreatedByLastAppend", () => {
   function makeGrouped() {
     const data = DataSet.create()
     data.addAttribute({ id: "pId", name: "p" })
@@ -1348,7 +1348,6 @@ describe("caseIdsCreatedByLastAppend", () => {
     data.validateCases()
     return data
   }
-
 
   // Both of the ways it can answer have to go stale together: the ids either would report
   // can name cases that no longer exist once anything else changes the dataset.
@@ -1364,7 +1363,7 @@ describe("caseIdsCreatedByLastAppend", () => {
   })
 
   // addCases leaves grouping alone, so a caller that appends while the dataset is invalid
-  // gets no report -- not an empty one. (Whether those items are grouped at all in this
+  // gets no report — not an empty one. (Whether those items are grouped at all in this
   // state is CODAP-1486; callers that need an answer, like the item handler, validate first.)
   it("declines to answer when it appended without grouping the items", () => {
     const data = makeGrouped()
@@ -1403,7 +1402,7 @@ describe("caseIdsCreatedByLastAppend", () => {
   })
 
   // Inserting regroups from scratch, so it can't name what it produced. It has to say so
-  // rather than answer emptily -- a caller told "nothing was created" acts on that.
+  // rather than answer emptily — a caller told "nothing was created" acts on that.
   it("declines to answer after an insert rather than reporting nothing", () => {
     const data = makeGrouped()
     data.addCases([{ __id__: "i1", pId: "b", vId: "2" }], { canonicalize: false, before: "i0" })

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -795,6 +795,7 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
       }
       return newCaseIds
     })
+    const childCollectionIndex = self.collections.length - 1
     self.collections.forEach((collection, index) => {
       // complete the case groups, including sorting child collection cases into groups
       const parentCaseGroups = index > 0 ? self.collections[index - 1].caseGroups : undefined
@@ -805,16 +806,16 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
       // full rebuild populates), so these ids are the ones the case groups ended up with.
       newCaseIdsByCollection[index].forEach(caseId => {
         const caseGroup = collection.getCaseGroup(caseId)
-        if (caseGroup) self.caseInfoMap.set(caseGroup.groupedCase.__id__, caseGroup)
+        if (!caseGroup) return
+        self.caseInfoMap.set(caseGroup.groupedCase.__id__, caseGroup)
+        // The childmost collection groups by item id (Collection.groupKey), so each of its new
+        // cases holds exactly one appended item and is keyed by it. Items the append didn't
+        // add keep the mapping they already had.
+        if (index === childCollectionIndex) {
+          const itemId = caseGroup.childItemIds[0] ?? caseGroup.hiddenChildItemIds[0]
+          if (itemId != null) self.itemIdChildCaseMap.set(itemId, caseGroup)
+        }
       })
-    })
-    // Map each new item to its child case. The childmost collection groups by item id
-    // (Collection.groupKey), so every appended item forms a case of its own and there is no
-    // existing mapping for it to invalidate — items the append didn't add keep theirs.
-    itemIds.forEach(itemId => {
-      const childCaseId = self.getItemChildCaseId(itemId)
-      const caseGroup = childCaseId ? self.childCollection.getCaseGroup(childCaseId) : undefined
-      if (caseGroup) self.itemIdChildCaseMap.set(itemId, caseGroup)
     })
   }
 }))

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -1385,7 +1385,7 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
           if (!afterCase?.childItemIds.length) return
           const afterCaseItemId = afterCase.childItemIds[afterCase.childItemIds.length - 1]
           const afterCaseItemIndex = self.getItemIndex(afterCaseItemId)
-          if (afterCaseItemIndex) return afterCaseItemIndex + 1
+          if (afterCaseItemIndex != null) return afterCaseItemIndex + 1
         }
         const afterPosition = getAfterPosition()
         const insertPosition = beforePosition ?? afterPosition ?? self._itemIds.length

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -183,6 +183,14 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
   // contains all items and child cases, including hidden ones
   itemIdChildCaseMap: new Map<string, CaseInfo>(),
 
+  // The cases created by the most recent addCases, keyed by collection id. Callers that need
+  // to report what a request created (e.g. the data interactive item handler) can read this
+  // immediately afterwards instead of comparing case ids before and after, which costs a walk
+  // of the whole dataset. Undefined when the last addCases couldn't say -- because it inserted
+  // rather than appended, or because grouping had to start over -- in which case there is no
+  // cheap answer and none is claimed.
+  newCaseIdsForLastAppend: undefined as Maybe<Record<string, string[]>>,
+
   // incremented when collection parent/child links are updated
   // Init: updated by initializeVolatileState
   syncCollectionLinksCount: 0,
@@ -780,21 +788,24 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
     // state and signal observers via _cacheVersion before the data is fully rebuilt.
     if (!self.isValidCases) return
 
-    const newCaseIdsByCollection = self.collections.map(collection => {
+    const newCaseIdsByCollection: string[][] = []
+    for (const collection of self.collections) {
       // update the cases (additive — only processes new itemIds)
       const { newCaseIds, unhiddenCaseIds } = collection.updateCaseGroups(itemIds)
       if (unhiddenCaseIds.length) {
-        // An appended item made an existing case visible again. That case isn't one of the new
-        // ones, so additive completion would leave it out of the cached case arrays while it
-        // sits in caseIds; rebuild the collection instead so the two agree.
-        collection.invalidateCaseGroups()
+        // An appended item made an existing case visible again. It isn't one of the new cases,
+        // and where it belongs among its siblings follows from item order, so no additive
+        // completion can place it correctly. Abandon the additive pass and regroup the whole
+        // dataset. This needs set-aside items to reach at all, so correctness is worth the
+        // full pass.
+        self.newCaseIdsForLastAppend = undefined
+        self.invalidateCases()
+        return
       }
-      else {
-        // tell collection about new cases for additive completion
-        collection.invalidateCaseGroupsForNewCases(newCaseIds)
-      }
-      return newCaseIds
-    })
+      // tell collection about new cases for additive completion
+      collection.invalidateCaseGroupsForNewCases(newCaseIds)
+      newCaseIdsByCollection.push(newCaseIds)
+    }
     const childCollectionIndex = self.collections.length - 1
     self.collections.forEach((collection, index) => {
       // complete the case groups, including sorting child collection cases into groups
@@ -817,6 +828,11 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
         }
       })
     })
+    const createdCaseIds: Record<string, string[]> = {}
+    self.collections.forEach((collection, index) => {
+      createdCaseIds[collection.id] = newCaseIdsByCollection[index]
+    })
+    self.newCaseIdsForLastAppend = createdCaseIds
   }
 }))
 .views(self => ({
@@ -1294,6 +1310,8 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
       addCases(cases: ICaseCreation[], options?: IAddCasesOptions) {
         const { before, after } = options || {}
         let didAppendItems = false
+        // only the additive path below can report what it created
+        self.newCaseIdsForLastAppend = undefined
 
         const beforePosition = before
           ? self.getItemIndex(before) ?? self.getItemIndex(self.caseInfoMap.get(before)?.childItemIds[0] ?? "")

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -780,22 +780,33 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
     // state and signal observers via _cacheVersion before the data is fully rebuilt.
     if (!self.isValidCases) return
 
-    self.collections.forEach((collection, index) => {
+    const newCaseIdsByCollection = self.collections.map(collection => {
       // update the cases (additive — only processes new itemIds)
       const { newCaseIds } = collection.updateCaseGroups(itemIds)
       // tell collection about new cases for additive completion
       collection.invalidateCaseGroupsForNewCases(newCaseIds)
+      return newCaseIds
     })
     self.collections.forEach((collection, index) => {
       // complete the case groups, including sorting child collection cases into groups
       const parentCaseGroups = index > 0 ? self.collections[index - 1].caseGroups : undefined
       collection.completeCaseGroups(parentCaseGroups)
-      // update the caseGroupMap
-      collection.caseGroupMap.forEach(group => self.caseInfoMap.set(group.groupedCase.__id__, group))
+      // Register the new cases. Cases the append didn't create are already registered, and
+      // their CaseInfo is updated in place rather than replaced, so their entries stay valid.
+      // The additive path never remaps case ids (remapping requires prevCaseIds, which only a
+      // full rebuild populates), so these ids are the ones the case groups ended up with.
+      newCaseIdsByCollection[index].forEach(caseId => {
+        const caseGroup = collection.getCaseGroup(caseId)
+        if (caseGroup) self.caseInfoMap.set(caseGroup.groupedCase.__id__, caseGroup)
+      })
     })
-    self.itemIdChildCaseMap.clear()
-    Array.from(self.childCollection.caseGroupMap.values()).forEach(caseGroup => {
-      self.itemIdChildCaseMap.set(caseGroup.childItemIds[0] ?? caseGroup.hiddenChildItemIds[0], caseGroup)
+    // Map each new item to its child case. The childmost collection groups by item id
+    // (Collection.groupKey), so every appended item forms a case of its own and there is no
+    // existing mapping for it to invalidate — items the append didn't add keep theirs.
+    itemIds.forEach(itemId => {
+      const childCaseId = self.getItemChildCaseId(itemId)
+      const caseGroup = childCaseId ? self.childCollection.getCaseGroup(childCaseId) : undefined
+      if (caseGroup) self.itemIdChildCaseMap.set(itemId, caseGroup)
     })
   }
 }))

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -183,13 +183,17 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
   // contains all items and child cases, including hidden ones
   itemIdChildCaseMap: new Map<string, CaseInfo>(),
 
-  // The cases created by the most recent addCases, keyed by collection id. Callers that need
-  // to report what a request created (e.g. the data interactive item handler) can read this
-  // immediately afterwards instead of comparing case ids before and after, which costs a walk
-  // of the whole dataset. Undefined when the last addCases couldn't say -- because it inserted
-  // rather than appended, or because grouping had to start over -- in which case there is no
-  // cheap answer and none is claimed.
+  // The cases created by the most recent append, keyed by collection id, when the additive
+  // path was able to say so directly. Read it through takeCaseIdsCreatedByLastAppend(), which
+  // also covers the un-hide fallback. Only valid until the next change to the dataset;
+  // invalidating the cases clears it.
   newCaseIdsForLastAppend: undefined as Maybe<Record<string, string[]>>,
+
+  // Case ids per collection as they stood immediately before an append that had to abandon
+  // its additive pass. Diffing against these once grouping has been rebuilt recovers the
+  // answer; it costs a walk of the dataset, but only on a path that is regrouping it anyway.
+  // Only recorded from a valid starting point, so the ids are the ones that really were there.
+  appendBaselineCaseIds: undefined as Maybe<Record<string, string[]>>,
 
   // incremented when collection parent/child links are updated
   // Init: updated by initializeVolatileState
@@ -339,6 +343,9 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
     actions: {
       invalidateCases(regrouping = true) {
         prf.measure("DataSet.invalidateCases", () => {
+          // any change to the dataset makes a previous append's report obsolete
+          self.newCaseIdsForLastAppend = undefined
+          self.appendBaselineCaseIds = undefined
           _isValidCases = false
           if (regrouping) {
             _needsRegrouping = true
@@ -782,10 +789,11 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
     // Append new items to the itemIds/items cache
     self.appendItemIdsToCache(itemIds)
 
-    // If a full invalidation is already pending (e.g., from an earlier insert in the same
-    // undo action), skip additive processing. The full rebuild will happen when validateCases()
-    // is next called. Without this check, completeCaseGroups() would run with incomplete volatile
-    // state and signal observers via _cacheVersion before the data is fully rebuilt.
+    // The additive pass needs grouping to be current: it has no consistent base to add to
+    // otherwise, and completeCaseGroups would signal observers over half-rebuilt state. Leave
+    // the rebuild to the next validateCases() and record nothing, so a caller that asks is
+    // told the append couldn't say what it created rather than that it created nothing.
+    // Callers that need an answer validate before appending; the item handler does.
     if (!self.isValidCases) return
 
     const newCaseIdsByCollection: string[][] = []
@@ -798,8 +806,29 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
         // completion can place it correctly. Abandon the additive pass and regroup the whole
         // dataset. This needs set-aside items to reach at all, so correctness is worth the
         // full pass.
-        self.newCaseIdsForLastAppend = undefined
+        //
+        // Collections already processed have had case ids pushed onto their caseIds — the new
+        // ones they reported, and for this collection the un-hidden one too — so subtract
+        // those to recover what each held beforehand. Collections after this one haven't been
+        // touched yet. Regrouping loses that history, and callers still need to know what the
+        // append produced.
+        const baseline: Record<string, string[]> = {}
+        self.collections.forEach((processed, index) => {
+          const added = index < newCaseIdsByCollection.length
+            ? new Set(newCaseIdsByCollection[index])
+            : processed === collection
+              ? new Set([...newCaseIds, ...unhiddenCaseIds])
+              : undefined
+          baseline[processed.id] = added
+            ? processed.caseIds.filter(caseId => !added.has(caseId))
+            : [...processed.caseIds]
+        })
+        // invalidating clears both fields, so record the baseline after it
         self.invalidateCases()
+        self.appendBaselineCaseIds = baseline
+        // leave the dataset grouped: an append shouldn't hand back a dataset that is both
+        // invalid and holding case ids its cached case arrays don't know about
+        self.validateCases()
         return
       }
       // tell collection about new cases for additive completion
@@ -846,6 +875,33 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
   }
 }))
 .actions(self => ({
+  // The cases the most recent addCases created, keyed by collection id. Appending reports
+  // this directly, having brought grouping up to date first so it could. The un-hide fallback
+  // abandons that pass, so it records what it started from and the answer is recovered by
+  // comparison once grouping is rebuilt. Inserting regroups from scratch and can't say, and
+  // returns undefined rather than an empty answer — "couldn't tell" must never be mistaken
+  // for "created nothing".
+  //
+  // Answers at most once, for the addCases immediately preceding it, and returns undefined
+  // otherwise: reading consumes the answer, and any intervening change to the cases discards
+  // it. That way the ids can never name cases that have since gone, without depending on an
+  // audit of which mutations could invalidate them.
+  takeCaseIdsCreatedByLastAppend(): Maybe<Record<string, string[]>> {
+    const { newCaseIdsForLastAppend, appendBaselineCaseIds } = self
+    self.newCaseIdsForLastAppend = undefined
+    self.appendBaselineCaseIds = undefined
+
+    if (newCaseIdsForLastAppend) return newCaseIdsForLastAppend
+    if (!appendBaselineCaseIds) return undefined
+
+    self.validateCases()
+    const created: Record<string, string[]> = {}
+    self.collections.forEach(collection => {
+      const before = new Set(appendBaselineCaseIds[collection.id] ?? [])
+      created[collection.id] = collection.caseIds.filter(caseId => !before.has(caseId))
+    })
+    return created
+  },
   clearFilterFormula() {
     self.filterFormula = undefined
     self.filteredOutItemIds.clear()
@@ -1310,8 +1366,9 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
       addCases(cases: ICaseCreation[], options?: IAddCasesOptions) {
         const { before, after } = options || {}
         let didAppendItems = false
-        // only the additive path below can report what it created
+        // only the paths below can report what this append created
         self.newCaseIdsForLastAppend = undefined
+        self.appendBaselineCaseIds = undefined
 
         const beforePosition = before
           ? self.getItemIndex(before) ?? self.getItemIndex(self.caseInfoMap.get(before)?.childItemIds[0] ?? "")

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -183,18 +183,6 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
   // contains all items and child cases, including hidden ones
   itemIdChildCaseMap: new Map<string, CaseInfo>(),
 
-  // The cases created by the most recent append, keyed by collection id, when the additive
-  // path was able to say so directly. Read it through takeCaseIdsCreatedByLastAppend(), which
-  // also covers the un-hide fallback. Only valid until the next change to the dataset;
-  // invalidating the cases clears it.
-  newCaseIdsForLastAppend: undefined as Maybe<Record<string, string[]>>,
-
-  // Case ids per collection as they stood immediately before an append that had to abandon
-  // its additive pass. Diffing against these once grouping has been rebuilt recovers the
-  // answer; it costs a walk of the dataset, but only on a path that is regrouping it anyway.
-  // Only recorded from a valid starting point, so the ids are the ones that really were there.
-  appendBaselineCaseIds: undefined as Maybe<Record<string, string[]>>,
-
   // incremented when collection parent/child links are updated
   // Init: updated by initializeVolatileState
   syncCollectionLinksCount: 0,
@@ -239,6 +227,15 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
   let _needsRegrouping = false
   let _needsValueRevalidation = false
   let _isValidItemIds = false
+  // What the most recent append can say about the cases it created, reachable only through
+  // the three actions below. Held here rather than as props so that reading really does
+  // consume: a direct reader could otherwise take the answer repeatedly, or find undefined and
+  // mistake "the append couldn't say" for "the append created nothing".
+  //   _appendReport   — the ids the additive pass minted, when it was able to report directly
+  //   _appendBaseline — what each collection held before an append that abandoned that pass,
+  //                     to be diffed against once grouping has been rebuilt
+  let _appendReport: Maybe<Record<string, string[]>>
+  let _appendBaseline: Maybe<Record<string, string[]>>
   // Item IDs removed during validation — flushed by setValidCases() in its runInAction
   let _pendingSelectionDeletes: string[] = []
 
@@ -341,11 +338,30 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
       }
     },
     actions: {
+      clearAppendReport() {
+        _appendReport = undefined
+        _appendBaseline = undefined
+      },
+      setAppendReport(report: Record<string, string[]>) {
+        _appendReport = report
+      },
+      setAppendBaseline(baseline: Record<string, string[]>) {
+        _appendBaseline = baseline
+      },
+      // Hands over whatever the last append can say and forgets it, so the answer is consumed
+      // by whoever asks first rather than left to be read again after the dataset has moved on.
+      takeAppendReport() {
+        const report = _appendReport
+        const baseline = _appendBaseline
+        _appendReport = undefined
+        _appendBaseline = undefined
+        return { report, baseline }
+      },
       invalidateCases(regrouping = true) {
         prf.measure("DataSet.invalidateCases", () => {
           // any change to the dataset makes a previous append's report obsolete
-          self.newCaseIdsForLastAppend = undefined
-          self.appendBaselineCaseIds = undefined
+          _appendReport = undefined
+          _appendBaseline = undefined
           _isValidCases = false
           if (regrouping) {
             _needsRegrouping = true
@@ -812,11 +828,12 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
         // those to recover what each held beforehand. Collections after this one haven't been
         // touched yet. Regrouping loses that history, and callers still need to know what the
         // append produced.
+        const bailIndex = newCaseIdsByCollection.length
         const baseline: Record<string, string[]> = {}
         self.collections.forEach((processed, index) => {
-          const added = index < newCaseIdsByCollection.length
+          const added = index < bailIndex
             ? new Set(newCaseIdsByCollection[index])
-            : processed === collection
+            : index === bailIndex
               ? new Set([...newCaseIds, ...unhiddenCaseIds])
               : undefined
           baseline[processed.id] = added
@@ -825,7 +842,7 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
         })
         // invalidating clears both fields, so record the baseline after it
         self.invalidateCases()
-        self.appendBaselineCaseIds = baseline
+        self.setAppendBaseline(baseline)
         // leave the dataset grouped: an append shouldn't hand back a dataset that is both
         // invalid and holding case ids its cached case arrays don't know about
         self.validateCases()
@@ -861,7 +878,7 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
     self.collections.forEach((collection, index) => {
       createdCaseIds[collection.id] = newCaseIdsByCollection[index]
     })
-    self.newCaseIdsForLastAppend = createdCaseIds
+    self.setAppendReport(createdCaseIds)
   }
 }))
 .views(self => ({
@@ -876,28 +893,29 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
 }))
 .actions(self => ({
   // The cases the most recent addCases created, keyed by collection id. Appending reports
-  // this directly, having brought grouping up to date first so it could. The un-hide fallback
-  // abandons that pass, so it records what it started from and the answer is recovered by
-  // comparison once grouping is rebuilt. Inserting regroups from scratch and can't say, and
-  // returns undefined rather than an empty answer — "couldn't tell" must never be mistaken
-  // for "created nothing".
+  // this directly, the caller having brought grouping up to date first so it could. The
+  // un-hide fallback abandons that pass, so it records what it started from and the answer is
+  // recovered by comparison once grouping is rebuilt. Inserting regroups from scratch and
+  // can't say, and returns undefined rather than an empty answer — "couldn't tell" must never
+  // be mistaken for "created nothing".
   //
   // Answers at most once, for the addCases immediately preceding it, and returns undefined
   // otherwise: reading consumes the answer, and any intervening change to the cases discards
   // it. That way the ids can never name cases that have since gone, without depending on an
   // audit of which mutations could invalidate them.
   takeCaseIdsCreatedByLastAppend(): Maybe<Record<string, string[]>> {
-    const { newCaseIdsForLastAppend, appendBaselineCaseIds } = self
-    self.newCaseIdsForLastAppend = undefined
-    self.appendBaselineCaseIds = undefined
+    const { report, baseline } = self.takeAppendReport()
 
-    if (newCaseIdsForLastAppend) return newCaseIdsForLastAppend
-    if (!appendBaselineCaseIds) return undefined
+    if (report) return report
+    if (!baseline) return undefined
 
+    // belt and braces: every path that records a baseline validates before returning, and the
+    // only caller validates too, so this should always be a no-op — but the diff below is
+    // meaningless against grouping that hasn't caught up
     self.validateCases()
     const created: Record<string, string[]> = {}
     self.collections.forEach(collection => {
-      const before = new Set(appendBaselineCaseIds[collection.id] ?? [])
+      const before = new Set(baseline[collection.id] ?? [])
       created[collection.id] = collection.caseIds.filter(caseId => !before.has(caseId))
     })
     return created
@@ -1367,8 +1385,7 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
         const { before, after } = options || {}
         let didAppendItems = false
         // only the paths below can report what this append created
-        self.newCaseIdsForLastAppend = undefined
-        self.appendBaselineCaseIds = undefined
+        self.clearAppendReport()
 
         const beforePosition = before
           ? self.getItemIndex(before) ?? self.getItemIndex(self.caseInfoMap.get(before)?.childItemIds[0] ?? "")

--- a/v3/src/models/data/data-set.ts
+++ b/v3/src/models/data/data-set.ts
@@ -782,9 +782,17 @@ export const DataSet = V2UserTitleModel.named("DataSet").props({
 
     const newCaseIdsByCollection = self.collections.map(collection => {
       // update the cases (additive — only processes new itemIds)
-      const { newCaseIds } = collection.updateCaseGroups(itemIds)
-      // tell collection about new cases for additive completion
-      collection.invalidateCaseGroupsForNewCases(newCaseIds)
+      const { newCaseIds, unhiddenCaseIds } = collection.updateCaseGroups(itemIds)
+      if (unhiddenCaseIds.length) {
+        // An appended item made an existing case visible again. That case isn't one of the new
+        // ones, so additive completion would leave it out of the cached case arrays while it
+        // sits in caseIds; rebuild the collection instead so the two agree.
+        collection.invalidateCaseGroups()
+      }
+      else {
+        // tell collection about new cases for additive completion
+        collection.invalidateCaseGroupsForNewCases(newCaseIds)
+      }
       return newCaseIds
     })
     self.collections.forEach((collection, index) => {


### PR DESCRIPTION
## Summary

`DataSet` has an optimized incremental-append path for new items, but it only fully applied to flat datasets. For hierarchical ones — including the Sampler plugin, which builds three collections (`experiments` → `samples` → `items`) — every append did an O(total cases) rebuild per child collection, making streamed item creation O(N²).

The append fast path in `Collection.completeCaseGroups` was gated on `!parentCases`, which is never true for a collection that has a parent. The earlier stages were already additive and correct for hierarchies; only the completion stage regressed.

**Streamed item creation through the plugin path is 7.4× faster at the tail** — 7.50 ms per request down to 1.01 ms at 4000 items.

## Results

Appending 400 samples of 10 items to a three-collection dataset — ms per append, by quartile:

| | Q1 | Q2 | Q3 | Q4 |
|---|---|---|---|---|
| flat, before | 0.52 | 0.84 | 1.17 | 1.50 |
| flat, after | 0.40 | 0.53 | 0.71 | 0.86 |
| hierarchical, before | 1.12 | 2.70 | 4.34 | 6.04 |
| hierarchical, after | 0.49 | 0.65 | 0.78 | 0.95 |

End-to-end through the plugin path (`createItemsInSegments`), ms per request:

| | Q1 | Q4 |
|---|---|---|
| before | 1.55 | 7.50 |
| after | 0.61 | 1.01 |

**7.4× faster at the tail.** This reduces the O(N²) cost of streamed creation rather than removing it — each append is still O(N), since the cached case arrays are rebuilt by spreading and `completeCaseGroups` rehashes every case id on both branches. Making the path genuinely O(new cases) is **CODAP-1487**.

## What changed

**The append path itself** — a child collection completes additively when the new cases provably sort to the end of the grouped order; inserts, additions under an older parent, and regrouping still rebuild. Streaming into an existing sample of an existing experiment no longer re-sorts either parent collection, which was O(accumulated parent cases) on every item.

**The lookup maps** — `caseInfoMap` was re-registered wholesale and `itemIdChildCaseMap` cleared and rebuilt on every append; both are now incremental.

**What a create request reports** — `createItemsInSegments` no longer diffs every collection's case ids before and after. The add reports the case ids it minted, read through a consume-once accessor. The request brings grouping up to date first so the additive pass can run, since `deleteItem`, `deleteCaseBy` and `itemSearch.delete` all `removeCases` without revalidating, so delete-then-create arrives with grouping invalid.

**Correctness fixes found along the way** — an appended item that un-hides a set-aside case is restored correctly (`main` dropped it from both the middle and childmost collections); `setLength` growing in place no longer loses the MobX notification that reassignment provided, and `isNumeric` reads `changeCount` like `length` and `type`; `getAfterPosition` no longer treats item index 0 as "no position".

## Review

Approved by @dougmartin after two rounds of requested changes, alongside three multi-agent review passes. Between them they found roughly twenty defects, all addressed. Two behaviours were kept deliberately and are called out in the thread: a set-aside case made visible again is reported as created, matching `main`; and the five per-index attribute accessors stay non-reactive, since making them read `changeCount` would re-render the case table on every value write.

## Testing

Twenty-three tests across `data-set-hierarchical-append.test.ts`, `data-set.test.ts` and `item-handler.test.ts`. Each assertion is mutation-verified — reverting the production change it covers fails at least one test. Several exist because mutation showed an earlier version constrained nothing, and the reporting tests derive ground truth independently (a case belongs to a request exactly when every item in it came from that request) rather than from the dataset's own case ids.

## Follow-ups

- **CODAP-1486** — items appended while a value-only invalidation is pending are never grouped. Pre-existing; reproduces on `main`.
- **CODAP-1487** — the remaining O(total cases) work per append: five full-length passes in `completeCaseGroups`, and `caseIdToIndexMap` encoding a hidden case two different ways.

Fixes CODAP-1485

🤖 Generated with [Claude Code](https://claude.com/claude-code)
